### PR TITLE
Draft: Don't allow nulls in required backend maps

### DIFF
--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -1399,6 +1399,19 @@ func (m *Meta) backendInitFromConfig(c *configs.Backend) (backend.Backend, cty.V
 		return nil, cty.NilVal, diags
 	}
 
+	// Try to coerce the provided value into the desired configuration type.
+	configVal, err := schema.CoerceValue(configVal)
+	if err != nil {
+		diags = diags.Append(tfdiags.AttributeValue(
+			tfdiags.Error,
+			"Invalid backend configuration",
+			fmt.Sprintf("The given configuration is not valid for backend %q: %s.", c.Type,
+				tfdiags.FormatError(err)),
+			cty.Path(nil).GetAttr("backend"),
+		))
+		return nil, cty.NilVal, diags
+	}
+
 	if !configVal.IsWhollyKnown() {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,

--- a/internal/configs/configschema/coerce_value.go
+++ b/internal/configs/configschema/coerce_value.go
@@ -71,6 +71,11 @@ func (b *Block) coerceValue(in cty.Value, path cty.Path) (cty.Value, error) {
 			return cty.UnknownVal(impliedType), path.NewErrorf("attribute %q is required", name)
 		}
 
+		// This might break backwards compatability
+		if !attrS.Computed && !attrS.Optional && val.IsNull() {
+			return val, path.NewErrorf("attribute %q is required, null provided", name)
+		}
+
 		val, err := convert.Convert(val, attrConvType)
 		if err != nil {
 			return cty.UnknownVal(impliedType), append(path, cty.GetAttrStep{Name: name}).NewError(err)

--- a/internal/legacy/tofu/state.go
+++ b/internal/legacy/tofu/state.go
@@ -793,7 +793,13 @@ func (s *BackendState) Config(schema *configschema.Block) (cty.Value, error) {
 	if s == nil {
 		return cty.NullVal(ty), nil
 	}
-	return ctyjson.Unmarshal(s.ConfigRaw, ty)
+	val, err := ctyjson.Unmarshal(s.ConfigRaw, ty)
+	if err != nil {
+		return cty.NullVal(ty), err
+	}
+
+	// Make sure it's actualy valid
+	return schema.CoerceValue(val)
 }
 
 // SetConfig replaces (in-place) the type-specific configuration object using


### PR DESCRIPTION
The tricky part of this PR is that previously nulls were allowed in required cty maps.  I believe that this functionality should not be allowed.  It led directly to #875 since the validation paths for data{} and backend{} are distinct.

The schema validation part of this PR should probably go in regardless of the null check as it validates that the current backend config matches the current schema.  It could be cherry picked out if the null check proves problematic.

After these changes the backend{} and data{} blocks function nearly identically, though the error message is slightly cryptic:
```
│ Error: Invalid backend configuration
│ 
│ The given configuration is not valid for backend "s3": attribute "endpoints" is required, null provided.
```
Notice the ", null provided".  It's probably good to have that in the error message, but it creates confusion because it defaults to null (see #875).  I think that this is probably good enough for now, but we probably want to remove the null defaults at some point as mentioned in #875 .

Related to #875

## Target Release

1.6.0
