### PR TITLE
Fixes #915: GPG signing of Debian and RPM packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-
+    environment: gpg
     permissions:
       contents: write
       id-token: write
@@ -68,14 +68,40 @@ jobs:
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_TOKEN }}
 
+      - name: Import GPG key
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        id: import_gpg
+        run: |
+          GPG_KEY_FILE=/tmp/signing-key.gpg
+          echo "${{ secrets.GPG_PRIVATE_KEY }}" | base64 --decode > $GPG_KEY_FILE
+          
+          echo "${{ secrets.GPG_PRIVATE_KEY }}" | base64 --decode | gpg --import
+          FINGERPRINT=$(gpg --list-secret-keys --keyid-format LONG | awk '/^sec/{sub(/.*\//, "", $2); print $2; exit}')
+          
+          echo "::set-output name=fingerprint::${FINGERPRINT}"
+          echo "::set-output name=file::${GPG_KEY_FILE}"
+        env:
+          GPG_TTY: /dev/ttys000  # Set the GPG_TTY to avoid issues with pinentry
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
           version: v1.21.2
           args: release --clean --timeout=60m --snapshot=${{ !startsWith(github.ref, 'refs/tags/v') }}
         env:
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GPG_KEY_FILE: ${{steps.import_gpg.outputs.file }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_TOKEN }}
+
+      - name: Remove GPG key
+        if: always()
+        env:
+          GPG_KEY_FILE: ${{ steps.import_gpg.outputs.file }}
+        run:
+          rm -rf ~/.gnupg
+          rm -rf "$GPG_KEY_FILE"
+
       - name: Upload Debian packages to PackageCloud
         uses: computology/packagecloud-github-action@v0.6
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -180,6 +180,12 @@ nfpms:
         dst: /usr/share/doc/opentofu/copyright
         file_info:
           mode: 0444
+    rpm:
+      signature:
+        key_file: "{{.Env.GPG_KEY_FILE}}"
+    deb:
+      signature:
+        key_file: "{{.Env.GPG_KEY_FILE}}"
 
 snapcrafts:
   - name: opentofu


### PR DESCRIPTION
This PR adds GPG signing for Debian and RPM packages so they can be verified when downloaded from the package repository.

Resolves #915

## Target Release

1.6.0
