### PR TITLE
Align CLI logic to be compliant with the stable registry module protocol

### DIFF
--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -269,7 +269,7 @@ func readModuleLocation(resp *http.Response) (string, error) {
 		var v response.ModuleLocationRegistryResp
 
 		if err := json.Unmarshal(body, &v); err != nil {
-			return "", fmt.Errorf("error deserializing %s: %v", body, err)
+			return "", fmt.Errorf("error deserializing %s: %w", body, err)
 		}
 
 		location = v.Location

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -225,10 +225,39 @@ func (c *Client) ModuleLocation(ctx context.Context, module *regsrc.Module, vers
 	if err != nil {
 		return "", err
 	}
+	defer resp.Body.Close()
 
-	location, err := readModuleLocation(resp)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("module %q version %s: %w", module, version, err)
+		return "", fmt.Errorf("error reading response body from registry: %w", err)
+	}
+
+	var location string
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var v response.ModuleLocationRegistryResp
+		if err := json.Unmarshal(body, &v); err != nil {
+			return "", fmt.Errorf("module %q version %q failed to deserialize response body %s: %w",
+				module, version, body, err)
+		}
+
+		location = v.Location
+
+	case http.StatusNoContent:
+		// FALLBACK: set the found location from the header
+		location = resp.Header.Get(xTerraformGet)
+
+	case http.StatusNotFound:
+		return "", fmt.Errorf("module %q version %q not found", module, version)
+
+	default:
+		// anything else is an error:
+		return "", fmt.Errorf("error getting download location for %q: %s resp:%s", module, resp.Status, body)
+	}
+
+	if location == "" {
+		return "", fmt.Errorf("failed to get download URL for %q: %s resp:%s", module, resp.Status, body)
 	}
 
 	// If location looks like it's trying to be a relative URL, treat it as
@@ -249,44 +278,6 @@ func (c *Client) ModuleLocation(ctx context.Context, module *regsrc.Module, vers
 		}
 		locationURL = download.ResolveReference(locationURL)
 		location = locationURL.String()
-	}
-
-	return location, nil
-}
-
-func readModuleLocation(resp *http.Response) (string, error) {
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("error reading response body from registry: %w", err)
-	}
-
-	var location string
-
-	switch resp.StatusCode {
-	case http.StatusOK:
-		var v response.ModuleLocationRegistryResp
-
-		if err := json.Unmarshal(body, &v); err != nil {
-			return "", fmt.Errorf("error deserializing %s: %w", body, err)
-		}
-
-		location = v.Location
-
-	// FALLBACK: set the found location from the header
-	case http.StatusNoContent:
-		location = resp.Header.Get(xTerraformGet)
-
-	case http.StatusNotFound:
-		return "", fmt.Errorf("not found")
-
-	default:
-		return "", fmt.Errorf("error getting download location: %s resp:%s", resp.Status, body)
-	}
-
-	if location == "" {
-		return "", fmt.Errorf("failed to get download URL: %s resp:%s", resp.Status, body)
 	}
 
 	return location, nil

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -25,7 +25,6 @@ import (
 	"github.com/opentofu/opentofu/internal/registry/regsrc"
 	"github.com/opentofu/opentofu/internal/registry/response"
 	"github.com/opentofu/opentofu/version"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -229,7 +228,7 @@ func (c *Client) ModuleLocation(ctx context.Context, module *regsrc.Module, vers
 
 	location, err := readModuleLocation(resp)
 	if err != nil {
-		return "", errors.Wrapf(err, "module %q version %s", module, version)
+		return "", fmt.Errorf("module %q version %s: %w", module, version, err)
 	}
 
 	// If location looks like it's trying to be a relative URL, treat it as

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -273,7 +273,6 @@ func readModuleLocation(resp *http.Response) (string, error) {
 			return "", fmt.Errorf("error deserializing %s: %v", body, err)
 		}
 
-		// overwrite with the value from the response body
 		location = v.Location
 
 	// FALLBACK: set the found location from the header

--- a/internal/registry/client_test.go
+++ b/internal/registry/client_test.go
@@ -391,7 +391,7 @@ func TestModuleLocation(t *testing.T) {
 		},
 		"shall fail to find the module": {
 			src: "not-exist/identifier/provider",
-			// note that the version is fixed on the mock
+			// note that the version is fixed in the mock
 			// see: /internal/registry/test/mock_registry.go:testMods
 			wantErrorStr: `module "not-exist/identifier/provider" version 0.2.0: not found`,
 		},

--- a/internal/registry/client_test.go
+++ b/internal/registry/client_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -374,32 +375,60 @@ func TestLookupModuleNetworkError(t *testing.T) {
 }
 
 func TestModuleLocation_readRegistryResponse(t *testing.T) {
-	server := test.Registry()
-	defer server.Close()
-
 	cases := map[string]struct {
-		src          string
-		wantErrorStr string
-		httpClient   *http.Client
+		src                  string
+		httpClient           *http.Client
+		registryFlags        []uint8
+		want                 string
+		wantErrorStr         string
+		wantToReadFromHeader bool
+		wantStatusCode       int
 	}{
-		"shall find the module relying on the OpenTofu registry protocol": {
-			src: "exists-in-registry/identifier/provider",
+		"shall find the module location in the registry response body": {
+			src:            "exists-in-registry/identifier/provider",
+			want:           "file:///registry/exists",
+			wantStatusCode: http.StatusOK,
+			httpClient: &http.Client{
+				Transport: &mockRoundTripper{},
+			},
 		},
-		"shall find the module relying on fallback - OpenTofu alpha registry protocol": {
-			src: "alpha/identifier/provider",
+		"shall find the module location in the registry response header": {
+			src:                  "exists-in-registry/identifier/provider",
+			registryFlags:        []uint8{test.WithModuleLocationInHeader},
+			want:                 "file:///registry/exists",
+			wantToReadFromHeader: true,
+			wantStatusCode:       http.StatusNoContent,
+			httpClient: &http.Client{
+				Transport: &mockRoundTripper{},
+			},
+		},
+		"shall read location from the registry response body even if the header with location address is also set": {
+			src:                  "exists-in-registry/identifier/provider",
+			want:                 "file:///registry/exists",
+			wantStatusCode:       http.StatusOK,
+			wantToReadFromHeader: false,
+			registryFlags:        []uint8{test.WithModuleLocationInBody, test.WithModuleLocationInHeader},
+			httpClient: &http.Client{
+				Transport: &mockRoundTripper{},
+			},
 		},
 		"shall fail to find the module": {
 			src: "not-exist/identifier/provider",
 			// note that the version is fixed in the mock
 			// see: /internal/registry/test/mock_registry.go:testMods
-			wantErrorStr: `module "not-exist/identifier/provider" version "0.2.0" not found`,
+			wantErrorStr:   `module "not-exist/identifier/provider" version "0.2.0" not found`,
+			wantStatusCode: http.StatusNotFound,
+			httpClient: &http.Client{
+				Transport: &mockRoundTripper{},
+			},
 		},
 		"shall fail because of reading response body error": {
-			src:          "foo/bar/baz",
-			wantErrorStr: "error reading response body from registry: foo",
+			src:            "foo/bar/baz",
+			wantErrorStr:   "error reading response body from registry: foo",
+			wantStatusCode: http.StatusOK,
 			httpClient: &http.Client{
-				Transport: mockRoundTripper{
-					v: &http.Response{
+				Transport: &mockRoundTripper{
+					forwardResponse: &http.Response{
 						StatusCode: http.StatusOK,
 						Body:       mockErrorReadCloser{err: errors.New("foo")},
 					},
@@ -407,25 +436,26 @@ func TestModuleLocation_readRegistryResponse(t *testing.T) {
 			},
 		},
 		"shall fail to deserialize JSON response": {
-			src:          "foo/bar/baz",
-			wantErrorStr: `module "foo/bar/baz" version "0.2.0" failed to deserialize response body {: unexpected end of JSON input`,
+			src:            "foo/bar/baz",
+			wantErrorStr:   `module "foo/bar/baz" version "0.2.0" failed to deserialize response body {: unexpected end of JSON input`,
+			wantStatusCode: http.StatusOK,
 			httpClient: &http.Client{
-				Transport: mockRoundTripper{
-					v: &http.Response{
+				Transport: &mockRoundTripper{
+					forwardResponse: &http.Response{
 						StatusCode: http.StatusOK,
 						Body:       io.NopCloser(strings.NewReader("{")),
 					},
 				},
 			},
 		},
-		"shall fail because of the registry error": {
-			src:          "foo/bar/baz",
-			wantErrorStr: `error getting download location for "foo/bar/baz": foo resp:bar`,
+		"shall fail because of unexpected protocol change - 422 http status": {
+			src:            "foo/bar/baz",
+			wantErrorStr:   `error getting download location for "foo/bar/baz": foo resp:bar`,
+			wantStatusCode: http.StatusUnprocessableEntity,
 			httpClient: &http.Client{
-				Transport: mockRoundTripper{
-					v: &http.Response{
-						// any arbitrary status, but 200, 204 and 404
-						StatusCode: http.StatusFound,
+				Transport: &mockRoundTripper{
+					forwardResponse: &http.Response{
+						StatusCode: http.StatusUnprocessableEntity,
 						Status:     "foo",
 						Body:       io.NopCloser(strings.NewReader("bar")),
 					},
@@ -433,11 +463,12 @@ func TestModuleLocation_readRegistryResponse(t *testing.T) {
 			},
 		},
 		"shall fail because location is not found in the response": {
-			src:          "foo/bar/baz",
-			wantErrorStr: `failed to get download URL for "foo/bar/baz": OK resp:{"foo":"git::https://github.com/foo/terraform-baz-bar?ref=v0.2.0"}`,
+			src:            "foo/bar/baz",
+			wantErrorStr:   `failed to get download URL for "foo/bar/baz": OK resp:{"foo":"git::https://github.com/foo/terraform-baz-bar?ref=v0.2.0"}`,
+			wantStatusCode: http.StatusOK,
 			httpClient: &http.Client{
-				Transport: mockRoundTripper{
-					v: &http.Response{
+				Transport: &mockRoundTripper{
+					forwardResponse: &http.Response{
 						StatusCode: http.StatusOK,
 						Status:     "OK",
 						// note that the response emulates a contract change
@@ -448,8 +479,12 @@ func TestModuleLocation_readRegistryResponse(t *testing.T) {
 		},
 	}
 
+	t.Parallel()
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			server := test.Registry(tc.registryFlags...)
+			defer server.Close()
+
 			client := NewClient(test.Disco(server), tc.httpClient)
 
 			mod, err := regsrc.ParseModuleSource(tc.src)
@@ -457,34 +492,60 @@ func TestModuleLocation_readRegistryResponse(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			_, err = client.ModuleLocation(context.Background(), mod, "0.2.0")
+			got, err := client.ModuleLocation(context.Background(), mod, "0.2.0")
 			if err != nil && tc.wantErrorStr == "" {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			if err != nil && err.Error() != tc.wantErrorStr {
 				t.Fatalf("unexpected error content: want=%s, got=%v", tc.wantErrorStr, err)
 			}
+			if got != tc.want {
+				t.Fatalf("unexpected location: want=%s, got=%v", tc.want, got)
+			}
+
+			gotStatusCode := tc.httpClient.Transport.(*mockRoundTripper).reverseResponse.StatusCode
+			if tc.wantStatusCode != gotStatusCode {
+				t.Fatalf("unexpected response status code: want=%d, got=%d", tc.wantStatusCode, gotStatusCode)
+			}
+
+			if tc.wantToReadFromHeader {
+				resp := tc.httpClient.Transport.(*mockRoundTripper).reverseResponse
+				if !reflect.DeepEqual(resp.Body, http.NoBody) {
+					t.Fatalf("expected no body")
+				}
+			}
 		})
 	}
 }
 
 type mockRoundTripper struct {
-	v   *http.Response
-	err error
+	// response to return without calling the server
+	// SET TO USE AS A REVERSE PROXY
+	forwardResponse *http.Response
+	// the response from the server will be written here
+	// DO NOT SET
+	reverseResponse *http.Response
+	err             error
 }
 
-func (m mockRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
-	return m.v, nil
+	if m.forwardResponse != nil {
+		m.reverseResponse = m.forwardResponse
+		return m.forwardResponse, nil
+	}
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	m.reverseResponse = resp
+	return resp, err
 }
 
 type mockErrorReadCloser struct {
 	err error
 }
 
-func (m mockErrorReadCloser) Read(p []byte) (n int, err error) {
+func (m mockErrorReadCloser) Read(_ []byte) (n int, err error) {
 	return 0, m.err
 }
 

--- a/internal/registry/response/module_download.go
+++ b/internal/registry/response/module_download.go
@@ -1,0 +1,11 @@
+// Copyright (c) OpenTofu
+// SPDX-License-Identifier: MPL-2.0
+
+package response
+
+// ModuleLocationRegistryResp defines the OpenTofu registry response
+// returned when calling the endpoint /v1/modules/:namespace/:name/:system/:version/download
+type ModuleLocationRegistryResp struct {
+	// The URL to download the module from.
+	Location string `json:"location"`
+}

--- a/internal/registry/test/mock_registry.go
+++ b/internal/registry/test/mock_registry.go
@@ -184,7 +184,7 @@ func mockRegHandler() http.Handler {
 			w.WriteHeader(http.StatusOK)
 			o, err := json.Marshal(response.ModuleLocationRegistryResp{Location: location})
 			if err != nil {
-				fmt.Printf("mock error: %v", err)
+				panic("mock error: " + err.Error())
 			}
 			_, _ = w.Write(o)
 		}

--- a/website/docs/internals/module-registry-protocol.mdx
+++ b/website/docs/internals/module-registry-protocol.mdx
@@ -197,19 +197,32 @@ $ curl -i 'https://registry.example.io/v1/modules/hashicorp/consul/aws/0.0.1/dow
 ### Sample Response
 
 ```text
-HTTP/1.1 204 No Content
-Content-Length: 0
-X-Terraform-Get: https://api.github.com/repos/hashicorp/terraform-aws-consul/tarball/v0.0.1//*?archive=tar.gz
+HTTP/2 200
+Content-Length: 81
+
+{"location": "git::https://github.com/hashicorp/terraform-aws-consul?ref=v0.0.1"}
 ```
 
-A successful response has no body, and includes the location from which the
-module version's source can be downloaded in the `X-Terraform-Get` header.
-The value of this header accepts the same values as the `source` argument
+A successful response contains the location from which the module version's source can be downloaded in the
+JSON encoded payload with the key `location`.
+
+This value accepts the same values as the `source` argument
 in a `module` block in OpenTofu configuration, as described in
 [Module Sources](/docs/language/modules/sources),
 except that it may not recursively refer to another module registry address.
 
-The value of `X-Terraform-Get` may instead be a relative URL, indicated by
+The value of the module location may instead be a relative URL, indicated by
 beginning with `/`, `./` or `../`, in which case it is resolved relative to
 the full URL of the download endpoint to produce
 [an HTTP URL module source](/docs/language/modules/sources#http-urls).
+
+:::info
+
+OpenTofu recognises the legacy protocol when the response has no body, and includes the location in the `X-Terraform-Get` header:
+
+```text
+HTTP/2 204 No Content
+Content-Length: 0
+X-Terraform-Get: git::https://github.com/hashicorp/terraform-aws-consul?ref=v0.0.1
+```
+:::

--- a/website/docs/internals/module-registry-protocol.mdx
+++ b/website/docs/internals/module-registry-protocol.mdx
@@ -191,38 +191,37 @@ This endpoint downloads the specified version of a module for a single target sy
 ### Sample Request
 
 ```text
-$ curl -i 'https://registry.example.io/v1/modules/hashicorp/consul/aws/0.0.1/download'
+$ curl -i 'https://registry.example.io/v1/modules/foo/bar/baz/0.0.1/download'
 ```
 
 ### Sample Response
+
+A successful response contains the location from which the module version's source can be downloaded.
+
+It is expected to be found in the JSON encoded body as the value for the key `location`:
 
 ```text
 HTTP/2 200
 Content-Length: 81
 
-{"location": "git::https://github.com/hashicorp/terraform-aws-consul?ref=v0.0.1"}
+{"location": "git::https://github.com/foo/terraform-baz-bar?ref=v0.0.1"}
 ```
 
-A successful response contains the location from which the module version's source can be downloaded in the
-JSON encoded payload with the key `location`.
-
-This value accepts the same values as the `source` argument
-in a `module` block in OpenTofu configuration, as described in
-[Module Sources](/docs/language/modules/sources),
-except that it may not recursively refer to another module registry address.
-
-The value of the module location may instead be a relative URL, indicated by
-beginning with `/`, `./` or `../`, in which case it is resolved relative to
-the full URL of the download endpoint to produce
-[an HTTP URL module source](/docs/language/modules/sources#http-urls).
-
-:::info
-
-OpenTofu recognises the legacy protocol when the response has no body, and includes the location in the `X-Terraform-Get` header:
+In the absence of a response body, OpenTofu will use the `X-Terraform-Get` header as the module location:
 
 ```text
 HTTP/2 204 No Content
 Content-Length: 0
-X-Terraform-Get: git::https://github.com/hashicorp/terraform-aws-consul?ref=v0.0.1
+X-Terraform-Get: git::https://github.com/foo/terraform-baz-bar?ref=v0.0.1
 ```
+
+:::warning
+OpenTofu will read the response body content if both, the body and the `X-Terraform-Get` header, are received from the registry server.
 :::
+
+The module location value accepts the same values as the `source` argument in a
+`module` block in OpenTofu configuration, as described in [Module Sources](/docs/language/modules/sources),
+except that it may not recursively refer to another module registry address.
+The value of the module location may instead be a relative URL, indicated by beginning with `/`, `./` or `../`,
+in which case it is resolved relative to the full URL of the download endpoint to
+produce [an HTTP URL module source](/docs/language/modules/sources#http-urls).

--- a/website/docs/internals/module-registry-protocol.mdx
+++ b/website/docs/internals/module-registry-protocol.mdx
@@ -216,7 +216,7 @@ X-Terraform-Get: git::https://github.com/foo/terraform-baz-bar?ref=v0.0.1
 ```
 
 :::warning
-OpenTofu will read the response body content if both, the body and the `X-Terraform-Get` header, are received from the registry server.
+OpenTofu will prioritize reading the response body content if both, the body and the `X-Terraform-Get` header, are received from the registry server.
 :::
 
 The module location value accepts the same values as the `source` argument in a


### PR DESCRIPTION
Resolves #900 

## Target Release

1.6.0

## What changed

- Added handling of the registry response in line with the server's [contract](https://github.com/opentofu/registry-stable/blob/c54f44a6b912bcb134c9727ab594af0be0e2e5bd/src/internal/v1api/responses.go#L5-L9).
- The http response status codes 200 and 204 are treated separately now: 200 - read location from the body, 204 - read location from the header.

## Why do we need it

For the OpenTofu CLI to be compliant with the OpenTofu registry "v1" protocol.
