### PR TITLE
(#721) remove reference to Hashicorp docker mirror in workflow

### DIFF
--- a/.github/workflows/build-Dockerfile
+++ b/.github/workflows/build-Dockerfile
@@ -7,7 +7,7 @@
 # action would set, and ensure that there's a suitable "tofu" executable
 # in the dist/linux/${TARGETARCH} directory.
 
-FROM docker.mirror.hashicorp.services/alpine:latest AS default
+FROM docker.io/alpine:latest AS default
 
 # This is intended to be run from the hashicorp/actions-docker-build GitHub
 # action, which sets these appropriately based on context.


### PR DESCRIPTION
<!--

Removes a reference to a hashicorp docker mirror in the github workflows

-->

<!--

#721 

-->

Resolves #721

<!--

-->

1.6.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

<!--

Write a short description of the user-facing change. Examples:

--> 

-  Removes reference to HashiCorp managed docker mirror in github workflows. No user facing change.
