### PR TITLE
fix(s3): allow aliases for kms key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,8 @@ BUG FIXES:
 * tofu_remote_state: Fixed a potential unsafe read panic when reading from multiple tofu_remote_state data sources ([#357](https://github.com/opentofu/opentofu/issues/357))
 * OpenTofu will now attempt to create the configuration directory `~/.terraform.d` on startup. ([#442](https://github.com/opentofu/opentofu/issues/442))
 * Conditionals with an unknown condition and sensitive branch won't crash anymore. ([#659](https://github.com/opentofu/opentofu/issues/659))
-- Fixed panic when using sensitive inputs for the ID field of an import configuration block ([#665](https://github.com/opentofu/opentofu/pull/665))
+* Fixed panic when using sensitive inputs for the ID field of an import configuration block ([#665](https://github.com/opentofu/opentofu/pull/665))
+* Fixes the ability to use KMS key aliases in the S3 backend ([#669](https://github.com/opentofu/opentofu/issues/669))
 ## Previous Releases
 
 For information on prior major and minor releases, see their changelogs:

--- a/internal/backend/remote-state/s3/validate.go
+++ b/internal/backend/remote-state/s3/validate.go
@@ -77,7 +77,7 @@ func keyIdFromARNResource(s string) string {
 }
 
 func aliasIdFromARNResource(s string) string {
-	aliasIdResourceRegex := regexp.MustCompile(`^` + aliasRegexPattern + `$`)
+	aliasIdResourceRegex := regexp.MustCompile(`^(` + aliasRegexPattern + `)$`)
 	matches := aliasIdResourceRegex.FindStringSubmatch(s)
 	if matches == nil || len(matches) != 2 {
 		return ""

--- a/internal/backend/remote-state/s3/validate.go
+++ b/internal/backend/remote-state/s3/validate.go
@@ -12,7 +12,7 @@ import (
 const (
 	multiRegionKeyIdPattern = `mrk-[a-f0-9]{32}`
 	uuidRegexPattern        = `[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[ab89][a-f0-9]{3}-[a-f0-9]{12}`
-	aliasRegexPattern       = `alias/(.*)`
+	aliasRegexPattern       = `alias/[a-zA-Z0-9/_-]+`
 )
 
 func validateKMSKey(path cty.Path, s string) (diags tfdiags.Diagnostics) {

--- a/internal/backend/remote-state/s3/validate.go
+++ b/internal/backend/remote-state/s3/validate.go
@@ -12,6 +12,7 @@ import (
 const (
 	multiRegionKeyIdPattern = `mrk-[a-f0-9]{32}`
 	uuidRegexPattern        = `[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[ab89][a-f0-9]{3}-[a-f0-9]{12}`
+	aliasRegexPattern       = `alias/(.*)`
 )
 
 func validateKMSKey(path cty.Path, s string) (diags tfdiags.Diagnostics) {
@@ -22,7 +23,7 @@ func validateKMSKey(path cty.Path, s string) (diags tfdiags.Diagnostics) {
 }
 
 func validateKMSKeyID(path cty.Path, s string) (diags tfdiags.Diagnostics) {
-	keyIdRegex := regexp.MustCompile(`^` + uuidRegexPattern + `|` + multiRegionKeyIdPattern + `$`)
+	keyIdRegex := regexp.MustCompile(`^` + uuidRegexPattern + `|` + multiRegionKeyIdPattern + `|` + aliasRegexPattern + `$`)
 	if !keyIdRegex.MatchString(s) {
 		diags = diags.Append(tfdiags.AttributeValue(
 			tfdiags.Error,
@@ -62,12 +63,22 @@ func validateKMSKeyARN(path cty.Path, s string) (diags tfdiags.Diagnostics) {
 }
 
 func isKeyARN(arn arn.ARN) bool {
-	return keyIdFromARNResource(arn.Resource) != ""
+	return keyIdFromARNResource(arn.Resource) != "" || aliasIdFromARNResource(arn.Resource) != ""
 }
 
 func keyIdFromARNResource(s string) string {
 	keyIdResourceRegex := regexp.MustCompile(`^key/(` + uuidRegexPattern + `|` + multiRegionKeyIdPattern + `)$`)
 	matches := keyIdResourceRegex.FindStringSubmatch(s)
+	if matches == nil || len(matches) != 2 {
+		return ""
+	}
+
+	return matches[1]
+}
+
+func aliasIdFromARNResource(s string) string {
+	aliasIdResourceRegex := regexp.MustCompile(`^` + aliasRegexPattern + `$`)
+	matches := aliasIdResourceRegex.FindStringSubmatch(s)
 	if matches == nil || len(matches) != 2 {
 		return ""
 	}

--- a/internal/backend/remote-state/s3/validate_test.go
+++ b/internal/backend/remote-state/s3/validate_test.go
@@ -31,25 +31,9 @@ func TestValidateKMSKey(t *testing.T) {
 		},
 		"kms key alias": {
 			in: "alias/arbitrary-key",
-			expected: tfdiags.Diagnostics{
-				tfdiags.AttributeValue(
-					tfdiags.Error,
-					"Invalid KMS Key ID",
-					`Value must be a valid KMS Key ID, got "alias/arbitrary-key"`,
-					path,
-				),
-			},
 		},
 		"kms key alias arn": {
 			in: "arn:aws:kms:us-west-2:111122223333:alias/arbitrary-key",
-			expected: tfdiags.Diagnostics{
-				tfdiags.AttributeValue(
-					tfdiags.Error,
-					"Invalid KMS Key ARN",
-					`Value must be a valid KMS Key ARN, got "arn:aws:kms:us-west-2:111122223333:alias/arbitrary-key"`,
-					path,
-				),
-			},
 		},
 		"invalid key": {
 			in: "$%wrongkey",


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->
Release 1.6.0 broke the ability to use s3 key aliases in the s3 backend. This change adjusts the tests, and validation of kms key arn's to look for aliases
<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #669

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.6.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

- `tofu show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTofu now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Fixes the ability to use KMS key aliases in the S3 backend
