### PR TITLE
904 missing provider module message

### DIFF
--- a/internal/command/e2etest/init_test.go
+++ b/internal/command/e2etest/init_test.go
@@ -380,6 +380,9 @@ func TestInitProviderNotFound(t *testing.T) {
 │ modules are currently depending on hashicorp/nonexist, run the following
 │ command:
 │     tofu providers
+│ 
+│ If you believe this provider is missing from the registry, please submit a
+│ issue on the OpenTofu Registry https://github.com/opentofu/registry/issues/
 ╵
 
 `

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -658,6 +658,10 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 					)
 				}
 
+				if provider.Hostname == addrs.DefaultProviderRegistryHost {
+					suggestion += "\n\nIf you believe this provider is missing from registry, please submit a issue on the OpenTofu Registry https://github.com/opentofu/registry/issues/"
+				}
+
 				diags = diags.Append(tfdiags.Sourceless(
 					tfdiags.Error,
 					"Failed to query available provider packages",

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -659,7 +659,7 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 				}
 
 				if provider.Hostname == addrs.DefaultProviderRegistryHost {
-					suggestion += "\n\nIf you believe this provider is missing from registry, please submit a issue on the OpenTofu Registry https://github.com/opentofu/registry/issues/"
+					suggestion += "\n\nIf you believe this provider is missing from the registry, please submit a issue on the OpenTofu Registry https://github.com/opentofu/registry/issues/"
 				}
 
 				diags = diags.Append(tfdiags.Sourceless(

--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -436,10 +436,15 @@ func (i *ModuleInstaller) installRegistryModule(ctx context.Context, req *config
 		resp, err = reg.ModuleVersions(ctx, regsrcAddr)
 		if err != nil {
 			if registry.IsModuleNotFound(err) {
+				suggestion := ""
+				if hostname == addrs.DefaultModuleRegistryHost {
+					suggestion = "\n\nIf you believe this module is missing from registry, please submit a issue on the OpenTofu Registry https://github.com/opentofu/registry/issues/"
+				}
+
 				diags = diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Module not found",
-					Detail:   fmt.Sprintf("Module %q (from %s:%d) cannot be found in the module registry at %s.", req.Name, req.CallRange.Filename, req.CallRange.Start.Line, hostname),
+					Detail:   fmt.Sprintf("Module %s (%q from %s:%d) cannot be found in the module registry at %s.%s", addr.Package.ForRegistryProtocol(), req.Name, req.CallRange.Filename, req.CallRange.Start.Line, hostname, suggestion),
 					Subject:  req.CallRange.Ptr(),
 				})
 			} else if errors.Is(err, context.Canceled) {

--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -438,7 +438,7 @@ func (i *ModuleInstaller) installRegistryModule(ctx context.Context, req *config
 			if registry.IsModuleNotFound(err) {
 				suggestion := ""
 				if hostname == addrs.DefaultModuleRegistryHost {
-					suggestion = "\n\nIf you believe this module is missing from registry, please submit a issue on the OpenTofu Registry https://github.com/opentofu/registry/issues/"
+					suggestion = "\n\nIf you believe this module is missing from the registry, please submit a issue on the OpenTofu Registry https://github.com/opentofu/registry/issues/"
 				}
 
 				diags = diags.Append(&hcl.Diagnostic{


### PR DESCRIPTION
Added a helpful message to point people at the correct location to submit modules/providers.

## Examples:
### Provider
```hcl
terraform {
  required_providers {
    foo = {
      source = "invalid"
    }
  }
}
```
```
$ ~/go/bin/tofu init

Initializing the backend...

Initializing provider plugins...
- Finding latest version of hashicorp/invalid...
╷
│ Error: Failed to query available provider packages
│ 
│ Could not retrieve the list of available versions for provider hashicorp/invalid: provider registry registry.opentofu.org does not have a provider named registry.opentofu.org/hashicorp/invalid
│ 
│ All modules should specify their required_providers so that external consumers will get the correct providers when using a module. To see which modules are currently depending on hashicorp/invalid, run the following command:
│     tofu providers
│ 
│ If you believe this provider is missing from registry, please submit a issue on the OpenTofu Registry https://github.com/opentofu/registry/issues/
╵

```

### Module
```hcl
module bar {
        source = "namespace/invalid/missing"
}
```
```
$ ~/go/bin/tofu init

Initializing the backend...
Initializing modules...
╷
│ Error: Module not found
│ 
│   on main.tf line 1:
│    1: module bar {
│ 
│ Module namespace/invalid/missing ("bar" from main.tf:1) cannot be found in the module registry at registry.opentofu.org.
│ 
│ If you believe this module is missing from registry, please submit a issue on the OpenTofu Registry https://github.com/opentofu/registry/issues/
╵

```

Resolves #904

## Target Release

1.6.0
