### PR TITLE
Add comparison to Terraform link

### DIFF
--- a/website/docs/intro/vs/index.mdx
+++ b/website/docs/intro/vs/index.mdx
@@ -17,5 +17,6 @@ Learn how OpenTofu compares to:
 
 - [Chef, Puppet, etc.](/docs/intro/vs/chef-puppet)
 - [CloudFormation, Heat, etc.](/docs/intro/vs/cloudformation)
-- [Boto, Fog, etc.](/docs/intro/vs/boto)
 - [Custom Solutions](/docs/intro/vs/custom)
+- [Boto, Fog, etc.](/docs/intro/vs/boto)
+- [Terraform](/faq/#opentofu-terraform-differences)


### PR DESCRIPTION
Update https://opentofu.org/docs/intro/vs/ to help readers compare OpenTofu to Terraform.


Resolves #736

## Draft CHANGELOG entry



### ENHANCEMENTS

<!--

Write a short description of the user-facing change. Examples:

- Help website readers compare OpenTofu to Terraform.

--> 