### PR TITLE
Correct comment in init_test.go that incorrectly described a test

### DIFF
--- a/internal/command/e2etest/init_test.go
+++ b/internal/command/e2etest/init_test.go
@@ -393,7 +393,7 @@ func TestInitProviderWarnings(t *testing.T) {
 	t.Parallel()
 
 	// This test will reach out to registry.terraform.io as one of the possible
-	// installation locations for hashicorp/nonexist, which should not exist.
+	// installation locations for hashicorp/terraform, which is an archived package that is no longer needed.
 	skipIfCannotAccessNetwork(t)
 
 	fixturePath := filepath.Join("testdata", "provider-warnings")


### PR DESCRIPTION
Resolves #614 

## Target Release

1.6.0

## Draft CHANGELOG entry
Not needed, its just a comment


This PR corrects a comment to explain what the e2e test is actually doing. See the testdata file that it uses here:  https://github.com/opentofu/opentofu/blob/main/internal/command/e2etest/testdata/provider-warnings/main.tf#L1-L12
