### PR TITLE
Fixes #539: Setting both "Type" and "NestedType" removes other validation error messages

### DIFF
--- a/internal/configs/configschema/internal_validate.go
+++ b/internal/configs/configschema/internal_validate.go
@@ -128,7 +128,7 @@ func (a *Attribute) internalValidate(name, prefix string) error {
 
 	if a.Type != cty.NilType {
 		if a.NestedType != nil {
-			err = multierror.Append(fmt.Errorf("%s: Type and NestedType cannot both be set", name))
+			err = multierror.Append(err, fmt.Errorf("%s: Type and NestedType cannot both be set", name))
 		}
 	}
 

--- a/internal/configs/configschema/internal_validate_test.go
+++ b/internal/configs/configschema/internal_validate_test.go
@@ -134,32 +134,32 @@ func TestBlockInternalValidate(t *testing.T) {
 			},
 			[]string{"foo: either Type or NestedType must be defined"},
 		},
-        "attribute with both type and nestedtype": {
-            &Block{
-                Attributes: map[string]*Attribute{
-                    "foo": {
-                        // These properties are here to make sure other errors are also reported.
-                        Optional: true,
-                        Required: true,
-                        // Here's what we actually want to validate:
-                        Type: cty.String,
-                        NestedType: &Object{
-                            Nesting: NestingSingle,
-                            Attributes: map[string]*Attribute{
-                                "foo": {
-                                    Type:     cty.String,
-                                    Required: true,
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-            []string{
-                "foo: cannot set both Optional and Required",
-                "foo: Type and NestedType cannot both be set",
-            },
-        },
+		"attribute with both type and nestedtype": {
+			&Block{
+				Attributes: map[string]*Attribute{
+					"foo": {
+						// These properties are here to make sure other errors are also reported.
+						Optional: true,
+						Required: true,
+						// Here's what we actually want to validate:
+						Type: cty.String,
+						NestedType: &Object{
+							Nesting: NestingSingle,
+							Attributes: map[string]*Attribute{
+								"foo": {
+									Type:     cty.String,
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			[]string{
+				"foo: cannot set both Optional and Required",
+				"foo: Type and NestedType cannot both be set",
+			},
+		},
 		/* FIXME: This caused errors when applied to existing providers (oci)
 		and cannot be enforced without coordination.
 

--- a/internal/configs/configschema/internal_validate_test.go
+++ b/internal/configs/configschema/internal_validate_test.go
@@ -134,7 +134,7 @@ func TestBlockInternalValidate(t *testing.T) {
 			},
 			[]string{"foo: either Type or NestedType must be defined"},
 		},
-		"attribute with both type and nestedtype": {
+		"attribute with both type and nestedtype should not suppress other validation messages": {
 			&Block{
 				Attributes: map[string]*Attribute{
 					"foo": {

--- a/internal/configs/configschema/internal_validate_test.go
+++ b/internal/configs/configschema/internal_validate_test.go
@@ -134,6 +134,32 @@ func TestBlockInternalValidate(t *testing.T) {
 			},
 			[]string{"foo: either Type or NestedType must be defined"},
 		},
+        "attribute with both type and nestedtype": {
+            &Block{
+                Attributes: map[string]*Attribute{
+                    "foo": {
+                        // These properties are here to make sure other errors are also reported.
+                        Optional: true,
+                        Required: true,
+                        // Here's what we actually want to validate:
+                        Type: cty.String,
+                        NestedType: &Object{
+                            Nesting: NestingSingle,
+                            Attributes: map[string]*Attribute{
+                                "foo": {
+                                    Type:     cty.String,
+                                    Required: true,
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            []string{
+                "foo: cannot set both Optional and Required",
+                "foo: Type and NestedType cannot both be set",
+            },
+        },
 		/* FIXME: This caused errors when applied to existing providers (oci)
 		and cannot be enforced without coordination.
 


### PR DESCRIPTION
Resolves #539

Note: the target file seems to be not gofmt'd. I left it as-is for now.

## Target Release

1.6.0
