### PR TITLE
implement gunzipbase64

### DIFF
--- a/internal/lang/funcs/descriptions.go
+++ b/internal/lang/funcs/descriptions.go
@@ -53,6 +53,10 @@ var DescriptionList = map[string]descriptionEntry{
 		Description:      "`base64gzip` compresses a string with gzip and then encodes the result in Base64 encoding.",
 		ParamDescription: []string{""},
 	},
+	"gunzipbase64": {
+		Description:      "`gunzipbase64` decodes a Base64 encoded string and uncompresses the result with gzip.",
+		ParamDescription: []string{""},
+	},
 	"base64sha256": {
 		Description:      "`base64sha256` computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256(\"test\"))` since `sha256()` returns hexadecimal representation.",
 		ParamDescription: []string{""},

--- a/internal/lang/funcs/descriptions.go
+++ b/internal/lang/funcs/descriptions.go
@@ -54,7 +54,7 @@ var DescriptionList = map[string]descriptionEntry{
 		ParamDescription: []string{""},
 	},
 	"gunzipbase64": {
-		Description:      "`gunzipbase64` decodes a Base64 encoded string and uncompresses the result with gzip.",
+		Description:      "`gunzipbase64` decodes a Base64-encoded string and uncompresses the result with gzip.",
 		ParamDescription: []string{""},
 	},
 	"base64sha256": {

--- a/internal/lang/funcs/encoding.go
+++ b/internal/lang/funcs/encoding.go
@@ -8,6 +8,7 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"log"
 	"net/url"
 	"unicode/utf8"
@@ -178,6 +179,37 @@ var Base64GzipFunc = function.New(&function.Spec{
 	},
 })
 
+// GunzipBase64Func constructs a function that Bae64 decodes a string and decompresses the result with gunzip.
+var GunzipBase64Func = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name: "str",
+			Type: cty.String,
+		},
+	},
+	Type:         function.StaticReturnType(cty.String),
+	RefineResult: refineNotNull,
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		str, strMarks := args[0].Unmark()
+		s := str.AsString()
+		sDec, err := base64.StdEncoding.DecodeString(s)
+		if err != nil {
+			return cty.UnknownVal(cty.String), fmt.Errorf("failed to decode base64 data %s", redactIfSensitive(s, strMarks))
+		}
+		sDecBuffer := bytes.NewReader(sDec)
+		gzipReader, err := gzip.NewReader(sDecBuffer)
+		if err != nil {
+			return cty.UnknownVal(cty.String), fmt.Errorf("failed to gunzip base64 decoded data: %w", err)
+		}
+		gunzip, err := io.ReadAll(gzipReader)
+		if err != nil {
+			return cty.UnknownVal(cty.String), fmt.Errorf("failed to read gunzip raw data: %w", err)
+		}
+
+		return cty.StringVal(string(gunzip)), nil
+	},
+})
+
 // URLEncodeFunc constructs a function that applies URL encoding to a given string.
 var URLEncodeFunc = function.New(&function.Spec{
 	Params: []function.Parameter{
@@ -226,6 +258,13 @@ func Base64Encode(str cty.Value) (cty.Value, error) {
 // as UTF-8, then apply gzip compression, and then finally apply Base64 encoding.
 func Base64Gzip(str cty.Value) (cty.Value, error) {
 	return Base64GzipFunc.Call([]cty.Value{str})
+}
+
+// GunzipBase64 decodes a Base64 encoded string and uncompresses the result with gzip.
+//
+// Terraform uses the "standard" Base64 alphabet as defined in RFC 4648 section 4.
+func GunzipBase64(str cty.Value) (cty.Value, error) {
+	return GunzipBase64Func.Call([]cty.Value{str})
 }
 
 // URLEncode applies URL encoding to a given string.

--- a/internal/lang/funcs/encoding.go
+++ b/internal/lang/funcs/encoding.go
@@ -199,7 +199,7 @@ var GunzipBase64Func = function.New(&function.Spec{
 		sDecBuffer := bytes.NewReader(sDec)
 		gzipReader, err := gzip.NewReader(sDecBuffer)
 		if err != nil {
-			return cty.UnknownVal(cty.String), fmt.Errorf("failed to gunzip base64 decoded data: %w", err)
+			return cty.UnknownVal(cty.String), fmt.Errorf("failed to gunzip bytestream: %w", err)
 		}
 		gunzip, err := io.ReadAll(gzipReader)
 		if err != nil {

--- a/internal/lang/funcs/encoding.go
+++ b/internal/lang/funcs/encoding.go
@@ -260,7 +260,7 @@ func Base64Gzip(str cty.Value) (cty.Value, error) {
 	return Base64GzipFunc.Call([]cty.Value{str})
 }
 
-// GunzipBase64 decodes a Base64 encoded string and uncompresses the result with gzip.
+// GunzipBase64 decodes a Base64-encoded string and uncompresses the result with gzip.
 //
 // Terraform uses the "standard" Base64 alphabet as defined in RFC 4648 section 4.
 func GunzipBase64(str cty.Value) (cty.Value, error) {

--- a/internal/lang/funcs/encoding.go
+++ b/internal/lang/funcs/encoding.go
@@ -262,7 +262,7 @@ func Base64Gzip(str cty.Value) (cty.Value, error) {
 
 // GunzipBase64 decodes a Base64-encoded string and uncompresses the result with gzip.
 //
-// Terraform uses the "standard" Base64 alphabet as defined in RFC 4648 section 4.
+// Opentofu uses the "standard" Base64 alphabet as defined in RFC 4648 section 4.
 func GunzipBase64(str cty.Value) (cty.Value, error) {
 	return GunzipBase64Func.Call([]cty.Value{str})
 }

--- a/internal/lang/funcs/encoding_test.go
+++ b/internal/lang/funcs/encoding_test.go
@@ -159,6 +159,39 @@ func TestBase64Gzip(t *testing.T) {
 	}
 }
 
+func TestGunzipBase64(t *testing.T) {
+	tests := []struct {
+		String cty.Value
+		Want   cty.Value
+		Err    bool
+	}{
+		{
+			cty.StringVal("H4sIAAAAAAAA/ypJLS4BAAAA//8BAAD//wx+f9gEAAAA"),
+			cty.StringVal("test"),
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("gunzipbase64(%#v)", test.String), func(t *testing.T) {
+			got, err := GunzipBase64(test.String)
+
+			if test.Err {
+				if err == nil {
+					t.Fatal("succeeded; want error")
+				}
+				return
+			} else if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if !got.RawEquals(test.Want) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
+			}
+		})
+	}
+}
+
 func TestURLEncode(t *testing.T) {
 	tests := []struct {
 		String cty.Value

--- a/internal/lang/functions.go
+++ b/internal/lang/functions.go
@@ -43,6 +43,7 @@ func (s *Scope) Functions() map[string]function.Function {
 			"base64decode":     funcs.Base64DecodeFunc,
 			"base64encode":     funcs.Base64EncodeFunc,
 			"base64gzip":       funcs.Base64GzipFunc,
+			"gunzipbase64":     funcs.GunzipBase64Func,
 			"base64sha256":     funcs.Base64Sha256Func,
 			"base64sha512":     funcs.Base64Sha512Func,
 			"bcrypt":           funcs.BcryptFunc,

--- a/internal/lang/functions_test.go
+++ b/internal/lang/functions_test.go
@@ -108,6 +108,13 @@ func TestFunctions(t *testing.T) {
 			},
 		},
 
+		"gunzipbase64": {
+			{
+				`gunzipbase64("H4sIAAAAAAAA/ypJLS4BAAAA//8BAAD//wx+f9gEAAAA")`,
+				cty.StringVal("test"),
+			},
+		},
+
 		"base64sha256": {
 			{
 				`base64sha256("test")`,

--- a/website/data/language-nav-data.json
+++ b/website/data/language-nav-data.json
@@ -514,6 +514,10 @@
             "path": "language/functions/base64gzip"
           },
           {
+            "title": "<code>gunzipbase64</code>",
+            "path": "language/functions/gunzipbase64"
+          },
+          {
             "title": "<code>csvdecode</code>",
             "path": "language/functions/csvdecode"
           },
@@ -763,8 +767,13 @@
         "hidden": true
       },
       {
-        "title": "base64sha256",
-        "path": "language/functions/base64sha256",
+        "title": "base64gzip",
+        "path": "language/functions/base64gzip",
+        "hidden": true
+      },
+      {
+        "title": "gunzipbase64",
+        "path": "language/functions/gunzipbase64",
         "hidden": true
       },
       {

--- a/website/data/language-nav-data.json
+++ b/website/data/language-nav-data.json
@@ -762,8 +762,8 @@
         "hidden": true
       },
       {
-        "title": "base64gzip",
-        "path": "language/functions/base64gzip",
+        "title": "base64sha256",
+        "path": "language/functions/base64sha256",
         "hidden": true
       },
       {

--- a/website/data/language-nav-data.json
+++ b/website/data/language-nav-data.json
@@ -514,12 +514,12 @@
             "path": "language/functions/base64gzip"
           },
           {
-            "title": "<code>gunzipbase64</code>",
-            "path": "language/functions/gunzipbase64"
-          },
-          {
             "title": "<code>csvdecode</code>",
             "path": "language/functions/csvdecode"
+          },
+          {
+            "title": "<code>gunzipbase64</code>",
+            "path": "language/functions/gunzipbase64"
           },
           {
             "title": "<code>jsondecode</code>",
@@ -772,11 +772,6 @@
         "hidden": true
       },
       {
-        "title": "gunzipbase64",
-        "path": "language/functions/gunzipbase64",
-        "hidden": true
-      },
-      {
         "title": "base64sha512",
         "path": "language/functions/base64sha512",
         "hidden": true
@@ -934,6 +929,11 @@
       {
         "title": "formatlist",
         "path": "language/functions/formatlist",
+        "hidden": true
+      },
+      {
+        "title": "gunzipbase64",
+        "path": "language/functions/gunzipbase64",
         "hidden": true
       },
       {

--- a/website/docs/language/functions/gunzipbase64.mdx
+++ b/website/docs/language/functions/gunzipbase64.mdx
@@ -1,0 +1,17 @@
+---
+page_title: gunzipbase64 - Functions - Configuration Language
+description: |-
+  The gunzipbase64 funtion decodes a Base64 encoded string and uncompresses the result with gzip.
+---
+
+# `gunzipbase64` Function
+
+`gunzipbase64` decodes a Base64 encoded string and uncompresses the result with gzip.
+
+Terraform uses the "standard" Base64 alphabet as defined in
+[RFC 4648 section 4](https://tools.ietf.org/html/rfc4648#section-4).
+
+## Related Functions
+
+* [`base64gzip`](/terraform/language/functions/base64gzip) compresses a string with gzip and then encodes the result in
+Base64 encoding.

--- a/website/docs/language/functions/gunzipbase64.mdx
+++ b/website/docs/language/functions/gunzipbase64.mdx
@@ -13,5 +13,5 @@ Opentofu uses the "standard" Base64 alphabet as defined in
 
 ## Related Functions
 
-* [`base64gzip`](/terraform/language/functions/base64gzip) compresses a string with gzip and then encodes the result in
+* [`base64gzip`](/docs/language/functions/base64gzip) compresses a string with gzip and then encodes the result in
 Base64 encoding.

--- a/website/docs/language/functions/gunzipbase64.mdx
+++ b/website/docs/language/functions/gunzipbase64.mdx
@@ -8,7 +8,7 @@ description: |-
 
 `gunzipbase64` decodes a Base64 encoded string and uncompresses the result with gzip.
 
-Terraform uses the "standard" Base64 alphabet as defined in
+Opentofu uses the "standard" Base64 alphabet as defined in
 [RFC 4648 section 4](https://tools.ietf.org/html/rfc4648#section-4).
 
 ## Related Functions

--- a/website/docs/language/functions/gunzipbase64.mdx
+++ b/website/docs/language/functions/gunzipbase64.mdx
@@ -1,7 +1,7 @@
 ---
 page_title: gunzipbase64 - Functions - Configuration Language
 description: |-
-  The gunzipbase64 funtion decodes a Base64 encoded string and uncompresses the result with gzip.
+  The gunzipbase64 funtion decodes a Base64-encoded string and uncompresses the result with gzip.
 ---
 
 # `gunzipbase64` Function

--- a/website/docs/language/functions/gunzipbase64.mdx
+++ b/website/docs/language/functions/gunzipbase64.mdx
@@ -6,7 +6,7 @@ description: |-
 
 # `gunzipbase64` Function
 
-`gunzipbase64` decodes a Base64 encoded string and uncompresses the result with gzip.
+`gunzipbase64` decodes a Base64-encoded string and uncompresses the result with gzip.
 
 Opentofu uses the "standard" Base64 alphabet as defined in
 [RFC 4648 section 4](https://tools.ietf.org/html/rfc4648#section-4).


### PR DESCRIPTION
add terraform function gunzipbase64 as opposite of base64gzip similar to

- base64decode opposite of base64encode
- textdecodebase64 opposite of textencodebase64
- jsondecode opposite of jsonencode
- yamldecode opposite of yamlencode

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #800

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.6.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `tofu show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTofu now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

terraform function gunzipbase64 can be used as opposite of base64gzip, e.g.

- write base64gzip content to any storage, read it and decode it with gunzipbase64
