### PR TITLE
Update `internal/command/arguments` to use OpenTF in user-provided strings.

### DIFF
--- a/internal/command/arguments/apply.go
+++ b/internal/command/arguments/apply.go
@@ -83,7 +83,7 @@ func ParseApply(args []string) (*Apply, tfdiags.Diagnostics) {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Plan file or auto-approve required",
-			"Terraform cannot ask for interactive approval when -json is set. You can either apply a saved plan file, or enable the -auto-approve option.",
+			"OpenTF cannot ask for interactive approval when -json is set. You can either apply a saved plan file, or enable the -auto-approve option.",
 		))
 	}
 
@@ -100,13 +100,13 @@ func ParseApply(args []string) (*Apply, tfdiags.Diagnostics) {
 }
 
 // ParseApplyDestroy is a special case of ParseApply that deals with the
-// "terraform destroy" command, which is effectively an alias for
-// "terraform apply -destroy".
+// "opentf destroy" command, which is effectively an alias for
+// "opentf apply -destroy".
 func ParseApplyDestroy(args []string) (*Apply, tfdiags.Diagnostics) {
 	apply, diags := ParseApply(args)
 
 	// So far ParseApply was using the command line options like -destroy
-	// and -refresh-only to determine the plan mode. For "terraform destroy"
+	// and -refresh-only to determine the plan mode. For "opentf destroy"
 	// we expect neither of those arguments to be set, and so the plan mode
 	// should currently be set to NormalMode, which we'll replace with
 	// DestroyMode here. If it's already set to something else then that
@@ -121,13 +121,13 @@ func ParseApplyDestroy(args []string) (*Apply, tfdiags.Diagnostics) {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Invalid mode option",
-			"The -destroy option is not valid for \"terraform destroy\", because this command always runs in destroy mode.",
+			"The -destroy option is not valid for \"opentf destroy\", because this command always runs in destroy mode.",
 		))
 	case plans.RefreshOnlyMode:
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Invalid mode option",
-			"The -refresh-only option is not valid for \"terraform destroy\".",
+			"The -refresh-only option is not valid for \"opentf destroy\".",
 		))
 	default:
 		// This is a non-ideal error message for if we forget to handle a
@@ -136,7 +136,7 @@ func ParseApplyDestroy(args []string) (*Apply, tfdiags.Diagnostics) {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Invalid mode option",
-			fmt.Sprintf("The \"terraform destroy\" command doesn't support %s.", apply.Operation.PlanMode),
+			fmt.Sprintf("The \"opentf destroy\" command doesn't support %s.", apply.Operation.PlanMode),
 		))
 	}
 

--- a/internal/command/arguments/extended.go
+++ b/internal/command/arguments/extended.go
@@ -10,16 +10,17 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/placeholderplaceholderplaceholder/opentf/internal/addrs"
 	"github.com/placeholderplaceholderplaceholder/opentf/internal/plans"
 	"github.com/placeholderplaceholderplaceholder/opentf/internal/tfdiags"
 )
 
-// DefaultParallelism is the limit Terraform places on total parallel
+// DefaultParallelism is the limit OpenTF places on total parallel
 // operations as it walks the dependency graph.
 const DefaultParallelism = 10
 
-// State describes arguments which are used to define how Terraform interacts
+// State describes arguments which are used to define how OpenTF interacts
 // with state.
 type State struct {
 	// Lock controls whether or not the state manager is used to lock state
@@ -46,7 +47,7 @@ type State struct {
 	BackupPath string
 }
 
-// Operation describes arguments which are used to configure how a Terraform
+// Operation describes arguments which are used to configure how a OpenTF
 // operation such as a plan or apply executes.
 type Operation struct {
 	// PlanMode selects one of the mutually-exclusive planning modes that
@@ -54,7 +55,7 @@ type Operation struct {
 	// only for an operation that produces a plan.
 	PlanMode plans.Mode
 
-	// Parallelism is the limit Terraform places on total parallel operations
+	// Parallelism is the limit OpenTF places on total parallel operations
 	// as it walks the dependency graph.
 	Parallelism int
 
@@ -66,7 +67,7 @@ type Operation struct {
 	// their dependencies.
 	Targets []addrs.Targetable
 
-	// ForceReplace addresses cause Terraform to force a particular set of
+	// ForceReplace addresses cause OpenTF to force a particular set of
 	// resource instances to generate "replace" actions in any plan where they
 	// would normally have generated "no-op" or "update" actions.
 	//
@@ -169,7 +170,7 @@ func (o *Operation) Parse() tfdiags.Diagnostics {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
 				"Incompatible refresh options",
-				"It doesn't make sense to use -refresh-only at the same time as -refresh=false, because Terraform would have nothing to do.",
+				"It doesn't make sense to use -refresh-only at the same time as -refresh=false, because OpenTF would have nothing to do.",
 			))
 		}
 	default:

--- a/internal/command/arguments/plan.go
+++ b/internal/command/arguments/plan.go
@@ -25,7 +25,7 @@ type Plan struct {
 	// OutPath contains an optional path to store the plan file
 	OutPath string
 
-	// GenerateConfigPath tells Terraform that config should be generated for
+	// GenerateConfigPath tells OpenTF that config should be generated for
 	// unmatched import target paths and which path the generated file should
 	// be written to.
 	GenerateConfigPath string

--- a/internal/command/arguments/validate.go
+++ b/internal/command/arguments/validate.go
@@ -18,7 +18,7 @@ type Validate struct {
 	// Path.
 	TestDirectory string
 
-	// NoTests indicates that Terraform should not validate any test files
+	// NoTests indicates that OpenTF should not validate any test files
 	// included with the module.
 	NoTests bool
 


### PR DESCRIPTION


<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/placeholderplaceholderplaceholder/opentf/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.5.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `opentf show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTF now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
