### PR TITLE
internal/backend/remote-state/kubernetes: Demote Exported Functions

### DIFF
--- a/internal/backend/remote-state/kubernetes/backend.go
+++ b/internal/backend/remote-state/kubernetes/backend.go
@@ -25,16 +25,6 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
-// Modified from github.com/terraform-providers/terraform-provider-kubernetes
-
-const (
-	noConfigError = `
-
-[Kubernetes backend] Neither service_account nor load_config_file were set to true, 
-this could cause issues connecting to your Kubernetes cluster.
-`
-)
-
 var (
 	secretResource = k8sSchema.GroupVersionResource{
 		Group:    "",
@@ -201,7 +191,7 @@ type Backend struct {
 	nameSuffix             string
 }
 
-func (b Backend) KubernetesSecretClient() (dynamic.ResourceInterface, error) {
+func (b Backend) getKubernetesSecretClient() (dynamic.ResourceInterface, error) {
 	if b.kubernetesSecretClient != nil {
 		return b.kubernetesSecretClient, nil
 	}
@@ -215,7 +205,7 @@ func (b Backend) KubernetesSecretClient() (dynamic.ResourceInterface, error) {
 	return b.kubernetesSecretClient, nil
 }
 
-func (b Backend) KubernetesLeaseClient() (coordinationv1.LeaseInterface, error) {
+func (b Backend) getKubernetesLeaseClient() (coordinationv1.LeaseInterface, error) {
 	if b.kubernetesLeaseClient != nil {
 		return b.kubernetesLeaseClient, nil
 	}

--- a/internal/backend/remote-state/kubernetes/backend_state.go
+++ b/internal/backend/remote-state/kubernetes/backend_state.go
@@ -19,7 +19,7 @@ import (
 // Workspaces returns a list of names for the workspaces found in k8s. The default
 // workspace is always returned as the first element in the slice.
 func (b *Backend) Workspaces() ([]string, error) {
-	secretClient, err := b.KubernetesSecretClient()
+	secretClient, err := b.getKubernetesSecretClient()
 	if err != nil {
 		return nil, err
 	}
@@ -146,12 +146,12 @@ func (b *Backend) remoteClient(name string) (*RemoteClient, error) {
 		return nil, errors.New("missing state name")
 	}
 
-	secretClient, err := b.KubernetesSecretClient()
+	secretClient, err := b.getKubernetesSecretClient()
 	if err != nil {
 		return nil, err
 	}
 
-	leaseClient, err := b.KubernetesLeaseClient()
+	leaseClient, err := b.getKubernetesLeaseClient()
 	if err != nil {
 		return nil, err
 	}
@@ -166,8 +166,4 @@ func (b *Backend) remoteClient(name string) (*RemoteClient, error) {
 	}
 
 	return client, nil
-}
-
-func (b *Backend) client() *RemoteClient {
-	return &RemoteClient{}
 }

--- a/internal/backend/remote-state/kubernetes/backend_test.go
+++ b/internal/backend/remote-state/kubernetes/backend_test.go
@@ -136,7 +136,7 @@ func cleanupK8sResources(t *testing.T) {
 
 	b := b1.(*Backend)
 
-	sClient, err := b.KubernetesSecretClient()
+	sClient, err := b.getKubernetesSecretClient()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -167,7 +167,7 @@ func cleanupK8sResources(t *testing.T) {
 		}
 	}
 
-	leaseClient, err := b.KubernetesLeaseClient()
+	leaseClient, err := b.getKubernetesLeaseClient()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
internal/backend/remote-state/kubernetes: demote KubernetesSecretClient()
internal/backend/remote-state/kubernetes: prune unused error
internal/backend/remote-state/kubernetes: demote KubernetesLeaseClient()

This demotes two needlessly exported functions and prunes the unused `noConfigError`.

Fixes #620