### PR TITLE
Remove all Terraform mentions in STDOUTs in the codebase

### DIFF
--- a/internal/backend/remote/backend_context.go
+++ b/internal/backend/remote/backend_context.go
@@ -146,7 +146,7 @@ func (b *Remote) LocalRun(op *backend.Operation) (*backend.LocalRun, statemgr.Fu
 	diags = diags.Append(ctxDiags)
 	ret.Core = tfCtx
 
-	log.Printf("[TRACE] backend/remote: finished building terraform.Context")
+	log.Printf("[TRACE] backend/remote: finished building tofu.Context")
 
 	return ret, stateMgr, diags
 }

--- a/internal/builtin/providers/tf/data_source_state.go
+++ b/internal/builtin/providers/tf/data_source_state.go
@@ -54,7 +54,7 @@ func dataSourceRemoteStateGetSchema() providers.Schema {
 				},
 				"workspace": {
 					Type: cty.String,
-					Description: "The Terraform workspace to use, if " +
+					Description: "The OpenTofu workspace to use, if " +
 						"the backend supports workspaces.",
 					DescriptionKind: configschema.StringMarkdown,
 					Optional:        true,

--- a/internal/configs/module.go
+++ b/internal/configs/module.go
@@ -716,7 +716,7 @@ func (m *Module) CheckCoreVersionRequirements(path addrs.Module, sourceAddr addr
 					Severity: hcl.DiagError,
 					Summary:  "Invalid required_version constraint",
 					Detail: fmt.Sprintf(
-						"Prerelease version constraints are not supported: %s. Remove the prerelease information from the constraint. Prerelease versions of terraform will match constraints using their version core only.",
+						"Prerelease version constraints are not supported: %s. Remove the prerelease information from the constraint. Prerelease versions of OpenTofu will match constraints using their version core only.",
 						required.String()),
 					Subject: constraint.DeclRange.Ptr(),
 				})

--- a/internal/configs/provisioner.go
+++ b/internal/configs/provisioner.go
@@ -39,7 +39,7 @@ func decodeProvisionerBlock(block *hcl.Block) (*Provisioner, hcl.Diagnostics) {
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  fmt.Sprintf("The \"%s\" provisioner has been removed", pv.Type),
-			Detail:   fmt.Sprintf("The \"%s\" provisioner was deprecated in OpenTofu 0.13.4 has been removed from OpenTofu.", pv.Type),
+			Detail:   fmt.Sprintf("The \"%s\" provisioner is deprecated and has been removed from OpenTofu.", pv.Type),
 			Subject:  &pv.TypeRange,
 		})
 		return nil, diags

--- a/internal/configs/provisioner.go
+++ b/internal/configs/provisioner.go
@@ -39,7 +39,7 @@ func decodeProvisionerBlock(block *hcl.Block) (*Provisioner, hcl.Diagnostics) {
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  fmt.Sprintf("The \"%s\" provisioner has been removed", pv.Type),
-			Detail:   fmt.Sprintf("The \"%s\" provisioner was deprecated in OpenTofu 0.13.4 has been removed from OpenTofu. Visit https://learn.hashicorp.com/collections/terraform/provision for alternatives to using provisioners that are a better fit for the OpenTofu workflow.", pv.Type),
+			Detail:   fmt.Sprintf("The \"%s\" provisioner was deprecated in OpenTofu 0.13.4 has been removed from OpenTofu.", pv.Type),
 			Subject:  &pv.TypeRange,
 		})
 		return nil, diags

--- a/internal/lang/funcs/descriptions.go
+++ b/internal/lang/funcs/descriptions.go
@@ -341,7 +341,7 @@ var DescriptionList = map[string]descriptionEntry{
 		ParamDescription: []string{"", ""},
 	},
 	"sensitive": {
-		Description:      "`sensitive` takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).",
+		Description:      "`sensitive` takes any value and returns a copy of it marked so that OpenTofu will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).",
 		ParamDescription: []string{""},
 	},
 	"setintersection": {

--- a/internal/legacy/tofu/state.go
+++ b/internal/legacy/tofu/state.go
@@ -2250,7 +2250,7 @@ const stateValidateErrMultiModule = `
 Multiple modules with the same path: %s
 
 This means that there are multiple entries in the "modules" field
-in your state file that point to the same module. This will cause Terraform
+in your state file that point to the same module. This will cause OpenTofu
 to behave in unexpected and error prone ways and is invalid. Please back up
 and modify your state file manually to resolve this.
 `

--- a/internal/logging/panic.go
+++ b/internal/logging/panic.go
@@ -20,7 +20,7 @@ const panicOutput = `
 OpenTofu crashed! This is always indicative of a bug within OpenTofu.
 Please report the crash with OpenTofu[1] so that we can fix this.
 
-When reporting bugs, please include your terraform version, the stack trace
+When reporting bugs, please include your OpenTofu version, the stack trace
 shown below, and any additional information which may help replicate the issue.
 
 [1]: https://github.com/opentofu/opentofu/issues

--- a/internal/repl/session.go
+++ b/internal/repl/session.go
@@ -88,7 +88,7 @@ func (s *Session) handleEval(line string) (string, tfdiags.Diagnostics) {
 
 func (s *Session) handleHelp() (string, tfdiags.Diagnostics) {
 	text := `
-The Terraform console allows you to experiment with Terraform interpolations.
+The OpenTofu console allows you to experiment with OpenTofu interpolations.
 You may access resources in the state (if you have one) just as you would
 from a configuration. For example: "aws_instance.foo.id" would evaluate
 to the ID of "aws_instance.foo" if it exists in your state.


### PR DESCRIPTION
As part of https://github.com/opentofu/opentofu/issues/702

Removes all leftover mentions of Terraform in the codebase, specifically for user-facing outputs of the OpenTofu CLI

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.6.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `tofu show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTofu now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
