### PR TITLE
Add dependencies for integration tests with Consul as backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ test-azure: ## Directs the developer to follow a runbook describing how to run A
 	@ exit 1 # don't want the user to miss this
 
 # integration test with Consul as backend
-.PHONY: test-consul
+.PHONY: test-consul test-consul-clean
 
 define infoTestConsul
 Test requires:
@@ -144,7 +144,7 @@ test-consul: ## Runs tests using in docker container using Consul as the backend
  		test ./internal/backend/remote-state/consul/...
 
 test-consul-clean: ## Cleans environment after `test-consul`.
-	@ docker rmi -f tofu-consul 2> /dev/null
+	@ docker rmi -f tofu-consul:latest
 
 .PHONY:
 integration-tests: test-s3 test-pg test-consul integration-tests-clean ## Runs all integration tests test.

--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,31 @@ test-azure: ## Directs the developer to follow a runbook describing how to run A
 	@ echo "To run Azure integration tests, please follow the runbook in internal/backend/remote-state/azure/README.md".
 	@ exit 1 # don't want the user to miss this
 
-.PHONY:
-integration-tests: test-s3 test-pg integration-tests-clean ## Runs all integration tests test.
+# integration test with Consul as backend
+.PHONY: test-consul
+
+define infoTestConsul
+Test requires:
+* Docker: https://docs.docker.com/engine/install/
+
+endef
+
+GO_VER := `cat $(PWD)/.go-version`
+
+test-consul: ## Runs tests using in docker container using Consul as the backend.
+	@ $(info $(infoTestConsul))
+	@ echo "Build docker image with Consul and Go v$(GO_VER)"
+	@ cd ./internal/backend/remote-state/consul &&\
+  		docker build --build-arg="GO_VERSION=${GO_VER}" -t tofu-consul --progress=plain . &> /dev/null
+	@ echo "Run tests"
+	@ docker run --rm --name tofu-consul -v $(PWD):/app -e TF_CONSUL_TEST=1 -t tofu-consul \
+ 		test ./internal/backend/remote-state/consul/...
+
+test-consul-clean: ## Cleans environment after `test-consul`.
+	@ docker rmi -f tofu-consul 2> /dev/null
 
 .PHONY:
-integration-tests-clean: test-pg-clean ## Cleans environment after all integration tests.
+integration-tests: test-s3 test-pg test-consul integration-tests-clean ## Runs all integration tests test.
+
+.PHONY:
+integration-tests-clean: test-pg-clean test-consul-clean ## Cleans environment after all integration tests.

--- a/internal/backend/remote-state/consul/Dockerfile
+++ b/internal/backend/remote-state/consul/Dockerfile
@@ -1,0 +1,30 @@
+FROM consul:1.15
+
+# install dependencies to install Go
+RUN apk add -q curl tar
+
+# download Go
+ARG GO_VERSION
+RUN if [ "$(uname -m)"=="aarch64" ]; then curl -SLo /tmp/go.tar.gz https://go.dev/dl/go${GO_VERSION}.linux-arm64.tar.gz;\
+      elif [ "$(uname -m)"=="arm64" ]; then curl -SLo /tmp/go.tar.gz https://go.dev/dl/go${GO_VERSION}.linux-arm64.tar.gz;\
+      elif [ "$(uname -m)"=="arm" ]; then curl -SLo /tmp/go.tar.gz https://go.dev/dl/go${GO_VERSION}.linux-armv6l.tar.gz;\
+      else curl -SLo /tmp/go.tar.gz https://go.dev/dl/go${GO_VERSION}.linux-386.tar.gz; \
+    fi
+
+# install Go
+RUN cd tmp && \
+    tar -xzf go.tar.gz && \
+    ln -s /tmp/go/bin/go /usr/local/bin/go && \
+    rm go.tar.gz
+
+# cleanup installation dependencies
+RUN apk del -q curl tar
+
+VOLUME "/app"
+WORKDIR "/app"
+
+# launch Consul agent
+RUN consul agent -dev 1> /dev/null &
+
+ENV TF_CONSUL_TEST=1
+ENTRYPOINT [ "go" ]

--- a/internal/backend/remote-state/consul/Dockerfile
+++ b/internal/backend/remote-state/consul/Dockerfile
@@ -23,8 +23,5 @@ RUN apk del -q curl tar
 VOLUME "/app"
 WORKDIR "/app"
 
-# launch Consul agent
-RUN consul agent -dev 1> /dev/null &
-
 ENV TF_CONSUL_TEST=1
 ENTRYPOINT [ "go" ]

--- a/internal/backend/remote-state/consul/backend_test.go
+++ b/internal/backend/remote-state/consul/backend_test.go
@@ -49,6 +49,7 @@ func newConsulTestServer(t *testing.T) *testutil.TestServer {
 
 func TestBackend(t *testing.T) {
 	srv := newConsulTestServer(t)
+	defer func() { _ = srv.Stop() }()
 
 	path := fmt.Sprintf("tf-unit/%s", time.Now().String())
 
@@ -70,6 +71,7 @@ func TestBackend(t *testing.T) {
 
 func TestBackend_lockDisabled(t *testing.T) {
 	srv := newConsulTestServer(t)
+	defer func() { _ = srv.Stop() }()
 
 	path := fmt.Sprintf("tf-unit/%s", time.Now().String())
 
@@ -93,6 +95,7 @@ func TestBackend_lockDisabled(t *testing.T) {
 
 func TestBackend_gzip(t *testing.T) {
 	srv := newConsulTestServer(t)
+	defer func() { _ = srv.Stop() }()
 
 	// Get the backend
 	b := backend.TestBackendConfig(t, New(), backend.TestWrapConfig(map[string]interface{}{

--- a/internal/backend/remote-state/consul/client_test.go
+++ b/internal/backend/remote-state/consul/client_test.go
@@ -28,6 +28,7 @@ func TestRemoteClient_impl(t *testing.T) {
 
 func TestRemoteClient(t *testing.T) {
 	srv := newConsulTestServer(t)
+	defer func() { _ = srv.Stop() }()
 
 	testCases := []string{
 		fmt.Sprintf("tf-unit/%s", time.Now().String()),
@@ -57,6 +58,7 @@ func TestRemoteClient(t *testing.T) {
 // test the gzip functionality of the client
 func TestRemoteClient_gzipUpgrade(t *testing.T) {
 	srv := newConsulTestServer(t)
+	defer func() { _ = srv.Stop() }()
 
 	statePath := fmt.Sprintf("tf-unit/%s", time.Now().String())
 
@@ -97,6 +99,7 @@ func TestRemoteClient_gzipUpgrade(t *testing.T) {
 // will need to be split up before being saved and put back together when read.
 func TestConsul_largeState(t *testing.T) {
 	srv := newConsulTestServer(t)
+	defer func() { _ = srv.Stop() }()
 
 	path := "tf-unit/test-large-state"
 
@@ -238,6 +241,7 @@ func TestConsul_largeState(t *testing.T) {
 
 func TestConsul_stateLock(t *testing.T) {
 	srv := newConsulTestServer(t)
+	defer func() { _ = srv.Stop() }()
 
 	testCases := []string{
 		fmt.Sprintf("tf-unit/%s", time.Now().String()),
@@ -270,6 +274,7 @@ func TestConsul_stateLock(t *testing.T) {
 
 func TestConsul_destroyLock(t *testing.T) {
 	srv := newConsulTestServer(t)
+	defer func() { _ = srv.Stop() }()
 
 	testCases := []string{
 		fmt.Sprintf("tf-unit/%s", time.Now().String()),
@@ -352,6 +357,7 @@ func TestConsul_destroyLock(t *testing.T) {
 
 func TestConsul_lostLock(t *testing.T) {
 	srv := newConsulTestServer(t)
+	defer func() { _ = srv.Stop() }()
 
 	path := fmt.Sprintf("tf-unit/%s", time.Now().String())
 
@@ -401,6 +407,7 @@ func TestConsul_lostLock(t *testing.T) {
 
 func TestConsul_lostLockConnection(t *testing.T) {
 	srv := newConsulTestServer(t)
+	defer func() { _ = srv.Stop() }()
 
 	// create an "unreliable" network by closing all the consul client's
 	// network connections

--- a/internal/backend/remote-state/consul/client_test.go
+++ b/internal/backend/remote-state/consul/client_test.go
@@ -207,12 +207,12 @@ func TestConsul_largeState(t *testing.T) {
 	// being gziped
 
 	// We use a fixed seed so the test can be reproductible
-	rand.Seed(1234)
+	randomizer := rand.New(rand.NewSource(1234))
 	RandStringRunes := func(n int) string {
 		var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 		b := make([]rune, n)
 		for i := range b {
-			b[i] = letterRunes[rand.Intn(len(letterRunes))]
+			b[i] = letterRunes[randomizer.Intn(len(letterRunes))]
 		}
 		return string(b)
 	}


### PR DESCRIPTION
Resolves #911 

## Target Release

1.6.0

## What changed

- Added the makefile rule to trigger the integration test with Consul
- Added dockerfile with deps definition to provision local env
- Fixed tests definition: a Consul server provisioned by every test is being stopped to cleanup and free the ports

## Why do we need it

- To ensure the OpenTofu stability with various backends
