### PR TITLE
Adapt user-facing usages of terraform in `internal/lang`

### DIFF
--- a/internal/lang/data.go
+++ b/internal/lang/data.go
@@ -15,7 +15,7 @@ import (
 // the addrs package.
 //
 // This interface will grow each time a new type of reference is added, and so
-// implementations outside of the Terraform codebases are not advised.
+// implementations outside of the OpenTF codebases are not advised.
 //
 // Each method returns a suitable value and optionally some diagnostics. If the
 // returned diagnostics contains errors then the type of the returned value is

--- a/internal/lang/doc.go
+++ b/internal/lang/doc.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-// Package lang deals with the runtime aspects of Terraform's configuration
+// Package lang deals with the runtime aspects of OpenTF's configuration
 // language, with concerns such as expression evaluation. It is closely related
 // to sibling package "configs", which is responsible for configuration
 // parsing and static validation.

--- a/internal/lang/funcs/collection.go
+++ b/internal/lang/funcs/collection.go
@@ -625,10 +625,10 @@ var ListFunc = function.New(&function.Spec{
 		AllowNull:        true,
 	},
 	Type: func(args []cty.Value) (ret cty.Type, err error) {
-		return cty.DynamicPseudoType, fmt.Errorf("the \"list\" function was deprecated in Terraform v0.12 and is no longer available; use tolist([ ... ]) syntax to write a literal list")
+		return cty.DynamicPseudoType, fmt.Errorf("the \"list\" function was deprecated in Terraform v0.12 and is not available in OpenTF; use tolist([ ... ]) syntax to write a literal list")
 	},
 	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
-		return cty.DynamicVal, fmt.Errorf("the \"list\" function was deprecated in Terraform v0.12 and is no longer available; use tolist([ ... ]) syntax to write a literal list")
+		return cty.DynamicVal, fmt.Errorf("the \"list\" function was deprecated in Terraform v0.12 and is not available in OpenTF; use tolist([ ... ]) syntax to write a literal list")
 	},
 })
 
@@ -646,10 +646,10 @@ var MapFunc = function.New(&function.Spec{
 		AllowNull:        true,
 	},
 	Type: func(args []cty.Value) (ret cty.Type, err error) {
-		return cty.DynamicPseudoType, fmt.Errorf("the \"map\" function was deprecated in Terraform v0.12 and is no longer available; use tomap({ ... }) syntax to write a literal map")
+		return cty.DynamicPseudoType, fmt.Errorf("the \"map\" function was deprecated in Terraform v0.12 and is not available in OpenTF; use tomap({ ... }) syntax to write a literal map")
 	},
 	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
-		return cty.DynamicVal, fmt.Errorf("the \"map\" function was deprecated in Terraform v0.12 and is no longer available; use tomap({ ... }) syntax to write a literal map")
+		return cty.DynamicVal, fmt.Errorf("the \"map\" function was deprecated in Terraform v0.12 and is not available in OpenTF; use tomap({ ... }) syntax to write a literal map")
 	},
 })
 

--- a/internal/lang/funcs/crypto.go
+++ b/internal/lang/funcs/crypto.go
@@ -291,7 +291,7 @@ func UUIDV5(namespace cty.Value, name cty.Value) (cty.Value, error) {
 //
 // The given string is first encoded as UTF-8 and then the SHA256 algorithm is applied
 // as defined in RFC 4634. The raw hash is then encoded with Base64 before returning.
-// Terraform uses the "standard" Base64 alphabet as defined in RFC 4648 section 4.
+// OpenTF uses the "standard" Base64 alphabet as defined in RFC 4648 section 4.
 func Base64Sha256(str cty.Value) (cty.Value, error) {
 	return Base64Sha256Func.Call([]cty.Value{str})
 }
@@ -301,7 +301,7 @@ func Base64Sha256(str cty.Value) (cty.Value, error) {
 //
 // The given string is first encoded as UTF-8 and then the SHA256 algorithm is applied
 // as defined in RFC 4634. The raw hash is then encoded with Base64 before returning.
-// Terraform uses the "standard" Base64  alphabet as defined in RFC 4648 section 4
+// OpenTF uses the "standard" Base64  alphabet as defined in RFC 4648 section 4
 func Base64Sha512(str cty.Value) (cty.Value, error) {
 	return Base64Sha512Func.Call([]cty.Value{str})
 }

--- a/internal/lang/funcs/datetime.go
+++ b/internal/lang/funcs/datetime.go
@@ -99,7 +99,7 @@ var TimeCmpFunc = function.New(&function.Spec{
 
 // Timestamp returns a string representation of the current date and time.
 //
-// In the Terraform language, timestamps are conventionally represented as
+// In the OpenTF language, timestamps are conventionally represented as
 // strings using RFC 3339 "Date and Time format" syntax, and so timestamp
 // returns a string in this format.
 func Timestamp() (cty.Value, error) {
@@ -108,7 +108,7 @@ func Timestamp() (cty.Value, error) {
 
 // TimeAdd adds a duration to a timestamp, returning a new timestamp.
 //
-// In the Terraform language, timestamps are conventionally represented as
+// In the OpenTF language, timestamps are conventionally represented as
 // strings using RFC 3339 "Date and Time format" syntax. Timeadd requires
 // the timestamp argument to be a string conforming to this syntax.
 //
@@ -129,7 +129,7 @@ func TimeAdd(timestamp cty.Value, duration cty.Value) (cty.Value, error) {
 // TimeCmp considers the UTC offset of each given timestamp when making its
 // decision, so for example 6:00 +0200 and 4:00 UTC are equal.
 //
-// In the Terraform language, timestamps are conventionally represented as
+// In the OpenTF language, timestamps are conventionally represented as
 // strings using RFC 3339 "Date and Time format" syntax. TimeCmp requires
 // the timestamp argument to be a string conforming to this syntax.
 //

--- a/internal/lang/funcs/descriptions.go
+++ b/internal/lang/funcs/descriptions.go
@@ -18,7 +18,7 @@ type descriptionEntry struct {
 }
 
 // DescriptionList is a consolidated list containing all descriptions for all
-// functions available within Terraform. A function's description should point
+// functions available within OpenTF. A function's description should point
 // to the matching entry in this list.
 //
 // We keep this as a single list, so we can quickly review descriptions within
@@ -257,7 +257,7 @@ var DescriptionList = map[string]descriptionEntry{
 		ParamDescription: []string{""},
 	},
 	"list": {
-		Description:      "The `list` function is no longer available. Prior to Terraform v0.12 it was the only available syntax for writing a literal list inside an expression, but Terraform v0.12 introduced a new first-class syntax.",
+		Description:      "The `list` function is no longer available. See `tolist` instead.",
 		ParamDescription: []string{""},
 	},
 	"log": {
@@ -273,7 +273,7 @@ var DescriptionList = map[string]descriptionEntry{
 		ParamDescription: []string{""},
 	},
 	"map": {
-		Description:      "The `map` function is no longer available. Prior to Terraform v0.12 it was the only available syntax for writing a literal map inside an expression, but Terraform v0.12 introduced a new first-class syntax.",
+		Description:      "The `map` function is no longer available. See `tomap` instead.",
 		ParamDescription: []string{""},
 	},
 	"matchkeys": {
@@ -419,7 +419,7 @@ var DescriptionList = map[string]descriptionEntry{
 		ParamDescription: []string{"", ""},
 	},
 	"textencodebase64": {
-		Description:      "`textencodebase64` encodes the unicode characters in a given string using a specified character encoding, returning the result base64 encoded because Terraform language strings are always sequences of unicode characters.",
+		Description:      "`textencodebase64` encodes the unicode characters in a given string using a specified character encoding, returning the result base64 encoded because OpenTF language strings are always sequences of unicode characters.",
 		ParamDescription: []string{"", ""},
 	},
 	"timeadd": {

--- a/internal/lang/funcs/encoding.go
+++ b/internal/lang/funcs/encoding.go
@@ -75,7 +75,7 @@ var TextEncodeBase64Func = function.New(&function.Spec{
 	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
 		encoding, err := ianaindex.IANA.Encoding(args[1].AsString())
 		if err != nil || encoding == nil {
-			return cty.UnknownVal(cty.String), function.NewArgErrorf(1, "%q is not a supported IANA encoding name or alias in this Terraform version", args[1].AsString())
+			return cty.UnknownVal(cty.String), function.NewArgErrorf(1, "%q is not a supported IANA encoding name or alias in this OpenTF version", args[1].AsString())
 		}
 
 		encName, err := ianaindex.IANA.Name(encoding)
@@ -119,7 +119,7 @@ var TextDecodeBase64Func = function.New(&function.Spec{
 	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
 		encoding, err := ianaindex.IANA.Encoding(args[1].AsString())
 		if err != nil || encoding == nil {
-			return cty.UnknownVal(cty.String), function.NewArgErrorf(1, "%q is not a supported IANA encoding name or alias in this Terraform version", args[1].AsString())
+			return cty.UnknownVal(cty.String), function.NewArgErrorf(1, "%q is not a supported IANA encoding name or alias in this OpenTF version", args[1].AsString())
 		}
 
 		encName, err := ianaindex.IANA.Name(encoding)
@@ -195,9 +195,9 @@ var URLEncodeFunc = function.New(&function.Spec{
 
 // Base64Decode decodes a string containing a base64 sequence.
 //
-// Terraform uses the "standard" Base64 alphabet as defined in RFC 4648 section 4.
+// OpenTF uses the "standard" Base64 alphabet as defined in RFC 4648 section 4.
 //
-// Strings in the Terraform language are sequences of unicode characters rather
+// Strings in the OpenTF language are sequences of unicode characters rather
 // than bytes, so this function will also interpret the resulting bytes as
 // UTF-8. If the bytes after Base64 decoding are _not_ valid UTF-8, this function
 // produces an error.
@@ -207,9 +207,9 @@ func Base64Decode(str cty.Value) (cty.Value, error) {
 
 // Base64Encode applies Base64 encoding to a string.
 //
-// Terraform uses the "standard" Base64 alphabet as defined in RFC 4648 section 4.
+// OpenTF uses the "standard" Base64 alphabet as defined in RFC 4648 section 4.
 //
-// Strings in the Terraform language are sequences of unicode characters rather
+// Strings in the OpenTF language are sequences of unicode characters rather
 // than bytes, so this function will first encode the characters from the string
 // as UTF-8, and then apply Base64 encoding to the result.
 func Base64Encode(str cty.Value) (cty.Value, error) {
@@ -219,9 +219,9 @@ func Base64Encode(str cty.Value) (cty.Value, error) {
 // Base64Gzip compresses a string with gzip and then encodes the result in
 // Base64 encoding.
 //
-// Terraform uses the "standard" Base64 alphabet as defined in RFC 4648 section 4.
+// OpenTF uses the "standard" Base64 alphabet as defined in RFC 4648 section 4.
 //
-// Strings in the Terraform language are sequences of unicode characters rather
+// Strings in the OpenTF language are sequences of unicode characters rather
 // than bytes, so this function will first encode the characters from the string
 // as UTF-8, then apply gzip compression, and then finally apply Base64 encoding.
 func Base64Gzip(str cty.Value) (cty.Value, error) {
@@ -242,10 +242,10 @@ func URLEncode(str cty.Value) (cty.Value, error) {
 
 // TextEncodeBase64 applies Base64 encoding to a string that was encoded before with a target encoding.
 //
-// Terraform uses the "standard" Base64 alphabet as defined in RFC 4648 section 4.
+// OpenTF uses the "standard" Base64 alphabet as defined in RFC 4648 section 4.
 //
 // First step is to apply the target IANA encoding (e.g. UTF-16LE).
-// Strings in the Terraform language are sequences of unicode characters rather
+// Strings in the OpenTF language are sequences of unicode characters rather
 // than bytes, so this function will first encode the characters from the string
 // as UTF-8, and then apply Base64 encoding to the result.
 func TextEncodeBase64(str, enc cty.Value) (cty.Value, error) {
@@ -254,9 +254,9 @@ func TextEncodeBase64(str, enc cty.Value) (cty.Value, error) {
 
 // TextDecodeBase64 decodes a string containing a base64 sequence whereas a specific encoding of the string is expected.
 //
-// Terraform uses the "standard" Base64 alphabet as defined in RFC 4648 section 4.
+// OpenTF uses the "standard" Base64 alphabet as defined in RFC 4648 section 4.
 //
-// Strings in the Terraform language are sequences of unicode characters rather
+// Strings in the OpenTF language are sequences of unicode characters rather
 // than bytes, so this function will also interpret the resulting bytes as
 // the target encoding.
 func TextDecodeBase64(str, enc cty.Value) (cty.Value, error) {

--- a/internal/lang/funcs/encoding_test.go
+++ b/internal/lang/funcs/encoding_test.go
@@ -236,7 +236,7 @@ func TestBase64TextEncode(t *testing.T) {
 			cty.StringVal("abc123!?$*&()'-=@~"),
 			cty.StringVal("NOT-EXISTS"),
 			cty.UnknownVal(cty.String).RefineNotNull(),
-			`"NOT-EXISTS" is not a supported IANA encoding name or alias in this Terraform version`,
+			`"NOT-EXISTS" is not a supported IANA encoding name or alias in this OpenTF version`,
 		},
 		{
 			cty.StringVal("🤔"),
@@ -310,7 +310,7 @@ func TestBase64TextDecode(t *testing.T) {
 			cty.StringVal("doesn't matter"),
 			cty.StringVal("NOT-EXISTS"),
 			cty.UnknownVal(cty.String).RefineNotNull(),
-			`"NOT-EXISTS" is not a supported IANA encoding name or alias in this Terraform version`,
+			`"NOT-EXISTS" is not a supported IANA encoding name or alias in this OpenTF version`,
 		},
 		{
 			cty.StringVal("<invalid base64>"),

--- a/internal/lang/funcs/filesystem.go
+++ b/internal/lang/funcs/filesystem.go
@@ -419,7 +419,7 @@ func readFileBytes(baseDir, path string, marks cty.ValueMarks) ([]byte, error) {
 	f, err := openFile(baseDir, path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			// An extra Terraform-specific hint for this situation
+			// An extra OpenTF-specific hint for this situation
 			return nil, fmt.Errorf("no file exists at %s; this function works only with files that are distributed as part of the configuration source code, so if this file will be created by a resource in this configuration you must instead obtain this result from an attribute of that resource", redactIfSensitive(path, marks))
 		}
 		return nil, err

--- a/internal/lang/funcs/sensitive.go
+++ b/internal/lang/funcs/sensitive.go
@@ -10,7 +10,7 @@ import (
 )
 
 // SensitiveFunc returns a value identical to its argument except that
-// Terraform will consider it to be sensitive.
+// OpenTF will consider it to be sensitive.
 var SensitiveFunc = function.New(&function.Spec{
 	Params: []function.Parameter{
 		{

--- a/internal/lang/funcs/sensitive_test.go
+++ b/internal/lang/funcs/sensitive_test.go
@@ -87,7 +87,7 @@ func TestSensitive(t *testing.T) {
 				// above. Any others are an error, even if they happen to
 				// appear alongside "sensitive". (We might change this rule
 				// if someday we decide to use marks for some additional
-				// unrelated thing in Terraform, but currently we assume that
+				// unrelated thing in OpenTF, but currently we assume that
 				// _all_ marks imply sensitive, and so returning any other
 				// marks would be confusing.)
 				t.Errorf("extraneous marks %#v", gotMarks)

--- a/internal/lang/functions.go
+++ b/internal/lang/functions.go
@@ -159,12 +159,12 @@ func (s *Scope) Functions() map[string]function.Function {
 		})
 
 		if s.ConsoleMode {
-			// The type function is only available in terraform console.
+			// The type function is only available in opentf console.
 			s.funcs["type"] = funcs.TypeFunc
 		}
 
 		if !s.ConsoleMode {
-			// The plantimestamp function doesn't make sense in the terraform
+			// The plantimestamp function doesn't make sense in the opentf
 			// console.
 			s.funcs["plantimestamp"] = funcs.MakeStaticTimestampFunc(s.PlanTimestamp)
 		}

--- a/internal/lang/functions_test.go
+++ b/internal/lang/functions_test.go
@@ -138,7 +138,7 @@ func TestFunctions(t *testing.T) {
 				// Note: "can" only works with expressions that pass static
 				// validation, because it only gets an opportunity to run in
 				// that case. The following "works" (captures the error) because
-				// Terraform understands it as a reference to an attribute
+				// OpenTF understands it as a reference to an attribute
 				// that does not exist during dynamic evaluation.
 				//
 				// "can" doesn't work with references that could never possibly
@@ -1076,7 +1076,7 @@ func TestFunctions(t *testing.T) {
 				// Note: "try" only works with expressions that pass static
 				// validation, because it only gets an opportunity to run in
 				// that case. The following "works" (captures the error) because
-				// Terraform understands it as a reference to an attribute
+				// OpenTF understands it as a reference to an attribute
 				// that does not exist during dynamic evaluation.
 				//
 				// "try" doesn't work with references that could never possibly
@@ -1084,7 +1084,7 @@ func TestFunctions(t *testing.T) {
 				// as an expression like "foo" alone which would be understood
 				// as an invalid resource reference. That's okay because this
 				// function exists primarily to ease access to dynamically-typed
-				// structures that Terraform can't statically validate by
+				// structures that OpenTF can't statically validate by
 				// definition.
 				`try({}.baz, "fallback")`,
 				cty.StringVal("fallback"),

--- a/internal/lang/globalref/reference.go
+++ b/internal/lang/globalref/reference.go
@@ -15,7 +15,7 @@ import (
 // Reference combines an addrs.Reference with the address of the module
 // instance or resource instance where it was found.
 //
-// Because of the design of the Terraform language, our main model of
+// Because of the design of the OpenTF language, our main model of
 // references only captures the module-local part of the reference and assumes
 // that it's always clear from context which module a reference belongs to.
 // That's not true for globalref because our whole purpose is to work across
@@ -112,7 +112,7 @@ func (r Reference) ResourceInstance() (addrs.AbsResourceInstance, bool) {
 	}
 }
 
-// DebugString returns an internal (but still somewhat Terraform-language-like)
+// DebugString returns an internal (but still somewhat OpenTF-language-like)
 // compact string representation of the reciever, which isn't an address that
 // any of our usual address parsers could accept but still captures the
 // essence of what the reference represents.

--- a/internal/lang/marks/marks.go
+++ b/internal/lang/marks/marks.go
@@ -36,7 +36,7 @@ func Contains(val cty.Value, mark valueMark) bool {
 }
 
 // Sensitive indicates that this value is marked as sensitive in the context of
-// Terraform.
+// OpenTF.
 const Sensitive = valueMark("Sensitive")
 
 // TypeType is used to indicate that the value contains a representation of

--- a/internal/lang/scope.go
+++ b/internal/lang/scope.go
@@ -27,7 +27,7 @@ type Scope struct {
 	// ParseRef is a function that the scope uses to extract references from
 	// a hcl.Traversal. This controls the type of references the scope currently
 	// supports. As an example, the testing scope can reference outputs directly
-	// while the main Terraform context scope can not. This means that this
+	// while the main OpenTF context scope can not. This means that this
 	// function for the testing scope will happily return outputs, while the
 	// main context scope would fail if a user attempts to reference an output.
 	ParseRef ParseRef

--- a/internal/lang/types/types.go
+++ b/internal/lang/types/types.go
@@ -1,5 +1,5 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-// Package types contains non-standard cty types used only within Terraform.
+// Package types contains non-standard cty types used only within OpenTF.
 package types


### PR DESCRIPTION
**I changed**:
- Some comments mentioning terraform
- The deprecation errors for `list` and `map`. Those still mention TF 0.12, but have been changed to clarify that this is not supported at all in OpenTF
- The descriptions of `list` and `map`
- Some more deprecation errors

Fixes https://github.com/opentffoundation/opentf/issues/103

1.6.0-alpha

