### PR TITLE
Draft: Support the XDG Base Directory Specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ ENHANCEMENTS:
 * Added "base64gunzip" function. ([$800](https://github.com/opentofu/opentofu/issues/800))
 * Added "cidrcontains" function. ([$366](https://github.com/opentofu/opentofu/issues/366))
 * Allow test run blocks to reference previous run block's module outputs ([#1129](https://github.com/opentofu/opentofu/pull/1129))
+* Support the XDG Base Directory Specification ([#1145](https://github.com/opentofu/opentofu/pull/1145))
 
 BUG FIXES:
 * `tofu test` resources cleanup at the end of tests changed to use simple reverse run block order. ([#1043](https://github.com/opentofu/opentofu/pull/1043))

--- a/cmd/tofu/main.go
+++ b/cmd/tofu/main.go
@@ -501,7 +501,7 @@ func extractChdirOption(args []string) (string, []string, error) {
 }
 
 // Creates the the configuration directory.
-// `configDir` should refer to `~/.terraform.d` or its equivalent
+// `configDir` should refer to `~/.terraform.d`, `$XDG_CONFIG_HOME/opentofu` or its equivalent
 // on non-UNIX platforms.
 func mkConfigDir(configDir string) error {
 	err := os.Mkdir(configDir, os.ModePerm)

--- a/cmd/tofu/plugins.go
+++ b/cmd/tofu/plugins.go
@@ -21,13 +21,15 @@ import (
 func globalPluginDirs() []string {
 	var ret []string
 	// Look in ~/.terraform.d/plugins/, $XDG_DATA_HOME/opentofu/plugins, or its equivalent on non-UNIX platforms
-	dir, err := cliconfig.DataDir()
+	dirs, err := cliconfig.DataDirs()
 	if err != nil {
-		log.Printf("[ERROR] Error finding global config directory: %s", err)
+		log.Printf("[ERROR] Error finding global plugin directories: %s", err)
 	} else {
 		machineDir := fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH)
-		ret = append(ret, filepath.Join(dir, "plugins"))
-		ret = append(ret, filepath.Join(dir, "plugins", machineDir))
+		for _, dir := range dirs {
+			ret = append(ret, filepath.Join(dir, "plugins"))
+			ret = append(ret, filepath.Join(dir, "plugins", machineDir))
+		}
 	}
 
 	return ret

--- a/cmd/tofu/plugins.go
+++ b/cmd/tofu/plugins.go
@@ -21,7 +21,7 @@ import (
 func globalPluginDirs() []string {
 	var ret []string
 	// Look in ~/.terraform.d/plugins/ , or its equivalent on non-UNIX
-	dir, err := cliconfig.ConfigDir()
+	dir, err := cliconfig.PluginDir()
 	if err != nil {
 		log.Printf("[ERROR] Error finding global config directory: %s", err)
 	} else {

--- a/cmd/tofu/plugins.go
+++ b/cmd/tofu/plugins.go
@@ -21,7 +21,7 @@ import (
 func globalPluginDirs() []string {
 	var ret []string
 	// Look in ~/.terraform.d/plugins/, $XDG_DATA_HOME/opentofu/plugins, or its equivalent on non-UNIX platforms
-	dir, err := cliconfig.PluginDir()
+	dir, err := cliconfig.DataDir()
 	if err != nil {
 		log.Printf("[ERROR] Error finding global config directory: %s", err)
 	} else {

--- a/cmd/tofu/plugins.go
+++ b/cmd/tofu/plugins.go
@@ -20,7 +20,7 @@ import (
 // older versions where both satisfy the provider version constraints.
 func globalPluginDirs() []string {
 	var ret []string
-	// Look in ~/.terraform.d/plugins/ , or its equivalent on non-UNIX
+	// Look in ~/.terraform.d/plugins/, $XDG_DATA_HOME/opentofu/plugins, or its equivalent on non-UNIX platforms
 	dir, err := cliconfig.PluginDir()
 	if err != nil {
 		log.Printf("[ERROR] Error finding global config directory: %s", err)

--- a/cmd/tofu/provider_source.go
+++ b/cmd/tofu/provider_source.go
@@ -96,7 +96,8 @@ func implicitProviderSource(services *disco.Disco) getproviders.Source {
 	//   way to include them in bundles uploaded to Terraform Cloud, where
 	//   there has historically otherwise been no way to use custom providers.
 	// - The "plugins" subdirectory of the CLI config search directory.
-	//   (thats ~/.terraform.d/plugins on Unix systems, equivalents elsewhere)
+	//   (thats ~/.terraform.d/plugins or $XDG_DATA_HOME/opentofu/plugins
+	//   on Unix systems, equivalents elsewhere)
 	// - The "plugins" subdirectory of any platform-specific search paths,
 	//   following e.g. the XDG base directory specification on Unix systems,
 	//   Apple's guidelines on OS X, and "known folders" on Windows.

--- a/cmd/tofu/provider_source.go
+++ b/cmd/tofu/provider_source.go
@@ -145,7 +145,7 @@ func implicitProviderSource(services *disco.Disco) getproviders.Source {
 	}
 
 	addLocalDir("terraform.d/plugins") // our "vendor" directory
-	cliConfigDir, err := cliconfig.PluginDir()
+	cliConfigDir, err := cliconfig.DataDir()
 	if err == nil {
 		addLocalDir(filepath.Join(cliConfigDir, "plugins"))
 	}

--- a/cmd/tofu/provider_source.go
+++ b/cmd/tofu/provider_source.go
@@ -145,9 +145,11 @@ func implicitProviderSource(services *disco.Disco) getproviders.Source {
 	}
 
 	addLocalDir("terraform.d/plugins") // our "vendor" directory
-	cliConfigDir, err := cliconfig.DataDir()
+	cliDataDirs, err := cliconfig.DataDirs()
 	if err == nil {
-		addLocalDir(filepath.Join(cliConfigDir, "plugins"))
+		for _, cliDataDir := range cliDataDirs {
+			addLocalDir(filepath.Join(cliDataDir, "plugins"))
+		}
 	}
 
 	// This "userdirs" library implements an appropriate user-specific and

--- a/cmd/tofu/provider_source.go
+++ b/cmd/tofu/provider_source.go
@@ -144,7 +144,7 @@ func implicitProviderSource(services *disco.Disco) getproviders.Source {
 	}
 
 	addLocalDir("terraform.d/plugins") // our "vendor" directory
-	cliConfigDir, err := cliconfig.ConfigDir()
+	cliConfigDir, err := cliconfig.PluginDir()
 	if err == nil {
 		addLocalDir(filepath.Join(cliConfigDir, "plugins"))
 	}

--- a/internal/command/cliconfig/cliconfig.go
+++ b/internal/command/cliconfig/cliconfig.go
@@ -96,9 +96,9 @@ func ConfigDir() (string, error) {
 	return configDir()
 }
 
-// DataDir returns the data directory for OpenTofu.
-func DataDir() (string, error) {
-	return dataDir()
+// DataDirs returns the data directories for OpenTofu.
+func DataDirs() ([]string, error) {
+	return dataDirs()
 }
 
 // LoadConfig reads the CLI configuration from the various filesystem locations

--- a/internal/command/cliconfig/cliconfig.go
+++ b/internal/command/cliconfig/cliconfig.go
@@ -96,6 +96,11 @@ func ConfigDir() (string, error) {
 	return configDir()
 }
 
+// PluginDir returns the plugin directory for OpenTofu.
+func PluginDir() (string, error) {
+	return pluginDir()
+}
+
 // LoadConfig reads the CLI configuration from the various filesystem locations
 // and from the environment, returning a merged configuration along with any
 // diagnostics (errors and warnings) encountered along the way.

--- a/internal/command/cliconfig/cliconfig.go
+++ b/internal/command/cliconfig/cliconfig.go
@@ -96,9 +96,9 @@ func ConfigDir() (string, error) {
 	return configDir()
 }
 
-// PluginDir returns the plugin directory for OpenTofu.
-func PluginDir() (string, error) {
-	return pluginDir()
+// DataDir returns the data directory for OpenTofu.
+func DataDir() (string, error) {
+	return dataDir()
 }
 
 // LoadConfig reads the CLI configuration from the various filesystem locations

--- a/internal/command/cliconfig/config_unix.go
+++ b/internal/command/cliconfig/config_unix.go
@@ -45,7 +45,7 @@ func configDir() (string, error) {
 	return configDir, nil
 }
 
-func pluginDir() (string, error) {
+func dataDir() (string, error) {
 	dir, err := homeDir()
 	if err != nil {
 		return "", err

--- a/internal/command/cliconfig/config_unix.go
+++ b/internal/command/cliconfig/config_unix.go
@@ -45,6 +45,20 @@ func configDir() (string, error) {
 	return configDir, nil
 }
 
+func pluginDir() (string, error) {
+	dir, err := homeDir()
+	if err != nil {
+		return "", err
+	}
+
+	configDir := filepath.Join(dir, ".terraform.d")
+	if xdgDir := os.Getenv("XDG_DATA_HOME"); xdgDir != "" && !pathExists(configDir) {
+		configDir = filepath.Join(xdgDir, "opentofu")
+	}
+
+	return configDir, nil
+}
+
 func homeDir() (string, error) {
 	// First prefer the HOME environmental variable
 	if home := os.Getenv("HOME"); home != "" {

--- a/internal/command/cliconfig/config_unix.go
+++ b/internal/command/cliconfig/config_unix.go
@@ -51,18 +51,24 @@ func configDir() (string, error) {
 	return configDir, nil
 }
 
-func dataDir() (string, error) {
+func dataDirs() ([]string, error) {
 	dir, err := homeDir()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	dataDir := filepath.Join(dir, ".terraform.d")
-	if !pathExists(dataDir) {
-		dataDir = filepath.Join(lookupEnv("XDG_DATA_HOME", filepath.Join(dir, defaultDataDir)), "opentofu")
+	defaultDir := filepath.Join(dir, defaultDataDir)
+	customDir := lookupEnv("XDG_DATA_HOME", defaultDir)
+
+	dirs := []string{
+		filepath.Join(dir, ".terraform.d"),
+		filepath.Join(defaultDir, "opentofu"),
+	}
+	if customDir != defaultDir {
+		dirs = append(dirs, filepath.Join(customDir, "opentofu"))
 	}
 
-	return dataDir, nil
+	return dirs, nil
 }
 
 func lookupEnv(name, defaultValue string) string {

--- a/internal/command/cliconfig/config_unix.go
+++ b/internal/command/cliconfig/config_unix.go
@@ -44,8 +44,8 @@ func configDir() (string, error) {
 	}
 
 	configDir := filepath.Join(dir, ".terraform.d")
-	if !pathExists(configDir) {
-		configDir = filepath.Join(lookupEnv("XDG_CONFIG_HOME", filepath.Join(dir, defaultConfigDir)), "opentofu")
+	if xdgDir := os.Getenv("XDG_CONFIG_HOME"); xdgDir != "" && !pathExists(configDir) {
+		configDir = filepath.Join(xdgDir, "opentofu")
 	}
 
 	return configDir, nil

--- a/internal/command/cliconfig/config_unix_test.go
+++ b/internal/command/cliconfig/config_unix_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !windows
+// +build !windows
+
+package cliconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestConfigFileConfigDir(t *testing.T) {
+	baseDir := t.TempDir()
+	homeDir := filepath.Join(baseDir, "home")
+
+	tests := []struct {
+		name     string
+		xdgHome  string
+		files    []string
+		testFunc func() (string, error)
+		expect   string
+	}{
+		{
+			name:     "configFile: use home tofurc",
+			testFunc: configFile,
+			files:    []string{filepath.Join(homeDir, ".tofurc")},
+			expect:   filepath.Join(homeDir, ".tofurc"),
+		},
+		{
+			name:     "configFile: use home terraformrc",
+			testFunc: configFile,
+			files:    []string{filepath.Join(homeDir, ".terraformrc")},
+			expect:   filepath.Join(homeDir, ".terraformrc"),
+		},
+		{
+			name:     "configFile: use home tofurc fallback",
+			testFunc: configFile,
+			expect:   filepath.Join(homeDir, ".tofurc"),
+		},
+		{
+			name:     "configFile: use xdg tofurc",
+			testFunc: configFile,
+			xdgHome:  filepath.Join(baseDir, "xdg"),
+			expect:   filepath.Join(baseDir, "xdg", "opentofu", "tofurc"),
+		},
+		{
+			name:     "configFile: prefer home tofurc",
+			testFunc: configFile,
+			xdgHome:  filepath.Join(baseDir, "xdg"),
+			files:    []string{filepath.Join(homeDir, ".tofurc")},
+			expect:   filepath.Join(homeDir, ".tofurc"),
+		},
+		{
+			name:     "configFile: prefer home terraformrc",
+			testFunc: configFile,
+			xdgHome:  filepath.Join(baseDir, "xdg"),
+			files:    []string{filepath.Join(homeDir, ".terraformrc")},
+			expect:   filepath.Join(homeDir, ".terraformrc"),
+		},
+		{
+			name:     "configDir: no xdg",
+			testFunc: configDir,
+			expect:   filepath.Join(homeDir, ".terraform.d"),
+		},
+		{
+			name:     "configDir: xdg but path exists",
+			testFunc: configDir,
+			xdgHome:  filepath.Join(baseDir, "xdg"),
+			files:    []string{filepath.Join(homeDir, ".terraform.d", "placeholder")},
+			expect:   filepath.Join(homeDir, ".terraform.d"),
+		},
+		{
+			name:     "configDir: use xdg",
+			testFunc: configDir,
+			xdgHome:  filepath.Join(baseDir, "xdg"),
+			expect:   filepath.Join(baseDir, "xdg", "opentofu"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("HOME", homeDir)
+			t.Setenv("XDG_CONFIG_HOME", test.xdgHome)
+			for _, f := range test.files {
+				createFile(t, f)
+			}
+
+			file, err := test.testFunc()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if test.expect != file {
+				t.Fatalf("expected %q, but got %q", test.expect, file)
+			}
+		})
+	}
+}
+
+func createFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Dir(path)) })
+}

--- a/internal/command/cliconfig/config_unix_test.go
+++ b/internal/command/cliconfig/config_unix_test.go
@@ -81,19 +81,19 @@ func TestConfigFileConfigDir(t *testing.T) {
 		},
 		{
 			name:     "pluginDir: no xdg",
-			testFunc: pluginDir,
+			testFunc: dataDir,
 			expect:   filepath.Join(homeDir, ".terraform.d"),
 		},
 		{
 			name:        "pluginDir: xdg but path exists",
-			testFunc:    pluginDir,
+			testFunc:    dataDir,
 			xdgDataHome: filepath.Join(baseDir, "xdg"),
 			files:       []string{filepath.Join(homeDir, ".terraform.d", "placeholder")},
 			expect:      filepath.Join(homeDir, ".terraform.d"),
 		},
 		{
 			name:        "pluginDir: use xdg",
-			testFunc:    pluginDir,
+			testFunc:    dataDir,
 			xdgDataHome: filepath.Join(baseDir, "xdg"),
 			expect:      filepath.Join(baseDir, "xdg", "opentofu"),
 		},

--- a/internal/command/cliconfig/config_unix_test.go
+++ b/internal/command/cliconfig/config_unix_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func TestConfigFileConfigDir(t *testing.T) {
-	baseDir := t.TempDir()
-	homeDir := filepath.Join(baseDir, "home")
+	homeDir := filepath.Join(t.TempDir(), "home")
 
 	tests := []struct {
 		name          string
@@ -37,65 +36,65 @@ func TestConfigFileConfigDir(t *testing.T) {
 			expect:   filepath.Join(homeDir, ".terraformrc"),
 		},
 		{
-			name:     "configFile: use home tofurc fallback",
+			name:     "configFile: use default XDG config directory",
 			testFunc: configFile,
-			expect:   filepath.Join(homeDir, ".tofurc"),
+			expect:   filepath.Join(homeDir, defaultConfigDir, "opentofu", "tofurc"),
 		},
 		{
-			name:          "configFile: use xdg tofurc",
+			name:          "configFile: use XDG tofurc",
 			testFunc:      configFile,
-			xdgConfigHome: filepath.Join(baseDir, "xdg"),
-			expect:        filepath.Join(baseDir, "xdg", "opentofu", "tofurc"),
+			xdgConfigHome: filepath.Join(homeDir, "xdg"),
+			expect:        filepath.Join(homeDir, "xdg", "opentofu", "tofurc"),
 		},
 		{
 			name:          "configFile: prefer home tofurc",
 			testFunc:      configFile,
-			xdgConfigHome: filepath.Join(baseDir, "xdg"),
+			xdgConfigHome: filepath.Join(homeDir, "xdg"),
 			files:         []string{filepath.Join(homeDir, ".tofurc")},
 			expect:        filepath.Join(homeDir, ".tofurc"),
 		},
 		{
 			name:          "configFile: prefer home terraformrc",
 			testFunc:      configFile,
-			xdgConfigHome: filepath.Join(baseDir, "xdg"),
+			xdgConfigHome: filepath.Join(homeDir, "xdg"),
 			files:         []string{filepath.Join(homeDir, ".terraformrc")},
 			expect:        filepath.Join(homeDir, ".terraformrc"),
 		},
 		{
-			name:     "configDir: no xdg",
+			name:     "configDir: use XDG default",
 			testFunc: configDir,
-			expect:   filepath.Join(homeDir, ".terraform.d"),
+			expect:   filepath.Join(homeDir, defaultConfigDir, "opentofu"),
 		},
 		{
-			name:          "configDir: xdg but path exists",
+			name:          "configDir: prefer .terraform.d",
 			testFunc:      configDir,
-			xdgConfigHome: filepath.Join(baseDir, "xdg"),
+			xdgConfigHome: filepath.Join(homeDir, "xdg"),
 			files:         []string{filepath.Join(homeDir, ".terraform.d", "placeholder")},
 			expect:        filepath.Join(homeDir, ".terraform.d"),
 		},
 		{
-			name:          "configDir: use xdg",
+			name:          "configDir: use XDG value",
 			testFunc:      configDir,
-			xdgConfigHome: filepath.Join(baseDir, "xdg"),
-			expect:        filepath.Join(baseDir, "xdg", "opentofu"),
+			xdgConfigHome: filepath.Join(homeDir, "xdg"),
+			expect:        filepath.Join(homeDir, "xdg", "opentofu"),
 		},
 		{
-			name:     "pluginDir: no xdg",
+			name:     "pluginDir: use XDG default",
 			testFunc: dataDir,
-			expect:   filepath.Join(homeDir, ".terraform.d"),
+			expect:   filepath.Join(homeDir, defaultDataDir, "opentofu"),
 		},
 		{
-			name:        "pluginDir: xdg but path exists",
+			name:        "pluginDir: prefer .terraform.d",
 			testFunc:    dataDir,
-			xdgDataHome: filepath.Join(baseDir, "xdg"),
+			xdgDataHome: filepath.Join(homeDir, "xdg"),
 			files:       []string{filepath.Join(homeDir, ".terraform.d", "placeholder")},
 			expect:      filepath.Join(homeDir, ".terraform.d"),
 		},
 		{
-			name:        "pluginDir: use xdg",
+			name:        "pluginDir: use XDG value",
 			testFunc:    dataDir,
-			xdgDataHome: filepath.Join(baseDir, "xdg"),
-			expect:      filepath.Join(baseDir, "xdg", "opentofu"),
+			xdgDataHome: filepath.Join(homeDir, "xdg"),
+			expect:      filepath.Join(homeDir, "xdg", "opentofu"),
 		},
 	}
 

--- a/internal/command/cliconfig/config_unix_test.go
+++ b/internal/command/cliconfig/config_unix_test.go
@@ -61,9 +61,9 @@ func TestConfigFileConfigDir(t *testing.T) {
 			expect:        filepath.Join(homeDir, ".terraformrc"),
 		},
 		{
-			name:     "configDir: use XDG default",
+			name:     "configDir: use .terraform.d default",
 			testFunc: configDir,
-			expect:   filepath.Join(homeDir, defaultConfigDir, "opentofu"),
+			expect:   filepath.Join(homeDir, ".terraform.d"),
 		},
 		{
 			name:          "configDir: prefer .terraform.d",

--- a/internal/command/cliconfig/config_unix_test.go
+++ b/internal/command/cliconfig/config_unix_test.go
@@ -17,11 +17,12 @@ func TestConfigFileConfigDir(t *testing.T) {
 	homeDir := filepath.Join(baseDir, "home")
 
 	tests := []struct {
-		name     string
-		xdgHome  string
-		files    []string
-		testFunc func() (string, error)
-		expect   string
+		name          string
+		xdgConfigHome string
+		xdgDataHome   string
+		files         []string
+		testFunc      func() (string, error)
+		expect        string
 	}{
 		{
 			name:     "configFile: use home tofurc",
@@ -41,24 +42,24 @@ func TestConfigFileConfigDir(t *testing.T) {
 			expect:   filepath.Join(homeDir, ".tofurc"),
 		},
 		{
-			name:     "configFile: use xdg tofurc",
-			testFunc: configFile,
-			xdgHome:  filepath.Join(baseDir, "xdg"),
-			expect:   filepath.Join(baseDir, "xdg", "opentofu", "tofurc"),
+			name:          "configFile: use xdg tofurc",
+			testFunc:      configFile,
+			xdgConfigHome: filepath.Join(baseDir, "xdg"),
+			expect:        filepath.Join(baseDir, "xdg", "opentofu", "tofurc"),
 		},
 		{
-			name:     "configFile: prefer home tofurc",
-			testFunc: configFile,
-			xdgHome:  filepath.Join(baseDir, "xdg"),
-			files:    []string{filepath.Join(homeDir, ".tofurc")},
-			expect:   filepath.Join(homeDir, ".tofurc"),
+			name:          "configFile: prefer home tofurc",
+			testFunc:      configFile,
+			xdgConfigHome: filepath.Join(baseDir, "xdg"),
+			files:         []string{filepath.Join(homeDir, ".tofurc")},
+			expect:        filepath.Join(homeDir, ".tofurc"),
 		},
 		{
-			name:     "configFile: prefer home terraformrc",
-			testFunc: configFile,
-			xdgHome:  filepath.Join(baseDir, "xdg"),
-			files:    []string{filepath.Join(homeDir, ".terraformrc")},
-			expect:   filepath.Join(homeDir, ".terraformrc"),
+			name:          "configFile: prefer home terraformrc",
+			testFunc:      configFile,
+			xdgConfigHome: filepath.Join(baseDir, "xdg"),
+			files:         []string{filepath.Join(homeDir, ".terraformrc")},
+			expect:        filepath.Join(homeDir, ".terraformrc"),
 		},
 		{
 			name:     "configDir: no xdg",
@@ -66,24 +67,43 @@ func TestConfigFileConfigDir(t *testing.T) {
 			expect:   filepath.Join(homeDir, ".terraform.d"),
 		},
 		{
-			name:     "configDir: xdg but path exists",
-			testFunc: configDir,
-			xdgHome:  filepath.Join(baseDir, "xdg"),
-			files:    []string{filepath.Join(homeDir, ".terraform.d", "placeholder")},
+			name:          "configDir: xdg but path exists",
+			testFunc:      configDir,
+			xdgConfigHome: filepath.Join(baseDir, "xdg"),
+			files:         []string{filepath.Join(homeDir, ".terraform.d", "placeholder")},
+			expect:        filepath.Join(homeDir, ".terraform.d"),
+		},
+		{
+			name:          "configDir: use xdg",
+			testFunc:      configDir,
+			xdgConfigHome: filepath.Join(baseDir, "xdg"),
+			expect:        filepath.Join(baseDir, "xdg", "opentofu"),
+		},
+		{
+			name:     "pluginDir: no xdg",
+			testFunc: pluginDir,
 			expect:   filepath.Join(homeDir, ".terraform.d"),
 		},
 		{
-			name:     "configDir: use xdg",
-			testFunc: configDir,
-			xdgHome:  filepath.Join(baseDir, "xdg"),
-			expect:   filepath.Join(baseDir, "xdg", "opentofu"),
+			name:        "pluginDir: xdg but path exists",
+			testFunc:    pluginDir,
+			xdgDataHome: filepath.Join(baseDir, "xdg"),
+			files:       []string{filepath.Join(homeDir, ".terraform.d", "placeholder")},
+			expect:      filepath.Join(homeDir, ".terraform.d"),
+		},
+		{
+			name:        "pluginDir: use xdg",
+			testFunc:    pluginDir,
+			xdgDataHome: filepath.Join(baseDir, "xdg"),
+			expect:      filepath.Join(baseDir, "xdg", "opentofu"),
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Setenv("HOME", homeDir)
-			t.Setenv("XDG_CONFIG_HOME", test.xdgHome)
+			t.Setenv("XDG_CONFIG_HOME", test.xdgConfigHome)
+			t.Setenv("XDG_DATA_HOME", test.xdgDataHome)
 			for _, f := range test.files {
 				createFile(t, f)
 			}

--- a/internal/command/cliconfig/config_windows.go
+++ b/internal/command/cliconfig/config_windows.go
@@ -40,7 +40,7 @@ func configDir() (string, error) {
 	return filepath.Join(dir, "terraform.d"), nil
 }
 
-func pluginDir() (string, error) {
+func dataDir() (string, error) {
 	return configDir()
 }
 

--- a/internal/command/cliconfig/config_windows.go
+++ b/internal/command/cliconfig/config_windows.go
@@ -40,8 +40,12 @@ func configDir() (string, error) {
 	return filepath.Join(dir, "terraform.d"), nil
 }
 
-func dataDir() (string, error) {
-	return configDir()
+func dataDirs() ([]string, error) {
+	dir, err := configDir()
+	if err != nil {
+		return nil, err
+	}
+	return []string{dir}, nil
 }
 
 func homeDir() (string, error) {

--- a/internal/command/cliconfig/config_windows.go
+++ b/internal/command/cliconfig/config_windows.go
@@ -40,6 +40,10 @@ func configDir() (string, error) {
 	return filepath.Join(dir, "terraform.d"), nil
 }
 
+func pluginDir() (string, error) {
+	return configDir()
+}
+
 func homeDir() (string, error) {
 	b := make([]uint16, syscall.MAX_PATH)
 

--- a/website/docs/cli/config/config-file.mdx
+++ b/website/docs/cli/config/config-file.mdx
@@ -278,10 +278,11 @@ the operating system where you are running OpenTofu:
   `~/Library/Application Support/io.terraform/plugins`, and
   `/Library/Application Support/io.terraform/plugins`
 * **Linux and other Unix-like systems**:`$HOME/.terraform.d/plugins` and
-  `terraform/plugins` located within a valid
+  `opentofu/plugins` located within a valid
   [XDG Base Directory](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
   data directory such as `$XDG_DATA_HOME/opentofu/plugins`.
-  Without any XDG environment variables set, OpenTofu will use `~/.terraform.d/plugins`.
+  OpenTofu will always look in `~/.local/share/opentofu/plugins`,
+  regardless whether `XDG_DATA_HOME` is defined or not.
 
 If a `terraform.d/plugins` directory exists in the current working directory
 then OpenTofu will also include that directory, regardless of your operating

--- a/website/docs/cli/config/config-file.mdx
+++ b/website/docs/cli/config/config-file.mdx
@@ -24,9 +24,12 @@ on the host operating system:
   If both `terraform.rc` and `tofu.rc` files exists, the later would take precedence.
 * On all other systems, the file must be named `.tofurc` (note
   the leading period) and placed directly in the home directory
-  of the relevant user.
+  of the relevant user or be named `tofurc` and placed in a valid
+  [XDG Base Directory](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+  config directory such as `$XDG_CONFIG_HOME/opentofu`.
   The `.terraformrc` is supported for backward-compatability purposes.
-  If both `.terraformrc` and `.tofurc` files exists, the later would take precedence.
+  If both `.terraformrc` and `.tofurc` files exists, the latter would take precedence.
+  When using an XDG config directory `.terraformrc` and `terraformrc` are ignored.
 
 On Windows, beware of Windows Explorer's default behavior of hiding filename
 extensions. OpenTofu will not recognize a file named `tofuc.rc.txt` as a
@@ -277,10 +280,8 @@ the operating system where you are running OpenTofu:
 * **Linux and other Unix-like systems**:`$HOME/.terraform.d/plugins` and
   `terraform/plugins` located within a valid
   [XDG Base Directory](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
-  data directory such as `$XDG_DATA_HOME/terraform/plugins`.
-  Without any XDG environment variables set, OpenTofu will use
-  `~/.local/share/terraform/plugins`,
-  `/usr/local/share/terraform/plugins`, and `/usr/share/terraform/plugins`.
+  data directory such as `$XDG_DATA_HOME/opentofu/plugins`.
+  Without any XDG environment variables set, OpenTofu will use `~/.terraform.d/plugins`.
 
 If a `terraform.d/plugins` directory exists in the current working directory
 then OpenTofu will also include that directory, regardless of your operating

--- a/website/docs/language/resources/provisioners/syntax.mdx
+++ b/website/docs/language/resources/provisioners/syntax.mdx
@@ -195,7 +195,7 @@ provisioners must connect to the remote system using SSH or WinRM.
 You must include [a `connection` block](/docs/language/resources/provisioners/connection) so that OpenTofu knows how to communicate with the server.
 
 OpenTofu includes several built-in provisioners. You can also use third-party provisioners as plugins, by placing them
-in `%APPDATA%\terraform.d\plugins`, `~/.terraform.d/plugins`, or the same
+in `%APPDATA%\terraform.d\plugins`, `~/.terraform.d/plugins`, `$XDG_DATA_HOME/opentofu/plugins`, or the same
 directory where the OpenTofu binary is installed. However, we do not recommend
 using any provisioners except the built-in `file`, `local-exec`, and
 `remote-exec` provisioners.


### PR DESCRIPTION
This PR introduces support for XDG environment variables. `XDG_CONFIG_HOME` for config and `XDG_DATA_HOME` for plugins.

If the `~/.terraform.d` directory doesn't exist, config is assumed to live in `XDG_CONFIG_HOME/opentofu` with `XDG_CONFIG_HOME` defaulting to `~/.config`.
`~/.local/share/opentofu` and `~/.terraform.d` are always used for looking up plugins with `XDG_DATA_HOME` as third option when it is set to a non-default value.

This ensures that existing config and plugins will still get used, but allow users to gradually migrate to the new structure, with and without setting `XDG_*` environment variables.

The CLI ensures that the intermediate config directory exists, so either `$XDG_CONFIG_HOME/opentofu` or `~/.config/opentofu` will be created if neither `~/.terraformrc`, `~/.tofurc` or `~/.terraform.d` exist. The lookup behavior remains unchanged after this directory was created.

Only affects unix* platforms.

Resolves #303

## Target Release

1.7.0
