### PR TITLE
Fix: Global provider schema cache is never used

### DIFF
--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -78,8 +78,8 @@ func (p *GRPCProvider) GetProviderSchema() (resp providers.GetProviderSchemaResp
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	// check the global cache if we can
-	if !p.Addr.IsZero() && resp.ServerCapabilities.GetProviderSchemaOptional {
+	// check the global cache
+	if !p.Addr.IsZero() {
 		if resp, ok := providers.SchemaCache.Get(p.Addr); ok {
 			return resp
 		}
@@ -141,7 +141,7 @@ func (p *GRPCProvider) GetProviderSchema() (resp providers.GetProviderSchemaResp
 	}
 
 	// set the global cache if we can
-	if !p.Addr.IsZero() {
+	if !p.Addr.IsZero() && resp.ServerCapabilities.GetProviderSchemaOptional {
 		providers.SchemaCache.Set(p.Addr, resp)
 	}
 

--- a/internal/plugin/grpc_provider_test.go
+++ b/internal/plugin/grpc_provider_test.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/opentofu/opentofu/internal/addrs"
+
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
 	"github.com/opentofu/opentofu/internal/configs/hcl2shim"
@@ -123,6 +125,100 @@ func TestGRPCProvider_GetSchema_GRPCError(t *testing.T) {
 	resp := p.GetProviderSchema()
 
 	checkDiagsHasError(t, resp.Diagnostics)
+}
+
+func TestGRPCProvider_GetSchema_GlobalCacheEnabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	client := mockproto.NewMockProviderClient(ctrl)
+	// The SchemaCache is global and is saved between test runs
+	providers.SchemaCache = providers.NewMockSchemaCache()
+
+	providerAddr := addrs.Provider{
+		Namespace: "namespace",
+		Type:      "type",
+	}
+
+	mockedProviderResponse := &proto.Schema{Version: 2, Block: &proto.Schema_Block{}}
+
+	client.EXPECT().GetSchema(
+		gomock.Any(),
+		gomock.Any(),
+		gomock.Any(),
+	).Times(1).Return(&proto.GetProviderSchema_Response{
+		Provider:           mockedProviderResponse,
+		ServerCapabilities: &proto.GetProviderSchema_ServerCapabilities{GetProviderSchemaOptional: true},
+	}, nil)
+
+	// Run GetProviderTwice, expect GetSchema to be called once
+	// Re-initialize the provider before each run to avoid usage of the local cache
+	p := &GRPCProvider{
+		client: client,
+		Addr:   providerAddr,
+	}
+	resp := p.GetProviderSchema()
+
+	checkDiags(t, resp.Diagnostics)
+	if !cmp.Equal(resp.Provider.Version, mockedProviderResponse.Version) {
+		t.Fatal(cmp.Diff(resp.Provider.Version, mockedProviderResponse.Version))
+	}
+
+	p = &GRPCProvider{
+		client: client,
+		Addr:   providerAddr,
+	}
+	resp = p.GetProviderSchema()
+
+	checkDiags(t, resp.Diagnostics)
+	if !cmp.Equal(resp.Provider.Version, mockedProviderResponse.Version) {
+		t.Fatal(cmp.Diff(resp.Provider.Version, mockedProviderResponse.Version))
+	}
+}
+
+func TestGRPCProvider_GetSchema_GlobalCacheDisabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	client := mockproto.NewMockProviderClient(ctrl)
+	// The SchemaCache is global and is saved between test runs
+	providers.SchemaCache = providers.NewMockSchemaCache()
+
+	providerAddr := addrs.Provider{
+		Namespace: "namespace",
+		Type:      "type",
+	}
+
+	mockedProviderResponse := &proto.Schema{Version: 2, Block: &proto.Schema_Block{}}
+
+	client.EXPECT().GetSchema(
+		gomock.Any(),
+		gomock.Any(),
+		gomock.Any(),
+	).Times(2).Return(&proto.GetProviderSchema_Response{
+		Provider:           mockedProviderResponse,
+		ServerCapabilities: &proto.GetProviderSchema_ServerCapabilities{GetProviderSchemaOptional: false},
+	}, nil)
+
+	// Run GetProviderTwice, expect GetSchema to be called once
+	// Re-initialize the provider before each run to avoid usage of the local cache
+	p := &GRPCProvider{
+		client: client,
+		Addr:   providerAddr,
+	}
+	resp := p.GetProviderSchema()
+
+	checkDiags(t, resp.Diagnostics)
+	if !cmp.Equal(resp.Provider.Version, mockedProviderResponse.Version) {
+		t.Fatal(cmp.Diff(resp.Provider.Version, mockedProviderResponse.Version))
+	}
+
+	p = &GRPCProvider{
+		client: client,
+		Addr:   providerAddr,
+	}
+	resp = p.GetProviderSchema()
+
+	checkDiags(t, resp.Diagnostics)
+	if !cmp.Equal(resp.Provider.Version, mockedProviderResponse.Version) {
+		t.Fatal(cmp.Diff(resp.Provider.Version, mockedProviderResponse.Version))
+	}
 }
 
 // Ensure that provider error diagnostics are returned early.

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -78,8 +78,8 @@ func (p *GRPCProvider) GetProviderSchema() (resp providers.GetProviderSchemaResp
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	// check the global cache if we can
-	if !p.Addr.IsZero() && resp.ServerCapabilities.GetProviderSchemaOptional {
+	// check the global cache
+	if !p.Addr.IsZero() {
 		if resp, ok := providers.SchemaCache.Get(p.Addr); ok {
 			return resp
 		}
@@ -141,7 +141,7 @@ func (p *GRPCProvider) GetProviderSchema() (resp providers.GetProviderSchemaResp
 	}
 
 	// set the global cache if we can
-	if !p.Addr.IsZero() {
+	if !p.Addr.IsZero() && resp.ServerCapabilities.GetProviderSchemaOptional {
 		providers.SchemaCache.Set(p.Addr, resp)
 	}
 

--- a/internal/providers/mock_schema_cache.go
+++ b/internal/providers/mock_schema_cache.go
@@ -1,0 +1,9 @@
+package providers
+
+import "github.com/opentofu/opentofu/internal/addrs"
+
+func NewMockSchemaCache() *schemaCache {
+	return &schemaCache{
+		m: make(map[addrs.Provider]ProviderSchema),
+	}
+}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Fixes https://github.com/opentofu/opentofu/issues/688

The global provider cache was never used, as the cache was queried only if `ServerCapabilities.GetProviderSchemaOptional` was true, even though the `GetSchema` request didn't yet happen, so this data was always `false`

I changed to logic to only **put** the schema in the cache if the `GetProviderSchemaOptional` capability is on, and always fetch the schema if it's in the cache

Also added unit tests for the bug (had to deal with the fact that currently the SchemaCache leaks between tests, and "luckily" it didn't yet affect the results of the unit tests)

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.6.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `tofu show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTofu now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
