### PR TITLE
internal/command: wrap formatted test errors

### DIFF
--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -856,7 +856,7 @@ func testLockState(t *testing.T, sourceDir, path string) (func(), error) {
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("%s %s", err, out)
+		return nil, fmt.Errorf("%w %s", err, out)
 	}
 
 	locker := exec.Command(lockBin, path)
@@ -881,7 +881,7 @@ func testLockState(t *testing.T, sourceDir, path string) (func(), error) {
 	buf := make([]byte, 1024)
 	n, err := pr.Read(buf)
 	if err != nil {
-		return deferFunc, fmt.Errorf("read from statelocker returned: %s", err)
+		return deferFunc, fmt.Errorf("read from statelocker returned: %w", err)
 	}
 
 	output := string(buf[:n])

--- a/internal/command/testing/test_provider.go
+++ b/internal/command/testing/test_provider.go
@@ -209,7 +209,7 @@ func (provider *TestProvider) ApplyResourceChange(request providers.ApplyResourc
 	if !id.IsKnown() {
 		val, err := uuid.GenerateUUID()
 		if err != nil {
-			panic(fmt.Errorf("failed to generate uuid: %v", err))
+			panic(fmt.Errorf("failed to generate uuid: %w", err))
 		}
 
 		id = cty.StringVal(val)

--- a/internal/command/webbrowser/mock.go
+++ b/internal/command/webbrowser/mock.go
@@ -107,12 +107,12 @@ func (l *MockLauncher) openURL(u string) error {
 		log.Printf("[DEBUG] webbrowser.MockLauncher: requesting %s", u)
 		req, err := http.NewRequest("GET", u, nil)
 		if err != nil {
-			return fmt.Errorf("failed to construct HTTP request for %s: %s", u, err)
+			return fmt.Errorf("failed to construct HTTP request for %s: %w", u, err)
 		}
 		resp, err := l.Client.Do(req)
 		if err != nil {
 			log.Printf("[DEBUG] webbrowser.MockLauncher: request failed: %s", err)
-			return fmt.Errorf("error requesting %s: %s", u, err)
+			return fmt.Errorf("error requesting %s: %w", u, err)
 		}
 		l.Responses = append(l.Responses, resp)
 		if resp.StatusCode >= 400 {
@@ -135,7 +135,7 @@ func (l *MockLauncher) openURL(u string) error {
 			oldURL := resp.Request.URL
 			givenURL, err := url.Parse(u)
 			if err != nil {
-				return fmt.Errorf("invalid redirect URL %s: %s", u, err)
+				return fmt.Errorf("invalid redirect URL %s: %w", u, err)
 			}
 			u = oldURL.ResolveReference(givenURL).String()
 			log.Printf("[DEBUG] webbrowser.MockLauncher: redirected to %s", u)


### PR DESCRIPTION
This wraps the test errors in `internal/command` using the `%w` directive instead of `%v` or `%s`.

Part of #395

There are no user-facing changes worthy of a CHANGELOG entry, unless tiny tweaks to log messages warrant such.