### PR TITLE
Backend/S3: Change default of `use_legacy_workflow` to false and deprecate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.7.0 (Unreleased)
 
 UPGRADE NOTES:
+* Backend/S3: The default of `use_legacy_workflow` changed to `false` and is now deprecated. The S3 backend will follow the same behavior as AWS CLI and SDKs for credential search, preferring backend configuration over environment variables. To support the legacy credential search workflow, you can set this option as `true`. It'll be completely removed in a future minor version.
+
 
 NEW FEATURES:
 

--- a/internal/backend/remote-state/s3/backend_complete_test.go
+++ b/internal/backend/remote-state/s3/backend_complete_test.go
@@ -222,7 +222,8 @@ aws_secret_access_key = ProfileSharedCredentialsSecretKey
 
 		"environment AWS_ACCESS_KEY_ID overrides config Profile": { // Legacy behavior
 			config: map[string]any{
-				"profile": "SharedCredentialsProfile",
+				"profile":             "SharedCredentialsProfile",
+				"use_legacy_workflow": true,
 			},
 			EnvironmentVariables: map[string]string{
 				"AWS_ACCESS_KEY_ID":     servicemocks.MockEnvAccessKey,
@@ -240,13 +241,16 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 aws_access_key_id = ProfileSharedCredentialsAccessKey
 aws_secret_access_key = ProfileSharedCredentialsSecretKey
 `,
-			ValidateDiags: ExpectNoDiags,
+			ValidateDiags: ExpectDiagsMatching(
+				tfdiags.Warning,
+				equalsMatcher("Deprecated Parameter"),
+				noopMatcher{},
+			),
 		},
 
 		"environment AWS_ACCESS_KEY_ID does not override config Profile": {
 			config: map[string]any{
-				"profile":             "SharedCredentialsProfile",
-				"use_legacy_workflow": false,
+				"profile": "SharedCredentialsProfile",
 			},
 			EnvironmentVariables: map[string]string{
 				"AWS_ACCESS_KEY_ID":     servicemocks.MockEnvAccessKey,

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -177,7 +177,7 @@ The following configuration is optional:
 * `token` - (Optional) Multi-Factor Authentication (MFA) token. This can also be sourced from the `AWS_SESSION_TOKEN` environment variable.
 * `allowed_account_ids` (Optional): A list of permitted AWS account IDs to safeguard against accidental disruption of a live environment. This option conflicts with `forbidden_account_ids`.
 * `forbidden_account_ids` (Optional): A list of prohibited AWS account IDs to prevent unintentional disruption of a live environment. This option conflicts with `allowed_account_ids`.
-* `use_legacy_workflow` - (Optional) Prefer environment variables for legacy authentication; default is 'true.' This method doesn't match AWS CLI or SDK authentication and will be removed in the future.
+* `use_legacy_workflow` - (Optional) **Deprecated** Prefer environment variables for legacy authentication; default is 'false'. This method doesn't match AWS CLI or SDK authentication and will be removed in the future.
 * `custom_ca_bundle` - File containing custom root and intermediate certificates. Can also be configured using the `AWS_CA_BUNDLE` environment variable.
 * `ec2_metadata_service_endpoint` - Address of the EC2 metadata service (IMDS) endpoint to use. This can also be sourced from the `AWS_EC2_METADATA_SERVICE_ENDPOINT` environment variable.
 * `ec2_metadata_service_endpoint_mode` - Mode to use in communicating with the metadata service. Valid values are `IPv4` and `IPv6`. This can also be sourced from the `AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE` environment variable.


### PR DESCRIPTION
The `use_legacy_workflow` S3 backend option uses the legacy authentication workflow, preferring environment variables over backend configuration.
We'd want to stop supporting it gradually, as it'll probably eventually be removed from https://github.com/hashicorp/aws-sdk-go-base.

In this PR, we are:
1. Setting the default to `false`.
2. Adding a deprecation warning.
<img width="834" alt="Screenshot 2023-12-21 at 18 39 44" src="https://github.com/opentofu/opentofu/assets/20083583/eacc5a2b-d795-42ef-8e1c-8daa17569252">

Resolves https://github.com/opentofu/opentofu/issues/1014

## Target Release

1.7.0
