### PR TITLE
Fix broken links and add clarifications in documentation

### DIFF
--- a/website/docs/language/settings/backends/remote.mdx
+++ b/website/docs/language/settings/backends/remote.mdx
@@ -11,7 +11,7 @@ description: >-
 **We recommend using the [`cloud` built-in integration](/docs/cli/cloud/settings)** instead of this backend. The `cloud` option includes an improved user experience and more features.
 :::
 
-The remote backend is unique among all other OpenTofu backends because it can both store state snapshots and execute CLI-driven run workflow operations for TACOS (TF Automation and Collaboration Software) backends if supported by your TACOS provider. It used to be called an "enhanced" backend.
+The remote backend is unique among all other OpenTofu backends because it can both store state snapshots and execute CLI-driven run workflow operations for TF Automation and Collaboration Software (TACOS) backends. It used to be called an "enhanced" backend.
 
 If your TACOS provider enables full remote operations, you can execute commands such as `tofu plan` or `tofu apply` within the TACOS runtime environment, with log output streaming directly to your local terminal. Remote plans and applies use variable values from the associated remote workspace.
 
@@ -19,7 +19,11 @@ You can also use TACOS with local operations, where only state is stored in the 
 
 ## Command Support
 
-The remote backend supports the following OpenTofu commands (it's up to the TACOS provider to implement support for each command):
+:::note
+Features implementation might vary between different TACOS.
+:::
+
+The remote backend supports the following OpenTofu commands:
 
 - `apply`
 - `console`
@@ -62,7 +66,7 @@ setting both results in a configuration error.
 If previous state is present when you run `tofu init` and the corresponding
 remote workspaces are empty or absent, OpenTofu will create workspaces and
 update the remote state accordingly. However, if your workspace requires variables or a specific version of OpenTofu for remote operations, we
-recommend that you create your remote workspaces on TACOS (TF Automation and Collaboration Software) before
+recommend that you create your remote workspaces on TACOS before
 running any remote operations against them.
 
 ### Workspace Names
@@ -175,7 +179,7 @@ The following configuration options are supported:
     only the default workspace can be used. This option conflicts with `prefix`.
   - `prefix` - (Optional) A prefix used in the names of one or more remote
     workspaces, all of which can be used with this configuration. The full
-    workspace names are used in TACOS (TF Automation and Collaboration Software), and the short names
+    workspace names are used in TACOS, and the short names
     (minus the prefix) are used on the command line for OpenTofu CLI workspaces.
     If omitted, only the default workspace can be used. This option conflicts with `name`.
 
@@ -208,7 +212,7 @@ the remote workspace accept the following option to modify that behavior:
 ## Excluding Files from Upload with .terraformignore
 
 When executing a remote `plan` or `apply` in a CLI-driven run,
-an archive of your configuration directory is uploaded to TACOS (TF Automation and Collaboration Software). You can define
+an archive of your configuration directory is uploaded to TACOS. You can define
 paths to ignore from upload via a `.terraformignore` file at the root of your configuration directory. If this file is not present, the archive will exclude the following by default:
 
 - `.git/` directories

--- a/website/docs/language/settings/backends/remote.mdx
+++ b/website/docs/language/settings/backends/remote.mdx
@@ -11,15 +11,15 @@ description: >-
 **We recommend using the [`cloud` built-in integration](/docs/cli/cloud/settings)** instead of this backend. The `cloud` option includes an improved user experience and more features.
 :::
 
-The remote backend is unique among all other OpenTofu backends because it can both store state snapshots and execute operations for TACOS (TF Automation and Collaboration Software) [CLI-driven run workflow](/docs/cloud-docs/run/cli). It used to be called an "enhanced" backend.
+The remote backend is unique among all other OpenTofu backends because it can both store state snapshots and execute CLI-driven run workflow operations for TACOS (TF Automation and Collaboration Software) backends if supported by your TACOS provider. It used to be called an "enhanced" backend.
 
-When using full remote operations, operations like `tofu plan` or `tofu apply` can be executed in TACOS (TF Automation and Collaboration Software) run environment, with log output streaming to the local terminal. Remote plans and applies use variable values from the associated remote workspace.
+If your TACOS provider enables full remote operations, you can execute commands such as `tofu plan` or `tofu apply` within the TACOS runtime environment, with log output streaming directly to your local terminal. Remote plans and applies use variable values from the associated remote workspace.
 
-You can also use TACOS (TF Automation and Collaboration Software) with local operations, in which case only state is stored in the remote backend.
+You can also use TACOS with local operations, where only state is stored in the TACOS remote backend.
 
 ## Command Support
 
-The remote backend supports the following OpenTofu commands:
+The remote backend supports the following OpenTofu commands (it's up to the TACOS provider to implement support for each command):
 
 - `apply`
 - `console`
@@ -73,26 +73,6 @@ Because of this, the [`terraform.workspace`](/docs/language/state/workspaces#cur
 
 - For local operations, `terraform.workspace` = `prod`
 - For remote operations, `terraform.workspace`=  `networking-prod`
-
-### Determining Run Environment
-
-If you need to determine whether a run is local or remote in your OpenTofu configuration, we recommend using [run environment variables](/docs/cloud-docs/run/run-environment#environment-variables). The example below uses `TFC_RUN_ID`.
-
-```
-output "current_workspace_name" {
-  value = terraform.workspace
-}
-
-variable "TFC_RUN_ID" {
-  type    = string
-  default = ""
-}
-
-output "remote_execution_determine" {
-  value = "Remote run environment? %{if var.TFC_RUN_ID != ""}Yes%{else}No this is local%{endif}!"
-}
-```
-
 
 ## Example Configurations
 
@@ -227,7 +207,7 @@ the remote workspace accept the following option to modify that behavior:
 
 ## Excluding Files from Upload with .terraformignore
 
-When executing a remote `plan` or `apply` in a [CLI-driven run](/docs/cloud-docs/run/cli),
+When executing a remote `plan` or `apply` in a CLI-driven run,
 an archive of your configuration directory is uploaded to TACOS (TF Automation and Collaboration Software). You can define
 paths to ignore from upload via a `.terraformignore` file at the root of your configuration directory. If this file is not present, the archive will exclude the following by default:
 

--- a/website/docs/language/settings/tf-cloud.mdx
+++ b/website/docs/language/settings/tf-cloud.mdx
@@ -1,18 +1,18 @@
 ---
 description: >-
-  The nested `cloud` block configures OpenTofu's integration with a TACOS backend.
+  The nested `cloud` block configures OpenTofu's integration with a cloud backend.
 ---
 
 # Cloud Configuration
 
-The main module of an OpenTofu configuration can integrate with TACOS (TF Automation and Collaboration Software) backend to enable CLI-driven run workflow (if supported by the TACOS provider). You only need to configure these settings when you want to use OpenTofu CLI to interact with a TACOS backend.
-TACOS should ignore them when interacting with OpenTofu through version control or the API.
+The main module of an OpenTofu configuration can integrate with a cloud backend to enable CLI-driven run workflow (if supported by your cloud backend). You only need to configure these settings when you want to use OpenTofu CLI to interact with a cloud backend.
+A cloud backend ignores them when interacting with OpenTofu through version control or the API.
 
 ## Usage Example
 
-To configure the TACOS backend CLI integration, add a nested `cloud` block within the `terraform` block. You cannot use the CLI integration and a [state backend](/docs/language/settings/backends/configuration) in the same configuration.
+To configure the cloud CLI integration, add a nested `cloud` block within the `terraform` block. You cannot use the CLI integration and a state backend in the same configuration.
 
-Refer to [Using the TACOS cloud Backend](/docs/cli/cloud) in the OpenTofu CLI documentation for full configuration details, migration instructions, and command line arguments.
+Refer to [Using the Cloud Backend](/docs/cli/cloud) in the OpenTofu CLI documentation for full configuration details, migration instructions, and command line arguments.
 
 ```hcl
 terraform {

--- a/website/docs/language/settings/tf-cloud.mdx
+++ b/website/docs/language/settings/tf-cloud.mdx
@@ -1,18 +1,18 @@
 ---
 description: >-
-  The nested `cloud` block configures OpenTofu's integration with a cloud backend.
+  The nested `cloud` block configures OpenTofu's integration with a TACOS backend.
 ---
 
 # Cloud Configuration
 
-The main module of an OpenTofu configuration can integrate with a cloud backend to enable its [CLI-driven run workflow](/docs/cloud-docs/run/cli). You only need to configure these settings when you want to use OpenTofu CLI to interact with a cloud backend.
-A cloud backend ignores them when interacting with OpenTofu through version control or the API.
+The main module of an OpenTofu configuration can integrate with TACOS (TF Automation and Collaboration Software) backend to enable CLI-driven run workflow (if supported by the TACOS provider). You only need to configure these settings when you want to use OpenTofu CLI to interact with a TACOS backend.
+TACOS should ignore them when interacting with OpenTofu through version control or the API.
 
 ## Usage Example
 
-To configure the cloud CLI integration, add a nested `cloud` block within the `terraform` block. You cannot use the CLI integration and a [state backend](/docs/language/settings/backends/configuration) in the same configuration.
+To configure the TACOS backend CLI integration, add a nested `cloud` block within the `terraform` block. You cannot use the CLI integration and a [state backend](/docs/language/settings/backends/configuration) in the same configuration.
 
-Refer to [Using the Cloud Backend](/docs/cli/cloud) in the OpenTofu CLI documentation for full configuration details, migration instructions, and command line arguments.
+Refer to [Using the TACOS cloud Backend](/docs/cli/cloud) in the OpenTofu CLI documentation for full configuration details, migration instructions, and command line arguments.
 
 ```hcl
 terraform {

--- a/website/docs/language/state/remote-state-data.mdx
+++ b/website/docs/language/state/remote-state-data.mdx
@@ -65,7 +65,7 @@ use of. For example:
   store or Consul service catalog can make that data also accessible via
   [Consul Template](https://github.com/hashicorp/consul-template)
   or the
-  [HashiCorp Nomad](/nomad/docs/job-specification/template)
+  [HashiCorp Nomad](https://developer.hashicorp.com/nomad/docs/job-specification/template)
   `template` stanza.
 * If you use Kubernetes then you can
   [make Config Maps available to your Pods](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/).

--- a/website/docs/language/values/variables.mdx
+++ b/website/docs/language/values/variables.mdx
@@ -234,7 +234,7 @@ disclosing the content of one block might imply the content of a sibling block.
 ```
 
 A provider can also
-declare an attribute as sensitive,
+[declare an attribute as sensitive](https://developer.hashicorp.com/terraform/plugin/best-practices/sensitive-state#using-sensitive-flag-functionality),
 which will cause OpenTofu to hide it from regular output regardless of how
 you assign it a value. For more information, see
 [Sensitive Resource Attributes](/docs/language/expressions/references#sensitive-resource-attributes).

--- a/website/docs/language/values/variables.mdx
+++ b/website/docs/language/values/variables.mdx
@@ -234,7 +234,7 @@ disclosing the content of one block might imply the content of a sibling block.
 ```
 
 A provider can also
-[declare an attribute as sensitive](/docs/plugin/sdkv2/best-practices/sensitive-state#using-the-sensitive-flag),
+declare an attribute as sensitive,
 which will cause OpenTofu to hide it from regular output regardless of how
 you assign it a value. For more information, see
 [Sensitive Resource Attributes](/docs/language/expressions/references#sensitive-resource-attributes).


### PR DESCRIPTION
1. We had a few broken links in our docs. I fixed them.
2. Added some clarifications in documentation related to `remote` and `cloud` backends.

Resolves https://github.com/opentofu/opentofu/issues/1100

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.0
