### PR TITLE
Fixes #913: Incorrect installation instructions for RPM

### DIFF
--- a/website/docs/intro/install/deb-convenience.sh
+++ b/website/docs/intro/install/deb-convenience.sh
@@ -1,0 +1,6 @@
+curl -s https://packagecloud.io/install/repositories/opentofu/tofu/script.deb.sh?any=true -o /tmp/tofu-repository-setup.sh
+# Inspect the downloaded script at /tmp/tofu-repository-setup.sh before running
+sudo bash /tmp/tofu-repository-setup.sh
+rm /tmp/tofu-repository-setup.sh
+
+sudo apt-get install tofu

--- a/website/docs/intro/install/deb-step1.sh
+++ b/website/docs/intro/install/deb-step1.sh
@@ -1,0 +1,2 @@
+sudo apt-get update
+sudo apt-get install -y apt-transport-https ca-certificates curl gnupg

--- a/website/docs/intro/install/deb-step2.sh
+++ b/website/docs/intro/install/deb-step2.sh
@@ -1,0 +1,3 @@
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://packagecloud.io/opentofu/tofu/gpgkey | sudo gpg --no-tty --batch --dearmor -o /etc/apt/keyrings/opentofu.gpg
+sudo chmod a+r /etc/apt/keyrings/opentofu.gpg

--- a/website/docs/intro/install/deb-step3.sh
+++ b/website/docs/intro/install/deb-step3.sh
@@ -1,0 +1,4 @@
+echo \
+  "deb [signed-by=/etc/apt/keyrings/opentofu.gpg] https://packagecloud.io/opentofu/tofu/any/ any main
+deb-src [signed-by=/etc/apt/keyrings/opentofu.gpg] https://packagecloud.io/opentofu/tofu/any/ any main" | \
+  sudo tee /etc/apt/sources.list.d/opentofu.list > /dev/null

--- a/website/docs/intro/install/deb-step4.sh
+++ b/website/docs/intro/install/deb-step4.sh
@@ -1,0 +1,2 @@
+sudo apt-get update
+sudo apt-get install -y tofu

--- a/website/docs/intro/install/deb.mdx
+++ b/website/docs/intro/install/deb.mdx
@@ -5,6 +5,13 @@ description: |-
   Install OpenTofu on Debian Linux and its derivatives.
 ---
 
+import CodeBlock from '@theme/CodeBlock';
+import DebConvenienceScript from '!!raw-loader!./deb-convenience.sh'
+import DebStep1Script from '!!raw-loader!./deb-step1.sh'
+import DebStep2Script from '!!raw-loader!./deb-step2.sh'
+import DebStep3Script from '!!raw-loader!./deb-step3.sh'
+import DebStep4Script from '!!raw-loader!./deb-step4.sh'
+
 # Installing OpenTofu on .deb-based Linux (Debian, Ubuntu, etc.)
 
 OpenTofu is distributed in the .deb package format on [Packagecloud](https://packagecloud.io/opentofu/tofu). You can install it using a convenience script or by following the step-by-step instructions below.
@@ -13,14 +20,7 @@ OpenTofu is distributed in the .deb package format on [Packagecloud](https://pac
 
 You can install OpenTofu using the [convenience script](https://packagecloud.io/install/repositories/opentofu/tofu/script.deb.sh?any=true) with the following commands:
 
-```bash
-curl -s https://packagecloud.io/install/repositories/opentofu/tofu/script.deb.sh?any=true -o /tmp/tofu-repository-setup.sh
-# Inspect the downloaded script at /tmp/tofu-repository-setup.sh before running
-sudo bash /tmp/tofu-repository-setup.sh
-rm /tmp/tofu-repository-setup.sh
-
-sudo apt-get install tofu
-```
+<CodeBlock language={"bash"}>{DebConvenienceScript}</CodeBlock>
 
 ## Step-by-step instructions
 
@@ -30,35 +30,20 @@ The following steps explain how to set up the OpenTofu Debian repositories. Thes
 
 In order to add the repositories, you will need to install some tooling. On most Debian-based operating systems, these tools will already be installed.
 
-```bash
-sudo apt-get update
-sudo apt-get install apt-transport-https ca-certificates curl gnupg
-```
+<CodeBlock language={"bash"}>{DebStep1Script}</CodeBlock>
 
 ### Set up the OpenTofu repository
 
 First, you need to make sure you have a copy of the OpenTofu GPG key. This verifies that your packages have indeed been created using the official pipeline and have not been tampered with.
 
-```bash
-sudo install -m 0755 -d /etc/apt/keyrings
-curl -fsSL https://packagecloud.io/opentofu/tofu/gpgkey | sudo gpg --dearmor -o /etc/apt/keyrings/opentofu.gpg
-sudo chmod a+r /etc/apt/keyrings/opentofu.gpg
-```
+<CodeBlock language={"bash"}>{DebStep2Script}</CodeBlock>
 
 Now you have to create the OpenTofu source list.
 
-```bash
-echo \
-  "deb [signed-by=/etc/apt/keyrings/opentofu.gpg] https://packagecloud.io/opentofu/tofu/any/ any main
-deb-src [signed-by=/etc/apt/keyrings/opentofu.gpg] https://packagecloud.io/opentofu/tofu/any/ any main" | \
-  sudo tee /etc/apt/sources.list.d/opentofu.list > /dev/null
-```
+<CodeBlock language={"bash"}>{DebStep3Script}</CodeBlock>
 
 ### Installing OpenTofu
 
 Finally, you can install OpenTofu:
 
-```bash
-sudo apt-get update
-sudo apt-get install tofu
-```
+<CodeBlock language={"bash"}>{DebStep4Script}</CodeBlock>

--- a/website/docs/intro/install/deb.sh
+++ b/website/docs/intro/install/deb.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+apt update
+apt install -y sudo curl
+
+if [ "$1" = "--convenience" ]; then
+  bash -ex deb-convenience.sh
+else
+  bash -ex deb-step1.sh
+  bash -ex deb-step2.sh
+  bash -ex deb-step3.sh
+  bash -ex deb-step4.sh
+fi
+
+tofu --version

--- a/website/docs/intro/install/docker-compose.yaml
+++ b/website/docs/intro/install/docker-compose.yaml
@@ -1,0 +1,84 @@
+# This docker-compose file tests the installation instructions with all operating systems. See #
+# test-install-instructions.sh for details.
+version: '3.2'
+services:
+  debian-convenience:
+    image: debian:buster
+    volumes:
+      - source: ./
+        target: /data
+        type: bind
+    command: /data/deb.sh --convenience
+    working_dir: /data
+  debian-manual:
+    image: debian:buster
+    volumes:
+      - source: ./
+        target: /data
+        type: bind
+    command: /data/deb.sh
+    working_dir: /data
+  ubuntu-convenience:
+    image: ubuntu:latest
+    volumes:
+      - source: ./
+        target: /data
+        type: bind
+    command: /data/deb.sh --convenience
+    working_dir: /data
+  ubuntu-manual:
+    image: ubuntu:latest
+    volumes:
+      - source: ./
+        target: /data
+        type: bind
+    command: /data/deb.sh
+    working_dir: /data
+  fedora-convenience:
+    image: fedora:latest
+    volumes:
+      - source: ./
+        target: /data
+        type: bind
+    command: /data/rpm.sh --convenience
+    working_dir: /data
+  fedora-manual:
+    image: fedora:latest
+    volumes:
+      - source: ./
+        target: /data
+        type: bind
+    command: /data/rpm.sh
+    working_dir: /data
+  opensuse-convenience:
+    image: opensuse/leap:latest
+    volumes:
+      - source: ./
+        target: /data
+        type: bind
+    command: /data/rpm.sh --convenience
+    working_dir: /data
+  opensuse-manual:
+    image: opensuse/leap:latest
+    volumes:
+      - source: ./
+        target: /data
+        type: bind
+    command: /data/rpm.sh
+    working_dir: /data
+  rockylinux-convenience:
+    image: rockylinux:9
+    volumes:
+      - source: ./
+        target: /data
+        type: bind
+    command: /data/rpm.sh --convenience
+    working_dir: /data
+  rockylinux-manual:
+    image: rockylinux:9
+    volumes:
+      - source: ./
+        target: /data
+        type: bind
+    command: /data/rpm.sh
+    working_dir: /data

--- a/website/docs/intro/install/install-yum.sh
+++ b/website/docs/intro/install/install-yum.sh
@@ -1,1 +1,1 @@
-yum install tofu
+sudo yum install -y tofu

--- a/website/docs/intro/install/install-zypper.sh
+++ b/website/docs/intro/install/install-zypper.sh
@@ -1,3 +1,3 @@
 zypper --gpg-auto-import-keys refresh opentofu
 zypper --gpg-auto-import-keys refresh opentofu-source
-zypper install tofu
+zypper install -y tofu

--- a/website/docs/intro/install/repo-yum.sh
+++ b/website/docs/intro/install/repo-yum.sh
@@ -3,7 +3,7 @@ cat >/etc/yum.repos.d/opentofu.repo <<EOF
 name=opentofu
 baseurl=https://packagecloud.io/opentofu/tofu/rpm_any/rpm_any/\$basearch
 repo_gpgcheck=1
-gpgcheck=1
+gpgcheck=0
 enabled=1
 gpgkey=https://packagecloud.io/opentofu/tofu/gpgkey
 sslverify=1
@@ -14,7 +14,7 @@ metadata_expire=300
 name=opentofu-source
 baseurl=https://packagecloud.io/opentofu/tofu/rpm_any/rpm_any/SRPMS
 repo_gpgcheck=1
-gpgcheck=1
+gpgcheck=0
 enabled=1
 gpgkey=https://packagecloud.io/opentofu/tofu/gpgkey
 sslverify=1

--- a/website/docs/intro/install/repo-zypper.sh
+++ b/website/docs/intro/install/repo-zypper.sh
@@ -3,7 +3,7 @@ cat >/etc/zypp/repos.d/opentofu.repo <<EOF
 name=opentofu
 baseurl=https://packagecloud.io/opentofu/tofu/rpm_any/rpm_any/\$basearch
 repo_gpgcheck=1
-gpgcheck=1
+gpgcheck=0
 enabled=1
 gpgkey=https://packagecloud.io/opentofu/tofu/gpgkey
 sslverify=1
@@ -14,7 +14,7 @@ metadata_expire=300
 name=opentofu-source
 baseurl=https://packagecloud.io/opentofu/tofu/rpm_any/rpm_any/SRPMS
 repo_gpgcheck=1
-gpgcheck=1
+gpgcheck=0
 enabled=1
 gpgkey=https://packagecloud.io/opentofu/tofu/gpgkey
 sslverify=1

--- a/website/docs/intro/install/rpm-convenience-yum.sh
+++ b/website/docs/intro/install/rpm-convenience-yum.sh
@@ -1,0 +1,6 @@
+curl -s https://packagecloud.io/install/repositories/opentofu/tofu/script.rpm.sh?any=true -o /tmp/tofu-repository-setup.sh
+# Inspect the downloaded script at /tmp/tofu-repository-setup.sh before running
+sudo bash /tmp/tofu-repository-setup.sh
+rm /tmp/tofu-repository-setup.sh
+
+sudo yum install -y tofu

--- a/website/docs/intro/install/rpm-convenience-zypper.sh
+++ b/website/docs/intro/install/rpm-convenience-zypper.sh
@@ -1,0 +1,6 @@
+curl -s https://packagecloud.io/install/repositories/opentofu/tofu/script.rpm.sh?any=true -o /tmp/tofu-repository-setup.sh
+# Inspect the downloaded script at /tmp/tofu-repository-setup.sh before running
+sudo bash /tmp/tofu-repository-setup.sh
+rm /tmp/tofu-repository-setup.sh
+
+sudo zypper install -y tofu

--- a/website/docs/intro/install/rpm.mdx
+++ b/website/docs/intro/install/rpm.mdx
@@ -8,6 +8,8 @@ description: |-
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
+import YumConvenienceScript from '!!raw-loader!./rpm-convenience-yum.sh'
+import ZypperConvenienceScript from '!!raw-loader!./rpm-convenience-zypper.sh'
 import YumRepoScript from '!!raw-loader!./repo-yum.sh'
 import ZypperRepoScript from '!!raw-loader!./repo-zypper.sh'
 import YumInstallScript from '!!raw-loader!./install-yum.sh'
@@ -21,14 +23,14 @@ OpenTofu is distributed in the .rpm package format on [Packagecloud](https://pac
 
 You can install OpenTofu using the [convenience script](https://packagecloud.io/install/repositories/opentofu/tofu/script.rpm.sh?any=true) with the following commands:
 
-```bash
-curl -s https://packagecloud.io/install/repositories/opentofu/tofu/script.rpm.sh?any=true -o /tmp/tofu-repository-setup.sh
-# Inspect the downloaded script at /tmp/tofu-repository-setup.sh before running
-sudo bash /tmp/tofu-repository-setup.sh
-rm /tmp/tofu-repository-setup.sh
-
-sudo yum install tofu
-```
+<Tabs>
+    <TabItem value="redhat" label="Yum (RHEL/Fedora/etc.)" default>
+        <CodeBlock language={"bash"}>{YumConvenienceScript}</CodeBlock>
+    </TabItem>
+    <TabItem value="opensuse-leap" label="Zypper (openSUSE)">
+        <CodeBlock language={"bash"}>{ZypperConvenienceScript}</CodeBlock>
+    </TabItem>
+</Tabs>
 
 ## Step-by-step instructions
 

--- a/website/docs/intro/install/rpm.sh
+++ b/website/docs/intro/install/rpm.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+if [ -f /usr/bin/zypper ]; then
+  zypper install -y sudo
+  if [ "$1" = "--convenience" ]; then
+    bash -ex rpm-convenience-zypper.sh
+  else
+    bash -ex repo-zypper.sh
+    bash -ex install-zypper.sh
+  fi
+else
+  yum install -y sudo
+  if [ "$1" = "--convenience" ]; then
+    bash -ex rpm-convenience-yum.sh
+  else
+    bash -ex repo-yum.sh
+    bash -ex install-yum.sh
+  fi
+fi
+
+tofu --version

--- a/website/docs/intro/install/test-install-instructions.sh
+++ b/website/docs/intro/install/test-install-instructions.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This script tests the installation instructions on all relevant Linux operating systems listed in docker-compose.yaml.
+
+set -e
+
+docker compose down || true
+docker compose up $1
+
+echo -e "Test case\tExit code"
+docker compose ps -a --format '{{ .Service}}\t{{.ExitCode}}' | tee /tmp/$$
+FAILS=$(cat /tmp/$$ | cut -f 2 | grep -v '^0$' | wc -l)
+rm /tmp/$$
+if [ "${FAILS}" -ne 0 ]; then
+  echo "${FAILS} tests failed." >&2
+  exit 1
+fi
+docker compose down
+echo "All tests passed."


### PR DESCRIPTION
Currently, the installation instructions for RPM-based distributions are incorrect since we are not GPG-signing the packages. This change turns off GPG verification for those packages. This is preferable to disabling the GPG check on the command line because the GPG key will likely change anyway when we enable package signing.

The change also contains a fix in the convenience script instructions for openSUSE LEAP users, offering instructions for Zypper instead of Yum.

As an additional change, this commit also includes testing scripts for the installation instructions on various distributions to avoid such errors in the future. The test script can be invoked on a Linux distribution with Docker/Podman installed using
`test-install-instructions.sh`:

```
$ ./test-install-instructions.sh
[+] Running 10/10
 ✔ Container install-rockylinux-convenience-1  Removed
 ✔ Container install-debian-convenience-1      Removed
 ✔ Container install-ubuntu-convenience-1      Removed

...

install-fedora-convenience-1 exited with code 0
Test case       Exit code
debian-convenience      0
debian-manual   0
fedora-convenience      0
fedora-manual   0
opensuse-convenience   0
opensuse-manual 0
rockylinux-convenience  0
rockylinux-manual       0
ubuntu-convenience      0
ubuntu-manual   0
All tests passed.
```

Resolves #913

## Target Release

1.6.0
