### PR TITLE
Adapt user-facing usages of terraform in `internal/instances`

### DIFF
--- a/internal/instances/expander.go
+++ b/internal/instances/expander.go
@@ -16,7 +16,7 @@ import (
 // repetition values (count and for_each in configuration) and then later
 // making use of them to fully enumerate all of the instances of an object.
 //
-// The two repeatable object types in Terraform are modules and resources.
+// The two repeatable object types in OpenTF are modules and resources.
 // Because resources belong to modules and modules can nest inside other
 // modules, module expansion in particular has a recursive effect that can
 // cause deep objects to expand exponentially. Expander assumes that all


### PR DESCRIPTION
There were not user-facing mentions of Terraform in `internal/instances`
I've updated a single comment in `internal/instances` to `OpenTF`

Fixes https://github.com/opentffoundation/opentf/issues/99
