### PR TITLE
Add missing argument to PackageCloud install instructions

### DIFF
--- a/website/docs/intro/install.mdx
+++ b/website/docs/intro/install.mdx
@@ -40,7 +40,7 @@ OpenTofu is available via [PackageCloud](https://packagecloud.io/opentofu/tofu) 
 
 ### Debian and derivatives:
 ```bash
-curl -s https://packagecloud.io/install/repositories/opentofu/tofu/script.deb.sh -o /tmp/tofu-repository-setup.sh
+curl -s https://packagecloud.io/install/repositories/opentofu/tofu/script.deb.sh?any=true -o /tmp/tofu-repository-setup.sh
 # Inspect the downloaded script at /tmp/tofu-repository-setup.sh before running
 sudo bash /tmp/tofu-repository-setup.sh
 rm /tmp/tofu-repository-setup.sh
@@ -50,7 +50,7 @@ sudo apt install tofu
 
 ### RedHat and derivatives:
 ```bash
-curl -s https://packagecloud.io/install/repositories/opentofu/tofu/script.rpm.sh -o /tmp/tofu-repository-setup.sh
+curl -s https://packagecloud.io/install/repositories/opentofu/tofu/script.rpm.sh?any=true -o /tmp/tofu-repository-setup.sh
 # Inspect the downloaded script at /tmp/tofu-repository-setup.sh before running
 sudo bash /tmp/tofu-repository-setup.sh
 rm /tmp/tofu-repository-setup.sh


### PR DESCRIPTION
I missed an argument when copying to the docs.  I have copied and pasted the instructions verbatum to double check it on debian and fedora.

Part of #860 

## Target Release

1.6.0
