### PR TITLE
Update `internal/command/clistate` to use OpenTF in user-provided strings.

### DIFF
--- a/internal/command/clistate/state.go
+++ b/internal/command/clistate/state.go
@@ -23,18 +23,18 @@ const (
 	LockThreshold    = 400 * time.Millisecond
 	LockErrorMessage = `Error message: %s
 
-Terraform acquires a state lock to protect the state from being written
+OpenTF acquires a state lock to protect the state from being written
 by multiple users at the same time. Please resolve the issue above and try
 again. For most commands, you can disable locking with the "-lock=false"
 flag, but this is not recommended.`
 
 	UnlockErrorMessage = `Error message: %s
 
-Terraform acquires a lock when accessing your state to prevent others
-running Terraform to potentially modify the state at the same time. An
+OpenTF acquires a lock when accessing your state to prevent others
+running OpenTF to potentially modify the state at the same time. An
 error occurred while releasing this lock. This could mean that the lock
 did or did not release properly. If the lock didn't release properly,
-Terraform may not be able to run future commands since it'll appear as if
+OpenTF may not be able to run future commands since it'll appear as if
 the lock is held.
 
 In this scenario, please call the "force-unlock" command to unlock the


### PR DESCRIPTION


<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/placeholderplaceholderplaceholder/opentf/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.5.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `opentf show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTF now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
