### PR TITLE
doc(website): Adding missing import statement on homebrew installation documentation

### DIFF
--- a/website/docs/intro/install/homebrew.mdx
+++ b/website/docs/intro/install/homebrew.mdx
@@ -5,10 +5,11 @@ description: |-
   Install OpenTofu on MacOS or Linux.
 ---
 
+import CodeBlock from '@theme/CodeBlock';
 import BrewScript from '!!raw-loader!./brew-install.sh'
 
 # Installing OpenTofu via Homebrew
 
 You can use OpenTofu as a [portable binary](portable.mdx) or you can install it using [Homebrew](https://formulae.brew.sh/formula/opentofu). OpenTofu is available in the Homebrew Core repository, so you can install it by running:
 
-<CodeBlock language="shell">{BrewScript}</CodeBlock>
+<CodeBlock language={"bash"}>{BrewScript}</CodeBlock>


### PR DESCRIPTION
Adding missing import statement on `homebrew` installation documentation.

Resolves #1056 
