### PR TITLE
docs(install): add missing steps in Debian family when facing hardened umask

### DIFF
--- a/website/docs/intro/install/deb-step2.sh
+++ b/website/docs/intro/install/deb-step2.sh
@@ -1,4 +1,4 @@
 sudo install -m 0755 -d /etc/apt/keyrings
 curl -fsSL https://get.opentofu.org/opentofu.gpg | sudo tee /etc/apt/keyrings/opentofu.gpg >/dev/null
 curl -fsSL https://packages.opentofu.org/opentofu/tofu/gpgkey | sudo gpg --no-tty --batch --dearmor -o /etc/apt/keyrings/opentofu-repo.gpg >/dev/null
-sudo chmod a+r /etc/apt/keyrings/opentofu.gpg
+sudo chmod a+r /etc/apt/keyrings/opentofu.gpg /etc/apt/keyrings/opentofu-repo.gpg

--- a/website/docs/intro/install/deb-step3.sh
+++ b/website/docs/intro/install/deb-step3.sh
@@ -2,3 +2,4 @@ echo \
   "deb [signed-by=/etc/apt/keyrings/opentofu.gpg,/etc/apt/keyrings/opentofu-repo.gpg] https://packages.opentofu.org/opentofu/tofu/any/ any main
 deb-src [signed-by=/etc/apt/keyrings/opentofu.gpg,/etc/apt/keyrings/opentofu-repo.gpg] https://packages.opentofu.org/opentofu/tofu/any/ any main" | \
   sudo tee /etc/apt/sources.list.d/opentofu.list > /dev/null
+sudo chmod a+r /etc/apt/sources.list.d/opentofu.list


### PR DESCRIPTION
When facing a hardened umask (e.g. `0027`) the current installation steps aren't sufficient on a Debian family OS.

This PR adds the missing steps.