### PR TITLE
backend/s3: add allowed/forbidden account_ids argument

### DIFF
--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -61,6 +61,16 @@ func (b *Backend) ConfigSchema() *configschema.Block {
 				Optional:    true,
 				Description: "AWS region of the S3 Bucket and DynamoDB Table (if used).",
 			},
+			"allowed_account_ids": {
+				Type:        cty.Set(cty.String),
+				Optional:    true,
+				Description: "List of allowed AWS account IDs.",
+			},
+			"forbidden_account_ids": {
+				Type:        cty.Set(cty.String),
+				Optional:    true,
+				Description: "List of forbidden AWS account IDs.",
+			},
 			"dynamodb_endpoint": {
 				Type:        cty.String,
 				Optional:    true,

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -732,6 +732,16 @@ func TestBackendConfig_PrepareConfigValidation(t *testing.T) {
 			}),
 			expectedErr: `Only one of "kms_key_id" and "sse_customer_key" can be set`,
 		},
+		"allowed forbidden ids conflict": {
+			config: cty.ObjectVal(map[string]cty.Value{
+				"bucket":                cty.StringVal("test"),
+				"key":                   cty.StringVal("test"),
+				"region":                cty.StringVal("us-west-2"),
+				"allowed_account_ids":   cty.SetVal([]cty.Value{cty.StringVal("012345678901")}),
+				"forbidden_account_ids": cty.SetVal([]cty.Value{cty.StringVal("012345678901")}),
+			}),
+			expectedErr: `Only one of allowed_accound_ids, forbidden_account_ids can be set`,
+		},
 	}
 
 	for name, tc := range cases {

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -158,6 +158,8 @@ The following configuration is required:
 The following configuration is optional:
 
 * `access_key` - (Optional) AWS access key. If configured, must also configure `secret_key`. This can also be sourced from the `AWS_ACCESS_KEY_ID` environment variable, AWS shared credentials file (e.g. `~/.aws/credentials`), or AWS shared configuration file (e.g. `~/.aws/config`).
+* `allowed_account_ids` - (Optional) List of allowed AWS account IDs to prevent potential destruction of a live environment. Conflicts with `forbidden_account_ids`.
+* `forbidden_account_ids` - (Optional) List of forbidden AWS account IDs to prevent potential destruction of a live environment. Conflicts with `allowed_account_ids`.
 * `secret_key` - (Optional) AWS access key. If configured, must also configure `access_key`. This can also be sourced from the `AWS_SECRET_ACCESS_KEY` environment variable, AWS shared credentials file (e.g. `~/.aws/credentials`), or AWS shared configuration file (e.g. `~/.aws/config`).
 * `iam_endpoint` - (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API. This can also be sourced from the `AWS_IAM_ENDPOINT` environment variable.
 * `max_retries` - (Optional) The maximum number of times an AWS API request is retried on retryable failure. Defaults to 5.


### PR DESCRIPTION
Adds `allowed_account_ids` and `forbidden_account_ids` parameters as convenience helpers to prevent unintended modifications to certain environments.

Fix https://github.com/opentofu/opentofu/issues/489

Enhancements

- `allowed_account_ids` and `forbidden_account_ids` arguments to prevent unintended modifications to specified environments.