### PR TITLE
Conditionally use timeout when locking state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ BUG FIXES:
 * `GIT_SSH_COMMAND` environment variable is no longer ignored when downloading modules ([#717](https://github.com/opento
 * cloud: fixed a bug that would prevent nested symlinks from being dereferenced into the config sent to Cloud ([#686](https://github.com/opentofu/opentofu/issues/686)) 
 * cloud: state snapshots could not be disabled when header x-terraform-snapshot-interval is absent ([#687](https://github.com/opentofu/opentofu/issues/687))
+* Correctly handle state locking timeouts when locking state ([#834](https://github.com/opentofu/opentofu/pull/834))
 
 S3 BACKEND:
 


### PR DESCRIPTION
This resolves an issue where if the timeout was 0, we would immediately cancel the state locking mechanism due to a context timeout.

Before #789, this code was actually buggy and did not correctly handle timeouts.

Note: This PR also improves some of the comments in this file

Resolves #825 

## Target Release

1.6.0

## Draft CHANGELOG entry

### BUG FIXES
- Correctly handle timeouts when locking remote state (#834)
