### PR TITLE
Allow static evaluation of locals and variables for module sources and backends

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/hashicorp/hcl/v2"
 	svchost "github.com/hashicorp/terraform-svchost"
 	"github.com/mitchellh/go-homedir"
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -327,6 +328,22 @@ func (o *Operation) Config() (*configs.Config, tfdiags.Diagnostics) {
 	config, hclDiags := o.ConfigLoader.LoadConfig(o.ConfigDir)
 	diags = diags.Append(hclDiags)
 	return config, diags
+}
+
+func (o *Operation) RawVariables() configs.RawVariables {
+	// TODO copy paste from meta_config.go
+	vars := make(configs.RawVariables)
+	for k, v := range o.Variables {
+		v := v
+		vars[k] = func(mode configs.VariableParsingMode) (cty.Value, hcl.Diagnostics) {
+			parsed, _ := v.ParseVariableValue(mode)
+			// TODO DIAGS
+			return parsed.Value, nil
+
+		}
+	}
+
+	return vars
 }
 
 // ReportResult is a helper for the common chore of setting the status of

--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -142,7 +142,7 @@ func (b *Local) localRunDirect(op *backend.Operation, run *backend.LocalRun, cor
 	var diags tfdiags.Diagnostics
 
 	// Load the configuration using the caller-provided configuration loader.
-	config, configSnap, configDiags := op.ConfigLoader.LoadConfigWithSnapshot(op.ConfigDir)
+	config, configSnap, configDiags := op.ConfigLoader.LoadConfigWithSnapshot(op.ConfigDir, op.RawVariables())
 	diags = diags.Append(configDiags)
 	if configDiags.HasErrors() {
 		return nil, nil, diags

--- a/internal/backend/remote/backend_common.go
+++ b/internal/backend/remote/backend_common.go
@@ -221,7 +221,7 @@ func (b *Remote) waitForRun(stopCtx, cancelCtx context.Context, op *backend.Oper
 // remote system's responsibility to do final validation of the input.
 func (b *Remote) hasExplicitVariableValues(op *backend.Operation) bool {
 	// Load the configuration using the caller-provided configuration loader.
-	config, _, configDiags := op.ConfigLoader.LoadConfigWithSnapshot(op.ConfigDir)
+	config, _, configDiags := op.ConfigLoader.LoadConfigWithSnapshot(op.ConfigDir, op.RawVariables())
 	if configDiags.HasErrors() {
 		// If we can't load the configuration then we'll assume no explicit
 		// variable values just to let the remote operation start and let

--- a/internal/cloud/backend_plan.go
+++ b/internal/cloud/backend_plan.go
@@ -254,7 +254,7 @@ in order to capture the filesystem context the remote workspace expects:
 		}
 	}
 
-	config, _, configDiags := op.ConfigLoader.LoadConfigWithSnapshot(op.ConfigDir)
+	config, _, configDiags := op.ConfigLoader.LoadConfigWithSnapshot(op.ConfigDir, op.RawVariables())
 	if configDiags.HasErrors() {
 		return nil, fmt.Errorf("error loading config with snapshot: %w", configDiags.Errs()[0])
 	}

--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -95,6 +95,8 @@ func (c *ApplyCommand) Run(rawArgs []string) int {
 	// object state for now.
 	c.Meta.parallelism = args.Operation.Parallelism
 
+	c.GatherVariables(args.Vars)
+
 	// Prepare the backend, passing the plan file if present, and the
 	// backend-specific arguments
 	be, beDiags := c.PrepareBackend(planFile, args.State, args.ViewType)
@@ -109,7 +111,7 @@ func (c *ApplyCommand) Run(rawArgs []string) int {
 	diags = diags.Append(opDiags)
 
 	// Collect variable value and add them to the operation request
-	diags = diags.Append(c.GatherVariables(opReq, args.Vars))
+	diags = diags.Append(c.StuffVariables(opReq))
 
 	// Before we delegate to the backend, we'll print any warning diagnostics
 	// we've accumulated here, since the backend will start fresh with its own
@@ -285,9 +287,7 @@ func (c *ApplyCommand) OperationRequest(
 	return opReq, diags
 }
 
-func (c *ApplyCommand) GatherVariables(opReq *backend.Operation, args *arguments.Vars) tfdiags.Diagnostics {
-	var diags tfdiags.Diagnostics
-
+func (c *ApplyCommand) GatherVariables(args *arguments.Vars) {
 	// FIXME the arguments package currently trivially gathers variable related
 	// arguments in a heterogenous slice, in order to minimize the number of
 	// code paths gathering variables during the transition to this structure.
@@ -302,8 +302,11 @@ func (c *ApplyCommand) GatherVariables(opReq *backend.Operation, args *arguments
 		items[i].Value = varArgs[i].Value
 	}
 	c.Meta.variableArgs = rawFlags{items: &items}
-	opReq.Variables, diags = c.collectVariableValues()
+}
 
+func (c *ApplyCommand) StuffVariables(opReq *backend.Operation) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+	opReq.Variables, diags = c.collectVariableValues()
 	return diags
 }
 

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -45,6 +45,7 @@ func (c *InitCommand) Run(args []string) int {
 	var flagFromModule, flagLockfile, testsDirectory string
 	var flagBackend, flagCloud, flagGet, flagUpgrade bool
 	var flagPluginPath FlagStringSlice
+
 	flagConfigExtra := newRawFlags("-backend-config")
 
 	args = c.Meta.process(args)
@@ -65,6 +66,7 @@ func (c *InitCommand) Run(args []string) int {
 	cmdFlags.BoolVar(&c.Meta.ignoreRemoteVersion, "ignore-remote-version", false, "continue even if remote and local OpenTofu versions are incompatible")
 	cmdFlags.StringVar(&testsDirectory, "test-directory", "tests", "test-directory")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
+
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
 	}

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -1392,8 +1392,7 @@ func (m *Meta) backendInitFromConfig(c *configs.Backend) (backend.Backend, cty.V
 	b := f()
 
 	schema := b.ConfigSchema()
-	decSpec := schema.NoneRequired().DecoderSpec()
-	configVal, hclDiags := hcldec.Decode(c.Config, decSpec, nil)
+	configVal, hclDiags := c.Decode(schema.NoneRequired())
 	diags = diags.Append(hclDiags)
 	if hclDiags.HasErrors() {
 		return nil, cty.NilVal, diags

--- a/internal/command/meta_config.go
+++ b/internal/command/meta_config.go
@@ -88,7 +88,7 @@ func (m *Meta) loadSingleModule(dir string) (*configs.Module, tfdiags.Diagnostic
 		return nil, diags
 	}
 
-	module, hclDiags := loader.Parser().LoadConfigDir(dir)
+	module, hclDiags := loader.Parser().LoadConfigDir(dir, make(map[string]cty.Value))
 	diags = diags.Append(hclDiags)
 	return module, diags
 }
@@ -105,7 +105,7 @@ func (m *Meta) loadSingleModuleWithTests(dir string, testDir string) (*configs.M
 		return nil, diags
 	}
 
-	module, hclDiags := loader.Parser().LoadConfigDirWithTests(dir, testDir)
+	module, hclDiags := loader.Parser().LoadConfigDirWithTests(dir, testDir, make(map[string]cty.Value))
 	diags = diags.Append(hclDiags)
 	return module, diags
 }

--- a/internal/command/meta_config.go
+++ b/internal/command/meta_config.go
@@ -88,7 +88,7 @@ func (m *Meta) loadSingleModule(dir string) (*configs.Module, tfdiags.Diagnostic
 		return nil, diags
 	}
 
-	module, hclDiags := loader.Parser().LoadConfigDir(dir, make(map[string]cty.Value))
+	module, hclDiags := loader.Parser().LoadConfigDir(dir, configs.StaticParams{Name: "root"})
 	diags = diags.Append(hclDiags)
 	return module, diags
 }
@@ -105,7 +105,7 @@ func (m *Meta) loadSingleModuleWithTests(dir string, testDir string) (*configs.M
 		return nil, diags
 	}
 
-	module, hclDiags := loader.Parser().LoadConfigDirWithTests(dir, testDir, make(map[string]cty.Value))
+	module, hclDiags := loader.Parser().LoadConfigDirWithTests(dir, testDir, configs.StaticParams{Name: "root"})
 	diags = diags.Append(hclDiags)
 	return module, diags
 }

--- a/internal/command/meta_config.go
+++ b/internal/command/meta_config.go
@@ -88,7 +88,7 @@ func (m *Meta) loadSingleModule(dir string) (*configs.Module, tfdiags.Diagnostic
 		return nil, diags
 	}
 
-	module, hclDiags := loader.Parser().LoadConfigDir(dir, configs.StaticParams{Name: "root"})
+	module, hclDiags := loader.Parser().LoadConfigDir(dir, configs.StaticModuleCall{Name: "root"})
 	diags = diags.Append(hclDiags)
 	return module, diags
 }
@@ -105,7 +105,7 @@ func (m *Meta) loadSingleModuleWithTests(dir string, testDir string) (*configs.M
 		return nil, diags
 	}
 
-	module, hclDiags := loader.Parser().LoadConfigDirWithTests(dir, testDir, configs.StaticParams{Name: "root"})
+	module, hclDiags := loader.Parser().LoadConfigDirWithTests(dir, testDir, configs.StaticModuleCall{Name: "root"})
 	diags = diags.Append(hclDiags)
 	return module, diags
 }

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -66,6 +66,8 @@ func (c *PlanCommand) Run(rawArgs []string) int {
 
 	diags = diags.Append(c.providerDevOverrideRuntimeWarnings())
 
+	c.GatherVariables(args.Vars)
+
 	// Prepare the backend with the backend-specific arguments
 	be, beDiags := c.PrepareBackend(args.State, args.ViewType)
 	diags = diags.Append(beDiags)
@@ -83,7 +85,7 @@ func (c *PlanCommand) Run(rawArgs []string) int {
 	}
 
 	// Collect variable value and add them to the operation request
-	diags = diags.Append(c.GatherVariables(opReq, args.Vars))
+	diags = diags.Append(c.StuffVariables(opReq))
 	if diags.HasErrors() {
 		view.Diagnostics(diags)
 		return 1
@@ -171,8 +173,7 @@ func (c *PlanCommand) OperationRequest(
 	return opReq, diags
 }
 
-func (c *PlanCommand) GatherVariables(opReq *backend.Operation, args *arguments.Vars) tfdiags.Diagnostics {
-	var diags tfdiags.Diagnostics
+func (c *PlanCommand) GatherVariables(args *arguments.Vars) {
 
 	// FIXME the arguments package currently trivially gathers variable related
 	// arguments in a heterogenous slice, in order to minimize the number of
@@ -188,8 +189,11 @@ func (c *PlanCommand) GatherVariables(opReq *backend.Operation, args *arguments.
 		items[i].Value = varArgs[i].Value
 	}
 	c.Meta.variableArgs = rawFlags{items: &items}
-	opReq.Variables, diags = c.collectVariableValues()
+}
 
+func (c *PlanCommand) StuffVariables(opReq *backend.Operation) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+	opReq.Variables, diags = c.collectVariableValues()
 	return diags
 }
 

--- a/internal/configs/backend.go
+++ b/internal/configs/backend.go
@@ -14,18 +14,17 @@ import (
 type Backend struct {
 	Type   string
 	Config hcl.Body
-	ctx    StaticContext
+	ctx    *StaticContext
 
 	TypeRange hcl.Range
 	DeclRange hcl.Range
 }
 
-func decodeBackendBlock(block *hcl.Block, ctx StaticContext) (*Backend, hcl.Diagnostics) {
+func decodeBackendBlock(block *hcl.Block) (*Backend, hcl.Diagnostics) {
 	return &Backend{
 		Type:      block.Labels[0],
 		TypeRange: block.LabelRanges[0],
 		Config:    block.Body,
-		ctx:       ctx,
 		DeclRange: block.DefRange,
 	}, nil
 }

--- a/internal/configs/backend.go
+++ b/internal/configs/backend.go
@@ -5,7 +5,6 @@ package configs
 
 import (
 	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -15,16 +14,18 @@ import (
 type Backend struct {
 	Type   string
 	Config hcl.Body
+	ctx    StaticContext
 
 	TypeRange hcl.Range
 	DeclRange hcl.Range
 }
 
-func decodeBackendBlock(block *hcl.Block) (*Backend, hcl.Diagnostics) {
+func decodeBackendBlock(block *hcl.Block, ctx StaticContext) (*Backend, hcl.Diagnostics) {
 	return &Backend{
 		Type:      block.Labels[0],
 		TypeRange: block.LabelRanges[0],
 		Config:    block.Body,
+		ctx:       ctx,
 		DeclRange: block.DefRange,
 	}, nil
 }
@@ -43,8 +44,7 @@ func (b *Backend) Hash(schema *configschema.Block) int {
 	// Don't fail if required attributes are not set. Instead, we'll just
 	// hash them as nulls.
 	schema = schema.NoneRequired()
-	spec := schema.DecoderSpec()
-	val, _ := hcldec.Decode(b.Config, spec, nil)
+	val, _ := b.Decode(schema)
 	if val == cty.NilVal {
 		val = cty.UnknownVal(schema.ImpliedType())
 	}
@@ -55,4 +55,8 @@ func (b *Backend) Hash(schema *configschema.Block) int {
 	})
 
 	return toHash.Hash()
+}
+
+func (b *Backend) Decode(schema *configschema.Block) (cty.Value, hcl.Diagnostics) {
+	return b.ctx.DecodeBlock(b.Config, schema.DecoderSpec())
 }

--- a/internal/configs/backend.go
+++ b/internal/configs/backend.go
@@ -58,5 +58,5 @@ func (b *Backend) Hash(schema *configschema.Block) int {
 }
 
 func (b *Backend) Decode(schema *configschema.Block) (cty.Value, hcl.Diagnostics) {
-	return b.ctx.DecodeBlock(b.Config, schema.DecoderSpec())
+	return b.ctx.DecodeBlock(b.Config, schema.DecoderSpec(), "terraform.backend."+b.Type)
 }

--- a/internal/configs/backend.go
+++ b/internal/configs/backend.go
@@ -58,5 +58,5 @@ func (b *Backend) Hash(schema *configschema.Block) int {
 }
 
 func (b *Backend) Decode(schema *configschema.Block) (cty.Value, hcl.Diagnostics) {
-	return b.ctx.DecodeBlock(b.Config, schema.DecoderSpec(), "terraform.backend."+b.Type)
+	return b.ctx.DecodeBlock(b.Config, schema.DecoderSpec(), StaticIdentifier{Module: "terraform", Type: "backend", Name: b.Type})
 }

--- a/internal/configs/config_build.go
+++ b/internal/configs/config_build.go
@@ -137,11 +137,11 @@ func buildChildModules(parent *Config, walker ModuleWalker) (map[string]*Config,
 			Name:              call.Name,
 			Path:              path,
 			SourceAddr:        call.SourceAddr,
-			SourceAddrRange:   call.SourceAddrRange,
+			SourceAddrRange:   call.Source.Range(),
 			VersionConstraint: call.Version,
 			Parent:            parent,
 			CallRange:         call.DeclRange,
-			Variables:         call.Variables(parent.Module.Ctx),
+			Variables:         call.Variables,
 		}
 		child, modDiags := loadModule(parent.Root, &req, walker)
 		diags = append(diags, modDiags...)

--- a/internal/configs/config_build.go
+++ b/internal/configs/config_build.go
@@ -133,12 +133,6 @@ func buildChildModules(parent *Config, walker ModuleWalker) (map[string]*Config,
 		copy(path, parent.Path)
 		path[len(path)-1] = call.Name
 
-		vars, vDiags := call.Variables(parent.Module.Ctx)
-		if len(vDiags) != 0 {
-			diags = append(diags, vDiags...)
-			continue
-		}
-
 		req := ModuleRequest{
 			Name:              call.Name,
 			Path:              path,
@@ -147,7 +141,7 @@ func buildChildModules(parent *Config, walker ModuleWalker) (map[string]*Config,
 			VersionConstraint: call.Version,
 			Parent:            parent,
 			CallRange:         call.DeclRange,
-			Variables:         vars,
+			Variables:         call.Variables(parent.Module.Ctx),
 		}
 		child, modDiags := loadModule(parent.Root, &req, walker)
 		diags = append(diags, modDiags...)

--- a/internal/configs/config_build.go
+++ b/internal/configs/config_build.go
@@ -11,6 +11,7 @@ import (
 
 	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 )
@@ -141,6 +142,7 @@ func buildChildModules(parent *Config, walker ModuleWalker) (map[string]*Config,
 			VersionConstraint: call.Version,
 			Parent:            parent,
 			CallRange:         call.DeclRange,
+			Variables:         call.Variables(parent.Module.Ctx),
 		}
 		child, modDiags := loadModule(parent.Root, &req, walker)
 		diags = append(diags, modDiags...)
@@ -297,6 +299,8 @@ type ModuleRequest struct {
 	// subject of an error diagnostic that relates to the module call itself,
 	// rather than to either its source address or its version number.
 	CallRange hcl.Range
+
+	Variables map[string]cty.Value
 }
 
 // DisabledModuleWalker is a ModuleWalker that doesn't support

--- a/internal/configs/config_build.go
+++ b/internal/configs/config_build.go
@@ -11,7 +11,6 @@ import (
 
 	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
-	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 )
@@ -134,6 +133,12 @@ func buildChildModules(parent *Config, walker ModuleWalker) (map[string]*Config,
 		copy(path, parent.Path)
 		path[len(path)-1] = call.Name
 
+		vars, vDiags := call.Variables(parent.Module.Ctx)
+		if len(vDiags) != 0 {
+			diags = append(diags, vDiags...)
+			continue
+		}
+
 		req := ModuleRequest{
 			Name:              call.Name,
 			Path:              path,
@@ -142,7 +147,7 @@ func buildChildModules(parent *Config, walker ModuleWalker) (map[string]*Config,
 			VersionConstraint: call.Version,
 			Parent:            parent,
 			CallRange:         call.DeclRange,
-			Variables:         call.Variables(parent.Module.Ctx),
+			Variables:         vars,
 		}
 		child, modDiags := loadModule(parent.Root, &req, walker)
 		diags = append(diags, modDiags...)
@@ -300,7 +305,7 @@ type ModuleRequest struct {
 	// rather than to either its source address or its version number.
 	CallRange hcl.Range
 
-	Variables map[string]cty.Value
+	Variables StaticReferences
 }
 
 // DisabledModuleWalker is a ModuleWalker that doesn't support

--- a/internal/configs/configload/loader_load.go
+++ b/internal/configs/configload/loader_load.go
@@ -24,13 +24,13 @@ import (
 // required to process the individual modules
 func (l *Loader) LoadConfig(rootDir string) (*configs.Config, hcl.Diagnostics) {
 	// TODO inject vars from environment / cli flags
-	return l.loadConfig(l.parser.LoadConfigDir(rootDir, configs.StaticParams{Name: "root"}))
+	return l.loadConfig(l.parser.LoadConfigDir(rootDir, configs.StaticModuleCall{Name: "root"}))
 }
 
 // LoadConfigWithTests matches LoadConfig, except the configs.Config contains
 // any relevant .tftest.hcl files.
 func (l *Loader) LoadConfigWithTests(rootDir string, testDir string) (*configs.Config, hcl.Diagnostics) {
-	return l.loadConfig(l.parser.LoadConfigDirWithTests(rootDir, testDir, configs.StaticParams{Name: "root"}))
+	return l.loadConfig(l.parser.LoadConfigDirWithTests(rootDir, testDir, configs.StaticModuleCall{Name: "root"}))
 }
 
 func (l *Loader) loadConfig(rootMod *configs.Module, diags hcl.Diagnostics) (*configs.Config, hcl.Diagnostics) {
@@ -106,7 +106,7 @@ func (l *Loader) moduleWalkerLoad(req *configs.ModuleRequest) (*configs.Module, 
 		})
 	}
 
-	mod, mDiags := l.parser.LoadConfigDir(record.Dir, configs.StaticParams{Name: req.Path.String(), Call: req.Variables})
+	mod, mDiags := l.parser.LoadConfigDir(record.Dir, configs.StaticModuleCall{Name: req.Path.String(), Call: req.Variables})
 	diags = append(diags, mDiags...)
 	if mod == nil {
 		// nil specifically indicates that the directory does not exist or

--- a/internal/configs/configload/loader_load.go
+++ b/internal/configs/configload/loader_load.go
@@ -8,7 +8,6 @@ import (
 
 	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
-	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/configs"
 )
@@ -25,13 +24,13 @@ import (
 // required to process the individual modules
 func (l *Loader) LoadConfig(rootDir string) (*configs.Config, hcl.Diagnostics) {
 	// TODO inject vars from environment / cli flags
-	return l.loadConfig(l.parser.LoadConfigDir(rootDir, make(map[string]cty.Value)))
+	return l.loadConfig(l.parser.LoadConfigDir(rootDir, configs.StaticParams{Name: "root"}))
 }
 
 // LoadConfigWithTests matches LoadConfig, except the configs.Config contains
 // any relevant .tftest.hcl files.
 func (l *Loader) LoadConfigWithTests(rootDir string, testDir string) (*configs.Config, hcl.Diagnostics) {
-	return l.loadConfig(l.parser.LoadConfigDirWithTests(rootDir, testDir, make(map[string]cty.Value)))
+	return l.loadConfig(l.parser.LoadConfigDirWithTests(rootDir, testDir, configs.StaticParams{Name: "root"}))
 }
 
 func (l *Loader) loadConfig(rootMod *configs.Module, diags hcl.Diagnostics) (*configs.Config, hcl.Diagnostics) {
@@ -107,7 +106,7 @@ func (l *Loader) moduleWalkerLoad(req *configs.ModuleRequest) (*configs.Module, 
 		})
 	}
 
-	mod, mDiags := l.parser.LoadConfigDir(record.Dir, req.Variables)
+	mod, mDiags := l.parser.LoadConfigDir(record.Dir, configs.StaticParams{Name: req.Path.String(), Call: req.Variables})
 	diags = append(diags, mDiags...)
 	if mod == nil {
 		// nil specifically indicates that the directory does not exist or

--- a/internal/configs/configload/loader_load.go
+++ b/internal/configs/configload/loader_load.go
@@ -8,6 +8,7 @@ import (
 
 	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/configs"
 )
@@ -23,13 +24,14 @@ import (
 // LoadConfig performs the basic syntax and uniqueness validations that are
 // required to process the individual modules
 func (l *Loader) LoadConfig(rootDir string) (*configs.Config, hcl.Diagnostics) {
-	return l.loadConfig(l.parser.LoadConfigDir(rootDir))
+	// TODO inject vars from environment / cli flags
+	return l.loadConfig(l.parser.LoadConfigDir(rootDir, make(map[string]cty.Value)))
 }
 
 // LoadConfigWithTests matches LoadConfig, except the configs.Config contains
 // any relevant .tftest.hcl files.
 func (l *Loader) LoadConfigWithTests(rootDir string, testDir string) (*configs.Config, hcl.Diagnostics) {
-	return l.loadConfig(l.parser.LoadConfigDirWithTests(rootDir, testDir))
+	return l.loadConfig(l.parser.LoadConfigDirWithTests(rootDir, testDir, make(map[string]cty.Value)))
 }
 
 func (l *Loader) loadConfig(rootMod *configs.Module, diags hcl.Diagnostics) (*configs.Config, hcl.Diagnostics) {
@@ -105,7 +107,7 @@ func (l *Loader) moduleWalkerLoad(req *configs.ModuleRequest) (*configs.Module, 
 		})
 	}
 
-	mod, mDiags := l.parser.LoadConfigDir(record.Dir)
+	mod, mDiags := l.parser.LoadConfigDir(record.Dir, req.Variables)
 	diags = append(diags, mDiags...)
 	if mod == nil {
 		// nil specifically indicates that the directory does not exist or

--- a/internal/configs/configload/loader_load.go
+++ b/internal/configs/configload/loader_load.go
@@ -29,8 +29,8 @@ func (l *Loader) LoadConfig(rootDir string) (*configs.Config, hcl.Diagnostics) {
 
 // LoadConfigWithTests matches LoadConfig, except the configs.Config contains
 // any relevant .tftest.hcl files.
-func (l *Loader) LoadConfigWithTests(rootDir string, testDir string) (*configs.Config, hcl.Diagnostics) {
-	return l.loadConfig(l.parser.LoadConfigDirWithTests(rootDir, testDir, configs.StaticModuleCall{Name: "root"}))
+func (l *Loader) LoadConfigWithTests(rootDir string, testDir string, vars configs.RawVariables) (*configs.Config, hcl.Diagnostics) {
+	return l.loadConfig(l.parser.LoadConfigDirWithTests(rootDir, testDir, configs.StaticModuleCall{Name: "root", Raw: vars}))
 }
 
 func (l *Loader) loadConfig(rootMod *configs.Module, diags hcl.Diagnostics) (*configs.Config, hcl.Diagnostics) {
@@ -82,7 +82,7 @@ func (l *Loader) moduleWalkerLoad(req *configs.ModuleRequest) (*configs.Module, 
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Module source has changed",
-			Detail:   "The source address was changed since this module was installed. Run \"tofu init\" to install all modules required by this configuration.",
+			Detail:   fmt.Sprintf("The source address was changed from %q to %q since this module was installed. Run \"tofu init\" to install all modules required by this configuration.", record.SourceAddr, req.SourceAddr.String()),
 			Subject:  &req.SourceAddrRange,
 		})
 	}

--- a/internal/configs/configload/loader_snapshot.go
+++ b/internal/configs/configload/loader_snapshot.go
@@ -22,7 +22,7 @@ import (
 // creates an in-memory snapshot of the configuration files used, which can
 // be later used to create a loader that may read only from this snapshot.
 func (l *Loader) LoadConfigWithSnapshot(rootDir string) (*configs.Config, *Snapshot, hcl.Diagnostics) {
-	rootMod, diags := l.parser.LoadConfigDir(rootDir, configs.StaticParams{Name: "root"})
+	rootMod, diags := l.parser.LoadConfigDir(rootDir, configs.StaticModuleCall{Name: "root"})
 	if rootMod == nil {
 		return nil, nil, diags
 	}

--- a/internal/configs/configload/loader_snapshot.go
+++ b/internal/configs/configload/loader_snapshot.go
@@ -21,8 +21,8 @@ import (
 // LoadConfigWithSnapshot is a variant of LoadConfig that also simultaneously
 // creates an in-memory snapshot of the configuration files used, which can
 // be later used to create a loader that may read only from this snapshot.
-func (l *Loader) LoadConfigWithSnapshot(rootDir string) (*configs.Config, *Snapshot, hcl.Diagnostics) {
-	rootMod, diags := l.parser.LoadConfigDir(rootDir, configs.StaticModuleCall{Name: "root"})
+func (l *Loader) LoadConfigWithSnapshot(rootDir string, vars configs.RawVariables) (*configs.Config, *Snapshot, hcl.Diagnostics) {
+	rootMod, diags := l.parser.LoadConfigDir(rootDir, configs.StaticModuleCall{Name: "root", Raw: vars})
 	if rootMod == nil {
 		return nil, nil, diags
 	}

--- a/internal/configs/configload/loader_snapshot.go
+++ b/internal/configs/configload/loader_snapshot.go
@@ -16,13 +16,14 @@ import (
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/modsdir"
 	"github.com/spf13/afero"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // LoadConfigWithSnapshot is a variant of LoadConfig that also simultaneously
 // creates an in-memory snapshot of the configuration files used, which can
 // be later used to create a loader that may read only from this snapshot.
 func (l *Loader) LoadConfigWithSnapshot(rootDir string) (*configs.Config, *Snapshot, hcl.Diagnostics) {
-	rootMod, diags := l.parser.LoadConfigDir(rootDir)
+	rootMod, diags := l.parser.LoadConfigDir(rootDir, make(map[string]cty.Value))
 	if rootMod == nil {
 		return nil, nil, diags
 	}

--- a/internal/configs/configload/loader_snapshot.go
+++ b/internal/configs/configload/loader_snapshot.go
@@ -16,14 +16,13 @@ import (
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/modsdir"
 	"github.com/spf13/afero"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // LoadConfigWithSnapshot is a variant of LoadConfig that also simultaneously
 // creates an in-memory snapshot of the configuration files used, which can
 // be later used to create a loader that may read only from this snapshot.
 func (l *Loader) LoadConfigWithSnapshot(rootDir string) (*configs.Config, *Snapshot, hcl.Diagnostics) {
-	rootMod, diags := l.parser.LoadConfigDir(rootDir, make(map[string]cty.Value))
+	rootMod, diags := l.parser.LoadConfigDir(rootDir, configs.StaticParams{Name: "root"})
 	if rootMod == nil {
 		return nil, nil, diags
 	}

--- a/internal/configs/module.go
+++ b/internal/configs/module.go
@@ -55,6 +55,8 @@ type Module struct {
 	Checks map[string]*Check
 
 	Tests map[string]*TestFile
+
+	Ctx *hcl.EvalContext
 }
 
 // File describes the contents of a single configuration file.

--- a/internal/configs/module.go
+++ b/internal/configs/module.go
@@ -102,7 +102,7 @@ type File struct {
 
 // NewModuleWithTests matches NewModule except it will also load in the provided
 // test files.
-func NewModuleWithTests(primaryFiles, overrideFiles []*File, testFiles map[string]*TestFile, params StaticParams) (*Module, hcl.Diagnostics) {
+func NewModuleWithTests(primaryFiles, overrideFiles []*File, testFiles map[string]*TestFile, params StaticModuleCall) (*Module, hcl.Diagnostics) {
 	mod, diags := NewModule(primaryFiles, overrideFiles, params)
 	if mod != nil {
 		mod.Tests = testFiles
@@ -118,7 +118,7 @@ func NewModuleWithTests(primaryFiles, overrideFiles []*File, testFiles map[strin
 // will be incomplete and error diagnostics will be returned. Careful static
 // analysis of the returned Module is still possible in this case, but the
 // module will probably not be semantically valid.
-func NewModule(primaryFiles, overrideFiles []*File, params StaticParams) (*Module, hcl.Diagnostics) {
+func NewModule(primaryFiles, overrideFiles []*File, params StaticModuleCall) (*Module, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 	mod := &Module{
 		ProviderConfigs:    map[string]*Provider{},

--- a/internal/configs/module.go
+++ b/internal/configs/module.go
@@ -69,6 +69,9 @@ type Module struct {
 // analysis of individual elements, but must be built into a Module to detect
 // duplicate declarations.
 type File struct {
+	body     hcl.Body
+	override bool
+
 	CoreVersionConstraints []VersionConstraint
 
 	ActiveExperiments experiments.Set

--- a/internal/configs/module.go
+++ b/internal/configs/module.go
@@ -56,7 +56,7 @@ type Module struct {
 
 	Tests map[string]*TestFile
 
-	Ctx *hcl.EvalContext
+	Ctx *StaticContext
 }
 
 // File describes the contents of a single configuration file.

--- a/internal/configs/module.go
+++ b/internal/configs/module.go
@@ -71,8 +71,9 @@ type Module struct {
 // analysis of individual elements, but must be built into a Module to detect
 // duplicate declarations.
 type File struct {
-	body     hcl.Body
-	override bool
+	body             hcl.Body
+	override         bool
+	allowExperiments bool
 
 	CoreVersionConstraints []VersionConstraint
 
@@ -101,8 +102,8 @@ type File struct {
 
 // NewModuleWithTests matches NewModule except it will also load in the provided
 // test files.
-func NewModuleWithTests(primaryFiles, overrideFiles []*File, testFiles map[string]*TestFile) (*Module, hcl.Diagnostics) {
-	mod, diags := NewModule(primaryFiles, overrideFiles)
+func NewModuleWithTests(primaryFiles, overrideFiles []*File, testFiles map[string]*TestFile, params StaticParams) (*Module, hcl.Diagnostics) {
+	mod, diags := NewModule(primaryFiles, overrideFiles, params)
 	if mod != nil {
 		mod.Tests = testFiles
 	}
@@ -117,7 +118,7 @@ func NewModuleWithTests(primaryFiles, overrideFiles []*File, testFiles map[strin
 // will be incomplete and error diagnostics will be returned. Careful static
 // analysis of the returned Module is still possible in this case, but the
 // module will probably not be semantically valid.
-func NewModule(primaryFiles, overrideFiles []*File) (*Module, hcl.Diagnostics) {
+func NewModule(primaryFiles, overrideFiles []*File, params StaticParams) (*Module, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 	mod := &Module{
 		ProviderConfigs:    map[string]*Provider{},
@@ -131,6 +132,45 @@ func NewModule(primaryFiles, overrideFiles []*File) (*Module, hcl.Diagnostics) {
 		Checks:             map[string]*Check{},
 		ProviderMetas:      map[addrs.Provider]*ProviderMeta{},
 		Tests:              map[string]*TestFile{},
+	}
+
+	// Pre-process the files before static evaluation
+	for _, f := range primaryFiles {
+		fDiags := f.preParse()
+		diags = append(diags, fDiags...)
+	}
+	for _, f := range overrideFiles {
+		fDiags := f.preParse()
+		diags = append(diags, fDiags...)
+	}
+
+	// At this point, we should have all of the Locals and Vars parsed into the primary and override files
+	// Now we can start merging them into the Module structure prior to static evaluation
+	for _, file := range primaryFiles {
+		fileDiags := mod.appendFilePre(file)
+		diags = append(diags, fileDiags...)
+	}
+
+	for _, file := range overrideFiles {
+		fileDiags := mod.mergeFilePre(file)
+		diags = append(diags, fileDiags...)
+	}
+
+	// Static evaluation to build a StaticContext now that module has all relavent Locals / Variables
+	ctx, sDiags := CreateStaticContext(mod.Variables, mod.Locals, params)
+	diags = append(diags, sDiags...)
+
+	if ctx != nil {
+		for _, f := range primaryFiles {
+			fDiags := f.parse(f.allowExperiments, *ctx)
+			diags = append(diags, fDiags...)
+		}
+		for _, f := range overrideFiles {
+			fDiags := f.parse(f.allowExperiments, *ctx)
+			diags = append(diags, fDiags...)
+		}
+
+		mod.Ctx = ctx
 	}
 
 	// Process the required_providers blocks first, to ensure that all
@@ -198,6 +238,34 @@ func (m *Module) ResourceByAddr(addr addrs.Resource) *Resource {
 	default:
 		return nil
 	}
+}
+
+func (m *Module) appendFilePre(file *File) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+	for _, v := range file.Variables {
+		if existing, exists := m.Variables[v.Name]; exists {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Duplicate variable declaration",
+				Detail:   fmt.Sprintf("A variable named %q was already declared at %s. Variable names must be unique within a module.", existing.Name, existing.DeclRange),
+				Subject:  &v.DeclRange,
+			})
+		}
+		m.Variables[v.Name] = v
+	}
+
+	for _, l := range file.Locals {
+		if existing, exists := m.Locals[l.Name]; exists {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Duplicate local value definition",
+				Detail:   fmt.Sprintf("A local value named %q was already defined at %s. Local value names must be unique within a module.", existing.Name, existing.DeclRange),
+				Subject:  &l.DeclRange,
+			})
+		}
+		m.Locals[l.Name] = l
+	}
+	return diags
 }
 
 func (m *Module) appendFile(file *File) hcl.Diagnostics {
@@ -279,30 +347,6 @@ func (m *Module) appendFile(file *File) hcl.Diagnostics {
 			})
 		}
 		m.ProviderMetas[provider] = pm
-	}
-
-	for _, v := range file.Variables {
-		if existing, exists := m.Variables[v.Name]; exists {
-			diags = append(diags, &hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Duplicate variable declaration",
-				Detail:   fmt.Sprintf("A variable named %q was already declared at %s. Variable names must be unique within a module.", existing.Name, existing.DeclRange),
-				Subject:  &v.DeclRange,
-			})
-		}
-		m.Variables[v.Name] = v
-	}
-
-	for _, l := range file.Locals {
-		if existing, exists := m.Locals[l.Name]; exists {
-			diags = append(diags, &hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Duplicate local value definition",
-				Detail:   fmt.Sprintf("A local value named %q was already defined at %s. Local value names must be unique within a module.", existing.Name, existing.DeclRange),
-				Subject:  &l.DeclRange,
-			})
-		}
-		m.Locals[l.Name] = l
 	}
 
 	for _, o := range file.Outputs {
@@ -474,6 +518,42 @@ func (m *Module) appendFile(file *File) hcl.Diagnostics {
 	return diags
 }
 
+func (m *Module) mergeFilePre(file *File) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+
+	for _, v := range file.Variables {
+		existing, exists := m.Variables[v.Name]
+		if !exists {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Missing base variable declaration to override",
+				Detail:   fmt.Sprintf("There is no variable named %q. An override file can only override a variable that was already declared in a primary configuration file.", v.Name),
+				Subject:  &v.DeclRange,
+			})
+			continue
+		}
+		mergeDiags := existing.merge(v)
+		diags = append(diags, mergeDiags...)
+	}
+
+	for _, l := range file.Locals {
+		existing, exists := m.Locals[l.Name]
+		if !exists {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Missing base local value definition to override",
+				Detail:   fmt.Sprintf("There is no local value named %q. An override file can only override a local value that was already defined in a primary configuration file.", l.Name),
+				Subject:  &l.DeclRange,
+			})
+			continue
+		}
+		mergeDiags := existing.merge(l)
+		diags = append(diags, mergeDiags...)
+	}
+
+	return diags
+}
+
 func (m *Module) mergeFile(file *File) hcl.Diagnostics {
 	var diags hcl.Diagnostics
 
@@ -549,36 +629,6 @@ func (m *Module) mergeFile(file *File) hcl.Diagnostics {
 			mergeDiags := existing.merge(pc)
 			diags = append(diags, mergeDiags...)
 		}
-	}
-
-	for _, v := range file.Variables {
-		existing, exists := m.Variables[v.Name]
-		if !exists {
-			diags = append(diags, &hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Missing base variable declaration to override",
-				Detail:   fmt.Sprintf("There is no variable named %q. An override file can only override a variable that was already declared in a primary configuration file.", v.Name),
-				Subject:  &v.DeclRange,
-			})
-			continue
-		}
-		mergeDiags := existing.merge(v)
-		diags = append(diags, mergeDiags...)
-	}
-
-	for _, l := range file.Locals {
-		existing, exists := m.Locals[l.Name]
-		if !exists {
-			diags = append(diags, &hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Missing base local value definition to override",
-				Detail:   fmt.Sprintf("There is no local value named %q. An override file can only override a local value that was already defined in a primary configuration file.", l.Name),
-				Subject:  &l.DeclRange,
-			})
-			continue
-		}
-		mergeDiags := existing.merge(l)
-		diags = append(diags, mergeDiags...)
 	}
 
 	for _, o := range file.Outputs {

--- a/internal/configs/module_call.go
+++ b/internal/configs/module_call.go
@@ -5,6 +5,7 @@ package configs
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
@@ -37,13 +38,21 @@ type ModuleCall struct {
 	DeclRange hcl.Range
 }
 
-func decodeModuleBlock(block *hcl.Block, override bool) (*ModuleCall, hcl.Diagnostics) {
+func evaluateStringLiteralAsExpression(literal string, ctx *hcl.EvalContext) (string, hcl.Diagnostics) {
+	var output string
+	formatted := fmt.Sprintf("\"%s\"", strings.ReplaceAll(literal, "{", "${"))
+	expr, diags := hclsyntax.ParseExpression([]byte(formatted), literal, hcl.InitialPos)
+	return output, append(diags, gohcl.DecodeExpression(expr, ctx, &output)...)
+}
+
+func decodeModuleBlock(block *hcl.Block, override bool, ctx *hcl.EvalContext) (*ModuleCall, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 
 	mc := &ModuleCall{
-		Name:      block.Labels[0],
 		DeclRange: block.DefRange,
 	}
+
+	mc.Name, diags = evaluateStringLiteralAsExpression(block.Labels[0], ctx)
 
 	schema := moduleBlockSchema
 	if override {
@@ -74,7 +83,7 @@ func decodeModuleBlock(block *hcl.Block, override bool) (*ModuleCall, hcl.Diagno
 	if attr, exists := content.Attributes["source"]; exists {
 		mc.SourceSet = true
 		mc.SourceAddrRange = attr.Expr.Range()
-		valDiags := gohcl.DecodeExpression(attr.Expr, nil, &mc.SourceAddrRaw)
+		valDiags := gohcl.DecodeExpression(attr.Expr, ctx, &mc.SourceAddrRaw)
 		diags = append(diags, valDiags...)
 		if !valDiags.HasErrors() {
 			var addr addrs.ModuleSource

--- a/internal/configs/module_call.go
+++ b/internal/configs/module_call.go
@@ -87,7 +87,7 @@ func decodeModuleBlock(block *hcl.Block, override bool, ctx StaticContext) (*Mod
 	if attr, exists := content.Attributes["source"]; exists {
 		mc.SourceSet = true
 		mc.SourceAddrRange = attr.Expr.Range()
-		valDiags := ctx.Decode(attr.Expr, ctx.Params.Name+"."+mc.Name, &mc.SourceAddrRaw)
+		valDiags := ctx.DecodeExpression(attr.Expr, ctx.Params.Name+"."+mc.Name, &mc.SourceAddrRaw)
 		diags = append(diags, valDiags...)
 		if !valDiags.HasErrors() {
 			var addr addrs.ModuleSource

--- a/internal/configs/module_call.go
+++ b/internal/configs/module_call.go
@@ -17,14 +17,17 @@ import (
 type ModuleCall struct {
 	Name string
 
-	SourceAddr      addrs.ModuleSource
-	SourceAddrRaw   string
-	SourceAddrRange hcl.Range
-	SourceSet       bool
+	Source        hcl.Expression
+	SourceAddrRaw string
+	SourceAddr    addrs.ModuleSource
+	SourceSet     bool
+
+	Variables StaticReferences
 
 	Config hcl.Body
 
-	Version VersionConstraint
+	HasVersion bool
+	Version    VersionConstraint
 
 	Count   hcl.Expression
 	ForEach hcl.Expression
@@ -36,19 +39,80 @@ type ModuleCall struct {
 	DeclRange hcl.Range
 }
 
-func (m ModuleCall) Variables(ctx *StaticContext) StaticReferences {
-	result := make(StaticReferences)
+func (mc *ModuleCall) IncludeContext(ctx *StaticContext) hcl.Diagnostics {
+	var diags hcl.Diagnostics
 
-	attr, _ := m.Config.JustAttributes()
-	for k, v := range attr {
-		val := ctx.Evaluate(v.Expr, StaticIdentifier{Module: ctx.Params.Name, Type: m.Name, Name: k})
-		result[k] = val
+	valDiags := ctx.DecodeExpression(mc.Source, StaticIdentifier{Module: ctx.Params.Name, Name: mc.Name}, &mc.SourceAddrRaw)
+	diags = append(diags, valDiags...)
+	if !valDiags.HasErrors() {
+		var addr addrs.ModuleSource
+		var err error
+		if mc.HasVersion {
+			addr, err = addrs.ParseModuleSourceRegistry(mc.SourceAddrRaw)
+		} else {
+			addr, err = addrs.ParseModuleSource(mc.SourceAddrRaw)
+		}
+		mc.SourceAddr = addr
+		if err != nil {
+			// NOTE: We leave SourceAddr as nil for any situation where the
+			// source attribute is invalid, so any code which tries to carefully
+			// use the partial result of a failed config decode must be
+			// resilient to that.
+			mc.SourceAddr = nil
+
+			// NOTE: In practice it's actually very unlikely to end up here,
+			// because our source address parser can turn just about any string
+			// into some sort of remote package address, and so for most errors
+			// we'll detect them only during module installation. There are
+			// still a _few_ purely-syntax errors we can catch at parsing time,
+			// though, mostly related to remote package sub-paths and local
+			// paths.
+			switch err := err.(type) {
+			case *getmodules.MaybeRelativePathErr:
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid module source address",
+					Detail: fmt.Sprintf(
+						"OpenTofu failed to determine your intended installation method for remote module package %q.\n\nIf you intended this as a path relative to the current module, use \"./%s\" instead. The \"./\" prefix indicates that the address is a relative filesystem path.",
+						err.Addr, err.Addr,
+					),
+					Subject: mc.Source.Range().Ptr(),
+				})
+			default:
+				if mc.HasVersion {
+					// In this case we'll include some extra context that
+					// we assumed a registry source address due to the
+					// version argument.
+					diags = append(diags, &hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Invalid registry module source address",
+						Detail:   fmt.Sprintf("Failed to parse module registry address: %s.\n\nOpenTofu assumed that you intended a module registry source address because you also set the argument \"version\", which applies only to registry modules.", err),
+						Subject:  mc.Source.Range().Ptr(),
+					})
+				} else {
+					diags = append(diags, &hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Invalid module source address",
+						Detail:   fmt.Sprintf("Failed to parse module source address: %s.", err),
+						Subject:  mc.Source.Range().Ptr(),
+					})
+				}
+			}
+		}
 	}
 
-	return result
+	mc.Variables = make(StaticReferences)
+
+	attr, _ := mc.Config.JustAttributes()
+	for k, v := range attr {
+		val := ctx.Evaluate(v.Expr, StaticIdentifier{Module: ctx.Params.Name, Type: mc.Name, Name: k})
+		mc.Variables[k] = val
+	}
+
+	return diags
 }
 
-func decodeModuleBlock(block *hcl.Block, override bool, ctx StaticContext) (*ModuleCall, hcl.Diagnostics) {
+func decodeModuleBlock(block *hcl.Block, override bool) (*ModuleCall, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 
 	mc := &ModuleCall{
@@ -74,75 +138,17 @@ func decodeModuleBlock(block *hcl.Block, override bool, ctx StaticContext) (*Mod
 		})
 	}
 
-	haveVersionArg := false
+	mc.HasVersion = false
 	if attr, exists := content.Attributes["version"]; exists {
 		var versionDiags hcl.Diagnostics
 		mc.Version, versionDiags = decodeVersionConstraint(attr)
 		diags = append(diags, versionDiags...)
-		haveVersionArg = true
+		mc.HasVersion = true
 	}
 
 	if attr, exists := content.Attributes["source"]; exists {
 		mc.SourceSet = true
-		mc.SourceAddrRange = attr.Expr.Range()
-		valDiags := ctx.DecodeExpression(attr.Expr, StaticIdentifier{Module: ctx.Params.Name, Name: mc.Name}, &mc.SourceAddrRaw)
-		diags = append(diags, valDiags...)
-		if !valDiags.HasErrors() {
-			var addr addrs.ModuleSource
-			var err error
-			if haveVersionArg {
-				addr, err = addrs.ParseModuleSourceRegistry(mc.SourceAddrRaw)
-			} else {
-				addr, err = addrs.ParseModuleSource(mc.SourceAddrRaw)
-			}
-			mc.SourceAddr = addr
-			if err != nil {
-				// NOTE: We leave mc.SourceAddr as nil for any situation where the
-				// source attribute is invalid, so any code which tries to carefully
-				// use the partial result of a failed config decode must be
-				// resilient to that.
-				mc.SourceAddr = nil
-
-				// NOTE: In practice it's actually very unlikely to end up here,
-				// because our source address parser can turn just about any string
-				// into some sort of remote package address, and so for most errors
-				// we'll detect them only during module installation. There are
-				// still a _few_ purely-syntax errors we can catch at parsing time,
-				// though, mostly related to remote package sub-paths and local
-				// paths.
-				switch err := err.(type) {
-				case *getmodules.MaybeRelativePathErr:
-					diags = append(diags, &hcl.Diagnostic{
-						Severity: hcl.DiagError,
-						Summary:  "Invalid module source address",
-						Detail: fmt.Sprintf(
-							"OpenTofu failed to determine your intended installation method for remote module package %q.\n\nIf you intended this as a path relative to the current module, use \"./%s\" instead. The \"./\" prefix indicates that the address is a relative filesystem path.",
-							err.Addr, err.Addr,
-						),
-						Subject: mc.SourceAddrRange.Ptr(),
-					})
-				default:
-					if haveVersionArg {
-						// In this case we'll include some extra context that
-						// we assumed a registry source address due to the
-						// version argument.
-						diags = append(diags, &hcl.Diagnostic{
-							Severity: hcl.DiagError,
-							Summary:  "Invalid registry module source address",
-							Detail:   fmt.Sprintf("Failed to parse module registry address: %s.\n\nOpenTofu assumed that you intended a module registry source address because you also set the argument \"version\", which applies only to registry modules.", err),
-							Subject:  mc.SourceAddrRange.Ptr(),
-						})
-					} else {
-						diags = append(diags, &hcl.Diagnostic{
-							Severity: hcl.DiagError,
-							Summary:  "Invalid module source address",
-							Detail:   fmt.Sprintf("Failed to parse module source address: %s.", err),
-							Subject:  mc.SourceAddrRange.Ptr(),
-						})
-					}
-				}
-			}
-		}
+		mc.Source = attr.Expr
 	}
 
 	if attr, exists := content.Attributes["count"]; exists {

--- a/internal/configs/module_call.go
+++ b/internal/configs/module_call.go
@@ -41,7 +41,7 @@ func (m ModuleCall) Variables(ctx *StaticContext) StaticReferences {
 
 	attr, _ := m.Config.JustAttributes()
 	for k, v := range attr {
-		val := ctx.Evaluate(v.Expr, ctx.Params.Name+"."+m.Name+"."+k)
+		val := ctx.Evaluate(v.Expr, StaticIdentifier{Module: ctx.Params.Name, Type: m.Name, Name: k})
 		result[k] = val
 	}
 
@@ -85,7 +85,7 @@ func decodeModuleBlock(block *hcl.Block, override bool, ctx StaticContext) (*Mod
 	if attr, exists := content.Attributes["source"]; exists {
 		mc.SourceSet = true
 		mc.SourceAddrRange = attr.Expr.Range()
-		valDiags := ctx.DecodeExpression(attr.Expr, ctx.Params.Name+"."+mc.Name, &mc.SourceAddrRaw)
+		valDiags := ctx.DecodeExpression(attr.Expr, StaticIdentifier{Module: ctx.Params.Name, Name: mc.Name}, &mc.SourceAddrRaw)
 		diags = append(diags, valDiags...)
 		if !valDiags.HasErrors() {
 			var addr addrs.ModuleSource

--- a/internal/configs/module_call.go
+++ b/internal/configs/module_call.go
@@ -36,18 +36,16 @@ type ModuleCall struct {
 	DeclRange hcl.Range
 }
 
-func (m ModuleCall) Variables(ctx *StaticContext) (StaticReferences, hcl.Diagnostics) {
-	diags := make(hcl.Diagnostics, 0)
+func (m ModuleCall) Variables(ctx *StaticContext) StaticReferences {
 	result := make(StaticReferences)
 
 	attr, _ := m.Config.JustAttributes()
 	for k, v := range attr {
-		val, vDiags := ctx.Evaluate(v.Expr, ctx.Params.Name+"."+m.Name+"."+k)
-		diags = append(diags, vDiags...)
+		val := ctx.Evaluate(v.Expr, ctx.Params.Name+"."+m.Name+"."+k)
 		result[k] = val
 	}
 
-	return result, diags
+	return result
 }
 
 func decodeModuleBlock(block *hcl.Block, override bool, ctx StaticContext) (*ModuleCall, hcl.Diagnostics) {

--- a/internal/configs/module_call.go
+++ b/internal/configs/module_call.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/getmodules"
@@ -36,6 +37,19 @@ type ModuleCall struct {
 	DependsOn []hcl.Traversal
 
 	DeclRange hcl.Range
+}
+
+func (m ModuleCall) Variables(ctx *hcl.EvalContext) map[string]cty.Value {
+	result := make(map[string]cty.Value)
+
+	attr, _ := m.Config.JustAttributes()
+	for k, v := range attr {
+		val, _ := v.Expr.Value(ctx)
+		// TODO diags/nil
+		result[k] = val
+	}
+
+	return result
 }
 
 func evaluateStringLiteralAsExpression(literal string, ctx *hcl.EvalContext) (string, hcl.Diagnostics) {

--- a/internal/configs/module_call.go
+++ b/internal/configs/module_call.go
@@ -5,10 +5,8 @@ package configs
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -52,21 +50,13 @@ func (m ModuleCall) Variables(ctx *StaticContext) (StaticReferences, hcl.Diagnos
 	return result, diags
 }
 
-func evaluateStringLiteralAsExpression(literal string, ctx *hcl.EvalContext) (string, hcl.Diagnostics) {
-	var output string
-	formatted := fmt.Sprintf("\"%s\"", strings.ReplaceAll(literal, "{", "${"))
-	expr, diags := hclsyntax.ParseExpression([]byte(formatted), literal, hcl.InitialPos)
-	return output, append(diags, gohcl.DecodeExpression(expr, ctx, &output)...)
-}
-
 func decodeModuleBlock(block *hcl.Block, override bool, ctx StaticContext) (*ModuleCall, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 
 	mc := &ModuleCall{
 		DeclRange: block.DefRange,
+		Name:      block.Labels[0],
 	}
-
-	mc.Name, diags = evaluateStringLiteralAsExpression(block.Labels[0], ctx.EvalContext)
 
 	schema := moduleBlockSchema
 	if override {

--- a/internal/configs/module_merge.go
+++ b/internal/configs/module_merge.go
@@ -167,9 +167,7 @@ func (mc *ModuleCall) merge(omc *ModuleCall) hcl.Diagnostics {
 	var diags hcl.Diagnostics
 
 	if omc.SourceSet {
-		mc.SourceAddr = omc.SourceAddr
-		mc.SourceAddrRaw = omc.SourceAddrRaw
-		mc.SourceAddrRange = omc.SourceAddrRange
+		mc.Source = omc.Source
 		mc.SourceSet = omc.SourceSet
 	}
 

--- a/internal/configs/parser_config.go
+++ b/internal/configs/parser_config.go
@@ -55,8 +55,9 @@ func (p *Parser) loadConfigFile(path string, override bool) (*File, hcl.Diagnost
 	}
 
 	return &File{
-		body:     body,
-		override: override,
+		body:             body,
+		override:         override,
+		allowExperiments: p.allowExperiments,
 	}, nil
 }
 

--- a/internal/configs/parser_config.go
+++ b/internal/configs/parser_config.go
@@ -120,7 +120,7 @@ func (file *File) parse(allowExperiments bool, ctx StaticContext) hcl.Diagnostic
 				switch innerBlock.Type {
 
 				case "backend":
-					backendCfg, cfgDiags := decodeBackendBlock(innerBlock)
+					backendCfg, cfgDiags := decodeBackendBlock(innerBlock, ctx)
 					diags = append(diags, cfgDiags...)
 					if backendCfg != nil {
 						file.Backends = append(file.Backends, backendCfg)

--- a/internal/configs/parser_config.go
+++ b/internal/configs/parser_config.go
@@ -86,7 +86,7 @@ func (file *File) preParse() hcl.Diagnostics {
 	return diags
 }
 
-func (file *File) parse(allowExperiments bool, ctx *hcl.EvalContext) hcl.Diagnostics {
+func (file *File) parse(allowExperiments bool, ctx StaticContext) hcl.Diagnostics {
 	var diags hcl.Diagnostics
 	body := file.body
 	override := file.override

--- a/internal/configs/parser_config.go
+++ b/internal/configs/parser_config.go
@@ -54,7 +54,42 @@ func (p *Parser) loadConfigFile(path string, override bool) (*File, hcl.Diagnost
 		return nil, diags
 	}
 
-	file := &File{}
+	return &File{
+		body:     body,
+		override: override,
+	}, nil
+}
+
+func (file *File) preParse() hcl.Diagnostics {
+	body := file.body
+	override := file.override
+
+	content, diags := body.Content(configFileSchema)
+
+	for _, block := range content.Blocks {
+		switch block.Type {
+		case "variable":
+			cfg, cfgDiags := decodeVariableBlock(block, override)
+			diags = append(diags, cfgDiags...)
+			if cfg != nil {
+				file.Variables = append(file.Variables, cfg)
+			}
+
+		case "locals":
+			defs, defsDiags := decodeLocalsBlock(block)
+			diags = append(diags, defsDiags...)
+			file.Locals = append(file.Locals, defs...)
+
+		}
+	}
+
+	return diags
+}
+
+func (file *File) parse(allowExperiments bool, ctx *hcl.EvalContext) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+	body := file.body
+	override := file.override
 
 	var reqDiags hcl.Diagnostics
 	file.CoreVersionConstraints, reqDiags = sniffCoreVersionRequirements(body)
@@ -63,7 +98,7 @@ func (p *Parser) loadConfigFile(path string, override bool) (*File, hcl.Diagnost
 	// We'll load the experiments first because other decoding logic in the
 	// loop below might depend on these experiments.
 	var expDiags hcl.Diagnostics
-	file.ActiveExperiments, expDiags = sniffActiveExperiments(body, p.allowExperiments)
+	file.ActiveExperiments, expDiags = sniffActiveExperiments(body, allowExperiments)
 	diags = append(diags, expDiags...)
 
 	content, contentDiags := body.Content(configFileSchema)
@@ -133,18 +168,6 @@ func (p *Parser) loadConfigFile(path string, override bool) (*File, hcl.Diagnost
 				file.ProviderConfigs = append(file.ProviderConfigs, cfg)
 			}
 
-		case "variable":
-			cfg, cfgDiags := decodeVariableBlock(block, override)
-			diags = append(diags, cfgDiags...)
-			if cfg != nil {
-				file.Variables = append(file.Variables, cfg)
-			}
-
-		case "locals":
-			defs, defsDiags := decodeLocalsBlock(block)
-			diags = append(diags, defsDiags...)
-			file.Locals = append(file.Locals, defs...)
-
 		case "output":
 			cfg, cfgDiags := decodeOutputBlock(block, override)
 			diags = append(diags, cfgDiags...)
@@ -153,7 +176,7 @@ func (p *Parser) loadConfigFile(path string, override bool) (*File, hcl.Diagnost
 			}
 
 		case "module":
-			cfg, cfgDiags := decodeModuleBlock(block, override)
+			cfg, cfgDiags := decodeModuleBlock(block, override, ctx)
 			diags = append(diags, cfgDiags...)
 			if cfg != nil {
 				file.ModuleCalls = append(file.ModuleCalls, cfg)
@@ -202,7 +225,7 @@ func (p *Parser) loadConfigFile(path string, override bool) (*File, hcl.Diagnost
 		}
 	}
 
-	return file, diags
+	return diags
 }
 
 // sniffCoreVersionRequirements does minimal parsing of the given body for

--- a/internal/configs/parser_config.go
+++ b/internal/configs/parser_config.go
@@ -54,43 +54,7 @@ func (p *Parser) loadConfigFile(path string, override bool) (*File, hcl.Diagnost
 		return nil, diags
 	}
 
-	return &File{
-		body:             body,
-		override:         override,
-		allowExperiments: p.allowExperiments,
-	}, nil
-}
-
-func (file *File) preParse() hcl.Diagnostics {
-	body := file.body
-	override := file.override
-
-	content, diags := body.Content(configFileSchema)
-
-	for _, block := range content.Blocks {
-		switch block.Type {
-		case "variable":
-			cfg, cfgDiags := decodeVariableBlock(block, override)
-			diags = append(diags, cfgDiags...)
-			if cfg != nil {
-				file.Variables = append(file.Variables, cfg)
-			}
-
-		case "locals":
-			defs, defsDiags := decodeLocalsBlock(block)
-			diags = append(diags, defsDiags...)
-			file.Locals = append(file.Locals, defs...)
-
-		}
-	}
-
-	return diags
-}
-
-func (file *File) parse(allowExperiments bool, ctx StaticContext) hcl.Diagnostics {
-	var diags hcl.Diagnostics
-	body := file.body
-	override := file.override
+	file := &File{}
 
 	var reqDiags hcl.Diagnostics
 	file.CoreVersionConstraints, reqDiags = sniffCoreVersionRequirements(body)
@@ -99,7 +63,7 @@ func (file *File) parse(allowExperiments bool, ctx StaticContext) hcl.Diagnostic
 	// We'll load the experiments first because other decoding logic in the
 	// loop below might depend on these experiments.
 	var expDiags hcl.Diagnostics
-	file.ActiveExperiments, expDiags = sniffActiveExperiments(body, allowExperiments)
+	file.ActiveExperiments, expDiags = sniffActiveExperiments(body, p.allowExperiments)
 	diags = append(diags, expDiags...)
 
 	content, contentDiags := body.Content(configFileSchema)
@@ -120,7 +84,7 @@ func (file *File) parse(allowExperiments bool, ctx StaticContext) hcl.Diagnostic
 				switch innerBlock.Type {
 
 				case "backend":
-					backendCfg, cfgDiags := decodeBackendBlock(innerBlock, ctx)
+					backendCfg, cfgDiags := decodeBackendBlock(innerBlock)
 					diags = append(diags, cfgDiags...)
 					if backendCfg != nil {
 						file.Backends = append(file.Backends, backendCfg)
@@ -169,6 +133,18 @@ func (file *File) parse(allowExperiments bool, ctx StaticContext) hcl.Diagnostic
 				file.ProviderConfigs = append(file.ProviderConfigs, cfg)
 			}
 
+		case "variable":
+			cfg, cfgDiags := decodeVariableBlock(block, override)
+			diags = append(diags, cfgDiags...)
+			if cfg != nil {
+				file.Variables = append(file.Variables, cfg)
+			}
+
+		case "locals":
+			defs, defsDiags := decodeLocalsBlock(block)
+			diags = append(diags, defsDiags...)
+			file.Locals = append(file.Locals, defs...)
+
 		case "output":
 			cfg, cfgDiags := decodeOutputBlock(block, override)
 			diags = append(diags, cfgDiags...)
@@ -177,7 +153,7 @@ func (file *File) parse(allowExperiments bool, ctx StaticContext) hcl.Diagnostic
 			}
 
 		case "module":
-			cfg, cfgDiags := decodeModuleBlock(block, override, ctx)
+			cfg, cfgDiags := decodeModuleBlock(block, override)
 			diags = append(diags, cfgDiags...)
 			if cfg != nil {
 				file.ModuleCalls = append(file.ModuleCalls, cfg)
@@ -226,7 +202,7 @@ func (file *File) parse(allowExperiments bool, ctx StaticContext) hcl.Diagnostic
 		}
 	}
 
-	return diags
+	return file, diags
 }
 
 // sniffCoreVersionRequirements does minimal parsing of the given body for

--- a/internal/configs/parser_config_dir.go
+++ b/internal/configs/parser_config_dir.go
@@ -36,7 +36,7 @@ const (
 //
 // .tf files are parsed using the HCL native syntax while .tf.json files are
 // parsed using the HCL JSON syntax.
-func (p *Parser) LoadConfigDir(path string, params StaticParams) (*Module, hcl.Diagnostics) {
+func (p *Parser) LoadConfigDir(path string, params StaticModuleCall) (*Module, hcl.Diagnostics) {
 	primaryPaths, overridePaths, _, diags := p.dirFiles(path, "")
 	if diags.HasErrors() {
 		return nil, diags
@@ -57,7 +57,7 @@ func (p *Parser) LoadConfigDir(path string, params StaticParams) (*Module, hcl.D
 
 // LoadConfigDirWithTests matches LoadConfigDir, but the return Module also
 // contains any relevant .tftest.hcl files.
-func (p *Parser) LoadConfigDirWithTests(path string, testDirectory string, params StaticParams) (*Module, hcl.Diagnostics) {
+func (p *Parser) LoadConfigDirWithTests(path string, testDirectory string, params StaticModuleCall) (*Module, hcl.Diagnostics) {
 	primaryPaths, overridePaths, testPaths, diags := p.dirFiles(path, testDirectory)
 	if diags.HasErrors() {
 		return nil, diags

--- a/internal/configs/parser_config_dir.go
+++ b/internal/configs/parser_config_dir.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
-	"github.com/zclconf/go-cty/cty"
 )
 
 const (
@@ -37,20 +36,18 @@ const (
 //
 // .tf files are parsed using the HCL native syntax while .tf.json files are
 // parsed using the HCL JSON syntax.
-func (p *Parser) LoadConfigDir(path string, rootVars map[string]cty.Value) (*Module, hcl.Diagnostics) {
-	primaryPaths, overridePaths, _, diags := p.dirFiles(path, "")
+func (p *Parser) LoadConfigDir(path string, params StaticParams) (*Module, hcl.Diagnostics) {
+	primaryPaths, _, _, diags := p.dirFiles(path, "")
 	if diags.HasErrors() {
 		return nil, diags
 	}
 
-	ctx := &hcl.EvalContext{Variables: map[string]cty.Value{}}
-
-	primary, fDiags := p.loadFiles(primaryPaths, false, ctx, rootVars)
+	primary, ctx, fDiags := p.loadFiles(primaryPaths, false, params)
 	diags = append(diags, fDiags...)
-	override, fDiags := p.loadFiles(overridePaths, true, ctx, rootVars)
-	diags = append(diags, fDiags...)
+	//override, fDiags := p.loadFiles(overridePaths, true, ctx, rootVars)
+	//diags = append(diags, fDiags...)
 
-	mod, modDiags := NewModule(primary, override)
+	mod, modDiags := NewModule(primary, nil) //override)
 	diags = append(diags, modDiags...)
 
 	mod.SourceDir = path
@@ -61,22 +58,20 @@ func (p *Parser) LoadConfigDir(path string, rootVars map[string]cty.Value) (*Mod
 
 // LoadConfigDirWithTests matches LoadConfigDir, but the return Module also
 // contains any relevant .tftest.hcl files.
-func (p *Parser) LoadConfigDirWithTests(path string, testDirectory string, rootVars map[string]cty.Value) (*Module, hcl.Diagnostics) {
-	primaryPaths, overridePaths, testPaths, diags := p.dirFiles(path, testDirectory)
+func (p *Parser) LoadConfigDirWithTests(path string, testDirectory string, params StaticParams) (*Module, hcl.Diagnostics) {
+	primaryPaths, _, testPaths, diags := p.dirFiles(path, testDirectory)
 	if diags.HasErrors() {
 		return nil, diags
 	}
 
-	ctx := &hcl.EvalContext{Variables: map[string]cty.Value{}}
-
-	primary, fDiags := p.loadFiles(primaryPaths, false, ctx, rootVars)
+	primary, ctx, fDiags := p.loadFiles(primaryPaths, false, params)
 	diags = append(diags, fDiags...)
-	override, fDiags := p.loadFiles(overridePaths, true, ctx, rootVars)
-	diags = append(diags, fDiags...)
+	//override, fDiags := p.loadFiles(overridePaths, true, ctx, rootVars)
+	//diags = append(diags, fDiags...)
 	tests, fDiags := p.loadTestFiles(path, testPaths)
 	diags = append(diags, fDiags...)
 
-	mod, modDiags := NewModuleWithTests(primary, override, tests)
+	mod, modDiags := NewModuleWithTests(primary, nil /*override*/, tests)
 	diags = append(diags, modDiags...)
 
 	mod.SourceDir = path
@@ -110,7 +105,7 @@ func (p *Parser) IsConfigDir(path string) bool {
 	return (len(primaryPaths) + len(overridePaths)) > 0
 }
 
-func (p *Parser) loadFiles(paths []string, override bool, ctx *hcl.EvalContext, rootVars map[string]cty.Value) ([]*File, hcl.Diagnostics) {
+func (p *Parser) loadFiles(paths []string, override bool, params StaticParams) ([]*File, *StaticContext, hcl.Diagnostics) {
 	var files []*File
 	var diags hcl.Diagnostics
 
@@ -133,45 +128,28 @@ func (p *Parser) loadFiles(paths []string, override bool, ctx *hcl.EvalContext, 
 		diags = append(diags, fDiags...)
 	}
 
-	locals := make(map[string]cty.Value)
-	vars := make(map[string]cty.Value)
+	locals := make(map[string]*Local)
+	variables := make(map[string]*Variable)
 	for _, f := range files {
+		for _, l := range f.Locals {
+			locals[l.Name] = l
+		}
 		for _, v := range f.Variables {
-			if val, ok := rootVars[v.Name]; ok {
-				// TODO validation + parse
-				vars[v.Name] = val
-			} else {
-				// TODO v.Default expression
-				vars[v.Name] = v.Default
-			}
+			variables[v.Name] = v
 		}
 	}
 
-	ctx.Variables["var"] = cty.ObjectVal(vars)
-	// Init empty locals for better error messages
-	ctx.Variables["local"] = cty.ObjectVal(locals)
+	ctx, sDiags := CreateStaticContext(variables, locals, params)
+	diags = append(diags, sDiags...)
 
-	// This is quite terrible...
-	// We iterate until no new locals are successfully constructed
-	for last := -1; last != len(locals); {
-		last = len(locals)
+	if ctx != nil {
 		for _, f := range files {
-			for _, l := range f.Locals {
-				val, lDiags := l.Expr.Value(ctx)
-				if len(lDiags) == 0 && val != cty.NilVal {
-					locals[l.Name] = val
-				}
-			}
+			fDiags := f.parse(p.allowExperiments, *ctx) // TODO switch to ctx through parse stage
+			diags = append(diags, fDiags...)
 		}
-		ctx.Variables["local"] = cty.ObjectVal(locals)
 	}
 
-	for _, f := range files {
-		fDiags := f.parse(p.allowExperiments, ctx)
-		diags = append(diags, fDiags...)
-	}
-
-	return files, diags
+	return files, ctx, diags
 }
 
 // dirFiles finds OpenTofu configuration files within dir, splitting them into

--- a/internal/configs/parser_values.go
+++ b/internal/configs/parser_values.go
@@ -23,6 +23,7 @@ import (
 //
 // This method wraps LoadHCLFile, and so it inherits the syntax selection
 // behaviors documented for that method.
+// TODO this is dead code
 func (p *Parser) LoadValuesFile(path string) (map[string]cty.Value, hcl.Diagnostics) {
 	body, diags := p.LoadHCLFile(path)
 	if body == nil {

--- a/internal/configs/provider_validation.go
+++ b/internal/configs/provider_validation.go
@@ -254,13 +254,9 @@ func validateProviderConfigsForTests(cfg *Config) (diags hcl.Diagnostics) {
 				// Let's make a little fake module call that we can use to call
 				// into validateProviderConfigs.
 				mc := &ModuleCall{
-					Name:            run.Name,
-					SourceAddr:      run.Module.Source,
-					SourceAddrRange: run.Module.SourceDeclRange,
-					SourceSet:       true,
-					Version:         run.Module.Version,
-					Providers:       providers,
-					DeclRange:       run.Module.DeclRange,
+					Name:      run.Name,
+					Providers: providers,
+					DeclRange: run.Module.DeclRange,
 				}
 
 				diags = append(diags, validateProviderConfigs(mc, run.ConfigUnderTest, nil)...)

--- a/internal/configs/static.go
+++ b/internal/configs/static.go
@@ -328,7 +328,7 @@ func (s StaticContext) Evaluate(expr hcl.Expression, fullName string) (StaticRef
 }
 
 // This is heavily inspired by gohcl.DecodeExpression
-func (s StaticContext) Decode(expr hcl.Expression, fullName string, val any) hcl.Diagnostics {
+func (s StaticContext) DecodeExpression(expr hcl.Expression, fullName string, val any) hcl.Diagnostics {
 	ref, refDiags := s.Evaluate(expr, fullName)
 	if refDiags.HasErrors() {
 		return refDiags

--- a/internal/configs/static.go
+++ b/internal/configs/static.go
@@ -148,6 +148,11 @@ func (s *StaticContext) resolveVariable(variable *Variable) (StaticReference, hc
 		return ref, nil
 	}
 
+	if variable.Default.IsNull() {
+		ref.Error = "Variable not set with null default"
+		return ref, nil
+	}
+
 	ref.Value = &variable.Default
 	return ref, nil
 }

--- a/internal/configs/static.go
+++ b/internal/configs/static.go
@@ -60,7 +60,7 @@ func (r StaticReferences) ToCty() cty.Value {
 	return cty.ObjectVal(values)
 }
 
-type StaticParams struct {
+type StaticModuleCall struct {
 	// Absolute Module Name
 	Name string
 	Raw  map[string]string // CLI
@@ -73,7 +73,7 @@ type StaticContext struct {
 	Locals    map[string]*Local
 
 	// Parameters
-	Params StaticParams
+	Params StaticModuleCall
 
 	// Current Evaluation Context
 	EvalContext *hcl.EvalContext
@@ -81,7 +81,7 @@ type StaticContext struct {
 	locals      StaticReferences
 }
 
-func CreateStaticContext(vars map[string]*Variable, locals map[string]*Local, Params StaticParams) (*StaticContext, hcl.Diagnostics) {
+func CreateStaticContext(vars map[string]*Variable, locals map[string]*Local, Params StaticModuleCall) (*StaticContext, hcl.Diagnostics) {
 	ctx := StaticContext{
 		Variables: vars,
 		Locals:    locals,

--- a/internal/configs/static.go
+++ b/internal/configs/static.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/opentofu/opentofu/internal/lang"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
@@ -357,4 +358,9 @@ func (s StaticContext) Decode(expr hcl.Expression, fullName string, val any) hcl
 	}
 
 	return nil
+}
+
+func (s StaticContext) DecodeBlock(body hcl.Body, spec hcldec.Spec) (cty.Value, hcl.Diagnostics) {
+	// TODO integrated errors
+	return hcldec.Decode(body, spec, s.EvalContext)
 }

--- a/internal/configs/static.go
+++ b/internal/configs/static.go
@@ -1,0 +1,292 @@
+package configs
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type StaticMissing struct {
+	// Info
+	Name string
+	Decl hcl.Range
+
+	Reason    *string
+	Reference *StaticReference
+}
+
+func (m StaticMissing) Chain() []StaticMissing {
+	result := []StaticMissing{m}
+	if m.Reference != nil {
+		result = append(result, m.Reference.Missing.Chain()...)
+	}
+	return result
+}
+
+type StaticReference struct {
+	Value   *cty.Value
+	Missing *StaticMissing
+}
+
+type StaticReferences map[string]StaticReference
+
+func (r StaticReferences) ToCty() cty.Value {
+	values := make(map[string]cty.Value)
+	for name, ref := range r {
+		if ref.Value != nil {
+			values[name] = *ref.Value
+		}
+	}
+	return cty.ObjectVal(values)
+}
+
+type StaticParams struct {
+	// Absolute Module Name
+	Name string
+	Raw  map[string]string // CLI
+	Call StaticReferences  // Module Call
+}
+
+type StaticContext struct {
+	// What should be resolved
+	Variables map[string]*Variable
+	Locals    map[string]*Local
+
+	// Parameters
+	Params StaticParams
+
+	// Current Evaluation Context
+	EvalContext *hcl.EvalContext
+	vars        StaticReferences
+	locals      StaticReferences
+}
+
+func CreateStaticContext(vars map[string]*Variable, locals map[string]*Local, Params StaticParams) (*StaticContext, hcl.Diagnostics) {
+	ctx := StaticContext{
+		Variables: vars,
+		Locals:    locals,
+		Params:    Params,
+		EvalContext: &hcl.EvalContext{
+			Variables: map[string]cty.Value{},
+			// TODO functions
+		},
+		vars:   make(StaticReferences),
+		locals: make(StaticReferences),
+	}
+
+	ctx.EvalContext.Variables["terraform"] = cty.ObjectVal(map[string]cty.Value{
+		"workspace": cty.StringVal("TODO"),
+	})
+
+	// Process all variables
+	for _, v := range ctx.Variables {
+		_, diags := ctx.addVariable(v)
+		if len(diags) != 0 {
+			// Could not construct reference
+			return nil, diags
+		}
+	}
+
+	// Process all locals
+	for _, l := range ctx.Locals {
+		_, diags := ctx.addLocal(l)
+		if len(diags) != 0 {
+			// Could not construct reference
+			return nil, diags
+		}
+	}
+
+	return &ctx, nil
+}
+
+func (s *StaticContext) resolveVariable(variable *Variable) (StaticReference, hcl.Diagnostics) {
+	// This is a raw value passed in via the command line.
+	// Currently not EvalContextuated with any context.
+	if v, ok := s.Params.Raw[variable.Name]; ok {
+		val, diags := variable.ParsingMode.Parse(variable.Name, v)
+		if len(diags) == 0 {
+			return StaticReference{Value: &val}, nil
+		}
+		err := diags.Error()
+		return StaticReference{Missing: &StaticMissing{Reason: &err}}, diags
+	}
+
+	// This is a module call parameter and may or may not be a resolved reference
+	if ref, ok := s.Params.Call[variable.Name]; ok {
+		if ref.Value != nil {
+			// Resolved, pass through
+			return ref, nil
+		} else {
+			return StaticReference{Missing: &StaticMissing{Name: s.Params.Name + ".var." + variable.Name, Decl: variable.DeclRange, Reference: &ref}}, nil
+		}
+	}
+
+	return StaticReference{Value: &variable.Default}, nil
+}
+
+func (s *StaticContext) addVariable(variable *Variable) (StaticReference, hcl.Diagnostics) {
+	ref, diags := s.resolveVariable(variable)
+
+	// TODO type contraints
+	// TODO validations?
+
+	// Put var into context
+	if len(diags) == 0 {
+		s.vars[variable.Name] = ref
+		if ref.Value != nil {
+			s.EvalContext.Variables["var"] = s.vars.ToCty()
+		}
+	}
+
+	return ref, diags
+}
+
+func (s *StaticContext) resolveLocal(local *Local) (StaticReference, hcl.Diagnostics) {
+	fullName := s.Params.Name + ".local." + local.Name
+
+	// Determine dependencies, fail on first problem area
+	for _, ident := range local.Expr.Variables() {
+		// Everything *should* be root.attr
+		root := ident[0].(hcl.TraverseRoot)
+		attr := ident[1].(hcl.TraverseAttr)
+
+		switch root.Name {
+		case "var":
+			// All variables should be known at this point.  This could change if we make variable defaults an expression
+			ref, ok := s.vars[attr.Name]
+			if !ok {
+				// Undefined
+				diags := hcl.Diagnostics{&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Undefined variable",
+					Detail:   fmt.Sprintf("Undefined variable %s.%s used in %s", root.Name, attr.Name, fullName),
+					Subject:  &local.DeclRange,
+				}}
+				return StaticReference{}, diags
+			} else if ref.Value == nil {
+				// Not Static
+				return StaticReference{Missing: &StaticMissing{Name: fullName, Decl: local.DeclRange, Reference: &ref}}, nil
+			}
+		case "local":
+			// TODO We will need to prevent this from recursing infinitely
+
+			// First check if we have already processed this local
+			ref, ok := s.locals[attr.Name]
+			if !ok {
+				// If not, let's try to load this local
+				modLocal, exists := s.Locals[attr.Name]
+				if !exists {
+					// Undefined
+					diags := hcl.Diagnostics{&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Undefined local",
+						Detail:   fmt.Sprintf("Undefined local %s.%s used in %s", root.Name, attr.Name, fullName),
+						Subject:  &local.DeclRange,
+					}}
+					return StaticReference{}, diags
+				}
+				var diags hcl.Diagnostics
+				ref, diags = s.addLocal(modLocal)
+				if len(diags) != 0 {
+					// Passthrough
+					return ref, diags
+				}
+			}
+			// We now have valid ref, though it may not be available for use in a static context
+			if ref.Value == nil {
+				// Not static
+				return StaticReference{Missing: &StaticMissing{Name: fullName, Decl: local.DeclRange, Reference: &ref}}, nil
+			}
+		case "terraform":
+			// Static, rely on the EvalContext below.
+		default:
+			// not supported
+			reason := fmt.Sprintf("Unable to use %s.%s in static context", root.Name, attr.Name) //TODO this is a bad error message
+			return StaticReference{Missing: &StaticMissing{Name: fullName, Decl: local.DeclRange, Reason: &reason}}, nil
+		}
+	}
+
+	// If we have reached this point, all references *should* be valid.
+	val, diags := local.Expr.Value(s.EvalContext)
+	if len(diags) != 0 {
+		// Something broke, hopefully this is just a bad function reference
+		return StaticReference{}, diags
+	}
+	return StaticReference{Value: &val}, nil
+}
+
+func (s *StaticContext) addLocal(local *Local) (StaticReference, hcl.Diagnostics) {
+	ref, diags := s.resolveLocal(local)
+
+	if len(diags) == 0 {
+		// Update local map
+		s.locals[local.Name] = ref
+		if ref.Value != nil {
+			// Put local map into current context
+			s.EvalContext.Variables["local"] = s.locals.ToCty()
+		}
+	}
+
+	return ref, diags
+}
+
+func (s StaticContext) Evaluate(expr hcl.Expression, fullName string) (StaticReference, hcl.Diagnostics) {
+	// FIXME This is copy-pasted from locals above and slightly modified
+
+	// Determine dependencies, fail on first problem area
+	for _, ident := range expr.Variables() {
+
+		// Everything *should* be root.attr
+		root := ident[0].(hcl.TraverseRoot)
+		attr := ident[1].(hcl.TraverseAttr)
+		switch root.Name {
+		case "var":
+			// All variables should be known at this point.
+			ref, ok := s.vars[attr.Name]
+			if !ok {
+				// Undefined
+				diags := hcl.Diagnostics{&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Undefined variable",
+					Detail:   fmt.Sprintf("Undefined variable %s.%s used in %s", root.Name, attr.Name, fullName),
+					Subject:  expr.Range().Ptr(),
+				}}
+				return StaticReference{}, diags
+			} else if ref.Value == nil {
+				// Not Static
+				return StaticReference{Missing: &StaticMissing{Name: fullName, Decl: expr.Range(), Reference: &ref}}, nil
+			}
+		case "local":
+			// All locals should be known at this point.
+			ref, ok := s.locals[attr.Name]
+			if !ok {
+				// Undefined
+				diags := hcl.Diagnostics{&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Undefined local",
+					Detail:   fmt.Sprintf("Undefined local %s.%s used in %s", root.Name, attr.Name, fullName),
+					Subject:  expr.Range().Ptr(),
+				}}
+				return StaticReference{}, diags
+			} else if ref.Value == nil {
+				// Not static
+				return StaticReference{Missing: &StaticMissing{Name: fullName, Decl: expr.Range(), Reference: &ref}}, nil
+			}
+		case "terraform":
+			// Static, rely on the EvalContext below.
+		default:
+			// not supported
+			reason := fmt.Sprintf("Unable to use %s.%s in static context", root.Name, attr.Name) //TODO this is a bad error message
+			return StaticReference{Missing: &StaticMissing{Name: fullName, Decl: expr.Range(), Reason: &reason}}, nil
+		}
+	}
+
+	// If we have reached this point, all references *should* be valid.
+	val, diags := expr.Value(s.EvalContext)
+	if len(diags) != 0 {
+		// Something broke, hopefully this is just a bad function reference
+		return StaticReference{}, diags
+	}
+	return StaticReference{Value: &val}, nil
+}

--- a/internal/configs/static.go
+++ b/internal/configs/static.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/opentofu/opentofu/internal/lang"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
 	"github.com/zclconf/go-cty/cty/gocty"
@@ -91,7 +92,7 @@ func CreateStaticContext(vars map[string]*Variable, locals map[string]*Local, Pa
 		Params:    Params,
 		EvalContext: &hcl.EvalContext{
 			Variables: map[string]cty.Value{},
-			// TODO functions
+			Functions: (&lang.Scope{PureOnly: true}).Functions(),
 		},
 		vars:   make(StaticReferences),
 		locals: make(StaticReferences),
@@ -326,6 +327,7 @@ func (s StaticContext) Decode(expr hcl.Expression, fullName string, val any) hcl
 		return valDiags
 	}
 	srcVal := *refVal
+	// TODO make sure refVal IsKnown().  Some impure functions can break that
 
 	convTy, err := gocty.ImpliedType(val)
 	if err != nil {

--- a/internal/initwd/from_module.go
+++ b/internal/initwd/from_module.go
@@ -18,7 +18,6 @@ import (
 	"github.com/opentofu/opentofu/internal/configs/configload"
 	"github.com/opentofu/opentofu/internal/copy"
 	"github.com/opentofu/opentofu/internal/getmodules"
-	"github.com/zclconf/go-cty/cty"
 
 	version "github.com/hashicorp/go-version"
 	"github.com/opentofu/opentofu/internal/modsdir"
@@ -212,7 +211,7 @@ func DirFromModule(ctx context.Context, loader *configload.Loader, rootDir, modu
 			// and must thus be rewritten to be absolute addresses again.
 			// For now we can't do this rewriting automatically, but we'll
 			// generate an error to help the user do it manually.
-			mod, _ := loader.Parser().LoadConfigDir(rootDir, make(map[string]cty.Value)) // ignore diagnostics since we're just doing value-add here anyway
+			mod, _ := loader.Parser().LoadConfigDir(rootDir, configs.StaticParams{Name: "root"}) // ignore diagnostics since we're just doing value-add here anyway
 			if mod != nil {
 				for _, mc := range mod.ModuleCalls {
 					if pathTraversesUp(mc.SourceAddrRaw) {

--- a/internal/initwd/from_module.go
+++ b/internal/initwd/from_module.go
@@ -211,7 +211,7 @@ func DirFromModule(ctx context.Context, loader *configload.Loader, rootDir, modu
 			// and must thus be rewritten to be absolute addresses again.
 			// For now we can't do this rewriting automatically, but we'll
 			// generate an error to help the user do it manually.
-			mod, _ := loader.Parser().LoadConfigDir(rootDir, configs.StaticParams{Name: "root"}) // ignore diagnostics since we're just doing value-add here anyway
+			mod, _ := loader.Parser().LoadConfigDir(rootDir, configs.StaticModuleCall{Name: "root"}) // ignore diagnostics since we're just doing value-add here anyway
 			if mod != nil {
 				for _, mc := range mod.ModuleCalls {
 					if pathTraversesUp(mc.SourceAddrRaw) {

--- a/internal/initwd/from_module.go
+++ b/internal/initwd/from_module.go
@@ -18,6 +18,7 @@ import (
 	"github.com/opentofu/opentofu/internal/configs/configload"
 	"github.com/opentofu/opentofu/internal/copy"
 	"github.com/opentofu/opentofu/internal/getmodules"
+	"github.com/zclconf/go-cty/cty"
 
 	version "github.com/hashicorp/go-version"
 	"github.com/opentofu/opentofu/internal/modsdir"
@@ -211,7 +212,7 @@ func DirFromModule(ctx context.Context, loader *configload.Loader, rootDir, modu
 			// and must thus be rewritten to be absolute addresses again.
 			// For now we can't do this rewriting automatically, but we'll
 			// generate an error to help the user do it manually.
-			mod, _ := loader.Parser().LoadConfigDir(rootDir) // ignore diagnostics since we're just doing value-add here anyway
+			mod, _ := loader.Parser().LoadConfigDir(rootDir, make(map[string]cty.Value)) // ignore diagnostics since we're just doing value-add here anyway
 			if mod != nil {
 				for _, mc := range mod.ModuleCalls {
 					if pathTraversesUp(mc.SourceAddrRaw) {

--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -96,7 +96,7 @@ func (i *ModuleInstaller) InstallModules(ctx context.Context, rootDir, testsDir 
 	log.Printf("[TRACE] ModuleInstaller: installing child modules for %s into %s", rootDir, i.modsDir)
 	var diags tfdiags.Diagnostics
 
-	rootMod, mDiags := i.loader.Parser().LoadConfigDirWithTests(rootDir, testsDir, configs.StaticParams{Name: "root"})
+	rootMod, mDiags := i.loader.Parser().LoadConfigDirWithTests(rootDir, testsDir, configs.StaticModuleCall{Name: "root"})
 	if rootMod == nil {
 		// We drop the diagnostics here because we only want to report module
 		// loading errors after checking the core version constraints, which we
@@ -238,7 +238,7 @@ func (i *ModuleInstaller) moduleInstallWalker(ctx context.Context, manifest mods
 				// keep our existing record.
 				info, err := os.Stat(record.Dir)
 				if err == nil && info.IsDir() {
-					mod, mDiags := i.loader.Parser().LoadConfigDir(record.Dir, configs.StaticParams{Name: req.Path.String(), Call: req.Variables})
+					mod, mDiags := i.loader.Parser().LoadConfigDir(record.Dir, configs.StaticModuleCall{Name: req.Path.String(), Call: req.Variables})
 					if mod == nil {
 						// nil indicates an unreadable module, which should never happen,
 						// so we return the full loader diagnostics here.
@@ -379,7 +379,7 @@ func (i *ModuleInstaller) installLocalModule(req *configs.ModuleRequest, key str
 	}
 
 	// Finally we are ready to try actually loading the module.
-	mod, mDiags := i.loader.Parser().LoadConfigDir(newDir, configs.StaticParams{Name: req.Path.String(), Call: req.Variables})
+	mod, mDiags := i.loader.Parser().LoadConfigDir(newDir, configs.StaticModuleCall{Name: req.Path.String(), Call: req.Variables})
 	if mod == nil {
 		// nil indicates missing or unreadable directory, so we'll
 		// discard the returned diags and return a more specific
@@ -661,7 +661,7 @@ func (i *ModuleInstaller) installRegistryModule(ctx context.Context, req *config
 	log.Printf("[TRACE] ModuleInstaller: %s should now be at %s", key, modDir)
 
 	// Finally we are ready to try actually loading the module.
-	mod, mDiags := i.loader.Parser().LoadConfigDir(modDir, configs.StaticParams{Name: req.Path.String(), Call: req.Variables})
+	mod, mDiags := i.loader.Parser().LoadConfigDir(modDir, configs.StaticModuleCall{Name: req.Path.String(), Call: req.Variables})
 	if mod == nil {
 		// nil indicates missing or unreadable directory, so we'll
 		// discard the returned diags and return a more specific
@@ -762,7 +762,7 @@ func (i *ModuleInstaller) installGoGetterModule(ctx context.Context, req *config
 	log.Printf("[TRACE] ModuleInstaller: %s %q was downloaded to %s", key, addr, modDir)
 
 	// Finally we are ready to try actually loading the module.
-	mod, mDiags := i.loader.Parser().LoadConfigDir(modDir, configs.StaticParams{Name: req.Path.String(), Call: req.Variables})
+	mod, mDiags := i.loader.Parser().LoadConfigDir(modDir, configs.StaticModuleCall{Name: req.Path.String(), Call: req.Variables})
 	if mod == nil {
 		// nil indicates missing or unreadable directory, so we'll
 		// discard the returned diags and return a more specific

--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -17,6 +17,7 @@ import (
 	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
@@ -96,7 +97,7 @@ func (i *ModuleInstaller) InstallModules(ctx context.Context, rootDir, testsDir 
 	log.Printf("[TRACE] ModuleInstaller: installing child modules for %s into %s", rootDir, i.modsDir)
 	var diags tfdiags.Diagnostics
 
-	rootMod, mDiags := i.loader.Parser().LoadConfigDirWithTests(rootDir, testsDir)
+	rootMod, mDiags := i.loader.Parser().LoadConfigDirWithTests(rootDir, testsDir, make(map[string]cty.Value))
 	if rootMod == nil {
 		// We drop the diagnostics here because we only want to report module
 		// loading errors after checking the core version constraints, which we
@@ -238,7 +239,7 @@ func (i *ModuleInstaller) moduleInstallWalker(ctx context.Context, manifest mods
 				// keep our existing record.
 				info, err := os.Stat(record.Dir)
 				if err == nil && info.IsDir() {
-					mod, mDiags := i.loader.Parser().LoadConfigDir(record.Dir)
+					mod, mDiags := i.loader.Parser().LoadConfigDir(record.Dir, req.Variables)
 					if mod == nil {
 						// nil indicates an unreadable module, which should never happen,
 						// so we return the full loader diagnostics here.
@@ -379,7 +380,7 @@ func (i *ModuleInstaller) installLocalModule(req *configs.ModuleRequest, key str
 	}
 
 	// Finally we are ready to try actually loading the module.
-	mod, mDiags := i.loader.Parser().LoadConfigDir(newDir)
+	mod, mDiags := i.loader.Parser().LoadConfigDir(newDir, req.Variables)
 	if mod == nil {
 		// nil indicates missing or unreadable directory, so we'll
 		// discard the returned diags and return a more specific
@@ -661,7 +662,7 @@ func (i *ModuleInstaller) installRegistryModule(ctx context.Context, req *config
 	log.Printf("[TRACE] ModuleInstaller: %s should now be at %s", key, modDir)
 
 	// Finally we are ready to try actually loading the module.
-	mod, mDiags := i.loader.Parser().LoadConfigDir(modDir)
+	mod, mDiags := i.loader.Parser().LoadConfigDir(modDir, req.Variables)
 	if mod == nil {
 		// nil indicates missing or unreadable directory, so we'll
 		// discard the returned diags and return a more specific
@@ -762,7 +763,7 @@ func (i *ModuleInstaller) installGoGetterModule(ctx context.Context, req *config
 	log.Printf("[TRACE] ModuleInstaller: %s %q was downloaded to %s", key, addr, modDir)
 
 	// Finally we are ready to try actually loading the module.
-	mod, mDiags := i.loader.Parser().LoadConfigDir(modDir)
+	mod, mDiags := i.loader.Parser().LoadConfigDir(modDir, req.Variables)
 	if mod == nil {
 		// nil indicates missing or unreadable directory, so we'll
 		// discard the returned diags and return a more specific

--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -92,11 +92,11 @@ func NewModuleInstaller(modsDir string, loader *configload.Loader, reg *registry
 // If successful (the returned diagnostics contains no errors) then the
 // first return value is the early configuration tree that was constructed by
 // the installation process.
-func (i *ModuleInstaller) InstallModules(ctx context.Context, rootDir, testsDir string, upgrade, installErrsOnly bool, hooks ModuleInstallHooks) (*configs.Config, tfdiags.Diagnostics) {
+func (i *ModuleInstaller) InstallModules(ctx context.Context, rootDir, testsDir string, upgrade, installErrsOnly bool, hooks ModuleInstallHooks, vars configs.RawVariables) (*configs.Config, tfdiags.Diagnostics) {
 	log.Printf("[TRACE] ModuleInstaller: installing child modules for %s into %s", rootDir, i.modsDir)
 	var diags tfdiags.Diagnostics
 
-	rootMod, mDiags := i.loader.Parser().LoadConfigDirWithTests(rootDir, testsDir, configs.StaticModuleCall{Name: "root"})
+	rootMod, mDiags := i.loader.Parser().LoadConfigDirWithTests(rootDir, testsDir, configs.StaticModuleCall{Name: "root", Raw: vars})
 	if rootMod == nil {
 		// We drop the diagnostics here because we only want to report module
 		// loading errors after checking the core version constraints, which we

--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -17,7 +17,6 @@ import (
 	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
-	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
@@ -97,7 +96,7 @@ func (i *ModuleInstaller) InstallModules(ctx context.Context, rootDir, testsDir 
 	log.Printf("[TRACE] ModuleInstaller: installing child modules for %s into %s", rootDir, i.modsDir)
 	var diags tfdiags.Diagnostics
 
-	rootMod, mDiags := i.loader.Parser().LoadConfigDirWithTests(rootDir, testsDir, make(map[string]cty.Value))
+	rootMod, mDiags := i.loader.Parser().LoadConfigDirWithTests(rootDir, testsDir, configs.StaticParams{Name: "root"})
 	if rootMod == nil {
 		// We drop the diagnostics here because we only want to report module
 		// loading errors after checking the core version constraints, which we
@@ -239,7 +238,7 @@ func (i *ModuleInstaller) moduleInstallWalker(ctx context.Context, manifest mods
 				// keep our existing record.
 				info, err := os.Stat(record.Dir)
 				if err == nil && info.IsDir() {
-					mod, mDiags := i.loader.Parser().LoadConfigDir(record.Dir, req.Variables)
+					mod, mDiags := i.loader.Parser().LoadConfigDir(record.Dir, configs.StaticParams{Name: req.Path.String(), Call: req.Variables})
 					if mod == nil {
 						// nil indicates an unreadable module, which should never happen,
 						// so we return the full loader diagnostics here.
@@ -380,7 +379,7 @@ func (i *ModuleInstaller) installLocalModule(req *configs.ModuleRequest, key str
 	}
 
 	// Finally we are ready to try actually loading the module.
-	mod, mDiags := i.loader.Parser().LoadConfigDir(newDir, req.Variables)
+	mod, mDiags := i.loader.Parser().LoadConfigDir(newDir, configs.StaticParams{Name: req.Path.String(), Call: req.Variables})
 	if mod == nil {
 		// nil indicates missing or unreadable directory, so we'll
 		// discard the returned diags and return a more specific
@@ -662,7 +661,7 @@ func (i *ModuleInstaller) installRegistryModule(ctx context.Context, req *config
 	log.Printf("[TRACE] ModuleInstaller: %s should now be at %s", key, modDir)
 
 	// Finally we are ready to try actually loading the module.
-	mod, mDiags := i.loader.Parser().LoadConfigDir(modDir, req.Variables)
+	mod, mDiags := i.loader.Parser().LoadConfigDir(modDir, configs.StaticParams{Name: req.Path.String(), Call: req.Variables})
 	if mod == nil {
 		// nil indicates missing or unreadable directory, so we'll
 		// discard the returned diags and return a more specific
@@ -763,7 +762,7 @@ func (i *ModuleInstaller) installGoGetterModule(ctx context.Context, req *config
 	log.Printf("[TRACE] ModuleInstaller: %s %q was downloaded to %s", key, addr, modDir)
 
 	// Finally we are ready to try actually loading the module.
-	mod, mDiags := i.loader.Parser().LoadConfigDir(modDir, req.Variables)
+	mod, mDiags := i.loader.Parser().LoadConfigDir(modDir, configs.StaticParams{Name: req.Path.String(), Call: req.Variables})
 	if mod == nil {
 		// nil indicates missing or unreadable directory, so we'll
 		// discard the returned diags and return a more specific

--- a/internal/initwd/testing.go
+++ b/internal/initwd/testing.go
@@ -39,7 +39,7 @@ func LoadConfigForTests(t *testing.T, rootDir string, testsDir string) (*configs
 	loader, cleanup := configload.NewLoaderForTests(t)
 	inst := NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil))
 
-	_, moreDiags := inst.InstallModules(context.Background(), rootDir, testsDir, true, false, ModuleInstallHooksImpl{})
+	_, moreDiags := inst.InstallModules(context.Background(), rootDir, testsDir, true, false, ModuleInstallHooksImpl{}, nil)
 	diags = diags.Append(moreDiags)
 	if diags.HasErrors() {
 		cleanup()


### PR DESCRIPTION
This is the initial implementation of a static evaluation context that can be used to evaluate expression that do not rely on any state data (vars/locals only). 

This pretty closely follows the plan detailed in RFC #1042 as I had already started experimenting with this code and knew roughly what I needed to change.  All of the examples detailed in the RFC should be functional with this PR.

Current state of this work: Technical Preview.  Most components should be functional, but may have unexpected bugs or limitations.

TODO:
* [x] Circular references
* [ ] Fix a *lot* of tests
* [ ] Write a *lot* of tests
* [ ] Dramatically improve diagnostics.  The required information is there, but not well formatted.
* [ ] Make sure all module calls are passing the correct parameter context.  This was ad-hoc to start.
* [ ] Clean up how raw input variables are handled
* [ ] Update `tofu init` help text to include vars/var-file
* [ ] Pass workspace into root module context
* [ ] Changelog
* [ ] Docs

Open Questions:
* [ ] What are the performance implications?
* [x] What does lazy evaluation look like?  Does that have a dramatic performance benefit?
  - Added lazy evaluation, code is dramatically cleaner and only does the hcl evaluation when required
* [ ] How much type checking should be done for variables?

Resolves #1042

## Target Release

The corresponding RFC has not been discussed by the Technical Steering Committee.  Depending on timing and approval, this could potentially make it into 1.7.0 at the earliest.
