### PR TITLE
Snapcraft login shouldn't be called when credentials are set via env var.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,6 @@ jobs:
       - name: Setup snapcraft
         run: |
           sudo snap install snapcraft --classic --channel=7.x/stable
-          snapcraft login
 
           # See https://github.com/goreleaser/goreleaser/issues/1715
           mkdir -p "$HOME/.cache/snapcraft/download"
@@ -68,3 +67,4 @@ jobs:
           args: release --clean --timeout=60m --snapshot=${{ !startsWith(github.ref, 'refs/tags/v') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_TOKEN }}


### PR DESCRIPTION
Fixes #591 

It seems like snapcraft complains about `snapcraft login` if `SNAPCRAFT_STORE_CREDENTIALS` is set.

Thus, I've removed snapcraft login and just moved the env var to be available to the whole goreleaser invocation.

Example workflow: https://github.com/opentofu/opentofu/actions/runs/6313959167/job/17173820994

cc @jnsgruk 