### PR TITLE
internal/states/statefile: TestReadErrNoState()

### DIFF
--- a/internal/states/statefile/read_test.go
+++ b/internal/states/statefile/read_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MPL-2.0
+
+package statefile
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestReadErrNoState_emptyFile(t *testing.T) {
+	emptyFile, err := os.Open("testdata/read/empty")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer emptyFile.Close()
+
+	_, err = Read(emptyFile)
+	if !errors.Is(err, ErrNoState) {
+		t.Fatalf("expected ErrNoState, got %T", err)
+	}
+}
+
+func TestReadErrNoState_nilFile(t *testing.T) {
+	nilFile, err := os.Open("")
+	if err == nil {
+		t.Fatal("wrongly succeeded in opening non-existent file")
+	}
+
+	_, err = Read(nilFile)
+	if !errors.Is(err, ErrNoState) {
+		t.Fatalf("expected ErrNoState, got %T", err)
+	}
+}


### PR DESCRIPTION
This adds `TestReadErrNoState()` to exercise the places where `Read()` can return an `ErrNoState` error.

There are no user-facing changes that warrant a CHANGELOG entry.

Fixes #594