### PR TITLE
Re-add ssh and bash to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine:3.18
 
 LABEL maintainer="OpenTofu Core Team <core@opentofu.org>"
 
-RUN apk add --no-cache git
+RUN apk add --no-cache git bash openssh
 
 COPY tofu /usr/local/bin/tofu
 


### PR DESCRIPTION
It was removed in
https://github.com/opentofu/opentofu/pull/173/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L16 with no associated comment.

As was was reported in #1031, ssh is required for certain functionality. I've also re-added bash in case it was required for other examples.

Resolves #1031

## Target Release
1.6.0
