### PR TITLE
Add vscode launch.json sample for Contributors

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "tofu init",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${fileDirname}",
+            "env": {
+                "TF_LOG": "trace"
+            },
+            "args": ["init"]
+        },
+        {
+            "name": "tofu plan",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${fileDirname}",
+            "env": {
+                "TF_LOG": "trace"
+            },
+            "args": ["plan"]
+        },
+    ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,14 +14,16 @@ Generally, we appreciate external contributions very much and would love to work
 
 ---
 
-<!-- MarkdownTOC autolink="true" -->
+<!-- TOC -->
 
 - [Contributing a Code Change](#contributing-a-code-change)
 - [Working on the Code](#working-on-the-code)
+- [Debugging the code with VSCode](#debugging-the-code-with-vscode)
+- [Adding or updating dependencies](#adding-or-updating-dependencies)
 - [Acceptance Tests: Testing interactions with external services](#acceptance-tests-testing-interactions-with-external-services)
 - [Generated Code](#generated-code)
 
-<!-- /MarkdownTOC -->
+<!-- /TOC -->
 
 ## Contributing a Code Change
 
@@ -81,6 +83,10 @@ As you make your changes, you can re-run the above command to ensure that the te
 go test ./internal/command/...
 go test ./internal/addrs
 ```
+
+## Debugging the code with VSCode
+
+If you are using VSCode, you can start debugging on `main.go` file by selecting one of the debugging options described in [.vscode/launch.json](.vscode/launch.json). Feel free to update the `args` and `env` variables as you see fit during your debug session.
 
 ## Adding or updating dependencies
 


### PR DESCRIPTION
fixes #667. 

I'd be glad if you can add a `hacktoberfest-accepted` tag to this PR, please. 

I've updated the TOC with using https://marketplace.visualstudio.com/items?itemName=huntertran.auto-markdown-toc. In case needed, I can revert back the 
```
<!-- MarkdownTOC autolink="true" --> 
```
to 
```
<!-- TOC -->
```
change. 

If you have any more suggestions to add to the launch.json, I'd be more than happy to include into this PR. 

Please review.
 