### PR TITLE
Prune Unused String Functions

### DIFF
--- a/internal/legacy/tofu/util.go
+++ b/internal/legacy/tofu/util.go
@@ -49,17 +49,6 @@ func (s Semaphore) Release() {
 	}
 }
 
-// strSliceContains checks if a given string is contained in a slice
-// When anybody asks why Go needs generics, here you go.
-func strSliceContains(haystack []string, needle string) bool {
-	for _, s := range haystack {
-		if s == needle {
-			return true
-		}
-	}
-	return false
-}
-
 // deduplicate a slice of strings
 func uniqueStrings(s []string) []string {
 	if len(s) < 2 {

--- a/internal/legacy/tofu/util_test.go
+++ b/internal/legacy/tofu/util_test.go
@@ -37,21 +37,6 @@ func TestSemaphore(t *testing.T) {
 	s.Release()
 }
 
-func TestStrSliceContains(t *testing.T) {
-	if strSliceContains(nil, "foo") {
-		t.Fatalf("Bad")
-	}
-	if strSliceContains([]string{}, "foo") {
-		t.Fatalf("Bad")
-	}
-	if strSliceContains([]string{"bar"}, "foo") {
-		t.Fatalf("Bad")
-	}
-	if !strSliceContains([]string{"bar", "foo"}, "foo") {
-		t.Fatalf("Bad")
-	}
-}
-
 func TestUniqueStrings(t *testing.T) {
 	cases := []struct {
 		Input    []string

--- a/internal/tofu/util.go
+++ b/internal/tofu/util.go
@@ -3,10 +3,6 @@
 
 package tofu
 
-import (
-	"sort"
-)
-
 // Semaphore is a wrapper around a channel to provide
 // utility methods to clarify that we are treating the
 // channel as a semaphore
@@ -47,32 +43,4 @@ func (s Semaphore) Release() {
 	default:
 		panic("release without an acquire")
 	}
-}
-
-// strSliceContains checks if a given string is contained in a slice
-// When anybody asks why Go needs generics, here you go.
-func strSliceContains(haystack []string, needle string) bool {
-	for _, s := range haystack {
-		if s == needle {
-			return true
-		}
-	}
-	return false
-}
-
-// deduplicate a slice of strings
-func uniqueStrings(s []string) []string {
-	if len(s) < 2 {
-		return s
-	}
-
-	sort.Strings(s)
-	result := make([]string, 1, len(s))
-	result[0] = s[0]
-	for i := 1; i < len(s); i++ {
-		if s[i] != result[len(result)-1] {
-			result = append(result, s[i])
-		}
-	}
-	return result
 }

--- a/internal/tofu/util_test.go
+++ b/internal/tofu/util_test.go
@@ -4,8 +4,6 @@
 package tofu
 
 import (
-	"fmt"
-	"reflect"
 	"testing"
 	"time"
 )
@@ -35,60 +33,4 @@ func TestSemaphore(t *testing.T) {
 		}
 	}()
 	s.Release()
-}
-
-func TestStrSliceContains(t *testing.T) {
-	if strSliceContains(nil, "foo") {
-		t.Fatalf("Bad")
-	}
-	if strSliceContains([]string{}, "foo") {
-		t.Fatalf("Bad")
-	}
-	if strSliceContains([]string{"bar"}, "foo") {
-		t.Fatalf("Bad")
-	}
-	if !strSliceContains([]string{"bar", "foo"}, "foo") {
-		t.Fatalf("Bad")
-	}
-}
-
-func TestUniqueStrings(t *testing.T) {
-	cases := []struct {
-		Input    []string
-		Expected []string
-	}{
-		{
-			[]string{},
-			[]string{},
-		},
-		{
-			[]string{"x"},
-			[]string{"x"},
-		},
-		{
-			[]string{"a", "b", "c"},
-			[]string{"a", "b", "c"},
-		},
-		{
-			[]string{"a", "a", "a"},
-			[]string{"a"},
-		},
-		{
-			[]string{"a", "b", "a", "b", "a", "a"},
-			[]string{"a", "b"},
-		},
-		{
-			[]string{"c", "b", "a", "c", "b"},
-			[]string{"a", "b", "c"},
-		},
-	}
-
-	for i, tc := range cases {
-		t.Run(fmt.Sprintf("unique-%d", i), func(t *testing.T) {
-			actual := uniqueStrings(tc.Input)
-			if !reflect.DeepEqual(tc.Expected, actual) {
-				t.Fatalf("Expected: %q\nGot: %q", tc.Expected, actual)
-			}
-		})
-	}
 }


### PR DESCRIPTION
This prunes unused string functions (and their tests) from `internal/tofu` and `internal/legacy/tofu`.

There are no user-facing changes that warrant a CHANGELOG entry.

Fixes #610