### PR TITLE
Pull in docker cross buildx tooling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ jobs:
       packages: write
 
     steps:
+      - name: Set up QEMU cross build support
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
Succeeded (with some tag hackery 20d8fec51670aff84419005d32a9190b4759aef6 due to permissions) in https://github.com/opentofu/opentofu/actions/runs/6819063138

This broke in alpha3 -> alpha4 with https://github.com/opentofu/opentofu/pull/751.  Before we were just setting up the files for a building a docker container and not actually executing any commands within.  Unfortunately, this PR now causes docker to actually have to use qemu to cross-execute code inside the container, a understandable miss at the time.

The fix is to make sure the cross quemu tools are properly installed in the github runners, as referenced at the bottom of https://goreleaser.com/cookbooks/multi-platform-docker-images/#other-things-to-pay-attention-to

The `0.252 exec /bin/sh: exec format error` is cryptic and not great error handling by docker.  After I trimmed down the .goreleaser.yaml locally to only arm, I happened to check my systemctl log for the docker daemon and was greeted with:
`Nov 09 18:53:17 atavisage dockerd[2729]: time="2023-11-09T18:53:17.313554772-05:00" level=warning msg="exec: \"buildkit-qemu-arm\": executable file not found in $PATH" span="[2/3] RUN apk add --no-cache git"`.  To me that looks like a bug in docker where it's not handing missing tooling properly and just passing through a cryptic error.  We might want to upstream a change to fix that at some point.