### PR TITLE
Fix BackendWithRemoteTerraformVersion interface to accept context

### DIFF
--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -934,10 +934,10 @@ func (b *Cloud) IgnoreVersionConflict() {
 //
 // If the versions aren't compatible, it returns an error (or, if
 // b.ignoreVersionConflict is set, a warning).
-func (b *Cloud) VerifyWorkspaceTerraformVersion(workspaceName string) tfdiags.Diagnostics {
+func (b *Cloud) VerifyWorkspaceTerraformVersion(ctx context.Context, workspaceName string) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
-	workspace, err := b.getRemoteWorkspace(context.Background(), workspaceName)
+	workspace, err := b.getRemoteWorkspace(ctx, workspaceName)
 	if err != nil {
 		// If the workspace doesn't exist, there can be no compatibility
 		// problem, so we can return. This is most likely to happen when

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -1230,10 +1230,12 @@ func TestCloud_VerifyWorkspaceTerraformVersion(t *testing.T) {
 			tfversion.Version = local.String()
 			tfversion.SemVer = local
 
+			ctx := context.Background()
+
 			// Update the mock remote workspace Terraform version to the
 			// specified remote version
 			if _, err := b.client.Workspaces.Update(
-				context.Background(),
+				ctx,
 				b.organization,
 				b.WorkspaceMapping.Name,
 				tfe.WorkspaceUpdateOptions{
@@ -1244,7 +1246,7 @@ func TestCloud_VerifyWorkspaceTerraformVersion(t *testing.T) {
 				t.Fatalf("error: %v", err)
 			}
 
-			diags := b.VerifyWorkspaceTerraformVersion(backend.DefaultStateName)
+			diags := b.VerifyWorkspaceTerraformVersion(ctx, backend.DefaultStateName)
 			if tc.wantErr {
 				if len(diags) != 1 {
 					t.Fatal("expected diag, but none returned")
@@ -1265,16 +1267,18 @@ func TestCloud_VerifyWorkspaceTerraformVersion_workspaceErrors(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
+	ctx := context.Background()
+
 	// Attempting to check the version against a workspace which doesn't exist
 	// should result in no errors
-	diags := b.VerifyWorkspaceTerraformVersion("invalid-workspace")
+	diags := b.VerifyWorkspaceTerraformVersion(ctx, "invalid-workspace")
 	if len(diags) != 0 {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}
 
 	// Use a special workspace ID to trigger a 500 error, which should result
 	// in a failed check
-	diags = b.VerifyWorkspaceTerraformVersion("network-error")
+	diags = b.VerifyWorkspaceTerraformVersion(ctx, "network-error")
 	if len(diags) != 1 {
 		t.Fatal("expected diag, but none returned")
 	}
@@ -1293,7 +1297,7 @@ func TestCloud_VerifyWorkspaceTerraformVersion_workspaceErrors(t *testing.T) {
 	); err != nil {
 		t.Fatalf("error: %v", err)
 	}
-	diags = b.VerifyWorkspaceTerraformVersion(backend.DefaultStateName)
+	diags = b.VerifyWorkspaceTerraformVersion(ctx, backend.DefaultStateName)
 
 	if len(diags) != 1 {
 		t.Fatal("expected diag, but none returned")
@@ -1329,10 +1333,12 @@ func TestCloud_VerifyWorkspaceTerraformVersion_ignoreFlagSet(t *testing.T) {
 	tfversion.Version = local.String()
 	tfversion.SemVer = local
 
+	ctx := context.Background()
+
 	// Update the mock remote workspace Terraform version to the
 	// specified remote version
 	if _, err := b.client.Workspaces.Update(
-		context.Background(),
+		ctx,
 		b.organization,
 		b.WorkspaceMapping.Name,
 		tfe.WorkspaceUpdateOptions{
@@ -1342,7 +1348,7 @@ func TestCloud_VerifyWorkspaceTerraformVersion_ignoreFlagSet(t *testing.T) {
 		t.Fatalf("error: %v", err)
 	}
 
-	diags := b.VerifyWorkspaceTerraformVersion(backend.DefaultStateName)
+	diags := b.VerifyWorkspaceTerraformVersion(ctx, backend.DefaultStateName)
 	if len(diags) != 1 {
 		t.Fatal("expected diag, but none returned")
 	}

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -67,7 +67,7 @@ type BackendOpts struct {
 // for simplified type checking when calling functions common to those particular backends.
 type BackendWithRemoteTerraformVersion interface {
 	IgnoreVersionConflict()
-	VerifyWorkspaceTerraformVersion(workspace string) tfdiags.Diagnostics
+	VerifyWorkspaceTerraformVersion(ctx context.Context, workspace string) tfdiags.Diagnostics
 	IsLocalOperations() bool
 }
 
@@ -1500,7 +1500,7 @@ func (m *Meta) remoteVersionCheck(b backend.Backend, workspace string) tfdiags.D
 		}
 		// If the override is set, this check will return a warning instead of
 		// an error
-		versionDiags := back.VerifyWorkspaceTerraformVersion(workspace)
+		versionDiags := back.VerifyWorkspaceTerraformVersion(context.TODO(), workspace)
 		diags = diags.Append(versionDiags)
 		// If there are no errors resulting from this check, we do not need to
 		// check again


### PR DESCRIPTION
The Remote and Cloud backends did not cast to `BackendWithRemoteTerraformVersion` because `VerifyWorkspaceTerraformVersion` function did not accept the context.

Resolves #824

## Target Release

1.6.0
