### PR TITLE
Update `internal/command/cliconfig` to use OpenTF in user-provided strings.

### DIFF
--- a/internal/command/cliconfig/cliconfig.go
+++ b/internal/command/cliconfig/cliconfig.go
@@ -6,7 +6,7 @@
 //
 // The CLI config is a small collection of settings that a user can override via
 // some files in their home directory or, in some cases, via environment
-// variables. The CLI config is not the same thing as a Terraform configuration
+// variables. The CLI config is not the same thing as a OpenTF configuration
 // written in the Terraform language; the logic for those lives in the top-level
 // directory "configs".
 package cliconfig
@@ -24,15 +24,16 @@ import (
 	"github.com/hashicorp/hcl"
 
 	svchost "github.com/hashicorp/terraform-svchost"
+
 	"github.com/placeholderplaceholderplaceholder/opentf/internal/tfdiags"
 )
 
 const pluginCacheDirEnvVar = "TF_PLUGIN_CACHE_DIR"
 const pluginCacheMayBreakLockFileEnvVar = "TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE"
 
-// Config is the structure of the configuration for the Terraform CLI.
+// Config is the structure of the configuration for the OpenTF CLI.
 //
-// This is not the configuration for Terraform itself. That is in the
+// This is not the configuration for OpenTF itself. That is in the
 // "config" package.
 type Config struct {
 	Providers    map[string]string
@@ -49,9 +50,9 @@ type Config struct {
 	// those who wish to use the Plugin Cache Dir even in cases where doing so
 	// will cause the dependency lock file to be incomplete.
 	//
-	// This is likely to become a silent no-op in future Terraform versions but
+	// This is likely to become a silent no-op in future OpenTF versions but
 	// is here in recognition of the fact that the dependency lock file is not
-	// yet a good fit for all Terraform workflows and folks in that category
+	// yet a good fit for all OpenTF workflows and folks in that category
 	// would prefer to have the plugin cache dir's behavior to take priority
 	// over the requirements of the dependency lock file.
 	PluginCacheMayBreakDependencyLockFile bool `hcl:"plugin_cache_may_break_dependency_lock_file"`
@@ -94,7 +95,7 @@ func ConfigFile() (string, error) {
 	return configFile()
 }
 
-// ConfigDir returns the configuration directory for Terraform.
+// ConfigDir returns the configuration directory for OpenTF.
 func ConfigDir() (string, error) {
 	return configDir()
 }
@@ -122,7 +123,7 @@ func LoadConfig() (*Config, tfdiags.Diagnostics) {
 	// in the config directory. We skip the config directory when source
 	// file override is set because we interpret the environment variable
 	// being set as an intention to ignore the default set of CLI config
-	// files because we're doing something special, like running Terraform
+	// files because we're doing something special, like running OpenTF
 	// in automation with a locally-customized configuration.
 	if cliConfigFileOverride() == "" {
 		if configDir, err := ConfigDir(); err == nil {

--- a/internal/command/cliconfig/credentials.go
+++ b/internal/command/cliconfig/credentials.go
@@ -18,6 +18,7 @@ import (
 
 	svchost "github.com/hashicorp/terraform-svchost"
 	svcauth "github.com/hashicorp/terraform-svchost/auth"
+
 	"github.com/placeholderplaceholderplaceholder/opentf/internal/configs/hcl2shim"
 	pluginDiscovery "github.com/placeholderplaceholderplaceholder/opentf/internal/plugin/discovery"
 	"github.com/placeholderplaceholderplaceholder/opentf/internal/replacefile"
@@ -150,12 +151,12 @@ func collectCredentialsFromEnv() map[svchost.Hostname]string {
 		// libraries that might interfere with how they are encoded, we'll
 		// be tolerant of them being given either directly as UTF-8 IDNs
 		// or in Punycode form, normalizing to Punycode form here because
-		// that is what the Terraform credentials helper protocol will
+		// that is what the OpenTF credentials helper protocol will
 		// use in its requests.
 		//
-		// Using ForDisplay first here makes this more liberal than Terraform
+		// Using ForDisplay first here makes this more liberal than OpenTF
 		// itself would usually be in that it will tolerate pre-punycoded
-		// hostnames that Terraform normally rejects in other contexts in order
+		// hostnames that OpenTF normally rejects in other contexts in order
 		// to ensure stored hostnames are human-readable.
 		dispHost := svchost.ForDisplay(rawHost)
 		hostname, err := svchost.ForComparison(dispHost)

--- a/internal/command/cliconfig/provider_installation.go
+++ b/internal/command/cliconfig/provider_installation.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/hcl"
 	hclast "github.com/hashicorp/hcl/hcl/ast"
+
 	"github.com/placeholderplaceholderplaceholder/opentf/internal/addrs"
 	"github.com/placeholderplaceholderplaceholder/opentf/internal/getproviders"
 	"github.com/placeholderplaceholderplaceholder/opentf/internal/tfdiags"
@@ -30,7 +31,7 @@ type ProviderInstallation struct {
 	// This is _not_ intended for "production" use because it bypasses the
 	// usual version selection and checksum verification mechanisms for
 	// the providers in question. To make that intent/effect clearer, some
-	// Terraform commands emit warnings when overrides are present. Local
+	// OpenTF commands emit warnings when overrides are present. Local
 	// mirror directories are a better way to distribute "released"
 	// providers, because they are still subject to version constraints and
 	// checksum verification.

--- a/internal/command/cliconfig/testdata/credentials
+++ b/internal/command/cliconfig/testdata/credentials
@@ -6,7 +6,7 @@ credentials "example.com" {
 credentials "example.net" {
   # Username and password are not currently supported, but we want to tolerate
   # unknown keys in case future versions add new keys when both old and new
-  # versions of Terraform are installed on a system, sharing the same
+  # versions of OpenTF are installed on a system, sharing the same
   # CLI config.
   username = "foo"
   password = "baz"


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/placeholderplaceholderplaceholder/opentf/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.5.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `opentf show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTF now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
