### PR TITLE
Adapt user-facing usages of terraform in `internal/refactoring`

### DIFF
--- a/internal/refactoring/move_validate.go
+++ b/internal/refactoring/move_validate.go
@@ -228,7 +228,7 @@ func validateMoveStatementGraph(g *dag.AcyclicGraph) tfdiags.Diagnostics {
 				tfdiags.Error,
 				"Self reference in move statements",
 				fmt.Sprintf(
-					"The move statement %s refers to itself the move dependency graph, which is invalid. This is a bug in Terraform; please report it!",
+					"The move statement %s refers to itself the move dependency graph, which is invalid. This is a bug in OpenTF; please report it!",
 					src.(*MoveStatement).Name(),
 				),
 			))


### PR DESCRIPTION
This indeed is a one-line change.

Closes #124.