### PR TITLE
Add compare versions script

### DIFF
--- a/.github/scripts/compare-release-versions.sh
+++ b/.github/scripts/compare-release-versions.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Compare the semver tag against the current release in the VERSION file
+
+set -uo pipefail
+
+# Bail if VERSION cannot be found
+if [[ ! -f version/VERSION ]]; then
+    echo "The VERSION file could not be found. Please create a VERSION file in the version/ directory. The contents of version should match the tag without the v prefix."
+    exit 1
+fi
+
+# Bail if the input was not a tag
+if [[ ! "$GITHUB_REF_TYPE" == "tag" ]]; then
+    echo "This action only runs on tags. Please create a tag and try again."
+    exit 1
+fi
+
+# Create a clean semver tag without the v prefix
+CLEAN_TAG=$(echo "$GITHUB_REF_NAME" | sed 's/^v//')
+
+VERSION=$(cat version/VERSION)
+if [[ "$VERSION" != "$CLEAN_TAG" ]]; then
+    echo "The VERSION file does not match the tag. Please update the version/VERSION file to match the tag without the v prefix."
+    echo "The VERSION file contains: $VERSION but the tag is: $CLEAN_TAG."
+    exit 1
+fi
+
+echo "The VERSION file matches the tag. Proceeding with the release of $VERSION."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Fetch tags
         run: git fetch --force --tags
 
+      - name: Compare versions
+        run: ./.github/scripts/compare-release-version.sh
+
       - name: Determine Go version
         id: go
         uses: ./.github/actions/go-version


### PR DESCRIPTION
## Description

I'm adding a check to the release deployment workflow that will compare the triggering tag against the contents of the version/VERSION file.

Read the tag being passed in by GITHUB_REF context and compare it the version file. People rely on these versions being identical and since the update of the file is manual it could be missed.

I've tested this process in another repo. Keep in mind that if you modify default behaviour like continue-on-error in this repo, this may behave differently.

## Test Cases

- [x] version/VERSION file is missing

```bash
./.github/scripts/compare-release-version.sh
  shell: /usr/bin/bash -e {0}
The VERSION file could not be found. Please create a VERSION file in the version/ directory. The contents of version should match the tag without the v prefix.
Error: Process completed with exit code 1.
```

- [x] Contents mismatch -  Github trigger tag minus v prefix does not match the contents of version/VERSION

```bash
Run ./.github/scripts/compare-release-version.sh
The VERSION file does not match the tag. Please update the version/VERSION file to match the tag without the v prefix.
The VERSION file contains: 1.6.0-alpha2 but the tag is: 0.1.12.
Error: Process completed with exit code 1.
```

- [x] Release won't run without the compare step passing first

![image](https://github.com/opentofu/opentofu/assets/7433889/882fd159-baff-4945-b2cf-8a02a988cc01)


- [x] Matching version passes

```bash
Run ./.github/scripts/compare-release-version.sh
The VERSION file matches the tag. Proceeding with the release of 1.6.0-alpha2.
```

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #663 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

N/A I believe this can go in whenever.

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `tofu show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTofu now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  The release workflow will check that the tag version and the version in version/VERSION are consistent.
