### PR TITLE
Add a warning when multiple likely forks of a provider are detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ ENHANCEMENTS:
 * state: Provider addresses in the statefile referring to registry.terraform.io will be treated as referring to registry.opentofu.org unless the full provider address is specified in the config or `OPENTOFU_STATEFILE_PROVIDER_ADDRESS_TRANSLATION` is set to `0`. ([#773](https://github.com/opentofu/opentofu/pull/773))
 * The default provider namespace has been changed from "hasicorp" to "opentofu". This only impacts providers that do not explicitly have a namespace set, ex "aws" vs "hasicorp/aws". This change should be transparent and not require action to be taken by users.
 * init: Ensured that the `tofu init` command has consistent spelling of the word `initialization` in its output. ([#855](https://github.com/opentofu/opentofu/pull/855/files))
+* init: A warning is now emitted when two providers who share the same name are detected.  This can help prevent misconfigurations when switching a project to use a fork of a provider. ([#1009](https://github.com/opentofu/opentofu/pull/1009))
 
 BUG FIXES:
 

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -546,10 +546,12 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 		reqs = reqs.Merge(stateReqs)
 	}
 
-	providersByName := make(map[string][]string)
+	potentialProviderConflicts := make(map[string][]string)
 
 	for providerAddr := range reqs {
-		providersByName[providerAddr.Type] = append(providersByName[providerAddr.Type], providerAddr.ForDisplay())
+		if providerAddr.Namespace == "hashicorp" || providerAddr.Namespace == "opentofu" {
+			potentialProviderConflicts[providerAddr.Type] = append(potentialProviderConflicts[providerAddr.Type], providerAddr.ForDisplay())
+		}
 
 		if providerAddr.IsLegacy() {
 			diags = diags.Append(tfdiags.Sourceless(
@@ -563,7 +565,7 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 		}
 	}
 
-	for name, addrs := range providersByName {
+	for name, addrs := range potentialProviderConflicts {
 		if len(addrs) > 1 {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Warning,

--- a/internal/command/testdata/init-get-provider-detected-duplicate/child/main.tf
+++ b/internal/command/testdata/init-get-provider-detected-duplicate/child/main.tf
@@ -1,0 +1,10 @@
+terraform {
+	required_providers {
+		dupechild = {
+			source = "hashicorp/bar"
+		}
+	}
+}
+
+// This will try to install hashicorp/foo
+provider foo {}

--- a/internal/command/testdata/init-get-provider-detected-duplicate/main.tf
+++ b/internal/command/testdata/init-get-provider-detected-duplicate/main.tf
@@ -1,0 +1,15 @@
+terraform {
+	required_providers {
+		foo = {
+			// This will conflict with the child modules hashicorp/foo
+			source = "opentofu/foo"
+		}
+		dupe = {
+			// This should not conflict with the child modules hashicorp/bar
+			source = "bar"
+		}
+	}
+}
+module "some-baz-stuff" {
+  source = "./child"
+}


### PR DESCRIPTION
When we attempted to change the default namespace from "hashicorp" to "opentofu" we realized that there are no guardrails for when multiple potential duplicates of a provider are specified.

Example:
main.tf requires company/bar with configuration A
module/child.tf requires company/bar with configuration B tofu init finds a single provider company/bar is represented with configuration A + B

company/bar is forked into alt/bar with some additional fixes

main.tf is updated to alt/bar, and module/child.tf is forgotten. tofu init finds two providers, alt/bar with configuration A and company/bar with configuration B

This can cause all sorts of havoc depending on what provider configuration lives where.  It is also nearly invisible to the end user, which is why we added a warning message.

It is possible that someone may deliberately configure two identically typed providers from different namespaces.  Therefore this is a warning for a potential foot-gun instead of an outright error.

![image](https://github.com/opentofu/opentofu/assets/892136/f846e3e4-38b3-4f06-b156-bd9d6497bed0)


Resolves #1008

## Target Release

1.6.0
