### PR TITLE
Make backend.PrepareConfig accept a context

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -81,7 +81,7 @@ type Backend interface {
 	// as tfdiags.AttributeValue, and so the caller should provide the
 	// necessary context via the diags.InConfigBody method before returning
 	// diagnostics to the user.
-	PrepareConfig(cty.Value) (cty.Value, tfdiags.Diagnostics)
+	PrepareConfig(context.Context, cty.Value) (cty.Value, tfdiags.Diagnostics)
 
 	// Configure uses the provided configuration to set configuration fields
 	// within the backend.

--- a/internal/backend/init/deprecate_test.go
+++ b/internal/backend/init/deprecate_test.go
@@ -4,6 +4,7 @@
 package init
 
 import (
+	"context"
 	"testing"
 
 	"github.com/opentofu/opentofu/internal/backend/remote-state/inmem"
@@ -17,7 +18,7 @@ func TestDeprecateBackend(t *testing.T) {
 		deprecateMessage,
 	)
 
-	_, diags := deprecatedBackend.PrepareConfig(cty.EmptyObjectVal)
+	_, diags := deprecatedBackend.PrepareConfig(context.Background(), cty.EmptyObjectVal)
 	if len(diags) != 1 {
 		t.Errorf("got %d diagnostics; want 1", len(diags))
 		for _, diag := range diags {

--- a/internal/backend/init/init.go
+++ b/internal/backend/init/init.go
@@ -6,6 +6,7 @@
 package init
 
 import (
+	"context"
 	"sync"
 
 	"github.com/hashicorp/terraform-svchost/disco"
@@ -118,8 +119,8 @@ type deprecatedBackendShim struct {
 
 // PrepareConfig delegates to the wrapped backend to validate its config
 // and then appends shim's deprecation warning.
-func (b deprecatedBackendShim) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
-	newObj, diags := b.Backend.PrepareConfig(obj)
+func (b deprecatedBackendShim) PrepareConfig(ctx context.Context, obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
+	newObj, diags := b.Backend.PrepareConfig(ctx, obj)
 	return newObj, diags.Append(tfdiags.SimpleWarning(b.Message))
 }
 

--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -122,9 +122,9 @@ func (b *Local) ConfigSchema(ctx context.Context) *configschema.Block {
 	}
 }
 
-func (b *Local) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
+func (b *Local) PrepareConfig(ctx context.Context, obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
 	if b.Backend != nil {
-		return b.Backend.PrepareConfig(obj)
+		return b.Backend.PrepareConfig(ctx, obj)
 	}
 
 	var diags tfdiags.Diagnostics

--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -221,7 +221,7 @@ func (b backendWithStateStorageThatFailsRefresh) ConfigSchema(context.Context) *
 	return &configschema.Block{}
 }
 
-func (b backendWithStateStorageThatFailsRefresh) PrepareConfig(in cty.Value) (cty.Value, tfdiags.Diagnostics) {
+func (b backendWithStateStorageThatFailsRefresh) PrepareConfig(_ context.Context, in cty.Value) (cty.Value, tfdiags.Diagnostics) {
 	return in, nil
 }
 

--- a/internal/backend/remote-state/oss/backend_test.go
+++ b/internal/backend/remote-state/oss/backend_test.go
@@ -4,6 +4,7 @@
 package oss
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"os"
@@ -156,7 +157,9 @@ func TestBackendConfig_invalidKey(t *testing.T) {
 		"tablestore_table":    "TableStore",
 	})
 
-	_, results := New().PrepareConfig(cfg)
+	ctx := context.Background()
+
+	_, results := New().PrepareConfig(ctx, cfg)
 	if !results.HasErrors() {
 		t.Fatal("expected config validation error")
 	}

--- a/internal/backend/remote-state/pg/backend_test.go
+++ b/internal/backend/remote-state/pg/backend_test.go
@@ -159,7 +159,7 @@ func TestBackendConfig(t *testing.T) {
 			obj, decDiags := hcldec.Decode(config, spec, nil)
 			diags = diags.Append(decDiags)
 
-			newObj, valDiags := b.PrepareConfig(obj)
+			newObj, valDiags := b.PrepareConfig(ctx, obj)
 			diags = diags.Append(valDiags.InConfigBody(config, ""))
 
 			if tc.ExpectConfigurationError != "" {

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -315,7 +315,7 @@ func (b *Backend) ConfigSchema(context.Context) *configschema.Block {
 // configuration, and inserts any missing defaults, assuming that its
 // structure has already been validated per the schema returned by
 // ConfigSchema.
-func (b *Backend) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
+func (b *Backend) PrepareConfig(ctx context.Context, obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	if obj.IsNull() {
 		return obj, diags

--- a/internal/backend/remote-state/s3/backend_complete_test.go
+++ b/internal/backend/remote-state/s3/backend_complete_test.go
@@ -1845,7 +1845,7 @@ func configureBackend(t *testing.T, config map[string]any) (*Backend, tfdiags.Di
 
 	configSchema := populateSchema(t, b.ConfigSchema(ctx), hcl2shim.HCL2ValueFromConfigValue(config))
 
-	configSchema, diags := b.PrepareConfig(configSchema)
+	configSchema, diags := b.PrepareConfig(ctx, configSchema)
 
 	if diags.HasErrors() {
 		return b, diags

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -133,7 +133,7 @@ func TestBackendConfig_InvalidRegion(t *testing.T) {
 			b := New()
 			configSchema := populateSchema(t, b.ConfigSchema(ctx), hcl2shim.HCL2ValueFromConfigValue(tc.config))
 
-			configSchema, diags := b.PrepareConfig(configSchema)
+			configSchema, diags := b.PrepareConfig(ctx, configSchema)
 			if len(diags) > 0 {
 				t.Fatal(diags.ErrWithWarnings())
 			}
@@ -372,7 +372,7 @@ func TestBackendConfig_STSEndpoint(t *testing.T) {
 			b := New()
 			configSchema := populateSchema(t, b.ConfigSchema(ctx), hcl2shim.HCL2ValueFromConfigValue(config))
 
-			configSchema, diags := b.PrepareConfig(configSchema)
+			configSchema, diags := b.PrepareConfig(ctx, configSchema)
 			if len(diags) > 0 {
 				t.Fatal(diags.ErrWithWarnings())
 			}
@@ -740,7 +740,7 @@ func TestBackendConfig_PrepareConfigValidation(t *testing.T) {
 
 			ctx := context.Background()
 
-			_, valDiags := b.PrepareConfig(populateSchema(t, b.ConfigSchema(ctx), tc.config))
+			_, valDiags := b.PrepareConfig(ctx, populateSchema(t, b.ConfigSchema(ctx), tc.config))
 			if tc.expectedErr != "" {
 				if valDiags.Err() != nil {
 					actualErr := valDiags.Err().Error()
@@ -811,7 +811,7 @@ func TestBackendConfig_PrepareConfigWithEnvVars(t *testing.T) {
 
 			ctx := context.Background()
 
-			_, valDiags := b.PrepareConfig(populateSchema(t, b.ConfigSchema(ctx), tc.config))
+			_, valDiags := b.PrepareConfig(ctx, populateSchema(t, b.ConfigSchema(ctx), tc.config))
 			if tc.expectedErr != "" {
 				if valDiags.Err() != nil {
 					actualErr := valDiags.Err().Error()

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -149,7 +149,7 @@ func (b *Remote) ConfigSchema(context.Context) *configschema.Block {
 }
 
 // PrepareConfig implements backend.Backend.
-func (b *Remote) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
+func (b *Remote) PrepareConfig(ctx context.Context, obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	if obj.IsNull() {
 		return obj, diags

--- a/internal/backend/remote/backend_test.go
+++ b/internal/backend/remote/backend_test.go
@@ -152,8 +152,10 @@ func TestRemote_config(t *testing.T) {
 		s := testServer(t)
 		b := New(testDisco(s))
 
+		ctx := context.Background()
+
 		// Validate
-		_, valDiags := b.PrepareConfig(tc.config)
+		_, valDiags := b.PrepareConfig(ctx, tc.config)
 		if (valDiags.Err() != nil || tc.valErr != "") &&
 			(valDiags.Err() == nil || !strings.Contains(valDiags.Err().Error(), tc.valErr)) {
 			t.Fatalf("%s: unexpected validation result: %v", name, valDiags.Err())
@@ -231,8 +233,10 @@ func TestRemote_versionConstraints(t *testing.T) {
 		tfversion.Prerelease = tc.prerelease
 		tfversion.Version = tc.version
 
+		ctx := context.Background()
+
 		// Validate
-		_, valDiags := b.PrepareConfig(tc.config)
+		_, valDiags := b.PrepareConfig(ctx, tc.config)
 		if valDiags.HasErrors() {
 			t.Fatalf("%s: unexpected validation result: %v", name, valDiags.Err())
 		}

--- a/internal/backend/remote/testing.go
+++ b/internal/backend/remote/testing.go
@@ -123,8 +123,10 @@ func testBackend(t *testing.T, obj cty.Value) (*Remote, func()) {
 	s := testServer(t)
 	b := New(testDisco(s))
 
+	ctx := context.Background()
+
 	// Configure the backend so the client is created.
-	newObj, valDiags := b.PrepareConfig(obj)
+	newObj, valDiags := b.PrepareConfig(ctx, obj)
 	if len(valDiags) != 0 {
 		t.Fatal(valDiags.ErrWithWarnings())
 	}
@@ -154,8 +156,6 @@ func testBackend(t *testing.T, obj cty.Value) (*Remote, func()) {
 
 	// Set local to a local test backend.
 	b.local = testLocalBackend(t, b)
-
-	ctx := context.Background()
 
 	// Create the organization.
 	_, err := b.client.Organizations.Create(ctx, tfe.OrganizationCreateOptions{

--- a/internal/backend/testing.go
+++ b/internal/backend/testing.go
@@ -44,7 +44,7 @@ func TestBackendConfig(t *testing.T, b Backend, c hcl.Body) Backend {
 	obj, decDiags := hcldec.Decode(c, spec, nil)
 	diags = diags.Append(decDiags)
 
-	newObj, valDiags := b.PrepareConfig(obj)
+	newObj, valDiags := b.PrepareConfig(ctx, obj)
 	diags = diags.Append(valDiags.InConfigBody(c, ""))
 
 	// it's valid for a Backend to have warnings (e.g. a Deprecation) as such we should only raise on errors

--- a/internal/builtin/providers/tf/data_source_state.go
+++ b/internal/builtin/providers/tf/data_source_state.go
@@ -239,7 +239,7 @@ func getBackend(cfg cty.Value) (backend.Backend, cty.Value, tfdiags.Diagnostics)
 		return nil, cty.NilVal, diags
 	}
 
-	newVal, validateDiags := b.PrepareConfig(configVal)
+	newVal, validateDiags := b.PrepareConfig(ctx, configVal)
 	diags = diags.Append(validateDiags)
 	if validateDiags.HasErrors() {
 		return nil, cty.NilVal, diags

--- a/internal/builtin/providers/tf/data_source_state_test.go
+++ b/internal/builtin/providers/tf/data_source_state_test.go
@@ -350,7 +350,7 @@ func (b backendFailsConfigure) ConfigSchema(context.Context) *configschema.Block
 	return &configschema.Block{} // intentionally empty configuration schema
 }
 
-func (b backendFailsConfigure) PrepareConfig(given cty.Value) (cty.Value, tfdiags.Diagnostics) {
+func (b backendFailsConfigure) PrepareConfig(_ context.Context, given cty.Value) (cty.Value, tfdiags.Diagnostics) {
 	// No special actions to take here
 	return given, nil
 }

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -166,7 +166,7 @@ func (b *Cloud) ConfigSchema(context.Context) *configschema.Block {
 }
 
 // PrepareConfig implements backend.Backend.
-func (b *Cloud) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
+func (b *Cloud) PrepareConfig(ctx context.Context, obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	if obj.IsNull() {
 		return obj, diags

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -67,8 +67,10 @@ func TestCloud_backendWithoutHost(t *testing.T) {
 		}),
 	})
 
+	ctx := context.Background()
+
 	// Configure the backend so the client is created.
-	newObj, valDiags := b.PrepareConfig(obj)
+	newObj, valDiags := b.PrepareConfig(ctx, obj)
 	if len(valDiags) != 0 {
 		t.Fatalf("testBackend: backend.PrepareConfig() failed: %s", valDiags.ErrWithWarnings())
 	}
@@ -175,8 +177,10 @@ func TestCloud_PrepareConfig(t *testing.T) {
 		s := testServer(t)
 		b := New(testDisco(s))
 
+		ctx := context.Background()
+
 		// Validate
-		_, valDiags := b.PrepareConfig(tc.config)
+		_, valDiags := b.PrepareConfig(ctx, tc.config)
 		if valDiags.Err() != nil && tc.expectedErr != "" {
 			actualErr := valDiags.Err().Error()
 			if !strings.Contains(actualErr, tc.expectedErr) {
@@ -289,7 +293,9 @@ func TestCloud_PrepareConfigWithEnvVars(t *testing.T) {
 				}
 			})
 
-			_, valDiags := b.PrepareConfig(tc.config)
+			ctx := context.Background()
+
+			_, valDiags := b.PrepareConfig(ctx, tc.config)
 			if valDiags.Err() != nil && tc.expectedErr != "" {
 				actualErr := valDiags.Err().Error()
 				if !strings.Contains(actualErr, tc.expectedErr) {
@@ -578,7 +584,9 @@ func WithEnvVars(t *testing.T) {
 				}
 			})
 
-			_, valDiags := b.PrepareConfig(tc.config)
+			ctx := context.Background()
+
+			_, valDiags := b.PrepareConfig(ctx, tc.config)
 			if valDiags.Err() != nil {
 				t.Fatalf("%s: unexpected validation result: %v", name, valDiags.Err())
 			}
@@ -713,8 +721,10 @@ func TestCloud_config(t *testing.T) {
 			b, cleanup := testUnconfiguredBackend(t)
 			t.Cleanup(cleanup)
 
+			ctx := context.Background()
+
 			// Validate
-			_, valDiags := b.PrepareConfig(tc.config)
+			_, valDiags := b.PrepareConfig(ctx, tc.config)
 			if (valDiags.Err() != nil || tc.valErr != "") &&
 				(valDiags.Err() == nil || !strings.Contains(valDiags.Err().Error(), tc.valErr)) {
 				t.Fatalf("unexpected validation result: %v", valDiags.Err())

--- a/internal/cloud/testing.go
+++ b/internal/cloud/testing.go
@@ -233,8 +233,10 @@ func testBackend(t *testing.T, obj cty.Value, handlers map[string]func(http.Resp
 	}
 	b := New(testDisco(s))
 
+	ctx := context.Background()
+
 	// Configure the backend so the client is created.
-	newObj, valDiags := b.PrepareConfig(obj)
+	newObj, valDiags := b.PrepareConfig(ctx, obj)
 	if len(valDiags) != 0 {
 		t.Fatalf("testBackend: backend.PrepareConfig() failed: %s", valDiags.ErrWithWarnings())
 	}
@@ -278,8 +280,6 @@ func testBackend(t *testing.T, obj cty.Value, handlers map[string]func(http.Resp
 	readRedactedPlan = func(ctx context.Context, baseURL url.URL, token, planID string) ([]byte, error) {
 		return mc.RedactedPlans.Read(ctx, baseURL.Hostname(), token, planID)
 	}
-
-	ctx := context.Background()
 
 	// Create the organization.
 	_, err = b.client.Organizations.Create(ctx, tfe.OrganizationCreateOptions{

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -322,7 +322,7 @@ func (m *Meta) BackendForLocalPlan(settings plans.Backend) (backend.Enhanced, tf
 		return nil, diags
 	}
 
-	newVal, validateDiags := b.PrepareConfig(configVal)
+	newVal, validateDiags := b.PrepareConfig(ctx, configVal)
 	diags = diags.Append(validateDiags)
 	if validateDiags.HasErrors() {
 		return nil, diags
@@ -830,7 +830,7 @@ func (m *Meta) backendFromState(ctx context.Context) (backend.Backend, tfdiags.D
 	}
 
 	// Validate the config and then configure the backend
-	newVal, validDiags := b.PrepareConfig(configVal)
+	newVal, validDiags := b.PrepareConfig(ctx, configVal)
 	diags = diags.Append(validDiags)
 	if validDiags.HasErrors() {
 		return nil, diags
@@ -1293,7 +1293,7 @@ func (m *Meta) savedBackend(sMgr *clistate.LocalState) (backend.Backend, tfdiags
 	}
 
 	// Validate the config and then configure the backend
-	newVal, validDiags := b.PrepareConfig(configVal)
+	newVal, validDiags := b.PrepareConfig(ctx, configVal)
 	diags = diags.Append(validDiags)
 	if validDiags.HasErrors() {
 		return nil, diags
@@ -1439,7 +1439,7 @@ func (m *Meta) backendInitFromConfig(c *configs.Backend) (backend.Backend, cty.V
 		}
 	}
 
-	newVal, validateDiags := b.PrepareConfig(configVal)
+	newVal, validateDiags := b.PrepareConfig(ctx, configVal)
 	diags = diags.Append(validateDiags.InConfigBody(c.Config, ""))
 	if validateDiags.HasErrors() {
 		return nil, cty.NilVal, diags

--- a/internal/legacy/helper/schema/backend.go
+++ b/internal/legacy/helper/schema/backend.go
@@ -54,7 +54,7 @@ func (b *Backend) ConfigSchema(context.Context) *configschema.Block {
 	return b.CoreConfigSchema()
 }
 
-func (b *Backend) PrepareConfig(configVal cty.Value) (cty.Value, tfdiags.Diagnostics) {
+func (b *Backend) PrepareConfig(_ context.Context, configVal cty.Value) (cty.Value, tfdiags.Diagnostics) {
 	if b == nil {
 		return configVal, nil
 	}

--- a/internal/legacy/helper/schema/backend_test.go
+++ b/internal/legacy/helper/schema/backend_test.go
@@ -133,7 +133,10 @@ func TestBackendPrepare(t *testing.T) {
 			if tc.Config != nil {
 				cfgVal = cty.ObjectVal(tc.Config)
 			}
-			configVal, diags := tc.B.PrepareConfig(cfgVal)
+
+			ctx := context.Background()
+
+			configVal, diags := tc.B.PrepareConfig(ctx, cfgVal)
 			if diags.HasErrors() != tc.Err {
 				for _, d := range diags {
 					t.Error(d.Description())


### PR DESCRIPTION
Given that many state backend methods use contexts in their calls, we will make the related interfaces accept context as an input to all methods. Since it's a ton of work, we go one by one. This time it's a method (PrepareConfig) where the context is not yet used in any of the implementations.

related to https://github.com/opentofu/opentofu/issues/753

## Target Release

1.6.0

## Draft CHANGELOG entry

n/a, it's a purely internal change