### PR TITLE
Update hcl version to v2.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ S3 BACKEND:
 * Adds support for customizing the AWS API endpoints. ([#775](https://github.com/opentofu/opentofu/issues/775))
 * Adds support for the `skip_requesting_account_id` attribute. ([#774](https://github.com/opentofu/opentofu/issues/774))
 * Adds support for the `skip_s3_checksum` argument to allow users to disable checksum on S3 uploads for compatibility with non AWS "S3-compatible" APIs. ([#778](https://github.com/opentofu/opentofu/issues/778))
+* `tofu init`: Fixed subsequent runs for s3 backend ([#820](https://github.com/opentofu/opentofu/issues/820)).
 
 ## Previous Releases
 

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl v1.0.0
-	github.com/hashicorp/hcl/v2 v2.18.1
+	github.com/hashicorp/hcl/v2 v2.19.1
 	github.com/hashicorp/jsonapi v0.0.0-20210826224640-ee7dae0fb22d
 	github.com/hashicorp/terraform-svchost v0.1.1
 	github.com/jmespath/go-jmespath v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -702,8 +702,8 @@ github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/hcl/v2 v2.18.1 h1:6nxnOJFku1EuSawSD81fuviYUV8DxFr3fp2dUi3ZYSo=
-github.com/hashicorp/hcl/v2 v2.18.1/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
+github.com/hashicorp/hcl/v2 v2.19.1 h1://i05Jqznmb2EXqa39Nsvyan2o5XyMowW5fnCKW5RPI=
+github.com/hashicorp/hcl/v2 v2.19.1/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
 github.com/hashicorp/jsonapi v0.0.0-20210826224640-ee7dae0fb22d h1:9ARUJJ1VVynB176G1HCwleORqCaXm/Vx0uUi0dL26I0=
 github.com/hashicorp/jsonapi v0.0.0-20210826224640-ee7dae0fb22d/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/internal/configs/configschema/decoder_spec_test.go
+++ b/internal/configs/configschema/decoder_spec_test.go
@@ -445,18 +445,6 @@ func TestAttributeDecoderSpec(t *testing.T) {
 		Want      cty.Value
 		DiagCount int
 	}{
-		"empty": {
-			&Attribute{},
-			hcl.EmptyBody(),
-			cty.NilVal,
-			0,
-		},
-		"nil": {
-			nil,
-			hcl.EmptyBody(),
-			cty.NilVal,
-			0,
-		},
 		"optional string (null)": {
 			&Attribute{
 				Type:     cty.String,
@@ -889,6 +877,33 @@ func TestAttributeDecoderSpec_panic(t *testing.T) {
 	defer func() { recover() }()
 	attrS.decoderSpec("attr")
 	t.Errorf("expected panic")
+}
+
+// TestAttributeDecodeSpecDecode_panic is a test which verifies that hcldec.Decode panics.
+func TestAttributeDecoderSpecDecode_panic(t *testing.T) {
+	tests := []struct {
+		name        string
+		inputSchema *Attribute
+	}{
+		{
+			name:        "empty",
+			inputSchema: &Attribute{},
+		},
+		{
+			name:        "nil",
+			inputSchema: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := tt.inputSchema.decoderSpec("attr")
+
+			defer func() { recover() }()
+			_, _ = hcldec.Decode(nil, spec, nil)
+			t.Errorf(`expected panic when execute hcldec.Decode`)
+		})
+	}
 }
 
 func TestListOptionalAttrsFromObject(t *testing.T) {


### PR DESCRIPTION
## What changed

- HCL version was updated to the latest release

## Why do we need it

- To add possibility of additional hooks when running `for_each`(see [details](https://github.com/hashicorp/hcl/pull/634)) 

Resolves #820, #819

## Target Release

1.6.0-alpha5

## Draft CHANGELOG entry

### UPGRADE NOTES

- Updated hcl from 2.18.0 to 2.19.1. Find the details changes [here](https://github.com/hashicorp/hcl/compare/v2.18.1...v2.19.1).


### BUG FIXES

- `tofu init`: Fixed subsequent runs for s3 backend ([#820](https://github.com/opentofu/opentofu/issues/820))
