### PR TITLE
website: Dev server

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,0 +1,26 @@
+name: Website checks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - 'v[0-9]+.[0-9]+'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Prepare website container
+        run: docker compose -f docker-compose.build.yml build
+        working-directory: website
+      - name: Build website
+        run: docker compose -f docker-compose.build.yml up --exit-code-from website
+        working-directory: website

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine AS parent
+
+RUN apk add git
+RUN git clone https://github.com/opentofu/opentofu.org /work
+
+FROM node
+COPY --from=parent /work /work
+WORKDIR /work
+RUN npm i
+
+VOLUME /work/opentofu-repo
+EXPOSE 3000
+
+CMD ["npm", "run", "start", "--", "--host","0.0.0.0"]

--- a/website/README.md
+++ b/website/README.md
@@ -2,6 +2,16 @@
 
 This directory contains the portions of [the OpenTofu website](https://opentofu.org) that pertain to the core functionality, excluding providers and the overall configuration.
 
+## Development server
+
+You can start a local development server with Docker by running the following command from this (the `website`) directory:
+
+```
+docker compose up --build
+```
+
+The development server will be available on http://localhost:3000/ .
+
 ## Suggesting Changes
 
 You can [submit an issue](https://github.com/opentofu/opentofu/issues/new/choose) with documentation requests or submit a pull request with suggested changes.

--- a/website/docker-compose.build.yml
+++ b/website/docker-compose.build.yml
@@ -1,0 +1,13 @@
+version: '3.8'
+services:
+  website:
+    build: .
+    ports:
+      - "3000:3000"
+    volumes:
+      - ../:/work/opentofu-repo
+    command:
+      - npm
+      - run
+      - build
+    restart: no

--- a/website/docker-compose.yml
+++ b/website/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+services:
+  website:
+    build: .
+    ports:
+      - "3000:3000"
+    volumes:
+      - ../:/work/opentofu-repo


### PR DESCRIPTION
This PR adds a dev server that's runnable directly from the main repository. It also adds a GitHub workflow that checks if the website build passes.

![image](https://github.com/opentofu/opentofu/assets/86970079/b2c2c002-cc2b-4f66-a7b5-35b3b0062f76)


## Target Release

1.6.0
