### PR TITLE
Improve stability on 32-bit architectures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ BUG FIXES:
 * Don't check for version conflicts when doing a force-unlock ([#1123](https://github.com/opentofu/opentofu/pull/1123))
 * Fix Global Schema Cache not working in provider acceptance tests ([#1054](https://github.com/opentofu/opentofu/pull/1054))
 * Fix `tofu show` and `tofu state show` not working with state files referencing Terraform registry providers in some instances ([#1141](https://github.com/opentofu/opentofu/pull/1141))
+* Improved stability on 32-bit architectures ([#1154](https://github.com/opentofu/opentofu/pull/1154))
 
 ## Previous Releases
 

--- a/internal/legacy/helper/hashcode/hashcode.go
+++ b/internal/legacy/helper/hashcode/hashcode.go
@@ -10,19 +10,26 @@ import (
 )
 
 // String hashes a string to a unique hashcode.
-//
-// crc32 returns a uint32, but for our use we need
-// a non negative integer. Here we cast to an integer
-// and invert it if the result is negative.
+// Returns a non-negative integer representing the hashcode of the string.
 func String(s string) int {
-	v := int(crc32.ChecksumIEEE([]byte(s)))
-	if v >= 0 {
-		return v
+	// crc32 returns an uint32, so we need to massage it into an int.
+	crc := crc32.ChecksumIEEE([]byte(s))
+	// We need to first squash the result to 32 bits, embracing the overflow
+	// to ensure that there is no difference between 32 and 64-bit
+	// platforms.
+	squashed := int32(crc)
+	// convert into a generic int that is sized as per the architecture
+	systemSized := int(squashed)
+
+	// If the integer is negative, we return the absolute value of the
+	// integer. This is because we want to return a non-negative integer
+	if systemSized >= 0 {
+		return systemSized
 	}
-	if -v >= 0 {
-		return -v
+	if -systemSized >= 0 {
+		return -systemSized
 	}
-	// v == MinInt
+	// systemSized == MinInt
 	return 0
 }
 

--- a/internal/legacy/helper/schema/field_reader_config_test.go
+++ b/internal/legacy/helper/schema/field_reader_config_test.go
@@ -410,7 +410,7 @@ func TestConfigFieldReader_ComputedSet(t *testing.T) {
 			[]string{"strSet"},
 			FieldReadResult{
 				Value: map[string]interface{}{
-					"2356372769": "foo",
+					"1938594527": "foo",
 				},
 				Exists:   true,
 				Computed: false,

--- a/internal/legacy/helper/schema/resource_data_test.go
+++ b/internal/legacy/helper/schema/resource_data_test.go
@@ -1586,6 +1586,7 @@ func TestResourceDataSet(t *testing.T) {
 	var testNilPtr *string
 
 	cases := []struct {
+		TestName string
 		Schema   map[string]*Schema
 		State    *tofu.InstanceState
 		Diff     *tofu.InstanceDiff
@@ -1599,8 +1600,8 @@ func TestResourceDataSet(t *testing.T) {
 		// compared to GetValue
 		GetPreProcess func(interface{}) interface{}
 	}{
-		// #0: Basic good
 		{
+			TestName: "Basic good",
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{
 					Type:     TypeString,
@@ -1620,9 +1621,8 @@ func TestResourceDataSet(t *testing.T) {
 			GetKey:   "availability_zone",
 			GetValue: "foo",
 		},
-
-		// #1: Basic int
 		{
+			TestName: "Basic int",
 			Schema: map[string]*Schema{
 				"port": &Schema{
 					Type:     TypeInt,
@@ -1642,9 +1642,8 @@ func TestResourceDataSet(t *testing.T) {
 			GetKey:   "port",
 			GetValue: 80,
 		},
-
-		// #2: Basic bool
 		{
+			TestName: "Basic bool, true",
 			Schema: map[string]*Schema{
 				"vpc": &Schema{
 					Type:     TypeBool,
@@ -1662,9 +1661,8 @@ func TestResourceDataSet(t *testing.T) {
 			GetKey:   "vpc",
 			GetValue: true,
 		},
-
-		// #3
 		{
+			TestName: "Basic bool, false",
 			Schema: map[string]*Schema{
 				"vpc": &Schema{
 					Type:     TypeBool,
@@ -1682,9 +1680,8 @@ func TestResourceDataSet(t *testing.T) {
 			GetKey:   "vpc",
 			GetValue: false,
 		},
-
-		// #4: Invalid type
 		{
+			TestName: "Invalid type",
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{
 					Type:     TypeString,
@@ -1705,9 +1702,8 @@ func TestResourceDataSet(t *testing.T) {
 			GetKey:   "availability_zone",
 			GetValue: "",
 		},
-
-		// #5: List of primitives, set list
 		{
+			TestName: "List of primitives, set list",
 			Schema: map[string]*Schema{
 				"ports": &Schema{
 					Type:     TypeList,
@@ -1726,9 +1722,8 @@ func TestResourceDataSet(t *testing.T) {
 			GetKey:   "ports",
 			GetValue: []interface{}{1, 2, 5},
 		},
-
-		// #6: List of primitives, set list with error
 		{
+			TestName: "List of primitives, set list with error",
 			Schema: map[string]*Schema{
 				"ports": &Schema{
 					Type:     TypeList,
@@ -1748,9 +1743,8 @@ func TestResourceDataSet(t *testing.T) {
 			GetKey:   "ports",
 			GetValue: []interface{}{},
 		},
-
-		// #7: Set a list of maps
 		{
+			TestName: "Set a list of maps",
 			Schema: map[string]*Schema{
 				"config_vars": &Schema{
 					Type:     TypeList,
@@ -1787,9 +1781,8 @@ func TestResourceDataSet(t *testing.T) {
 				},
 			},
 		},
-
-		// #8: Set, with list
 		{
+			TestName: "Set, with list",
 			Schema: map[string]*Schema{
 				"ports": &Schema{
 					Type:     TypeSet,
@@ -1817,9 +1810,8 @@ func TestResourceDataSet(t *testing.T) {
 			GetKey:   "ports",
 			GetValue: []interface{}{100, 125},
 		},
-
-		// #9: Set, with Set
 		{
+			TestName: " Set, with Set",
 			Schema: map[string]*Schema{
 				"ports": &Schema{
 					Type:     TypeSet,
@@ -1852,9 +1844,8 @@ func TestResourceDataSet(t *testing.T) {
 			GetKey:   "ports",
 			GetValue: []interface{}{1, 2},
 		},
-
-		// #10: Set single item
 		{
+			TestName: "Set single item",
 			Schema: map[string]*Schema{
 				"ports": &Schema{
 					Type:     TypeSet,
@@ -1882,9 +1873,8 @@ func TestResourceDataSet(t *testing.T) {
 			GetKey:   "ports",
 			GetValue: []interface{}{100, 80},
 		},
-
-		// #11: Set with nested set
 		{
+			TestName: "Set with nested set",
 			Schema: map[string]*Schema{
 				"ports": &Schema{
 					Type: TypeSet,
@@ -1950,9 +1940,8 @@ func TestResourceDataSet(t *testing.T) {
 				return v
 			},
 		},
-
-		// #12: List of floats, set list
 		{
+			TestName: "List of floats, set list",
 			Schema: map[string]*Schema{
 				"ratios": &Schema{
 					Type:     TypeList,
@@ -1971,9 +1960,8 @@ func TestResourceDataSet(t *testing.T) {
 			GetKey:   "ratios",
 			GetValue: []interface{}{1.0, 2.2, 5.5},
 		},
-
-		// #12: Set of floats, set list
 		{
+			TestName: "Set of floats, set list",
 			Schema: map[string]*Schema{
 				"ratios": &Schema{
 					Type:     TypeSet,
@@ -2000,9 +1988,8 @@ func TestResourceDataSet(t *testing.T) {
 			GetKey:   "ratios",
 			GetValue: []interface{}{1.0, 2.2, 5.5},
 		},
-
-		// #13: Basic pointer
 		{
+			TestName: "Basic pointer",
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{
 					Type:     TypeString,
@@ -2022,9 +2009,8 @@ func TestResourceDataSet(t *testing.T) {
 			GetKey:   "availability_zone",
 			GetValue: "foo",
 		},
-
-		// #14: Basic nil value
 		{
+			TestName: "Basic nil value",
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{
 					Type:     TypeString,
@@ -2044,9 +2030,8 @@ func TestResourceDataSet(t *testing.T) {
 			GetKey:   "availability_zone",
 			GetValue: "",
 		},
-
-		// #15: Basic nil pointer
 		{
+			TestName: "Basic nil pointer",
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{
 					Type:     TypeString,
@@ -2066,9 +2051,8 @@ func TestResourceDataSet(t *testing.T) {
 			GetKey:   "availability_zone",
 			GetValue: "",
 		},
-
-		// #16: Set in a list
 		{
+			TestName: "Set in a list",
 			Schema: map[string]*Schema{
 				"ports": &Schema{
 					Type: TypeList,
@@ -2135,29 +2119,31 @@ func TestResourceDataSet(t *testing.T) {
 	os.Setenv(PanicOnErr, "")
 	defer os.Setenv(PanicOnErr, oldEnv)
 
-	for i, tc := range cases {
-		d, err := schemaMap(tc.Schema).Data(tc.State, tc.Diff)
-		if err != nil {
-			t.Fatalf("err: %s", err)
-		}
+	for _, tc := range cases {
+		t.Run(tc.TestName, func(t *testing.T) {
+			d, err := schemaMap(tc.Schema).Data(tc.State, tc.Diff)
+			if err != nil {
+				t.Fatalf("err: %s", err)
+			}
 
-		err = d.Set(tc.Key, tc.Value)
-		if err != nil != tc.Err {
-			t.Fatalf("%d err: %s", i, err)
-		}
+			err = d.Set(tc.Key, tc.Value)
+			if err != nil != tc.Err {
+				t.Fatalf("unexpected err: %s", err)
+			}
 
-		v := d.Get(tc.GetKey)
-		if s, ok := v.(*Set); ok {
-			v = s.List()
-		}
+			v := d.Get(tc.GetKey)
+			if s, ok := v.(*Set); ok {
+				v = s.List()
+			}
 
-		if tc.GetPreProcess != nil {
-			v = tc.GetPreProcess(v)
-		}
+			if tc.GetPreProcess != nil {
+				v = tc.GetPreProcess(v)
+			}
 
-		if !reflect.DeepEqual(v, tc.GetValue) {
-			t.Fatalf("Get Bad: %d\n\n%#v, expected:%v", i, v, tc.GetValue)
-		}
+			if !reflect.DeepEqual(v, tc.GetValue) {
+				t.Fatalf("Got unexpected value\nactual: %#v\nexpected:%#v", v, tc.GetValue)
+			}
+		})
 	}
 }
 

--- a/internal/legacy/helper/schema/resource_diff_test.go
+++ b/internal/legacy/helper/schema/resource_diff_test.go
@@ -129,7 +129,7 @@ func testDiffCases(t *testing.T, oldPrefix string, oldOffset int, computed bool)
 							NewComputed: true,
 						}
 					} else {
-						result["foo.2800005064"] = &tofu.ResourceAttrDiff{
+						result["foo.1494962232"] = &tofu.ResourceAttrDiff{
 							Old: "",
 							New: "qux",
 						}

--- a/internal/legacy/tofu/state_upgrade_v2_to_v3.go
+++ b/internal/legacy/tofu/state_upgrade_v2_to_v3.go
@@ -100,7 +100,10 @@ func upgradeAttributesV2ToV3(instanceState *InstanceState) error {
 		// First, detect "obvious" maps - which have non-numeric keys (mostly).
 		hasNonNumericKeys := false
 		for _, key := range actualKeysMatching {
-			if _, err := strconv.Atoi(key); err != nil {
+			// Ensure that we attempt to parse the key using 64 bits, this is because the state
+			// could've been generated on a 64-bit system, and we need to be able to
+			// convert this on both a 32-bit and 64-bit arch.
+			if _, err := strconv.ParseInt(key, 10, 64); err != nil {
 				hasNonNumericKeys = true
 			}
 		}


### PR DESCRIPTION
This PR attempts to fix the failing 32 bit unit tests throughout the codebase. 

It makes the following changes:

### Improve 32 bit processing of String hashing inside schema's Set type
    
This type is only really used in the remote backend packages lately, but nonetheless we should be fixing this.
This fix ensures that we squash the value to 32 bits (signed) and embrace the overflow to introduce consistency between 32 and 64 bit systems.

### Fix TestResourceDataSet test on 32-bit systems
    
The previous function used in the test was causing issues with clashing IDs. This commit attempts to fix this by re-working how the unit test generates IDs for the set elements in a way that's both friendly to 32 bit and 64 bit systems

### Use 64 bit integer conversions when parsing keys from v2 statefiles
This fixes an issue where we were using strconv.Atoi, and instead we should be enforcing 64-bit conversions here.

### Ensure we use 64 bit integers for durations when assuming roles in the s3 backend

We had a bug in the s3 backend role assumption logic that caused an overflow if used on a 32 bit system.

### Misc
- Reworked some of the test case names in TestResourceDataSet so it's clearer what is failing

Resolves #1069 

## Target Release

1.7.0, 1.6.1
