### PR TITLE
Docs update, remove additional terraform references

### DIFF
--- a/website/docs/cli/commands/providers/index.mdx
+++ b/website/docs/cli/commands/providers/index.mdx
@@ -15,4 +15,17 @@ This command also has several subcommands with different purposes.
 
 ## Usage
 
-Usage: `tofu providers`
+Usage:
+```
+$ tofu providers
+
+Providers required by configuration:
+.
+└── module.submodule
+    ├── provider[registry.opentofu.org/hashicorp/tfcoremock]
+    └── module.nested
+
+Providers required by state:
+
+    provider[registry.opentofu.org/hashicorp/tfcoremock]
+```

--- a/website/docs/cli/import/importability.mdx
+++ b/website/docs/cli/import/importability.mdx
@@ -9,7 +9,9 @@ description: |-
 Each resource in OpenTofu must implement some basic logic to become
 importable. As a result, you cannot import all OpenTofu resources.
 
-The resources that you can import are documented at the bottom of
-each resource documentation page in the [public Terraform Registry](https://registry.terraform.io/). If you have issues importing a resource, report an issue in the relevant provider repository.
+The resources that you can import for a provider are listed in that
+provider's specific documentation.  If you have issues importing a
+resource, report an issue in the relevant provider repository.
 
-To make a resource importable, refer to [Extending OpenTofu: Resources — Import](/docs/plugin/sdkv2/resources/import).
+OpenTofu supports all providers through the Terraform Plugin SDK. To
+make a resource importable, refer to the [Terraform Plugin SDK Documentation](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/import).

--- a/website/docs/cli/import/importability.mdx
+++ b/website/docs/cli/import/importability.mdx
@@ -9,8 +9,8 @@ description: |-
 Each resource in OpenTofu must implement some basic logic to become
 importable. As a result, you cannot import all OpenTofu resources.
 
-The resources that you can import for a provider are listed in that
-provider's specific documentation.  If you have issues importing a
+Please reference the provider's specific documentation on which
+resources can be imported.  If you have issues importing a
 resource, report an issue in the relevant provider repository.
 
 OpenTofu supports all providers through the Terraform Plugin SDK. To

--- a/website/docs/cli/plugins/signing.mdx
+++ b/website/docs/cli/plugins/signing.mdx
@@ -12,17 +12,8 @@ description: >-
 OpenTofu only authenticates provider plugins fetched from a registry.
 :::
 
-OpenTofu providers installed from the Registry are cryptographically signed, and the signature is verified at time of installation. There are three types of provider signatures, each with different trust implications:
-
-* **Signed by HashiCorp** - are built, signed, and supported by HashiCorp.
-* **Signed by Trusted Partners** - are built, signed, and supported by a third party. HashiCorp has
-  verified the ownership of the private key and we provide a chain of trust to the CLI to verify this
-  programatically.
-* **Self-signed** - are built, signed, and supported by a third party. OpenTofu does not provide a
-  verification or chain of trust for the signature. You may obtain and validate fingerprints manually
-  if you want to ensure you are using a binary you can trust.
+OpenTofu providers installed from the Registry are cryptographically signed, and the signature
+is verified at time of installation.
 
 OpenTofu does **NOT** support fetching and using unsigned binaries, but you can manually install
 unsigned binaries. You should take extreme care when doing so as no programatic authentication is performed.
-
-Usage of plugins from the registry is subject to the Registry's [Terms of Use](https://registry.terraform.io/terms).

--- a/website/docs/cli/plugins/signing.mdx
+++ b/website/docs/cli/plugins/signing.mdx
@@ -12,7 +12,7 @@ description: >-
 OpenTofu only authenticates provider plugins fetched from a registry.
 :::
 
-OpenTofu providers installed from the Registry are cryptographically signed, and the signature
+OpenTofu providers installed from the Registry are cryptographically signed and the signature
 is verified at time of installation.
 
 OpenTofu does **NOT** support fetching and using unsigned binaries, but you can manually install

--- a/website/docs/internals/credentials-helpers.mdx
+++ b/website/docs/internals/credentials-helpers.mdx
@@ -7,7 +7,7 @@ description: >-
 # Credentials Helpers
 
 For OpenTofu-specific features that interact with remote network services,
-such as [module registries](/docs/registry), OpenTofu by default looks for
+such as module registries, OpenTofu by default looks for
 API credentials to use in these calls in
 [the CLI configuration](/docs/cli/config/config-file).
 
@@ -27,7 +27,7 @@ particular location and whose name follows a specific naming convention.
 A credentials helper called "credstore", for example, would be implemented as
 an executable program named `terraform-credentials-credstore` (with an `.exe`
 extension on Windows only), and installed in one of the
-[default plugin search locations](/docs/plugin/how-opentofu-works#plugin-locations).
+[default plugin search locations](/docs/cli/config/config-file#provider-installation).
 
 ## How OpenTofu runs Credentials Helpers
 
@@ -157,7 +157,7 @@ other properties as described above.
 
 OpenTofu does not have any automatic installation mechanism for credentials
 helpers. Instead, the user must extract the helper program executable into
-one of the [default plugin search locations](/docs/plugin/how-opentofu-works#plugin-locations).
+one of the [default plugin search locations](/docs/cli/config/config-file#provider-installation).
 
 If you are packaging a credentials helper for distribution, place it in an
 named with the expected naming scheme (`terraform-credentials-example`) and,

--- a/website/docs/internals/module-registry-protocol.mdx
+++ b/website/docs/internals/module-registry-protocol.mdx
@@ -17,13 +17,6 @@ By writing and deploying your own implementation of this protocol, you can
 create a separate registry to distribute your own modules, as an alternative to
 publishing them on the public OpenTofu Registry.
 
-The public OpenTofu Registry implements a superset of the API described on
-this page, in order to capture additional information used in the registry UI.
-For information on those extensions, see
-[OpenTofu Registry HTTP API](/docs/registry/api-docs). Third-party registry
-implementations may choose to implement those extensions if desired, but
-OpenTofu CLI itself does not use them.
-
 ## Module Addresses
 
 Each OpenTofu module has an associated address. A module address has the

--- a/website/docs/intro/index.mdx
+++ b/website/docs/intro/index.mdx
@@ -14,7 +14,7 @@ OpenTofu creates and manages resources on cloud platforms and other services thr
 
 ![OpenTofu creates and manages cloud platforms and services through their APIs](/img/docs/intro-opentf-apis.png)
 
-The OpenTofu community have already written **thousands of providers** to manage many different types of resources and services. You can find all publicly available providers on the [Public Terraform Registry](https://registry.terraform.io/), including Amazon Web Services (AWS), Azure, Google Cloud Platform (GCP), Kubernetes, Helm, GitHub, Splunk, DataDog, and many more.
+The OpenTofu community have already written **thousands of providers** to manage many different types of resources and services. You can find all publicly available providers on the [Public OpenTofu Registry](https://github.com/opentofu/registry/tree/main/providers), including Amazon Web Services (AWS), Azure, Google Cloud Platform (GCP), Kubernetes, Helm, GitHub, Splunk, DataDog, and many more.
 
 The core OpenTofu workflow consists of three stages:
 
@@ -28,7 +28,7 @@ The core OpenTofu workflow consists of three stages:
 
 ### Manage any infrastructure
 
-Find providers for many of the platforms and services you already use in the [Public OpenTofu Registry](https://registry.opentofu.org/). You can also [write your own](/docs/plugin). OpenTofu takes an [immutable approach to infrastructure](https://www.hashicorp.com/resources/what-is-mutable-vs-immutable-infrastructure), reducing the complexity of upgrading or modifying your services and infrastructure.
+Find providers for many of the platforms and services you already use in the [Public OpenTofu Registry](https://registry.opentofu.org/). You can also use the [Terraform Plugin SDK](https://developer.hashicorp.com/terraform/plugin) to write your own. OpenTofu takes an [immutable approach to infrastructure](https://www.hashicorp.com/resources/what-is-mutable-vs-immutable-infrastructure), reducing the complexity of upgrading or modifying your services and infrastructure.
 
 ### Track your infrastructure
 

--- a/website/docs/intro/use-cases.mdx
+++ b/website/docs/intro/use-cases.mdx
@@ -15,7 +15,7 @@ Provisioning infrastructure across multiple clouds increases fault-tolerance, al
 
 ### Resources
 
-- Browse the [Public Terraform Registry](https://registry.terraform.io/browse/providers) to find thousands of publicly available providers.
+- Browse the [Public OpenTofu Registry](https://github.com/opentofu/registry/tree/main/providers) to find thousands of publicly available providers.
 
 ## Application Infrastructure Deployment, Scaling, and Monitoring Tools
 

--- a/website/docs/language/data-sources/index.mdx
+++ b/website/docs/language/data-sources/index.mdx
@@ -198,7 +198,7 @@ and name must be unique.
 Within the block (the `{ }`) is configuration for the data instance. The
 configuration is dependent on the type; as with
 [resources](/docs/language/resources), each provider on the
-[Public Terraform Registry](https://registry.terraform.io/browse/providers) has its own
+[Public OpenTofu Registry](https://registry.opentofu.org) has its own
 documentation for configuring and using the data types it provides.
 
 Each data instance will export one or more attributes, which can be

--- a/website/docs/language/files/dependency-lock.mdx
+++ b/website/docs/language/files/dependency-lock.mdx
@@ -121,7 +121,7 @@ There are two special considerations with the "trust on first use" model:
 
   In this case, the `tofu init` output will include the fingerprint of
   the key that signed the checksums, with a message like
-  `(signed by a HashiCorp partner, key ID DC9FC6B1FCE47986)`. You may wish to
+  `(signed, key ID 0C0AF313E5FD9F80)`. You may wish to
   confirm that you trust the holder of the given key before committing the
   lock file containing the signed checksums, or to retrieve and verify the
   full set of available packages for the given provider version.

--- a/website/docs/language/functions/cidrsubnets.mdx
+++ b/website/docs/language/functions/cidrsubnets.mdx
@@ -45,7 +45,7 @@ for backward compatibility, but recommend against relying on this behavior.
 :::
 
 :::note
-[The `hashicorp/subnets/cidr` module](https://registry.terraform.io/modules/hashicorp/subnets/cidr)
+[The `hashicorp/subnets/cidr` module](https://github.com/hashicorp/terraform-cidr-subnets)
 wraps `cidrsubnets` to provide additional functionality for assigning symbolic
 names to your networks and skipping prefixes for obsolete allocations. Its
 documentation includes usage examples for several popular cloud virtual network

--- a/website/docs/language/import/index.mdx
+++ b/website/docs/language/import/index.mdx
@@ -44,7 +44,7 @@ If you do not set the `provider` argument, OpenTofu attempts to import from the 
 
 The import block requires you to provide the `id` argument with a literal string of your resource's import ID. OpenTofu needs this import ID to locate the resource you want to import.
 
-The identifier you use for a resource's import ID is resource-specific. You can find the required ID in the [provider documentation](https://registry.terraform.io/browse/providers) for the resource you wish to import.
+The identifier you use for a resource's import ID is resource-specific. You can find the required ID in the provider's documentation for the resource you wish to import.
 
 ## Plan and apply an import
 

--- a/website/docs/language/modules/develop/publish.mdx
+++ b/website/docs/language/modules/develop/publish.mdx
@@ -5,7 +5,7 @@ description: A module is a container for multiple resources that are used togeth
 # Publishing Modules
 
 If you've built a module that you intend to be reused, we recommend
-[publishing the module](/docs/registry/modules/publish) on the
+[publishing the module](https://github.com/opentofu/registry/issues/new/choose) on the
 [Public OpenTofu Registry](https://registry.opentofu.org). This will version
 your module, generate documentation, and more.
 
@@ -21,7 +21,7 @@ module "consul" {
 ```
 
 If you do not wish to publish your modules in the public registry, you can
-instead use a [private registry](/docs/registry/private) to get
+instead use a [private registry](http://localhost:3000/docs/internals/module-registry-protocol) to get
 the same benefits.
 
 We welcome contributions of modules from our community members, partners, and customers. Our ecosystem is made richer by each new module created or an existing one updated, as they reflect the wide range of experience and technical requirements of the community that uses them. Our cloud provider partners often seek to develop specific modules for popular or challenging use cases on their platform and utilize them as valuable learning experiences to empathize with their users. Similarly, our community module developers incorporate a variety of opinions and use cases from the broader OpenTofu community. Both types of modules have their place in the registry, accessible to practitioners who can decide which modules best fit their requirements.

--- a/website/docs/language/modules/develop/structure.mdx
+++ b/website/docs/language/modules/develop/structure.mdx
@@ -18,7 +18,7 @@ don't need to do any extra work to follow the standard structure.
   module structure. OpenTofu files must exist in the root directory of
   the repository. This should be the primary entrypoint for the module and is
   expected to be opinionated. For the
-  [Consul module](https://registry.terraform.io/modules/hashicorp/consul)
+  [Consul module](https://github.com/hashicorp/terraform-aws-consul)
   the root module sets up a complete Consul cluster. It makes a lot of assumptions
   however, and we expect that advanced users will use specific _nested modules_
   to more carefully control what they want.
@@ -64,7 +64,7 @@ don't need to do any extra work to follow the standard structure.
   of internal modules. Nested modules should be used to split complex behavior
   into multiple small modules that advanced users can carefully pick and
   choose. For example, the
-  [Consul module](https://registry.terraform.io/modules/hashicorp/consul)
+  [Consul module](https://github.com/hashicorp/terraform-aws-consul)
   has a nested module for creating the Cluster that is separate from the
   module to setup necessary IAM policies. This allows a user to bring in their
   own IAM policy choices.

--- a/website/docs/language/modules/index.mdx
+++ b/website/docs/language/modules/index.mdx
@@ -34,7 +34,7 @@ In addition to modules from the local filesystem, OpenTofu can load modules
 from a public or private registry. This makes it possible to publish modules for
 others to use, and to use modules that others have published.
 
-The [Public Terraform Registry](https://registry.terraform.io/browse/modules) hosts a
+The [Public OpenTofu Registry](https://github.com/opentofu/registry/tree/main/modules) hosts a
 broad collection of publicly available OpenTofu modules for configuring many
 kinds of common infrastructure. These modules are free to use, and OpenTofu can
 download them automatically if you specify the appropriate source and version in

--- a/website/docs/language/modules/sources.mdx
+++ b/website/docs/language/modules/sources.mdx
@@ -94,10 +94,10 @@ to get started with OpenTofu and find modules created by others in the
 community.
 
 You can also use a
-[private registry](/docs/registry/private), either
+[private registry](/docs/internals/module-registry-protocol), either
 via TACOS (TF Automation and Collaboration Software), or by running a custom
 service that implements
-[the module registry protocol](/docs/registry/api-docs).
+[the module registry protocol](/docs/internals/module-registry-protocol).
 
 Modules on the public registry can be referenced using a registry
 source address of the form `<NAMESPACE>/<NAME>/<PROVIDER>`, with each
@@ -112,7 +112,7 @@ module "consul" {
 ```
 
 The above example will use the
-[Consul module for AWS](https://registry.terraform.io/modules/hashicorp/consul/aws)
+[Consul module for AWS](https://github.com/hashicorp/terraform-aws-consul)
 from a public registry.
 
 For modules hosted in other registries, prefix the source address with an
@@ -130,7 +130,7 @@ in the above examples, or use flexible
 [version constraints](/docs/language/modules/syntax#version).
 
 You can learn more about the registry at the
-[Module Registry documentation](/docs/registry/modules/use#using-modules).
+[Module Registry documentation](/docs/internals/module-registry-protocol).
 
 To access modules from a private registry, you may need to configure an access
 token [in the CLI config](/docs/cli/config/config-file#credentials). Use the

--- a/website/docs/language/providers/index.mdx
+++ b/website/docs/language/providers/index.mdx
@@ -35,22 +35,14 @@ The [Public OpenTofu Registry](https://github.com/opentofu/registry/tree/main/pr
 is the main directory of publicly available providers, and hosts
 providers for most major infrastructure platforms.
 
-<!--
 ## Provider Documentation
 
 Each provider has its own documentation, describing its resource
-types and their arguments.
+types and their arguments. This documentation can be found in the provider's
+github repository.
 
-The [Public OpenTofu Registry](https://registry.terraform.io/browse/providers)
-includes documentation for a wide range of providers developed by HashiCorp, third-party vendors, and our OpenTofu community. Use the
-"Documentation" link in a provider's header to browse its documentation.
-
-Provider documentation in the Registry is versioned; you can use the version
-menu in the header to change which version you're viewing.
-
-For details about writing, generating, and previewing provider documentation,
-see the [provider publishing documentation](/docs/registry/providers/docs).
--->
+Provider documentation is versioned, make sure you are referring to the correct
+tag/release.
 
 ## How to Use Providers
 

--- a/website/docs/language/providers/index.mdx
+++ b/website/docs/language/providers/index.mdx
@@ -31,16 +31,17 @@ generating random numbers for unique resource names.
 Providers are distributed separately from OpenTofu itself, and each provider
 has its own release cadence and version numbers.
 
-The [Public Terraform Registry](https://registry.terraform.io/browse/providers)
+The [Public OpenTofu Registry](https://github.com/opentofu/registry/tree/main/providers)
 is the main directory of publicly available providers, and hosts
 providers for most major infrastructure platforms.
 
+<!--
 ## Provider Documentation
 
 Each provider has its own documentation, describing its resource
 types and their arguments.
 
-The [Public Terraform Registry](https://registry.terraform.io/browse/providers)
+The [Public OpenTofu Registry](https://registry.terraform.io/browse/providers)
 includes documentation for a wide range of providers developed by HashiCorp, third-party vendors, and our OpenTofu community. Use the
 "Documentation" link in a provider's header to browse its documentation.
 
@@ -49,6 +50,7 @@ menu in the header to change which version you're viewing.
 
 For details about writing, generating, and previewing provider documentation,
 see the [provider publishing documentation](/docs/registry/providers/docs).
+-->
 
 ## How to Use Providers
 
@@ -91,7 +93,7 @@ installing providers.
 ## How to Find Providers
 
 To find providers for the infrastructure platforms you use, browse the
-[Public Terraform Registry](https://registry.terraform.io/browse/providers).
+[Public OpenTofu Registry](https://github.com/opentofu/registry/tree/main/providers).
 
 Some providers on the Registry are developed and published by HashiCorp, some
 are published by platform maintainers, and some are published by users and
@@ -100,4 +102,4 @@ volunteers.
 ## How to Develop Providers
 
 Providers are written in Go, using the Terraform Plugin SDK. For more
-information on developing providers, see the [Plugin Development](/docs/plugin) documentation.
+information on developing providers, see the [Plugin Development](https://developer.hashicorp.com/terraform/plugin) documentation.

--- a/website/docs/language/providers/requirements.mdx
+++ b/website/docs/language/providers/requirements.mdx
@@ -114,13 +114,12 @@ follows:
   be unique within a particular namespace on a particular registry host.
 
   The type is usually the provider's preferred local name. (There are
-  exceptions; for example,
-  [`hashicorp/google-beta`](https://registry.terraform.io/providers/hashicorp/google-beta/latest)
+  exceptions; for example, `hashicorp/google-beta`
   is an alternate release channel for `hashicorp/google`, so its preferred
   local name is `google`. If in doubt, check the provider's documentation.)
 
 For example,
-[the official HTTP provider](https://registry.terraform.io/providers/hashicorp/http)
+[the official HTTP provider](https://github.com/hashicorp/terraform-provider-http)
 belongs to the `hashicorp` namespace on `registry.opentofu.org`, so its
 source address is `registry.opentofu.org/hashicorp/http` or, more commonly, just
 `hashicorp/http`.


### PR DESCRIPTION
I went through and found a few more references to terraform that should be removed in the docs.  Also fixes some broken links

