### PR TITLE
Adapt user-facing usages of terraform in `internal/plans`

### DIFF
--- a/internal/plans/changes.go
+++ b/internal/plans/changes.go
@@ -10,7 +10,7 @@ import (
 	"github.com/placeholderplaceholderplaceholder/opentf/internal/states"
 )
 
-// Changes describes various actions that Terraform will attempt to take if
+// Changes describes various actions that OpenTF will attempt to take if
 // the corresponding plan is applied.
 //
 // A Changes object can be rendered into a visual diff (by the caller, using
@@ -244,7 +244,7 @@ type ResourceInstanceChange struct {
 	RequiredReplace cty.PathSet
 
 	// Private allows a provider to stash any extra data that is opaque to
-	// Terraform that relates to this change. Terraform will save this
+	// OpenTF that relates to this change. OpenTF will save this
 	// byte-for-byte and return it to the provider in the apply call.
 	Private []byte
 }
@@ -281,7 +281,7 @@ func (rc *ResourceInstanceChange) Moved() bool {
 
 // Simplify will, where possible, produce a change with a simpler action than
 // the receiever given a flag indicating whether the caller is dealing with
-// a normal apply or a destroy. This flag deals with the fact that Terraform
+// a normal apply or a destroy. This flag deals with the fact that OpenTF
 // Core uses a specialized graph node type for destroying; only that
 // specialized node should set "destroying" to true.
 //

--- a/internal/plans/changes_src.go
+++ b/internal/plans/changes_src.go
@@ -69,7 +69,7 @@ type ResourceInstanceChangeSrc struct {
 	RequiredReplace cty.PathSet
 
 	// Private allows a provider to stash any extra data that is opaque to
-	// Terraform that relates to this change. Terraform will save this
+	// OpenTF that relates to this change. OpenTF will save this
 	// byte-for-byte and return it to the provider in the apply call.
 	Private []byte
 }

--- a/internal/plans/doc.go
+++ b/internal/plans/doc.go
@@ -1,8 +1,8 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-// Package plans contains the types that are used to represent Terraform plans.
+// Package plans contains the types that are used to represent OpenTF plans.
 //
-// A plan describes a set of changes that Terraform will make to update remote
+// A plan describes a set of changes that OpenTF will make to update remote
 // objects to match with changes to the configuration.
 package plans

--- a/internal/plans/internal/planproto/doc.go
+++ b/internal/plans/internal/planproto/doc.go
@@ -4,7 +4,7 @@
 // Package planproto is home to the Go stubs generated from the tfplan protobuf
 // schema.
 //
-// This is an internal package to be used only by Terraform's planfile package.
-// From elsewhere in Terraform, use the API exported by the planfile package
+// This is an internal package to be used only by OpenTF's planfile package.
+// From elsewhere in OpenTF, use the API exported by the planfile package
 // itself.
 package planproto

--- a/internal/plans/internal/planproto/planfile.pb.go
+++ b/internal/plans/internal/planproto/planfile.pb.go
@@ -348,9 +348,9 @@ type Plan struct {
 	Version uint64 `protobuf:"varint,1,opt,name=version,proto3" json:"version,omitempty"`
 	// The mode that was active when this plan was created.
 	//
-	// This is saved only for UI purposes, so that Terraform can tailor its
+	// This is saved only for UI purposes, so that OpenTF can tailor its
 	// rendering of the plan depending on the mode. This must never be used to
-	// make decisions in Terraform Core during the applying of a plan.
+	// make decisions in OpenTF Core during the applying of a plan.
 	UiMode Mode `protobuf:"varint,17,opt,name=ui_mode,json=uiMode,proto3,enum=tfplan.Mode" json:"ui_mode,omitempty"`
 	// Errored is true for any plan whose creation was interrupted by an
 	// error. A plan with this flag set cannot be applied, and the changes
@@ -364,7 +364,7 @@ type Plan struct {
 	// each resource to determine which module it belongs to.
 	ResourceChanges []*ResourceInstanceChange `protobuf:"bytes,3,rep,name=resource_changes,json=resourceChanges,proto3" json:"resource_changes,omitempty"`
 	// An unordered set of detected drift: changes made to resources outside of
-	// Terraform, computed by comparing the previous run's state to the state
+	// OpenTF, computed by comparing the previous run's state to the state
 	// after refresh.
 	ResourceDrift []*ResourceInstanceChange `protobuf:"bytes,18,rep,name=resource_drift,json=resourceDrift,proto3" json:"resource_drift,omitempty"`
 	// An unordered set of proposed changes to outputs in the root module
@@ -387,7 +387,7 @@ type Plan struct {
 	// plan, or else applying the plan will fail when it reaches a different
 	// conclusion about what action a particular resource instance needs.
 	ForceReplaceAddrs []string `protobuf:"bytes,16,rep,name=force_replace_addrs,json=forceReplaceAddrs,proto3" json:"force_replace_addrs,omitempty"`
-	// The version string for the Terraform binary that created this plan.
+	// The version string for the OpenTF binary that created this plan.
 	TerraformVersion string `protobuf:"bytes,14,opt,name=terraform_version,json=terraformVersion,proto3" json:"terraform_version,omitempty"`
 	// Backend is a description of the backend configuration and other related
 	// settings at the time the plan was created.
@@ -715,7 +715,7 @@ type ResourceInstanceChange struct {
 	// this resource instance was tracked during the previous apply operation.
 	//
 	// This is populated only if it would be different from addr due to
-	// Terraform having reacted to refactoring annotations in the configuration.
+	// OpenTF having reacted to refactoring annotations in the configuration.
 	// If empty, the previous run address is the same as the current address.
 	PrevRunAddr string `protobuf:"bytes,14,opt,name=prev_run_addr,json=prevRunAddr,proto3" json:"prev_run_addr,omitempty"`
 	// deposed_key, if set, indicates that this change applies to a deposed

--- a/internal/plans/internal/planproto/planfile.proto
+++ b/internal/plans/internal/planproto/planfile.proto
@@ -4,7 +4,7 @@
 syntax = "proto3";
 package tfplan;
 
-// For Terraform's own parsing, the proto stub types go into an internal Go
+// For OpenTF's own parsing, the proto stub types go into an internal Go
 // package. The public API is in github.com/placeholderplaceholderplaceholder/opentf/plans/planfile .
 option go_package = "github.com/placeholderplaceholderplaceholder/opentf/internal/plans/internal/planproto";
 
@@ -22,9 +22,9 @@ message Plan {
 
     // The mode that was active when this plan was created.
     //
-    // This is saved only for UI purposes, so that Terraform can tailor its
+    // This is saved only for UI purposes, so that OpenTF can tailor its
     // rendering of the plan depending on the mode. This must never be used to
-    // make decisions in Terraform Core during the applying of a plan.
+    // make decisions in OpenTF Core during the applying of a plan.
     Mode ui_mode = 17;
 
     // Errored is true for any plan whose creation was interrupted by an
@@ -42,7 +42,7 @@ message Plan {
     repeated ResourceInstanceChange resource_changes = 3;
 
     // An unordered set of detected drift: changes made to resources outside of
-    // Terraform, computed by comparing the previous run's state to the state
+    // OpenTF, computed by comparing the previous run's state to the state
     // after refresh.
     repeated ResourceInstanceChange resource_drift = 18;
 
@@ -70,7 +70,7 @@ message Plan {
     // conclusion about what action a particular resource instance needs.
     repeated string force_replace_addrs = 16;
 
-    // The version string for the Terraform binary that created this plan.
+    // The version string for the OpenTF binary that created this plan.
     string terraform_version = 14;
 
     // Backend is a description of the backend configuration and other related
@@ -183,14 +183,14 @@ message ResourceInstanceChange {
     // this resource instance was tracked during the previous apply operation.
     //
     // This is populated only if it would be different from addr due to
-    // Terraform having reacted to refactoring annotations in the configuration.
+    // OpenTF having reacted to refactoring annotations in the configuration.
     // If empty, the previous run address is the same as the current address.
     string prev_run_addr = 14;
 
     // NOTE: Earlier versions of this format had fields 1 through 6 describing
     // various indivdual parts of "addr". We're now using our standard compact
     // string representation to capture the same information. We don't support
-    // preserving plan files from one Terraform version to the next, so we
+    // preserving plan files from one OpenTF version to the next, so we
     // no longer declare nor accept those fields.
 
     // deposed_key, if set, indicates that this change applies to a deposed

--- a/internal/plans/mode.go
+++ b/internal/plans/mode.go
@@ -19,8 +19,8 @@ const (
 	// prior state, even if the configuration for those instances is still
 	// present.
 	//
-	// This mode corresponds with the "-destroy" option to "terraform plan",
-	// and with the plan created by the "terraform destroy" command.
+	// This mode corresponds with the "-destroy" option to "opentf plan",
+	// and with the plan created by the "opentf destroy" command.
 	DestroyMode Mode = 'D'
 
 	// RefreshOnlyMode is a special planning mode which only performs the
@@ -29,6 +29,6 @@ const (
 	// the configuration has changed relative to the state.
 	//
 	// This mode corresponds with the "-refresh-only" option to
-	// "terraform plan".
+	// "opentf plan".
 	RefreshOnlyMode Mode = 'R'
 )

--- a/internal/plans/objchange/lcs.go
+++ b/internal/plans/objchange/lcs.go
@@ -28,7 +28,7 @@ func ValueEqual(x, y cty.Value) bool {
 // elements in a sequence.
 //
 // The approached used here is a "naive" one, assuming that both xs and ys will
-// generally be small in most reasonable Terraform configurations. For larger
+// generally be small in most reasonable OpenTF configurations. For larger
 // lists the time/space usage may be sub-optimal.
 //
 // A pair of lists may have multiple longest common subsequences. In that

--- a/internal/plans/objchange/objchange.go
+++ b/internal/plans/objchange/objchange.go
@@ -56,7 +56,7 @@ func ProposedNew(schema *configschema.Block, prior, config cty.Value) cty.Value 
 // provider when the data resource is finally read.
 //
 // Data resources are different because the planning of them is handled
-// entirely within Terraform Core and not subject to customization by the
+// entirely within OpenTF Core and not subject to customization by the
 // provider. This function is, in effect, producing an equivalent result to
 // passing the proposedNewBlock result into a provider's PlanResourceChange
 // function, assuming a fixed implementation of PlanResourceChange that just

--- a/internal/plans/plan.go
+++ b/internal/plans/plan.go
@@ -75,7 +75,7 @@ type Plan struct {
 	// was derived from:
 	//
 	// PrevRunState is a representation of the outcome of the previous
-	// Terraform operation, without any updates from the remote system but
+	// OpenTF operation, without any updates from the remote system but
 	// potentially including some changes that resulted from state upgrade
 	// actions.
 	//
@@ -98,7 +98,7 @@ type Plan struct {
 	// updated resources. It is easier to build the testing scope with access
 	// to same temporary state the plan used/built.
 	//
-	// This is never recorded outside of Terraform. It is not written into the
+	// This is never recorded outside of OpenTF. It is not written into the
 	// binary plan file, and it is not written into the JSON structured outputs.
 	// The testing framework never writes the plans out but holds everything in
 	// memory as it executes, so there is no need to add any kind of
@@ -108,7 +108,7 @@ type Plan struct {
 
 	// ExternalReferences are references that are being made to resources within
 	// the plan from external sources. As with PlannedState this is used by the
-	// terraform testing framework, and so isn't written into any external
+	// opentf testing framework, and so isn't written into any external
 	// representation of the plan.
 	ExternalReferences []*addrs.Reference
 
@@ -118,7 +118,7 @@ type Plan struct {
 
 // CanApply returns true if and only if the recieving plan includes content
 // that would make sense to apply. If it returns false, the plan operation
-// should indicate that there's nothing to do and Terraform should exit
+// should indicate that there's nothing to do and OpenTF should exit
 // without prompting the user to confirm the changes.
 //
 // This function represents our main business logic for making the decision
@@ -142,7 +142,7 @@ func (p *Plan) CanApply() bool {
 
 	case !p.PriorState.ManagedResourcesEqual(p.PrevRunState):
 		// If there are no changes planned but we detected some
-		// outside-Terraform changes while refreshing then we consider
+		// outside-OpenTF changes while refreshing then we consider
 		// that applyable in isolation only if this was a refresh-only
 		// plan where we expect updating the state to include these
 		// changes was the intended goal.

--- a/internal/plans/planfile/reader.go
+++ b/internal/plans/planfile/reader.go
@@ -61,7 +61,7 @@ func Open(filename string) (*Reader, error) {
 		// like our old plan format from versions prior to 0.12.
 		if b, sErr := ioutil.ReadFile(filename); sErr == nil {
 			if bytes.HasPrefix(b, []byte("tfplan")) {
-				return nil, errUnusable(fmt.Errorf("the given plan file was created by an earlier version of Terraform; plan files cannot be shared between different Terraform versions"))
+				return nil, errUnusable(fmt.Errorf("the given plan file was created by an earlier version of OpenTF, or an earlier version of Terraform; plan files cannot be shared between different OpenTF or Terraform versions"))
 			}
 		}
 		return nil, err
@@ -93,7 +93,7 @@ func Open(filename string) (*Reader, error) {
 //
 // Errors can be returned for various reasons, including if the plan file
 // is not of an appropriate format version, if it was created by a different
-// version of Terraform, if it is invalid, etc.
+// version of OpenTF, if it is invalid, etc.
 func (r *Reader) ReadPlan() (*plans.Plan, error) {
 	var planFile *zip.File
 	for _, file := range r.zip.File {
@@ -255,7 +255,7 @@ func (r *Reader) ReadDependencyLocks() (*depsfile.Locks, tfdiags.Diagnostics) {
 	diags = diags.Append(tfdiags.Sourceless(
 		tfdiags.Error,
 		"Saved plan has no dependency lock information",
-		"The specified saved plan file does not include any dependency lock information. This is a bug in the previous run of Terraform that created this file.",
+		"The specified saved plan file does not include any dependency lock information. This is a bug in the previous run of OpenTF that created this file.",
 	))
 	return nil, diags
 }

--- a/internal/plans/planfile/tfplan.go
+++ b/internal/plans/planfile/tfplan.go
@@ -53,7 +53,7 @@ func readTfplan(r io.Reader) (*plans.Plan, error) {
 	}
 
 	if rawPlan.TerraformVersion != version.String() {
-		return nil, fmt.Errorf("plan file was created by Terraform %s, but this is %s; plan files cannot be transferred between different Terraform versions", rawPlan.TerraformVersion, version.String())
+		return nil, fmt.Errorf("plan file was created by OpenTF or Terraform %s, but this is %s; plan files cannot be transferred between different versions of OpenTF / Terraform", rawPlan.TerraformVersion, version.String())
 	}
 
 	plan := &plans.Plan{
@@ -273,7 +273,7 @@ func resourceChangeFromTfplan(rawChange *planproto.ResourceInstanceChange) (*pla
 		// file created by an earlier version of Terraform, which had the
 		// same information spread over various other fields:
 		// ModulePath, Mode, Name, Type, and InstanceKey.
-		return nil, fmt.Errorf("no instance address for resource instance change; perhaps this plan was created by a different version of Terraform?")
+		return nil, fmt.Errorf("no instance address for resource instance change; perhaps this plan was created by a different version of OpenTF or a different version of Terraform?")
 	}
 
 	instAddr, diags := addrs.ParseAbsResourceInstanceStr(rawChange.Addr)

--- a/internal/plans/planfile/writer.go
+++ b/internal/plans/planfile/writer.go
@@ -48,7 +48,7 @@ type CreateArgs struct {
 // file that might already exist there.
 //
 // A plan file contains both a snapshot of the configuration and of the latest
-// state file in addition to the plan itself, so that Terraform can detect
+// state file in addition to the plan itself, so that OpenTF can detect
 // if the world has changed since the plan was created and thus refuse to
 // apply it.
 func Create(filename string, args CreateArgs) error {


### PR DESCRIPTION
**I changed:**
- Some comments
- Error messages suggesting that the plan file was created by a previous version of terraform - Changed to mention both OpenTF **and** Terraform

Fixes https://github.com/opentffoundation/opentf/issues/112

## Target Release

1.6.0-alpha
