### PR TITLE
Stop reading providers from the HashiCorp registry based on the statefile if not specified in code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ ENHANCEMENTS:
 * cloud: Remote plans on cloud backends can now be saved using the `-out` flag, referenced in the `show` command, and applied by specifying the plan file name. ([#33492](https://github.com/hashicorp/terraform/issues/33492))
 * config: The `import` block `id` field now accepts an expression referencing other values such as resource attributes, as long as the value is a string known at plan time. ([#33618](https://github.com/hashicorp/terraform/issues/33618))
 * telemetry: All checkpoint telemetry was removed ([#151](https://github.com/opentofu/opentofu/pull/151))
+* state: Provider addresses in the statefile referring to registry.terraform.io will be treated as referring to registry.opentofu.org unless the full provider address is specified in the config or `OPENTOFU_STATEFILE_PROVIDER_ADDRESS_TRANSLATION` is set to `0`. ([#773](https://github.com/opentofu/opentofu/pull/773))
 
 BUG FIXES:
 

--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -211,7 +211,12 @@ func (b *Local) localRunDirect(op *backend.Operation, run *backend.LocalRun, cor
 	// For a "direct" local run, the input state is the most recently stored
 	// snapshot, from the previous run.
 	rawState := s.State()
-	run.InputState = tofumigrate.MigrateStateProviderAddresses(config, rawState)
+	migratedState, migrateDiags := tofumigrate.MigrateStateProviderAddresses(config, rawState)
+	diags = diags.Append(migrateDiags)
+	if migrateDiags.HasErrors() {
+		return nil, nil, diags
+	}
+	run.InputState = migratedState
 
 	tfCtx, moreDiags := tofu.NewContext(coreOpts)
 	diags = diags.Append(moreDiags)

--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/backend"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/configs/configload"
@@ -17,7 +19,7 @@ import (
 	"github.com/opentofu/opentofu/internal/states/statemgr"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/opentofu/opentofu/internal/tofu"
-	"github.com/zclconf/go-cty/cty"
+	"github.com/opentofu/opentofu/internal/tofumigrate"
 )
 
 // backend.Local implementation.
@@ -208,7 +210,8 @@ func (b *Local) localRunDirect(op *backend.Operation, run *backend.LocalRun, cor
 
 	// For a "direct" local run, the input state is the most recently stored
 	// snapshot, from the previous run.
-	run.InputState = s.State()
+	rawState := s.State()
+	run.InputState = tofumigrate.MigrateStateProviderAddresses(config, rawState)
 
 	tfCtx, moreDiags := tofu.NewContext(coreOpts)
 	diags = diags.Append(moreDiags)

--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -210,13 +210,16 @@ func (b *Local) localRunDirect(op *backend.Operation, run *backend.LocalRun, cor
 
 	// For a "direct" local run, the input state is the most recently stored
 	// snapshot, from the previous run.
-	rawState := s.State()
-	migratedState, migrateDiags := tofumigrate.MigrateStateProviderAddresses(config, rawState)
-	diags = diags.Append(migrateDiags)
-	if migrateDiags.HasErrors() {
-		return nil, nil, diags
+	state := s.State()
+	if state != nil {
+		migratedState, migrateDiags := tofumigrate.MigrateStateProviderAddresses(config, state)
+		diags = diags.Append(migrateDiags)
+		if migrateDiags.HasErrors() {
+			return nil, nil, diags
+		}
+		state = migratedState
 	}
-	run.InputState = migratedState
+	run.InputState = state
 
 	tfCtx, moreDiags := tofu.NewContext(coreOpts)
 	diags = diags.Append(moreDiags)

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -306,7 +306,13 @@ func (c *InitCommand) Run(args []string) int {
 	if state != nil {
 		// Since we now have the full configuration loaded, we can use it to migrate the in-memory state view
 		// prior to fetching providers.
-		state = tofumigrate.MigrateStateProviderAddresses(config, state)
+		migratedState, migrateDiags := tofumigrate.MigrateStateProviderAddresses(config, state)
+		diags = diags.Append(migrateDiags)
+		if migrateDiags.HasErrors() {
+			c.showDiagnostics(diags)
+			return 1
+		}
+		state = migratedState
 	}
 
 	// Now that we have loaded all modules, check the module tree for missing providers.

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -31,6 +31,7 @@ import (
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/opentofu/opentofu/internal/tofu"
+	"github.com/opentofu/opentofu/internal/tofumigrate"
 	tfversion "github.com/opentofu/opentofu/version"
 )
 
@@ -300,6 +301,12 @@ func (c *InitCommand) Run(args []string) int {
 				return 1
 			}
 		}
+	}
+
+	if state != nil {
+		// Since we now have the full configuration loaded, we can use it to migrate the in-memory state view
+		// prior to fetching providers.
+		state = tofumigrate.MigrateStateProviderAddresses(config, state)
 	}
 
 	// Now that we have loaded all modules, check the module tree for missing providers.

--- a/internal/tofumigrate/testdata/mention/main.tf
+++ b/internal/tofumigrate/testdata/mention/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "registry.terraform.io/hashicorp/aws"
+    }
+  }
+}
+
+provider "random" {}
+provider "aws" {}
+
+resource "random_id" "example" {
+  byte_length = 8
+}
+
+resource "aws_instance" "example" {
+  ami           = "abc"
+  instance_type = "t2.micro"
+}

--- a/internal/tofumigrate/testdata/nomention/main.tf
+++ b/internal/tofumigrate/testdata/nomention/main.tf
@@ -1,0 +1,11 @@
+provider "random" {}
+provider "aws" {}
+
+resource "random_id" "example" {
+  byte_length = 8
+}
+
+resource "aws_instance" "example" {
+  ami           = "abc"
+  instance_type = "t2.micro"
+}

--- a/internal/tofumigrate/tofumigrate.go
+++ b/internal/tofumigrate/tofumigrate.go
@@ -1,0 +1,45 @@
+package tofumigrate
+
+import (
+	"github.com/opentofu/opentofu/internal/configs"
+	"github.com/opentofu/opentofu/internal/states"
+)
+
+// MigrateStateProviderAddresses can be used to update the in-memory view of the state to use registry.opentofu.org
+// provider addresses. This only applies for providers which are *not* explicitly referenced in the configuration in full form.
+// For example, if the configuration contains a provider block like this:
+//
+//	terraform {
+//	 required_providers {
+//	   random = {}
+//	 }
+//	}
+//
+// we will migrate the in-memory view of the statefile to use registry.opentofu.org/hashicorp/random.
+// However, if the configuration contains a provider block like this:
+//
+//	terraform {
+//	 required_providers {
+//	   random = {
+//	     source = "registry.terraform.io/hashicorp/random"
+//	   }
+//	 }
+//	}
+//
+// then we keep the old address.
+func MigrateStateProviderAddresses(config *configs.Config, state *states.State) *states.State {
+	stateCopy := state.DeepCopy()
+
+	providers, _ := config.ProviderRequirements() // TODO: Handle error.
+
+	for _, module := range stateCopy.Modules {
+		for _, resource := range module.Resources {
+			_, referencedInConfig := providers[resource.ProviderConfig.Provider]
+			if resource.ProviderConfig.Provider.Hostname == "registry.terraform.io" && !referencedInConfig {
+				resource.ProviderConfig.Provider.Hostname = "registry.opentofu.org"
+			}
+		}
+	}
+
+	return stateCopy
+}

--- a/internal/tofumigrate/tofumigrate.go
+++ b/internal/tofumigrate/tofumigrate.go
@@ -1,6 +1,8 @@
 package tofumigrate
 
 import (
+	tfaddr "github.com/opentofu/registry-address"
+
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
@@ -43,7 +45,7 @@ func MigrateStateProviderAddresses(config *configs.Config, state *states.State) 
 		for _, resource := range module.Resources {
 			_, referencedInConfig := providers[resource.ProviderConfig.Provider]
 			if resource.ProviderConfig.Provider.Hostname == "registry.terraform.io" && !referencedInConfig {
-				resource.ProviderConfig.Provider.Hostname = "registry.opentofu.org"
+				resource.ProviderConfig.Provider.Hostname = tfaddr.DefaultProviderRegistryHost
 			}
 		}
 	}

--- a/internal/tofumigrate/tofumigrate.go
+++ b/internal/tofumigrate/tofumigrate.go
@@ -1,6 +1,8 @@
 package tofumigrate
 
 import (
+	"os"
+
 	tfaddr "github.com/opentofu/registry-address"
 
 	"github.com/opentofu/opentofu/internal/configs"
@@ -31,6 +33,10 @@ import (
 //
 // then we keep the old address.
 func MigrateStateProviderAddresses(config *configs.Config, state *states.State) (*states.State, tfdiags.Diagnostics) {
+	if os.Getenv("OPENTOFU_STATEFILE_PROVIDER_ADDRESS_TRANSLATION") == "0" {
+		return state, nil
+	}
+
 	var diags tfdiags.Diagnostics
 
 	stateCopy := state.DeepCopy()

--- a/internal/tofumigrate/tofumigrate_test.go
+++ b/internal/tofumigrate/tofumigrate_test.go
@@ -1,0 +1,183 @@
+package tofumigrate
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/configs/configload"
+	"github.com/opentofu/opentofu/internal/states"
+)
+
+func TestMigrateStateProviderAddresses(t *testing.T) {
+	loader, close := configload.NewLoaderForTests(t)
+	defer close()
+
+	mustParseInstAddr := func(s string) addrs.AbsResourceInstance {
+		addr, err := addrs.ParseAbsResourceInstanceStr(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return addr
+	}
+
+	makeRootProviderAddr := func(s string) addrs.AbsProviderConfig {
+		return addrs.AbsProviderConfig{
+			Module:   addrs.RootModule,
+			Provider: addrs.MustParseProviderSourceString(s),
+		}
+	}
+
+	type args struct {
+		configDir string
+		state     *states.State
+	}
+	tests := []struct {
+		name string
+		args args
+		want *states.State
+	}{
+		{
+			name: "if there are no code references, migrate",
+			args: args{
+				configDir: "testdata/nomention",
+				state: states.BuildState(func(s *states.SyncState) {
+					s.SetResourceInstanceCurrent(
+						mustParseInstAddr("random_id.example"),
+						&states.ResourceInstanceObjectSrc{
+							Status:    states.ObjectReady,
+							AttrsJSON: []byte(`{}`),
+						},
+						makeRootProviderAddr("registry.terraform.io/hashicorp/random"),
+					)
+					s.SetResourceInstanceCurrent(
+						mustParseInstAddr("aws_instance.example"),
+						&states.ResourceInstanceObjectSrc{
+							Status:    states.ObjectReady,
+							AttrsJSON: []byte(`{}`),
+						},
+						makeRootProviderAddr("registry.terraform.io/hashicorp/aws"),
+					)
+				}),
+			},
+			want: states.BuildState(func(s *states.SyncState) {
+				s.SetResourceInstanceCurrent(
+					mustParseInstAddr("random_id.example"),
+					&states.ResourceInstanceObjectSrc{
+						Status:    states.ObjectReady,
+						AttrsJSON: []byte(`{}`),
+					},
+					makeRootProviderAddr("registry.opentofu.org/hashicorp/random"),
+				)
+				s.SetResourceInstanceCurrent(
+					mustParseInstAddr("aws_instance.example"),
+					&states.ResourceInstanceObjectSrc{
+						Status:    states.ObjectReady,
+						AttrsJSON: []byte(`{}`),
+					},
+					makeRootProviderAddr("registry.opentofu.org/hashicorp/aws"),
+				)
+			}),
+		},
+		{
+			name: "if there are some full-form references in the code, only migrate the ones not referenced",
+			args: args{
+				configDir: "testdata/mention",
+				state: states.BuildState(func(s *states.SyncState) {
+					s.SetResourceInstanceCurrent(
+						mustParseInstAddr("random_id.example"),
+						&states.ResourceInstanceObjectSrc{
+							Status:    states.ObjectReady,
+							AttrsJSON: []byte(`{}`),
+						},
+						makeRootProviderAddr("registry.terraform.io/hashicorp/random"),
+					)
+					s.SetResourceInstanceCurrent(
+						mustParseInstAddr("aws_instance.example"),
+						&states.ResourceInstanceObjectSrc{
+							Status:    states.ObjectReady,
+							AttrsJSON: []byte(`{}`),
+						},
+						makeRootProviderAddr("registry.terraform.io/hashicorp/aws"),
+					)
+				}),
+			},
+			want: states.BuildState(func(s *states.SyncState) {
+				s.SetResourceInstanceCurrent(
+					mustParseInstAddr("random_id.example"),
+					&states.ResourceInstanceObjectSrc{
+						Status:    states.ObjectReady,
+						AttrsJSON: []byte(`{}`),
+					},
+					makeRootProviderAddr("registry.opentofu.org/hashicorp/random"),
+				)
+				s.SetResourceInstanceCurrent(
+					mustParseInstAddr("aws_instance.example"),
+					&states.ResourceInstanceObjectSrc{
+						Status:    states.ObjectReady,
+						AttrsJSON: []byte(`{}`),
+					},
+					makeRootProviderAddr("registry.terraform.io/hashicorp/aws"),
+				)
+			}),
+		},
+		{
+			name: "if the state file contains no legacy references, return statefile unchanged",
+			args: args{
+				configDir: "testdata/nomention",
+				state: states.BuildState(func(s *states.SyncState) {
+					s.SetResourceInstanceCurrent(
+						mustParseInstAddr("random_id.example"),
+						&states.ResourceInstanceObjectSrc{
+							Status:    states.ObjectReady,
+							AttrsJSON: []byte(`{}`),
+						},
+						makeRootProviderAddr("registry.opentofu.org/hashicorp/random"),
+					)
+					s.SetResourceInstanceCurrent(
+						mustParseInstAddr("aws_instance.example"),
+						&states.ResourceInstanceObjectSrc{
+							Status:    states.ObjectReady,
+							AttrsJSON: []byte(`{}`),
+						},
+						makeRootProviderAddr("registry.opentofu.org/hashicorp/aws"),
+					)
+				}),
+			},
+			want: states.BuildState(func(s *states.SyncState) {
+				s.SetResourceInstanceCurrent(
+					mustParseInstAddr("random_id.example"),
+					&states.ResourceInstanceObjectSrc{
+						Status:    states.ObjectReady,
+						AttrsJSON: []byte(`{}`),
+					},
+					makeRootProviderAddr("registry.opentofu.org/hashicorp/random"),
+				)
+				s.SetResourceInstanceCurrent(
+					mustParseInstAddr("aws_instance.example"),
+					&states.ResourceInstanceObjectSrc{
+						Status:    states.ObjectReady,
+						AttrsJSON: []byte(`{}`),
+					},
+					makeRootProviderAddr("registry.opentofu.org/hashicorp/aws"),
+				)
+			}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, hclDiags := loader.LoadConfig(tt.args.configDir)
+			if hclDiags.HasErrors() {
+				t.Fatalf("invalid configuration: %s", hclDiags.Error())
+			}
+
+			got, err := MigrateStateProviderAddresses(cfg, tt.args.state)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MigrateStateProviderAddresses() got = %v, want %v", got, tt.want)
+			}
+			if err != nil {
+				t.Errorf("MigrateStateProviderAddresses() err = %v, want %v", err, nil)
+			}
+		})
+	}
+}


### PR DESCRIPTION
If you're migrating from Terraform to OpenTofu and run `tofu init` on a codebase and statefile which references providers like `hashicorp/aws` then the code will be interpreted as `registry.opentofu.org/hashicorp/aws` while in the statefile you'll still have `registry.terraform.org/hashicorp/aws`. In this case, `tofu init` will fetch both copies, one from each of the registries.

That is not intuitive and not what the user would expect, so this code makes it so that if a provider in the old registry is addressed in the statefile but not in the code, then we assume there was no intention to fetch from the HashiCorp registry, and translate the providers in-memory. You can still specify the full path in the code to override this behavior.

The statefile will be updated on the first `tofu apply`, or can also manually be updated with the `replace-provider` command.

Related to #763 