### PR TITLE
rename opentf to opentofu - internal/getproviders

### DIFF
--- a/internal/getproviders/errors.go
+++ b/internal/getproviders/errors.go
@@ -30,9 +30,9 @@ type ErrHostNoProviders struct {
 func (err ErrHostNoProviders) Error() string {
 	switch {
 	case err.HasOtherVersion:
-		return fmt.Sprintf("host %s does not support the provider registry protocol required by this OpenTF version, but may be compatible with a different OpenTF version", err.Hostname.ForDisplay())
+		return fmt.Sprintf("host %s does not support the provider registry protocol required by this OpenTofu version, but may be compatible with a different OpenTofu version", err.Hostname.ForDisplay())
 	default:
-		return fmt.Sprintf("host %s does not offer a OpenTF provider registry", err.Hostname.ForDisplay())
+		return fmt.Sprintf("host %s does not offer a OpenTofu provider registry", err.Hostname.ForDisplay())
 	}
 }
 
@@ -168,7 +168,7 @@ type ErrProtocolNotSupported struct {
 
 func (err ErrProtocolNotSupported) Error() string {
 	return fmt.Sprintf(
-		"provider %s %s is not supported by this version of OpenTF",
+		"provider %s %s is not supported by this version of OpenTofu",
 		err.Provider,
 		err.Version,
 	)

--- a/internal/getproviders/hash.go
+++ b/internal/getproviders/hash.go
@@ -200,7 +200,7 @@ func PackageMatchesHash(loc PackageLocation, want Hash) (bool, error) {
 		}
 		return got == want, nil
 	default:
-		return false, fmt.Errorf("unsupported hash format (this may require a newer version of OpenTF)")
+		return false, fmt.Errorf("unsupported hash format (this may require a newer version of OpenTofu)")
 	}
 }
 

--- a/internal/getproviders/package_authentication.go
+++ b/internal/getproviders/package_authentication.go
@@ -29,7 +29,7 @@ const (
 )
 
 const (
-	enforceGPGValidationEnvName = "OPENTF_ENFORCE_GPG_VALIDATION"
+	enforceGPGValidationEnvName = "OPENTOFU_ENFORCE_GPG_VALIDATION"
 )
 
 var (
@@ -222,7 +222,7 @@ func (a packageHashAuthentication) AuthenticatePackage(localLocation PackageLoca
 		// Indicates that none of the hashes given to
 		// NewPackageHashAuthentication were considered to be usable by this
 		// version of Terraform.
-		return nil, fmt.Errorf("this version of OpenTF does not support any of the checksum formats given for this provider")
+		return nil, fmt.Errorf("this version of OpenTofu does not support any of the checksum formats given for this provider")
 	}
 
 	matches, err := PackageMatchesAnyHash(localLocation, a.RequiredHashes)
@@ -412,7 +412,7 @@ func (s signatureAuthentication) AuthenticatePackage(location PackageLocation) (
 	if !shouldValidate {
 		// As this is a temporary measure, we will log a warning to the user making it very clear what is happening
 		// and why. This will be removed in a future release.
-		log.Printf("[WARN] Skipping GPG validation of provider package %s as no keys were provided by the registry. See https://github.com/opentffoundation/opentf/pull/309 for more information.", location)
+		log.Printf("[WARN] Skipping GPG validation of provider package %s as no keys were provided by the registry. See https://github.com/opentofu/opentofu/pull/309 for more information.", location)
 
 		// construct an empty keyID to indicate that we are not validating and return no errors
 		// this is to force a successful authentication

--- a/internal/getproviders/registry_source_test.go
+++ b/internal/getproviders/registry_source_test.go
@@ -48,12 +48,12 @@ func TestSourceAvailableVersions(t *testing.T) {
 		{
 			"not.example.com/foo/bar",
 			nil,
-			`host not.example.com does not offer a OpenTF provider registry`,
+			`host not.example.com does not offer a OpenTofu provider registry`,
 		},
 		{
 			"too-new.example.com/foo/bar",
 			nil,
-			`host too-new.example.com does not support the provider registry protocol required by this OpenTF version, but may be compatible with a different OpenTF version`,
+			`host too-new.example.com does not support the provider registry protocol required by this OpenTofu version, but may be compatible with a different OpenTofu version`,
 		},
 		{
 			"fails.example.com/foo/bar",
@@ -176,7 +176,7 @@ func TestSourcePackageMeta(t *testing.T) {
 			"linux", "amd64",
 			PackageMeta{},
 			nil,
-			`host not.example.com does not offer a OpenTF provider registry`,
+			`host not.example.com does not offer a OpenTofu provider registry`,
 		},
 		{
 			"too-new.example.com/awesomesauce/happycloud",
@@ -184,7 +184,7 @@ func TestSourcePackageMeta(t *testing.T) {
 			"linux", "amd64",
 			PackageMeta{},
 			nil,
-			`host too-new.example.com does not support the provider registry protocol required by this OpenTF version, but may be compatible with a different OpenTF version`,
+			`host too-new.example.com does not support the provider registry protocol required by this OpenTofu version, but may be compatible with a different OpenTofu version`,
 		},
 		{
 			"fails.example.com/awesomesauce/happycloud",


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentffoundation/opentf/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #490

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `opentf show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTF now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
