### PR TITLE
Revert PRs that introduced propogating contexts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2
 	github.com/aws/aws-sdk-go-v2 v1.21.2
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.13
-	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.92
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.21.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.40.2
 	github.com/bgentry/speakeasy v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -320,8 +320,6 @@ github.com/aws/aws-sdk-go-v2/credentials v1.13.43/go.mod h1:zWJBz1Yf1ZtX5NGax9Zd
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.6.0/go.mod h1:gqlclDEZp4aqJOancXK6TN24aKhT0W0Ae9MHk3wzTMM=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.13 h1:PIktER+hwIG286DqXyvVENjgLTAwGgoeriLDD5C+YlQ=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.13/go.mod h1:f/Ib/qYjhV2/qdsf79H3QP/eRE4AkVyEf6sk7XfZ1tg=
-github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.92 h1:nLA7dGFC6v4P6b+hzqt5GqIGmIuN+jTJzojfdOLXWFE=
-github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.92/go.mod h1:h+ei9z19AhoN+Dac92DwkzfbJ4mFUea92xgl5pKSG0Q=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.37/go.mod h1:Pdn4j43v49Kk6+82spO3Tu5gSeQXRsxo56ePPQAvFiA=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.38/go.mod h1:qggunOChCMu9ZF/UkAfhTz25+U2rLVb3ya0Ua6TTfCA=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.43 h1:nFBQlGtkbPzp/NjZLuFxRqmT91rLJkgvsEQs68h962Y=

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -112,7 +112,7 @@ type Backend interface {
 	// DeleteWorkspace cannot prevent deleting a state that is in use. It is
 	// the responsibility of the caller to hold a Lock for the state manager
 	// belonging to this workspace before calling this method.
-	DeleteWorkspace(_ context.Context, name string, force bool) error
+	DeleteWorkspace(name string, force bool) error
 
 	// States returns a list of the names of all of the workspaces that exist
 	// in this backend.

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -105,7 +105,7 @@ type Backend interface {
 	// If the named workspace doesn't exist, or if it has no state, it will
 	// be created either immediately on this call or the first time
 	// PersistState is called, depending on the state manager implementation.
-	StateMgr(_ context.Context, workspace string) (statemgr.Full, error)
+	StateMgr(workspace string) (statemgr.Full, error)
 
 	// DeleteWorkspace removes the workspace with the given name if it exists.
 	//

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -95,7 +95,7 @@ type Backend interface {
 	//
 	// If error diagnostics are returned, the internal state of the instance
 	// is undefined and no other methods may be called.
-	Configure(context.Context, cty.Value) tfdiags.Diagnostics
+	Configure(cty.Value) tfdiags.Diagnostics
 
 	// StateMgr returns the state manager for the given workspace name.
 	//

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -116,7 +116,7 @@ type Backend interface {
 
 	// States returns a list of the names of all of the workspaces that exist
 	// in this backend.
-	Workspaces(context.Context) ([]string, error)
+	Workspaces() ([]string, error)
 }
 
 // HostAlias describes a list of aliases that should be used when initializing an

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -81,7 +81,7 @@ type Backend interface {
 	// as tfdiags.AttributeValue, and so the caller should provide the
 	// necessary context via the diags.InConfigBody method before returning
 	// diagnostics to the user.
-	PrepareConfig(context.Context, cty.Value) (cty.Value, tfdiags.Diagnostics)
+	PrepareConfig(cty.Value) (cty.Value, tfdiags.Diagnostics)
 
 	// Configure uses the provided configuration to set configuration fields
 	// within the backend.

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -61,7 +61,7 @@ type Backend interface {
 	//
 	// This method does not have any side-effects for the backend and can
 	// be safely used before configuring.
-	ConfigSchema(context.Context) *configschema.Block
+	ConfigSchema() *configschema.Block
 
 	// PrepareConfig checks the validity of the values in the given
 	// configuration, and inserts any missing defaults, assuming that its

--- a/internal/backend/init/deprecate_test.go
+++ b/internal/backend/init/deprecate_test.go
@@ -4,7 +4,6 @@
 package init
 
 import (
-	"context"
 	"testing"
 
 	"github.com/opentofu/opentofu/internal/backend/remote-state/inmem"
@@ -18,7 +17,7 @@ func TestDeprecateBackend(t *testing.T) {
 		deprecateMessage,
 	)
 
-	_, diags := deprecatedBackend.PrepareConfig(context.Background(), cty.EmptyObjectVal)
+	_, diags := deprecatedBackend.PrepareConfig(cty.EmptyObjectVal)
 	if len(diags) != 1 {
 		t.Errorf("got %d diagnostics; want 1", len(diags))
 		for _, diag := range diags {

--- a/internal/backend/init/init.go
+++ b/internal/backend/init/init.go
@@ -6,7 +6,6 @@
 package init
 
 import (
-	"context"
 	"sync"
 
 	"github.com/hashicorp/terraform-svchost/disco"
@@ -119,8 +118,8 @@ type deprecatedBackendShim struct {
 
 // PrepareConfig delegates to the wrapped backend to validate its config
 // and then appends shim's deprecation warning.
-func (b deprecatedBackendShim) PrepareConfig(ctx context.Context, obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
-	newObj, diags := b.Backend.PrepareConfig(ctx, obj)
+func (b deprecatedBackendShim) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
+	newObj, diags := b.Backend.PrepareConfig(obj)
 	return newObj, diags.Append(tfdiags.SimpleWarning(b.Message))
 }
 

--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -122,9 +122,9 @@ func (b *Local) ConfigSchema(ctx context.Context) *configschema.Block {
 	}
 }
 
-func (b *Local) PrepareConfig(ctx context.Context, obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
+func (b *Local) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
 	if b.Backend != nil {
-		return b.Backend.PrepareConfig(ctx, obj)
+		return b.Backend.PrepareConfig(obj)
 	}
 
 	var diags tfdiags.Diagnostics

--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -186,10 +186,10 @@ func (b *Local) ServiceDiscoveryAliases() ([]backend.HostAlias, error) {
 	return []backend.HostAlias{}, nil
 }
 
-func (b *Local) Workspaces(ctx context.Context) ([]string, error) {
+func (b *Local) Workspaces() ([]string, error) {
 	// If we have a backend handling state, defer to that.
 	if b.Backend != nil {
-		return b.Backend.Workspaces(ctx)
+		return b.Backend.Workspaces()
 	}
 
 	// the listing always start with "default"
@@ -430,9 +430,9 @@ func (b *Local) StatePaths(name string) (stateIn, stateOut, backupOut string) {
 // This should be used when "migrating" from one local backend configuration to
 // another in order to avoid deleting the "old" state snapshots if they are
 // in the same files as the "new" state snapshots.
-func (b *Local) PathsConflictWith(ctx context.Context, other *Local) bool {
+func (b *Local) PathsConflictWith(other *Local) bool {
 	otherPaths := map[string]struct{}{}
-	otherWorkspaces, err := other.Workspaces(ctx)
+	otherWorkspaces, err := other.Workspaces()
 	if err != nil {
 		// If we can't enumerate the workspaces then we'll conservatively
 		// assume that paths _do_ overlap, since we can't be certain.
@@ -443,7 +443,7 @@ func (b *Local) PathsConflictWith(ctx context.Context, other *Local) bool {
 		otherPaths[p] = struct{}{}
 	}
 
-	ourWorkspaces, err := other.Workspaces(ctx)
+	ourWorkspaces, err := other.Workspaces()
 	if err != nil {
 		// If we can't enumerate the workspaces then we'll conservatively
 		// assume that paths _do_ overlap, since we can't be certain.

--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -220,10 +220,10 @@ func (b *Local) Workspaces() ([]string, error) {
 // DeleteWorkspace removes a workspace.
 //
 // The "default" workspace cannot be removed.
-func (b *Local) DeleteWorkspace(ctx context.Context, name string, force bool) error {
+func (b *Local) DeleteWorkspace(name string, force bool) error {
 	// If we have a backend handling state, defer to that.
 	if b.Backend != nil {
-		return b.Backend.DeleteWorkspace(ctx, name, force)
+		return b.Backend.DeleteWorkspace(name, force)
 	}
 
 	if name == "" {

--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -104,9 +104,9 @@ func NewWithBackend(backend backend.Backend) *Local {
 	}
 }
 
-func (b *Local) ConfigSchema(ctx context.Context) *configschema.Block {
+func (b *Local) ConfigSchema() *configschema.Block {
 	if b.Backend != nil {
-		return b.Backend.ConfigSchema(ctx)
+		return b.Backend.ConfigSchema()
 	}
 	return &configschema.Block{
 		Attributes: map[string]*configschema.Attribute{

--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -156,9 +156,9 @@ func (b *Local) PrepareConfig(ctx context.Context, obj cty.Value) (cty.Value, tf
 	return obj, diags
 }
 
-func (b *Local) Configure(ctx context.Context, obj cty.Value) tfdiags.Diagnostics {
+func (b *Local) Configure(obj cty.Value) tfdiags.Diagnostics {
 	if b.Backend != nil {
-		return b.Backend.Configure(ctx, obj)
+		return b.Backend.Configure(obj)
 	}
 
 	var diags tfdiags.Diagnostics

--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -348,14 +348,9 @@ func (b *Local) opWait(
 	case <-stopCtx.Done():
 		view.Stopping()
 
-		// We want to have a context that's guaranteed to be active that can be
-		// used to persist the state. Otherwise, if the operation is canceled
-		// or stopped before we can persist the state, we'll lose the state.
-		persistCtx := context.Background()
-
 		// try to force a PersistState just in case the process is terminated
 		// before we can complete.
-		if err := opStateMgr.PersistState(persistCtx, nil); err != nil {
+		if err := opStateMgr.PersistState(nil); err != nil {
 			// We can't error out from here, but warn the user if there was an error.
 			// If this isn't transient, we will catch it again below, and
 			// attempt to save the state another way.

--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -238,10 +238,10 @@ func (b *Local) DeleteWorkspace(name string, force bool) error {
 	return os.RemoveAll(filepath.Join(b.stateWorkspaceDir(), name))
 }
 
-func (b *Local) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {
+func (b *Local) StateMgr(name string) (statemgr.Full, error) {
 	// If we have a backend handling state, delegate to that.
 	if b.Backend != nil {
-		return b.Backend.StateMgr(ctx, name)
+		return b.Backend.StateMgr(name)
 	}
 
 	if s, ok := b.states[name]; ok {

--- a/internal/backend/local/backend_apply_test.go
+++ b/internal/backend/local/backend_apply_test.go
@@ -347,7 +347,7 @@ type backendWithFailingState struct {
 	Local
 }
 
-func (b *backendWithFailingState) StateMgr(_ context.Context, name string) (statemgr.Full, error) {
+func (b *backendWithFailingState) StateMgr(name string) (statemgr.Full, error) {
 	return &failingState{
 		statemgr.NewFilesystem("failing-state.tfstate"),
 	}, nil

--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -41,11 +41,9 @@ func (b *Local) LocalRun(op *backend.Operation) (*backend.LocalRun, statemgr.Ful
 func (b *Local) localRun(op *backend.Operation) (*backend.LocalRun, *configload.Snapshot, statemgr.Full, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	ctx := context.TODO()
-
 	// Get the latest state.
 	log.Printf("[TRACE] backend/local: requesting state manager for workspace %q", op.Workspace)
-	s, err := b.StateMgr(ctx, op.Workspace)
+	s, err := b.StateMgr(op.Workspace)
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("error loading state: %w", err))
 		return nil, nil, nil, diags

--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -64,7 +64,7 @@ func (b *Local) localRun(op *backend.Operation) (*backend.LocalRun, *configload.
 	}()
 
 	log.Printf("[TRACE] backend/local: reading remote state for workspace %q", op.Workspace)
-	if err := s.RefreshState(ctx); err != nil {
+	if err := s.RefreshState(); err != nil {
 		diags = diags.Append(fmt.Errorf("error loading state: %w", err))
 		return nil, nil, nil, diags
 	}

--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -138,10 +138,8 @@ func TestLocalRun_stalePlan(t *testing.T) {
 		t.Fatalf("unexpected error writing state file: %s", err)
 	}
 
-	ctx := context.Background()
-
 	// Refresh the state
-	sm, err := b.StateMgr(ctx, "")
+	sm, err := b.StateMgr("")
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -215,7 +213,7 @@ type backendWithStateStorageThatFailsRefresh struct {
 
 var _ backend.Backend = backendWithStateStorageThatFailsRefresh{}
 
-func (b backendWithStateStorageThatFailsRefresh) StateMgr(_ context.Context, workspace string) (statemgr.Full, error) {
+func (b backendWithStateStorageThatFailsRefresh) StateMgr(workspace string) (statemgr.Full, error) {
 	return &stateStorageThatFailsRefresh{}, nil
 }
 

--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -243,7 +243,7 @@ type stateStorageThatFailsRefresh struct {
 	locked bool
 }
 
-func (s *stateStorageThatFailsRefresh) Lock(_ context.Context, info *statemgr.LockInfo) (string, error) {
+func (s *stateStorageThatFailsRefresh) Lock(info *statemgr.LockInfo) (string, error) {
 	if s.locked {
 		return "", fmt.Errorf("already locked")
 	}
@@ -251,7 +251,7 @@ func (s *stateStorageThatFailsRefresh) Lock(_ context.Context, info *statemgr.Lo
 	return "locked", nil
 }
 
-func (s *stateStorageThatFailsRefresh) Unlock(_ context.Context, id string) error {
+func (s *stateStorageThatFailsRefresh) Unlock(id string) error {
 	if !s.locked {
 		return fmt.Errorf("not locked")
 	}

--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -235,7 +235,7 @@ func (b backendWithStateStorageThatFailsRefresh) DeleteWorkspace(_ context.Conte
 	return fmt.Errorf("unimplemented")
 }
 
-func (b backendWithStateStorageThatFailsRefresh) Workspaces(context.Context) ([]string, error) {
+func (b backendWithStateStorageThatFailsRefresh) Workspaces() ([]string, error) {
 	return []string{"default"}, nil
 }
 

--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -231,7 +231,7 @@ func (b backendWithStateStorageThatFailsRefresh) Configure(context.Context, cty.
 	return nil
 }
 
-func (b backendWithStateStorageThatFailsRefresh) DeleteWorkspace(_ context.Context, name string, force bool) error {
+func (b backendWithStateStorageThatFailsRefresh) DeleteWorkspace(name string, force bool) error {
 	return fmt.Errorf("unimplemented")
 }
 

--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -145,7 +145,7 @@ func TestLocalRun_stalePlan(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if err := sm.RefreshState(ctx); err != nil {
+	if err := sm.RefreshState(); err != nil {
 		t.Fatalf("unexpected error refreshing state: %s", err)
 	}
 
@@ -263,7 +263,7 @@ func (s *stateStorageThatFailsRefresh) State() *states.State {
 	return nil
 }
 
-func (s *stateStorageThatFailsRefresh) GetRootOutputValues(context.Context) (map[string]*states.OutputValue, error) {
+func (s *stateStorageThatFailsRefresh) GetRootOutputValues() (map[string]*states.OutputValue, error) {
 	return nil, fmt.Errorf("unimplemented")
 }
 
@@ -271,10 +271,10 @@ func (s *stateStorageThatFailsRefresh) WriteState(*states.State) error {
 	return fmt.Errorf("unimplemented")
 }
 
-func (s *stateStorageThatFailsRefresh) RefreshState(context.Context) error {
+func (s *stateStorageThatFailsRefresh) RefreshState() error {
 	return fmt.Errorf("intentionally failing for testing purposes")
 }
 
-func (s *stateStorageThatFailsRefresh) PersistState(_ context.Context, schemas *tofu.Schemas) error {
+func (s *stateStorageThatFailsRefresh) PersistState(schemas *tofu.Schemas) error {
 	return fmt.Errorf("unimplemented")
 }

--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -225,7 +225,7 @@ func (b backendWithStateStorageThatFailsRefresh) PrepareConfig(_ context.Context
 	return in, nil
 }
 
-func (b backendWithStateStorageThatFailsRefresh) Configure(context.Context, cty.Value) tfdiags.Diagnostics {
+func (b backendWithStateStorageThatFailsRefresh) Configure(cty.Value) tfdiags.Diagnostics {
 	return nil
 }
 

--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -4,7 +4,6 @@
 package local
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -217,7 +216,7 @@ func (b backendWithStateStorageThatFailsRefresh) StateMgr(workspace string) (sta
 	return &stateStorageThatFailsRefresh{}, nil
 }
 
-func (b backendWithStateStorageThatFailsRefresh) ConfigSchema(context.Context) *configschema.Block {
+func (b backendWithStateStorageThatFailsRefresh) ConfigSchema() *configschema.Block {
 	return &configschema.Block{}
 }
 

--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -221,7 +221,7 @@ func (b backendWithStateStorageThatFailsRefresh) ConfigSchema(context.Context) *
 	return &configschema.Block{}
 }
 
-func (b backendWithStateStorageThatFailsRefresh) PrepareConfig(_ context.Context, in cty.Value) (cty.Value, tfdiags.Diagnostics) {
+func (b backendWithStateStorageThatFailsRefresh) PrepareConfig(in cty.Value) (cty.Value, tfdiags.Diagnostics) {
 	return in, nil
 }
 

--- a/internal/backend/local/backend_test.go
+++ b/internal/backend/local/backend_test.go
@@ -139,7 +139,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatalf("expected %q, got %q", expectedStates, states)
 	}
 
-	if err := b.DeleteWorkspace(ctx, expectedA, true); err != nil {
+	if err := b.DeleteWorkspace(expectedA, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -153,7 +153,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatalf("expected %q, got %q", expectedStates, states)
 	}
 
-	if err := b.DeleteWorkspace(ctx, expectedB, true); err != nil {
+	if err := b.DeleteWorkspace(expectedB, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -167,7 +167,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatalf("expected %q, got %q", expectedStates, states)
 	}
 
-	if err := b.DeleteWorkspace(ctx, dflt, true); err == nil {
+	if err := b.DeleteWorkspace(dflt, true); err == nil {
 		t.Fatal("expected error deleting default state")
 	}
 }
@@ -202,7 +202,7 @@ func (b *testDelegateBackend) Workspaces() ([]string, error) {
 	return []string{"default"}, nil
 }
 
-func (b *testDelegateBackend) DeleteWorkspace(_ context.Context, name string, force bool) error {
+func (b *testDelegateBackend) DeleteWorkspace(name string, force bool) error {
 	if b.deleteErr {
 		return errTestDelegateDeleteState
 	}
@@ -218,9 +218,7 @@ func TestLocal_multiStateBackend(t *testing.T) {
 		deleteErr: true,
 	})
 
-	ctx := context.Background()
-
-	if _, err := b.StateMgr(ctx, "test"); err != errTestDelegateState {
+	if _, err := b.StateMgr(context.Background(), "test"); err != errTestDelegateState {
 		t.Fatal("expected errTestDelegateState, got:", err)
 	}
 
@@ -228,7 +226,7 @@ func TestLocal_multiStateBackend(t *testing.T) {
 		t.Fatal("expected errTestDelegateStates, got:", err)
 	}
 
-	if err := b.DeleteWorkspace(ctx, "test", true); err != errTestDelegateDeleteState {
+	if err := b.DeleteWorkspace("test", true); err != errTestDelegateDeleteState {
 		t.Fatal("expected errTestDelegateDeleteState, got:", err)
 	}
 }

--- a/internal/backend/local/backend_test.go
+++ b/internal/backend/local/backend_test.go
@@ -4,7 +4,6 @@
 package local
 
 import (
-	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -107,10 +106,8 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatalf("expected []string{%q}, got %q", dflt, states)
 	}
 
-	ctx := context.Background()
-
 	expectedA := "test_A"
-	if _, err := b.StateMgr(ctx, expectedA); err != nil {
+	if _, err := b.StateMgr(expectedA); err != nil {
 		t.Fatal(err)
 	}
 
@@ -125,7 +122,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 	}
 
 	expectedB := "test_B"
-	if _, err := b.StateMgr(ctx, expectedB); err != nil {
+	if _, err := b.StateMgr(expectedB); err != nil {
 		t.Fatal(err)
 	}
 
@@ -187,7 +184,7 @@ var errTestDelegateState = errors.New("state called")
 var errTestDelegateStates = errors.New("states called")
 var errTestDelegateDeleteState = errors.New("delete called")
 
-func (b *testDelegateBackend) StateMgr(_ context.Context, name string) (statemgr.Full, error) {
+func (b *testDelegateBackend) StateMgr(name string) (statemgr.Full, error) {
 	if b.stateErr {
 		return nil, errTestDelegateState
 	}
@@ -218,7 +215,7 @@ func TestLocal_multiStateBackend(t *testing.T) {
 		deleteErr: true,
 	})
 
-	if _, err := b.StateMgr(context.Background(), "test"); err != errTestDelegateState {
+	if _, err := b.StateMgr("test"); err != errTestDelegateState {
 		t.Fatal("expected errTestDelegateState, got:", err)
 	}
 

--- a/internal/backend/local/backend_test.go
+++ b/internal/backend/local/backend_test.go
@@ -98,9 +98,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 	expectedStates := []string{dflt}
 
 	b := New()
-	ctx := context.Background()
-
-	states, err := b.Workspaces(ctx)
+	states, err := b.Workspaces()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,12 +107,14 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatalf("expected []string{%q}, got %q", dflt, states)
 	}
 
+	ctx := context.Background()
+
 	expectedA := "test_A"
 	if _, err := b.StateMgr(ctx, expectedA); err != nil {
 		t.Fatal(err)
 	}
 
-	states, err = b.Workspaces(ctx)
+	states, err = b.Workspaces()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -129,7 +129,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	states, err = b.Workspaces(ctx)
+	states, err = b.Workspaces()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -143,7 +143,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	states, err = b.Workspaces(ctx)
+	states, err = b.Workspaces()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +157,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	states, err = b.Workspaces(ctx)
+	states, err = b.Workspaces()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -195,7 +195,7 @@ func (b *testDelegateBackend) StateMgr(_ context.Context, name string) (statemgr
 	return s, nil
 }
 
-func (b *testDelegateBackend) Workspaces(context.Context) ([]string, error) {
+func (b *testDelegateBackend) Workspaces() ([]string, error) {
 	if b.statesErr {
 		return nil, errTestDelegateStates
 	}
@@ -224,7 +224,7 @@ func TestLocal_multiStateBackend(t *testing.T) {
 		t.Fatal("expected errTestDelegateState, got:", err)
 	}
 
-	if _, err := b.Workspaces(ctx); err != errTestDelegateStates {
+	if _, err := b.Workspaces(); err != errTestDelegateStates {
 		t.Fatal("expected errTestDelegateStates, got:", err)
 	}
 

--- a/internal/backend/local/hook_state.go
+++ b/internal/backend/local/hook_state.go
@@ -4,7 +4,6 @@
 package local
 
 import (
-	"context"
 	"log"
 	"sync"
 	"time"
@@ -80,7 +79,7 @@ func (h *StateHook) PostStateUpdate(new *states.State) (tofu.HookAction, error) 
 		}
 		if mgrPersist, ok := h.StateMgr.(statemgr.Persister); ok && h.PersistInterval != 0 && h.Schemas != nil {
 			if h.shouldPersist() {
-				err := mgrPersist.PersistState(context.TODO(), h.Schemas)
+				err := mgrPersist.PersistState(h.Schemas)
 				if err != nil {
 					return tofu.HookActionHalt, err
 				}
@@ -114,7 +113,7 @@ func (h *StateHook) Stopping() {
 		h.intermediatePersist.ForcePersist = true
 
 		if h.shouldPersist() {
-			err := mgrPersist.PersistState(context.TODO(), h.Schemas)
+			err := mgrPersist.PersistState(h.Schemas)
 			if err != nil {
 				// This hook can't affect OpenTofu Core's ongoing behavior,
 				// but it's a best effort thing anyway, so we'll just emit a

--- a/internal/backend/local/hook_state_test.go
+++ b/internal/backend/local/hook_state_test.go
@@ -4,7 +4,6 @@
 package local
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -256,7 +255,7 @@ func (sm *testPersistentState) WriteState(state *states.State) error {
 	return nil
 }
 
-func (sm *testPersistentState) PersistState(_ context.Context, schemas *tofu.Schemas) error {
+func (sm *testPersistentState) PersistState(schemas *tofu.Schemas) error {
 	if schemas == nil {
 		return fmt.Errorf("no schemas")
 	}
@@ -282,7 +281,7 @@ func (sm *testPersistentStateThatRefusesToPersist) WriteState(state *states.Stat
 	return nil
 }
 
-func (sm *testPersistentStateThatRefusesToPersist) PersistState(_ context.Context, schemas *tofu.Schemas) error {
+func (sm *testPersistentStateThatRefusesToPersist) PersistState(schemas *tofu.Schemas) error {
 	if schemas == nil {
 		return fmt.Errorf("no schemas")
 	}

--- a/internal/backend/local/testing.go
+++ b/internal/backend/local/testing.go
@@ -122,7 +122,7 @@ func (b *TestLocalSingleState) Workspaces() ([]string, error) {
 	return nil, backend.ErrWorkspacesNotSupported
 }
 
-func (b *TestLocalSingleState) DeleteWorkspace(context.Context, string, bool) error {
+func (b *TestLocalSingleState) DeleteWorkspace(string, bool) error {
 	return backend.ErrWorkspacesNotSupported
 }
 
@@ -164,11 +164,11 @@ func (b *TestLocalNoDefaultState) Workspaces() ([]string, error) {
 	return filtered, nil
 }
 
-func (b *TestLocalNoDefaultState) DeleteWorkspace(ctx context.Context, name string, force bool) error {
+func (b *TestLocalNoDefaultState) DeleteWorkspace(name string, force bool) error {
 	if name == backend.DefaultStateName {
 		return backend.ErrDefaultWorkspaceNotSupported
 	}
-	return b.Local.DeleteWorkspace(ctx, name, force)
+	return b.Local.DeleteWorkspace(name, force)
 }
 
 func (b *TestLocalNoDefaultState) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {

--- a/internal/backend/local/testing.go
+++ b/internal/backend/local/testing.go
@@ -118,7 +118,7 @@ func TestNewLocalSingle() backend.Backend {
 	return &TestLocalSingleState{Local: New()}
 }
 
-func (b *TestLocalSingleState) Workspaces(context.Context) ([]string, error) {
+func (b *TestLocalSingleState) Workspaces() ([]string, error) {
 	return nil, backend.ErrWorkspacesNotSupported
 }
 
@@ -148,8 +148,8 @@ func TestNewLocalNoDefault() backend.Backend {
 	return &TestLocalNoDefaultState{Local: New()}
 }
 
-func (b *TestLocalNoDefaultState) Workspaces(ctx context.Context) ([]string, error) {
-	workspaces, err := b.Local.Workspaces(ctx)
+func (b *TestLocalNoDefaultState) Workspaces() ([]string, error) {
+	workspaces, err := b.Local.Workspaces()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/local/testing.go
+++ b/internal/backend/local/testing.go
@@ -4,7 +4,6 @@
 package local
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 
@@ -126,12 +125,12 @@ func (b *TestLocalSingleState) DeleteWorkspace(string, bool) error {
 	return backend.ErrWorkspacesNotSupported
 }
 
-func (b *TestLocalSingleState) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {
+func (b *TestLocalSingleState) StateMgr(name string) (statemgr.Full, error) {
 	if name != backend.DefaultStateName {
 		return nil, backend.ErrWorkspacesNotSupported
 	}
 
-	return b.Local.StateMgr(ctx, name)
+	return b.Local.StateMgr(name)
 }
 
 // TestLocalNoDefaultState is a backend implementation that wraps
@@ -171,11 +170,11 @@ func (b *TestLocalNoDefaultState) DeleteWorkspace(name string, force bool) error
 	return b.Local.DeleteWorkspace(name, force)
 }
 
-func (b *TestLocalNoDefaultState) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {
+func (b *TestLocalNoDefaultState) StateMgr(name string) (statemgr.Full, error) {
 	if name == backend.DefaultStateName {
 		return nil, backend.ErrDefaultWorkspaceNotSupported
 	}
-	return b.Local.StateMgr(ctx, name)
+	return b.Local.StateMgr(name)
 }
 
 func testStateFile(t *testing.T, path string, s *states.State) {
@@ -204,10 +203,7 @@ func mustResourceInstanceAddr(s string) addrs.AbsResourceInstance {
 // return true.
 func assertBackendStateUnlocked(t *testing.T, b *Local) bool {
 	t.Helper()
-
-	ctx := context.Background()
-
-	stateMgr, _ := b.StateMgr(ctx, backend.DefaultStateName)
+	stateMgr, _ := b.StateMgr(backend.DefaultStateName)
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Errorf("state is already locked: %s", err.Error())
 		return false
@@ -220,10 +216,7 @@ func assertBackendStateUnlocked(t *testing.T, b *Local) bool {
 // return false.
 func assertBackendStateLocked(t *testing.T, b *Local) bool {
 	t.Helper()
-
-	ctx := context.Background()
-
-	stateMgr, _ := b.StateMgr(ctx, backend.DefaultStateName)
+	stateMgr, _ := b.StateMgr(backend.DefaultStateName)
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		return true
 	}

--- a/internal/backend/local/testing.go
+++ b/internal/backend/local/testing.go
@@ -208,7 +208,7 @@ func assertBackendStateUnlocked(t *testing.T, b *Local) bool {
 	ctx := context.Background()
 
 	stateMgr, _ := b.StateMgr(ctx, backend.DefaultStateName)
-	if _, err := stateMgr.Lock(ctx, statemgr.NewLockInfo()); err != nil {
+	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Errorf("state is already locked: %s", err.Error())
 		return false
 	}
@@ -224,7 +224,7 @@ func assertBackendStateLocked(t *testing.T, b *Local) bool {
 	ctx := context.Background()
 
 	stateMgr, _ := b.StateMgr(ctx, backend.DefaultStateName)
-	if _, err := stateMgr.Lock(ctx, statemgr.NewLockInfo()); err != nil {
+	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		return true
 	}
 	t.Error("unexpected success locking state")

--- a/internal/backend/remote-state/azure/backend.go
+++ b/internal/backend/remote-state/azure/backend.go
@@ -259,7 +259,7 @@ func (b *Backend) configure(ctx context.Context) error {
 		UseAzureADAuthentication:      data.Get("use_azuread_auth").(bool),
 	}
 
-	armClient, err := buildArmClient(ctx, config)
+	armClient, err := buildArmClient(context.TODO(), config)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/remote-state/azure/backend_state.go
+++ b/internal/backend/remote-state/azure/backend_state.go
@@ -61,11 +61,12 @@ func (b *Backend) Workspaces() ([]string, error) {
 	return result, nil
 }
 
-func (b *Backend) DeleteWorkspace(ctx context.Context, name string, _ bool) error {
+func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	if name == backend.DefaultStateName || name == "" {
 		return fmt.Errorf("can't delete default state")
 	}
 
+	ctx := context.TODO()
 	client, err := b.armClient.getBlobClient(ctx)
 	if err != nil {
 		return err

--- a/internal/backend/remote-state/azure/backend_state.go
+++ b/internal/backend/remote-state/azure/backend_state.go
@@ -96,7 +96,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 	stateMgr := &remote.State{Client: client}
 
 	// Grab the value
-	if err := stateMgr.RefreshState(ctx); err != nil {
+	if err := stateMgr.RefreshState(); err != nil {
 		return nil, err
 	}
 	//if this isn't the default state name, we need to create the object so
@@ -119,7 +119,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 		}
 
 		// Grab the value
-		if err := stateMgr.RefreshState(ctx); err != nil {
+		if err := stateMgr.RefreshState(); err != nil {
 			err = lockUnlock(err)
 			return nil, err
 		}
@@ -131,7 +131,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 				err = lockUnlock(err)
 				return nil, err
 			}
-			if err := stateMgr.PersistState(ctx, nil); err != nil {
+			if err := stateMgr.PersistState(nil); err != nil {
 				err = lockUnlock(err)
 				return nil, err
 			}

--- a/internal/backend/remote-state/azure/backend_state.go
+++ b/internal/backend/remote-state/azure/backend_state.go
@@ -81,7 +81,8 @@ func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	return nil
 }
 
-func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {
+func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
+	ctx := context.TODO()
 	blobClient, err := b.armClient.getBlobClient(ctx)
 	if err != nil {
 		return nil, err
@@ -146,6 +147,10 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 	}
 
 	return stateMgr, nil
+}
+
+func (b *Backend) client() *RemoteClient {
+	return &RemoteClient{}
 }
 
 func (b *Backend) path(name string) string {

--- a/internal/backend/remote-state/azure/backend_state.go
+++ b/internal/backend/remote-state/azure/backend_state.go
@@ -105,14 +105,14 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 		// take a lock on this state while we write it
 		lockInfo := statemgr.NewLockInfo()
 		lockInfo.Operation = "init"
-		lockId, err := client.Lock(ctx, lockInfo)
+		lockId, err := client.Lock(lockInfo)
 		if err != nil {
 			return nil, fmt.Errorf("failed to lock azure state: %w", err)
 		}
 
 		// Local helper function so we can call it multiple places
 		lockUnlock := func(parent error) error {
-			if err := stateMgr.Unlock(ctx, lockId); err != nil {
+			if err := stateMgr.Unlock(lockId); err != nil {
 				return fmt.Errorf(strings.TrimSpace(errStateUnlock), lockId, err)
 			}
 			return parent

--- a/internal/backend/remote-state/azure/backend_state.go
+++ b/internal/backend/remote-state/azure/backend_state.go
@@ -23,12 +23,13 @@ const (
 	keyEnvPrefix = "env:"
 )
 
-func (b *Backend) Workspaces(ctx context.Context) ([]string, error) {
+func (b *Backend) Workspaces() ([]string, error) {
 	prefix := b.keyName + keyEnvPrefix
 	params := containers.ListBlobsInput{
 		Prefix: &prefix,
 	}
 
+	ctx := context.TODO()
 	client, err := b.armClient.getContainersClient(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/backend/remote-state/azure/client.go
+++ b/internal/backend/remote-state/azure/client.go
@@ -33,12 +33,13 @@ type RemoteClient struct {
 	snapshot           bool
 }
 
-func (c *RemoteClient) Get(ctx context.Context) (*remote.Payload, error) {
+func (c *RemoteClient) Get() (*remote.Payload, error) {
 	options := blobs.GetInput{}
 	if c.leaseID != "" {
 		options.LeaseID = &c.leaseID
 	}
 
+	ctx := context.TODO()
 	blob, err := c.giovanniBlobClient.Get(ctx, c.accountName, c.containerName, c.keyName, options)
 	if err != nil {
 		if blob.Response.IsHTTPStatus(http.StatusNotFound) {
@@ -59,7 +60,7 @@ func (c *RemoteClient) Get(ctx context.Context) (*remote.Payload, error) {
 	return payload, nil
 }
 
-func (c *RemoteClient) Put(ctx context.Context, data []byte) error {
+func (c *RemoteClient) Put(data []byte) error {
 	getOptions := blobs.GetPropertiesInput{}
 	setOptions := blobs.SetPropertiesInput{}
 	putOptions := blobs.PutBlockBlobInput{}
@@ -71,6 +72,8 @@ func (c *RemoteClient) Put(ctx context.Context, data []byte) error {
 		setOptions.LeaseID = &c.leaseID
 		putOptions.LeaseID = &c.leaseID
 	}
+
+	ctx := context.TODO()
 
 	if c.snapshot {
 		snapshotInput := blobs.SnapshotInput{LeaseID: options.LeaseID}

--- a/internal/backend/remote-state/azure/client.go
+++ b/internal/backend/remote-state/azure/client.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
-
 	"github.com/opentofu/opentofu/internal/states/remote"
 	"github.com/opentofu/opentofu/internal/states/statemgr"
 	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/blobs"
@@ -116,7 +115,7 @@ func (c *RemoteClient) Delete(ctx context.Context) error {
 	return nil
 }
 
-func (c *RemoteClient) Lock(ctx context.Context, info *statemgr.LockInfo) (string, error) {
+func (c *RemoteClient) Lock(info *statemgr.LockInfo) (string, error) {
 	stateName := fmt.Sprintf("%s/%s", c.containerName, c.keyName)
 	info.Path = stateName
 
@@ -130,7 +129,7 @@ func (c *RemoteClient) Lock(ctx context.Context, info *statemgr.LockInfo) (strin
 	}
 
 	getLockInfoErr := func(err error) error {
-		lockInfo, infoErr := c.getLockInfo(ctx)
+		lockInfo, infoErr := c.getLockInfo()
 		if infoErr != nil {
 			err = multierror.Append(err, infoErr)
 		}
@@ -145,6 +144,7 @@ func (c *RemoteClient) Lock(ctx context.Context, info *statemgr.LockInfo) (strin
 		ProposedLeaseID: &info.ID,
 		LeaseDuration:   -1,
 	}
+	ctx := context.TODO()
 
 	// obtain properties to see if the blob lease is already in use. If the blob doesn't exist, create it
 	properties, err := c.giovanniBlobClient.GetProperties(ctx, c.accountName, c.containerName, c.keyName, blobs.GetPropertiesInput{})
@@ -179,19 +179,20 @@ func (c *RemoteClient) Lock(ctx context.Context, info *statemgr.LockInfo) (strin
 	info.ID = leaseID.LeaseID
 	c.leaseID = leaseID.LeaseID
 
-	if err := c.writeLockInfo(ctx, info); err != nil {
+	if err := c.writeLockInfo(info); err != nil {
 		return "", err
 	}
 
 	return info.ID, nil
 }
 
-func (c *RemoteClient) getLockInfo(ctx context.Context) (*statemgr.LockInfo, error) {
+func (c *RemoteClient) getLockInfo() (*statemgr.LockInfo, error) {
 	options := blobs.GetPropertiesInput{}
 	if c.leaseID != "" {
 		options.LeaseID = &c.leaseID
 	}
 
+	ctx := context.TODO()
 	blob, err := c.giovanniBlobClient.GetProperties(ctx, c.accountName, c.containerName, c.keyName, options)
 	if err != nil {
 		return nil, err
@@ -217,7 +218,8 @@ func (c *RemoteClient) getLockInfo(ctx context.Context) (*statemgr.LockInfo, err
 }
 
 // writes info to blob meta data, deletes metadata entry if info is nil
-func (c *RemoteClient) writeLockInfo(ctx context.Context, info *statemgr.LockInfo) error {
+func (c *RemoteClient) writeLockInfo(info *statemgr.LockInfo) error {
+	ctx := context.TODO()
 	blob, err := c.giovanniBlobClient.GetProperties(ctx, c.accountName, c.containerName, c.keyName, blobs.GetPropertiesInput{LeaseID: &c.leaseID})
 	if err != nil {
 		return err
@@ -242,10 +244,10 @@ func (c *RemoteClient) writeLockInfo(ctx context.Context, info *statemgr.LockInf
 	return err
 }
 
-func (c *RemoteClient) Unlock(ctx context.Context, id string) error {
+func (c *RemoteClient) Unlock(id string) error {
 	lockErr := &statemgr.LockError{}
 
-	lockInfo, err := c.getLockInfo(ctx)
+	lockInfo, err := c.getLockInfo()
 	if err != nil {
 		lockErr.Err = fmt.Errorf("failed to retrieve lock info: %w", err)
 		return lockErr
@@ -258,11 +260,12 @@ func (c *RemoteClient) Unlock(ctx context.Context, id string) error {
 	}
 
 	c.leaseID = lockInfo.ID
-	if err := c.writeLockInfo(ctx, nil); err != nil {
+	if err := c.writeLockInfo(nil); err != nil {
 		lockErr.Err = fmt.Errorf("failed to delete lock info from metadata: %w", err)
 		return lockErr
 	}
 
+	ctx := context.TODO()
 	_, err = c.giovanniBlobClient.ReleaseLease(ctx, c.accountName, c.containerName, c.keyName, id)
 	if err != nil {
 		lockErr.Err = err

--- a/internal/backend/remote-state/azure/client.go
+++ b/internal/backend/remote-state/azure/client.go
@@ -102,13 +102,14 @@ func (c *RemoteClient) Put(data []byte) error {
 	return err
 }
 
-func (c *RemoteClient) Delete(ctx context.Context) error {
+func (c *RemoteClient) Delete() error {
 	options := blobs.DeleteInput{}
 
 	if c.leaseID != "" {
 		options.LeaseID = &c.leaseID
 	}
 
+	ctx := context.TODO()
 	resp, err := c.giovanniBlobClient.Delete(ctx, c.accountName, c.containerName, c.keyName, options)
 	if err != nil {
 		if !resp.IsHTTPStatus(http.StatusNotFound) {

--- a/internal/backend/remote-state/azure/client_test.go
+++ b/internal/backend/remote-state/azure/client_test.go
@@ -297,7 +297,7 @@ func TestPutMaintainsMetaData(t *testing.T) {
 	}
 
 	bytes := []byte(acctest.RandString(20))
-	err = remoteClient.Put(ctx, bytes)
+	err = remoteClient.Put(bytes)
 	if err != nil {
 		t.Fatalf("Error putting data: %+v", err)
 	}

--- a/internal/backend/remote-state/azure/client_test.go
+++ b/internal/backend/remote-state/azure/client_test.go
@@ -25,7 +25,7 @@ func TestRemoteClientAccessKeyBasic(t *testing.T) {
 	res := testResourceNames(rs, "testState")
 	armClient := buildTestClient(t, res)
 
-	ctx := context.Background()
+	ctx := context.TODO()
 	err := armClient.buildTestResources(ctx, &res)
 	defer armClient.destroyTestResources(ctx, res)
 	if err != nil {
@@ -41,7 +41,7 @@ func TestRemoteClientAccessKeyBasic(t *testing.T) {
 		"endpoint":             os.Getenv("ARM_ENDPOINT"),
 	})).(*Backend)
 
-	state, err := b.StateMgr(ctx, backend.DefaultStateName)
+	state, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func TestRemoteClientManagedServiceIdentityBasic(t *testing.T) {
 	res := testResourceNames(rs, "testState")
 	armClient := buildTestClient(t, res)
 
-	ctx := context.Background()
+	ctx := context.TODO()
 	err := armClient.buildTestResources(ctx, &res)
 	defer armClient.destroyTestResources(ctx, res)
 	if err != nil {
@@ -74,7 +74,7 @@ func TestRemoteClientManagedServiceIdentityBasic(t *testing.T) {
 		"endpoint":             os.Getenv("ARM_ENDPOINT"),
 	})).(*Backend)
 
-	state, err := b.StateMgr(ctx, backend.DefaultStateName)
+	state, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +88,7 @@ func TestRemoteClientSasTokenBasic(t *testing.T) {
 	res := testResourceNames(rs, "testState")
 	armClient := buildTestClient(t, res)
 
-	ctx := context.Background()
+	ctx := context.TODO()
 	err := armClient.buildTestResources(ctx, &res)
 	defer armClient.destroyTestResources(ctx, res)
 	if err != nil {
@@ -109,7 +109,7 @@ func TestRemoteClientSasTokenBasic(t *testing.T) {
 		"endpoint":             os.Getenv("ARM_ENDPOINT"),
 	})).(*Backend)
 
-	state, err := b.StateMgr(ctx, backend.DefaultStateName)
+	state, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -123,7 +123,7 @@ func TestRemoteClientServicePrincipalBasic(t *testing.T) {
 	res := testResourceNames(rs, "testState")
 	armClient := buildTestClient(t, res)
 
-	ctx := context.Background()
+	ctx := context.TODO()
 	err := armClient.buildTestResources(ctx, &res)
 	defer armClient.destroyTestResources(ctx, res)
 	if err != nil {
@@ -143,7 +143,7 @@ func TestRemoteClientServicePrincipalBasic(t *testing.T) {
 		"endpoint":             os.Getenv("ARM_ENDPOINT"),
 	})).(*Backend)
 
-	state, err := b.StateMgr(ctx, backend.DefaultStateName)
+	state, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +157,7 @@ func TestRemoteClientAccessKeyLocks(t *testing.T) {
 	res := testResourceNames(rs, "testState")
 	armClient := buildTestClient(t, res)
 
-	ctx := context.Background()
+	ctx := context.TODO()
 	err := armClient.buildTestResources(ctx, &res)
 	defer armClient.destroyTestResources(ctx, res)
 	if err != nil {
@@ -182,12 +182,12 @@ func TestRemoteClientAccessKeyLocks(t *testing.T) {
 		"endpoint":             os.Getenv("ARM_ENDPOINT"),
 	})).(*Backend)
 
-	s1, err := b1.StateMgr(ctx, backend.DefaultStateName)
+	s1, err := b1.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	s2, err := b2.StateMgr(ctx, backend.DefaultStateName)
+	s2, err := b2.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -201,7 +201,7 @@ func TestRemoteClientServicePrincipalLocks(t *testing.T) {
 	res := testResourceNames(rs, "testState")
 	armClient := buildTestClient(t, res)
 
-	ctx := context.Background()
+	ctx := context.TODO()
 	err := armClient.buildTestResources(ctx, &res)
 	defer armClient.destroyTestResources(ctx, res)
 	if err != nil {
@@ -234,12 +234,12 @@ func TestRemoteClientServicePrincipalLocks(t *testing.T) {
 		"endpoint":             os.Getenv("ARM_ENDPOINT"),
 	})).(*Backend)
 
-	s1, err := b1.StateMgr(ctx, backend.DefaultStateName)
+	s1, err := b1.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	s2, err := b2.StateMgr(ctx, backend.DefaultStateName)
+	s2, err := b2.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/remote-state/consul/backend_state.go
+++ b/internal/backend/remote-state/consul/backend_state.go
@@ -53,7 +53,7 @@ func (b *Backend) Workspaces() ([]string, error) {
 	return result, nil
 }
 
-func (b *Backend) DeleteWorkspace(_ context.Context, name string, _ bool) error {
+func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	if name == backend.DefaultStateName || name == "" {
 		return fmt.Errorf("can't delete default state")
 	}

--- a/internal/backend/remote-state/consul/backend_state.go
+++ b/internal/backend/remote-state/consul/backend_state.go
@@ -18,7 +18,7 @@ const (
 	keyEnvPrefix = "-env:"
 )
 
-func (b *Backend) Workspaces(ctx context.Context) ([]string, error) {
+func (b *Backend) Workspaces() ([]string, error) {
 	// List our raw path
 	prefix := b.configData.Get("path").(string) + keyEnvPrefix
 	keys, _, err := b.client.KV().Keys(prefix, "/", nil)

--- a/internal/backend/remote-state/consul/backend_state.go
+++ b/internal/backend/remote-state/consul/backend_state.go
@@ -4,7 +4,6 @@
 package consul
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -46,7 +45,7 @@ func (b *Backend) Workspaces() ([]string, error) {
 
 	result := make([]string, 1, len(envs)+1)
 	result[0] = backend.DefaultStateName
-	for k := range envs {
+	for k, _ := range envs {
 		result = append(result, k)
 	}
 
@@ -67,7 +66,7 @@ func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	return err
 }
 
-func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {
+func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	// Determine the path of the data
 	path := b.path(name)
 

--- a/internal/backend/remote-state/consul/backend_state.go
+++ b/internal/backend/remote-state/consul/backend_state.go
@@ -98,14 +98,14 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 	// so States() knows it exists.
 	lockInfo := statemgr.NewLockInfo()
 	lockInfo.Operation = "init"
-	lockId, err := stateMgr.Lock(ctx, lockInfo)
+	lockId, err := stateMgr.Lock(lockInfo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to lock state in Consul: %w", err)
 	}
 
 	// Local helper function so we can call it multiple places
 	lockUnlock := func(parent error) error {
-		if err := stateMgr.Unlock(ctx, lockId); err != nil {
+		if err := stateMgr.Unlock(lockId); err != nil {
 			return fmt.Errorf(strings.TrimSpace(errStateUnlock), lockId, err)
 		}
 

--- a/internal/backend/remote-state/consul/backend_state.go
+++ b/internal/backend/remote-state/consul/backend_state.go
@@ -113,7 +113,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 	}
 
 	// Grab the value
-	if err := stateMgr.RefreshState(ctx); err != nil {
+	if err := stateMgr.RefreshState(); err != nil {
 		err = lockUnlock(err)
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 			err = lockUnlock(err)
 			return nil, err
 		}
-		if err := stateMgr.PersistState(ctx, nil); err != nil {
+		if err := stateMgr.PersistState(nil); err != nil {
 			err = lockUnlock(err)
 			return nil, err
 		}

--- a/internal/backend/remote-state/consul/client.go
+++ b/internal/backend/remote-state/consul/client.go
@@ -71,7 +71,7 @@ type RemoteClient struct {
 	sessionCancel context.CancelFunc
 }
 
-func (c *RemoteClient) Get(context.Context) (*remote.Payload, error) {
+func (c *RemoteClient) Get() (*remote.Payload, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -123,7 +123,7 @@ func (c *RemoteClient) Get(context.Context) (*remote.Payload, error) {
 	}, nil
 }
 
-func (c *RemoteClient) Put(_ context.Context, data []byte) error {
+func (c *RemoteClient) Put(data []byte) error {
 	// The state can be stored in 4 different ways, based on the payload size
 	// and whether the user enabled gzip:
 	//  - single entry mode with plain JSON: a single JSON is stored at

--- a/internal/backend/remote-state/consul/client.go
+++ b/internal/backend/remote-state/consul/client.go
@@ -293,7 +293,7 @@ func (c *RemoteClient) Put(data []byte) error {
 	return store(payload)
 }
 
-func (c *RemoteClient) Delete(_ context.Context) error {
+func (c *RemoteClient) Delete() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/internal/backend/remote-state/consul/client.go
+++ b/internal/backend/remote-state/consul/client.go
@@ -353,7 +353,7 @@ func (c *RemoteClient) getLockInfo() (*statemgr.LockInfo, error) {
 	return li, nil
 }
 
-func (c *RemoteClient) Lock(ctx context.Context, info *statemgr.LockInfo) (string, error) {
+func (c *RemoteClient) Lock(info *statemgr.LockInfo) (string, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -377,15 +377,15 @@ func (c *RemoteClient) Lock(ctx context.Context, info *statemgr.LockInfo) (strin
 		}
 	}
 
-	return c.lock(ctx)
+	return c.lock()
 }
 
 // the lock implementation.
 // Only to be called while holding Client.mu
-func (c *RemoteClient) lock(ctx context.Context) (string, error) {
+func (c *RemoteClient) lock() (string, error) {
 	// We create a new session here, so it can be canceled when the lock is
 	// lost or unlocked.
-	lockSession, err := c.createSession(ctx)
+	lockSession, err := c.createSession()
 	if err != nil {
 		return "", err
 	}
@@ -460,7 +460,7 @@ func (c *RemoteClient) lock(ctx context.Context) (string, error) {
 	// If we lose the lock to due communication issues with the consul agent,
 	// attempt to immediately reacquire the lock. Put will verify the integrity
 	// of the state by using a CAS operation.
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(context.Background())
 	c.monitorCancel = cancel
 	c.monitorWG.Add(1)
 	go func() {
@@ -477,7 +477,7 @@ func (c *RemoteClient) lock(ctx context.Context) (string, error) {
 				c.sessionCancel()
 
 				c.consulLock = nil
-				_, err := c.lock(ctx)
+				_, err := c.lock()
 				c.mu.Unlock()
 
 				if err != nil {
@@ -516,10 +516,10 @@ func (c *RemoteClient) lock(ctx context.Context) (string, error) {
 // called after a lock is acquired
 var testLockHook func()
 
-func (c *RemoteClient) createSession(ctx context.Context) (string, error) {
+func (c *RemoteClient) createSession() (string, error) {
 	// create the context first. Even if the session creation fails, we assume
 	// that the CancelFunc is always callable.
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(context.Background())
 	c.sessionCancel = cancel
 
 	session := c.Client.Session()
@@ -542,7 +542,7 @@ func (c *RemoteClient) createSession(ctx context.Context) (string, error) {
 	return id, nil
 }
 
-func (c *RemoteClient) Unlock(_ context.Context, id string) error {
+func (c *RemoteClient) Unlock(id string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/internal/backend/remote-state/consul/client_test.go
+++ b/internal/backend/remote-state/consul/client_test.go
@@ -42,10 +42,8 @@ func TestRemoteClient(t *testing.T) {
 				"path":    path,
 			}))
 
-			ctx := context.Background()
-
 			// Grab the client
-			state, err := b.StateMgr(ctx, backend.DefaultStateName)
+			state, err := b.StateMgr(backend.DefaultStateName)
 			if err != nil {
 				t.Fatalf("err: %s", err)
 			}
@@ -68,10 +66,8 @@ func TestRemoteClient_gzipUpgrade(t *testing.T) {
 		"path":    statePath,
 	}))
 
-	ctx := context.Background()
-
 	// Grab the client
-	state, err := b.StateMgr(ctx, backend.DefaultStateName)
+	state, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -87,7 +83,7 @@ func TestRemoteClient_gzipUpgrade(t *testing.T) {
 	}))
 
 	// Grab the client
-	state, err = b.StateMgr(ctx, backend.DefaultStateName)
+	state, err = b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -109,9 +105,7 @@ func TestConsul_largeState(t *testing.T) {
 		"path":    path,
 	}))
 
-	ctx := context.Background()
-
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,7 +192,7 @@ func TestConsul_largeState(t *testing.T) {
 		"gzip":    true,
 	}))
 
-	s, err = b.StateMgr(ctx, backend.DefaultStateName)
+	s, err = b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -251,14 +245,12 @@ func TestConsul_stateLock(t *testing.T) {
 	}
 
 	for _, path := range testCases {
-		ctx := context.Background()
-
 		t.Run(path, func(*testing.T) {
 			// create 2 instances to get 2 remote.Clients
 			sA, err := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 				"address": srv.HTTPAddr,
 				"path":    path,
-			})).StateMgr(ctx, backend.DefaultStateName)
+			})).StateMgr(backend.DefaultStateName)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -266,7 +258,7 @@ func TestConsul_stateLock(t *testing.T) {
 			sB, err := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 				"address": srv.HTTPAddr,
 				"path":    path,
-			})).StateMgr(ctx, backend.DefaultStateName)
+			})).StateMgr(backend.DefaultStateName)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -297,8 +289,6 @@ func TestConsul_destroyLock(t *testing.T) {
 
 	for _, path := range testCases {
 		t.Run(path, func(*testing.T) {
-			ctx := context.Background()
-
 			// Get the backend
 			b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 				"address": srv.HTTPAddr,
@@ -306,7 +296,7 @@ func TestConsul_destroyLock(t *testing.T) {
 			}))
 
 			// Grab the client
-			s, err := b.StateMgr(ctx, backend.DefaultStateName)
+			s, err := b.StateMgr(backend.DefaultStateName)
 			if err != nil {
 				t.Fatalf("err: %s", err)
 			}
@@ -329,7 +319,7 @@ func TestConsul_destroyLock(t *testing.T) {
 
 			// The release the lock from a second client to test the
 			// `tofu force-unlock <lock_id>` functionality
-			s, err = b.StateMgr(ctx, backend.DefaultStateName)
+			s, err = b.StateMgr(backend.DefaultStateName)
 			if err != nil {
 				t.Fatalf("err: %s", err)
 			}
@@ -365,13 +355,11 @@ func TestConsul_lostLock(t *testing.T) {
 
 	path := fmt.Sprintf("tf-unit/%s", time.Now().String())
 
-	ctx := context.Background()
-
 	// create 2 instances to get 2 remote.Clients
 	sA, err := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"address": srv.HTTPAddr,
 		"path":    path,
-	})).StateMgr(ctx, backend.DefaultStateName)
+	})).StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -379,7 +367,7 @@ func TestConsul_lostLock(t *testing.T) {
 	sB, err := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{
 		"address": srv.HTTPAddr,
 		"path":    path + "-not-used",
-	})).StateMgr(ctx, backend.DefaultStateName)
+	})).StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -430,9 +418,7 @@ func TestConsul_lostLockConnection(t *testing.T) {
 		"path":    path,
 	}))
 
-	ctx := context.Background()
-
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/remote-state/consul/client_test.go
+++ b/internal/backend/remote-state/consul/client_test.go
@@ -141,12 +141,12 @@ func TestConsul_largeState(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = c.Put(ctx, payload)
+		err = c.Put(payload)
 		if err != nil {
 			t.Fatal("could not put payload", err)
 		}
 
-		remote, err := c.Get(ctx)
+		remote, err := c.Get()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/backend/remote-state/consul/client_test.go
+++ b/internal/backend/remote-state/consul/client_test.go
@@ -235,7 +235,7 @@ func TestConsul_largeState(t *testing.T) {
 	)
 
 	// Deleting the state should remove all chunks
-	err = c.Delete(ctx)
+	err = c.Delete()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/remote-state/consul/client_test.go
+++ b/internal/backend/remote-state/consul/client_test.go
@@ -314,14 +314,14 @@ func TestConsul_destroyLock(t *testing.T) {
 			clientA := s.(*remote.State).Client.(*RemoteClient)
 
 			info := statemgr.NewLockInfo()
-			id, err := clientA.Lock(ctx, info)
+			id, err := clientA.Lock(info)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			lockPath := clientA.Path + lockSuffix
 
-			if err := clientA.Unlock(ctx, id); err != nil {
+			if err := clientA.Unlock(id); err != nil {
 				t.Fatal(err)
 			}
 
@@ -337,18 +337,18 @@ func TestConsul_destroyLock(t *testing.T) {
 			clientB := s.(*remote.State).Client.(*RemoteClient)
 
 			info = statemgr.NewLockInfo()
-			id, err = clientA.Lock(ctx, info)
+			id, err = clientA.Lock(info)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if err := clientB.Unlock(ctx, id); err != nil {
+			if err := clientB.Unlock(id); err != nil {
 				t.Fatal(err)
 			}
 
 			testLock(clientA, lockPath)
 
-			err = clientA.Unlock(ctx, id)
+			err = clientA.Unlock(id)
 
 			if err == nil {
 				t.Fatal("consul lock should have been lost")
@@ -386,7 +386,7 @@ func TestConsul_lostLock(t *testing.T) {
 
 	info := statemgr.NewLockInfo()
 	info.Operation = "test-lost-lock"
-	id, err := sA.Lock(ctx, info)
+	id, err := sA.Lock(info)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -406,7 +406,7 @@ func TestConsul_lostLock(t *testing.T) {
 
 	<-reLocked
 
-	if err := sA.Unlock(ctx, id); err != nil {
+	if err := sA.Unlock(id); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -439,7 +439,7 @@ func TestConsul_lostLockConnection(t *testing.T) {
 
 	info := statemgr.NewLockInfo()
 	info.Operation = "test-lost-lock-connection"
-	id, err := s.Lock(ctx, info)
+	id, err := s.Lock(info)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -453,7 +453,7 @@ func TestConsul_lostLockConnection(t *testing.T) {
 		<-dialed
 	}
 
-	if err := s.Unlock(ctx, id); err != nil {
+	if err := s.Unlock(id); err != nil {
 		t.Fatal("unlock error:", err)
 	}
 }

--- a/internal/backend/remote-state/cos/backend.go
+++ b/internal/backend/remote-state/cos/backend.go
@@ -38,9 +38,10 @@ type Backend struct {
 	*schema.Backend
 	credential *common.Credential
 
-	cosClient *cos.Client
-	tagClient *tag.Client
-	stsClient *sts.Client
+	cosContext context.Context
+	cosClient  *cos.Client
+	tagClient  *tag.Client
+	stsClient  *sts.Client
 
 	region  string
 	bucket  string
@@ -206,7 +207,8 @@ func (b *Backend) configure(ctx context.Context) error {
 		return nil
 	}
 
-	data := schema.FromContextBackendConfig(ctx)
+	b.cosContext = ctx
+	data := schema.FromContextBackendConfig(b.cosContext)
 
 	b.region = data.Get("region").(string)
 	b.bucket = data.Get("bucket").(string)

--- a/internal/backend/remote-state/cos/backend_state.go
+++ b/internal/backend/remote-state/cos/backend_state.go
@@ -4,7 +4,6 @@
 package cos
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"path"
@@ -77,7 +76,7 @@ func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 }
 
 // StateMgr manage the state, if the named state not exists, a new file will created
-func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {
+func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	log.Printf("[DEBUG] state manager, current workspace: %v", name)
 
 	c, err := b.client(name)

--- a/internal/backend/remote-state/cos/backend_state.go
+++ b/internal/backend/remote-state/cos/backend_state.go
@@ -61,7 +61,7 @@ func (b *Backend) Workspaces() ([]string, error) {
 }
 
 // DeleteWorkspace deletes the named workspaces. The "default" state cannot be deleted.
-func (b *Backend) DeleteWorkspace(ctx context.Context, name string, _ bool) error {
+func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	log.Printf("[DEBUG] delete workspace, workspace: %v", name)
 
 	if name == backend.DefaultStateName || name == "" {
@@ -73,7 +73,7 @@ func (b *Backend) DeleteWorkspace(ctx context.Context, name string, _ bool) erro
 		return err
 	}
 
-	return c.Delete(ctx)
+	return c.Delete()
 }
 
 // StateMgr manage the state, if the named state not exists, a new file will created

--- a/internal/backend/remote-state/cos/backend_state.go
+++ b/internal/backend/remote-state/cos/backend_state.go
@@ -24,13 +24,13 @@ const (
 )
 
 // Workspaces returns a list of names for the workspaces
-func (b *Backend) Workspaces(ctx context.Context) ([]string, error) {
+func (b *Backend) Workspaces() ([]string, error) {
 	c, err := b.client("tencentcloud")
 	if err != nil {
 		return nil, err
 	}
 
-	obs, err := c.getBucket(ctx, b.prefix)
+	obs, err := c.getBucket(b.prefix)
 	log.Printf("[DEBUG] list all workspaces, objects: %v, error: %v", obs, err)
 	if err != nil {
 		return nil, err
@@ -86,7 +86,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 	}
 	stateMgr := &remote.State{Client: c}
 
-	ws, err := b.Workspaces(ctx)
+	ws, err := b.Workspaces()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/remote-state/cos/backend_state.go
+++ b/internal/backend/remote-state/cos/backend_state.go
@@ -119,7 +119,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 		}
 
 		// Grab the value
-		if err := stateMgr.RefreshState(ctx); err != nil {
+		if err := stateMgr.RefreshState(); err != nil {
 			err = lockUnlock(err)
 			return nil, err
 		}
@@ -130,7 +130,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 				err = lockUnlock(err)
 				return nil, err
 			}
-			if err := stateMgr.PersistState(ctx, nil); err != nil {
+			if err := stateMgr.PersistState(nil); err != nil {
 				err = lockUnlock(err)
 				return nil, err
 			}

--- a/internal/backend/remote-state/cos/backend_state.go
+++ b/internal/backend/remote-state/cos/backend_state.go
@@ -105,14 +105,14 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 		// take a lock on this state while we write it
 		lockInfo := statemgr.NewLockInfo()
 		lockInfo.Operation = "init"
-		lockId, err := c.Lock(ctx, lockInfo)
+		lockId, err := c.Lock(lockInfo)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to lock cos state: %w", err)
 		}
 
 		// Local helper function so we can call it multiple places
 		lockUnlock := func(e error) error {
-			if err := stateMgr.Unlock(ctx, lockId); err != nil {
+			if err := stateMgr.Unlock(lockId); err != nil {
 				return fmt.Errorf(unlockErrMsg, err, lockId)
 			}
 			return e
@@ -152,13 +152,14 @@ func (b *Backend) client(name string) (*remoteClient, error) {
 	}
 
 	return &remoteClient{
-		cosClient: b.cosClient,
-		tagClient: b.tagClient,
-		bucket:    b.bucket,
-		stateFile: b.stateFile(name),
-		lockFile:  b.lockFile(name),
-		encrypt:   b.encrypt,
-		acl:       b.acl,
+		cosContext: b.cosContext,
+		cosClient:  b.cosClient,
+		tagClient:  b.tagClient,
+		bucket:     b.bucket,
+		stateFile:  b.stateFile(name),
+		lockFile:   b.lockFile(name),
+		encrypt:    b.encrypt,
+		acl:        b.acl,
 	}, nil
 }
 

--- a/internal/backend/remote-state/cos/backend_test.go
+++ b/internal/backend/remote-state/cos/backend_test.go
@@ -4,7 +4,6 @@
 package cos
 
 import (
-	"context"
 	"crypto/md5"
 	"fmt"
 	"os"
@@ -64,9 +63,7 @@ func TestRemoteClient(t *testing.T) {
 	be := setupBackend(t, bucket, defaultPrefix, defaultKey, false)
 	defer teardownBackend(t, be)
 
-	ctx := context.Background()
-
-	ss, err := be.StateMgr(ctx, backend.DefaultStateName)
+	ss, err := be.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -88,9 +85,7 @@ func TestRemoteClientWithPrefix(t *testing.T) {
 	be := setupBackend(t, bucket, prefix, defaultKey, false)
 	defer teardownBackend(t, be)
 
-	ctx := context.Background()
-
-	ss, err := be.StateMgr(ctx, backend.DefaultStateName)
+	ss, err := be.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -111,9 +106,7 @@ func TestRemoteClientWithEncryption(t *testing.T) {
 	be := setupBackend(t, bucket, defaultPrefix, defaultKey, true)
 	defer teardownBackend(t, be)
 
-	ctx := context.Background()
-
-	ss, err := be.StateMgr(ctx, backend.DefaultStateName)
+	ss, err := be.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -135,9 +128,7 @@ func TestRemoteLocks(t *testing.T) {
 	defer teardownBackend(t, be)
 
 	remoteClient := func() (remote.Client, error) {
-		ctx := context.Background()
-
-		ss, err := be.StateMgr(ctx, backend.DefaultStateName)
+		ss, err := be.StateMgr(backend.DefaultStateName)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/backend/remote-state/cos/backend_test.go
+++ b/internal/backend/remote-state/cos/backend_test.go
@@ -240,7 +240,7 @@ func setupBackend(t *testing.T, bucket, prefix, key string, encrypt bool) backen
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	err = c.putBucket(context.Background())
+	err = c.putBucket()
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -256,7 +256,7 @@ func teardownBackend(t *testing.T, b backend.Backend) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	err = c.deleteBucket(context.Background(), true)
+	err = c.deleteBucket(true)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/internal/backend/remote-state/cos/client.go
+++ b/internal/backend/remote-state/cos/client.go
@@ -28,6 +28,9 @@ const (
 
 // RemoteClient implements the client of remote state
 type remoteClient struct {
+	// TODO: remove once all methods are using context passed via the CLI.
+	cosContext context.Context
+
 	cosClient *cos.Client
 	tagClient *tag.Client
 
@@ -74,74 +77,74 @@ func (c *remoteClient) Delete(ctx context.Context) error {
 }
 
 // Lock lock remote state file for writing
-func (c *remoteClient) Lock(ctx context.Context, info *statemgr.LockInfo) (string, error) {
+func (c *remoteClient) Lock(info *statemgr.LockInfo) (string, error) {
 	log.Printf("[DEBUG] lock remote state file %s", c.lockFile)
 
 	err := c.cosLock(c.bucket, c.lockFile)
 	if err != nil {
-		return "", c.lockError(ctx, err)
+		return "", c.lockError(err)
 	}
 	defer c.cosUnlock(c.bucket, c.lockFile)
 
-	exists, _, _, err := c.getObject(ctx, c.lockFile)
+	exists, _, _, err := c.getObject(c.cosContext, c.lockFile)
 	if err != nil {
-		return "", c.lockError(ctx, err)
+		return "", c.lockError(err)
 	}
 
 	if exists {
-		return "", c.lockError(ctx, fmt.Errorf("lock file %s exists", c.lockFile))
+		return "", c.lockError(fmt.Errorf("lock file %s exists", c.lockFile))
 	}
 
 	info.Path = c.lockFile
 	data, err := json.Marshal(info)
 	if err != nil {
-		return "", c.lockError(ctx, err)
+		return "", c.lockError(err)
 	}
 
 	check := fmt.Sprintf("%x", md5.Sum(data))
-	err = c.putObject(ctx, c.lockFile, data)
+	err = c.putObject(c.cosContext, c.lockFile, data)
 	if err != nil {
-		return "", c.lockError(ctx, err)
+		return "", c.lockError(err)
 	}
 
 	return check, nil
 }
 
-// Unlock unlocks remote state file
-func (c *remoteClient) Unlock(ctx context.Context, check string) error {
+// Unlock unlock remote state file
+func (c *remoteClient) Unlock(check string) error {
 	log.Printf("[DEBUG] unlock remote state file %s", c.lockFile)
 
-	info, err := c.lockInfo(ctx)
+	info, err := c.lockInfo()
 	if err != nil {
-		return c.lockError(ctx, err)
+		return c.lockError(err)
 	}
 
 	if info.ID != check {
-		return c.lockError(ctx, fmt.Errorf("lock id mismatch, %v != %v", info.ID, check))
+		return c.lockError(fmt.Errorf("lock id mismatch, %v != %v", info.ID, check))
 	}
 
-	err = c.deleteObject(ctx, c.lockFile)
+	err = c.deleteObject(c.cosContext, c.lockFile)
 	if err != nil {
-		return c.lockError(ctx, err)
+		return c.lockError(err)
 	}
 
 	err = c.cosUnlock(c.bucket, c.lockFile)
 	if err != nil {
-		return c.lockError(ctx, err)
+		return c.lockError(err)
 	}
 
 	return nil
 }
 
 // lockError returns statemgr.LockError
-func (c *remoteClient) lockError(ctx context.Context, err error) *statemgr.LockError {
+func (c *remoteClient) lockError(err error) *statemgr.LockError {
 	log.Printf("[DEBUG] failed to lock or unlock %s: %v", c.lockFile, err)
 
 	lockErr := &statemgr.LockError{
 		Err: err,
 	}
 
-	info, infoErr := c.lockInfo(ctx)
+	info, infoErr := c.lockInfo()
 	if infoErr != nil {
 		lockErr.Err = multierror.Append(lockErr.Err, infoErr)
 	} else {
@@ -152,8 +155,8 @@ func (c *remoteClient) lockError(ctx context.Context, err error) *statemgr.LockE
 }
 
 // lockInfo returns LockInfo from lock file
-func (c *remoteClient) lockInfo(ctx context.Context) (*statemgr.LockInfo, error) {
-	exists, data, checksum, err := c.getObject(ctx, c.lockFile)
+func (c *remoteClient) lockInfo() (*statemgr.LockInfo, error) {
+	exists, data, checksum, err := c.getObject(c.cosContext, c.lockFile)
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +238,7 @@ func (c *remoteClient) putObject(ctx context.Context, cosFile string, data []byt
 	}
 
 	r := bytes.NewReader(data)
-	rsp, err := c.cosClient.Object.Put(ctx, cosFile, r, opt)
+	rsp, err := c.cosClient.Object.Put(c.cosContext, cosFile, r, opt)
 	if rsp == nil {
 		log.Printf("[DEBUG] putObject %s: error: %v", cosFile, err)
 		return fmt.Errorf("failed to save file to %v: %w", cosFile, err)

--- a/internal/backend/remote-state/cos/client.go
+++ b/internal/backend/remote-state/cos/client.go
@@ -275,8 +275,8 @@ func (c *remoteClient) deleteObject(ctx context.Context, cosFile string) error {
 }
 
 // getBucket list bucket by prefix
-func (c *remoteClient) getBucket(ctx context.Context, prefix string) (obs []cos.Object, err error) {
-	fs, rsp, err := c.cosClient.Bucket.Get(ctx, &cos.BucketGetOptions{Prefix: prefix})
+func (c *remoteClient) getBucket(prefix string) (obs []cos.Object, err error) {
+	fs, rsp, err := c.cosClient.Bucket.Get(c.cosContext, &cos.BucketGetOptions{Prefix: prefix})
 	if rsp == nil {
 		log.Printf("[DEBUG] getBucket %s/%s: error: %v", c.bucket, prefix, err)
 		err = fmt.Errorf("bucket %s not exists", c.bucket)
@@ -298,8 +298,8 @@ func (c *remoteClient) getBucket(ctx context.Context, prefix string) (obs []cos.
 }
 
 // putBucket create cos bucket
-func (c *remoteClient) putBucket(ctx context.Context) error {
-	rsp, err := c.cosClient.Bucket.Put(ctx, nil)
+func (c *remoteClient) putBucket() error {
+	rsp, err := c.cosClient.Bucket.Put(c.cosContext, nil)
 	if rsp == nil {
 		log.Printf("[DEBUG] putBucket %s: error: %v", c.bucket, err)
 		return fmt.Errorf("failed to create bucket %v: %w", c.bucket, err)
@@ -319,9 +319,9 @@ func (c *remoteClient) putBucket(ctx context.Context) error {
 }
 
 // deleteBucket delete cos bucket
-func (c *remoteClient) deleteBucket(ctx context.Context, recursive bool) error {
+func (c *remoteClient) deleteBucket(recursive bool) error {
 	if recursive {
-		obs, err := c.getBucket(ctx, "")
+		obs, err := c.getBucket("")
 		if err != nil {
 			if strings.Contains(err.Error(), "not exists") {
 				return nil
@@ -330,11 +330,11 @@ func (c *remoteClient) deleteBucket(ctx context.Context, recursive bool) error {
 			return fmt.Errorf("failed to empty bucket %v: %w", c.bucket, err)
 		}
 		for _, v := range obs {
-			c.deleteObject(ctx, v.Key)
+			c.deleteObject(c.cosContext, v.Key)
 		}
 	}
 
-	rsp, err := c.cosClient.Bucket.Delete(ctx)
+	rsp, err := c.cosClient.Bucket.Delete(c.cosContext)
 	if rsp == nil {
 		log.Printf("[DEBUG] deleteBucket %s: error: %v", c.bucket, err)
 		return fmt.Errorf("failed to delete bucket %v: %w", c.bucket, err)

--- a/internal/backend/remote-state/cos/client.go
+++ b/internal/backend/remote-state/cos/client.go
@@ -42,10 +42,10 @@ type remoteClient struct {
 }
 
 // Get returns remote state file
-func (c *remoteClient) Get(ctx context.Context) (*remote.Payload, error) {
+func (c *remoteClient) Get() (*remote.Payload, error) {
 	log.Printf("[DEBUG] get remote state file %s", c.stateFile)
 
-	exists, data, checksum, err := c.getObject(ctx, c.stateFile)
+	exists, data, checksum, err := c.getObject(c.stateFile)
 	if err != nil {
 		return nil, err
 	}
@@ -63,10 +63,10 @@ func (c *remoteClient) Get(ctx context.Context) (*remote.Payload, error) {
 }
 
 // Put put state file to remote
-func (c *remoteClient) Put(ctx context.Context, data []byte) error {
+func (c *remoteClient) Put(data []byte) error {
 	log.Printf("[DEBUG] put remote state file %s", c.stateFile)
 
-	return c.putObject(ctx, c.stateFile, data)
+	return c.putObject(c.stateFile, data)
 }
 
 // Delete delete remote state file
@@ -86,7 +86,7 @@ func (c *remoteClient) Lock(info *statemgr.LockInfo) (string, error) {
 	}
 	defer c.cosUnlock(c.bucket, c.lockFile)
 
-	exists, _, _, err := c.getObject(c.cosContext, c.lockFile)
+	exists, _, _, err := c.getObject(c.lockFile)
 	if err != nil {
 		return "", c.lockError(err)
 	}
@@ -102,7 +102,7 @@ func (c *remoteClient) Lock(info *statemgr.LockInfo) (string, error) {
 	}
 
 	check := fmt.Sprintf("%x", md5.Sum(data))
-	err = c.putObject(c.cosContext, c.lockFile, data)
+	err = c.putObject(c.lockFile, data)
 	if err != nil {
 		return "", c.lockError(err)
 	}
@@ -156,7 +156,7 @@ func (c *remoteClient) lockError(err error) *statemgr.LockError {
 
 // lockInfo returns LockInfo from lock file
 func (c *remoteClient) lockInfo() (*statemgr.LockInfo, error) {
-	exists, data, checksum, err := c.getObject(c.cosContext, c.lockFile)
+	exists, data, checksum, err := c.getObject(c.lockFile)
 	if err != nil {
 		return nil, err
 	}
@@ -176,8 +176,8 @@ func (c *remoteClient) lockInfo() (*statemgr.LockInfo, error) {
 }
 
 // getObject get remote object
-func (c *remoteClient) getObject(ctx context.Context, cosFile string) (exists bool, data []byte, checksum string, err error) {
-	rsp, err := c.cosClient.Object.Get(ctx, cosFile, nil)
+func (c *remoteClient) getObject(cosFile string) (exists bool, data []byte, checksum string, err error) {
+	rsp, err := c.cosClient.Object.Get(c.cosContext, cosFile, nil)
 	if rsp == nil {
 		log.Printf("[DEBUG] getObject %s: error: %v", cosFile, err)
 		err = fmt.Errorf("failed to open file at %v: %w", cosFile, err)
@@ -221,7 +221,7 @@ func (c *remoteClient) getObject(ctx context.Context, cosFile string) (exists bo
 }
 
 // putObject put object to remote
-func (c *remoteClient) putObject(ctx context.Context, cosFile string, data []byte) error {
+func (c *remoteClient) putObject(cosFile string, data []byte) error {
 	opt := &cos.ObjectPutOptions{
 		ObjectPutHeaderOptions: &cos.ObjectPutHeaderOptions{
 			XCosMetaXXX: &http.Header{

--- a/internal/backend/remote-state/gcs/backend.go
+++ b/internal/backend/remote-state/gcs/backend.go
@@ -28,9 +28,7 @@ import (
 type Backend struct {
 	*schema.Backend
 
-	storageClient *storage.Client
-
-	// TODO: Remove storageContext once all methods are accepting a context.
+	storageClient  *storage.Client
 	storageContext context.Context
 
 	bucketName string

--- a/internal/backend/remote-state/gcs/backend_state.go
+++ b/internal/backend/remote-state/gcs/backend_state.go
@@ -79,12 +79,13 @@ func (b *Backend) client(name string) (*remoteClient, error) {
 	}
 
 	return &remoteClient{
-		storageClient: b.storageClient,
-		bucketName:    b.bucketName,
-		stateFilePath: b.stateFile(name),
-		lockFilePath:  b.lockFile(name),
-		encryptionKey: b.encryptionKey,
-		kmsKeyName:    b.kmsKeyName,
+		storageContext: b.storageContext,
+		storageClient:  b.storageClient,
+		bucketName:     b.bucketName,
+		stateFilePath:  b.stateFile(name),
+		lockFilePath:   b.lockFile(name),
+		encryptionKey:  b.encryptionKey,
+		kmsKeyName:     b.kmsKeyName,
 	}, nil
 }
 
@@ -108,14 +109,14 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 
 		lockInfo := statemgr.NewLockInfo()
 		lockInfo.Operation = "init"
-		lockID, err := st.Lock(ctx, lockInfo)
+		lockID, err := st.Lock(lockInfo)
 		if err != nil {
 			return nil, err
 		}
 
 		// Local helper function so we can call it multiple places
 		unlock := func(baseErr error) error {
-			if err := st.Unlock(ctx, lockID); err != nil {
+			if err := st.Unlock(lockID); err != nil {
 				const unlockErrMsg = `%v
 				Additionally, unlocking the state file on Google Cloud Storage failed:
 

--- a/internal/backend/remote-state/gcs/backend_state.go
+++ b/internal/backend/remote-state/gcs/backend_state.go
@@ -100,7 +100,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 	st := &remote.State{Client: c}
 
 	// Grab the value
-	if err := st.RefreshState(ctx); err != nil {
+	if err := st.RefreshState(); err != nil {
 		return nil, err
 	}
 
@@ -136,7 +136,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 		if err := st.WriteState(states.NewState()); err != nil {
 			return nil, unlock(err)
 		}
-		if err := st.PersistState(ctx, nil); err != nil {
+		if err := st.PersistState(nil); err != nil {
 			return nil, unlock(err)
 		}
 

--- a/internal/backend/remote-state/gcs/backend_state.go
+++ b/internal/backend/remote-state/gcs/backend_state.go
@@ -4,7 +4,6 @@
 package gcs
 
 import (
-	"context"
 	"fmt"
 	"path"
 	"sort"
@@ -91,7 +90,7 @@ func (b *Backend) client(name string) (*remoteClient, error) {
 
 // StateMgr reads and returns the named state from GCS. If the named state does
 // not yet exist, a new state file is created.
-func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {
+func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	c, err := b.client(name)
 	if err != nil {
 		return nil, err

--- a/internal/backend/remote-state/gcs/backend_state.go
+++ b/internal/backend/remote-state/gcs/backend_state.go
@@ -59,7 +59,7 @@ func (b *Backend) Workspaces() ([]string, error) {
 }
 
 // DeleteWorkspace deletes the named workspaces. The "default" state cannot be deleted.
-func (b *Backend) DeleteWorkspace(ctx context.Context, name string, _ bool) error {
+func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	if name == backend.DefaultStateName {
 		return fmt.Errorf("cowardly refusing to delete the %q state", name)
 	}
@@ -69,7 +69,7 @@ func (b *Backend) DeleteWorkspace(ctx context.Context, name string, _ bool) erro
 		return err
 	}
 
-	return c.Delete(ctx)
+	return c.Delete()
 }
 
 // client returns a remoteClient for the named state.

--- a/internal/backend/remote-state/gcs/backend_state.go
+++ b/internal/backend/remote-state/gcs/backend_state.go
@@ -26,11 +26,11 @@ const (
 
 // Workspaces returns a list of names for the workspaces found on GCS. The default
 // state is always returned as the first element in the slice.
-func (b *Backend) Workspaces(ctx context.Context) ([]string, error) {
+func (b *Backend) Workspaces() ([]string, error) {
 	states := []string{backend.DefaultStateName}
 
 	bucket := b.storageClient.Bucket(b.bucketName)
-	objs := bucket.Objects(ctx, &storage.Query{
+	objs := bucket.Objects(b.storageContext, &storage.Query{
 		Delimiter: "/",
 		Prefix:    b.prefix,
 	})

--- a/internal/backend/remote-state/gcs/backend_test.go
+++ b/internal/backend/remote-state/gcs/backend_test.go
@@ -244,11 +244,10 @@ func setupBackend(t *testing.T, bucket, prefix, key, kmsName string) backend.Bac
 
 	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(config))
 	be := b.(*Backend)
-	ctx := context.Background()
 
 	// create the bucket if it doesn't exist
 	bkt := be.storageClient.Bucket(bucket)
-	_, err := bkt.Attrs(ctx)
+	_, err := bkt.Attrs(be.storageContext)
 	if err != nil {
 		if err != storage.ErrBucketNotExist {
 			t.Fatal(err)
@@ -257,7 +256,7 @@ func setupBackend(t *testing.T, bucket, prefix, key, kmsName string) backend.Bac
 		attrs := &storage.BucketAttrs{
 			Location: os.Getenv("GOOGLE_REGION"),
 		}
-		err := bkt.Create(ctx, projectID, attrs)
+		err := bkt.Create(be.storageContext, projectID, attrs)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -387,7 +386,7 @@ func teardownBackend(t *testing.T, be backend.Backend, prefix string) {
 	if !ok {
 		t.Fatalf("be is a %T, want a *gcsBackend", be)
 	}
-	ctx := context.Background()
+	ctx := gcsBE.storageContext
 
 	bucket := gcsBE.storageClient.Bucket(gcsBE.bucketName)
 	objs := bucket.Objects(ctx, nil)

--- a/internal/backend/remote-state/gcs/backend_test.go
+++ b/internal/backend/remote-state/gcs/backend_test.go
@@ -79,9 +79,7 @@ func TestRemoteClient(t *testing.T) {
 	be := setupBackend(t, bucket, noPrefix, noEncryptionKey, noKmsKeyName)
 	defer teardownBackend(t, be, noPrefix)
 
-	ctx := context.Background()
-
-	ss, err := be.StateMgr(ctx, backend.DefaultStateName)
+	ss, err := be.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("be.StateMgr(%q) = %v", backend.DefaultStateName, err)
 	}
@@ -100,9 +98,7 @@ func TestRemoteClientWithEncryption(t *testing.T) {
 	be := setupBackend(t, bucket, noPrefix, encryptionKey, noKmsKeyName)
 	defer teardownBackend(t, be, noPrefix)
 
-	ctx := context.Background()
-
-	ss, err := be.StateMgr(ctx, backend.DefaultStateName)
+	ss, err := be.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("be.StateMgr(%q) = %v", backend.DefaultStateName, err)
 	}
@@ -123,9 +119,7 @@ func TestRemoteLocks(t *testing.T) {
 	defer teardownBackend(t, be, noPrefix)
 
 	remoteClient := func() (remote.Client, error) {
-		ctx := context.Background()
-
-		ss, err := be.StateMgr(ctx, backend.DefaultStateName)
+		ss, err := be.StateMgr(backend.DefaultStateName)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/backend/remote-state/gcs/client.go
+++ b/internal/backend/remote-state/gcs/client.go
@@ -31,8 +31,8 @@ type remoteClient struct {
 	kmsKeyName    string
 }
 
-func (c *remoteClient) Get(ctx context.Context) (payload *remote.Payload, err error) {
-	stateFileReader, err := c.stateFile().NewReader(ctx)
+func (c *remoteClient) Get() (payload *remote.Payload, err error) {
+	stateFileReader, err := c.stateFile().NewReader(c.storageContext)
 	if err != nil {
 		if err == storage.ErrObjectNotExist {
 			return nil, nil
@@ -60,9 +60,9 @@ func (c *remoteClient) Get(ctx context.Context) (payload *remote.Payload, err er
 	return result, nil
 }
 
-func (c *remoteClient) Put(ctx context.Context, data []byte) error {
+func (c *remoteClient) Put(data []byte) error {
 	err := func() error {
-		stateFileWriter := c.stateFile().NewWriter(ctx)
+		stateFileWriter := c.stateFile().NewWriter(c.storageContext)
 		if len(c.kmsKeyName) > 0 {
 			stateFileWriter.KMSKeyName = c.kmsKeyName
 		}

--- a/internal/backend/remote-state/gcs/client.go
+++ b/internal/backend/remote-state/gcs/client.go
@@ -20,15 +20,13 @@ import (
 // blobs representing state.
 // Implements "state/remote".ClientLocker
 type remoteClient struct {
-	// TODO: remove this once all methods are accepting an explicit context
 	storageContext context.Context
-
-	storageClient *storage.Client
-	bucketName    string
-	stateFilePath string
-	lockFilePath  string
-	encryptionKey []byte
-	kmsKeyName    string
+	storageClient  *storage.Client
+	bucketName     string
+	stateFilePath  string
+	lockFilePath   string
+	encryptionKey  []byte
+	kmsKeyName     string
 }
 
 func (c *remoteClient) Get() (payload *remote.Payload, err error) {
@@ -78,8 +76,8 @@ func (c *remoteClient) Put(data []byte) error {
 	return nil
 }
 
-func (c *remoteClient) Delete(ctx context.Context) error {
-	if err := c.stateFile().Delete(ctx); err != nil {
+func (c *remoteClient) Delete() error {
+	if err := c.stateFile().Delete(c.storageContext); err != nil {
 		return fmt.Errorf("Failed to delete state file %v: %w", c.stateFileURL(), err)
 	}
 

--- a/internal/backend/remote-state/gcs/client.go
+++ b/internal/backend/remote-state/gcs/client.go
@@ -20,6 +20,9 @@ import (
 // blobs representing state.
 // Implements "state/remote".ClientLocker
 type remoteClient struct {
+	// TODO: remove this once all methods are accepting an explicit context
+	storageContext context.Context
+
 	storageClient *storage.Client
 	bucketName    string
 	stateFilePath string
@@ -44,7 +47,7 @@ func (c *remoteClient) Get(ctx context.Context) (payload *remote.Payload, err er
 		return nil, fmt.Errorf("Failed to read state file from %v: %w", c.stateFileURL(), err)
 	}
 
-	stateFileAttrs, err := c.stateFile().Attrs(ctx)
+	stateFileAttrs, err := c.stateFile().Attrs(c.storageContext)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read state file attrs from %v: %w", c.stateFileURL(), err)
 	}
@@ -85,7 +88,7 @@ func (c *remoteClient) Delete(ctx context.Context) error {
 
 // Lock writes to a lock file, ensuring file creation. Returns the generation
 // number, which must be passed to Unlock().
-func (c *remoteClient) Lock(ctx context.Context, info *statemgr.LockInfo) (string, error) {
+func (c *remoteClient) Lock(info *statemgr.LockInfo) (string, error) {
 	// update the path we're using
 	// we can't set the ID until the info is written
 	info.Path = c.lockFileURL()
@@ -96,7 +99,7 @@ func (c *remoteClient) Lock(ctx context.Context, info *statemgr.LockInfo) (strin
 	}
 
 	lockFile := c.lockFile()
-	w := lockFile.If(storage.Conditions{DoesNotExist: true}).NewWriter(ctx)
+	w := lockFile.If(storage.Conditions{DoesNotExist: true}).NewWriter(c.storageContext)
 	err = func() error {
 		if _, err := w.Write(infoJson); err != nil {
 			return err
@@ -105,7 +108,7 @@ func (c *remoteClient) Lock(ctx context.Context, info *statemgr.LockInfo) (strin
 	}()
 
 	if err != nil {
-		return "", c.lockError(ctx, fmt.Errorf("writing %q failed: %w", c.lockFileURL(), err))
+		return "", c.lockError(fmt.Errorf("writing %q failed: %w", c.lockFileURL(), err))
 	}
 
 	info.ID = strconv.FormatInt(w.Attrs().Generation, 10)
@@ -113,25 +116,25 @@ func (c *remoteClient) Lock(ctx context.Context, info *statemgr.LockInfo) (strin
 	return info.ID, nil
 }
 
-func (c *remoteClient) Unlock(ctx context.Context, id string) error {
+func (c *remoteClient) Unlock(id string) error {
 	gen, err := strconv.ParseInt(id, 10, 64)
 	if err != nil {
 		return fmt.Errorf("Lock ID should be numerical value, got '%s'", id)
 	}
 
-	if err := c.lockFile().If(storage.Conditions{GenerationMatch: gen}).Delete(ctx); err != nil {
-		return c.lockError(ctx, err)
+	if err := c.lockFile().If(storage.Conditions{GenerationMatch: gen}).Delete(c.storageContext); err != nil {
+		return c.lockError(err)
 	}
 
 	return nil
 }
 
-func (c *remoteClient) lockError(ctx context.Context, err error) *statemgr.LockError {
+func (c *remoteClient) lockError(err error) *statemgr.LockError {
 	lockErr := &statemgr.LockError{
 		Err: err,
 	}
 
-	info, infoErr := c.lockInfo(ctx)
+	info, infoErr := c.lockInfo()
 	if infoErr != nil {
 		lockErr.Err = multierror.Append(lockErr.Err, infoErr)
 	} else {
@@ -142,8 +145,8 @@ func (c *remoteClient) lockError(ctx context.Context, err error) *statemgr.LockE
 
 // lockInfo reads the lock file, parses its contents and returns the parsed
 // LockInfo struct.
-func (c *remoteClient) lockInfo(ctx context.Context) (*statemgr.LockInfo, error) {
-	r, err := c.lockFile().NewReader(ctx)
+func (c *remoteClient) lockInfo() (*statemgr.LockInfo, error) {
+	r, err := c.lockFile().NewReader(c.storageContext)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +165,7 @@ func (c *remoteClient) lockInfo(ctx context.Context) (*statemgr.LockInfo, error)
 	// We use the Generation as the ID, so overwrite the ID in the json.
 	// This can't be written into the Info, since the generation isn't known
 	// until it's written.
-	attrs, err := c.lockFile().Attrs(ctx)
+	attrs, err := c.lockFile().Attrs(c.storageContext)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/remote-state/http/backend.go
+++ b/internal/backend/remote-state/http/backend.go
@@ -255,6 +255,6 @@ func (b *Backend) Workspaces() ([]string, error) {
 	return nil, backend.ErrWorkspacesNotSupported
 }
 
-func (b *Backend) DeleteWorkspace(context.Context, string, bool) error {
+func (b *Backend) DeleteWorkspace(string, bool) error {
 	return backend.ErrWorkspacesNotSupported
 }

--- a/internal/backend/remote-state/http/backend.go
+++ b/internal/backend/remote-state/http/backend.go
@@ -243,7 +243,7 @@ func (b *Backend) configure(ctx context.Context) error {
 	return nil
 }
 
-func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {
+func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	if name != backend.DefaultStateName {
 		return nil, backend.ErrWorkspacesNotSupported
 	}

--- a/internal/backend/remote-state/http/backend.go
+++ b/internal/backend/remote-state/http/backend.go
@@ -251,7 +251,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 	return &remote.State{Client: b.client}, nil
 }
 
-func (b *Backend) Workspaces(context.Context) ([]string, error) {
+func (b *Backend) Workspaces() ([]string, error) {
 	return nil, backend.ErrWorkspacesNotSupported
 }
 

--- a/internal/backend/remote-state/http/client.go
+++ b/internal/backend/remote-state/http/client.go
@@ -77,14 +77,14 @@ func (c *httpClient) httpRequest(ctx context.Context, method string, url *url.UR
 	return resp, nil
 }
 
-func (c *httpClient) Lock(ctx context.Context, info *statemgr.LockInfo) (string, error) {
+func (c *httpClient) Lock(info *statemgr.LockInfo) (string, error) {
 	if c.LockURL == nil {
 		return "", nil
 	}
 	c.lockID = ""
 
 	jsonLockInfo := info.Marshal()
-	resp, err := c.httpRequest(ctx, c.LockMethod, c.LockURL, &jsonLockInfo, "lock")
+	resp, err := c.httpRequest(context.TODO(), c.LockMethod, c.LockURL, &jsonLockInfo, "lock")
 	if err != nil {
 		return "", err
 	}
@@ -125,12 +125,12 @@ func (c *httpClient) Lock(ctx context.Context, info *statemgr.LockInfo) (string,
 	}
 }
 
-func (c *httpClient) Unlock(ctx context.Context, id string) error {
+func (c *httpClient) Unlock(id string) error {
 	if c.UnlockURL == nil {
 		return nil
 	}
 
-	resp, err := c.httpRequest(ctx, c.UnlockMethod, c.UnlockURL, &c.jsonLockInfo, "unlock")
+	resp, err := c.httpRequest(context.TODO(), c.UnlockMethod, c.UnlockURL, &c.jsonLockInfo, "unlock")
 	if err != nil {
 		return err
 	}

--- a/internal/backend/remote-state/http/client.go
+++ b/internal/backend/remote-state/http/client.go
@@ -144,8 +144,8 @@ func (c *httpClient) Unlock(id string) error {
 	}
 }
 
-func (c *httpClient) Get(ctx context.Context) (*remote.Payload, error) {
-	resp, err := c.httpRequest(ctx, "GET", c.URL, nil, "get state")
+func (c *httpClient) Get() (*remote.Payload, error) {
+	resp, err := c.httpRequest(context.TODO(), "GET", c.URL, nil, "get state")
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +203,7 @@ func (c *httpClient) Get(ctx context.Context) (*remote.Payload, error) {
 	return payload, nil
 }
 
-func (c *httpClient) Put(ctx context.Context, data []byte) error {
+func (c *httpClient) Put(data []byte) error {
 	// Copy the target URL
 	base := *c.URL
 
@@ -226,7 +226,7 @@ func (c *httpClient) Put(ctx context.Context, data []byte) error {
 	if c.UpdateMethod != "" {
 		method = c.UpdateMethod
 	}
-	resp, err := c.httpRequest(ctx, method, &base, &data, "upload state")
+	resp, err := c.httpRequest(context.TODO(), method, &base, &data, "upload state")
 	if err != nil {
 		return err
 	}

--- a/internal/backend/remote-state/http/server_test.go
+++ b/internal/backend/remote-state/http/server_test.go
@@ -279,10 +279,8 @@ func TestMTLSServer_NoCertFails(t *testing.T) {
 		t.Fatal("nil backend")
 	}
 
-	ctx := context.Background()
-
 	// Now get a state manager and check that it fails to refresh the state
-	sm, err := b.StateMgr(ctx, backend.DefaultStateName)
+	sm, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error fetching StateMgr with %s: %v", backend.DefaultStateName, err)
 	}
@@ -352,10 +350,8 @@ func TestMTLSServer_WithCertPasses(t *testing.T) {
 		t.Fatal("nil backend")
 	}
 
-	ctx := context.Background()
-
 	// Now get a state manager, fetch the state, and ensure that the "foo" output is not set
-	sm, err := b.StateMgr(ctx, backend.DefaultStateName)
+	sm, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error fetching StateMgr with %s: %v", backend.DefaultStateName, err)
 	}

--- a/internal/backend/remote-state/http/server_test.go
+++ b/internal/backend/remote-state/http/server_test.go
@@ -288,7 +288,7 @@ func TestMTLSServer_NoCertFails(t *testing.T) {
 	}
 
 	opErr := new(net.OpError)
-	err = sm.RefreshState(ctx)
+	err = sm.RefreshState()
 	if err == nil {
 		t.Fatal("expected error when refreshing state without a client cert")
 	}
@@ -359,7 +359,7 @@ func TestMTLSServer_WithCertPasses(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error fetching StateMgr with %s: %v", backend.DefaultStateName, err)
 	}
-	if err = sm.RefreshState(ctx); err != nil {
+	if err = sm.RefreshState(); err != nil {
 		t.Fatalf("unexpected error calling RefreshState: %v", err)
 	}
 	state := sm.State()
@@ -400,10 +400,10 @@ func TestMTLSServer_WithCertPasses(t *testing.T) {
 	if err = sm.WriteState(state); err != nil {
 		t.Errorf("error writing state: %v", err)
 	}
-	if err = sm.PersistState(ctx, nil); err != nil {
+	if err = sm.PersistState(nil); err != nil {
 		t.Errorf("error persisting state: %v", err)
 	}
-	if err = sm.RefreshState(ctx); err != nil {
+	if err = sm.RefreshState(); err != nil {
 		t.Errorf("error refreshing state: %v", err)
 	}
 

--- a/internal/backend/remote-state/inmem/backend.go
+++ b/internal/backend/remote-state/inmem/backend.go
@@ -90,7 +90,7 @@ func (b *Backend) configure(ctx context.Context) error {
 	return nil
 }
 
-func (b *Backend) Workspaces(context.Context) ([]string, error) {
+func (b *Backend) Workspaces() ([]string, error) {
 	states.Lock()
 	defer states.Unlock()
 

--- a/internal/backend/remote-state/inmem/backend.go
+++ b/internal/backend/remote-state/inmem/backend.go
@@ -116,7 +116,7 @@ func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	return nil
 }
 
-func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {
+func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	states.Lock()
 	defer states.Unlock()
 

--- a/internal/backend/remote-state/inmem/backend.go
+++ b/internal/backend/remote-state/inmem/backend.go
@@ -144,7 +144,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 			if err := s.WriteState(statespkg.NewState()); err != nil {
 				return nil, err
 			}
-			if err := s.PersistState(ctx, nil); err != nil {
+			if err := s.PersistState(nil); err != nil {
 				return nil, err
 			}
 		}

--- a/internal/backend/remote-state/inmem/backend.go
+++ b/internal/backend/remote-state/inmem/backend.go
@@ -133,11 +133,11 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 		// take a lock and create a new state if it doesn't exist.
 		lockInfo := statemgr.NewLockInfo()
 		lockInfo.Operation = "init"
-		lockID, err := s.Lock(ctx, lockInfo)
+		lockID, err := s.Lock(lockInfo)
 		if err != nil {
 			return nil, fmt.Errorf("failed to lock inmem state: %w", err)
 		}
-		defer s.Unlock(ctx, lockID)
+		defer s.Unlock(lockID)
 
 		// If we have no state, we have to create an empty state
 		if v := s.State(); v == nil {

--- a/internal/backend/remote-state/inmem/backend.go
+++ b/internal/backend/remote-state/inmem/backend.go
@@ -104,7 +104,7 @@ func (b *Backend) Workspaces() ([]string, error) {
 	return workspaces, nil
 }
 
-func (b *Backend) DeleteWorkspace(_ context.Context, name string, _ bool) error {
+func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	states.Lock()
 	defer states.Unlock()
 

--- a/internal/backend/remote-state/inmem/backend_test.go
+++ b/internal/backend/remote-state/inmem/backend_test.go
@@ -4,7 +4,6 @@
 package inmem
 
 import (
-	"context"
 	"flag"
 	"os"
 	"testing"
@@ -37,9 +36,7 @@ func TestBackendConfig(t *testing.T) {
 
 	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(config)).(*Backend)
 
-	ctx := context.Background()
-
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,10 +72,8 @@ func TestRemoteState(t *testing.T) {
 
 	workspace := "workspace"
 
-	ctx := context.Background()
-
 	// create a new workspace in this backend
-	s, err := b.StateMgr(ctx, workspace)
+	s, err := b.StateMgr(workspace)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/remote-state/inmem/backend_test.go
+++ b/internal/backend/remote-state/inmem/backend_test.go
@@ -90,11 +90,11 @@ func TestRemoteState(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := s.PersistState(ctx, nil); err != nil {
+	if err := s.PersistState(nil); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := s.RefreshState(ctx); err != nil {
+	if err := s.RefreshState(); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/backend/remote-state/inmem/client.go
+++ b/internal/backend/remote-state/inmem/client.go
@@ -18,7 +18,7 @@ type RemoteClient struct {
 	Name string
 }
 
-func (c *RemoteClient) Get(context.Context) (*remote.Payload, error) {
+func (c *RemoteClient) Get() (*remote.Payload, error) {
 	if c.Data == nil {
 		return nil, nil
 	}
@@ -29,7 +29,7 @@ func (c *RemoteClient) Get(context.Context) (*remote.Payload, error) {
 	}, nil
 }
 
-func (c *RemoteClient) Put(_ context.Context, data []byte) error {
+func (c *RemoteClient) Put(data []byte) error {
 	md5 := md5.Sum(data)
 
 	c.Data = data

--- a/internal/backend/remote-state/inmem/client.go
+++ b/internal/backend/remote-state/inmem/client.go
@@ -4,7 +4,6 @@
 package inmem
 
 import (
-	"context"
 	"crypto/md5"
 
 	"github.com/opentofu/opentofu/internal/states/remote"
@@ -37,7 +36,7 @@ func (c *RemoteClient) Put(data []byte) error {
 	return nil
 }
 
-func (c *RemoteClient) Delete(context.Context) error {
+func (c *RemoteClient) Delete() error {
 	c.Data = nil
 	c.MD5 = nil
 	return nil

--- a/internal/backend/remote-state/inmem/client.go
+++ b/internal/backend/remote-state/inmem/client.go
@@ -43,9 +43,9 @@ func (c *RemoteClient) Delete(context.Context) error {
 	return nil
 }
 
-func (c *RemoteClient) Lock(_ context.Context, info *statemgr.LockInfo) (string, error) {
+func (c *RemoteClient) Lock(info *statemgr.LockInfo) (string, error) {
 	return locks.lock(c.Name, info)
 }
-func (c *RemoteClient) Unlock(_ context.Context, id string) error {
+func (c *RemoteClient) Unlock(id string) error {
 	return locks.unlock(c.Name, id)
 }

--- a/internal/backend/remote-state/inmem/client_test.go
+++ b/internal/backend/remote-state/inmem/client_test.go
@@ -4,7 +4,6 @@
 package inmem
 
 import (
-	"context"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
@@ -21,9 +20,7 @@ func TestRemoteClient(t *testing.T) {
 	defer Reset()
 	b := backend.TestBackendConfig(t, New(), hcl.EmptyBody())
 
-	ctx := context.Background()
-
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,9 +30,7 @@ func TestRemoteClient(t *testing.T) {
 
 func TestInmemLocks(t *testing.T) {
 	defer Reset()
-
-	ctx := context.Background()
-	s, err := backend.TestBackendConfig(t, New(), hcl.EmptyBody()).StateMgr(ctx, backend.DefaultStateName)
+	s, err := backend.TestBackendConfig(t, New(), hcl.EmptyBody()).StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/remote-state/kubernetes/backend_state.go
+++ b/internal/backend/remote-state/kubernetes/backend_state.go
@@ -18,14 +18,14 @@ import (
 
 // Workspaces returns a list of names for the workspaces found in k8s. The default
 // workspace is always returned as the first element in the slice.
-func (b *Backend) Workspaces(ctx context.Context) ([]string, error) {
+func (b *Backend) Workspaces() ([]string, error) {
 	secretClient, err := b.getKubernetesSecretClient()
 	if err != nil {
 		return nil, err
 	}
 
 	secrets, err := secretClient.List(
-		ctx,
+		context.Background(),
 		metav1.ListOptions{
 			LabelSelector: tfstateKey + "=true",
 		},

--- a/internal/backend/remote-state/kubernetes/backend_state.go
+++ b/internal/backend/remote-state/kubernetes/backend_state.go
@@ -63,7 +63,7 @@ func (b *Backend) Workspaces() ([]string, error) {
 	return states, nil
 }
 
-func (b *Backend) DeleteWorkspace(ctx context.Context, name string, _ bool) error {
+func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	if name == backend.DefaultStateName || name == "" {
 		return fmt.Errorf("can't delete default state")
 	}
@@ -73,7 +73,7 @@ func (b *Backend) DeleteWorkspace(ctx context.Context, name string, _ bool) erro
 		return err
 	}
 
-	return client.Delete(ctx)
+	return client.Delete()
 }
 
 func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {

--- a/internal/backend/remote-state/kubernetes/backend_state.go
+++ b/internal/backend/remote-state/kubernetes/backend_state.go
@@ -85,7 +85,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 	stateMgr := &remote.State{Client: c}
 
 	// Grab the value
-	if err := stateMgr.RefreshState(ctx); err != nil {
+	if err := stateMgr.RefreshState(); err != nil {
 		return nil, err
 	}
 
@@ -126,7 +126,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 		if err := stateMgr.WriteState(states.NewState()); err != nil {
 			return nil, unlock(err)
 		}
-		if err := stateMgr.PersistState(ctx, nil); err != nil {
+		if err := stateMgr.PersistState(nil); err != nil {
 			return nil, unlock(err)
 		}
 

--- a/internal/backend/remote-state/kubernetes/backend_state.go
+++ b/internal/backend/remote-state/kubernetes/backend_state.go
@@ -76,7 +76,7 @@ func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	return client.Delete()
 }
 
-func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {
+func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	c, err := b.remoteClient(name)
 	if err != nil {
 		return nil, err

--- a/internal/backend/remote-state/kubernetes/backend_state.go
+++ b/internal/backend/remote-state/kubernetes/backend_state.go
@@ -94,7 +94,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 
 		lockInfo := statemgr.NewLockInfo()
 		lockInfo.Operation = "init"
-		lockID, err := stateMgr.Lock(ctx, lockInfo)
+		lockID, err := stateMgr.Lock(lockInfo)
 		if err != nil {
 			return nil, err
 		}
@@ -106,7 +106,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 
 		// Local helper function so we can call it multiple places
 		unlock := func(baseErr error) error {
-			if err := stateMgr.Unlock(ctx, lockID); err != nil {
+			if err := stateMgr.Unlock(lockID); err != nil {
 				const unlockErrMsg = `%v
 				Additionally, unlocking the state in Kubernetes failed:
 

--- a/internal/backend/remote-state/kubernetes/backend_test.go
+++ b/internal/backend/remote-state/kubernetes/backend_test.go
@@ -89,9 +89,7 @@ func TestBackendLocksSoak(t *testing.T) {
 			"secret_suffix": secretSuffix,
 		}))
 
-		ctx := context.Background()
-
-		s, err := b.StateMgr(ctx, backend.DefaultStateName)
+		s, err := b.StateMgr(backend.DefaultStateName)
 		if err != nil {
 			t.Fatalf("Error creating state manager: %v", err)
 		}

--- a/internal/backend/remote-state/kubernetes/backend_test.go
+++ b/internal/backend/remote-state/kubernetes/backend_test.go
@@ -101,8 +101,6 @@ func TestBackendLocksSoak(t *testing.T) {
 
 	wg := sync.WaitGroup{}
 	for i, l := range lockers {
-		ctx := context.Background()
-
 		wg.Add(1)
 		go func(locker statemgr.Locker, n int) {
 			defer wg.Done()
@@ -112,7 +110,7 @@ func TestBackendLocksSoak(t *testing.T) {
 			li.Who = fmt.Sprintf("client-%v", n)
 
 			for i := 0; i < lockAttempts; i++ {
-				id, err := locker.Lock(ctx, li)
+				id, err := locker.Lock(li)
 				if err != nil {
 					continue
 				}
@@ -120,7 +118,7 @@ func TestBackendLocksSoak(t *testing.T) {
 				// hold onto the lock for a little bit
 				time.Sleep(time.Duration(rand.Intn(10)) * time.Microsecond)
 
-				err = locker.Unlock(ctx, id)
+				err = locker.Unlock(id)
 				if err != nil {
 					t.Errorf("failed to unlock: %v", err)
 				}

--- a/internal/backend/remote-state/kubernetes/client.go
+++ b/internal/backend/remote-state/kubernetes/client.go
@@ -122,7 +122,7 @@ func (c *RemoteClient) Put(data []byte) error {
 }
 
 // Delete the state secret
-func (c *RemoteClient) Delete(context.Context) error {
+func (c *RemoteClient) Delete() error {
 	secretName, err := c.createSecretName()
 	if err != nil {
 		return err

--- a/internal/backend/remote-state/kubernetes/client.go
+++ b/internal/backend/remote-state/kubernetes/client.go
@@ -45,12 +45,12 @@ type RemoteClient struct {
 	workspace              string
 }
 
-func (c *RemoteClient) Get(ctx context.Context) (payload *remote.Payload, err error) {
+func (c *RemoteClient) Get() (payload *remote.Payload, err error) {
 	secretName, err := c.createSecretName()
 	if err != nil {
 		return nil, err
 	}
-	secret, err := c.kubernetesSecretClient.Get(ctx, secretName, metav1.GetOptions{})
+	secret, err := c.kubernetesSecretClient.Get(context.Background(), secretName, metav1.GetOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil, nil
@@ -81,7 +81,8 @@ func (c *RemoteClient) Get(ctx context.Context) (payload *remote.Payload, err er
 	return p, nil
 }
 
-func (c *RemoteClient) Put(ctx context.Context, data []byte) error {
+func (c *RemoteClient) Put(data []byte) error {
+	ctx := context.Background()
 	secretName, err := c.createSecretName()
 	if err != nil {
 		return err

--- a/internal/backend/remote-state/kubernetes/client_test.go
+++ b/internal/backend/remote-state/kubernetes/client_test.go
@@ -4,7 +4,6 @@
 package kubernetes
 
 import (
-	"context"
 	"testing"
 
 	"github.com/opentofu/opentofu/internal/backend"
@@ -25,9 +24,7 @@ func TestRemoteClient(t *testing.T) {
 		"secret_suffix": secretSuffix,
 	}))
 
-	ctx := context.Background()
-
-	state, err := b.StateMgr(ctx, backend.DefaultStateName)
+	state, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,14 +44,12 @@ func TestRemoteClientLocks(t *testing.T) {
 		"secret_suffix": secretSuffix,
 	}))
 
-	ctx := context.Background()
-
-	s1, err := b1.StateMgr(ctx, backend.DefaultStateName)
+	s1, err := b1.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	s2, err := b2.StateMgr(ctx, backend.DefaultStateName)
+	s2, err := b2.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,10 +69,8 @@ func TestForceUnlock(t *testing.T) {
 		"secret_suffix": secretSuffix,
 	}))
 
-	ctx := context.Background()
-
 	// first test with default
-	s1, err := b1.StateMgr(ctx, backend.DefaultStateName)
+	s1, err := b1.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,7 +85,7 @@ func TestForceUnlock(t *testing.T) {
 	}
 
 	// s1 is now locked, get the same state through s2 and unlock it
-	s2, err := b2.StateMgr(ctx, backend.DefaultStateName)
+	s2, err := b2.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal("failed to get default state to force unlock:", err)
 	}
@@ -103,7 +96,7 @@ func TestForceUnlock(t *testing.T) {
 
 	// now try the same thing with a named state
 	// first test with default
-	s1, err = b1.StateMgr(ctx, "test")
+	s1, err = b1.StateMgr("test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +111,7 @@ func TestForceUnlock(t *testing.T) {
 	}
 
 	// s1 is now locked, get the same state through s2 and unlock it
-	s2, err = b2.StateMgr(ctx, "test")
+	s2, err = b2.StateMgr("test")
 	if err != nil {
 		t.Fatal("failed to get named state to force unlock:", err)
 	}

--- a/internal/backend/remote-state/kubernetes/client_test.go
+++ b/internal/backend/remote-state/kubernetes/client_test.go
@@ -86,7 +86,7 @@ func TestForceUnlock(t *testing.T) {
 	info.Operation = "test"
 	info.Who = "clientA"
 
-	lockID, err := s1.Lock(ctx, info)
+	lockID, err := s1.Lock(info)
 	if err != nil {
 		t.Fatal("unable to get initial lock:", err)
 	}
@@ -97,7 +97,7 @@ func TestForceUnlock(t *testing.T) {
 		t.Fatal("failed to get default state to force unlock:", err)
 	}
 
-	if err := s2.Unlock(ctx, lockID); err != nil {
+	if err := s2.Unlock(lockID); err != nil {
 		t.Fatal("failed to force-unlock default state")
 	}
 
@@ -112,7 +112,7 @@ func TestForceUnlock(t *testing.T) {
 	info.Operation = "test"
 	info.Who = "clientA"
 
-	lockID, err = s1.Lock(ctx, info)
+	lockID, err = s1.Lock(info)
 	if err != nil {
 		t.Fatal("unable to get initial lock:", err)
 	}
@@ -123,7 +123,7 @@ func TestForceUnlock(t *testing.T) {
 		t.Fatal("failed to get named state to force unlock:", err)
 	}
 
-	if err = s2.Unlock(ctx, lockID); err != nil {
+	if err = s2.Unlock(lockID); err != nil {
 		t.Fatal("failed to force-unlock named state")
 	}
 }

--- a/internal/backend/remote-state/oss/backend_state.go
+++ b/internal/backend/remote-state/oss/backend_state.go
@@ -100,7 +100,7 @@ func (b *Backend) Workspaces() ([]string, error) {
 	return result, nil
 }
 
-func (b *Backend) DeleteWorkspace(ctx context.Context, name string, _ bool) error {
+func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	if name == backend.DefaultStateName || name == "" {
 		return fmt.Errorf("can't delete default state")
 	}
@@ -109,7 +109,7 @@ func (b *Backend) DeleteWorkspace(ctx context.Context, name string, _ bool) erro
 	if err != nil {
 		return err
 	}
-	return client.Delete(ctx)
+	return client.Delete()
 }
 
 func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {

--- a/internal/backend/remote-state/oss/backend_state.go
+++ b/internal/backend/remote-state/oss/backend_state.go
@@ -4,7 +4,6 @@
 package oss
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -112,7 +111,7 @@ func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	return client.Delete()
 }
 
-func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {
+func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	client, err := b.remoteClient(name)
 	if err != nil {
 		return nil, err

--- a/internal/backend/remote-state/oss/backend_state.go
+++ b/internal/backend/remote-state/oss/backend_state.go
@@ -139,14 +139,14 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 		// take a lock on this state while we write it
 		lockInfo := statemgr.NewLockInfo()
 		lockInfo.Operation = "init"
-		lockId, err := client.Lock(ctx, lockInfo)
+		lockId, err := client.Lock(lockInfo)
 		if err != nil {
 			return nil, fmt.Errorf("failed to lock OSS state: %w", err)
 		}
 
 		// Local helper function so we can call it multiple places
 		lockUnlock := func(e error) error {
-			if err := stateMgr.Unlock(ctx, lockId); err != nil {
+			if err := stateMgr.Unlock(lockId); err != nil {
 				return fmt.Errorf(strings.TrimSpace(stateUnlockError), lockId, err)
 			}
 			return e

--- a/internal/backend/remote-state/oss/backend_state.go
+++ b/internal/backend/remote-state/oss/backend_state.go
@@ -53,7 +53,7 @@ func (b *Backend) remoteClient(name string) (*RemoteClient, error) {
 	return client, nil
 }
 
-func (b *Backend) Workspaces(ctx context.Context) ([]string, error) {
+func (b *Backend) Workspaces() ([]string, error) {
 	bucket, err := b.ossClient.Bucket(b.bucketName)
 	if err != nil {
 		return []string{""}, fmt.Errorf("error getting bucket: %w", err)
@@ -120,7 +120,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 	stateMgr := &remote.State{Client: client}
 
 	// Check to see if this state already exists.
-	existing, err := b.Workspaces(ctx)
+	existing, err := b.Workspaces()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/remote-state/oss/backend_state.go
+++ b/internal/backend/remote-state/oss/backend_state.go
@@ -153,7 +153,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 		}
 
 		// Grab the value
-		if err := stateMgr.RefreshState(ctx); err != nil {
+		if err := stateMgr.RefreshState(); err != nil {
 			err = lockUnlock(err)
 			return nil, err
 		}
@@ -164,7 +164,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 				err = lockUnlock(err)
 				return nil, err
 			}
-			if err := stateMgr.PersistState(ctx, nil); err != nil {
+			if err := stateMgr.PersistState(nil); err != nil {
 				err = lockUnlock(err)
 				return nil, err
 			}

--- a/internal/backend/remote-state/oss/backend_test.go
+++ b/internal/backend/remote-state/oss/backend_test.go
@@ -87,7 +87,7 @@ func TestBackendConfigWorkSpace(t *testing.T) {
 	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(config)).(*Backend)
 	createOSSBucket(t, b.ossClient, bucketName)
 	defer deleteOSSBucket(t, b.ossClient, bucketName)
-	if _, err := b.Workspaces(context.Background()); err != nil {
+	if _, err := b.Workspaces(); err != nil {
 		t.Fatal(err.Error())
 	}
 	if !strings.HasPrefix(b.ossClient.Config.Endpoint, "https://oss-cn-beijing") {

--- a/internal/backend/remote-state/oss/backend_test.go
+++ b/internal/backend/remote-state/oss/backend_test.go
@@ -4,7 +4,6 @@
 package oss
 
 import (
-	"context"
 	"fmt"
 	"math/rand"
 	"os"
@@ -157,9 +156,7 @@ func TestBackendConfig_invalidKey(t *testing.T) {
 		"tablestore_table":    "TableStore",
 	})
 
-	ctx := context.Background()
-
-	_, results := New().PrepareConfig(ctx, cfg)
+	_, results := New().PrepareConfig(cfg)
 	if !results.HasErrors() {
 		t.Fatal("expected config validation error")
 	}

--- a/internal/backend/remote-state/oss/client.go
+++ b/internal/backend/remote-state/oss/client.go
@@ -148,7 +148,7 @@ func (c *RemoteClient) Delete(ctx context.Context) error {
 	return nil
 }
 
-func (c *RemoteClient) Lock(_ context.Context, info *statemgr.LockInfo) (string, error) {
+func (c *RemoteClient) Lock(info *statemgr.LockInfo) (string, error) {
 	if c.otsTable == "" {
 		return "", nil
 	}
@@ -359,7 +359,7 @@ func (c *RemoteClient) getLockInfo() (*statemgr.LockInfo, error) {
 	}
 	return lockInfo, nil
 }
-func (c *RemoteClient) Unlock(ctx context.Context, id string) error {
+func (c *RemoteClient) Unlock(id string) error {
 	if c.otsTable == "" {
 		return nil
 	}

--- a/internal/backend/remote-state/oss/client.go
+++ b/internal/backend/remote-state/oss/client.go
@@ -54,7 +54,7 @@ type RemoteClient struct {
 	otsTable             string
 }
 
-func (c *RemoteClient) Get(context.Context) (payload *remote.Payload, err error) {
+func (c *RemoteClient) Get() (payload *remote.Payload, err error) {
 	deadline := time.Now().Add(consistencyRetryTimeout)
 
 	// If we have a checksum, and the returned payload doesn't match, we retry
@@ -97,7 +97,7 @@ func (c *RemoteClient) Get(context.Context) (payload *remote.Payload, err error)
 	return payload, nil
 }
 
-func (c *RemoteClient) Put(_ context.Context, data []byte) error {
+func (c *RemoteClient) Put(data []byte) error {
 	bucket, err := c.ossClient.Bucket(c.bucketName)
 	if err != nil {
 		return fmt.Errorf("error getting bucket: %w", err)

--- a/internal/backend/remote-state/oss/client.go
+++ b/internal/backend/remote-state/oss/client.go
@@ -5,7 +5,6 @@ package oss
 
 import (
 	"bytes"
-	"context"
 	"crypto/md5"
 	"encoding/hex"
 	"encoding/json"
@@ -130,7 +129,7 @@ func (c *RemoteClient) Put(data []byte) error {
 	return nil
 }
 
-func (c *RemoteClient) Delete(ctx context.Context) error {
+func (c *RemoteClient) Delete() error {
 	bucket, err := c.ossClient.Bucket(c.bucketName)
 	if err != nil {
 		return fmt.Errorf("error getting bucket %s: %w", c.bucketName, err)

--- a/internal/backend/remote-state/oss/client_test.go
+++ b/internal/backend/remote-state/oss/client_test.go
@@ -328,22 +328,22 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 	client2 := s2.(*remote.State).Client
 
 	// write the new state through client2 so that there is no checksum yet
-	if err := client2.Put(ctx, newState.Bytes()); err != nil {
+	if err := client2.Put(newState.Bytes()); err != nil {
 		t.Fatal(err)
 	}
 
 	// verify that we can pull a state without a checksum
-	if _, err := client1.Get(ctx); err != nil {
+	if _, err := client1.Get(); err != nil {
 		t.Fatal(err)
 	}
 
 	// write the new state back with its checksum
-	if err := client1.Put(ctx, newState.Bytes()); err != nil {
+	if err := client1.Put(newState.Bytes()); err != nil {
 		t.Fatal(err)
 	}
 
 	// put an empty state in place to check for panics during get
-	if err := client2.Put(ctx, []byte{}); err != nil {
+	if err := client2.Put([]byte{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -359,24 +359,24 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 
 	// fetching an empty state through client1 should now error out due to a
 	// mismatched checksum.
-	if _, err := client1.Get(ctx); !strings.HasPrefix(err.Error(), errBadChecksumFmt[:80]) {
+	if _, err := client1.Get(); !strings.HasPrefix(err.Error(), errBadChecksumFmt[:80]) {
 		t.Fatalf("expected state checksum error: got %s", err)
 	}
 
 	// put the old state in place of the new, without updating the checksum
-	if err := client2.Put(ctx, oldState.Bytes()); err != nil {
+	if err := client2.Put(oldState.Bytes()); err != nil {
 		t.Fatal(err)
 	}
 
 	// fetching the wrong state through client1 should now error out due to a
 	// mismatched checksum.
-	if _, err := client1.Get(ctx); !strings.HasPrefix(err.Error(), errBadChecksumFmt[:80]) {
+	if _, err := client1.Get(); !strings.HasPrefix(err.Error(), errBadChecksumFmt[:80]) {
 		t.Fatalf("expected state checksum error: got %s", err)
 	}
 
 	// update the state with the correct one after we Get again
 	testChecksumHook = func() {
-		if err := client2.Put(ctx, newState.Bytes()); err != nil {
+		if err := client2.Put(newState.Bytes()); err != nil {
 			t.Fatal(err)
 		}
 		testChecksumHook = nil
@@ -387,7 +387,7 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 	// this final Get will fail to fail the checksum verification, the above
 	// callback will update the state with the correct version, and Get should
 	// retry automatically.
-	if _, err := client1.Get(ctx); err != nil {
+	if _, err := client1.Get(); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/backend/remote-state/oss/client_test.go
+++ b/internal/backend/remote-state/oss/client_test.go
@@ -127,7 +127,7 @@ func TestRemoteClientLocks_multipleStates(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s1.Lock(ctx, statemgr.NewLockInfo()); err != nil {
+	if _, err := s1.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatal("failed to get lock for s1:", err)
 	}
 
@@ -136,7 +136,7 @@ func TestRemoteClientLocks_multipleStates(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s2.Lock(ctx, statemgr.NewLockInfo()); err != nil {
+	if _, err := s2.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatal("failed to get lock for s2:", err)
 	}
 }
@@ -181,7 +181,7 @@ func TestRemoteForceUnlock(t *testing.T) {
 	info.Operation = "test"
 	info.Who = "clientA"
 
-	lockID, err := s1.Lock(ctx, info)
+	lockID, err := s1.Lock(info)
 	if err != nil {
 		t.Fatal("unable to get initial lock:", err)
 	}
@@ -192,7 +192,7 @@ func TestRemoteForceUnlock(t *testing.T) {
 		t.Fatal("failed to get default state to force unlock:", err)
 	}
 
-	if err := s2.Unlock(ctx, lockID); err != nil {
+	if err := s2.Unlock(lockID); err != nil {
 		t.Fatal("failed to force-unlock default state")
 	}
 
@@ -207,7 +207,7 @@ func TestRemoteForceUnlock(t *testing.T) {
 	info.Operation = "test"
 	info.Who = "clientA"
 
-	lockID, err = s1.Lock(ctx, info)
+	lockID, err = s1.Lock(info)
 	if err != nil {
 		t.Fatal("unable to get initial lock:", err)
 	}
@@ -218,7 +218,7 @@ func TestRemoteForceUnlock(t *testing.T) {
 		t.Fatal("failed to get named state to force unlock:", err)
 	}
 
-	if err = s2.Unlock(ctx, lockID); err != nil {
+	if err = s2.Unlock(lockID); err != nil {
 		t.Fatal("failed to force-unlock named state")
 	}
 }

--- a/internal/backend/remote-state/oss/client_test.go
+++ b/internal/backend/remote-state/oss/client_test.go
@@ -4,7 +4,6 @@
 package oss
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -41,9 +40,7 @@ func TestRemoteClient(t *testing.T) {
 	createOSSBucket(t, b.ossClient, bucketName)
 	defer deleteOSSBucket(t, b.ossClient, bucketName)
 
-	ctx := context.Background()
-
-	state, err := b.StateMgr(ctx, backend.DefaultStateName)
+	state, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,14 +75,12 @@ func TestRemoteClientLocks(t *testing.T) {
 	createTablestoreTable(t, b1.otsClient, tableName)
 	defer deleteTablestoreTable(t, b1.otsClient, tableName)
 
-	ctx := context.Background()
-
-	s1, err := b1.StateMgr(ctx, backend.DefaultStateName)
+	s1, err := b1.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	s2, err := b2.StateMgr(ctx, backend.DefaultStateName)
+	s2, err := b2.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,9 +116,7 @@ func TestRemoteClientLocks_multipleStates(t *testing.T) {
 	createTablestoreTable(t, b1.otsClient, tableName)
 	defer deleteTablestoreTable(t, b1.otsClient, tableName)
 
-	ctx := context.Background()
-
-	s1, err := b1.StateMgr(ctx, "s1")
+	s1, err := b1.StateMgr("s1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,7 +125,7 @@ func TestRemoteClientLocks_multipleStates(t *testing.T) {
 	}
 
 	// s1 is now locked, s2 should not be locked as it's a different state file
-	s2, err := b2.StateMgr(ctx, "s2")
+	s2, err := b2.StateMgr("s2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,10 +162,8 @@ func TestRemoteForceUnlock(t *testing.T) {
 	createTablestoreTable(t, b1.otsClient, tableName)
 	defer deleteTablestoreTable(t, b1.otsClient, tableName)
 
-	ctx := context.Background()
-
 	// first test with default
-	s1, err := b1.StateMgr(ctx, backend.DefaultStateName)
+	s1, err := b1.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -187,7 +178,7 @@ func TestRemoteForceUnlock(t *testing.T) {
 	}
 
 	// s1 is now locked, get the same state through s2 and unlock it
-	s2, err := b2.StateMgr(ctx, backend.DefaultStateName)
+	s2, err := b2.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal("failed to get default state to force unlock:", err)
 	}
@@ -198,7 +189,7 @@ func TestRemoteForceUnlock(t *testing.T) {
 
 	// now try the same thing with a named state
 	// first test with default
-	s1, err = b1.StateMgr(ctx, "test")
+	s1, err = b1.StateMgr("test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -213,7 +204,7 @@ func TestRemoteForceUnlock(t *testing.T) {
 	}
 
 	// s1 is now locked, get the same state through s2 and unlock it
-	s2, err = b2.StateMgr(ctx, "test")
+	s2, err = b2.StateMgr("test")
 	if err != nil {
 		t.Fatal("failed to get named state to force unlock:", err)
 	}
@@ -242,9 +233,7 @@ func TestRemoteClient_clientMD5(t *testing.T) {
 	createTablestoreTable(t, b.otsClient, tableName)
 	defer deleteTablestoreTable(t, b.otsClient, tableName)
 
-	ctx := context.Background()
-
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -294,9 +283,7 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 	createTablestoreTable(t, b1.otsClient, tableName)
 	defer deleteTablestoreTable(t, b1.otsClient, tableName)
 
-	ctx := context.Background()
-
-	s1, err := b1.StateMgr(ctx, backend.DefaultStateName)
+	s1, err := b1.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -321,7 +308,7 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 		"bucket": bucketName,
 		"prefix": path,
 	})).(*Backend)
-	s2, err := b2.StateMgr(ctx, backend.DefaultStateName)
+	s2, err := b2.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/remote-state/pg/backend_state.go
+++ b/internal/backend/remote-state/pg/backend_state.go
@@ -13,9 +13,9 @@ import (
 	"github.com/opentofu/opentofu/internal/states/statemgr"
 )
 
-func (b *Backend) Workspaces(ctx context.Context) ([]string, error) {
+func (b *Backend) Workspaces() ([]string, error) {
 	query := `SELECT name FROM %s.%s WHERE name != 'default' ORDER BY name`
-	rows, err := b.db.QueryContext(ctx, fmt.Sprintf(query, b.schemaName, statesTableName))
+	rows, err := b.db.Query(fmt.Sprintf(query, b.schemaName, statesTableName))
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 	// Check to see if this state already exists.
 	// If the state doesn't exist, we have to assume this
 	// is a normal create operation, and take the lock at that point.
-	existing, err := b.Workspaces(ctx)
+	existing, err := b.Workspaces()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/remote-state/pg/backend_state.go
+++ b/internal/backend/remote-state/pg/backend_state.go
@@ -85,14 +85,14 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 	if !exists {
 		lockInfo := statemgr.NewLockInfo()
 		lockInfo.Operation = "init"
-		lockId, err := stateMgr.Lock(ctx, lockInfo)
+		lockId, err := stateMgr.Lock(lockInfo)
 		if err != nil {
 			return nil, fmt.Errorf("failed to lock state in Postgres: %w", err)
 		}
 
 		// Local helper function so we can call it multiple places
 		lockUnlock := func(parent error) error {
-			if err := stateMgr.Unlock(ctx, lockId); err != nil {
+			if err := stateMgr.Unlock(lockId); err != nil {
 				return fmt.Errorf("error unlocking Postgres state: %w", err)
 			}
 			return parent

--- a/internal/backend/remote-state/pg/backend_state.go
+++ b/internal/backend/remote-state/pg/backend_state.go
@@ -103,7 +103,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 				err = lockUnlock(err)
 				return nil, err
 			}
-			if err := stateMgr.PersistState(ctx, nil); err != nil {
+			if err := stateMgr.PersistState(nil); err != nil {
 				err = lockUnlock(err)
 				return nil, err
 			}

--- a/internal/backend/remote-state/pg/backend_state.go
+++ b/internal/backend/remote-state/pg/backend_state.go
@@ -39,13 +39,13 @@ func (b *Backend) Workspaces() ([]string, error) {
 	return result, nil
 }
 
-func (b *Backend) DeleteWorkspace(ctx context.Context, name string, _ bool) error {
+func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	if name == backend.DefaultStateName || name == "" {
 		return fmt.Errorf("can't delete default state")
 	}
 
 	query := `DELETE FROM %s.%s WHERE name = $1`
-	_, err := b.db.ExecContext(ctx, fmt.Sprintf(query, b.schemaName, statesTableName), name)
+	_, err := b.db.Exec(fmt.Sprintf(query, b.schemaName, statesTableName), name)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/remote-state/pg/backend_state.go
+++ b/internal/backend/remote-state/pg/backend_state.go
@@ -4,7 +4,6 @@
 package pg
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/opentofu/opentofu/internal/backend"
@@ -53,7 +52,7 @@ func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	return nil
 }
 
-func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {
+func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	// Build the state client
 	var stateMgr statemgr.Full = &remote.State{
 		Client: &RemoteClient{

--- a/internal/backend/remote-state/pg/backend_test.go
+++ b/internal/backend/remote-state/pg/backend_test.go
@@ -7,7 +7,6 @@ package pg
 // TF_ACC=1 GO111MODULE=on go test -v -mod=vendor -timeout=2m -parallel=4 github.com/opentofu/opentofu/backend/remote-state/pg
 
 import (
-	"context"
 	"database/sql"
 	"fmt"
 	"net/url"
@@ -150,11 +149,9 @@ func TestBackendConfig(t *testing.T) {
 			}
 			defer dbCleaner.Query(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", schemaName))
 
-			ctx := context.Background()
-
 			var diags tfdiags.Diagnostics
 			b := New().(*Backend)
-			schema := b.ConfigSchema(ctx)
+			schema := b.ConfigSchema()
 			spec := schema.DecoderSpec()
 			obj, decDiags := hcldec.Decode(config, spec, nil)
 			diags = diags.Append(decDiags)

--- a/internal/backend/remote-state/pg/backend_test.go
+++ b/internal/backend/remote-state/pg/backend_test.go
@@ -475,9 +475,7 @@ func TestBackendConcurrentLock(t *testing.T) {
 		t.Fatalf("failed to lock first state: %v", err)
 	}
 
-	ctx := context.Background()
-
-	if err = s1.PersistState(ctx, nil); err != nil {
+	if err = s1.PersistState(nil); err != nil {
 		t.Fatalf("failed to persist state: %v", err)
 	}
 
@@ -490,7 +488,7 @@ func TestBackendConcurrentLock(t *testing.T) {
 		t.Fatalf("failed to lock second state: %v", err)
 	}
 
-	if err = s2.PersistState(ctx, nil); err != nil {
+	if err = s2.PersistState(nil); err != nil {
 		t.Fatalf("failed to persist state: %v", err)
 	}
 

--- a/internal/backend/remote-state/pg/backend_test.go
+++ b/internal/backend/remote-state/pg/backend_test.go
@@ -159,7 +159,7 @@ func TestBackendConfig(t *testing.T) {
 			obj, decDiags := hcldec.Decode(config, spec, nil)
 			diags = diags.Append(decDiags)
 
-			newObj, valDiags := b.PrepareConfig(ctx, obj)
+			newObj, valDiags := b.PrepareConfig(obj)
 			diags = diags.Append(valDiags.InConfigBody(config, ""))
 
 			if tc.ExpectConfigurationError != "" {

--- a/internal/backend/remote-state/pg/backend_test.go
+++ b/internal/backend/remote-state/pg/backend_test.go
@@ -200,12 +200,12 @@ func TestBackendConfig(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			_, err = b.StateMgr(ctx, backend.DefaultStateName)
+			_, err = b.StateMgr(backend.DefaultStateName)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			s, err := b.StateMgr(ctx, backend.DefaultStateName)
+			s, err := b.StateMgr(backend.DefaultStateName)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -341,14 +341,12 @@ func TestBackendConfigSkipOptions(t *testing.T) {
 				}
 			}
 
-			ctx := context.Background()
-
-			_, err = b.StateMgr(ctx, backend.DefaultStateName)
+			_, err = b.StateMgr(backend.DefaultStateName)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			s, err := b.StateMgr(ctx, backend.DefaultStateName)
+			s, err := b.StateMgr(backend.DefaultStateName)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -450,10 +448,7 @@ func TestBackendConcurrentLock(t *testing.T) {
 		if b == nil {
 			t.Fatal("Backend could not be configured")
 		}
-
-		ctx := context.Background()
-
-		stateMgr, err := b.StateMgr(ctx, backend.DefaultStateName)
+		stateMgr, err := b.StateMgr(backend.DefaultStateName)
 		if err != nil {
 			t.Fatalf("Failed to get the state manager: %v", err)
 		}

--- a/internal/backend/remote-state/pg/backend_test.go
+++ b/internal/backend/remote-state/pg/backend_test.go
@@ -439,8 +439,6 @@ func TestBackendConcurrentLock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx := context.Background()
-
 	getStateMgr := func(schemaName string) (statemgr.Full, *statemgr.LockInfo) {
 		defer dbCleaner.Query(fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", schemaName))
 		config := backend.TestWrapConfig(map[string]interface{}{
@@ -452,6 +450,8 @@ func TestBackendConcurrentLock(t *testing.T) {
 		if b == nil {
 			t.Fatal("Backend could not be configured")
 		}
+
+		ctx := context.Background()
 
 		stateMgr, err := b.StateMgr(ctx, backend.DefaultStateName)
 		if err != nil {
@@ -470,20 +470,22 @@ func TestBackendConcurrentLock(t *testing.T) {
 
 	// First we need to create the workspace as the lock for creating them is
 	// global
-	lockID1, err := s1.Lock(ctx, i1)
+	lockID1, err := s1.Lock(i1)
 	if err != nil {
 		t.Fatalf("failed to lock first state: %v", err)
 	}
+
+	ctx := context.Background()
 
 	if err = s1.PersistState(ctx, nil); err != nil {
 		t.Fatalf("failed to persist state: %v", err)
 	}
 
-	if err := s1.Unlock(ctx, lockID1); err != nil {
+	if err := s1.Unlock(lockID1); err != nil {
 		t.Fatalf("failed to unlock first state: %v", err)
 	}
 
-	lockID2, err := s2.Lock(ctx, i2)
+	lockID2, err := s2.Lock(i2)
 	if err != nil {
 		t.Fatalf("failed to lock second state: %v", err)
 	}
@@ -492,26 +494,26 @@ func TestBackendConcurrentLock(t *testing.T) {
 		t.Fatalf("failed to persist state: %v", err)
 	}
 
-	if err := s2.Unlock(ctx, lockID2); err != nil {
+	if err := s2.Unlock(lockID2); err != nil {
 		t.Fatalf("failed to unlock first state: %v", err)
 	}
 
 	// Now we can test concurrent lock
-	lockID1, err = s1.Lock(ctx, i1)
+	lockID1, err = s1.Lock(i1)
 	if err != nil {
 		t.Fatalf("failed to lock first state: %v", err)
 	}
 
-	lockID2, err = s2.Lock(ctx, i2)
+	lockID2, err = s2.Lock(i2)
 	if err != nil {
 		t.Fatalf("failed to lock second state: %v", err)
 	}
 
-	if err := s1.Unlock(ctx, lockID1); err != nil {
+	if err := s1.Unlock(lockID1); err != nil {
 		t.Fatalf("failed to unlock first state: %v", err)
 	}
 
-	if err := s2.Unlock(ctx, lockID2); err != nil {
+	if err := s2.Unlock(lockID2); err != nil {
 		t.Fatalf("failed to unlock first state: %v", err)
 	}
 }

--- a/internal/backend/remote-state/pg/backend_test.go
+++ b/internal/backend/remote-state/pg/backend_test.go
@@ -176,7 +176,7 @@ func TestBackendConfig(t *testing.T) {
 
 			obj = newObj
 
-			confDiags := b.Configure(ctx, obj)
+			confDiags := b.Configure(obj)
 			if tc.ExpectConnectionError != "" {
 				err := confDiags.InConfigBody(config, "").ErrWithWarnings()
 				if err == nil {

--- a/internal/backend/remote-state/pg/client.go
+++ b/internal/backend/remote-state/pg/client.go
@@ -4,7 +4,6 @@
 package pg
 
 import (
-	"context"
 	"crypto/md5"
 	"database/sql"
 	"fmt"
@@ -55,9 +54,9 @@ func (c *RemoteClient) Put(data []byte) error {
 	return nil
 }
 
-func (c *RemoteClient) Delete(ctx context.Context) error {
+func (c *RemoteClient) Delete() error {
 	query := `DELETE FROM %s.%s WHERE name = $1`
-	_, err := c.Client.ExecContext(ctx, fmt.Sprintf(query, c.SchemaName, statesTableName), c.Name)
+	_, err := c.Client.Exec(fmt.Sprintf(query, c.SchemaName, statesTableName), c.Name)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/remote-state/pg/client.go
+++ b/internal/backend/remote-state/pg/client.go
@@ -24,9 +24,9 @@ type RemoteClient struct {
 	info *statemgr.LockInfo
 }
 
-func (c *RemoteClient) Get(ctx context.Context) (*remote.Payload, error) {
+func (c *RemoteClient) Get() (*remote.Payload, error) {
 	query := `SELECT data FROM %s.%s WHERE name = $1`
-	row := c.Client.QueryRowContext(ctx, fmt.Sprintf(query, c.SchemaName, statesTableName), c.Name)
+	row := c.Client.QueryRow(fmt.Sprintf(query, c.SchemaName, statesTableName), c.Name)
 	var data []byte
 	err := row.Scan(&data)
 	switch {
@@ -44,11 +44,11 @@ func (c *RemoteClient) Get(ctx context.Context) (*remote.Payload, error) {
 	}
 }
 
-func (c *RemoteClient) Put(ctx context.Context, data []byte) error {
+func (c *RemoteClient) Put(data []byte) error {
 	query := `INSERT INTO %s.%s (name, data) VALUES ($1, $2)
 		ON CONFLICT (name) DO UPDATE
 		SET data = $2 WHERE %s.name = $1`
-	_, err := c.Client.ExecContext(ctx, fmt.Sprintf(query, c.SchemaName, statesTableName, statesTableName), c.Name, data)
+	_, err := c.Client.Exec(fmt.Sprintf(query, c.SchemaName, statesTableName, statesTableName), c.Name, data)
 	if err != nil {
 		return err
 	}

--- a/internal/backend/remote-state/pg/client.go
+++ b/internal/backend/remote-state/pg/client.go
@@ -64,7 +64,7 @@ func (c *RemoteClient) Delete(ctx context.Context) error {
 	return nil
 }
 
-func (c *RemoteClient) Lock(ctx context.Context, info *statemgr.LockInfo) (string, error) {
+func (c *RemoteClient) Lock(info *statemgr.LockInfo) (string, error) {
 	var err error
 	var lockID string
 
@@ -80,7 +80,7 @@ func (c *RemoteClient) Lock(ctx context.Context, info *statemgr.LockInfo) (strin
 	//
 	lockUnlock := func(pgLockId string) error {
 		query := `SELECT pg_advisory_unlock(%s)`
-		row := c.Client.QueryRowContext(ctx, fmt.Sprintf(query, pgLockId))
+		row := c.Client.QueryRow(fmt.Sprintf(query, pgLockId))
 		var didUnlock []byte
 		err := row.Scan(&didUnlock)
 		if err != nil {
@@ -91,13 +91,13 @@ func (c *RemoteClient) Lock(ctx context.Context, info *statemgr.LockInfo) (strin
 
 	// Try to acquire locks for the existing row `id` and the creation lock `-1`.
 	query := `SELECT %s.id, pg_try_advisory_lock(%s.id), pg_try_advisory_lock(-1) FROM %s.%s WHERE %s.name = $1`
-	row := c.Client.QueryRowContext(ctx, fmt.Sprintf(query, statesTableName, statesTableName, c.SchemaName, statesTableName, statesTableName), c.Name)
+	row := c.Client.QueryRow(fmt.Sprintf(query, statesTableName, statesTableName, c.SchemaName, statesTableName, statesTableName), c.Name)
 	var pgLockId, didLock, didLockForCreate []byte
 	err = row.Scan(&pgLockId, &didLock, &didLockForCreate)
 	switch {
 	case err == sql.ErrNoRows:
 		// No rows means we're creating the workspace. Take the creation lock.
-		innerRow := c.Client.QueryRowContext(ctx, `SELECT pg_try_advisory_lock(-1)`)
+		innerRow := c.Client.QueryRow(`SELECT pg_try_advisory_lock(-1)`)
 		var innerDidLock []byte
 		err := innerRow.Scan(&innerDidLock)
 		if err != nil {
@@ -131,10 +131,10 @@ func (c *RemoteClient) getLockInfo() (*statemgr.LockInfo, error) {
 	return c.info, nil
 }
 
-func (c *RemoteClient) Unlock(ctx context.Context, id string) error {
+func (c *RemoteClient) Unlock(id string) error {
 	if c.info != nil && c.info.Path != "" {
 		query := `SELECT pg_advisory_unlock(%s)`
-		row := c.Client.QueryRowContext(ctx, fmt.Sprintf(query, c.info.Path))
+		row := c.Client.QueryRow(fmt.Sprintf(query, c.info.Path))
 		var didUnlock []byte
 		err := row.Scan(&didUnlock)
 		if err != nil {

--- a/internal/backend/remote-state/pg/client_test.go
+++ b/internal/backend/remote-state/pg/client_test.go
@@ -7,7 +7,6 @@ package pg
 // TF_ACC=1 GO111MODULE=on go test -v -mod=vendor -timeout=2m -parallel=4 github.com/opentofu/opentofu/backend/remote-state/pg
 
 import (
-	"context"
 	"database/sql"
 	"fmt"
 	"testing"
@@ -41,9 +40,7 @@ func TestRemoteClient(t *testing.T) {
 		t.Fatal("Backend could not be configured")
 	}
 
-	ctx := context.Background()
-
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,16 +63,14 @@ func TestRemoteLocks(t *testing.T) {
 		"schema_name": schemaName,
 	})
 
-	ctx := context.Background()
-
 	b1 := backend.TestBackendConfig(t, New(), config).(*Backend)
-	s1, err := b1.StateMgr(ctx, backend.DefaultStateName)
+	s1, err := b1.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	b2 := backend.TestBackendConfig(t, New(), config).(*Backend)
-	s2, err := b2.StateMgr(ctx, backend.DefaultStateName)
+	s2, err := b2.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -49,7 +49,7 @@ type Backend struct {
 
 // ConfigSchema returns a description of the expected configuration
 // structure for the receiving backend.
-func (b *Backend) ConfigSchema(context.Context) *configschema.Block {
+func (b *Backend) ConfigSchema() *configschema.Block {
 	return &configschema.Block{
 		Attributes: map[string]*configschema.Attribute{
 			"bucket": {

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -764,6 +764,14 @@ func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
 		cfg.ForbiddenAccountIds = val
 	}
 
+	if val, ok := stringAttrOk(obj, "retry_mode"); ok {
+		mode, err := aws.ParseRetryMode(val)
+		if err != nil {
+			panic(fmt.Sprintf("invalid retry mode %q: %s", val, err))
+		}
+		cfg.RetryMode = mode
+	}
+
 	ctx := context.TODO()
 	_, awsConfig, awsDiags := awsbase.GetAwsConfig(ctx, cfg)
 

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -623,7 +623,7 @@ func (b *Backend) PrepareConfig(ctx context.Context, obj cty.Value) (cty.Value, 
 // The given configuration is assumed to have already been validated
 // against the schema returned by ConfigSchema and passed validation
 // via PrepareConfig.
-func (b *Backend) Configure(ctx context.Context, obj cty.Value) tfdiags.Diagnostics {
+func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 	if obj.IsNull() {
 		return diags
@@ -764,14 +764,7 @@ func (b *Backend) Configure(ctx context.Context, obj cty.Value) tfdiags.Diagnost
 		cfg.ForbiddenAccountIds = val
 	}
 
-	if val, ok := stringAttrOk(obj, "retry_mode"); ok {
-		mode, err := aws.ParseRetryMode(val)
-		if err != nil {
-			panic(fmt.Sprintf("invalid retry mode %q: %s", val, err))
-		}
-		cfg.RetryMode = mode
-	}
-
+	ctx := context.TODO()
 	_, awsConfig, awsDiags := awsbase.GetAwsConfig(ctx, cfg)
 
 	for _, d := range awsDiags {

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -443,7 +443,7 @@ func (b *Backend) ConfigSchema(context.Context) *configschema.Block {
 // configuration, and inserts any missing defaults, assuming that its
 // structure has already been validated per the schema returned by
 // ConfigSchema.
-func (b *Backend) PrepareConfig(ctx context.Context, obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
+func (b *Backend) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	if obj.IsNull() {
 		return obj, diags

--- a/internal/backend/remote-state/s3/backend_complete_test.go
+++ b/internal/backend/remote-state/s3/backend_complete_test.go
@@ -46,7 +46,7 @@ func ExpectDiagsEqual(expected tfdiags.Diagnostics) diagsValidator {
 
 type diagsValidator func(*testing.T, tfdiags.Diagnostics)
 
-// ExpectDiagsMatching returns a validator expecting a single Diagnostic with fields matching the expectation
+// ExpectDiagsMatching returns a validator expeceting a single Diagnostic with fields matching the expectation
 func ExpectDiagsMatching(severity tfdiags.Severity, summary matcher, detail matcher) diagsValidator {
 	return func(t *testing.T, diags tfdiags.Diagnostics) {
 		for _, d := range diags {
@@ -2208,9 +2208,7 @@ func setSharedConfigFile(filename string) {
 
 func configureBackend(t *testing.T, config map[string]any) (*Backend, tfdiags.Diagnostics) {
 	b := New().(*Backend)
-	ctx := context.Background()
-
-	configSchema := populateSchema(t, b.ConfigSchema(ctx), hcl2shim.HCL2ValueFromConfigValue(config))
+	configSchema := populateSchema(t, b.ConfigSchema(), hcl2shim.HCL2ValueFromConfigValue(config))
 
 	configSchema, diags := b.PrepareConfig(configSchema)
 

--- a/internal/backend/remote-state/s3/backend_complete_test.go
+++ b/internal/backend/remote-state/s3/backend_complete_test.go
@@ -2212,7 +2212,7 @@ func configureBackend(t *testing.T, config map[string]any) (*Backend, tfdiags.Di
 
 	configSchema := populateSchema(t, b.ConfigSchema(ctx), hcl2shim.HCL2ValueFromConfigValue(config))
 
-	configSchema, diags := b.PrepareConfig(ctx, configSchema)
+	configSchema, diags := b.PrepareConfig(configSchema)
 
 	if diags.HasErrors() {
 		return b, diags

--- a/internal/backend/remote-state/s3/backend_complete_test.go
+++ b/internal/backend/remote-state/s3/backend_complete_test.go
@@ -2218,7 +2218,7 @@ func configureBackend(t *testing.T, config map[string]any) (*Backend, tfdiags.Di
 		return b, diags
 	}
 
-	confDiags := b.Configure(ctx, configSchema)
+	confDiags := b.Configure(configSchema)
 	diags = diags.Append(confDiags)
 
 	return b, diags

--- a/internal/backend/remote-state/s3/backend_state.go
+++ b/internal/backend/remote-state/s3/backend_state.go
@@ -185,7 +185,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 		// Grab the value
 		// This is to ensure that no one beat us to writing a state between
 		// the `exists` check and taking the lock.
-		if err := stateMgr.RefreshState(ctx); err != nil {
+		if err := stateMgr.RefreshState(); err != nil {
 			err = lockUnlock(err)
 			return nil, err
 		}
@@ -196,7 +196,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 				err = lockUnlock(err)
 				return nil, err
 			}
-			if err := stateMgr.PersistState(ctx, nil); err != nil {
+			if err := stateMgr.PersistState(nil); err != nil {
 				err = lockUnlock(err)
 				return nil, err
 			}

--- a/internal/backend/remote-state/s3/backend_state.go
+++ b/internal/backend/remote-state/s3/backend_state.go
@@ -102,7 +102,7 @@ func (b *Backend) keyEnv(key string) string {
 	return parts[0]
 }
 
-func (b *Backend) DeleteWorkspace(ctx context.Context, name string, _ bool) error {
+func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	if name == backend.DefaultStateName || name == "" {
 		return fmt.Errorf("can't delete default state")
 	}
@@ -112,7 +112,7 @@ func (b *Backend) DeleteWorkspace(ctx context.Context, name string, _ bool) erro
 		return err
 	}
 
-	return client.Delete(ctx)
+	return client.Delete()
 }
 
 // get a remote client configured for this state

--- a/internal/backend/remote-state/s3/backend_state.go
+++ b/internal/backend/remote-state/s3/backend_state.go
@@ -21,7 +21,7 @@ import (
 	"github.com/opentofu/opentofu/internal/states/statemgr"
 )
 
-func (b *Backend) Workspaces(ctx context.Context) ([]string, error) {
+func (b *Backend) Workspaces() ([]string, error) {
 	const maxKeys = 1000
 
 	prefix := ""
@@ -39,6 +39,7 @@ func (b *Backend) Workspaces(ctx context.Context) ([]string, error) {
 	wss := []string{backend.DefaultStateName}
 	pg := s3.NewListObjectsV2Paginator(b.s3Client, params)
 
+	ctx := context.TODO()
 	for pg.HasMorePages() {
 		page, err := pg.NextPage(ctx)
 		if err != nil {
@@ -151,7 +152,7 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 	// If we need to force-unlock, but for some reason the state no longer
 	// exists, the user will have to use aws tools to manually fix the
 	// situation.
-	existing, err := b.Workspaces(ctx)
+	existing, err := b.Workspaces()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/remote-state/s3/backend_state.go
+++ b/internal/backend/remote-state/s3/backend_state.go
@@ -137,7 +137,7 @@ func (b *Backend) remoteClient(name string) (*RemoteClient, error) {
 	return client, nil
 }
 
-func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {
+func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	client, err := b.remoteClient(name)
 	if err != nil {
 		return nil, err

--- a/internal/backend/remote-state/s3/backend_state.go
+++ b/internal/backend/remote-state/s3/backend_state.go
@@ -169,14 +169,14 @@ func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, err
 		// take a lock on this state while we write it
 		lockInfo := statemgr.NewLockInfo()
 		lockInfo.Operation = "init"
-		lockId, err := client.Lock(ctx, lockInfo)
+		lockId, err := client.Lock(lockInfo)
 		if err != nil {
 			return nil, fmt.Errorf("failed to lock s3 state: %w", err)
 		}
 
 		// Local helper function so we can call it multiple places
 		lockUnlock := func(parent error) error {
-			if err := stateMgr.Unlock(ctx, lockId); err != nil {
+			if err := stateMgr.Unlock(lockId); err != nil {
 				return fmt.Errorf(strings.TrimSpace(errStateUnlock), lockId, err)
 			}
 			return parent

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -829,9 +829,7 @@ func TestBackendConfig_PrepareConfigValidationWarnings(t *testing.T) {
 
 			b := New()
 
-			ctx := context.Background()
-
-			_, diags := b.PrepareConfig(ctx, populateSchema(t, b.ConfigSchema(ctx), tc.config))
+			_, diags := b.PrepareConfig(populateSchema(t, b.ConfigSchema(), tc.config))
 			if tc.expectedWarn != "" {
 				if err := diags.ErrWithWarnings(); err != nil {
 					if !strings.Contains(err.Error(), tc.expectedWarn) {

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -127,11 +127,9 @@ func TestBackendConfig_InvalidRegion(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		ctx := context.Background()
-
 		t.Run(name, func(t *testing.T) {
 			b := New()
-			configSchema := populateSchema(t, b.ConfigSchema(ctx), hcl2shim.HCL2ValueFromConfigValue(tc.config))
+			configSchema := populateSchema(t, b.ConfigSchema(), hcl2shim.HCL2ValueFromConfigValue(tc.config))
 
 			configSchema, diags := b.PrepareConfig(configSchema)
 			if len(diags) > 0 {
@@ -367,10 +365,8 @@ func TestBackendConfig_STSEndpoint(t *testing.T) {
 				config["sts_endpoint"] = endpoint
 			}
 
-			ctx := context.Background()
-
 			b := New()
-			configSchema := populateSchema(t, b.ConfigSchema(ctx), hcl2shim.HCL2ValueFromConfigValue(config))
+			configSchema := populateSchema(t, b.ConfigSchema(), hcl2shim.HCL2ValueFromConfigValue(config))
 
 			configSchema, diags := b.PrepareConfig(configSchema)
 			if len(diags) > 0 {
@@ -602,15 +598,13 @@ func TestBackendConfig_AssumeRole(t *testing.T) {
 		testCase := testCase
 
 		t.Run(testCase.Description, func(t *testing.T) {
-			ctx := context.Background()
-
 			closeSts, _, endpoint := mockdata.GetMockedAwsApiSession("STS", testCase.MockStsEndpoints)
 			defer closeSts()
 
 			testCase.Config["sts_endpoint"] = endpoint
 
 			b := New()
-			diags := b.Configure(populateSchema(t, b.ConfigSchema(ctx), hcl2shim.HCL2ValueFromConfigValue(testCase.Config)))
+			diags := b.Configure(populateSchema(t, b.ConfigSchema(), hcl2shim.HCL2ValueFromConfigValue(testCase.Config)))
 
 			if diags.HasErrors() {
 				for _, diag := range diags {
@@ -795,9 +789,7 @@ func TestBackendConfig_PrepareConfigValidation(t *testing.T) {
 
 			b := New()
 
-			ctx := context.Background()
-
-			_, valDiags := b.PrepareConfig(populateSchema(t, b.ConfigSchema(ctx), tc.config))
+			_, valDiags := b.PrepareConfig(populateSchema(t, b.ConfigSchema(), tc.config))
 			if tc.expectedErr != "" {
 				if valDiags.Err() != nil {
 					actualErr := valDiags.Err().Error()
@@ -907,9 +899,7 @@ func TestBackendConfig_PrepareConfigWithEnvVars(t *testing.T) {
 				os.Setenv(k, v)
 			}
 
-			ctx := context.Background()
-
-			_, valDiags := b.PrepareConfig(populateSchema(t, b.ConfigSchema(ctx), tc.config))
+			_, valDiags := b.PrepareConfig(populateSchema(t, b.ConfigSchema(), tc.config))
 			if tc.expectedErr != "" {
 				if valDiags.Err() != nil {
 					actualErr := valDiags.Err().Error()
@@ -1012,9 +1002,7 @@ func TestBackendSSECustomerKeyConfig(t *testing.T) {
 			}
 
 			b := New().(*Backend)
-			ctx := context.Background()
-
-			diags := b.Configure(populateSchema(t, b.ConfigSchema(ctx), hcl2shim.HCL2ValueFromConfigValue(config)))
+			diags := b.Configure(populateSchema(t, b.ConfigSchema(), hcl2shim.HCL2ValueFromConfigValue(config)))
 
 			if testCase.expectedErr != "" {
 				if diags.Err() != nil {
@@ -1081,9 +1069,7 @@ func TestBackendSSECustomerKeyEnvVar(t *testing.T) {
 			})
 
 			b := New().(*Backend)
-			ctx := context.Background()
-
-			diags := b.Configure(populateSchema(t, b.ConfigSchema(ctx), hcl2shim.HCL2ValueFromConfigValue(config)))
+			diags := b.Configure(populateSchema(t, b.ConfigSchema(), hcl2shim.HCL2ValueFromConfigValue(config)))
 
 			if testCase.expectedErr != "" {
 				if diags.Err() != nil {

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -138,7 +138,7 @@ func TestBackendConfig_InvalidRegion(t *testing.T) {
 				t.Fatal(diags.ErrWithWarnings())
 			}
 
-			confDiags := b.Configure(ctx, configSchema)
+			confDiags := b.Configure(configSchema)
 			diags = diags.Append(confDiags)
 
 			if diff := cmp.Diff(diags, tc.expectedDiags, cmp.Comparer(diagnosticComparer)); diff != "" {
@@ -377,7 +377,7 @@ func TestBackendConfig_STSEndpoint(t *testing.T) {
 				t.Fatal(diags.ErrWithWarnings())
 			}
 
-			confDiags := b.Configure(ctx, configSchema)
+			confDiags := b.Configure(configSchema)
 			diags = diags.Append(confDiags)
 
 			if diff := cmp.Diff(diags, tc.expectedDiags, cmp.Comparer(diagnosticSummaryComparer)); diff != "" {
@@ -610,7 +610,7 @@ func TestBackendConfig_AssumeRole(t *testing.T) {
 			testCase.Config["sts_endpoint"] = endpoint
 
 			b := New()
-			diags := b.Configure(ctx, populateSchema(t, b.ConfigSchema(ctx), hcl2shim.HCL2ValueFromConfigValue(testCase.Config)))
+			diags := b.Configure(populateSchema(t, b.ConfigSchema(ctx), hcl2shim.HCL2ValueFromConfigValue(testCase.Config)))
 
 			if diags.HasErrors() {
 				for _, diag := range diags {
@@ -1014,7 +1014,7 @@ func TestBackendSSECustomerKeyConfig(t *testing.T) {
 			b := New().(*Backend)
 			ctx := context.Background()
 
-			diags := b.Configure(ctx, populateSchema(t, b.ConfigSchema(ctx), hcl2shim.HCL2ValueFromConfigValue(config)))
+			diags := b.Configure(populateSchema(t, b.ConfigSchema(ctx), hcl2shim.HCL2ValueFromConfigValue(config)))
 
 			if testCase.expectedErr != "" {
 				if diags.Err() != nil {
@@ -1083,7 +1083,7 @@ func TestBackendSSECustomerKeyEnvVar(t *testing.T) {
 			b := New().(*Backend)
 			ctx := context.Background()
 
-			diags := b.Configure(ctx, populateSchema(t, b.ConfigSchema(ctx), hcl2shim.HCL2ValueFromConfigValue(config)))
+			diags := b.Configure(populateSchema(t, b.ConfigSchema(ctx), hcl2shim.HCL2ValueFromConfigValue(config)))
 
 			if testCase.expectedErr != "" {
 				if diags.Err() != nil {

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -1149,7 +1149,7 @@ func TestBackendExtraPaths(t *testing.T) {
 	if err := stateMgr.WriteState(s1); err != nil {
 		t.Fatal(err)
 	}
-	if err := stateMgr.PersistState(ctx, nil); err != nil {
+	if err := stateMgr.PersistState(nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1161,7 +1161,7 @@ func TestBackendExtraPaths(t *testing.T) {
 	if err := stateMgr2.WriteState(s2); err != nil {
 		t.Fatal(err)
 	}
-	if err := stateMgr2.PersistState(ctx, nil); err != nil {
+	if err := stateMgr2.PersistState(nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1176,7 +1176,7 @@ func TestBackendExtraPaths(t *testing.T) {
 	if err := stateMgr.WriteState(states.NewState()); err != nil {
 		t.Fatal(err)
 	}
-	if err := stateMgr.PersistState(ctx, nil); err != nil {
+	if err := stateMgr.PersistState(nil); err != nil {
 		t.Fatal(err)
 	}
 	if err := checkStateList(b, []string{"default", "s1", "s2"}); err != nil {
@@ -1188,7 +1188,7 @@ func TestBackendExtraPaths(t *testing.T) {
 	if err := stateMgr.WriteState(states.NewState()); err != nil {
 		t.Fatal(err)
 	}
-	if err := stateMgr.PersistState(ctx, nil); err != nil {
+	if err := stateMgr.PersistState(nil); err != nil {
 		t.Fatal(err)
 	}
 	if err := checkStateList(b, []string{"default", "s1", "s2"}); err != nil {
@@ -1214,7 +1214,7 @@ func TestBackendExtraPaths(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s2Mgr.RefreshState(ctx); err != nil {
+	if err := s2Mgr.RefreshState(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1229,7 +1229,7 @@ func TestBackendExtraPaths(t *testing.T) {
 	if err := stateMgr.WriteState(states.NewState()); err != nil {
 		t.Fatal(err)
 	}
-	if err := stateMgr.PersistState(ctx, nil); err != nil {
+	if err := stateMgr.PersistState(nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1238,7 +1238,7 @@ func TestBackendExtraPaths(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s2Mgr.RefreshState(ctx); err != nil {
+	if err := s2Mgr.RefreshState(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1272,7 +1272,7 @@ func TestBackendPrefixInWorkspace(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := sMgr.RefreshState(ctx); err != nil {
+	if err := sMgr.RefreshState(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -133,7 +133,7 @@ func TestBackendConfig_InvalidRegion(t *testing.T) {
 			b := New()
 			configSchema := populateSchema(t, b.ConfigSchema(ctx), hcl2shim.HCL2ValueFromConfigValue(tc.config))
 
-			configSchema, diags := b.PrepareConfig(ctx, configSchema)
+			configSchema, diags := b.PrepareConfig(configSchema)
 			if len(diags) > 0 {
 				t.Fatal(diags.ErrWithWarnings())
 			}
@@ -372,7 +372,7 @@ func TestBackendConfig_STSEndpoint(t *testing.T) {
 			b := New()
 			configSchema := populateSchema(t, b.ConfigSchema(ctx), hcl2shim.HCL2ValueFromConfigValue(config))
 
-			configSchema, diags := b.PrepareConfig(ctx, configSchema)
+			configSchema, diags := b.PrepareConfig(configSchema)
 			if len(diags) > 0 {
 				t.Fatal(diags.ErrWithWarnings())
 			}
@@ -797,7 +797,7 @@ func TestBackendConfig_PrepareConfigValidation(t *testing.T) {
 
 			ctx := context.Background()
 
-			_, valDiags := b.PrepareConfig(ctx, populateSchema(t, b.ConfigSchema(ctx), tc.config))
+			_, valDiags := b.PrepareConfig(populateSchema(t, b.ConfigSchema(ctx), tc.config))
 			if tc.expectedErr != "" {
 				if valDiags.Err() != nil {
 					actualErr := valDiags.Err().Error()
@@ -909,7 +909,7 @@ func TestBackendConfig_PrepareConfigWithEnvVars(t *testing.T) {
 
 			ctx := context.Background()
 
-			_, valDiags := b.PrepareConfig(ctx, populateSchema(t, b.ConfigSchema(ctx), tc.config))
+			_, valDiags := b.PrepareConfig(populateSchema(t, b.ConfigSchema(ctx), tc.config))
 			if tc.expectedErr != "" {
 				if valDiags.Err() != nil {
 					actualErr := valDiags.Err().Error()

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -1210,7 +1210,7 @@ func TestBackendExtraPaths(t *testing.T) {
 	}
 
 	// fetch that state again, which should produce a new lineage
-	s2Mgr, err := b.StateMgr(ctx, "s2")
+	s2Mgr, err := b.StateMgr("s2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1234,7 +1234,7 @@ func TestBackendExtraPaths(t *testing.T) {
 	}
 
 	// make sure s2 is OK
-	s2Mgr, err = b.StateMgr(ctx, "s2")
+	s2Mgr, err = b.StateMgr("s2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1268,7 +1268,7 @@ func TestBackendPrefixInWorkspace(t *testing.T) {
 	defer deleteS3Bucket(ctx, t, b.s3Client, bucketName)
 
 	// get a state that contains the prefix as a substring
-	sMgr, err := b.StateMgr(ctx, "env-1")
+	sMgr, err := b.StateMgr("env-1")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -1196,12 +1196,12 @@ func TestBackendExtraPaths(t *testing.T) {
 	}
 
 	// remove the state with extra subkey
-	if err := client.Delete(ctx); err != nil {
+	if err := client.Delete(); err != nil {
 		t.Fatal(err)
 	}
 
 	// delete the real workspace
-	if err := b.DeleteWorkspace(ctx, "s2", true); err != nil {
+	if err := b.DeleteWorkspace("s2", true); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -1399,7 +1399,7 @@ func testGetWorkspaceForKey(b *Backend, key string, expected string) error {
 }
 
 func checkStateList(b backend.Backend, expected []string) error {
-	states, err := b.Workspaces(context.Background())
+	states, err := b.Workspaces()
 	if err != nil {
 		return err
 	}

--- a/internal/backend/remote-state/s3/client.go
+++ b/internal/backend/remote-state/s3/client.go
@@ -225,7 +225,7 @@ func (c *RemoteClient) Delete(ctx context.Context) error {
 	return nil
 }
 
-func (c *RemoteClient) Lock(ctx context.Context, info *statemgr.LockInfo) (string, error) {
+func (c *RemoteClient) Lock(info *statemgr.LockInfo) (string, error) {
 	if c.ddbTable == "" {
 		return "", nil
 	}
@@ -250,6 +250,7 @@ func (c *RemoteClient) Lock(ctx context.Context, info *statemgr.LockInfo) (strin
 		ConditionExpression: aws.String("attribute_not_exists(LockID)"),
 	}
 
+	ctx := context.TODO()
 	_, err := c.dynClient.PutItem(ctx, putParams)
 	if err != nil {
 		lockInfo, infoErr := c.getLockInfo(ctx)
@@ -375,12 +376,13 @@ func (c *RemoteClient) getLockInfo(ctx context.Context) (*statemgr.LockInfo, err
 	return lockInfo, nil
 }
 
-func (c *RemoteClient) Unlock(ctx context.Context, id string) error {
+func (c *RemoteClient) Unlock(id string) error {
 	if c.ddbTable == "" {
 		return nil
 	}
 
 	lockErr := &statemgr.LockError{}
+	ctx := context.TODO()
 
 	// TODO: store the path and lock ID in separate fields, and have proper
 	// projection expression only delete the lock if both match, rather than

--- a/internal/backend/remote-state/s3/client.go
+++ b/internal/backend/remote-state/s3/client.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	dtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -61,7 +60,8 @@ var (
 // test hook called when checksums don't match
 var testChecksumHook func()
 
-func (c *RemoteClient) Get(ctx context.Context) (payload *remote.Payload, err error) {
+func (c *RemoteClient) Get() (payload *remote.Payload, err error) {
+	ctx := context.TODO()
 	deadline := time.Now().Add(consistencyRetryTimeout)
 
 	// If we have a checksum, and the returned payload doesn't match, we retry
@@ -156,7 +156,7 @@ func (c *RemoteClient) get(ctx context.Context) (*remote.Payload, error) {
 	return payload, nil
 }
 
-func (c *RemoteClient) Put(ctx context.Context, data []byte) error {
+func (c *RemoteClient) Put(data []byte) error {
 	contentType := "application/json"
 	contentLength := int64(len(data))
 
@@ -191,8 +191,8 @@ func (c *RemoteClient) Put(ctx context.Context, data []byte) error {
 
 	log.Printf("[DEBUG] Uploading remote state to S3: %#v", i)
 
-	uploader := manager.NewUploader(c.s3Client, nil)
-	_, err := uploader.Upload(ctx, i)
+	ctx := context.TODO()
+	_, err := c.s3Client.PutObject(ctx, i)
 	if err != nil {
 		return fmt.Errorf("failed to upload state: %w", err)
 	}

--- a/internal/backend/remote-state/s3/client.go
+++ b/internal/backend/remote-state/s3/client.go
@@ -208,7 +208,8 @@ func (c *RemoteClient) Put(data []byte) error {
 	return nil
 }
 
-func (c *RemoteClient) Delete(ctx context.Context) error {
+func (c *RemoteClient) Delete() error {
+	ctx := context.TODO()
 	_, err := c.s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: &c.bucketName,
 		Key:    &c.path,

--- a/internal/backend/remote-state/s3/client_test.go
+++ b/internal/backend/remote-state/s3/client_test.go
@@ -104,7 +104,7 @@ func TestForceUnlock(t *testing.T) {
 		"dynamodb_table": bucketName,
 	})).(*Backend)
 
-	ctx := context.Background()
+	ctx := context.TODO()
 	createS3Bucket(ctx, t, b1.s3Client, bucketName, b1.awsConfig.Region)
 	defer deleteS3Bucket(ctx, t, b1.s3Client, bucketName)
 	createDynamoDBTable(ctx, t, b1.dynClient, bucketName)
@@ -120,7 +120,7 @@ func TestForceUnlock(t *testing.T) {
 	info.Operation = "test"
 	info.Who = "clientA"
 
-	lockID, err := s1.Lock(ctx, info)
+	lockID, err := s1.Lock(info)
 	if err != nil {
 		t.Fatal("unable to get initial lock:", err)
 	}
@@ -131,7 +131,7 @@ func TestForceUnlock(t *testing.T) {
 		t.Fatal("failed to get default state to force unlock:", err)
 	}
 
-	if err := s2.Unlock(ctx, lockID); err != nil {
+	if err := s2.Unlock(lockID); err != nil {
 		t.Fatal("failed to force-unlock default state")
 	}
 
@@ -146,7 +146,7 @@ func TestForceUnlock(t *testing.T) {
 	info.Operation = "test"
 	info.Who = "clientA"
 
-	lockID, err = s1.Lock(ctx, info)
+	lockID, err = s1.Lock(info)
 	if err != nil {
 		t.Fatal("unable to get initial lock:", err)
 	}
@@ -157,7 +157,7 @@ func TestForceUnlock(t *testing.T) {
 		t.Fatal("failed to get named state to force unlock:", err)
 	}
 
-	if err = s2.Unlock(ctx, lockID); err != nil {
+	if err = s2.Unlock(lockID); err != nil {
 		t.Fatal("failed to force-unlock named state")
 	}
 }

--- a/internal/backend/remote-state/s3/client_test.go
+++ b/internal/backend/remote-state/s3/client_test.go
@@ -261,22 +261,22 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 	client2 := s2.(*remote.State).Client
 
 	// write the new state through client2 so that there is no checksum yet
-	if err := client2.Put(ctx, newState.Bytes()); err != nil {
+	if err := client2.Put(newState.Bytes()); err != nil {
 		t.Fatal(err)
 	}
 
 	// verify that we can pull a state without a checksum
-	if _, err := client1.Get(ctx); err != nil {
+	if _, err := client1.Get(); err != nil {
 		t.Fatal(err)
 	}
 
 	// write the new state back with its checksum
-	if err := client1.Put(ctx, newState.Bytes()); err != nil {
+	if err := client1.Put(newState.Bytes()); err != nil {
 		t.Fatal(err)
 	}
 
 	// put an empty state in place to check for panics during get
-	if err := client2.Put(ctx, []byte{}); err != nil {
+	if err := client2.Put([]byte{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -292,24 +292,24 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 
 	// fetching an empty state through client1 should now error out due to a
 	// mismatched checksum.
-	if _, err := client1.Get(ctx); !strings.HasPrefix(err.Error(), errBadChecksumFmt[:80]) {
+	if _, err := client1.Get(); !strings.HasPrefix(err.Error(), errBadChecksumFmt[:80]) {
 		t.Fatalf("expected state checksum error: got %s", err)
 	}
 
 	// put the old state in place of the new, without updating the checksum
-	if err := client2.Put(ctx, oldState.Bytes()); err != nil {
+	if err := client2.Put(oldState.Bytes()); err != nil {
 		t.Fatal(err)
 	}
 
 	// fetching the wrong state through client1 should now error out due to a
 	// mismatched checksum.
-	if _, err := client1.Get(ctx); !strings.HasPrefix(err.Error(), errBadChecksumFmt[:80]) {
+	if _, err := client1.Get(); !strings.HasPrefix(err.Error(), errBadChecksumFmt[:80]) {
 		t.Fatalf("expected state checksum error: got %s", err)
 	}
 
 	// update the state with the correct one after we Get again
 	testChecksumHook = func() {
-		if err := client2.Put(ctx, newState.Bytes()); err != nil {
+		if err := client2.Put(newState.Bytes()); err != nil {
 			t.Fatal(err)
 		}
 		testChecksumHook = nil
@@ -320,7 +320,7 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 	// this final Get will fail to fail the checksum verification, the above
 	// callback will update the state with the correct version, and Get should
 	// retry automatically.
-	if _, err := client1.Get(ctx); err != nil {
+	if _, err := client1.Get(); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/backend/remote-state/s3/client_test.go
+++ b/internal/backend/remote-state/s3/client_test.go
@@ -34,11 +34,11 @@ func TestRemoteClient(t *testing.T) {
 		"encrypt": true,
 	})).(*Backend)
 
-	ctx := context.Background()
+	ctx := context.TODO()
 	createS3Bucket(ctx, t, b.s3Client, bucketName, b.awsConfig.Region)
 	defer deleteS3Bucket(ctx, t, b.s3Client, bucketName)
 
-	state, err := b.StateMgr(ctx, backend.DefaultStateName)
+	state, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,12 +71,12 @@ func TestRemoteClientLocks(t *testing.T) {
 	createDynamoDBTable(ctx, t, b1.dynClient, bucketName)
 	defer deleteDynamoDBTable(ctx, t, b1.dynClient, bucketName)
 
-	s1, err := b1.StateMgr(ctx, backend.DefaultStateName)
+	s1, err := b1.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	s2, err := b2.StateMgr(ctx, backend.DefaultStateName)
+	s2, err := b2.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +111,7 @@ func TestForceUnlock(t *testing.T) {
 	defer deleteDynamoDBTable(ctx, t, b1.dynClient, bucketName)
 
 	// first test with default
-	s1, err := b1.StateMgr(ctx, backend.DefaultStateName)
+	s1, err := b1.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,7 +126,7 @@ func TestForceUnlock(t *testing.T) {
 	}
 
 	// s1 is now locked, get the same state through s2 and unlock it
-	s2, err := b2.StateMgr(ctx, backend.DefaultStateName)
+	s2, err := b2.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal("failed to get default state to force unlock:", err)
 	}
@@ -137,7 +137,7 @@ func TestForceUnlock(t *testing.T) {
 
 	// now try the same thing with a named state
 	// first test with default
-	s1, err = b1.StateMgr(ctx, "test")
+	s1, err = b1.StateMgr("test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -152,7 +152,7 @@ func TestForceUnlock(t *testing.T) {
 	}
 
 	// s1 is now locked, get the same state through s2 and unlock it
-	s2, err = b2.StateMgr(ctx, "test")
+	s2, err = b2.StateMgr("test")
 	if err != nil {
 		t.Fatal("failed to get named state to force unlock:", err)
 	}
@@ -180,7 +180,7 @@ func TestRemoteClient_clientMD5(t *testing.T) {
 	createDynamoDBTable(ctx, t, b.dynClient, bucketName)
 	defer deleteDynamoDBTable(ctx, t, b.dynClient, bucketName)
 
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -229,7 +229,7 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 	createDynamoDBTable(ctx, t, b1.dynClient, bucketName)
 	defer deleteDynamoDBTable(ctx, t, b1.dynClient, bucketName)
 
-	s1, err := b1.StateMgr(ctx, backend.DefaultStateName)
+	s1, err := b1.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -254,7 +254,7 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 		"bucket": bucketName,
 		"key":    keyName,
 	})).(*Backend)
-	s2, err := b2.StateMgr(ctx, backend.DefaultStateName)
+	s2, err := b2.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -613,7 +613,7 @@ func (b *Remote) WorkspaceNamePattern() string {
 }
 
 // DeleteWorkspace implements backend.Enhanced.
-func (b *Remote) DeleteWorkspace(ctx context.Context, name string, _ bool) error {
+func (b *Remote) DeleteWorkspace(name string, _ bool) error {
 	if b.workspace == "" && name == backend.DefaultStateName {
 		return backend.ErrDefaultWorkspaceNotSupported
 	}
@@ -637,7 +637,7 @@ func (b *Remote) DeleteWorkspace(ctx context.Context, name string, _ bool) error
 		},
 	}
 
-	return client.Delete(ctx)
+	return client.Delete()
 }
 
 // StateMgr implements backend.Enhanced.

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -221,7 +221,7 @@ func (b *Remote) ServiceDiscoveryAliases() ([]backend.HostAlias, error) {
 }
 
 // Configure implements backend.Enhanced.
-func (b *Remote) Configure(ctx context.Context, obj cty.Value) tfdiags.Diagnostics {
+func (b *Remote) Configure(obj cty.Value) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 	if obj.IsNull() {
 		return diags
@@ -353,7 +353,7 @@ func (b *Remote) Configure(ctx context.Context, obj cty.Value) tfdiags.Diagnosti
 	}
 
 	// Check if the organization exists by reading its entitlements.
-	entitlements, err := b.client.Organizations.ReadEntitlements(ctx, b.organization)
+	entitlements, err := b.client.Organizations.ReadEntitlements(context.Background(), b.organization)
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			err = fmt.Errorf("organization %q at host %s not found.\n\n"+

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -550,15 +550,15 @@ func (b *Remote) retryLogHook(attemptNum int, resp *http.Response) {
 }
 
 // Workspaces implements backend.Enhanced.
-func (b *Remote) Workspaces(ctx context.Context) ([]string, error) {
+func (b *Remote) Workspaces() ([]string, error) {
 	if b.prefix == "" {
 		return nil, backend.ErrWorkspacesNotSupported
 	}
-	return b.workspaces(ctx)
+	return b.workspaces()
 }
 
 // workspaces returns a filtered list of remote workspace names.
-func (b *Remote) workspaces(ctx context.Context) ([]string, error) {
+func (b *Remote) workspaces() ([]string, error) {
 	options := &tfe.WorkspaceListOptions{}
 	switch {
 	case b.workspace != "":
@@ -571,7 +571,7 @@ func (b *Remote) workspaces(ctx context.Context) ([]string, error) {
 	var names []string
 
 	for {
-		wl, err := b.client.Workspaces.List(ctx, b.organization, options)
+		wl, err := b.client.Workspaces.List(context.Background(), b.organization, options)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -923,10 +923,10 @@ func (b *Remote) IgnoreVersionConflict() {
 // that there are no compatibility concerns, so it returns no diagnostics.
 //
 // If the versions differ,
-func (b *Remote) VerifyWorkspaceTerraformVersion(ctx context.Context, workspaceName string) tfdiags.Diagnostics {
+func (b *Remote) VerifyWorkspaceTerraformVersion(workspaceName string) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
-	workspace, err := b.getRemoteWorkspace(ctx, workspaceName)
+	workspace, err := b.getRemoteWorkspace(context.Background(), workspaceName)
 	if err != nil {
 		// If the workspace doesn't exist, there can be no compatibility
 		// problem, so we can return. This is most likely to happen when

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -641,7 +641,7 @@ func (b *Remote) DeleteWorkspace(name string, _ bool) error {
 }
 
 // StateMgr implements backend.Enhanced.
-func (b *Remote) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {
+func (b *Remote) StateMgr(name string) (statemgr.Full, error) {
 	if b.workspace == "" && name == backend.DefaultStateName {
 		return nil, backend.ErrDefaultWorkspaceNotSupported
 	}
@@ -657,7 +657,7 @@ func (b *Remote) StateMgr(ctx context.Context, name string) (statemgr.Full, erro
 		name = b.prefix + name
 	}
 
-	workspace, err := b.client.Workspaces.Read(ctx, b.organization, name)
+	workspace, err := b.client.Workspaces.Read(context.Background(), b.organization, name)
 	if err != nil && err != tfe.ErrResourceNotFound {
 		return nil, fmt.Errorf("Failed to retrieve workspace %s: %w", name, err)
 	}
@@ -673,7 +673,7 @@ func (b *Remote) StateMgr(ctx context.Context, name string) (statemgr.Full, erro
 			options.TerraformVersion = tfe.String(tfversion.String())
 		}
 
-		workspace, err = b.client.Workspaces.Create(ctx, b.organization, options)
+		workspace, err = b.client.Workspaces.Create(context.Background(), b.organization, options)
 		if err != nil {
 			return nil, fmt.Errorf("Error creating workspace %s: %w", name, err)
 		}

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -150,7 +150,7 @@ func (b *Remote) ConfigSchema(context.Context) *configschema.Block {
 }
 
 // PrepareConfig implements backend.Backend.
-func (b *Remote) PrepareConfig(ctx context.Context, obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
+func (b *Remote) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	if obj.IsNull() {
 		return obj, diags

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -107,7 +107,7 @@ func New(services *disco.Disco) *Remote {
 }
 
 // ConfigSchema implements backend.Enhanced.
-func (b *Remote) ConfigSchema(context.Context) *configschema.Block {
+func (b *Remote) ConfigSchema() *configschema.Block {
 	return &configschema.Block{
 		Attributes: map[string]*configschema.Attribute{
 			"hostname": {

--- a/internal/backend/remote/backend_apply_test.go
+++ b/internal/backend/remote/backend_apply_test.go
@@ -81,9 +81,7 @@ func TestRemote_applyBasic(t *testing.T) {
 	op.UIOut = b.CLI
 	op.Workspace = backend.DefaultStateName
 
-	ctx := context.Background()
-
-	run, err := b.Operation(ctx, op)
+	run, err := b.Operation(context.Background(), op)
 	if err != nil {
 		t.Fatalf("error starting operation: %v", err)
 	}
@@ -111,7 +109,7 @@ func TestRemote_applyBasic(t *testing.T) {
 		t.Fatalf("expected apply summery in output: %s", output)
 	}
 
-	stateMgr, _ := b.StateMgr(ctx, backend.DefaultStateName)
+	stateMgr, _ := b.StateMgr(backend.DefaultStateName)
 	// An error suggests that the state was not unlocked after apply
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after apply: %s", err.Error())
@@ -128,9 +126,7 @@ func TestRemote_applyCanceled(t *testing.T) {
 
 	op.Workspace = backend.DefaultStateName
 
-	ctx := context.Background()
-
-	run, err := b.Operation(ctx, op)
+	run, err := b.Operation(context.Background(), op)
 	if err != nil {
 		t.Fatalf("error starting operation: %v", err)
 	}
@@ -143,7 +139,7 @@ func TestRemote_applyCanceled(t *testing.T) {
 		t.Fatal("expected apply operation to fail")
 	}
 
-	stateMgr, _ := b.StateMgr(ctx, backend.DefaultStateName)
+	stateMgr, _ := b.StateMgr(backend.DefaultStateName)
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after cancelling apply: %s", err.Error())
 	}
@@ -613,8 +609,7 @@ func TestRemote_applyNoConfig(t *testing.T) {
 
 	op.Workspace = backend.DefaultStateName
 
-	ctx := context.Background()
-	run, err := b.Operation(ctx, op)
+	run, err := b.Operation(context.Background(), op)
 	if err != nil {
 		t.Fatalf("error starting operation: %v", err)
 	}
@@ -633,7 +628,7 @@ func TestRemote_applyNoConfig(t *testing.T) {
 		t.Fatalf("expected configuration files error, got: %v", errOutput)
 	}
 
-	stateMgr, _ := b.StateMgr(ctx, backend.DefaultStateName)
+	stateMgr, _ := b.StateMgr(backend.DefaultStateName)
 	// An error suggests that the state was not unlocked after apply
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after failed apply: %s", err.Error())

--- a/internal/backend/remote/backend_apply_test.go
+++ b/internal/backend/remote/backend_apply_test.go
@@ -113,7 +113,7 @@ func TestRemote_applyBasic(t *testing.T) {
 
 	stateMgr, _ := b.StateMgr(ctx, backend.DefaultStateName)
 	// An error suggests that the state was not unlocked after apply
-	if _, err := stateMgr.Lock(ctx, statemgr.NewLockInfo()); err != nil {
+	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after apply: %s", err.Error())
 	}
 }
@@ -144,7 +144,7 @@ func TestRemote_applyCanceled(t *testing.T) {
 	}
 
 	stateMgr, _ := b.StateMgr(ctx, backend.DefaultStateName)
-	if _, err := stateMgr.Lock(ctx, statemgr.NewLockInfo()); err != nil {
+	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after cancelling apply: %s", err.Error())
 	}
 }
@@ -635,7 +635,7 @@ func TestRemote_applyNoConfig(t *testing.T) {
 
 	stateMgr, _ := b.StateMgr(ctx, backend.DefaultStateName)
 	// An error suggests that the state was not unlocked after apply
-	if _, err := stateMgr.Lock(ctx, statemgr.NewLockInfo()); err != nil {
+	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after failed apply: %s", err.Error())
 	}
 }

--- a/internal/backend/remote/backend_context.go
+++ b/internal/backend/remote/backend_context.go
@@ -30,12 +30,12 @@ func (b *Remote) LocalRun(op *backend.Operation) (*backend.LocalRun, statemgr.Fu
 		},
 	}
 
-	ctx := context.TODO()
-
-	op.StateLocker = op.StateLocker.WithContext(ctx)
+	op.StateLocker = op.StateLocker.WithContext(context.Background())
 
 	// Get the remote workspace name.
 	remoteWorkspaceName := b.getRemoteWorkspaceName(op.Workspace)
+
+	ctx := context.TODO()
 
 	// Get the latest state.
 	log.Printf("[TRACE] backend/remote: requesting state manager for workspace %q", remoteWorkspaceName)
@@ -97,13 +97,13 @@ func (b *Remote) LocalRun(op *backend.Operation) (*backend.LocalRun, statemgr.Fu
 		// The underlying API expects us to use the opaque workspace id to request
 		// variables, so we'll need to look that up using our organization name
 		// and workspace name.
-		remoteWorkspaceID, err := b.getRemoteWorkspaceID(ctx, op.Workspace)
+		remoteWorkspaceID, err := b.getRemoteWorkspaceID(context.Background(), op.Workspace)
 		if err != nil {
 			diags = diags.Append(fmt.Errorf("error finding remote workspace: %w", err))
 			return nil, nil, diags
 		}
 
-		w, err := b.fetchWorkspace(ctx, b.organization, op.Workspace)
+		w, err := b.fetchWorkspace(context.Background(), b.organization, op.Workspace)
 		if err != nil {
 			diags = diags.Append(fmt.Errorf("error loading workspace: %w", err))
 			return nil, nil, diags
@@ -113,7 +113,7 @@ func (b *Remote) LocalRun(op *backend.Operation) (*backend.LocalRun, statemgr.Fu
 			log.Printf("[TRACE] skipping retrieving variables from workspace %s/%s (%s), workspace is in Local Execution mode", remoteWorkspaceName, b.organization, remoteWorkspaceID)
 		} else {
 			log.Printf("[TRACE] backend/remote: retrieving variables from workspace %s/%s (%s)", remoteWorkspaceName, b.organization, remoteWorkspaceID)
-			tfeVariables, err := b.client.Variables.List(ctx, remoteWorkspaceID, nil)
+			tfeVariables, err := b.client.Variables.List(context.Background(), remoteWorkspaceID, nil)
 			if err != nil && err != tfe.ErrResourceNotFound {
 				diags = diags.Append(fmt.Errorf("error loading variables: %w", err))
 				return nil, nil, diags

--- a/internal/backend/remote/backend_context.go
+++ b/internal/backend/remote/backend_context.go
@@ -59,7 +59,7 @@ func (b *Remote) LocalRun(op *backend.Operation) (*backend.LocalRun, statemgr.Fu
 	}()
 
 	log.Printf("[TRACE] backend/remote: reading remote state for workspace %q", remoteWorkspaceName)
-	if err := stateMgr.RefreshState(ctx); err != nil {
+	if err := stateMgr.RefreshState(); err != nil {
 		diags = diags.Append(fmt.Errorf("error loading state: %w", err))
 		return nil, nil, diags
 	}

--- a/internal/backend/remote/backend_context.go
+++ b/internal/backend/remote/backend_context.go
@@ -35,11 +35,9 @@ func (b *Remote) LocalRun(op *backend.Operation) (*backend.LocalRun, statemgr.Fu
 	// Get the remote workspace name.
 	remoteWorkspaceName := b.getRemoteWorkspaceName(op.Workspace)
 
-	ctx := context.TODO()
-
 	// Get the latest state.
 	log.Printf("[TRACE] backend/remote: requesting state manager for workspace %q", remoteWorkspaceName)
-	stateMgr, err := b.StateMgr(ctx, op.Workspace)
+	stateMgr, err := b.StateMgr(op.Workspace)
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("error loading state: %w", err))
 		return nil, nil, diags

--- a/internal/backend/remote/backend_context_test.go
+++ b/internal/backend/remote/backend_context_test.go
@@ -190,9 +190,7 @@ func TestRemoteContextWithVars(t *testing.T) {
 			_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
 			defer configCleanup()
 
-			ctx := context.Background()
-
-			workspaceID, err := b.getRemoteWorkspaceID(ctx, backend.DefaultStateName)
+			workspaceID, err := b.getRemoteWorkspaceID(context.Background(), backend.DefaultStateName)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -213,6 +211,8 @@ func TestRemoteContextWithVars(t *testing.T) {
 				v.Key = &key
 			}
 
+			ctx := context.Background()
+
 			b.client.Variables.Create(ctx, workspaceID, *v)
 
 			_, _, diags := b.LocalRun(op)
@@ -228,7 +228,7 @@ func TestRemoteContextWithVars(t *testing.T) {
 				// When Context() returns an error, it should unlock the state,
 				// so re-locking it is expected to succeed.
 				stateMgr, _ := b.StateMgr(ctx, backend.DefaultStateName)
-				if _, err := stateMgr.Lock(ctx, statemgr.NewLockInfo()); err != nil {
+				if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 					t.Fatalf("unexpected error locking state: %s", err.Error())
 				}
 			} else {
@@ -237,7 +237,7 @@ func TestRemoteContextWithVars(t *testing.T) {
 				}
 				// When Context() succeeds, this should fail w/ "workspace already locked"
 				stateMgr, _ := b.StateMgr(ctx, backend.DefaultStateName)
-				if _, err := stateMgr.Lock(ctx, statemgr.NewLockInfo()); err == nil {
+				if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err == nil {
 					t.Fatal("unexpected success locking state after Context")
 				}
 			}
@@ -445,7 +445,7 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 			}
 			// When Context() succeeds, this should fail w/ "workspace already locked"
 			stateMgr, _ := b.StateMgr(ctx, backend.DefaultStateName)
-			if _, err := stateMgr.Lock(ctx, statemgr.NewLockInfo()); err == nil {
+			if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err == nil {
 				t.Fatal("unexpected success locking state after Context")
 			}
 

--- a/internal/backend/remote/backend_context_test.go
+++ b/internal/backend/remote/backend_context_test.go
@@ -210,10 +210,7 @@ func TestRemoteContextWithVars(t *testing.T) {
 				key := "key"
 				v.Key = &key
 			}
-
-			ctx := context.Background()
-
-			b.client.Variables.Create(ctx, workspaceID, *v)
+			b.client.Variables.Create(context.TODO(), workspaceID, *v)
 
 			_, _, diags := b.LocalRun(op)
 
@@ -227,7 +224,7 @@ func TestRemoteContextWithVars(t *testing.T) {
 				}
 				// When Context() returns an error, it should unlock the state,
 				// so re-locking it is expected to succeed.
-				stateMgr, _ := b.StateMgr(ctx, backend.DefaultStateName)
+				stateMgr, _ := b.StateMgr(backend.DefaultStateName)
 				if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 					t.Fatalf("unexpected error locking state: %s", err.Error())
 				}
@@ -236,7 +233,7 @@ func TestRemoteContextWithVars(t *testing.T) {
 					t.Fatalf("unexpected error\ngot:  %s\nwant: <no error>", diags.Err().Error())
 				}
 				// When Context() succeeds, this should fail w/ "workspace already locked"
-				stateMgr, _ := b.StateMgr(ctx, backend.DefaultStateName)
+				stateMgr, _ := b.StateMgr(backend.DefaultStateName)
 				if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err == nil {
 					t.Fatal("unexpected success locking state after Context")
 				}
@@ -432,10 +429,8 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 				Variables:    test.localVariables,
 			}
 
-			ctx := context.Background()
-
 			for _, v := range test.remoteVariables {
-				b.client.Variables.Create(ctx, workspaceID, *v)
+				b.client.Variables.Create(context.TODO(), workspaceID, *v)
 			}
 
 			lr, _, diags := b.LocalRun(op)
@@ -444,7 +439,7 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 				t.Fatalf("unexpected error\ngot:  %s\nwant: <no error>", diags.Err().Error())
 			}
 			// When Context() succeeds, this should fail w/ "workspace already locked"
-			stateMgr, _ := b.StateMgr(ctx, backend.DefaultStateName)
+			stateMgr, _ := b.StateMgr(backend.DefaultStateName)
 			if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err == nil {
 				t.Fatal("unexpected success locking state after Context")
 			}

--- a/internal/backend/remote/backend_plan_test.go
+++ b/internal/backend/remote/backend_plan_test.go
@@ -98,7 +98,7 @@ func TestRemote_planBasic(t *testing.T) {
 
 	stateMgr, _ := b.StateMgr(ctx, backend.DefaultStateName)
 	// An error suggests that the state was not unlocked after the operation finished
-	if _, err := stateMgr.Lock(ctx, statemgr.NewLockInfo()); err != nil {
+	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after successful plan: %s", err.Error())
 	}
 }
@@ -130,7 +130,7 @@ func TestRemote_planCanceled(t *testing.T) {
 
 	stateMgr, _ := b.StateMgr(ctx, backend.DefaultStateName)
 	// An error suggests that the state was not unlocked after the operation finished
-	if _, err := stateMgr.Lock(ctx, statemgr.NewLockInfo()); err != nil {
+	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after cancelled plan: %s", err.Error())
 	}
 }

--- a/internal/backend/remote/backend_plan_test.go
+++ b/internal/backend/remote/backend_plan_test.go
@@ -94,9 +94,7 @@ func TestRemote_planBasic(t *testing.T) {
 		t.Fatalf("expected plan summary in output: %s", output)
 	}
 
-	ctx := context.Background()
-
-	stateMgr, _ := b.StateMgr(ctx, backend.DefaultStateName)
+	stateMgr, _ := b.StateMgr(backend.DefaultStateName)
 	// An error suggests that the state was not unlocked after the operation finished
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after successful plan: %s", err.Error())
@@ -126,9 +124,7 @@ func TestRemote_planCanceled(t *testing.T) {
 		t.Fatal("expected plan operation to fail")
 	}
 
-	ctx := context.Background()
-
-	stateMgr, _ := b.StateMgr(ctx, backend.DefaultStateName)
+	stateMgr, _ := b.StateMgr(backend.DefaultStateName)
 	// An error suggests that the state was not unlocked after the operation finished
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after cancelled plan: %s", err.Error())

--- a/internal/backend/remote/backend_state.go
+++ b/internal/backend/remote/backend_state.go
@@ -153,7 +153,9 @@ func (r *remoteClient) EnableForcePush() {
 }
 
 // Lock the remote state.
-func (r *remoteClient) Lock(ctx context.Context, info *statemgr.LockInfo) (string, error) {
+func (r *remoteClient) Lock(info *statemgr.LockInfo) (string, error) {
+	ctx := context.Background()
+
 	lockErr := &statemgr.LockError{Info: r.lockInfo}
 
 	// Lock the workspace.
@@ -175,7 +177,9 @@ func (r *remoteClient) Lock(ctx context.Context, info *statemgr.LockInfo) (strin
 }
 
 // Unlock the remote state.
-func (r *remoteClient) Unlock(ctx context.Context, id string) error {
+func (r *remoteClient) Unlock(id string) error {
+	ctx := context.Background()
+
 	// We first check if there was an error while uploading the latest
 	// state. If so, we will not unlock the workspace to prevent any
 	// changes from being applied until the correct state is uploaded.

--- a/internal/backend/remote/backend_state.go
+++ b/internal/backend/remote/backend_state.go
@@ -32,7 +32,9 @@ type remoteClient struct {
 }
 
 // Get the remote state.
-func (r *remoteClient) Get(ctx context.Context) (*remote.Payload, error) {
+func (r *remoteClient) Get() (*remote.Payload, error) {
+	ctx := context.Background()
+
 	sv, err := r.client.StateVersions.ReadCurrent(ctx, r.workspace.ID)
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
@@ -87,7 +89,9 @@ func (r *remoteClient) uploadStateFallback(ctx context.Context, stateFile *state
 }
 
 // Put the remote state.
-func (r *remoteClient) Put(ctx context.Context, state []byte) error {
+func (r *remoteClient) Put(state []byte) error {
+	ctx := context.Background()
+
 	// Read the raw state into a OpenTofu state.
 	stateFile, err := statefile.Read(bytes.NewReader(state))
 	if err != nil {

--- a/internal/backend/remote/backend_state.go
+++ b/internal/backend/remote/backend_state.go
@@ -141,8 +141,8 @@ func (r *remoteClient) Put(state []byte) error {
 }
 
 // Delete the remote state.
-func (r *remoteClient) Delete(ctx context.Context) error {
-	err := r.client.Workspaces.Delete(ctx, r.organization, r.workspace.Name)
+func (r *remoteClient) Delete() error {
+	err := r.client.Workspaces.Delete(context.Background(), r.organization, r.workspace.Name)
 	if err != nil && err != tfe.ErrResourceNotFound {
 		return fmt.Errorf("error deleting workspace %s: %w", r.workspace.Name, err)
 	}

--- a/internal/backend/remote/backend_state_test.go
+++ b/internal/backend/remote/backend_state_test.go
@@ -5,7 +5,6 @@ package remote
 
 import (
 	"bytes"
-	"context"
 	"os"
 	"testing"
 
@@ -29,14 +28,12 @@ func TestRemoteClient_stateLock(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	ctx := context.Background()
-
-	s1, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s1, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	s2, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s2, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/internal/backend/remote/backend_state_test.go
+++ b/internal/backend/remote/backend_state_test.go
@@ -60,7 +60,7 @@ func TestRemoteClient_Put_withRunID(t *testing.T) {
 
 	// Store the new state to verify (this will be done
 	// by the mock that is used) that the run ID is set.
-	if err := client.Put(context.Background(), buf.Bytes()); err != nil {
+	if err := client.Put(buf.Bytes()); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 }

--- a/internal/backend/remote/backend_test.go
+++ b/internal/backend/remote/backend_test.go
@@ -162,7 +162,7 @@ func TestRemote_config(t *testing.T) {
 		}
 
 		// Configure
-		confDiags := b.Configure(ctx, tc.config)
+		confDiags := b.Configure(tc.config)
 		if (confDiags.Err() != nil || tc.confErr != "") &&
 			(confDiags.Err() == nil || !strings.Contains(confDiags.Err().Error(), tc.confErr)) {
 			t.Fatalf("%s: unexpected configure result: %v", name, confDiags.Err())
@@ -242,7 +242,7 @@ func TestRemote_versionConstraints(t *testing.T) {
 		}
 
 		// Configure
-		confDiags := b.Configure(ctx, tc.config)
+		confDiags := b.Configure(tc.config)
 		if (confDiags.Err() != nil || tc.result != "") &&
 			(confDiags.Err() == nil || !strings.Contains(confDiags.Err().Error(), tc.result)) {
 			t.Fatalf("%s: unexpected configure result: %v", name, confDiags.Err())
@@ -746,7 +746,7 @@ func TestRemote_ServiceDiscoveryAliases(t *testing.T) {
 	s := testServer(t)
 	b := New(testDisco(s))
 
-	diag := b.Configure(context.Background(), cty.ObjectVal(map[string]cty.Value{
+	diag := b.Configure(cty.ObjectVal(map[string]cty.Value{
 		"hostname":     cty.StringVal("app.terraform.io"),
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),

--- a/internal/backend/remote/backend_test.go
+++ b/internal/backend/remote/backend_test.go
@@ -269,11 +269,11 @@ func TestRemote_addAndRemoveWorkspacesDefault(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	ctx := context.Background()
-
-	if _, err := b.Workspaces(ctx); err != backend.ErrWorkspacesNotSupported {
+	if _, err := b.Workspaces(); err != backend.ErrWorkspacesNotSupported {
 		t.Fatalf("expected error %v, got %v", backend.ErrWorkspacesNotSupported, err)
 	}
+
+	ctx := context.Background()
 
 	if _, err := b.StateMgr(ctx, backend.DefaultStateName); err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -296,9 +296,7 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 	b, bCleanup := testBackendNoDefault(t)
 	defer bCleanup()
 
-	ctx := context.Background()
-
-	states, err := b.Workspaces(ctx)
+	states, err := b.Workspaces()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -307,6 +305,8 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 	if !reflect.DeepEqual(states, expectedWorkspaces) {
 		t.Fatalf("expected states %#+v, got %#+v", expectedWorkspaces, states)
 	}
+
+	ctx := context.Background()
 
 	if _, err := b.StateMgr(ctx, backend.DefaultStateName); err != backend.ErrDefaultWorkspaceNotSupported {
 		t.Fatalf("expected error %v, got %v", backend.ErrDefaultWorkspaceNotSupported, err)
@@ -317,7 +317,7 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	states, err = b.Workspaces(ctx)
+	states, err = b.Workspaces()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -332,7 +332,7 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	states, err = b.Workspaces(ctx)
+	states, err = b.Workspaces()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -350,7 +350,7 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	states, err = b.Workspaces(ctx)
+	states, err = b.Workspaces()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -364,7 +364,7 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	states, err = b.Workspaces(ctx)
+	states, err = b.Workspaces()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/remote/backend_test.go
+++ b/internal/backend/remote/backend_test.go
@@ -273,13 +273,11 @@ func TestRemote_addAndRemoveWorkspacesDefault(t *testing.T) {
 		t.Fatalf("expected error %v, got %v", backend.ErrWorkspacesNotSupported, err)
 	}
 
-	ctx := context.Background()
-
-	if _, err := b.StateMgr(ctx, backend.DefaultStateName); err != nil {
+	if _, err := b.StateMgr(backend.DefaultStateName); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if _, err := b.StateMgr(ctx, "prod"); err != backend.ErrWorkspacesNotSupported {
+	if _, err := b.StateMgr("prod"); err != backend.ErrWorkspacesNotSupported {
 		t.Fatalf("expected error %v, got %v", backend.ErrWorkspacesNotSupported, err)
 	}
 
@@ -306,14 +304,12 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 		t.Fatalf("expected states %#+v, got %#+v", expectedWorkspaces, states)
 	}
 
-	ctx := context.Background()
-
-	if _, err := b.StateMgr(ctx, backend.DefaultStateName); err != backend.ErrDefaultWorkspaceNotSupported {
+	if _, err := b.StateMgr(backend.DefaultStateName); err != backend.ErrDefaultWorkspaceNotSupported {
 		t.Fatalf("expected error %v, got %v", backend.ErrDefaultWorkspaceNotSupported, err)
 	}
 
 	expectedA := "test_A"
-	if _, err := b.StateMgr(ctx, expectedA); err != nil {
+	if _, err := b.StateMgr(expectedA); err != nil {
 		t.Fatal(err)
 	}
 
@@ -328,7 +324,7 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 	}
 
 	expectedB := "test_B"
-	if _, err := b.StateMgr(ctx, expectedB); err != nil {
+	if _, err := b.StateMgr(expectedB); err != nil {
 		t.Fatal(err)
 	}
 
@@ -514,10 +510,8 @@ func TestRemote_StateMgr_versionCheck(t *testing.T) {
 		t.Fatalf("error: %v", err)
 	}
 
-	ctx := context.Background()
-
 	// This should succeed
-	if _, err := b.StateMgr(ctx, backend.DefaultStateName); err != nil {
+	if _, err := b.StateMgr(backend.DefaultStateName); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
@@ -535,7 +529,7 @@ func TestRemote_StateMgr_versionCheck(t *testing.T) {
 
 	// This should fail
 	want := `Remote workspace OpenTofu version "0.13.5" does not match local OpenTofu version "0.14.0"`
-	if _, err := b.StateMgr(ctx, backend.DefaultStateName); err.Error() != want {
+	if _, err := b.StateMgr(backend.DefaultStateName); err.Error() != want {
 		t.Fatalf("wrong error\n got: %v\nwant: %v", err.Error(), want)
 	}
 }
@@ -573,10 +567,8 @@ func TestRemote_StateMgr_versionCheckLatest(t *testing.T) {
 		t.Fatalf("error: %v", err)
 	}
 
-	ctx := context.Background()
-
 	// This should succeed despite not being a string match
-	if _, err := b.StateMgr(ctx, backend.DefaultStateName); err != nil {
+	if _, err := b.StateMgr(backend.DefaultStateName); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 }

--- a/internal/backend/remote/backend_test.go
+++ b/internal/backend/remote/backend_test.go
@@ -621,12 +621,10 @@ func TestRemote_VerifyWorkspaceTerraformVersion(t *testing.T) {
 			tfversion.Version = local.String()
 			tfversion.SemVer = local
 
-			ctx := context.Background()
-
 			// Update the mock remote workspace OpenTofu version to the
 			// specified remote version
 			if _, err := b.client.Workspaces.Update(
-				ctx,
+				context.Background(),
 				b.organization,
 				b.workspace,
 				tfe.WorkspaceUpdateOptions{
@@ -637,7 +635,7 @@ func TestRemote_VerifyWorkspaceTerraformVersion(t *testing.T) {
 				t.Fatalf("error: %v", err)
 			}
 
-			diags := b.VerifyWorkspaceTerraformVersion(ctx, backend.DefaultStateName)
+			diags := b.VerifyWorkspaceTerraformVersion(backend.DefaultStateName)
 			if tc.wantErr {
 				if len(diags) != 1 {
 					t.Fatal("expected diag, but none returned")
@@ -658,18 +656,16 @@ func TestRemote_VerifyWorkspaceTerraformVersion_workspaceErrors(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	ctx := context.Background()
-
 	// Attempting to check the version against a workspace which doesn't exist
 	// should result in no errors
-	diags := b.VerifyWorkspaceTerraformVersion(ctx, "invalid-workspace")
+	diags := b.VerifyWorkspaceTerraformVersion("invalid-workspace")
 	if len(diags) != 0 {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}
 
 	// Use a special workspace ID to trigger a 500 error, which should result
 	// in a failed check
-	diags = b.VerifyWorkspaceTerraformVersion(ctx, "network-error")
+	diags = b.VerifyWorkspaceTerraformVersion("network-error")
 	if len(diags) != 1 {
 		t.Fatal("expected diag, but none returned")
 	}
@@ -688,7 +684,7 @@ func TestRemote_VerifyWorkspaceTerraformVersion_workspaceErrors(t *testing.T) {
 	); err != nil {
 		t.Fatalf("error: %v", err)
 	}
-	diags = b.VerifyWorkspaceTerraformVersion(ctx, backend.DefaultStateName)
+	diags = b.VerifyWorkspaceTerraformVersion(backend.DefaultStateName)
 
 	if len(diags) != 1 {
 		t.Fatal("expected diag, but none returned")
@@ -724,12 +720,10 @@ func TestRemote_VerifyWorkspaceTerraformVersion_ignoreFlagSet(t *testing.T) {
 	tfversion.Version = local.String()
 	tfversion.SemVer = local
 
-	ctx := context.Background()
-
 	// Update the mock remote workspace OpenTofu version to the
 	// specified remote version
 	if _, err := b.client.Workspaces.Update(
-		ctx,
+		context.Background(),
 		b.organization,
 		b.workspace,
 		tfe.WorkspaceUpdateOptions{
@@ -739,7 +733,7 @@ func TestRemote_VerifyWorkspaceTerraformVersion_ignoreFlagSet(t *testing.T) {
 		t.Fatalf("error: %v", err)
 	}
 
-	diags := b.VerifyWorkspaceTerraformVersion(ctx, backend.DefaultStateName)
+	diags := b.VerifyWorkspaceTerraformVersion(backend.DefaultStateName)
 	if len(diags) != 1 {
 		t.Fatal("expected diag, but none returned")
 	}

--- a/internal/backend/remote/backend_test.go
+++ b/internal/backend/remote/backend_test.go
@@ -283,11 +283,11 @@ func TestRemote_addAndRemoveWorkspacesDefault(t *testing.T) {
 		t.Fatalf("expected error %v, got %v", backend.ErrWorkspacesNotSupported, err)
 	}
 
-	if err := b.DeleteWorkspace(ctx, backend.DefaultStateName, true); err != nil {
+	if err := b.DeleteWorkspace(backend.DefaultStateName, true); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if err := b.DeleteWorkspace(ctx, "prod", true); err != backend.ErrWorkspacesNotSupported {
+	if err := b.DeleteWorkspace("prod", true); err != backend.ErrWorkspacesNotSupported {
 		t.Fatalf("expected error %v, got %v", backend.ErrWorkspacesNotSupported, err)
 	}
 }
@@ -342,11 +342,11 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 		t.Fatalf("expected %#+v, got %#+v", expectedWorkspaces, states)
 	}
 
-	if err := b.DeleteWorkspace(ctx, backend.DefaultStateName, true); err != backend.ErrDefaultWorkspaceNotSupported {
+	if err := b.DeleteWorkspace(backend.DefaultStateName, true); err != backend.ErrDefaultWorkspaceNotSupported {
 		t.Fatalf("expected error %v, got %v", backend.ErrDefaultWorkspaceNotSupported, err)
 	}
 
-	if err := b.DeleteWorkspace(ctx, expectedA, true); err != nil {
+	if err := b.DeleteWorkspace(expectedA, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -360,7 +360,7 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 		t.Fatalf("expected %#+v got %#+v", expectedWorkspaces, states)
 	}
 
-	if err := b.DeleteWorkspace(ctx, expectedB, true); err != nil {
+	if err := b.DeleteWorkspace(expectedB, true); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/backend/remote/backend_test.go
+++ b/internal/backend/remote/backend_test.go
@@ -152,10 +152,8 @@ func TestRemote_config(t *testing.T) {
 		s := testServer(t)
 		b := New(testDisco(s))
 
-		ctx := context.Background()
-
 		// Validate
-		_, valDiags := b.PrepareConfig(ctx, tc.config)
+		_, valDiags := b.PrepareConfig(tc.config)
 		if (valDiags.Err() != nil || tc.valErr != "") &&
 			(valDiags.Err() == nil || !strings.Contains(valDiags.Err().Error(), tc.valErr)) {
 			t.Fatalf("%s: unexpected validation result: %v", name, valDiags.Err())
@@ -233,10 +231,8 @@ func TestRemote_versionConstraints(t *testing.T) {
 		tfversion.Prerelease = tc.prerelease
 		tfversion.Version = tc.version
 
-		ctx := context.Background()
-
 		// Validate
-		_, valDiags := b.PrepareConfig(ctx, tc.config)
+		_, valDiags := b.PrepareConfig(tc.config)
 		if valDiags.HasErrors() {
 			t.Fatalf("%s: unexpected validation result: %v", name, valDiags.Err())
 		}

--- a/internal/backend/remote/testing.go
+++ b/internal/backend/remote/testing.go
@@ -132,7 +132,7 @@ func testBackend(t *testing.T, obj cty.Value) (*Remote, func()) {
 	}
 	obj = newObj
 
-	confDiags := b.Configure(ctx, obj)
+	confDiags := b.Configure(obj)
 	if len(confDiags) != 0 {
 		t.Fatal(confDiags.ErrWithWarnings())
 	}

--- a/internal/backend/remote/testing.go
+++ b/internal/backend/remote/testing.go
@@ -123,10 +123,8 @@ func testBackend(t *testing.T, obj cty.Value) (*Remote, func()) {
 	s := testServer(t)
 	b := New(testDisco(s))
 
-	ctx := context.Background()
-
 	// Configure the backend so the client is created.
-	newObj, valDiags := b.PrepareConfig(ctx, obj)
+	newObj, valDiags := b.PrepareConfig(obj)
 	if len(valDiags) != 0 {
 		t.Fatal(valDiags.ErrWithWarnings())
 	}
@@ -156,6 +154,8 @@ func testBackend(t *testing.T, obj cty.Value) (*Remote, func()) {
 
 	// Set local to a local test backend.
 	b.local = testLocalBackend(t, b)
+
+	ctx := context.Background()
 
 	// Create the organization.
 	_, err := b.client.Organizations.Create(ctx, tfe.OrganizationCreateOptions{

--- a/internal/backend/remote/testing.go
+++ b/internal/backend/remote/testing.go
@@ -111,9 +111,7 @@ func testRemoteClient(t *testing.T) remote.Client {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	ctx := context.Background()
-
-	raw, err := b.StateMgr(ctx, backend.DefaultStateName)
+	raw, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("error: %v", err)
 	}

--- a/internal/backend/testing.go
+++ b/internal/backend/testing.go
@@ -111,7 +111,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}
-	if err := foo.RefreshState(ctx); err != nil {
+	if err := foo.RefreshState(); err != nil {
 		t.Fatalf("bad: %s", err)
 	}
 	if v := foo.State(); v.HasManagedResourceInstanceObjects() {
@@ -122,7 +122,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}
-	if err := bar.RefreshState(ctx); err != nil {
+	if err := bar.RefreshState(); err != nil {
 		t.Fatalf("bad: %s", err)
 	}
 	if v := bar.State(); v.HasManagedResourceInstanceObjects() {
@@ -140,7 +140,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 		if err := foo.WriteState(fooState); err != nil {
 			t.Fatal("error writing foo state:", err)
 		}
-		if err := foo.PersistState(ctx, nil); err != nil {
+		if err := foo.PersistState(nil); err != nil {
 			t.Fatal("error persisting foo state:", err)
 		}
 
@@ -168,12 +168,12 @@ func TestBackendStates(t *testing.T, b Backend) {
 		if err := bar.WriteState(barState); err != nil {
 			t.Fatalf("bad: %s", err)
 		}
-		if err := bar.PersistState(ctx, nil); err != nil {
+		if err := bar.PersistState(nil); err != nil {
 			t.Fatalf("bad: %s", err)
 		}
 
 		// verify that foo is unchanged with the existing state manager
-		if err := foo.RefreshState(ctx); err != nil {
+		if err := foo.RefreshState(); err != nil {
 			t.Fatal("error refreshing foo:", err)
 		}
 		fooState = foo.State()
@@ -186,7 +186,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 		if err != nil {
 			t.Fatal("error re-fetching state:", err)
 		}
-		if err := foo.RefreshState(ctx); err != nil {
+		if err := foo.RefreshState(); err != nil {
 			t.Fatal("error refreshing foo:", err)
 		}
 		fooState = foo.State()
@@ -199,7 +199,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 		if err != nil {
 			t.Fatal("error re-fetching state:", err)
 		}
-		if err := bar.RefreshState(ctx); err != nil {
+		if err := bar.RefreshState(); err != nil {
 			t.Fatal("error refreshing bar:", err)
 		}
 		barState = bar.State()
@@ -243,7 +243,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}
-	if err := foo.RefreshState(ctx); err != nil {
+	if err := foo.RefreshState(); err != nil {
 		t.Fatalf("bad: %s", err)
 	}
 	if v := foo.State(); v.HasManagedResourceInstanceObjects() {
@@ -318,7 +318,7 @@ func testLocksInWorkspace(t *testing.T, b1, b2 Backend, testForceUnlock bool, wo
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}
-	if err := b1StateMgr.RefreshState(ctx); err != nil {
+	if err := b1StateMgr.RefreshState(); err != nil {
 		t.Fatalf("bad: %s", err)
 	}
 
@@ -334,7 +334,7 @@ func testLocksInWorkspace(t *testing.T, b1, b2 Backend, testForceUnlock bool, wo
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}
-	if err := b2StateMgr.RefreshState(ctx); err != nil {
+	if err := b2StateMgr.RefreshState(); err != nil {
 		t.Fatalf("bad: %s", err)
 	}
 

--- a/internal/backend/testing.go
+++ b/internal/backend/testing.go
@@ -81,10 +81,8 @@ func TestWrapConfig(raw map[string]interface{}) hcl.Body {
 func TestBackendStates(t *testing.T, b Backend) {
 	t.Helper()
 
-	ctx := context.Background()
-
 	noDefault := false
-	if _, err := b.StateMgr(ctx, DefaultStateName); err != nil {
+	if _, err := b.StateMgr(DefaultStateName); err != nil {
 		if err == ErrDefaultWorkspaceNotSupported {
 			noDefault = true
 		} else {
@@ -107,7 +105,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 	}
 
 	// Create a couple states
-	foo, err := b.StateMgr(ctx, "foo")
+	foo, err := b.StateMgr("foo")
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}
@@ -118,7 +116,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 		t.Fatalf("should be empty: %s", v)
 	}
 
-	bar, err := b.StateMgr(ctx, "bar")
+	bar, err := b.StateMgr("bar")
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}
@@ -182,7 +180,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 		}
 
 		// fetch foo again from the backend
-		foo, err = b.StateMgr(ctx, "foo")
+		foo, err = b.StateMgr("foo")
 		if err != nil {
 			t.Fatal("error re-fetching state:", err)
 		}
@@ -195,7 +193,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 		}
 
 		// fetch the bar again from the backend
-		bar, err = b.StateMgr(ctx, "bar")
+		bar, err = b.StateMgr("bar")
 		if err != nil {
 			t.Fatal("error re-fetching state:", err)
 		}
@@ -239,7 +237,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 	// Create and delete the foo workspace again.
 	// Make sure that there are no leftover artifacts from a deleted state
 	// preventing re-creation.
-	foo, err = b.StateMgr(ctx, "foo")
+	foo, err = b.StateMgr("foo")
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}
@@ -311,10 +309,8 @@ func testLocks(t *testing.T, b1, b2 Backend, testForceUnlock bool) {
 func testLocksInWorkspace(t *testing.T, b1, b2 Backend, testForceUnlock bool, workspace string) {
 	t.Helper()
 
-	ctx := context.Background()
-
 	// Get the default state for each
-	b1StateMgr, err := b1.StateMgr(ctx, DefaultStateName)
+	b1StateMgr, err := b1.StateMgr(DefaultStateName)
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}
@@ -330,7 +326,7 @@ func testLocksInWorkspace(t *testing.T, b1, b2 Backend, testForceUnlock bool, wo
 
 	t.Logf("TestBackend: testing state locking for %T", b1)
 
-	b2StateMgr, err := b2.StateMgr(ctx, DefaultStateName)
+	b2StateMgr, err := b2.StateMgr(DefaultStateName)
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}
@@ -358,7 +354,7 @@ func testLocksInWorkspace(t *testing.T, b1, b2 Backend, testForceUnlock bool, wo
 	// Make sure we can still get the statemgr.Full from another instance even
 	// when locked.  This should only happen when a state is loaded via the
 	// backend, and as a remote state.
-	_, err = b2.StateMgr(ctx, DefaultStateName)
+	_, err = b2.StateMgr(DefaultStateName)
 	if err != nil {
 		t.Errorf("failed to read locked state from another backend instance: %s", err)
 	}

--- a/internal/backend/testing.go
+++ b/internal/backend/testing.go
@@ -227,12 +227,12 @@ func TestBackendStates(t *testing.T, b Backend) {
 	}
 
 	// Delete some workspaces
-	if err := b.DeleteWorkspace(ctx, "foo", true); err != nil {
+	if err := b.DeleteWorkspace("foo", true); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
 	// Verify the default state can't be deleted
-	if err := b.DeleteWorkspace(ctx, DefaultStateName, true); err == nil {
+	if err := b.DeleteWorkspace(DefaultStateName, true); err == nil {
 		t.Fatal("expected error")
 	}
 
@@ -250,7 +250,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 		t.Fatalf("should be empty: %s", v)
 	}
 	// and delete it again
-	if err := b.DeleteWorkspace(ctx, "foo", true); err != nil {
+	if err := b.DeleteWorkspace("foo", true); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/internal/backend/testing.go
+++ b/internal/backend/testing.go
@@ -350,7 +350,7 @@ func testLocksInWorkspace(t *testing.T, b1, b2 Backend, testForceUnlock bool, wo
 	infoB.Operation = "test"
 	infoB.Who = "clientB"
 
-	lockIDA, err := lockerA.Lock(ctx, infoA)
+	lockIDA, err := lockerA.Lock(infoA)
 	if err != nil {
 		t.Fatal("unable to get initial lock:", err)
 	}
@@ -369,17 +369,17 @@ func testLocksInWorkspace(t *testing.T, b1, b2 Backend, testForceUnlock bool, wo
 		return
 	}
 
-	_, err = lockerB.Lock(ctx, infoB)
+	_, err = lockerB.Lock(infoB)
 	if err == nil {
-		lockerA.Unlock(ctx, lockIDA)
+		lockerA.Unlock(lockIDA)
 		t.Fatal("client B obtained lock while held by client A")
 	}
 
-	if err := lockerA.Unlock(ctx, lockIDA); err != nil {
+	if err := lockerA.Unlock(lockIDA); err != nil {
 		t.Fatal("error unlocking client A", err)
 	}
 
-	lockIDB, err := lockerB.Lock(ctx, infoB)
+	lockIDB, err := lockerB.Lock(infoB)
 	if err != nil {
 		t.Fatal("unable to obtain lock from client B")
 	}
@@ -388,7 +388,7 @@ func testLocksInWorkspace(t *testing.T, b1, b2 Backend, testForceUnlock bool, wo
 		t.Errorf("duplicate lock IDs: %q", lockIDB)
 	}
 
-	if err = lockerB.Unlock(ctx, lockIDB); err != nil {
+	if err = lockerB.Unlock(lockIDB); err != nil {
 		t.Fatal("error unlocking client B:", err)
 	}
 
@@ -404,18 +404,18 @@ func testLocksInWorkspace(t *testing.T, b1, b2 Backend, testForceUnlock bool, wo
 		panic(err)
 	}
 
-	lockIDA, err = lockerA.Lock(ctx, infoA)
+	lockIDA, err = lockerA.Lock(infoA)
 	if err != nil {
 		t.Fatal("unable to get re lock A:", err)
 	}
 	unlock := func() {
-		err := lockerA.Unlock(ctx, lockIDA)
+		err := lockerA.Unlock(lockIDA)
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	_, err = lockerB.Lock(ctx, infoB)
+	_, err = lockerB.Lock(infoB)
 	if err == nil {
 		unlock()
 		t.Fatal("client B obtained lock while held by client A")
@@ -428,7 +428,7 @@ func testLocksInWorkspace(t *testing.T, b1, b2 Backend, testForceUnlock bool, wo
 	}
 
 	// try to unlock with the second unlocker, using the ID from the error
-	if err := lockerB.Unlock(ctx, infoErr.Info.ID); err != nil {
+	if err := lockerB.Unlock(infoErr.Info.ID); err != nil {
 		unlock()
 		t.Fatalf("could not unlock with the reported ID %q: %s", infoErr.Info.ID, err)
 	}

--- a/internal/backend/testing.go
+++ b/internal/backend/testing.go
@@ -4,7 +4,6 @@
 package backend
 
 import (
-	"context"
 	"reflect"
 	"sort"
 	"testing"
@@ -37,9 +36,7 @@ func TestBackendConfig(t *testing.T, b Backend, c hcl.Body) Backend {
 		c = hcl.EmptyBody()
 	}
 
-	ctx := context.Background()
-
-	schema := b.ConfigSchema(ctx)
+	schema := b.ConfigSchema()
 	spec := schema.DecoderSpec()
 	obj, decDiags := hcldec.Decode(c, spec, nil)
 	diags = diags.Append(decDiags)

--- a/internal/backend/testing.go
+++ b/internal/backend/testing.go
@@ -54,7 +54,7 @@ func TestBackendConfig(t *testing.T, b Backend, c hcl.Body) Backend {
 
 	obj = newObj
 
-	confDiags := b.Configure(ctx, obj)
+	confDiags := b.Configure(obj)
 	if len(confDiags) != 0 {
 		confDiags = confDiags.InConfigBody(c, "")
 		t.Fatal(confDiags.ErrWithWarnings())

--- a/internal/backend/testing.go
+++ b/internal/backend/testing.go
@@ -92,7 +92,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 		}
 	}
 
-	workspaces, err := b.Workspaces(ctx)
+	workspaces, err := b.Workspaces()
 	if err != nil {
 		if err == ErrWorkspacesNotSupported {
 			t.Logf("TestBackend: workspaces not supported in %T, skipping", b)
@@ -211,7 +211,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 	// Verify we can now list them
 	{
 		// we determined that named stated are supported earlier
-		workspaces, err := b.Workspaces(ctx)
+		workspaces, err := b.Workspaces()
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -256,7 +256,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 
 	// Verify deletion
 	{
-		workspaces, err := b.Workspaces(ctx)
+		workspaces, err := b.Workspaces()
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}

--- a/internal/backend/testing.go
+++ b/internal/backend/testing.go
@@ -44,7 +44,7 @@ func TestBackendConfig(t *testing.T, b Backend, c hcl.Body) Backend {
 	obj, decDiags := hcldec.Decode(c, spec, nil)
 	diags = diags.Append(decDiags)
 
-	newObj, valDiags := b.PrepareConfig(ctx, obj)
+	newObj, valDiags := b.PrepareConfig(obj)
 	diags = diags.Append(valDiags.InConfigBody(c, ""))
 
 	// it's valid for a Backend to have warnings (e.g. a Deprecation) as such we should only raise on errors

--- a/internal/builtin/providers/tf/data_source_state.go
+++ b/internal/builtin/providers/tf/data_source_state.go
@@ -110,9 +110,7 @@ func dataSourceRemoteStateRead(d cty.Value) (cty.Value, tfdiags.Diagnostics) {
 		return cty.NilVal, diags
 	}
 
-	ctx := context.TODO()
-
-	configureDiags := b.Configure(ctx, cfg)
+	configureDiags := b.Configure(cfg)
 	if configureDiags.HasErrors() {
 		diags = diags.Append(configureDiags.Err())
 		return cty.NilVal, diags

--- a/internal/builtin/providers/tf/data_source_state.go
+++ b/internal/builtin/providers/tf/data_source_state.go
@@ -143,7 +143,7 @@ func dataSourceRemoteStateRead(d cty.Value) (cty.Value, tfdiags.Diagnostics) {
 		return cty.NilVal, diags
 	}
 
-	if err := state.RefreshState(ctx); err != nil {
+	if err := state.RefreshState(); err != nil {
 		diags = diags.Append(err)
 		return cty.NilVal, diags
 	}

--- a/internal/builtin/providers/tf/data_source_state.go
+++ b/internal/builtin/providers/tf/data_source_state.go
@@ -239,7 +239,7 @@ func getBackend(cfg cty.Value) (backend.Backend, cty.Value, tfdiags.Diagnostics)
 		return nil, cty.NilVal, diags
 	}
 
-	newVal, validateDiags := b.PrepareConfig(ctx, configVal)
+	newVal, validateDiags := b.PrepareConfig(configVal)
 	diags = diags.Append(validateDiags)
 	if validateDiags.HasErrors() {
 		return nil, cty.NilVal, diags

--- a/internal/builtin/providers/tf/data_source_state.go
+++ b/internal/builtin/providers/tf/data_source_state.go
@@ -132,7 +132,7 @@ func dataSourceRemoteStateRead(d cty.Value) (cty.Value, tfdiags.Diagnostics) {
 		workspaceName = workspaceVal.AsString()
 	}
 
-	state, err := b.StateMgr(ctx, workspaceName)
+	state, err := b.StateMgr(workspaceName)
 	if err != nil {
 		diags = diags.Append(tfdiags.AttributeValue(
 			tfdiags.Error,

--- a/internal/builtin/providers/tf/data_source_state.go
+++ b/internal/builtin/providers/tf/data_source_state.go
@@ -4,7 +4,6 @@
 package tf
 
 import (
-	"context"
 	"fmt"
 	"log"
 
@@ -223,9 +222,7 @@ func getBackend(cfg cty.Value) (backend.Backend, cty.Value, tfdiags.Diagnostics)
 		config = cty.ObjectVal(config.AsValueMap())
 	}
 
-	ctx := context.TODO()
-
-	schema := b.ConfigSchema(ctx)
+	schema := b.ConfigSchema()
 	// Try to coerce the provided value into the desired configuration type.
 	configVal, err := schema.CoerceValue(config)
 	if err != nil {

--- a/internal/builtin/providers/tf/data_source_state_test.go
+++ b/internal/builtin/providers/tf/data_source_state_test.go
@@ -370,6 +370,6 @@ func (b backendFailsConfigure) DeleteWorkspace(_ context.Context, name string, _
 	return fmt.Errorf("DeleteWorkspace not implemented")
 }
 
-func (b backendFailsConfigure) Workspaces(context.Context) ([]string, error) {
+func (b backendFailsConfigure) Workspaces() ([]string, error) {
 	return nil, fmt.Errorf("Workspaces not implemented")
 }

--- a/internal/builtin/providers/tf/data_source_state_test.go
+++ b/internal/builtin/providers/tf/data_source_state_test.go
@@ -355,7 +355,7 @@ func (b backendFailsConfigure) PrepareConfig(_ context.Context, given cty.Value)
 	return given, nil
 }
 
-func (b backendFailsConfigure) Configure(_ context.Context, config cty.Value) tfdiags.Diagnostics {
+func (b backendFailsConfigure) Configure(config cty.Value) tfdiags.Diagnostics {
 	log.Printf("[TRACE] backendFailsConfigure.Configure(%#v)", config)
 	var diags tfdiags.Diagnostics
 	diags = diags.Append(fmt.Errorf("Configure should never be called"))

--- a/internal/builtin/providers/tf/data_source_state_test.go
+++ b/internal/builtin/providers/tf/data_source_state_test.go
@@ -4,7 +4,6 @@
 package tf
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"testing"
@@ -345,7 +344,7 @@ func TestState_validation(t *testing.T) {
 
 type backendFailsConfigure struct{}
 
-func (b backendFailsConfigure) ConfigSchema(context.Context) *configschema.Block {
+func (b backendFailsConfigure) ConfigSchema() *configschema.Block {
 	log.Printf("[TRACE] backendFailsConfigure.ConfigSchema")
 	return &configschema.Block{} // intentionally empty configuration schema
 }

--- a/internal/builtin/providers/tf/data_source_state_test.go
+++ b/internal/builtin/providers/tf/data_source_state_test.go
@@ -362,7 +362,7 @@ func (b backendFailsConfigure) Configure(_ context.Context, config cty.Value) tf
 	return diags
 }
 
-func (b backendFailsConfigure) StateMgr(context.Context, string) (statemgr.Full, error) {
+func (b backendFailsConfigure) StateMgr(workspace string) (statemgr.Full, error) {
 	return nil, fmt.Errorf("StateMgr not implemented")
 }
 

--- a/internal/builtin/providers/tf/data_source_state_test.go
+++ b/internal/builtin/providers/tf/data_source_state_test.go
@@ -350,7 +350,7 @@ func (b backendFailsConfigure) ConfigSchema(context.Context) *configschema.Block
 	return &configschema.Block{} // intentionally empty configuration schema
 }
 
-func (b backendFailsConfigure) PrepareConfig(_ context.Context, given cty.Value) (cty.Value, tfdiags.Diagnostics) {
+func (b backendFailsConfigure) PrepareConfig(given cty.Value) (cty.Value, tfdiags.Diagnostics) {
 	// No special actions to take here
 	return given, nil
 }

--- a/internal/builtin/providers/tf/data_source_state_test.go
+++ b/internal/builtin/providers/tf/data_source_state_test.go
@@ -366,7 +366,7 @@ func (b backendFailsConfigure) StateMgr(context.Context, string) (statemgr.Full,
 	return nil, fmt.Errorf("StateMgr not implemented")
 }
 
-func (b backendFailsConfigure) DeleteWorkspace(_ context.Context, name string, _ bool) error {
+func (b backendFailsConfigure) DeleteWorkspace(name string, _ bool) error {
 	return fmt.Errorf("DeleteWorkspace not implemented")
 }
 

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -535,7 +535,7 @@ func (b *Cloud) retryLogHook(attemptNum int, resp *http.Response) {
 
 // Workspaces implements backend.Enhanced, returning a filtered list of workspace names according to
 // the workspace mapping strategy configured.
-func (b *Cloud) Workspaces(ctx context.Context) ([]string, error) {
+func (b *Cloud) Workspaces() ([]string, error) {
 	// Create a slice to contain all the names.
 	var names []string
 
@@ -558,7 +558,7 @@ func (b *Cloud) Workspaces(ctx context.Context) ([]string, error) {
 		listOpts := &tfe.ProjectListOptions{
 			Name: b.WorkspaceMapping.Project,
 		}
-		projects, err := b.client.Projects.List(ctx, b.organization, listOpts)
+		projects, err := b.client.Projects.List(context.Background(), b.organization, listOpts)
 		if err != nil && err != tfe.ErrResourceNotFound {
 			return nil, fmt.Errorf("failed to retrieve project %s: %w", listOpts.Name, err)
 		}
@@ -571,7 +571,7 @@ func (b *Cloud) Workspaces(ctx context.Context) ([]string, error) {
 	}
 
 	for {
-		wl, err := b.client.Workspaces.List(ctx, b.organization, options)
+		wl, err := b.client.Workspaces.List(context.Background(), b.organization, options)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -119,7 +119,7 @@ func New(services *disco.Disco) *Cloud {
 }
 
 // ConfigSchema implements backend.Enhanced.
-func (b *Cloud) ConfigSchema(context.Context) *configschema.Block {
+func (b *Cloud) ConfigSchema() *configschema.Block {
 	return &configschema.Block{
 		Attributes: map[string]*configschema.Attribute{
 			"hostname": {

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -596,7 +596,7 @@ func (b *Cloud) Workspaces() ([]string, error) {
 }
 
 // DeleteWorkspace implements backend.Enhanced.
-func (b *Cloud) DeleteWorkspace(ctx context.Context, name string, force bool) error {
+func (b *Cloud) DeleteWorkspace(name string, force bool) error {
 	if name == backend.DefaultStateName {
 		return backend.ErrDefaultWorkspaceNotSupported
 	}
@@ -605,7 +605,7 @@ func (b *Cloud) DeleteWorkspace(ctx context.Context, name string, force bool) er
 		return backend.ErrWorkspacesNotSupported
 	}
 
-	workspace, err := b.client.Workspaces.Read(ctx, b.organization, name)
+	workspace, err := b.client.Workspaces.Read(context.Background(), b.organization, name)
 	if err == tfe.ErrResourceNotFound {
 		return nil // If the workspace does not exist, succeed
 	}
@@ -616,7 +616,7 @@ func (b *Cloud) DeleteWorkspace(ctx context.Context, name string, force bool) er
 
 	// Configure the remote workspace name.
 	State := &State{tfeClient: b.client, organization: b.organization, workspace: workspace, enableIntermediateSnapshots: false}
-	return State.Delete(ctx, force)
+	return State.Delete(force)
 }
 
 // StateMgr implements backend.Enhanced.

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -620,7 +620,7 @@ func (b *Cloud) DeleteWorkspace(name string, force bool) error {
 }
 
 // StateMgr implements backend.Enhanced.
-func (b *Cloud) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {
+func (b *Cloud) StateMgr(name string) (statemgr.Full, error) {
 	var remoteTFVersion string
 
 	if name == backend.DefaultStateName {
@@ -631,7 +631,7 @@ func (b *Cloud) StateMgr(ctx context.Context, name string) (statemgr.Full, error
 		return nil, backend.ErrWorkspacesNotSupported
 	}
 
-	workspace, err := b.client.Workspaces.Read(ctx, b.organization, name)
+	workspace, err := b.client.Workspaces.Read(context.Background(), b.organization, name)
 	if err != nil && err != tfe.ErrResourceNotFound {
 		return nil, fmt.Errorf("Failed to retrieve workspace %s: %w", name, err)
 	}
@@ -646,7 +646,7 @@ func (b *Cloud) StateMgr(ctx context.Context, name string) (statemgr.Full, error
 		listOpts := &tfe.ProjectListOptions{
 			Name: b.WorkspaceMapping.Project,
 		}
-		projects, err := b.client.Projects.List(ctx, b.organization, listOpts)
+		projects, err := b.client.Projects.List(context.Background(), b.organization, listOpts)
 		if err != nil && err != tfe.ErrResourceNotFound {
 			// This is a failure to make an API request, fail to initialize
 			return nil, fmt.Errorf("Attempted to find configured project %s but was unable to.", b.WorkspaceMapping.Project)
@@ -685,7 +685,7 @@ func (b *Cloud) StateMgr(ctx context.Context, name string) (statemgr.Full, error
 				}
 				// didn't find project, create it instead
 				log.Printf("[TRACE] cloud: Creating cloud backend project %s/%s", b.organization, b.WorkspaceMapping.Project)
-				project, err := b.client.Projects.Create(ctx, b.organization, createOpts)
+				project, err := b.client.Projects.Create(context.Background(), b.organization, createOpts)
 				if err != nil && err != tfe.ErrResourceNotFound {
 					return nil, fmt.Errorf("failed to create project %s: %w", b.WorkspaceMapping.Project, err)
 				}
@@ -696,7 +696,7 @@ func (b *Cloud) StateMgr(ctx context.Context, name string) (statemgr.Full, error
 
 		// Create a workspace
 		log.Printf("[TRACE] cloud: Creating cloud backend workspace %s/%s", b.organization, name)
-		workspace, err = b.client.Workspaces.Create(ctx, b.organization, workspaceCreateOptions)
+		workspace, err = b.client.Workspaces.Create(context.Background(), b.organization, workspaceCreateOptions)
 		if err != nil {
 			return nil, fmt.Errorf("error creating workspace %s: %w", name, err)
 		}
@@ -709,7 +709,7 @@ func (b *Cloud) StateMgr(ctx context.Context, name string) (statemgr.Full, error
 		versionOptions := tfe.WorkspaceUpdateOptions{
 			TerraformVersion: tfe.String(tfversion.String()),
 		}
-		_, err := b.client.Workspaces.UpdateByID(ctx, workspace.ID, versionOptions)
+		_, err := b.client.Workspaces.UpdateByID(context.Background(), workspace.ID, versionOptions)
 		if err == nil {
 			remoteTFVersion = tfversion.String()
 		} else {
@@ -731,7 +731,7 @@ func (b *Cloud) StateMgr(ctx context.Context, name string) (statemgr.Full, error
 			Tags: b.WorkspaceMapping.tfeTags(),
 		}
 		log.Printf("[TRACE] cloud: Adding tags for cloud backend workspace %s/%s", b.organization, name)
-		err = b.client.Workspaces.AddTags(ctx, workspace.ID, options)
+		err = b.client.Workspaces.AddTags(context.Background(), workspace.ID, options)
 		if err != nil {
 			return nil, fmt.Errorf("Error updating workspace %s: %w", name, err)
 		}

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -167,7 +167,7 @@ func (b *Cloud) ConfigSchema(context.Context) *configschema.Block {
 }
 
 // PrepareConfig implements backend.Backend.
-func (b *Cloud) PrepareConfig(ctx context.Context, obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
+func (b *Cloud) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	if obj.IsNull() {
 		return obj, diags

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -233,7 +233,7 @@ func (b *Cloud) ServiceDiscoveryAliases() ([]backend.HostAlias, error) {
 }
 
 // Configure implements backend.Enhanced.
-func (b *Cloud) Configure(ctx context.Context, obj cty.Value) tfdiags.Diagnostics {
+func (b *Cloud) Configure(obj cty.Value) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 	if obj.IsNull() {
 		return diags
@@ -327,7 +327,7 @@ func (b *Cloud) Configure(ctx context.Context, obj cty.Value) tfdiags.Diagnostic
 	}
 
 	// Check if the organization exists by reading its entitlements.
-	entitlements, err := b.client.Organizations.ReadEntitlements(ctx, b.organization)
+	entitlements, err := b.client.Organizations.ReadEntitlements(context.Background(), b.organization)
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			err = fmt.Errorf("organization %q at host %s not found.\n\n"+
@@ -347,7 +347,7 @@ func (b *Cloud) Configure(ctx context.Context, obj cty.Value) tfdiags.Diagnostic
 
 	if ws, ok := os.LookupEnv("TF_WORKSPACE"); ok {
 		if ws == b.WorkspaceMapping.Name || b.WorkspaceMapping.Strategy() == WorkspaceTagsStrategy {
-			diag := b.validWorkspaceEnvVar(ctx, b.organization, ws)
+			diag := b.validWorkspaceEnvVar(context.Background(), b.organization, ws)
 			if diag != nil {
 				diags = diags.Append(diag)
 				return diags

--- a/internal/cloud/backend_apply_test.go
+++ b/internal/cloud/backend_apply_test.go
@@ -117,7 +117,7 @@ func TestCloud_applyBasic(t *testing.T) {
 
 	stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after apply
-	if _, err := stateMgr.Lock(ctx, statemgr.NewLockInfo()); err != nil {
+	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after apply: %s", err.Error())
 	}
 }
@@ -178,7 +178,7 @@ func TestCloud_applyJSONBasic(t *testing.T) {
 
 	stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after apply
-	if _, err := stateMgr.Lock(ctx, statemgr.NewLockInfo()); err != nil {
+	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after apply: %s", err.Error())
 	}
 }
@@ -268,7 +268,7 @@ func TestCloud_applyJSONWithOutputs(t *testing.T) {
 	}
 	stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after apply
-	if _, err := stateMgr.Lock(ctx, statemgr.NewLockInfo()); err != nil {
+	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after apply: %s", err.Error())
 	}
 }
@@ -299,7 +299,7 @@ func TestCloud_applyCanceled(t *testing.T) {
 	}
 
 	stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
-	if _, err := stateMgr.Lock(ctx, statemgr.NewLockInfo()); err != nil {
+	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after cancelling apply: %s", err.Error())
 	}
 }
@@ -513,7 +513,7 @@ func TestCloud_applyWithCloudPlan(t *testing.T) {
 
 	stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after apply
-	if _, err := stateMgr.Lock(ctx, statemgr.NewLockInfo()); err != nil {
+	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after apply: %s", err.Error())
 	}
 }
@@ -731,7 +731,7 @@ func TestCloud_applyNoConfig(t *testing.T) {
 
 	stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after apply
-	if _, err := stateMgr.Lock(ctx, statemgr.NewLockInfo()); err != nil {
+	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after failed apply: %s", err.Error())
 	}
 }
@@ -1409,7 +1409,7 @@ func TestCloud_applyJSONWithProvisioner(t *testing.T) {
 
 	stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after apply
-	if _, err := stateMgr.Lock(ctx, statemgr.NewLockInfo()); err != nil {
+	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after apply: %s", err.Error())
 	}
 }

--- a/internal/cloud/backend_apply_test.go
+++ b/internal/cloud/backend_apply_test.go
@@ -85,9 +85,7 @@ func TestCloud_applyBasic(t *testing.T) {
 	op.UIOut = b.CLI
 	op.Workspace = testBackendSingleWorkspaceName
 
-	ctx := context.Background()
-
-	run, err := b.Operation(ctx, op)
+	run, err := b.Operation(context.Background(), op)
 	if err != nil {
 		t.Fatalf("error starting operation: %v", err)
 	}
@@ -115,7 +113,7 @@ func TestCloud_applyBasic(t *testing.T) {
 		t.Fatalf("expected apply summery in output: %s", output)
 	}
 
-	stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
+	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after apply
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after apply: %s", err.Error())
@@ -147,9 +145,7 @@ func TestCloud_applyJSONBasic(t *testing.T) {
 
 	mockSROWorkspace(t, b, op.Workspace)
 
-	ctx := context.Background()
-
-	run, err := b.Operation(ctx, op)
+	run, err := b.Operation(context.Background(), op)
 	if err != nil {
 		t.Fatalf("error starting operation: %v", err)
 	}
@@ -176,7 +172,7 @@ func TestCloud_applyJSONBasic(t *testing.T) {
 		t.Fatalf("expected apply summary in output: %s", gotOut)
 	}
 
-	stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
+	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after apply
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after apply: %s", err.Error())
@@ -208,9 +204,7 @@ func TestCloud_applyJSONWithOutputs(t *testing.T) {
 
 	mockSROWorkspace(t, b, op.Workspace)
 
-	ctx := context.Background()
-
-	run, err := b.Operation(ctx, op)
+	run, err := b.Operation(context.Background(), op)
 	if err != nil {
 		t.Fatalf("error starting operation: %v", err)
 	}
@@ -266,7 +260,7 @@ func TestCloud_applyJSONWithOutputs(t *testing.T) {
 	if !strings.Contains(gotOut, expectedComplexOutput) {
 		t.Fatalf("expected output: %s, got: %s", expectedComplexOutput, gotOut)
 	}
-	stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
+	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after apply
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after apply: %s", err.Error())
@@ -283,9 +277,7 @@ func TestCloud_applyCanceled(t *testing.T) {
 
 	op.Workspace = testBackendSingleWorkspaceName
 
-	ctx := context.Background()
-
-	run, err := b.Operation(ctx, op)
+	run, err := b.Operation(context.Background(), op)
 	if err != nil {
 		t.Fatalf("error starting operation: %v", err)
 	}
@@ -298,7 +290,7 @@ func TestCloud_applyCanceled(t *testing.T) {
 		t.Fatal("expected apply operation to fail")
 	}
 
-	stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
+	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after cancelling apply: %s", err.Error())
 	}
@@ -489,10 +481,8 @@ func TestCloud_applyWithCloudPlan(t *testing.T) {
 		Colorize: mockColorize(),
 	}
 
-	ctx := context.Background()
-
 	// Try apply
-	run, err := b.Operation(ctx, op)
+	run, err := b.Operation(context.Background(), op)
 	if err != nil {
 		t.Fatalf("error starting operation: %v", err)
 	}
@@ -511,7 +501,7 @@ func TestCloud_applyWithCloudPlan(t *testing.T) {
 		t.Fatalf("expected apply summary in output: %s", gotOut)
 	}
 
-	stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
+	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after apply
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after apply: %s", err.Error())
@@ -708,9 +698,7 @@ func TestCloud_applyNoConfig(t *testing.T) {
 
 	op.Workspace = testBackendSingleWorkspaceName
 
-	ctx := context.Background()
-
-	run, err := b.Operation(ctx, op)
+	run, err := b.Operation(context.Background(), op)
 	if err != nil {
 		t.Fatalf("error starting operation: %v", err)
 	}
@@ -729,7 +717,7 @@ func TestCloud_applyNoConfig(t *testing.T) {
 		t.Fatalf("expected configuration files error, got: %v", errOutput)
 	}
 
-	stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
+	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after apply
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after failed apply: %s", err.Error())
@@ -1373,9 +1361,7 @@ func TestCloud_applyJSONWithProvisioner(t *testing.T) {
 
 	mockSROWorkspace(t, b, op.Workspace)
 
-	ctx := context.Background()
-
-	run, err := b.Operation(ctx, op)
+	run, err := b.Operation(context.Background(), op)
 	if err != nil {
 		t.Fatalf("error starting operation: %v", err)
 	}
@@ -1407,7 +1393,7 @@ func TestCloud_applyJSONWithProvisioner(t *testing.T) {
 		t.Fatalf("expected provisioner local-exec output in logs: %s", gotOut)
 	}
 
-	stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
+	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after apply
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after apply: %s", err.Error())

--- a/internal/cloud/backend_context.go
+++ b/internal/cloud/backend_context.go
@@ -30,15 +30,14 @@ func (b *Cloud) LocalRun(op *backend.Operation) (*backend.LocalRun, statemgr.Ful
 		},
 	}
 
-	ctx := context.TODO()
-	op.StateLocker = op.StateLocker.WithContext(ctx)
+	op.StateLocker = op.StateLocker.WithContext(context.Background())
 
 	// Get the remote workspace name.
 	remoteWorkspaceName := b.getRemoteWorkspaceName(op.Workspace)
 
 	// Get the latest state.
 	log.Printf("[TRACE] cloud: requesting state manager for workspace %q", remoteWorkspaceName)
-	stateMgr, err := b.StateMgr(ctx, op.Workspace)
+	stateMgr, err := b.StateMgr(op.Workspace)
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("error loading state: %w", err))
 		return nil, nil, diags

--- a/internal/cloud/backend_context.go
+++ b/internal/cloud/backend_context.go
@@ -58,7 +58,7 @@ func (b *Cloud) LocalRun(op *backend.Operation) (*backend.LocalRun, statemgr.Ful
 	}()
 
 	log.Printf("[TRACE] cloud: reading remote state for workspace %q", remoteWorkspaceName)
-	if err := stateMgr.RefreshState(ctx); err != nil {
+	if err := stateMgr.RefreshState(); err != nil {
 		diags = diags.Append(fmt.Errorf("error loading state: %w", err))
 		return nil, nil, diags
 	}

--- a/internal/cloud/backend_context_test.go
+++ b/internal/cloud/backend_context_test.go
@@ -227,7 +227,7 @@ func TestRemoteContextWithVars(t *testing.T) {
 				// When Context() returns an error, it should unlock the state,
 				// so re-locking it is expected to succeed.
 				stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
-				if _, err := stateMgr.Lock(ctx, statemgr.NewLockInfo()); err != nil {
+				if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 					t.Fatalf("unexpected error locking state: %s", err.Error())
 				}
 			} else {
@@ -236,7 +236,7 @@ func TestRemoteContextWithVars(t *testing.T) {
 				}
 				// When Context() succeeds, this should fail w/ "workspace already locked"
 				stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
-				if _, err := stateMgr.Lock(ctx, statemgr.NewLockInfo()); err == nil {
+				if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err == nil {
 					t.Fatal("unexpected success locking state after Context")
 				}
 			}
@@ -444,7 +444,7 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 			}
 			// When Context() succeeds, this should fail w/ "workspace already locked"
 			stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
-			if _, err := stateMgr.Lock(ctx, statemgr.NewLockInfo()); err == nil {
+			if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err == nil {
 				t.Fatal("unexpected success locking state after Context")
 			}
 

--- a/internal/cloud/backend_context_test.go
+++ b/internal/cloud/backend_context_test.go
@@ -209,10 +209,7 @@ func TestRemoteContextWithVars(t *testing.T) {
 				key := "key"
 				v.Key = &key
 			}
-
-			ctx := context.Background()
-
-			b.client.Variables.Create(ctx, workspaceID, *v)
+			b.client.Variables.Create(context.TODO(), workspaceID, *v)
 
 			_, _, diags := b.LocalRun(op)
 
@@ -226,7 +223,7 @@ func TestRemoteContextWithVars(t *testing.T) {
 				}
 				// When Context() returns an error, it should unlock the state,
 				// so re-locking it is expected to succeed.
-				stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
+				stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
 				if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 					t.Fatalf("unexpected error locking state: %s", err.Error())
 				}
@@ -235,7 +232,7 @@ func TestRemoteContextWithVars(t *testing.T) {
 					t.Fatalf("unexpected error\ngot:  %s\nwant: <no error>", diags.Err().Error())
 				}
 				// When Context() succeeds, this should fail w/ "workspace already locked"
-				stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
+				stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
 				if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err == nil {
 					t.Fatal("unexpected success locking state after Context")
 				}
@@ -431,10 +428,8 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 				Variables:    test.localVariables,
 			}
 
-			ctx := context.Background()
-
 			for _, v := range test.remoteVariables {
-				b.client.Variables.Create(ctx, workspaceID, *v)
+				b.client.Variables.Create(context.TODO(), workspaceID, *v)
 			}
 
 			lr, _, diags := b.LocalRun(op)
@@ -443,7 +438,7 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 				t.Fatalf("unexpected error\ngot:  %s\nwant: <no error>", diags.Err().Error())
 			}
 			// When Context() succeeds, this should fail w/ "workspace already locked"
-			stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
+			stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
 			if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err == nil {
 				t.Fatal("unexpected success locking state after Context")
 			}

--- a/internal/cloud/backend_plan_test.go
+++ b/internal/cloud/backend_plan_test.go
@@ -101,7 +101,7 @@ func TestCloud_planBasic(t *testing.T) {
 
 	stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after the operation finished
-	if _, err := stateMgr.Lock(ctx, statemgr.NewLockInfo()); err != nil {
+	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after successful plan: %s", err.Error())
 	}
 }
@@ -148,7 +148,7 @@ func TestCloud_planJSONBasic(t *testing.T) {
 
 	stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after the operation finished
-	if _, err := stateMgr.Lock(ctx, statemgr.NewLockInfo()); err != nil {
+	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after successful plan: %s", err.Error())
 	}
 }
@@ -179,7 +179,7 @@ func TestCloud_planCanceled(t *testing.T) {
 
 	stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after the operation finished
-	if _, err := stateMgr.Lock(ctx, statemgr.NewLockInfo()); err != nil {
+	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after cancelled plan: %s", err.Error())
 	}
 }
@@ -262,7 +262,7 @@ func TestCloud_planJSONFull(t *testing.T) {
 
 	stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after the operation finished
-	if _, err := stateMgr.Lock(ctx, statemgr.NewLockInfo()); err != nil {
+	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after successful plan: %s", err.Error())
 	}
 }
@@ -1337,7 +1337,7 @@ func TestCloud_planImportConfigGeneration(t *testing.T) {
 
 	stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after the operation finished
-	if _, err := stateMgr.Lock(ctx, statemgr.NewLockInfo()); err != nil {
+	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after successful plan: %s", err.Error())
 	}
 

--- a/internal/cloud/backend_plan_test.go
+++ b/internal/cloud/backend_plan_test.go
@@ -76,9 +76,7 @@ func TestCloud_planBasic(t *testing.T) {
 
 	op.Workspace = testBackendSingleWorkspaceName
 
-	ctx := context.Background()
-
-	run, err := b.Operation(ctx, op)
+	run, err := b.Operation(context.Background(), op)
 	if err != nil {
 		t.Fatalf("error starting operation: %v", err)
 	}
@@ -99,7 +97,7 @@ func TestCloud_planBasic(t *testing.T) {
 		t.Fatalf("expected plan summary in output: %s", output)
 	}
 
-	stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
+	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after the operation finished
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after successful plan: %s", err.Error())
@@ -125,8 +123,7 @@ func TestCloud_planJSONBasic(t *testing.T) {
 
 	mockSROWorkspace(t, b, op.Workspace)
 
-	ctx := context.Background()
-	run, err := b.Operation(ctx, op)
+	run, err := b.Operation(context.Background(), op)
 	if err != nil {
 		t.Fatalf("error starting operation: %v", err)
 	}
@@ -146,7 +143,7 @@ func TestCloud_planJSONBasic(t *testing.T) {
 		t.Fatalf("expected plan summary in output: %s", gotOut)
 	}
 
-	stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
+	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after the operation finished
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after successful plan: %s", err.Error())
@@ -163,8 +160,7 @@ func TestCloud_planCanceled(t *testing.T) {
 
 	op.Workspace = testBackendSingleWorkspaceName
 
-	ctx := context.Background()
-	run, err := b.Operation(ctx, op)
+	run, err := b.Operation(context.Background(), op)
 	if err != nil {
 		t.Fatalf("error starting operation: %v", err)
 	}
@@ -177,7 +173,7 @@ func TestCloud_planCanceled(t *testing.T) {
 		t.Fatal("expected plan operation to fail")
 	}
 
-	stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
+	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after the operation finished
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after cancelled plan: %s", err.Error())
@@ -235,8 +231,7 @@ func TestCloud_planJSONFull(t *testing.T) {
 
 	mockSROWorkspace(t, b, op.Workspace)
 
-	ctx := context.Background()
-	run, err := b.Operation(ctx, op)
+	run, err := b.Operation(context.Background(), op)
 	if err != nil {
 		t.Fatalf("error starting operation: %v", err)
 	}
@@ -260,7 +255,7 @@ func TestCloud_planJSONFull(t *testing.T) {
 		t.Fatalf("expected plan summary in output: %s", gotOut)
 	}
 
-	stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
+	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after the operation finished
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after successful plan: %s", err.Error())
@@ -1315,8 +1310,7 @@ func TestCloud_planImportConfigGeneration(t *testing.T) {
 
 	mockSROWorkspace(t, b, op.Workspace)
 
-	ctx := context.Background()
-	run, err := b.Operation(ctx, op)
+	run, err := b.Operation(context.Background(), op)
 	if err != nil {
 		t.Fatalf("error starting operation: %v", err)
 	}
@@ -1335,7 +1329,7 @@ func TestCloud_planImportConfigGeneration(t *testing.T) {
 		t.Fatalf("expected plan summary in output: %s", gotOut)
 	}
 
-	stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
+	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after the operation finished
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after successful plan: %s", err.Error())

--- a/internal/cloud/backend_refresh_test.go
+++ b/internal/cloud/backend_refresh_test.go
@@ -78,7 +78,7 @@ func TestCloud_refreshBasicActuallyRunsApplyRefresh(t *testing.T) {
 
 	stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after apply
-	if _, err := stateMgr.Lock(ctx, statemgr.NewLockInfo()); err != nil {
+	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after apply: %s", err.Error())
 	}
 }

--- a/internal/cloud/backend_refresh_test.go
+++ b/internal/cloud/backend_refresh_test.go
@@ -60,8 +60,7 @@ func TestCloud_refreshBasicActuallyRunsApplyRefresh(t *testing.T) {
 	op.PlanMode = plans.RefreshOnlyMode
 	op.Workspace = testBackendSingleWorkspaceName
 
-	ctx := context.Background()
-	run, err := b.Operation(ctx, op)
+	run, err := b.Operation(context.Background(), op)
 	if err != nil {
 		t.Fatalf("error starting operation: %v", err)
 	}
@@ -76,7 +75,7 @@ func TestCloud_refreshBasicActuallyRunsApplyRefresh(t *testing.T) {
 		t.Fatalf("expected TFC header in output: %s", output)
 	}
 
-	stateMgr, _ := b.StateMgr(ctx, testBackendSingleWorkspaceName)
+	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after apply
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after apply: %s", err.Error())

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -32,7 +32,7 @@ func TestCloud_backendWithName(t *testing.T) {
 
 	ctx := context.Background()
 
-	workspaces, err := b.Workspaces(ctx)
+	workspaces, err := b.Workspaces()
 	if err != nil {
 		t.Fatalf("error: %v", err)
 	}
@@ -105,7 +105,7 @@ func TestCloud_backendWithTags(t *testing.T) {
 		}
 	}
 
-	workspaces, err := b.Workspaces(ctx)
+	workspaces, err := b.Workspaces()
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}
@@ -1378,7 +1378,7 @@ func TestCloudBackend_DeleteWorkspace_SafeAndForce(t *testing.T) {
 	}
 
 	// sanity check that the mock now contains two workspaces
-	wl, err := b.Workspaces(ctx)
+	wl, err := b.Workspaces()
 	if err != nil {
 		t.Fatalf("error fetching workspace names: %v", err)
 	}

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -76,7 +76,7 @@ func TestCloud_backendWithoutHost(t *testing.T) {
 	}
 	obj = newObj
 
-	confDiags := b.Configure(ctx, obj)
+	confDiags := b.Configure(obj)
 
 	if !confDiags.HasErrors() {
 		t.Fatalf("testBackend: backend.Configure() should have failed")
@@ -595,7 +595,7 @@ func WithEnvVars(t *testing.T) {
 				tc.setup(b)
 			}
 
-			diags := b.Configure(ctx, tc.config)
+			diags := b.Configure(tc.config)
 			if (diags.Err() != nil || tc.expectedErr != "") &&
 				(diags.Err() == nil || !strings.Contains(diags.Err().Error(), tc.expectedErr)) {
 				t.Fatalf("%s: unexpected configure result: %v", name, diags.Err())
@@ -731,7 +731,7 @@ func TestCloud_config(t *testing.T) {
 			}
 
 			// Configure
-			confDiags := b.Configure(ctx, tc.config)
+			confDiags := b.Configure(tc.config)
 			if (confDiags.Err() != nil || tc.confErr != "") &&
 				(confDiags.Err() == nil || !strings.Contains(confDiags.Err().Error(), tc.confErr)) {
 				t.Fatalf("unexpected configure result: %v", confDiags.Err())
@@ -766,9 +766,7 @@ func TestCloud_configVerifyMinimumTFEVersion(t *testing.T) {
 
 	b := New(testDisco(s))
 
-	ctx := context.Background()
-
-	confDiags := b.Configure(ctx, config)
+	confDiags := b.Configure(config)
 	if confDiags.Err() == nil {
 		t.Fatalf("expected configure to error")
 	}
@@ -806,9 +804,7 @@ func TestCloud_configVerifyMinimumTFEVersionInAutomation(t *testing.T) {
 	b := New(testDisco(s))
 	b.runningInAutomation = true
 
-	ctx := context.Background()
-
-	confDiags := b.Configure(ctx, config)
+	confDiags := b.Configure(config)
 	if confDiags.Err() == nil {
 		t.Fatalf("expected configure to error")
 	}
@@ -1427,7 +1423,7 @@ func TestCloud_ServiceDiscoveryAliases(t *testing.T) {
 	s := testServer(t)
 	b := New(testDisco(s))
 
-	diag := b.Configure(context.Background(), cty.ObjectVal(map[string]cty.Value{
+	diag := b.Configure(cty.ObjectVal(map[string]cty.Value{
 		"hostname":     cty.StringVal("app.terraform.io"),
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -30,8 +30,6 @@ func TestCloud_backendWithName(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	ctx := context.Background()
-
 	workspaces, err := b.Workspaces()
 	if err != nil {
 		t.Fatalf("error: %v", err)
@@ -41,7 +39,7 @@ func TestCloud_backendWithName(t *testing.T) {
 		t.Fatalf("should only have a single configured workspace matching the configured 'name' strategy, but got: %#v", workspaces)
 	}
 
-	if _, err := b.StateMgr(ctx, "foo"); err != backend.ErrWorkspacesNotSupported {
+	if _, err := b.StateMgr("foo"); err != backend.ErrWorkspacesNotSupported {
 		t.Fatalf("expected fetching a state which is NOT the single configured workspace to have an ErrWorkspacesNotSupported error, but got: %v", err)
 	}
 
@@ -95,11 +93,9 @@ func TestCloud_backendWithTags(t *testing.T) {
 
 	backend.TestBackendStates(t, b)
 
-	ctx := context.Background()
-
 	// Test pagination works
 	for i := 0; i < 25; i++ {
-		_, err := b.StateMgr(ctx, fmt.Sprintf("foo-%d", i+1))
+		_, err := b.StateMgr(fmt.Sprintf("foo-%d", i+1))
 		if err != nil {
 			t.Fatalf("error: %s", err)
 		}
@@ -848,18 +844,16 @@ func TestCloud_setUnavailableTerraformVersion(t *testing.T) {
 	b, _, bCleanup := testBackend(t, config, nil)
 	defer bCleanup()
 
-	ctx := context.Background()
-
 	// Make sure the workspace doesn't exist yet -- otherwise, we can't test what
 	// happens when a workspace gets created. This is why we can't use "name" in
 	// the backend config above, btw: if you do, testBackend() creates the default
 	// workspace before we get a chance to do anything.
-	_, err := b.client.Workspaces.Read(ctx, b.organization, workspaceName)
+	_, err := b.client.Workspaces.Read(context.Background(), b.organization, workspaceName)
 	if err != tfe.ErrResourceNotFound {
 		t.Fatalf("the workspace we were about to try and create (%s/%s) already exists in the mocks somehow, so this test isn't trustworthy anymore", b.organization, workspaceName)
 	}
 
-	_, err = b.StateMgr(ctx, workspaceName)
+	_, err = b.StateMgr(workspaceName)
 	if err != nil {
 		t.Fatalf("expected no error from StateMgr, despite not being able to set remote TF version: %#v", err)
 	}
@@ -1065,9 +1059,7 @@ func TestCloud_addAndRemoveWorkspacesDefault(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	ctx := context.Background()
-
-	if _, err := b.StateMgr(ctx, testBackendSingleWorkspaceName); err != nil {
+	if _, err := b.StateMgr(testBackendSingleWorkspaceName); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
@@ -1100,12 +1092,10 @@ func TestCloud_StateMgr_versionCheck(t *testing.T) {
 	tfversion.Version = v0140.String()
 	tfversion.SemVer = v0140
 
-	ctx := context.Background()
-
 	// Update the mock remote workspace Terraform version to match the local
 	// Terraform version
 	if _, err := b.client.Workspaces.Update(
-		ctx,
+		context.Background(),
 		b.organization,
 		b.WorkspaceMapping.Name,
 		tfe.WorkspaceUpdateOptions{
@@ -1116,7 +1106,7 @@ func TestCloud_StateMgr_versionCheck(t *testing.T) {
 	}
 
 	// This should succeed
-	if _, err := b.StateMgr(ctx, testBackendSingleWorkspaceName); err != nil {
+	if _, err := b.StateMgr(testBackendSingleWorkspaceName); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
@@ -1134,7 +1124,7 @@ func TestCloud_StateMgr_versionCheck(t *testing.T) {
 
 	// This should fail
 	want := `Remote workspace TF version "0.13.5" does not match local OpenTofu version "0.14.0"`
-	if _, err := b.StateMgr(ctx, testBackendSingleWorkspaceName); err.Error() != want {
+	if _, err := b.StateMgr(testBackendSingleWorkspaceName); err.Error() != want {
 		t.Fatalf("wrong error\n got: %v\nwant: %v", err.Error(), want)
 	}
 }
@@ -1160,11 +1150,9 @@ func TestCloud_StateMgr_versionCheckLatest(t *testing.T) {
 	tfversion.Version = v0140.String()
 	tfversion.SemVer = v0140
 
-	ctx := context.Background()
-
 	// Update the remote workspace to the pseudo-version "latest"
 	if _, err := b.client.Workspaces.Update(
-		ctx,
+		context.Background(),
 		b.organization,
 		b.WorkspaceMapping.Name,
 		tfe.WorkspaceUpdateOptions{
@@ -1175,7 +1163,7 @@ func TestCloud_StateMgr_versionCheckLatest(t *testing.T) {
 	}
 
 	// This should succeed despite not being a string match
-	if _, err := b.StateMgr(ctx, testBackendSingleWorkspaceName); err != nil {
+	if _, err := b.StateMgr(testBackendSingleWorkspaceName); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 }
@@ -1365,14 +1353,12 @@ func TestCloudBackend_DeleteWorkspace_SafeAndForce(t *testing.T) {
 	safeDeleteWorkspaceName := "safe-delete-workspace"
 	forceDeleteWorkspaceName := "force-delete-workspace"
 
-	ctx := context.Background()
-
-	_, err := b.StateMgr(ctx, safeDeleteWorkspaceName)
+	_, err := b.StateMgr(safeDeleteWorkspaceName)
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}
 
-	_, err = b.StateMgr(ctx, forceDeleteWorkspaceName)
+	_, err = b.StateMgr(forceDeleteWorkspaceName)
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}
@@ -1383,16 +1369,17 @@ func TestCloudBackend_DeleteWorkspace_SafeAndForce(t *testing.T) {
 		t.Fatalf("error fetching workspace names: %v", err)
 	}
 	if len(wl) != 2 {
-		t.Fatalf("expected 2 workspaces but got %d", len(wl))
+		t.Fatalf("expected 2 workspaced but got %d", len(wl))
 	}
 
-	safeDeleteWorkspace, err := b.client.Workspaces.Read(ctx, b.organization, safeDeleteWorkspaceName)
+	c := context.Background()
+	safeDeleteWorkspace, err := b.client.Workspaces.Read(c, b.organization, safeDeleteWorkspaceName)
 	if err != nil {
 		t.Fatalf("error fetching workspace: %v", err)
 	}
 
 	// Lock a workspace so that it should fail to be safe deleted
-	_, err = b.client.Workspaces.Lock(ctx, safeDeleteWorkspace.ID, tfe.WorkspaceLockOptions{Reason: tfe.String("test")})
+	_, err = b.client.Workspaces.Lock(context.Background(), safeDeleteWorkspace.ID, tfe.WorkspaceLockOptions{Reason: tfe.String("test")})
 	if err != nil {
 		t.Fatalf("error locking workspace: %v", err)
 	}
@@ -1402,7 +1389,7 @@ func TestCloudBackend_DeleteWorkspace_SafeAndForce(t *testing.T) {
 	}
 
 	// unlock the workspace and confirm that safe-delete now works
-	_, err = b.client.Workspaces.Unlock(ctx, safeDeleteWorkspace.ID)
+	_, err = b.client.Workspaces.Unlock(context.Background(), safeDeleteWorkspace.ID)
 	if err != nil {
 		t.Fatalf("error unlocking workspace: %v", err)
 	}
@@ -1412,11 +1399,11 @@ func TestCloudBackend_DeleteWorkspace_SafeAndForce(t *testing.T) {
 	}
 
 	// lock a workspace and then confirm that force deleting it works
-	forceDeleteWorkspace, err := b.client.Workspaces.Read(ctx, b.organization, forceDeleteWorkspaceName)
+	forceDeleteWorkspace, err := b.client.Workspaces.Read(c, b.organization, forceDeleteWorkspaceName)
 	if err != nil {
 		t.Fatalf("error fetching workspace: %v", err)
 	}
-	_, err = b.client.Workspaces.Lock(ctx, forceDeleteWorkspace.ID, tfe.WorkspaceLockOptions{Reason: tfe.String("test")})
+	_, err = b.client.Workspaces.Lock(context.Background(), forceDeleteWorkspace.ID, tfe.WorkspaceLockOptions{Reason: tfe.String("test")})
 	if err != nil {
 		t.Fatalf("error locking workspace: %v", err)
 	}

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -45,11 +45,11 @@ func TestCloud_backendWithName(t *testing.T) {
 		t.Fatalf("expected fetching a state which is NOT the single configured workspace to have an ErrWorkspacesNotSupported error, but got: %v", err)
 	}
 
-	if err := b.DeleteWorkspace(ctx, testBackendSingleWorkspaceName, true); err != backend.ErrWorkspacesNotSupported {
+	if err := b.DeleteWorkspace(testBackendSingleWorkspaceName, true); err != backend.ErrWorkspacesNotSupported {
 		t.Fatalf("expected deleting the single configured workspace name to result in an error, but got: %v", err)
 	}
 
-	if err := b.DeleteWorkspace(ctx, "foo", true); err != backend.ErrWorkspacesNotSupported {
+	if err := b.DeleteWorkspace("foo", true); err != backend.ErrWorkspacesNotSupported {
 		t.Fatalf("expected deleting a workspace which is NOT the configured workspace name to result in an error, but got: %v", err)
 	}
 }
@@ -1071,7 +1071,7 @@ func TestCloud_addAndRemoveWorkspacesDefault(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if err := b.DeleteWorkspace(ctx, testBackendSingleWorkspaceName, true); err != backend.ErrWorkspacesNotSupported {
+	if err := b.DeleteWorkspace(testBackendSingleWorkspaceName, true); err != backend.ErrWorkspacesNotSupported {
 		t.Fatalf("expected error %v, got %v", backend.ErrWorkspacesNotSupported, err)
 	}
 }
@@ -1396,7 +1396,7 @@ func TestCloudBackend_DeleteWorkspace_SafeAndForce(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error locking workspace: %v", err)
 	}
-	err = b.DeleteWorkspace(ctx, safeDeleteWorkspaceName, false)
+	err = b.DeleteWorkspace(safeDeleteWorkspaceName, false)
 	if err == nil {
 		t.Fatalf("workspace should have failed to safe delete")
 	}
@@ -1406,7 +1406,7 @@ func TestCloudBackend_DeleteWorkspace_SafeAndForce(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error unlocking workspace: %v", err)
 	}
-	err = b.DeleteWorkspace(ctx, safeDeleteWorkspaceName, false)
+	err = b.DeleteWorkspace(safeDeleteWorkspaceName, false)
 	if err != nil {
 		t.Fatalf("error safe deleting workspace: %v", err)
 	}
@@ -1420,7 +1420,7 @@ func TestCloudBackend_DeleteWorkspace_SafeAndForce(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error locking workspace: %v", err)
 	}
-	err = b.DeleteWorkspace(ctx, forceDeleteWorkspaceName, true)
+	err = b.DeleteWorkspace(forceDeleteWorkspaceName, true)
 	if err != nil {
 		t.Fatalf("error force deleting workspace: %v", err)
 	}
@@ -1430,9 +1430,7 @@ func TestCloudBackend_DeleteWorkspace_DoesNotExist(t *testing.T) {
 	b, bCleanup := testBackendWithTags(t)
 	defer bCleanup()
 
-	ctx := context.Background()
-
-	err := b.DeleteWorkspace(ctx, "non-existent-workspace", false)
+	err := b.DeleteWorkspace("non-existent-workspace", false)
 	if err != nil {
 		t.Fatalf("expected deleting a workspace which does not exist to succeed")
 	}

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -67,10 +67,8 @@ func TestCloud_backendWithoutHost(t *testing.T) {
 		}),
 	})
 
-	ctx := context.Background()
-
 	// Configure the backend so the client is created.
-	newObj, valDiags := b.PrepareConfig(ctx, obj)
+	newObj, valDiags := b.PrepareConfig(obj)
 	if len(valDiags) != 0 {
 		t.Fatalf("testBackend: backend.PrepareConfig() failed: %s", valDiags.ErrWithWarnings())
 	}
@@ -177,10 +175,8 @@ func TestCloud_PrepareConfig(t *testing.T) {
 		s := testServer(t)
 		b := New(testDisco(s))
 
-		ctx := context.Background()
-
 		// Validate
-		_, valDiags := b.PrepareConfig(ctx, tc.config)
+		_, valDiags := b.PrepareConfig(tc.config)
 		if valDiags.Err() != nil && tc.expectedErr != "" {
 			actualErr := valDiags.Err().Error()
 			if !strings.Contains(actualErr, tc.expectedErr) {
@@ -293,9 +289,7 @@ func TestCloud_PrepareConfigWithEnvVars(t *testing.T) {
 				}
 			})
 
-			ctx := context.Background()
-
-			_, valDiags := b.PrepareConfig(ctx, tc.config)
+			_, valDiags := b.PrepareConfig(tc.config)
 			if valDiags.Err() != nil && tc.expectedErr != "" {
 				actualErr := valDiags.Err().Error()
 				if !strings.Contains(actualErr, tc.expectedErr) {
@@ -584,9 +578,7 @@ func WithEnvVars(t *testing.T) {
 				}
 			})
 
-			ctx := context.Background()
-
-			_, valDiags := b.PrepareConfig(ctx, tc.config)
+			_, valDiags := b.PrepareConfig(tc.config)
 			if valDiags.Err() != nil {
 				t.Fatalf("%s: unexpected validation result: %v", name, valDiags.Err())
 			}
@@ -721,10 +713,8 @@ func TestCloud_config(t *testing.T) {
 			b, cleanup := testUnconfiguredBackend(t)
 			t.Cleanup(cleanup)
 
-			ctx := context.Background()
-
 			// Validate
-			_, valDiags := b.PrepareConfig(ctx, tc.config)
+			_, valDiags := b.PrepareConfig(tc.config)
 			if (valDiags.Err() != nil || tc.valErr != "") &&
 				(valDiags.Err() == nil || !strings.Contains(valDiags.Err().Error(), tc.valErr)) {
 				t.Fatalf("unexpected validation result: %v", valDiags.Err())

--- a/internal/cloud/state.go
+++ b/internal/cloud/state.go
@@ -330,13 +330,14 @@ func (s *State) uploadState(ctx context.Context, lineage string, serial uint64, 
 }
 
 // Lock calls the Client's Lock method if it's implemented.
-func (s *State) Lock(ctx context.Context, info *statemgr.LockInfo) (string, error) {
+func (s *State) Lock(info *statemgr.LockInfo) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if s.disableLocks {
 		return "", nil
 	}
+	ctx := context.Background()
 
 	lockErr := &statemgr.LockError{Info: s.lockInfo}
 
@@ -433,13 +434,15 @@ func (s *State) getStatePayload(ctx context.Context) (*remote.Payload, error) {
 }
 
 // Unlock calls the Client's Unlock method if it's implemented.
-func (s *State) Unlock(ctx context.Context, id string) error {
+func (s *State) Unlock(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if s.disableLocks {
 		return nil
 	}
+
+	ctx := context.Background()
 
 	// We first check if there was an error while uploading the latest
 	// state. If so, we will not unlock the workspace to prevent any

--- a/internal/cloud/state.go
+++ b/internal/cloud/state.go
@@ -497,15 +497,15 @@ func (s *State) Unlock(id string) error {
 }
 
 // Delete the remote state.
-func (s *State) Delete(ctx context.Context, force bool) error {
+func (s *State) Delete(force bool) error {
 
 	var err error
 
 	isSafeDeleteSupported := s.workspace.Permissions.CanForceDelete != nil
 	if force || !isSafeDeleteSupported {
-		err = s.tfeClient.Workspaces.Delete(ctx, s.organization, s.workspace.Name)
+		err = s.tfeClient.Workspaces.Delete(context.Background(), s.organization, s.workspace.Name)
 	} else {
-		err = s.tfeClient.Workspaces.SafeDelete(ctx, s.organization, s.workspace.Name)
+		err = s.tfeClient.Workspaces.SafeDelete(context.Background(), s.organization, s.workspace.Name)
 	}
 
 	if err != nil && err != tfe.ErrResourceNotFound {

--- a/internal/cloud/state.go
+++ b/internal/cloud/state.go
@@ -162,7 +162,7 @@ func (s *State) WriteState(state *states.State) error {
 }
 
 // PersistState uploads a snapshot of the latest state as a StateVersion to Terraform Cloud
-func (s *State) PersistState(ctx context.Context, schemas *tofu.Schemas) error {
+func (s *State) PersistState(schemas *tofu.Schemas) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -182,7 +182,7 @@ func (s *State) PersistState(ctx context.Context, schemas *tofu.Schemas) error {
 		// We might be writing a new state altogether, but before we do that
 		// we'll check to make sure there isn't already a snapshot present
 		// that we ought to be updating.
-		err := s.refreshState(ctx)
+		err := s.refreshState()
 		if err != nil {
 			return fmt.Errorf("failed checking for existing remote state: %w", err)
 		}
@@ -229,7 +229,7 @@ func (s *State) PersistState(ctx context.Context, schemas *tofu.Schemas) error {
 		return fmt.Errorf("failed to marshal outputs to json: %w", err)
 	}
 
-	err = s.uploadState(ctx, s.lineage, s.serial, s.forcePush, buf.Bytes(), jsonState, jsonStateOutputs)
+	err = s.uploadState(s.lineage, s.serial, s.forcePush, buf.Bytes(), jsonState, jsonStateOutputs)
 	if err != nil {
 		s.stateUploadErr = true
 		return fmt.Errorf("error uploading state: %w", err)
@@ -293,7 +293,9 @@ func (s *State) uploadStateFallback(ctx context.Context, lineage string, serial 
 	return err
 }
 
-func (s *State) uploadState(ctx context.Context, lineage string, serial uint64, isForcePush bool, state, jsonState, jsonStateOutputs []byte) error {
+func (s *State) uploadState(lineage string, serial uint64, isForcePush bool, state, jsonState, jsonStateOutputs []byte) error {
+	ctx := context.Background()
+
 	options := tfe.StateVersionUploadOptions{
 		StateVersionCreateOptions: tfe.StateVersionCreateOptions{
 			Lineage:          tfe.String(lineage),
@@ -360,17 +362,17 @@ func (s *State) Lock(info *statemgr.LockInfo) (string, error) {
 }
 
 // statemgr.Refresher impl.
-func (s *State) RefreshState(ctx context.Context) error {
+func (s *State) RefreshState() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.refreshState(ctx)
+	return s.refreshState()
 }
 
 // refreshState is the main implementation of RefreshState, but split out so
 // that we can make internal calls to it from methods that are already holding
 // the s.mu lock.
-func (s *State) refreshState(ctx context.Context) error {
-	payload, err := s.getStatePayload(ctx)
+func (s *State) refreshState() error {
+	payload, err := s.getStatePayload()
 	if err != nil {
 		return err
 	}
@@ -400,7 +402,9 @@ func (s *State) refreshState(ctx context.Context) error {
 	return nil
 }
 
-func (s *State) getStatePayload(ctx context.Context) (*remote.Payload, error) {
+func (s *State) getStatePayload() (*remote.Payload, error) {
+	ctx := context.Background()
+
 	// Check the x-terraform-snapshot-interval header to see if it has a non-empty
 	// value which would indicate snapshots are enabled
 	ctx = tfe.ContextWithResponseHeaderHook(ctx, s.readSnapshotIntervalHeader)
@@ -512,7 +516,9 @@ func (s *State) Delete(ctx context.Context, force bool) error {
 }
 
 // GetRootOutputValues fetches output values from Terraform Cloud
-func (s *State) GetRootOutputValues(ctx context.Context) (map[string]*states.OutputValue, error) {
+func (s *State) GetRootOutputValues() (map[string]*states.OutputValue, error) {
+	ctx := context.Background()
+
 	so, err := s.tfeClient.StateVersionOutputs.ReadCurrent(ctx, s.workspace.ID)
 
 	if err != nil {
@@ -529,7 +535,7 @@ func (s *State) GetRootOutputValues(ctx context.Context) (map[string]*states.Out
 			// requires a higher level of authorization.
 			log.Printf("[DEBUG] falling back to reading full state")
 
-			if err := s.RefreshState(ctx); err != nil {
+			if err := s.RefreshState(); err != nil {
 				return nil, fmt.Errorf("failed to load state: %w", err)
 			}
 

--- a/internal/cloud/state_test.go
+++ b/internal/cloud/state_test.go
@@ -41,10 +41,7 @@ func TestState_GetRootOutputValues(t *testing.T) {
 	state := &State{tfeClient: b.client, organization: b.organization, workspace: &tfe.Workspace{
 		ID: "ws-abcd",
 	}}
-
-	ctx := context.Background()
-
-	outputs, err := state.GetRootOutputValues(ctx)
+	outputs, err := state.GetRootOutputValues()
 
 	if err != nil {
 		t.Fatalf("error returned from GetRootOutputValues: %s", err)
@@ -118,13 +115,11 @@ func TestState(t *testing.T) {
 	}
 }`)
 
-	ctx := context.Background()
-
-	if err := state.uploadState(ctx, state.lineage, state.serial, state.forcePush, data, jsonState, jsonStateOutputs); err != nil {
+	if err := state.uploadState(state.lineage, state.serial, state.forcePush, data, jsonState, jsonStateOutputs); err != nil {
 		t.Fatalf("put: %s", err)
 	}
 
-	payload, err := state.getStatePayload(ctx)
+	payload, err := state.getStatePayload()
 	if err != nil {
 		t.Fatalf("get: %s", err)
 	}
@@ -132,11 +127,13 @@ func TestState(t *testing.T) {
 		t.Fatalf("expected full state %q\n\ngot: %q", string(payload.Data), string(data))
 	}
 
+	ctx := context.Background()
+
 	if err := state.Delete(ctx, true); err != nil {
 		t.Fatalf("delete: %s", err)
 	}
 
-	p, err := state.getStatePayload(ctx)
+	p, err := state.getStatePayload()
 	if err != nil {
 		t.Fatalf("get: %s", err)
 	}
@@ -280,7 +277,7 @@ func TestState_PersistState(t *testing.T) {
 			t.Fatal("expected nil initial readState")
 		}
 
-		err := cloudState.PersistState(context.Background(), nil)
+		err := cloudState.PersistState(nil)
 		if err != nil {
 			t.Fatalf("expected no error, got %q", err)
 		}
@@ -340,9 +337,7 @@ func TestState_PersistState(t *testing.T) {
 			}
 			cloudState.tfeClient = client
 
-			ctx := context.Background()
-
-			err = cloudState.RefreshState(ctx)
+			err = cloudState.RefreshState()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -353,7 +348,7 @@ func TestState_PersistState(t *testing.T) {
 				)
 			}))
 
-			err = cloudState.PersistState(ctx, nil)
+			err = cloudState.PersistState(nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/cloud/state_test.go
+++ b/internal/cloud/state_test.go
@@ -178,25 +178,25 @@ func TestCloudLocks(t *testing.T) {
 	infoB.Operation = "test"
 	infoB.Who = "clientB"
 
-	lockIDA, err := lockerA.Lock(ctx, infoA)
+	lockIDA, err := lockerA.Lock(infoA)
 	if err != nil {
 		t.Fatal("unable to get initial lock:", err)
 	}
 
-	_, err = lockerB.Lock(ctx, infoB)
+	_, err = lockerB.Lock(infoB)
 	if err == nil {
-		lockerA.Unlock(ctx, lockIDA)
+		lockerA.Unlock(lockIDA)
 		t.Fatal("client B obtained lock while held by client A")
 	}
 	if _, ok := err.(*statemgr.LockError); !ok {
 		t.Errorf("expected a LockError, but was %t: %s", err, err)
 	}
 
-	if err := lockerA.Unlock(ctx, lockIDA); err != nil {
+	if err := lockerA.Unlock(lockIDA); err != nil {
 		t.Fatal("error unlocking client A", err)
 	}
 
-	lockIDB, err := lockerB.Lock(ctx, infoB)
+	lockIDB, err := lockerB.Lock(infoB)
 	if err != nil {
 		t.Fatal("unable to obtain lock from client B")
 	}
@@ -205,7 +205,7 @@ func TestCloudLocks(t *testing.T) {
 		t.Fatalf("duplicate lock IDs: %q", lockIDB)
 	}
 
-	if err = lockerB.Unlock(ctx, lockIDB); err != nil {
+	if err = lockerB.Unlock(lockIDB); err != nil {
 		t.Fatal("error unlocking client B:", err)
 	}
 }

--- a/internal/cloud/state_test.go
+++ b/internal/cloud/state_test.go
@@ -127,9 +127,7 @@ func TestState(t *testing.T) {
 		t.Fatalf("expected full state %q\n\ngot: %q", string(payload.Data), string(data))
 	}
 
-	ctx := context.Background()
-
-	if err := state.Delete(ctx, true); err != nil {
+	if err := state.Delete(true); err != nil {
 		t.Fatalf("delete: %s", err)
 	}
 
@@ -213,11 +211,9 @@ func TestDelete_SafeDeleteNotSupported(t *testing.T) {
 	state.workspace.Permissions.CanForceDelete = nil
 	state.workspace.ResourceCount = 5
 
-	ctx := context.Background()
-
 	// Typically delete(false) should safe-delete a cloud workspace, which should fail on this workspace with resources
 	// However, since we have set the workspace canForceDelete permission to nil, we should fall back to force delete
-	if err := state.Delete(ctx, false); err != nil {
+	if err := state.Delete(false); err != nil {
 		t.Fatalf("delete: %s", err)
 	}
 	workspace, err := state.tfeClient.Workspaces.ReadByID(context.Background(), workspaceId)
@@ -232,9 +228,7 @@ func TestDelete_ForceDelete(t *testing.T) {
 	state.workspace.Permissions.CanForceDelete = tfe.Bool(true)
 	state.workspace.ResourceCount = 5
 
-	ctx := context.Background()
-
-	if err := state.Delete(ctx, true); err != nil {
+	if err := state.Delete(true); err != nil {
 		t.Fatalf("delete: %s", err)
 	}
 	workspace, err := state.tfeClient.Workspaces.ReadByID(context.Background(), workspaceId)
@@ -249,17 +243,15 @@ func TestDelete_SafeDelete(t *testing.T) {
 	state.workspace.Permissions.CanForceDelete = tfe.Bool(false)
 	state.workspace.ResourceCount = 5
 
-	ctx := context.Background()
-
 	// safe-deleting a workspace with resources should fail
-	err := state.Delete(ctx, false)
+	err := state.Delete(false)
 	if err == nil {
 		t.Fatalf("workspace should have failed to safe delete")
 	}
 
 	// safe-deleting a workspace with resources should succeed once it has no resources
 	state.workspace.ResourceCount = 0
-	if err = state.Delete(ctx, false); err != nil {
+	if err = state.Delete(false); err != nil {
 		t.Fatalf("workspace safe-delete err: %s", err)
 	}
 

--- a/internal/cloud/state_test.go
+++ b/internal/cloud/state_test.go
@@ -144,13 +144,11 @@ func TestCloudLocks(t *testing.T) {
 	back, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	ctx := context.Background()
-
-	a, err := back.StateMgr(ctx, testBackendSingleWorkspaceName)
+	a, err := back.StateMgr(testBackendSingleWorkspaceName)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	b, err := back.StateMgr(ctx, testBackendSingleWorkspaceName)
+	b, err := back.StateMgr(testBackendSingleWorkspaceName)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/internal/cloud/testing.go
+++ b/internal/cloud/testing.go
@@ -242,7 +242,7 @@ func testBackend(t *testing.T, obj cty.Value, handlers map[string]func(http.Resp
 	}
 	obj = newObj
 
-	confDiags := b.Configure(ctx, obj)
+	confDiags := b.Configure(obj)
 	if len(confDiags) != 0 {
 		t.Fatalf("testBackend: backend.Configure() failed: %s", confDiags.ErrWithWarnings())
 	}

--- a/internal/cloud/testing.go
+++ b/internal/cloud/testing.go
@@ -233,10 +233,8 @@ func testBackend(t *testing.T, obj cty.Value, handlers map[string]func(http.Resp
 	}
 	b := New(testDisco(s))
 
-	ctx := context.Background()
-
 	// Configure the backend so the client is created.
-	newObj, valDiags := b.PrepareConfig(ctx, obj)
+	newObj, valDiags := b.PrepareConfig(obj)
 	if len(valDiags) != 0 {
 		t.Fatalf("testBackend: backend.PrepareConfig() failed: %s", valDiags.ErrWithWarnings())
 	}
@@ -280,6 +278,8 @@ func testBackend(t *testing.T, obj cty.Value, handlers map[string]func(http.Resp
 	readRedactedPlan = func(ctx context.Context, baseURL url.URL, token, planID string) ([]byte, error) {
 		return mc.RedactedPlans.Read(ctx, baseURL.Hostname(), token, planID)
 	}
+
+	ctx := context.Background()
 
 	// Create the organization.
 	_, err = b.client.Organizations.Create(ctx, tfe.OrganizationCreateOptions{

--- a/internal/cloud/testing.go
+++ b/internal/cloud/testing.go
@@ -154,9 +154,7 @@ func testCloudState(t *testing.T) *State {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	ctx := context.Background()
-
-	raw, err := b.StateMgr(ctx, testBackendSingleWorkspaceName)
+	raw, err := b.StateMgr(testBackendSingleWorkspaceName)
 	if err != nil {
 		t.Fatalf("error: %v", err)
 	}

--- a/internal/command/autocomplete.go
+++ b/internal/command/autocomplete.go
@@ -4,8 +4,6 @@
 package command
 
 import (
-	"context"
-
 	"github.com/posener/complete"
 )
 
@@ -62,7 +60,7 @@ func (m *Meta) completePredictWorkspaceName() complete.Predictor {
 			return nil
 		}
 
-		names, _ := b.Workspaces(context.TODO())
+		names, _ := b.Workspaces()
 		return names
 	})
 }

--- a/internal/command/clistate/local_state.go
+++ b/internal/command/clistate/local_state.go
@@ -5,7 +5,6 @@ package clistate
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -176,7 +175,7 @@ func (s *LocalState) RefreshState() error {
 }
 
 // Lock implements a local filesystem state.Locker.
-func (s *LocalState) Lock(ctx context.Context, info *statemgr.LockInfo) (string, error) {
+func (s *LocalState) Lock(info *statemgr.LockInfo) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -208,7 +207,7 @@ func (s *LocalState) Lock(ctx context.Context, info *statemgr.LockInfo) (string,
 	return s.lockID, s.writeLockInfo(info)
 }
 
-func (s *LocalState) Unlock(ctx context.Context, id string) error {
+func (s *LocalState) Unlock(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/internal/command/clistate/state.go
+++ b/internal/command/clistate/state.go
@@ -148,7 +148,7 @@ func (l *locker) Unlock() tfdiags.Diagnostics {
 	}
 
 	err := slowmessage.Do(LockThreshold, func() error {
-		return l.state.Unlock(l.ctx, l.lockID)
+		return l.state.Unlock(l.lockID)
 	}, l.view.Unlocking)
 
 	if err != nil {

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -773,10 +773,7 @@ func testBackendState(t *testing.T, s *states.State, c int) (*legacy.State, *htt
 		Config: configs.SynthBody("<testBackendState>", map[string]cty.Value{}),
 	}
 	b := backendInit.Backend("http")()
-
-	ctx := context.Background()
-
-	configSchema := b.ConfigSchema(ctx)
+	configSchema := b.ConfigSchema()
 	hash := backendConfig.Hash(configSchema)
 
 	state := legacy.NewState()

--- a/internal/command/import.go
+++ b/internal/command/import.go
@@ -4,7 +4,6 @@
 package command
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -270,10 +269,7 @@ func (c *ImportCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Error writing state file: %s", err))
 		return 1
 	}
-
-	ctx := context.TODO()
-
-	if err := state.PersistState(ctx, schemas); err != nil {
+	if err := state.PersistState(schemas); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error writing state file: %s", err))
 		return 1
 	}

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -226,7 +226,7 @@ func (c *InitCommand) Run(args []string) int {
 			return 1
 		}
 
-		if err := sMgr.RefreshState(ctx); err != nil {
+		if err := sMgr.RefreshState(); err != nil {
 			c.Ui.Error(fmt.Sprintf("Error refreshing state: %s", err))
 			return 1
 		}

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -220,7 +220,7 @@ func (c *InitCommand) Run(args []string) int {
 			c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
 			return 1
 		}
-		sMgr, err := back.StateMgr(ctx, workspace)
+		sMgr, err := back.StateMgr(workspace)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Error loading state: %s", err))
 			return 1

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -477,7 +477,7 @@ func (c *InitCommand) initBackend(ctx context.Context, root *configs.Module, ext
 		}
 
 		b := bf()
-		backendSchema := b.ConfigSchema(ctx)
+		backendSchema := b.ConfigSchema()
 		backendConfig = root.Backend
 
 		var overrideDiags tfdiags.Diagnostics

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -328,7 +328,7 @@ func (m *Meta) BackendForLocalPlan(settings plans.Backend) (backend.Enhanced, tf
 		return nil, diags
 	}
 
-	configureDiags := b.Configure(ctx, newVal)
+	configureDiags := b.Configure(newVal)
 	diags = diags.Append(configureDiags)
 	if configureDiags.HasErrors() {
 		return nil, diags
@@ -836,7 +836,7 @@ func (m *Meta) backendFromState(ctx context.Context) (backend.Backend, tfdiags.D
 		return nil, diags
 	}
 
-	configDiags := b.Configure(ctx, newVal)
+	configDiags := b.Configure(newVal)
 	diags = diags.Append(configDiags)
 	if configDiags.HasErrors() {
 		return nil, diags
@@ -1299,7 +1299,7 @@ func (m *Meta) savedBackend(sMgr *clistate.LocalState) (backend.Backend, tfdiags
 		return nil, diags
 	}
 
-	configDiags := b.Configure(ctx, newVal)
+	configDiags := b.Configure(newVal)
 	diags = diags.Append(configDiags)
 	if configDiags.HasErrors() {
 		return nil, diags
@@ -1445,7 +1445,7 @@ func (m *Meta) backendInitFromConfig(c *configs.Backend) (backend.Backend, cty.V
 		return nil, cty.NilVal, diags
 	}
 
-	configureDiags := b.Configure(ctx, newVal)
+	configureDiags := b.Configure(newVal)
 	diags = diags.Append(configureDiags.InConfigBody(c.Config, ""))
 
 	// If the result of loading the backend is an enhanced backend,

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -975,11 +975,9 @@ func (m *Meta) backend_C_r_s(c *configs.Backend, cHash int, sMgr *clistate.Local
 		return nil, diags
 	}
 
-	ctx := context.TODO()
-
 	var localStates []statemgr.Full
 	for _, workspace := range workspaces {
-		localState, err := localB.StateMgr(ctx, workspace)
+		localState, err := localB.StateMgr(workspace)
 		if err != nil {
 			diags = diags.Append(fmt.Errorf(errBackendLocalRead, err))
 			return nil, diags
@@ -1064,6 +1062,8 @@ func (m *Meta) backend_C_r_s(c *configs.Backend, cHash int, sMgr *clistate.Local
 		}
 		defer stateLocker.Unlock()
 	}
+
+	ctx := context.TODO()
 
 	configJSON, err := ctyjson.Marshal(configVal, b.ConfigSchema(ctx).ImpliedType())
 	if err != nil {

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -313,9 +313,7 @@ func (m *Meta) BackendForLocalPlan(settings plans.Backend) (backend.Enhanced, tf
 	b := f()
 	log.Printf("[TRACE] Meta.BackendForLocalPlan: instantiated backend of type %T", b)
 
-	ctx := context.TODO()
-
-	schema := b.ConfigSchema(ctx)
+	schema := b.ConfigSchema()
 	configVal, err := settings.Config.Decode(schema.ImpliedType())
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("saved backend configuration is invalid: %w", err))
@@ -406,9 +404,7 @@ func (m *Meta) backendCLIOpts() (*backend.CLIOpts, error) {
 // to modify fields of the operation such as Sequence to specify what will
 // be called.
 func (m *Meta) Operation(b backend.Backend, vt arguments.ViewType) *backend.Operation {
-	ctx := context.TODO()
-
-	schema := b.ConfigSchema(ctx)
+	schema := b.ConfigSchema()
 	workspace, err := m.Workspace()
 	if err != nil {
 		// An invalid workspace error would have been raised when creating the
@@ -497,9 +493,7 @@ func (m *Meta) backendConfig(opts *BackendOpts) (*configs.Backend, int, tfdiags.
 	}
 	b := bf()
 
-	ctx := context.TODO()
-
-	configSchema := b.ConfigSchema(ctx)
+	configSchema := b.ConfigSchema()
 	configBody := c.Config
 	configHash := c.Hash(configSchema)
 
@@ -818,7 +812,7 @@ func (m *Meta) backendFromState(ctx context.Context) (backend.Backend, tfdiags.D
 	// The configuration saved in the working directory state file is used
 	// in this case, since it will contain any additional values that
 	// were provided via -backend-config arguments on tofu init.
-	schema := b.ConfigSchema(ctx)
+	schema := b.ConfigSchema()
 	configVal, err := s.Backend.Config(schema)
 	if err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -1063,9 +1057,7 @@ func (m *Meta) backend_C_r_s(c *configs.Backend, cHash int, sMgr *clistate.Local
 		defer stateLocker.Unlock()
 	}
 
-	ctx := context.TODO()
-
-	configJSON, err := ctyjson.Marshal(configVal, b.ConfigSchema(ctx).ImpliedType())
+	configJSON, err := ctyjson.Marshal(configVal, b.ConfigSchema().ImpliedType())
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("Can't serialize backend configuration as JSON: %w", err))
 		return nil, diags
@@ -1210,9 +1202,7 @@ func (m *Meta) backend_C_r_S_changed(c *configs.Backend, cHash int, sMgr *clista
 		}
 	}
 
-	ctx := context.TODO()
-
-	configJSON, err := ctyjson.Marshal(configVal, b.ConfigSchema(ctx).ImpliedType())
+	configJSON, err := ctyjson.Marshal(configVal, b.ConfigSchema().ImpliedType())
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("Can't serialize backend configuration as JSON: %w", err))
 		return nil, diags
@@ -1276,12 +1266,10 @@ func (m *Meta) savedBackend(sMgr *clistate.LocalState) (backend.Backend, tfdiags
 	}
 	b := f()
 
-	ctx := context.TODO()
-
 	// The configuration saved in the working directory state file is used
 	// in this case, since it will contain any additional values that
 	// were provided via -backend-config arguments on tofu init.
-	schema := b.ConfigSchema(ctx)
+	schema := b.ConfigSchema()
 	configVal, err := s.Backend.Config(schema)
 	if err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -1366,9 +1354,7 @@ func (m *Meta) backendConfigNeedsMigration(c *configs.Backend, s *legacy.Backend
 	}
 	b := f()
 
-	ctx := context.TODO()
-
-	schema := b.ConfigSchema(ctx)
+	schema := b.ConfigSchema()
 	decSpec := schema.NoneRequired().DecoderSpec()
 	givenVal, diags := hcldec.Decode(c.Config, decSpec, nil)
 	if diags.HasErrors() {
@@ -1405,9 +1391,7 @@ func (m *Meta) backendInitFromConfig(c *configs.Backend) (backend.Backend, cty.V
 	}
 	b := f()
 
-	ctx := context.TODO()
-
-	schema := b.ConfigSchema(ctx)
+	schema := b.ConfigSchema()
 	decSpec := schema.NoneRequired().DecoderSpec()
 	configVal, hclDiags := hcldec.Decode(c.Config, decSpec, nil)
 	diags = diags.Append(hclDiags)

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -986,7 +986,7 @@ func (m *Meta) backend_C_r_s(c *configs.Backend, cHash int, sMgr *clistate.Local
 			diags = diags.Append(fmt.Errorf(errBackendLocalRead, err))
 			return nil, diags
 		}
-		if err := localState.RefreshState(ctx); err != nil {
+		if err := localState.RefreshState(); err != nil {
 			diags = diags.Append(fmt.Errorf(errBackendLocalRead, err))
 			return nil, diags
 		}
@@ -1049,7 +1049,7 @@ func (m *Meta) backend_C_r_s(c *configs.Backend, cHash int, sMgr *clistate.Local
 					diags = diags.Append(fmt.Errorf(errBackendMigrateLocalDelete, err))
 					return nil, diags
 				}
-				if err := localState.PersistState(ctx, nil); err != nil {
+				if err := localState.PersistState(nil); err != nil {
 					diags = diags.Append(fmt.Errorf(errBackendMigrateLocalDelete, err))
 					return nil, diags
 				}

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -322,7 +322,7 @@ func (m *Meta) BackendForLocalPlan(settings plans.Backend) (backend.Enhanced, tf
 		return nil, diags
 	}
 
-	newVal, validateDiags := b.PrepareConfig(ctx, configVal)
+	newVal, validateDiags := b.PrepareConfig(configVal)
 	diags = diags.Append(validateDiags)
 	if validateDiags.HasErrors() {
 		return nil, diags
@@ -830,7 +830,7 @@ func (m *Meta) backendFromState(ctx context.Context) (backend.Backend, tfdiags.D
 	}
 
 	// Validate the config and then configure the backend
-	newVal, validDiags := b.PrepareConfig(ctx, configVal)
+	newVal, validDiags := b.PrepareConfig(configVal)
 	diags = diags.Append(validDiags)
 	if validDiags.HasErrors() {
 		return nil, diags
@@ -1293,7 +1293,7 @@ func (m *Meta) savedBackend(sMgr *clistate.LocalState) (backend.Backend, tfdiags
 	}
 
 	// Validate the config and then configure the backend
-	newVal, validDiags := b.PrepareConfig(ctx, configVal)
+	newVal, validDiags := b.PrepareConfig(configVal)
 	diags = diags.Append(validDiags)
 	if validDiags.HasErrors() {
 		return nil, diags
@@ -1439,7 +1439,7 @@ func (m *Meta) backendInitFromConfig(c *configs.Backend) (backend.Backend, cty.V
 		}
 	}
 
-	newVal, validateDiags := b.PrepareConfig(ctx, configVal)
+	newVal, validateDiags := b.PrepareConfig(configVal)
 	diags = diags.Append(validateDiags.InConfigBody(c.Config, ""))
 	if validateDiags.HasErrors() {
 		return nil, cty.NilVal, diags

--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -267,7 +267,7 @@ func (m *Meta) backendMigrateState_s_s(opts *backendMigrateOpts) error {
 		return fmt.Errorf(strings.TrimSpace(
 			errMigrateSingleLoadDefault), opts.SourceType, err)
 	}
-	if err := sourceState.RefreshState(ctx); err != nil {
+	if err := sourceState.RefreshState(); err != nil {
 		return fmt.Errorf(strings.TrimSpace(
 			errMigrateSingleLoadDefault), opts.SourceType, err)
 	}
@@ -315,7 +315,7 @@ func (m *Meta) backendMigrateState_s_s(opts *backendMigrateOpts) error {
 		return fmt.Errorf(strings.TrimSpace(
 			errMigrateSingleLoadDefault), opts.DestinationType, err)
 	}
-	if err := destinationState.RefreshState(ctx); err != nil {
+	if err := destinationState.RefreshState(); err != nil {
 		return fmt.Errorf(strings.TrimSpace(
 			errMigrateSingleLoadDefault), opts.DestinationType, err)
 	}
@@ -368,12 +368,12 @@ func (m *Meta) backendMigrateState_s_s(opts *backendMigrateOpts) error {
 		// We now own a lock, so double check that we have the version
 		// corresponding to the lock.
 		log.Print("[TRACE] backendMigrateState: refreshing source workspace state")
-		if err := sourceState.RefreshState(ctx); err != nil {
+		if err := sourceState.RefreshState(); err != nil {
 			return fmt.Errorf(strings.TrimSpace(
 				errMigrateSingleLoadDefault), opts.SourceType, err)
 		}
 		log.Print("[TRACE] backendMigrateState: refreshing destination workspace state")
-		if err := destinationState.RefreshState(ctx); err != nil {
+		if err := destinationState.RefreshState(); err != nil {
 			return fmt.Errorf(strings.TrimSpace(
 				errMigrateSingleLoadDefault), opts.SourceType, err)
 		}
@@ -451,8 +451,8 @@ func (m *Meta) backendMigrateState_s_s(opts *backendMigrateOpts) error {
 	// The backend is currently handled before providers are installed during init,
 	// so requiring schemas here could lead to a catch-22 where it requires some manual
 	// intervention to proceed far enough for provider installation. To avoid this,
-	// when migrating to TFC backend, the initial JSON variant of state won't be generated and stored.
-	if err := destinationState.PersistState(ctx, nil); err != nil {
+	// when migrating to TFC backend, the initial JSON varient of state won't be generated and stored.
+	if err := destinationState.PersistState(nil); err != nil {
 		return fmt.Errorf(strings.TrimSpace(errBackendStateCopy),
 			opts.SourceType, opts.DestinationType, err)
 	}
@@ -602,7 +602,7 @@ func (m *Meta) backendMigrateTFC(opts *backendMigrateOpts) error {
 		if err != nil {
 			return err
 		}
-		if err := sourceState.RefreshState(ctx); err != nil {
+		if err := sourceState.RefreshState(); err != nil {
 			return err
 		}
 		if sourceState.State().Empty() {
@@ -692,7 +692,7 @@ func (m *Meta) backendMigrateState_S_TFC(opts *backendMigrateOpts, sourceWorkspa
 					errMigrateSingleLoadDefault), opts.SourceType, err)
 			}
 			// RefreshState is what actually pulls the state to be evaluated.
-			if err := sourceState.RefreshState(ctx); err != nil {
+			if err := sourceState.RefreshState(); err != nil {
 				return fmt.Errorf(strings.TrimSpace(
 					errMigrateSingleLoadDefault), opts.SourceType, err)
 			}

--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -186,7 +186,7 @@ func (m *Meta) backendMigrateState_S_S(opts *backendMigrateOpts) error {
 	}
 
 	// Read all the states
-	sourceWorkspaces, err := opts.Source.Workspaces(context.TODO())
+	sourceWorkspaces, err := opts.Source.Workspaces()
 	if err != nil {
 		return fmt.Errorf(strings.TrimSpace(
 			errMigrateLoadStates), opts.SourceType, err)
@@ -538,7 +538,7 @@ func (m *Meta) backendMigrateNonEmptyConfirm(
 func retrieveWorkspaces(back backend.Backend, sourceType string) ([]string, bool, error) {
 	var singleState bool
 	var err error
-	workspaces, err := back.Workspaces(context.TODO())
+	workspaces, err := back.Workspaces()
 	if err == backend.ErrWorkspacesNotSupported {
 		singleState = true
 		err = nil
@@ -761,7 +761,7 @@ func (m *Meta) backendMigrateState_S_TFC(opts *backendMigrateOpts, sourceWorkspa
 
 	// After migrating multiple workspaces, we need to reselect the current workspace as it may
 	// have been renamed. Query the backend first to be sure it now exists.
-	workspaces, err := opts.Destination.Workspaces(context.TODO())
+	workspaces, err := opts.Destination.Workspaces()
 	if err != nil {
 		return err
 	}

--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -250,7 +250,7 @@ func (m *Meta) backendMigrateState_S_s(opts *backendMigrateOpts) error {
 	// Copy the default state
 	opts.sourceWorkspace = currentWorkspace
 
-	// now switch back to the default env so we can access the new backend
+	// now switch back to the default env so we can acccess the new backend
 	m.SetWorkspace(backend.DefaultStateName)
 
 	return m.backendMigrateState_s_s(opts)
@@ -260,9 +260,7 @@ func (m *Meta) backendMigrateState_S_s(opts *backendMigrateOpts) error {
 func (m *Meta) backendMigrateState_s_s(opts *backendMigrateOpts) error {
 	log.Printf("[INFO] backendMigrateState: single-to-single migrating %q workspace to %q workspace", opts.sourceWorkspace, opts.destinationWorkspace)
 
-	ctx := context.TODO()
-
-	sourceState, err := opts.Source.StateMgr(ctx, opts.sourceWorkspace)
+	sourceState, err := opts.Source.StateMgr(opts.sourceWorkspace)
 	if err != nil {
 		return fmt.Errorf(strings.TrimSpace(
 			errMigrateSingleLoadDefault), opts.SourceType, err)
@@ -278,7 +276,7 @@ func (m *Meta) backendMigrateState_s_s(opts *backendMigrateOpts) error {
 		return nil
 	}
 
-	destinationState, err := opts.Destination.StateMgr(ctx, opts.destinationWorkspace)
+	destinationState, err := opts.Destination.StateMgr(opts.destinationWorkspace)
 	if err == backend.ErrDefaultWorkspaceNotSupported {
 		// If the backend doesn't support using the default state, we ask the user
 		// for a new name and migrate the default state to the given named state.
@@ -292,7 +290,7 @@ func (m *Meta) backendMigrateState_s_s(opts *backendMigrateOpts) error {
 			// Update the name of the destination state.
 			opts.destinationWorkspace = name
 
-			destinationState, err := opts.Destination.StateMgr(ctx, opts.destinationWorkspace)
+			destinationState, err := opts.Destination.StateMgr(opts.destinationWorkspace)
 			if err != nil {
 				return nil, err
 			}
@@ -559,7 +557,7 @@ func (m *Meta) backendMigrateTFC(opts *backendMigrateOpts) error {
 	if err != nil {
 		return err
 	}
-	//to be used below, not yet implemented
+	//to be used below, not yet implamented
 	// destinationWorkspaces, destinationSingleState
 	_, _, err = retrieveWorkspaces(opts.Destination, opts.SourceType)
 	if err != nil {
@@ -594,11 +592,9 @@ func (m *Meta) backendMigrateTFC(opts *backendMigrateOpts) error {
 
 		log.Printf("[INFO] backendMigrateTFC: single-to-single migration from source %s to destination %q", opts.sourceWorkspace, opts.destinationWorkspace)
 
-		ctx := context.TODO()
-
 		// If the current workspace is has no state we do not need to ask
 		// if they want to migrate the state.
-		sourceState, err := opts.Source.StateMgr(ctx, currentWorkspace)
+		sourceState, err := opts.Source.StateMgr(currentWorkspace)
 		if err != nil {
 			return err
 		}
@@ -666,8 +662,6 @@ func (m *Meta) backendMigrateTFC(opts *backendMigrateOpts) error {
 func (m *Meta) backendMigrateState_S_TFC(opts *backendMigrateOpts, sourceWorkspaces []string) error {
 	log.Print("[TRACE] backendMigrateState: migrating all named workspaces")
 
-	ctx := context.TODO()
-
 	currentWorkspace, err := m.Workspace()
 	if err != nil {
 		return err
@@ -686,7 +680,7 @@ func (m *Meta) backendMigrateState_S_TFC(opts *backendMigrateOpts, sourceWorkspa
 		if sourceWorkspaces[i] == backend.DefaultStateName {
 			// For the default workspace we want to look to see if there is any state
 			// before we ask for a workspace name to migrate the default workspace into.
-			sourceState, err := opts.Source.StateMgr(ctx, backend.DefaultStateName)
+			sourceState, err := opts.Source.StateMgr(backend.DefaultStateName)
 			if err != nil {
 				return fmt.Errorf(strings.TrimSpace(
 					errMigrateSingleLoadDefault), opts.SourceType, err)

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -43,10 +43,8 @@ func TestMetaBackend_emptyDir(t *testing.T) {
 		t.Fatal(diags.Err())
 	}
 
-	ctx := context.Background()
-
 	// Write some state
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -114,10 +112,8 @@ func TestMetaBackend_emptyWithDefaultState(t *testing.T) {
 		t.Fatal(diags.Err())
 	}
 
-	ctx := context.Background()
-
 	// Check the state
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -187,10 +183,8 @@ func TestMetaBackend_emptyWithExplicitState(t *testing.T) {
 		t.Fatal(diags.Err())
 	}
 
-	ctx := context.Background()
-
 	// Check the state
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -257,10 +251,8 @@ func TestMetaBackend_configureNew(t *testing.T) {
 		t.Fatal(diags.Err())
 	}
 
-	ctx := context.Background()
-
 	// Check the state
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -330,10 +322,8 @@ func TestMetaBackend_configureNewWithState(t *testing.T) {
 		t.Fatal(diags.Err())
 	}
 
-	ctx := context.Background()
-
 	// Check the state
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -455,10 +445,8 @@ func TestMetaBackend_configureNewWithStateNoMigrate(t *testing.T) {
 		t.Fatal(diags.Err())
 	}
 
-	ctx := context.Background()
-
 	// Check the state
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -500,10 +488,8 @@ func TestMetaBackend_configureNewWithStateExisting(t *testing.T) {
 		t.Fatal(diags.Err())
 	}
 
-	ctx := context.Background()
-
 	// Check the state
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -574,10 +560,8 @@ func TestMetaBackend_configureNewWithStateExistingNoMigrate(t *testing.T) {
 		t.Fatal(diags.Err())
 	}
 
-	ctx := context.Background()
-
 	// Check the state
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -641,10 +625,8 @@ func TestMetaBackend_configuredUnchanged(t *testing.T) {
 		t.Fatal(diags.Err())
 	}
 
-	ctx := context.Background()
-
 	// Check the state
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -689,10 +671,8 @@ func TestMetaBackend_configuredChange(t *testing.T) {
 		t.Fatal(diags.Err())
 	}
 
-	ctx := context.Background()
-
 	// Check the state
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -777,10 +757,8 @@ func TestMetaBackend_reconfigureChange(t *testing.T) {
 		t.Fatal(diags.Err())
 	}
 
-	ctx := context.Background()
-
 	// Check the state
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -919,10 +897,8 @@ func TestMetaBackend_configuredChangeCopy(t *testing.T) {
 		t.Fatal(diags.Err())
 	}
 
-	ctx := context.Background()
-
 	// Check the state
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -974,10 +950,8 @@ func TestMetaBackend_configuredChangeCopy_singleState(t *testing.T) {
 		t.Fatal(diags.Err())
 	}
 
-	ctx := context.Background()
-
 	// Check the state
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1030,10 +1004,8 @@ func TestMetaBackend_configuredChangeCopy_multiToSingleDefault(t *testing.T) {
 		t.Fatal(diags.Err())
 	}
 
-	ctx := context.Background()
-
 	// Check the state
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1086,10 +1058,8 @@ func TestMetaBackend_configuredChangeCopy_multiToSingle(t *testing.T) {
 		t.Fatal(diags.Err())
 	}
 
-	ctx := context.Background()
-
 	// Check the state
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1162,10 +1132,8 @@ func TestMetaBackend_configuredChangeCopy_multiToSingleCurrentEnv(t *testing.T) 
 		t.Fatal(diags.Err())
 	}
 
-	ctx := context.Background()
-
 	// Check the state
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1231,11 +1199,9 @@ func TestMetaBackend_configuredChangeCopy_multiToMulti(t *testing.T) {
 		t.Fatalf("bad: %#v", workspaces)
 	}
 
-	ctx := context.Background()
-
 	{
 		// Check the default state
-		s, err := b.StateMgr(ctx, backend.DefaultStateName)
+		s, err := b.StateMgr(backend.DefaultStateName)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -1253,7 +1219,7 @@ func TestMetaBackend_configuredChangeCopy_multiToMulti(t *testing.T) {
 
 	{
 		// Check the other state
-		s, err := b.StateMgr(ctx, "env2")
+		s, err := b.StateMgr("env2")
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -1331,11 +1297,9 @@ func TestMetaBackend_configuredChangeCopy_multiToNoDefaultWithDefault(t *testing
 		t.Fatalf("bad: %#v", workspaces)
 	}
 
-	ctx := context.Background()
-
 	{
 		// Check the renamed default state
-		s, err := b.StateMgr(ctx, "env1")
+		s, err := b.StateMgr("env1")
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -1408,9 +1372,8 @@ func TestMetaBackend_configuredChangeCopy_multiToNoDefaultWithoutDefault(t *test
 	}
 
 	{
-		ctx := context.Background()
 		// Check the named state
-		s, err := b.StateMgr(ctx, "env2")
+		s, err := b.StateMgr("env2")
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -1462,10 +1425,8 @@ func TestMetaBackend_configuredUnset(t *testing.T) {
 		t.Fatal(diags.Err())
 	}
 
-	ctx := context.Background()
-
 	// Check the state
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1526,10 +1487,8 @@ func TestMetaBackend_configuredUnsetCopy(t *testing.T) {
 		t.Fatal(diags.Err())
 	}
 
-	ctx := context.Background()
-
 	// Check the state
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1596,10 +1555,8 @@ func TestMetaBackend_planLocal(t *testing.T) {
 		t.Fatal(diags.Err())
 	}
 
-	ctx := context.Background()
-
 	// Check the state
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1699,10 +1656,8 @@ func TestMetaBackend_planLocalStatePath(t *testing.T) {
 		t.Fatal(diags.Err())
 	}
 
-	ctx := context.Background()
-
 	// Check the state
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1790,10 +1745,8 @@ func TestMetaBackend_planLocalMatch(t *testing.T) {
 		t.Fatal(diags.Err())
 	}
 
-	ctx := context.Background()
-
 	// Check the state
-	s, err := b.StateMgr(ctx, backend.DefaultStateName)
+	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -1219,10 +1219,8 @@ func TestMetaBackend_configuredChangeCopy_multiToMulti(t *testing.T) {
 		t.Fatal(diags.Err())
 	}
 
-	ctx := context.Background()
-
 	// Check resulting states
-	workspaces, err := b.Workspaces(ctx)
+	workspaces, err := b.Workspaces()
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1232,6 +1230,8 @@ func TestMetaBackend_configuredChangeCopy_multiToMulti(t *testing.T) {
 	if !reflect.DeepEqual(workspaces, expected) {
 		t.Fatalf("bad: %#v", workspaces)
 	}
+
+	ctx := context.Background()
 
 	{
 		// Check the default state
@@ -1319,10 +1319,8 @@ func TestMetaBackend_configuredChangeCopy_multiToNoDefaultWithDefault(t *testing
 		t.Fatal(diags.Err())
 	}
 
-	ctx := context.Background()
-
 	// Check resulting states
-	workspaces, err := b.Workspaces(ctx)
+	workspaces, err := b.Workspaces()
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1332,6 +1330,8 @@ func TestMetaBackend_configuredChangeCopy_multiToNoDefaultWithDefault(t *testing
 	if !reflect.DeepEqual(workspaces, expected) {
 		t.Fatalf("bad: %#v", workspaces)
 	}
+
+	ctx := context.Background()
 
 	{
 		// Check the renamed default state
@@ -1395,10 +1395,8 @@ func TestMetaBackend_configuredChangeCopy_multiToNoDefaultWithoutDefault(t *test
 		t.Fatal(diags.Err())
 	}
 
-	ctx := context.Background()
-
 	// Check resulting states
-	workspaces, err := b.Workspaces(ctx)
+	workspaces, err := b.Workspaces()
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1410,6 +1408,7 @@ func TestMetaBackend_configuredChangeCopy_multiToNoDefaultWithoutDefault(t *test
 	}
 
 	{
+		ctx := context.Background()
 		// Check the named state
 		s, err := b.StateMgr(ctx, "env2")
 		if err != nil {

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -51,7 +51,7 @@ func TestMetaBackend_emptyDir(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	s.WriteState(testState())
-	if err := s.PersistState(ctx, nil); err != nil {
+	if err := s.PersistState(nil); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -121,7 +121,7 @@ func TestMetaBackend_emptyWithDefaultState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if err := s.RefreshState(ctx); err != nil {
+	if err := s.RefreshState(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 	if actual := s.State().String(); actual != testState().String() {
@@ -142,7 +142,7 @@ func TestMetaBackend_emptyWithDefaultState(t *testing.T) {
 	next := testState()
 	next.RootModule().SetOutputValue("foo", cty.StringVal("bar"), false)
 	s.WriteState(next)
-	if err := s.PersistState(ctx, nil); err != nil {
+	if err := s.PersistState(nil); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -194,7 +194,7 @@ func TestMetaBackend_emptyWithExplicitState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if err := s.RefreshState(ctx); err != nil {
+	if err := s.RefreshState(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 	if actual := s.State().String(); actual != testState().String() {
@@ -215,7 +215,7 @@ func TestMetaBackend_emptyWithExplicitState(t *testing.T) {
 	next := testState()
 	markStateForMatching(next, "bar") // just any change so it shows as different than before
 	s.WriteState(next)
-	if err := s.PersistState(ctx, nil); err != nil {
+	if err := s.PersistState(nil); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -264,7 +264,7 @@ func TestMetaBackend_configureNew(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if err := s.RefreshState(ctx); err != nil {
+	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	state := s.State()
@@ -277,7 +277,7 @@ func TestMetaBackend_configureNew(t *testing.T) {
 	mark := markStateForMatching(state, "changing")
 
 	s.WriteState(state)
-	if err := s.PersistState(ctx, nil); err != nil {
+	if err := s.PersistState(nil); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -462,7 +462,7 @@ func TestMetaBackend_configureNewWithStateNoMigrate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if err := s.RefreshState(ctx); err != nil {
+	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	if state := s.State(); state != nil {
@@ -507,7 +507,7 @@ func TestMetaBackend_configureNewWithStateExisting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if err := s.RefreshState(ctx); err != nil {
+	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	state := s.State()
@@ -523,7 +523,7 @@ func TestMetaBackend_configureNewWithStateExisting(t *testing.T) {
 	mark := markStateForMatching(state, "changing")
 
 	s.WriteState(state)
-	if err := s.PersistState(ctx, nil); err != nil {
+	if err := s.PersistState(nil); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -581,7 +581,7 @@ func TestMetaBackend_configureNewWithStateExistingNoMigrate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if err := s.RefreshState(ctx); err != nil {
+	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	state := s.State()
@@ -596,7 +596,7 @@ func TestMetaBackend_configureNewWithStateExistingNoMigrate(t *testing.T) {
 	state = states.NewState()
 	mark := markStateForMatching(state, "changing")
 	s.WriteState(state)
-	if err := s.PersistState(ctx, nil); err != nil {
+	if err := s.PersistState(nil); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -648,7 +648,7 @@ func TestMetaBackend_configuredUnchanged(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if err := s.RefreshState(ctx); err != nil {
+	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	state := s.State()
@@ -696,7 +696,7 @@ func TestMetaBackend_configuredChange(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if err := s.RefreshState(ctx); err != nil {
+	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	state := s.State()
@@ -719,7 +719,7 @@ func TestMetaBackend_configuredChange(t *testing.T) {
 	mark := markStateForMatching(state, "changing")
 
 	s.WriteState(state)
-	if err := s.PersistState(ctx, nil); err != nil {
+	if err := s.PersistState(nil); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -784,7 +784,7 @@ func TestMetaBackend_reconfigureChange(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if err := s.RefreshState(ctx); err != nil {
+	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	newState := s.State()
@@ -794,7 +794,7 @@ func TestMetaBackend_reconfigureChange(t *testing.T) {
 
 	// verify that the old state is still there
 	s = statemgr.NewFilesystem("local-state.tfstate")
-	if err := s.RefreshState(ctx); err != nil {
+	if err := s.RefreshState(); err != nil {
 		t.Fatal(err)
 	}
 	oldState := s.State()
@@ -926,7 +926,7 @@ func TestMetaBackend_configuredChangeCopy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if err := s.RefreshState(ctx); err != nil {
+	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	state := s.State()
@@ -981,7 +981,7 @@ func TestMetaBackend_configuredChangeCopy_singleState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if err := s.RefreshState(ctx); err != nil {
+	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	state := s.State()
@@ -1037,7 +1037,7 @@ func TestMetaBackend_configuredChangeCopy_multiToSingleDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if err := s.RefreshState(ctx); err != nil {
+	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	state := s.State()
@@ -1093,7 +1093,7 @@ func TestMetaBackend_configuredChangeCopy_multiToSingle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if err := s.RefreshState(ctx); err != nil {
+	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	state := s.State()
@@ -1169,7 +1169,7 @@ func TestMetaBackend_configuredChangeCopy_multiToSingleCurrentEnv(t *testing.T) 
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if err := s.RefreshState(ctx); err != nil {
+	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	state := s.State()
@@ -1239,7 +1239,7 @@ func TestMetaBackend_configuredChangeCopy_multiToMulti(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
-		if err := s.RefreshState(ctx); err != nil {
+		if err := s.RefreshState(); err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
 		state := s.State()
@@ -1257,7 +1257,7 @@ func TestMetaBackend_configuredChangeCopy_multiToMulti(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
-		if err := s.RefreshState(ctx); err != nil {
+		if err := s.RefreshState(); err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
 		state := s.State()
@@ -1339,7 +1339,7 @@ func TestMetaBackend_configuredChangeCopy_multiToNoDefaultWithDefault(t *testing
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
-		if err := s.RefreshState(ctx); err != nil {
+		if err := s.RefreshState(); err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
 		state := s.State()
@@ -1415,7 +1415,7 @@ func TestMetaBackend_configuredChangeCopy_multiToNoDefaultWithoutDefault(t *test
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
-		if err := s.RefreshState(ctx); err != nil {
+		if err := s.RefreshState(); err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
 		state := s.State()
@@ -1470,7 +1470,7 @@ func TestMetaBackend_configuredUnset(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if err := s.RefreshState(ctx); err != nil {
+	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	state := s.State()
@@ -1492,7 +1492,7 @@ func TestMetaBackend_configuredUnset(t *testing.T) {
 
 	// Write some state
 	s.WriteState(testState())
-	if err := s.PersistState(ctx, nil); err != nil {
+	if err := s.PersistState(nil); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -1534,7 +1534,7 @@ func TestMetaBackend_configuredUnsetCopy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if err := s.RefreshState(ctx); err != nil {
+	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	state := s.State()
@@ -1552,7 +1552,7 @@ func TestMetaBackend_configuredUnsetCopy(t *testing.T) {
 
 	// Write some state
 	s.WriteState(testState())
-	if err := s.PersistState(ctx, nil); err != nil {
+	if err := s.PersistState(nil); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -1604,7 +1604,7 @@ func TestMetaBackend_planLocal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if err := s.RefreshState(ctx); err != nil {
+	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	state := s.State()
@@ -1633,7 +1633,7 @@ func TestMetaBackend_planLocal(t *testing.T) {
 	mark := markStateForMatching(state, "changing")
 
 	s.WriteState(state)
-	if err := s.PersistState(ctx, nil); err != nil {
+	if err := s.PersistState(nil); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -1707,7 +1707,7 @@ func TestMetaBackend_planLocalStatePath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if err := s.RefreshState(ctx); err != nil {
+	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	state := s.State()
@@ -1736,7 +1736,7 @@ func TestMetaBackend_planLocalStatePath(t *testing.T) {
 	mark := markStateForMatching(state, "changing")
 
 	s.WriteState(state)
-	if err := s.PersistState(ctx, nil); err != nil {
+	if err := s.PersistState(nil); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -1798,7 +1798,7 @@ func TestMetaBackend_planLocalMatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if err := s.RefreshState(ctx); err != nil {
+	if err := s.RefreshState(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	state := s.State()
@@ -1825,7 +1825,7 @@ func TestMetaBackend_planLocalMatch(t *testing.T) {
 	mark := markStateForMatching(state, "changing")
 
 	s.WriteState(state)
-	if err := s.PersistState(ctx, nil); err != nil {
+	if err := s.PersistState(nil); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 

--- a/internal/command/output.go
+++ b/internal/command/output.go
@@ -4,7 +4,6 @@
 package command
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -79,10 +78,8 @@ func (c *OutputCommand) Outputs(statePath string) (map[string]*states.OutputValu
 		return nil, diags
 	}
 
-	ctx := context.TODO()
-
 	// Get the state
-	stateStore, err := b.StateMgr(ctx, env)
+	stateStore, err := b.StateMgr(env)
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("Failed to load state: %w", err))
 		return nil, diags

--- a/internal/command/output.go
+++ b/internal/command/output.go
@@ -88,7 +88,7 @@ func (c *OutputCommand) Outputs(statePath string) (map[string]*states.OutputValu
 		return nil, diags
 	}
 
-	output, err := stateStore.GetRootOutputValues(ctx)
+	output, err := stateStore.GetRootOutputValues()
 	if err != nil {
 		return nil, diags.Append(err)
 	}

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -478,7 +478,7 @@ func TestPlan_outBackend(t *testing.T) {
 	}
 	{
 		httpBackend := backendinit.Backend("http")()
-		schema := httpBackend.ConfigSchema(context.Background())
+		schema := httpBackend.ConfigSchema()
 		got, err := plan.Backend.Config.Decode(schema.ImpliedType())
 		if err != nil {
 			t.Fatalf("failed to decode backend config in plan: %s", err)

--- a/internal/command/providers.go
+++ b/internal/command/providers.go
@@ -4,7 +4,6 @@
 package command
 
 import (
-	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -100,10 +99,7 @@ func (c *ProvidersCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
 		return 1
 	}
-
-	ctx := context.TODO()
-
-	s, err := b.StateMgr(ctx, env)
+	s, err := b.StateMgr(env)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
 		return 1

--- a/internal/command/providers.go
+++ b/internal/command/providers.go
@@ -108,7 +108,7 @@ func (c *ProvidersCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
 		return 1
 	}
-	if err := s.RefreshState(ctx); err != nil {
+	if err := s.RefreshState(); err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
 		return 1
 	}

--- a/internal/command/refresh_test.go
+++ b/internal/command/refresh_test.go
@@ -5,7 +5,6 @@ package command
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -243,7 +242,7 @@ func TestRefresh_defaultState(t *testing.T) {
 	statePath := testStateFile(t, originalState)
 
 	localState := statemgr.NewFilesystem(statePath)
-	if err := localState.RefreshState(context.Background()); err != nil {
+	if err := localState.RefreshState(); err != nil {
 		t.Fatal(err)
 	}
 	s := localState.State()

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -336,10 +336,8 @@ func getStateFromPath(path string) (*statefile.File, error) {
 
 // getStateFromBackend returns the State for the current workspace, if available.
 func getStateFromBackend(b backend.Backend, workspace string) (*statefile.File, error) {
-	ctx := context.TODO()
-
 	// Get the state store for the given workspace
-	stateStore, err := b.StateMgr(ctx, workspace)
+	stateStore, err := b.StateMgr(workspace)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to load state manager: %w", err)
 	}

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -345,7 +345,7 @@ func getStateFromBackend(b backend.Backend, workspace string) (*statefile.File, 
 	}
 
 	// Refresh the state store with the latest state snapshot from persistent storage
-	if err := stateStore.RefreshState(ctx); err != nil {
+	if err := stateStore.RefreshState(); err != nil {
 		return nil, fmt.Errorf("Failed to load state: %w", err)
 	}
 

--- a/internal/command/state_list.go
+++ b/internal/command/state_list.go
@@ -62,7 +62,7 @@ func (c *StateListCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf(errStateLoadingState, err))
 		return 1
 	}
-	if err := stateMgr.RefreshState(ctx); err != nil {
+	if err := stateMgr.RefreshState(); err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
 		return 1
 	}

--- a/internal/command/state_list.go
+++ b/internal/command/state_list.go
@@ -4,7 +4,6 @@
 package command
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -54,10 +53,7 @@ func (c *StateListCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
 		return 1
 	}
-
-	ctx := context.TODO()
-
-	stateMgr, err := b.StateMgr(ctx, env)
+	stateMgr, err := b.StateMgr(env)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf(errStateLoadingState, err))
 		return 1

--- a/internal/command/state_meta.go
+++ b/internal/command/state_meta.go
@@ -4,7 +4,6 @@
 package command
 
 import (
-	"context"
 	"fmt"
 	"sort"
 	"time"
@@ -53,10 +52,8 @@ func (c *StateMeta) State() (statemgr.Full, error) {
 			return nil, fmt.Errorf("Error checking remote OpenTofu version")
 		}
 
-		ctx := context.TODO()
-
 		// Get the state
-		s, err := b.StateMgr(ctx, workspace)
+		s, err := b.StateMgr(workspace)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/command/state_mv.go
+++ b/internal/command/state_mv.go
@@ -4,7 +4,6 @@
 package command
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -111,9 +110,7 @@ func (c *StateMvCommand) Run(args []string) int {
 		}()
 	}
 
-	ctx := context.TODO()
-
-	if err := stateFromMgr.RefreshState(ctx); err != nil {
+	if err := stateFromMgr.RefreshState(); err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to refresh source state: %s", err))
 		return 1
 	}
@@ -151,7 +148,7 @@ func (c *StateMvCommand) Run(args []string) int {
 			}()
 		}
 
-		if err := stateToMgr.RefreshState(ctx); err != nil {
+		if err := stateToMgr.RefreshState(); err != nil {
 			c.Ui.Error(fmt.Sprintf("Failed to refresh destination state: %s", err))
 			return 1
 		}
@@ -413,7 +410,7 @@ func (c *StateMvCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf(errStateRmPersist, err))
 		return 1
 	}
-	if err := stateToMgr.PersistState(ctx, schemas); err != nil {
+	if err := stateToMgr.PersistState(schemas); err != nil {
 		c.Ui.Error(fmt.Sprintf(errStateRmPersist, err))
 		return 1
 	}
@@ -424,7 +421,7 @@ func (c *StateMvCommand) Run(args []string) int {
 			c.Ui.Error(fmt.Sprintf(errStateRmPersist, err))
 			return 1
 		}
-		if err := stateFromMgr.PersistState(ctx, schemas); err != nil {
+		if err := stateFromMgr.PersistState(schemas); err != nil {
 			c.Ui.Error(fmt.Sprintf(errStateRmPersist, err))
 			return 1
 		}

--- a/internal/command/state_pull.go
+++ b/internal/command/state_pull.go
@@ -56,7 +56,7 @@ func (c *StatePullCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf(errStateLoadingState, err))
 		return 1
 	}
-	if err := stateMgr.RefreshState(ctx); err != nil {
+	if err := stateMgr.RefreshState(); err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to refresh state: %s", err))
 		return 1
 	}

--- a/internal/command/state_pull.go
+++ b/internal/command/state_pull.go
@@ -5,7 +5,6 @@ package command
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"strings"
 
@@ -48,10 +47,7 @@ func (c *StatePullCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
 		return 1
 	}
-
-	ctx := context.TODO()
-
-	stateMgr, err := b.StateMgr(ctx, env)
+	stateMgr, err := b.StateMgr(env)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf(errStateLoadingState, err))
 		return 1

--- a/internal/command/state_push.go
+++ b/internal/command/state_push.go
@@ -4,7 +4,6 @@
 package command
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -98,10 +97,8 @@ func (c *StatePushCommand) Run(args []string) int {
 		return 1
 	}
 
-	ctx := context.TODO()
-
 	// Get the state manager for the currently-selected workspace
-	stateMgr, err := b.StateMgr(ctx, workspace)
+	stateMgr, err := b.StateMgr(workspace)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load destination state: %s", err))
 		return 1

--- a/internal/command/state_push.go
+++ b/internal/command/state_push.go
@@ -120,7 +120,7 @@ func (c *StatePushCommand) Run(args []string) int {
 		}()
 	}
 
-	if err := stateMgr.RefreshState(ctx); err != nil {
+	if err := stateMgr.RefreshState(); err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to refresh destination state: %s", err))
 		return 1
 	}
@@ -147,7 +147,7 @@ func (c *StatePushCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Failed to write state: %s", err))
 		return 1
 	}
-	if err := stateMgr.PersistState(ctx, schemas); err != nil {
+	if err := stateMgr.PersistState(schemas); err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to persist state: %s", err))
 		return 1
 	}

--- a/internal/command/state_push_test.go
+++ b/internal/command/state_push_test.go
@@ -273,7 +273,7 @@ func TestStatePush_forceRemoteState(t *testing.T) {
 	if err := sMgr.WriteState(states.NewState()); err != nil {
 		t.Fatal(err)
 	}
-	if err := sMgr.PersistState(ctx, nil); err != nil {
+	if err := sMgr.PersistState(nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/command/state_push_test.go
+++ b/internal/command/state_push_test.go
@@ -5,7 +5,6 @@ package command
 
 import (
 	"bytes"
-	"context"
 	"strings"
 	"testing"
 
@@ -262,11 +261,9 @@ func TestStatePush_forceRemoteState(t *testing.T) {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
 	}
 
-	ctx := context.Background()
-
 	// put a dummy state in place, so we have something to force
 	b := backend.TestBackendConfig(t, inmem.New(), nil)
-	sMgr, err := b.StateMgr(ctx, "test")
+	sMgr, err := b.StateMgr("test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/command/state_replace_provider.go
+++ b/internal/command/state_replace_provider.go
@@ -4,7 +4,6 @@
 package command
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -98,10 +97,8 @@ func (c *StateReplaceProviderCommand) Run(args []string) int {
 		}()
 	}
 
-	ctx := context.TODO()
-
 	// Refresh and load state
-	if err := stateMgr.RefreshState(ctx); err != nil {
+	if err := stateMgr.RefreshState(); err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to refresh source state: %s", err))
 		return 1
 	}
@@ -188,7 +185,7 @@ func (c *StateReplaceProviderCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf(errStateRmPersist, err))
 		return 1
 	}
-	if err := stateMgr.PersistState(ctx, schemas); err != nil {
+	if err := stateMgr.PersistState(schemas); err != nil {
 		c.Ui.Error(fmt.Sprintf(errStateRmPersist, err))
 		return 1
 	}

--- a/internal/command/state_rm.go
+++ b/internal/command/state_rm.go
@@ -4,7 +4,6 @@
 package command
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -68,9 +67,7 @@ func (c *StateRmCommand) Run(args []string) int {
 		}()
 	}
 
-	ctx := context.TODO()
-
-	if err := stateMgr.RefreshState(ctx); err != nil {
+	if err := stateMgr.RefreshState(); err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to refresh state: %s", err))
 		return 1
 	}
@@ -137,7 +134,7 @@ func (c *StateRmCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf(errStateRmPersist, err))
 		return 1
 	}
-	if err := stateMgr.PersistState(ctx, schemas); err != nil {
+	if err := stateMgr.PersistState(schemas); err != nil {
 		c.Ui.Error(fmt.Sprintf(errStateRmPersist, err))
 		return 1
 	}

--- a/internal/command/state_show.go
+++ b/internal/command/state_show.go
@@ -118,7 +118,7 @@ func (c *StateShowCommand) Run(args []string) int {
 		c.Streams.Eprintln(fmt.Sprintf(errStateLoadingState, err))
 		return 1
 	}
-	if err := stateMgr.RefreshState(ctx); err != nil {
+	if err := stateMgr.RefreshState(); err != nil {
 		c.Streams.Eprintf("Failed to refresh state: %s\n", err)
 		return 1
 	}

--- a/internal/command/state_show.go
+++ b/internal/command/state_show.go
@@ -4,7 +4,6 @@
 package command
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -110,10 +109,7 @@ func (c *StateShowCommand) Run(args []string) int {
 		c.Streams.Eprintf("Error selecting workspace: %s\n", err)
 		return 1
 	}
-
-	ctx := context.TODO()
-
-	stateMgr, err := b.StateMgr(ctx, env)
+	stateMgr, err := b.StateMgr(env)
 	if err != nil {
 		c.Streams.Eprintln(fmt.Sprintf(errStateLoadingState, err))
 		return 1

--- a/internal/command/taint.go
+++ b/internal/command/taint.go
@@ -4,7 +4,6 @@
 package command
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -89,10 +88,8 @@ func (c *TaintCommand) Run(args []string) int {
 		return 1
 	}
 
-	ctx := context.TODO()
-
 	// Get the state
-	stateMgr, err := b.StateMgr(ctx, workspace)
+	stateMgr, err := b.StateMgr(workspace)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
 		return 1

--- a/internal/command/taint.go
+++ b/internal/command/taint.go
@@ -111,7 +111,7 @@ func (c *TaintCommand) Run(args []string) int {
 		}()
 	}
 
-	if err := stateMgr.RefreshState(ctx); err != nil {
+	if err := stateMgr.RefreshState(); err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
 		return 1
 	}
@@ -186,7 +186,7 @@ func (c *TaintCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Error writing state file: %s", err))
 		return 1
 	}
-	if err := stateMgr.PersistState(ctx, schemas); err != nil {
+	if err := stateMgr.PersistState(schemas); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error writing state file: %s", err))
 		return 1
 	}

--- a/internal/command/testdata/statelocker.go
+++ b/internal/command/testdata/statelocker.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"io"
 	"log"
 	"os"
@@ -29,9 +28,7 @@ func main() {
 	info.Operation = "test"
 	info.Info = "state locker"
 
-	ctx := context.Background()
-
-	lockID, err := s.Lock(ctx, info)
+	lockID, err := s.Lock(info)
 	if err != nil {
 		io.WriteString(os.Stderr, err.Error())
 		return
@@ -41,7 +38,7 @@ func main() {
 	io.WriteString(os.Stdout, "LOCKID "+lockID)
 
 	defer func() {
-		if err := s.Unlock(ctx, lockID); err != nil {
+		if err := s.Unlock(lockID); err != nil {
 			io.WriteString(os.Stderr, err.Error())
 		}
 	}()

--- a/internal/command/unlock.go
+++ b/internal/command/unlock.go
@@ -97,7 +97,7 @@ func (c *UnlockCommand) Run(args []string) int {
 			"This will allow local OpenTofu commands to modify this state, even though it\n" +
 			"may still be in use. Only 'yes' will be accepted to confirm."
 
-		v, err := c.UIInput().Input(ctx, &tofu.InputOpts{
+		v, err := c.UIInput().Input(context.Background(), &tofu.InputOpts{
 			Id:          "force-unlock",
 			Query:       "Do you really want to force-unlock?",
 			Description: desc,
@@ -112,7 +112,7 @@ func (c *UnlockCommand) Run(args []string) int {
 		}
 	}
 
-	if err := stateMgr.Unlock(ctx, lockID); err != nil {
+	if err := stateMgr.Unlock(lockID); err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to unlock state: %s", err))
 		return 1
 	}

--- a/internal/command/unlock.go
+++ b/internal/command/unlock.go
@@ -74,10 +74,7 @@ func (c *UnlockCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
 		return 1
 	}
-
-	ctx := context.TODO()
-
-	stateMgr, err := b.StateMgr(ctx, env)
+	stateMgr, err := b.StateMgr(env)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
 		return 1

--- a/internal/command/untaint.go
+++ b/internal/command/untaint.go
@@ -4,7 +4,6 @@
 package command
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -79,10 +78,8 @@ func (c *UntaintCommand) Run(args []string) int {
 		return 1
 	}
 
-	ctx := context.TODO()
-
 	// Get the state
-	stateMgr, err := b.StateMgr(ctx, workspace)
+	stateMgr, err := b.StateMgr(workspace)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
 		return 1

--- a/internal/command/untaint.go
+++ b/internal/command/untaint.go
@@ -101,7 +101,7 @@ func (c *UntaintCommand) Run(args []string) int {
 		}()
 	}
 
-	if err := stateMgr.RefreshState(ctx); err != nil {
+	if err := stateMgr.RefreshState(); err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
 		return 1
 	}
@@ -186,7 +186,7 @@ func (c *UntaintCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Error writing state file: %s", err))
 		return 1
 	}
-	if err := stateMgr.PersistState(ctx, schemas); err != nil {
+	if err := stateMgr.PersistState(schemas); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error writing state file: %s", err))
 		return 1
 	}

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -4,7 +4,6 @@
 package command
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -276,7 +275,7 @@ func TestWorkspace_createWithState(t *testing.T) {
 	}
 
 	b := backend.TestBackendConfig(t, inmem.New(), nil)
-	sMgr, err := b.StateMgr(context.Background(), workspace)
+	sMgr, err := b.StateMgr(workspace)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -270,7 +270,7 @@ func TestWorkspace_createWithState(t *testing.T) {
 
 	newPath := filepath.Join(local.DefaultWorkspaceDir, "test", DefaultStateFilename)
 	envState := statemgr.NewFilesystem(newPath)
-	err = envState.RefreshState(context.Background())
+	err = envState.RefreshState()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/command/workspace_delete.go
+++ b/internal/command/workspace_delete.go
@@ -75,9 +75,7 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 	// This command will not write state
 	c.ignoreRemoteVersionConflict(b)
 
-	ctx := context.TODO()
-
-	workspaces, err := b.Workspaces(ctx)
+	workspaces, err := b.Workspaces()
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1
@@ -106,6 +104,8 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf(strings.TrimSpace(envDelCurrent), workspace))
 		return 1
 	}
+
+	ctx := context.Background()
 
 	// we need the actual state to see if it's empty
 	stateMgr, err := b.StateMgr(ctx, workspace)

--- a/internal/command/workspace_delete.go
+++ b/internal/command/workspace_delete.go
@@ -125,7 +125,7 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 		stateLocker = clistate.NewNoopLocker()
 	}
 
-	if err := stateMgr.RefreshState(ctx); err != nil {
+	if err := stateMgr.RefreshState(); err != nil {
 		// We need to release the lock before exit
 		stateLocker.Unlock()
 		c.Ui.Error(err.Error())

--- a/internal/command/workspace_delete.go
+++ b/internal/command/workspace_delete.go
@@ -172,7 +172,7 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 	// be delegated from the Backend to the State itself.
 	stateLocker.Unlock()
 
-	err = b.DeleteWorkspace(ctx, workspace, force)
+	err = b.DeleteWorkspace(workspace, force)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1

--- a/internal/command/workspace_delete.go
+++ b/internal/command/workspace_delete.go
@@ -4,7 +4,6 @@
 package command
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -105,10 +104,8 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 		return 1
 	}
 
-	ctx := context.Background()
-
 	// we need the actual state to see if it's empty
-	stateMgr, err := b.StateMgr(ctx, workspace)
+	stateMgr, err := b.StateMgr(workspace)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1

--- a/internal/command/workspace_list.go
+++ b/internal/command/workspace_list.go
@@ -5,7 +5,6 @@ package command
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"strings"
 
@@ -59,9 +58,7 @@ func (c *WorkspaceListCommand) Run(args []string) int {
 	// This command will not write state
 	c.ignoreRemoteVersionConflict(b)
 
-	ctx := context.TODO()
-
-	states, err := b.Workspaces(ctx)
+	states, err := b.Workspaces()
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1

--- a/internal/command/workspace_new.go
+++ b/internal/command/workspace_new.go
@@ -163,7 +163,7 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 		c.Ui.Error(err.Error())
 		return 1
 	}
-	err = stateMgr.PersistState(ctx, nil)
+	err = stateMgr.PersistState(nil)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1

--- a/internal/command/workspace_new.go
+++ b/internal/command/workspace_new.go
@@ -4,7 +4,6 @@
 package command
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -102,8 +101,7 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 		}
 	}
 
-	ctx := context.Background()
-	_, err = b.StateMgr(ctx, workspace)
+	_, err = b.StateMgr(workspace)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1
@@ -124,7 +122,7 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 	}
 
 	// load the new Backend state
-	stateMgr, err := b.StateMgr(ctx, workspace)
+	stateMgr, err := b.StateMgr(workspace)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1

--- a/internal/command/workspace_new.go
+++ b/internal/command/workspace_new.go
@@ -90,9 +90,7 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 	// This command will not write state
 	c.ignoreRemoteVersionConflict(b)
 
-	ctx := context.TODO()
-
-	workspaces, err := b.Workspaces(ctx)
+	workspaces, err := b.Workspaces()
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to get configured named states: %s", err))
 		return 1
@@ -104,6 +102,7 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 		}
 	}
 
+	ctx := context.Background()
 	_, err = b.StateMgr(ctx, workspace)
 	if err != nil {
 		c.Ui.Error(err.Error())

--- a/internal/command/workspace_select.go
+++ b/internal/command/workspace_select.go
@@ -83,9 +83,7 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 		return 1
 	}
 
-	ctx := context.TODO()
-
-	states, err := b.Workspaces(ctx)
+	states, err := b.Workspaces()
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1
@@ -105,6 +103,7 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 	}
 
 	var newState bool
+	ctx := context.Background()
 
 	if !found {
 		if orCreate {

--- a/internal/command/workspace_select.go
+++ b/internal/command/workspace_select.go
@@ -4,7 +4,6 @@
 package command
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -103,11 +102,10 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 	}
 
 	var newState bool
-	ctx := context.Background()
 
 	if !found {
 		if orCreate {
-			_, err = b.StateMgr(ctx, name)
+			_, err = b.StateMgr(name)
 			if err != nil {
 				c.Ui.Error(err.Error())
 				return 1

--- a/internal/legacy/helper/schema/backend.go
+++ b/internal/legacy/helper/schema/backend.go
@@ -54,7 +54,7 @@ func (b *Backend) ConfigSchema(context.Context) *configschema.Block {
 	return b.CoreConfigSchema()
 }
 
-func (b *Backend) PrepareConfig(_ context.Context, configVal cty.Value) (cty.Value, tfdiags.Diagnostics) {
+func (b *Backend) PrepareConfig(configVal cty.Value) (cty.Value, tfdiags.Diagnostics) {
 	if b == nil {
 		return configVal, nil
 	}

--- a/internal/legacy/helper/schema/backend.go
+++ b/internal/legacy/helper/schema/backend.go
@@ -48,7 +48,7 @@ func FromContextBackendConfig(ctx context.Context) *ResourceData {
 	return ctx.Value(backendConfigKey).(*ResourceData)
 }
 
-func (b *Backend) ConfigSchema(context.Context) *configschema.Block {
+func (b *Backend) ConfigSchema() *configschema.Block {
 	// This is an alias of CoreConfigSchema just to implement the
 	// backend.Backend interface.
 	return b.CoreConfigSchema()

--- a/internal/legacy/helper/schema/backend.go
+++ b/internal/legacy/helper/schema/backend.go
@@ -144,7 +144,7 @@ func (b *Backend) PrepareConfig(_ context.Context, configVal cty.Value) (cty.Val
 	return configVal, diags
 }
 
-func (b *Backend) Configure(ctx context.Context, obj cty.Value) tfdiags.Diagnostics {
+func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
 	if b == nil {
 		return nil
 	}
@@ -169,7 +169,8 @@ func (b *Backend) Configure(ctx context.Context, obj cty.Value) tfdiags.Diagnost
 	b.config = data
 
 	if b.ConfigureFunc != nil {
-		err = b.ConfigureFunc(context.WithValue(ctx, backendConfigKey, data))
+		err = b.ConfigureFunc(context.WithValue(
+			context.Background(), backendConfigKey, data))
 		if err != nil {
 			diags = diags.Append(err)
 			return diags

--- a/internal/legacy/helper/schema/backend_test.go
+++ b/internal/legacy/helper/schema/backend_test.go
@@ -190,7 +190,7 @@ func TestBackendConfigure(t *testing.T) {
 
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.Name), func(t *testing.T) {
-			diags := tc.B.Configure(context.Background(), cty.ObjectVal(tc.Config))
+			diags := tc.B.Configure(cty.ObjectVal(tc.Config))
 			if diags.HasErrors() != tc.Err {
 				t.Errorf("wrong number of diagnostics")
 			}

--- a/internal/legacy/helper/schema/backend_test.go
+++ b/internal/legacy/helper/schema/backend_test.go
@@ -133,10 +133,7 @@ func TestBackendPrepare(t *testing.T) {
 			if tc.Config != nil {
 				cfgVal = cty.ObjectVal(tc.Config)
 			}
-
-			ctx := context.Background()
-
-			configVal, diags := tc.B.PrepareConfig(ctx, cfgVal)
+			configVal, diags := tc.B.PrepareConfig(cfgVal)
 			if diags.HasErrors() != tc.Err {
 				for _, d := range diags {
 					t.Error(d.Description())

--- a/internal/states/remote/remote.go
+++ b/internal/states/remote/remote.go
@@ -13,8 +13,8 @@ import (
 // driver. It supports dumb put/get/delete, and the higher level structs
 // handle persisting the state properly here.
 type Client interface {
-	Get(context.Context) (*Payload, error)
-	Put(context.Context, []byte) error
+	Get() (*Payload, error)
+	Put([]byte) error
 	Delete(context.Context) error
 }
 

--- a/internal/states/remote/remote.go
+++ b/internal/states/remote/remote.go
@@ -4,8 +4,6 @@
 package remote
 
 import (
-	"context"
-
 	"github.com/opentofu/opentofu/internal/states/statemgr"
 )
 
@@ -15,7 +13,7 @@ import (
 type Client interface {
 	Get() (*Payload, error)
 	Put([]byte) error
-	Delete(context.Context) error
+	Delete() error
 }
 
 // ClientForcePusher is an optional interface that allows a remote

--- a/internal/states/remote/remote_test.go
+++ b/internal/states/remote/remote_test.go
@@ -14,7 +14,7 @@ func TestRemoteClient_noPayload(t *testing.T) {
 	s := &State{
 		Client: nilClient{},
 	}
-	if err := s.RefreshState(context.Background()); err != nil {
+	if err := s.RefreshState(); err != nil {
 		t.Fatal("error refreshing empty remote state")
 	}
 }
@@ -22,9 +22,9 @@ func TestRemoteClient_noPayload(t *testing.T) {
 // nilClient returns nil for everything
 type nilClient struct{}
 
-func (nilClient) Get(context.Context) (*Payload, error) { return nil, nil }
+func (nilClient) Get() (*Payload, error) { return nil, nil }
 
-func (c nilClient) Put(context.Context, []byte) error { return nil }
+func (c nilClient) Put([]byte) error { return nil }
 
 func (c nilClient) Delete(context.Context) error { return nil }
 
@@ -41,7 +41,7 @@ type mockClientRequest struct {
 	Content map[string]interface{}
 }
 
-func (c *mockClient) Get(context.Context) (*Payload, error) {
+func (c *mockClient) Get() (*Payload, error) {
 	c.appendLog("Get", c.current)
 	if c.current == nil {
 		return nil, nil
@@ -53,7 +53,7 @@ func (c *mockClient) Get(context.Context) (*Payload, error) {
 	}, nil
 }
 
-func (c *mockClient) Put(_ context.Context, data []byte) error {
+func (c *mockClient) Put(data []byte) error {
 	c.appendLog("Put", data)
 	c.current = data
 	return nil
@@ -90,7 +90,7 @@ type mockClientForcePusher struct {
 	log     []mockClientRequest
 }
 
-func (c *mockClientForcePusher) Get(context.Context) (*Payload, error) {
+func (c *mockClientForcePusher) Get() (*Payload, error) {
 	c.appendLog("Get", c.current)
 	if c.current == nil {
 		return nil, nil
@@ -102,7 +102,7 @@ func (c *mockClientForcePusher) Get(context.Context) (*Payload, error) {
 	}, nil
 }
 
-func (c *mockClientForcePusher) Put(_ context.Context, data []byte) error {
+func (c *mockClientForcePusher) Put(data []byte) error {
 	if c.force {
 		c.appendLog("Force Put", data)
 	} else {

--- a/internal/states/remote/remote_test.go
+++ b/internal/states/remote/remote_test.go
@@ -4,7 +4,6 @@
 package remote
 
 import (
-	"context"
 	"crypto/md5"
 	"encoding/json"
 	"testing"
@@ -26,7 +25,7 @@ func (nilClient) Get() (*Payload, error) { return nil, nil }
 
 func (c nilClient) Put([]byte) error { return nil }
 
-func (c nilClient) Delete(context.Context) error { return nil }
+func (c nilClient) Delete() error { return nil }
 
 // mockClient is a client that tracks persisted state snapshots only in
 // memory and also logs what it has been asked to do for use in test
@@ -59,7 +58,7 @@ func (c *mockClient) Put(data []byte) error {
 	return nil
 }
 
-func (c *mockClient) Delete(context.Context) error {
+func (c *mockClient) Delete() error {
 	c.appendLog("Delete", c.current)
 	c.current = nil
 	return nil
@@ -117,7 +116,7 @@ func (c *mockClientForcePusher) EnableForcePush() {
 	c.force = true
 }
 
-func (c *mockClientForcePusher) Delete(context.Context) error {
+func (c *mockClientForcePusher) Delete() error {
 	c.appendLog("Delete", c.current)
 	c.current = nil
 	return nil

--- a/internal/states/remote/state.go
+++ b/internal/states/remote/state.go
@@ -237,7 +237,7 @@ func (s *State) ShouldPersistIntermediateState(info *local.IntermediateStatePers
 }
 
 // Lock calls the Client's Lock method if it's implemented.
-func (s *State) Lock(ctx context.Context, info *statemgr.LockInfo) (string, error) {
+func (s *State) Lock(info *statemgr.LockInfo) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -246,13 +246,13 @@ func (s *State) Lock(ctx context.Context, info *statemgr.LockInfo) (string, erro
 	}
 
 	if c, ok := s.Client.(ClientLocker); ok {
-		return c.Lock(ctx, info)
+		return c.Lock(info)
 	}
 	return "", nil
 }
 
 // Unlock calls the Client's Unlock method if it's implemented.
-func (s *State) Unlock(ctx context.Context, id string) error {
+func (s *State) Unlock(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -261,7 +261,7 @@ func (s *State) Unlock(ctx context.Context, id string) error {
 	}
 
 	if c, ok := s.Client.(ClientLocker); ok {
-		return c.Unlock(ctx, id)
+		return c.Unlock(id)
 	}
 	return nil
 }

--- a/internal/states/remote/state.go
+++ b/internal/states/remote/state.go
@@ -5,7 +5,6 @@ package remote
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"log"
 	"sync"
@@ -61,8 +60,8 @@ func (s *State) State() *states.State {
 	return s.state.DeepCopy()
 }
 
-func (s *State) GetRootOutputValues(ctx context.Context) (map[string]*states.OutputValue, error) {
-	if err := s.RefreshState(ctx); err != nil {
+func (s *State) GetRootOutputValues() (map[string]*states.OutputValue, error) {
+	if err := s.RefreshState(); err != nil {
 		return nil, fmt.Errorf("Failed to load state: %w", err)
 	}
 
@@ -126,17 +125,17 @@ func (s *State) WriteStateForMigration(f *statefile.File, force bool) error {
 }
 
 // statemgr.Refresher impl.
-func (s *State) RefreshState(ctx context.Context) error {
+func (s *State) RefreshState() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.refreshState(ctx)
+	return s.refreshState()
 }
 
 // refreshState is the main implementation of RefreshState, but split out so
 // that we can make internal calls to it from methods that are already holding
 // the s.mu lock.
-func (s *State) refreshState(ctx context.Context) error {
-	payload, err := s.Client.Get(ctx)
+func (s *State) refreshState() error {
+	payload, err := s.Client.Get()
 	if err != nil {
 		return err
 	}
@@ -167,7 +166,7 @@ func (s *State) refreshState(ctx context.Context) error {
 }
 
 // statemgr.Persister impl.
-func (s *State) PersistState(ctx context.Context, schemas *tofu.Schemas) error {
+func (s *State) PersistState(schemas *tofu.Schemas) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -187,7 +186,7 @@ func (s *State) PersistState(ctx context.Context, schemas *tofu.Schemas) error {
 		// We might be writing a new state altogether, but before we do that
 		// we'll check to make sure there isn't already a snapshot present
 		// that we ought to be updating.
-		err := s.refreshState(ctx)
+		err := s.refreshState()
 		if err != nil {
 			return fmt.Errorf("failed checking for existing remote state: %w", err)
 		}
@@ -211,7 +210,7 @@ func (s *State) PersistState(ctx context.Context, schemas *tofu.Schemas) error {
 		return err
 	}
 
-	err = s.Client.Put(ctx, buf.Bytes())
+	err = s.Client.Put(buf.Bytes())
 	if err != nil {
 		return err
 	}

--- a/internal/states/remote/state_test.go
+++ b/internal/states/remote/state_test.go
@@ -4,7 +4,6 @@
 package remote
 
 import (
-	"context"
 	"log"
 	"sync"
 	"testing"
@@ -42,12 +41,10 @@ func TestStateRace(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
 		go func() {
-			ctx := context.Background()
-
 			defer wg.Done()
 			s.WriteState(current)
-			s.PersistState(ctx, nil)
-			s.RefreshState(ctx)
+			s.PersistState(nil)
+			s.RefreshState()
 		}()
 	}
 	wg.Wait()
@@ -332,13 +329,11 @@ func TestStatePersist(t *testing.T) {
 		Client: &mockClient{},
 	}
 
-	ctx := context.Background()
-
 	// In normal use (during a OpenTofu operation) we always refresh and read
 	// before any writes would happen, so we'll mimic that here for realism.
 	// NB This causes a GET to be logged so the first item in the test cases
 	// must account for this
-	if err := mgr.RefreshState(ctx); err != nil {
+	if err := mgr.RefreshState(); err != nil {
 		t.Fatalf("failed to RefreshState: %s", err)
 	}
 
@@ -359,7 +354,7 @@ func TestStatePersist(t *testing.T) {
 			if err := mgr.WriteState(s); err != nil {
 				t.Fatalf("failed to WriteState for %q: %s", tc.name, err)
 			}
-			if err := mgr.PersistState(ctx, nil); err != nil {
+			if err := mgr.PersistState(nil); err != nil {
 				t.Fatalf("failed to PersistState for %q: %s", tc.name, err)
 			}
 
@@ -407,7 +402,7 @@ func TestState_GetRootOutputValues(t *testing.T) {
 		},
 	}
 
-	outputs, err := mgr.GetRootOutputValues(context.Background())
+	outputs, err := mgr.GetRootOutputValues()
 	if err != nil {
 		t.Errorf("Expected GetRootOutputValues to not return an error, but it returned %v", err)
 	}
@@ -518,13 +513,11 @@ func TestWriteStateForMigration(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
-
 	// In normal use (during a OpenTofu operation) we always refresh and read
 	// before any writes would happen, so we'll mimic that here for realism.
 	// NB This causes a GET to be logged so the first item in the test cases
 	// must account for this
-	if err := mgr.RefreshState(ctx); err != nil {
+	if err := mgr.RefreshState(); err != nil {
 		t.Fatalf("failed to RefreshState: %s", err)
 	}
 
@@ -564,7 +557,7 @@ func TestWriteStateForMigration(t *testing.T) {
 			// At this point we should just do a normal write and persist
 			// as would happen from the CLI
 			mgr.WriteState(mgr.State())
-			mgr.PersistState(ctx, nil)
+			mgr.PersistState(nil)
 
 			if logIdx >= len(mockClient.log) {
 				t.Fatalf("request lock and index are out of sync on %q: idx=%d len=%d", tc.name, logIdx, len(mockClient.log))
@@ -676,13 +669,11 @@ func TestWriteStateForMigrationWithForcePushClient(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
-
 	// In normal use (during a OpenTofu operation) we always refresh and read
 	// before any writes would happen, so we'll mimic that here for realism.
 	// NB This causes a GET to be logged so the first item in the test cases
 	// must account for this
-	if err := mgr.RefreshState(ctx); err != nil {
+	if err := mgr.RefreshState(); err != nil {
 		t.Fatalf("failed to RefreshState: %s", err)
 	}
 
@@ -732,7 +723,7 @@ func TestWriteStateForMigrationWithForcePushClient(t *testing.T) {
 			// At this point we should just do a normal write and persist
 			// as would happen from the CLI
 			mgr.WriteState(mgr.State())
-			mgr.PersistState(ctx, nil)
+			mgr.PersistState(nil)
 
 			if logIdx >= len(mockClient.log) {
 				t.Fatalf("request lock and index are out of sync on %q: idx=%d len=%d", tc.name, logIdx, len(mockClient.log))

--- a/internal/states/remote/testing.go
+++ b/internal/states/remote/testing.go
@@ -5,7 +5,6 @@ package remote
 
 import (
 	"bytes"
-	"context"
 	"testing"
 
 	"github.com/opentofu/opentofu/internal/states/statefile"
@@ -35,9 +34,7 @@ func TestClient(t *testing.T, c Client) {
 		t.Fatalf("expected full state %q\n\ngot: %q", string(p.Data), string(data))
 	}
 
-	ctx := context.Background()
-
-	if err := c.Delete(ctx); err != nil {
+	if err := c.Delete(); err != nil {
 		t.Fatalf("delete: %s", err)
 	}
 

--- a/internal/states/remote/testing.go
+++ b/internal/states/remote/testing.go
@@ -73,27 +73,25 @@ func TestRemoteLocks(t *testing.T, a, b Client) {
 	infoB.Operation = "test"
 	infoB.Who = "clientB"
 
-	ctx := context.Background()
-
-	lockIDA, err := lockerA.Lock(ctx, infoA)
+	lockIDA, err := lockerA.Lock(infoA)
 	if err != nil {
 		t.Fatal("unable to get initial lock:", err)
 	}
 
-	_, err = lockerB.Lock(ctx, infoB)
+	_, err = lockerB.Lock(infoB)
 	if err == nil {
-		lockerA.Unlock(ctx, lockIDA)
+		lockerA.Unlock(lockIDA)
 		t.Fatal("client B obtained lock while held by client A")
 	}
 	if _, ok := err.(*statemgr.LockError); !ok {
 		t.Errorf("expected a LockError, but was %t: %s", err, err)
 	}
 
-	if err := lockerA.Unlock(ctx, lockIDA); err != nil {
+	if err := lockerA.Unlock(lockIDA); err != nil {
 		t.Fatal("error unlocking client A", err)
 	}
 
-	lockIDB, err := lockerB.Lock(ctx, infoB)
+	lockIDB, err := lockerB.Lock(infoB)
 	if err != nil {
 		t.Fatal("unable to obtain lock from client B")
 	}
@@ -102,7 +100,7 @@ func TestRemoteLocks(t *testing.T, a, b Client) {
 		t.Fatalf("duplicate lock IDs: %q", lockIDB)
 	}
 
-	if err = lockerB.Unlock(ctx, lockIDB); err != nil {
+	if err = lockerB.Unlock(lockIDB); err != nil {
 		t.Fatal("error unlocking client B:", err)
 	}
 

--- a/internal/states/remote/testing.go
+++ b/internal/states/remote/testing.go
@@ -23,13 +23,11 @@ func TestClient(t *testing.T, c Client) {
 	}
 	data := buf.Bytes()
 
-	ctx := context.Background()
-
-	if err := c.Put(ctx, data); err != nil {
+	if err := c.Put(data); err != nil {
 		t.Fatalf("put: %s", err)
 	}
 
-	p, err := c.Get(ctx)
+	p, err := c.Get()
 	if err != nil {
 		t.Fatalf("get: %s", err)
 	}
@@ -37,11 +35,13 @@ func TestClient(t *testing.T, c Client) {
 		t.Fatalf("expected full state %q\n\ngot: %q", string(p.Data), string(data))
 	}
 
+	ctx := context.Background()
+
 	if err := c.Delete(ctx); err != nil {
 		t.Fatalf("delete: %s", err)
 	}
 
-	p, err = c.Get(ctx)
+	p, err = c.Get()
 	if err != nil {
 		t.Fatalf("get: %s", err)
 	}

--- a/internal/states/statemgr/filesystem.go
+++ b/internal/states/statemgr/filesystem.go
@@ -5,7 +5,6 @@ package statemgr
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -91,7 +90,7 @@ func NewFilesystemBetweenPaths(readPath, writePath string) *Filesystem {
 	}
 }
 
-// SetBackupPath configures the receiver so that it will create a local
+// SetBackupPath configures the receiever so that it will create a local
 // backup file of the next state snapshot it reads (in State) if a different
 // snapshot is subsequently written (in WriteState). Only one backup is
 // written for the lifetime of the object, unless reset as described below.
@@ -227,18 +226,18 @@ func (s *Filesystem) writeState(state *states.State, meta *SnapshotMeta) error {
 
 // PersistState is an implementation of Persister that does nothing because
 // this type's Writer implementation does its own persistence.
-func (s *Filesystem) PersistState(_ context.Context, schemas *tofu.Schemas) error {
+func (s *Filesystem) PersistState(schemas *tofu.Schemas) error {
 	return nil
 }
 
 // RefreshState is an implementation of Refresher.
-func (s *Filesystem) RefreshState(ctx context.Context) error {
+func (s *Filesystem) RefreshState() error {
 	defer s.mutex()()
 	return s.refreshState()
 }
 
-func (s *Filesystem) GetRootOutputValues(ctx context.Context) (map[string]*states.OutputValue, error) {
-	err := s.RefreshState(ctx)
+func (s *Filesystem) GetRootOutputValues() (map[string]*states.OutputValue, error) {
+	err := s.RefreshState()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/states/statemgr/filesystem.go
+++ b/internal/states/statemgr/filesystem.go
@@ -314,7 +314,7 @@ func (s *Filesystem) refreshState() error {
 }
 
 // Lock implements Locker using filesystem discretionary locks.
-func (s *Filesystem) Lock(_ context.Context, info *LockInfo) (string, error) {
+func (s *Filesystem) Lock(info *LockInfo) (string, error) {
 	defer s.mutex()()
 
 	if s.stateFileOut == nil {
@@ -345,8 +345,8 @@ func (s *Filesystem) Lock(_ context.Context, info *LockInfo) (string, error) {
 	return s.lockID, s.writeLockInfo(info)
 }
 
-// Unlock is the companion to Lock, completing the implementation of Locker.
-func (s *Filesystem) Unlock(_ context.Context, id string) error {
+// Unlock is the companion to Lock, completing the implemention of Locker.
+func (s *Filesystem) Unlock(id string) error {
 	defer s.mutex()()
 
 	if s.lockID == "" {

--- a/internal/states/statemgr/filesystem_test.go
+++ b/internal/states/statemgr/filesystem_test.go
@@ -4,7 +4,6 @@
 package statemgr
 
 import (
-	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -289,7 +288,7 @@ func TestFilesystem_backupAndReadPath(t *testing.T) {
 func TestFilesystem_nonExist(t *testing.T) {
 	defer testOverrideVersion(t, "1.2.3")()
 	ls := NewFilesystem("ishouldntexist")
-	if err := ls.RefreshState(context.Background()); err != nil {
+	if err := ls.RefreshState(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -362,7 +361,7 @@ func testFilesystem(t *testing.T) *Filesystem {
 	f.Close()
 
 	ls := NewFilesystem(f.Name())
-	if err := ls.RefreshState(context.Background()); err != nil {
+	if err := ls.RefreshState(); err != nil {
 		t.Fatalf("initial refresh failed: %s", err)
 	}
 
@@ -404,7 +403,7 @@ func TestFilesystem_refreshWhileLocked(t *testing.T) {
 		}
 	}()
 
-	if err := s.RefreshState(context.Background()); err != nil {
+	if err := s.RefreshState(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -417,7 +416,7 @@ func TestFilesystem_refreshWhileLocked(t *testing.T) {
 func TestFilesystem_GetRootOutputValues(t *testing.T) {
 	fs := testFilesystem(t)
 
-	outputs, err := fs.GetRootOutputValues(context.Background())
+	outputs, err := fs.GetRootOutputValues()
 	if err != nil {
 		t.Errorf("Expected GetRootOutputValues to not return an error, but it returned %v", err)
 	}

--- a/internal/states/statemgr/filesystem_test.go
+++ b/internal/states/statemgr/filesystem_test.go
@@ -52,12 +52,10 @@ func TestFilesystemLocks(t *testing.T) {
 	s := testFilesystem(t)
 	defer os.Remove(s.readPath)
 
-	ctx := context.Background()
-
 	// lock first
 	info := NewLockInfo()
 	info.Operation = "test"
-	lockID, err := s.Lock(ctx, info)
+	lockID, err := s.Lock(info)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,22 +80,22 @@ func TestFilesystemLocks(t *testing.T) {
 	}
 
 	// a noop, since we unlock on exit
-	if err := s.Unlock(ctx, lockID); err != nil {
+	if err := s.Unlock(lockID); err != nil {
 		t.Fatal(err)
 	}
 
 	// local locks can re-lock
-	lockID, err = s.Lock(ctx, info)
+	lockID, err = s.Lock(info)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := s.Unlock(ctx, lockID); err != nil {
+	if err := s.Unlock(lockID); err != nil {
 		t.Fatal(err)
 	}
 
 	// we should not be able to unlock the same lock twice
-	if err := s.Unlock(ctx, lockID); err == nil {
+	if err := s.Unlock(lockID); err == nil {
 		t.Fatal("unlocking an unlocked state should fail")
 	}
 
@@ -115,17 +113,15 @@ func TestFilesystem_writeWhileLocked(t *testing.T) {
 	s := testFilesystem(t)
 	defer os.Remove(s.readPath)
 
-	ctx := context.Background()
-
 	// lock first
 	info := NewLockInfo()
 	info.Operation = "test"
-	lockID, err := s.Lock(ctx, info)
+	lockID, err := s.Lock(info)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		if err := s.Unlock(ctx, lockID); err != nil {
+		if err := s.Unlock(lockID); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -311,10 +307,8 @@ func TestFilesystem_lockUnlockWithoutWrite(t *testing.T) {
 	// Delete the just-created tempfile so that Lock recreates it
 	os.Remove(ls.path)
 
-	ctx := context.Background()
-
 	// Lock the state, and in doing so recreate the tempfile
-	lockID, err := ls.Lock(ctx, info)
+	lockID, err := ls.Lock(info)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -323,7 +317,7 @@ func TestFilesystem_lockUnlockWithoutWrite(t *testing.T) {
 		t.Fatal("should have marked state as created")
 	}
 
-	if err := ls.Unlock(ctx, lockID); err != nil {
+	if err := ls.Unlock(lockID); err != nil {
 		t.Fatal(err)
 	}
 
@@ -397,17 +391,15 @@ func TestFilesystem_refreshWhileLocked(t *testing.T) {
 	s := NewFilesystem(f.Name())
 	defer os.Remove(s.path)
 
-	ctx := context.Background()
-
 	// lock first
 	info := NewLockInfo()
 	info.Operation = "test"
-	lockID, err := s.Lock(ctx, info)
+	lockID, err := s.Lock(info)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		if err := s.Unlock(ctx, lockID); err != nil {
+		if err := s.Unlock(lockID); err != nil {
 			t.Fatal(err)
 		}
 	}()

--- a/internal/states/statemgr/helper.go
+++ b/internal/states/statemgr/helper.go
@@ -7,8 +7,6 @@ package statemgr
 // operations done against full state managers.
 
 import (
-	"context"
-
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/states/statefile"
 	"github.com/opentofu/opentofu/internal/tofu"
@@ -31,7 +29,7 @@ func NewStateFile() *statefile.File {
 // This is a wrapper around calling RefreshState and then State on the given
 // manager.
 func RefreshAndRead(mgr Storage) (*states.State, error) {
-	err := mgr.RefreshState(context.Background())
+	err := mgr.RefreshState()
 	if err != nil {
 		return nil, err
 	}
@@ -55,5 +53,5 @@ func WriteAndPersist(mgr Storage, state *states.State, schemas *tofu.Schemas) er
 	if err != nil {
 		return err
 	}
-	return mgr.PersistState(context.Background(), schemas)
+	return mgr.PersistState(schemas)
 }

--- a/internal/states/statemgr/lock.go
+++ b/internal/states/statemgr/lock.go
@@ -39,10 +39,10 @@ func (s *LockDisabled) PersistState(ctx context.Context, schemas *tofu.Schemas) 
 	return s.Inner.PersistState(ctx, schemas)
 }
 
-func (s *LockDisabled) Lock(ctx context.Context, info *LockInfo) (string, error) {
+func (s *LockDisabled) Lock(info *LockInfo) (string, error) {
 	return "", nil
 }
 
-func (s *LockDisabled) Unlock(ctx context.Context, id string) error {
+func (s *LockDisabled) Unlock(id string) error {
 	return nil
 }

--- a/internal/states/statemgr/lock.go
+++ b/internal/states/statemgr/lock.go
@@ -4,8 +4,6 @@
 package statemgr
 
 import (
-	"context"
-
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tofu"
 )
@@ -23,20 +21,20 @@ func (s *LockDisabled) State() *states.State {
 	return s.Inner.State()
 }
 
-func (s *LockDisabled) GetRootOutputValues(ctx context.Context) (map[string]*states.OutputValue, error) {
-	return s.Inner.GetRootOutputValues(ctx)
+func (s *LockDisabled) GetRootOutputValues() (map[string]*states.OutputValue, error) {
+	return s.Inner.GetRootOutputValues()
 }
 
 func (s *LockDisabled) WriteState(v *states.State) error {
 	return s.Inner.WriteState(v)
 }
 
-func (s *LockDisabled) RefreshState(ctx context.Context) error {
-	return s.Inner.RefreshState(ctx)
+func (s *LockDisabled) RefreshState() error {
+	return s.Inner.RefreshState()
 }
 
-func (s *LockDisabled) PersistState(ctx context.Context, schemas *tofu.Schemas) error {
-	return s.Inner.PersistState(ctx, schemas)
+func (s *LockDisabled) PersistState(schemas *tofu.Schemas) error {
+	return s.Inner.PersistState(schemas)
 }
 
 func (s *LockDisabled) Lock(info *LockInfo) (string, error) {

--- a/internal/states/statemgr/locker.go
+++ b/internal/states/statemgr/locker.go
@@ -53,7 +53,7 @@ type Locker interface {
 	// an instance of LockError immediately if the lock is already held,
 	// and the helper function LockWithContext uses this to automatically
 	// retry lock acquisition periodically until a timeout is reached.
-	Lock(ctx context.Context, info *LockInfo) (string, error)
+	Lock(info *LockInfo) (string, error)
 
 	// Unlock releases a lock previously acquired by Lock.
 	//
@@ -61,7 +61,7 @@ type Locker interface {
 	// another user with some sort of administrative override privilege --
 	// then an error is returned explaining the situation in a way that
 	// is suitable for returning to an end-user.
-	Unlock(ctx context.Context, id string) error
+	Unlock(id string) error
 }
 
 // test hook to verify that LockWithContext has attempted a lock
@@ -76,7 +76,7 @@ func LockWithContext(ctx context.Context, s Locker, info *LockInfo) (string, err
 	delay := time.Second
 	maxDelay := 16 * time.Second
 	for {
-		id, err := s.Lock(ctx, info)
+		id, err := s.Lock(info)
 		if err == nil {
 			return id, nil
 		}

--- a/internal/states/statemgr/persistent.go
+++ b/internal/states/statemgr/persistent.go
@@ -4,8 +4,6 @@
 package statemgr
 
 import (
-	"context"
-
 	version "github.com/hashicorp/go-version"
 
 	"github.com/opentofu/opentofu/internal/states"
@@ -33,7 +31,7 @@ type Persistent interface {
 // to differentiate reading the state and reading the outputs within the state.
 type OutputReader interface {
 	// GetRootOutputValues fetches the root module output values from state or another source
-	GetRootOutputValues(context.Context) (map[string]*states.OutputValue, error)
+	GetRootOutputValues() (map[string]*states.OutputValue, error)
 }
 
 // Refresher is the interface for managers that can read snapshots from
@@ -63,7 +61,7 @@ type Refresher interface {
 	// return only a subset of what was written. Callers must assume that
 	// ephemeral portions of the state may be unpopulated after calling
 	// RefreshState.
-	RefreshState(context.Context) error
+	RefreshState() error
 }
 
 // Persister is the interface for managers that can write snapshots to
@@ -83,7 +81,7 @@ type Refresher interface {
 // state. For example, when representing state in an external JSON
 // representation.
 type Persister interface {
-	PersistState(context.Context, *tofu.Schemas) error
+	PersistState(*tofu.Schemas) error
 }
 
 // PersistentMeta is an optional extension to Persistent that allows inspecting

--- a/internal/states/statemgr/statemgr_fake.go
+++ b/internal/states/statemgr/statemgr_fake.go
@@ -4,7 +4,6 @@
 package statemgr
 
 import (
-	"context"
 	"errors"
 	"sync"
 
@@ -62,15 +61,15 @@ func (m *fakeFull) WriteState(s *states.State) error {
 	return m.t.WriteState(s)
 }
 
-func (m *fakeFull) RefreshState(context.Context) error {
+func (m *fakeFull) RefreshState() error {
 	return m.t.WriteState(m.fakeP.State())
 }
 
-func (m *fakeFull) PersistState(_ context.Context, schemas *tofu.Schemas) error {
+func (m *fakeFull) PersistState(schemas *tofu.Schemas) error {
 	return m.fakeP.WriteState(m.t.State())
 }
 
-func (m *fakeFull) GetRootOutputValues(ctx context.Context) (map[string]*states.OutputValue, error) {
+func (m *fakeFull) GetRootOutputValues() (map[string]*states.OutputValue, error) {
 	return m.State().RootModule().OutputValues, nil
 }
 
@@ -120,7 +119,7 @@ func (m *fakeErrorFull) State() *states.State {
 	return nil
 }
 
-func (m *fakeErrorFull) GetRootOutputValues(context.Context) (map[string]*states.OutputValue, error) {
+func (m *fakeErrorFull) GetRootOutputValues() (map[string]*states.OutputValue, error) {
 	return nil, errors.New("fake state manager error")
 }
 
@@ -128,11 +127,11 @@ func (m *fakeErrorFull) WriteState(s *states.State) error {
 	return errors.New("fake state manager error")
 }
 
-func (m *fakeErrorFull) RefreshState(context.Context) error {
+func (m *fakeErrorFull) RefreshState() error {
 	return errors.New("fake state manager error")
 }
 
-func (m *fakeErrorFull) PersistState(_ context.Context, schemas *tofu.Schemas) error {
+func (m *fakeErrorFull) PersistState(schemas *tofu.Schemas) error {
 	return errors.New("fake state manager error")
 }
 

--- a/internal/states/statemgr/statemgr_fake.go
+++ b/internal/states/statemgr/statemgr_fake.go
@@ -74,7 +74,7 @@ func (m *fakeFull) GetRootOutputValues(ctx context.Context) (map[string]*states.
 	return m.State().RootModule().OutputValues, nil
 }
 
-func (m *fakeFull) Lock(_ context.Context, info *LockInfo) (string, error) {
+func (m *fakeFull) Lock(info *LockInfo) (string, error) {
 	m.lockLock.Lock()
 	defer m.lockLock.Unlock()
 
@@ -89,7 +89,7 @@ func (m *fakeFull) Lock(_ context.Context, info *LockInfo) (string, error) {
 	return "placeholder", nil
 }
 
-func (m *fakeFull) Unlock(_ context.Context, id string) error {
+func (m *fakeFull) Unlock(id string) error {
 	m.lockLock.Lock()
 	defer m.lockLock.Unlock()
 
@@ -136,10 +136,10 @@ func (m *fakeErrorFull) PersistState(_ context.Context, schemas *tofu.Schemas) e
 	return errors.New("fake state manager error")
 }
 
-func (m *fakeErrorFull) Lock(_ context.Context, info *LockInfo) (string, error) {
+func (m *fakeErrorFull) Lock(info *LockInfo) (string, error) {
 	return "placeholder", nil
 }
 
-func (m *fakeErrorFull) Unlock(_ context.Context, id string) error {
+func (m *fakeErrorFull) Unlock(id string) error {
 	return errors.New("fake state manager error")
 }

--- a/internal/states/statemgr/statemgr_test.go
+++ b/internal/states/statemgr/statemgr_test.go
@@ -45,7 +45,7 @@ func TestNewLockInfo(t *testing.T) {
 func TestLockWithContext(t *testing.T) {
 	s := NewFullFake(nil, TestFullInitialState())
 
-	id, err := s.Lock(context.Background(), NewLockInfo())
+	id, err := s.Lock(NewLockInfo())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +61,7 @@ func TestLockWithContext(t *testing.T) {
 		t.Fatal("lock should have failed immediately")
 	}
 
-	// block until LockWithContext has made a first attempt
+	// block until LockwithContext has made a first attempt
 	attempted := make(chan struct{})
 	postLockHook = func() {
 		close(attempted)
@@ -74,7 +74,7 @@ func TestLockWithContext(t *testing.T) {
 	go func() {
 		defer close(unlocked)
 		<-attempted
-		unlockErr = s.Unlock(context.Background(), id)
+		unlockErr = s.Unlock(id)
 	}()
 
 	ctx, cancel = context.WithTimeout(context.Background(), 2*time.Second)
@@ -85,7 +85,7 @@ func TestLockWithContext(t *testing.T) {
 		t.Fatal("lock should have completed within 2s:", err)
 	}
 
-	// ensure the goroutine completes
+	// ensure the goruotine completes
 	<-unlocked
 	if unlockErr != nil {
 		t.Fatal(unlockErr)

--- a/internal/states/statemgr/testdata/lockstate.go
+++ b/internal/states/statemgr/testdata/lockstate.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"io"
 	"log"
 	"os"
@@ -22,9 +21,7 @@ func main() {
 	info.Operation = "test"
 	info.Info = "state locker"
 
-	ctx := context.Background()
-
-	_, err := s.Lock(ctx, info)
+	_, err := s.Lock(info)
 	if err != nil {
 		io.WriteString(os.Stderr, "lock failed")
 	}

--- a/internal/states/statemgr/testing.go
+++ b/internal/states/statemgr/testing.go
@@ -4,7 +4,6 @@
 package statemgr
 
 import (
-	"context"
 	"reflect"
 	"testing"
 
@@ -26,9 +25,7 @@ import (
 func TestFull(t *testing.T, s Full) {
 	t.Helper()
 
-	ctx := context.Background()
-
-	if err := s.RefreshState(ctx); err != nil {
+	if err := s.RefreshState(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -62,12 +59,12 @@ func TestFull(t *testing.T, s Full) {
 	}
 
 	// Test persistence
-	if err := s.PersistState(ctx, nil); err != nil {
+	if err := s.PersistState(nil); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
 	// Refresh if we got it
-	if err := s.RefreshState(ctx); err != nil {
+	if err := s.RefreshState(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -87,7 +84,7 @@ func TestFull(t *testing.T, s Full) {
 	if err := s.WriteState(current); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if err := s.PersistState(ctx, nil); err != nil {
+	if err := s.PersistState(nil); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -110,7 +107,7 @@ func TestFull(t *testing.T, s Full) {
 	if err := s.WriteState(current); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if err := s.PersistState(ctx, nil); err != nil {
+	if err := s.PersistState(nil); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 


### PR DESCRIPTION
We would like to not include this during the stable release and we would love to be able to include these once the stable release is completed.

Once this PR is merged, we will do a revert-revert and create a PR to introduce this back into the codebase.

This is to reduce the risk overall of introducing bugs into the codebase where test coverage is not great.

Resolves #836 #825 

1.6.0

