### PR TITLE
Change Terraform to OpenTF in comment regarding the program

### DIFF
--- a/internal/dag/marshal.go
+++ b/internal/dag/marshal.go
@@ -179,7 +179,7 @@ func marshalVertexID(v Vertex) string {
 	return VertexName(v)
 
 	// we could try harder by attempting to read the arbitrary value from the
-	// interface, but we shouldn't get here from terraform right now.
+	// interface, but we shouldn't get here from OpenTF right now.
 }
 
 // check for a Subgrapher, and return the underlying *Graph.


### PR DESCRIPTION
`internal/dag` has only a single mention of `terraform`, in a comment, referring to this program as "terraform"
Changed it to opentf

Fixes https://github.com/opentffoundation/opentf/issues/51

## Target Release

1.6.0-alpha
