### PR TITLE
S3 Client HeadObject requires SSE parameters

### DIFF
--- a/internal/backend/remote-state/s3/client.go
+++ b/internal/backend/remote-state/s3/client.go
@@ -117,6 +117,12 @@ func (c *RemoteClient) get(ctx context.Context) (*remote.Payload, error) {
 		Key:    &c.path,
 	}
 
+	if c.serverSideEncryption && c.customerEncryptionKey != nil {
+		inputHead.SSECustomerKey = aws.String(base64.StdEncoding.EncodeToString(c.customerEncryptionKey))
+		inputHead.SSECustomerAlgorithm = aws.String(s3EncryptionAlgorithm)
+		inputHead.SSECustomerKeyMD5 = aws.String(c.getSSECustomerKeyMD5())
+	}
+
 	// Head works around some s3 compatible backends not handling missing GetObject requests correctly (ex: minio Get returns Missing Bucket)
 	_, err = c.s3Client.HeadObject(ctx, inputHead)
 	if err != nil {


### PR DESCRIPTION
Matching GetObject, though we can't re-use the code since it's a distinct struct.

Broken in #840
Resolves #863

@Yantrio suggests that since this bug was not released in a stable release, it does not need to go in the CHANGELOG.md

## Target Release

1.6.0
