### PR TITLE
Updated the copyright notice in LICENSE.md

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
-Copyright (c) 2014 HashiCorp, Inc.
+Copyright (c) 2014-2023 HashiCorp, Inc.
+Copyright (c) 2023- OpenTofu contributors
 
 Mozilla Public License, version 2.0
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentffoundation/opentf/blob/main/CONTRIBUTING.md

-->

Resolves #454

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.0

## CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### UPGRADE NOTES 

<!--

Write a short description of the user-facing change. Examples:

- `opentf show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTF now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Changed the copyright notice in LICENSE.md from  `Copyright (c) 2014 HashiCorp, Inc.` to 
```
Copyright (c) 2014-2023 HashiCorp, Inc.
Copyright (c) 2023- OpenTofu contributors
```
