### PR TITLE
Add sensitivity check for import configuration block IDs and comprehensive test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ BUG FIXES:
 * tofu_remote_state: Fixed a potential unsafe read panic when reading from multiple tofu_remote_state data sources ([#357](https://github.com/opentofu/opentofu/issues/357))
 * OpenTofu will now attempt to create the configuration directory `~/.terraform.d` on startup. ([#442](https://github.com/opentofu/opentofu/issues/442))
 * Conditionals with an unknown condition and sensitive branch won't crash anymore. ([#659](https://github.com/opentofu/opentofu/issues/659))
-
+- Fixed panic when using sensitive inputs for the ID field of an import configuration block ([#665](https://github.com/opentofu/opentofu/pull/665))
 ## Previous Releases
 
 For information on prior major and minor releases, see their changelogs:

--- a/internal/tofu/eval_import.go
+++ b/internal/tofu/eval_import.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/opentofu/opentofu/internal/lang/marks"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
@@ -17,7 +18,7 @@ func evaluateImportIdExpression(expr hcl.Expression, ctx EvalContext) (string, t
 			Severity: hcl.DiagError,
 			Summary:  "Invalid import id argument",
 			Detail:   "The import ID cannot be null.",
-			Subject:  expr.Range().Ptr(),
+			Subject:  nil,
 		})
 	}
 
@@ -42,6 +43,15 @@ func evaluateImportIdExpression(expr hcl.Expression, ctx EvalContext) (string, t
 			//	Expression:
 			//	EvalContext:
 			Extra: diagnosticCausedByUnknown(true),
+		})
+	}
+
+	if importIdVal.HasMark(marks.Sensitive) {
+		return "", diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid import id argument",
+			Detail:   "The import ID cannot be sensitive.",
+			Subject:  expr.Range().Ptr(),
 		})
 	}
 

--- a/internal/tofu/eval_import_test.go
+++ b/internal/tofu/eval_import_test.go
@@ -1,0 +1,1 @@
+package tofu

--- a/internal/tofu/eval_import_test.go
+++ b/internal/tofu/eval_import_test.go
@@ -1,1 +1,66 @@
 package tofu
+
+import (
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hcltest"
+	"github.com/opentofu/opentofu/internal/lang/marks"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestEvaluateImportIdExpression_SensitiveValue(t *testing.T) {
+	ctx := &MockEvalContext{}
+	ctx.installSimpleEval()
+
+	testCases := []struct {
+		name    string
+		expr    hcl.Expression
+		wantErr string
+	}{
+		{
+			name:    "sensitive_value",
+			expr:    hcltest.MockExprLiteral(cty.StringVal("value").Mark(marks.Sensitive)),
+			wantErr: "Invalid import id argument: The import ID cannot be sensitive.",
+		},
+		{
+			name:    "expr_is_nil",
+			expr:    nil,
+			wantErr: "Invalid import id argument: The import ID cannot be null.",
+		},
+		{
+			name:    "evaluates_to_null",
+			expr:    hcltest.MockExprLiteral(cty.NullVal(cty.String)),
+			wantErr: "Invalid import id argument: The import ID cannot be null.",
+		},
+		{
+			name:    "evaluates_to_unknown",
+			expr:    hcltest.MockExprLiteral(cty.UnknownVal(cty.String)),
+			wantErr: "Invalid import id argument: The import block \"id\" argument depends on resource attributes that cannot be determined until apply, so OpenTofu cannot plan to import this resource.", // Adapted the message from your original code
+		},
+		{
+			name:    "valid_value",
+			expr:    hcltest.MockExprLiteral(cty.StringVal("value")),
+			wantErr: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, diags := evaluateImportIdExpression(tc.expr, ctx)
+
+			if tc.wantErr != "" {
+				if len(diags) != 1 {
+					t.Errorf("expected diagnostics, got %s", spew.Sdump(diags))
+				} else if diags.Err().Error() != tc.wantErr {
+					t.Errorf("unexpected error diagnostic %s", diags.Err().Error())
+				}
+			} else {
+				if len(diags) != 0 {
+					t.Errorf("unexpected diagnostics %s", spew.Sdump(diags))
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Introduction

- Update `evaluateImportIdExpression` to append diagnostics for sensitive import IDs.
- Create `eval_import_test.go` with unit tests to cover various cases for import ID evaluation, including `nil`, `null`, `unknown`, `sensitive`, and valid values.
- Fixes an edge case where a nil expression passed to the ID parser would panic

These changes ensure that the function correctly handles various edge cases and reports appropriate errors.

Resolves #664 

## Target Release

1.6.0

## Draft CHANGELOG entry

### BUG FIXES

Fixed panic when using sensitive inputs for the ID field of an import configuration block

- 
