### PR TITLE
website: Better direct-download instructions

### DIFF
--- a/website/docs/intro/install.mdx
+++ b/website/docs/intro/install.mdx
@@ -8,21 +8,38 @@ description: |-
 
 ## Installing via direct download
 
-The most direct method to install OpenTofu is to download it from GitHub releases. Each GitHub release has an Assets section, where you can find the `zip` archive for your platform and download it.
+The most direct method to install OpenTofu is to download it from [GitHub releases](https://github.com/opentofu/opentofu/releases/latest). Each GitHub release has an Assets section, where you can find the `zip` archive for your platform and download it. Once you download a zip archive from there, you can unzip it and move the `tofu` binary into your $PATH, e.g. into `/usr/local/bin` on many Unix operating systems.
 
-Once you download a zip archive from there, you can unzip it and move the `tofu` binary into your $PATH, e.g. into `/usr/local/bin` on many Unix operating systems.
-
-You could, for example, run these commands:
+On Linux and MacOS, you can use the following commands to install OpenTofu:
 
 ```bash
-wget https://github.com/opentofu/opentofu/releases/download/v1.6.0-alpha2/tofu_1.6.0-alpha2_darwin_arm64.zip
-unzip tofu_1.6.0-alpha2_darwin_arm64.zip
-mv tofu /usr/local/bin/tofu
+TOFU_VERSION="1.6.0-alpha2"
+OS="$(uname | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m | sed -e 's/aarch64/arm64/' -e 's/x86_64/amd64/')"
+TEMPDIR="$(mktemp -d)"
+pushd "${TEMPDIR}" >/dev/null
+wget "https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_${OS}_${ARCH}.zip"
+unzip "tofu_${TOFU_VERSION}_${OS}_${ARCH}.zip"
+sudo mv tofu /usr/local/bin/tofu
+popd >/dev/null
+rm -rf "${TEMPDIR}"
+echo "OpenTofu is now available at /usr/local/bin/tofu."
 ```
 
-to install OpenTofu on an arm64 MacOS system.
+On Windows, you can use the following PowerShell commands:
 
-You can find the latest GitHub release of OpenTofu [here](https://github.com/opentofu/opentofu/releases/latest).
+```powershell
+$TOFU_VERSION="1.6.0-alpha2"
+$TARGET=Join-Path $env:LOCALAPPDATA OpenTofu
+New-Item -ItemType Directory -Path $TARGET
+Push-Location $TARGET
+Invoke-WebRequest -Uri "https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_windows_amd64.zip" -OutFile "tofu_${TOFU_VERSION}_windows_amd64.zip"
+Expand-Archive "tofu_${TOFU_VERSION}_windows_amd64.zip" -DestinationPath $TARGET
+Remove-Item "tofu_${TOFU_VERSION}_windows_amd64.zip"
+$TOFU_PATH=Join-Path $TARGET tofu.exe
+Pop-Location
+echo "OpenTofu is now available at ${TOFU_PATH}. Please add it to your path for easier access."
+```
 
 ## Installing on MacOS
 


### PR DESCRIPTION
This change adds more detailed instructions for direct-download installations. The provided SH works on both Linux and MacOS, and the Powershell script works on Windows 10/11.

Partially resolves #859 (more coming)
Related to #860

## Target Release

N/A
