### PR TITLE
internal/lang: wrap formatted errors

### DIFF
--- a/internal/lang/funcs/cidr.go
+++ b/internal/lang/funcs/cidr.go
@@ -36,7 +36,7 @@ var CidrHostFunc = function.New(&function.Spec{
 		}
 		_, network, err := ipaddr.ParseCIDR(args[0].AsString())
 		if err != nil {
-			return cty.UnknownVal(cty.String), fmt.Errorf("invalid CIDR expression: %s", err)
+			return cty.UnknownVal(cty.String), fmt.Errorf("invalid CIDR expression: %w", err)
 		}
 
 		ip, err := cidr.HostBig(network, hostNum)
@@ -62,7 +62,7 @@ var CidrNetmaskFunc = function.New(&function.Spec{
 	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
 		_, network, err := ipaddr.ParseCIDR(args[0].AsString())
 		if err != nil {
-			return cty.UnknownVal(cty.String), fmt.Errorf("invalid CIDR expression: %s", err)
+			return cty.UnknownVal(cty.String), fmt.Errorf("invalid CIDR expression: %w", err)
 		}
 
 		if network.IP.To4() == nil {
@@ -104,7 +104,7 @@ var CidrSubnetFunc = function.New(&function.Spec{
 
 		_, network, err := ipaddr.ParseCIDR(args[0].AsString())
 		if err != nil {
-			return cty.UnknownVal(cty.String), fmt.Errorf("invalid CIDR expression: %s", err)
+			return cty.UnknownVal(cty.String), fmt.Errorf("invalid CIDR expression: %w", err)
 		}
 
 		newNetwork, err := cidr.SubnetBig(network, newbits, netnum)

--- a/internal/lang/funcs/collection.go
+++ b/internal/lang/funcs/collection.go
@@ -456,7 +456,7 @@ var OneFunc = function.New(&function.Spec{
 				// It would be very strange to get here, because that would
 				// suggest that the length is either not a number or isn't
 				// an integer, which would suggest a bug in cty.
-				return cty.NilVal, fmt.Errorf("invalid collection length: %s", err)
+				return cty.NilVal, fmt.Errorf("invalid collection length: %w", err)
 			}
 			switch l {
 			case 0:

--- a/internal/lang/funcs/crypto.go
+++ b/internal/lang/funcs/crypto.go
@@ -65,7 +65,7 @@ var UUIDV5Func = function.New(&function.Spec{
 			namespace = uuidv5.NameSpaceX500
 		default:
 			if namespace, err = uuidv5.Parse(args[0].AsString()); err != nil {
-				return cty.UnknownVal(cty.String), fmt.Errorf("uuidv5() doesn't support namespace %s (%v)", args[0].AsString(), err)
+				return cty.UnknownVal(cty.String), fmt.Errorf("uuidv5() doesn't support namespace %s (%w)", args[0].AsString(), err)
 			}
 		}
 		val := args[1].AsString()
@@ -125,7 +125,7 @@ var BcryptFunc = function.New(&function.Spec{
 		input := args[0].AsString()
 		out, err := bcrypt.GenerateFromPassword([]byte(input), defaultCost)
 		if err != nil {
-			return cty.UnknownVal(cty.String), fmt.Errorf("error occurred generating password %s", err.Error())
+			return cty.UnknownVal(cty.String), fmt.Errorf("error occurred generating password %w", err)
 		}
 
 		return cty.StringVal(string(out)), nil
@@ -184,7 +184,7 @@ var RsaDecryptFunc = function.New(&function.Spec{
 
 		out, err := rsa.DecryptPKCS1v15(nil, privateKey, b)
 		if err != nil {
-			return cty.UnknownVal(cty.String), fmt.Errorf("failed to decrypt: %s", err)
+			return cty.UnknownVal(cty.String), fmt.Errorf("failed to decrypt: %w", err)
 		}
 
 		return cty.StringVal(string(out)), nil

--- a/internal/lang/funcs/datetime.go
+++ b/internal/lang/funcs/datetime.go
@@ -156,9 +156,7 @@ func parseTimestamp(ts string) (time.Time, error) {
 			// the timestamp portions by name rather than by Go's example
 			// values.
 			if err.LayoutElem == "" && err.ValueElem == "" && err.Message != "" {
-				// For some reason err.Message is populated with a ": " prefix
-				// by the time package.
-				return time.Time{}, fmt.Errorf("not a valid RFC3339 timestamp%s", err.Message)
+				return time.Time{}, fmt.Errorf("not a valid RFC3339 timestamp: %w", err)
 			}
 			var what string
 			switch err.LayoutElem {


### PR DESCRIPTION
This wraps the errors in `internal/lang` using the `%w` directive instead of `%v` or `%s`. I left the tests alone. 

I took extra care in this PR to use `opentf cnnsole` to verify that there were no visible changes to the error messages from the changed functions.

part of #395

There are no user-facing changes worthy of a CHANGELOG entry, unless tiny tweaks to log messages warrant such.