### PR TITLE
Fix typo in dynamic_value.go

### DIFF
--- a/internal/plans/dynamic_value.go
+++ b/internal/plans/dynamic_value.go
@@ -21,9 +21,9 @@ import (
 // the serialized form, whose format may change in future. Values of this
 // type must always be created by calling NewDynamicValue.
 //
-// The zero value of DynamicValue is nil, and represents the absense of a
+// The zero value of DynamicValue is nil, and represents the absence of a
 // value within the Go type system. This is distinct from a cty.NullVal
-// result, which represents the absense of a value within the cty type system.
+// result, which represents the absence of a value within the cty type system.
 type DynamicValue []byte
 
 // NewDynamicValue creates a DynamicValue by serializing the given value
@@ -36,14 +36,14 @@ type DynamicValue []byte
 // value, and then also pass cty.DynamicPseudoType to method Decode to recover
 // the original value.
 //
-// cty.NilVal can be used to represent the absense of a value, but callers
+// cty.NilVal can be used to represent the absence of a value, but callers
 // must be careful to distinguish values that are absent at the Go layer
 // (cty.NilVal) vs. values that are absent at the cty layer (cty.NullVal
 // results).
 func NewDynamicValue(val cty.Value, ty cty.Type) (DynamicValue, error) {
 	// If we're given cty.NilVal (the zero value of cty.Value, which is
 	// distinct from a typed null value created by cty.NullVal) then we'll
-	// assume the caller is trying to represent the _absense_ of a value,
+	// assume the caller is trying to represent the _absence_ of a value,
 	// and so we'll return a nil DynamicValue.
 	if val == cty.NilVal {
 		return DynamicValue(nil), nil


### PR DESCRIPTION


<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

1.6.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `tofu show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTofu now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  absense -> absence
