### PR TITLE
User Facing in internal/legacy

### DIFF
--- a/internal/legacy/helper/schema/provider.go
+++ b/internal/legacy/helper/schema/provider.go
@@ -412,7 +412,7 @@ func (p *Provider) ImportState(
 			return nil, fmt.Errorf(
 				"nil entry in ImportState results. This is always a bug with\n" +
 					"the resource that is being imported. Please report this as\n" +
-					"a bug to Terraform.")
+					"a bug to OpenTF.")
 		}
 	}
 

--- a/internal/legacy/terraform/resource_provider.go
+++ b/internal/legacy/terraform/resource_provider.go
@@ -225,15 +225,15 @@ func ProviderHasDataSource(p ResourceProvider, n string) bool {
 }
 
 const errPluginInit = `
-Plugin reinitialization required. Please run "terraform init".
+Plugin reinitialization required. Please run "opentf init".
 
-Plugins are external binaries that Terraform uses to access and manipulate
+Plugins are external binaries that OpenTF uses to access and manipulate
 resources. The configuration provided requires plugins which can't be located,
 don't satisfy the version constraints, or are otherwise incompatible.
 
-Terraform automatically discovers provider requirements from your
+OpenTF automatically discovers provider requirements from your
 configuration, including providers used in child modules. To see the
-requirements and constraints, run "terraform providers".
+requirements and constraints, run "opentf providers".
 
 %s
 `

--- a/internal/legacy/terraform/state.go
+++ b/internal/legacy/terraform/state.go
@@ -1922,10 +1922,10 @@ func testForV0State(buf *bufio.Reader) error {
 		return fmt.Errorf("Failed to check for magic bytes: %v", err)
 	}
 	if string(start) == "tfstate" {
-		return fmt.Errorf("Terraform 0.7 no longer supports upgrading the binary state\n" +
-			"format which was used prior to Terraform 0.3. Please upgrade\n" +
-			"this state file using Terraform 0.6.16 prior to using it with\n" +
-			"Terraform 0.7.")
+		return fmt.Errorf("OpenTF 0.7 no longer supports upgrading the binary state\n" +
+			"format which was used prior to OpenTF 0.3. Please upgrade\n" +
+			"this state file using OpenTF 0.6.16 prior to using it with\n" +
+			"OpenTF 0.7.")
 	}
 
 	return nil
@@ -2011,7 +2011,7 @@ func ReadState(src io.Reader) (*State, error) {
 
 		result = v3State
 	default:
-		return nil, fmt.Errorf("Terraform %s does not support state version %d, please update.",
+		return nil, fmt.Errorf("OpenTF %s does not support state version %d, please update.",
 			tfversion.SemVer.String(), versionIdentifier.Version)
 	}
 
@@ -2055,7 +2055,7 @@ func ReadStateV2(jsonBytes []byte) (*State, error) {
 	// Check the version, this to ensure we don't read a future
 	// version that we don't understand
 	if state.Version > StateVersion {
-		return nil, fmt.Errorf("Terraform %s does not support state version %d, please update.",
+		return nil, fmt.Errorf("OpenTF %s does not support state version %d, please update.",
 			tfversion.SemVer.String(), state.Version)
 	}
 
@@ -2064,9 +2064,9 @@ func ReadStateV2(jsonBytes []byte) (*State, error) {
 		if _, err := version.NewVersion(state.TFVersion); err != nil {
 			return nil, fmt.Errorf(
 				"State contains invalid version: %s\n\n"+
-					"Terraform validates the version format prior to writing it. This\n"+
+					"OpenTF validates the version format prior to writing it. This\n"+
 					"means that this is invalid of the state becoming corrupted through\n"+
-					"some external means. Please manually modify the Terraform version\n"+
+					"some external means. Please manually modify the OpenTF version\n"+
 					"field to be a proper semantic version.",
 				state.TFVersion)
 		}
@@ -2090,7 +2090,7 @@ func ReadStateV3(jsonBytes []byte) (*State, error) {
 	// Check the version, this to ensure we don't read a future
 	// version that we don't understand
 	if state.Version > StateVersion {
-		return nil, fmt.Errorf("Terraform %s does not support state version %d, please update.",
+		return nil, fmt.Errorf("OpenTF %s does not support state version %d, please update.",
 			tfversion.SemVer.String(), state.Version)
 	}
 
@@ -2099,9 +2099,9 @@ func ReadStateV3(jsonBytes []byte) (*State, error) {
 		if _, err := version.NewVersion(state.TFVersion); err != nil {
 			return nil, fmt.Errorf(
 				"State contains invalid version: %s\n\n"+
-					"Terraform validates the version format prior to writing it. This\n"+
+					"OpenTF validates the version format prior to writing it. This\n"+
 					"means that this is invalid of the state becoming corrupted through\n"+
-					"some external means. Please manually modify the Terraform version\n"+
+					"some external means. Please manually modify the OpenTF version\n"+
 					"field to be a proper semantic version.",
 				state.TFVersion)
 		}
@@ -2153,7 +2153,7 @@ func WriteState(d *State, dst io.Writer) error {
 		if _, err := version.NewVersion(d.TFVersion); err != nil {
 			return fmt.Errorf(
 				"Error writing state, invalid version: %s\n\n"+
-					"The Terraform version when writing the state must be a semantic\n"+
+					"The OpenTF version when writing the state must be a semantic\n"+
 					"version.",
 				d.TFVersion)
 		}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/placeholderplaceholderplaceholder/opentf/blob/main/.github/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior
related PRs.

-->

Fixes #105

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.5.x

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `opentf show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTF now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
