### PR TITLE
Fix flakiness in equivalence tests

### DIFF
--- a/testing/equivalence-tests/outputs/basic_list/apply.json
+++ b/testing/equivalence-tests/outputs/basic_list/apply.json
@@ -37,11 +37,11 @@
   },
   {
     "@level": "info",
-    "@message": "tfcoremock_list.list: Creation complete after 12s [id=985820B3-ACF9-4F00-94AD-F81C5EA33663]",
+    "@message": "tfcoremock_list.list: Creation complete after 0s [id=985820B3-ACF9-4F00-94AD-F81C5EA33663]",
     "@module": "opentf.ui",
     "hook": {
       "action": "create",
-      "elapsed_seconds": 12,
+      "elapsed_seconds": 0,
       "id_key": "id",
       "id_value": "985820B3-ACF9-4F00-94AD-F81C5EA33663",
       "resource": {


### PR DESCRIPTION
**The issue:**

The equivalence tests are flaky over time of execution of the apply actions. All existing tests rely on each test taking less than 1 second to execute.

All existing tests have `Creation complete after 0s` / `Modifications complete after 0s` / `Destruction complete after 0s`, and also have `"elapsed_seconds": 0,`.
If one of the tests took 1 second or more, then you see a `git diff` on those lines

[Link to failed action](https://github.com/opentffoundation/opentf/actions/runs/5990424878/job/16247709150?pr=190)

**The solution:**

Add another step to the github action, checking if there was a change to any of those lines. If there has been a change - go over all lines that say `complete after [number]s` or `"elapsed_seconds": [number]`, and change the number to 0. Only then, run the snapshot test

This way, if there was only flakiness due to execution time, the test suite will not fail. But if there was an issue in execution time alongside an actual snapshot change, we will still get an error
