### PR TITLE
Removing backport bot reference from PR template. No longer needed

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,9 +27,6 @@ release, or as a patch to the current minor version. If you need to
 port a security fix to an older release, highlight this here by listing
 all targeted releases.
 
-If targeting the next patch release, also add the relevant x.y-backport
-label to enable the backport bot.
-
 -->
 
 1.6.0


### PR DESCRIPTION
This PR removes a reference in Github's PR template to backport bot, which comes from Hashicorp and won't be used anymore

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #514 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

If targeting the next patch release, also add the relevant x.y-backport
label to enable the backport bot.

-->

N/A
