### PR TITLE
chore: moving from opentf to opentofu in CODE_OF_CONDUCT and Dockerfile

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -7,4 +7,4 @@ We follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/mai
     If your project isn't prepared to handle reports, remove the project email address and just have
     reporters send to conduct@cncf.io.
 -->
-Please contact contact@opentf.org in order to report violations of the Code of Conduct.
+Please contact contact@opentofu.org in order to report violations of the Code of Conduct.

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM alpine:3.18
 
-LABEL maintainer="OpenTofu Team <opentf@opentf.org>"
+LABEL maintainer="OpenTofu Team <opentofu@opentofu.org>"
 
 COPY tofu /usr/local/bin/tofu
 


### PR DESCRIPTION
Found two places where OpenTF was still being used

## Target Release

1.6.0

## Draft CHANGELOG entry

### BUG FIXES

- Now both CODE_OF_CONDUCT and Dockerfile state OpenTofu instead of OpenTF
