### PR TITLE
Remove user-facing mentions of Hashi TFE/TFC

### DIFF
--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -338,10 +338,10 @@ func (b *Remote) Configure(obj cty.Value) tfdiags.Diagnostics {
 	if err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
-			"Failed to create the Terraform Enterprise client",
+			"Failed to create the remote backend client",
 			fmt.Sprintf(
 				`The "remote" backend encountered an unexpected error while creating the `+
-					`Terraform Enterprise client: %s.`, err,
+					`remote backend client: %s.`, err,
 			),
 		))
 		return diags
@@ -487,7 +487,7 @@ func (b *Remote) checkConstraints(c *disco.Constraints) tfdiags.Diagnostics {
 
 	summary := fmt.Sprintf("Incompatible OpenTF version v%s", v.String())
 	details := fmt.Sprintf(
-		"The configured OpenTF Enterprise backend is compatible with OpenTF "+
+		"The configured remote backend is compatible with OpenTF "+
 			"versions >= %s, <= %s%s.", c.Minimum, c.Maximum, excluding,
 	)
 

--- a/internal/cloud/backend_apply.go
+++ b/internal/cloud/backend_apply.go
@@ -91,7 +91,7 @@ func (b *Cloud) opApply(stopCtx, cancelCtx context.Context, op *backend.Operatio
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
 				"Saved plan is for a different hostname",
-				fmt.Sprintf("The given saved plan refers to a run on %s, but the currently configured Terraform Cloud or Terraform Enterprise instance is %s.", cp.Hostname, b.hostname),
+				fmt.Sprintf("The given saved plan refers to a run on %s, but the currently configured cloud backend instance is %s.", cp.Hostname, b.hostname),
 			))
 			return r, diags.Err()
 		}

--- a/internal/cloud/backend_plan.go
+++ b/internal/cloud/backend_plan.go
@@ -404,7 +404,7 @@ func (b *Cloud) AssertImportCompatible(config *configs.Config) error {
 		}
 		desiredAPIVersion, _ := version.NewVersion("2.6")
 		if currentAPIVersion.LessThan(desiredAPIVersion) {
-			return fmt.Errorf("Import blocks are not supported in this version of Terraform Enterprise. Please remove any import blocks from your config or upgrade Terraform Enterprise.")
+			return fmt.Errorf("Import blocks are not supported in this version of the cloud backend. Please remove any import blocks from your config or upgrade the cloud backend.")
 		}
 
 		// Second, check the agent version is high enough.

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -728,7 +728,7 @@ func TestCloud_configVerifyMinimumTFEVersion(t *testing.T) {
 		t.Fatalf("expected configure to error")
 	}
 
-	expected := `The 'cloud' option is not supported with this version of Terraform Enterprise.`
+	expected := `The 'cloud' option is not supported with this version of the cloud backend.`
 	if !strings.Contains(confDiags.Err().Error(), expected) {
 		t.Fatalf("expected configure to error with %q, got %q", expected, confDiags.Err().Error())
 	}
@@ -766,7 +766,7 @@ func TestCloud_configVerifyMinimumTFEVersionInAutomation(t *testing.T) {
 		t.Fatalf("expected configure to error")
 	}
 
-	expected := `This version of Terraform Cloud/Enterprise does not support the state mechanism
+	expected := `This version of cloud backend does not support the state mechanism
 attempting to be used by the platform. This should never happen.`
 	if !strings.Contains(confDiags.Err().Error(), expected) {
 		t.Fatalf("expected configure to error with %q, got %q", expected, confDiags.Err().Error())

--- a/internal/command/login.go
+++ b/internal/command/login.go
@@ -307,7 +307,7 @@ func (c *LoginCommand) outputDefaultTFELoginSuccess(dispHostname string) {
 	c.Ui.Output(
 		fmt.Sprintf(
 			c.Colorize().Color(strings.TrimSpace(`
-[green][bold]Success![reset] [bold]Logged in to Terraform Enterprise (%s)[reset]
+[green][bold]Success![reset] [bold]Logged in to the cloud backend (%s)[reset]
 `)),
 			dispHostname,
 		) + "\n",

--- a/internal/command/login_test.go
+++ b/internal/command/login_test.go
@@ -224,7 +224,7 @@ func TestLogin(t *testing.T) {
 			t.Errorf("wrong token %q; want %q", got, want)
 		}
 
-		if got, want := ui.OutputWriter.String(), "Logged in to Terraform Enterprise"; !strings.Contains(got, want) {
+		if got, want := ui.OutputWriter.String(), "Logged in to the cloud backend"; !strings.Contains(got, want) {
 			t.Errorf("expected output to contain %q, but was:\n%s", want, got)
 		}
 	}))

--- a/internal/command/push.go
+++ b/internal/command/push.go
@@ -19,7 +19,7 @@ func (c *PushCommand) Run(args []string) int {
 	c.showDiagnostics(tfdiags.Sourceless(
 		tfdiags.Error,
 		"Command \"terraform push\" is no longer supported",
-		"This command was used to push configuration to Terraform Enterprise legacy (v1), which has now reached end-of-life. To push configuration to Terraform Enterprise v2, use its REST API. Contact Terraform Enterprise support for more information.",
+		"This command was used to push configuration to Terraform Enterprise legacy (v1), which has now reached end-of-life. To push configuration to a new cloud backend, use its REST API.",
 	))
 	return 1
 }

--- a/website/docs/language/state/remote-state-data.mdx
+++ b/website/docs/language/state/remote-state-data.mdx
@@ -14,8 +14,6 @@ from some other Terraform configuration.
 
 You can use the `terraform_remote_state` data source without requiring or configuring a provider. It is always available through a built-in provider with the [source address](/terraform/language/providers/requirements#source-addresses) `terraform.io/builtin/terraform`. That provider does not include any other resources or data sources.
 
-~> **Important:** We recommend using the [`tfe_outputs` data source](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/outputs) in the [Terraform Cloud/Enterprise Provider](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs) to access remote state outputs in Terraform Cloud or Terraform Enterprise. The `tfe_outputs` data source is more secure because it does not require full access to workspace state to fetch outputs.
-
 ## Alternative Ways to Share Data Between Configurations
 
 Sharing data with root module outputs is convenient, but it has drawbacks.


### PR DESCRIPTION
Closes #64 
[Build](https://github.com/opentffoundation/opentf/actions/runs/5953642288)

Instead, we will consistently refer to `remote backend` for the `remote` backend and `cloud backend` for the `cloud` backend. The only mentions of TFE that are left are ones that refer to a specific deprecated version of the Enterprise product, in which cases the user would presumably expect to see this explicit reference, and a reference to a more abstract entity would be confusing.

Note that I have not updated the docs which will need a bigger intervention here, presumably redesigning the entire "cloud" section to show how different vendors handle that. Spacelift for one would only support remote state access using "cloud" / "remote" backend, and remote operations would be handled by a [separate CLI](https://github.com/spacelift-io/spacectl), which is IaC-agnostic. So I guess that would need input from the other vendors, too, but I decided to keep it a separate story.