### PR TITLE
Refactor base64gunzip function to be more in line with other functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ ENHANCEMENTS:
  - This change fixes the local state filesystem interface to function as the statemgr API describes.
  - A possible side effect is that a hard crash mid-apply will no longer have a in-progress state file to reference. This matches the other state managers.
 * `tofu console` should work in Solaris and AIX as readline has been updated. ([#632](https://github.com/opentofu/opentofu/pull/632))
-
+* Added "base64gunzip" function. ([$800](https://github.com/opentofu/opentofu/issues/800))
 
 BUG FIXES:
 * `tofu test` resources cleanup at the end of tests changed to use simple reverse run block order. ([#1043](https://github.com/opentofu/opentofu/pull/1043))

--- a/internal/lang/funcs/descriptions.go
+++ b/internal/lang/funcs/descriptions.go
@@ -53,8 +53,8 @@ var DescriptionList = map[string]descriptionEntry{
 		Description:      "`base64gzip` compresses a string with gzip and then encodes the result in Base64 encoding.",
 		ParamDescription: []string{""},
 	},
-	"gunzipbase64": {
-		Description:      "`gunzipbase64` decodes a Base64-encoded string and uncompresses the result with gzip.",
+	"base64gunzip": {
+		Description:      "`base64gunzip` decodes a Base64-encoded string and uncompresses the result with gzip.",
 		ParamDescription: []string{""},
 	},
 	"base64sha256": {

--- a/internal/lang/funcs/encoding.go
+++ b/internal/lang/funcs/encoding.go
@@ -179,8 +179,8 @@ var Base64GzipFunc = function.New(&function.Spec{
 	},
 })
 
-// GunzipBase64Func constructs a function that Bae64 decodes a string and decompresses the result with gunzip.
-var GunzipBase64Func = function.New(&function.Spec{
+// Base64GunzipFunc constructs a function that Bae64 decodes a string and decompresses the result with gunzip.
+var Base64GunzipFunc = function.New(&function.Spec{
 	Params: []function.Parameter{
 		{
 			Name: "str",
@@ -260,11 +260,11 @@ func Base64Gzip(str cty.Value) (cty.Value, error) {
 	return Base64GzipFunc.Call([]cty.Value{str})
 }
 
-// GunzipBase64 decodes a Base64-encoded string and uncompresses the result with gzip.
+// Base64Gunzip decodes a Base64-encoded string and uncompresses the result with gzip.
 //
 // Opentofu uses the "standard" Base64 alphabet as defined in RFC 4648 section 4.
-func GunzipBase64(str cty.Value) (cty.Value, error) {
-	return GunzipBase64Func.Call([]cty.Value{str})
+func Base64Gunzip(str cty.Value) (cty.Value, error) {
+	return Base64GunzipFunc.Call([]cty.Value{str})
 }
 
 // URLEncode applies URL encoding to a given string.

--- a/internal/lang/funcs/encoding_test.go
+++ b/internal/lang/funcs/encoding_test.go
@@ -174,7 +174,7 @@ func TestBase64Gunzip(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(fmt.Sprintf("gunzipbase64(%#v)", test.String), func(t *testing.T) {
+		t.Run(fmt.Sprintf("base64gunzip(%#v)", test.String), func(t *testing.T) {
 			got, err := Base64Gunzip(test.String)
 
 			if test.Err {

--- a/internal/lang/funcs/encoding_test.go
+++ b/internal/lang/funcs/encoding_test.go
@@ -7,8 +7,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/opentofu/opentofu/internal/lang/marks"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/opentofu/opentofu/internal/lang/marks"
 )
 
 func TestBase64Decode(t *testing.T) {
@@ -159,7 +160,7 @@ func TestBase64Gzip(t *testing.T) {
 	}
 }
 
-func TestGunzipBase64(t *testing.T) {
+func TestBase64Gunzip(t *testing.T) {
 	tests := []struct {
 		String cty.Value
 		Want   cty.Value
@@ -174,7 +175,7 @@ func TestGunzipBase64(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("gunzipbase64(%#v)", test.String), func(t *testing.T) {
-			got, err := GunzipBase64(test.String)
+			got, err := Base64Gunzip(test.String)
 
 			if test.Err {
 				if err == nil {

--- a/internal/lang/functions.go
+++ b/internal/lang/functions.go
@@ -43,7 +43,7 @@ func (s *Scope) Functions() map[string]function.Function {
 			"base64decode":     funcs.Base64DecodeFunc,
 			"base64encode":     funcs.Base64EncodeFunc,
 			"base64gzip":       funcs.Base64GzipFunc,
-			"gunzipbase64":     funcs.Base64GunzipFunc,
+			"base64gunzip":     funcs.Base64GunzipFunc,
 			"base64sha256":     funcs.Base64Sha256Func,
 			"base64sha512":     funcs.Base64Sha512Func,
 			"bcrypt":           funcs.BcryptFunc,

--- a/internal/lang/functions.go
+++ b/internal/lang/functions.go
@@ -43,7 +43,7 @@ func (s *Scope) Functions() map[string]function.Function {
 			"base64decode":     funcs.Base64DecodeFunc,
 			"base64encode":     funcs.Base64EncodeFunc,
 			"base64gzip":       funcs.Base64GzipFunc,
-			"gunzipbase64":     funcs.GunzipBase64Func,
+			"gunzipbase64":     funcs.Base64GunzipFunc,
 			"base64sha256":     funcs.Base64Sha256Func,
 			"base64sha512":     funcs.Base64Sha512Func,
 			"bcrypt":           funcs.BcryptFunc,

--- a/internal/lang/functions_test.go
+++ b/internal/lang/functions_test.go
@@ -13,9 +13,10 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	homedir "github.com/mitchellh/go-homedir"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/experiments"
 	"github.com/opentofu/opentofu/internal/lang/marks"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // TestFunctions tests that functions are callable through the functionality
@@ -108,9 +109,9 @@ func TestFunctions(t *testing.T) {
 			},
 		},
 
-		"gunzipbase64": {
+		"base64gunzip": {
 			{
-				`gunzipbase64("H4sIAAAAAAAA/ypJLS4BAAAA//8BAAD//wx+f9gEAAAA")`,
+				`base64gunzip("H4sIAAAAAAAA/ypJLS4BAAAA//8BAAD//wx+f9gEAAAA")`,
 				cty.StringVal("test"),
 			},
 		},

--- a/website/data/language-nav-data.json
+++ b/website/data/language-nav-data.json
@@ -518,8 +518,8 @@
             "path": "language/functions/csvdecode"
           },
           {
-            "title": "<code>gunzipbase64</code>",
-            "path": "language/functions/gunzipbase64"
+            "title": "<code>base64gunzip</code>",
+            "path": "language/functions/base64gunzip"
           },
           {
             "title": "<code>jsondecode</code>",
@@ -932,8 +932,8 @@
         "hidden": true
       },
       {
-        "title": "gunzipbase64",
-        "path": "language/functions/gunzipbase64",
+        "title": "base64gunzip",
+        "path": "language/functions/base64gunzip",
         "hidden": true
       },
       {

--- a/website/docs/language/functions/base64gunzip.mdx
+++ b/website/docs/language/functions/base64gunzip.mdx
@@ -1,12 +1,12 @@
 ---
-page_title: gunzipbase64 - Functions - Configuration Language
+page_title: base64gunzip - Functions - Configuration Language
 description: |-
-  The gunzipbase64 funtion decodes a Base64-encoded string and uncompresses the result with gzip.
+  The base64gunzip funtion decodes a Base64-encoded string and uncompresses the result with gzip.
 ---
 
-# `gunzipbase64` Function
+# `base64gunzip` Function
 
-`gunzipbase64` decodes a Base64-encoded string and uncompresses the result with gzip.
+`base64gunzip` decodes a Base64-encoded string and uncompresses the result with gzip.
 
 Opentofu uses the "standard" Base64 alphabet as defined in
 [RFC 4648 section 4](https://tools.ietf.org/html/rfc4648#section-4).


### PR DESCRIPTION
Change the name of the gunzipbase64 function to base64gunzip, so it's more in line with the others.

Adds changelog entry.

Improves #800.

## Target Release

1.7.0
