### PR TITLE
Provide git for module installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ FROM alpine:3.18
 
 LABEL maintainer="OpenTofu Team <opentofu@opentofu.org>"
 
+RUN apk add --no-cache git
+
 COPY tofu /usr/local/bin/tofu
 
 ENTRYPOINT ["/usr/local/bin/tofu"]


### PR DESCRIPTION
OpenTofu is unable to fetch modules from Git repository without `git` binary in PATH.

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #750

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.6.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### BUG FIXES

- Fix module installation when OpenTofu runs in container.

<!--

Write a short description of the user-facing change. Examples:

- `tofu show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTofu now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

