### PR TITLE
Allow expired provider pgp keys, with warning

### DIFF
--- a/internal/getproviders/package_authentication.go
+++ b/internal/getproviders/package_authentication.go
@@ -491,7 +491,7 @@ func (s signatureAuthentication) findSigningKey() (*SigningKey, string, error) {
 		if err == openpgpErrors.ErrSignatureExpired || err == openpgpErrors.ErrKeyExpired {
 			// Internally openpgp will *only* return the Expired errors if all other checks have succeded
 			// This is currently the best way to work around expired provider keys
-			fmt.Printf("[WARN] Provider %s/%s (%v) gpg key expired, this will fail in future versions of OpenTofu: '%s'\n", s.Meta.Provider.Namespace, s.Meta.Provider.Type, s.Meta.Provider.Hostname, s.Meta.Location.String())
+			fmt.Printf("[WARN] Provider %s/%s (%v) gpg key expired, this will fail in future versions of OpenTofu\n", s.Meta.Provider.Namespace, s.Meta.Provider.Type, s.Meta.Provider.Hostname)
 			err = nil
 		}
 

--- a/internal/getproviders/package_authentication.go
+++ b/internal/getproviders/package_authentication.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/ProtonMail/go-crypto/openpgp"
 	openpgpErrors "github.com/ProtonMail/go-crypto/openpgp/errors"
-	openpgpPacket "github.com/ProtonMail/go-crypto/openpgp/packet"
 	tfaddr "github.com/opentofu/registry-address"
 )
 
@@ -30,12 +29,6 @@ const (
 
 const (
 	enforceGPGValidationEnvName = "OPENTOFU_ENFORCE_GPG_VALIDATION"
-)
-
-var (
-	// openpgpConfig is only populated during testing, so that a fake clock can be
-	// injected, preventing signature expiration errors.
-	openpgpConfig *openpgpPacket.Config
 )
 
 // PackageAuthenticationResult is returned from a PackageAuthentication
@@ -360,6 +353,7 @@ type signatureAuthentication struct {
 	Signature      []byte
 	Keys           []SigningKey
 	ProviderSource *tfaddr.Provider
+	Meta           PackageMeta
 }
 
 // NewSignatureAuthentication returns a PackageAuthentication implementation
@@ -378,12 +372,13 @@ type signatureAuthentication struct {
 //
 // Any failure in the process of validating the signature will result in an
 // unauthenticated result.
-func NewSignatureAuthentication(document, signature []byte, keys []SigningKey, source *tfaddr.Provider) PackageAuthentication {
+func NewSignatureAuthentication(meta PackageMeta, document, signature []byte, keys []SigningKey, source *tfaddr.Provider) PackageAuthentication {
 	return signatureAuthentication{
 		Document:       document,
 		Signature:      signature,
 		Keys:           keys,
 		ProviderSource: source,
+		Meta:           meta,
 	}
 }
 
@@ -424,6 +419,7 @@ func (s signatureAuthentication) AuthenticatePackage(location PackageLocation) (
 
 	// Find the key that signed the checksum file. This can fail if there is no
 	// valid signature for any of the provided keys.
+
 	_, keyID, err := s.findSigningKey()
 	if err != nil {
 		return nil, err
@@ -491,7 +487,13 @@ func (s signatureAuthentication) findSigningKey() (*SigningKey, string, error) {
 			return nil, "", fmt.Errorf("error decoding signing key: %w", err)
 		}
 
-		entity, err := openpgp.CheckDetachedSignature(keyring, bytes.NewReader(s.Document), bytes.NewReader(s.Signature), openpgpConfig)
+		entity, err := openpgp.CheckDetachedSignature(keyring, bytes.NewReader(s.Document), bytes.NewReader(s.Signature), nil)
+		if err == openpgpErrors.ErrSignatureExpired || err == openpgpErrors.ErrKeyExpired {
+			// Internally openpgp will *only* return the Expired errors if all other checks have succeded
+			// This is currently the best way to work around expired provider keys
+			fmt.Printf("[WARN] Provider %s/%s (%v) gpg key expired, this will fail in future versions of OpenTofu: '%s'\n", s.Meta.Provider.Namespace, s.Meta.Provider.Type, s.Meta.Provider.Hostname, s.Meta.Location.String())
+			err = nil
+		}
 
 		// If the signature issuer does not match the key, keep trying the
 		// rest of the provided keys.

--- a/internal/getproviders/package_authentication_test.go
+++ b/internal/getproviders/package_authentication_test.go
@@ -241,6 +241,7 @@ func TestMatchingChecksumAuthentication_success(t *testing.T) {
 	auth := NewMatchingChecksumAuthentication(document, filename, wantSHA256Sum)
 	result, err := auth.AuthenticatePackage(location)
 
+	// NOTE: This also tests the expired key ignore logic as they key in the test is expired
 	if result != nil {
 		t.Errorf("wrong result: got %#v, want nil", result)
 	}

--- a/internal/getproviders/package_authentication_test.go
+++ b/internal/getproviders/package_authentication_test.go
@@ -8,30 +8,15 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
-	"time"
 
 	tfaddr "github.com/opentofu/registry-address"
 
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
-	"github.com/ProtonMail/go-crypto/openpgp/packet"
 )
-
-func TestMain(m *testing.M) {
-	openpgpConfig = &packet.Config{
-		Time: func() time.Time {
-			// Scientifically chosen time that satisfies the validity periods of all
-			// of the keys and signatures used.
-			t, _ := time.Parse(time.RFC3339, "2021-04-25T16:00:00-07:00")
-			return t
-		},
-	}
-	os.Exit(m.Run())
-}
 
 func TestPackageAuthenticationResult(t *testing.T) {
 	tests := []struct {
@@ -378,7 +363,7 @@ func TestSignatureAuthentication_success(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			auth := NewSignatureAuthentication([]byte(testShaSumsPlaceholder), signature, test.keys, nil)
+			auth := NewSignatureAuthentication(PackageMeta{Location: location}, []byte(testShaSumsPlaceholder), signature, test.keys, nil)
 			result, err := auth.AuthenticatePackage(location)
 
 			if result == nil || *result != test.result {
@@ -421,7 +406,7 @@ func TestNewSignatureAuthentication_success(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			auth := NewSignatureAuthentication([]byte(testProviderShaSums), signature, test.keys, nil)
+			auth := NewSignatureAuthentication(PackageMeta{Location: location}, []byte(testProviderShaSums), signature, test.keys, nil)
 			result, err := auth.AuthenticatePackage(location)
 
 			if result == nil || *result != test.result {
@@ -481,7 +466,7 @@ func TestSignatureAuthentication_failure(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			auth := NewSignatureAuthentication([]byte(testShaSumsPlaceholder), signature, test.keys, nil)
+			auth := NewSignatureAuthentication(PackageMeta{Location: location}, []byte(testShaSumsPlaceholder), signature, test.keys, nil)
 			result, err := auth.AuthenticatePackage(location)
 
 			if result != nil {
@@ -495,7 +480,7 @@ func TestSignatureAuthentication_failure(t *testing.T) {
 }
 
 func TestSignatureAuthentication_acceptableHashes(t *testing.T) {
-	auth := NewSignatureAuthentication([]byte(testShaSumsRealistic), nil, nil, nil)
+	auth := NewSignatureAuthentication(PackageMeta{}, []byte(testShaSumsRealistic), nil, nil, nil)
 	authWithHashes, ok := auth.(PackageAuthenticationHashes)
 	if !ok {
 		t.Fatalf("%T does not implement PackageAuthenticationHashes", auth)

--- a/internal/getproviders/registry_client.go
+++ b/internal/getproviders/registry_client.go
@@ -357,7 +357,7 @@ func (c *registryClient) PackageMeta(ctx context.Context, provider addrs.Provide
 	ret.Authentication = PackageAuthenticationAll(
 		NewMatchingChecksumAuthentication(document, body.Filename, checksum),
 		NewArchiveChecksumAuthentication(ret.TargetPlatform, checksum),
-		NewSignatureAuthentication(document, signature, keys, &provider),
+		NewSignatureAuthentication(ret, document, signature, keys, &provider),
 	)
 
 	return ret, nil


### PR DESCRIPTION
Example:
```
- Installing hashicorp/tfcoremock v0.2.0...
[WARN] Provider hashicorp/tfcoremock (registry.opentofu.org) gpg key expired, this will fail in future versions of OpenTofu: 'https://github.com/opentofu/terraform-provider-tfcoremock/releases/download/v0.2.0/terraform-provider-tfcoremock_0.2.0_linux_amd64.zip'
```

Resolves #822

## Target Release

1.6.0

## Draft CHANGELOG entry

### BUG FIXES
* Allow providers with expired gpg keys (with a warning)