### PR TITLE
nonsensitive no longer produces error when applied to values that are not sensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ENHANCEMENTS:
 
 BUG FIXES:
 * `tofu test` resources cleanup at the end of tests changed to use simple reverse run block order. ([#1043](https://github.com/opentofu/opentofu/pull/1043))
+* nonsensitive no longer produces error when applied to values that are not sensitive
 
 ## Previous Releases
 

--- a/internal/lang/funcs/sensitive.go
+++ b/internal/lang/funcs/sensitive.go
@@ -52,9 +52,6 @@ var NonsensitiveFunc = function.New(&function.Spec{
 		return args[0].Type(), nil
 	},
 	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
-		if args[0].IsKnown() && !args[0].HasMark(marks.Sensitive) {
-			return cty.DynamicVal, function.NewArgErrorf(0, "the given value is not sensitive, so this call is redundant")
-		}
 		v, m := args[0].Unmark()
 		delete(m, marks.Sensitive) // remove the sensitive marking
 		return v.WithMarks(m), nil

--- a/internal/lang/funcs/sensitive_test.go
+++ b/internal/lang/funcs/sensitive_test.go
@@ -130,16 +130,16 @@ func TestNonsensitive(t *testing.T) {
 			``,
 		},
 
-		// Passing a value that is already non-sensitive is an error,
-		// because this function should always be used with specific
-		// intention, not just as a "make everything visible" hammer.
+		// Passing a value that is already non-sensitive is not an error,
+		// as this function may be used with specific to ensure that all
+		// values are indeed non-sensitive
 		{
 			cty.NumberIntVal(1),
-			`the given value is not sensitive, so this call is redundant`,
+			``,
 		},
 		{
 			cty.NullVal(cty.String),
-			`the given value is not sensitive, so this call is redundant`,
+			``,
 		},
 
 		// Unknown values may become sensitive once they are known, so we

--- a/website/docs/language/functions/nonsensitive.mdx
+++ b/website/docs/language/functions/nonsensitive.mdx
@@ -73,8 +73,8 @@ due to an inappropriate call to `nonsensitive` in your module, that's a bug in
 your module and not a bug in OpenTofu itself.
 **Use this function sparingly and only with due care.**
 
-`nonsensitive` will return an error if you pass a value that isn't marked
-as sensitive, because such a call would be redundant and potentially confusing
+`nonsensitive` will no longer return an error if you pass a value that isn't marked
+as sensitive, even though such a call may be redundant and potentially confusing
 or misleading to a future maintainer of your module. Use `nonsensitive` only
 after careful consideration and with definite intent.
 


### PR DESCRIPTION
Fixes #394

This is has also been posted to hashicorp/terraform, under PR 33856. Evidence of number of users affected is mentioned there.

The behaviour of nonsensitive in 1.5.x causes an error if nonsensitive is called on a value that is not marked as "sensitive".
The documentation at https://developer.hashicorp.com/terraform/language/functions/nonsensitive offers a rationale
> nonsensitive will return an error if you pass a value that isn't marked as sensitive, because such a call would be redundant and potentially confusing or misleading to a future maintainer of your module.

Other issues describe a set of situations where users are effectively locked into a situation where they can't use derivations of collections of objects where some fields are marked as sensitive into for_each, and are also unable to use nonsensitive because some of the values are indeed nonsensitive already. It also applies to arrays of elements where some are marked as sensitive while others are not.
In these hybrid situations, there doesn't seem to be an way to mark everything as nonsensitive.

Also, this behaviour is not consistent with that of sensitive, where sensitive can be applied to any value, regardless of whether it is already sensitive or not.

However, from the sheer amount of issues complaining about the implications of this decision, this well-intentioned decision is causing unintended pain.
The current behaviour is not only interfering with developer decision of determining what is and what isn't sensitive, but also doing that when there is not even a security risk (fields are already nonsensitive). The workarounds proposed force developers away from simpler and more straightforward solutions, more difficult to understand and maintain, without any tangible benefit in terms of security.

For this reason, this PR proposes that nonsensitive does what it is meant to do, which is to allow developers to mark fields as nonsensitive, leaving softer aspects of maintainability and maintainer confusion to be decided by each developer.

This PR should not cause breaking behaviours, as it is enabling a behaviour that wasn't allowed before.

## Target Release
1.5.x (hashicorp/terraform version equivalent)

## Draft CHANGELOG entry
- nonsensitive no longer produces error when applied to values that are not sensitive
BUG FIXES
- nonsensitive can now be used to remove sensitive from any element, regardless of it's original sensitivity flag.
