### PR TITLE
Alter the help message for test command to print the expected behaviour

### DIFF
--- a/internal/command/get.go
+++ b/internal/command/get.go
@@ -75,7 +75,9 @@ Options:
 
   -no-color             Disable text coloring in the output.
 
-  -test-directory=path	Set the OpenTofu test directory, defaults to "tests".
+  -test-directory=path  Set the OpenTofu test directory, defaults to "tests". When set, the
+                        test command will search for test files in the current directory and
+                        in the one specified by the flag.
 
 `
 	return strings.TrimSpace(helpText)

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -1181,7 +1181,9 @@ Options:
                           See the documentation on configuring OpenTofu with
                           Terraform Cloud for more information.
 
-  -test-directory=path    Set the OpenTofu test directory, defaults to "tests".
+  -test-directory=path    Set the OpenTofu test directory, defaults to "tests". When set, the
+                          test command will search for test files in the current directory and
+                          in the one specified by the flag.
 
 `
 	return strings.TrimSpace(helpText)

--- a/internal/command/providers.go
+++ b/internal/command/providers.go
@@ -186,5 +186,7 @@ Usage: tofu [global options] providers [options] [DIR]
 
 Options:
 
-  -test-directory=path	Set the OpenTofu test directory, defaults to "tests".
+  -test-directory=path  Set the OpenTofu test directory, defaults to "tests". When set, the
+                        test command will search for test files in the current directory and
+                        in the one specified by the flag.
 `

--- a/internal/command/test.go
+++ b/internal/command/test.go
@@ -61,7 +61,9 @@ Options:
 
   -no-color             If specified, output won't contain any color.
 
-  -test-directory=path	Set the OpenTofu test directory, defaults to "tests".    
+  -test-directory=path  Set the OpenTofu test directory, defaults to "tests". When set, the
+                        test command will search for test files in the current directory and
+                        in the one specified by the flag.
 
   -var 'foo=bar'        Set a value for one of the input variables in the root
                         module of the configuration. Use this option more than

--- a/internal/command/validate.go
+++ b/internal/command/validate.go
@@ -179,7 +179,9 @@ Options:
 
   -no-tests             If specified, OpenTofu will not validate test files.
 
-  -test-directory=path	Set the OpenTofu test directory, defaults to "tests".
+  -test-directory=path  Set the OpenTofu test directory, defaults to "tests". When set, the
+                        test command will search for test files in the current directory and
+                        in the one specified by the flag.
 `
 	return strings.TrimSpace(helpText)
 }


### PR DESCRIPTION
This change adds additional information to the help message of `tofu test -test-directory` command (the help message is invoked by `tofu test --help`) to let the user know the command will search for test files both in the local folder and the one specified with the `-test-directory` flag.

Resolves https://github.com/opentofu/opentofu/issues/181

## Target Release

1.6.0

## Draft CHANGELOG entry

### ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `tofu show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTofu now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  `tofu test --help`: description of the `-test-directory` flag includes expected behaviour
