### PR TITLE
Adapt user-facing usages of terraform in `version`

### DIFF
--- a/version/dependencies.go
+++ b/version/dependencies.go
@@ -16,8 +16,8 @@ var interestingDependencies = map[string]struct{}{
 }
 
 // InterestingDependencies returns the compiled-in module version info for
-// a small number of dependencies that Terraform uses broadly and which we
-// tend to upgrade relatively often as part of improvements to Terraform.
+// a small number of dependencies that OpenTF uses broadly and which
+// tend to upgrade relatively often.
 //
 // The set of dependencies this reports might change over time if our
 // opinions change about what's "interesting". This is here only to create

--- a/version/version.go
+++ b/version/version.go
@@ -4,7 +4,7 @@
 // The version package provides a location to set the release versions for all
 // packages to consume, without creating import cycles.
 //
-// This package should not import any other terraform packages.
+// This package should not import any other OpenTF packages.
 package version
 
 import (
@@ -49,7 +49,7 @@ func init() {
 	}
 }
 
-// Header is the header name used to send the current terraform version
+// Header is the header name used to send the current OpenTF version
 // in http requests.
 const Header = "Terraform-Version"
 


### PR DESCRIPTION
I only changed comments here
**I did not change** the HTTP Header used for sharing the version number with `remote` / `cloud` backends

Fixes https://github.com/opentffoundation/opentf/issues/143

## Target Release

1.6.0-alpha
