### PR TITLE
Proper context propagation in Consul state backend implementation

### DIFF
--- a/internal/backend/remote-state/consul/backend.go
+++ b/internal/backend/remote-state/consul/backend.go
@@ -18,76 +18,76 @@ import (
 func New() backend.Backend {
 	s := &schema.Backend{
 		Schema: map[string]*schema.Schema{
-			"path": &schema.Schema{
+			"path": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Path to store state in Consul",
 			},
 
-			"access_token": &schema.Schema{
+			"access_token": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Access token for a Consul ACL",
 				Default:     "", // To prevent input
 			},
 
-			"address": &schema.Schema{
+			"address": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Address to the Consul Cluster",
 				Default:     "", // To prevent input
 			},
 
-			"scheme": &schema.Schema{
+			"scheme": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Scheme to communicate to Consul with",
 				Default:     "", // To prevent input
 			},
 
-			"datacenter": &schema.Schema{
+			"datacenter": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Datacenter to communicate with",
 				Default:     "", // To prevent input
 			},
 
-			"http_auth": &schema.Schema{
+			"http_auth": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "HTTP Auth in the format of 'username:password'",
 				Default:     "", // To prevent input
 			},
 
-			"gzip": &schema.Schema{
+			"gzip": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "Compress the state data using gzip",
 				Default:     false,
 			},
 
-			"lock": &schema.Schema{
+			"lock": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "Lock state access",
 				Default:     true,
 			},
 
-			"ca_file": &schema.Schema{
+			"ca_file": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "A path to a PEM-encoded certificate authority used to verify the remote agent's certificate.",
 				DefaultFunc: schema.EnvDefaultFunc("CONSUL_CACERT", ""),
 			},
 
-			"cert_file": &schema.Schema{
+			"cert_file": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "A path to a PEM-encoded certificate provided to the remote agent; requires use of key_file.",
 				DefaultFunc: schema.EnvDefaultFunc("CONSUL_CLIENT_CERT", ""),
 			},
 
-			"key_file": &schema.Schema{
+			"key_file": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "A path to a PEM-encoded private key, required if cert_file is specified.",
@@ -108,6 +108,11 @@ type Backend struct {
 	client     *consulapi.Client
 	configData *schema.ResourceData
 	lock       bool
+
+	// If more configuration options are provided in the future (eg. namespace
+	// or partition) they should be added to query and write opts.
+	queryOpts *consulapi.QueryOptions
+	writeOpts *consulapi.WriteOptions
 }
 
 func (b *Backend) configure(ctx context.Context) error {
@@ -172,6 +177,9 @@ func (b *Backend) configure(ctx context.Context) error {
 	}
 
 	b.client = client
+	b.queryOpts = &consulapi.QueryOptions{}
+	b.writeOpts = &consulapi.WriteOptions{}
+
 	return nil
 }
 

--- a/internal/backend/remote-state/consul/backend_state.go
+++ b/internal/backend/remote-state/consul/backend_state.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"strings"
 
-	consulapi "github.com/hashicorp/consul/api"
-
 	"github.com/opentofu/opentofu/internal/backend"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/states/remote"
@@ -24,9 +22,7 @@ func (b *Backend) Workspaces(ctx context.Context) ([]string, error) {
 	// List our raw path
 	prefix := b.configData.Get("path").(string) + keyEnvPrefix
 
-	var queryOpts consulapi.QueryOptions
-
-	keys, _, err := b.client.KV().Keys(prefix, "/", queryOpts.WithContext(ctx))
+	keys, _, err := b.client.KV().Keys(prefix, "/", b.queryOpts.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -66,11 +62,9 @@ func (b *Backend) DeleteWorkspace(ctx context.Context, name string, _ bool) erro
 	// Determine the path of the data
 	path := b.path(name)
 
-	var writeOpts consulapi.WriteOptions
-
 	// Delete it. We just delete it without any locking since
 	// the DeleteState API is documented as such.
-	_, err := b.client.KV().Delete(path, writeOpts.WithContext(ctx))
+	_, err := b.client.KV().Delete(path, b.writeOpts.WithContext(ctx))
 	return err
 }
 
@@ -88,6 +82,8 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 			Path:      path,
 			GZip:      gzip,
 			lockState: b.lock,
+			queryOpts: b.queryOpts,
+			writeOpts: b.writeOpts,
 		},
 	}
 


### PR DESCRIPTION
While working on the context propagation in state backend implementations, I noticed that Consul was missing context handling entirely. I investigated the API a bit and figured out how to handle this properly. Here's my attempt on propagating the context to all Consul operations.

Related to #753

## Target Release

1.6.0

## Draft CHANGELOG entry

n/a since this is a pure housekeeping change