### PR TITLE
state encryption callsites rough draft (NOT FOR MERGING)

### DIFF
--- a/internal/builtin/providers/tf/encryption.go
+++ b/internal/builtin/providers/tf/encryption.go
@@ -1,0 +1,192 @@
+package tf
+
+import (
+	"errors"
+	"fmt"
+	"github.com/opentofu/opentofu/internal/configs/configschema"
+	"github.com/opentofu/opentofu/internal/states/encryption/encryptionconfig"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// TODO this is not completely correct - see the one failing unit test to see the problem
+// (internal/command/e2etest/remote_state_test.go:13)
+
+// the block, if defined like this, is not optional, so the operation fails with
+//    Provider "provider[\"terraform.io/builtin/terraform\"]" produced an invalid
+//    value for data.terraform_remote_state.test: missing required attribute
+//    "state_decryption_fallback".
+
+func StateEncryptionConfigSchema() *configschema.NestedBlock {
+	return &configschema.NestedBlock{
+		Block: configschema.Block{
+			Attributes: map[string]*configschema.Attribute{
+				"required": {
+					Type: cty.Bool,
+					Description: "Enforce state encryption while writing state.\n\n" +
+						"If set, tofu will fail rather than write unencrypted state, " +
+						"e.g. due to missing configuration.",
+					DescriptionKind: configschema.StringMarkdown,
+					Optional:        true,
+				},
+			},
+			BlockTypes: map[string]*configschema.NestedBlock{
+				"key_provider": KeyProviderConfigSchema(),
+				"method":       MethodConfigSchema(),
+			},
+			Description:     "Configures client-side state encryption.",
+			DescriptionKind: configschema.StringMarkdown,
+		},
+		// TODO setting this to NestingSingle does not allow omitting the entire block,
+		// TODO even though the documentation suggests it should unless we also set MinItems and MaxItems to 1???
+		Nesting: configschema.NestingSingle,
+	}
+}
+
+func StateDecryptionFallbackConfigSchema() *configschema.NestedBlock {
+	return &configschema.NestedBlock{
+		Block: configschema.Block{
+			BlockTypes: map[string]*configschema.NestedBlock{
+				"key_provider": KeyProviderConfigSchema(),
+				"method":       MethodConfigSchema(),
+			},
+			Description: "Configures client-side state decryption fallback.\n\n" +
+				"This configuration is tried for decrypting state if it cannot" +
+				"be decrypted using the primary encryption configuraiton. " +
+				"Useful for situations like key rotation.",
+			DescriptionKind: configschema.StringMarkdown,
+		},
+		// TODO setting this to NestingSingle does not allow omitting the entire block,
+		// TODO even though the documentation suggests it should unless we also set MinItems and MaxItems to 1???
+		Nesting: configschema.NestingSingle,
+	}
+}
+
+func KeyProviderConfigSchema() *configschema.NestedBlock {
+	return &configschema.NestedBlock{
+		Block: configschema.Block{
+			Attributes: map[string]*configschema.Attribute{
+				"name": {
+					Type:            cty.String,
+					Description:     "The key provider to use, e.g. `passphrase` (the default) or `direct`.",
+					DescriptionKind: configschema.StringMarkdown,
+					Optional:        true,
+				},
+				"config": {
+					Type: cty.DynamicPseudoType,
+					Description: "The configuration of the key provider. " +
+						"Although this is optional, most key providers require " +
+						"some configuration.\n\n" +
+						"You can overwrite or add values using environment variables.",
+					DescriptionKind: configschema.StringMarkdown,
+					Optional:        true,
+				},
+			},
+		},
+		Nesting: configschema.NestingSingle,
+	}
+}
+
+func MethodConfigSchema() *configschema.NestedBlock {
+	return &configschema.NestedBlock{
+		Block: configschema.Block{
+			Attributes: map[string]*configschema.Attribute{
+				"name": {
+					Type:            cty.String,
+					Description:     "The encryption method to use, e.g. `full` (the default).",
+					DescriptionKind: configschema.StringMarkdown,
+					Optional:        true,
+				},
+				"config": {
+					Type: cty.DynamicPseudoType,
+					Description: "The configuration of the encryption method. " +
+						"Although this is optional, some encryption methods may require " +
+						"some configuration.\n\n" +
+						"You can overwrite or add values using environment variables.",
+					DescriptionKind: configschema.StringMarkdown,
+					Optional:        true,
+				},
+			},
+		},
+		Nesting: configschema.NestingSingle,
+	}
+}
+
+func ParseEncryptionConfig(cfg cty.Value) (encryptionconfig.Config, error) {
+	result := encryptionconfig.Config{}
+
+	// TODO this is not completely correct
+
+	keyProvider := cfg.GetAttr("key_provider")
+	if !keyProvider.IsNull() {
+		result.KeyProvider = encryptionconfig.KeyProviderConfig{}
+
+		name := keyProvider.GetAttr("name")
+		if !name.IsNull() {
+			if name.Type() != cty.String {
+				return encryptionconfig.Config{}, errors.New("key provider name must be a string")
+			}
+			result.KeyProvider.Name = encryptionconfig.KeyProviderName(name.AsString())
+			if err := result.KeyProvider.NameValid(); err != nil {
+				return encryptionconfig.Config{}, err
+			}
+		}
+
+		configParams := keyProvider.GetAttr("config")
+		if !configParams.IsNull() {
+			converted, err := toConfigParamsMap(configParams, "key_provider.config")
+			if err != nil {
+				return encryptionconfig.Config{}, err
+			}
+			result.KeyProvider.Config = converted
+		}
+	}
+
+	method := cfg.GetAttr("method")
+	if !method.IsNull() {
+		result.Method = encryptionconfig.EncryptionMethodConfig{}
+
+		name := method.GetAttr("name")
+		if !name.IsNull() {
+			if name.Type() != cty.String {
+				return encryptionconfig.Config{}, errors.New("key provider name must be a string")
+			}
+			result.Method.Name = encryptionconfig.EncryptionMethodName(name.AsString())
+			if err := result.Method.NameValid(); err != nil {
+				return encryptionconfig.Config{}, err
+			}
+		}
+
+		configParams := method.GetAttr("config")
+		if !configParams.IsNull() {
+			converted, err := toConfigParamsMap(configParams, "method.config")
+			if err != nil {
+				return encryptionconfig.Config{}, err
+			}
+			result.Method.Config = converted
+		}
+	}
+
+	required := cfg.GetAttr("required")
+	if !required.IsNull() && required.Equals(cty.True).True() {
+		result.Required = true
+	}
+
+	return result, nil
+}
+
+func toConfigParamsMap(cfg cty.Value, field string) (map[string]string, error) {
+	// gocty.FromCtyValue produces horrible error messages, so let's do it by hand
+	result := make(map[string]string)
+	if cfg.CanIterateElements() {
+		for k, v := range cfg.AsValueMap() {
+			if v.IsNull() || v.Type() != cty.String {
+				return nil, fmt.Errorf("invalid value for key '%s' in %s, must be a string", k, field)
+			} else {
+				result[k] = v.AsString()
+			}
+		}
+		return result, nil
+	} else {
+		return nil, fmt.Errorf("%s must be a map", field)
+	}
+}

--- a/internal/builtin/providers/tf/provider.go
+++ b/internal/builtin/providers/tf/provider.go
@@ -52,6 +52,11 @@ func (p *Provider) ValidateDataResourceConfig(req providers.ValidateDataResource
 		return res
 	}
 
+	// TODO this is the big one
+	// TODO construct the resourcePath on the way to here, because further down we don't know what it is
+	// resourcePath := "foo[3]"
+
+	// TODO pass the resourcePath down to this
 	diags := dataSourceRemoteStateValidate(req.Config)
 	res.Diagnostics = diags
 

--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -64,6 +64,13 @@ func (c *ApplyCommand) Run(rawArgs []string) int {
 		return 1
 	}
 
+	// plan may need encryption, so set this up first
+	diags = diags.Append(c.Meta.SetupEncryption())
+	if diags.HasErrors() {
+		view.Diagnostics(diags)
+		return 1
+	}
+
 	// Attempt to load the plan file, if specified
 	planFile, diags := c.LoadPlanFile(args.PlanPath)
 	if diags.HasErrors() {
@@ -156,6 +163,12 @@ func (c *ApplyCommand) LoadPlanFile(path string) (*planfile.WrappedPlanFile, tfd
 
 	// Try to load plan if path is specified
 	if path != "" {
+		// Plan files may need encryption, so do basic setup
+		diags = diags.Append(c.SetupEncryption())
+		if diags.HasErrors() {
+			return nil, diags
+		}
+
 		var err error
 		planFile, err = c.PlanFile(path)
 		if err != nil {

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -92,6 +92,13 @@ type BackendWithRemoteTerraformVersion interface {
 func (m *Meta) Backend(opts *BackendOpts) (backend.Enhanced, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
+	// backend may need encryption, so set this up first
+	encryptionDiags := m.SetupEncryption()
+	diags = diags.Append(encryptionDiags)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
 	// If no opts are set, then initialize
 	if opts == nil {
 		opts = &BackendOpts{}

--- a/internal/command/meta_encryption.go
+++ b/internal/command/meta_encryption.go
@@ -1,0 +1,29 @@
+package command
+
+import (
+	"github.com/opentofu/opentofu/internal/states/encryption"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+	"log"
+)
+
+// SetupEncryption initializes the encryption instance cache and validates the
+// environment variables used to configure state and plan encryption.
+//
+// A side-effect of this method is the creation of the encryption instance cache.
+func (m *Meta) SetupEncryption() tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+
+	encryption.EnableSingletonCaching() // idempotent
+	err := encryption.ParseEnvironmentVariables()
+	if err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Error parsing environment variables for state encryption",
+			err.Error(),
+		))
+		return diags
+	}
+
+	log.Print("[TRACE] Meta.SetupEncryption: state encryption environment is valid")
+	return nil
+}

--- a/internal/configs/parser_config.go
+++ b/internal/configs/parser_config.go
@@ -109,6 +109,12 @@ func (p *Parser) loadConfigFile(path string, override bool) (*File, hcl.Diagnost
 						file.ProviderMetas = append(file.ProviderMetas, providerCfg)
 					}
 
+				case "state_encryption":
+					encDiags := handleStateEncryptionBlock(innerBlock)
+					diags = append(diags, encDiags...)
+
+				// TODO same for state_decryption_fallback
+
 				default:
 					// Should never happen because the above cases should be exhaustive
 					// for all block type names in our schema.
@@ -317,6 +323,10 @@ var terraformBlockSchema = &hcl.BodySchema{
 			Type:       "provider_meta",
 			LabelNames: []string{"provider"},
 		},
+		{
+			Type: "state_encryption",
+		},
+		// TODO same for state_decryption_fallback
 	},
 }
 

--- a/internal/configs/state_encryption.go
+++ b/internal/configs/state_encryption.go
@@ -1,0 +1,51 @@
+package configs
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/opentofu/opentofu/internal/states/encryption"
+	"github.com/opentofu/opentofu/internal/states/encryption/encryptionconfig"
+	"github.com/opentofu/opentofu/internal/states/encryption/encryptionflow"
+)
+
+func handleStateEncryptionBlock(block *hcl.Block) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+
+	// here we would parse the contents of the block, but for now let's just set some config
+
+	// this example is for the "statefile" subblock, the others would be handled in very similar fashion
+
+	mockConfig := encryptionconfig.Config{
+		KeyProvider: encryptionconfig.KeyProviderConfig{
+			Name: encryptionconfig.KeyProviderPassphrase,
+			// passphrase intentionally missing, will let that come from env to try config merge
+		},
+		Method: encryptionconfig.EncryptionMethodConfig{
+			Name: encryptionconfig.EncryptionMethodFull,
+		},
+	}
+
+	instance, err := encryption.GetStatefileSingleton()
+	if err != nil {
+		// this shouldn't happen because we've already validated the environment variables much earlier
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Failed to construct statefile encryption instance",
+			Detail:   err.Error(),
+			Subject:  &block.DefRange,
+		})
+		return diags
+	}
+
+	if err := instance.EncryptionConfiguration(encryptionflow.ConfigurationSourceCode, mockConfig); err != nil {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Failed to add encryption configuration",
+			Detail:   err.Error(),
+			Subject:  &block.DefRange,
+		})
+	}
+
+	return diags
+}
+
+// same for fallback block (omitted)

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -161,6 +161,24 @@ type ValidateDataResourceConfigRequest struct {
 	// Config is the configuration value to validate, which may contain unknown
 	// values.
 	Config cty.Value
+
+	// TODO this is the big one. Can we just expand this, or will it have side effects?
+
+	// ResourcePath provides a unique addressing name for the resource determined from code.
+	//
+	// In the top-level module, this will be the resource name assigned in code,
+	// possibly followed by the for_each key or iterator in square brackets.
+	// For submodules, the name assigned to the module, possibly again with
+	// the for_each or iterator, is placed before that.
+	//
+	// Examples:
+	//  - "resource_type.foo"
+	//  - "resource_type.foo[17]"
+	//  - "resource_type.foo[my_for_each_key]"
+	//  - "module.bar.resource_type.foo[17]" (maybe?)
+	//  - "module.bar[3].resource_type.foo[17]" (maybe?)
+	//  - "module.bar[for_each_key].resource_type.foo[another_for_each_key]" (maybe?)
+	ResourcePath string
 }
 
 type ValidateDataResourceConfigResponse struct {

--- a/internal/states/encryption/caching.go
+++ b/internal/states/encryption/caching.go
@@ -1,0 +1,59 @@
+package encryption
+
+import (
+	"github.com/opentofu/opentofu/internal/logging"
+	"github.com/opentofu/opentofu/internal/states/encryption/encryptionflow"
+)
+
+type instanceCache struct {
+	instances map[string]encryptionflow.Flow
+}
+
+var cache *instanceCache
+
+// EnableCaching enables encryption flow instance caching.
+//
+// This allows code outside this package to call Instance() multiple times with the same key and receive
+// the same instance each time.
+//
+// Similarly, RemoteStateInstance(), StatefileInstance(), or PlanfileInstance() will only construct their
+// instance the first time they are called.
+//
+// Note: you should not enable the instance cache in low level unit tests, but if you do use it in a test,
+// you should
+//
+//	defer DisableCaching()
+//
+// right after the call to EnableCaching() to clean up after yourself.
+func EnableCaching() {
+	logging.HCLogger().Trace("enabling state encryption flow instance cache")
+	if cache == nil {
+		cache = &instanceCache{
+			instances: make(map[string]encryptionflow.Flow),
+		}
+	}
+}
+
+// DisableCaching disables encryption flow instance caching.
+//
+// see EnableCaching().
+func DisableCaching() {
+	logging.HCLogger().Trace("disabling state encryption flow instance cache")
+	cache = nil
+}
+
+func (c *instanceCache) cachedOrNewInstance(configKey string, defaultsApply bool) (encryptionflow.Flow, error) {
+	instance, found := c.instances[configKey]
+	if found {
+		logging.HCLogger().Trace("found state encryption flow instance in cache", "configKey", configKey)
+		return instance, nil
+	}
+
+	instance, err := newInstance(configKey, defaultsApply)
+	if err != nil {
+		return nil, err
+	}
+
+	c.instances[configKey] = instance
+	return instance, nil
+}

--- a/internal/states/encryption/caching_test.go
+++ b/internal/states/encryption/caching_test.go
@@ -1,0 +1,44 @@
+package encryption
+
+import "testing"
+
+func TestEnableDisableCaching(t *testing.T) {
+	EnableCaching() // MUST be followed by defer DisableCaching() in tests
+	defer func() {
+		if cache != nil {
+			t.Errorf("DisableCaching did not remove the cache, it was still non-nil")
+		}
+	}()
+	defer DisableCaching()
+
+	if cache == nil {
+		t.Fatalf("EnableCaching did not create the cache, it was still nil")
+	}
+}
+
+func TestCachedOrNewInstance(t *testing.T) {
+	EnableCaching() // MUST be followed by defer DisableCaching() in tests
+	defer DisableCaching()
+
+	const configKey = "unit_testing.test_cached_or_new[1]"
+
+	instance, err := cache.cachedOrNewInstance(configKey, false)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+	if instance == nil {
+		t.Errorf("instance on initial creation was unexpectedly nil")
+	}
+
+	if len(cache.instances) == 0 {
+		t.Error("instance was not cached after creation")
+	}
+
+	instance, err = cache.cachedOrNewInstance(configKey, false)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+	if instance == nil {
+		t.Errorf("instance on cache retrieval was unexpectedly nil")
+	}
+}

--- a/internal/states/encryption/encryptionconfig/config.go
+++ b/internal/states/encryption/encryptionconfig/config.go
@@ -119,7 +119,7 @@ type KeyProviderConfig struct {
 //
 // This is an early check, unlike Validate().
 func (k KeyProviderConfig) NameValid() error {
-	validator, ok := keyProviderConfigValidation[k.Name]
+	validator, ok := getKeyProviderConfigValidation(k.Name)
 	if !ok || validator == nil {
 		return fmt.Errorf("error in configuration for key provider %s: no registered key provider with this name", k.Name)
 	}
@@ -132,7 +132,7 @@ func (k KeyProviderConfig) Validate() error {
 		return err
 	}
 
-	validator := keyProviderConfigValidation[k.Name]
+	validator, _ := getKeyProviderConfigValidation(k.Name)
 	if err := validator(k); err != nil {
 		return fmt.Errorf("error in configuration for key provider %s: %s", k.Name, err.Error())
 	}
@@ -160,7 +160,7 @@ type EncryptionMethodConfig struct {
 //
 // This is an early check, unlike Validate().
 func (m EncryptionMethodConfig) NameValid() error {
-	validator, ok := encryptionMethodConfigValidation[m.Name]
+	validator, ok := getEncryptionMethodConfigValidation(m.Name)
 	if !ok || validator == nil {
 		return fmt.Errorf("error in configuration for encryption method %s: no registered encryption method with this name", m.Name)
 	}
@@ -173,7 +173,7 @@ func (m EncryptionMethodConfig) Validate() error {
 		return err
 	}
 
-	validator := encryptionMethodConfigValidation[m.Name]
+	validator, _ := getEncryptionMethodConfigValidation(m.Name)
 
 	if err := validator(m); err != nil {
 		return fmt.Errorf("error in configuration for encryption method %s: %s", m.Name, err.Error())

--- a/internal/states/encryption/encryptionconfig/config.go
+++ b/internal/states/encryption/encryptionconfig/config.go
@@ -1,0 +1,212 @@
+// Package encryptionconfig contains the data structures and constants to configure client-side state encryption.
+package encryptionconfig
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/opentofu/opentofu/internal/logging"
+	"os"
+	"strings"
+)
+
+// Config is a configuration for transparent client-side state encryption.
+//
+// There can be more than one configuration with different encryption or key derivation methods.
+type Config struct {
+	KeyProvider KeyProviderConfig `json:"key_provider"`
+
+	Method EncryptionMethodConfig `json:"method"`
+
+	// Required forces encryption operations to fail if they would
+	// result in an unencrypted output.
+	Required bool `json:"required"`
+}
+
+func (c Config) Validate() error {
+	if err := c.KeyProvider.Validate(); err != nil {
+		return err
+	}
+	if err := c.Method.Validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
+const (
+	ConfigKeyDefault   = "default"   // a default for all remote states (backend + any remote_state data sources)
+	ConfigKeyBackend   = "backend"   // for our own remote state backend
+	ConfigKeyStatefile = "statefile" // for local state files
+	ConfigKeyPlanfile  = "planfile"  // for plan files
+)
+
+// ConfigEnvJsonStructure is used to parse multiple named configurations from environment variables.
+//
+// The key either specifies a resource that accesses remote state, such as "terraform_remote_state.foo", or
+// it is one of the pre-defined convenience keys ConfigKeyDefault, ConfigKeyBackend, ConfigKeyStatefile, or
+// ConfigKeyPlanfile.
+//
+// If the key is "terraform_remote_state.foo", its value sets/overrides encryption configuration for
+//
+//	data "terraform_remote_state" "foo" {}
+//
+// For enumerated resources, the format is "terraform_remote_state.foo[17]" or "terraform_remote_state.foo[key]"
+// (no quotes around the for_each key).
+type ConfigEnvJsonStructure map[string]Config
+
+// ConfigEnvName is the name of the environment variable used to configure encryption and decryption
+//
+// Set this environment variable to a json representation of ConfigEnvJsonStructure, or leave it unset/blank
+// to disable encryption (default behaviour).
+//
+// Note: With rare exceptions, you should avoid setting the state encryption environment variables in tests,
+// as this may make tests depend on each other. See the comments on encryption.ParseEnvironmentVariables().
+var ConfigEnvName = "TF_STATE_ENCRYPTION"
+
+// EncryptionConfigurationsFromEnv parses the encryption configuration from the environment variable configured
+// in ConfigEnvName.
+//
+// It is not an error if the environment variable is unset or empty, that just means no encryption configuration
+// is provided via environment.
+func EncryptionConfigurationsFromEnv() (ConfigEnvJsonStructure, error) {
+	return parseEnvJsonStructure(ConfigEnvName, "encryption configuration")
+}
+
+// FallbackConfigEnvName is the name of the environment variable used to configure fallback decryption
+//
+// Set this environment variable to a json representation of ConfigEnvJsonStructure, or leave it unset/blank
+// in order to not supply any fallbacks (default behaviour).
+//
+// Note that decryption will always try the relevant configuration specified in TF_STATE_ENCRYPTION first.
+// Only if decryption fails with that, it will try this configuration.
+//
+// Why is this useful?
+//   - key rotation (put the old key here until all state has been migrated)
+//   - decryption (leave TF_STATE_ENCRYPTION unset, but set this variable, and your state will be decrypted on next write)
+//
+// Note: With rare exceptions, you should avoid setting the state encryption environment variables in tests,
+// as this may make tests depend on each other. See the comments on encryption.ParseEnvironmentVariables().
+var FallbackConfigEnvName = "TF_STATE_DECRYPTION_FALLBACK"
+
+// FallbackConfigurationsFromEnv parses the decryption fallback configuration from the environment variable
+// configured in FallbackConfigEnvName.
+//
+// It is not an error if the environment variable is unset or empty, that just means no decryption fallback
+// configuration is provided via environment.
+func FallbackConfigurationsFromEnv() (ConfigEnvJsonStructure, error) {
+	return parseEnvJsonStructure(FallbackConfigEnvName, "fallback decryption configuration")
+}
+
+type KeyProviderName string
+
+const (
+	KeyProviderPassphrase KeyProviderName = "passphrase" // derive key from config field "passphrase"
+	KeyProviderDirect     KeyProviderName = "direct"     // key is explicitly specified in config field "key"
+)
+
+type KeyProviderConfig struct {
+	// Name specifies which key provider to use.
+	Name KeyProviderName `json:"name"`
+
+	// Config configures the key provider.
+	//
+	// The available values are key provider dependent.
+	Config map[string]string `json:"config"`
+}
+
+// NameValid checks that the name has been registered correctly.
+//
+// This is an early check, unlike Validate().
+func (k KeyProviderConfig) NameValid() error {
+	validator, ok := keyProviderConfigValidation[k.Name]
+	if !ok || validator == nil {
+		return fmt.Errorf("error in configuration for key provider %s: no registered key provider with this name", k.Name)
+	}
+	return nil
+}
+
+// Validate checks the configuration after it has been merged from all sources.
+func (k KeyProviderConfig) Validate() error {
+	if err := k.NameValid(); err != nil {
+		return err
+	}
+
+	validator := keyProviderConfigValidation[k.Name]
+	if err := validator(k); err != nil {
+		return fmt.Errorf("error in configuration for key provider %s: %s", k.Name, err.Error())
+	}
+
+	return nil
+}
+
+type EncryptionMethodName string
+
+const (
+	EncryptionMethodFull EncryptionMethodName = "full" // full state encryption
+)
+
+type EncryptionMethodConfig struct {
+	// Name specifies which encryption method to use.
+	Name EncryptionMethodName `json:"name"`
+
+	// Config configures the key provider.
+	//
+	// The available values are key provider dependent.
+	Config map[string]string `json:"config"`
+}
+
+// NameValid checks that the name has been registered correctly.
+//
+// This is an early check, unlike Validate().
+func (m EncryptionMethodConfig) NameValid() error {
+	validator, ok := encryptionMethodConfigValidation[m.Name]
+	if !ok || validator == nil {
+		return fmt.Errorf("error in configuration for encryption method %s: no registered encryption method with this name", m.Name)
+	}
+	return nil
+}
+
+// Validate checks the configuration after it has been merged from all sources.
+func (m EncryptionMethodConfig) Validate() error {
+	if err := m.NameValid(); err != nil {
+		return err
+	}
+
+	validator := encryptionMethodConfigValidation[m.Name]
+
+	if err := validator(m); err != nil {
+		return fmt.Errorf("error in configuration for encryption method %s: %s", m.Name, err.Error())
+	}
+
+	return nil
+}
+
+func parseJsonStructure(jsonValue string) (ConfigEnvJsonStructure, error) {
+	parsed := make(ConfigEnvJsonStructure)
+
+	decoder := json.NewDecoder(strings.NewReader(jsonValue))
+	decoder.DisallowUnknownFields()
+	err := decoder.Decode(&parsed)
+	if err != nil {
+		logging.HCLogger().Trace("json parse error", "details", err.Error())
+		return nil, errors.New("json parse error, wrong structure, or unknown fields - details omitted for security reasons (may contain key related settings)")
+	}
+
+	// we cannot validate just this part of the configuration - may need to be merged with
+	// values from code first
+	return parsed, nil
+}
+
+func parseEnvJsonStructure(envName string, what string) (ConfigEnvJsonStructure, error) {
+	envValue := os.Getenv(envName)
+	if envValue == "" {
+		return nil, nil
+	}
+
+	parsed, err := parseJsonStructure(envValue)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing %s from environment variable %s: %s", what, envName, err.Error())
+	}
+
+	return parsed, nil
+}

--- a/internal/states/encryption/encryptionconfig/config.go
+++ b/internal/states/encryption/encryptionconfig/config.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/opentofu/opentofu/internal/logging"
 	"os"
 	"strings"
+
+	"github.com/opentofu/opentofu/internal/logging"
 )
 
 // Config is a configuration for transparent client-side state encryption.

--- a/internal/states/encryption/encryptionconfig/config_test.go
+++ b/internal/states/encryption/encryptionconfig/config_test.go
@@ -3,7 +3,6 @@ package encryptionconfig
 import (
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 )
 
@@ -346,8 +345,7 @@ func TestParseEnvJsonStructure(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.testcase, func(t *testing.T) {
 			envName := fmt.Sprintf("STATE_ENCRYPTION_TESTCASE_TestParseEnvJsonStructure_%s", tc.testcase)
-			os.Setenv(envName, tc.input)
-			defer os.Unsetenv(envName)
+			t.Setenv(envName, tc.input)
 
 			actual, err := parseEnvJsonStructure(envName, "what")
 			expectErr(t, err, tc.expectedErr)

--- a/internal/states/encryption/encryptionconfig/config_test.go
+++ b/internal/states/encryption/encryptionconfig/config_test.go
@@ -1,0 +1,371 @@
+package encryptionconfig
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestConfigValidate(t *testing.T) {
+	testCases := []struct {
+		testcase    string
+		config      Config
+		expectedErr error
+	}{
+		{
+			testcase: "correct",
+			config: Config{
+				KeyProvider: KeyProviderConfig{
+					Name:   "passphrase",
+					Config: map[string]string{"passphrase": "quick brown fox"},
+				},
+				Method: EncryptionMethodConfig{
+					Name: "full",
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			testcase: "key_provider_wrong",
+			config: Config{
+				KeyProvider: KeyProviderConfig{
+					Name: "unknown",
+				},
+				Method: EncryptionMethodConfig{
+					Name: "full",
+				},
+			},
+			expectedErr: errors.New("error in configuration for key provider unknown: no registered key provider with this name"),
+		},
+		{
+			testcase: "method_wrong",
+			config: Config{
+				KeyProvider: KeyProviderConfig{
+					Name:   "passphrase",
+					Config: map[string]string{"passphrase": "quick brown fox"},
+				},
+				Method: EncryptionMethodConfig{
+					Name: "unknown",
+				},
+			},
+			expectedErr: errors.New("error in configuration for encryption method unknown: no registered encryption method with this name"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.testcase, func(t *testing.T) {
+			err := tc.config.Validate()
+			expectErr(t, err, tc.expectedErr)
+		})
+	}
+}
+
+func TestEncryptionConfigurationsFromEnv(t *testing.T) {
+	empty, err := EncryptionConfigurationsFromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error for empty env: %s", err)
+	}
+	if empty != nil {
+		t.Fatalf("unexpected result for empty env: %s", err)
+	}
+}
+
+func TestFallbackConfigurationsFromEnv(t *testing.T) {
+	empty, err := FallbackConfigurationsFromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error for empty env fallback: %s", err)
+	}
+	if empty != nil {
+		t.Fatalf("unexpected result for empty env fallback: %s", err)
+	}
+}
+
+const validKey1 = "a0a1a2a3a4a5a6a7a8a9b0b1b2b3b4b5b6b7b8b9c0c1c2c3c4c5c6c7c8c9d0d1"
+
+const tooShortKey = "a0a1a2a3a4a5a6a7a8a9b0b1b2b3b4b5b6b7b8b9c0c1c2c3c4c5c6c7c8c9"
+const tooLongKey = "a0a1a2a3a4a5a6a7a8a9b0b1b2b3b4b5b6b7b8b9c0c1c2c3c4c5c6c7c8c9d0d1d2d3d4d5"
+const invalidChars = "somethingsomethinga9b0b1b2b3b4b5b6b7b8b9c0c1c2c3c4c5c6c7c8c9d0d1"
+
+func TestKeyProviderConfigValidate(t *testing.T) {
+	testCases := []struct {
+		testcase    string
+		config      KeyProviderConfig
+		nameInvalid bool
+		expectedErr error
+	}{
+		{
+			testcase: "correct",
+			config: KeyProviderConfig{
+				Name:   "passphrase",
+				Config: map[string]string{"passphrase": "quick brown fox"},
+			},
+			expectedErr: nil,
+		},
+		{
+			testcase: "unknown_name",
+			config: KeyProviderConfig{
+				Name: "unknown",
+			},
+			nameInvalid: true,
+			expectedErr: errors.New("error in configuration for key provider unknown: no registered key provider with this name"),
+		},
+		// tests for "passphrase" validation
+		{
+			testcase: "passphrase_no_phrase",
+			config: KeyProviderConfig{
+				Name: "passphrase",
+			},
+			expectedErr: errors.New("error in configuration for key provider passphrase: passphrase missing or empty"),
+		},
+		{
+			testcase: "passphrase_additional",
+			config: KeyProviderConfig{
+				Name: "passphrase",
+				Config: map[string]string{
+					"passphrase": "12345",
+					"additional": "nonsense",
+				},
+			},
+			expectedErr: errors.New("error in configuration for key provider passphrase: unexpected additional configuration fields, only 'passphrase' is allowed for this key provider"),
+		},
+		// tests for "direct" validation
+		{
+			testcase: "direct_no_key",
+			config: KeyProviderConfig{
+				Name: "direct",
+			},
+			expectedErr: errors.New("error in configuration for key provider direct: field 'key' missing or empty"),
+		},
+		{
+			testcase: "direct_empty_key",
+			config: KeyProviderConfig{
+				Name: "direct",
+				Config: map[string]string{
+					"key": "",
+				},
+			},
+			expectedErr: errors.New("error in configuration for key provider direct: field 'key' missing or empty"),
+		},
+		{
+			testcase: "direct_invalid_key",
+			config: KeyProviderConfig{
+				Name: "direct",
+				Config: map[string]string{
+					"key": invalidChars,
+				},
+			},
+			expectedErr: errors.New("error in configuration for key provider direct: field 'key' is not a hex string representing 32 bytes"),
+		},
+		{
+			testcase: "direct_key_short",
+			config: KeyProviderConfig{
+				Name: "direct",
+				Config: map[string]string{
+					"key": tooShortKey,
+				},
+			},
+			expectedErr: errors.New("error in configuration for key provider direct: field 'key' is not a hex string representing 32 bytes"),
+		},
+		{
+			testcase: "direct_key_long",
+			config: KeyProviderConfig{
+				Name: "direct",
+				Config: map[string]string{
+					"key": tooLongKey,
+				},
+			},
+			expectedErr: errors.New("error in configuration for key provider direct: field 'key' is not a hex string representing 32 bytes"),
+		},
+		{
+			testcase: "direct_additional",
+			config: KeyProviderConfig{
+				Name: "direct",
+				Config: map[string]string{
+					"key":        validKey1,
+					"additional": "nonsense",
+				},
+			},
+			expectedErr: errors.New("error in configuration for key provider direct: unexpected additional configuration fields, only 'key' is allowed for this key provider"),
+		},
+		{
+			testcase: "direct_success",
+			config: KeyProviderConfig{
+				Name: "direct",
+				Config: map[string]string{
+					"key": validKey1,
+				},
+			},
+			expectedErr: nil,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.testcase, func(t *testing.T) {
+			err := tc.config.Validate()
+			expectErr(t, err, tc.expectedErr)
+
+			err = tc.config.NameValid()
+			if tc.nameInvalid {
+				expectErr(t, err, tc.expectedErr)
+			} else {
+				expectErr(t, err, nil)
+			}
+		})
+	}
+}
+
+func TestEncryptionMethodConfigValidate(t *testing.T) {
+	testCases := []struct {
+		testcase    string
+		config      EncryptionMethodConfig
+		nameInvalid bool
+		expectedErr error
+	}{
+		{
+			testcase: "correct",
+			config: EncryptionMethodConfig{
+				Name: "full",
+			},
+			expectedErr: nil,
+		},
+		{
+			testcase: "unknown_name",
+			config: EncryptionMethodConfig{
+				Name: "unknown",
+			},
+			nameInvalid: true,
+			expectedErr: errors.New("error in configuration for encryption method unknown: no registered encryption method with this name"),
+		},
+		{
+			testcase: "incorrect",
+			config: EncryptionMethodConfig{
+				Name:   "full",
+				Config: map[string]string{"unexpected": "quick brown fox"},
+			},
+			expectedErr: errors.New("error in configuration for encryption method full: unexpected fields, this method needs no configuration"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.testcase, func(t *testing.T) {
+			err := tc.config.Validate()
+			expectErr(t, err, tc.expectedErr)
+
+			err = tc.config.NameValid()
+			if tc.nameInvalid {
+				expectErr(t, err, tc.expectedErr)
+			} else {
+				expectErr(t, err, nil)
+			}
+		})
+	}
+}
+
+const invalidJsonConfigSyntax = `{
+  "unclosed": {
+}`
+
+const invalidJsonConfigUnexpectedKeys = `{
+  "unexpected_keys": {
+    "tofu": true,
+    "fries": false
+  }
+}`
+
+const validJsonConfig = `{
+  "default": { 
+    "key_provider": {
+	  "name": "awskms",
+	  "config": {
+	    "region": "us-east-1",
+	    "key_id": "abc"
+	  }
+    },
+	"method": {
+	  "name": "full"
+    },
+	"required": true
+  }
+}`
+
+func TestParseJsonStructure(t *testing.T) {
+	testCases := []struct {
+		testcase    string
+		input       string
+		outputSize  int
+		expectedErr error
+	}{
+		{
+			testcase:    "invalid_syntax",
+			input:       invalidJsonConfigSyntax,
+			outputSize:  0,
+			expectedErr: errors.New("json parse error, wrong structure, or unknown fields - details omitted for security reasons (may contain key related settings)"),
+		},
+		{
+			testcase:    "unknown_fields",
+			input:       invalidJsonConfigUnexpectedKeys,
+			outputSize:  0,
+			expectedErr: errors.New("json parse error, wrong structure, or unknown fields - details omitted for security reasons (may contain key related settings)"),
+		},
+		{
+			testcase:    "valid",
+			input:       validJsonConfig,
+			outputSize:  1,
+			expectedErr: nil,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.testcase, func(t *testing.T) {
+			actual, err := parseJsonStructure(tc.input)
+			expectErr(t, err, tc.expectedErr)
+			if len(actual) != tc.outputSize {
+				t.Errorf("wrong output size %d instead of %d", len(actual), tc.outputSize)
+			}
+		})
+	}
+}
+
+func TestParseEnvJsonStructure(t *testing.T) {
+	testCases := []struct {
+		testcase    string
+		input       string
+		outputSize  int
+		expectedErr error
+	}{
+		{
+			testcase:    "invalid",
+			input:       invalidJsonConfigUnexpectedKeys,
+			outputSize:  0,
+			expectedErr: errors.New("error parsing what from environment variable STATE_ENCRYPTION_TESTCASE_TestParseEnvJsonStructure_invalid: json parse error, wrong structure, or unknown fields - details omitted for security reasons (may contain key related settings)"),
+		},
+		{
+			testcase:    "valid",
+			input:       validJsonConfig,
+			outputSize:  1,
+			expectedErr: nil,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.testcase, func(t *testing.T) {
+			envName := fmt.Sprintf("STATE_ENCRYPTION_TESTCASE_TestParseEnvJsonStructure_%s", tc.testcase)
+			os.Setenv(envName, tc.input)
+			defer os.Unsetenv(envName)
+
+			actual, err := parseEnvJsonStructure(envName, "what")
+			expectErr(t, err, tc.expectedErr)
+			if len(actual) != tc.outputSize {
+				t.Errorf("wrong output size %d instead of %d", len(actual), tc.outputSize)
+			}
+		})
+	}
+}
+
+func expectErr(t *testing.T, actual error, expected error) {
+	if actual != nil {
+		if actual.Error() != expected.Error() {
+			t.Errorf("received unexpected error '%s' instead of '%s'", actual.Error(), expected.Error())
+		}
+	} else {
+		if expected != nil {
+			t.Errorf("unexpected success instead of expected error '%s'", expected.Error())
+		}
+	}
+}

--- a/internal/states/encryption/encryptionconfig/deepmerge.go
+++ b/internal/states/encryption/encryptionconfig/deepmerge.go
@@ -1,0 +1,97 @@
+package encryptionconfig
+
+// InjectDefaultNamesIfUnset sets some configuration defaults, but only if there is a configuration.
+//
+// If config is nil, state encryption / decryption is disabled and this function does nothing.
+//
+// If a config is present, but any of the names are blank, we choose sensible defaults.
+//
+// Note that a blank configuration with these defaults will fail because it will be missing the passphrase.
+func InjectDefaultNamesIfUnset(config *Config) {
+	if config != nil {
+		if config.KeyProvider.Name == "" {
+			config.KeyProvider.Name = KeyProviderPassphrase
+		}
+		if config.Method.Name == "" {
+			config.Method.Name = EncryptionMethodFull
+		}
+	}
+}
+
+// MergeConfigs performs a merge of a number of (optional) configurations.
+//
+// Each argument is permitted to be nil, the result is nil if and only if all
+// arguments are nil.
+//
+// Any of the deepMergeIncreasingPriority arguments that are non-nil are
+// consecutively deep-merged.
+//
+// The defaultIfAllOthersNil plays a special role, it is NOT deep-merged,
+// but if all other arguments are nil or missing, it will be returned.
+func MergeConfigs(defaultIfAllOthersNil *Config, deepMergeIncreasingPriority ...*Config) *Config {
+	var current *Config
+	for _, deepMergeMe := range deepMergeIncreasingPriority {
+		current = deepMergeConfig(deepMergeMe, current)
+	}
+	if current != nil {
+		return current
+	} else {
+		return defaultIfAllOthersNil
+	}
+}
+
+func deepMergeConfig(addon *Config, base *Config) *Config {
+	if base == nil {
+		return addon
+	}
+	if addon == nil {
+		return base
+	}
+
+	// now we know both are non-nil
+	result := Config{}
+	result.KeyProvider = mergeKeyProvider(addon.KeyProvider, base.KeyProvider)
+	result.Method = mergeMethod(addon.Method, base.Method)
+	result.Required = valOrDefault(addon.Required, false, base.Required)
+	return &result
+}
+
+func mergeKeyProvider(addon KeyProviderConfig, base KeyProviderConfig) KeyProviderConfig {
+	return KeyProviderConfig{
+		Name:   valOrDefault(addon.Name, "", base.Name),
+		Config: mapMerge(addon.Config, base.Config),
+	}
+}
+
+func mergeMethod(addon EncryptionMethodConfig, base EncryptionMethodConfig) EncryptionMethodConfig {
+	return EncryptionMethodConfig{
+		Name:   valOrDefault(addon.Name, "", base.Name),
+		Config: mapMerge(addon.Config, base.Config),
+	}
+}
+
+func valOrDefault[T comparable](val T, empty T, defaultVal T) T {
+	if val == empty {
+		return defaultVal
+	} else {
+		return val
+	}
+}
+
+func mapMerge[K comparable, V any](addon map[K]V, base map[K]V) map[K]V {
+	if len(addon) == 0 {
+		return base
+	}
+	if len(base) == 0 {
+		return addon
+	}
+
+	result := make(map[K]V)
+	for k, v := range base {
+		result[k] = v
+	}
+	for k, v := range addon {
+		result[k] = v
+	}
+	return result
+}

--- a/internal/states/encryption/encryptionconfig/deepmerge_test.go
+++ b/internal/states/encryption/encryptionconfig/deepmerge_test.go
@@ -1,0 +1,194 @@
+package encryptionconfig
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestInjectDefaultNamesIfUnset(t *testing.T) {
+	testCases := []struct {
+		testcase   string
+		config     *Config
+		expectNil  bool
+		expectedKP string
+		expectedM  string
+	}{
+		{
+			testcase:  "no_configuration",
+			config:    nil,
+			expectNil: true,
+		},
+		{
+			testcase:   "all_defaults",
+			config:     &Config{},
+			expectNil:  false,
+			expectedKP: "passphrase",
+			expectedM:  "full",
+		},
+		{
+			testcase: "key_provider_default",
+			config: &Config{
+				Method: EncryptionMethodConfig{
+					Name: "other",
+				},
+			},
+			expectNil:  false,
+			expectedKP: "passphrase",
+			expectedM:  "other",
+		},
+		{
+			testcase: "method_default",
+			config: &Config{
+				KeyProvider: KeyProviderConfig{
+					Name: "direct",
+					Config: map[string]string{
+						"key": validKey1,
+					},
+				},
+			},
+			expectNil:  false,
+			expectedKP: "direct",
+			expectedM:  "full",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.testcase, func(t *testing.T) {
+			InjectDefaultNamesIfUnset(tc.config)
+			if tc.expectNil != (tc.config == nil) {
+				t.Error("unexpected nil state change")
+			}
+			if tc.config != nil {
+				if tc.expectedKP != string(tc.config.KeyProvider.Name) {
+					t.Errorf("unexpected key provider name '%s' instead of '%s'", tc.config.KeyProvider.Name, tc.expectedKP)
+				}
+				if tc.expectedM != string(tc.config.Method.Name) {
+					t.Errorf("unexpected method name '%s' instead of '%s'", tc.config.Method.Name, tc.expectedM)
+				}
+			}
+		})
+	}
+}
+
+func tstConfig(kp string, kpcount int, m string, mcount int, required bool) *Config {
+	tstMap := func(base string, count int) map[string]string {
+		var result map[string]string
+		if count >= 0 {
+			result = make(map[string]string)
+			for i := 0; i < count; i++ {
+				result[fmt.Sprintf("%s.%d", base, i+1)] = fmt.Sprintf("%d", i+1)
+			}
+		}
+		return result
+	}
+
+	return &Config{
+		KeyProvider: KeyProviderConfig{
+			Name:   KeyProviderName(kp),
+			Config: tstMap(kp, kpcount),
+		},
+		Method: EncryptionMethodConfig{
+			Name:   EncryptionMethodName(m),
+			Config: tstMap(m, mcount),
+		},
+		Required: required,
+	}
+}
+
+func TestMergeConfigs(t *testing.T) {
+	testCases := []struct {
+		testcase      string
+		defaultConfig *Config
+		mergeList     []*Config
+		expected      *Config
+	}{
+		{
+			testcase:      "nothing",
+			defaultConfig: nil,
+			mergeList:     nil,
+			expected:      nil,
+		},
+		{
+			testcase:      "many_nils",
+			defaultConfig: nil,
+			mergeList:     []*Config{nil, nil, nil, nil, nil},
+			expected:      nil,
+		},
+		{
+			testcase:      "use_default",
+			defaultConfig: tstConfig("kpdefault", 1, "mdefault", 2, false),
+			mergeList:     []*Config{nil, nil},
+			expected:      tstConfig("kpdefault", 1, "mdefault", 2, false),
+		},
+		{
+			testcase:      "use_non_nil1_ignore_default",
+			defaultConfig: tstConfig("kpdefault", 1, "mdefault", 2, false),
+			mergeList:     []*Config{tstConfig("kp1", 0, "m1", 1, true), nil, nil},
+			expected:      tstConfig("kp1", 0, "m1", 1, true),
+		},
+		{
+			testcase:      "use_non_nil2",
+			defaultConfig: nil,
+			mergeList:     []*Config{nil, tstConfig("kp2", 3, "m2", 2, false)},
+			expected:      tstConfig("kp2", 3, "m2", 2, false),
+		},
+		{
+			testcase:      "merge_ignore_default",
+			defaultConfig: tstConfig("kpdefault", 1, "mdefault", 2, true),
+			mergeList: []*Config{
+				tstConfig("kp1", 1, "m1", 0, false),
+				tstConfig("kp2", 0, "m2", 2, false),
+				tstConfig("kp3", 1, "m3", 1, false),
+			},
+			expected: &Config{
+				KeyProvider: KeyProviderConfig{
+					Name: "kp3",
+					Config: map[string]string{
+						"kp1.1": "1",
+						"kp3.1": "1",
+					},
+				},
+				Method: EncryptionMethodConfig{
+					Name: "m3",
+					Config: map[string]string{
+						"m2.1": "1",
+						"m2.2": "2",
+						"m3.1": "1",
+					},
+				},
+				Required: false,
+			},
+		},
+	}
+
+	helpfulDeepCompare := func(t *testing.T, expected Config, actual Config) {
+		if expected.Required != actual.Required {
+			t.Error("unexpected value for required")
+		}
+		if expected.KeyProvider.Name != actual.KeyProvider.Name {
+			t.Errorf("unexpected key provider name '%s' instead of '%s'", actual.KeyProvider.Name, expected.KeyProvider.Name)
+		}
+		if !reflect.DeepEqual(expected.KeyProvider.Config, actual.KeyProvider.Config) {
+			t.Error("key provider parameters differ")
+		}
+		if expected.Method.Name != actual.Method.Name {
+			t.Errorf("unexpected method name '%s' instead of '%s'", actual.Method.Name, expected.Method.Name)
+		}
+		if !reflect.DeepEqual(expected.Method.Config, actual.Method.Config) {
+			t.Error("method parameters differ")
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testcase, func(t *testing.T) {
+			actual := MergeConfigs(tc.defaultConfig, tc.mergeList...)
+			if tc.expected == nil || actual == nil {
+				if tc.expected != actual {
+					t.Error("unexpected nil state")
+				}
+			} else {
+				helpfulDeepCompare(t, *tc.expected, *actual)
+			}
+		})
+	}
+}

--- a/internal/states/encryption/encryptionconfig/validation.go
+++ b/internal/states/encryption/encryptionconfig/validation.go
@@ -1,0 +1,97 @@
+package encryptionconfig
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+)
+
+type KeyProviderConfigValidationFunction func(config KeyProviderConfig) error
+
+var keyProviderConfigValidation = make(map[KeyProviderName]KeyProviderConfigValidationFunction)
+
+// RegisterKeyProviderConfigValidationFunction allows registering config validation for additional key providers.
+//
+// The default key providers KeyProviderPassphrase and KeyProviderDirect are automatically registered.
+//
+// Note: You must also register the key provider with the encryption flow, or it will still not be available.
+func RegisterKeyProviderConfigValidationFunction(name KeyProviderName, validator KeyProviderConfigValidationFunction) error {
+	_, conflict := keyProviderConfigValidation[name]
+	if conflict {
+		return fmt.Errorf("duplicate registration for key provider %s", name)
+	}
+	if validator == nil {
+		return fmt.Errorf("missing validator during registration for key provider %s: nil", name)
+	}
+	keyProviderConfigValidation[name] = validator
+	return nil
+}
+
+type EncryptionMethodConfigValidationFunction func(config EncryptionMethodConfig) error
+
+var encryptionMethodConfigValidation = make(map[EncryptionMethodName]EncryptionMethodConfigValidationFunction)
+
+// RegisterEncryptionMethodConfigValidationFunction allows registering config validation for additional encryption methods.
+//
+// The default encryption method EncryptionMethodFull is automatically registered.
+//
+// Note: You must also register the method with the encryption flow, or it will still not be available.
+func RegisterEncryptionMethodConfigValidationFunction(name EncryptionMethodName, validator EncryptionMethodConfigValidationFunction) error {
+	_, conflict := encryptionMethodConfigValidation[name]
+	if conflict {
+		return fmt.Errorf("duplicate registration for encryption method %s", name)
+	}
+	if validator == nil {
+		return fmt.Errorf("missing validator during registration for encryption method %s: nil", name)
+	}
+	encryptionMethodConfigValidation[name] = validator
+	return nil
+}
+
+// validation for the built-in key providers and encryption methods
+
+func validateKPPassphraseConfig(k KeyProviderConfig) error {
+	phrase, ok := k.Config["passphrase"]
+	if !ok || phrase == "" {
+		return errors.New("passphrase missing or empty")
+	}
+
+	if len(k.Config) > 1 {
+		return errors.New("unexpected additional configuration fields, only 'passphrase' is allowed for this key provider")
+	}
+
+	return nil
+}
+
+func validateKPDirectConfig(k KeyProviderConfig) error {
+	keyStr, ok := k.Config["key"]
+	if !ok || keyStr == "" {
+		return errors.New("field 'key' missing or empty")
+	}
+
+	key, err := hex.DecodeString(keyStr)
+	if err != nil || len(key) != 32 {
+		return errors.New("field 'key' is not a hex string representing 32 bytes")
+	}
+
+	if len(k.Config) > 1 {
+		return errors.New("unexpected additional configuration fields, only 'key' is allowed for this key provider")
+	}
+
+	return nil
+}
+
+func validateEMFullConfig(m EncryptionMethodConfig) error {
+	if len(m.Config) > 0 {
+		return errors.New("unexpected fields, this method needs no configuration")
+	}
+	// no config fields
+	return nil
+}
+
+func init() {
+	_ = RegisterKeyProviderConfigValidationFunction(KeyProviderPassphrase, validateKPPassphraseConfig)
+	_ = RegisterKeyProviderConfigValidationFunction(KeyProviderDirect, validateKPDirectConfig)
+
+	_ = RegisterEncryptionMethodConfigValidationFunction(EncryptionMethodFull, validateEMFullConfig)
+}

--- a/internal/states/encryption/encryptionconfig/validation.go
+++ b/internal/states/encryption/encryptionconfig/validation.go
@@ -4,11 +4,10 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"sync"
 )
 
 type KeyProviderConfigValidationFunction func(config KeyProviderConfig) error
-
-var keyProviderConfigValidation = make(map[KeyProviderName]KeyProviderConfigValidationFunction)
 
 // RegisterKeyProviderConfigValidationFunction allows registering config validation for additional key providers.
 //
@@ -16,20 +15,19 @@ var keyProviderConfigValidation = make(map[KeyProviderName]KeyProviderConfigVali
 //
 // Note: You must also register the key provider with the encryption flow, or it will still not be available.
 func RegisterKeyProviderConfigValidationFunction(name KeyProviderName, validator KeyProviderConfigValidationFunction) error {
-	_, conflict := keyProviderConfigValidation[name]
-	if conflict {
-		return fmt.Errorf("duplicate registration for key provider %s", name)
-	}
 	if validator == nil {
 		return fmt.Errorf("missing validator during registration for key provider %s: nil", name)
 	}
-	keyProviderConfigValidation[name] = validator
+
+	conflict := setKeyProviderConfigValidation(name, validator)
+	if conflict {
+		return fmt.Errorf("duplicate registration for key provider %s", name)
+	}
+
 	return nil
 }
 
 type EncryptionMethodConfigValidationFunction func(config EncryptionMethodConfig) error
-
-var encryptionMethodConfigValidation = make(map[EncryptionMethodName]EncryptionMethodConfigValidationFunction)
 
 // RegisterEncryptionMethodConfigValidationFunction allows registering config validation for additional encryption methods.
 //
@@ -37,15 +35,62 @@ var encryptionMethodConfigValidation = make(map[EncryptionMethodName]EncryptionM
 //
 // Note: You must also register the method with the encryption flow, or it will still not be available.
 func RegisterEncryptionMethodConfigValidationFunction(name EncryptionMethodName, validator EncryptionMethodConfigValidationFunction) error {
-	_, conflict := encryptionMethodConfigValidation[name]
-	if conflict {
-		return fmt.Errorf("duplicate registration for encryption method %s", name)
-	}
 	if validator == nil {
 		return fmt.Errorf("missing validator during registration for encryption method %s: nil", name)
 	}
-	encryptionMethodConfigValidation[name] = validator
+
+	conflict := setEncryptionMethodConfigValidation(name, validator)
+	if conflict {
+		return fmt.Errorf("duplicate registration for encryption method %s", name)
+	}
+
 	return nil
+}
+
+// low level implementation and locking for validators
+
+var keyProviderConfigValidation_useGetAndSet = make(map[KeyProviderName]KeyProviderConfigValidationFunction)
+var keyProviderConfigValidationMutex = sync.RWMutex{}
+
+func getKeyProviderConfigValidation(name KeyProviderName) (validator KeyProviderConfigValidationFunction, ok bool) {
+	keyProviderConfigValidationMutex.RLock()
+	defer keyProviderConfigValidationMutex.RUnlock()
+
+	validator, ok = keyProviderConfigValidation_useGetAndSet[name]
+	return
+}
+
+func setKeyProviderConfigValidation(name KeyProviderName, validator KeyProviderConfigValidationFunction) (conflict bool) {
+	keyProviderConfigValidationMutex.Lock()
+	defer keyProviderConfigValidationMutex.Unlock()
+
+	_, conflict = keyProviderConfigValidation_useGetAndSet[name]
+	if !conflict {
+		keyProviderConfigValidation_useGetAndSet[name] = validator
+	}
+	return
+}
+
+var encryptionMethodConfigValidation_useGetAndSet = make(map[EncryptionMethodName]EncryptionMethodConfigValidationFunction)
+var encryptionMethodConfigValidationMutex = sync.RWMutex{}
+
+func getEncryptionMethodConfigValidation(name EncryptionMethodName) (validator EncryptionMethodConfigValidationFunction, ok bool) {
+	encryptionMethodConfigValidationMutex.RLock()
+	defer encryptionMethodConfigValidationMutex.RUnlock()
+
+	validator, ok = encryptionMethodConfigValidation_useGetAndSet[name]
+	return
+}
+
+func setEncryptionMethodConfigValidation(name EncryptionMethodName, validator EncryptionMethodConfigValidationFunction) (conflict bool) {
+	encryptionMethodConfigValidationMutex.Lock()
+	defer encryptionMethodConfigValidationMutex.Unlock()
+
+	_, conflict = encryptionMethodConfigValidation_useGetAndSet[name]
+	if !conflict {
+		encryptionMethodConfigValidation_useGetAndSet[name] = validator
+	}
+	return
 }
 
 // validation for the built-in key providers and encryption methods

--- a/internal/states/encryption/encryptionconfig/validation_test.go
+++ b/internal/states/encryption/encryptionconfig/validation_test.go
@@ -1,0 +1,64 @@
+package encryptionconfig
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestRegisterKeyProviderConfigValidationFunction(t *testing.T) {
+	testCases := []struct {
+		testcase    string
+		name        KeyProviderName
+		validator   KeyProviderConfigValidationFunction
+		expectedErr error
+	}{
+		{
+			testcase:    "duplicate", // already done in init()
+			name:        KeyProviderPassphrase,
+			validator:   validateKPPassphraseConfig,
+			expectedErr: errors.New("duplicate registration for key provider passphrase"),
+		},
+		{
+			testcase:    "no_validator",
+			name:        "some_fancy_kms",
+			validator:   nil,
+			expectedErr: errors.New("missing validator during registration for key provider some_fancy_kms: nil"),
+		},
+		// success case covered via init()
+	}
+	for _, tc := range testCases {
+		t.Run(tc.testcase, func(t *testing.T) {
+			err := RegisterKeyProviderConfigValidationFunction(tc.name, tc.validator)
+			expectErr(t, err, tc.expectedErr)
+		})
+	}
+}
+
+func TestRegisterEncryptionMethodConfigValidationFunction(t *testing.T) {
+	testCases := []struct {
+		testcase    string
+		name        EncryptionMethodName
+		validator   EncryptionMethodConfigValidationFunction
+		expectedErr error
+	}{
+		{
+			testcase:    "duplicate", // already done in init()
+			name:        EncryptionMethodFull,
+			validator:   validateEMFullConfig,
+			expectedErr: errors.New("duplicate registration for encryption method full"),
+		},
+		{
+			testcase:    "no_validator",
+			name:        "base64encrypt",
+			validator:   nil,
+			expectedErr: errors.New("missing validator during registration for encryption method base64encrypt: nil"),
+		},
+		// success case covered via init()
+	}
+	for _, tc := range testCases {
+		t.Run(tc.testcase, func(t *testing.T) {
+			err := RegisterEncryptionMethodConfigValidationFunction(tc.name, tc.validator)
+			expectErr(t, err, tc.expectedErr)
+		})
+	}
+}

--- a/internal/states/encryption/encryptionflow/interface.go
+++ b/internal/states/encryption/encryptionflow/interface.go
@@ -1,5 +1,5 @@
-// Package encryptionflow contains the top-level flow for client-side state encryption and the interfaces an encryption
-// or key derivation method need to implement.
+// Package encryptionflow contains the top-level flow for client-side state encryption and the interfaces
+// an encryption method or key provider need to implement.
 package encryptionflow
 
 import "github.com/opentofu/opentofu/internal/states/encryption/encryptionconfig"

--- a/internal/states/encryption/encryptionflow/interface.go
+++ b/internal/states/encryption/encryptionflow/interface.go
@@ -38,10 +38,10 @@ var EncryptionTopLevelJsonKey = "encryption"
 // Flow represents the top-level state or plan encryption/decryption flow
 // for a particular encryption configuration.
 //
-// Instances of Flow are kept in an internal cache per configuration key.
+// Instances of Flow are kept in an internal singleton cache per configuration key.
 // Unless you are writing tests, you should not create them in your code.
 //
-// See also encryption.Instance().
+// See also encryption.GetSingleton().
 type Flow interface {
 	// DecryptState decrypts encrypted state.
 	//
@@ -84,6 +84,9 @@ type Flow interface {
 	// If the plan is not actually encrypted, but plan encryption is configured,
 	// this will fail to prevent working with invalid plans (plans are binary data).
 	//
+	// Note that decryption fallback configurations are not considered for plans.
+	// Plans are not stored for a long time, so key rotation is not an issue for them.
+	//
 	// If DecryptPlan returns no error, then
 	//  - either there is no configuration for plan encryption, and
 	//    payload is returned as-is
@@ -96,13 +99,14 @@ type Flow interface {
 	// If no configuration for plan encryption is specified, the plan
 	// is returned as-is. This is not an error.
 	//
-	// In the presence of a configuration suitable for plan encryption
-	// (must be full encryption because plans are binary data),
-	// EncryptPlan returns a json document which contains the EncryptionTopLevelJsonKey key
+	// In the presence of a configuration suitable for plan encryption, EncryptPlan
+	// returns a json document which contains the EncryptionTopLevelJsonKey key
 	// at the 1st level.
 	//
 	// A configuration that is not suitable for plan encryption is treated as
-	// an error.
+	// an error. Whether a configuration is suitable for plan encryption or not is mostly determined
+	// by the encryption method. For example, plans cannot be partially encrypted, because
+	// they are binary data.
 	EncryptPlan(plan []byte) ([]byte, error)
 
 	// EncryptionConfiguration provides this Flow with configuration for

--- a/internal/states/encryption/encryptionflow/interface.go
+++ b/internal/states/encryption/encryptionflow/interface.go
@@ -108,6 +108,11 @@ type Flow interface {
 	// by the encryption method. For example, plans cannot be partially encrypted, because
 	// they are binary data.
 	EncryptPlan(plan []byte) ([]byte, error)
+}
+
+// FlowBuilder is the configuration builder for an encryption flow. Use this interface to allow assembling a valid
+// encryption configuration.
+type FlowBuilder interface {
 
 	// EncryptionConfiguration provides this Flow with configuration for
 	// encryption and decryption.
@@ -133,7 +138,7 @@ type Flow interface {
 	// Note: Some errors in the configuration can only be detected once it is used.
 	DecryptionFallbackConfiguration(source ConfigurationSource, config encryptionconfig.Config) error
 
-	// MergeAndValidateConfigurations merges and validates all configurations of this Flow.
+	// Build merges and validates all configurations of this Flow.
 	//
 	// Call this only after all configurations have been supplied via EncryptionConfiguration()
 	// and DecryptionFallbackConfiguration().
@@ -144,5 +149,5 @@ type Flow interface {
 	//
 	// Note: Some errors in the encryption or decryption fallback configurations can only be
 	// detected once they are used, especially when external key management systems are involved.
-	MergeAndValidateConfigurations() error
+	Build() (Flow, error)
 }

--- a/internal/states/encryption/encryptionflow/interface.go
+++ b/internal/states/encryption/encryptionflow/interface.go
@@ -1,0 +1,144 @@
+// Package encryptionflow contains the top-level flow for client-side state encryption and the interfaces an encryption
+// or key derivation method need to implement.
+package encryptionflow
+
+import "github.com/opentofu/opentofu/internal/states/encryption/encryptionconfig"
+
+type ConfigurationSource string
+
+const (
+	ConfigurationSourceEnvDefault ConfigurationSource = "env-default"
+	ConfigurationSourceCode       ConfigurationSource = "code"
+	ConfigurationSourceEnv        ConfigurationSource = "env"
+)
+
+func (s ConfigurationSource) IsValid() bool {
+	return s == ConfigurationSourceEnvDefault || s == ConfigurationSourceCode || s == ConfigurationSourceEnv
+}
+
+// IsForExternalUse checks that a ConfigurationSource is suitable for production-code outside this package tree.
+//
+// Provided mainly for documentation purposes.
+//
+// All other ConfigurationSource values are used internally, though you may need them when writing tests,
+// which is why they are exported.
+func (s ConfigurationSource) IsForExternalUse() bool {
+	return s == ConfigurationSourceCode
+}
+
+// EncryptionTopLevelJsonKey is the json key used to mark state or plans as encrypted.
+//
+// Changing this will invalidate all existing encrypted state, so migration code would have to be added
+// that can deal with the old key.
+//
+// Unencrypted state must not contain this key, so you cannot choose any of the top-level keys of the current
+// state data structure (currently stateV4).
+var EncryptionTopLevelJsonKey = "encryption"
+
+// Flow represents the top-level state or plan encryption/decryption flow
+// for a particular encryption configuration.
+//
+// Instances of Flow are kept in an internal cache per configuration key.
+// Unless you are writing tests, you should not create them in your code.
+//
+// See also encryption.Instance().
+type Flow interface {
+	// DecryptState decrypts encrypted state.
+	//
+	// If the state is not actually encrypted, it will be returned
+	// as-is. DecryptState will first try decryption using the state
+	// encryption configuration. If this fails, it tries the decryption
+	// fallback configuration. If neither produces a valid result it fails.
+	//
+	// payload must be a json document passed in as a []byte.
+	// This can be encrypted or unencrypted state. Encryption is detected
+	// by presence of the EncryptionTopLevelJsonKey key at the 1st level.
+	//
+	// If no error is returned, then the first return value will always
+	// be a json document, possibly the same one passed in as payload
+	// if the payload was not actually encrypted.
+	DecryptState(payload []byte) ([]byte, error)
+
+	// EncryptState encrypts plaintext state.
+	//
+	// There are special configurations that will not actually encrypt
+	// state. This happens when you only configure a decryption fallback,
+	// but not encryption. This is not an error.
+	//
+	// state is a json document passed in as a []byte. It is an error
+	// if this document already contains the EncryptionTopLevelJsonKey key
+	// at the 1st level.
+	//
+	// If no error is returned, then the first return value will always
+	// be a json document as a []byte. If encryption took place,
+	// this json document will have the EncryptionTopLevelJsonKey key
+	// at the 1st level.
+	EncryptState(state []byte) ([]byte, error)
+
+	// DecryptPlan decrypts an encrypted plan.
+	//
+	// The presence of encryption is detected by attempting to parse
+	// payload as a json document and looking at the EncryptionTopLevelJsonKey key
+	// at the 1st level.
+	//
+	// If the plan is not actually encrypted, but plan encryption is configured,
+	// this will fail to prevent working with invalid plans (plans are binary data).
+	//
+	// If DecryptPlan returns no error, then
+	//  - either there is no configuration for plan encryption, and
+	//    payload is returned as-is
+	//  - or it has successfully decrypted the payload using the configuration
+	//    for plan encryption.
+	DecryptPlan(payload []byte) ([]byte, error)
+
+	// EncryptPlan encrypts a plaintext plan.
+	//
+	// If no configuration for plan encryption is specified, the plan
+	// is returned as-is. This is not an error.
+	//
+	// In the presence of a configuration suitable for plan encryption
+	// (must be full encryption because plans are binary data),
+	// EncryptPlan returns a json document which contains the EncryptionTopLevelJsonKey key
+	// at the 1st level.
+	//
+	// A configuration that is not suitable for plan encryption is treated as
+	// an error.
+	EncryptPlan(plan []byte) ([]byte, error)
+
+	// EncryptionConfiguration provides this Flow with configuration for
+	// encryption and decryption.
+	//
+	// Configurations are deep-merged with ConfigurationSourceEnv taking precedence
+	// over ConfigurationSourceCode.
+	//
+	// The configuration from ConfigurationSourceEnvDefault is only considered if
+	// no specific configuration is present.
+	//
+	// Note: Some errors in the configuration can only be detected once it is used.
+	EncryptionConfiguration(source ConfigurationSource, config encryptionconfig.Config) error
+
+	// DecryptionFallbackConfiguration provides this Flow with a fallback configuration
+	// for decryption.
+	//
+	// Configurations are deep-merged with ConfigurationSourceEnv taking precedence
+	// over ConfigurationSourceCode.
+	//
+	// The configuration from ConfigurationSourceEnvDefault is only considered if
+	// no specific configuration is present.
+	//
+	// Note: Some errors in the configuration can only be detected once it is used.
+	DecryptionFallbackConfiguration(source ConfigurationSource, config encryptionconfig.Config) error
+
+	// MergeAndValidateConfigurations merges and validates all configurations of this Flow.
+	//
+	// Call this only after all configurations have been supplied via EncryptionConfiguration()
+	// and DecryptionFallbackConfiguration().
+	//
+	// This validation is far more complete than what EncryptionConfiguration() and
+	// DecryptionFallbackConfiguration() can detect, because the configurations are now
+	// completely known.
+	//
+	// Note: Some errors in the encryption or decryption fallback configurations can only be
+	// detected once they are used, especially when external key management systems are involved.
+	MergeAndValidateConfigurations() error
+}

--- a/internal/states/encryption/encryptionflow/interface_example_test.go
+++ b/internal/states/encryption/encryptionflow/interface_example_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+
 	"github.com/opentofu/opentofu/internal/states/encryption/encryptionconfig"
 	"github.com/opentofu/opentofu/internal/states/encryption/encryptionflow"
 )

--- a/internal/states/encryption/encryptionflow/interface_example_test.go
+++ b/internal/states/encryption/encryptionflow/interface_example_test.go
@@ -1,0 +1,104 @@
+package encryptionflow_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"github.com/opentofu/opentofu/internal/states/encryption/encryptionconfig"
+	"github.com/opentofu/opentofu/internal/states/encryption/encryptionflow"
+)
+
+func ExampleFlow() {
+	var builder encryptionflow.FlowBuilder = &base64UnsafeFlowBuilder{}
+
+	flow, err := builder.Build()
+	if err != nil {
+		panic(err)
+	}
+	encryptedState, err := flow.EncryptState([]byte(`{"message":"Hello world!"}`))
+	if err != nil {
+		panic(err)
+	}
+
+	decryptedState, err := flow.DecryptState(encryptedState)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%s\n", decryptedState)
+
+	//Output: {"message":"Hello world!"}
+}
+
+type base64UnsafeFlowBuilder struct{}
+
+func (b base64UnsafeFlowBuilder) EncryptionConfiguration(source encryptionflow.ConfigurationSource, config encryptionconfig.Config) error {
+	return nil
+}
+
+func (b base64UnsafeFlowBuilder) DecryptionFallbackConfiguration(source encryptionflow.ConfigurationSource, config encryptionconfig.Config) error {
+	return nil
+}
+
+func (b base64UnsafeFlowBuilder) Build() (encryptionflow.Flow, error) {
+	return &base64UnsafeFlow{}, nil
+}
+
+type base64UnsafeFlow struct {
+}
+
+type encryptedState struct {
+	Data string `json:"data"`
+}
+
+func (b base64UnsafeFlow) DecryptState(payload []byte) ([]byte, error) {
+	return b.decrypt(payload)
+}
+
+func (b base64UnsafeFlow) EncryptState(state []byte) ([]byte, error) {
+	return b.encrypt(state)
+}
+
+func (b base64UnsafeFlow) DecryptPlan(payload []byte) ([]byte, error) {
+	return b.decrypt(payload)
+}
+
+func (b base64UnsafeFlow) EncryptPlan(plan []byte) ([]byte, error) {
+	return b.encrypt(plan)
+}
+
+func (b base64UnsafeFlow) decrypt(payload []byte) ([]byte, error) {
+	var unmarshalledPayload *encryptedState
+	if err := json.Unmarshal(payload, &unmarshalledPayload); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal encrypted data (%w)", err)
+	}
+
+	// Decode the data.
+	decodedData, err := base64.StdEncoding.DecodeString(unmarshalledPayload.Data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to base64-decode encrypted payload (%w)", err)
+	}
+
+	// Make sure there's valid JSON in the decrypted data.
+	var result any
+	if err := json.Unmarshal(decodedData, &result); err != nil {
+		return nil, fmt.Errorf("failed to decode decrypted data (%w)", err)
+	}
+	return decodedData, nil
+}
+
+func (b base64UnsafeFlow) encrypt(payload []byte) ([]byte, error) {
+	var testResult any
+	if err := json.Unmarshal(payload, &testResult); err != nil {
+		return nil, fmt.Errorf("failed to decode decrypted data (%w)", err)
+	}
+
+	encryptedPayload := &encryptedState{
+		base64.StdEncoding.EncodeToString(payload),
+	}
+	result, err := json.Marshal(encryptedPayload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to JSON-encode encrypted payload (%w)", err)
+	}
+	return result, nil
+}

--- a/internal/states/encryption/encryptionflow/interface_test.go
+++ b/internal/states/encryption/encryptionflow/interface_test.go
@@ -1,0 +1,45 @@
+package encryptionflow
+
+import "testing"
+
+const invalidConfigurationSource ConfigurationSource = "invalid"
+
+func TestConfigurationSourceEnum(t *testing.T) {
+	testCases := []struct {
+		value                ConfigurationSource
+		expectValid          bool
+		expectForExternalUse bool
+	}{
+		{
+			value:                invalidConfigurationSource,
+			expectValid:          false,
+			expectForExternalUse: false,
+		},
+		{
+			value:                ConfigurationSourceEnvDefault,
+			expectValid:          true,
+			expectForExternalUse: false,
+		},
+		{
+			value:                ConfigurationSourceCode,
+			expectValid:          true,
+			expectForExternalUse: true,
+		},
+		{
+			value:                ConfigurationSourceEnv,
+			expectValid:          true,
+			expectForExternalUse: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(string(tc.value), func(t *testing.T) {
+			if tc.expectValid != tc.value.IsValid() {
+				t.Error("unexpected result for IsValid")
+			}
+			if tc.expectForExternalUse != tc.value.IsForExternalUse() {
+				t.Error("unexpected result for IsForExternalUse")
+			}
+		})
+	}
+}

--- a/internal/states/encryption/encryptionflow/mockup.go
+++ b/internal/states/encryption/encryptionflow/mockup.go
@@ -2,6 +2,7 @@ package encryptionflow
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/go-hclog"
 	"github.com/opentofu/opentofu/internal/logging"
 	"github.com/opentofu/opentofu/internal/states/encryption/encryptionconfig"

--- a/internal/states/encryption/encryptionflow/mockup.go
+++ b/internal/states/encryption/encryptionflow/mockup.go
@@ -1,0 +1,120 @@
+package encryptionflow
+
+import (
+	"fmt"
+	"github.com/hashicorp/go-hclog"
+	"github.com/opentofu/opentofu/internal/logging"
+	"github.com/opentofu/opentofu/internal/states/encryption/encryptionconfig"
+)
+
+// MockUpLoggingFlow will be removed when we replace it with the real implementation.
+type MockUpLoggingFlow struct {
+	configKey                 string
+	encryptionConfigs         map[ConfigurationSource]encryptionconfig.Config
+	decryptionFallbackConfigs map[ConfigurationSource]encryptionconfig.Config
+	logger                    hclog.Logger
+}
+
+func NewMock(configKey string) Flow {
+	return &MockUpLoggingFlow{
+		configKey:                 configKey,
+		encryptionConfigs:         make(map[ConfigurationSource]encryptionconfig.Config),
+		decryptionFallbackConfigs: make(map[ConfigurationSource]encryptionconfig.Config),
+		logger:                    logging.HCLogger(),
+	}
+}
+
+func (m *MockUpLoggingFlow) DecryptState(payload []byte) ([]byte, error) {
+	m.logger.Trace("encryption:DecryptState", "key", m.configKey, "payloadSize", len(payload))
+	if err := m.MergeAndValidateConfigurations(); err != nil {
+		return []byte{}, err
+	}
+	return payload, nil
+}
+
+func (m *MockUpLoggingFlow) EncryptState(state []byte) ([]byte, error) {
+	m.logger.Trace("encryption:EncryptState", "key", m.configKey, "stateSize", len(state))
+	if err := m.MergeAndValidateConfigurations(); err != nil {
+		return []byte{}, err
+	}
+	return state, nil
+}
+
+func (m *MockUpLoggingFlow) DecryptPlan(payload []byte) ([]byte, error) {
+	m.logger.Trace("encryption:DecryptPlan", "key", m.configKey, "payloadSize", len(payload))
+	if err := m.MergeAndValidateConfigurations(); err != nil {
+		return []byte{}, err
+	}
+	return payload, nil
+}
+
+func (m *MockUpLoggingFlow) EncryptPlan(plan []byte) ([]byte, error) {
+	m.logger.Trace("encryption:EncryptPlan", "key", m.configKey, "planSize", len(plan))
+	if err := m.MergeAndValidateConfigurations(); err != nil {
+		return []byte{}, err
+	}
+	return plan, nil
+}
+
+func (m *MockUpLoggingFlow) EncryptionConfiguration(source ConfigurationSource, config encryptionconfig.Config) error {
+	if !source.IsValid() {
+		panic("EncryptionConfiguration() called with invalid source value. This is a bug.")
+	}
+	m.logger.Trace("encryption:EncryptionConfiguration", "key", m.configKey, "source", source, "config", config)
+	// for this simple mock, we just store the configuration, so we can later merge and validate it
+	m.encryptionConfigs[source] = config
+	return nil
+}
+
+func (m *MockUpLoggingFlow) DecryptionFallbackConfiguration(source ConfigurationSource, config encryptionconfig.Config) error {
+	if !source.IsValid() {
+		panic("DecryptionFallbackConfiguration() called with invalid source value. This is a bug.")
+	}
+	m.logger.Trace("encryption:DecryptionFallbackConfiguration", "key", m.configKey, "source", source, "config", config)
+	// for this simple mock, we just store the configuration, so we can later merge and validate it
+	m.decryptionFallbackConfigs[source] = config
+	return nil
+}
+
+func (m *MockUpLoggingFlow) MergeAndValidateConfigurations() error {
+	// this logic will appear in a similar form in the actual flow implementation. For now, we just merge
+	// and validate the configuration.
+
+	mergedEncryptionConfig := encryptionconfig.MergeConfigs(
+		configOrNil(m.encryptionConfigs, ConfigurationSourceEnvDefault),
+		configOrNil(m.encryptionConfigs, ConfigurationSourceCode),
+		configOrNil(m.encryptionConfigs, ConfigurationSourceEnv),
+	)
+	encryptionconfig.InjectDefaultNamesIfUnset(mergedEncryptionConfig)
+
+	mergedDecryptionFallbackConfig := encryptionconfig.MergeConfigs(
+		configOrNil(m.decryptionFallbackConfigs, ConfigurationSourceEnvDefault),
+		configOrNil(m.decryptionFallbackConfigs, ConfigurationSourceCode),
+		configOrNil(m.decryptionFallbackConfigs, ConfigurationSourceEnv),
+	)
+	encryptionconfig.InjectDefaultNamesIfUnset(mergedDecryptionFallbackConfig)
+
+	if mergedEncryptionConfig != nil {
+		m.logger.Trace("encryption:MergeAndValidateConfigurations using encryption config", "key", m.configKey, "config", *mergedEncryptionConfig)
+		if err := mergedEncryptionConfig.Validate(); err != nil {
+			return fmt.Errorf("error invalid encryption configuration after merge: %s", err.Error())
+		}
+	}
+	if mergedDecryptionFallbackConfig != nil {
+		m.logger.Trace("encryption:MergeAndValidateConfigurations using fallback config", "key", m.configKey, "config", *mergedDecryptionFallbackConfig)
+		if err := mergedDecryptionFallbackConfig.Validate(); err != nil {
+			return fmt.Errorf("error invalid decryption fallback configuration after merge: %s", err.Error())
+		}
+	}
+
+	return nil
+}
+
+func configOrNil(configs map[ConfigurationSource]encryptionconfig.Config, source ConfigurationSource) *encryptionconfig.Config {
+	conf, ok := configs[source]
+	if ok {
+		return &conf
+	} else {
+		return nil
+	}
+}

--- a/internal/states/encryption/encryptionflow/mockup_test.go
+++ b/internal/states/encryption/encryptionflow/mockup_test.go
@@ -3,9 +3,10 @@ package encryptionflow
 import (
 	"errors"
 	"fmt"
-	"github.com/opentofu/opentofu/internal/states/encryption/encryptionconfig"
 	"strings"
 	"testing"
+
+	"github.com/opentofu/opentofu/internal/states/encryption/encryptionconfig"
 )
 
 // tstNoConfigurationInstance constructs a mockup Flow with no configuration.

--- a/internal/states/encryption/encryptionflow/mockup_test.go
+++ b/internal/states/encryption/encryptionflow/mockup_test.go
@@ -1,0 +1,170 @@
+package encryptionflow
+
+import (
+	"errors"
+	"fmt"
+	"github.com/opentofu/opentofu/internal/states/encryption/encryptionconfig"
+	"strings"
+	"testing"
+)
+
+// tstNoConfigurationInstance constructs a mockup Flow with no configuration.
+//
+// This is the most important case, because this will happen if tofu is run without
+// any encryption configuration. We need to ensure all state and plans are passed through
+// unchanged.
+func tstNoConfigurationInstance() Flow {
+	return NewMock("testing_no_configuration")
+}
+
+func tstPassthrough(t *testing.T, value string, method func([]byte) ([]byte, error)) {
+	actual, err := method([]byte(value))
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+	if string(actual) != value {
+		t.Error("failed to pass through")
+	}
+}
+
+func TestDecryptState_Passthrough(t *testing.T) {
+	cut := tstNoConfigurationInstance()
+	tstPassthrough(t, `{"version":"4"}`, cut.DecryptState)
+}
+
+func TestEncryptState_Passthrough(t *testing.T) {
+	cut := tstNoConfigurationInstance()
+	tstPassthrough(t, `{"version":"4"}`, cut.EncryptState)
+}
+
+func TestDecryptPlan_Passthrough(t *testing.T) {
+	cut := tstNoConfigurationInstance()
+	tstPassthrough(t, `zip64`, cut.DecryptPlan)
+}
+
+func TestEncryptPlan_Passthrough(t *testing.T) {
+	cut := tstNoConfigurationInstance()
+	tstPassthrough(t, `zip64`, cut.EncryptPlan)
+}
+
+func tstCodeConfigurationInstance(encValid bool, decValid bool) Flow {
+	encConfig := encryptionconfig.Config{
+		KeyProvider: encryptionconfig.KeyProviderConfig{
+			Config: map[string]string{},
+		},
+		Method: encryptionconfig.EncryptionMethodConfig{},
+	}
+	if encValid {
+		encConfig.KeyProvider.Config["passphrase"] = "a new passphrase"
+	}
+
+	decConfig := encryptionconfig.Config{
+		KeyProvider: encryptionconfig.KeyProviderConfig{
+			Config: map[string]string{},
+		},
+		Method: encryptionconfig.EncryptionMethodConfig{},
+	}
+	if decValid {
+		decConfig.KeyProvider.Config["passphrase"] = "the old passphrase"
+	}
+
+	cut := NewMock("testing_code_configuration")
+	_ = cut.EncryptionConfiguration(ConfigurationSourceCode, encConfig)
+	_ = cut.DecryptionFallbackConfiguration(ConfigurationSourceCode, decConfig)
+	return cut
+}
+
+func TestMergeAndValidateConfigurations(t *testing.T) {
+	testCases := []struct {
+		testcase    string
+		cut         Flow
+		expectError error
+	}{
+		{
+			testcase:    "no_configuration",
+			cut:         tstNoConfigurationInstance(),
+			expectError: nil,
+		},
+		{
+			testcase:    "valid_configurations",
+			cut:         tstCodeConfigurationInstance(true, true),
+			expectError: nil,
+		},
+		{
+			testcase:    "invalid_enc_config",
+			cut:         tstCodeConfigurationInstance(false, true),
+			expectError: errors.New("error invalid encryption configuration after merge: error in configuration for key provider passphrase: passphrase missing or empty"),
+		},
+		{
+			testcase:    "invalid_dec_config",
+			cut:         tstCodeConfigurationInstance(true, false),
+			expectError: errors.New("error invalid decryption fallback configuration after merge: error in configuration for key provider passphrase: passphrase missing or empty"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testcase, func(t *testing.T) {
+			err := tc.cut.MergeAndValidateConfigurations()
+			expectErr(t, err, tc.expectError)
+		})
+	}
+}
+
+func TestDecryptEncryptPropagateErrors(t *testing.T) {
+	cut := tstCodeConfigurationInstance(false, true)
+	expected := errors.New("error invalid encryption configuration after merge: error in configuration for key provider passphrase: passphrase missing or empty")
+
+	_, err := cut.DecryptState([]byte(`{"version":"4"}`))
+	expectErr(t, err, expected)
+
+	_, err = cut.EncryptState([]byte(`{"version":"4"}`))
+	expectErr(t, err, expected)
+
+	_, err = cut.DecryptPlan([]byte(`zip64`))
+	expectErr(t, err, expected)
+
+	_, err = cut.EncryptPlan([]byte(`zip64`))
+	expectErr(t, err, expected)
+}
+
+func expectErr(t *testing.T, actual error, expected error) {
+	if actual != nil {
+		if expected == nil {
+			t.Errorf("received unexpected error '%s' instead of success", actual.Error())
+		} else if actual.Error() != expected.Error() {
+			t.Errorf("received unexpected error '%s' instead of '%s'", actual.Error(), expected.Error())
+		}
+	} else {
+		if expected != nil {
+			t.Errorf("unexpected success instead of expected error '%s'", expected.Error())
+		}
+	}
+}
+
+func TestEncryptionConfigurationEnforcesSource(t *testing.T) {
+	cut := tstNoConfigurationInstance()
+
+	defer tstExpectPanic(t, "called with invalid source value")()
+	_ = cut.EncryptionConfiguration(invalidConfigurationSource, encryptionconfig.Config{})
+}
+
+func TestDecryptionFallbackConfigurationEnforcesSource(t *testing.T) {
+	cut := tstNoConfigurationInstance()
+
+	defer tstExpectPanic(t, "called with invalid source value")()
+	_ = cut.DecryptionFallbackConfiguration(invalidConfigurationSource, encryptionconfig.Config{})
+}
+
+func tstExpectPanic(t *testing.T, snippet string) func() {
+	return func() {
+		r := recover()
+		if r == nil {
+			t.Errorf("expected a panic")
+		} else {
+			actual := fmt.Sprintf("%v", r)
+			if !strings.Contains(actual, snippet) {
+				t.Errorf("panic message did not contain '%s'", snippet)
+			}
+		}
+	}
+}

--- a/internal/states/encryption/environment.go
+++ b/internal/states/encryption/environment.go
@@ -13,8 +13,8 @@ import (
 //
 // It is not an error if either of the environment variables has an empty value or is unset.
 //
-// If this function returns nil, Instance(), RemoteStateInstance(), StatefileInstance(), and PlanfileInstance()
-// will not fail at inopportune times.
+// If this function returns nil, GetSingleton(), GetRemoteStateSingleton(), GetStatefileSingleton(), and
+// GetPlanfileSingleton() are much less likely to fail at inopportune times.
 //
 // Note: You should generally avoid setting the state encryption environment variables in tests, as this may make
 // tests depend on each other. Just obtain a suitable Instance(), then call EncryptionConfiguration() and/or

--- a/internal/states/encryption/environment.go
+++ b/internal/states/encryption/environment.go
@@ -32,7 +32,7 @@ func ParseEnvironmentVariables() error {
 	return nil
 }
 
-func applyEncryptionConfigIfExists(flow encryptionflow.Flow, source encryptionflow.ConfigurationSource, configKey string) error {
+func applyEncryptionConfigIfExists(flow encryptionflow.FlowBuilder, source encryptionflow.ConfigurationSource, configKey string) error {
 	configs, err := encryptionconfig.EncryptionConfigurationsFromEnv()
 	if err != nil {
 		return err
@@ -65,7 +65,7 @@ func applyEncryptionConfigIfExists(flow encryptionflow.Flow, source encryptionfl
 	return nil
 }
 
-func applyDecryptionFallbackConfigIfExists(flow encryptionflow.Flow, source encryptionflow.ConfigurationSource, configKey string) error {
+func applyDecryptionFallbackConfigIfExists(flow encryptionflow.FlowBuilder, source encryptionflow.ConfigurationSource, configKey string) error {
 	configs, err := encryptionconfig.FallbackConfigurationsFromEnv()
 	if err != nil {
 		return err

--- a/internal/states/encryption/environment.go
+++ b/internal/states/encryption/environment.go
@@ -1,0 +1,99 @@
+package encryption
+
+import (
+	"github.com/opentofu/opentofu/internal/logging"
+	"github.com/opentofu/opentofu/internal/states/encryption/encryptionconfig"
+	"github.com/opentofu/opentofu/internal/states/encryption/encryptionflow"
+)
+
+// ParseEnvironmentVariables checks the state encryption environment variables for structure and syntax errors.
+//
+// Call ParseEnvironmentVariables early during OpenTofu's initialization to ensure that the configuration from
+// environment variables can be correctly parsed.
+//
+// It is not an error if either of the environment variables has an empty value or is unset.
+//
+// If this function returns nil, Instance(), RemoteStateInstance(), StatefileInstance(), and PlanfileInstance()
+// will not fail at inopportune times.
+//
+// Note: You should generally avoid setting the state encryption environment variables in tests, as this may make
+// tests depend on each other. Just obtain a suitable Instance(), then call EncryptionConfiguration() and/or
+// DecryptionFallbackConfiguration() on it to explicitly set up configuration that would normally have come from
+// the environment.
+func ParseEnvironmentVariables() error {
+	if _, err := encryptionconfig.EncryptionConfigurationsFromEnv(); err != nil {
+		return err
+	}
+
+	if _, err := encryptionconfig.FallbackConfigurationsFromEnv(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func applyEncryptionConfigIfExists(flow encryptionflow.Flow, source encryptionflow.ConfigurationSource, configKey string) error {
+	configs, err := encryptionconfig.EncryptionConfigurationsFromEnv()
+	if err != nil {
+		return err
+	}
+	if configs == nil {
+		logging.HCLogger().Trace("nothing to apply, environment variable for encryption is not set",
+			"source", source, "configKey", configKey)
+		return nil
+	}
+
+	config, ok := configs[configKey]
+	if !ok {
+		logging.HCLogger().Trace("nothing to apply from environment variable for encryption",
+			"source", source, "configKey", configKey)
+		return nil
+	}
+
+	err = flow.EncryptionConfiguration(source, config)
+	if err != nil {
+		logging.HCLogger().Error("encryption configuration from environment failed to apply. "+
+			"This is a bug. It should not be validated, only stored at this point in time because it could still "+
+			"be incomplete. Validation of the configuration can only occur once it is known to be complete.",
+			"source", source, "configKey", configKey)
+		logging.HCLogger().Error(err.Error())
+		return err
+	}
+
+	logging.HCLogger().Trace("successfully applied config from environment variable for encryption",
+		"source", source, "configKey", configKey)
+	return nil
+}
+
+func applyDecryptionFallbackConfigIfExists(flow encryptionflow.Flow, source encryptionflow.ConfigurationSource, configKey string) error {
+	configs, err := encryptionconfig.FallbackConfigurationsFromEnv()
+	if err != nil {
+		return err
+	}
+	if configs == nil {
+		logging.HCLogger().Trace("nothing to apply, environment variable for decryption fallback is not set",
+			"source", source, "configKey", configKey)
+		return nil
+	}
+
+	config, ok := configs[configKey]
+	if !ok {
+		logging.HCLogger().Trace("nothing to apply from environment variable for decryption fallback",
+			"source", source, "configKey", configKey)
+		return nil
+	}
+
+	err = flow.DecryptionFallbackConfiguration(source, config)
+	if err != nil {
+		logging.HCLogger().Error("decryption fallback configuration from environment failed to apply. "+
+			"This is a bug. It should not be validated, only stored at this point in time because it could still "+
+			"be incomplete. Validation of the configuration can only occur once it is known to be complete.",
+			"source", source, "configKey", configKey)
+		logging.HCLogger().Error(err.Error())
+		return err
+	}
+
+	logging.HCLogger().Trace("successfully applied config from environment variable for encryption",
+		"source", source, "configKey", configKey)
+	return nil
+}

--- a/internal/states/encryption/environment_test.go
+++ b/internal/states/encryption/environment_test.go
@@ -1,0 +1,111 @@
+package encryption
+
+import (
+	"errors"
+	"fmt"
+	"github.com/opentofu/opentofu/internal/states/encryption/encryptionconfig"
+	"github.com/opentofu/opentofu/internal/states/encryption/encryptionflow"
+	"testing"
+)
+
+func TestParseEnvironmentVariables(t *testing.T) {
+	configKey := "unit_testing.parse_environment_variables"
+
+	testCases := []struct {
+		testcase    string
+		encEnv      string
+		decEnv      string
+		expectError error
+	}{
+		{
+			testcase: "no_configuration",
+		},
+		// parse failures
+		{
+			testcase: "syntactically_invalid_enc",
+			encEnv:   `{`,
+			decEnv:   envConfig(configKey, true),
+			expectError: fmt.Errorf(
+				"error parsing encryption configuration from environment variable %s: "+
+					"json parse error, wrong structure, or unknown fields - "+
+					"details omitted for security reasons (may contain key related settings)",
+				encryptionconfig.ConfigEnvName,
+			),
+		},
+		{
+			testcase: "syntactically_invalid_dec",
+			encEnv:   envConfig(configKey, true),
+			decEnv:   `{not_a_json}}}}}}`,
+			expectError: fmt.Errorf(
+				"error parsing fallback decryption configuration from environment variable %s: "+
+					"json parse error, wrong structure, or unknown fields - "+
+					"details omitted for security reasons (may contain key related settings)",
+				encryptionconfig.FallbackConfigEnvName,
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testcase, func(t *testing.T) {
+			if tc.encEnv != "" {
+				t.Setenv(encryptionconfig.ConfigEnvName, tc.encEnv)
+			}
+			if tc.decEnv != "" {
+				t.Setenv(encryptionconfig.FallbackConfigEnvName, tc.decEnv)
+			}
+
+			err := ParseEnvironmentVariables()
+			expectErr(t, err, tc.expectError)
+		})
+	}
+}
+
+type tstAlwaysFailingFlow struct{}
+
+var alwaysFailError = errors.New("always fails")
+
+func (t *tstAlwaysFailingFlow) DecryptState(_ []byte) ([]byte, error) {
+	return []byte{}, alwaysFailError
+}
+
+func (t *tstAlwaysFailingFlow) EncryptState(_ []byte) ([]byte, error) {
+	return []byte{}, alwaysFailError
+}
+
+func (t *tstAlwaysFailingFlow) DecryptPlan(_ []byte) ([]byte, error) {
+	return []byte{}, alwaysFailError
+}
+
+func (t *tstAlwaysFailingFlow) EncryptPlan(_ []byte) ([]byte, error) {
+	return []byte{}, alwaysFailError
+}
+
+func (t *tstAlwaysFailingFlow) EncryptionConfiguration(_ encryptionflow.ConfigurationSource, _ encryptionconfig.Config) error {
+	return alwaysFailError
+}
+
+func (t *tstAlwaysFailingFlow) DecryptionFallbackConfiguration(_ encryptionflow.ConfigurationSource, _ encryptionconfig.Config) error {
+	return alwaysFailError
+}
+
+func (t *tstAlwaysFailingFlow) MergeAndValidateConfigurations() error {
+	return alwaysFailError
+}
+
+func TestApplyEncryptionConfigIfExists_ApplyError(t *testing.T) {
+	configKey := "unit_testing.apply_encryption_config_if_exists"
+	t.Setenv(encryptionconfig.ConfigEnvName, envConfig(configKey, true))
+
+	failFlow := &tstAlwaysFailingFlow{}
+	err := applyEncryptionConfigIfExists(failFlow, encryptionflow.ConfigurationSourceEnv, configKey)
+	expectErr(t, err, alwaysFailError)
+}
+
+func TestApplyDecryptionFallbackConfigIfExists_ApplyError(t *testing.T) {
+	configKey := "unit_testing.apply_decryption_fallback_config_if_exists"
+	t.Setenv(encryptionconfig.FallbackConfigEnvName, envConfig(configKey, true))
+
+	failFlow := &tstAlwaysFailingFlow{}
+	err := applyDecryptionFallbackConfigIfExists(failFlow, encryptionflow.ConfigurationSourceEnv, configKey)
+	expectErr(t, err, alwaysFailError)
+}

--- a/internal/states/encryption/environment_test.go
+++ b/internal/states/encryption/environment_test.go
@@ -3,9 +3,10 @@ package encryption
 import (
 	"errors"
 	"fmt"
+	"testing"
+
 	"github.com/opentofu/opentofu/internal/states/encryption/encryptionconfig"
 	"github.com/opentofu/opentofu/internal/states/encryption/encryptionflow"
-	"testing"
 )
 
 func TestParseEnvironmentVariables(t *testing.T) {

--- a/internal/states/encryption/environment_test.go
+++ b/internal/states/encryption/environment_test.go
@@ -61,43 +61,27 @@ func TestParseEnvironmentVariables(t *testing.T) {
 	}
 }
 
-type tstAlwaysFailingFlow struct{}
+type tstAlwaysFailingFlowBuilder struct{}
 
 var alwaysFailError = errors.New("always fails")
 
-func (t *tstAlwaysFailingFlow) DecryptState(_ []byte) ([]byte, error) {
-	return []byte{}, alwaysFailError
-}
-
-func (t *tstAlwaysFailingFlow) EncryptState(_ []byte) ([]byte, error) {
-	return []byte{}, alwaysFailError
-}
-
-func (t *tstAlwaysFailingFlow) DecryptPlan(_ []byte) ([]byte, error) {
-	return []byte{}, alwaysFailError
-}
-
-func (t *tstAlwaysFailingFlow) EncryptPlan(_ []byte) ([]byte, error) {
-	return []byte{}, alwaysFailError
-}
-
-func (t *tstAlwaysFailingFlow) EncryptionConfiguration(_ encryptionflow.ConfigurationSource, _ encryptionconfig.Config) error {
+func (t *tstAlwaysFailingFlowBuilder) EncryptionConfiguration(_ encryptionflow.ConfigurationSource, _ encryptionconfig.Config) error {
 	return alwaysFailError
 }
 
-func (t *tstAlwaysFailingFlow) DecryptionFallbackConfiguration(_ encryptionflow.ConfigurationSource, _ encryptionconfig.Config) error {
+func (t *tstAlwaysFailingFlowBuilder) DecryptionFallbackConfiguration(_ encryptionflow.ConfigurationSource, _ encryptionconfig.Config) error {
 	return alwaysFailError
 }
 
-func (t *tstAlwaysFailingFlow) MergeAndValidateConfigurations() error {
-	return alwaysFailError
+func (t *tstAlwaysFailingFlowBuilder) Build() (encryptionflow.Flow, error) {
+	return nil, alwaysFailError
 }
 
 func TestApplyEncryptionConfigIfExists_ApplyError(t *testing.T) {
 	configKey := "unit_testing.apply_encryption_config_if_exists"
 	t.Setenv(encryptionconfig.ConfigEnvName, envConfig(configKey, true))
 
-	failFlow := &tstAlwaysFailingFlow{}
+	failFlow := &tstAlwaysFailingFlowBuilder{}
 	err := applyEncryptionConfigIfExists(failFlow, encryptionflow.ConfigurationSourceEnv, configKey)
 	expectErr(t, err, alwaysFailError)
 }
@@ -106,7 +90,7 @@ func TestApplyDecryptionFallbackConfigIfExists_ApplyError(t *testing.T) {
 	configKey := "unit_testing.apply_decryption_fallback_config_if_exists"
 	t.Setenv(encryptionconfig.FallbackConfigEnvName, envConfig(configKey, true))
 
-	failFlow := &tstAlwaysFailingFlow{}
+	failFlow := &tstAlwaysFailingFlowBuilder{}
 	err := applyDecryptionFallbackConfigIfExists(failFlow, encryptionflow.ConfigurationSourceEnv, configKey)
 	expectErr(t, err, alwaysFailError)
 }

--- a/internal/states/encryption/example_test.go
+++ b/internal/states/encryption/example_test.go
@@ -137,11 +137,20 @@ func ExampleGetRemoteStateSingleton() {
 		// code block to isolate variables in sections of this example that would normally
 		// be in different places in the tofu code
 
-		instance, err := GetRemoteStateSingleton()
+		builder, err := GetRemoteStateSingleton()
 		if err != nil {
+			// TODO update this comment.
 			// errors here should not normally happen if the singleton cache was enabled using EnableSingletonCaching()
 			// and ValidateAllCachedInstances() was successful, but if they do, fail state read or write
-			fmt.Println("error constructing instance", err.Error())
+			fmt.Println("error fetching singleton", err.Error())
+			return
+		}
+		instance, err := builder.Build()
+		if err != nil {
+			// TODO update this comment.
+			// errors here should not normally happen if the singleton cache was enabled using EnableSingletonCaching()
+			// and ValidateAllCachedInstances() was successful, but if they do, fail state read or write
+			fmt.Println("error building encryption flow", err.Error())
 			return
 		}
 

--- a/internal/states/encryption/example_test.go
+++ b/internal/states/encryption/example_test.go
@@ -1,0 +1,174 @@
+package encryption
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/opentofu/opentofu/internal/states/encryption/encryptionconfig"
+	"github.com/opentofu/opentofu/internal/states/encryption/encryptionflow"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+)
+
+// Note: at the moment, we are still using MockUpLoggingFlow, which does not actually encrypt anything.
+
+func ExampleGetRemoteStateSingleton() {
+	// this is an example how the rest of tofu's codebase should interact with this package
+	// (case of our own remote state)
+
+	// before starting tofu, environment variables TF_STATE_ENCRYPTION and TF_STATE_DECRYPTION_FALLBACK
+	// are set by the user executing tofu. It is ok to not set either of them.
+
+	// Here is an example value that affects our own remote state (providing a passphrase):
+	TF_STATE_ENCRYPTION := `{
+      "backend": {
+		"key_provider": {
+			"config": {
+				"passphrase": "the current passphrase"
+			}
+		}
+	  }
+    }`
+	TF_STATE_DECRYPTION_FALLBACK := `{
+      "backend": {
+		"key_provider": {
+			"config": {
+				"passphrase": "the previous passphrase for key rotation"
+			}
+		}
+	  }
+    }`
+
+	// For the sake of this example, we set them here, but YOU WOULD NOT DO THAT IN YOUR CODE.
+	_ = os.Setenv(encryptionconfig.ConfigEnvName, TF_STATE_ENCRYPTION)
+	defer os.Unsetenv(encryptionconfig.ConfigEnvName)
+
+	_ = os.Setenv(encryptionconfig.FallbackConfigEnvName, TF_STATE_DECRYPTION_FALLBACK)
+	defer os.Unsetenv(encryptionconfig.FallbackConfigEnvName)
+
+	// -----------------------------------------
+	// during tofu startup (in the meta command)
+	// -----------------------------------------
+
+	EnableSingletonCaching()
+	defer DisableSingletonCaching() // only needed in tests
+
+	err := ParseEnvironmentVariables()
+	if err != nil {
+		fmt.Println("environment variables are syntactically/logically invalid - abort and print the error", err.Error())
+		return
+	}
+
+	// -----------------------------------------------------------------------------------
+	// while parsing terraform {...} block (assuming a remote state backend is configured)
+	// -----------------------------------------------------------------------------------
+
+	{
+		// code block to isolate variables in sections of this example that would normally
+		// be in different places in the tofu code
+
+		// this is what you might parse from terraform.state_encryption (if set)
+		config := encryptionconfig.Config{
+			KeyProvider: encryptionconfig.KeyProviderConfig{
+				Name: "passphrase",
+			},
+			Method: encryptionconfig.EncryptionMethodConfig{
+				Name: "full",
+			},
+			Required: true,
+		}
+
+		// this is what you might parse from terraform.state_decryption_fallback (if set)
+		fallbackConfig := encryptionconfig.Config{
+			KeyProvider: encryptionconfig.KeyProviderConfig{
+				Name: "passphrase",
+			},
+			Method: encryptionconfig.EncryptionMethodConfig{
+				Name: "full",
+			},
+			Required: true,
+		}
+		// yes, it's the same configuration in this example. The difference might be a different passphrase
+		// which should come from the TF_STATE_DECRYPTION_FALLBACK environment variable.
+
+		instance, err := GetRemoteStateSingleton()
+		if err != nil {
+			// errors here should not normally happen if ParseEnvironmentVariables() was successful
+			fmt.Println("error constructing state encryption instance", err.Error())
+			return
+		}
+
+		// only call this if terraform.state_encryption block was present
+		err = instance.EncryptionConfiguration(encryptionflow.ConfigurationSourceCode, config)
+		if err != nil {
+			fmt.Println("errors here mean the supplied configuration was invalid (not all problems can be detected at this time)", err.Error())
+			return
+		}
+
+		// only call this if terraform.state_decryption_fallback block was present
+		err = instance.DecryptionFallbackConfiguration(encryptionflow.ConfigurationSourceCode, fallbackConfig)
+		if err != nil {
+			fmt.Println("errors here mean the supplied fallback configuration was invalid (not all problems can be detected at this time)", err.Error())
+			return
+		}
+	}
+
+	// ---------------------------------------------
+	// at the end of tofu configuration / parse time
+	// ---------------------------------------------
+
+	diags := ValidateAllCachedInstances()
+	// errors here mean that configurations for state encryption singletons were invalid
+	// at this time, practically all static configuration errors can be detected.
+	// Of course, key providers that access external systems could still fail later.
+	for _, d := range diags {
+		if d.Severity() == tfdiags.Error {
+			fmt.Println("error in configuration: ", d.Description())
+			return
+		}
+		// Note: warnings can also occur, and should be printed, but the run can continue.
+		fmt.Println("warning: ", d.Description())
+	}
+
+	// -----------------------------------------------------------------
+	// while working with remote state (internal/states/remote/state.go)
+	// -----------------------------------------------------------------
+
+	{
+		// code block to isolate variables in sections of this example that would normally
+		// be in different places in the tofu code
+
+		instance, err := GetRemoteStateSingleton()
+		if err != nil {
+			// errors here should not normally happen if the singleton cache was enabled using EnableSingletonCaching()
+			// and ValidateAllCachedInstances() was successful, but if they do, fail state read or write
+			fmt.Println("error constructing instance", err.Error())
+			return
+		}
+
+		// during state write:
+
+		stateToEncrypt := []byte(`{"version":"4"}`) // omitted a lot more fields in stateV4
+
+		encrypted, err := instance.EncryptState(stateToEncrypt)
+		if err != nil {
+			fmt.Println("error writing remote state", err.Error())
+			return
+		}
+
+		// during state read:
+
+		// for the sake of the example we simply decrypt what we just encrypted
+
+		decrypted, err := instance.DecryptState(encrypted)
+		if err != nil {
+			fmt.Println("error reading remote state", err.Error())
+			return
+		}
+
+		// success
+
+		fmt.Println(string(decrypted))
+	}
+
+	// Output: {"version":"4"}
+}

--- a/internal/states/encryption/example_test.go
+++ b/internal/states/encryption/example_test.go
@@ -139,18 +139,17 @@ func ExampleGetRemoteStateSingleton() {
 
 		builder, err := GetRemoteStateSingleton()
 		if err != nil {
-			// TODO update this comment.
 			// errors here should not normally happen if the singleton cache was enabled using EnableSingletonCaching()
-			// and ValidateAllCachedInstances() was successful, but if they do, fail state read or write
-			fmt.Println("error fetching singleton", err.Error())
+			// and ParseEnvironmentVariables() was successful, but if errors do happen, fail state read or write
+			fmt.Println("error fetching singleton, most likely invalid configuration in environment variables", err.Error())
 			return
 		}
 		instance, err := builder.Build()
 		if err != nil {
-			// TODO update this comment.
 			// errors here should not normally happen if the singleton cache was enabled using EnableSingletonCaching()
 			// and ValidateAllCachedInstances() was successful, but if they do, fail state read or write
-			fmt.Println("error building encryption flow", err.Error())
+			fmt.Println("error building encryption flow, most likely invalid configuration in terraform block, "+
+				"or merged configuration between environment variable and terraform block was incomplete or invalid", err.Error())
 			return
 		}
 

--- a/internal/states/encryption/instance.go
+++ b/internal/states/encryption/instance.go
@@ -1,10 +1,11 @@
 package encryption
 
 import (
+	"strings"
+
 	"github.com/opentofu/opentofu/internal/logging"
 	"github.com/opentofu/opentofu/internal/states/encryption/encryptionconfig"
 	"github.com/opentofu/opentofu/internal/states/encryption/encryptionflow"
-	"strings"
 )
 
 // Instance obtains the instance of the encryption flow for the given configKey.

--- a/internal/states/encryption/instance.go
+++ b/internal/states/encryption/instance.go
@@ -1,0 +1,86 @@
+package encryption
+
+import (
+	"github.com/opentofu/opentofu/internal/logging"
+	"github.com/opentofu/opentofu/internal/states/encryption/encryptionconfig"
+	"github.com/opentofu/opentofu/internal/states/encryption/encryptionflow"
+	"strings"
+)
+
+// Instance obtains the instance of the encryption flow for the given configKey.
+//
+// configKey specifies a resource that accesses remote state. It must contain at least one ".".
+//
+// If the key is "terraform_remote_state.foo", the returned Flow is intended for
+//
+//	data "terraform_remote_state" "foo" {}
+//
+// For enumerated resources, the format is "terraform_remote_state.foo[17]" or
+// "terraform_remote_state.foo[key]" (no quotes around the for_each key).
+//
+// The first time a particular instance is requested, Instance may bail out due to invalid configuration.
+//
+// See also RemoteStateInstance(), StatefileInstance(), PlanfileInstance().
+func Instance(configKey string) (encryptionflow.Flow, error) {
+	if !strings.Contains(configKey, ".") {
+		panic("call to encryption.Instance with a key that does not contain '.'. This is a bug. " +
+			"Instance() is intended to obtain named instances only. For predefined instances use " +
+			"RemoteStateInstance(), StatefileInstance(), or PlanfileInstance()")
+	}
+	if cache != nil {
+		return cache.cachedOrNewInstance(configKey, true)
+	} else {
+		return newInstance(configKey, true)
+	}
+}
+
+// RemoteStateInstance obtains the instance of the encryption flow that is intended for our own remote
+// state backend, as opposed to terraform_remote_state data sources.
+func RemoteStateInstance() (encryptionflow.Flow, error) {
+	if cache != nil {
+		return cache.cachedOrNewInstance(encryptionconfig.ConfigKeyBackend, true)
+	} else {
+		return newInstance(encryptionconfig.ConfigKeyBackend, true)
+	}
+}
+
+// StatefileInstance obtains the instance of the encryption flow that is intended for our own local state file.
+func StatefileInstance() (encryptionflow.Flow, error) {
+	if cache != nil {
+		return cache.cachedOrNewInstance(encryptionconfig.ConfigKeyStatefile, false)
+	} else {
+		return newInstance(encryptionconfig.ConfigKeyStatefile, false)
+	}
+}
+
+// PlanfileInstance obtains the instance of the encryption flow that is intended for our plan file.
+func PlanfileInstance() (encryptionflow.Flow, error) {
+	if cache != nil {
+		return cache.cachedOrNewInstance(encryptionconfig.ConfigKeyPlanfile, false)
+	} else {
+		return newInstance(encryptionconfig.ConfigKeyPlanfile, false)
+	}
+}
+
+func newInstance(configKey string, defaultsApply bool) (encryptionflow.Flow, error) {
+	logging.HCLogger().Trace("constructing new state encryption flow instance", "configKey", configKey)
+	instance := encryptionflow.NewMock(configKey)
+
+	if defaultsApply {
+		if err := applyEncryptionConfigIfExists(instance, encryptionflow.ConfigurationSourceEnvDefault, encryptionconfig.ConfigKeyDefault); err != nil {
+			return nil, err
+		}
+		if err := applyDecryptionFallbackConfigIfExists(instance, encryptionflow.ConfigurationSourceEnvDefault, encryptionconfig.ConfigKeyDefault); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := applyEncryptionConfigIfExists(instance, encryptionflow.ConfigurationSourceEnv, configKey); err != nil {
+		return nil, err
+	}
+	if err := applyDecryptionFallbackConfigIfExists(instance, encryptionflow.ConfigurationSourceEnv, configKey); err != nil {
+		return nil, err
+	}
+
+	return instance, nil
+}

--- a/internal/states/encryption/instance.go
+++ b/internal/states/encryption/instance.go
@@ -54,7 +54,7 @@ import (
 // The first time a particular instance is requested, GetSingleton may bail out due to invalid configuration.
 //
 // See also GetRemoteStateSingleton(), GetStatefileSingleton(), GetPlanfileSingleton().
-func GetSingleton(configKey string) (encryptionflow.Flow, error) {
+func GetSingleton(configKey string) (encryptionflow.FlowBuilder, error) {
 	if !strings.Contains(configKey, ".") {
 		panic("call to encryption.GetSingleton with a key that does not contain '.'. This is a bug. " +
 			"GetSingleton() is intended to obtain named instances only. For predefined instances use " +
@@ -69,7 +69,7 @@ func GetSingleton(configKey string) (encryptionflow.Flow, error) {
 
 // GetRemoteStateSingleton obtains the singleton instance of the encryption flow that is intended for our own remote
 // state backend, as opposed to terraform_remote_state data sources.
-func GetRemoteStateSingleton() (encryptionflow.Flow, error) {
+func GetRemoteStateSingleton() (encryptionflow.FlowBuilder, error) {
 	if cache != nil {
 		return cache.cachedOrNewInstance(encryptionconfig.ConfigKeyBackend, true)
 	} else {
@@ -78,7 +78,7 @@ func GetRemoteStateSingleton() (encryptionflow.Flow, error) {
 }
 
 // GetStatefileSingleton obtains the singleton instance of the encryption flow that is intended for our own local state file.
-func GetStatefileSingleton() (encryptionflow.Flow, error) {
+func GetStatefileSingleton() (encryptionflow.FlowBuilder, error) {
 	if cache != nil {
 		return cache.cachedOrNewInstance(encryptionconfig.ConfigKeyStatefile, false)
 	} else {
@@ -87,7 +87,7 @@ func GetStatefileSingleton() (encryptionflow.Flow, error) {
 }
 
 // GetPlanfileSingleton obtains the instance of the encryption flow that is intended for our plan file.
-func GetPlanfileSingleton() (encryptionflow.Flow, error) {
+func GetPlanfileSingleton() (encryptionflow.FlowBuilder, error) {
 	if cache != nil {
 		return cache.cachedOrNewInstance(encryptionconfig.ConfigKeyPlanfile, false)
 	} else {
@@ -95,7 +95,7 @@ func GetPlanfileSingleton() (encryptionflow.Flow, error) {
 	}
 }
 
-func newInstance(configKey string, defaultsApply bool) (encryptionflow.Flow, error) {
+func newInstance(configKey string, defaultsApply bool) (encryptionflow.FlowBuilder, error) {
 	logging.HCLogger().Trace("constructing new state encryption flow instance", "configKey", configKey)
 	instance := encryptionflow.NewMock(configKey)
 

--- a/internal/states/encryption/instance.go
+++ b/internal/states/encryption/instance.go
@@ -10,7 +10,7 @@ import (
 
 // --------------------------------------------------------------------------------------------
 // IMPORTANT NOTE:
-// This package contains a cache for singleton instances.
+// This package contains a cache for singleton instances of encryptionflow.FlowBuilder
 //   - there is one instance for our own remote state
 //   - there is one instance for our local state file
 //   - there is one instance for our local plan file
@@ -40,7 +40,7 @@ import (
 //
 // --------------------------------------------------------------------------------------------
 
-// GetSingleton obtains the singleton instance of the encryption flow for the given configKey.
+// GetSingleton obtains the singleton instance of the encryption flow builder for the given configKey.
 //
 // configKey specifies a resource that accesses remote state. It must contain at least one ".".
 //
@@ -67,7 +67,7 @@ func GetSingleton(configKey string) (encryptionflow.FlowBuilder, error) {
 	}
 }
 
-// GetRemoteStateSingleton obtains the singleton instance of the encryption flow that is intended for our own remote
+// GetRemoteStateSingleton obtains the singleton instance of the encryption flow builder that is intended for our own remote
 // state backend, as opposed to terraform_remote_state data sources.
 func GetRemoteStateSingleton() (encryptionflow.FlowBuilder, error) {
 	if cache != nil {
@@ -77,7 +77,7 @@ func GetRemoteStateSingleton() (encryptionflow.FlowBuilder, error) {
 	}
 }
 
-// GetStatefileSingleton obtains the singleton instance of the encryption flow that is intended for our own local state file.
+// GetStatefileSingleton obtains the singleton instance of the encryption flow builder that is intended for our own local state file.
 func GetStatefileSingleton() (encryptionflow.FlowBuilder, error) {
 	if cache != nil {
 		return cache.cachedOrNewInstance(encryptionconfig.ConfigKeyStatefile, false)
@@ -86,7 +86,7 @@ func GetStatefileSingleton() (encryptionflow.FlowBuilder, error) {
 	}
 }
 
-// GetPlanfileSingleton obtains the instance of the encryption flow that is intended for our plan file.
+// GetPlanfileSingleton obtains the instance of the encryption flow builder that is intended for our plan file.
 func GetPlanfileSingleton() (encryptionflow.FlowBuilder, error) {
 	if cache != nil {
 		return cache.cachedOrNewInstance(encryptionconfig.ConfigKeyPlanfile, false)

--- a/internal/states/encryption/instance_test.go
+++ b/internal/states/encryption/instance_test.go
@@ -109,7 +109,7 @@ func getSingletonTestCases(configKey string, canExtendConfigKey bool) []instance
 	}
 }
 
-func runGetSingletonTestcase(t *testing.T, tc instanceTestCase, useSingletonCache bool, functionUnderTest func() (encryptionflow.Flow, error)) {
+func runGetSingletonTestcase(t *testing.T, tc instanceTestCase, useSingletonCache bool, functionUnderTest func() (encryptionflow.FlowBuilder, error)) {
 	if cache != nil {
 		t.Fatal("cache was enabled at start of test - probably some other test forgot to defer DisableSingletonCaching()")
 	}
@@ -133,7 +133,7 @@ func runGetSingletonTestcase(t *testing.T, tc instanceTestCase, useSingletonCach
 			t.Fatal("instance was unexpectedly nil despite no error")
 		}
 
-		err := instance.MergeAndValidateConfigurations()
+		_, err := instance.Build()
 		expectErr(t, err, tc.expectValidationError)
 	}
 
@@ -144,7 +144,7 @@ func TestGetSingleton_NoCache(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testcase, func(t *testing.T) {
-			runGetSingletonTestcase(t, tc, false, func() (encryptionflow.Flow, error) {
+			runGetSingletonTestcase(t, tc, false, func() (encryptionflow.FlowBuilder, error) {
 				return GetSingleton(tc.key)
 			})
 		})
@@ -156,7 +156,7 @@ func TestGetSingleton_Cache(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testcase, func(t *testing.T) {
-			runGetSingletonTestcase(t, tc, true, func() (encryptionflow.Flow, error) {
+			runGetSingletonTestcase(t, tc, true, func() (encryptionflow.FlowBuilder, error) {
 				return GetSingleton(tc.key)
 			})
 		})

--- a/internal/states/encryption/instance_test.go
+++ b/internal/states/encryption/instance_test.go
@@ -3,9 +3,10 @@ package encryption
 import (
 	"errors"
 	"fmt"
-	"github.com/opentofu/opentofu/internal/states/encryption/encryptionconfig"
 	"strings"
 	"testing"
+
+	"github.com/opentofu/opentofu/internal/states/encryption/encryptionconfig"
 )
 
 func TestInstanceEnforcesDotInKey(t *testing.T) {

--- a/internal/states/encryption/instance_test.go
+++ b/internal/states/encryption/instance_test.go
@@ -1,0 +1,341 @@
+package encryption
+
+import (
+	"errors"
+	"fmt"
+	"github.com/opentofu/opentofu/internal/states/encryption/encryptionconfig"
+	"strings"
+	"testing"
+)
+
+func TestInstanceEnforcesDotInKey(t *testing.T) {
+	defer expectPanic(t, "call to encryption.Instance with a key that does not contain '.'. This is a bug.")()
+	_, _ = Instance("no_dot")
+}
+
+func envConfig(configKey string, logicallyValid bool) string {
+	if logicallyValid {
+		return fmt.Sprintf(`{"%s":{"key_provider":{"config":{"passphrase":"somephrase"}}}}`, configKey)
+	} else {
+		return fmt.Sprintf(`{"%s":{}}`, configKey)
+	}
+}
+
+type instanceTestCase struct {
+	testcase              string
+	key                   string
+	encEnv                string
+	decEnv                string
+	expectInstanceError   error
+	expectValidationError error
+}
+
+func instanceTestCases(configKey string, canExtendConfigKey bool) []instanceTestCase {
+	key := func(base string, num int) string {
+		if canExtendConfigKey {
+			return fmt.Sprintf("%s[%d]", base, num)
+		} else {
+			return base
+		}
+	}
+
+	return []instanceTestCase{
+		// success cases
+		{
+			testcase: "no_configuration",
+			key:      key(configKey, 1),
+		},
+		{
+			testcase: "full_configuration",
+			key:      key(configKey, 2),
+			encEnv:   envConfig(key(configKey, 2), true),
+			decEnv:   envConfig(key(configKey, 2), true),
+		},
+		{
+			testcase: "all_defaults",
+			key:      key(configKey, 3),
+			encEnv:   envConfig("default", true),
+			decEnv:   envConfig("default", true),
+		},
+		// validation error cases
+		{
+			testcase: "logically_invalid_enc",
+			key:      key(configKey, 4),
+			encEnv:   envConfig(key(configKey, 4), false),
+			decEnv:   envConfig(key(configKey, 4), true),
+			expectValidationError: errors.New(
+				"error invalid encryption configuration after merge: " +
+					"error in configuration for key provider passphrase: passphrase missing or empty",
+			),
+		},
+		{
+			testcase: "logically_invalid_dec",
+			key:      key(configKey, 5),
+			encEnv:   envConfig(key(configKey, 5), true),
+			decEnv:   envConfig(key(configKey, 5), false),
+			expectValidationError: errors.New(
+				"error invalid decryption fallback configuration after merge: " +
+					"error in configuration for key provider passphrase: passphrase missing or empty",
+			),
+		},
+		// instance creation error cases (parse failure)
+		{
+			testcase: "syntactically_invalid_enc",
+			key:      key(configKey, 6),
+			encEnv:   `{`,
+			decEnv:   envConfig(key(configKey, 6), true),
+			expectInstanceError: fmt.Errorf(
+				"error parsing encryption configuration from environment variable %s: "+
+					"json parse error, wrong structure, or unknown fields - "+
+					"details omitted for security reasons (may contain key related settings)",
+				encryptionconfig.ConfigEnvName,
+			),
+		},
+		{
+			testcase: "syntactically_invalid_dec",
+			key:      key(configKey, 7),
+			encEnv:   envConfig(key(configKey, 7), true),
+			decEnv:   `{not_a_json}}}}}}`,
+			expectInstanceError: fmt.Errorf(
+				"error parsing fallback decryption configuration from environment variable %s: "+
+					"json parse error, wrong structure, or unknown fields - "+
+					"details omitted for security reasons (may contain key related settings)",
+				encryptionconfig.FallbackConfigEnvName,
+			),
+		},
+	}
+}
+
+func TestInstance_NoCache(t *testing.T) {
+	testCases := instanceTestCases("unit_testing.instance_no_cache", true)
+
+	for _, tc := range testCases {
+		t.Run(tc.testcase, func(t *testing.T) {
+			if cache != nil {
+				t.Fatal("cache was enabled at start of test - probably some other test forgot to defer DisableCache()")
+			}
+
+			if tc.encEnv != "" {
+				t.Setenv(encryptionconfig.ConfigEnvName, tc.encEnv)
+			}
+			if tc.decEnv != "" {
+				t.Setenv(encryptionconfig.FallbackConfigEnvName, tc.decEnv)
+			}
+
+			instance, err := Instance(tc.key)
+			expectErr(t, err, tc.expectInstanceError)
+			if err == nil {
+				if instance == nil {
+					t.Fatal("instance was unexpectedly nil despite no error")
+				}
+
+				err := instance.MergeAndValidateConfigurations()
+				expectErr(t, err, tc.expectValidationError)
+			}
+		})
+	}
+}
+
+func TestInstance_Cache(t *testing.T) {
+	testCases := instanceTestCases("unit_testing.instance_cache", true)
+
+	for _, tc := range testCases {
+		t.Run(tc.testcase, func(t *testing.T) {
+			EnableCaching()
+			defer DisableCaching()
+
+			if tc.encEnv != "" {
+				t.Setenv(encryptionconfig.ConfigEnvName, tc.encEnv)
+			}
+			if tc.decEnv != "" {
+				t.Setenv(encryptionconfig.FallbackConfigEnvName, tc.decEnv)
+			}
+
+			instance, err := Instance(tc.key)
+			expectErr(t, err, tc.expectInstanceError)
+			if err == nil {
+				if instance == nil {
+					t.Fatal("instance was unexpectedly nil despite no error")
+				}
+
+				err := instance.MergeAndValidateConfigurations()
+				expectErr(t, err, tc.expectValidationError)
+			}
+		})
+	}
+}
+
+func TestRemoteStateInstance_NoCache(t *testing.T) {
+	testCases := instanceTestCases("backend", false)
+
+	for _, tc := range testCases {
+		t.Run(tc.testcase, func(t *testing.T) {
+			if tc.encEnv != "" {
+				t.Setenv(encryptionconfig.ConfigEnvName, tc.encEnv)
+			}
+			if tc.decEnv != "" {
+				t.Setenv(encryptionconfig.FallbackConfigEnvName, tc.decEnv)
+			}
+
+			instance, err := RemoteStateInstance()
+			expectErr(t, err, tc.expectInstanceError)
+			if err == nil {
+				if instance == nil {
+					t.Fatal("instance was unexpectedly nil despite no error")
+				}
+			}
+		})
+	}
+}
+
+func TestRemoteStateInstance_Cache(t *testing.T) {
+	testCases := instanceTestCases("backend", false)
+
+	for _, tc := range testCases {
+		t.Run(tc.testcase, func(t *testing.T) {
+			EnableCaching()
+			defer DisableCaching()
+
+			if tc.encEnv != "" {
+				t.Setenv(encryptionconfig.ConfigEnvName, tc.encEnv)
+			}
+			if tc.decEnv != "" {
+				t.Setenv(encryptionconfig.FallbackConfigEnvName, tc.decEnv)
+			}
+
+			instance, err := RemoteStateInstance()
+			expectErr(t, err, tc.expectInstanceError)
+			if err == nil {
+				if instance == nil {
+					t.Fatal("instance was unexpectedly nil despite no error")
+				}
+			}
+		})
+	}
+}
+
+func TestStatefileInstance_NoCache(t *testing.T) {
+	testCases := instanceTestCases("statefile", false)
+
+	for _, tc := range testCases {
+		t.Run(tc.testcase, func(t *testing.T) {
+			if tc.encEnv != "" {
+				t.Setenv(encryptionconfig.ConfigEnvName, tc.encEnv)
+			}
+			if tc.decEnv != "" {
+				t.Setenv(encryptionconfig.FallbackConfigEnvName, tc.decEnv)
+			}
+
+			instance, err := StatefileInstance()
+			expectErr(t, err, tc.expectInstanceError)
+			if err == nil {
+				if instance == nil {
+					t.Fatal("instance was unexpectedly nil despite no error")
+				}
+			}
+		})
+	}
+}
+
+func TestStatefileInstance_Cache(t *testing.T) {
+	testCases := instanceTestCases("statefile", false)
+
+	for _, tc := range testCases {
+		t.Run(tc.testcase, func(t *testing.T) {
+			EnableCaching()
+			defer DisableCaching()
+
+			if tc.encEnv != "" {
+				t.Setenv(encryptionconfig.ConfigEnvName, tc.encEnv)
+			}
+			if tc.decEnv != "" {
+				t.Setenv(encryptionconfig.FallbackConfigEnvName, tc.decEnv)
+			}
+
+			instance, err := StatefileInstance()
+			expectErr(t, err, tc.expectInstanceError)
+			if err == nil {
+				if instance == nil {
+					t.Fatal("instance was unexpectedly nil despite no error")
+				}
+			}
+		})
+	}
+}
+
+func TestPlanfileInstance_NoCache(t *testing.T) {
+	testCases := instanceTestCases("planfile", false)
+
+	for _, tc := range testCases {
+		t.Run(tc.testcase, func(t *testing.T) {
+			if tc.encEnv != "" {
+				t.Setenv(encryptionconfig.ConfigEnvName, tc.encEnv)
+			}
+			if tc.decEnv != "" {
+				t.Setenv(encryptionconfig.FallbackConfigEnvName, tc.decEnv)
+			}
+
+			instance, err := PlanfileInstance()
+			expectErr(t, err, tc.expectInstanceError)
+			if err == nil {
+				if instance == nil {
+					t.Fatal("instance was unexpectedly nil despite no error")
+				}
+			}
+		})
+	}
+}
+
+func TestPlanfileInstance_Cache(t *testing.T) {
+	testCases := instanceTestCases("planfile", false)
+
+	for _, tc := range testCases {
+		t.Run(tc.testcase, func(t *testing.T) {
+			EnableCaching()
+			defer DisableCaching()
+
+			if tc.encEnv != "" {
+				t.Setenv(encryptionconfig.ConfigEnvName, tc.encEnv)
+			}
+			if tc.decEnv != "" {
+				t.Setenv(encryptionconfig.FallbackConfigEnvName, tc.decEnv)
+			}
+
+			instance, err := PlanfileInstance()
+			expectErr(t, err, tc.expectInstanceError)
+			if err == nil {
+				if instance == nil {
+					t.Fatal("instance was unexpectedly nil despite no error")
+				}
+			}
+		})
+	}
+}
+
+func expectPanic(t *testing.T, snippet string) func() {
+	return func() {
+		r := recover()
+		if r == nil {
+			t.Errorf("expected a panic")
+		} else {
+			actual := fmt.Sprintf("%v", r)
+			if !strings.Contains(actual, snippet) {
+				t.Errorf("panic message did not contain '%s'", snippet)
+			}
+		}
+	}
+}
+
+func expectErr(t *testing.T, actual error, expected error) {
+	if actual != nil {
+		if expected == nil {
+			t.Errorf("received unexpected error '%s' instead of success", actual.Error())
+		} else if actual.Error() != expected.Error() {
+			t.Errorf("received unexpected error '%s' instead of '%s'", actual.Error(), expected.Error())
+		}
+	} else {
+		if expected != nil {
+			t.Errorf("unexpected success instead of expected error '%s'", expected.Error())
+		}
+	}
+}

--- a/internal/states/encryption/singletoncache.go
+++ b/internal/states/encryption/singletoncache.go
@@ -18,12 +18,12 @@ type instanceCache struct {
 
 var cache *instanceCache
 
-// EnableSingletonCaching enables encryption flow instance caching.
+// EnableSingletonCaching enables encryption flow builder instance caching.
 //
-// This allows code outside this package to call Instance() multiple times with the same key and receive
+// This allows code outside this package to call GetSingleton() multiple times with the same key and receive
 // the same instance each time.
 //
-// Similarly, RemoteStateInstance(), StatefileInstance(), or PlanfileInstance() will only construct their
+// Similarly, GetRemoteStateSingleton(), GetStatefileSingleton(), or GetPlanfileSingleton() will only construct their
 // instance the first time they are called.
 //
 // Note: you should not enable the instance cache in low level unit tests, but if you do use it in a test,
@@ -41,7 +41,7 @@ func EnableSingletonCaching() {
 	}
 }
 
-// DisableSingletonCaching disables encryption flow instance caching.
+// DisableSingletonCaching disables encryption flow builder instance caching.
 //
 // see EnableSingletonCaching().
 func DisableSingletonCaching() {
@@ -65,7 +65,7 @@ func (c *instanceCache) set(configKey string, cacheEntry encryptionflow.FlowBuil
 func (c *instanceCache) cachedOrNewInstance(configKey string, defaultsApply bool) (encryptionflow.FlowBuilder, error) {
 	instance, found := c.get(configKey)
 	if found {
-		logging.HCLogger().Trace("found state encryption flow singleton instance in cache", "configKey", configKey)
+		logging.HCLogger().Trace("found state encryption flow builder singleton in cache", "configKey", configKey)
 		return instance, nil
 	}
 

--- a/internal/states/encryption/singletoncache.go
+++ b/internal/states/encryption/singletoncache.go
@@ -12,7 +12,7 @@ import (
 // please read the note at the top of instance.go for details
 
 type instanceCache struct {
-	instances_useGetAndSet map[string]encryptionflow.Flow
+	instances_useGetAndSet map[string]encryptionflow.FlowBuilder
 	mutex                  sync.RWMutex
 }
 
@@ -36,7 +36,7 @@ func EnableSingletonCaching() {
 	logging.HCLogger().Trace("enabling state encryption flow singleton instance cache")
 	if cache == nil {
 		cache = &instanceCache{
-			instances_useGetAndSet: make(map[string]encryptionflow.Flow),
+			instances_useGetAndSet: make(map[string]encryptionflow.FlowBuilder),
 		}
 	}
 }
@@ -49,20 +49,20 @@ func DisableSingletonCaching() {
 	cache = nil
 }
 
-func (c *instanceCache) get(configKey string) (cacheEntry encryptionflow.Flow, ok bool) {
+func (c *instanceCache) get(configKey string) (cacheEntry encryptionflow.FlowBuilder, ok bool) {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
 	cacheEntry, ok = c.instances_useGetAndSet[configKey]
 	return
 }
 
-func (c *instanceCache) set(configKey string, cacheEntry encryptionflow.Flow) {
+func (c *instanceCache) set(configKey string, cacheEntry encryptionflow.FlowBuilder) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	c.instances_useGetAndSet[configKey] = cacheEntry
 }
 
-func (c *instanceCache) cachedOrNewInstance(configKey string, defaultsApply bool) (encryptionflow.Flow, error) {
+func (c *instanceCache) cachedOrNewInstance(configKey string, defaultsApply bool) (encryptionflow.FlowBuilder, error) {
 	instance, found := c.get(configKey)
 	if found {
 		logging.HCLogger().Trace("found state encryption flow singleton instance in cache", "configKey", configKey)

--- a/internal/states/encryption/singletoncache.go
+++ b/internal/states/encryption/singletoncache.go
@@ -5,13 +5,17 @@ import (
 	"github.com/opentofu/opentofu/internal/states/encryption/encryptionflow"
 )
 
+// IMPORTANT: we cache singletons in this package!
+//
+// please read the note at the top of instance.go for details
+
 type instanceCache struct {
 	instances map[string]encryptionflow.Flow
 }
 
 var cache *instanceCache
 
-// EnableCaching enables encryption flow instance caching.
+// EnableSingletonCaching enables encryption flow instance caching.
 //
 // This allows code outside this package to call Instance() multiple times with the same key and receive
 // the same instance each time.
@@ -22,11 +26,11 @@ var cache *instanceCache
 // Note: you should not enable the instance cache in low level unit tests, but if you do use it in a test,
 // you should
 //
-//	defer DisableCaching()
+//	defer DisableSingletonCaching()
 //
-// right after the call to EnableCaching() to clean up after yourself.
-func EnableCaching() {
-	logging.HCLogger().Trace("enabling state encryption flow instance cache")
+// right after the call to EnableSingletonCaching() to clean up after yourself.
+func EnableSingletonCaching() {
+	logging.HCLogger().Trace("enabling state encryption flow singleton instance cache")
 	if cache == nil {
 		cache = &instanceCache{
 			instances: make(map[string]encryptionflow.Flow),
@@ -34,18 +38,18 @@ func EnableCaching() {
 	}
 }
 
-// DisableCaching disables encryption flow instance caching.
+// DisableSingletonCaching disables encryption flow instance caching.
 //
-// see EnableCaching().
-func DisableCaching() {
-	logging.HCLogger().Trace("disabling state encryption flow instance cache")
+// see EnableSingletonCaching().
+func DisableSingletonCaching() {
+	logging.HCLogger().Trace("disabling state encryption flow singleton instance cache")
 	cache = nil
 }
 
 func (c *instanceCache) cachedOrNewInstance(configKey string, defaultsApply bool) (encryptionflow.Flow, error) {
 	instance, found := c.instances[configKey]
 	if found {
-		logging.HCLogger().Trace("found state encryption flow instance in cache", "configKey", configKey)
+		logging.HCLogger().Trace("found state encryption flow singleton instance in cache", "configKey", configKey)
 		return instance, nil
 	}
 

--- a/internal/states/encryption/singletoncache_test.go
+++ b/internal/states/encryption/singletoncache_test.go
@@ -3,13 +3,13 @@ package encryption
 import "testing"
 
 func TestEnableDisableCaching(t *testing.T) {
-	EnableCaching() // MUST be followed by defer DisableCaching() in tests
+	EnableSingletonCaching() // MUST be followed by defer DisableCaching() in tests
 	defer func() {
 		if cache != nil {
 			t.Errorf("DisableCaching did not remove the cache, it was still non-nil")
 		}
 	}()
-	defer DisableCaching()
+	defer DisableSingletonCaching()
 
 	if cache == nil {
 		t.Fatalf("EnableCaching did not create the cache, it was still nil")
@@ -17,8 +17,8 @@ func TestEnableDisableCaching(t *testing.T) {
 }
 
 func TestCachedOrNewInstance(t *testing.T) {
-	EnableCaching() // MUST be followed by defer DisableCaching() in tests
-	defer DisableCaching()
+	EnableSingletonCaching() // MUST be followed by defer DisableCaching() in tests
+	defer DisableSingletonCaching()
 
 	const configKey = "unit_testing.test_cached_or_new[1]"
 

--- a/internal/states/encryption/singletoncache_test.go
+++ b/internal/states/encryption/singletoncache_test.go
@@ -30,7 +30,7 @@ func TestCachedOrNewInstance(t *testing.T) {
 		t.Errorf("instance on initial creation was unexpectedly nil")
 	}
 
-	if len(cache.instances) == 0 {
+	if len(cache.instances_useGetAndSet) == 0 {
 		t.Error("instance was not cached after creation")
 	}
 

--- a/internal/states/encryption/validation.go
+++ b/internal/states/encryption/validation.go
@@ -6,10 +6,10 @@ import (
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
-// ValidateAllCachedInstances validates the configuration of all known flow.Flow instances.
+// ValidateAllCachedInstances validates the configuration of all known encryptionflow.FlowBuilder instances.
 //
-// Call this after tofu is done with the configuration phase and all instances are configured
-// to get early errors.
+// Call this after tofu is done with the configuration phase to get early errors as soon as all configurations
+// are known.
 //
 // This avoids that errors will occur when first reading state, with possibly misleading
 // error message titles such as "could not acquire state lock". The detailed error

--- a/internal/states/encryption/validation.go
+++ b/internal/states/encryption/validation.go
@@ -32,7 +32,7 @@ func ValidateAllCachedInstances() tfdiags.Diagnostics {
 	defer cache.mutex.RUnlock()
 
 	for configKey, instance := range cache.instances_useGetAndSet {
-		if err := instance.MergeAndValidateConfigurations(); err != nil {
+		if _, err := instance.Build(); err != nil {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
 				fmt.Sprintf("Invalid state encryption configuration for configuration key %s", configKey),

--- a/internal/states/encryption/validation.go
+++ b/internal/states/encryption/validation.go
@@ -2,6 +2,7 @@ package encryption
 
 import (
 	"fmt"
+
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 

--- a/internal/states/encryption/validation.go
+++ b/internal/states/encryption/validation.go
@@ -1,0 +1,41 @@
+package encryption
+
+import (
+	"fmt"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+)
+
+// ValidateAllCachedInstances validates the configuration of all known flow.Flow instances.
+//
+// Call this after tofu is done with the configuration phase and all instances are configured
+// to get early errors.
+//
+// This avoids that errors will occur when first reading state, with possibly misleading
+// error message titles such as "could not acquire state lock". The detailed error
+// messages will still be printed, but further down, confusing the user.
+//
+// Obviously, this will only work if the cache is enabled, otherwise this emits a warning.
+func ValidateAllCachedInstances() tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+
+	if cache == nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Warning,
+			"no encryption instance cache available, cannot validate configurations",
+			"this warning may be an indication of a bug. ValidateAllCachedInstances() was called, but the cache is not enabled",
+		))
+		return diags
+	}
+
+	for configKey, instance := range cache.instances {
+		if err := instance.MergeAndValidateConfigurations(); err != nil {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				fmt.Sprintf("Invalid state encryption configuration for configuration key %s", configKey),
+				err.Error(),
+			))
+		}
+	}
+
+	return diags
+}

--- a/internal/states/encryption/validation.go
+++ b/internal/states/encryption/validation.go
@@ -28,7 +28,10 @@ func ValidateAllCachedInstances() tfdiags.Diagnostics {
 		return diags
 	}
 
-	for configKey, instance := range cache.instances {
+	cache.mutex.RLock()
+	defer cache.mutex.RUnlock()
+
+	for configKey, instance := range cache.instances_useGetAndSet {
 		if err := instance.MergeAndValidateConfigurations(); err != nil {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,

--- a/internal/states/encryption/validation_test.go
+++ b/internal/states/encryption/validation_test.go
@@ -2,9 +2,10 @@ package encryption
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/opentofu/opentofu/internal/states/encryption/encryptionconfig"
 	"github.com/opentofu/opentofu/internal/tfdiags"
-	"testing"
 )
 
 func TestValidateAllCachedInstances_NoCache(t *testing.T) {

--- a/internal/states/encryption/validation_test.go
+++ b/internal/states/encryption/validation_test.go
@@ -56,14 +56,14 @@ func TestValidateAllCachedInstances(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testcase, func(t *testing.T) {
-			EnableCaching()
-			defer DisableCaching()
+			EnableSingletonCaching()
+			defer DisableSingletonCaching()
 
 			if tc.encEnv != "" {
 				t.Setenv(encryptionconfig.ConfigEnvName, tc.encEnv)
 			}
 
-			_, err := Instance(tc.key)
+			_, err := GetSingleton(tc.key)
 			if err != nil {
 				t.Fatal("unexpected error during instance creation")
 			}

--- a/internal/states/encryption/validation_test.go
+++ b/internal/states/encryption/validation_test.go
@@ -1,0 +1,94 @@
+package encryption
+
+import (
+	"fmt"
+	"github.com/opentofu/opentofu/internal/states/encryption/encryptionconfig"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+	"testing"
+)
+
+func TestValidateAllCachedInstances_NoCache(t *testing.T) {
+	if cache != nil {
+		t.Fatal("cache was enabled at start of test - probably some other test forgot to defer DisableCache()")
+	}
+
+	diags := ValidateAllCachedInstances()
+	if len(diags) != 1 {
+		t.Fatal("did not see expected diags")
+	}
+	expectDiag(t, diags[0], tfdiags.Warning,
+		"no encryption instance cache available, cannot validate configurations",
+		"this warning may be an indication of a bug. ValidateAllCachedInstances() was called, but the cache is not enabled")
+}
+
+func TestValidateAllCachedInstances(t *testing.T) {
+	configKey := "unit_testing.validate_all_cached_instances"
+
+	testCases := []struct {
+		testcase        string
+		key             string
+		encEnv          string
+		expectDiagCount int
+		expectSeverity  tfdiags.Severity
+		expectSummary   string
+		expectDetail    string
+	}{
+		// success case
+		{
+			testcase:        "full_configuration",
+			key:             configKey,
+			encEnv:          envConfig(configKey, true),
+			expectDiagCount: 0,
+		},
+		// validation error case
+		{
+			testcase:        "logically_invalid_enc",
+			key:             configKey,
+			encEnv:          envConfig(configKey, false),
+			expectDiagCount: 1,
+			expectSeverity:  tfdiags.Error,
+			expectSummary:   fmt.Sprintf("Invalid state encryption configuration for configuration key %s", configKey),
+			expectDetail: "error invalid encryption configuration after merge: " +
+				"error in configuration for key provider passphrase: passphrase missing or empty",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testcase, func(t *testing.T) {
+			EnableCaching()
+			defer DisableCaching()
+
+			if tc.encEnv != "" {
+				t.Setenv(encryptionconfig.ConfigEnvName, tc.encEnv)
+			}
+
+			_, err := Instance(tc.key)
+			if err != nil {
+				t.Fatal("unexpected error during instance creation")
+			}
+
+			diags := ValidateAllCachedInstances()
+			if len(diags) != tc.expectDiagCount {
+				t.Fatal("unexpected diagnostics count")
+			}
+			if len(diags) > 0 {
+				expectDiag(t, diags[0], tc.expectSeverity, tc.expectSummary, tc.expectDetail)
+			}
+		})
+	}
+}
+
+func expectDiag(t *testing.T, actual tfdiags.Diagnostic, expectSeverity tfdiags.Severity, expectSummary string, expectDetail string) {
+	if actual == nil {
+		t.Error("unexpected nil diag")
+	} else {
+		if expectSeverity != actual.Severity() {
+			t.Error("unexpected severity")
+		}
+		if expectSummary != actual.Description().Summary || expectDetail != actual.Description().Detail {
+			t.Errorf("unexpected '%s'/'%s' instead of '%s'/'%s'",
+				actual.Description().Summary, actual.Description().Detail,
+				expectSummary, expectDetail)
+		}
+	}
+}

--- a/internal/states/statemgr/encryption.go
+++ b/internal/states/statemgr/encryption.go
@@ -1,0 +1,9 @@
+package statemgr
+
+import "github.com/opentofu/opentofu/internal/states/encryption/encryptionflow"
+
+type SupportsEncryption interface {
+	// UseEncryptionFlowBuilder provides the state with the encryption flow builder to use
+	// for encryption / decryption.
+	UseEncryptionFlowBuilder(builder encryptionflow.FlowBuilder)
+}


### PR DESCRIPTION
This is a draft PR that is NOT intended for merging.

It is based on https://github.com/opentofu/opentofu/pull/1063, so the first 3 commits include the changes from that PR.

This PR shows a very rough draft with many TODO comments of how the state encryption configuration layer from https://github.com/opentofu/opentofu/pull/1063 could be integrated.

Part of the subtask "Implement all callsites" from https://github.com/opentofu/opentofu/issues/1030. It is my current best guess of where these "callsites" would be in the codebase and how they might look.

RFC see https://github.com/opentofu/opentofu/issues/874