### PR TITLE
Fix build workflow is failing

### DIFF
--- a/.github/scripts/e2e_test_linux_darwin.sh
+++ b/.github/scripts/e2e_test_linux_darwin.sh
@@ -7,12 +7,12 @@ set -uo pipefail
 if [[ $arch == 'arm' || $arch == 'arm64' ]]
 then
     export DIR=$(mktemp -d)
-    unzip -d $DIR "${e2e_cache_path}/opentofu-e2etest_${os}_${arch}.zip"
-    unzip -d $DIR "./opentofu_${version}_${os}_${arch}.zip"
+    unzip -d $DIR "${e2e_cache_path}/tofu-e2etest_${os}_${arch}.zip"
+    unzip -d $DIR "./tofu_${version}_${os}_${arch}.zip"
     sudo chmod +x $DIR/e2etest
     docker run --platform=linux/arm64 -v $DIR:/src -w /src arm64v8/alpine ./e2etest -test.v
 else
-    unzip "${e2e_cache_path}/opentofu-e2etest_${os}_${arch}.zip"
-    unzip "./opentofu_${version}_${os}_${arch}.zip"
+    unzip "${e2e_cache_path}/tofu-e2etest_${os}_${arch}.zip"
+    unzip "./tofu_${version}_${os}_${arch}.zip"
     TF_ACC=1 ./e2etest -test.v
 fi

--- a/.github/workflows/build-opentofu-oss.yml
+++ b/.github/workflows/build-opentofu-oss.yml
@@ -23,6 +23,9 @@ on:
       package-name:
         type: string
         default: opentofu
+      bin-name:
+        type: string
+        default: tofu
       product-version:
         type: string
         required: true
@@ -53,7 +56,8 @@ jobs:
           CGO_ENABLED: ${{ inputs.cgo-enabled }}
         uses: hashicorp/actions-go-build@v0.1.7
         with:
-          product_name: ${{ inputs.package-name }}
+          bin_name: ${{ inputs.bin-name }}
+          product_name: ${{ inputs.product-name }}
           product_version: ${{ inputs.product-version }}
           go_version: ${{ inputs.go-version }}
           os: ${{ inputs.goos }}

--- a/.github/workflows/build-opentofu-oss.yml
+++ b/.github/workflows/build-opentofu-oss.yml
@@ -22,7 +22,7 @@ on:
         type: string
       package-name:
         type: string
-        default: opentofu
+        default: tofu
       bin-name:
         type: string
         default: tofu

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 env:
-  PKG_NAME: "opentofu"
+  PKG_NAME: "tofu"
 
 permissions:
   contents: read
@@ -256,13 +256,13 @@ jobs:
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         id: clipkg
         with:
-          name: opentofu_${{env.version}}_${{ env.os }}_${{ env.arch }}.zip
+          name: tofu_${{env.version}}_${{ env.os }}_${{ env.arch }}.zip
           path: .
       - name: Extract packages
         if: ${{ matrix.goos == 'windows' }}
         run: |
           unzip "${{ needs.e2etest-build.outputs.e2e-cache-path }}/tofu-e2etest_${{ env.os }}_${{ env.arch }}.zip"
-          unzip "./opentofu_${{env.version}}_${{ env.os }}_${{ env.arch }}.zip"
+          unzip "./tofu_${{env.version}}_${{ env.os }}_${{ env.arch }}.zip"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2.2.0
         if: ${{ contains(matrix.goarch, 'arm') }}
@@ -305,7 +305,7 @@ jobs:
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         id: clipkg
         with:
-          name: opentofu_${{ env.version }}_linux_amd64.zip
+          name: tofu_${{ env.version }}_linux_amd64.zip
           path: .
       - name: Checkout tofu-exec repo
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -315,7 +315,7 @@ jobs:
       - name: Run tofu-exec end-to-end tests
         run: |
           FULL_RELEASE_VERSION="${{ env.version }}"
-          unzip opentofu_${FULL_RELEASE_VERSION}_linux_amd64.zip
+          unzip tofu_${FULL_RELEASE_VERSION}_linux_amd64.zip
           export TFEXEC_E2ETEST_TERRAFORM_PATH="$(pwd)/tofu"
           cd tofu-exec
           go test -race -timeout=30m -v ./tfexec/internal/e2etest


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.at 
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

part of #605
fix #609

https://github.com/opentofu/opentofu/actions/runs/6331460912 works

Seems like `hashicorp/actions-go-build@v0.1.7` docs are wrong, they say the `BIN_PATH` is concatenation with `package_name` input but it seems not to change
so using `bin_name`
## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.6.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `tofu show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTofu now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
