### PR TITLE
Remove draft CHANGELOG section of PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,15 +30,3 @@ all targeted releases.
 -->
 
 1.6.0
-
-<!--
-
-Write a short description of the user-facing change. Examples:
-
-- `tofu show -json`: Fixed crash with sensitive set values.
-- When rendering a diff, OpenTofu now quotes the name of any object attribute whose string representation is not a valid identifier.
-- The local token configuration in the cloud and remote backend now has higher priority than a token specified in a credentials block in the CLI configuration.
-
---> 
-
--  

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,16 +31,6 @@ all targeted releases.
 
 1.6.0
 
-## Draft CHANGELOG entry
-
-<!--
-
-Choose a category, delete the others:
-
--->
-
-### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS
-
 <!--
 
 Write a short description of the user-facing change. Examples:


### PR DESCRIPTION
This primarily caused confusion of where the CHANGELOG was supposed to be updated.  The current bot that requests the actual CHANGELOG.md file be updated is a much better reminder.
