### PR TITLE
internal/depsfile: deprecate io/ioutil

### DIFF
--- a/internal/depsfile/locks_file_test.go
+++ b/internal/depsfile/locks_file_test.go
@@ -5,7 +5,6 @@ package depsfile
 
 import (
 	"bufio"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,7 +27,7 @@ func TestLoadLocksFromFile(t *testing.T) {
 	// Some of the files also have additional assertions that
 	// are encoded in the test code below. These must pass
 	// in addition to the standard diagnostics tests, if present.
-	files, err := ioutil.ReadDir("testdata/locks-files")
+	files, err := os.ReadDir("testdata/locks-files")
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -239,7 +238,7 @@ func TestSaveLocksToFile(t *testing.T) {
 		t.Fatalf("Expected lock file to be non-executable: %o", mode)
 	}
 
-	gotContentBytes, err := ioutil.ReadFile(filename)
+	gotContentBytes, err := os.ReadFile(filename)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}


### PR DESCRIPTION
This replaces the deprecated package 'io/ioutil' in 'internal/depsfile'.

There are no user-facing changes that warrant a CHANGELOG entry.

https://github.com/opentffoundation/opentf/issues/313