### PR TITLE
Fix typo in standalone-install.sh

### DIFF
--- a/website/docs/intro/install/standalone-install.sh
+++ b/website/docs/intro/install/standalone-install.sh
@@ -2,7 +2,7 @@
 curl --proto '=https' --tlsv1.2 -fsSL https://get.opentofu.org/install-opentofu.sh -o install-opentofu.sh
 # Alternatively: wget --secure-protocol=TLSv1_2 --https-only https://get.opentofu.org/install-opentofu.sh -O install-opentofu.sh
 
-# Grand execution permissions:
+# Grant execution permissions:
 chmod +x install-opentofu.sh
 
 # Please inspect the downloaded script at this point.


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

Fixes what I believe is a typo in the standalone install instructions. Should be "grant", not "grand".

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.0
