### PR TITLE
Add details on who/what/why the TSC is and list of current members

### DIFF
--- a/TSC_SUMMARY.md
+++ b/TSC_SUMMARY.md
@@ -3,11 +3,11 @@
 The Technical Steering Committee is a group comprised of people from companies and projects backing OpenTofu. It’s purpose is to have the final decision on any technical matters concerning the OpenTofu project, providing a model of governance that benefits the community as a whole, as opposed to being guided by any single company. The current members of the steering committee are:
 
 - Igor Savchenko ([@DiscyDel](https://github.com/DicsyDel)) representing Scalr Inc.
-- Marcin Wyszynski ([@marcinwyszynski](https://github.com/marcinwyszynski)) representing Spacelift.io
-- Roger Simms ([@allofthesepeople](https://github.com/allofthesepeople)) representing Harness.io
-- Yevgeniy Brikman ([@brikis98](https://github.com/brikis98)) representing Gruntwork.io
-- Omry Hay ([@omry-hay](https://github.com/omry-hay)) representing Env0
-- Roni Frantchi ([@roni-frantchi](https://github.com/roni-frantchi)) temporarily filling in for Omry Hay at Env0
+- Marcin Wyszynski ([@marcinwyszynski](https://github.com/marcinwyszynski)) representing Spacelift Inc.
+- Roger Simms ([@allofthesepeople](https://github.com/allofthesepeople)) representing Harness Inc.
+- Yevgeniy Brikman ([@brikis98](https://github.com/brikis98)) representing Gruntwork, Inc.
+- Omry Hay ([@omry-hay](https://github.com/omry-hay)) representing env0
+- Roni Frantchi ([@roni-frantchi](https://github.com/roni-frantchi)) temporarily filling in for Omry Hay at env0
 
 ## 2023-12-11
 

--- a/TSC_SUMMARY.md
+++ b/TSC_SUMMARY.md
@@ -1,7 +1,17 @@
 # Technical Steering Committee (TSC) Summary  
 
+The Technical Steering Committee is a group comprised of people from companies and projects backing OpenTofu. It’s purpose is to have the final decision on any technical matters concerning the OpenTofu project, providing a model of governance that benefits the community as a whole, as opposed to being guided by any single company. The current members of the steering committee are:
+
+- Igor Savchenko ([@DiscyDel](https://github.com/DicsyDel)) representing Scalr Inc.
+- Marcin Wyszynski ([@marcinwyszynski](https://github.com/marcinwyszynski)) representing Spacelift.io
+- Roger Simms ([@allofthesepeople](https://github.com/allofthesepeople)) representing Harness.io
+- Yevgeniy Brikman ([@brikis98](https://github.com/brikis98)) representing Gruntwork.io
+- Omry Hay ([@omry-hay](https://github.com/omry-hay)) representing Env0
+- Roni Frantchi ([@roni-frantchi](https://github.com/roni-frantchi)) temporarily filling in for Omry Hay at Env0
+
 ## 2023-12-11
-Steering committee summary### Attendees:
+
+### Attendees:
 
 - Igor Savchenko ([@DiscyDel](https://github.com/DicsyDel))
 - Marcin Wyszynski ([@marcinwyszynski](https://github.com/marcinwyszynski))
@@ -10,7 +20,7 @@ Steering committee summary### Attendees:
 - Yevgeniy Brikman ([@brikis98](https://github.com/brikis98))
 
 ### Absent
-- Omry Hary ([@omry-hay](https://github.com/omry-hay))
+- Omry Hay ([@omry-hay](https://github.com/omry-hay))
 
 ### Agenda
 
@@ -56,7 +66,7 @@ Steering committee summary### Attendees:
 
 ### Absent
 - Yevgeniy Brikman ([@brikis98](https://github.com/brikis98))
-- Omry Hary ([@omry-hay](https://github.com/omry-hay))
+- Omry Hay ([@omry-hay](https://github.com/omry-hay))
 
 ### Agenda
 
@@ -117,7 +127,7 @@ With that, our time’s up. We’ll convene again next week to discuss more item
 
 ### Absent
 - Yevgeniy Brikman ([@brikis98](https://github.com/brikis98))
-- Omry Hary ([@omry-hay](https://github.com/omry-hay))
+- Omry Hay ([@omry-hay](https://github.com/omry-hay))
 
 ### Agenda
 
@@ -177,7 +187,7 @@ With that, our time’s up. We’ll convene again next week to discuss more item
 
 ### Absent
 - Yevgeniy Brikman ([@brikis98](https://github.com/brikis98))
-- Omry Hary ([@omry-hay](https://github.com/omry-hay))
+- Omry Hay ([@omry-hay](https://github.com/omry-hay))
 
 ### Agenda
 


### PR DESCRIPTION
This information has been referenced in a few places, but it is good to have a clear description in the repo to help explain the issue flow and governance.

Also fixed the spelling of Omry Hay's name.