### PR TITLE
Add codeowners and maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,4 @@
 # Each line is a file pattern followed by one or more owners.
 # More on CODEOWNERS files: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-# We currently do not have any specific code owners
-# In the future, we will have a Github team of global code owners of the entire package
-# Later on, we will start splitting up the responsibilities, and packages will be assigned more specific code owners
-# * @opentofu-code-owners
+* @opentofu/core-engineers

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,6 @@
+Kuba Martin <kubam@spacelift.io> @cube2222
+James Humphries <jamesh@spacelift.io> @Yantrio
+Arel Rabinowitz <arel.rabinowitz@env0.com> @RLRabinowitz
+Dmitry Kisler <dmitryk@opentofu.org> @kislerdm
+Christian Mesh <christianm@opentofu.org> @cam72cam
+János Bonic <janosb@opentofu.org> @janosdebugs


### PR DESCRIPTION
Resolves #918 

## What changed

- Added the core team as the code owners
- Added the core team as the maintainers

## Why do we need it

- Clarity
- CNCF application
