### PR TITLE
Make backend.Configure accept a context

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -95,7 +95,7 @@ type Backend interface {
 	//
 	// If error diagnostics are returned, the internal state of the instance
 	// is undefined and no other methods may be called.
-	Configure(cty.Value) tfdiags.Diagnostics
+	Configure(context.Context, cty.Value) tfdiags.Diagnostics
 
 	// StateMgr returns the state manager for the given workspace name.
 	//

--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -156,9 +156,9 @@ func (b *Local) PrepareConfig(ctx context.Context, obj cty.Value) (cty.Value, tf
 	return obj, diags
 }
 
-func (b *Local) Configure(obj cty.Value) tfdiags.Diagnostics {
+func (b *Local) Configure(ctx context.Context, obj cty.Value) tfdiags.Diagnostics {
 	if b.Backend != nil {
-		return b.Backend.Configure(obj)
+		return b.Backend.Configure(ctx, obj)
 	}
 
 	var diags tfdiags.Diagnostics

--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -225,7 +225,7 @@ func (b backendWithStateStorageThatFailsRefresh) PrepareConfig(_ context.Context
 	return in, nil
 }
 
-func (b backendWithStateStorageThatFailsRefresh) Configure(cty.Value) tfdiags.Diagnostics {
+func (b backendWithStateStorageThatFailsRefresh) Configure(context.Context, cty.Value) tfdiags.Diagnostics {
 	return nil
 }
 

--- a/internal/backend/remote-state/pg/backend_test.go
+++ b/internal/backend/remote-state/pg/backend_test.go
@@ -176,7 +176,7 @@ func TestBackendConfig(t *testing.T) {
 
 			obj = newObj
 
-			confDiags := b.Configure(obj)
+			confDiags := b.Configure(ctx, obj)
 			if tc.ExpectConnectionError != "" {
 				err := confDiags.InConfigBody(config, "").ErrWithWarnings()
 				if err == nil {

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -457,7 +457,7 @@ func (b *Backend) PrepareConfig(ctx context.Context, obj cty.Value) (cty.Value, 
 // The given configuration is assumed to have already been validated
 // against the schema returned by ConfigSchema and passed validation
 // via PrepareConfig.
-func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
+func (b *Backend) Configure(ctx context.Context, obj cty.Value) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 	if obj.IsNull() {
 		return diags
@@ -592,7 +592,6 @@ func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
 		cfg.ForbiddenAccountIds = val
 	}
 
-	ctx := context.TODO()
 	_, awsConfig, awsDiags := awsbase.GetAwsConfig(ctx, cfg)
 
 	for _, d := range awsDiags {

--- a/internal/backend/remote-state/s3/backend_complete_test.go
+++ b/internal/backend/remote-state/s3/backend_complete_test.go
@@ -1851,7 +1851,7 @@ func configureBackend(t *testing.T, config map[string]any) (*Backend, tfdiags.Di
 		return b, diags
 	}
 
-	confDiags := b.Configure(configSchema)
+	confDiags := b.Configure(ctx, configSchema)
 	diags = diags.Append(confDiags)
 
 	return b, diags

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -138,7 +138,7 @@ func TestBackendConfig_InvalidRegion(t *testing.T) {
 				t.Fatal(diags.ErrWithWarnings())
 			}
 
-			confDiags := b.Configure(configSchema)
+			confDiags := b.Configure(ctx, configSchema)
 			diags = diags.Append(confDiags)
 
 			if diff := cmp.Diff(diags, tc.expectedDiags, cmp.Comparer(diagnosticComparer)); diff != "" {
@@ -377,7 +377,7 @@ func TestBackendConfig_STSEndpoint(t *testing.T) {
 				t.Fatal(diags.ErrWithWarnings())
 			}
 
-			confDiags := b.Configure(configSchema)
+			confDiags := b.Configure(ctx, configSchema)
 			diags = diags.Append(confDiags)
 
 			if diff := cmp.Diff(diags, tc.expectedDiags, cmp.Comparer(diagnosticSummaryComparer)); diff != "" {
@@ -610,7 +610,7 @@ func TestBackendConfig_AssumeRole(t *testing.T) {
 			testCase.Config["sts_endpoint"] = endpoint
 
 			b := New()
-			diags := b.Configure(populateSchema(t, b.ConfigSchema(ctx), hcl2shim.HCL2ValueFromConfigValue(testCase.Config)))
+			diags := b.Configure(ctx, populateSchema(t, b.ConfigSchema(ctx), hcl2shim.HCL2ValueFromConfigValue(testCase.Config)))
 
 			if diags.HasErrors() {
 				for _, diag := range diags {
@@ -916,7 +916,7 @@ func TestBackendSSECustomerKeyConfig(t *testing.T) {
 			b := New().(*Backend)
 			ctx := context.Background()
 
-			diags := b.Configure(populateSchema(t, b.ConfigSchema(ctx), hcl2shim.HCL2ValueFromConfigValue(config)))
+			diags := b.Configure(ctx, populateSchema(t, b.ConfigSchema(ctx), hcl2shim.HCL2ValueFromConfigValue(config)))
 
 			if testCase.expectedErr != "" {
 				if diags.Err() != nil {
@@ -985,7 +985,7 @@ func TestBackendSSECustomerKeyEnvVar(t *testing.T) {
 			b := New().(*Backend)
 			ctx := context.Background()
 
-			diags := b.Configure(populateSchema(t, b.ConfigSchema(ctx), hcl2shim.HCL2ValueFromConfigValue(config)))
+			diags := b.Configure(ctx, populateSchema(t, b.ConfigSchema(ctx), hcl2shim.HCL2ValueFromConfigValue(config)))
 
 			if testCase.expectedErr != "" {
 				if diags.Err() != nil {

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -220,7 +220,7 @@ func (b *Remote) ServiceDiscoveryAliases() ([]backend.HostAlias, error) {
 }
 
 // Configure implements backend.Enhanced.
-func (b *Remote) Configure(obj cty.Value) tfdiags.Diagnostics {
+func (b *Remote) Configure(ctx context.Context, obj cty.Value) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 	if obj.IsNull() {
 		return diags
@@ -349,7 +349,7 @@ func (b *Remote) Configure(obj cty.Value) tfdiags.Diagnostics {
 	}
 
 	// Check if the organization exists by reading its entitlements.
-	entitlements, err := b.client.Organizations.ReadEntitlements(context.Background(), b.organization)
+	entitlements, err := b.client.Organizations.ReadEntitlements(ctx, b.organization)
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			err = fmt.Errorf("organization %q at host %s not found.\n\n"+

--- a/internal/backend/remote/backend_test.go
+++ b/internal/backend/remote/backend_test.go
@@ -162,7 +162,7 @@ func TestRemote_config(t *testing.T) {
 		}
 
 		// Configure
-		confDiags := b.Configure(tc.config)
+		confDiags := b.Configure(ctx, tc.config)
 		if (confDiags.Err() != nil || tc.confErr != "") &&
 			(confDiags.Err() == nil || !strings.Contains(confDiags.Err().Error(), tc.confErr)) {
 			t.Fatalf("%s: unexpected configure result: %v", name, confDiags.Err())
@@ -242,7 +242,7 @@ func TestRemote_versionConstraints(t *testing.T) {
 		}
 
 		// Configure
-		confDiags := b.Configure(tc.config)
+		confDiags := b.Configure(ctx, tc.config)
 		if (confDiags.Err() != nil || tc.result != "") &&
 			(confDiags.Err() == nil || !strings.Contains(confDiags.Err().Error(), tc.result)) {
 			t.Fatalf("%s: unexpected configure result: %v", name, confDiags.Err())
@@ -746,7 +746,7 @@ func TestRemote_ServiceDiscoveryAliases(t *testing.T) {
 	s := testServer(t)
 	b := New(testDisco(s))
 
-	diag := b.Configure(cty.ObjectVal(map[string]cty.Value{
+	diag := b.Configure(context.Background(), cty.ObjectVal(map[string]cty.Value{
 		"hostname":     cty.StringVal("app.terraform.io"),
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),

--- a/internal/backend/remote/testing.go
+++ b/internal/backend/remote/testing.go
@@ -132,7 +132,7 @@ func testBackend(t *testing.T, obj cty.Value) (*Remote, func()) {
 	}
 	obj = newObj
 
-	confDiags := b.Configure(obj)
+	confDiags := b.Configure(ctx, obj)
 	if len(confDiags) != 0 {
 		t.Fatal(confDiags.ErrWithWarnings())
 	}

--- a/internal/backend/testing.go
+++ b/internal/backend/testing.go
@@ -54,7 +54,7 @@ func TestBackendConfig(t *testing.T, b Backend, c hcl.Body) Backend {
 
 	obj = newObj
 
-	confDiags := b.Configure(obj)
+	confDiags := b.Configure(ctx, obj)
 	if len(confDiags) != 0 {
 		confDiags = confDiags.InConfigBody(c, "")
 		t.Fatal(confDiags.ErrWithWarnings())

--- a/internal/builtin/providers/tf/data_source_state.go
+++ b/internal/builtin/providers/tf/data_source_state.go
@@ -110,7 +110,9 @@ func dataSourceRemoteStateRead(d cty.Value) (cty.Value, tfdiags.Diagnostics) {
 		return cty.NilVal, diags
 	}
 
-	configureDiags := b.Configure(cfg)
+	ctx := context.TODO()
+
+	configureDiags := b.Configure(ctx, cfg)
 	if configureDiags.HasErrors() {
 		diags = diags.Append(configureDiags.Err())
 		return cty.NilVal, diags

--- a/internal/builtin/providers/tf/data_source_state_test.go
+++ b/internal/builtin/providers/tf/data_source_state_test.go
@@ -355,7 +355,7 @@ func (b backendFailsConfigure) PrepareConfig(_ context.Context, given cty.Value)
 	return given, nil
 }
 
-func (b backendFailsConfigure) Configure(config cty.Value) tfdiags.Diagnostics {
+func (b backendFailsConfigure) Configure(_ context.Context, config cty.Value) tfdiags.Diagnostics {
 	log.Printf("[TRACE] backendFailsConfigure.Configure(%#v)", config)
 	var diags tfdiags.Diagnostics
 	diags = diags.Append(fmt.Errorf("Configure should never be called"))

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -232,7 +232,7 @@ func (b *Cloud) ServiceDiscoveryAliases() ([]backend.HostAlias, error) {
 }
 
 // Configure implements backend.Enhanced.
-func (b *Cloud) Configure(obj cty.Value) tfdiags.Diagnostics {
+func (b *Cloud) Configure(ctx context.Context, obj cty.Value) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 	if obj.IsNull() {
 		return diags
@@ -323,7 +323,7 @@ func (b *Cloud) Configure(obj cty.Value) tfdiags.Diagnostics {
 	}
 
 	// Check if the organization exists by reading its entitlements.
-	entitlements, err := b.client.Organizations.ReadEntitlements(context.Background(), b.organization)
+	entitlements, err := b.client.Organizations.ReadEntitlements(ctx, b.organization)
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			err = fmt.Errorf("organization %q at host %s not found.\n\n"+
@@ -343,7 +343,7 @@ func (b *Cloud) Configure(obj cty.Value) tfdiags.Diagnostics {
 
 	if ws, ok := os.LookupEnv("TF_WORKSPACE"); ok {
 		if ws == b.WorkspaceMapping.Name || b.WorkspaceMapping.Strategy() == WorkspaceTagsStrategy {
-			diag := b.validWorkspaceEnvVar(context.Background(), b.organization, ws)
+			diag := b.validWorkspaceEnvVar(ctx, b.organization, ws)
 			if diag != nil {
 				diags = diags.Append(diag)
 				return diags

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -76,7 +76,7 @@ func TestCloud_backendWithoutHost(t *testing.T) {
 	}
 	obj = newObj
 
-	confDiags := b.Configure(obj)
+	confDiags := b.Configure(ctx, obj)
 
 	if !confDiags.HasErrors() {
 		t.Fatalf("testBackend: backend.Configure() should have failed")
@@ -595,7 +595,7 @@ func WithEnvVars(t *testing.T) {
 				tc.setup(b)
 			}
 
-			diags := b.Configure(tc.config)
+			diags := b.Configure(ctx, tc.config)
 			if (diags.Err() != nil || tc.expectedErr != "") &&
 				(diags.Err() == nil || !strings.Contains(diags.Err().Error(), tc.expectedErr)) {
 				t.Fatalf("%s: unexpected configure result: %v", name, diags.Err())
@@ -731,7 +731,7 @@ func TestCloud_config(t *testing.T) {
 			}
 
 			// Configure
-			confDiags := b.Configure(tc.config)
+			confDiags := b.Configure(ctx, tc.config)
 			if (confDiags.Err() != nil || tc.confErr != "") &&
 				(confDiags.Err() == nil || !strings.Contains(confDiags.Err().Error(), tc.confErr)) {
 				t.Fatalf("unexpected configure result: %v", confDiags.Err())
@@ -766,7 +766,9 @@ func TestCloud_configVerifyMinimumTFEVersion(t *testing.T) {
 
 	b := New(testDisco(s))
 
-	confDiags := b.Configure(config)
+	ctx := context.Background()
+
+	confDiags := b.Configure(ctx, config)
 	if confDiags.Err() == nil {
 		t.Fatalf("expected configure to error")
 	}
@@ -804,7 +806,9 @@ func TestCloud_configVerifyMinimumTFEVersionInAutomation(t *testing.T) {
 	b := New(testDisco(s))
 	b.runningInAutomation = true
 
-	confDiags := b.Configure(config)
+	ctx := context.Background()
+
+	confDiags := b.Configure(ctx, config)
 	if confDiags.Err() == nil {
 		t.Fatalf("expected configure to error")
 	}
@@ -1423,7 +1427,7 @@ func TestCloud_ServiceDiscoveryAliases(t *testing.T) {
 	s := testServer(t)
 	b := New(testDisco(s))
 
-	diag := b.Configure(cty.ObjectVal(map[string]cty.Value{
+	diag := b.Configure(context.Background(), cty.ObjectVal(map[string]cty.Value{
 		"hostname":     cty.StringVal("app.terraform.io"),
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),

--- a/internal/cloud/testing.go
+++ b/internal/cloud/testing.go
@@ -242,7 +242,7 @@ func testBackend(t *testing.T, obj cty.Value, handlers map[string]func(http.Resp
 	}
 	obj = newObj
 
-	confDiags := b.Configure(obj)
+	confDiags := b.Configure(ctx, obj)
 	if len(confDiags) != 0 {
 		t.Fatalf("testBackend: backend.Configure() failed: %s", confDiags.ErrWithWarnings())
 	}

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -328,7 +328,7 @@ func (m *Meta) BackendForLocalPlan(settings plans.Backend) (backend.Enhanced, tf
 		return nil, diags
 	}
 
-	configureDiags := b.Configure(newVal)
+	configureDiags := b.Configure(ctx, newVal)
 	diags = diags.Append(configureDiags)
 	if configureDiags.HasErrors() {
 		return nil, diags
@@ -836,7 +836,7 @@ func (m *Meta) backendFromState(ctx context.Context) (backend.Backend, tfdiags.D
 		return nil, diags
 	}
 
-	configDiags := b.Configure(newVal)
+	configDiags := b.Configure(ctx, newVal)
 	diags = diags.Append(configDiags)
 	if configDiags.HasErrors() {
 		return nil, diags
@@ -1299,7 +1299,7 @@ func (m *Meta) savedBackend(sMgr *clistate.LocalState) (backend.Backend, tfdiags
 		return nil, diags
 	}
 
-	configDiags := b.Configure(newVal)
+	configDiags := b.Configure(ctx, newVal)
 	diags = diags.Append(configDiags)
 	if configDiags.HasErrors() {
 		return nil, diags
@@ -1445,7 +1445,7 @@ func (m *Meta) backendInitFromConfig(c *configs.Backend) (backend.Backend, cty.V
 		return nil, cty.NilVal, diags
 	}
 
-	configureDiags := b.Configure(newVal)
+	configureDiags := b.Configure(ctx, newVal)
 	diags = diags.Append(configureDiags.InConfigBody(c.Config, ""))
 
 	// If the result of loading the backend is an enhanced backend,

--- a/internal/legacy/helper/schema/backend.go
+++ b/internal/legacy/helper/schema/backend.go
@@ -144,7 +144,7 @@ func (b *Backend) PrepareConfig(_ context.Context, configVal cty.Value) (cty.Val
 	return configVal, diags
 }
 
-func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
+func (b *Backend) Configure(ctx context.Context, obj cty.Value) tfdiags.Diagnostics {
 	if b == nil {
 		return nil
 	}
@@ -169,8 +169,7 @@ func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
 	b.config = data
 
 	if b.ConfigureFunc != nil {
-		err = b.ConfigureFunc(context.WithValue(
-			context.Background(), backendConfigKey, data))
+		err = b.ConfigureFunc(context.WithValue(ctx, backendConfigKey, data))
 		if err != nil {
 			diags = diags.Append(err)
 			return diags

--- a/internal/legacy/helper/schema/backend_test.go
+++ b/internal/legacy/helper/schema/backend_test.go
@@ -190,7 +190,7 @@ func TestBackendConfigure(t *testing.T) {
 
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.Name), func(t *testing.T) {
-			diags := tc.B.Configure(cty.ObjectVal(tc.Config))
+			diags := tc.B.Configure(context.Background(), cty.ObjectVal(tc.Config))
 			if diags.HasErrors() != tc.Err {
 				t.Errorf("wrong number of diagnostics")
 			}


### PR DESCRIPTION
Given that many state backend methods use contexts in their calls, we will make the related interfaces accept context as an input to all methods. Since it's a ton of work, we go one by one. This time it's a method (Configure) where the context is used in some of the implementations.

related to #753

## Target Release

1.6.0

## Draft CHANGELOG entry

n/a, it's a purely internal change