### PR TITLE
internal/registry: Prune and Demote Exported Functions

### DIFF
--- a/internal/registry/errors.go
+++ b/internal/registry/errors.go
@@ -6,7 +6,6 @@ package registry
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform-svchost/disco"
 	"github.com/opentofu/opentofu/internal/registry/regsrc"
 )
 
@@ -23,14 +22,6 @@ func (e *errModuleNotFound) Error() string {
 // as distinct from operational errors such as poor network connectivity.
 func IsModuleNotFound(err error) bool {
 	_, ok := err.(*errModuleNotFound)
-	return ok
-}
-
-// IsServiceNotProvided returns true only if the given error is a "service not provided"
-// error. This allows callers to recognize this particular error condition
-// as distinct from operational errors such as poor network connectivity.
-func IsServiceNotProvided(err error) bool {
-	_, ok := err.(*disco.ErrServiceNotProvided)
 	return ok
 }
 

--- a/internal/registry/regsrc/friendly_host.go
+++ b/internal/registry/regsrc/friendly_host.go
@@ -63,11 +63,11 @@ type FriendlyHost struct {
 	Raw string
 }
 
-func NewFriendlyHost(host string) *FriendlyHost {
+func newFriendlyHost(host string) *FriendlyHost {
 	return &FriendlyHost{Raw: host}
 }
 
-// ParseFriendlyHost attempts to parse a valid "friendly host" prefix from the
+// parseFriendlyHost attempts to parse a valid "friendly host" prefix from the
 // given string. If no valid prefix is found, host will be nil and rest will
 // contain the full source string. The host prefix must terminate at the end of
 // the input or at the first / character. If one or more characters exist after
@@ -77,7 +77,7 @@ func NewFriendlyHost(host string) *FriendlyHost {
 // invalid if the string came from a user directly. This must be checked
 // explicitly for user-input strings by calling Valid() on the
 // returned host.
-func ParseFriendlyHost(source string) (host *FriendlyHost, rest string) {
+func parseFriendlyHost(source string) (host *FriendlyHost, rest string) {
 	parts := strings.SplitN(source, "/", 2)
 
 	if hostRe.MatchString(parts[0]) {

--- a/internal/registry/regsrc/friendly_host_test.go
+++ b/internal/registry/regsrc/friendly_host_test.go
@@ -78,7 +78,7 @@ func TestFriendlyHost(t *testing.T) {
 		// Matrix each test with prefix and total match variants
 		for _, sfx := range []string{"", "/", "/foo/bar/baz"} {
 			t.Run(tt.name+" suffix:"+sfx, func(t *testing.T) {
-				gotHost, gotRest := ParseFriendlyHost(tt.source + sfx)
+				gotHost, gotRest := parseFriendlyHost(tt.source + sfx)
 
 				if gotHost == nil {
 					if tt.wantHost != "" {
@@ -121,7 +121,7 @@ func TestFriendlyHost(t *testing.T) {
 }
 
 func TestInvalidHostEquals(t *testing.T) {
-	invalid := NewFriendlyHost("NOT_A_HOST_NAME")
+	invalid := newFriendlyHost("NOT_A_HOST_NAME")
 	valid := PublicRegistryHost
 
 	// invalid hosts are not comparable
@@ -133,8 +133,8 @@ func TestInvalidHostEquals(t *testing.T) {
 		t.Fatalf("%q is not equal to %q", valid, invalid)
 	}
 
-	puny := NewFriendlyHost("xn--s-fka0wmm0zea7g8b.xn--o-8ta85a3b1dwcda1k.io")
-	display := NewFriendlyHost("ʎɹʇsıƃǝɹ.ɯɹoɟɐɹɹǝʇ.io")
+	puny := newFriendlyHost("xn--s-fka0wmm0zea7g8b.xn--o-8ta85a3b1dwcda1k.io")
+	display := newFriendlyHost("ʎɹʇsıƃǝɹ.ɯɹoɟɐɹɹǝʇ.io")
 
 	// The pre-normalized host is not a valid source, and therefore not
 	// comparable to the display version.

--- a/internal/registry/regsrc/module.go
+++ b/internal/registry/regsrc/module.go
@@ -127,17 +127,6 @@ func ParseModuleSource(source string) (*Module, error) {
 	return m, nil
 }
 
-// Display returns the source formatted for display to the user in CLI or web
-// output.
-func (m *Module) Display() string {
-	return m.formatWithPrefix(m.normalizedHostPrefix(m.Host().Display()), false)
-}
-
-// Normalized returns the source formatted for internal reference or comparison.
-func (m *Module) Normalized() string {
-	return m.formatWithPrefix(m.normalizedHostPrefix(m.Host().Normalized()), false)
-}
-
 // String returns the source formatted as the user originally typed it assuming
 // it was parsed from user input.
 func (m *Module) String() string {
@@ -148,29 +137,6 @@ func (m *Module) String() string {
 		hostPrefix = m.RawHost.String() + "/"
 	}
 	return m.formatWithPrefix(hostPrefix, true)
-}
-
-// Equal compares the module source against another instance taking
-// normalization into account.
-func (m *Module) Equal(other *Module) bool {
-	return m.Normalized() == other.Normalized()
-}
-
-// Host returns the FriendlyHost object describing which registry this module is
-// in. If the original source string had not host component this will return the
-// PublicRegistryHost.
-func (m *Module) Host() *FriendlyHost {
-	if m.RawHost == nil {
-		return PublicRegistryHost
-	}
-	return m.RawHost
-}
-
-func (m *Module) normalizedHostPrefix(host string) string {
-	if m.Host().Equal(PublicRegistryHost) {
-		return ""
-	}
-	return host + "/"
 }
 
 func (m *Module) formatWithPrefix(hostPrefix string, preserveCase bool) string {

--- a/internal/registry/regsrc/module.go
+++ b/internal/registry/regsrc/module.go
@@ -81,7 +81,7 @@ func NewModule(host, namespace, name, provider, submodule string) (*Module, erro
 		RawSubmodule: submodule,
 	}
 	if host != "" {
-		h := NewFriendlyHost(host)
+		h := newFriendlyHost(host)
 		if h != nil {
 			fmt.Println("HOST:", h)
 			if !h.Valid() || disallowed[h.Display()] {
@@ -125,7 +125,7 @@ func ModuleFromModuleSourceAddr(addr addrs.ModuleSourceRegistry) *Module {
 // for the higher-level module installer to deal with.
 func ModuleFromRegistryPackageAddr(addr addrs.ModuleRegistryPackage) *Module {
 	return &Module{
-		RawHost:      NewFriendlyHost(addr.Host.String()),
+		RawHost:      newFriendlyHost(addr.Host.String()),
 		RawNamespace: addr.Namespace,
 		RawName:      addr.Name,
 		RawProvider:  addr.TargetSystem, // this field was never actually enforced to be a provider address, so now has a more general name
@@ -143,7 +143,7 @@ func ModuleFromRegistryPackageAddr(addr addrs.ModuleRegistryPackage) *Module {
 // string equality operator.
 func ParseModuleSource(source string) (*Module, error) {
 	// See if there is a friendly host prefix.
-	host, rest := ParseFriendlyHost(source)
+	host, rest := parseFriendlyHost(source)
 	if host != nil {
 		if !host.Valid() || disallowed[host.Display()] {
 			return nil, ErrInvalidModuleSource

--- a/internal/registry/regsrc/module.go
+++ b/internal/registry/regsrc/module.go
@@ -71,48 +71,6 @@ type Module struct {
 	RawSubmodule string
 }
 
-// NewModule construct a new module source from separate parts. Pass empty
-// string if host or submodule are not needed.
-func NewModule(host, namespace, name, provider, submodule string) (*Module, error) {
-	m := &Module{
-		RawNamespace: namespace,
-		RawName:      name,
-		RawProvider:  provider,
-		RawSubmodule: submodule,
-	}
-	if host != "" {
-		h := newFriendlyHost(host)
-		if h != nil {
-			fmt.Println("HOST:", h)
-			if !h.Valid() || disallowed[h.Display()] {
-				return nil, ErrInvalidModuleSource
-			}
-		}
-		m.RawHost = h
-	}
-	return m, nil
-}
-
-// ModuleFromModuleSourceAddr is an adapter to automatically transform the
-// modern representation of registry module addresses,
-// addrs.ModuleSourceRegistry, into the legacy representation regsrc.Module.
-//
-// Note that the new-style model always does normalization during parsing and
-// does not preserve the raw user input at all, and so although the fields
-// of regsrc.Module are all called "Raw...", initializing a Module indirectly
-// through an addrs.ModuleSourceRegistry will cause those values to be the
-// normalized ones, not the raw user input.
-//
-// Use this only for temporary shims to call into existing code that still
-// uses regsrc.Module. Eventually all other subsystems should be updated to
-// use addrs.ModuleSourceRegistry instead, and then package regsrc can be
-// removed altogether.
-func ModuleFromModuleSourceAddr(addr addrs.ModuleSourceRegistry) *Module {
-	ret := ModuleFromRegistryPackageAddr(addr.Package)
-	ret.RawSubmodule = addr.Subdir
-	return ret
-}
-
 // ModuleFromRegistryPackageAddr is similar to ModuleFromModuleSourceAddr, but
 // it works with just the isolated registry package address, and not the
 // full source address.

--- a/internal/registry/regsrc/module_test.go
+++ b/internal/registry/regsrc/module_test.go
@@ -125,20 +125,6 @@ func TestModule(t *testing.T) {
 			if v := got.String(); v != tt.wantString {
 				t.Fatalf("String() = %v, want %v", v, tt.wantString)
 			}
-			if v := got.Display(); v != tt.wantDisplay {
-				t.Fatalf("Display() = %v, want %v", v, tt.wantDisplay)
-			}
-			if v := got.Normalized(); v != tt.wantNorm {
-				t.Fatalf("Normalized() = %v, want %v", v, tt.wantNorm)
-			}
-
-			gotDisplay, err := ParseModuleSource(tt.wantDisplay)
-			if err != nil {
-				t.Fatalf("ParseModuleSource(wantDisplay) error = %v", err)
-			}
-			if !got.Equal(gotDisplay) {
-				t.Fatalf("Equal() failed for %s and %s", tt.source, tt.wantDisplay)
-			}
 		})
 	}
 }

--- a/internal/registry/regsrc/regsrc.go
+++ b/internal/registry/regsrc/regsrc.go
@@ -7,5 +7,5 @@ package regsrc
 
 var (
 	// PublicRegistryHost is a FriendlyHost that represents the public registry.
-	PublicRegistryHost = NewFriendlyHost("registry.opentofu.org")
+	PublicRegistryHost = newFriendlyHost("registry.opentofu.org")
 )

--- a/internal/registry/response/pagination.go
+++ b/internal/registry/response/pagination.go
@@ -18,8 +18,8 @@ type PaginationMeta struct {
 	PrevURL       string `json:"prev_url,omitempty"`
 }
 
-// NewPaginationMeta populates pagination meta data from result parameters
-func NewPaginationMeta(offset, limit int, hasMore bool, currentURL string) PaginationMeta {
+// newPaginationMeta populates pagination meta data from result parameters
+func newPaginationMeta(offset, limit int, hasMore bool, currentURL string) PaginationMeta {
 	pm := PaginationMeta{
 		Limit:         limit,
 		CurrentOffset: offset,

--- a/internal/registry/response/pagination_test.go
+++ b/internal/registry/response/pagination_test.go
@@ -105,7 +105,7 @@ func TestNewPaginationMeta(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := NewPaginationMeta(tt.args.offset, tt.args.limit, tt.args.hasMore,
+			got := newPaginationMeta(tt.args.offset, tt.args.limit, tt.args.hasMore,
 				tt.args.currentURL)
 			gotJSON, err := prettyJSON(got)
 			if err != nil {


### PR DESCRIPTION
There are numerous exported functions in `internal/registry` that are either unused or only called locally. This PR removes unused functions (both exported and local) and demotes functions, and it demotes those needlessly exported.

Fixes #725 

There are no user-facing changes that warrant a CHANGELOG entry.