### PR TITLE
[Issue 364] Stop Consolidation of Warnings

### DIFF
--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -372,6 +372,10 @@ Options:
                          "-state". This can be used to preserve the old
                          state.
 
+  -verbose-warnings      If OpenTF produces any warnings, no compaction
+                         will be performed.  All locations, for all warnings
+                         will be listed.
+
   If you don't provide a saved plan file then this command will also accept
   all of the plan-customization options accepted by the tofu plan command.
   For more information on those options, run:

--- a/internal/command/arguments/view.go
+++ b/internal/command/arguments/view.go
@@ -13,6 +13,7 @@ type View struct {
 	// level of noise when multiple instances of the same warning are raised
 	// for a configuration.
 	CompactWarnings bool
+	VerboseWarnings bool
 }
 
 // ParseView processes CLI arguments, returning a View value and a
@@ -30,6 +31,8 @@ func ParseView(args []string) (*View, []string) {
 			common.NoColor = true
 		case "-compact-warnings":
 			common.CompactWarnings = true
+		case "-verbose-warnings":
+			common.VerboseWarnings = true
 		default:
 			// Unsupported argument: move left to the current position, and
 			// increment the index.

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -283,6 +283,10 @@ Other Options:
   -state=statefile           A legacy option used for the local backend only.
                              See the local backend's documentation for more
                              information.
+
+  -verbose-warnings          If OpenTF produces any warnings, no compaction
+                             will be performed.  All locations, for all warnings
+                             will be listed.
 `
 	return strings.TrimSpace(helpText)
 }

--- a/internal/command/refresh.go
+++ b/internal/command/refresh.go
@@ -219,6 +219,10 @@ Options:
                       a file. If "terraform.tfvars" or any ".auto.tfvars"
                       files are present, they will be automatically loaded.
 
+  -verbose-warnings   If OpenTF produces any warnings, no compaction
+                      will be performed.  All locations, for all warnings
+                      will be listed.
+
   -state, state-out, and -backup are legacy options supported for the local
   backend only. For more information, see the local backend's documentation.
 `

--- a/internal/command/views/view.go
+++ b/internal/command/views/view.go
@@ -19,6 +19,7 @@ type View struct {
 	colorize *colorstring.Colorize
 
 	compactWarnings bool
+	verboseWarnings bool
 
 	// When this is true it's a hint that Terraform is being run indirectly
 	// via a wrapper script or other automation and so we may wish to replace
@@ -68,6 +69,7 @@ func (v *View) RunningInAutomation() bool {
 func (v *View) Configure(view *arguments.View) {
 	v.colorize.Disable = view.NoColor
 	v.compactWarnings = view.CompactWarnings
+	v.verboseWarnings = view.VerboseWarnings
 }
 
 // SetConfigSources overrides the default no-op callback with a new function
@@ -79,13 +81,20 @@ func (v *View) SetConfigSources(cb func() map[string][]byte) {
 // Diagnostics renders a set of warnings and errors in human-readable form.
 // Warnings are printed to stdout, and errors to stderr.
 func (v *View) Diagnostics(diags tfdiags.Diagnostics) {
+	var warningCount int
+	warningCount = 1
+
 	diags.Sort()
 
 	if len(diags) == 0 {
 		return
 	}
 
-	diags = diags.ConsolidateWarnings(1)
+	if v.verboseWarnings {
+		warningCount = -1
+	}
+
+	diags = diags.ConsolidateWarnings(warningCount)
 
 	// Since warning messages are generally competing
 	if v.compactWarnings {

--- a/internal/tfdiags/consolidate_warnings.go
+++ b/internal/tfdiags/consolidate_warnings.go
@@ -46,7 +46,8 @@ func (diags Diagnostics) ConsolidateWarnings(threshold int) Diagnostics {
 			continue
 		}
 
-		if DoNotConsolidateDiagnostic(diag) {
+		// A threshold of -1 is unlimited
+		if DoNotConsolidateDiagnostic(diag) || threshold == -1 {
 			// Then do not consolidate this diagnostic.
 			newDiags = newDiags.Append(diag)
 			continue

--- a/internal/tfdiags/consolidate_warnings_test.go
+++ b/internal/tfdiags/consolidate_warnings_test.go
@@ -259,3 +259,63 @@ var _ DiagnosticExtraDoNotConsolidate = doNotConsolidate(true)
 func (d doNotConsolidate) DoNotConsolidateDiagnostic() bool {
 	return bool(d)
 }
+
+// when threshold is -1, we want unlimited (non-consolidated) results
+func TestConsolidateWarningsUnlimited(t *testing.T) {
+	var diags Diagnostics
+
+	// create a multiplicity of warnings; notice the subject and location differences
+	for i := 0; i < 3; i++ {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Summary:  "Warning 1",
+			Detail:   fmt.Sprintf("This one has a subject %d", i),
+			Subject: &hcl.Range{
+				Filename: "foo.tf",
+				Start:    hcl.Pos{Line: i*5 + 1, Column: 1, Byte: 0},
+				End:      hcl.Pos{Line: i*5 + 2, Column: 1, Byte: 0},
+			},
+		})
+	}
+
+	// We're using ForRPC here to force the diagnostics to be of a consistent
+	// type that we can easily assert against below.
+	got := diags.ConsolidateWarnings(-1).ForRPC()
+	want := Diagnostics{
+		// First set
+		&rpcFriendlyDiag{
+			Severity_: Warning,
+			Summary_:  "Warning 1",
+			Detail_:   "This one has a subject 0",
+			Subject_: &SourceRange{
+				Filename: "foo.tf",
+				Start:    SourcePos{Line: 1, Column: 1, Byte: 0},
+				End:      SourcePos{Line: 2, Column: 1, Byte: 0},
+			},
+		},
+		&rpcFriendlyDiag{
+			Severity_: Warning,
+			Summary_:  "Warning 1",
+			Detail_:   "This one has a subject 1",
+			Subject_: &SourceRange{
+				Filename: "foo.tf",
+				Start:    SourcePos{Line: 6, Column: 1, Byte: 0},
+				End:      SourcePos{Line: 7, Column: 1, Byte: 0},
+			},
+		},
+		&rpcFriendlyDiag{
+			Severity_: Warning,
+			Summary_:  "Warning 1",
+			Detail_:   "This one has a subject 2",
+			Subject_: &SourceRange{
+				Filename: "foo.tf",
+				Start:    SourcePos{Line: 11, Column: 1, Byte: 0},
+				End:      SourcePos{Line: 12, Column: 1, Byte: 0},
+			},
+		},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("wrong result\n%s", diff)
+	}
+}


### PR DESCRIPTION
Change:
add a flag to show all instances of similar warnings

Rationale:
Multiple instances of similar warnings are consolidated into one entry, with notation that there may be more.  This obscures the location of those additional warnings.  If one desires to change those warnings, one must iteratively fix them, rerunning the plan after each change, to get the tooling to show you these changes.

This new flag stops the consolidation.

Issue: https://github.com/opentffoundation/opentf/issues/364
Resolves #364

## Target Release

1.6.0

## Draft CHANGELOG entry

Add `-verbose-warnings` flag, optionally stopping the consolidation of similar warnings, instead listing the full details for every warning individually.

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

-  `opentf plan -verbose-warnings`: show details on all warnings.


### Example Output
```
$ opentf plan 
...
╷
│ Warning: Argument is deprecated
│ 
│   with aws_s3_bucket.b1,
│   on main.tf line 14, in resource "aws_s3_bucket" "b1":
│   14: resource "aws_s3_bucket" "b1" {
│ 
│ Use the aws_s3_bucket_versioning resource instead
│ 
│ (and 3 more similar warnings elsewhere)
╵
$ opentf plan -verbose-warnings
...
╷
│ Warning: Argument is deprecated
│ 
│   with aws_s3_bucket.b1,
│   on main.tf line 14, in resource "aws_s3_bucket" "b1":
│   14: resource "aws_s3_bucket" "b1" {
│ 
│ Use the aws_s3_bucket_versioning resource instead
╵
╷
│ Warning: Argument is deprecated
│ 
│   with aws_s3_bucket.b1,
│   on main.tf line 16, in resource "aws_s3_bucket" "b1":
│   16:   acl    = "private"
│ 
│ Use the aws_s3_bucket_acl resource instead
╵
╷
│ Warning: Argument is deprecated
│ 
│   with aws_s3_bucket.b2,
│   on main.tf line 23, in resource "aws_s3_bucket" "b2":
│   23: resource "aws_s3_bucket" "b2" {
│ 
│ Use the aws_s3_bucket_versioning resource instead
╵
╷
│ Warning: Argument is deprecated
│ 
│   with aws_s3_bucket.b2,
│   on main.tf line 25, in resource "aws_s3_bucket" "b2":
│   25:   acl    = "private"
│ 
│ Use the aws_s3_bucket_acl resource instead
╵
```