### PR TITLE
Adapt user-facing usages of terraform in `internal/ipaddr`

### DIFF
--- a/internal/ipaddr/README.md
+++ b/internal/ipaddr/README.md
@@ -19,6 +19,14 @@ implementations may cause naive validation or policy checks to produce
 incorrect results, and thus it's a potential security concern. For more
 information, see [Go issue #30999](https://golang.org/issue/30999).
 
+After careful consideration, it was concluded that OpenTF's
+use of these functions as part of the implementation of the `cidrhost`,
+`cidrsubnet`, `cidrsubnets`, and `cidrnetmask` functions has a more limited
+impact than the general availability of these functions in the Go standard
+library, and so we can't justify a similar exception to our Terraform 1.0
+compatibility promises as the Go team made to their Go 1.0 compatibility
+promises.
+
 If you're considering using this package for new functionality _other than_ the
 built-in functions mentioned above, please do so only if consistency with the
 behavior of those functions is important. Otherwise, new features are not


### PR DESCRIPTION
`internal/ipaddr` has a README mentioning Terraform. I've updated the readme.

Fixes https://github.com/opentffoundation/opentf/issues/101

## Target Release

1.6.0-alpha
