### PR TITLE
internal/command: wrap formatted errors

### DIFF
--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -823,7 +823,7 @@ func (m *Meta) checkRequiredVersion() tfdiags.Diagnostics {
 
 	pwd, err := os.Getwd()
 	if err != nil {
-		diags = diags.Append(fmt.Errorf("Error getting pwd: %s", err))
+		diags = diags.Append(fmt.Errorf("Error getting pwd: %w", err))
 		return diags
 	}
 

--- a/internal/command/meta_config.go
+++ b/internal/command/meta_config.go
@@ -191,7 +191,7 @@ func (m *Meta) installModules(ctx context.Context, rootDir, testsDir string, upg
 
 	err := os.MkdirAll(m.modulesDir(), os.ModePerm)
 	if err != nil {
-		diags = diags.Append(fmt.Errorf("failed to create local modules directory: %s", err))
+		diags = diags.Append(fmt.Errorf("failed to create local modules directory: %w", err))
 		return true, diags
 	}
 
@@ -294,7 +294,7 @@ func (m *Meta) inputForSchema(given cty.Value, schema *configschema.Block) (cty.
 			val := cty.StringVal(strVal)
 			val, err = convert.Convert(val, attrS.Type)
 			if err != nil {
-				m.showDiagnostics(fmt.Errorf("Invalid value: %s", err))
+				m.showDiagnostics(fmt.Errorf("Invalid value: %w", err))
 				continue
 			}
 

--- a/internal/command/output.go
+++ b/internal/command/output.go
@@ -74,14 +74,14 @@ func (c *OutputCommand) Outputs(statePath string) (map[string]*states.OutputValu
 
 	env, err := c.Workspace()
 	if err != nil {
-		diags = diags.Append(fmt.Errorf("Error selecting workspace: %s", err))
+		diags = diags.Append(fmt.Errorf("Error selecting workspace: %w", err))
 		return nil, diags
 	}
 
 	// Get the state
 	stateStore, err := b.StateMgr(env)
 	if err != nil {
-		diags = diags.Append(fmt.Errorf("Failed to load state: %s", err))
+		diags = diags.Append(fmt.Errorf("Failed to load state: %w", err))
 		return nil, diags
 	}
 

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -164,7 +164,7 @@ func (c *PlanCommand) OperationRequest(
 	var err error
 	opReq.ConfigLoader, err = c.initConfigLoader()
 	if err != nil {
-		diags = diags.Append(fmt.Errorf("Failed to initialize config loader: %s", err))
+		diags = diags.Append(fmt.Errorf("Failed to initialize config loader: %w", err))
 		return nil, diags
 	}
 

--- a/internal/command/refresh.go
+++ b/internal/command/refresh.go
@@ -150,7 +150,7 @@ func (c *RefreshCommand) OperationRequest(be backend.Enhanced, view views.Refres
 	var err error
 	opReq.ConfigLoader, err = c.initConfigLoader()
 	if err != nil {
-		diags = diags.Append(fmt.Errorf("Failed to initialize config loader: %s", err))
+		diags = diags.Append(fmt.Errorf("Failed to initialize config loader: %w", err))
 		return nil, diags
 	}
 

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -69,7 +69,7 @@ func (c *ShowCommand) Run(rawArgs []string) int {
 	// Check for user-supplied plugin path
 	var err error
 	if c.pluginPath, err = c.loadPluginPath(); err != nil {
-		diags = diags.Append(fmt.Errorf("error loading plugin path: %s", err))
+		diags = diags.Append(fmt.Errorf("error loading plugin path: %w", err))
 		view.Diagnostics(diags)
 		return 1
 	}
@@ -160,7 +160,7 @@ func (c *ShowCommand) showFromLatestStateSnapshot() (*statefile.File, tfdiags.Di
 	// Load the workspace
 	workspace, err := c.Workspace()
 	if err != nil {
-		diags = diags.Append(fmt.Errorf("error selecting workspace: %s", err))
+		diags = diags.Append(fmt.Errorf("error selecting workspace: %w", err))
 		return nil, diags
 	}
 

--- a/internal/command/validate.go
+++ b/internal/command/validate.go
@@ -44,13 +44,13 @@ func (c *ValidateCommand) Run(rawArgs []string) int {
 
 	dir, err := filepath.Abs(args.Path)
 	if err != nil {
-		diags = diags.Append(fmt.Errorf("unable to locate module: %s", err))
+		diags = diags.Append(fmt.Errorf("unable to locate module: %w", err))
 		return view.Results(diags)
 	}
 
 	// Check for user-supplied plugin path
 	if c.pluginPath, err = c.loadPluginPath(); err != nil {
-		diags = diags.Append(fmt.Errorf("error loading plugin path: %s", err))
+		diags = diags.Append(fmt.Errorf("error loading plugin path: %w", err))
 		return view.Results(diags)
 	}
 


### PR DESCRIPTION
This wraps the errors in internal/lang using the `%w` directive instead of `%v` or `%s`. I left the tests alone.

Part of #395 

There are no user-facing changes worthy of a CHANGELOG entry, unless tiny tweaks to log messages warrant such.