### PR TITLE
Fix renaming mistakes in docs

### DIFF
--- a/website/docs/cli/commands/output.mdx
+++ b/website/docs/cli/commands/output.mdx
@@ -28,7 +28,7 @@ The command-line flags are all optional. The following flags are available:
   it only supports string, number, and boolean values. Use `-json` instead
   for processing complex data types.
 * `-no-color` - If specified, output won't contain any color.
-* `-state=path` - Path to the state file. Defaults to "tofu.tfstate".
+* `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
   Ignored when [remote state](/docs/language/state/remote) is used.
 
 :::note

--- a/website/docs/cli/commands/state/list.mdx
+++ b/website/docs/cli/commands/state/list.mdx
@@ -27,7 +27,7 @@ in [resource addressing format](/docs/cli/state/resource-addressing).
 
 The command-line flags are all optional. The following flags are available:
 
-* `-state=path` - Path to the state file. Defaults to "tofu.tfstate".
+* `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
   Ignored when [remote state](/docs/language/state/remote) is used.
 * `-id=id` - ID of resources to show. Ignored when unset.
 

--- a/website/docs/cli/commands/state/pull.mdx
+++ b/website/docs/cli/commands/state/pull.mdx
@@ -27,5 +27,5 @@ the remote state, as it will always be converted to the current OpenTofu
 version before output.
 
 :::note
-OpenTofu state files must be in UTF-8 format without a byte order mark (BOM). For PowerShell on Windows, use `Set-Content` to automatically encode files in UTF-8 format. For example, run `tofu state pull | sc tofu.tfstate`.
+OpenTofu state files must be in UTF-8 format without a byte order mark (BOM). For PowerShell on Windows, use `Set-Content` to automatically encode files in UTF-8 format. For example, run `tofu state pull | sc terraform.tfstate`.
 :::

--- a/website/docs/cli/commands/state/push.mdx
+++ b/website/docs/cli/commands/state/push.mdx
@@ -23,7 +23,7 @@ is loaded completely into memory and verified prior to being written to
 the destination state.
 
 :::note
-OpenTofu state files must be in UTF-8 format without a byte order mark (BOM). For PowerShell on Windows, use `Set-Content` to automatically encode files in UTF-8 format. For example, run `tofu state push | sc tofu.tfstate`.
+OpenTofu state files must be in UTF-8 format without a byte order mark (BOM). For PowerShell on Windows, use `Set-Content` to automatically encode files in UTF-8 format. For example, run `tofu state push | sc terraform.tfstate`.
 :::
 
 OpenTofu will perform a number of safety checks to prevent you from

--- a/website/docs/cli/commands/state/show.mdx
+++ b/website/docs/cli/commands/state/show.mdx
@@ -23,7 +23,7 @@ in [resource addressing format](/docs/cli/state/resource-addressing).
 
 The command-line flags are all optional. The following flags are available:
 
-* `-state=path` - Path to the state file. Defaults to "tofu.tfstate".
+* `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
   Ignored when [remote state](/docs/language/state/remote) is used.
 
 The output of `tofu state show` is intended for human consumption, not

--- a/website/docs/cli/commands/workspace/new.mdx
+++ b/website/docs/cli/commands/workspace/new.mdx
@@ -40,7 +40,7 @@ for this configuration.
 To create a new workspace from a pre-existing local state file:
 
 ```
-$ tofu workspace new -state=old.tofu.tfstate example
+$ tofu workspace new -state=old.terraform.tfstate example
 Created and switched to workspace "example".
 
 You're now on a new, empty workspace. Workspaces isolate their state,

--- a/website/docs/language/modules/sources.mdx
+++ b/website/docs/language/modules/sources.mdx
@@ -327,7 +327,7 @@ optionally return a different result when OpenTofu is requesting it.
 If the response is successful (`200`-range status code), OpenTofu looks in
 the following locations in order for the next address to access:
 
-- The value of a response header field named `X-OpenTofu-Get`.
+- The value of a response header field named `X-Terraform-Get`.
 
 - If the response is an HTML page, a `meta` element with the name `tofu-get`:
 


### PR DESCRIPTION
Resolves https://github.com/opentofu/opentofu/issues/530

As part of the renaming process to opentofu, several discrepancies have surfaced in our documentation.

To fix them we:
1. Renamed `X-OpenTofu-Get` to `X-Terraform-Get`.
2. Renamed `tofu.tfstate` to `terraform.tfstate`.

Items in the issue that weren't addressed:
1. `tofu.rc` - it's supported in opentofu.
2. `tofu {` is not found.

## Target Release

1.6.0
