### PR TITLE
Adapt user-facing usages of terraform in `internal/getmodules`

### DIFF
--- a/internal/getmodules/file_detector.go
+++ b/internal/getmodules/file_detector.go
@@ -10,7 +10,7 @@ import (
 )
 
 // fileDetector is a replacement for go-getter's own file detector which
-// better meets Terraform's needs: specifically, it rejects relative filesystem
+// better meets OpenTF's needs: specifically, it rejects relative filesystem
 // paths with a somewhat-decent error message.
 //
 // This is a replacement for some historical hackery we did where we tried to

--- a/internal/getmodules/getter.go
+++ b/internal/getmodules/getter.go
@@ -22,7 +22,7 @@ import (
 // executable.
 //
 // Note that over time we've found go-getter's design to be not wholly fit
-// for Terraform's purposes in various ways, and so we're continuing to use
+// for OpenTF's purposes in various ways, and so we're continuing to use
 // it here because our backward compatibility with earlier versions depends
 // on it, but we use go-getter very carefully and always only indirectly via
 // the public API of this package so that we can get the subset of the

--- a/internal/getmodules/package.go
+++ b/internal/getmodules/package.go
@@ -32,7 +32,7 @@ import (
 //
 // Some of go-getter's detectors make outgoing HTTP requests, and so
 // the behavior of this function may depend on the network connectivity
-// of the system where Terraform is running. However, most of the getters
+// of the system where OpenTF is running. However, most of the getters
 // we use are local-only, and so HTTP requests are only for some ambiguous
 // edge-cases, such as the BitBucket detector which has a mechanism to
 // detect whether to use Git or Mercurial, because earlier versions of
@@ -48,7 +48,7 @@ func NormalizePackageAddress(given string) (packageAddr, subDir string, err erro
 
 	// NOTE: We're passing an empty string to the "current working directory"
 	// here because that's only relevant for relative filesystem paths,
-	// but Terraform handles relative filesystem paths itself outside of
+	// but OpenTF handles relative filesystem paths itself outside of
 	// go-getter and so it'd always be an error to pass one into here.
 	// go-getter's "file" detector returns an error if it encounters a
 	// relative path when the pwd argument is empty.

--- a/internal/getmodules/subdir.go
+++ b/internal/getmodules/subdir.go
@@ -27,11 +27,11 @@ func SplitPackageSubdir(given string) (packageAddr, subDir string) {
 	// versions just used go-getter directly and so we need to preserve
 	// its various quirks for compatibility reasons.
 	//
-	// However, note that in Terraform we _always_ split off the subdirectory
-	// portion and handle it within Terraform-level code, _never_ passing
+	// However, note that in OpenTF we _always_ split off the subdirectory
+	// portion and handle it within OpenTF-level code, _never_ passing
 	// a subdirectory portion down into go-getter's own Get function, because
-	// Terraform's ability to refer between local paths inside the same
-	// package depends on Terraform itself always being aware of where the
+	// OpenTF's ability to refer between local paths inside the same
+	// package depends on OpenTF itself always being aware of where the
 	// package's root directory ended up on disk, and always needs the
 	// package installed wholesale.
 	packageAddr, subDir = getter.SourceDirSubdir(given)


### PR DESCRIPTION
There we no use-facing mentions of Terraform in `internal/getmodules`
I just changed some comments

Fixes https://github.com/opentffoundation/opentf/issues/86

## Target Release

1.6.0-alpha
