### PR TITLE
Make goreleaser create draft releases instead of full releases, so that we can customize the description.

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -219,5 +219,4 @@ changelog:
 
 release:
   prerelease: auto
-  # If you want to examine the release before its live, uncomment this line:
-  # draft: false
+  draft: false


### PR DESCRIPTION
fixes #948 