### PR TITLE
remove ProviderTable component from docs

### DIFF
--- a/website/docs/language/providers/index.mdx
+++ b/website/docs/language/providers/index.mdx
@@ -95,11 +95,7 @@ To find providers for the infrastructure platforms you use, browse the
 
 Some providers on the Registry are developed and published by HashiCorp, some
 are published by platform maintainers, and some are published by users and
-volunteers. The provider listings use the following badges to indicate who
-develops and maintains a given provider.
-
-<ProviderTable />
-<p></p>
+volunteers.
 
 ## How to Develop Providers
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentffoundation/opentf/blob/main/CONTRIBUTING.md

-->

This PR removes ProviderTable component from docs and preceding description for it. The description was redundant as there hasn't been ProviderTable rendered at all. More info [here](https://github.com/opentofu/opentofu.org/issues/111)

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves issue created for opentofu.org website https://github.com/opentofu/opentofu.org/issues/111

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->


### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `opentf show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTF now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

- removes "The provider listings use the following badges to indicate who develops and maintains a given provider." from docs about Providers which was missleading
