### PR TITLE
Address s3 compatible remote state issues + logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ BUG FIXES:
 * cloud: fixed a bug that would prevent nested symlinks from being dereferenced into the config sent to Cloud ([#686](https://github.com/opentofu/opentofu/issues/686)) 
 * cloud: state snapshots could not be disabled when header x-terraform-snapshot-interval is absent ([#687](https://github.com/opentofu/opentofu/issues/687))
 * Fixed crash during tofu destroy inside module with variable validation ([#817](https://github.com/opentofu/opentofu/issues/817))
+* S3 backend endpoints without proto:// now default to https:// instead of failing ([#821](https://github.com/opentofu/opentofu/issues/821))
+* Most S3 compatible remote state backends should now work without checksum errors / 400s by default ([#821](https://github.com/opentofu/opentofu/issues/821))
+* Logging has been re-added to S3 remote state calls ([#821](https://github.com/opentofu/opentofu/issues/821))
 
 S3 BACKEND:
 

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -840,8 +840,6 @@ func verifyAllowedAccountID(ctx context.Context, awsConfig aws.Config, cfg *awsb
 func getDynamoDBConfig(obj cty.Value) func(options *dynamodb.Options) {
 	return func(options *dynamodb.Options) {
 		if v, ok := customEndpoints["dynamodb"].StringOk(obj); ok {
-			// EndpointResolver does not require scheme://
-			//options.EndpointResolver = dynamodb.EndpointResolverFromURL(v)
 			options.BaseEndpoint = aws.String(v)
 		}
 	}
@@ -850,8 +848,6 @@ func getDynamoDBConfig(obj cty.Value) func(options *dynamodb.Options) {
 func getS3Config(obj cty.Value) func(options *s3.Options) {
 	return func(options *s3.Options) {
 		if v, ok := customEndpoints["s3"].StringOk(obj); ok {
-			// EndpointResolver does not require scheme://
-			//options.EndpointResolver = s3.EndpointResolverFromURL(v)
 			options.BaseEndpoint = aws.String(v)
 		}
 		if v, ok := boolAttrOk(obj, "force_path_style"); ok {

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -697,7 +697,7 @@ func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
 	}
 
 	ctx := context.TODO()
-	ctx, baselog := baselogging.NewHcLogger(ctx, logging.HCLogger().Named("s3-backend"))
+	ctx, baselog := attachLoggerToContext(ctx)
 
 	cfg := &awsbase.Config{
 		AccessKey:               stringAttr(obj, "access_key"),
@@ -803,6 +803,12 @@ func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
 	b.s3Client = s3.NewFromConfig(awsConfig, getS3Config(obj))
 
 	return diags
+}
+
+func attachLoggerToContext(ctx context.Context) (context.Context, baselogging.HcLogger) {
+	ctx, baselog := baselogging.NewHcLogger(ctx, logging.HCLogger().Named("backend-s3"))
+	ctx = baselogging.RegisterLogger(ctx, baselog)
+	return ctx, baselog
 }
 
 func verifyAllowedAccountID(ctx context.Context, awsConfig aws.Config, cfg *awsbase.Config) tfdiags.Diagnostics {

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -841,7 +841,8 @@ func getDynamoDBConfig(obj cty.Value) func(options *dynamodb.Options) {
 	return func(options *dynamodb.Options) {
 		if v, ok := customEndpoints["dynamodb"].StringOk(obj); ok {
 			// EndpointResolver does not require scheme://
-			options.EndpointResolver = dynamodb.EndpointResolverFromURL(v)
+			//options.EndpointResolver = dynamodb.EndpointResolverFromURL(v)
+			options.BaseEndpoint = aws.String(v)
 		}
 	}
 }
@@ -850,7 +851,8 @@ func getS3Config(obj cty.Value) func(options *s3.Options) {
 	return func(options *s3.Options) {
 		if v, ok := customEndpoints["s3"].StringOk(obj); ok {
 			// EndpointResolver does not require scheme://
-			options.EndpointResolver = s3.EndpointResolverFromURL(v)
+			//options.EndpointResolver = s3.EndpointResolverFromURL(v)
+			options.BaseEndpoint = aws.String(v)
 		}
 		if v, ok := boolAttrOk(obj, "force_path_style"); ok {
 			options.UsePathStyle = v

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -1185,7 +1185,6 @@ func (e customEndpoint) String(obj cty.Value) string {
 }
 
 func includeProtoIfNessesary(endpoint string) string {
-	//if !strings.HasPrefix(endpoint, "http://") || strings.HasPrefix(endpoint, "https://") {
 	if matched, _ := regexp.MatchString("[a-z]*://.*", endpoint); !matched {
 		log.Printf("[DEBUG] Adding https:// prefix to endpoint '%s'", endpoint)
 		endpoint = fmt.Sprintf("https://%s", endpoint)

--- a/internal/backend/remote-state/s3/backend_state.go
+++ b/internal/backend/remote-state/s3/backend_state.go
@@ -14,8 +14,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	baselogging "github.com/hashicorp/aws-sdk-go-base/v2/logging"
 
 	"github.com/opentofu/opentofu/internal/backend"
+	"github.com/opentofu/opentofu/internal/logging"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/states/remote"
 	"github.com/opentofu/opentofu/internal/states/statemgr"
@@ -36,10 +38,14 @@ func (b *Backend) Workspaces() ([]string, error) {
 		MaxKeys: maxKeys,
 	}
 
+	ctx := context.TODO()
+
+	ctx, baselog := baselogging.NewHcLogger(ctx, logging.HCLogger().Named("s3-backend"))
+	ctx = baselogging.RegisterLogger(ctx, baselog)
+
 	wss := []string{backend.DefaultStateName}
 	pg := s3.NewListObjectsV2Paginator(b.s3Client, params)
 
-	ctx := context.TODO()
 	for pg.HasMorePages() {
 		page, err := pg.NextPage(ctx)
 		if err != nil {

--- a/internal/backend/remote-state/s3/backend_state.go
+++ b/internal/backend/remote-state/s3/backend_state.go
@@ -14,10 +14,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	types "github.com/aws/aws-sdk-go-v2/service/s3/types"
-	baselogging "github.com/hashicorp/aws-sdk-go-base/v2/logging"
 
 	"github.com/opentofu/opentofu/internal/backend"
-	"github.com/opentofu/opentofu/internal/logging"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/states/remote"
 	"github.com/opentofu/opentofu/internal/states/statemgr"
@@ -40,8 +38,7 @@ func (b *Backend) Workspaces() ([]string, error) {
 
 	ctx := context.TODO()
 
-	ctx, baselog := baselogging.NewHcLogger(ctx, logging.HCLogger().Named("s3-backend"))
-	ctx = baselogging.RegisterLogger(ctx, baselog)
+	ctx, _ = attachLoggerToContext(ctx)
 
 	wss := []string{backend.DefaultStateName}
 	pg := s3.NewListObjectsV2Paginator(b.s3Client, params)

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -1375,6 +1375,49 @@ func Test_pathString(t *testing.T) {
 	}
 }
 
+func TestBackend_includeProtoIfNessesary(t *testing.T) {
+	tests := []struct {
+		name     string
+		provided string
+		expected string
+	}{
+		{
+			name:     "Unmodified S3",
+			provided: "https://s3.us-east-1.amazonaws.com",
+			expected: "https://s3.us-east-1.amazonaws.com",
+		},
+		{
+			name:     "Modified S3",
+			provided: "s3.us-east-1.amazonaws.com",
+			expected: "https://s3.us-east-1.amazonaws.com",
+		},
+		{
+			name:     "Unmodified With Port",
+			provided: "http://localhost:9000/",
+			expected: "http://localhost:9000/",
+		},
+		{
+			name:     "Modified With Port",
+			provided: "localhost:9000/",
+			expected: "https://localhost:9000/",
+		},
+		{
+			name:     "Umodified with strange proto",
+			provided: "ftp://localhost:9000/",
+			expected: "ftp://localhost:9000/",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := includeProtoIfNessesary(test.provided)
+			if result != test.expected {
+				t.Errorf("Expected: %s, Got: %s", test.expected, result)
+			}
+		})
+	}
+}
+
 func testGetWorkspaceForKey(b *Backend, key string, expected string) error {
 	if actual := b.keyEnv(key); actual != expected {
 		return fmt.Errorf("incorrect workspace for key[%q]. Expected[%q]: Actual[%q]", key, expected, actual)

--- a/internal/backend/remote-state/s3/client.go
+++ b/internal/backend/remote-state/s3/client.go
@@ -251,6 +251,9 @@ func (c *RemoteClient) Put(data []byte) error {
 
 func (c *RemoteClient) Delete() error {
 	ctx := context.TODO()
+	ctx, baselog := baselogging.NewHcLogger(ctx, logging.HCLogger().Named("backend-s3"))
+	ctx = baselogging.RegisterLogger(ctx, baselog)
+
 	_, err := c.s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: &c.bucketName,
 		Key:    &c.path,

--- a/internal/backend/remote-state/s3/client.go
+++ b/internal/backend/remote-state/s3/client.go
@@ -187,27 +187,27 @@ func (c *RemoteClient) Put(data []byte) error {
 	contentType := "application/json"
 	contentLength := int64(len(data))
 
-	// There is a conflict in the aws-go-sdk-v2 that prevents it from working with many s3 compatible services
-	// Since we can pre-compute the hash here, we can work around it.
-	// ref: https://github.com/aws/aws-sdk-go-v2/issues/1689
-	algo := sha256.New()
-	algo.Write(data)
-	sum256 := algo.Sum(nil)
-	sum64 := make([]byte, base64.StdEncoding.EncodedLen(len(sum256)))
-	base64.StdEncoding.Encode(sum64, sum256)
-	sum64str := string(sum64)
-
 	i := &s3.PutObjectInput{
-		ContentType:    &contentType,
-		ContentLength:  contentLength,
-		Body:           bytes.NewReader(data),
-		Bucket:         &c.bucketName,
-		Key:            &c.path,
-		ChecksumSHA256: &sum64str,
+		ContentType:   &contentType,
+		ContentLength: contentLength,
+		Body:          bytes.NewReader(data),
+		Bucket:        &c.bucketName,
+		Key:           &c.path,
 	}
 
 	if !c.skipS3Checksum {
 		i.ChecksumAlgorithm = types.ChecksumAlgorithmSha256
+
+		// There is a conflict in the aws-go-sdk-v2 that prevents it from working with many s3 compatible services
+		// Since we can pre-compute the hash here, we can work around it.
+		// ref: https://github.com/aws/aws-sdk-go-v2/issues/1689
+		algo := sha256.New()
+		algo.Write(data)
+		sum256 := algo.Sum(nil)
+		sum64 := make([]byte, base64.StdEncoding.EncodedLen(len(sum256)))
+		base64.StdEncoding.Encode(sum64, sum256)
+		sum64str := string(sum64)
+		i.ChecksumSHA256 = &sum64str
 	}
 
 	if c.serverSideEncryption {

--- a/internal/backend/remote-state/s3/client.go
+++ b/internal/backend/remote-state/s3/client.go
@@ -203,10 +203,7 @@ func (c *RemoteClient) Put(data []byte) error {
 		// ref: https://github.com/aws/aws-sdk-go-v2/issues/1689
 		algo := sha256.New()
 		algo.Write(data)
-		sum256 := algo.Sum(nil)
-		sum64 := make([]byte, base64.StdEncoding.EncodedLen(len(sum256)))
-		base64.StdEncoding.Encode(sum64, sum256)
-		sum64str := string(sum64)
+		sum64str := base64.StdEncoding.EncodeToString(algo.Sum(nil))
 		i.ChecksumSHA256 = &sum64str
 	}
 

--- a/internal/backend/remote-state/s3/client.go
+++ b/internal/backend/remote-state/s3/client.go
@@ -22,10 +22,8 @@ import (
 	dtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	types "github.com/aws/aws-sdk-go-v2/service/s3/types"
-	baselogging "github.com/hashicorp/aws-sdk-go-base/v2/logging"
 	multierror "github.com/hashicorp/go-multierror"
 	uuid "github.com/hashicorp/go-uuid"
-	"github.com/opentofu/opentofu/internal/logging"
 	"github.com/opentofu/opentofu/internal/states/remote"
 	"github.com/opentofu/opentofu/internal/states/statemgr"
 )
@@ -112,8 +110,7 @@ func (c *RemoteClient) get(ctx context.Context) (*remote.Payload, error) {
 	var output *s3.GetObjectOutput
 	var err error
 
-	ctx, baselog := baselogging.NewHcLogger(ctx, logging.HCLogger().Named("backend-s3"))
-	ctx = baselogging.RegisterLogger(ctx, baselog)
+	ctx, _ = attachLoggerToContext(ctx)
 
 	inputHead := &s3.HeadObjectInput{
 		Bucket: &c.bucketName,
@@ -227,8 +224,7 @@ func (c *RemoteClient) Put(data []byte) error {
 	log.Printf("[DEBUG] Uploading remote state to S3: %#v", i)
 
 	ctx := context.TODO()
-	ctx, baselog := baselogging.NewHcLogger(ctx, logging.HCLogger().Named("backend-s3"))
-	ctx = baselogging.RegisterLogger(ctx, baselog)
+	ctx, _ = attachLoggerToContext(ctx)
 
 	_, err := c.s3Client.PutObject(ctx, i)
 	if err != nil {
@@ -248,8 +244,7 @@ func (c *RemoteClient) Put(data []byte) error {
 
 func (c *RemoteClient) Delete() error {
 	ctx := context.TODO()
-	ctx, baselog := baselogging.NewHcLogger(ctx, logging.HCLogger().Named("backend-s3"))
-	ctx = baselogging.RegisterLogger(ctx, baselog)
+	ctx, _ = attachLoggerToContext(ctx)
 
 	_, err := c.s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: &c.bucketName,


### PR DESCRIPTION
This PR started out addressing #821, but ended up being an investigation of the workflow itself instead of the not-adopted validation changes.

* Add in the relevant context hooks for aws-go-sdk-base logging.  This is required to easily debug the rest of the changes.
* Missing proto:// backwards compatibility
  - BaseEndpoint -> EndpointResolver fixed many of the issues related to non-proto endpoints.
  - Unfortunately it did not cover all cases, the main one I identified was in the aws-go-sdk-base middleware.
  - A workaround was added such that any non-proto endpoints would automatically have the https:// prefix added.
  - This is hopefully a sane default, and comes with a debug message that should help track down if it ever causes issues.
* PutObject checksum calculation
  - `skip_s3_checksum` was added in https://github.com/opentofu/opentofu/pull/795/files to partially work around s3 compatible endpoints not supporting the default sha256 PARTIAL headers.
  - This can be turned off, but should be avoided if possible.
  - Since we already have the payload as a `[]byte` in memory, it's simple to compute the hash ahead of time and bypass the streaming PARTIAL header issue.
  - In testing with DigitalOcean, providing the full sha256 instead of messing with PARTIAL fixed the issue.  Issues here and on related repositories suggest that this should fix the issue for multiple providers.
  - More reading: https://github.com/aws/aws-sdk-go-v2/issues/1689
* Added a HeadObject check to state.get to work around a MinIO issue where the GetObject request would return the wrong error message and fail.  I'm not sure that this is worth keeping in, though it might solve issues with other providers?


TODO:
- [x] Add tests to detecting / adding `proto://`
- [x] Decide if removing the new HeadObject call is the right call.

Resolves #821

## Target Release

1.6.0

## Draft CHANGELOG entry

### BUG FIXES
* S3 backend endpoints without `proto://` now default to `https://` instead of failing.
* Most S3 compatible remote state backends should now work without checksum errors / 400s by default.
* Logging has been re-added to S3 remote state calls.