### PR TITLE
cmd: Demote Exported Functions and Variables

### DIFF
--- a/cmd/tofu/commands.go
+++ b/cmd/tofu/commands.go
@@ -82,7 +82,7 @@ func initCommands(
 		configDir = "" // No config dir available (e.g. looking up a home directory failed)
 	}
 
-	wd := WorkingDir(originalWorkingDir, os.Getenv("TF_DATA_DIR"))
+	wd := workingDir(originalWorkingDir, os.Getenv("TF_DATA_DIR"))
 
 	meta := command.Meta{
 		WorkingDir: wd,

--- a/cmd/tofu/commands.go
+++ b/cmd/tofu/commands.go
@@ -109,7 +109,7 @@ func initCommands(
 		ProviderDevOverrides: providerDevOverrides,
 		UnmanagedProviders:   unmanagedProviders,
 
-		AllowExperimentalFeatures: ExperimentsAllowed(),
+		AllowExperimentalFeatures: experimentsAreAllowed(),
 	}
 
 	// The command list is included in the tofu -help

--- a/cmd/tofu/commands.go
+++ b/cmd/tofu/commands.go
@@ -29,25 +29,25 @@ import (
 // that assume that OpenTofu is being run from a command prompt.
 const runningInAutomationEnvName = "TF_IN_AUTOMATION"
 
-// Commands is the mapping of all the available OpenTofu commands.
-var Commands map[string]cli.CommandFactory
+// commands is the mapping of all the available OpenTofu commands.
+var commands map[string]cli.CommandFactory
 
-// PrimaryCommands is an ordered sequence of the top-level commands (not
+// primaryCommands is an ordered sequence of the top-level commands (not
 // subcommands) that we emphasize at the top of our help output. This is
 // ordered so that we can show them in the typical workflow order, rather
 // than in alphabetical order. Anything not in this sequence or in the
 // HiddenCommands set appears under "all other commands".
-var PrimaryCommands []string
+var primaryCommands []string
 
-// HiddenCommands is a set of top-level commands (not subcommands) that are
+// hiddenCommands is a set of top-level commands (not subcommands) that are
 // not advertised in the top-level help at all. This is typically because
 // they are either just stubs that return an error message about something
 // no longer being supported or backward-compatibility aliases for other
 // commands.
 //
 // No commands in the PrimaryCommands sequence should also appear in the
-// HiddenCommands set, because that would be rather silly.
-var HiddenCommands map[string]struct{}
+// hiddenCommands set, because that would be rather silly.
+var hiddenCommands map[string]struct{}
 
 // Ui is the cli.Ui used for communicating to the outside world.
 var Ui cli.Ui
@@ -118,7 +118,7 @@ func initCommands(
 	// add, remove or reclassify commands then consider updating
 	// that to match.
 
-	Commands = map[string]cli.CommandFactory{
+	commands = map[string]cli.CommandFactory{
 		"apply": func() (cli.Command, error) {
 			return &command.ApplyCommand{
 				Meta: meta,
@@ -414,14 +414,14 @@ func initCommands(
 	}
 
 	if meta.AllowExperimentalFeatures {
-		Commands["cloud"] = func() (cli.Command, error) {
+		commands["cloud"] = func() (cli.Command, error) {
 			return &command.CloudCommand{
 				Meta: meta,
 			}, nil
 		}
 	}
 
-	PrimaryCommands = []string{
+	primaryCommands = []string{
 		"init",
 		"validate",
 		"plan",
@@ -429,7 +429,7 @@ func initCommands(
 		"destroy",
 	}
 
-	HiddenCommands = map[string]struct{}{
+	hiddenCommands = map[string]struct{}{
 		"env":             {},
 		"internal-plugin": {},
 		"push":            {},

--- a/cmd/tofu/experiments.go
+++ b/cmd/tofu/experiments.go
@@ -22,6 +22,6 @@ package main
 // open experiment.)
 var experimentsAllowed string
 
-func ExperimentsAllowed() bool {
+func experimentsAreAllowed() bool {
 	return experimentsAllowed != ""
 }

--- a/cmd/tofu/help.go
+++ b/cmd/tofu/help.go
@@ -20,7 +20,7 @@ func helpFunc(commands map[string]cli.CommandFactory) string {
 	maxKeyLen := 0
 
 	for key := range commands {
-		if _, ok := HiddenCommands[key]; ok {
+		if _, ok := hiddenCommands[key]; ok {
 			// We don't consider hidden commands when deciding the
 			// maximum command length.
 			continue
@@ -31,7 +31,7 @@ func helpFunc(commands map[string]cli.CommandFactory) string {
 		}
 
 		isOther := true
-		for _, candidate := range PrimaryCommands {
+		for _, candidate := range primaryCommands {
 			if candidate == key {
 				isOther = false
 				break
@@ -62,7 +62,7 @@ Global options (use these before the subcommand, if any):
                 given subcommand.
   -help         Show this help output, or the help for a specified subcommand.
   -version      An alias for the "version" subcommand.
-`, listCommands(commands, PrimaryCommands, maxKeyLen), listCommands(commands, otherCommands, maxKeyLen))
+`, listCommands(commands, primaryCommands, maxKeyLen), listCommands(commands, otherCommands, maxKeyLen))
 
 	return strings.TrimSpace(helpText)
 }

--- a/cmd/tofu/main.go
+++ b/cmd/tofu/main.go
@@ -241,7 +241,7 @@ func realMain() int {
 	}
 
 	// In tests, Commands may already be set to provide mock commands
-	if Commands == nil {
+	if commands == nil {
 		// Commands get to hold on to the original working directory here,
 		// in case they need to refer back to it for any special reason, though
 		// they should primarily be working with the override working directory
@@ -263,7 +263,7 @@ func realMain() int {
 	// Build the CLI so far, we do this so we can query the subcommand.
 	cliRunner := &cli.CLI{
 		Args:       args,
-		Commands:   Commands,
+		Commands:   commands,
 		HelpFunc:   helpFunc,
 		HelpWriter: os.Stdout,
 	}
@@ -301,7 +301,7 @@ func realMain() int {
 	cliRunner = &cli.CLI{
 		Name:       binName,
 		Args:       args,
-		Commands:   Commands,
+		Commands:   commands,
 		HelpFunc:   helpFunc,
 		HelpWriter: os.Stdout,
 
@@ -327,9 +327,9 @@ func realMain() int {
 		// for typos of top-level commands. For a subcommand typo, like
 		// "tofu state push", cmd would be "state" here and thus would
 		// be considered to exist, and it would print out its own usage message.
-		if _, exists := Commands[cmd]; !exists {
-			suggestions := make([]string, 0, len(Commands))
-			for name := range Commands {
+		if _, exists := commands[cmd]; !exists {
+			suggestions := make([]string, 0, len(commands))
+			for name := range commands {
 				suggestions = append(suggestions, name)
 			}
 			suggestion := didyoumean.NameSuggestion(cmd, suggestions)

--- a/cmd/tofu/main.go
+++ b/cmd/tofu/main.go
@@ -108,7 +108,7 @@ func realMain() int {
 	}
 	log.Printf("[INFO] Go runtime version: %s", runtime.Version())
 	log.Printf("[INFO] CLI args: %#v", os.Args)
-	if ExperimentsAllowed() {
+	if experimentsAreAllowed() {
 		log.Printf("[INFO] This build of OpenTofu allows using experimental features")
 	}
 

--- a/cmd/tofu/main_test.go
+++ b/cmd/tofu/main_test.go
@@ -22,13 +22,13 @@ func TestMain_cliArgsFromEnv(t *testing.T) {
 	defer func() { os.Args = oldArgs }()
 
 	// Set up test command and restore that
-	Commands = make(map[string]cli.CommandFactory)
+	commands = make(map[string]cli.CommandFactory)
 	defer func() {
-		Commands = nil
+		commands = nil
 	}()
 	testCommandName := "unit-test-cli-args"
 	testCommand := &testCommandCLI{}
-	Commands[testCommandName] = func() (cli.Command, error) {
+	commands[testCommandName] = func() (cli.Command, error) {
 		return testCommand, nil
 	}
 
@@ -158,9 +158,9 @@ func TestMain_cliArgsFromEnvAdvanced(t *testing.T) {
 	defer func() { os.Args = oldArgs }()
 
 	// Set up test command and restore that
-	Commands = make(map[string]cli.CommandFactory)
+	commands = make(map[string]cli.CommandFactory)
 	defer func() {
-		Commands = nil
+		commands = nil
 	}()
 
 	cases := []struct {
@@ -218,8 +218,8 @@ func TestMain_cliArgsFromEnvAdvanced(t *testing.T) {
 			// Set up test command and restore that
 			testCommandName := tc.Command
 			testCommand := &testCommandCLI{}
-			defer func() { delete(Commands, testCommandName) }()
-			Commands[testCommandName] = func() (cli.Command, error) {
+			defer func() { delete(commands, testCommandName) }()
+			commands[testCommandName] = func() (cli.Command, error) {
 				return testCommand, nil
 			}
 
@@ -264,13 +264,13 @@ func TestMain_autoComplete(t *testing.T) {
 	defer func() { os.Args = oldArgs }()
 
 	// Set up test command and restore that
-	Commands = make(map[string]cli.CommandFactory)
+	commands = make(map[string]cli.CommandFactory)
 	defer func() {
-		Commands = nil
+		commands = nil
 	}()
 
 	// Set up test command and restore that
-	Commands["foo"] = func() (cli.Command, error) {
+	commands["foo"] = func() (cli.Command, error) {
 		return &testCommandCLI{}, nil
 	}
 

--- a/cmd/tofu/working_dir.go
+++ b/cmd/tofu/working_dir.go
@@ -5,7 +5,7 @@ package main
 
 import "github.com/opentofu/opentofu/internal/command/workdir"
 
-func WorkingDir(originalDir string, overrideDataDir string) *workdir.Dir {
+func workingDir(originalDir string, overrideDataDir string) *workdir.Dir {
 	ret := workdir.NewDir(".") // caller should already have used os.Chdir in "-chdir=..." mode
 	ret.OverrideOriginalWorkingDir(originalDir)
 	if overrideDataDir != "" {


### PR DESCRIPTION
This demotes the exported functions `ExperimentsAllowed()` and `WorkingDir()`. This also demotes several exported variables relating to commands.

Fixes #657