### PR TITLE
fix: broken links in website

### DIFF
--- a/website/docs/intro/index.mdx
+++ b/website/docs/intro/index.mdx
@@ -54,6 +54,6 @@ Learn more about [OpenTF use cases](/docs/intro/use-cases) and [how OpenTF compa
 
 We welcome questions, suggestions, and contributions from the community.
 
-- Ask questions in [OpenTF Discuss](https://github.com/placeholderplaceholderplaceholder/opentf/discussions).
-- Read our [contributing guide](https://github.com/placeholderplaceholderplaceholder/opentf/blob/main/.github/CONTRIBUTING.md).
-- [Submit an issue](https://github.com/placeholderplaceholderplaceholder/opentf/issues/new/choose) for bugs and feature requests.
+- Ask questions in [OpenTF Discuss](https://github.com/orgs/opentofu/discussions).
+- Read our [contributing guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
+- [Submit an issue](https://github.com/opentofu/opentofu/issues) for bugs and feature requests.


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentffoundation/opentf/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #447 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `opentf show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTF now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Fix broken 404 links in the [website](https://opentofu.org/docs/intro/#community)
