### PR TITLE
Backport: Fix typo in standalone-install.sh (#1186)

### DIFF
--- a/website/docs/intro/install/standalone-install.sh
+++ b/website/docs/intro/install/standalone-install.sh
@@ -2,7 +2,7 @@
 curl --proto '=https' --tlsv1.2 -fsSL https://get.opentofu.org/install-opentofu.sh -o install-opentofu.sh
 # Alternatively: wget --secure-protocol=TLSv1_2 --https-only https://get.opentofu.org/install-opentofu.sh -O install-opentofu.sh
 
-# Grand execution permissions:
+# Grant execution permissions:
 chmod +x install-opentofu.sh
 
 # Please inspect the downloaded script at this point.


### PR DESCRIPTION
Backport of #1186 

1.6.0
