### PR TITLE
Fix wording in documentation

### DIFF
--- a/website/docs/language/attr-as-blocks.mdx
+++ b/website/docs/language/attr-as-blocks.mdx
@@ -53,7 +53,7 @@ or a nested block type.
 ## Defining a Fixed Object Collection Value
 
 When working with resource type arguments that behave in this way, it is valid
-and we recommend to use the nested block syntax whenever defining a fixed
+and we recommend the use of nested block syntax whenever defining a fixed
 collection of objects:
 
 ```hcl


### PR DESCRIPTION
As a native English speaker, I find the expression "recommend to use" very awkward.  I propose we eradicate it from the documentation.


