### PR TITLE
Correct docs for `terraform` block

### DIFF
--- a/website/docs/language/expressions/version-constraints.mdx
+++ b/website/docs/language/expressions/version-constraints.mdx
@@ -12,7 +12,7 @@ constraint. Version constraints are used when configuring:
 
 - [Modules](/docs/language/modules)
 - [Provider requirements](/docs/language/providers/requirements)
-- [The `required_version` setting](/docs/language/settings#specifying-a-required-tofu-version) in the `tofu` block.
+- [The `required_version` setting](/docs/language/settings#specifying-a-required-tofu-version) in the `terraform` block.
 
 ## Version Constraint Syntax
 

--- a/website/docs/language/settings/backends/configuration.mdx
+++ b/website/docs/language/settings/backends/configuration.mdx
@@ -24,7 +24,7 @@ You do not need to configure a backend when using TACOS (TF Automation and Colla
 it automatically manages state in the workspaces associated with your configuration. If your configuration includes a [`cloud` block](/docs/language/settings/tf-cloud), it cannot include a `backend` block.
 
 To configure a backend, add a nested `backend` block within the top-level
-`tofu` block. The following example configures the `remote` backend.
+`terraform` block. The following example configures the `remote` backend.
 
 ```hcl
 terraform {

--- a/website/docs/language/settings/index.mdx
+++ b/website/docs/language/settings/index.mdx
@@ -1,19 +1,26 @@
 ---
 description: >-
-  The tofu block allows you to configure OpenTofu behavior, including the
+  The terraform block allows you to configure OpenTofu behavior, including the
   OpenTofu version, backend, integration with TACOS (TF Automation and Collaboration Software),
   and required providers.
 ---
 
 # OpenTofu Settings
 
-The special `tofu` configuration block type is used to configure some
+The special `terraform` configuration block type is used to configure some
 behaviors of OpenTofu itself, such as requiring a minimum OpenTofu version to
 apply your configuration.
 
-## OpenTofu Block Syntax
+:::note
+As a part of [OpenTofu v1.x Compatibility Promises](/docs/language/v1-compatibility-promises),
+the `terraform` block stays as-is. A `tofu` block may be introduced in the future, but it doesn't
+exist yet.
+:::
 
-OpenTofu settings are gathered together into `tofu` blocks:
+
+## OpenTofu `terraform` Block Syntax
+
+OpenTofu settings are gathered together into `terraform` blocks:
 
 ```hcl
 terraform {
@@ -21,12 +28,12 @@ terraform {
 }
 ```
 
-Each `tofu` block can contain a number of settings related to OpenTofu's
-behavior. Within a `tofu` block, only constant values can be used;
+Each `terraform` block can contain a number of settings related to OpenTofu's
+behavior. Within a `terraform` block, only constant values can be used;
 arguments may not refer to named objects such as resources, input variables,
 etc, and may not use any of the OpenTofu language built-in functions.
 
-The various options supported within a `tofu` block are described in the
+The various options supported within a `terraform` block are described in the
 following sections.
 
 ## Configuring an OpenTofu Backend
@@ -116,7 +123,7 @@ if any, are available in a particular OpenTofu release.
 
 ## Passing Metadata to Providers
 
-The `tofu` block can have a nested `provider_meta` block for each
+The `terraform` block can have a nested `provider_meta` block for each
 provider a module is using, if the provider defines a schema for it. This
 allows the provider to receive module-specific information, and is primarily
 intended for modules distributed by the same vendor as the associated provider.


### PR DESCRIPTION
fixes #630.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.6.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `tofu show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTofu now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
