### PR TITLE
internal/command: demote modulePath() export

### DIFF
--- a/internal/command/autocomplete.go
+++ b/internal/command/autocomplete.go
@@ -43,7 +43,7 @@ func (m *Meta) completePredictWorkspaceName() complete.Predictor {
 		// directory, since we don't have enough context to know where to
 		// find any config path argument, and it might be _after_ the argument
 		// we're trying to complete here anyway.
-		configPath, err := ModulePath(nil)
+		configPath, err := modulePath(nil)
 		if err != nil {
 			return nil
 		}

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -50,7 +50,7 @@ is configured to use a non-local backend. This backend doesn't support this
 operation.
 `
 
-// ModulePath returns the path to the root module and validates CLI arguments.
+// modulePath returns the path to the root module and validates CLI arguments.
 //
 // This centralizes the logic for any commands that previously accepted
 // a module path via CLI arguments. This will error if any extraneous arguments
@@ -58,7 +58,7 @@ operation.
 //
 // If your command accepts more than one arg, then change the slice bounds
 // to pass validation.
-func ModulePath(args []string) (string, error) {
+func modulePath(args []string) (string, error) {
 	// TODO: test
 
 	if len(args) > 0 {

--- a/internal/command/console.go
+++ b/internal/command/console.go
@@ -35,7 +35,7 @@ func (c *ConsoleCommand) Run(args []string) int {
 		return 1
 	}
 
-	configPath, err := ModulePath(cmdFlags.Args())
+	configPath, err := modulePath(cmdFlags.Args())
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1

--- a/internal/command/get.go
+++ b/internal/command/get.go
@@ -35,7 +35,7 @@ func (c *GetCommand) Run(args []string) int {
 	ctx, done := c.InterruptibleContext(c.CommandContext())
 	defer done()
 
-	path, err := ModulePath(cmdFlags.Args())
+	path, err := modulePath(cmdFlags.Args())
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1

--- a/internal/command/graph.go
+++ b/internal/command/graph.go
@@ -42,7 +42,7 @@ func (c *GraphCommand) Run(args []string) int {
 		return 1
 	}
 
-	configPath, err := ModulePath(cmdFlags.Args())
+	configPath, err := modulePath(cmdFlags.Args())
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -100,7 +100,7 @@ func (c *InitCommand) Run(args []string) int {
 
 	// Validate the arg count and get the working directory
 	args = cmdFlags.Args()
-	path, err := ModulePath(args)
+	path, err := modulePath(args)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1

--- a/internal/command/providers.go
+++ b/internal/command/providers.go
@@ -41,7 +41,7 @@ func (c *ProvidersCommand) Run(args []string) int {
 		return 1
 	}
 
-	configPath, err := ModulePath(cmdFlags.Args())
+	configPath, err := modulePath(cmdFlags.Args())
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1

--- a/internal/command/unlock.go
+++ b/internal/command/unlock.go
@@ -44,7 +44,7 @@ func (c *UnlockCommand) Run(args []string) int {
 
 	// assume everything is initialized. The user can manually init if this is
 	// required.
-	configPath, err := ModulePath(args)
+	configPath, err := modulePath(args)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1

--- a/internal/command/workspace_delete.go
+++ b/internal/command/workspace_delete.go
@@ -46,7 +46,7 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 		return cli.RunResultHelp
 	}
 
-	configPath, err := ModulePath(args[1:])
+	configPath, err := modulePath(args[1:])
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1

--- a/internal/command/workspace_list.go
+++ b/internal/command/workspace_list.go
@@ -30,7 +30,7 @@ func (c *WorkspaceListCommand) Run(args []string) int {
 	}
 
 	args = cmdFlags.Args()
-	configPath, err := ModulePath(args)
+	configPath, err := modulePath(args)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1

--- a/internal/command/workspace_new.go
+++ b/internal/command/workspace_new.go
@@ -61,7 +61,7 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 		return 1
 	}
 
-	configPath, err := ModulePath(args[1:])
+	configPath, err := modulePath(args[1:])
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1

--- a/internal/command/workspace_select.go
+++ b/internal/command/workspace_select.go
@@ -37,7 +37,7 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 		return cli.RunResultHelp
 	}
 
-	configPath, err := ModulePath(args[1:])
+	configPath, err := modulePath(args[1:])
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1


### PR DESCRIPTION
Demote the function `ModulePath()` that is exported but used by no other packages.

Fixes #616