### PR TITLE
Return false when assertBackendStateLocked fails and update comments for it and assertBackendStateUnlocked

### DIFF
--- a/internal/backend/local/testing.go
+++ b/internal/backend/local/testing.go
@@ -201,9 +201,9 @@ func mustResourceInstanceAddr(s string) addrs.AbsResourceInstance {
 	return addr
 }
 
-// assertBackendStateUnlocked attempts to lock the backend state. Failure
-// indicates that the state was locked and false is returned. True is
-// returned if a lock was obtained.
+// assertBackendStateUnlocked attempts to lock the backend state for a test.
+// Failure indicates that the state was locked and false is returned.
+// True is returned if a lock was obtained.
 func assertBackendStateUnlocked(t *testing.T, b *Local) bool {
 	t.Helper()
 	stateMgr, _ := b.StateMgr(backend.DefaultStateName)

--- a/internal/backend/local/testing.go
+++ b/internal/backend/local/testing.go
@@ -202,8 +202,8 @@ func mustResourceInstanceAddr(s string) addrs.AbsResourceInstance {
 }
 
 // assertBackendStateUnlocked attempts to lock the backend state. Failure
-// indicates that the state was indeed locked and therefore this function will
-// return true.
+// indicates that the state was locked and false is returned. True is
+// returned is a lock obtained.
 func assertBackendStateUnlocked(t *testing.T, b *Local) bool {
 	t.Helper()
 	stateMgr, _ := b.StateMgr(backend.DefaultStateName)
@@ -214,9 +214,9 @@ func assertBackendStateUnlocked(t *testing.T, b *Local) bool {
 	return true
 }
 
-// assertBackendStateLocked attempts to lock the backend state. Failure
-// indicates that the state was already locked and therefore this function will
-// return false.
+// assertBackendStateLocked attempts to lock the backend state for a test.
+// Failure indicates that the state was not locked and false is returned.
+// True is returned if a lock was not obtained.
 func assertBackendStateLocked(t *testing.T, b *Local) bool {
 	t.Helper()
 	stateMgr, _ := b.StateMgr(backend.DefaultStateName)
@@ -224,5 +224,5 @@ func assertBackendStateLocked(t *testing.T, b *Local) bool {
 		return true
 	}
 	t.Error("unexpected success locking state")
-	return true
+	return false
 }

--- a/internal/backend/local/testing.go
+++ b/internal/backend/local/testing.go
@@ -209,8 +209,10 @@ func assertBackendStateUnlocked(t *testing.T, b *Local) bool {
 	stateMgr, _ := b.StateMgr(backend.DefaultStateName)
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Errorf("state is already locked: %s", err.Error())
+		// lock was obtained
 		return false
 	}
+	// lock was not obtained
 	return true
 }
 
@@ -221,8 +223,10 @@ func assertBackendStateLocked(t *testing.T, b *Local) bool {
 	t.Helper()
 	stateMgr, _ := b.StateMgr(backend.DefaultStateName)
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
+		// lock was not obtained
 		return true
 	}
 	t.Error("unexpected success locking state")
+	// lock was obtained
 	return false
 }

--- a/internal/backend/local/testing.go
+++ b/internal/backend/local/testing.go
@@ -203,7 +203,7 @@ func mustResourceInstanceAddr(s string) addrs.AbsResourceInstance {
 
 // assertBackendStateUnlocked attempts to lock the backend state. Failure
 // indicates that the state was locked and false is returned. True is
-// returned is a lock obtained.
+// returned if a lock was obtained.
 func assertBackendStateUnlocked(t *testing.T, b *Local) bool {
 	t.Helper()
 	stateMgr, _ := b.StateMgr(backend.DefaultStateName)


### PR DESCRIPTION

`assertBackendStateLocked` was always returning true. It has been updated to return false when it fails. The comments for it and `assertBackendStateUnlocked` have also been updated for clarity.

## Target Release

1.7.0
