### PR TITLE
Updated installation instructions to packages.opentofu.org

### DIFF
--- a/website/docs/intro/install/deb-convenience.sh
+++ b/website/docs/intro/install/deb-convenience.sh
@@ -1,4 +1,4 @@
-curl --proto '=https' --tlsv1.2 -fsSL 'https://packagecloud.io/install/repositories/opentofu/tofu/script.deb.sh?any=true' -o /tmp/tofu-repository-setup.sh
+curl --proto '=https' --tlsv1.2 -fsSL 'https://packages.opentofu.org/install/repositories/opentofu/tofu/script.deb.sh?any=true' -o /tmp/tofu-repository-setup.sh
 # Inspect the downloaded script at /tmp/tofu-repository-setup.sh before running
 sudo bash /tmp/tofu-repository-setup.sh
 rm /tmp/tofu-repository-setup.sh

--- a/website/docs/intro/install/deb-step2.sh
+++ b/website/docs/intro/install/deb-step2.sh
@@ -1,3 +1,3 @@
 sudo install -m 0755 -d /etc/apt/keyrings
-curl -fsSL https://packagecloud.io/opentofu/tofu/gpgkey | sudo gpg --no-tty --batch --dearmor -o /etc/apt/keyrings/opentofu.gpg
+curl -fsSL https://packages.opentofu.org/opentofu/tofu/gpgkey | sudo gpg --no-tty --batch --dearmor -o /etc/apt/keyrings/opentofu.gpg
 sudo chmod a+r /etc/apt/keyrings/opentofu.gpg

--- a/website/docs/intro/install/deb-step3.sh
+++ b/website/docs/intro/install/deb-step3.sh
@@ -1,4 +1,4 @@
 echo \
-  "deb [signed-by=/etc/apt/keyrings/opentofu.gpg] https://packagecloud.io/opentofu/tofu/any/ any main
-deb-src [signed-by=/etc/apt/keyrings/opentofu.gpg] https://packagecloud.io/opentofu/tofu/any/ any main" | \
+  "deb [signed-by=/etc/apt/keyrings/opentofu.gpg] https://packages.opentofu.org/opentofu/tofu/any/ any main
+deb-src [signed-by=/etc/apt/keyrings/opentofu.gpg] https://packages.opentofu.org/opentofu/tofu/any/ any main" | \
   sudo tee /etc/apt/sources.list.d/opentofu.list > /dev/null

--- a/website/docs/intro/install/repo-yum.sh
+++ b/website/docs/intro/install/repo-yum.sh
@@ -1,22 +1,22 @@
 cat >/etc/yum.repos.d/opentofu.repo <<EOF
 [opentofu]
 name=opentofu
-baseurl=https://packagecloud.io/opentofu/tofu/rpm_any/rpm_any/\$basearch
+baseurl=https://packages.opentofu.org/opentofu/tofu/rpm_any/rpm_any/\$basearch
 repo_gpgcheck=1
 gpgcheck=0
 enabled=1
-gpgkey=https://packagecloud.io/opentofu/tofu/gpgkey
+gpgkey=https://packages.opentofu.org/opentofu/tofu/gpgkey
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
 metadata_expire=300
 
 [opentofu-source]
 name=opentofu-source
-baseurl=https://packagecloud.io/opentofu/tofu/rpm_any/rpm_any/SRPMS
+baseurl=https://packages.opentofu.org/opentofu/tofu/rpm_any/rpm_any/SRPMS
 repo_gpgcheck=1
 gpgcheck=0
 enabled=1
-gpgkey=https://packagecloud.io/opentofu/tofu/gpgkey
+gpgkey=https://packages.opentofu.org/opentofu/tofu/gpgkey
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
 metadata_expire=300

--- a/website/docs/intro/install/rpm-convenience-yum.sh
+++ b/website/docs/intro/install/rpm-convenience-yum.sh
@@ -1,4 +1,4 @@
-curl --proto '=https' --tlsv1.2 -fsSL 'https://packagecloud.io/install/repositories/opentofu/tofu/script.rpm.sh?any=true' -o /tmp/tofu-repository-setup.sh
+curl --proto '=https' --tlsv1.2 -fsSL 'https://packages.opentofu.org/install/repositories/opentofu/tofu/script.rpm.sh?any=true' -o /tmp/tofu-repository-setup.sh
 # Inspect the downloaded script at /tmp/tofu-repository-setup.sh before running
 sudo bash /tmp/tofu-repository-setup.sh
 rm /tmp/tofu-repository-setup.sh

--- a/website/docs/intro/install/rpm-convenience-zypper.sh
+++ b/website/docs/intro/install/rpm-convenience-zypper.sh
@@ -1,4 +1,4 @@
-curl --proto '=https' --tlsv1.2 -fsSL 'https://packagecloud.io/install/repositories/opentofu/tofu/script.rpm.sh?any=true' -o /tmp/tofu-repository-setup.sh
+curl --proto '=https' --tlsv1.2 -fsSL 'https://packages.opentofu.org/install/repositories/opentofu/tofu/script.rpm.sh?any=true' -o /tmp/tofu-repository-setup.sh
 # Inspect the downloaded script at /tmp/tofu-repository-setup.sh before running
 sudo bash /tmp/tofu-repository-setup.sh
 rm /tmp/tofu-repository-setup.sh


### PR DESCRIPTION
This PR updates the installation instructions to `packages.opentofu.org`. However, the convenience script will need rewriting as the script still loads from packagecloud.io (see [this issue](https://github.com/opentofu/opentofu/issues/979)).

## Target Release

1.6.0
