### PR TITLE
More Wrapped Tests

### DIFF
--- a/internal/communicator/ssh/communicator_test.go
+++ b/internal/communicator/ssh/communicator_test.go
@@ -749,7 +749,7 @@ func acceptPublicKey(keystr string) func(ssh.ConnMetadata, ssh.PublicKey) (*ssh.
 	return func(_ ssh.ConnMetadata, inkey ssh.PublicKey) (*ssh.Permissions, error) {
 		goodkey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(keystr))
 		if err != nil {
-			return nil, fmt.Errorf("error parsing key: %v", err)
+			return nil, fmt.Errorf("error parsing key: %w", err)
 		}
 
 		if bytes.Equal(inkey.Marshal(), goodkey.Marshal()) {

--- a/internal/getproviders/mock_source.go
+++ b/internal/getproviders/mock_source.go
@@ -175,12 +175,12 @@ func FakeInstallablePackageMeta(provider addrs.Provider, version Version, protoc
 	zw := zip.NewWriter(f)
 	fw, err := zw.Create(execFilename)
 	if err != nil {
-		return PackageMeta{}, close, fmt.Errorf("failed to add %s to mock zip file: %s", execFilename, err)
+		return PackageMeta{}, close, fmt.Errorf("failed to add %s to mock zip file: %w", execFilename, err)
 	}
 	fmt.Fprintf(fw, "This is a fake provider package for %s %s, not a real provider.\n", provider, version)
 	err = zw.Close()
 	if err != nil {
-		return PackageMeta{}, close, fmt.Errorf("failed to close the mock zip file: %s", err)
+		return PackageMeta{}, close, fmt.Errorf("failed to close the mock zip file: %w", err)
 	}
 
 	// Compute the SHA256 checksum of the generated file, to allow package

--- a/internal/initwd/module_install_test.go
+++ b/internal/initwd/module_install_test.go
@@ -947,7 +947,7 @@ func tempChdir(t *testing.T, sourceDir string) (string, func()) {
 	return tmpDir, func() {
 		err := os.Chdir(oldDir)
 		if err != nil {
-			panic(fmt.Errorf("failed to restore previous working directory %s: %s", oldDir, err))
+			panic(fmt.Errorf("failed to restore previous working directory %s: %w", oldDir, err))
 		}
 
 		if os.Getenv("TF_CONFIGLOAD_TEST_KEEP_TMP") == "" {


### PR DESCRIPTION
This wraps the test errors in the following packages using the `%w` directive instead of `%v` or `%s`:

`internal/communicator/ssh`
`internal/getproviders`
`internal/initwd`

Fixes #395

There are no user-facing changes worthy of a CHANGELOG entry, unless tiny tweaks to log messages warrant such.