### PR TITLE
internal/backend: wrap formatted test errors

### DIFF
--- a/internal/backend/remote-state/azure/helpers_test.go
+++ b/internal/backend/remote-state/azure/helpers_test.go
@@ -125,7 +125,7 @@ func buildSasToken(accountName, accessKey string) (*string, error) {
 	sasToken, err := sasStorage.ComputeAccountSASToken(accountName, accessKey, permissions, services, resourceTypes,
 		startDate, endDate, signedProtocol, signedIp, signedVersion)
 	if err != nil {
-		return nil, fmt.Errorf("Error computing SAS Token: %+v", err)
+		return nil, fmt.Errorf("Error computing SAS Token: %w", err)
 	}
 	log.Printf("SAS Token should be %q", sasToken)
 	return &sasToken, nil
@@ -156,7 +156,7 @@ func (c *ArmClient) buildTestResources(ctx context.Context, names *resourceNames
 	log.Printf("Creating Resource Group %q", names.resourceGroup)
 	_, err := c.groupsClient.CreateOrUpdate(ctx, names.resourceGroup, resources.Group{Location: &names.location})
 	if err != nil {
-		return fmt.Errorf("failed to create test resource group: %s", err)
+		return fmt.Errorf("failed to create test resource group: %w", err)
 	}
 
 	log.Printf("Creating Storage Account %q in Resource Group %q", names.storageAccountName, names.resourceGroup)
@@ -175,12 +175,12 @@ func (c *ArmClient) buildTestResources(ctx context.Context, names *resourceNames
 	}
 	future, err := c.storageAccountsClient.Create(ctx, names.resourceGroup, names.storageAccountName, storageProps)
 	if err != nil {
-		return fmt.Errorf("failed to create test storage account: %s", err)
+		return fmt.Errorf("failed to create test storage account: %w", err)
 	}
 
 	err = future.WaitForCompletionRef(ctx, c.storageAccountsClient.Client)
 	if err != nil {
-		return fmt.Errorf("failed waiting for the creation of storage account: %s", err)
+		return fmt.Errorf("failed waiting for the creation of storage account: %w", err)
 	}
 
 	containersClient := containers.NewWithEnvironment(c.environment)
@@ -190,7 +190,7 @@ func (c *ArmClient) buildTestResources(ctx context.Context, names *resourceNames
 		log.Printf("fetching access key for storage account")
 		resp, err := c.storageAccountsClient.ListKeys(ctx, names.resourceGroup, names.storageAccountName, "")
 		if err != nil {
-			return fmt.Errorf("failed to list storage account keys %s:", err)
+			return fmt.Errorf("failed to list storage account keys %w:", err)
 		}
 
 		keys := *resp.Keys
@@ -199,7 +199,7 @@ func (c *ArmClient) buildTestResources(ctx context.Context, names *resourceNames
 
 		storageAuth, err := autorest.NewSharedKeyAuthorizer(names.storageAccountName, accessKey, autorest.SharedKey)
 		if err != nil {
-			return fmt.Errorf("Error building Authorizer: %+v", err)
+			return fmt.Errorf("Error building Authorizer: %w", err)
 		}
 
 		containersClient.Client.Authorizer = storageAuth
@@ -208,7 +208,7 @@ func (c *ArmClient) buildTestResources(ctx context.Context, names *resourceNames
 	log.Printf("Creating Container %q in Storage Account %q (Resource Group %q)", names.storageContainerName, names.storageAccountName, names.resourceGroup)
 	_, err = containersClient.Create(ctx, names.storageAccountName, names.storageContainerName, containers.CreateInput{})
 	if err != nil {
-		return fmt.Errorf("failed to create storage container: %s", err)
+		return fmt.Errorf("failed to create storage container: %w", err)
 	}
 
 	return nil
@@ -218,13 +218,13 @@ func (c ArmClient) destroyTestResources(ctx context.Context, resources resourceN
 	log.Printf("[DEBUG] Deleting Resource Group %q..", resources.resourceGroup)
 	future, err := c.groupsClient.Delete(ctx, resources.resourceGroup)
 	if err != nil {
-		return fmt.Errorf("Error deleting Resource Group: %+v", err)
+		return fmt.Errorf("Error deleting Resource Group: %w", err)
 	}
 
 	log.Printf("[DEBUG] Waiting for deletion of Resource Group %q..", resources.resourceGroup)
 	err = future.WaitForCompletionRef(ctx, c.groupsClient.Client)
 	if err != nil {
-		return fmt.Errorf("Error waiting for the deletion of Resource Group: %+v", err)
+		return fmt.Errorf("Error waiting for the deletion of Resource Group: %w", err)
 	}
 
 	return nil

--- a/internal/backend/remote-state/gcs/backend_test.go
+++ b/internal/backend/remote-state/gcs/backend_test.go
@@ -275,12 +275,12 @@ func setupKmsKey(t *testing.T, keyDetails map[string]string) string {
 	ctx := context.Background()
 	opts, err := testGetClientOptions(t)
 	if err != nil {
-		e := fmt.Errorf("testGetClientOptions() failed: %s", err)
+		e := fmt.Errorf("testGetClientOptions() failed: %w", err)
 		t.Fatal(e)
 	}
 	c, err := kms.NewKeyManagementClient(ctx, opts...)
 	if err != nil {
-		e := fmt.Errorf("kms.NewKeyManagementClient() failed: %v", err)
+		e := fmt.Errorf("kms.NewKeyManagementClient() failed: %w", err)
 		t.Fatal(e)
 	}
 	defer c.Close()
@@ -345,7 +345,7 @@ func setupKmsKey(t *testing.T, keyDetails map[string]string) string {
 	// because the KMS key needs to exist before the backend buckets are made in the test.
 	sc, err := storage.NewClient(ctx, opts...) //reuse opts from KMS client
 	if err != nil {
-		e := fmt.Errorf("storage.NewClient() failed: %v", err)
+		e := fmt.Errorf("storage.NewClient() failed: %w", err)
 		t.Fatal(e)
 	}
 	defer sc.Close()
@@ -432,7 +432,7 @@ func testGetClientOptions(t *testing.T) ([]option.ClientOption, error) {
 
 	contents, err := backend.ReadPathOrContents(creds)
 	if err != nil {
-		return nil, fmt.Errorf("error loading credentials: %s", err)
+		return nil, fmt.Errorf("error loading credentials: %w", err)
 	}
 	if !json.Valid([]byte(contents)) {
 		return nil, fmt.Errorf("the string provided in credentials is neither valid json nor a valid file path")


### PR DESCRIPTION
This wraps the test errors in `internal/backend` using the `%w` directive instead of `%v` or `%`s.

Part of #395

There are no user-facing changes worthy of a CHANGELOG entry, unless tiny tweaks to log messages warrant such.