### PR TITLE
Fix S3 Remote State Backend Validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ S3 BACKEND:
 * S3 backend endpoints without proto:// default to https:// instead of failing ([#821](https://github.com/opentofu/opentofu/issues/821))
 * Most S3 compatible remote state backends should now work without checksum errors / 400s ([#821](https://github.com/opentofu/opentofu/issues/821))
 * Logging has been re-added to S3 remote state calls ([#821](https://github.com/opentofu/opentofu/issues/821))
+* Fixed validation for certain optional fields ([875](https://github.com/opentofu/opentofu/issues/875))
 
 ## Previous Releases
 

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -71,6 +71,7 @@ func (b *Backend) ConfigSchema() *configschema.Block {
 				Description: "AWS region of the S3 Bucket and DynamoDB Table (if used).",
 			},
 			"endpoints": {
+				Optional: true,
 				NestedType: &configschema.Object{
 					Nesting: configschema.NestingSingle,
 					Attributes: map[string]*configschema.Attribute{
@@ -302,6 +303,7 @@ func (b *Backend) ConfigSchema() *configschema.Block {
 				Description: "The endpoint mode of IMDS. Valid values: IPv4, IPv6.",
 			},
 			"assume_role": {
+				Optional: true,
 				NestedType: &configschema.Object{
 					Nesting: configschema.NestingSingle,
 					Attributes: map[string]*configschema.Attribute{
@@ -361,6 +363,7 @@ func (b *Backend) ConfigSchema() *configschema.Block {
 				},
 			},
 			"assume_role_with_web_identity": {
+				Optional: true,
 				NestedType: &configschema.Object{
 					Nesting: configschema.NestingSingle,
 					Attributes: map[string]*configschema.Attribute{

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -1420,6 +1420,18 @@ func TestBackend_includeProtoIfNessesary(t *testing.T) {
 	}
 }
 
+func TestBackend_schemaCoercionMinimal(t *testing.T) {
+	example := cty.ObjectVal(map[string]cty.Value{
+		"bucket": cty.StringVal("my-bucket"),
+		"key":    cty.StringVal("state.tf"),
+	})
+	schema := New().ConfigSchema()
+	_, err := schema.CoerceValue(example)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err.Error())
+	}
+}
+
 func testGetWorkspaceForKey(b *Backend, key string, expected string) error {
 	if actual := b.keyEnv(key); actual != expected {
 		return fmt.Errorf("incorrect workspace for key[%q]. Expected[%q]: Actual[%q]", key, expected, actual)

--- a/internal/configs/configschema/coerce_value.go
+++ b/internal/configs/configschema/coerce_value.go
@@ -5,6 +5,7 @@ package configschema
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
@@ -57,7 +58,15 @@ func (b *Block) coerceValue(in cty.Value, path cty.Path) (cty.Value, error) {
 
 	attrs := make(map[string]cty.Value)
 
-	for name, attrS := range b.Attributes {
+	// Stable sort keys for consistent error reports
+	attrKeys := make([]string, 0, len(b.Attributes))
+	for key, _ := range b.Attributes {
+		attrKeys = append(attrKeys, key)
+	}
+	sort.Strings(attrKeys)
+
+	for _, name := range attrKeys {
+		attrS := b.Attributes[name]
 		attrType := impliedType.AttributeType(name)
 		attrConvType := convType.AttributeType(name)
 
@@ -78,7 +87,15 @@ func (b *Block) coerceValue(in cty.Value, path cty.Path) (cty.Value, error) {
 		attrs[name] = val
 	}
 
-	for typeName, blockS := range b.BlockTypes {
+	// Stable sort keys for consistent error reports
+	typeKeys := make([]string, 0, len(b.BlockTypes))
+	for key, _ := range b.BlockTypes {
+		typeKeys = append(typeKeys, key)
+	}
+	sort.Strings(typeKeys)
+
+	for _, typeName := range typeKeys {
+		blockS := b.BlockTypes[typeName]
 		switch blockS.Nesting {
 
 		case NestingSingle, NestingGroup:

--- a/internal/configs/configschema/coerce_value.go
+++ b/internal/configs/configschema/coerce_value.go
@@ -60,7 +60,7 @@ func (b *Block) coerceValue(in cty.Value, path cty.Path) (cty.Value, error) {
 
 	// Stable sort keys for consistent error reports
 	attrKeys := make([]string, 0, len(b.Attributes))
-	for key, _ := range b.Attributes {
+	for key := range b.Attributes {
 		attrKeys = append(attrKeys, key)
 	}
 	sort.Strings(attrKeys)
@@ -89,7 +89,7 @@ func (b *Block) coerceValue(in cty.Value, path cty.Path) (cty.Value, error) {
 
 	// Stable sort keys for consistent error reports
 	typeKeys := make([]string, 0, len(b.BlockTypes))
-	for key, _ := range b.BlockTypes {
+	for key := range b.BlockTypes {
 		typeKeys = append(typeKeys, key)
 	}
 	sort.Strings(typeKeys)


### PR DESCRIPTION
This is the first part of #875 and fixes the main issue reported.  The schema validation for backends has two paths, one from data blocks, the other from backend blocks.  At the moment, backend blocks pre-populates empty maps as shown in the issue.  This will be fixed in a followup PR.

This PR fixes the schema optional fields, adds a test for the minimum set of fields required, and also improves the user facing errors when they are missing multiple fields (stable key sort).

Resolves #875

## Target Release

1.6.0
