### PR TITLE
Rename GitHub settings to OpenTofu

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,7 +10,7 @@ body:
       value: |
         # Thank you for opening an issue.
 
-        The [OpenTF](https://github.com/opentffoundation/opentf) issue tracker is reserved for bug reports relating to the core OpenTF CLI application and configuration language.
+        The [OpenTofu](https://github.com/opentofu/opentofu) issue tracker is reserved for bug reports relating to the core OpenTofu CLI application and configuration language.
 
         ## Filing a bug report
 
@@ -19,16 +19,16 @@ body:
         * A short example can be directly copy-pasteable; longer examples should be in separate git repositories, especially if multiple files are needed
         * Please include all needed context. For example, if you figured out that an expression can cause a crash, put the expression in a variable definition or a resource
         * Set defaults on (or omit) any variables. The person reproducing it should not need to invent variable settings
-        * If multiple steps are required, such as running opentf twice, consider scripting it in a simple shell script. Providing a script can be easier than explaining what changes to make to the config between runs.
+        * If multiple steps are required, such as running tofu twice, consider scripting it in a simple shell script. Providing a script can be easier than explaining what changes to make to the config between runs.
         * Omit any unneeded complexity: remove variables, conditional statements, functions, modules, providers, and resources that are not needed to trigger the bug
 
   - type: textarea
     id: tf-version
     attributes:
-      label: OpenTF Version
-      description: Run `opentf version` to show the version, and paste the result below. If you are not running the latest version of OpenTF, please try upgrading because your issue may have already been fixed.
+      label: OpenTofu Version
+      description: Run `tofu version` to show the version, and paste the result below. If you are not running the latest version of OpenTofu, please try upgrading because your issue may have already been fixed.
       render: shell
-      placeholder: ...output of `opentf version`...
+      placeholder: ...output of `tofu version`...
       value:
     validations:
       required: true
@@ -36,12 +36,12 @@ body:
   - type: textarea
     id: tf-config
     attributes:
-      label: OpenTF Configuration Files
-      description: Paste the relevant parts of your OpenTF configuration between the ``` marks below. For OpenTF configs larger than a few resources, or that involve multiple files, please make a GitHub repository that we can clone, rather than copy-pasting multiple files in here.
+      label: OpenTofu Configuration Files
+      description: Paste the relevant parts of your OpenTofu configuration between the ``` marks below. For OpenTofu configs larger than a few resources, or that involve multiple files, please make a GitHub repository that we can clone, rather than copy-pasting multiple files in here.
       placeholder:
       value: |
         ```hcl
-        ...opentf config...
+        ...tofu config...
         ```
     validations:
       required: true
@@ -50,7 +50,7 @@ body:
     id: tf-debug
     attributes:
       label: Debug Output
-      description: Full debug output can be obtained by running OpenTF with the environment variable `TF_LOG=trace`. Please create a GitHub Gist containing the debug output. Please do _not_ paste the debug output in the issue, since debug output is long. Debug output may contain sensitive information. Please review it before posting publicly.
+      description: Full debug output can be obtained by running OpenTofu with the environment variable `TF_LOG=trace`. Please create a GitHub Gist containing the debug output. Please do _not_ paste the debug output in the issue, since debug output is long. Debug output may contain sensitive information. Please review it before posting publicly.
       placeholder: ...link to gist...
       value:
     validations:
@@ -79,11 +79,11 @@ body:
       label: Steps to Reproduce
       description: |
         Please list the full steps required to reproduce the issue, for example:
-          1. `opentf init`
-          2. `opentf apply`
+          1. `tofu init`
+          2. `tofu apply`
       placeholder: |
-        1. `opentf init`
-        2. `opentf apply`
+        1. `tofu init`
+        2. `tofu apply`
       value:
     validations:
       required: true
@@ -93,7 +93,7 @@ body:
       label: Additional Context
       description: |
         Are there anything atypical about your situation that we should know?
-        For example: is OpenTF running in a wrapper script or in a CI system? Are you passing any unusual command line options or environment variables to opt-in to non-default behavior?"
+        For example: is OpenTofu running in a wrapper script or in a CI system? Are you passing any unusual command line options or environment variables to opt-in to non-default behavior?"
       placeholder: Additional context...
       value:
     validations:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -13,10 +13,10 @@ body:
   - type: textarea
     id: tf-version
     attributes:
-      label: OpenTF Version
-      description: Run `opentf version` to show the version, and paste the result below. If you're not using the latest version, please check to see if something related to your request has already been implemented in a later version.
+      label: OpenTofu Version
+      description: Run `tofu version` to show the version, and paste the result below. If you're not using the latest version, please check to see if something related to your request has already been implemented in a later version.
       render: shell
-      placeholder: ...output of `opentf version`...
+      placeholder: ...output of `tofu version`...
       value:
     validations:
       required: true
@@ -39,8 +39,8 @@ body:
     attributes:
       label: Attempted Solutions
       description: |
-          If you've already tried to solve the problem within OpenTF's existing features and found a limitation that prevented you from succeeding, please describe it below in as much detail as possible.
-          Ideally, this would include real configuration snippets that you tried, real OpenTF command lines you ran, and what results you got in each case.
+          If you've already tried to solve the problem within OpenTofu's existing features and found a limitation that prevented you from succeeding, please describe it below in as much detail as possible.
+          Ideally, this would include real configuration snippets that you tried, real OpenTofu command lines you ran, and what results you got in each case.
           Please remove any sensitive information such as passwords before sharing configuration snippets and command lines.
       placeholder:
       value:
@@ -52,9 +52,9 @@ body:
     attributes:
       label: Proposal
       description: |
-          If you have an idea for a way to address the problem via a change to OpenTF features, please describe it below.
+          If you have an idea for a way to address the problem via a change to OpenTofu features, please describe it below.
           In this section, it's helpful to include specific examples of how what you are suggesting might look in configuration files, or on the command line, since that allows us to understand the full picture of what you are proposing.
-          If you're not sure of some details, don't worry! When we evaluate the feature request we may suggest modifications as necessary to work within the design constraints of OpenTF Core.
+          If you're not sure of some details, don't worry! When we evaluate the feature request we may suggest modifications as necessary to work within the design constraints of OpenTofu Core.
       placeholder:
       value:
     validations:

--- a/.github/ISSUE_TEMPLATE/rfc.yml
+++ b/.github/ISSUE_TEMPLATE/rfc.yml
@@ -9,7 +9,7 @@ body:
       value: |
         Thank you for opening an RFC!
         
-        RFCs are a highly-structured format for submitting change requests. All major changes to OpenTF should first go through an RFC, to have a place for the community to discuss.
+        RFCs are a highly-structured format for submitting change requests. All major changes to OpenTofu should first go through an RFC, to have a place for the community to discuss.
         
         The template has a lot of fields and is inspired by the Rust RFC template. Please take your time to fill it out carefully.
         
@@ -58,7 +58,7 @@ body:
       label: Technical Description
       description: |
         Please describe in detail how the feature would work from a technical perspective:
-          - Which components of OpenTF would be involved in the change?
+          - Which components of OpenTofu would be involved in the change?
           - How would the components need to change?
           - Are there any interactions with other features that should be mentioned?
           - Are the any edge cases of the feature that should be discussed?
@@ -74,7 +74,7 @@ body:
       description: |
         - What would be the impact of this feature?
         - Why is this solution better than alternative solutions to this problem, if there are any?
-        - How would the OpenTF user experience suffer if we didn't do this.
+        - How would the OpenTofu user experience suffer if we didn't do this.
       placeholder:
       value:
     validations:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@ Describe in detail the changes you are proposing, and the rationale.
 
 See the contributing guide:
 
-https://github.com/opentffoundation/opentf/blob/main/CONTRIBUTING.md
+https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md
 
 -->
 
@@ -48,8 +48,8 @@ Choose a category, delete the others:
 
 Write a short description of the user-facing change. Examples:
 
-- `opentf show -json`: Fixed crash with sensitive set values.
-- When rendering a diff, OpenTF now quotes the name of any object attribute whose string representation is not a valid identifier.
+- `tofu show -json`: Fixed crash with sensitive set values.
+- When rendering a diff, OpenTofu now quotes the name of any object attribute whose string representation is not a valid identifier.
 - The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.
 
 --> 

--- a/.github/scripts/e2e_test_linux_darwin.sh
+++ b/.github/scripts/e2e_test_linux_darwin.sh
@@ -7,12 +7,12 @@ set -uo pipefail
 if [[ $arch == 'arm' || $arch == 'arm64' ]]
 then
     export DIR=$(mktemp -d)
-    unzip -d $DIR "${e2e_cache_path}/opentf-e2etest_${os}_${arch}.zip"
-    unzip -d $DIR "./opentf_${version}_${os}_${arch}.zip"
+    unzip -d $DIR "${e2e_cache_path}/opentofu-e2etest_${os}_${arch}.zip"
+    unzip -d $DIR "./opentofu_${version}_${os}_${arch}.zip"
     sudo chmod +x $DIR/e2etest
     docker run --platform=linux/arm64 -v $DIR:/src -w /src arm64v8/alpine ./e2etest -test.v
 else
-    unzip "${e2e_cache_path}/opentf-e2etest_${os}_${arch}.zip"
-    unzip "./opentf_${version}_${os}_${arch}.zip"
+    unzip "${e2e_cache_path}/opentofu-e2etest_${os}_${arch}.zip"
+    unzip "./opentofu_${version}_${os}_${arch}.zip"
     TF_ACC=1 ./e2etest -test.v
 fi

--- a/.github/scripts/equivalence-test.sh
+++ b/.github/scripts/equivalence-test.sh
@@ -10,7 +10,7 @@ Usage: ./equivalence-test.sh <command> [<args>] [<options>]
 
 Description:
   This script will handle various commands related to the execution of the
-  opentf equivalence tests.
+  tofu equivalence tests.
 
 Commands:
   download_equivalence_test_binary <version> <target> <os> <arch>
@@ -35,7 +35,7 @@ function download_equivalence_test_binary {
 
   curl \
     -H "Accept: application/vnd.github+json" \
-    "https://api.github.com/repos/opentffoundation/equivalence-testing/releases" > releases.json
+    "https://api.github.com/repos/opentofu/equivalence-testing/releases" > releases.json
 
   ASSET="equivalence-testing_v${VERSION}_${OS}_${ARCH}.zip"
   ASSET_ID=$(jq -r --arg VERSION "v$VERSION" --arg ASSET "$ASSET" '.[] | select(.name == $VERSION) | .assets[] | select(.name == $ASSET) | .id' releases.json)
@@ -43,7 +43,7 @@ function download_equivalence_test_binary {
   mkdir -p zip
   curl -L \
     -H "Accept: application/octet-stream" \
-    "https://api.github.com/repos/opentffoundation/equivalence-testing/releases/assets/$ASSET_ID" > "zip/$ASSET"
+    "https://api.github.com/repos/opentofu/equivalence-testing/releases/assets/$ASSET_ID" > "zip/$ASSET"
 
   mkdir -p bin
   unzip -p "zip/$ASSET" equivalence-testing > "$TARGET"

--- a/.github/scripts/get_product_version.sh
+++ b/.github/scripts/get_product_version.sh
@@ -30,7 +30,7 @@ LDFLAGS="${LDFLAGS} -X 'main.experimentsAllowed=yes'"
 fi
 LDFLAGS="${LDFLAGS} -X 'github.com/opentofu/opentofu/version.dev=no'"
 
-echo "Building OpenTF CLI ${VERSION}"
+echo "Building OpenTofu CLI ${VERSION}"
 if [[ "$EXPERIMENTS_ENABLED" == 1 ]]; then
 echo "This build allows use of experimental features"
 fi

--- a/.github/workflows/build-Dockerfile
+++ b/.github/workflows/build-Dockerfile
@@ -4,7 +4,7 @@
 #
 # If you want to test this locally you'll need to set the three arguments
 # to values realistic for what the hashicorp/actions-docker-build GitHub
-# action would set, and ensure that there's a suitable "opentf" executable
+# action would set, and ensure that there's a suitable "tofu" executable
 # in the dist/linux/${TARGETARCH} directory.
 
 FROM docker.mirror.hashicorp.services/alpine:latest AS default
@@ -13,21 +13,21 @@ FROM docker.mirror.hashicorp.services/alpine:latest AS default
 # action, which sets these appropriately based on context.
 ARG PRODUCT_VERSION=UNSPECIFIED
 ARG PRODUCT_REVISION=UNSPECIFIED
-ARG BIN_NAME=opentf
+ARG BIN_NAME=tofu
 
 # This argument is set by the Docker toolchain itself, to the name
 # of the CPU architecture we're building an image for.
-# Our caller should've extracted the corresponding "opentf" executable
+# Our caller should've extracted the corresponding "tofu" executable
 # into dist/linux/${TARGETARCH} for us to use.
 ARG TARGETARCH
 
-LABEL maintainer="OpenTF Team"
+LABEL maintainer="OpenTofu Team"
 
 # New standard version label.
 LABEL version=$PRODUCT_VERSION
 
-# Historical OpenTF-specific label preserved for backward compatibility.
-LABEL "com.opentf.version"="${PRODUCT_VERSION}"
+# Historical OpenTofu-specific label preserved for backward compatibility.
+LABEL "com.tofu.version"="${PRODUCT_VERSION}"
 
 RUN apk add --no-cache git openssh
 
@@ -36,6 +36,6 @@ RUN apk add --no-cache git openssh
 # directory before running "docker build", which we'll then copy into the
 # Docker image to make sure that we use an identical binary as all of the
 # other official release channels.
-COPY ["dist/linux/${TARGETARCH}/opentf", "/bin/opentf"]
+COPY ["dist/linux/${TARGETARCH}/tofu", "/bin/tofu"]
 
-ENTRYPOINT ["/bin/opentf"]
+ENTRYPOINT ["/bin/tofu"]

--- a/.github/workflows/build-opentf-oss.yml
+++ b/.github/workflows/build-opentf-oss.yml
@@ -1,9 +1,9 @@
 ---
-name: build_opentf
+name: build_opentofu
 
 # This workflow is intended to be called by the build workflow. The crt make
 # targets that are utilized automatically determine build metadata and
-# handle building and packing OpenTF.
+# handle building and packing OpenTofu.
 
 on:
   workflow_call:
@@ -22,7 +22,7 @@ on:
         type: string
       package-name:
         type: string
-        default: opentf
+        default: opentofu
       product-version:
         type: string
         required: true
@@ -36,7 +36,7 @@ on:
 jobs:
   build:
     runs-on: ${{ inputs.runson }}
-    name: OpenTF ${{ inputs.goos }} ${{ inputs.goarch }} v${{ inputs.product-version }}
+    name: OpenTofu ${{ inputs.goos }} ${{ inputs.goarch }} v${{ inputs.product-version }}
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
@@ -44,7 +44,7 @@ jobs:
           go-version: ${{ inputs.go-version }}
       - name: Determine artifact basename
         run: echo "ARTIFACT_BASENAME=${{ inputs.package-name }}_${{ inputs.product-version }}_${{ inputs.goos }}_${{ inputs.goarch }}.zip" >> $GITHUB_ENV
-      - name: Build OpenTF
+      - name: Build OpenTofu
         env:
           GOOS: ${{ inputs.goos }}
           GOARCH: ${{ inputs.goarch }}
@@ -72,14 +72,14 @@ jobs:
       - if: ${{ inputs.goos == 'linux' }}
         uses: hashicorp/actions-packaging-linux@v1
         with:
-          name: "opentf"
-          description: "OpenTF enables you to safely and predictably create, change, and improve infrastructure. It is an open source tool that codifies APIs into declarative configuration files that can be shared amongst team members, treated as code, edited, reviewed, and versioned."
+          name: "opentofu"
+          description: "OpenTofu enables you to safely and predictably create, change, and improve infrastructure. It is an open source tool that codifies APIs into declarative configuration files that can be shared amongst team members, treated as code, edited, reviewed, and versioned."
           arch: ${{ inputs.goarch }}
           version: ${{ inputs.product-version }}
           maintainer: "HashiCorp"
-          homepage: "https://opentf.org/"
+          homepage: "https://opentofu.org/"
           license: "MPL-2.0"
-          binary: "dist/opentf"
+          binary: "dist/tofu"
           deb_depends: "git"
           rpm_depends: "git"
       - if: ${{ inputs.goos == 'linux' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 env:
-  PKG_NAME: "opentf"
+  PKG_NAME: "opentofu"
 
 permissions:
   contents: read
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   get-product-version:
-    name: "Determine intended OpenTF version"
+    name: "Determine intended OpenTofu version"
     runs-on: ubuntu-latest
     outputs:
       product-version: ${{ steps.get-product-version.outputs.product-version }}
@@ -53,7 +53,7 @@ jobs:
       - name: Report chosen version number
         run: |
           [ -n "${{steps.get-product-version.outputs.product-version}}" ]
-          echo "::notice title=OpenTF CLI Version::${{ steps.get-product-version.outputs.product-version }}"
+          echo "::notice title=OpenTofu CLI Version::${{ steps.get-product-version.outputs.product-version }}"
 
   get-go-version:
     name: "Determine Go toolchain version"
@@ -93,7 +93,7 @@ jobs:
     needs:
       - get-product-version
       - get-go-version
-    uses: ./.github/workflows/build-opentf-oss.yml
+    uses: ./.github/workflows/build-opentofu-oss.yml
     with:
       goarch: ${{ matrix.goarch }}
       goos: ${{ matrix.goos }}
@@ -134,16 +134,16 @@ jobs:
         arch: ["amd64", "386", "arm", "arm64"]
       fail-fast: false
     env:
-      repo: "opentf"
+      repo: "opentofu"
       version: ${{needs.get-product-version.outputs.product-version}}
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Build Docker images
         uses: hashicorp/actions-docker-build@v1
         with:
-          pkg_name: "opentf_${{env.version}}"
+          pkg_name: "opentofu_${{env.version}}"
           version: ${{env.version}}
-          bin_name: opentf
+          bin_name: tofu
           target: default
           arch: ${{matrix.arch}}
           dockerfile: .github/workflows/build-Dockerfile
@@ -201,7 +201,7 @@ jobs:
           # NOTE: This script reacts to the GOOS, GOARCH, and GO_LDFLAGS
           # environment variables defined above. The e2e test harness
           # needs to know the version we're building for so it can verify
-          # that "opentf version" is returning that version number.
+          # that "tofu version" is returning that version number.
           bash ./internal/command/e2etest/make-archive.sh
 
       - name: Save test harness to cache
@@ -252,17 +252,17 @@ jobs:
           key: ${{ needs.e2etest-build.outputs.e2e-cache-key }}_${{ matrix.goos }}_${{ matrix.goarch }}
           fail-on-cache-miss: true
           enableCrossOsArchive: true
-      - name: "Download OpenTF CLI package"
+      - name: "Download OpenTofu CLI package"
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         id: clipkg
         with:
-          name: opentf_${{env.version}}_${{ env.os }}_${{ env.arch }}.zip
+          name: opentofu_${{env.version}}_${{ env.os }}_${{ env.arch }}.zip
           path: .
       - name: Extract packages
         if: ${{ matrix.goos == 'windows' }}
         run: |
-          unzip "${{ needs.e2etest-build.outputs.e2e-cache-path }}/opentf-e2etest_${{ env.os }}_${{ env.arch }}.zip"
-          unzip "./opentf_${{env.version}}_${{ env.os }}_${{ env.arch }}.zip"
+          unzip "${{ needs.e2etest-build.outputs.e2e-cache-path }}/tofu-e2etest_${{ env.os }}_${{ env.arch }}.zip"
+          unzip "./opentofu_${{env.version}}_${{ env.os }}_${{ env.arch }}.zip"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2.2.0
         if: ${{ contains(matrix.goarch, 'arm') }}
@@ -284,7 +284,7 @@ jobs:
 
 
   e2e-test-exec:
-    name: Run opentf-exec test for linux amd64
+    name: Run tofu-exec test for linux amd64
     runs-on: ubuntu-latest
     needs:
       - get-product-version
@@ -301,21 +301,21 @@ jobs:
         uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
-      - name: Download OpenTF CLI package
+      - name: Download OpenTofu CLI package
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         id: clipkg
         with:
-          name: opentf_${{ env.version }}_linux_amd64.zip
+          name: opentofu_${{ env.version }}_linux_amd64.zip
           path: .
-      - name: Checkout opentf-exec repo
+      - name: Checkout tofu-exec repo
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           repository: hashicorp/terraform-exec
-          path: opentf-exec
-      - name: Run opentf-exec end-to-end tests
+          path: tofu-exec
+      - name: Run tofu-exec end-to-end tests
         run: |
           FULL_RELEASE_VERSION="${{ env.version }}"
-          unzip opentf_${FULL_RELEASE_VERSION}_linux_amd64.zip
-          export TFEXEC_E2ETEST_TERRAFORM_PATH="$(pwd)/opentf"
-          cd opentf-exec
+          unzip opentofu_${FULL_RELEASE_VERSION}_linux_amd64.zip
+          export TFEXEC_E2ETEST_TERRAFORM_PATH="$(pwd)/tofu"
+          cd tofu-exec
           go test -race -timeout=30m -v ./tfexec/internal/e2etest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -100,7 +100,7 @@ jobs:
 
   e2e-tests:
     # This is an intentionally-limited form of our E2E test run which only
-    # covers OpenTF running on Linux. The build.yml workflow runs these
+    # covers OpenTofu running on Linux. The build.yml workflow runs these
     # tests across various other platforms in order to catch the rare exception
     # that might leak through this.
     name: "End-to-end Tests"

--- a/.github/workflows/compare-snapshots.yml
+++ b/.github/workflows/compare-snapshots.yml
@@ -30,9 +30,9 @@ jobs:
             linux \
             amd64
 
-      - name: Build the OpenTF binary
+      - name: Build the OpenTofu binary
         run: |
-          go build -o ./bin/opentf
+          go build -o ./bin/tofu
 
       - name: Run the equivalence tests
         run: |
@@ -40,7 +40,7 @@ jobs:
             --tests=testing/equivalence-tests/tests \
             --goldens=testing/equivalence-tests/outputs \
             --rewrites=testing/rewrites.jsonc \
-            --binary=./bin/opentf \
+            --binary=./bin/tofu \
 
       - name: Ensure there is no diff
         shell: bash

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -18,7 +18,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_BODY=$(gh pr view ${{ github.event.pull_request.number }} --json body --jq ".body")
-          ISSUES=$(echo $PR_BODY | tr '[:upper:]' '[:lower:]' | sed -n -E '\;((close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved|relates to|related to|part of) (#|https://github.com/opentffoundation/opentf/issues/)[0-9]+);p')
+          ISSUES=$(echo $PR_BODY | tr '[:upper:]' '[:lower:]' | sed -n -E '\;((close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved|relates to|related to|part of) (#|https://github.com/opentofu/opentofu/issues/)[0-9]+);p')
           if [ -z "$ISSUES" ]
           then
             gh pr comment ${{ github.event.pull_request.number }} -b "Please link the relevant issue that this PR handles using one of the following words


### PR DESCRIPTION
I saw this was one of the things not yet in any scope of the rename. I thought I'd throw together a PR and help. But(!): I fully understand that you might have your own order or steps/progress and maybe updating .github settings is planned for later or you want to do it in a different way. I fully understand, please just close this PR, this is totally okay! :-)


Updated links to the new repository (Repo and API links respectively), renamed OpenTF to OpenTofu and 'opentf' to 'tofu'.

I searched for all references, so I am sure that all of them under .github are updated. Hopefully to the right thing.

This also renames the github actions jobs which will cause a discontinuation of log history in the runs It also updates the packages names in the build scripts. I have not yet tested if this breaks the container release process. Also I am not sure if the package name is 'opentofu' or 'tofu', I assumed 'opentofu' and used this for the package references, 'tofu' for the binary references. Also, 'opentf' as the output directory for the tests/binaries etc. was renamed to 'opentofu' instead of just 'tofu'.


It defiantly needs a review since there are basically five things:
- Project Name (OpenTF)
- Repo (/opentofu/opentofu)
- Package (opentofu ?)
- Local directory (opentofu ?)
- Binary (tofu)

and I am not sure if I always picked the right one.

Fix #525