### PR TITLE
Change hashicorp.com to opentofu.org where appropriate

### DIFF
--- a/internal/command/e2etest/automation_test.go
+++ b/internal/command/e2etest/automation_test.go
@@ -19,7 +19,7 @@ import (
 func TestPlanApplyInAutomation(t *testing.T) {
 	t.Parallel()
 
-	// This test reaches out to releases.hashicorp.com to download the
+	// This test reaches out to registry.opentofu.org to download the
 	// template and null providers, so it can only run if network access is
 	// allowed.
 	skipIfCannotAccessNetwork(t)
@@ -126,7 +126,7 @@ func TestPlanApplyInAutomation(t *testing.T) {
 func TestAutoApplyInAutomation(t *testing.T) {
 	t.Parallel()
 
-	// This test reaches out to releases.hashicorp.com to download the
+	// This test reaches out to registry.opentofu.org to download the
 	// template and null providers, so it can only run if network access is
 	// allowed.
 	skipIfCannotAccessNetwork(t)
@@ -192,7 +192,7 @@ func TestAutoApplyInAutomation(t *testing.T) {
 func TestPlanOnlyInAutomation(t *testing.T) {
 	t.Parallel()
 
-	// This test reaches out to releases.hashicorp.com to download the
+	// This test reaches out to registry.opentofu.org to download the
 	// template and null providers, so it can only run if network access is
 	// allowed.
 	skipIfCannotAccessNetwork(t)

--- a/internal/command/e2etest/init_test.go
+++ b/internal/command/e2etest/init_test.go
@@ -20,7 +20,7 @@ import (
 func TestInitProviders(t *testing.T) {
 	t.Parallel()
 
-	// This test reaches out to releases.hashicorp.com to download the
+	// This test reaches out to registry.opentofu.org to download the
 	// template provider, so it can only run if network access is allowed.
 	// We intentionally don't try to stub this here, because there's already
 	// a stubbed version of this in the "command" package and so the goal here
@@ -232,7 +232,7 @@ func TestInitProvidersCustomMethod(t *testing.T) {
 func TestInitProviders_pluginCache(t *testing.T) {
 	t.Parallel()
 
-	// This test reaches out to releases.hashicorp.com to access plugin
+	// This test reaches out to registry.opentofu.org to access plugin
 	// metadata, and download the null plugin, though the template plugin
 	// should come from local cache.
 	skipIfCannotAccessNetwork(t)

--- a/internal/command/e2etest/primary_test.go
+++ b/internal/command/e2etest/primary_test.go
@@ -26,7 +26,7 @@ import (
 func TestPrimarySeparatePlan(t *testing.T) {
 	t.Parallel()
 
-	// This test reaches out to releases.hashicorp.com to download the
+	// This test reaches out to registry.opentofu.org to download the
 	// template and null providers, so it can only run if network access is
 	// allowed.
 	skipIfCannotAccessNetwork(t)

--- a/internal/command/e2etest/providers_mirror_test.go
+++ b/internal/command/e2etest/providers_mirror_test.go
@@ -28,7 +28,7 @@ func TestTerraformProvidersMirrorWithLockFile(t *testing.T) {
 }
 
 func testTerraformProvidersMirror(t *testing.T, fixture string) {
-	// This test reaches out to releases.hashicorp.com to download the
+	// This test reaches out to registry.opentofu.org to download the
 	// template and null providers, so it can only run if network access is
 	// allowed.
 	skipIfCannotAccessNetwork(t)

--- a/internal/command/e2etest/providers_tamper_test.go
+++ b/internal/command/e2etest/providers_tamper_test.go
@@ -24,7 +24,7 @@ func TestProviderTampering(t *testing.T) {
 	// provider.
 	t.Parallel()
 
-	// This test reaches out to releases.hashicorp.com to download the
+	// This test reaches out to registry.opentofu.org to download the
 	// null provider, so it can only run if network access is allowed.
 	skipIfCannotAccessNetwork(t)
 

--- a/internal/command/e2etest/provisioner_plugin_test.go
+++ b/internal/command/e2etest/provisioner_plugin_test.go
@@ -25,7 +25,7 @@ func TestProvisionerPlugin(t *testing.T) {
 	}
 	t.Parallel()
 
-	// This test reaches out to releases.hashicorp.com to download the
+	// This test reaches out to registry.opentofu.org to download the
 	// template and null providers, so it can only run if network access is
 	// allowed.
 	skipIfCannotAccessNetwork(t)

--- a/internal/command/e2etest/provisioner_test.go
+++ b/internal/command/e2etest/provisioner_test.go
@@ -15,7 +15,7 @@ import (
 func TestProvisioner(t *testing.T) {
 	t.Parallel()
 
-	// This test reaches out to releases.hashicorp.com to download the
+	// This test reaches out to registry.opentofu.org to download the
 	// template and null providers, so it can only run if network access is
 	// allowed.
 	skipIfCannotAccessNetwork(t)

--- a/internal/command/e2etest/version_test.go
+++ b/internal/command/e2etest/version_test.go
@@ -44,7 +44,7 @@ func TestVersionWithProvider(t *testing.T) {
 	// versions of plugins too.
 	t.Parallel()
 
-	// This test reaches out to releases.hashicorp.com to download the
+	// This test reaches out to registry.opentofu.org to download the
 	// template and null providers, so it can only run if network access is
 	// allowed.
 	skipIfCannotAccessNetwork(t)

--- a/internal/configs/test_file.go
+++ b/internal/configs/test_file.go
@@ -73,7 +73,7 @@ type TestRun struct {
 
 	// Options contains the embedded plan options that will affect the given
 	// Command. These should map to the options documented here:
-	//   - https://developer.hashicorp.com/terraform/cli/commands/plan#planning-options
+	//   - https://opentofu.org/docs/cli/commands/plan/#planning-options
 	//
 	// Note, that the Variables are a top level concept and not embedded within
 	// the options despite being listed as plan options in the documentation.

--- a/website/docs/internals/module-registry-protocol.mdx
+++ b/website/docs/internals/module-registry-protocol.mdx
@@ -136,7 +136,7 @@ available versions for a given fully-qualified module.
 ### Sample Request
 
 ```text
-$ curl 'https://registry.example.io/v1/modules/hashicorp/consul/aws/versions'
+$ curl 'https://registry.opentofu.org/v1/modules/hashicorp/consul/aws/versions'
 ```
 
 ### Sample Response
@@ -191,7 +191,7 @@ This endpoint downloads the specified version of a module for a single target sy
 ### Sample Request
 
 ```text
-$ curl -i 'https://registry.example.io/v1/modules/foo/bar/baz/0.0.1/download'
+$ curl -i 'https://registry.opentofu.org/v1/modules/foo/bar/baz/0.0.1/download'
 ```
 
 ### Sample Response

--- a/website/docs/internals/provider-registry-protocol.mdx
+++ b/website/docs/internals/provider-registry-protocol.mdx
@@ -62,10 +62,10 @@ hostname that is under your control.
 
 OpenTofu uses the full address (after normalization to always include a
 hostname) as its global identifier for providers internally, and so it's
-important to note that re-uploading the `hashicorp/azurerm` provider into
+important to note that re-uploading the `examplecorp/azurerm` provider into
 another namespace or publishing it on a different hostname will cause OpenTofu
 to see it as an entirely separate provider that will _not_ be usable by modules
-that declare a dependency on `hashicorp/azurerm`. If your goal is to create
+that declare a dependency on `examplecorp/azurerm`. If your goal is to create
 an alternative local distribution source for an existing provider -- that is,
 a _mirror_ of the provider -- refer to
 [the provider installation method configuration](/docs/cli/config/config-file#provider-installation)
@@ -141,7 +141,7 @@ particular provider.
 ### Sample Request
 
 ```
-curl 'https://registry.example.io/v1/providers/hashicorp/random/versions'
+curl 'https://registry.opentofu.org/v1/providers/examplecorp/random/versions'
 ```
 
 ### Sample Response
@@ -240,7 +240,7 @@ archive containing the plugin itself.
 ### Sample Request
 
 ```
-curl 'https://registry.example.io/v1/providers/hashicorp/random/2.0.0/download/linux/amd64'
+curl 'https://registry.opentofu.org/v1/providers/examplecorp/random/2.0.0/download/linux/amd64'
 ```
 
 ### Sample Response
@@ -261,8 +261,8 @@ curl 'https://registry.example.io/v1/providers/hashicorp/random/2.0.0/download/l
         "key_id": "51852D87348FFC4C",
         "ascii_armor": "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v1\n\nmQENBFMORM0BCADBRyKO1MhCirazOSVwcfTr1xUxjPvfxD3hjUwHtjsOy/bT6p9f\nW2mRPfwnq2JB5As+paL3UGDsSRDnK9KAxQb0NNF4+eVhr/EJ18s3wwXXDMjpIifq\nfIm2WyH3G+aRLTLPIpscUNKDyxFOUbsmgXAmJ46Re1fn8uKxKRHbfa39aeuEYWFA\n3drdL1WoUngvED7f+RnKBK2G6ZEpO+LDovQk19xGjiMTtPJrjMjZJ3QXqPvx5wca\nKSZLr4lMTuoTI/ZXyZy5bD4tShiZz6KcyX27cD70q2iRcEZ0poLKHyEIDAi3TM5k\nSwbbWBFd5RNPOR0qzrb/0p9ksKK48IIfH2FvABEBAAG0K0hhc2hpQ29ycCBTZWN1\ncml0eSA8c2VjdXJpdHlAaGFzaGljb3JwLmNvbT6JATgEEwECACIFAlMORM0CGwMG\nCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEFGFLYc0j/xMyWIIAIPhcVqiQ59n\nJc07gjUX0SWBJAxEG1lKxfzS4Xp+57h2xxTpdotGQ1fZwsihaIqow337YHQI3q0i\nSqV534Ms+j/tU7X8sq11xFJIeEVG8PASRCwmryUwghFKPlHETQ8jJ+Y8+1asRydi\npsP3B/5Mjhqv/uOK+Vy3zAyIpyDOMtIpOVfjSpCplVRdtSTFWBu9Em7j5I2HMn1w\nsJZnJgXKpybpibGiiTtmnFLOwibmprSu04rsnP4ncdC2XRD4wIjoyA+4PKgX3sCO\nklEzKryWYBmLkJOMDdo52LttP3279s7XrkLEE7ia0fXa2c12EQ0f0DQ1tGUvyVEW\nWmJVccm5bq25AQ0EUw5EzQEIANaPUY04/g7AmYkOMjaCZ6iTp9hB5Rsj/4ee/ln9\nwArzRO9+3eejLWh53FoN1rO+su7tiXJA5YAzVy6tuolrqjM8DBztPxdLBbEi4V+j\n2tK0dATdBQBHEh3OJApO2UBtcjaZBT31zrG9K55D+CrcgIVEHAKY8Cb4kLBkb5wM\nskn+DrASKU0BNIV1qRsxfiUdQHZfSqtp004nrql1lbFMLFEuiY8FZrkkQ9qduixo\nmTT6f34/oiY+Jam3zCK7RDN/OjuWheIPGj/Qbx9JuNiwgX6yRj7OE1tjUx6d8g9y\n0H1fmLJbb3WZZbuuGFnK6qrE3bGeY8+AWaJAZ37wpWh1p0cAEQEAAYkBHwQYAQIA\nCQUCUw5EzQIbDAAKCRBRhS2HNI/8TJntCAClU7TOO/X053eKF1jqNW4A1qpxctVc\nz8eTcY8Om5O4f6a/rfxfNFKn9Qyja/OG1xWNobETy7MiMXYjaa8uUx5iFy6kMVaP\n0BXJ59NLZjMARGw6lVTYDTIvzqqqwLxgliSDfSnqUhubGwvykANPO+93BBx89MRG\nunNoYGXtPlhNFrAsB1VR8+EyKLv2HQtGCPSFBhrjuzH3gxGibNDDdFQLxxuJWepJ\nEK1UbTS4ms0NgZ2Uknqn1WRU1Ki7rE4sTy68iZtWpKQXZEJa0IGnuI2sSINGcXCJ\noEIgXTMyCILo34Fa/C6VCm2WBgz9zZO8/rHIiQm1J5zqz0DrDwKBUM9C\n=LYpS\n-----END PGP PUBLIC KEY BLOCK-----",
         "trust_signature": "",
-        "source": "HashiCorp",
-        "source_url": "https://www.hashicorp.com/security.html"
+        "source": "ExampleCorp",
+        "source_url": "https://www.examplecorp.com/security.html"
       }
     ]
   }


### PR DESCRIPTION
Resolves #891 by updating references from hashicorp.com to opentofu.org, where appropriate.

During the process, I noticed the test in
`package_authentication_test.go`
uses [accounts from
hashicorp.com](https://github.com/opentofu/opentofu/blob/70dd385136bb4d1fa2875672a06905b864ecb41b/internal/getproviders/package_authentication_test.go#L682C2-L682C2), which probably should be updated.


Resolves 891

## Target Release

1.6.0
