### PR TITLE
command/views: Remove extra newline in validate output

### DIFF
--- a/internal/command/views/validate.go
+++ b/internal/command/views/validate.go
@@ -63,9 +63,9 @@ func (v *ValidateHuman) Results(diags tfdiags.Diagnostics) int {
 	return 0
 }
 
-const validateSuccess = "[green][bold]Success![reset] The configuration is valid.\n"
+const validateSuccess = "[green][bold]Success![reset] The configuration is valid."
 
-const validateWarnings = "[green][bold]Success![reset] The configuration is valid, but there were some validation warnings as shown above.\n"
+const validateWarnings = "[green][bold]Success![reset] The configuration is valid, but there were some validation warnings as shown above."
 
 func (v *ValidateHuman) Diagnostics(diags tfdiags.Diagnostics) {
 	v.view.Diagnostics(diags)


### PR DESCRIPTION
Remove extra newline in validate output.
before:
```bash
% tofu validate                             
Success! The configuration is valid.

%
```

after:
```bash
% tofu validate                             
Success! The configuration is valid.
%
```

Fixes #765

## Target Release
1.6.1

## Draft CHANGELOG entry

### BUG FIXES
-  Remove extra newline from validate output
