### PR TITLE
Need proper repo address in docs.

### DIFF
--- a/website/docs/cli/install/yum.mdx
+++ b/website/docs/cli/install/yum.mdx
@@ -32,15 +32,16 @@ If you are using a Yum-based distribution, add the repository using
 
 ```bash
 sudo yum install -y yum-utils
-sudo yum-config-manager --add-repo https://rpm.releases.placeholderplaceholderplaceholder.com/$release/hashicorp.repo
+sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/$release/hashicorp.repo
 ```
 
 If you are using a DNF-based distribution, add the repository using
 `dnf config-manager` as follows:
 
 ```bash
+export release='fedora' # or 'RHEL' or 'AmazonLinux'
 sudo dnf install -y dnf-plugins-core
-sudo dnf config-manager --add-repo https://rpm.releases.placeholderplaceholderplaceholder.com/$release/hashicorp.repo
+sudo dnf config-manager --add-repo https://rpm.releases.hashicorp.com/$release/hashicorp.repo
 ```
 
 In both cases, the OpenTofu package name is `tofu`. For example:


### PR DESCRIPTION
description on https://opentofu.org/docs/cli/install/yum includes a placeholder. 3, really.

```bash
sudo yum install -y yum-utils
sudo yum-config-manager --add-repo https://rpm.releases.placeholderplaceholderplaceholder.com/$release/hashicorp.repo
```

Please help us use opentofu on fedora,
and share a usable address here.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.6.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `tofu show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTofu now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
