### PR TITLE
On crash, change text to `OPENTF CRASH`

### DIFF
--- a/internal/logging/panic.go
+++ b/internal/logging/panic.go
@@ -25,7 +25,7 @@ shown below, and any additional information which may help replicate the issue.
 
 [1]: https://github.com/placeholderplaceholderplaceholder/opentf/issues
 
-!!!!!!!!!!!!!!!!!!!!!!!!!!! TERRAFORM CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!! OPENTF CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 `
 


### PR DESCRIPTION
When the CLI crashes, it says `TERRAFORM CRASH` instead of `OPENTF CRASH`
So this PR fixes the text