### PR TITLE
Improve unclear provider resolver error messages

### DIFF
--- a/internal/command/e2etest/provider_dev_test.go
+++ b/internal/command/e2etest/provider_dev_test.go
@@ -91,7 +91,7 @@ func TestProviderDevOverrides(t *testing.T) {
 	if got, want := stdout, `Provider development overrides are in effect`; !strings.Contains(got, want) {
 		t.Errorf("stdout doesn't include the warning about development overrides\nwant: %s\n%s", want, got)
 	}
-	if got, want := stderr, `Failed to query available provider packages`; !strings.Contains(got, want) {
+	if got, want := stderr, `Failed to resolve provider packages`; !strings.Contains(got, want) {
 		t.Errorf("stderr doesn't include the error about listing unavailable development provider\nwant: %s\n%s", want, got)
 	}
 }

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -716,7 +716,7 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 				diags = diags.Append(tfdiags.Sourceless(
 					tfdiags.Error,
 					"Failed to resolve provider packages",
-					fmt.Sprintf("Could resolve provider %s: %s",
+					fmt.Sprintf("Could not resolve provider %s: %s",
 						provider.ForDisplay(), err,
 					),
 				))

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -715,8 +715,8 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 			default:
 				diags = diags.Append(tfdiags.Sourceless(
 					tfdiags.Error,
-					"Failed to query available provider packages",
-					fmt.Sprintf("Could not retrieve the list of available versions for provider %s: %s",
+					"Failed to resolve provider packages",
+					fmt.Sprintf("Could resolve provider %s: %s",
 						provider.ForDisplay(), err,
 					),
 				))

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -2805,7 +2805,7 @@ func TestInit_testsWithProvider(t *testing.T) {
 	want := `
 Error: Failed to resolve provider packages
 
-Could resolve provider hashicorp/test: no available releases match the given
+Could not resolve provider hashicorp/test: no available releases match the given
 constraints 1.0.1, 1.0.2
 
 `

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -2803,11 +2803,10 @@ func TestInit_testsWithProvider(t *testing.T) {
 
 	got := ui.ErrorWriter.String()
 	want := `
-Error: Failed to query available provider packages
+Error: Failed to resolve provider packages
 
-Could not retrieve the list of available versions for provider
-hashicorp/test: no available releases match the given constraints 1.0.1,
-1.0.2
+Could resolve provider hashicorp/test: no available releases match the given
+constraints 1.0.1, 1.0.2
 
 `
 	if diff := cmp.Diff(got, want); len(diff) > 0 {

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -2805,8 +2805,8 @@ func TestInit_testsWithProvider(t *testing.T) {
 	want := `
 Error: Failed to resolve provider packages
 
-Could not resolve provider hashicorp/test: no available releases match the given
-constraints 1.0.1, 1.0.2
+Could not resolve provider hashicorp/test: no available releases match the
+given constraints 1.0.1, 1.0.2
 
 `
 	if diff := cmp.Diff(got, want); len(diff) > 0 {

--- a/internal/providercache/installer.go
+++ b/internal/providercache/installer.go
@@ -329,6 +329,8 @@ NeedProvider:
 			err = fmt.Errorf("the previously-selected version %s is no longer available", lock.Version())
 		} else {
 			err = fmt.Errorf("no available releases match the given constraints %s", getproviders.VersionConstraintsString(reqs[provider]))
+			log.Printf("[DEBUG] %s", err.Error())
+			log.Printf("[DEBUG] Available releases: %s", available)
 		}
 		errs[provider] = err
 		if cb := evts.QueryPackagesFailure; cb != nil {


### PR DESCRIPTION
This both improves the error message display in tfdiags and lists the available versions in TF_LOG=debug to help trace down issues.

IMO "can't resolve" is clearer than "can't list" for any generic provider error.  Can't resolve makes you read the rest of the error message instead of assuming it's a registry issue

Result from the example in the issue:
```
╷
│ Error: Failed to resolve provider packages
│ 
│ Could resolve provider cloudflare/cloudflare: no available releases match the given constraints 4.14.0, 4.19.0
```

With TF_LOG=debug
```
- Finding cloudflare/cloudflare versions matching "4.14.0, 4.19.0"...
2023-12-12T12:14:24.716-0500 [DEBUG] Service discovery for registry.opentofu.org at https://registry.opentofu.org/.well-known/terraform.json
2023-12-12T12:14:25.061-0500 [DEBUG] GET https://registry.opentofu.org/v1/providers/cloudflare/cloudflare/versions
2023-12-12T12:14:25.352-0500 [DEBUG] no available releases match the given constraints 4.14.0, 4.19.0
2023-12-12T12:14:25.352-0500 [DEBUG] Available releases: [2.9.0 2.10.0 2.10.1 2.11.0 2.12.0 2.13.0 2.13.1 2.13.2 2.14.0 2.15.0 2.16.0 2.17.0 2.18.0 2.19.0 2.19.1 2.19.2 2.20.0 2.21.0 2.22.0 2.23.0 2.24.0 2.25.0 2.26.0 2.26.1 2.27.0 3.0.0 3.0.1 3.1.0 3.2.0 3.3.0 3.4.0 3.5.0 3.6.0 3.7.0 3.8.0 3.9.0 3.9.1 3.10.0 3.10.1 3.11.0 3.12.0 3.12.1 3.12.2 3.13.0 3.14.0 3.15.0 3.16.0 3.17.0 3.18.0 3.19.0 3.20.0 3.21.0 3.22.0 3.23.0 3.24.0 3.25.0 3.26.0 3.27.0 3.28.0 3.29.0 3.30.0 3.31.0 3.32.0 3.33.0 3.33.1 3.34.0 3.35.0 4.0.0-rc1 4.0.0-rc2 4.0.0 4.1.0 4.2.0 4.3.0 4.4.0 4.5.0 4.6.0 4.7.0 4.7.1 4.8.0 4.9.0 4.10.0 4.11.0 4.12.0 4.13.0 4.14.0 4.15.0 4.16.0 4.17.0 4.18.0 4.19.0 4.20.0]
```

Resolves #1002 

## Target Release

1.6.0
