### PR TITLE
Backend/S3: Add HTTP parameters for parity with AWS Provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ S3 BACKEND:
 * Adds support for the `sts_region` argument. ([#695](https://github.com/opentofu/opentofu/issues/695))
 * Adds support for `ec2_metadata_service_endpoint` and `ec2_metadata_service_endpoint_mode` arguments to enable overriding the EC2 metadata service (IMDS) endpoint. ([#693](https://github.com/opentofu/opentofu/issues/693))
 * Adds support for the `retry_mode` attribute. ([#698](https://github.com/opentofu/opentofu/issues/698))
-* Adds support for the `http_proxy` attribute. ([#694](https://github.com/opentofu/opentofu/issues/694))
+* Adds support for the `http_proxy` and `insecure` attributes. ([#694](https://github.com/opentofu/opentofu/issues/694))
 
 ## Previous Releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ S3 BACKEND:
 * Adds support for the `sts_region` argument. ([#695](https://github.com/opentofu/opentofu/issues/695))
 * Adds support for `ec2_metadata_service_endpoint` and `ec2_metadata_service_endpoint_mode` arguments to enable overriding the EC2 metadata service (IMDS) endpoint. ([#693](https://github.com/opentofu/opentofu/issues/693))
 * Adds support for the `retry_mode` attribute. ([#698](https://github.com/opentofu/opentofu/issues/698))
+* Adds support for the `http_proxy` attribute. ([#694](https://github.com/opentofu/opentofu/issues/694))
 
 ## Previous Releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ S3 BACKEND:
 * Adds support for the `sts_region` argument. ([#695](https://github.com/opentofu/opentofu/issues/695))
 * Adds support for `ec2_metadata_service_endpoint` and `ec2_metadata_service_endpoint_mode` arguments to enable overriding the EC2 metadata service (IMDS) endpoint. ([#693](https://github.com/opentofu/opentofu/issues/693))
 * Adds support for the `retry_mode` attribute. ([#698](https://github.com/opentofu/opentofu/issues/698))
-* Adds support for the `http_proxy` and `insecure` attributes. ([#694](https://github.com/opentofu/opentofu/issues/694))
+* Adds support for the `http_proxy`, `insecure`, and `use_dualstack_endpoint` attributes. ([#694](https://github.com/opentofu/opentofu/issues/694))
 
 ## Previous Releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ S3 BACKEND:
 * Adds support for the `sts_region` argument. ([#695](https://github.com/opentofu/opentofu/issues/695))
 * Adds support for `ec2_metadata_service_endpoint` and `ec2_metadata_service_endpoint_mode` arguments to enable overriding the EC2 metadata service (IMDS) endpoint. ([#693](https://github.com/opentofu/opentofu/issues/693))
 * Adds support for the `retry_mode` attribute. ([#698](https://github.com/opentofu/opentofu/issues/698))
-* Adds support for the `http_proxy`, `insecure`, and `use_dualstack_endpoint` attributes. ([#694](https://github.com/opentofu/opentofu/issues/694))
+* Adds support for the `http_proxy`, `insecure`, `use_dualstack_endpoint`, and `use_fips_endpoint` attributes. ([#694](https://github.com/opentofu/opentofu/issues/694))
 
 ## Previous Releases
 

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -367,6 +367,11 @@ func (b *Backend) ConfigSchema(context.Context) *configschema.Block {
 				Optional:    true,
 				Description: "List of allowed AWS account IDs.",
 			},
+			"http_proxy": {
+				Type:        cty.String,
+				Optional:    true,
+				Description: "The address of an HTTP proxy to use when accessing the AWS API.",
+			},
 		},
 	}
 }
@@ -616,6 +621,7 @@ func (b *Backend) Configure(ctx context.Context, obj cty.Value) tfdiags.Diagnost
 		StsEndpoint:            stringAttrDefaultEnvVar(obj, "sts_endpoint", "AWS_STS_ENDPOINT"),
 		StsRegion:              stringAttr(obj, "sts_region"),
 		Token:                  stringAttr(obj, "token"),
+		HTTPProxy:              stringAttrDefaultEnvVar(obj, "http_proxy", "HTTP_PROXY", "HTTPS_PROXY"),
 		UserAgent: awsbase.UserAgentProducts{
 			{Name: "APN", Version: "1.0"},
 			{Name: httpclient.DefaultApplicationName, Version: version.String()},

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -382,6 +382,11 @@ func (b *Backend) ConfigSchema(context.Context) *configschema.Block {
 				Optional:    true,
 				Description: "Resolve an endpoint with DualStack capability.",
 			},
+			"use_fips_endpoint": {
+				Type:        cty.Bool,
+				Optional:    true,
+				Description: "Resolve an endpoint with FIPS capability.",
+			},
 		},
 	}
 }
@@ -634,6 +639,7 @@ func (b *Backend) Configure(ctx context.Context, obj cty.Value) tfdiags.Diagnost
 		HTTPProxy:              stringAttrDefaultEnvVar(obj, "http_proxy", "HTTP_PROXY", "HTTPS_PROXY"),
 		Insecure:               boolAttr(obj, "insecure"),
 		UseDualStackEndpoint:   boolAttr(obj, "use_dualstack_endpoint"),
+		UseFIPSEndpoint:        boolAttr(obj, "use_fips_endpoint"),
 		UserAgent: awsbase.UserAgentProducts{
 			{Name: "APN", Version: "1.0"},
 			{Name: httpclient.DefaultApplicationName, Version: version.String()},

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -372,6 +372,11 @@ func (b *Backend) ConfigSchema(context.Context) *configschema.Block {
 				Optional:    true,
 				Description: "The address of an HTTP proxy to use when accessing the AWS API.",
 			},
+			"insecure": {
+				Type:        cty.Bool,
+				Optional:    true,
+				Description: "Explicitly allow the backend to perform \"insecure\" SSL requests.",
+			},
 		},
 	}
 }
@@ -622,6 +627,7 @@ func (b *Backend) Configure(ctx context.Context, obj cty.Value) tfdiags.Diagnost
 		StsRegion:              stringAttr(obj, "sts_region"),
 		Token:                  stringAttr(obj, "token"),
 		HTTPProxy:              stringAttrDefaultEnvVar(obj, "http_proxy", "HTTP_PROXY", "HTTPS_PROXY"),
+		Insecure:               boolAttr(obj, "insecure"),
 		UserAgent: awsbase.UserAgentProducts{
 			{Name: "APN", Version: "1.0"},
 			{Name: httpclient.DefaultApplicationName, Version: version.String()},

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -377,6 +377,11 @@ func (b *Backend) ConfigSchema(context.Context) *configschema.Block {
 				Optional:    true,
 				Description: "Explicitly allow the backend to perform \"insecure\" SSL requests.",
 			},
+			"use_dualstack_endpoint": {
+				Type:        cty.Bool,
+				Optional:    true,
+				Description: "Resolve an endpoint with DualStack capability.",
+			},
 		},
 	}
 }
@@ -628,6 +633,7 @@ func (b *Backend) Configure(ctx context.Context, obj cty.Value) tfdiags.Diagnost
 		Token:                  stringAttr(obj, "token"),
 		HTTPProxy:              stringAttrDefaultEnvVar(obj, "http_proxy", "HTTP_PROXY", "HTTPS_PROXY"),
 		Insecure:               boolAttr(obj, "insecure"),
+		UseDualStackEndpoint:   boolAttr(obj, "use_dualstack_endpoint"),
 		UserAgent: awsbase.UserAgentProducts{
 			{Name: "APN", Version: "1.0"},
 			{Name: httpclient.DefaultApplicationName, Version: version.String()},

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -180,6 +180,7 @@ The following configuration is optional:
 * `ec2_metadata_service_endpoint_mode` - Mode to use in communicating with the metadata service. Valid values are `IPv4` and `IPv6`. This can also be sourced from the `AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE` environment variable.
 * `http_proxy` - (Optional) The address of an HTTP proxy to use when accessing the AWS API. This can also be sourced from the `HTTP_PROXY` or `HTTPS_PROXY` environment variables.
 * `insecure` - (Optional) Explicitly allow the backend to perform "insecure" SSL requests; default is `false`.
+* `use_dualstack_endpoint` - (Optional) Resolve an endpoint with DualStack capability.
 
 #### Assume Role Configuration
 

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -178,6 +178,7 @@ The following configuration is optional:
 * `custom_ca_bundle` - File containing custom root and intermediate certificates. Can also be configured using the `AWS_CA_BUNDLE` environment variable.
 * `ec2_metadata_service_endpoint` - Address of the EC2 metadata service (IMDS) endpoint to use. This can also be sourced from the `AWS_EC2_METADATA_SERVICE_ENDPOINT` environment variable.
 * `ec2_metadata_service_endpoint_mode` - Mode to use in communicating with the metadata service. Valid values are `IPv4` and `IPv6`. This can also be sourced from the `AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE` environment variable.
+* `http_proxy` - (Optional) The address of an HTTP proxy to use when accessing the AWS API. This can also be sourced from the `HTTP_PROXY` or `HTTPS_PROXY` environment variables.
 
 #### Assume Role Configuration
 

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -179,6 +179,7 @@ The following configuration is optional:
 * `ec2_metadata_service_endpoint` - Address of the EC2 metadata service (IMDS) endpoint to use. This can also be sourced from the `AWS_EC2_METADATA_SERVICE_ENDPOINT` environment variable.
 * `ec2_metadata_service_endpoint_mode` - Mode to use in communicating with the metadata service. Valid values are `IPv4` and `IPv6`. This can also be sourced from the `AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE` environment variable.
 * `http_proxy` - (Optional) The address of an HTTP proxy to use when accessing the AWS API. This can also be sourced from the `HTTP_PROXY` or `HTTPS_PROXY` environment variables.
+* `insecure` - (Optional) Explicitly allow the backend to perform "insecure" SSL requests; default is `false`.
 
 #### Assume Role Configuration
 

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -181,6 +181,7 @@ The following configuration is optional:
 * `http_proxy` - (Optional) The address of an HTTP proxy to use when accessing the AWS API. This can also be sourced from the `HTTP_PROXY` or `HTTPS_PROXY` environment variables.
 * `insecure` - (Optional) Explicitly allow the backend to perform "insecure" SSL requests; default is `false`.
 * `use_dualstack_endpoint` - (Optional) Resolve an endpoint with DualStack capability.
+* `use_fips_endpoint` - (Optional) Resolve an endpoint with FIPS capability.
 
 #### Assume Role Configuration
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

Adds HTTP parameters.

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #694 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.6.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `tofu show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTofu now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
