### PR TITLE
Use correct location for LICENSE file during installation (opentofu instead of nfpm)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -177,7 +177,7 @@ nfpms:
     section: default
     contents:
       - src: ./LICENSE
-        dst: /usr/share/doc/nfpm/copyright
+        dst: /usr/share/doc/opentofu/copyright
         file_info:
           mode: 0444
 


### PR DESCRIPTION
Resolves #805 