### PR TITLE
Find additional places where terraform should be replaced with tofu

### DIFF
--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -39,7 +39,7 @@ const (
 	defaultParallelism = 10
 	stateServiceID     = "state.v2"
 	tfeServiceID       = "tfe.v2.1"
-	genericHostname    = "localterraform.com"
+	genericHostname    = "localtofu.com"
 )
 
 // Remote is an implementation of EnhancedBackend that performs all

--- a/internal/cloud/e2e/main_test.go
+++ b/internal/cloud/e2e/main_test.go
@@ -18,7 +18,7 @@ import (
 	tfversion "github.com/opentofu/opentofu/version"
 )
 
-var terraformBin string
+var tofuBin string
 var cliConfigFileEnv string
 
 var tfeClient *tfe.Client
@@ -91,7 +91,7 @@ func testRunner(t *testing.T, cases testCases, orgCount int, tfEnvFlags ...strin
 
 			tmpDir := t.TempDir()
 
-			tf := e2e.NewBinary(t, terraformBin, tmpDir)
+			tf := e2e.NewBinary(t, tofuBin, tmpDir)
 			tfEnvFlags = append(tfEnvFlags, "TF_LOG=INFO")
 			tfEnvFlags = append(tfEnvFlags, cliConfigFileEnv)
 			for _, env := range tfEnvFlags {
@@ -221,7 +221,7 @@ func setupBinary() func() {
 	credFile := fmt.Sprintf("%s/dev.tfrc", tmpTerraformBinaryDir)
 	writeCredRC(credFile)
 
-	terraformBin = fmt.Sprintf("%s/terraform", tmpTerraformBinaryDir)
+	tofuBin = fmt.Sprintf("%s/terraform", tmpTerraformBinaryDir)
 	cliConfigFileEnv = fmt.Sprintf("TF_CLI_CONFIG_FILE=%s", credFile)
 
 	return func() {

--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -1734,7 +1734,7 @@ func TestApply_disableBackup(t *testing.T) {
 }
 
 // Test that the Terraform env is passed through
-func TestApply_terraformEnv(t *testing.T) {
+func TestApply_tofuEnv(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-tofu-workspace"), td)
@@ -1771,7 +1771,7 @@ output = default
 }
 
 // Test that the Terraform env is passed through
-func TestApply_terraformEnvNonDefault(t *testing.T) {
+func TestApply_tofuEnvNonDefault(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-tofu-workspace"), td)

--- a/internal/command/e2etest/automation_test.go
+++ b/internal/command/e2etest/automation_test.go
@@ -25,7 +25,7 @@ func TestPlanApplyInAutomation(t *testing.T) {
 	skipIfCannotAccessNetwork(t)
 
 	fixturePath := filepath.Join("testdata", "full-workflow-null")
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+	tf := e2e.NewBinary(t, tofuBin, fixturePath)
 
 	// We advertise that _any_ non-empty value works, so we'll test something
 	// unconventional here.
@@ -132,7 +132,7 @@ func TestAutoApplyInAutomation(t *testing.T) {
 	skipIfCannotAccessNetwork(t)
 
 	fixturePath := filepath.Join("testdata", "full-workflow-null")
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+	tf := e2e.NewBinary(t, tofuBin, fixturePath)
 
 	// We advertise that _any_ non-empty value works, so we'll test something
 	// unconventional here.
@@ -198,7 +198,7 @@ func TestPlanOnlyInAutomation(t *testing.T) {
 	skipIfCannotAccessNetwork(t)
 
 	fixturePath := filepath.Join("testdata", "full-workflow-null")
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+	tf := e2e.NewBinary(t, tofuBin, fixturePath)
 
 	// We advertise that _any_ non-empty value works, so we'll test something
 	// unconventional here.

--- a/internal/command/e2etest/init_test.go
+++ b/internal/command/e2etest/init_test.go
@@ -28,7 +28,7 @@ func TestInitProviders(t *testing.T) {
 	skipIfCannotAccessNetwork(t)
 
 	fixturePath := filepath.Join("testdata", "template-provider")
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+	tf := e2e.NewBinary(t, tofuBin, fixturePath)
 
 	stdout, stderr, err := tf.Run("init")
 	if err != nil {
@@ -61,7 +61,7 @@ func TestInitProvidersInternal(t *testing.T) {
 	// provider is internal to the core tofu binary.
 
 	fixturePath := filepath.Join("testdata", "tf-provider")
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+	tf := e2e.NewBinary(t, tofuBin, fixturePath)
 
 	stdout, stderr, err := tf.Run("init")
 	if err != nil {
@@ -100,7 +100,7 @@ func TestInitProvidersVendored(t *testing.T) {
 	skipIfCannotAccessNetwork(t)
 
 	fixturePath := filepath.Join("testdata", "vendored-provider")
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+	tf := e2e.NewBinary(t, tofuBin, fixturePath)
 
 	// Our fixture dir has a generic os_arch dir, which we need to customize
 	// to the actual OS/arch where this test is running in order to get the
@@ -143,7 +143,7 @@ func TestInitProvidersLocalOnly(t *testing.T) {
 	// the test fixture.)
 
 	fixturePath := filepath.Join("testdata", "local-only-provider")
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+	tf := e2e.NewBinary(t, tofuBin, fixturePath)
 	// If you run this test on a workstation with a plugin-cache directory
 	// configured, it will leave a bad directory behind and tofu init will
 	// not work until you remove it.
@@ -193,7 +193,7 @@ func TestInitProvidersCustomMethod(t *testing.T) {
 	for _, configFile := range []string{"cliconfig.tfrc", "cliconfig.tfrc.json"} {
 		t.Run(configFile, func(t *testing.T) {
 			fixturePath := filepath.Join("testdata", "custom-provider-install-method")
-			tf := e2e.NewBinary(t, terraformBin, fixturePath)
+			tf := e2e.NewBinary(t, tofuBin, fixturePath)
 
 			// Our fixture dir has a generic os_arch dir, which we need to customize
 			// to the actual OS/arch where this test is running in order to get the
@@ -238,7 +238,7 @@ func TestInitProviders_pluginCache(t *testing.T) {
 	skipIfCannotAccessNetwork(t)
 
 	fixturePath := filepath.Join("testdata", "plugin-cache")
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+	tf := e2e.NewBinary(t, tofuBin, fixturePath)
 
 	// Our fixture dir has a generic os_arch dir, which we need to customize
 	// to the actual OS/arch where this test is running in order to get the
@@ -294,7 +294,7 @@ func TestInit_fromModule(t *testing.T) {
 	skipIfCannotAccessNetwork(t)
 
 	fixturePath := filepath.Join("testdata", "empty")
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+	tf := e2e.NewBinary(t, tofuBin, fixturePath)
 
 	cmd := tf.Cmd("init", "-from-module=hashicorp/vault/aws")
 	cmd.Stdin = nil
@@ -327,7 +327,7 @@ func TestInitProviderNotFound(t *testing.T) {
 	skipIfCannotAccessNetwork(t)
 
 	fixturePath := filepath.Join("testdata", "provider-not-found")
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+	tf := e2e.NewBinary(t, tofuBin, fixturePath)
 
 	t.Run("registry provider not found", func(t *testing.T) {
 		_, stderr, err := tf.Run("init", "-no-color")
@@ -402,7 +402,7 @@ func TestInitProviderNotFound(t *testing.T) {
 //	skipIfCannotAccessNetwork(t)
 //
 //	fixturePath := filepath.Join("testdata", "provider-warnings")
-//	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+//	tf := e2e.NewBinary(t, tofuBin, fixturePath)
 //
 //	stdout, _, err := tf.Run("init")
 //	if err == nil {

--- a/internal/command/e2etest/main_test.go
+++ b/internal/command/e2etest/main_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/opentofu/opentofu/internal/e2e"
 )
 
-var terraformBin string
+var tofuBin string
 
 // canRunGoBuild is a short-term compromise to account for the fact that we
 // have a small number of tests that work by building helper programs using
@@ -23,7 +23,7 @@ var terraformBin string
 // (test plugins, etc) as part of the initial suite setup, and in the
 // make-archive.sh script, so that we can run all of the tests in both
 // situations with the tests just using the executable already built for
-// them, as we do for terraformBin.
+// them, as we do for tofuBin.
 var canRunGoBuild bool
 
 func TestMain(m *testing.M) {
@@ -34,14 +34,14 @@ func TestMain(m *testing.M) {
 }
 
 func setup() func() {
-	if terraformBin != "" {
+	if tofuBin != "" {
 		// this is pre-set when we're running in a binary produced from
 		// the make-archive.sh script, since that is for testing an
 		// executable obtained from a real release package. However, we do
 		// need to turn it into an absolute path so that we can find it
 		// when we change the working directory during tests.
 		var err error
-		terraformBin, err = filepath.Abs(terraformBin)
+		tofuBin, err = filepath.Abs(tofuBin)
 		if err != nil {
 			panic(fmt.Sprintf("failed to find absolute path of tofu executable: %s", err))
 		}
@@ -51,7 +51,7 @@ func setup() func() {
 	tmpFilename := e2e.GoBuild("github.com/opentofu/opentofu/cmd/tofu", "tofu")
 
 	// Make the executable available for use in tests
-	terraformBin = tmpFilename
+	tofuBin = tmpFilename
 
 	// Tests running in the ad-hoc testing mode are allowed to use "go build"
 	// and similar to produce other test executables.

--- a/internal/command/e2etest/make-archive.sh
+++ b/internal/command/e2etest/make-archive.sh
@@ -34,7 +34,7 @@ GOEXE="$(go env GOEXE)"
 OUTDIR="build/${GOOS}_${GOARCH}"
 OUTFILE="tofu-e2etest_${GOOS}_${GOARCH}.zip"
 
-LDFLAGS="-X github.com/opentofu/opentofu/internal/command/e2etest.terraformBin=./tofu$GOEXE"
+LDFLAGS="-X github.com/opentofu/opentofu/internal/command/e2etest.tofuBin=./tofu$GOEXE"
 # Caller may pass in the environment variable GO_LDFLAGS with additional
 # flags we'll use when building.
 if [ -n "${GO_LDFLAGS+set}" ]; then

--- a/internal/command/e2etest/module_archive_test.go
+++ b/internal/command/e2etest/module_archive_test.go
@@ -18,7 +18,7 @@ func TestInitModuleArchive(t *testing.T) {
 	skipIfCannotAccessNetwork(t)
 
 	fixturePath := filepath.Join("testdata", "module-archive")
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+	tf := e2e.NewBinary(t, tofuBin, fixturePath)
 
 	stdout, stderr, err := tf.Run("init")
 	if err != nil {

--- a/internal/command/e2etest/primary_test.go
+++ b/internal/command/e2etest/primary_test.go
@@ -32,7 +32,7 @@ func TestPrimarySeparatePlan(t *testing.T) {
 	skipIfCannotAccessNetwork(t)
 
 	fixturePath := filepath.Join("testdata", "full-workflow-null")
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+	tf := e2e.NewBinary(t, tofuBin, fixturePath)
 
 	//// INIT
 	stdout, stderr, err := tf.Run("init")
@@ -152,7 +152,7 @@ func TestPrimaryChdirOption(t *testing.T) {
 	// safe to run it even when network access is disallowed.
 
 	fixturePath := filepath.Join("testdata", "chdir-option")
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+	tf := e2e.NewBinary(t, tofuBin, fixturePath)
 
 	//// INIT
 	_, stderr, err := tf.Run("-chdir=subdir", "init")

--- a/internal/command/e2etest/provider_dev_test.go
+++ b/internal/command/e2etest/provider_dev_test.go
@@ -30,7 +30,7 @@ func TestProviderDevOverrides(t *testing.T) {
 	}
 	t.Parallel()
 
-	tf := e2e.NewBinary(t, terraformBin, "testdata/provider-dev-override")
+	tf := e2e.NewBinary(t, tofuBin, "testdata/provider-dev-override")
 
 	// In order to do a decent end-to-end test for this case we will need a
 	// real enough provider plugin to try to run and make sure we are able

--- a/internal/command/e2etest/provider_plugin_test.go
+++ b/internal/command/e2etest/provider_plugin_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/opentofu/opentofu/internal/getproviders"
 )
 
-// TestProviderProtocols verifies that Terraform can execute provider plugins
+// TestProviderProtocols verifies that OpenTofu can execute provider plugins
 // with both supported protocol versions.
 func TestProviderProtocols(t *testing.T) {
 	if !canRunGoBuild {
@@ -26,7 +26,7 @@ func TestProviderProtocols(t *testing.T) {
 	}
 	t.Parallel()
 
-	tf := e2e.NewBinary(t, terraformBin, "testdata/provider-plugin")
+	tf := e2e.NewBinary(t, tofuBin, "testdata/provider-plugin")
 
 	// In order to do a decent end-to-end test for this case we will need a real
 	// enough provider plugin to try to run and make sure we are able to

--- a/internal/command/e2etest/providers_mirror_test.go
+++ b/internal/command/e2etest/providers_mirror_test.go
@@ -37,7 +37,7 @@ func testTerraformProvidersMirror(t *testing.T, fixture string) {
 	t.Logf("creating mirror directory in %s", outputDir)
 
 	fixturePath := filepath.Join("testdata", fixture)
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+	tf := e2e.NewBinary(t, tofuBin, fixturePath)
 
 	stdout, stderr, err := tf.Run("providers", "mirror", "-platform=linux_amd64", "-platform=windows_386", outputDir)
 	if err != nil {

--- a/internal/command/e2etest/providers_tamper_test.go
+++ b/internal/command/e2etest/providers_tamper_test.go
@@ -29,7 +29,7 @@ func TestProviderTampering(t *testing.T) {
 	skipIfCannotAccessNetwork(t)
 
 	fixturePath := filepath.Join("testdata", "provider-tampering-base")
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+	tf := e2e.NewBinary(t, tofuBin, fixturePath)
 
 	stdout, stderr, err := tf.Run("init")
 	if err != nil {
@@ -53,7 +53,7 @@ func TestProviderTampering(t *testing.T) {
 	providerCacheDir := filepath.Join(".terraform", "providers")
 
 	t.Run("cache dir totally gone", func(t *testing.T) {
-		tf := e2e.NewBinary(t, terraformBin, seedDir)
+		tf := e2e.NewBinary(t, tofuBin, seedDir)
 		workDir := tf.WorkDir()
 
 		err := os.RemoveAll(filepath.Join(workDir, ".terraform"))
@@ -83,7 +83,7 @@ func TestProviderTampering(t *testing.T) {
 		}
 	})
 	t.Run("cache dir totally gone, explicit backend", func(t *testing.T) {
-		tf := e2e.NewBinary(t, terraformBin, seedDir)
+		tf := e2e.NewBinary(t, tofuBin, seedDir)
 		workDir := tf.WorkDir()
 
 		err := os.WriteFile(filepath.Join(workDir, "backend.tf"), []byte(localBackendConfig), 0600)
@@ -118,7 +118,7 @@ func TestProviderTampering(t *testing.T) {
 		}
 	})
 	t.Run("null plugin package modified before plan", func(t *testing.T) {
-		tf := e2e.NewBinary(t, terraformBin, seedDir)
+		tf := e2e.NewBinary(t, tofuBin, seedDir)
 		workDir := tf.WorkDir()
 
 		err := os.WriteFile(filepath.Join(workDir, pluginExe), []byte("tamper"), 0600)
@@ -138,7 +138,7 @@ func TestProviderTampering(t *testing.T) {
 		}
 	})
 	t.Run("version constraint changed in config before plan", func(t *testing.T) {
-		tf := e2e.NewBinary(t, terraformBin, seedDir)
+		tf := e2e.NewBinary(t, tofuBin, seedDir)
 		workDir := tf.WorkDir()
 
 		err := os.WriteFile(filepath.Join(workDir, "provider-tampering-base.tf"), []byte(`
@@ -167,7 +167,7 @@ func TestProviderTampering(t *testing.T) {
 		}
 	})
 	t.Run("lock file modified before plan", func(t *testing.T) {
-		tf := e2e.NewBinary(t, terraformBin, seedDir)
+		tf := e2e.NewBinary(t, tofuBin, seedDir)
 		workDir := tf.WorkDir()
 
 		// NOTE: We're just emptying out the lock file here because that's
@@ -193,7 +193,7 @@ func TestProviderTampering(t *testing.T) {
 		}
 	})
 	t.Run("lock file modified after plan", func(t *testing.T) {
-		tf := e2e.NewBinary(t, terraformBin, seedDir)
+		tf := e2e.NewBinary(t, tofuBin, seedDir)
 		workDir := tf.WorkDir()
 
 		_, stderr, err := tf.Run("plan", "-out", "tfplan")
@@ -218,7 +218,7 @@ func TestProviderTampering(t *testing.T) {
 		}
 	})
 	t.Run("plugin cache dir entirely removed after plan", func(t *testing.T) {
-		tf := e2e.NewBinary(t, terraformBin, seedDir)
+		tf := e2e.NewBinary(t, tofuBin, seedDir)
 		workDir := tf.WorkDir()
 
 		_, stderr, err := tf.Run("plan", "-out", "tfplan")
@@ -240,7 +240,7 @@ func TestProviderTampering(t *testing.T) {
 		}
 	})
 	t.Run("null plugin package modified after plan", func(t *testing.T) {
-		tf := e2e.NewBinary(t, terraformBin, seedDir)
+		tf := e2e.NewBinary(t, tofuBin, seedDir)
 		workDir := tf.WorkDir()
 
 		_, stderr, err := tf.Run("plan", "-out", "tfplan")

--- a/internal/command/e2etest/provisioner_plugin_test.go
+++ b/internal/command/e2etest/provisioner_plugin_test.go
@@ -30,7 +30,7 @@ func TestProvisionerPlugin(t *testing.T) {
 	// allowed.
 	skipIfCannotAccessNetwork(t)
 
-	tf := e2e.NewBinary(t, terraformBin, "testdata/provisioner-plugin")
+	tf := e2e.NewBinary(t, tofuBin, "testdata/provisioner-plugin")
 
 	// In order to do a decent end-to-end test for this case we will need a
 	// real enough provisioner plugin to try to run and make sure we are able

--- a/internal/command/e2etest/provisioner_test.go
+++ b/internal/command/e2etest/provisioner_test.go
@@ -20,7 +20,7 @@ func TestProvisioner(t *testing.T) {
 	// allowed.
 	skipIfCannotAccessNetwork(t)
 
-	tf := e2e.NewBinary(t, terraformBin, "testdata/provisioner")
+	tf := e2e.NewBinary(t, tofuBin, "testdata/provisioner")
 
 	//// INIT
 	_, stderr, err := tf.Run("init")

--- a/internal/command/e2etest/remote_state_test.go
+++ b/internal/command/e2etest/remote_state_test.go
@@ -11,11 +11,11 @@ import (
 )
 
 func TestTerraformProviderRead(t *testing.T) {
-	// Ensure the terraform provider can correctly read a remote state
+	// Ensure the tofu provider can correctly read a remote state
 
 	t.Parallel()
 	fixturePath := filepath.Join("testdata", "tf-provider")
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+	tf := e2e.NewBinary(t, tofuBin, fixturePath)
 
 	//// INIT
 	_, stderr, err := tf.Run("init")

--- a/internal/command/e2etest/test_test.go
+++ b/internal/command/e2etest/test_test.go
@@ -20,7 +20,7 @@ func TestMultipleRunBlocks(t *testing.T) {
 
 	go func() {
 		fixturePath := filepath.Join("testdata", "multiple-run-blocks")
-		tf := e2e.NewBinary(t, terraformBin, fixturePath)
+		tf := e2e.NewBinary(t, tofuBin, fixturePath)
 		stdout, stderr, err := tf.Run("test")
 		done <- &testResult{
 			stdout: stdout,

--- a/internal/command/e2etest/tf_provider_data_test.go
+++ b/internal/command/e2etest/tf_provider_data_test.go
@@ -15,7 +15,7 @@ import (
 func TestTerraformProviderData(t *testing.T) {
 
 	fixturePath := filepath.Join("testdata", "tofu-managed-data")
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+	tf := e2e.NewBinary(t, tofuBin, fixturePath)
 
 	_, stderr, err := tf.Run("init", "-input=false")
 	if err != nil {

--- a/internal/command/e2etest/unmanaged_test.go
+++ b/internal/command/e2etest/unmanaged_test.go
@@ -149,7 +149,7 @@ func TestUnmanagedSeparatePlan(t *testing.T) {
 	t.Parallel()
 
 	fixturePath := filepath.Join("testdata", "test-provider")
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+	tf := e2e.NewBinary(t, tofuBin, fixturePath)
 
 	reattachCh := make(chan *plugin.ReattachConfig)
 	closeCh := make(chan struct{})
@@ -254,7 +254,7 @@ func TestUnmanagedSeparatePlan_proto5(t *testing.T) {
 	t.Parallel()
 
 	fixturePath := filepath.Join("testdata", "test-provider")
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+	tf := e2e.NewBinary(t, tofuBin, fixturePath)
 
 	reattachCh := make(chan *plugin.ReattachConfig)
 	closeCh := make(chan struct{})

--- a/internal/command/e2etest/version_test.go
+++ b/internal/command/e2etest/version_test.go
@@ -22,7 +22,7 @@ func TestVersion(t *testing.T) {
 	t.Parallel()
 
 	fixturePath := filepath.Join("testdata", "empty")
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+	tf := e2e.NewBinary(t, tofuBin, fixturePath)
 
 	stdout, stderr, err := tf.Run("version")
 	if err != nil {
@@ -50,7 +50,7 @@ func TestVersionWithProvider(t *testing.T) {
 	skipIfCannotAccessNetwork(t)
 
 	fixturePath := filepath.Join("testdata", "template-provider")
-	tf := e2e.NewBinary(t, terraformBin, fixturePath)
+	tf := e2e.NewBinary(t, tofuBin, fixturePath)
 
 	// Initial run (before "init") should work without error but will not
 	// include the provider version, since we've not "locked" one yet.

--- a/internal/command/jsonprovider/doc.go
+++ b/internal/command/jsonprovider/doc.go
@@ -1,6 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-// Package jsonprovider contains types and functions to marshal terraform
+// Package jsonprovider contains types and functions to marshal OpenTofu
 // provider schemas into a json formatted output.
 package jsonprovider

--- a/internal/getproviders/mock_source.go
+++ b/internal/getproviders/mock_source.go
@@ -152,7 +152,7 @@ func FakePackageMeta(provider addrs.Provider, version Version, protocols Version
 // should call the callback even if this function returns an error, because
 // some error conditions leave a partially-created file on disk.
 func FakeInstallablePackageMeta(provider addrs.Provider, version Version, protocols VersionList, target Platform, execFilename string) (PackageMeta, func(), error) {
-	f, err := os.CreateTemp("", "terraform-getproviders-fake-package-")
+	f, err := os.CreateTemp("", "tofu-getproviders-fake-package-")
 	if err != nil {
 		return PackageMeta{}, func() {}, err
 	}

--- a/internal/getproviders/registry_client.go
+++ b/internal/getproviders/registry_client.go
@@ -167,7 +167,7 @@ func (c *registryClient) ProviderVersions(ctx context.Context, addr addrs.Provid
 //     under the assumption that the caller previously checked that the provider
 //     and version are valid.
 //   - ErrProtocolNotSupported if the requested provider version's protocols are not
-//     supported by this version of terraform.
+//     supported by this version of tofu.
 //   - ErrUnauthorized if the registry responds with 401 or 403 status codes
 //   - ErrQueryFailed for any other operational problem.
 func (c *registryClient) PackageMeta(ctx context.Context, provider addrs.Provider, version Version, target Platform) (PackageMeta, error) {
@@ -250,7 +250,7 @@ func (c *registryClient) PackageMeta(ctx context.Context, provider addrs.Provide
 	}
 	protoVersions.Sort()
 
-	// Verify that this version of terraform supports the providers' protocol
+	// Verify that this version of tofu supports the providers' protocol
 	// version(s)
 	if len(protoVersions) > 0 {
 		supportedProtos := MeetingConstraints(SupportedPluginProtocols)

--- a/internal/initwd/doc.go
+++ b/internal/initwd/doc.go
@@ -1,10 +1,10 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-// Package initwd contains various helper functions used by the "terraform init"
+// Package initwd contains various helper functions used by the "tofu init"
 // command to initialize a working directory.
 //
 // These functions may also be used from testing code to simulate the behaviors
-// of "terraform init" against test fixtures, but should not be used elsewhere
+// of "tofu init" against test fixtures, but should not be used elsewhere
 // in the main code.
 package initwd

--- a/internal/lang/references.go
+++ b/internal/lang/references.go
@@ -66,7 +66,7 @@ func ReferencesInBlock(parseRef ParseRef, body hcl.Body, schema *configschema.Bl
 	// already know which variables are required.
 	//
 	// The set of cases we want to detect here is covered by the tests for
-	// the plan graph builder in the main 'terraform' package, since it's
+	// the plan graph builder in the main 'tofu' package, since it's
 	// in a better position to test this due to having mock providers etc
 	// available.
 	traversals := blocktoattr.ExpandedVariables(body, schema)

--- a/internal/plugin/discovery/requirements.go
+++ b/internal/plugin/discovery/requirements.go
@@ -9,7 +9,7 @@ import (
 
 // PluginInstallProtocolVersion is the protocol version TF-core
 // supports to communicate with servers, and is used to resolve
-// plugin discovery with terraform registry, in addition to
+// plugin discovery with OpenTofu registry, in addition to
 // any specified plugin version constraints
 const PluginInstallProtocolVersion = 5
 

--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -45,7 +45,7 @@ func (p *GRPCProviderPlugin) GRPCServer(broker *plugin.GRPCBroker, s *grpc.Serve
 
 // GRPCProvider handles the client, or core side of the plugin rpc connection.
 // The GRPCProvider methods are mostly a translation layer between the
-// terraform providers types and the grpc proto types, directly converting
+// tofu providers types and the grpc proto types, directly converting
 // between the two.
 type GRPCProvider struct {
 	// PluginClient provides a reference to the plugin.Client which controls the plugin process.
@@ -684,7 +684,7 @@ func (p *GRPCProvider) ReadDataSource(r providers.ReadDataSourceRequest) (resp p
 	return resp
 }
 
-// closing the grpc connection is final, and terraform will call it at the end of every phase.
+// closing the grpc connection is final, and tofu will call it at the end of every phase.
 func (p *GRPCProvider) Close() error {
 	logger.Trace("GRPCProvider: Close")
 

--- a/internal/plugin6/doc.go
+++ b/internal/plugin6/doc.go
@@ -4,7 +4,7 @@
 package plugin6
 
 // plugin6 builds on types in package plugin to include support for plugin
-// protocol v6. The main gRPC functions use by terraform (and initialized in
+// protocol v6. The main gRPC functions use by tofu (and initialized in
 // init.go), such as Serve, are in the plugin package. The version of those
 // functions in this package are used by various mocks and in tests.
 

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -45,7 +45,7 @@ func (p *GRPCProviderPlugin) GRPCServer(broker *plugin.GRPCBroker, s *grpc.Serve
 
 // GRPCProvider handles the client, or core side of the plugin rpc connection.
 // The GRPCProvider methods are mostly a translation layer between the
-// terraform providers types and the grpc proto types, directly converting
+// tofu providers types and the grpc proto types, directly converting
 // between the two.
 type GRPCProvider struct {
 	// PluginClient provides a reference to the plugin.Client which controls the plugin process.
@@ -673,7 +673,7 @@ func (p *GRPCProvider) ReadDataSource(r providers.ReadDataSourceRequest) (resp p
 	return resp
 }
 
-// closing the grpc connection is final, and terraform will call it at the end of every phase.
+// closing the grpc connection is final, and tofu will call it at the end of every phase.
 func (p *GRPCProvider) Close() error {
 	logger.Trace("GRPCProvider.v6: Close")
 


### PR DESCRIPTION
Hopefully the last search of the codebase for replacing terraform with tofu/opentofu

Relates to #898

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.6.0
