### PR TITLE
statemgr: Make Filesystem impl "correct" and fast

### DIFF
--- a/internal/backend/local/testing.go
+++ b/internal/backend/local/testing.go
@@ -178,8 +178,11 @@ func (b *TestLocalNoDefaultState) StateMgr(name string) (statemgr.Full, error) {
 }
 
 func testStateFile(t *testing.T, path string, s *states.State) {
-	stateFile := statemgr.NewFilesystem(path)
-	stateFile.WriteState(s)
+	t.Helper()
+
+	if err := statemgr.WriteAndPersist(statemgr.NewFilesystem(path), s, nil); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func mustProviderConfig(s string) addrs.AbsProviderConfig {

--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -419,8 +419,7 @@ func TestApply_defaultState(t *testing.T) {
 	}
 
 	// create an existing state file
-	localState := statemgr.NewFilesystem(statePath)
-	if err := localState.WriteState(states.NewState()); err != nil {
+	if err := statemgr.WriteAndPersist(statemgr.NewFilesystem(statePath), states.NewState(), nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -710,8 +709,7 @@ func TestApply_plan_backup(t *testing.T) {
 	// create a state file that needs to be backed up
 	fs := statemgr.NewFilesystem(statePath)
 	fs.StateSnapshotMeta()
-	err := fs.WriteState(states.NewState())
-	if err != nil {
+	if err := statemgr.WriteAndPersist(fs, states.NewState(), nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -1257,7 +1257,7 @@ func TestInit_inputFalse(t *testing.T) {
 			false, // not sensitive
 		)
 	})
-	if err := statemgr.NewFilesystem("foo").WriteState(fooState); err != nil {
+	if err := statemgr.WriteAndPersist(statemgr.NewFilesystem("foo"), fooState, nil); err != nil {
 		t.Fatal(err)
 	}
 	barState := states.BuildState(func(s *states.SyncState) {
@@ -1267,7 +1267,7 @@ func TestInit_inputFalse(t *testing.T) {
 			false, // not sensitive
 		)
 	})
-	if err := statemgr.NewFilesystem("bar").WriteState(barState); err != nil {
+	if err := statemgr.WriteAndPersist(statemgr.NewFilesystem("bar"), barState, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -495,8 +495,7 @@ func (m *Meta) backendMigrateNonEmptyConfirm(
 
 	// Helper to write the state
 	saveHelper := func(n, path string, s *states.State) error {
-		mgr := statemgr.NewFilesystem(path)
-		return mgr.WriteState(s)
+		return statemgr.WriteAndPersist(statemgr.NewFilesystem(path), s, nil)
 	}
 
 	// Write the states

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -1641,7 +1641,7 @@ func TestMetaBackend_planLocalStatePath(t *testing.T) {
 	statePath := "foo.tfstate"
 
 	// put an initial state there that needs to be backed up
-	err = (statemgr.NewFilesystem(statePath)).WriteState(original)
+	err = statemgr.WriteAndPersist(statemgr.NewFilesystem(statePath), original, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -251,7 +251,7 @@ func TestWorkspace_createWithState(t *testing.T) {
 		)
 	})
 
-	err := statemgr.NewFilesystem("test.tfstate").WriteState(originalState)
+	err := statemgr.WriteAndPersist(statemgr.NewFilesystem("test.tfstate"), originalState, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/states/statemgr/filesystem_test.go
+++ b/internal/states/statemgr/filesystem_test.go
@@ -247,7 +247,7 @@ func TestFilesystem_backupAndReadPath(t *testing.T) {
 			false, // not sensitive
 		)
 	})
-	err = ls.WriteState(newState)
+	err = WriteAndPersist(ls, newState, nil)
 	if err != nil {
 		t.Fatalf("failed to write new state: %s", err)
 	}


### PR DESCRIPTION
The existing Filesystem statemgr implementation claims to use in-memory transient storage and the local filesystem for persistent storage.

> // Filesystem is a full state manager that uses a file in the local filesystem
> // for persistent storage.
> //
> // The transient storage for Filesystem is always in-memory.

However, the actual WriteState impl admits to being "incorrect":

> // WriteState is an incorrect implementation of Writer that actually also
> // persists.

It appears to have been this way since 2018. Perhaps this incorrectness is load-bearing, but given that this is only one of many implementations of the state manager interface, I suspect it would be fine to fix the implementation to be "correct".

This change splits off the expensive parts of WriteState into the PersistState method, which was previously a no-op.

Without this change, the time we spend maintaining is roughly quadratic with the number of resources being managed because each resouce causes:

1. The statefile to grow by some small amount.
2. The entire statefile to be serialized 3x.

For a small number of resources, serializing the statefile to JSON and writing it to disk is neglibible compared to the actual work being done by providers.

Once you start dealing with thousands of resources and megabytes of state, the overall time spent is dominated by this WriteState method. This is made worse by the fact that access to the statefile is managed by a mutex, so throwing more parallelism at the problem solves nothing.

Resolves #578 

## Target Release

1.6.0

## Draft CHANGELOG entry

### ENHANCEMENTS

- Managing large `terraform.tfstate` files is now much faster. 