### PR TITLE
Clean up docs nav data JSON files

### DIFF
--- a/website/data/cli-nav-data.json
+++ b/website/data/cli-nav-data.json
@@ -1,137 +1,129 @@
 [
   { "heading": "OpenTF CLI" },
-  { "title": "Overview", "path": "" },
-  { "title": "Basic CLI Features", "href": "/cli/commands" },
+  { "title": "Overview", "path": "cli/index" },
+  { "title": "Basic CLI Features", "path": "cli/commands/index" },
   {
     "title": "Initializing Working Directories",
     "routes": [
-      { "title": "Overview", "path": "init" },
-      { "title": "<code>init</code>", "href": "/cli/commands/init" },
-      { "title": "<code>get</code>", "href": "/cli/commands/get" }
+      { "title": "Overview", "path": "cli/init/index" },
+      { "title": "<code>init</code>", "path": "cli/commands/init" },
+      { "title": "<code>get</code>", "path": "cli/commands/get" }
     ]
   },
   {
     "title": "Provisioning Infrastructure",
     "routes": [
-      { "title": "Overview", "path": "run" },
-      { "title": "<code>plan</code>", "href": "/cli/commands/plan" },
-      { "title": "<code>apply</code>", "href": "/cli/commands/apply" },
-      { "title": "<code>destroy</code>", "href": "/cli/commands/destroy" }
+      { "title": "Overview", "path": "cli/run/index" },
+      { "title": "<code>plan</code>", "path": "cli/commands/plan" },
+      { "title": "<code>apply</code>", "path": "cli/commands/apply" },
+      { "title": "<code>destroy</code>", "path": "cli/commands/destroy" }
     ]
   },
   {
     "title": "Authenticating",
     "routes": [
-      { "title": "Overview", "path": "auth" },
-      { "title": "<code>login</code>", "href": "/cli/commands/login" },
-      { "title": "<code>logout</code>", "href": "/cli/commands/logout" }
+      { "title": "Overview", "path": "cli/auth/index" },
+      { "title": "<code>login</code>", "path": "cli/commands/login" },
+      { "title": "<code>logout</code>", "path": "cli/commands/logout" }
     ]
   },
   {
     "title": "Writing and Modifying Code",
     "routes": [
-      { "title": "Overview", "path": "code" },
-      { "title": "<code>console</code>", "href": "/cli/commands/console" },
-      { "title": "<code>fmt</code>", "href": "/cli/commands/fmt" },
-      { "title": "<code>validate</code>", "href": "/cli/commands/validate" },
-      {
-        "title": "<code>0.13upgrade</code>",
-        "href": "/cli/commands/0.13upgrade"
-      },
-      {
-        "title": "<code>0.12upgrade</code>",
-        "href": "/cli/commands/0.12upgrade"
-      }
+      { "title": "Overview", "path": "cli/code/index" },
+      { "title": "<code>console</code>", "path": "cli/commands/console" },
+      { "title": "<code>fmt</code>", "path": "cli/commands/fmt" },
+      { "title": "<code>validate</code>", "path": "cli/commands/validate" }
     ]
   },
   {
     "title": "Inspecting Infrastructure",
     "routes": [
-      { "title": "Overview", "path": "inspect" },
-      { "title": "<code>graph</code>", "href": "/cli/commands/graph" },
-      { "title": "<code>output</code>", "href": "/cli/commands/output" },
-      { "title": "<code>show</code>", "href": "/cli/commands/show" },
+      { "title": "Overview", "path": "cli/inspect/index" },
+      { "title": "<code>graph</code>", "path": "cli/commands/graph" },
+      { "title": "<code>output</code>", "path": "cli/commands/output" },
+      { "title": "<code>show</code>", "path": "cli/commands/show" },
       {
         "title": "<code>state list</code>",
-        "href": "/cli/commands/state/list"
+        "path": "cli/commands/state/list"
       },
       {
         "title": "<code>state show</code>",
-        "href": "/cli/commands/state/show"
+        "path": "cli/commands/state/show"
       }
     ]
   },
   {
     "title": "Importing Infrastructure",
     "routes": [
-      { "title": "Overview", "path": "import" },
+      { "title": "Overview", "path": "cli/import/index" },
       {
         "title": "<code>import</code>",
-        "href": "/cli/commands/import"
+        "path": "cli/commands/import"
       },
-      { "title": "Usage Tips", "path": "import/usage" },
+      { "title": "Usage Tips", "path": "cli/import/usage" },
       {
         "title": "Resource Importability",
-        "path": "import/importability"
+        "path": "cli/import/importability"
       }
     ]
   },
   {
     "title": "Manipulating State",
     "routes": [
-      { "title": "Overview", "path": "state" },
+      { "title": "Overview", "path": "cli/state/index" },
       {
         "title": "Resource Addressing",
-        "path": "state/resource-addressing"
+        "path": "cli/state/resource-addressing"
       },
-      { "title": "<code>state</code>", "href": "/cli/commands/state" },
+      { "title": "<code>state</code>", "path": "cli/commands/state/index" },
       {
         "title": "Inspecting State",
         "routes": [
-          { "title": "Overview", "path": "state/inspect" },
+          { "title": "Overview", "path": "cli/state/inspect" },
           {
             "title": "<code>state list</code>",
-            "href": "/cli/commands/state/list"
+            "path": "cli/commands/state/list"
           },
           {
             "title": "<code>state show</code>",
-            "href": "/cli/commands/state/show"
+            "path": "cli/commands/state/show"
           },
           {
             "title": "<code>refresh</code>",
-            "href": "/cli/commands/refresh"
+            "path": "cli/commands/refresh"
           }
         ]
       },
       {
         "title": "Forcing Re-creation (Tainting)",
         "routes": [
-          { "title": "Overview", "path": "state/taint" },
+          { "title": "Overview", "path": "cli/state/taint" },
           {
             "title": "<code>taint</code>",
-            "href": "/cli/commands/taint"
+            "path": "cli/commands/taint"
           },
           {
             "title": "<code>untaint</code>",
-            "href": "/cli/commands/untaint"
+            "path": "cli/commands/untaint"
           }
         ]
       },
       {
         "title": "Moving Resources",
         "routes": [
-          { "title": "Overview", "path": "state/move" },
+          { "title": "Overview", "path": "cli/state/move" },
           {
             "title": "<code>state mv</code>",
-            "href": "/cli/commands/state/mv"
+            "path": "cli/commands/state/mv"
           },
           {
             "title": "<code>state rm</code>",
-            "href": "/cli/commands/state/rm"
+            "path": "cli/commands/state/rm"
           },
           {
             "title": "<code>state replace-provider</code>",
-            "href": "/cli/commands/state/replace-provider"
+            "path": "cli/commands/state/replace-provider"
           }
         ]
       },
@@ -140,19 +132,19 @@
         "routes": [
           {
             "title": "Overview",
-            "path": "state/recover"
+            "path": "cli/state/recover"
           },
           {
             "title": "<code>state pull</code>",
-            "href": "/cli/commands/state/pull"
+            "path": "cli/commands/state/pull"
           },
           {
             "title": "<code>state push</code>",
-            "href": "/cli/commands/state/push"
+            "path": "cli/commands/state/push"
           },
           {
             "title": "<code>force-unlock</code>",
-            "href": "/cli/commands/force-unlock"
+            "path": "cli/commands/force-unlock"
           }
         ]
       }
@@ -161,30 +153,30 @@
   {
     "title": "Managing Workspaces",
     "routes": [
-      { "title": "Overview", "path": "workspaces" },
+      { "title": "Overview", "path": "cli/workspaces/index" },
       {
         "title": "<code>workspace</code>",
         "routes": [
-          { "title": "Overview", "href": "/cli/commands/workspace" },
+          { "title": "Overview", "path": "cli/commands/workspace/index" },
           {
             "title": "<code>workspace list</code>",
-            "href": "/cli/commands/workspace/list"
+            "path": "cli/commands/workspace/list"
           },
           {
             "title": "<code>workspace select</code>",
-            "href": "/cli/commands/workspace/select"
+            "path": "cli/commands/workspace/select"
           },
           {
             "title": "<code>workspace new</code>",
-            "href": "/cli/commands/workspace/new"
+            "path": "cli/commands/workspace/new"
           },
           {
             "title": "<code>workspace delete</code>",
-            "href": "/cli/commands/workspace/delete"
+            "path": "cli/commands/workspace/delete"
           },
           {
             "title": "<code>workspace show</code>",
-            "href": "/cli/commands/workspace/show"
+            "path": "cli/commands/workspace/show"
           }
         ]
       }
@@ -193,155 +185,146 @@
   {
     "title": "Managing Plugins",
     "routes": [
-      { "title": "Overview", "path": "plugins" },
-      { "title": "Plugin Signing", "path": "plugins/signing" },
+      { "title": "Overview", "path": "cli/plugins/index" },
+      { "title": "Plugin Signing", "path": "cli/plugins/signing" },
       {
         "title": "<code>providers</code>",
-        "href": "/cli/commands/providers"
+        "path": "cli/commands/providers"
       },
       {
         "title": "<code>version</code>",
-        "href": "/cli/commands/version"
+        "path": "cli/commands/version"
       },
       {
         "title": "<code>providers lock</code>",
-        "href": "/cli/commands/providers/lock"
+        "path": "cli/commands/providers/lock"
       },
       {
         "title": "<code>providers mirror</code>",
-        "href": "/cli/commands/providers/mirror"
+        "path": "cli/commands/providers/mirror"
       },
       {
         "title": "<code>providers schema</code>",
-        "href": "/cli/commands/providers/schema"
+        "path": "cli/commands/providers/schema"
       }
     ]
   },
   {
     "title": "CLI Configuration",
     "routes": [
-      { "title": "Overview", "path": "config" },
-      { "title": "CLI Configuration", "path": "config/config-file" },
+      { "title": "Overview", "path": "cli/config/index" },
+      { "title": "CLI Configuration", "path": "cli/config/config-file" },
       {
         "title": "Environment Variables",
-        "path": "config/environment-variables"
+        "path": "cli/config/environment-variables"
       }
     ]
   },
   {
     "title": "Using Cloud Backend",
     "routes": [
-      { "title": "Overview", "path": "cloud" },
-      { "title": "Cloud Backend Settings", "path": "cloud/settings" },
+      { "title": "Overview", "path": "cli/cloud/index" },
+      { "title": "Cloud Backend Settings", "path": "cli/cloud/settings" },
       {
         "title": "Initializing and Migrating",
-        "path": "cloud/migrating"
+        "path": "cli/cloud/migrating"
       },
       {
         "title": "Command Line Arguments",
-        "path": "cloud/command-line-arguments"
+        "path": "cli/cloud/command-line-arguments"
       }
     ]
   },
   {
     "title": "Alphabetical List of Commands",
     "routes": [
-      { "title": "Overview", "href": "/cli/commands" },
-      { "title": "<code>apply</code>", "href": "/cli/commands/apply" },
-      { "title": "<code>console</code>", "href": "/cli/commands/console" },
-      { "title": "<code>destroy</code>", "href": "/cli/commands/destroy" },
-      { "title": "<code>env</code>", "href": "/cli/commands/env" },
-      { "title": "<code>fmt</code>", "href": "/cli/commands/fmt" },
+      { "title": "Overview", "path": "cli/commands/index" },
+      { "title": "<code>apply</code>", "path": "cli/commands/apply" },
+      { "title": "<code>console</code>", "path": "cli/commands/console" },
+      { "title": "<code>destroy</code>", "path": "cli/commands/destroy" },
+      { "title": "<code>env</code>", "path": "cli/commands/env" },
+      { "title": "<code>fmt</code>", "path": "cli/commands/fmt" },
       {
         "title": "<code>force-unlock</code>",
-        "href": "/cli/commands/force-unlock"
+        "path": "cli/commands/force-unlock"
       },
-      { "title": "<code>get</code>", "href": "/cli/commands/get" },
-      { "title": "<code>graph</code>", "href": "/cli/commands/graph" },
-      { "title": "<code>import</code>", "href": "/cli/commands/import" },
-      { "title": "<code>init</code>", "href": "/cli/commands/init" },
-      { "title": "<code>login</code>", "href": "/cli/commands/login" },
-      { "title": "<code>logout</code>", "href": "/cli/commands/logout" },
-      { "title": "<code>output</code>", "href": "/cli/commands/output" },
-      { "title": "<code>plan</code>", "href": "/cli/commands/plan" },
-      { "title": "<code>providers</code>", "href": "/cli/commands/providers" },
+      { "title": "<code>get</code>", "path": "cli/commands/get" },
+      { "title": "<code>graph</code>", "path": "cli/commands/graph" },
+      { "title": "<code>import</code>", "path": "cli/commands/import" },
+      { "title": "<code>init</code>", "path": "cli/commands/init" },
+      { "title": "<code>login</code>", "path": "cli/commands/login" },
+      { "title": "<code>logout</code>", "path": "cli/commands/logout" },
+      { "title": "<code>output</code>", "path": "cli/commands/output" },
+      { "title": "<code>plan</code>", "path": "cli/commands/plan" },
+      { "title": "<code>providers</code>", "path": "cli/commands/providers" },
       {
         "title": "<code>providers lock</code>",
-        "href": "/cli/commands/providers/lock"
+        "path": "cli/commands/providers/lock"
       },
       {
         "title": "<code>providers mirror</code>",
-        "href": "/cli/commands/providers/mirror"
+        "path": "cli/commands/providers/mirror"
       },
       {
         "title": "<code>providers schema</code>",
-        "href": "/cli/commands/providers/schema"
+        "path": "cli/commands/providers/schema"
       },
-      {
-        "title": "<code>push (deprecated)</code>",
-        "href": "/cli/commands/push"
-      },
-      { "title": "<code>refresh</code>", "href": "/cli/commands/refresh" },
-      { "title": "<code>show</code>", "href": "/cli/commands/show" },
-      { "title": "<code>state</code>", "href": "/cli/commands/state" },
+      { "title": "<code>refresh</code>", "path": "cli/commands/refresh" },
+      { "title": "<code>show</code>", "path": "cli/commands/show" },
+      { "title": "<code>state</code>", "path": "cli/commands/state/index" },
       {
         "title": "<code>state list</code>",
-        "href": "/cli/commands/state/list"
+        "path": "cli/commands/state/list"
       },
-      { "title": "<code>state mv</code>", "href": "/cli/commands/state/mv" },
+      { "title": "<code>state mv</code>", "path": "cli/commands/state/mv" },
       {
         "title": "<code>state pull</code>",
-        "href": "/cli/commands/state/pull"
+        "path": "cli/commands/state/pull"
       },
       {
         "title": "<code>state push</code>",
-        "href": "/cli/commands/state/push"
+        "path": "cli/commands/state/push"
       },
       {
         "title": "<code>state replace-provider</code>",
-        "href": "/cli/commands/state/replace-provider"
+        "path": "cli/commands/state/replace-provider"
       },
-      { "title": "<code>state rm</code>", "href": "/cli/commands/state/rm" },
+      { "title": "<code>state rm</code>", "path": "cli/commands/state/rm" },
       {
         "title": "<code>state show</code>",
-        "href": "/cli/commands/state/show"
+        "path": "cli/commands/state/show"
       },
-      { "title": "<code>taint</code>", "href": "/cli/commands/taint" },
+      { "title": "<code>taint</code>", "path": "cli/commands/taint" },
       {
         "title": "<code>test (deprecated)</code>",
-        "href": "/cli/commands/test"
+        "path": "cli/commands/test"
       },
-      { "title": "<code>untaint</code>", "href": "/cli/commands/untaint" },
-      { "title": "<code>validate</code>", "href": "/cli/commands/validate" },
-      { "title": "<code>version</code>", "href": "/cli/commands/version" },
-      { "title": "<code>workspace</code>", "href": "/cli/commands/workspace" },
+      { "title": "<code>untaint</code>", "path": "cli/commands/untaint" },
+      { "title": "<code>validate</code>", "path": "cli/commands/validate" },
+      { "title": "<code>version</code>", "path": "cli/commands/version" },
+      {
+        "title": "<code>workspace</code>",
+        "path": "cli/commands/workspace/index"
+      },
       {
         "title": "<code>workspace list</code>",
-        "href": "/cli/commands/workspace/list"
+        "path": "cli/commands/workspace/list"
       },
       {
         "title": "<code>workspace select</code>",
-        "href": "/cli/commands/workspace/select"
+        "path": "cli/commands/workspace/select"
       },
       {
         "title": "<code>workspace new</code>",
-        "href": "/cli/commands/workspace/new"
+        "path": "cli/commands/workspace/new"
       },
       {
         "title": "<code>workspace delete</code>",
-        "href": "/cli/commands/workspace/delete"
+        "path": "cli/commands/workspace/delete"
       },
       {
         "title": "<code>workspace show</code>",
-        "href": "/cli/commands/workspace/show"
-      },
-      {
-        "title": "<code>0.12upgrade</code>",
-        "href": "/cli/commands/0.12upgrade"
-      },
-      {
-        "title": "<code>0.13upgrade</code>",
-        "href": "/cli/commands/0.13upgrade"
+        "path": "cli/commands/workspace/show"
       }
     ]
   },
@@ -349,70 +332,83 @@
     "title": "Alphabetical list of commands",
     "hidden": true,
     "routes": [
-      { "title": "Overview", "path": "commands" },
-      { "title": "apply", "path": "commands/apply" },
-      { "title": "console", "path": "commands/console" },
-      { "title": "destroy", "path": "commands/destroy" },
-      { "title": "env", "path": "commands/env" },
-      { "title": "fmt", "path": "commands/fmt" },
-      { "title": "force-unlock", "path": "commands/force-unlock" },
-      { "title": "get", "path": "commands/get" },
-      { "title": "graph", "path": "commands/graph" },
-      { "title": "import", "path": "commands/import" },
-      { "title": "init", "path": "commands/init" },
-      { "title": "login", "path": "commands/login" },
-      { "title": "logout", "path": "commands/logout" },
-      { "title": "output", "path": "commands/output" },
-      { "title": "plan", "path": "commands/plan" },
+      { "title": "Overview", "path": "cli/commands/index" },
+      { "title": "apply", "path": "cli/commands/apply" },
+      { "title": "console", "path": "cli/commands/console" },
+      { "title": "destroy", "path": "cli/commands/destroy" },
+      { "title": "env", "path": "cli/commands/env" },
+      { "title": "fmt", "path": "cli/commands/fmt" },
+      { "title": "force-unlock", "path": "cli/commands/force-unlock" },
+      { "title": "get", "path": "cli/commands/get" },
+      { "title": "graph", "path": "cli/commands/graph" },
+      { "title": "import", "path": "cli/commands/import" },
+      { "title": "init", "path": "cli/commands/init" },
+      { "title": "login", "path": "cli/commands/login" },
+      { "title": "logout", "path": "cli/commands/logout" },
+      { "title": "output", "path": "cli/commands/output" },
+      { "title": "plan", "path": "cli/commands/plan" },
       {
         "title": "providers",
         "routes": [
-          { "title": "providers", "path": "commands/providers" },
-          { "title": "providers lock", "path": "commands/providers/lock" },
-          { "title": "providers mirror", "path": "commands/providers/mirror" },
-          { "title": "providers schema", "path": "commands/providers/schema" }
+          { "title": "providers", "path": "cli/commands/providers" },
+          { "title": "providers lock", "path": "cli/commands/providers/lock" },
+          {
+            "title": "providers mirror",
+            "path": "cli/commands/providers/mirror"
+          },
+          {
+            "title": "providers schema",
+            "path": "cli/commands/providers/schema"
+          }
         ]
       },
-      { "title": "push (deprecated)", "path": "commands/push" },
-      { "title": "refresh", "path": "commands/refresh" },
-      { "title": "show", "path": "commands/show" },
+      { "title": "refresh", "path": "cli/commands/refresh" },
+      { "title": "show", "path": "cli/commands/show" },
       {
         "title": "state",
         "routes": [
-          { "title": "state", "path": "commands/state" },
-          { "title": "state list", "path": "commands/state/list" },
-          { "title": "state mv", "path": "commands/state/mv" },
-          { "title": "state pull", "path": "commands/state/pull" },
-          { "title": "state push", "path": "commands/state/push" },
+          { "title": "state", "path": "cli/commands/state" },
+          { "title": "state list", "path": "cli/commands/state/list" },
+          { "title": "state mv", "path": "cli/commands/state/mv" },
+          { "title": "state pull", "path": "cli/commands/state/pull" },
+          { "title": "state push", "path": "cli/commands/state/push" },
           {
             "title": "state replace-provider",
-            "path": "commands/state/replace-provider"
+            "path": "cli/commands/state/replace-provider"
           },
-          { "title": "state rm", "path": "commands/state/rm" },
-          { "title": "state show", "path": "commands/state/show" }
+          { "title": "state rm", "path": "cli/commands/state/rm" },
+          { "title": "state show", "path": "cli/commands/state/show" }
         ]
       },
-      { "title": "taint", "path": "commands/taint" },
-      { "title": "test (deprecated)", "path": "commands/test", "hidden": true },
-      { "title": "untaint", "path": "commands/untaint" },
-      { "title": "validate", "path": "commands/validate" },
-      { "title": "version", "path": "commands/version" },
+      { "title": "taint", "path": "cli/commands/taint" },
+      {
+        "title": "test (deprecated)",
+        "path": "cli/commands/test",
+        "hidden": true
+      },
+      { "title": "untaint", "path": "cli/commands/untaint" },
+      { "title": "validate", "path": "cli/commands/validate" },
+      { "title": "version", "path": "cli/commands/version" },
       {
         "title": "workspace",
         "routes": [
           {
             "title": "workspace",
-            "path": "commands/workspace"
+            "path": "cli/commands/workspace"
           },
-          { "title": "workspace list", "path": "commands/workspace/list" },
-          { "title": "workspace select", "path": "commands/workspace/select" },
-          { "title": "workspace new", "path": "commands/workspace/new" },
-          { "title": "workspace delete", "path": "commands/workspace/delete" },
-          { "title": "workspace show", "path": "commands/workspace/show" }
+          { "title": "workspace list", "path": "cli/commands/workspace/list" },
+          {
+            "title": "workspace select",
+            "path": "cli/commands/workspace/select"
+          },
+          { "title": "workspace new", "path": "cli/commands/workspace/new" },
+          {
+            "title": "workspace delete",
+            "path": "cli/commands/workspace/delete"
+          },
+          { "title": "workspace show", "path": "cli/commands/workspace/show" }
         ]
-      },
-      { "title": "0.12upgrade", "path": "commands/0.12upgrade" },
-      { "title": "0.13upgrade", "path": "commands/0.13upgrade" }
+      }
     ]
   },
   {
@@ -421,14 +417,12 @@
     "routes": [
       {
         "title": "APT Packages for Debian and Ubuntu",
-        "path": "install/apt"
+        "path": "cli/install/apt"
       },
       {
         "title": "Yum Packages for Red Hat Enterprise Linux, Fedora, and Amazon Linux",
-        "path": "install/yum"
+        "path": "cli/install/yum"
       }
     ]
-  },
-  { "divider": true },
-  { "title": "OpenTF Internals", "href": "/internals" }
+  }
 ]

--- a/website/data/internals-nav-data.json
+++ b/website/data/internals-nav-data.json
@@ -1,65 +1,56 @@
 [
   { "heading": "OpenTF Internals" },
   {
-    "title": "Overview", 
-    "path": ""
-   },
+    "title": "Overview",
+    "path": "internals/index"
+  },
   {
     "title": "Credentials Helpers",
-    "path": "credentials-helpers"
+    "path": "internals/credentials-helpers"
   },
   {
     "title": "Debugging OpenTF",
-    "path": "debugging"
+    "path": "internals/debugging"
   },
   {
     "title": "Module Registry Protocol",
-    "path": "module-registry-protocol"
+    "path": "internals/module-registry-protocol"
   },
   {
     "title": "Provider Network Mirror Protocol",
-    "path": "provider-network-mirror-protocol"
+    "path": "internals/provider-network-mirror-protocol"
   },
   {
     "title": "Provider Registry Protocol",
-    "path": "provider-registry-protocol"
+    "path": "internals/provider-registry-protocol"
   },
   {
     "title": "Resource Graph",
-    "path": "graph"
+    "path": "internals/graph"
   },
   {
     "title": "Login Protocol",
-    "path": "login-protocol"
+    "path": "internals/login-protocol"
   },
   {
     "title": "JSON Output Format",
-    "path": "json-format"
+    "path": "internals/json-format"
   },
   {
     "title": "Remote Service Discovery",
-    "path": "remote-service-discovery"
+    "path": "internals/remote-service-discovery"
   },
   {
     "title": "Provider Metadata",
-    "path": "provider-meta"
+    "path": "internals/provider-meta"
   },
   {
     "title": "Functions Metadata",
-    "path": "functions-meta"
+    "path": "internals/functions-meta"
   },
   {
     "title": "Machine Readable UI",
-    "path": "machine-readable-ui",
+    "path": "internals/machine-readable-ui",
     "hidden": true
-  },
-  {
-    "title": "Archiving",
-    "path": "archiving",
-    "hidden": true
-  },
-  { "divider": true },
-  { "title": "OpenTF CLI", "href": "/cli" },
-  { "divider": true },
-  { "title": "Configuration Language", "href": "/language" }
+  }
 ]

--- a/website/data/intro-nav-data.json
+++ b/website/data/intro-nav-data.json
@@ -1,20 +1,20 @@
 [
   { "heading": "Introduction to OpenTF" },
-  { "title": "What is OpenTF?", "path": "" },
-  { "title": "Use Cases", "path": "use-cases" },
-  { "title": "OpenTF Editions", "path": "terraform-editions" },
-  { "title": "The Core OpenTF Workflow", "path": "core-workflow" },
+  { "title": "What is OpenTF?", "path": "intro/index" },
+  { "title": "Use Cases", "path": "intro/use-cases" },
+  { "title": "OpenTF Editions", "path": "intro/terraform-editions" },
+  { "title": "The Core OpenTF Workflow", "path": "intro/core-workflow" },
   {
     "title": "OpenTF vs. Alternatives",
     "routes": [
-      { "title": "Overview", "path": "vs" },
-      { "title": "Chef, Puppet, etc.", "path": "vs/chef-puppet" },
+      { "title": "Overview", "path": "intro/vs/index" },
+      { "title": "Chef, Puppet, etc.", "path": "intro/vs/chef-puppet" },
       {
         "title": "CloudFormation, Heat, etc.",
-        "path": "vs/cloudformation"
+        "path": "intro/vs/cloudformation"
       },
-      { "title": "Boto, Fog, etc.", "path": "vs/boto" },
-      { "title": "Custom Solutions", "path": "vs/custom" }
+      { "title": "Boto, Fog, etc.", "path": "intro/vs/boto" },
+      { "title": "Custom Solutions", "path": "intro/vs/custom" }
     ]
   }
 ]

--- a/website/data/language-nav-data.json
+++ b/website/data/language-nav-data.json
@@ -1,68 +1,68 @@
 [
   { "heading": "OpenTF Language" },
-  { "title": "Overview", "path": "" },
+  { "title": "Overview", "path": "language/index" },
   {
     "title": "Attributes as Blocks - Configuration Language",
-    "path": "attr-as-blocks",
+    "path": "language/attr-as-blocks",
     "hidden": true
   },
   {
     "title": "Files and Directories",
     "routes": [
-      { "title": "Overview", "path": "files" },
-      { "title": "Override Files", "path": "files/override" },
+      { "title": "Overview", "path": "language/files/index" },
+      { "title": "Override Files", "path": "language/files/override" },
       {
         "title": "Dependency Lock File",
-        "path": "files/dependency-lock"
+        "path": "language/files/dependency-lock"
       }
     ]
   },
   {
     "title": "Syntax",
     "routes": [
-      { "title": "Overview", "path": "syntax" },
+      { "title": "Overview", "path": "language/syntax/index" },
       {
         "title": "Configuration Syntax",
-        "path": "syntax/configuration"
+        "path": "language/syntax/configuration"
       },
       {
         "title": "JSON Configuration Syntax",
-        "path": "syntax/json"
+        "path": "language/syntax/json"
       },
-      { "title": "Style Conventions", "path": "syntax/style" }
+      { "title": "Style Conventions", "path": "language/syntax/style" }
     ]
   },
   {
-    "title": "Resources",
+    "title": "language/Resources",
     "routes": [
-      { "title": "Overview", "path": "resources" },
-      { "title": "Resource Blocks", "path": "resources/syntax" },
+      { "title": "Overview", "path": "language/resources/index" },
+      { "title": "Resource Blocks", "path": "language/resources/syntax" },
       {
         "title": "Resource Behavior",
-        "path": "resources/behavior"
+        "path": "language/resources/behavior"
       },
       {
         "title": "Meta-Arguments",
         "routes": [
           {
             "title": "<code>depends_on</code>",
-            "href": "/language/meta-arguments/depends_on"
+            "path": "language/meta-arguments/depends_on"
           },
           {
             "title": "<code>count</code>",
-            "href": "/language/meta-arguments/count"
+            "path": "language/meta-arguments/count"
           },
           {
             "title": "<code>for_each</code>",
-            "href": "/language/meta-arguments/for_each"
+            "path": "language/meta-arguments/for_each"
           },
           {
             "title": "<code>provider</code>",
-            "href": "/language/meta-arguments/resource-provider"
+            "path": "language/meta-arguments/resource-provider"
           },
           {
             "title": "<code>lifecycle</code>",
-            "href": "/language/meta-arguments/lifecycle"
+            "path": "language/meta-arguments/lifecycle"
           }
         ]
       },
@@ -71,64 +71,64 @@
         "routes": [
           {
             "title": "Declaring Provisioners",
-            "path": "resources/provisioners/syntax"
+            "path": "language/resources/provisioners/syntax"
           },
           {
             "title": "Provisioner Connections",
-            "path": "resources/provisioners/connection"
+            "path": "language/resources/provisioners/connection"
           },
           {
             "title": "Provisioners Without a Resource",
-            "path": "resources/provisioners/null_resource"
+            "path": "language/resources/provisioners/null_resource"
           },
           {
             "title": "file",
-            "path": "resources/provisioners/file"
+            "path": "language/resources/provisioners/file"
           },
           {
             "title": "local-exec",
-            "path": "resources/provisioners/local-exec"
+            "path": "language/resources/provisioners/local-exec"
           },
           {
             "title": "remote-exec",
-            "path": "resources/provisioners/remote-exec"
+            "path": "language/resources/provisioners/remote-exec"
           }
         ]
       },
       {
         "title": "The <code>terraform_data</code> Resource Type",
-        "path": "resources/tf-data"
+        "path": "language/resources/tf-data"
       }
     ]
   },
-  { "title": "Data Sources", "path": "data-sources" },
+  { "title": "Data Sources", "path": "language/data-sources/index" },
   {
     "title": "Meta-Arguments",
     "hidden": true,
     "routes": [
       {
         "title": "<code>count</code>",
-        "path": "meta-arguments/count"
+        "path": "language/meta-arguments/count"
       },
       {
         "title": "<code>depends_on</code>",
-        "path": "meta-arguments/depends_on"
+        "path": "language/meta-arguments/depends_on"
       },
       {
         "title": "<code>for_each</code>",
-        "path": "meta-arguments/for_each"
+        "path": "language/meta-arguments/for_each"
       },
       {
         "title": "<code>lifecycle</code>",
-        "path": "meta-arguments/lifecycle"
+        "path": "language/meta-arguments/lifecycle"
       },
       {
         "title": "<code>providers</code>",
-        "path": "meta-arguments/module-providers"
+        "path": "language/meta-arguments/module-providers"
       },
       {
         "title": "<code>provider</code>",
-        "path": "meta-arguments/resource-provider"
+        "path": "language/meta-arguments/resource-provider"
       }
     ]
   },
@@ -136,172 +136,172 @@
   {
     "title": "Providers",
     "routes": [
-      { "title": "Overview", "path": "providers" },
+      { "title": "Overview", "path": "language/providers/index" },
       {
         "title": "Provider Configuration",
-        "path": "providers/configuration"
+        "path": "language/providers/configuration"
       },
       {
         "title": "Provider Requirements",
-        "path": "providers/requirements"
+        "path": "language/providers/requirements"
       },
       {
         "title": "Dependency Lock File",
-        "href": "/language/files/dependency-lock"
+        "path": "language/files/dependency-lock"
       }
     ]
   },
   {
     "title": "Variables and Outputs",
     "routes": [
-      { "title": "Overview", "path": "values" },
-      { "title": "Input Variables", "path": "values/variables" },
-      { "title": "Output Values", "path": "values/outputs" },
-      { "title": "Local Values", "path": "values/locals" }
+      { "title": "Overview", "path": "language/values/index" },
+      { "title": "Input Variables", "path": "language/values/variables" },
+      { "title": "Output Values", "path": "language/values/outputs" },
+      { "title": "Local Values", "path": "language/values/locals" }
     ]
   },
   {
     "title": "Modules",
     "routes": [
-      { "title": "Overview", "path": "modules" },
+      { "title": "Overview", "path": "language/modules/index" },
 
-      { "title": "Module Blocks", "path": "modules/syntax" },
-      { "title": "Module Sources", "path": "modules/sources" },
+      { "title": "Module Blocks", "path": "language/modules/syntax" },
+      { "title": "Module Sources", "path": "language/modules/sources" },
       {
         "title": "Meta-Arguments",
         "routes": [
           {
             "title": "<code>providers</code>",
-            "href": "/language/meta-arguments/module-providers"
+            "path": "language/meta-arguments/module-providers"
           },
           {
             "title": "<code>depends_on</code>",
-            "href": "/language/meta-arguments/depends_on"
+            "path": "language/meta-arguments/depends_on"
           },
           {
             "title": "<code>count</code>",
-            "href": "/language/meta-arguments/count"
+            "path": "language/meta-arguments/count"
           },
           {
             "title": "<code>for_each</code>",
-            "href": "/language/meta-arguments/for_each"
+            "path": "language/meta-arguments/for_each"
           }
         ]
       },
       {
         "title": "Module Development",
         "routes": [
-          { "title": "Overview", "path": "modules/develop" },
+          { "title": "Overview", "path": "language/modules/develop/index" },
           {
             "title": "Standard Module Structure",
-            "path": "modules/develop/structure"
+            "path": "language/modules/develop/structure"
           },
           {
             "title": "Providers Within Modules",
-            "path": "modules/develop/providers"
+            "path": "language/modules/develop/providers"
           },
           {
             "title": "Best Practices: Module Composition",
-            "path": "modules/develop/composition"
+            "path": "language/modules/develop/composition"
           },
           {
             "title": "Publishing Modules",
-            "path": "modules/develop/publish"
+            "path": "language/modules/develop/publish"
           },
           {
             "title": "Refactoring Modules",
-            "path": "modules/develop/refactoring"
+            "path": "language/modules/develop/refactoring"
           }
         ]
       },
       {
         "title": "Module Testing Experiment",
-        "path": "modules/testing-experiment",
+        "path": "language/modules/testing-experiment",
         "hidden": true
       }
     ]
   },
-  { "title": "Checks", "path": "checks" },
+  { "title": "Checks", "path": "language/checks/index" },
   {
-      "title": "Import",
-      "routes": [
-       { "title": "Overview", "path": "import" },
-       {
-         "title": "Generating Configuration",
-         "path": "import/generating-configuration"
-       }
+    "title": "Import",
+    "routes": [
+      { "title": "Overview", "path": "language/import/index" },
+      {
+        "title": "Generating Configuration",
+        "path": "language/import/generating-configuration"
+      }
     ]
   },
   {
     "title": "Expressions",
     "routes": [
-      { "title": "Overview", "path": "expressions" },
-      { "title": "Types and Values", "path": "expressions/types" },
+      { "title": "Overview", "path": "language/expressions/index" },
+      { "title": "Types and Values", "path": "language/expressions/types" },
       {
         "title": "Strings and Templates",
-        "path": "expressions/strings"
+        "path": "language/expressions/strings"
       },
       {
         "title": "References to Values",
-        "path": "expressions/references"
+        "path": "language/expressions/references"
       },
-      { "title": "Operators", "path": "expressions/operators" },
+      { "title": "Operators", "path": "language/expressions/operators" },
       {
         "title": "Function Calls",
-        "path": "expressions/function-calls"
+        "path": "language/expressions/function-calls"
       },
       {
         "title": "Conditional Expressions",
-        "path": "expressions/conditionals"
+        "path": "language/expressions/conditionals"
       },
-      { "title": "For Expressions", "path": "expressions/for" },
+      { "title": "For Expressions", "path": "language/expressions/for" },
       {
         "title": "Splat Expressions",
-        "path": "expressions/splat"
+        "path": "language/expressions/splat"
       },
 
       {
         "title": "Dynamic Blocks",
-        "path": "expressions/dynamic-blocks"
+        "path": "language/expressions/dynamic-blocks"
       },
       {
         "title": "Custom Conditions",
-        "path": "expressions/custom-conditions"
+        "path": "language/expressions/custom-conditions"
       },
       {
         "title": "Type Constraints",
-        "path": "expressions/type-constraints"
+        "path": "language/expressions/type-constraints"
       },
       {
         "title": "Version Constraints",
-        "path": "expressions/version-constraints"
+        "path": "language/expressions/version-constraints"
       }
     ]
   },
   {
     "title": "Functions",
     "routes": [
-      { "title": "Overview", "path": "functions" },
+      { "title": "Overview", "path": "language/functions/index" },
       {
         "title": "Numeric Functions",
         "routes": [
-          { "title": "<code>abs</code>", "href": "/language/functions/abs" },
-          { "title": "<code>ceil</code>", "href": "/language/functions/ceil" },
+          { "title": "<code>abs</code>", "path": "language/functions/abs" },
+          { "title": "<code>ceil</code>", "path": "language/functions/ceil" },
           {
             "title": "<code>floor</code>",
-            "href": "/language/functions/floor"
+            "path": "language/functions/floor"
           },
-          { "title": "<code>log</code>", "href": "/language/functions/log" },
-          { "title": "<code>max</code>", "href": "/language/functions/max" },
-          { "title": "<code>min</code>", "href": "/language/functions/min" },
+          { "title": "<code>log</code>", "path": "language/functions/log" },
+          { "title": "<code>max</code>", "path": "language/functions/max" },
+          { "title": "<code>min</code>", "path": "language/functions/min" },
           {
             "title": "<code>parseint</code>",
-            "href": "/language/functions/parseint"
+            "path": "language/functions/parseint"
           },
-          { "title": "<code>pow</code>", "href": "/language/functions/pow" },
+          { "title": "<code>pow</code>", "path": "language/functions/pow" },
           {
             "title": "<code>signum</code>",
-            "href": "/language/functions/signum"
+            "path": "language/functions/signum"
           }
         ]
       },
@@ -310,79 +310,79 @@
         "routes": [
           {
             "title": "<code>chomp</code>",
-            "href": "/language/functions/chomp"
+            "path": "language/functions/chomp"
           },
           {
             "title": "<code>endswith</code>",
-            "href": "/language/functions/endswith"
+            "path": "language/functions/endswith"
           },
           {
             "title": "<code>format</code>",
-            "href": "/language/functions/format"
+            "path": "language/functions/format"
           },
           {
             "title": "<code>formatlist</code>",
-            "href": "/language/functions/formatlist"
+            "path": "language/functions/formatlist"
           },
           {
             "title": "<code>indent</code>",
-            "href": "/language/functions/indent"
+            "path": "language/functions/indent"
           },
-          { "title": "<code>join</code>", "href": "/language/functions/join" },
+          { "title": "<code>join</code>", "path": "language/functions/join" },
           {
             "title": "<code>lower</code>",
-            "href": "/language/functions/lower"
+            "path": "language/functions/lower"
           },
           {
             "title": "<code>regex</code>",
-            "href": "/language/functions/regex"
+            "path": "language/functions/regex"
           },
           {
             "title": "<code>regexall</code>",
-            "href": "/language/functions/regexall"
+            "path": "language/functions/regexall"
           },
           {
             "title": "<code>replace</code>",
-            "href": "/language/functions/replace"
+            "path": "language/functions/replace"
           },
           {
             "title": "<code>split</code>",
-            "href": "/language/functions/split"
+            "path": "language/functions/split"
           },
           {
             "title": "<code>startswith</code>",
-            "href": "/language/functions/startswith"
+            "path": "language/functions/startswith"
           },
           {
             "title": "<code>strcontains</code>",
-            "href": "/language/functions/strcontains"
+            "path": "language/functions/strcontains"
           },
           {
             "title": "<code>strrev</code>",
-            "href": "/language/functions/strrev"
+            "path": "language/functions/strrev"
           },
           {
             "title": "<code>substr</code>",
-            "href": "/language/functions/substr"
+            "path": "language/functions/substr"
           },
           {
             "title": "<code>title</code>",
-            "href": "/language/functions/title"
+            "path": "language/functions/title"
           },
-          { "title": "<code>trim</code>", "href": "/language/functions/trim" },
+          { "title": "<code>trim</code>", "path": "language/functions/trim" },
           {
             "title": "<code>trimprefix</code>",
-            "href": "/language/functions/trimprefix"
+            "path": "language/functions/trimprefix"
           },
           {
             "title": "<code>trimsuffix</code>",
-            "href": "/language/functions/trimsuffix"
+            "path": "language/functions/trimsuffix"
           },
           {
             "title": "<code>trimspace</code>",
-            "href": "/language/functions/trimspace"
+            "path": "language/functions/trimspace"
           },
-          { "title": "<code>upper</code>", "href": "/language/functions/upper" }
+          { "title": "<code>upper</code>", "path": "language/functions/upper" }
         ]
       },
       {
@@ -390,113 +390,113 @@
         "routes": [
           {
             "title": "<code>alltrue</code>",
-            "href": "/language/functions/alltrue"
+            "path": "language/functions/alltrue"
           },
           {
             "title": "<code>anytrue</code>",
-            "href": "/language/functions/anytrue"
+            "path": "language/functions/anytrue"
           },
           {
             "title": "<code>chunklist</code>",
-            "href": "/language/functions/chunklist"
+            "path": "language/functions/chunklist"
           },
           {
             "title": "<code>coalesce</code>",
-            "href": "/language/functions/coalesce"
+            "path": "language/functions/coalesce"
           },
           {
             "title": "<code>coalescelist</code>",
-            "href": "/language/functions/coalescelist"
+            "path": "language/functions/coalescelist"
           },
           {
             "title": "<code>compact</code>",
-            "href": "/language/functions/compact"
+            "path": "language/functions/compact"
           },
           {
             "title": "<code>concat</code>",
-            "href": "/language/functions/concat"
+            "path": "language/functions/concat"
           },
           {
             "title": "<code>contains</code>",
-            "href": "/language/functions/contains"
+            "path": "language/functions/contains"
           },
           {
             "title": "<code>distinct</code>",
-            "href": "/language/functions/distinct"
+            "path": "language/functions/distinct"
           },
           {
             "title": "<code>element</code>",
-            "href": "/language/functions/element"
+            "path": "language/functions/element"
           },
           {
             "title": "<code>flatten</code>",
-            "href": "/language/functions/flatten"
+            "path": "language/functions/flatten"
           },
           {
             "title": "<code>index</code>",
-            "href": "/language/functions/index_function"
+            "path": "language/functions/index_function"
           },
-          { "title": "<code>keys</code>", "href": "/language/functions/keys" },
+          { "title": "<code>keys</code>", "path": "language/functions/keys" },
           {
             "title": "<code>length</code>",
-            "href": "/language/functions/length"
+            "path": "language/functions/length"
           },
-          { "title": "<code>list</code>", "href": "/language/functions/list" },
+          { "title": "<code>list</code>", "path": "language/functions/list" },
           {
             "title": "<code>lookup</code>",
-            "href": "/language/functions/lookup"
+            "path": "language/functions/lookup"
           },
-          { "title": "<code>map</code>", "href": "/language/functions/map" },
+          { "title": "<code>map</code>", "path": "language/functions/map" },
           {
             "title": "<code>matchkeys</code>",
-            "href": "/language/functions/matchkeys"
+            "path": "language/functions/matchkeys"
           },
           {
             "title": "<code>merge</code>",
-            "href": "/language/functions/merge"
+            "path": "language/functions/merge"
           },
-          { "title": "<code>one</code>", "href": "/language/functions/one" },
+          { "title": "<code>one</code>", "path": "language/functions/one" },
           {
             "title": "<code>range</code>",
-            "href": "/language/functions/range"
+            "path": "language/functions/range"
           },
           {
             "title": "<code>reverse</code>",
-            "href": "/language/functions/reverse"
+            "path": "language/functions/reverse"
           },
           {
             "title": "<code>setintersection</code>",
-            "href": "/language/functions/setintersection"
+            "path": "language/functions/setintersection"
           },
           {
             "title": "<code>setproduct</code>",
-            "href": "/language/functions/setproduct"
+            "path": "language/functions/setproduct"
           },
           {
             "title": "<code>setsubtract</code>",
-            "href": "/language/functions/setsubtract"
+            "path": "language/functions/setsubtract"
           },
           {
             "title": "<code>setunion</code>",
-            "href": "/language/functions/setunion"
+            "path": "language/functions/setunion"
           },
           {
             "title": "<code>slice</code>",
-            "href": "/language/functions/slice"
+            "path": "language/functions/slice"
           },
-          { "title": "<code>sort</code>", "href": "/language/functions/sort" },
-          { "title": "<code>sum</code>", "href": "/language/functions/sum" },
+          { "title": "<code>sort</code>", "path": "language/functions/sort" },
+          { "title": "<code>sum</code>", "path": "language/functions/sum" },
           {
             "title": "<code>transpose</code>",
-            "href": "/language/functions/transpose"
+            "path": "language/functions/transpose"
           },
           {
             "title": "<code>values</code>",
-            "href": "/language/functions/values"
+            "path": "language/functions/values"
           },
           {
             "title": "<code>zipmap</code>",
-            "href": "/language/functions/zipmap"
+            "path": "language/functions/zipmap"
           }
         ]
       },
@@ -505,47 +505,47 @@
         "routes": [
           {
             "title": "<code>base64decode</code>",
-            "href": "/language/functions/base64decode"
+            "path": "language/functions/base64decode"
           },
           {
             "title": "<code>base64encode</code>",
-            "href": "/language/functions/base64encode"
+            "path": "language/functions/base64encode"
           },
           {
             "title": "<code>base64gzip</code>",
-            "href": "/language/functions/base64gzip"
+            "path": "language/functions/base64gzip"
           },
           {
             "title": "<code>csvdecode</code>",
-            "href": "/language/functions/csvdecode"
+            "path": "language/functions/csvdecode"
           },
           {
             "title": "<code>jsondecode</code>",
-            "href": "/language/functions/jsondecode"
+            "path": "language/functions/jsondecode"
           },
           {
             "title": "<code>jsonencode</code>",
-            "href": "/language/functions/jsonencode"
+            "path": "language/functions/jsonencode"
           },
           {
             "title": "<code>textdecodebase64</code>",
-            "href": "/language/functions/textdecodebase64"
+            "path": "language/functions/textdecodebase64"
           },
           {
             "title": "<code>textencodebase64</code>",
-            "href": "/language/functions/textencodebase64"
+            "path": "language/functions/textencodebase64"
           },
           {
             "title": "<code>urlencode</code>",
-            "href": "/language/functions/urlencode"
+            "path": "language/functions/urlencode"
           },
           {
             "title": "<code>yamldecode</code>",
-            "href": "/language/functions/yamldecode"
+            "path": "language/functions/yamldecode"
           },
           {
             "title": "<code>yamlencode</code>",
-            "href": "/language/functions/yamlencode"
+            "path": "language/functions/yamlencode"
           }
         ]
       },
@@ -554,36 +554,36 @@
         "routes": [
           {
             "title": "<code>abspath</code>",
-            "href": "/language/functions/abspath"
+            "path": "language/functions/abspath"
           },
           {
             "title": "<code>dirname</code>",
-            "href": "/language/functions/dirname"
+            "path": "language/functions/dirname"
           },
           {
             "title": "<code>pathexpand</code>",
-            "href": "/language/functions/pathexpand"
+            "path": "language/functions/pathexpand"
           },
           {
             "title": "<code>basename</code>",
-            "href": "/language/functions/basename"
+            "path": "language/functions/basename"
           },
-          { "title": "<code>file</code>", "href": "/language/functions/file" },
+          { "title": "<code>file</code>", "path": "language/functions/file" },
           {
             "title": "<code>fileexists</code>",
-            "href": "/language/functions/fileexists"
+            "path": "language/functions/fileexists"
           },
           {
             "title": "<code>fileset</code>",
-            "href": "/language/functions/fileset"
+            "path": "language/functions/fileset"
           },
           {
             "title": "<code>filebase64</code>",
-            "href": "/language/functions/filebase64"
+            "path": "language/functions/filebase64"
           },
           {
             "title": "<code>templatefile</code>",
-            "href": "/language/functions/templatefile"
+            "path": "language/functions/templatefile"
           }
         ]
       },
@@ -592,23 +592,23 @@
         "routes": [
           {
             "title": "<code>formatdate</code>",
-            "href": "/language/functions/formatdate"
+            "path": "language/functions/formatdate"
           },
           {
             "title": "<code>plantimestamp</code>",
-            "href": "/language/functions/plantimestamp"
+            "path": "language/functions/plantimestamp"
           },
           {
             "title": "<code>timeadd</code>",
-            "href": "/language/functions/timeadd"
+            "path": "language/functions/timeadd"
           },
           {
             "title": "<code>timecmp</code>",
-            "href": "/language/functions/timecmp"
+            "path": "language/functions/timecmp"
           },
           {
             "title": "<code>timestamp</code>",
-            "href": "/language/functions/timestamp"
+            "path": "language/functions/timestamp"
           }
         ]
       },
@@ -617,58 +617,58 @@
         "routes": [
           {
             "title": "<code>base64sha256</code>",
-            "href": "/language/functions/base64sha256"
+            "path": "language/functions/base64sha256"
           },
           {
             "title": "<code>base64sha512</code>",
-            "href": "/language/functions/base64sha512"
+            "path": "language/functions/base64sha512"
           },
           {
             "title": "<code>bcrypt</code>",
-            "href": "/language/functions/bcrypt"
+            "path": "language/functions/bcrypt"
           },
           {
             "title": "<code>filebase64sha256</code>",
-            "href": "/language/functions/filebase64sha256"
+            "path": "language/functions/filebase64sha256"
           },
           {
             "title": "<code>filebase64sha512</code>",
-            "href": "/language/functions/filebase64sha512"
+            "path": "language/functions/filebase64sha512"
           },
           {
             "title": "<code>filemd5</code>",
-            "href": "/language/functions/filemd5"
+            "path": "language/functions/filemd5"
           },
           {
             "title": "<code>filesha1</code>",
-            "href": "/language/functions/filesha1"
+            "path": "language/functions/filesha1"
           },
           {
             "title": "<code>filesha256</code>",
-            "href": "/language/functions/filesha256"
+            "path": "language/functions/filesha256"
           },
           {
             "title": "<code>filesha512</code>",
-            "href": "/language/functions/filesha512"
+            "path": "language/functions/filesha512"
           },
-          { "title": "<code>md5</code>", "href": "/language/functions/md5" },
+          { "title": "<code>md5</code>", "path": "language/functions/md5" },
           {
             "title": "<code>rsadecrypt</code>",
-            "href": "/language/functions/rsadecrypt"
+            "path": "language/functions/rsadecrypt"
           },
-          { "title": "<code>sha1</code>", "href": "/language/functions/sha1" },
+          { "title": "<code>sha1</code>", "path": "language/functions/sha1" },
           {
             "title": "<code>sha256</code>",
-            "href": "/language/functions/sha256"
+            "path": "language/functions/sha256"
           },
           {
             "title": "<code>sha512</code>",
-            "href": "/language/functions/sha512"
+            "path": "language/functions/sha512"
           },
-          { "title": "<code>uuid</code>", "href": "/language/functions/uuid" },
+          { "title": "<code>uuid</code>", "path": "language/functions/uuid" },
           {
             "title": "<code>uuidv5</code>",
-            "href": "/language/functions/uuidv5"
+            "path": "language/functions/uuidv5"
           }
         ]
       },
@@ -677,356 +677,632 @@
         "routes": [
           {
             "title": "<code>cidrhost</code>",
-            "href": "/language/functions/cidrhost"
+            "path": "language/functions/cidrhost"
           },
           {
             "title": "<code>cidrnetmask</code>",
-            "href": "/language/functions/cidrnetmask"
+            "path": "language/functions/cidrnetmask"
           },
           {
             "title": "<code>cidrsubnet</code>",
-            "href": "/language/functions/cidrsubnet"
+            "path": "language/functions/cidrsubnet"
           },
           {
             "title": "<code>cidrsubnets</code>",
-            "href": "/language/functions/cidrsubnets"
+            "path": "language/functions/cidrsubnets"
           }
         ]
       },
       {
         "title": "Type Conversion Functions",
         "routes": [
-          { "title": "<code>can</code>", "href": "/language/functions/can" },
+          { "title": "<code>can</code>", "path": "language/functions/can" },
           {
             "title": "<code>nonsensitive</code>",
-            "href": "/language/functions/nonsensitive"
+            "path": "language/functions/nonsensitive"
           },
           {
             "title": "<code>sensitive</code>",
-            "href": "/language/functions/sensitive"
+            "path": "language/functions/sensitive"
           },
           {
             "title": "<code>tobool</code>",
-            "href": "/language/functions/tobool"
+            "path": "language/functions/tobool"
           },
           {
             "title": "<code>tolist</code>",
-            "href": "/language/functions/tolist"
+            "path": "language/functions/tolist"
           },
           {
             "title": "<code>tomap</code>",
-            "href": "/language/functions/tomap"
+            "path": "language/functions/tomap"
           },
           {
             "title": "<code>tonumber</code>",
-            "href": "/language/functions/tonumber"
+            "path": "language/functions/tonumber"
           },
           {
             "title": "<code>toset</code>",
-            "href": "/language/functions/toset"
+            "path": "language/functions/toset"
           },
           {
             "title": "<code>tostring</code>",
-            "href": "/language/functions/tostring"
+            "path": "language/functions/tostring"
           },
-          { "title": "<code>try</code>", "href": "/language/functions/try" },
-          { "title": "<code>type</code>", "href": "/language/functions/type" }
+          { "title": "<code>try</code>", "path": "language/functions/try" },
+          { "title": "<code>type</code>", "path": "language/functions/type" }
         ]
       },
-      { "title": "abs", "path": "functions/abs", "hidden": true },
-      { "title": "abspath", "path": "functions/abspath", "hidden": true },
-      { "title": "alltrue", "path": "functions/alltrue", "hidden": true },
-      { "title": "anytrue", "path": "functions/anytrue", "hidden": true },
+      { "title": "abs", "path": "language/functions/abs", "hidden": true },
+      {
+        "title": "abspath",
+        "path": "language/functions/abspath",
+        "hidden": true
+      },
+      {
+        "title": "alltrue",
+        "path": "language/functions/alltrue",
+        "hidden": true
+      },
+      {
+        "title": "anytrue",
+        "path": "language/functions/anytrue",
+        "hidden": true
+      },
       {
         "title": "base64decode",
-        "path": "functions/base64decode",
+        "path": "language/functions/base64decode",
         "hidden": true
       },
       {
         "title": "base64encode",
-        "path": "functions/base64encode",
+        "path": "language/functions/base64encode",
         "hidden": true
       },
-      { "title": "base64gzip", "path": "functions/base64gzip", "hidden": true },
+      {
+        "title": "base64gzip",
+        "path": "language/functions/base64gzip",
+        "hidden": true
+      },
       {
         "title": "base64sha256",
-        "path": "functions/base64sha256",
+        "path": "language/functions/base64sha256",
         "hidden": true
       },
       {
         "title": "base64sha512",
-        "path": "functions/base64sha512",
+        "path": "language/functions/base64sha512",
         "hidden": true
       },
-      { "title": "basename", "path": "functions/basename", "hidden": true },
-      { "title": "bcrypt", "path": "functions/bcrypt", "hidden": true },
-      { "title": "can", "path": "functions/can", "hidden": true },
-      { "title": "ceil", "path": "functions/ceil", "hidden": true },
-      { "title": "chomp", "path": "functions/chomp", "hidden": true },
-      { "title": "chunklist", "path": "functions/chunklist", "hidden": true },
-      { "title": "cidrhost", "path": "functions/cidrhost", "hidden": true },
+      {
+        "title": "basename",
+        "path": "language/functions/basename",
+        "hidden": true
+      },
+      {
+        "title": "bcrypt",
+        "path": "language/functions/bcrypt",
+        "hidden": true
+      },
+      { "title": "can", "path": "language/functions/can", "hidden": true },
+      { "title": "ceil", "path": "language/functions/ceil", "hidden": true },
+      { "title": "chomp", "path": "language/functions/chomp", "hidden": true },
+      {
+        "title": "chunklist",
+        "path": "language/functions/chunklist",
+        "hidden": true
+      },
+      {
+        "title": "cidrhost",
+        "path": "language/functions/cidrhost",
+        "hidden": true
+      },
       {
         "title": "cidrnetmask",
-        "path": "functions/cidrnetmask",
+        "path": "language/functions/cidrnetmask",
         "hidden": true
       },
-      { "title": "cidrsubnet", "path": "functions/cidrsubnet", "hidden": true },
+      {
+        "title": "cidrsubnet",
+        "path": "language/functions/cidrsubnet",
+        "hidden": true
+      },
       {
         "title": "cidrsubnets",
-        "path": "functions/cidrsubnets",
+        "path": "language/functions/cidrsubnets",
         "hidden": true
       },
-      { "title": "coalesce", "path": "functions/coalesce", "hidden": true },
+      {
+        "title": "coalesce",
+        "path": "language/functions/coalesce",
+        "hidden": true
+      },
       {
         "title": "coalescelist",
-        "path": "functions/coalescelist",
+        "path": "language/functions/coalescelist",
         "hidden": true
       },
-      { "title": "compact", "path": "functions/compact", "hidden": true },
-      { "title": "concat", "path": "functions/concat", "hidden": true },
-      { "title": "contains", "path": "functions/contains", "hidden": true },
-      { "title": "csvdecode", "path": "functions/csvdecode", "hidden": true },
-      { "title": "dirname", "path": "functions/dirname", "hidden": true },
-      { "title": "distinct", "path": "functions/distinct", "hidden": true },
-      { "title": "element", "path": "functions/element", "hidden": true },
-      { "title": "endswith", "path": "functions/endswith", "hidden": true },
-      { "title": "file", "path": "functions/file", "hidden": true },
-      { "title": "filebase64", "path": "functions/filebase64", "hidden": true },
+      {
+        "title": "compact",
+        "path": "language/functions/compact",
+        "hidden": true
+      },
+      {
+        "title": "concat",
+        "path": "language/functions/concat",
+        "hidden": true
+      },
+      {
+        "title": "contains",
+        "path": "language/functions/contains",
+        "hidden": true
+      },
+      {
+        "title": "csvdecode",
+        "path": "language/functions/csvdecode",
+        "hidden": true
+      },
+      {
+        "title": "dirname",
+        "path": "language/functions/dirname",
+        "hidden": true
+      },
+      {
+        "title": "distinct",
+        "path": "language/functions/distinct",
+        "hidden": true
+      },
+      {
+        "title": "element",
+        "path": "language/functions/element",
+        "hidden": true
+      },
+      {
+        "title": "endswith",
+        "path": "language/functions/endswith",
+        "hidden": true
+      },
+      { "title": "file", "path": "language/functions/file", "hidden": true },
+      {
+        "title": "filebase64",
+        "path": "language/functions/filebase64",
+        "hidden": true
+      },
       {
         "title": "filebase64sha256",
-        "path": "functions/filebase64sha256",
+        "path": "language/functions/filebase64sha256",
         "hidden": true
       },
       {
         "title": "filebase64sha512",
-        "path": "functions/filebase64sha512",
+        "path": "language/functions/filebase64sha512",
         "hidden": true
       },
-      { "title": "fileexists", "path": "functions/fileexists", "hidden": true },
-      { "title": "filemd5", "path": "functions/filemd5", "hidden": true },
-      { "title": "fileset", "path": "functions/fileset", "hidden": true },
-      { "title": "filesha1", "path": "functions/filesha1", "hidden": true },
-      { "title": "filesha256", "path": "functions/filesha256", "hidden": true },
-      { "title": "filesha512", "path": "functions/filesha512", "hidden": true },
-      { "title": "flatten", "path": "functions/flatten", "hidden": true },
-      { "title": "floor", "path": "functions/floor", "hidden": true },
-      { "title": "format", "path": "functions/format", "hidden": true },
-      { "title": "formatdate", "path": "functions/formatdate", "hidden": true },
-      { "title": "formatlist", "path": "functions/formatlist", "hidden": true },
-      { "title": "indent", "path": "functions/indent", "hidden": true },
-      { "title": "index", "path": "functions/index_function", "hidden": true },
-      { "title": "join", "path": "functions/join", "hidden": true },
-      { "title": "jsondecode", "path": "functions/jsondecode", "hidden": true },
-      { "title": "jsonencode", "path": "functions/jsonencode", "hidden": true },
-      { "title": "keys", "path": "functions/keys", "hidden": true },
-      { "title": "length", "path": "functions/length", "hidden": true },
-      { "title": "list", "path": "functions/list", "hidden": true },
-      { "title": "log", "path": "functions/log", "hidden": true },
-      { "title": "lookup", "path": "functions/lookup", "hidden": true },
-      { "title": "lower", "path": "functions/lower", "hidden": true },
-      { "title": "map", "path": "functions/map", "hidden": true },
-      { "title": "matchkeys", "path": "functions/matchkeys", "hidden": true },
-      { "title": "max", "path": "functions/max", "hidden": true },
-      { "title": "md5", "path": "functions/md5", "hidden": true },
-      { "title": "merge", "path": "functions/merge", "hidden": true },
-      { "title": "min", "path": "functions/min", "hidden": true },
+      {
+        "title": "fileexists",
+        "path": "language/functions/fileexists",
+        "hidden": true
+      },
+      {
+        "title": "filemd5",
+        "path": "language/functions/filemd5",
+        "hidden": true
+      },
+      {
+        "title": "fileset",
+        "path": "language/functions/fileset",
+        "hidden": true
+      },
+      {
+        "title": "filesha1",
+        "path": "language/functions/filesha1",
+        "hidden": true
+      },
+      {
+        "title": "filesha256",
+        "path": "language/functions/filesha256",
+        "hidden": true
+      },
+      {
+        "title": "filesha512",
+        "path": "language/functions/filesha512",
+        "hidden": true
+      },
+      {
+        "title": "flatten",
+        "path": "language/functions/flatten",
+        "hidden": true
+      },
+      { "title": "floor", "path": "language/functions/floor", "hidden": true },
+      {
+        "title": "format",
+        "path": "language/functions/format",
+        "hidden": true
+      },
+      {
+        "title": "formatdate",
+        "path": "language/functions/formatdate",
+        "hidden": true
+      },
+      {
+        "title": "formatlist",
+        "path": "language/functions/formatlist",
+        "hidden": true
+      },
+      {
+        "title": "indent",
+        "path": "language/functions/indent",
+        "hidden": true
+      },
+      {
+        "title": "index",
+        "path": "language/functions/index_function",
+        "hidden": true
+      },
+      { "title": "join", "path": "language/functions/join", "hidden": true },
+      {
+        "title": "jsondecode",
+        "path": "language/functions/jsondecode",
+        "hidden": true
+      },
+      {
+        "title": "jsonencode",
+        "path": "language/functions/jsonencode",
+        "hidden": true
+      },
+      { "title": "keys", "path": "language/functions/keys", "hidden": true },
+      {
+        "title": "length",
+        "path": "language/functions/length",
+        "hidden": true
+      },
+      { "title": "list", "path": "language/functions/list", "hidden": true },
+      { "title": "log", "path": "language/functions/log", "hidden": true },
+      {
+        "title": "lookup",
+        "path": "language/functions/lookup",
+        "hidden": true
+      },
+      { "title": "lower", "path": "language/functions/lower", "hidden": true },
+      { "title": "map", "path": "language/functions/map", "hidden": true },
+      {
+        "title": "matchkeys",
+        "path": "language/functions/matchkeys",
+        "hidden": true
+      },
+      { "title": "max", "path": "language/functions/max", "hidden": true },
+      { "title": "md5", "path": "language/functions/md5", "hidden": true },
+      { "title": "merge", "path": "language/functions/merge", "hidden": true },
+      { "title": "min", "path": "language/functions/min", "hidden": true },
       {
         "title": "nonsensitive",
-        "path": "functions/nonsensitive",
+        "path": "language/functions/nonsensitive",
         "hidden": true
       },
-      { "title": "one", "path": "functions/one", "hidden": true },
-      { "title": "parseint", "path": "functions/parseint", "hidden": true },
-      { "title": "pathexpand", "path": "functions/pathexpand", "hidden": true },
-      { "title": "plantimestamp", "path": "functions/plantimestamp", "hidden": true },
-      { "title": "pow", "path": "functions/pow", "hidden": true },
-      { "title": "range", "path": "functions/range", "hidden": true },
-      { "title": "regex", "path": "functions/regex", "hidden": true },
-      { "title": "regexall", "path": "functions/regexall", "hidden": true },
-      { "title": "replace", "path": "functions/replace", "hidden": true },
-      { "title": "reverse", "path": "functions/reverse", "hidden": true },
-      { "title": "rsadecrypt", "path": "functions/rsadecrypt", "hidden": true },
-      { "title": "sensitive", "path": "functions/sensitive", "hidden": true },
+      { "title": "one", "path": "language/functions/one", "hidden": true },
+      {
+        "title": "parseint",
+        "path": "language/functions/parseint",
+        "hidden": true
+      },
+      {
+        "title": "pathexpand",
+        "path": "language/functions/pathexpand",
+        "hidden": true
+      },
+      {
+        "title": "plantimestamp",
+        "path": "language/functions/plantimestamp",
+        "hidden": true
+      },
+      { "title": "pow", "path": "language/functions/pow", "hidden": true },
+      { "title": "range", "path": "language/functions/range", "hidden": true },
+      { "title": "regex", "path": "language/functions/regex", "hidden": true },
+      {
+        "title": "regexall",
+        "path": "language/functions/regexall",
+        "hidden": true
+      },
+      {
+        "title": "replace",
+        "path": "language/functions/replace",
+        "hidden": true
+      },
+      {
+        "title": "reverse",
+        "path": "language/functions/reverse",
+        "hidden": true
+      },
+      {
+        "title": "rsadecrypt",
+        "path": "language/functions/rsadecrypt",
+        "hidden": true
+      },
+      {
+        "title": "sensitive",
+        "path": "language/functions/sensitive",
+        "hidden": true
+      },
       {
         "title": "setintersection",
-        "path": "functions/setintersection",
+        "path": "language/functions/setintersection",
         "hidden": true
       },
-      { "title": "setproduct", "path": "functions/setproduct", "hidden": true },
+      {
+        "title": "setproduct",
+        "path": "language/functions/setproduct",
+        "hidden": true
+      },
       {
         "title": "setsubtract",
-        "path": "functions/setsubtract",
+        "path": "language/functions/setsubtract",
         "hidden": true
       },
-      { "title": "setunion", "path": "functions/setunion", "hidden": true },
-      { "title": "sha1", "path": "functions/sha1", "hidden": true },
-      { "title": "sha256", "path": "functions/sha256", "hidden": true },
-      { "title": "sha512", "path": "functions/sha512", "hidden": true },
-      { "title": "signum", "path": "functions/signum", "hidden": true },
-      { "title": "slice", "path": "functions/slice", "hidden": true },
-      { "title": "sort", "path": "functions/sort", "hidden": true },
-      { "title": "split", "path": "functions/split", "hidden": true },
-      { "title": "startswith", "path": "functions/startswith", "hidden": true },
-      { "title": "strcontains", "path": "functions/strcontains", "hidden": true},
-      { "title": "strrev", "path": "functions/strrev", "hidden": true },
-      { "title": "substr", "path": "functions/substr", "hidden": true },
-      { "title": "sum", "path": "functions/sum", "hidden": true },
+      {
+        "title": "setunion",
+        "path": "language/functions/setunion",
+        "hidden": true
+      },
+      { "title": "sha1", "path": "language/functions/sha1", "hidden": true },
+      {
+        "title": "sha256",
+        "path": "language/functions/sha256",
+        "hidden": true
+      },
+      {
+        "title": "sha512",
+        "path": "language/functions/sha512",
+        "hidden": true
+      },
+      {
+        "title": "signum",
+        "path": "language/functions/signum",
+        "hidden": true
+      },
+      { "title": "slice", "path": "language/functions/slice", "hidden": true },
+      { "title": "sort", "path": "language/functions/sort", "hidden": true },
+      { "title": "split", "path": "language/functions/split", "hidden": true },
+      {
+        "title": "startswith",
+        "path": "language/functions/startswith",
+        "hidden": true
+      },
+      {
+        "title": "strcontains",
+        "path": "language/functions/strcontains",
+        "hidden": true
+      },
+      {
+        "title": "strrev",
+        "path": "language/functions/strrev",
+        "hidden": true
+      },
+      {
+        "title": "substr",
+        "path": "language/functions/substr",
+        "hidden": true
+      },
+      { "title": "sum", "path": "language/functions/sum", "hidden": true },
       {
         "title": "templatefile",
-        "path": "functions/templatefile",
+        "path": "language/functions/templatefile",
         "hidden": true
       },
       {
         "title": "textdecodebase64",
-        "path": "functions/textdecodebase64",
+        "path": "language/functions/textdecodebase64",
         "hidden": true
       },
       {
         "title": "textencodebase64",
-        "path": "functions/textencodebase64",
+        "path": "language/functions/textencodebase64",
         "hidden": true
       },
-      { "title": "timeadd", "path": "functions/timeadd", "hidden": true },
-      { "title": "timecmp", "path": "functions/timecmp", "hidden": true },
-      { "title": "timestamp", "path": "functions/timestamp", "hidden": true },
-      { "title": "title", "path": "functions/title", "hidden": true },
-      { "title": "tobool", "path": "functions/tobool", "hidden": true },
-      { "title": "tolist", "path": "functions/tolist", "hidden": true },
-      { "title": "tomap", "path": "functions/tomap", "hidden": true },
-      { "title": "tonumber", "path": "functions/tonumber", "hidden": true },
-      { "title": "toset", "path": "functions/toset", "hidden": true },
-      { "title": "tostring", "path": "functions/tostring", "hidden": true },
-      { "title": "transpose", "path": "functions/transpose", "hidden": true },
-      { "title": "trim", "path": "functions/trim", "hidden": true },
-      { "title": "trimprefix", "path": "functions/trimprefix", "hidden": true },
-      { "title": "trimspace", "path": "functions/trimspace", "hidden": true },
-      { "title": "trimsuffix", "path": "functions/trimsuffix", "hidden": true },
-      { "title": "try", "path": "functions/try", "hidden": true },
-      { "title": "type", "path": "functions/type", "hidden": true },
-      { "title": "upper", "path": "functions/upper", "hidden": true },
-      { "title": "urlencode", "path": "functions/urlencode", "hidden": true },
-      { "title": "uuid", "path": "functions/uuid", "hidden": true },
-      { "title": "uuidv5", "path": "functions/uuidv5", "hidden": true },
-      { "title": "values", "path": "functions/values", "hidden": true },
-      { "title": "yamldecode", "path": "functions/yamldecode", "hidden": true },
-      { "title": "yamlencode", "path": "functions/yamlencode", "hidden": true },
-      { "title": "zipmap", "path": "functions/zipmap", "hidden": true }
+      {
+        "title": "timeadd",
+        "path": "language/functions/timeadd",
+        "hidden": true
+      },
+      {
+        "title": "timecmp",
+        "path": "language/functions/timecmp",
+        "hidden": true
+      },
+      {
+        "title": "timestamp",
+        "path": "language/functions/timestamp",
+        "hidden": true
+      },
+      { "title": "title", "path": "language/functions/title", "hidden": true },
+      {
+        "title": "tobool",
+        "path": "language/functions/tobool",
+        "hidden": true
+      },
+      {
+        "title": "tolist",
+        "path": "language/functions/tolist",
+        "hidden": true
+      },
+      { "title": "tomap", "path": "language/functions/tomap", "hidden": true },
+      {
+        "title": "tonumber",
+        "path": "language/functions/tonumber",
+        "hidden": true
+      },
+      { "title": "toset", "path": "language/functions/toset", "hidden": true },
+      {
+        "title": "tostring",
+        "path": "language/functions/tostring",
+        "hidden": true
+      },
+      {
+        "title": "transpose",
+        "path": "language/functions/transpose",
+        "hidden": true
+      },
+      { "title": "trim", "path": "language/functions/trim", "hidden": true },
+      {
+        "title": "trimprefix",
+        "path": "language/functions/trimprefix",
+        "hidden": true
+      },
+      {
+        "title": "trimspace",
+        "path": "language/functions/trimspace",
+        "hidden": true
+      },
+      {
+        "title": "trimsuffix",
+        "path": "language/functions/trimsuffix",
+        "hidden": true
+      },
+      { "title": "try", "path": "language/functions/try", "hidden": true },
+      { "title": "type", "path": "language/functions/type", "hidden": true },
+      { "title": "upper", "path": "language/functions/upper", "hidden": true },
+      {
+        "title": "urlencode",
+        "path": "language/functions/urlencode",
+        "hidden": true
+      },
+      { "title": "uuid", "path": "language/functions/uuid", "hidden": true },
+      {
+        "title": "uuidv5",
+        "path": "language/functions/uuidv5",
+        "hidden": true
+      },
+      {
+        "title": "values",
+        "path": "language/functions/values",
+        "hidden": true
+      },
+      {
+        "title": "yamldecode",
+        "path": "language/functions/yamldecode",
+        "hidden": true
+      },
+      {
+        "title": "yamlencode",
+        "path": "language/functions/yamlencode",
+        "hidden": true
+      },
+      { "title": "zipmap", "path": "language/functions/zipmap", "hidden": true }
     ]
   },
   {
     "title": "OpenTF Settings",
     "routes": [
-      { "title": "Overview", "path": "settings" },
+      { "title": "Overview", "path": "language/settings/index" },
       {
         "title": "Backends",
         "routes": [
           {
             "title": "Backend Configuration",
-            "path": "settings/backends/configuration"
+            "path": "language/settings/backends/configuration"
           },
           {
             "title": "Available Backends",
             "routes": [
               {
                 "title": "local",
-                "href": "/language/settings/backends/local"
+                "path": "language/settings/backends/local"
               },
               {
                 "title": "remote",
-                "href": "/language/settings/backends/remote"
+                "path": "language/settings/backends/remote"
               },
               {
                 "title": "azurerm",
-                "href": "/language/settings/backends/azurerm"
+                "path": "language/settings/backends/azurerm"
               },
               {
                 "title": "consul",
-                "href": "/language/settings/backends/consul"
+                "path": "language/settings/backends/consul"
               },
               {
                 "title": "cos",
-                "href": "/language/settings/backends/cos"
+                "path": "language/settings/backends/cos"
               },
               {
                 "title": "gcs",
-                "href": "/language/settings/backends/gcs"
+                "path": "language/settings/backends/gcs"
               },
               {
                 "title": "http",
-                "href": "/language/settings/backends/http"
+                "path": "language/settings/backends/http"
               },
               {
                 "title": "Kubernetes",
-                "href": "/language/settings/backends/kubernetes"
+                "path": "language/settings/backends/kubernetes"
               },
               {
                 "title": "oss",
-                "href": "/language/settings/backends/oss"
+                "path": "language/settings/backends/oss"
               },
               {
                 "title": "pg",
-                "href": "/language/settings/backends/pg"
+                "path": "language/settings/backends/pg"
               },
               {
                 "title": "s3",
-                "href": "/language/settings/backends/s3"
+                "path": "language/settings/backends/s3"
               }
             ]
           },
           {
             "title": "local",
             "hidden": true,
-            "path": "settings/backends/local"
+            "path": "language/settings/backends/local"
           },
           {
             "title": "remote",
             "hidden": true,
-            "path": "settings/backends/remote"
+            "path": "language/settings/backends/remote"
           },
           {
             "title": "azurerm",
             "hidden": true,
-            "path": "settings/backends/azurerm"
+            "path": "language/settings/backends/azurerm"
           },
           {
             "title": "consul",
             "hidden": true,
-            "path": "settings/backends/consul"
+            "path": "language/settings/backends/consul"
           },
           {
             "title": "cos",
             "hidden": true,
-            "path": "settings/backends/cos"
+            "path": "language/settings/backends/cos"
           },
           {
             "title": "gcs",
             "hidden": true,
-            "path": "settings/backends/gcs"
+            "path": "language/settings/backends/gcs"
           },
           {
             "title": "http",
             "hidden": true,
-            "path": "settings/backends/http"
+            "path": "language/settings/backends/http"
           },
           {
             "title": "Kubernetes",
             "hidden": true,
-            "path": "settings/backends/kubernetes"
+            "path": "language/settings/backends/kubernetes"
           },
           {
             "title": "oss",
             "hidden": true,
-            "path": "settings/backends/oss"
+            "path": "language/settings/backends/oss"
           },
           {
             "title": "pg",
             "hidden": true,
-            "path": "settings/backends/pg"
+            "path": "language/settings/backends/pg"
           },
           {
             "title": "s3",
             "hidden": true,
-            "path": "settings/backends/s3"
+            "path": "language/settings/backends/s3"
           }
         ]
       }
@@ -1035,37 +1311,35 @@
   {
     "title": "State",
     "routes": [
-      { "title": "Overview", "path": "state" },
-      { "title": "Purpose", "path": "state/purpose" },
+      { "title": "Overview", "path": "language/state/index" },
+      { "title": "Purpose", "path": "language/state/purpose" },
       {
         "title": "The <code>terraform_remote_state</code> Data Source",
-        "path": "state/remote-state-data"
+        "path": "language/state/remote-state-data"
       },
       {
         "title": "Backends: State Storage and Locking",
-        "path": "state/backends"
+        "path": "language/state/backends"
       },
       {
         "title": "Import Existing Resources",
-        "path": "state/import"
+        "path": "language/state/import"
       },
-      { "title": "Locking", "path": "state/locking" },
-      { "title": "Workspaces", "path": "state/workspaces" },
-      { "title": "Remote State", "path": "state/remote" },
+      { "title": "Locking", "path": "language/state/locking" },
+      { "title": "Workspaces", "path": "language/state/workspaces" },
+      { "title": "Remote State", "path": "language/state/remote" },
       {
         "title": "Sensitive Data",
-        "path": "state/sensitive-data"
+        "path": "language/state/sensitive-data"
       }
     ]
   },
   {
     "title": "Upgrading to OpenTF v1.5",
-    "path": "upgrade-guides"
+    "path": "language/upgrade-guides/index"
   },
   {
     "title": "v1.x Compatibility Promises",
-    "path": "v1-compatibility-promises"
-  },
-  { "divider": true },
-  { "title": "OpenTF Internals", "href": "/internals" }
+    "path": "language/v1-compatibility-promises"
+  }
 ]


### PR DESCRIPTION
Fixes #TBA

## Target Release

1.5.x

## Draft CHANGELOG entry

### ENHANCEMENTS

This PR cleans up paths to various documentation pages inside JSON files in `website/data`. Previous structure was a bit inconsistent and hard to work with on the docs side of things. Now every link uses `path` property that maps 1:1 to a file inside `website/docs`.

A few links that were pointing to pages that don't exist anymore were removed as well as links pointing to different docs sections (internal, cli, language, intro).
