### PR TITLE
Rewrite provider namespace hashicorp -> opentofu

### DIFF
--- a/internal/configs/provider_requirements.go
+++ b/internal/configs/provider_requirements.go
@@ -9,6 +9,7 @@ import (
 	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/opentofu/opentofu/internal/addrs"
+	tfaddr "github.com/opentofu/registry-address"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -240,6 +241,10 @@ func decodeRequiredProvidersBlock(block *hcl.Block) (*RequiredProviders, hcl.Dia
 			} else {
 				rp.Type = addrs.ImpliedProviderForUnqualifiedType(pType)
 			}
+		}
+
+		if rp.Type.Namespace == "hashicorp" && rp.Type.Hostname == tfaddr.DefaultProviderRegistryHost {
+			rp.Type.Namespace = "opentofu"
 		}
 
 		ret.RequiredProviders[rp.Name] = rp

--- a/internal/tofumigrate/tofumigrate.go
+++ b/internal/tofumigrate/tofumigrate.go
@@ -53,6 +53,9 @@ func MigrateStateProviderAddresses(config *configs.Config, state *states.State) 
 			if resource.ProviderConfig.Provider.Hostname == "registry.terraform.io" && !referencedInConfig {
 				resource.ProviderConfig.Provider.Hostname = tfaddr.DefaultProviderRegistryHost
 			}
+			if resource.ProviderConfig.Provider.Namespace == "hashicorp" && resource.ProviderConfig.Provider.Hostname == tfaddr.DefaultProviderRegistryHost {
+				resource.ProviderConfig.Provider.Namespace = "opentofu"
+			}
 		}
 	}
 

--- a/internal/tofumigrate/tofumigrate_test.go
+++ b/internal/tofumigrate/tofumigrate_test.go
@@ -67,7 +67,7 @@ func TestMigrateStateProviderAddresses(t *testing.T) {
 						Status:    states.ObjectReady,
 						AttrsJSON: []byte(`{}`),
 					},
-					makeRootProviderAddr("registry.opentofu.org/hashicorp/random"),
+					makeRootProviderAddr("registry.opentofu.org/opentofu/random"),
 				)
 				s.SetResourceInstanceCurrent(
 					mustParseInstAddr("aws_instance.example"),
@@ -75,7 +75,7 @@ func TestMigrateStateProviderAddresses(t *testing.T) {
 						Status:    states.ObjectReady,
 						AttrsJSON: []byte(`{}`),
 					},
-					makeRootProviderAddr("registry.opentofu.org/hashicorp/aws"),
+					makeRootProviderAddr("registry.opentofu.org/opentofu/aws"),
 				)
 			}),
 		},
@@ -109,7 +109,7 @@ func TestMigrateStateProviderAddresses(t *testing.T) {
 						Status:    states.ObjectReady,
 						AttrsJSON: []byte(`{}`),
 					},
-					makeRootProviderAddr("registry.opentofu.org/hashicorp/random"),
+					makeRootProviderAddr("registry.opentofu.org/opentofu/random"),
 				)
 				s.SetResourceInstanceCurrent(
 					mustParseInstAddr("aws_instance.example"),
@@ -132,7 +132,7 @@ func TestMigrateStateProviderAddresses(t *testing.T) {
 							Status:    states.ObjectReady,
 							AttrsJSON: []byte(`{}`),
 						},
-						makeRootProviderAddr("registry.opentofu.org/hashicorp/random"),
+						makeRootProviderAddr("registry.opentofu.org/opentofu/random"),
 					)
 					s.SetResourceInstanceCurrent(
 						mustParseInstAddr("aws_instance.example"),
@@ -140,7 +140,7 @@ func TestMigrateStateProviderAddresses(t *testing.T) {
 							Status:    states.ObjectReady,
 							AttrsJSON: []byte(`{}`),
 						},
-						makeRootProviderAddr("registry.opentofu.org/hashicorp/aws"),
+						makeRootProviderAddr("registry.opentofu.org/opentofu/aws"),
 					)
 				}),
 			},
@@ -151,7 +151,7 @@ func TestMigrateStateProviderAddresses(t *testing.T) {
 						Status:    states.ObjectReady,
 						AttrsJSON: []byte(`{}`),
 					},
-					makeRootProviderAddr("registry.opentofu.org/hashicorp/random"),
+					makeRootProviderAddr("registry.opentofu.org/opentofu/random"),
 				)
 				s.SetResourceInstanceCurrent(
 					mustParseInstAddr("aws_instance.example"),
@@ -159,7 +159,7 @@ func TestMigrateStateProviderAddresses(t *testing.T) {
 						Status:    states.ObjectReady,
 						AttrsJSON: []byte(`{}`),
 					},
-					makeRootProviderAddr("registry.opentofu.org/hashicorp/aws"),
+					makeRootProviderAddr("registry.opentofu.org/opentofu/aws"),
 				)
 			}),
 		},


### PR DESCRIPTION
## This is blocked as https://github.com/opentofu/opentofu/pull/995 reverted the broken namespace defaults. 

I'm going to leave this open for now as we consider re-adding those changes in a future version.

# Proposal

## Summary
This set of changes create the rule that *every* hashicorp provider will be exactly mirrored into the opentofu namespace under the same name.  This solves the issue of a given configuration containing `opentofu/xyz`, `hashicorp/xyz` and `xyz`, which are all effectively the same provider and should share configuration / version requirements.   This would allow the change to the default provider namespace to opentofu to go forward without breaking any existing configurations/states.

## Caveats

By design, this would require our registry to keep a copy of every hashicorp provider in the opentofu namespace (which we currently do).  It would prevent us from making changes to the opentofu direct forks of of hashicorp's provider.

If we wished to make a "true" fork of any hashicorp provider, we would be required to choose a new name.  For example:  A true fork of `hasicorp/aws` / `opentofu/aws` / `aws` could be named `aws-ng` or similar.  This would be a clear indicator that this forked provider is differing from the upstream terraform-provider-aws repository and may require a migration.

To make this process easier, we could introduce the idea of user supplied provider substitutions.  For example:
```hcl
provider_substitutions {
  "opentofu/aws" = "opentofu/aws-ng"
}
```
This is not required but may be a helpful feature to consider down the line for this and other use cases.


# Details

Ideally we would be able to support both hashicorp and opentofu provider namespaces in tofu. Unfortunately there are some odd version constraints at play.

Example: (usually split between submodules)
```hcl
terraform {
	required_providers {
		nonamespace = {
			source = "tfcoremock"
		}
		legacynamespace = {
			source = "hashicorp/tfcoremock"
			version = "0.1.3"
		}
	}
}
```

In prior versions, the version requirement would propagate to both providers as "tfcoremock" would have the default namespace "hashicorp" added. As of #973 the namespace now defaults to "opentofu". As a result, "tfcoremock" -> "opentofu/tfcoremock" does not share version requirements with "hashicorp/tfcoremock"

Workflow: hcl -> config -> gatherProviderReqss -> enforceProviderReqs

There are a few potential approaches to fix this.

The approach taken here is likely the simplest, though I'm not a fan of how it rewrites the config at such a deep level.

Another approach considered was to add a tofumigrate function that is called from init. This would rewrite the config after it's already been built but before it is enforced. Unfortunately, during the config building process, it is easy for provider FQNs to be copied and used through other dependent blocks. For example, a resource that uses a provider will *copy* the provider name during the config loading process. Finding all of these edge cases could prove to be problematic.

Another approach considered was to enhance the version requirements enforcer to merge checks between different providers.  Modifying the enforcement should be seriously considered as an alternative to the approach implemented in this commit.  It also would not require migrating the provider namespaces in the statefile.

In all of these approaches, there is a precedence being set that we also need to consider.  Does provider namespace "hashicorp" == "opentofu". As of today it does, but what happens in the future when an opentofu provider diverges from hashicorp?  My recommendation on how to handle this is to state clearly that "Hashicorp providers are not supported in opentofu and will be automatically migrated to the default opentofu namespace".  This solves the problem we are facing of compatability today, and provides us wiggle room in the future if that divergence ever happens.

There is a followup question though from that precedence.  How should we handle registry.terraform.io/hashicorp/name provider entries?  These are not currently migrated and would have already diverged early on when the default registry host was changed to registry.opentofu.org. As stated above, this is a divergence from previous versions where: "registry.terraform.io/hashicorp/name" == "hashicorp/name" == "name".

Resolves #988

## Target Release

1.6.0
