### PR TITLE
Change user-facing occurrences of Terraform to OpenTF in `internal/builtin`

### DIFF
--- a/internal/builtin/providers/terraform/resource_data.go
+++ b/internal/builtin/providers/terraform/resource_data.go
@@ -125,7 +125,7 @@ func applyDataStoreResourceChange(req providers.ApplyResourceChangeRequest) (res
 
 	if !req.PlannedState.GetAttr("id").IsKnown() {
 		idString, err := uuid.GenerateUUID()
-		// Terraform would probably never get this far without a good random
+		// OpenTF would probably never get this far without a good random
 		// source, but catch the error anyway.
 		if err != nil {
 			diag := tfdiags.AttributeValue(


### PR DESCRIPTION
Going over `internal/builtin`, checking for user-facing usages of Terraform, this folder contains:
1. The [`terraform` provider](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs). All usages of the word `terraform` in the code there refer to this provider, so I did not change them
2. The provisioners, for which the word `terraform` didn't exist in code

So, at the end, I just ended up changing a single comment that referred to this CLI as "Terraform"

Fixes https://github.com/opentffoundation/opentf/issues/39

## Target Release

1.6.0-alpha
