### PR TITLE
Upload packages to PackageCloud during release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,3 +76,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_TOKEN }}
+      - name: Upload Debian packages to PackageCloud
+        uses: computology/packagecloud-github-action@v0.6
+        with:
+                PACKAGE-NAME: dist/*.deb
+                PACKAGECLOUD-USERNAME: opentofu
+                PACKAGECLOUD-REPONAME: tofu
+                PACKAGECLOUD-DISTRO: any/any
+                PACKAGECLOUD-TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
+      - name: Upload RPM packages to PackageCloud
+        uses: computology/packagecloud-github-action@v0.6
+        with:
+                PACKAGE-NAME: dist/*.rpm
+                PACKAGECLOUD-USERNAME: opentofu
+                PACKAGECLOUD-REPONAME: tofu
+                PACKAGECLOUD-DISTRO: rpm_any/rpm_any
+                PACKAGECLOUD-TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}

--- a/website/docs/intro/install.mdx
+++ b/website/docs/intro/install.mdx
@@ -36,6 +36,24 @@ brew install opentofu
 
 ## Installing on Linux
 
+OpenTofu is available via [PackageCloud](https://packagecloud.io/opentofu/tofu) and Snapcraft
+
+### Debian and derivatives:
+```bash
+curl -s https://packagecloud.io/install/repositories/opentofu/tofu/script.deb.sh -o /tmp/tofu-repository-setup.sh
+# Inspect the downloaded script at /tmp/tofu-repository-setup.sh before running
+sudo bash /tmp/tofu-repository-setup.sh
+sudo apt install tofu
+```
+
+### RedHat and derivatives:
+```bash
+curl -s https://packagecloud.io/install/repositories/opentofu/tofu/script.rpm.sh -o /tmp/tofu-repository-setup.sh
+# Inspect the downloaded script at /tmp/tofu-repository-setup.sh before running
+sudo bash /tmp/tofu-repository-setup.sh
+sudo yum install tofu
+```
+
 ### Ubuntu (Snapcraft)
 
 If you're on Ubuntu and using Snapcraft you can install OpenTofu by running:

--- a/website/docs/intro/install.mdx
+++ b/website/docs/intro/install.mdx
@@ -43,6 +43,8 @@ OpenTofu is available via [PackageCloud](https://packagecloud.io/opentofu/tofu) 
 curl -s https://packagecloud.io/install/repositories/opentofu/tofu/script.deb.sh -o /tmp/tofu-repository-setup.sh
 # Inspect the downloaded script at /tmp/tofu-repository-setup.sh before running
 sudo bash /tmp/tofu-repository-setup.sh
+rm /tmp/tofu-repository-setup.sh
+
 sudo apt install tofu
 ```
 
@@ -51,6 +53,8 @@ sudo apt install tofu
 curl -s https://packagecloud.io/install/repositories/opentofu/tofu/script.rpm.sh -o /tmp/tofu-repository-setup.sh
 # Inspect the downloaded script at /tmp/tofu-repository-setup.sh before running
 sudo bash /tmp/tofu-repository-setup.sh
+rm /tmp/tofu-repository-setup.sh
+
 sudo yum install tofu
 ```
 


### PR DESCRIPTION
Debian based instructions:
```bash
curl -s https://packagecloud.io/install/repositories/opentofu/tofu/script.deb.sh -o /tmp/tofu-repository-setup.sh
# Inspect the downloaded script at /tmp/tofu-repository-setup.sh
sudo bash /tmp/tofu-repository-setup.sh
sudo apt install tofu
```

RedHat based instructions:
```bash
curl -s https://packagecloud.io/install/repositories/opentofu/tofu/script.rpm.sh -o /tmp/tofu-repository-setup.sh
# Inspect the downloaded script at /tmp/tofu-repository-setup.sh
sudo bash /tmp/tofu-repository-setup.sh
sudo yum install tofu
```

Resolves #567 

This won't be able to be tested until the next alpha / rc release.  I have run the package_cloud commands locally to test the workflow and to backfill alpha4

TODO:
* [x] Where should we document these instructions? Related to #859
* [x] Add key to github org @cube2222 