### PR TITLE
Make backend.Workspaces accept a context

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -116,7 +116,7 @@ type Backend interface {
 
 	// States returns a list of the names of all of the workspaces that exist
 	// in this backend.
-	Workspaces() ([]string, error)
+	Workspaces(context.Context) ([]string, error)
 }
 
 // HostAlias describes a list of aliases that should be used when initializing an

--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -186,10 +186,10 @@ func (b *Local) ServiceDiscoveryAliases() ([]backend.HostAlias, error) {
 	return []backend.HostAlias{}, nil
 }
 
-func (b *Local) Workspaces() ([]string, error) {
+func (b *Local) Workspaces(ctx context.Context) ([]string, error) {
 	// If we have a backend handling state, defer to that.
 	if b.Backend != nil {
-		return b.Backend.Workspaces()
+		return b.Backend.Workspaces(ctx)
 	}
 
 	// the listing always start with "default"
@@ -430,9 +430,9 @@ func (b *Local) StatePaths(name string) (stateIn, stateOut, backupOut string) {
 // This should be used when "migrating" from one local backend configuration to
 // another in order to avoid deleting the "old" state snapshots if they are
 // in the same files as the "new" state snapshots.
-func (b *Local) PathsConflictWith(other *Local) bool {
+func (b *Local) PathsConflictWith(ctx context.Context, other *Local) bool {
 	otherPaths := map[string]struct{}{}
-	otherWorkspaces, err := other.Workspaces()
+	otherWorkspaces, err := other.Workspaces(ctx)
 	if err != nil {
 		// If we can't enumerate the workspaces then we'll conservatively
 		// assume that paths _do_ overlap, since we can't be certain.
@@ -443,7 +443,7 @@ func (b *Local) PathsConflictWith(other *Local) bool {
 		otherPaths[p] = struct{}{}
 	}
 
-	ourWorkspaces, err := other.Workspaces()
+	ourWorkspaces, err := other.Workspaces(ctx)
 	if err != nil {
 		// If we can't enumerate the workspaces then we'll conservatively
 		// assume that paths _do_ overlap, since we can't be certain.

--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -235,7 +235,7 @@ func (b backendWithStateStorageThatFailsRefresh) DeleteWorkspace(_ context.Conte
 	return fmt.Errorf("unimplemented")
 }
 
-func (b backendWithStateStorageThatFailsRefresh) Workspaces() ([]string, error) {
+func (b backendWithStateStorageThatFailsRefresh) Workspaces(context.Context) ([]string, error) {
 	return []string{"default"}, nil
 }
 

--- a/internal/backend/local/backend_test.go
+++ b/internal/backend/local/backend_test.go
@@ -98,7 +98,9 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 	expectedStates := []string{dflt}
 
 	b := New()
-	states, err := b.Workspaces()
+	ctx := context.Background()
+
+	states, err := b.Workspaces(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,14 +109,12 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatalf("expected []string{%q}, got %q", dflt, states)
 	}
 
-	ctx := context.Background()
-
 	expectedA := "test_A"
 	if _, err := b.StateMgr(ctx, expectedA); err != nil {
 		t.Fatal(err)
 	}
 
-	states, err = b.Workspaces()
+	states, err = b.Workspaces(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -129,7 +129,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	states, err = b.Workspaces()
+	states, err = b.Workspaces(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -143,7 +143,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	states, err = b.Workspaces()
+	states, err = b.Workspaces(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +157,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	states, err = b.Workspaces()
+	states, err = b.Workspaces(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -195,7 +195,7 @@ func (b *testDelegateBackend) StateMgr(_ context.Context, name string) (statemgr
 	return s, nil
 }
 
-func (b *testDelegateBackend) Workspaces() ([]string, error) {
+func (b *testDelegateBackend) Workspaces(context.Context) ([]string, error) {
 	if b.statesErr {
 		return nil, errTestDelegateStates
 	}
@@ -224,7 +224,7 @@ func TestLocal_multiStateBackend(t *testing.T) {
 		t.Fatal("expected errTestDelegateState, got:", err)
 	}
 
-	if _, err := b.Workspaces(); err != errTestDelegateStates {
+	if _, err := b.Workspaces(ctx); err != errTestDelegateStates {
 		t.Fatal("expected errTestDelegateStates, got:", err)
 	}
 

--- a/internal/backend/local/testing.go
+++ b/internal/backend/local/testing.go
@@ -118,7 +118,7 @@ func TestNewLocalSingle() backend.Backend {
 	return &TestLocalSingleState{Local: New()}
 }
 
-func (b *TestLocalSingleState) Workspaces() ([]string, error) {
+func (b *TestLocalSingleState) Workspaces(context.Context) ([]string, error) {
 	return nil, backend.ErrWorkspacesNotSupported
 }
 
@@ -148,8 +148,8 @@ func TestNewLocalNoDefault() backend.Backend {
 	return &TestLocalNoDefaultState{Local: New()}
 }
 
-func (b *TestLocalNoDefaultState) Workspaces() ([]string, error) {
-	workspaces, err := b.Local.Workspaces()
+func (b *TestLocalNoDefaultState) Workspaces(ctx context.Context) ([]string, error) {
+	workspaces, err := b.Local.Workspaces(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/remote-state/azure/backend_state.go
+++ b/internal/backend/remote-state/azure/backend_state.go
@@ -23,13 +23,12 @@ const (
 	keyEnvPrefix = "env:"
 )
 
-func (b *Backend) Workspaces() ([]string, error) {
+func (b *Backend) Workspaces(ctx context.Context) ([]string, error) {
 	prefix := b.keyName + keyEnvPrefix
 	params := containers.ListBlobsInput{
 		Prefix: &prefix,
 	}
 
-	ctx := context.TODO()
 	client, err := b.armClient.getContainersClient(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/backend/remote-state/consul/backend_state.go
+++ b/internal/backend/remote-state/consul/backend_state.go
@@ -18,7 +18,7 @@ const (
 	keyEnvPrefix = "-env:"
 )
 
-func (b *Backend) Workspaces() ([]string, error) {
+func (b *Backend) Workspaces(ctx context.Context) ([]string, error) {
 	// List our raw path
 	prefix := b.configData.Get("path").(string) + keyEnvPrefix
 	keys, _, err := b.client.KV().Keys(prefix, "/", nil)

--- a/internal/backend/remote-state/cos/backend_state.go
+++ b/internal/backend/remote-state/cos/backend_state.go
@@ -24,13 +24,13 @@ const (
 )
 
 // Workspaces returns a list of names for the workspaces
-func (b *Backend) Workspaces() ([]string, error) {
+func (b *Backend) Workspaces(ctx context.Context) ([]string, error) {
 	c, err := b.client("tencentcloud")
 	if err != nil {
 		return nil, err
 	}
 
-	obs, err := c.getBucket(b.prefix)
+	obs, err := c.getBucket(ctx, b.prefix)
 	log.Printf("[DEBUG] list all workspaces, objects: %v, error: %v", obs, err)
 	if err != nil {
 		return nil, err
@@ -86,7 +86,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 	}
 	stateMgr := &remote.State{Client: c}
 
-	ws, err := b.Workspaces()
+	ws, err := b.Workspaces(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/remote-state/cos/backend_test.go
+++ b/internal/backend/remote-state/cos/backend_test.go
@@ -240,7 +240,7 @@ func setupBackend(t *testing.T, bucket, prefix, key string, encrypt bool) backen
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	err = c.putBucket()
+	err = c.putBucket(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -256,7 +256,7 @@ func teardownBackend(t *testing.T, b backend.Backend) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	err = c.deleteBucket(true)
+	err = c.deleteBucket(context.Background(), true)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/internal/backend/remote-state/cos/client.go
+++ b/internal/backend/remote-state/cos/client.go
@@ -275,8 +275,8 @@ func (c *remoteClient) deleteObject(ctx context.Context, cosFile string) error {
 }
 
 // getBucket list bucket by prefix
-func (c *remoteClient) getBucket(prefix string) (obs []cos.Object, err error) {
-	fs, rsp, err := c.cosClient.Bucket.Get(c.cosContext, &cos.BucketGetOptions{Prefix: prefix})
+func (c *remoteClient) getBucket(ctx context.Context, prefix string) (obs []cos.Object, err error) {
+	fs, rsp, err := c.cosClient.Bucket.Get(ctx, &cos.BucketGetOptions{Prefix: prefix})
 	if rsp == nil {
 		log.Printf("[DEBUG] getBucket %s/%s: error: %v", c.bucket, prefix, err)
 		err = fmt.Errorf("bucket %s not exists", c.bucket)
@@ -298,8 +298,8 @@ func (c *remoteClient) getBucket(prefix string) (obs []cos.Object, err error) {
 }
 
 // putBucket create cos bucket
-func (c *remoteClient) putBucket() error {
-	rsp, err := c.cosClient.Bucket.Put(c.cosContext, nil)
+func (c *remoteClient) putBucket(ctx context.Context) error {
+	rsp, err := c.cosClient.Bucket.Put(ctx, nil)
 	if rsp == nil {
 		log.Printf("[DEBUG] putBucket %s: error: %v", c.bucket, err)
 		return fmt.Errorf("failed to create bucket %v: %w", c.bucket, err)
@@ -319,9 +319,9 @@ func (c *remoteClient) putBucket() error {
 }
 
 // deleteBucket delete cos bucket
-func (c *remoteClient) deleteBucket(recursive bool) error {
+func (c *remoteClient) deleteBucket(ctx context.Context, recursive bool) error {
 	if recursive {
-		obs, err := c.getBucket("")
+		obs, err := c.getBucket(ctx, "")
 		if err != nil {
 			if strings.Contains(err.Error(), "not exists") {
 				return nil
@@ -330,11 +330,11 @@ func (c *remoteClient) deleteBucket(recursive bool) error {
 			return fmt.Errorf("failed to empty bucket %v: %w", c.bucket, err)
 		}
 		for _, v := range obs {
-			c.deleteObject(c.cosContext, v.Key)
+			c.deleteObject(ctx, v.Key)
 		}
 	}
 
-	rsp, err := c.cosClient.Bucket.Delete(c.cosContext)
+	rsp, err := c.cosClient.Bucket.Delete(ctx)
 	if rsp == nil {
 		log.Printf("[DEBUG] deleteBucket %s: error: %v", c.bucket, err)
 		return fmt.Errorf("failed to delete bucket %v: %w", c.bucket, err)

--- a/internal/backend/remote-state/gcs/backend.go
+++ b/internal/backend/remote-state/gcs/backend.go
@@ -28,7 +28,9 @@ import (
 type Backend struct {
 	*schema.Backend
 
-	storageClient  *storage.Client
+	storageClient *storage.Client
+
+	// TODO: Remove storageContext once all methods are accepting a context.
 	storageContext context.Context
 
 	bucketName string

--- a/internal/backend/remote-state/gcs/backend_state.go
+++ b/internal/backend/remote-state/gcs/backend_state.go
@@ -26,11 +26,11 @@ const (
 
 // Workspaces returns a list of names for the workspaces found on GCS. The default
 // state is always returned as the first element in the slice.
-func (b *Backend) Workspaces() ([]string, error) {
+func (b *Backend) Workspaces(ctx context.Context) ([]string, error) {
 	states := []string{backend.DefaultStateName}
 
 	bucket := b.storageClient.Bucket(b.bucketName)
-	objs := bucket.Objects(b.storageContext, &storage.Query{
+	objs := bucket.Objects(ctx, &storage.Query{
 		Delimiter: "/",
 		Prefix:    b.prefix,
 	})

--- a/internal/backend/remote-state/http/backend.go
+++ b/internal/backend/remote-state/http/backend.go
@@ -251,7 +251,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 	return &remote.State{Client: b.client}, nil
 }
 
-func (b *Backend) Workspaces() ([]string, error) {
+func (b *Backend) Workspaces(context.Context) ([]string, error) {
 	return nil, backend.ErrWorkspacesNotSupported
 }
 

--- a/internal/backend/remote-state/inmem/backend.go
+++ b/internal/backend/remote-state/inmem/backend.go
@@ -90,7 +90,7 @@ func (b *Backend) configure(ctx context.Context) error {
 	return nil
 }
 
-func (b *Backend) Workspaces() ([]string, error) {
+func (b *Backend) Workspaces(context.Context) ([]string, error) {
 	states.Lock()
 	defer states.Unlock()
 

--- a/internal/backend/remote-state/kubernetes/backend_state.go
+++ b/internal/backend/remote-state/kubernetes/backend_state.go
@@ -18,14 +18,14 @@ import (
 
 // Workspaces returns a list of names for the workspaces found in k8s. The default
 // workspace is always returned as the first element in the slice.
-func (b *Backend) Workspaces() ([]string, error) {
+func (b *Backend) Workspaces(ctx context.Context) ([]string, error) {
 	secretClient, err := b.getKubernetesSecretClient()
 	if err != nil {
 		return nil, err
 	}
 
 	secrets, err := secretClient.List(
-		context.Background(),
+		ctx,
 		metav1.ListOptions{
 			LabelSelector: tfstateKey + "=true",
 		},

--- a/internal/backend/remote-state/oss/backend_state.go
+++ b/internal/backend/remote-state/oss/backend_state.go
@@ -53,7 +53,7 @@ func (b *Backend) remoteClient(name string) (*RemoteClient, error) {
 	return client, nil
 }
 
-func (b *Backend) Workspaces() ([]string, error) {
+func (b *Backend) Workspaces(ctx context.Context) ([]string, error) {
 	bucket, err := b.ossClient.Bucket(b.bucketName)
 	if err != nil {
 		return []string{""}, fmt.Errorf("error getting bucket: %w", err)
@@ -120,7 +120,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 	stateMgr := &remote.State{Client: client}
 
 	// Check to see if this state already exists.
-	existing, err := b.Workspaces()
+	existing, err := b.Workspaces(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/remote-state/oss/backend_test.go
+++ b/internal/backend/remote-state/oss/backend_test.go
@@ -87,7 +87,7 @@ func TestBackendConfigWorkSpace(t *testing.T) {
 	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(config)).(*Backend)
 	createOSSBucket(t, b.ossClient, bucketName)
 	defer deleteOSSBucket(t, b.ossClient, bucketName)
-	if _, err := b.Workspaces(); err != nil {
+	if _, err := b.Workspaces(context.Background()); err != nil {
 		t.Fatal(err.Error())
 	}
 	if !strings.HasPrefix(b.ossClient.Config.Endpoint, "https://oss-cn-beijing") {

--- a/internal/backend/remote-state/pg/backend_state.go
+++ b/internal/backend/remote-state/pg/backend_state.go
@@ -13,9 +13,9 @@ import (
 	"github.com/opentofu/opentofu/internal/states/statemgr"
 )
 
-func (b *Backend) Workspaces() ([]string, error) {
+func (b *Backend) Workspaces(ctx context.Context) ([]string, error) {
 	query := `SELECT name FROM %s.%s WHERE name != 'default' ORDER BY name`
-	rows, err := b.db.Query(fmt.Sprintf(query, b.schemaName, statesTableName))
+	rows, err := b.db.QueryContext(ctx, fmt.Sprintf(query, b.schemaName, statesTableName))
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 	// Check to see if this state already exists.
 	// If the state doesn't exist, we have to assume this
 	// is a normal create operation, and take the lock at that point.
-	existing, err := b.Workspaces()
+	existing, err := b.Workspaces(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/remote-state/s3/backend_state.go
+++ b/internal/backend/remote-state/s3/backend_state.go
@@ -21,7 +21,7 @@ import (
 	"github.com/opentofu/opentofu/internal/states/statemgr"
 )
 
-func (b *Backend) Workspaces() ([]string, error) {
+func (b *Backend) Workspaces(ctx context.Context) ([]string, error) {
 	const maxKeys = 1000
 
 	prefix := ""
@@ -39,7 +39,6 @@ func (b *Backend) Workspaces() ([]string, error) {
 	wss := []string{backend.DefaultStateName}
 	pg := s3.NewListObjectsV2Paginator(b.s3Client, params)
 
-	ctx := context.TODO()
 	for pg.HasMorePages() {
 		page, err := pg.NextPage(ctx)
 		if err != nil {
@@ -151,7 +150,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 	// If we need to force-unlock, but for some reason the state no longer
 	// exists, the user will have to use aws tools to manually fix the
 	// situation.
-	existing, err := b.Workspaces()
+	existing, err := b.Workspaces(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -1310,7 +1310,7 @@ func testGetWorkspaceForKey(b *Backend, key string, expected string) error {
 }
 
 func checkStateList(b backend.Backend, expected []string) error {
-	states, err := b.Workspaces()
+	states, err := b.Workspaces(context.Background())
 	if err != nil {
 		return err
 	}

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -546,15 +546,15 @@ func (b *Remote) retryLogHook(attemptNum int, resp *http.Response) {
 }
 
 // Workspaces implements backend.Enhanced.
-func (b *Remote) Workspaces() ([]string, error) {
+func (b *Remote) Workspaces(ctx context.Context) ([]string, error) {
 	if b.prefix == "" {
 		return nil, backend.ErrWorkspacesNotSupported
 	}
-	return b.workspaces()
+	return b.workspaces(ctx)
 }
 
 // workspaces returns a filtered list of remote workspace names.
-func (b *Remote) workspaces() ([]string, error) {
+func (b *Remote) workspaces(ctx context.Context) ([]string, error) {
 	options := &tfe.WorkspaceListOptions{}
 	switch {
 	case b.workspace != "":
@@ -567,7 +567,7 @@ func (b *Remote) workspaces() ([]string, error) {
 	var names []string
 
 	for {
-		wl, err := b.client.Workspaces.List(context.Background(), b.organization, options)
+		wl, err := b.client.Workspaces.List(ctx, b.organization, options)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/backend/remote/backend_test.go
+++ b/internal/backend/remote/backend_test.go
@@ -269,11 +269,11 @@ func TestRemote_addAndRemoveWorkspacesDefault(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	if _, err := b.Workspaces(); err != backend.ErrWorkspacesNotSupported {
+	ctx := context.Background()
+
+	if _, err := b.Workspaces(ctx); err != backend.ErrWorkspacesNotSupported {
 		t.Fatalf("expected error %v, got %v", backend.ErrWorkspacesNotSupported, err)
 	}
-
-	ctx := context.Background()
 
 	if _, err := b.StateMgr(ctx, backend.DefaultStateName); err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -296,7 +296,9 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 	b, bCleanup := testBackendNoDefault(t)
 	defer bCleanup()
 
-	states, err := b.Workspaces()
+	ctx := context.Background()
+
+	states, err := b.Workspaces(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -305,8 +307,6 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 	if !reflect.DeepEqual(states, expectedWorkspaces) {
 		t.Fatalf("expected states %#+v, got %#+v", expectedWorkspaces, states)
 	}
-
-	ctx := context.Background()
 
 	if _, err := b.StateMgr(ctx, backend.DefaultStateName); err != backend.ErrDefaultWorkspaceNotSupported {
 		t.Fatalf("expected error %v, got %v", backend.ErrDefaultWorkspaceNotSupported, err)
@@ -317,7 +317,7 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	states, err = b.Workspaces()
+	states, err = b.Workspaces(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -332,7 +332,7 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	states, err = b.Workspaces()
+	states, err = b.Workspaces(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -350,7 +350,7 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	states, err = b.Workspaces()
+	states, err = b.Workspaces(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -364,7 +364,7 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	states, err = b.Workspaces()
+	states, err = b.Workspaces(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/testing.go
+++ b/internal/backend/testing.go
@@ -92,7 +92,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 		}
 	}
 
-	workspaces, err := b.Workspaces()
+	workspaces, err := b.Workspaces(ctx)
 	if err != nil {
 		if err == ErrWorkspacesNotSupported {
 			t.Logf("TestBackend: workspaces not supported in %T, skipping", b)
@@ -211,7 +211,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 	// Verify we can now list them
 	{
 		// we determined that named stated are supported earlier
-		workspaces, err := b.Workspaces()
+		workspaces, err := b.Workspaces(ctx)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -256,7 +256,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 
 	// Verify deletion
 	{
-		workspaces, err := b.Workspaces()
+		workspaces, err := b.Workspaces(ctx)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}

--- a/internal/builtin/providers/tf/data_source_state_test.go
+++ b/internal/builtin/providers/tf/data_source_state_test.go
@@ -370,6 +370,6 @@ func (b backendFailsConfigure) DeleteWorkspace(_ context.Context, name string, _
 	return fmt.Errorf("DeleteWorkspace not implemented")
 }
 
-func (b backendFailsConfigure) Workspaces() ([]string, error) {
+func (b backendFailsConfigure) Workspaces(context.Context) ([]string, error) {
 	return nil, fmt.Errorf("Workspaces not implemented")
 }

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -531,7 +531,7 @@ func (b *Cloud) retryLogHook(attemptNum int, resp *http.Response) {
 
 // Workspaces implements backend.Enhanced, returning a filtered list of workspace names according to
 // the workspace mapping strategy configured.
-func (b *Cloud) Workspaces() ([]string, error) {
+func (b *Cloud) Workspaces(ctx context.Context) ([]string, error) {
 	// Create a slice to contain all the names.
 	var names []string
 
@@ -554,7 +554,7 @@ func (b *Cloud) Workspaces() ([]string, error) {
 		listOpts := &tfe.ProjectListOptions{
 			Name: b.WorkspaceMapping.Project,
 		}
-		projects, err := b.client.Projects.List(context.Background(), b.organization, listOpts)
+		projects, err := b.client.Projects.List(ctx, b.organization, listOpts)
 		if err != nil && err != tfe.ErrResourceNotFound {
 			return nil, fmt.Errorf("failed to retrieve project %s: %w", listOpts.Name, err)
 		}
@@ -567,7 +567,7 @@ func (b *Cloud) Workspaces() ([]string, error) {
 	}
 
 	for {
-		wl, err := b.client.Workspaces.List(context.Background(), b.organization, options)
+		wl, err := b.client.Workspaces.List(ctx, b.organization, options)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -32,7 +32,7 @@ func TestCloud_backendWithName(t *testing.T) {
 
 	ctx := context.Background()
 
-	workspaces, err := b.Workspaces()
+	workspaces, err := b.Workspaces(ctx)
 	if err != nil {
 		t.Fatalf("error: %v", err)
 	}
@@ -105,7 +105,7 @@ func TestCloud_backendWithTags(t *testing.T) {
 		}
 	}
 
-	workspaces, err := b.Workspaces()
+	workspaces, err := b.Workspaces(ctx)
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}
@@ -1378,7 +1378,7 @@ func TestCloudBackend_DeleteWorkspace_SafeAndForce(t *testing.T) {
 	}
 
 	// sanity check that the mock now contains two workspaces
-	wl, err := b.Workspaces()
+	wl, err := b.Workspaces(ctx)
 	if err != nil {
 		t.Fatalf("error fetching workspace names: %v", err)
 	}

--- a/internal/command/autocomplete.go
+++ b/internal/command/autocomplete.go
@@ -4,6 +4,8 @@
 package command
 
 import (
+	"context"
+
 	"github.com/posener/complete"
 )
 
@@ -60,7 +62,7 @@ func (m *Meta) completePredictWorkspaceName() complete.Predictor {
 			return nil
 		}
 
-		names, _ := b.Workspaces()
+		names, _ := b.Workspaces(context.TODO())
 		return names
 	})
 }

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -215,7 +215,9 @@ func (m *Meta) Backend(opts *BackendOpts) (backend.Enhanced, tfdiags.Diagnostics
 // if the currently selected workspace is valid. If not, it will ask
 // the user to select a workspace from the list.
 func (m *Meta) selectWorkspace(b backend.Backend) error {
-	workspaces, err := b.Workspaces()
+	ctx := context.TODO()
+
+	workspaces, err := b.Workspaces(ctx)
 	if err == backend.ErrWorkspacesNotSupported {
 		return nil
 	}
@@ -227,7 +229,7 @@ func (m *Meta) selectWorkspace(b backend.Backend) error {
 			// len is always 1 if using Name; 0 means we're using Tags and there
 			// aren't any matching workspaces. Which might be normal and fine, so
 			// let's just ask:
-			name, err := m.UIInput().Input(context.Background(), &tofu.InputOpts{
+			name, err := m.UIInput().Input(ctx, &tofu.InputOpts{
 				Id:          "create-workspace",
 				Query:       "\n[reset][bold][yellow]No workspaces found.[reset]",
 				Description: fmt.Sprintf(inputCloudInitCreateWorkspace, strings.Join(c.WorkspaceMapping.Tags, ", ")),
@@ -274,7 +276,7 @@ func (m *Meta) selectWorkspace(b backend.Backend) error {
 	}
 
 	// Otherwise, ask the user to select a workspace from the list of existing workspaces.
-	v, err := m.UIInput().Input(context.Background(), &tofu.InputOpts{
+	v, err := m.UIInput().Input(ctx, &tofu.InputOpts{
 		Id: "select-workspace",
 		Query: fmt.Sprintf(
 			"\n[reset][bold][yellow]The currently selected workspace (%s) does not exist.[reset]",
@@ -969,13 +971,13 @@ func (m *Meta) backend_C_r_s(c *configs.Backend, cHash int, sMgr *clistate.Local
 		return nil, diags
 	}
 
-	workspaces, err := localB.Workspaces()
+	ctx := context.TODO()
+
+	workspaces, err := localB.Workspaces(ctx)
 	if err != nil {
 		diags = diags.Append(fmt.Errorf(errBackendLocalRead, err))
 		return nil, diags
 	}
-
-	ctx := context.TODO()
 
 	var localStates []statemgr.Full
 	for _, workspace := range workspaces {
@@ -1032,7 +1034,7 @@ func (m *Meta) backend_C_r_s(c *configs.Backend, cHash int, sMgr *clistate.Local
 		erase := true
 		if newLocalB, ok := b.(*backendLocal.Local); ok {
 			if localB, ok := localB.(*backendLocal.Local); ok {
-				if newLocalB.PathsConflictWith(localB) {
+				if newLocalB.PathsConflictWith(ctx, localB) {
 					erase = false
 					log.Printf("[TRACE] Meta.Backend: both old and new backends share the same local state paths, so not erasing old state")
 				}

--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -186,7 +186,7 @@ func (m *Meta) backendMigrateState_S_S(opts *backendMigrateOpts) error {
 	}
 
 	// Read all the states
-	sourceWorkspaces, err := opts.Source.Workspaces()
+	sourceWorkspaces, err := opts.Source.Workspaces(context.TODO())
 	if err != nil {
 		return fmt.Errorf(strings.TrimSpace(
 			errMigrateLoadStates), opts.SourceType, err)
@@ -538,7 +538,7 @@ func (m *Meta) backendMigrateNonEmptyConfirm(
 func retrieveWorkspaces(back backend.Backend, sourceType string) ([]string, bool, error) {
 	var singleState bool
 	var err error
-	workspaces, err := back.Workspaces()
+	workspaces, err := back.Workspaces(context.TODO())
 	if err == backend.ErrWorkspacesNotSupported {
 		singleState = true
 		err = nil
@@ -761,7 +761,7 @@ func (m *Meta) backendMigrateState_S_TFC(opts *backendMigrateOpts, sourceWorkspa
 
 	// After migrating multiple workspaces, we need to reselect the current workspace as it may
 	// have been renamed. Query the backend first to be sure it now exists.
-	workspaces, err := opts.Destination.Workspaces()
+	workspaces, err := opts.Destination.Workspaces(context.TODO())
 	if err != nil {
 		return err
 	}

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -1219,8 +1219,10 @@ func TestMetaBackend_configuredChangeCopy_multiToMulti(t *testing.T) {
 		t.Fatal(diags.Err())
 	}
 
+	ctx := context.Background()
+
 	// Check resulting states
-	workspaces, err := b.Workspaces()
+	workspaces, err := b.Workspaces(ctx)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1230,8 +1232,6 @@ func TestMetaBackend_configuredChangeCopy_multiToMulti(t *testing.T) {
 	if !reflect.DeepEqual(workspaces, expected) {
 		t.Fatalf("bad: %#v", workspaces)
 	}
-
-	ctx := context.Background()
 
 	{
 		// Check the default state
@@ -1319,8 +1319,10 @@ func TestMetaBackend_configuredChangeCopy_multiToNoDefaultWithDefault(t *testing
 		t.Fatal(diags.Err())
 	}
 
+	ctx := context.Background()
+
 	// Check resulting states
-	workspaces, err := b.Workspaces()
+	workspaces, err := b.Workspaces(ctx)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1330,8 +1332,6 @@ func TestMetaBackend_configuredChangeCopy_multiToNoDefaultWithDefault(t *testing
 	if !reflect.DeepEqual(workspaces, expected) {
 		t.Fatalf("bad: %#v", workspaces)
 	}
-
-	ctx := context.Background()
 
 	{
 		// Check the renamed default state
@@ -1395,8 +1395,10 @@ func TestMetaBackend_configuredChangeCopy_multiToNoDefaultWithoutDefault(t *test
 		t.Fatal(diags.Err())
 	}
 
+	ctx := context.Background()
+
 	// Check resulting states
-	workspaces, err := b.Workspaces()
+	workspaces, err := b.Workspaces(ctx)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1408,7 +1410,6 @@ func TestMetaBackend_configuredChangeCopy_multiToNoDefaultWithoutDefault(t *test
 	}
 
 	{
-		ctx := context.Background()
 		// Check the named state
 		s, err := b.StateMgr(ctx, "env2")
 		if err != nil {

--- a/internal/command/workspace_delete.go
+++ b/internal/command/workspace_delete.go
@@ -75,7 +75,7 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 	// This command will not write state
 	c.ignoreRemoteVersionConflict(b)
 
-	ctx := context.Background()
+	ctx := context.TODO()
 
 	workspaces, err := b.Workspaces(ctx)
 	if err != nil {

--- a/internal/command/workspace_delete.go
+++ b/internal/command/workspace_delete.go
@@ -75,7 +75,9 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 	// This command will not write state
 	c.ignoreRemoteVersionConflict(b)
 
-	workspaces, err := b.Workspaces()
+	ctx := context.Background()
+
+	workspaces, err := b.Workspaces(ctx)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1
@@ -104,8 +106,6 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf(strings.TrimSpace(envDelCurrent), workspace))
 		return 1
 	}
-
-	ctx := context.Background()
 
 	// we need the actual state to see if it's empty
 	stateMgr, err := b.StateMgr(ctx, workspace)

--- a/internal/command/workspace_list.go
+++ b/internal/command/workspace_list.go
@@ -5,6 +5,7 @@ package command
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strings"
 
@@ -58,7 +59,9 @@ func (c *WorkspaceListCommand) Run(args []string) int {
 	// This command will not write state
 	c.ignoreRemoteVersionConflict(b)
 
-	states, err := b.Workspaces()
+	ctx := context.Background()
+
+	states, err := b.Workspaces(ctx)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1

--- a/internal/command/workspace_list.go
+++ b/internal/command/workspace_list.go
@@ -59,7 +59,7 @@ func (c *WorkspaceListCommand) Run(args []string) int {
 	// This command will not write state
 	c.ignoreRemoteVersionConflict(b)
 
-	ctx := context.Background()
+	ctx := context.TODO()
 
 	states, err := b.Workspaces(ctx)
 	if err != nil {

--- a/internal/command/workspace_new.go
+++ b/internal/command/workspace_new.go
@@ -90,7 +90,9 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 	// This command will not write state
 	c.ignoreRemoteVersionConflict(b)
 
-	workspaces, err := b.Workspaces()
+	ctx := context.Background()
+
+	workspaces, err := b.Workspaces(ctx)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to get configured named states: %s", err))
 		return 1
@@ -102,7 +104,6 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 		}
 	}
 
-	ctx := context.Background()
 	_, err = b.StateMgr(ctx, workspace)
 	if err != nil {
 		c.Ui.Error(err.Error())

--- a/internal/command/workspace_new.go
+++ b/internal/command/workspace_new.go
@@ -90,7 +90,7 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 	// This command will not write state
 	c.ignoreRemoteVersionConflict(b)
 
-	ctx := context.Background()
+	ctx := context.TODO()
 
 	workspaces, err := b.Workspaces(ctx)
 	if err != nil {

--- a/internal/command/workspace_select.go
+++ b/internal/command/workspace_select.go
@@ -83,7 +83,7 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 		return 1
 	}
 
-	ctx := context.Background()
+	ctx := context.TODO()
 
 	states, err := b.Workspaces(ctx)
 	if err != nil {

--- a/internal/command/workspace_select.go
+++ b/internal/command/workspace_select.go
@@ -83,7 +83,9 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 		return 1
 	}
 
-	states, err := b.Workspaces()
+	ctx := context.Background()
+
+	states, err := b.Workspaces(ctx)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1
@@ -103,7 +105,6 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 	}
 
 	var newState bool
-	ctx := context.Background()
 
 	if !found {
 		if orCreate {


### PR DESCRIPTION
Given that many state backend methods use contexts in their calls, we will make the related interfaces accept context as an input to all methods. Since it's a ton of work, we go one by one. This time it's a method (Workspaces) where the context is fairly widely used.

related to https://github.com/opentofu/opentofu/issues/753

## Target Release

1.6.0

## Draft CHANGELOG entry

n/a, it's a purely internal change