### PR TITLE
Consider missing `x-terraform-snapshot-interval` for State Snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ BUG FIXES:
 * Fixed panic when using sensitive inputs for the ID field of an import configuration block ([#665](https://github.com/opentofu/opentofu/pull/665))
 * Fixes the ability to use KMS key aliases in the S3 backend ([#669](https://github.com/opentofu/opentofu/issues/669))
 * cloud: fixed a bug that would prevent nested symlinks from being dereferenced into the config sent to Cloud ([#686](https://github.com/opentofu/opentofu/issues/686)) 
+* cloud: state snapshots could not be disabled when header x-terraform-snapshot-interval is absent ([#687](https://github.com/opentofu/opentofu/issues/687))
 ## Previous Releases
 
 For information on prior major and minor releases, see their changelogs:

--- a/internal/cloud/state.go
+++ b/internal/cloud/state.go
@@ -34,6 +34,11 @@ import (
 	"github.com/opentofu/opentofu/internal/tofu"
 )
 
+const (
+	// HeaderSnapshotInterval is the header key that controls the snapshot interval
+	HeaderSnapshotInterval = "x-terraform-snapshot-interval"
+)
+
 // State implements the State interfaces in the state package to handle
 // reading and writing the remote state to TFC. This State on its own does no
 // local caching so every persist will go to the remote storage and local
@@ -248,6 +253,8 @@ func (s *State) ShouldPersistIntermediateState(info *local.IntermediateStatePers
 		return true
 	}
 
+	// This value is controlled by a x-terraform-snapshot-interval header intercepted during
+	// state-versions API responses
 	if !s.enableIntermediateSnapshots && info.RequestedPersistInterval == time.Duration(0) {
 		return false
 	}
@@ -577,7 +584,13 @@ func clamp(val, min, max int64) int64 {
 }
 
 func (s *State) readSnapshotIntervalHeader(status int, header http.Header) {
-	intervalStr := header.Get("x-terraform-snapshot-interval")
+	contentType := header.Get("Content-Type")
+	if !strings.Contains(contentType, tfe.ContentTypeJSONAPI) {
+		log.Printf("[TRACE] Skipping intermediate state interval because Content-Type was %q", contentType)
+		return
+	}
+
+	intervalStr := header.Get(HeaderSnapshotInterval)
 
 	if intervalSecs, err := strconv.ParseInt(intervalStr, 10, 64); err == nil {
 		// More than an hour is an unreasonable delay, so we'll just
@@ -588,11 +601,12 @@ func (s *State) readSnapshotIntervalHeader(status int, header http.Header) {
 		// If the header field is either absent or invalid then we'll
 		// just choose zero, which effectively means that we'll just use
 		// the caller's requested interval instead. If the caller has no
-		// requested interval or it is zero, then we will disable snapshots.
+		// requested interval, or it is zero, then we will disable snapshots.
 		s.stateSnapshotInterval = time.Duration(0)
 	}
 
 	// We will only enable snapshots for intervals greater than zero
+	log.Printf("[TRACE] Intermediate state interval is set by header to %v", s.stateSnapshotInterval)
 	s.enableIntermediateSnapshots = s.stateSnapshotInterval > 0
 }
 

--- a/internal/cloud/state.go
+++ b/internal/cloud/state.go
@@ -255,7 +255,7 @@ func (s *State) ShouldPersistIntermediateState(info *local.IntermediateStatePers
 
 	// This value is controlled by a x-terraform-snapshot-interval header intercepted during
 	// state-versions API responses
-	if !s.enableIntermediateSnapshots && info.RequestedPersistInterval == time.Duration(0) {
+	if !s.enableIntermediateSnapshots {
 		return false
 	}
 
@@ -584,6 +584,7 @@ func clamp(val, min, max int64) int64 {
 }
 
 func (s *State) readSnapshotIntervalHeader(status int, header http.Header) {
+	// Only proceed if this came from tfe.v2 API
 	contentType := header.Get("Content-Type")
 	if !strings.Contains(contentType, tfe.ContentTypeJSONAPI) {
 		log.Printf("[TRACE] Skipping intermediate state interval because Content-Type was %q", contentType)

--- a/internal/cloud/testing.go
+++ b/internal/cloud/testing.go
@@ -437,7 +437,7 @@ func testServerWithSnapshotsEnabled(t *testing.T, enabled bool) *httptest.Server
 			t.Fatal(err)
 		}
 
-		w.Header().Set("content-type", "application/json")
+		w.Header().Set("content-type", tfe.ContentTypeJSONAPI)
 		w.Header().Set("content-length", strconv.FormatInt(int64(len(fakeBodyRaw)), 10))
 
 		switch r.Method {


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #687 
Ported MPL code from https://github.com/hashicorp/terraform/pull/33834 - Seems like we ported some of it already
## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.6.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `tofu show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTofu now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
