### PR TITLE
Fix typo for expect_failures example

### DIFF
--- a/website/docs/cli/commands/test.mdx
+++ b/website/docs/cli/commands/test.mdx
@@ -210,7 +210,7 @@ The `expect_failures` attribute lists the resources, or variable which are expec
 
 ```hcl
 run "unhappy-path" {
-  variable {
+  variables {
     input0 = "faulty-input"
   }
   expect_failures = [


### PR DESCRIPTION
part of #8 

## Target Release

1.6.0


## What changed

- Fixed typo

## Why do we need it

- To share working snippets with users
