### PR TITLE
Fixes #980: Remove Packagecloud instructions

### DIFF
--- a/website/docs/intro/install/deb-step2.sh
+++ b/website/docs/intro/install/deb-step2.sh
@@ -1,3 +1,4 @@
 sudo install -m 0755 -d /etc/apt/keyrings
-curl -fsSL https://packages.opentofu.org/opentofu/tofu/gpgkey | sudo gpg --no-tty --batch --dearmor -o /etc/apt/keyrings/opentofu.gpg
+curl -fsSL https://get.opentofu.org/opentofu.gpg | sudo tee /etc/apt/keyrings/opentofu.gpg >/dev/null
+curl -fsSL https://packages.opentofu.org/opentofu/tofu/gpgkey | sudo gpg --no-tty --batch --dearmor -o /etc/apt/keyrings/opentofu-repo.gpg >/dev/null
 sudo chmod a+r /etc/apt/keyrings/opentofu.gpg

--- a/website/docs/intro/install/deb-step3.sh
+++ b/website/docs/intro/install/deb-step3.sh
@@ -1,4 +1,4 @@
 echo \
-  "deb [signed-by=/etc/apt/keyrings/opentofu.gpg] https://packages.opentofu.org/opentofu/tofu/any/ any main
-deb-src [signed-by=/etc/apt/keyrings/opentofu.gpg] https://packages.opentofu.org/opentofu/tofu/any/ any main" | \
+  "deb [signed-by=/etc/apt/keyrings/opentofu.gpg,/etc/apt/keyrings/opentofu-repo.gpg] https://packages.opentofu.org/opentofu/tofu/any/ any main
+deb-src [signed-by=/etc/apt/keyrings/opentofu.gpg,/etc/apt/keyrings/opentofu-repo.gpg] https://packages.opentofu.org/opentofu/tofu/any/ any main" | \
   sudo tee /etc/apt/sources.list.d/opentofu.list > /dev/null

--- a/website/docs/intro/install/deb.mdx
+++ b/website/docs/intro/install/deb.mdx
@@ -17,13 +17,7 @@ import Buildkite from './buildkite'
 
 <Buildkite />
 
-OpenTofu is distributed in the .deb package format on [Packagecloud](https://packagecloud.io/opentofu/tofu). You can install it using a convenience script or by following the step-by-step instructions below.
-
-## Installing using the convenience script
-
-You can install OpenTofu using the [convenience script](https://packagecloud.io/install/repositories/opentofu/tofu/script.deb.sh?any=true) with the following commands:
-
-<CodeBlock language={"bash"}>{DebConvenienceScript}</CodeBlock>
+You can install OpenTofu from our Debian repository by following the step-by-step instructions below.
 
 ## Step-by-step instructions
 

--- a/website/docs/intro/install/repo-yum.sh
+++ b/website/docs/intro/install/repo-yum.sh
@@ -2,10 +2,10 @@ cat >/etc/yum.repos.d/opentofu.repo <<EOF
 [opentofu]
 name=opentofu
 baseurl=https://packages.opentofu.org/opentofu/tofu/rpm_any/rpm_any/\$basearch
-repo_gpgcheck=1
-gpgcheck=0
+repo_gpgcheck=0
+gpgcheck=1
 enabled=1
-gpgkey=https://packages.opentofu.org/opentofu/tofu/gpgkey
+gpgkey=https://get.opentofu.org/opentofu.gpg
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
 metadata_expire=300
@@ -13,10 +13,10 @@ metadata_expire=300
 [opentofu-source]
 name=opentofu-source
 baseurl=https://packages.opentofu.org/opentofu/tofu/rpm_any/rpm_any/SRPMS
-repo_gpgcheck=1
-gpgcheck=0
+repo_gpgcheck=0
+gpgcheck=1
 enabled=1
-gpgkey=https://packages.opentofu.org/opentofu/tofu/gpgkey
+gpgkey=https://get.opentofu.org/opentofu.gpg
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
 metadata_expire=300

--- a/website/docs/intro/install/repo-zypper.sh
+++ b/website/docs/intro/install/repo-zypper.sh
@@ -1,22 +1,22 @@
 cat >/etc/zypp/repos.d/opentofu.repo <<EOF
 [opentofu]
 name=opentofu
-baseurl=https://packagecloud.io/opentofu/tofu/rpm_any/rpm_any/\$basearch
-repo_gpgcheck=1
-gpgcheck=0
+baseurl=https://packages.opentofu.org/opentofu/tofu/rpm_any/rpm_any/\$basearch
+repo_gpgcheck=0
+gpgcheck=1
 enabled=1
-gpgkey=https://packagecloud.io/opentofu/tofu/gpgkey
+gpgkey=https://get.opentofu.org/opentofu.gpg
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
 metadata_expire=300
 
 [opentofu-source]
 name=opentofu-source
-baseurl=https://packagecloud.io/opentofu/tofu/rpm_any/rpm_any/SRPMS
-repo_gpgcheck=1
-gpgcheck=0
+baseurl=https://packages.opentofu.org/opentofu/tofu/rpm_any/rpm_any/SRPMS
+repo_gpgcheck=0
+gpgcheck=1
 enabled=1
-gpgkey=https://packagecloud.io/opentofu/tofu/gpgkey
+gpgkey=https://get.opentofu.org/opentofu.gpg
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
 metadata_expire=300

--- a/website/docs/intro/install/rpm.mdx
+++ b/website/docs/intro/install/rpm.mdx
@@ -20,20 +20,7 @@ import Buildkite from "./buildkite";
 
 <Buildkite />
 
-OpenTofu is distributed in the .rpm package format on [Packagecloud](https://packagecloud.io/opentofu/tofu). You can install it using a convenience script or by following the step-by-step instructions below.
-
-## Installing using the convenience script
-
-You can install OpenTofu using the [convenience script](https://packagecloud.io/install/repositories/opentofu/tofu/script.rpm.sh?any=true) with the following commands:
-
-<Tabs>
-    <TabItem value="redhat" label="Yum (RHEL/Fedora/etc.)" default>
-        <CodeBlock language={"bash"}>{YumConvenienceScript}</CodeBlock>
-    </TabItem>
-    <TabItem value="opensuse-leap" label="Zypper (openSUSE)">
-        <CodeBlock language={"bash"}>{ZypperConvenienceScript}</CodeBlock>
-    </TabItem>
-</Tabs>
+You can install OpenTofu from our RPM repository by following the step-by-step instructions below.
 
 ## Step-by-step instructions
 

--- a/website/docs/intro/install/test-install-instructions.sh
+++ b/website/docs/intro/install/test-install-instructions.sh
@@ -30,7 +30,7 @@ for SERVICE in $SERVICES; do
     echo -e "::group::\033[0;31m❌  ${SERVICE}\033[0m"
     FAILED=$(("${FAILED}"+1))
   fi
-  cat $TEMPFILE | grep -E "^[a-zA-Z]+-${SERVICE}-1\s+\| " | sed -E "s/^[a-zA-Z]+-${SERVICE}-1\s+\| //"
+  cat $TEMPFILE | grep -a -E "^[a-zA-Z]+-${SERVICE}-1\s+\| " | sed -E "s/^[a-zA-Z]+-${SERVICE}-1\s+\| //"
   echo "::endgroup::"
 done
 


### PR DESCRIPTION
This PR removes the Packagecloud instructions.

**Note 1:** Special consideration is given to Deb, where we still need to include the Packagecloud GPG key in order to make the repository signed. This is less than ideal, but works for now.
**Note 2:** The instructions need to be re-tested before merging this.

Resolves #980

## Target Release

1.6.0
