### PR TITLE
Enhance the documentation to show how to run the docs website locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,21 +37,6 @@ staticcheck:
 exhaustive:
 	"$(CURDIR)/scripts/exhaustive.sh"
 
-# Run this if working on the website locally to run in watch mode.
-.PHONY: website
-website:
-	$(MAKE) -C website website
-
-# Use this if you have run `website/build-local` to use the locally built image.
-.PHONY: website/local
-website/local:
-	$(MAKE) -C website website/local
-
-# Run this to generate a new local Docker image.
-.PHONY: website/build-local
-website/build-local:
-	$(MAKE) -C website website/build-local
-
 # Run license check
 .PHONY: license-check
 license-check:

--- a/website/README.md
+++ b/website/README.md
@@ -8,16 +8,6 @@ You can [submit an issue](https://github.com/opentofu/opentofu/issues/new/choose
 
 Click **Edit this page** at the bottom of any OpenTofu website page to go directly to the associated markdown file in GitHub.
 
-## Validating Content
-
-Content changes are automatically validated against a set of rules as part of the pull request process. If you want to run these checks locally to validate your content before committing your changes, you can run the following command:
-
-```
-npm run content-check
-```
-
-If the validation fails, actionable error messages will be displayed to help you address detected issues.
-
 ## Modifying Sidebar Navigation
 
 You must update the sidebar navigation when you add or delete documentation .mdx files. If you do not update the navigation, the website deploy preview fails.
@@ -30,7 +20,13 @@ To update the sidebar navigation, you must edit the appropriate `nav-data.json` 
 
 ## Previewing Changes
 
-Coming soon: Documenting the development process for the documentation website repo.
+Currently, you can preview your changes through the [opentofu/opentofu.org](https://github.com/opentofu/opentofu.org/blob/main/README.md) repository.
+
+Follow the [Getting Started](https://github.com/opentofu/opentofu.org/blob/main/README.md#getting-started) guide.
+If you would like to fetch the documentation from another repository and another branch, you can run the make command with REPO_URL and BRANCH arguments before starting the development server:
+```
+make REPO_URL="<your_forked_repo_url>" BRANCH="<branch_name>"
+```
 
 ## Deploying Changes
 


### PR DESCRIPTION
The unused website targets in Makefile are removed. They are left over artifacts from terraform repository.

Validating Content part of the website README.md is also removed. content-check script doesn't exist in website/package.json. Moreover, it's a hashicorp related script.

fixes #634.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.6.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `tofu show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTofu now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
