### PR TITLE
Update user-agent from go-tfe to opentofu where go-tfe is used

### DIFF
--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -334,8 +334,12 @@ func (b *Remote) Configure(obj cty.Value) tfdiags.Diagnostics {
 	// Set the version header to the current version.
 	cfg.Headers.Set(tfversion.Header, tfversion.Version)
 
+	// Update user-agent from go-tfe to opentofu
+	cfg.Headers.set("User-Agent", httpclient.OpenTofuUserAgent(version.String()))
+
 	// Create the remote backend API client.
 	b.client, err = tfe.NewClient(cfg)
+
 	if err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -28,6 +28,7 @@ import (
 	"github.com/opentofu/opentofu/internal/states/statemgr"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/opentofu/opentofu/internal/tofu"
+	"github.com/opentofu/opentofu/internal/httpclient"
 	tfversion "github.com/opentofu/opentofu/version"
 	"github.com/zclconf/go-cty/cty"
 
@@ -335,7 +336,7 @@ func (b *Remote) Configure(obj cty.Value) tfdiags.Diagnostics {
 	cfg.Headers.Set(tfversion.Header, tfversion.Version)
 
 	// Update user-agent from go-tfe to opentofu
-	cfg.Headers.Set("User-Agent", httpclient.OpenTofuUserAgent(version.String()))
+	cfg.Headers.Set("User-Agent", httpclient.OpenTofuUserAgent(tfversion.String()))
 
 	// Create the remote backend API client.
 	b.client, err = tfe.NewClient(cfg)

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -335,7 +335,7 @@ func (b *Remote) Configure(obj cty.Value) tfdiags.Diagnostics {
 	// Set the version header to the current version.
 	cfg.Headers.Set(tfversion.Header, tfversion.Version)
 
-	// Update user-agent from go-tfe to opentofu
+	// Update user-agent from 'go-tfe' to opentofu
 	cfg.Headers.Set("User-Agent", httpclient.OpenTofuUserAgent(tfversion.String()))
 
 	// Create the remote backend API client.

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -23,12 +23,12 @@ import (
 	"github.com/mitchellh/colorstring"
 	"github.com/opentofu/opentofu/internal/backend"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
+	"github.com/opentofu/opentofu/internal/httpclient"
 	"github.com/opentofu/opentofu/internal/logging"
 	"github.com/opentofu/opentofu/internal/states/remote"
 	"github.com/opentofu/opentofu/internal/states/statemgr"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/opentofu/opentofu/internal/tofu"
-	"github.com/opentofu/opentofu/internal/httpclient"
 	tfversion "github.com/opentofu/opentofu/version"
 	"github.com/zclconf/go-cty/cty"
 

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -335,7 +335,7 @@ func (b *Remote) Configure(obj cty.Value) tfdiags.Diagnostics {
 	cfg.Headers.Set(tfversion.Header, tfversion.Version)
 
 	// Update user-agent from go-tfe to opentofu
-	cfg.Headers.set("User-Agent", httpclient.OpenTofuUserAgent(version.String()))
+	cfg.Headers.Set("User-Agent", httpclient.OpenTofuUserAgent(version.String()))
 
 	// Create the remote backend API client.
 	b.client, err = tfe.NewClient(cfg)

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -339,7 +339,6 @@ func (b *Remote) Configure(obj cty.Value) tfdiags.Diagnostics {
 
 	// Create the remote backend API client.
 	b.client, err = tfe.NewClient(cfg)
-
 	if err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -28,6 +28,7 @@ import (
 	"github.com/opentofu/opentofu/internal/backend"
 	"github.com/opentofu/opentofu/internal/command/jsonformat"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
+	"github.com/opentofu/opentofu/internal/httpclient"
 	"github.com/opentofu/opentofu/internal/plans"
 	"github.com/opentofu/opentofu/internal/states/statemgr"
 	"github.com/opentofu/opentofu/internal/tfdiags"
@@ -306,6 +307,9 @@ func (b *Cloud) Configure(obj cty.Value) tfdiags.Diagnostics {
 		// Set the version header to the current version.
 		cfg.Headers.Set(tfversion.Header, tfversion.Version)
 		cfg.Headers.Set(headerSourceKey, headerSourceValue)
+
+		// Update user-agent from 'go-tfe' to opentofu
+		cfg.Headers.Set("User-Agent", httpclient.OpenTofuUserAgent(tfversion.String()))
 
 		// Create the TFC/E API client.
 		b.client, err = tfe.NewClient(cfg)

--- a/internal/command/login.go
+++ b/internal/command/login.go
@@ -29,6 +29,7 @@ import (
 	"github.com/opentofu/opentofu/internal/logging"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/opentofu/opentofu/internal/tofu"
+	"github.com/opentofu/opentofu/version"
 
 	uuid "github.com/hashicorp/go-uuid"
 	"golang.org/x/oauth2"
@@ -648,6 +649,10 @@ func (c *LoginCommand) interactiveGetTokenByUI(hostname svchost.Hostname, credsC
 		Token:    token,
 		Headers:  make(http.Header),
 	}
+
+	// Update user-agent from 'go-tfe' to opentofu
+	cfg.Headers.Set("User-Agent", httpclient.OpenTofuUserAgent(version.String()))
+
 	client, err := tfe.NewClient(cfg)
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("Failed to create API client: %w", err))


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

Updates  user-agent to use opentofu if go-tfe library is used (login, remote and cloud backends)

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #806

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.6.0

## Draft CHANGELOG entry

<!--

Choose a category, delete the others:

-->

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of the user-facing change. Examples:

- `tofu show -json`: Fixed crash with sensitive set values.
- When rendering a diff, OpenTofu now quotes the name of any object attribute whose string representation is not a valid identifier.
- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.

--> 

-  
