### PR TITLE
Add the license to compare-release-versions.sh

### DIFF
--- a/.github/scripts/compare-release-versions.sh
+++ b/.github/scripts/compare-release-versions.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+
 # Compare the semver tag against the current release in the VERSION file
 
 set -uo pipefail


### PR DESCRIPTION
This change adds a license I missed when writing the compare-release-versions script for the release workflow version comparison.

Relates to #720 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

N/A This can go in anytime, asap ideally since it's a license.

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- `tofu show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTofu now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  Update license for compare-release-versions script. Not user facing.
