### PR TITLE
replaced placeholder message in build cmd

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -16,7 +16,7 @@ OpenTF accepts certain options passed using `ldflags` at build time which contro
 OpenTF will include a `-dev` flag when reporting its own version (ex: 1.5.0-dev) unless `version.dev` is set to `no`:
 
 ```
-go build -ldflags "-w -s -X 'github.com/placeholderplaceholderplaceholder/opentf/version.dev=no'" -o bin/ .
+go build -ldflags "-w -s -X 'github.com/opentffoundation/opentf/version.dev=no'" -o bin/ .
 ```
 
 ### Experimental Features


### PR DESCRIPTION
replaced github.com/placeholderplaceholderplaceholder/opentf/version.dev=no with github.com/opentffoundation/opentf/version.dev=no

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentffoundation/opentf/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open issue, get community approval and then create Pull Request to resolve it

-->

Resolves #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `opentf show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTF now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
