### PR TITLE
Fix HTML link in contribution guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,4 +37,4 @@ to [the main OpenTF CLI documentation](https://www.placeholderplaceholderplaceho
 
 ## Contribution Guides
 
-* [Contributing to OpenTF](../.github/CONTRIBUTING.md): a complete guideline for those who want to contribute to this project.
+* [Contributing to OpenTF](../CONTRIBUTING.md): a complete guideline for those who want to contribute to this project.


### PR DESCRIPTION

## Change
This PR fixes the HTML link in the documentation.

Part of [issue 443](https://github.com/opentffoundation/opentf/issues/443).

Resolves [issue 443](https://github.com/opentffoundation/opentf/issues/443).


## Target Release

N/A

This is a change to the documentation and no binary needs to be build.

## Draft CHANGELOG entry


###  BUG FIXES


- Fix HTML link in the documentation.
