### PR TITLE
Allow known references in import blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ ENHANCEMENTS:
 
 BUG FIXES:
 * `tofu test` resources cleanup at the end of tests changed to use simple reverse run block order. ([#1043](https://github.com/opentofu/opentofu/pull/1043))
+* Fix access to known references when using a import block for module resources ([#1105](https://github.com/opentofu/opentofu/pull/1105))
 
 ## Previous Releases
 

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -4631,6 +4631,39 @@ func TestContext2Plan_importIdVariable(t *testing.T) {
 	}
 }
 
+func TestContext2Plan_importIdReference(t *testing.T) {
+	p := testProvider("aws")
+	m := testModule(t, "import-id-reference")
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
+		},
+	})
+
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
+		ImportedResources: []providers.ImportedResource{
+			{
+				TypeName: "aws_instance",
+				State: cty.ObjectVal(map[string]cty.Value{
+					"id": cty.StringVal("foo"),
+				}),
+			},
+		},
+	}
+
+	_, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		SetVariables: InputValues{
+			"the_id": &InputValue{
+				// let var take its default value
+				Value: cty.NilVal,
+			},
+		},
+	})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Err())
+	}
+}
+
 func TestContext2Plan_importIdFunc(t *testing.T) {
 	p := testProvider("aws")
 	m := testModule(t, "import-id-func")

--- a/internal/tofu/eval_import.go
+++ b/internal/tofu/eval_import.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/lang/marks"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
@@ -21,6 +22,10 @@ func evaluateImportIdExpression(expr hcl.Expression, ctx EvalContext) (string, t
 			Subject:  nil,
 		})
 	}
+
+	// The import expression is declared within the root module
+	// We need to explicitly use that context
+	ctx = ctx.WithPath(addrs.RootModuleInstance)
 
 	importIdVal, evalDiags := ctx.EvaluateExpr(expr, cty.String, nil)
 	diags = diags.Append(evalDiags)

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -111,6 +111,7 @@ var (
 	_ GraphNodeModuleInstance            = (*NodeAbstractResourceInstance)(nil)
 	_ GraphNodeReferenceable             = (*NodeAbstractResourceInstance)(nil)
 	_ GraphNodeReferencer                = (*NodeAbstractResourceInstance)(nil)
+	_ GraphNodeRootReferencer            = (*NodeAbstractResourceInstance)(nil)
 	_ GraphNodeProviderConsumer          = (*NodeAbstractResourceInstance)(nil)
 	_ GraphNodeProvisionerConsumer       = (*NodeAbstractResourceInstance)(nil)
 	_ GraphNodeConfigResource            = (*NodeAbstractResourceInstance)(nil)
@@ -205,12 +206,18 @@ func (n *NodeAbstractResource) References() []*addrs.Reference {
 		}
 	}
 
+	return result
+}
+
+func (n *NodeAbstractResource) RootReferences() []*addrs.Reference {
+	var root []*addrs.Reference
+
 	for _, importTarget := range n.importTargets {
 		refs, _ := lang.ReferencesInExpr(addrs.ParseRef, importTarget.ID)
-		result = append(result, refs...)
+		root = append(root, refs...)
 	}
 
-	return result
+	return root
 }
 
 func (n *NodeAbstractResource) DependsOn() []*addrs.Reference {

--- a/internal/tofu/testdata/import-id-reference/main.tf
+++ b/internal/tofu/testdata/import-id-reference/main.tf
@@ -1,0 +1,13 @@
+variable "the_id" {
+  default = "123"
+}
+
+module "refmod" {
+	source = "./mod"
+}
+
+import {
+  to = module.refmod.aws_instance.foo
+  id = var.the_id
+}
+

--- a/internal/tofu/testdata/import-id-reference/mod/mod.tf
+++ b/internal/tofu/testdata/import-id-reference/mod/mod.tf
@@ -1,0 +1,2 @@
+resource "aws_instance" "foo" {
+}


### PR DESCRIPTION
Imports are attached to their respective modules, but must execute expressions in the root module context.  This PR fixes that and makes sure that refererences to the root module are properly described via the graph.

It is recommended to review this with hide-whitespace (?w=true) turned on as it makes the diff easier to read.

Resolves #1084 

## Target Release

1.7.0, 1.6.1
