### PR TITLE
Escape wildcard signs in docs/cli/commands/test/index.mdx

### DIFF
--- a/website/docs/cli/commands/test/index.mdx
+++ b/website/docs/cli/commands/test/index.mdx
@@ -81,14 +81,14 @@ The `tofu test` command supports two directory layouts, flat or nested:
 
 <Tabs>
     <TabItem value="flat" label="Flat layout" default>
-        This layout places the <code>*.tftest.hcl</code> test files directly next to the <code>*.tf</code> files they
-        test. There are no rules that each <code>*.tf</code> file must have its own test file, but it is a good practice
+        This layout places the <code>\*.tftest.hcl</code> test files directly next to the <code>\*.tf</code> files they
+        test. There are no rules that each <code>\*.tf</code> file must have its own test file, but it is a good practice
         to follow.
         <CodeBlock>{FlatLayout}</CodeBlock>
     </TabItem>
     <TabItem value="nested" label="Nested layout">
-        This layout places the <code>*.tftest.hcl</code> files in a separate <code>tests</code> directory. Similar to
-        the flat layout, there are no rules that each <code>*.tf</code> file must have its own test file, but it is a
+        This layout places the <code>\*.tftest.hcl</code> files in a separate <code>tests</code> directory. Similar to
+        the flat layout, there are no rules that each <code>\*.tf</code> file must have its own test file, but it is a
         good practice to follow.
         <CodeBlock>{NestedLayout}</CodeBlock>
     </TabItem>


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them
Resolves #
-->

This fixes [MDX compilation error](https://github.com/opentofu/opentofu.org/actions/runs/7500877361/job/20420431095?pr=99) that popped up after trying to upgrade all deps in the docs:

![Screenshot 2024-01-12 at 11 31 10](https://github.com/opentofu/opentofu/assets/920747/b452f2bc-9d42-4eb4-bdec-245b98c86702)

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.0
