### PR TITLE
Add gate for TFE tests that use the network

### DIFF
--- a/internal/cloud/backend_plan_test.go
+++ b/internal/cloud/backend_plan_test.go
@@ -399,7 +399,7 @@ func TestCloud_planWithPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error loading cloud plan file: %v", err)
 	}
-	if !strings.Contains(plan.RunID, "run-") || plan.Hostname != "app.terraform.io" {
+	if !strings.Contains(plan.RunID, "run-") || plan.Hostname != tfeHost {
 		t.Fatalf("unexpected contents in saved cloud plan: %v", plan)
 	}
 

--- a/internal/cloud/backend_show_test.go
+++ b/internal/cloud/backend_show_test.go
@@ -38,7 +38,7 @@ func TestCloud_showMissingRun(t *testing.T) {
 	mockSROWorkspace(t, b, testBackendSingleWorkspaceName)
 
 	absentRunID := "run-WwwwXxxxYyyyZzzz"
-	_, err := b.ShowPlanForRun(context.Background(), absentRunID, "app.terraform.io", true)
+	_, err := b.ShowPlanForRun(context.Background(), absentRunID, tfeHost, true)
 	if !strings.Contains(err.Error(), "tofu login") {
 		t.Fatalf("expected error message to suggest checking your login status, instead got: %s", err)
 	}
@@ -57,7 +57,7 @@ func TestCloud_showMissingUnredactedJson(t *testing.T) {
 		t.Fatalf("failed to init test data: %s", err)
 	}
 	// Showing the human-formatted plan should still work as expected!
-	redacted, err := b.ShowPlanForRun(ctx, runID, "app.terraform.io", true)
+	redacted, err := b.ShowPlanForRun(ctx, runID, tfeHost, true)
 	if err != nil {
 		t.Fatalf("failed to show plan for human, even though redacted json should be present: %s", err)
 	}
@@ -80,7 +80,7 @@ func TestCloud_showMissingUnredactedJson(t *testing.T) {
 	}
 
 	// But show -json should result in a special error.
-	_, err = b.ShowPlanForRun(ctx, runID, "app.terraform.io", false)
+	_, err = b.ShowPlanForRun(ctx, runID, tfeHost, false)
 	if err == nil {
 		t.Fatalf("unexpected success: reading unredacted json without admin permissions should have errored")
 	}
@@ -102,7 +102,7 @@ func TestCloud_showIncludesUnredactedJson(t *testing.T) {
 		t.Fatalf("failed to init test data: %s", err)
 	}
 	// Showing the human-formatted plan should work as expected:
-	redacted, err := b.ShowPlanForRun(ctx, runID, "app.terraform.io", true)
+	redacted, err := b.ShowPlanForRun(ctx, runID, tfeHost, true)
 	if err != nil {
 		t.Fatalf("failed to show plan for human, even though redacted json should be present: %s", err)
 	}
@@ -110,7 +110,7 @@ func TestCloud_showIncludesUnredactedJson(t *testing.T) {
 		t.Fatalf("show for human doesn't include expected redacted json content")
 	}
 	// Showing the external json plan format should work as expected:
-	unredacted, err := b.ShowPlanForRun(ctx, runID, "app.terraform.io", false)
+	unredacted, err := b.ShowPlanForRun(ctx, runID, tfeHost, false)
 	if err != nil {
 		t.Fatalf("failed to show plan for robot, even though unredacted json should be present: %s", err)
 	}
@@ -131,7 +131,7 @@ func TestCloud_showNoChanges(t *testing.T) {
 		t.Fatalf("failed to init test data: %s", err)
 	}
 	// Showing the human-formatted plan should work as expected:
-	redacted, err := b.ShowPlanForRun(ctx, runID, "app.terraform.io", true)
+	redacted, err := b.ShowPlanForRun(ctx, runID, tfeHost, true)
 	if err != nil {
 		t.Fatalf("failed to show plan for human, even though redacted json should be present: %s", err)
 	}
@@ -163,7 +163,7 @@ func TestCloud_showFooterNotConfirmable(t *testing.T) {
 	mc.Runs.Runs[runID].Actions.IsConfirmable = false
 
 	// Showing the human-formatted plan should work as expected:
-	redacted, err := b.ShowPlanForRun(ctx, runID, "app.terraform.io", true)
+	redacted, err := b.ShowPlanForRun(ctx, runID, tfeHost, true)
 	if err != nil {
 		t.Fatalf("failed to show plan for human, even though redacted json should be present: %s", err)
 	}

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -469,7 +469,7 @@ func TestCloud_config(t *testing.T) {
 
 func TestCloud_configVerifyMinimumTFEVersion(t *testing.T) {
 	config := cty.ObjectVal(map[string]cty.Value{
-		"hostname":     cty.StringVal("app.terraform.io"),
+		"hostname":     cty.StringVal(tfeHost),
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),
 		"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -506,7 +506,7 @@ func TestCloud_configVerifyMinimumTFEVersion(t *testing.T) {
 
 func TestCloud_configVerifyMinimumTFEVersionInAutomation(t *testing.T) {
 	config := cty.ObjectVal(map[string]cty.Value{
-		"hostname":     cty.StringVal("app.terraform.io"),
+		"hostname":     cty.StringVal(tfeHost),
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),
 		"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -550,7 +550,7 @@ func TestCloud_setUnavailableTerraformVersion(t *testing.T) {
 	workspaceName := "unavailable-terraform-version"
 
 	config := cty.ObjectVal(map[string]cty.Value{
-		"hostname":     cty.StringVal("app.terraform.io"),
+		"hostname":     cty.StringVal(tfeHost),
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),
 		"workspaces": cty.ObjectVal(map[string]cty.Value{
@@ -1293,7 +1293,7 @@ func TestCloud_ServiceDiscoveryAliases(t *testing.T) {
 	b := New(testDisco(s))
 
 	diag := b.Configure(cty.ObjectVal(map[string]cty.Value{
-		"hostname":     cty.StringVal("app.terraform.io"),
+		"hostname":     cty.StringVal(tfeHost),
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),
 		"workspaces": cty.ObjectVal(map[string]cty.Value{


### PR DESCRIPTION
We don't want opentofu to connect to app.terraform.io during testing, unless explicitly specified.

Validation was performed by unplugging my network cable and adding the skipIfTFENotEnabled(t) where nessesary.

Related to https://github.com/opentofu/opentofu/issues/898

## Target Release

1.6.0
