### PR TITLE
Import ForEach: Prerequisite - Prepare codebase for dynamic addresses for `ImportTarget`s

### DIFF
--- a/internal/command/import.go
+++ b/internal/command/import.go
@@ -12,8 +12,6 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
-	"github.com/zclconf/go-cty/cty"
-
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/backend"
 	"github.com/opentofu/opentofu/internal/command/arguments"
@@ -236,11 +234,10 @@ func (c *ImportCommand) Run(args []string) int {
 	newState, importDiags := lr.Core.Import(lr.Config, lr.InputState, &tofu.ImportOpts{
 		Targets: []*tofu.ImportTarget{
 			{
-				Addr: addr,
-
-				// In the import block, the ID can be an arbitrary hcl.Expression,
-				// but here it's always interpreted as a literal string.
-				ID: hcl.StaticExpr(cty.StringVal(args[1]), configs.SynthBody("import", nil).MissingItemRange()),
+				CommandLineImportTarget: &tofu.CommandLineImportTarget{
+					Addr: addr,
+					ID:   args[1],
+				},
 			},
 		},
 

--- a/internal/configs/import.go
+++ b/internal/configs/import.go
@@ -10,7 +10,9 @@ import (
 
 type Import struct {
 	ID hcl.Expression
-	To addrs.AbsResourceInstance
+	// FIXME Change the type of To
+	To    addrs.AbsResourceInstance
+	ToHCL hcl.Expression // FIXME fill in ToHCL
 
 	ProviderConfigRef *ProviderConfigRef
 	Provider          addrs.Provider
@@ -40,6 +42,7 @@ func decodeImportBlock(block *hcl.Block) (*Import, hcl.Diagnostics) {
 			diags = append(diags, toDiags.ToHCL()...)
 			imp.To = to
 		}
+		imp.ToHCL = attr.Expr
 	}
 
 	if attr, exists := content.Attributes["provider"]; exists {

--- a/internal/configs/import.go
+++ b/internal/configs/import.go
@@ -11,8 +11,6 @@ import (
 type Import struct {
 	ID hcl.Expression
 	To addrs.AbsResourceInstance
-	// TODO - Change the type for "To" once import supports more dynamic addresses
-	//ToHCL hcl.Expression
 
 	ProviderConfigRef *ProviderConfigRef
 	Provider          addrs.Provider
@@ -42,7 +40,6 @@ func decodeImportBlock(block *hcl.Block) (*Import, hcl.Diagnostics) {
 			diags = append(diags, toDiags.ToHCL()...)
 			imp.To = to
 		}
-		//imp.ToHCL = attr.Expr
 	}
 
 	if attr, exists := content.Attributes["provider"]; exists {

--- a/internal/configs/import.go
+++ b/internal/configs/import.go
@@ -10,9 +10,9 @@ import (
 
 type Import struct {
 	ID hcl.Expression
-	// FIXME Change the type of To
-	To    addrs.AbsResourceInstance
-	ToHCL hcl.Expression // FIXME fill in ToHCL
+	To addrs.AbsResourceInstance
+	// TODO - Change the type for "To" once import supports more dynamic addresses
+	//ToHCL hcl.Expression
 
 	ProviderConfigRef *ProviderConfigRef
 	Provider          addrs.Provider
@@ -42,7 +42,7 @@ func decodeImportBlock(block *hcl.Block) (*Import, hcl.Diagnostics) {
 			diags = append(diags, toDiags.ToHCL()...)
 			imp.To = to
 		}
-		imp.ToHCL = attr.Expr
+		//imp.ToHCL = attr.Expr
 	}
 
 	if attr, exists := content.Attributes["provider"]; exists {

--- a/internal/tofu/context_import.go
+++ b/internal/tofu/context_import.go
@@ -62,6 +62,14 @@ func (i *ImportTarget) StaticAddr() addrs.ConfigResource {
 	return i.Config.To.ConfigResource()
 }
 
+// ResolvedImports is a struct that maintains a map of all imports as they are being resolved
+// Import targets' addresses are not fully known from the get-go, and could only be resolved later when walking
+// the graph. This struct helps keep track of the resolved imports, for tracking
+// (mostly for validation that all imports have been addressed and point to an actual configuration)
+type ResolvedImports struct {
+	imports map[ResolvedConfigImportTarget]bool
+}
+
 // Import takes already-created external resources and brings them
 // under OpenTofu management. Import requires the exact type, name, and ID
 // of the resources to import.

--- a/internal/tofu/context_import.go
+++ b/internal/tofu/context_import.go
@@ -50,6 +50,18 @@ type ImportTarget struct {
 	*CommandLineImportTarget
 }
 
+// IsFromImportBlock checks whether the import target originates from an `import` block
+// Currently, it should yield the opposite result of IsFromImportCommandLine, as those two are mutually-exclusive
+func (i *ImportTarget) IsFromImportBlock() bool {
+	return i.Config != nil
+}
+
+// IsFromImportCommandLine checks whether the import target originates from a `tofu import` command
+// Currently, it should yield the opposite result of IsFromImportBlock, as those two are mutually-exclusive
+func (i *ImportTarget) IsFromImportCommandLine() bool {
+	return i.CommandLineImportTarget != nil
+}
+
 // StaticAddr returns the static address part of an import target
 // For an ImportTarget originating from the command line, the address is already known
 // However for an ImportTarget originating from an import block, the full address might not be known initially,

--- a/internal/tofu/context_import.go
+++ b/internal/tofu/context_import.go
@@ -75,14 +75,6 @@ func (i *ImportTarget) ResolvedAddr() (address addrs.AbsResourceInstance, evalua
 	} else {
 		// TODO change this later, when Config.To is not a static address
 		address = i.Config.To
-
-		//traversal, traversalDiags := hcl.AbsTraversalForExpr(i.Config.ToHCL)
-		//evaluationDiags = append(evaluationDiags, traversalDiags...)
-		//if !traversalDiags.HasErrors() {
-		//	var toDiags tfdiags.Diagnostics
-		//	address, toDiags = addrs.ParseAbsResourceInstance(traversal)
-		//	evaluationDiags = append(evaluationDiags, toDiags.ToHCL()...)
-		//}
 	}
 	return
 }

--- a/internal/tofu/context_import.go
+++ b/internal/tofu/context_import.go
@@ -4,8 +4,9 @@
 package tofu
 
 import (
-	"github.com/hashicorp/hcl/v2"
 	"log"
+
+	"github.com/hashicorp/hcl/v2"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"

--- a/internal/tofu/context_import_test.go
+++ b/internal/tofu/context_import_test.go
@@ -11,10 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/hcltest"
 	"github.com/opentofu/opentofu/internal/addrs"
-	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/states"
@@ -40,14 +37,15 @@ func TestContextImport_basic(t *testing.T) {
 		},
 	}
 
-	barExpr := hcl.StaticExpr(cty.StringVal("bar"), configs.SynthBody("import", nil).MissingItemRange())
 	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
-				Addr: addrs.RootModuleInstance.ResourceInstance(
-					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
-				),
-				ID: barExpr,
+				CommandLineImportTarget: &CommandLineImportTarget{
+					Addr: addrs.RootModuleInstance.ResourceInstance(
+						addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
+					),
+					ID: "bar",
+				},
 			},
 		},
 	})
@@ -92,14 +90,15 @@ resource "aws_instance" "foo" {
 		},
 	}
 
-	barExpr := hcl.StaticExpr(cty.StringVal("bar"), configs.SynthBody("import", nil).MissingItemRange())
 	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
-				Addr: addrs.RootModuleInstance.ResourceInstance(
-					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.IntKey(0),
-				),
-				ID: barExpr,
+				CommandLineImportTarget: &CommandLineImportTarget{
+					Addr: addrs.RootModuleInstance.ResourceInstance(
+						addrs.ManagedResourceMode, "aws_instance", "foo", addrs.IntKey(0),
+					),
+					ID: "bar",
+				},
 			},
 		},
 	})
@@ -154,14 +153,15 @@ func TestContextImport_collision(t *testing.T) {
 		},
 	}
 
-	barExpr := hcl.StaticExpr(cty.StringVal("bar"), configs.SynthBody("import", nil).MissingItemRange())
 	state, diags := ctx.Import(m, state, &ImportOpts{
 		Targets: []*ImportTarget{
 			{
-				Addr: addrs.RootModuleInstance.ResourceInstance(
-					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
-				),
-				ID: barExpr,
+				CommandLineImportTarget: &CommandLineImportTarget{
+					Addr: addrs.RootModuleInstance.ResourceInstance(
+						addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
+					),
+					ID: "bar",
+				},
 			},
 		},
 	})
@@ -199,14 +199,15 @@ func TestContextImport_missingType(t *testing.T) {
 		},
 	})
 
-	barExpr := hcl.StaticExpr(cty.StringVal("bar"), configs.SynthBody("import", nil).MissingItemRange())
 	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
-				Addr: addrs.RootModuleInstance.ResourceInstance(
-					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
-				),
-				ID: barExpr,
+				CommandLineImportTarget: &CommandLineImportTarget{
+					Addr: addrs.RootModuleInstance.ResourceInstance(
+						addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
+					),
+					ID: "bar",
+				},
 			},
 		},
 	})
@@ -251,14 +252,15 @@ func TestContextImport_moduleProvider(t *testing.T) {
 		},
 	})
 
-	barExpr := hcl.StaticExpr(cty.StringVal("bar"), configs.SynthBody("import", nil).MissingItemRange())
 	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
-				Addr: addrs.RootModuleInstance.ResourceInstance(
-					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
-				),
-				ID: barExpr,
+				CommandLineImportTarget: &CommandLineImportTarget{
+					Addr: addrs.RootModuleInstance.ResourceInstance(
+						addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
+					),
+					ID: "bar",
+				},
 			},
 		},
 	})
@@ -307,14 +309,15 @@ func TestContextImport_providerModule(t *testing.T) {
 		return
 	}
 
-	barExpr := hcl.StaticExpr(cty.StringVal("bar"), configs.SynthBody("import", nil).MissingItemRange())
 	_, diags := ctx.Import(m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
-				Addr: addrs.RootModuleInstance.Child("child", addrs.NoKey).ResourceInstance(
-					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
-				),
-				ID: barExpr,
+				CommandLineImportTarget: &CommandLineImportTarget{
+					Addr: addrs.RootModuleInstance.Child("child", addrs.NoKey).ResourceInstance(
+						addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
+					),
+					ID: "bar",
+				},
 			},
 		},
 	})
@@ -364,14 +367,15 @@ func TestContextImport_providerConfig(t *testing.T) {
 				},
 			}
 
-			barExpr := hcl.StaticExpr(cty.StringVal("bar"), configs.SynthBody("import", nil).MissingItemRange())
 			state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
 				Targets: []*ImportTarget{
 					{
-						Addr: addrs.RootModuleInstance.ResourceInstance(
-							addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
-						),
-						ID: barExpr,
+						CommandLineImportTarget: &CommandLineImportTarget{
+							Addr: addrs.RootModuleInstance.ResourceInstance(
+								addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
+							),
+							ID: "bar",
+						},
 					},
 				},
 				SetVariables: InputValues{
@@ -425,14 +429,15 @@ func TestContextImport_providerConfigResources(t *testing.T) {
 		},
 	}
 
-	barExpr := hcl.StaticExpr(cty.StringVal("bar"), configs.SynthBody("import", nil).MissingItemRange())
 	_, diags := ctx.Import(m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
-				Addr: addrs.RootModuleInstance.ResourceInstance(
-					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
-				),
-				ID: barExpr,
+				CommandLineImportTarget: &CommandLineImportTarget{
+					Addr: addrs.RootModuleInstance.ResourceInstance(
+						addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
+					),
+					ID: "bar",
+				},
 			},
 		},
 	})
@@ -497,14 +502,15 @@ data "aws_data_source" "bar" {
 		}),
 	}
 
-	barExpr := hcl.StaticExpr(cty.StringVal("bar"), configs.SynthBody("import", nil).MissingItemRange())
 	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
-				Addr: addrs.RootModuleInstance.ResourceInstance(
-					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
-				),
-				ID: barExpr,
+				CommandLineImportTarget: &CommandLineImportTarget{
+					Addr: addrs.RootModuleInstance.ResourceInstance(
+						addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
+					),
+					ID: "bar",
+				},
 			},
 		},
 	})
@@ -549,14 +555,15 @@ func TestContextImport_refreshNil(t *testing.T) {
 		}
 	}
 
-	barExpr := hcl.StaticExpr(cty.StringVal("bar"), configs.SynthBody("import", nil).MissingItemRange())
 	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
-				Addr: addrs.RootModuleInstance.ResourceInstance(
-					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
-				),
-				ID: barExpr,
+				CommandLineImportTarget: &CommandLineImportTarget{
+					Addr: addrs.RootModuleInstance.ResourceInstance(
+						addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
+					),
+					ID: "bar",
+				},
 			},
 		},
 	})
@@ -591,14 +598,15 @@ func TestContextImport_module(t *testing.T) {
 		},
 	}
 
-	barExpr := hcl.StaticExpr(cty.StringVal("bar"), configs.SynthBody("import", nil).MissingItemRange())
 	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
-				Addr: addrs.RootModuleInstance.Child("child", addrs.IntKey(0)).ResourceInstance(
-					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
-				),
-				ID: barExpr,
+				CommandLineImportTarget: &CommandLineImportTarget{
+					Addr: addrs.RootModuleInstance.Child("child", addrs.IntKey(0)).ResourceInstance(
+						addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
+					),
+					ID: "bar",
+				},
 			},
 		},
 	})
@@ -633,14 +641,15 @@ func TestContextImport_moduleDepth2(t *testing.T) {
 		},
 	}
 
-	bazExpr := hcl.StaticExpr(cty.StringVal("baz"), configs.SynthBody("import", nil).MissingItemRange())
 	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
-				Addr: addrs.RootModuleInstance.Child("child", addrs.IntKey(0)).Child("nested", addrs.NoKey).ResourceInstance(
-					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
-				),
-				ID: bazExpr,
+				CommandLineImportTarget: &CommandLineImportTarget{
+					Addr: addrs.RootModuleInstance.Child("child", addrs.IntKey(0)).Child("nested", addrs.NoKey).ResourceInstance(
+						addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
+					),
+					ID: "baz",
+				},
 			},
 		},
 	})
@@ -675,14 +684,15 @@ func TestContextImport_moduleDiff(t *testing.T) {
 		},
 	}
 
-	bazExpr := hcl.StaticExpr(cty.StringVal("baz"), configs.SynthBody("import", nil).MissingItemRange())
 	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
-				Addr: addrs.RootModuleInstance.Child("child", addrs.IntKey(0)).ResourceInstance(
-					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
-				),
-				ID: bazExpr,
+				CommandLineImportTarget: &CommandLineImportTarget{
+					Addr: addrs.RootModuleInstance.Child("child", addrs.IntKey(0)).ResourceInstance(
+						addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
+					),
+					ID: "baz",
+				},
 			},
 		},
 	})
@@ -744,14 +754,15 @@ func TestContextImport_multiState(t *testing.T) {
 		},
 	})
 
-	barExpr := hcl.StaticExpr(cty.StringVal("bar"), configs.SynthBody("import", nil).MissingItemRange())
 	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
-				Addr: addrs.RootModuleInstance.ResourceInstance(
-					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
-				),
-				ID: barExpr,
+				CommandLineImportTarget: &CommandLineImportTarget{
+					Addr: addrs.RootModuleInstance.ResourceInstance(
+						addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
+					),
+					ID: "bar",
+				},
 			},
 		},
 	})
@@ -819,14 +830,15 @@ func TestContextImport_multiStateSame(t *testing.T) {
 		},
 	})
 
-	barExpr := hcl.StaticExpr(cty.StringVal("bar"), configs.SynthBody("import", nil).MissingItemRange())
 	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
-				Addr: addrs.RootModuleInstance.ResourceInstance(
-					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
-				),
-				ID: barExpr,
+				CommandLineImportTarget: &CommandLineImportTarget{
+					Addr: addrs.RootModuleInstance.ResourceInstance(
+						addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
+					),
+					ID: "bar",
+				},
 			},
 		},
 	})
@@ -914,14 +926,15 @@ resource "test_resource" "unused" {
 		},
 	})
 
-	testExpr := hcl.StaticExpr(cty.StringVal("test"), configs.SynthBody("import", nil).MissingItemRange())
 	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
-				Addr: addrs.RootModuleInstance.ResourceInstance(
-					addrs.ManagedResourceMode, "test_resource", "test", addrs.NoKey,
-				),
-				ID: testExpr,
+				CommandLineImportTarget: &CommandLineImportTarget{
+					Addr: addrs.RootModuleInstance.ResourceInstance(
+						addrs.ManagedResourceMode, "test_resource", "test", addrs.NoKey,
+					),
+					ID: "test",
+				},
 			},
 		},
 	})
@@ -985,14 +998,15 @@ resource "test_resource" "test" {
 		},
 	})
 
-	testExpr := hcl.StaticExpr(cty.StringVal("test"), configs.SynthBody("import", nil).MissingItemRange())
 	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
-				Addr: addrs.RootModuleInstance.ResourceInstance(
-					addrs.ManagedResourceMode, "test_resource", "test", addrs.NoKey,
-				),
-				ID: testExpr,
+				CommandLineImportTarget: &CommandLineImportTarget{
+					Addr: addrs.RootModuleInstance.ResourceInstance(
+						addrs.ManagedResourceMode, "test_resource", "test", addrs.NoKey,
+					),
+					ID: "test",
+				},
 			},
 		},
 	})
@@ -1013,7 +1027,6 @@ resource "test_resource" "test" {
 func TestContextImport_33572(t *testing.T) {
 	p := testProvider("aws")
 	m := testModule(t, "issue-33572")
-	bar_expr := hcltest.MockExprLiteral(cty.StringVal("bar"))
 
 	ctx := testContext2(t, &ContextOpts{
 		Providers: map[addrs.Provider]providers.Factory{
@@ -1035,10 +1048,12 @@ func TestContextImport_33572(t *testing.T) {
 	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
-				Addr: addrs.RootModuleInstance.ResourceInstance(
-					addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
-				),
-				ID: bar_expr,
+				CommandLineImportTarget: &CommandLineImportTarget{
+					Addr: addrs.RootModuleInstance.ResourceInstance(
+						addrs.ManagedResourceMode, "aws_instance", "foo", addrs.NoKey,
+					),
+					ID: "bar",
+				},
 			},
 		},
 	})

--- a/internal/tofu/context_plan.go
+++ b/internal/tofu/context_plan.go
@@ -540,18 +540,8 @@ func (c *Context) postPlanValidateImports(resolvedImports *ResolvedImports, allI
 			return addrParseDiags
 		}
 
-		// TODO - validate behaviour with generateConfig
-
-		// TODO make this error not Sourceless
 		if !allInst.HasResourceInstance(address) {
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Cannot import to non-existent resource address", // TODO - align the error message with terraform?
-				fmt.Sprintf(
-					"Importing to resource address %s is not possible, because that address does not exist in configuration. Please ensure that the resource key is correct, or remove this import block.",
-					address,
-				),
-			))
+			diags = diags.Append(importResourceWithoutConfigDiags(address, nil))
 		}
 	}
 	return diags

--- a/internal/tofu/context_plan.go
+++ b/internal/tofu/context_plan.go
@@ -527,26 +527,29 @@ func (c *Context) postPlanValidateMoves(config *configs.Config, stmts []refactor
 // When we are able to generate config for expanded resources, this rule can be
 // relaxed.
 func (c *Context) postPlanValidateImports(config *configs.Config, importTargets []*ImportTarget, allInst instances.Set) tfdiags.Diagnostics {
+	// FIXME - Fix this post plan validation that imports have all been satisfied by a resource
+	//   From now on import targets can represent multiple response instances, so we'd need a way to figure out what
+	//   those instances were
 	var diags tfdiags.Diagnostics
-	for _, it := range importTargets {
-		// We only care about import target addresses that have a key.
-		// If the address does not have a key, we don't need it to be in config
-		// because are able to generate config.
-		if it.Addr.Resource.Key == nil {
-			continue
-		}
-
-		if !allInst.HasResourceInstance(it.Addr) {
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Cannot import to non-existent resource address",
-				fmt.Sprintf(
-					"Importing to resource address %s is not possible, because that address does not exist in configuration. Please ensure that the resource key is correct, or remove this import block.",
-					it.Addr,
-				),
-			))
-		}
-	}
+	//for _, it := range importTargets {
+	//	// We only care about import target addresses that have a key.
+	//	// If the address does not have a key, we don't need it to be in config
+	//	// because are able to generate config.
+	//	if it.Addr.Resource.Key == nil {
+	//		continue
+	//	}
+	//
+	//	if !allInst.HasResourceInstance(it.Addr) {
+	//		diags = diags.Append(tfdiags.Sourceless(
+	//			tfdiags.Error,
+	//			"Cannot import to non-existent resource address",
+	//			fmt.Sprintf(
+	//				"Importing to resource address %s is not possible, because that address does not exist in configuration. Please ensure that the resource key is correct, or remove this import block.",
+	//				it.Addr,
+	//			),
+	//		))
+	//	}
+	//}
 	return diags
 }
 
@@ -557,8 +560,6 @@ func (c *Context) findImportTargets(config *configs.Config, priorState *states.S
 	for _, ic := range config.Module.Import {
 		if priorState.ResourceInstance(ic.To) == nil {
 			importTargets = append(importTargets, &ImportTarget{
-				Addr:   ic.To,
-				ID:     ic.ID,
 				Config: ic,
 			})
 		}

--- a/internal/tofu/context_plan.go
+++ b/internal/tofu/context_plan.go
@@ -570,7 +570,7 @@ func (c *Context) validateImportTargets(config *configs.Config, importTargets []
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Cannot import to non-existent resource address",
-				Detail:   fmt.Sprintf("Importing to resource address %s is not possible, because that address does not exist in configuration. Please ensure that the resource key is correct, or remove this import block.", staticAddress),
+				Detail:   fmt.Sprintf("Importing to resource address '%s' is not possible, because that address does not exist in configuration. Please ensure that the resource key is correct, or remove this import block.", staticAddress),
 				Subject:  imp.Config.DeclRange.Ptr(),
 			})
 			return

--- a/internal/tofu/context_plan.go
+++ b/internal/tofu/context_plan.go
@@ -6,11 +6,12 @@ package tofu
 import (
 	"bytes"
 	"fmt"
-	"github.com/hashicorp/hcl/v2"
 	"log"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/hcl/v2"
 
 	"github.com/zclconf/go-cty/cty"
 

--- a/internal/tofu/context_plan.go
+++ b/internal/tofu/context_plan.go
@@ -550,7 +550,7 @@ func (c *Context) postPlanValidateImports(resolvedImports *ResolvedImports, allI
 		if !allInst.HasResourceInstance(address) {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
-				"Cannot import to non-existent resource address",
+				"Cannot import to non-existent resource address", // TODO - align the error message with terraform?
 				fmt.Sprintf(
 					"Importing to resource address %s is not possible, because that address does not exist in configuration. Please ensure that the resource key is correct, or remove this import block.",
 					address,

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -4555,49 +4555,6 @@ import {
 	}
 }
 
-func TestContext2Plan_importTargetWithKeyDoesNotExist(t *testing.T) {
-	m := testModuleInline(t, map[string]string{
-		"main.tf": `
-resource "test_object" "a" {
-  count = 1
-  test_string = "bar"
-}
-
-import {
-  to   = test_object.a[42]
-  id   = "123"
-}
-`,
-	})
-
-	p := simpleMockProvider()
-	ctx := testContext2(t, &ContextOpts{
-		Providers: map[addrs.Provider]providers.Factory{
-			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
-		},
-	})
-	p.ReadResourceResponse = &providers.ReadResourceResponse{
-		NewState: cty.ObjectVal(map[string]cty.Value{
-			"test_string": cty.StringVal("foo"),
-		}),
-	}
-	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
-		ImportedResources: []providers.ImportedResource{
-			{
-				TypeName: "test_object",
-				State: cty.ObjectVal(map[string]cty.Value{
-					"test_string": cty.StringVal("foo"),
-				}),
-			},
-		},
-	}
-
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
-	if !diags.HasErrors() {
-		t.Fatalf("expected error but got none")
-	}
-}
-
 func TestContext2Plan_importIdVariable(t *testing.T) {
 	p := testProvider("aws")
 	m := testModule(t, "import-id-variable")
@@ -4946,6 +4903,157 @@ resource "test_object" "a" {
 	}
 }
 
+func TestContext2Plan_importIntoNonExistentModule(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+import {
+  to = module.mod.test_object.a
+  id = "456"
+}
+
+`,
+	})
+	p := simpleMockProvider()
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+	_, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		Mode: plans.NormalMode,
+	})
+	if !diags.HasErrors() {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(diags.Err().Error(), "Cannot import to non-existent resource address") {
+		t.Fatalf("expected error to be \"Cannot import to non-existent resource address\", but it was %s", diags.Err().Error())
+	}
+}
+
+func TestContext2Plan_importIntoNonExistentConfiguration(t *testing.T) {
+	type TestConfiguration struct {
+		Description         string
+		inlineConfiguration map[string]string
+	}
+	configurations := []TestConfiguration{
+		{
+			Description: "Basic missing configuration",
+			inlineConfiguration: map[string]string{
+				"main.tf": `
+import {
+  to   = test_object.a
+  id   = "123"
+}
+`,
+			},
+		},
+		{
+			Description: "Wrong module key",
+			inlineConfiguration: map[string]string{
+				"main.tf": `
+import {
+  to   = module.mod["non-existent"].test_object.a
+  id   = "123"
+}
+
+module "mod" {
+  for_each = {
+    existent = "1"
+  }
+  source = "./mod"
+}
+`,
+				"./mod/main.tf": `
+resource "test_object" "a" {
+  test_string = "bar"
+}
+`,
+			},
+		},
+		{
+			Description: "Module key without for_each",
+			inlineConfiguration: map[string]string{
+				"main.tf": `
+import {
+  to   = module.mod["non-existent"].test_object.a
+  id   = "123"
+}
+
+module "mod" {
+  source = "./mod"
+}
+`,
+				"./mod/main.tf": `
+resource "test_object" "a" {
+  test_string = "bar"
+}
+`,
+			},
+		},
+		{
+			Description: "Non-existent resource key - in module",
+			inlineConfiguration: map[string]string{
+				"main.tf": `
+import {
+  to   = module.mod.test_object.a["non-existent"]
+  id   = "123"
+}
+
+module "mod" {
+  source = "./mod"
+}
+`,
+				"./mod/main.tf": `
+resource "test_object" "a" {
+  for_each = {
+    existent = "1"
+  }
+  test_string = "bar"
+}
+`,
+			},
+		},
+		{
+			Description: "Non-existent resource key - in root",
+			inlineConfiguration: map[string]string{
+				"main.tf": `
+import {
+  to   = test_object.a[42]
+  id   = "123"
+}
+
+resource "test_object" "a" {
+  test_string = "bar"
+}
+`,
+			},
+		},
+	}
+
+	for _, configuration := range configurations {
+		t.Run(configuration.Description, func(t *testing.T) {
+			m := testModuleInline(t, configuration.inlineConfiguration)
+
+			p := simpleMockProvider()
+			ctx := testContext2(t, &ContextOpts{
+				Providers: map[addrs.Provider]providers.Factory{
+					addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+				},
+			})
+
+			_, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+				Mode: plans.NormalMode,
+			})
+			if !diags.HasErrors() {
+				t.Fatalf("expected error")
+			}
+			if !strings.Contains(diags.Err().Error(), "Configuration for import target does not exist") {
+				t.Fatalf("expected error to be \"Configuration for import target does not exist\", but it was %s", diags.Err().Error())
+			}
+		})
+	}
+}
+
 func TestContext2Plan_importResourceConfigGen(t *testing.T) {
 	addr := mustResourceInstanceAddr("test_object.a")
 	m := testModuleInline(t, map[string]string{
@@ -5144,6 +5252,9 @@ import {
 	})
 	if !diags.HasErrors() {
 		t.Fatalf("expected plan to error, but it did not")
+	}
+	if !strings.Contains(diags.Err().Error(), "Config generation for count and for_each resources not supported") {
+		t.Fatalf("expected error to be \"Config generation for count and for_each resources not supported\", but it is %s", diags.Err().Error())
 	}
 }
 

--- a/internal/tofu/context_walk.go
+++ b/internal/tofu/context_walk.go
@@ -147,6 +147,7 @@ func (c *Context) graphWalker(operation walkOperation, opts *graphWalkOpts) *Con
 		Checks:           checkState,
 		InstanceExpander: instances.NewExpander(),
 		MoveResults:      opts.MoveResults,
+		ResolvedImports:  &ResolvedImports{imports: make(map[ResolvedConfigImportTarget]bool)},
 		Operation:        operation,
 		StopContext:      c.runContext,
 		PlanTimestamp:    opts.PlanTimeTimestamp,

--- a/internal/tofu/context_walk.go
+++ b/internal/tofu/context_walk.go
@@ -147,7 +147,7 @@ func (c *Context) graphWalker(operation walkOperation, opts *graphWalkOpts) *Con
 		Checks:           checkState,
 		InstanceExpander: instances.NewExpander(),
 		MoveResults:      opts.MoveResults,
-		ResolvedImports:  &ResolvedImports{imports: make(map[ResolvedConfigImportTarget]bool)},
+		ResolvedImports:  &ResolvedImports{imports: make(map[ResolvedConfigImportsKey]bool)},
 		Operation:        operation,
 		StopContext:      c.runContext,
 		PlanTimestamp:    opts.PlanTimeTimestamp,

--- a/internal/tofu/eval_context.go
+++ b/internal/tofu/eval_context.go
@@ -201,6 +201,14 @@ type EvalContext interface {
 	// objects accessible through it.
 	MoveResults() refactoring.MoveResults
 
+	// ResolvedImports returns a map describing the resolved imports
+	// after evaluating the dynamic address of the import targets
+	//
+	// This data is created during the graph walk, as import target addresses are being resolved
+	// Its primary use is for validation at the end of a plan - To make sure all imports have been satisfied
+	// and have a configuration
+	ResolvedImports() *ResolvedImports
+
 	// WithPath returns a copy of the context with the internal path set to the
 	// path argument.
 	WithPath(path addrs.ModuleInstance) EvalContext

--- a/internal/tofu/eval_context_builtin.go
+++ b/internal/tofu/eval_context_builtin.go
@@ -73,6 +73,7 @@ type BuiltinEvalContext struct {
 	PrevRunStateValue     *states.SyncState
 	InstanceExpanderValue *instances.Expander
 	MoveResultsValue      refactoring.MoveResults
+	ResolvedImportsValue  *ResolvedImports
 }
 
 // BuiltinEvalContext implements EvalContext
@@ -507,4 +508,8 @@ func (ctx *BuiltinEvalContext) InstanceExpander() *instances.Expander {
 
 func (ctx *BuiltinEvalContext) MoveResults() refactoring.MoveResults {
 	return ctx.MoveResultsValue
+}
+
+func (ctx *BuiltinEvalContext) ResolvedImports() *ResolvedImports {
+	return ctx.ResolvedImportsValue
 }

--- a/internal/tofu/eval_context_mock.go
+++ b/internal/tofu/eval_context_mock.go
@@ -149,6 +149,9 @@ type MockEvalContext struct {
 	MoveResultsCalled  bool
 	MoveResultsResults refactoring.MoveResults
 
+	ResolvedImportsCalled  bool
+	ResolvedImportsResults *ResolvedImports
+
 	InstanceExpanderCalled   bool
 	InstanceExpanderExpander *instances.Expander
 }
@@ -396,6 +399,11 @@ func (c *MockEvalContext) PrevRunState() *states.SyncState {
 func (c *MockEvalContext) MoveResults() refactoring.MoveResults {
 	c.MoveResultsCalled = true
 	return c.MoveResultsResults
+}
+
+func (c *MockEvalContext) ResolvedImports() *ResolvedImports {
+	c.ResolvedImportsCalled = true
+	return c.ResolvedImportsResults
 }
 
 func (c *MockEvalContext) InstanceExpander() *instances.Expander {

--- a/internal/tofu/graph_builder_plan.go
+++ b/internal/tofu/graph_builder_plan.go
@@ -331,13 +331,6 @@ func (b *PlanGraphBuilder) initImport() {
 			// as the new state, and users are not expecting the import process
 			// to update any other instances in state.
 			skipRefresh: true,
-
-			// If we get here, we know that we are in legacy import mode, and
-			// that the user has run the import command rather than plan.
-			// This flag must be propagated down to the
-			// NodePlannableResourceInstance so we can ignore the new import
-			// behaviour.
-			legacyImportMode: true,
 		}
 	}
 }

--- a/internal/tofu/graph_walk_context.go
+++ b/internal/tofu/graph_walk_context.go
@@ -30,13 +30,13 @@ type ContextGraphWalker struct {
 
 	// Configurable values
 	Context            *Context
-	State              *states.SyncState   // Used for safe concurrent access to state
-	RefreshState       *states.SyncState   // Used for safe concurrent access to state
-	PrevRunState       *states.SyncState   // Used for safe concurrent access to state
-	Changes            *plans.ChangesSync  // Used for safe concurrent writes to changes
-	Checks             *checks.State       // Used for safe concurrent writes of checkable objects and their check results
-	InstanceExpander   *instances.Expander // Tracks our gradual expansion of module and resource instances
-	Imports            []configs.Import
+	State              *states.SyncState       // Used for safe concurrent access to state
+	RefreshState       *states.SyncState       // Used for safe concurrent access to state
+	PrevRunState       *states.SyncState       // Used for safe concurrent access to state
+	Changes            *plans.ChangesSync      // Used for safe concurrent writes to changes
+	Checks             *checks.State           // Used for safe concurrent writes of checkable objects and their check results
+	InstanceExpander   *instances.Expander     // Tracks our gradual expansion of module and resource instances
+	ResolvedImports    *ResolvedImports        // Tracks import targets as they are being resolved
 	MoveResults        refactoring.MoveResults // Read-only record of earlier processing of move statements
 	Operation          walkOperation
 	StopContext        context.Context
@@ -101,6 +101,7 @@ func (w *ContextGraphWalker) EvalContext() EvalContext {
 		InstanceExpanderValue: w.InstanceExpander,
 		Plugins:               w.Context.plugins,
 		MoveResultsValue:      w.MoveResults,
+		ResolvedImportsValue:  w.ResolvedImports,
 		ProviderCache:         w.providerCache,
 		ProviderInputConfig:   w.Context.providerInputConfig,
 		ProviderLock:          &w.providerLock,

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -217,7 +217,7 @@ func (n *NodeAbstractResource) RootReferences() []*addrs.Reference {
 		if importTarget.Config == nil {
 			continue
 		}
-		
+
 		refs, _ := lang.ReferencesInExpr(addrs.ParseRef, importTarget.Config.ID)
 		root = append(root, refs...)
 	}

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -213,7 +213,12 @@ func (n *NodeAbstractResource) RootReferences() []*addrs.Reference {
 	var root []*addrs.Reference
 
 	for _, importTarget := range n.importTargets {
-		refs, _ := lang.ReferencesInExpr(addrs.ParseRef, importTarget.ID)
+		// References are only possible in import targets originating from an import block
+		if importTarget.Config == nil {
+			continue
+		}
+		
+		refs, _ := lang.ReferencesInExpr(addrs.ParseRef, importTarget.Config.ID)
 		root = append(root, refs...)
 	}
 

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -214,7 +214,7 @@ func (n *NodeAbstractResource) RootReferences() []*addrs.Reference {
 
 	for _, importTarget := range n.importTargets {
 		// References are only possible in import targets originating from an import block
-		if importTarget.Config == nil {
+		if importTarget.IsFromImportBlock() {
 			continue
 		}
 

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -214,7 +214,7 @@ func (n *NodeAbstractResource) RootReferences() []*addrs.Reference {
 
 	for _, importTarget := range n.importTargets {
 		// References are only possible in import targets originating from an import block
-		if importTarget.IsFromImportBlock() {
+		if !importTarget.IsFromImportBlock() {
 			continue
 		}
 

--- a/internal/tofu/node_resource_plan.go
+++ b/internal/tofu/node_resource_plan.go
@@ -299,11 +299,6 @@ func (n *nodeExpandPlannableResource) expandResourceInstances(globalCtx EvalCont
 func (n *nodeExpandPlannableResource) resourceInstanceSubgraph(ctx EvalContext, addr addrs.AbsResource, instanceAddrs []addrs.AbsResourceInstance) (*Graph, error) {
 	var diags tfdiags.Diagnostics
 
-	// Our graph transformers require access to the full state, so we'll
-	// temporarily lock it while we work on this.
-	state := ctx.State().Lock()
-	defer ctx.State().Unlock()
-
 	var commandLineImportTargets []CommandLineImportTarget
 	var evaluatedConfigImportTargets []EvaluatedConfigImportTarget
 	// FIXME - Deal with cases of duplicate addresses
@@ -330,6 +325,11 @@ func (n *nodeExpandPlannableResource) resourceInstanceSubgraph(ctx EvalContext, 
 
 		}
 	}
+
+	// Our graph transformers require access to the full state, so we'll
+	// temporarily lock it while we work on this.
+	state := ctx.State().Lock()
+	defer ctx.State().Unlock()
 
 	// The concrete resource factory we'll use
 	concreteResource := func(a *NodeAbstractResourceInstance) dag.Vertex {

--- a/internal/tofu/node_resource_plan.go
+++ b/internal/tofu/node_resource_plan.go
@@ -305,7 +305,7 @@ func (n *nodeExpandPlannableResource) resourceInstanceSubgraph(ctx EvalContext, 
 	// FIXME - Deal with cases of duplicate addresses
 
 	for _, importTarget := range n.importTargets {
-		if importTarget.CommandLineImportTarget != nil {
+		if importTarget.IsFromImportCommandLine() {
 			commandLineImportTargets = append(commandLineImportTargets, *importTarget.CommandLineImportTarget)
 		} else {
 			importId, evalDiags := evaluateImportIdExpression(importTarget.Config.ID, ctx)

--- a/internal/tofu/node_resource_plan.go
+++ b/internal/tofu/node_resource_plan.go
@@ -336,7 +336,7 @@ func (n *nodeExpandPlannableResource) resourceInstanceSubgraph(ctx EvalContext, 
 	concreteResource := func(a *NodeAbstractResourceInstance) dag.Vertex {
 		var m *NodePlannableResourceInstance
 
-		// If we're in legacy import mode (the import CLI command), we only need
+		// If we're in the `tofu import` CLI command, we only need
 		// to return the import node, not a plannable resource node.
 		for _, c := range commandLineImportTargets {
 			if c.Addr.Equal(a.Addr) {

--- a/internal/tofu/node_resource_plan.go
+++ b/internal/tofu/node_resource_plan.go
@@ -5,11 +5,12 @@ package tofu
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/dag"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
-	"strings"
 )
 
 // nodeExpandPlannableResource represents an addrs.ConfigResource and implements

--- a/internal/tofu/node_resource_plan.go
+++ b/internal/tofu/node_resource_plan.go
@@ -309,7 +309,6 @@ func (n *nodeExpandPlannableResource) resourceInstanceSubgraph(ctx EvalContext, 
 	// FIXME - Deal with cases of duplicate addresses
 
 	for _, importTarget := range n.importTargets {
-		// TODO maybe make behaviour with resolved here align with command line imports?
 		if importTarget.CommandLineImportTarget != nil {
 			commandLineImportTargets = append(commandLineImportTargets, *importTarget.CommandLineImportTarget)
 		} else {
@@ -324,7 +323,7 @@ func (n *nodeExpandPlannableResource) resourceInstanceSubgraph(ctx EvalContext, 
 			})
 
 			resolvedImports := ctx.ResolvedImports().imports
-			resolvedImports[ResolvedConfigImportTarget{
+			resolvedImports[ResolvedConfigImportsKey{
 				AddrStr: importTarget.Config.To.String(),
 				ID:      importId,
 			}] = true

--- a/internal/tofu/node_resource_plan_instance.go
+++ b/internal/tofu/node_resource_plan_instance.go
@@ -61,23 +61,6 @@ type EvaluatedConfigImportTarget struct {
 	// if the import did not originate in config.
 	Config *configs.Import
 
-	// Addr is the address for the resource instance that the new object should
-	// be imported into.
-	Addr addrs.AbsResourceInstance // FIXME validate no duplicates?
-
-	// ID is the string ID of the resource to import. This is resource-instance specific.
-	ID string
-}
-
-// FIXME comments
-// ResolvedConfigImportTarget is a target that we need to import. It's created when an import target originated from
-// an import block, after everything regarding the configuration has been evaluated.
-// At this point, the import target is of a single resource instance
-type ResolvedConfigImportTarget struct {
-	// Addr is the address for the resource instance that the new object should
-	// be imported into.
-	AddrStr string // FIXME validate no duplicates?
-
 	// ID is the string ID of the resource to import. This is resource-instance specific.
 	ID string
 }

--- a/internal/tofu/node_resource_plan_instance.go
+++ b/internal/tofu/node_resource_plan_instance.go
@@ -186,6 +186,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 			// You can't generate config for a resource that is inside a
 			// module, so we will present a different error message for
 			// this case.
+			// TODO - This validation might not technically be necessary anymore, as we check for this in transform_config.go
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Import block target does not exist",

--- a/internal/tofu/node_resource_plan_instance.go
+++ b/internal/tofu/node_resource_plan_instance.go
@@ -187,6 +187,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 			// module, so we will present a different error message for
 			// this case.
 			// TODO - This validation might not technically be necessary anymore, as we check for this in transform_config.go
+			// TODO - Align this with terraform
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Import block target does not exist",

--- a/internal/tofu/node_resource_plan_instance.go
+++ b/internal/tofu/node_resource_plan_instance.go
@@ -186,14 +186,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 			// You can't generate config for a resource that is inside a
 			// module, so we will present a different error message for
 			// this case.
-			// TODO - This validation might not technically be necessary anymore, as we check for this in transform_config.go
-			// TODO - Align this with terraform
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Import block target does not exist",
-				Detail:   "The target for the given import block does not exist. The specified target is within a module, and must be defined as a resource within that module before anything can be imported.",
-				Subject:  n.importTarget.Config.DeclRange.Ptr(),
-			})
+			diags = diags.Append(importResourceWithoutConfigDiags(n.Addr, n.importTarget.Config))
 		}
 		return diags
 	}

--- a/internal/tofu/node_resource_plan_instance.go
+++ b/internal/tofu/node_resource_plan_instance.go
@@ -61,6 +61,23 @@ type EvaluatedConfigImportTarget struct {
 	// if the import did not originate in config.
 	Config *configs.Import
 
+	// Addr is the address for the resource instance that the new object should
+	// be imported into.
+	Addr addrs.AbsResourceInstance // FIXME validate no duplicates?
+
+	// ID is the string ID of the resource to import. This is resource-instance specific.
+	ID string
+}
+
+// FIXME comments
+// ResolvedConfigImportTarget is a target that we need to import. It's created when an import target originated from
+// an import block, after everything regarding the configuration has been evaluated.
+// At this point, the import target is of a single resource instance
+type ResolvedConfigImportTarget struct {
+	// Addr is the address for the resource instance that the new object should
+	// be imported into.
+	AddrStr string // FIXME validate no duplicates?
+
 	// ID is the string ID of the resource to import. This is resource-instance specific.
 	ID string
 }

--- a/internal/tofu/transform_config.go
+++ b/internal/tofu/transform_config.go
@@ -5,8 +5,9 @@ package tofu
 
 import (
 	"fmt"
-	"github.com/hashicorp/hcl/v2"
 	"log"
+
+	"github.com/hashicorp/hcl/v2"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"

--- a/internal/tofu/transform_config.go
+++ b/internal/tofu/transform_config.go
@@ -188,9 +188,7 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config, ge
 				return fmt.Errorf("Config generation for count and for_each resources not supported.\n\nYour configuration contains an import block with a \"to\" address of %s. This resource instance does not exist in configuration.\n\nIf you intended to target a resource that exists in configuration, please double-check the address. Otherwise, please remove this import block or re-run the plan without the -generate-config-out flag to ignore the import block.", address)
 			}
 
-			// Create a node with the exact resource and import target, whether we have config generation enabled or not
-			// If config generation is enabled, then it will be applied during execution
-			// If it is not, an error will be thrown and handled from the node
+			// Create a node with the resource and import target. This node will take care of the config generation
 			abstract := &NodeAbstractResource{
 				Addr:               address.ConfigResource(),
 				importTargets:      []*ImportTarget{i},

--- a/internal/tofu/transform_config.go
+++ b/internal/tofu/transform_config.go
@@ -186,11 +186,6 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config, ge
 				return fmt.Errorf("Config generation for count and for_each resources not supported.\n\nYour configuration contains an import block with a \"to\" address of %s. This resource instance does not exist in configuration.\n\nIf you intended to target a resource that exists in configuration, please double-check the address. Otherwise, please remove this import block or re-run the plan without the -generate-config-out flag to ignore the import block.", address)
 			}
 
-			// TODO check why this
-			if !address.Module.IsRoot() {
-				return fmt.Errorf("Config generation inside modules is not supported.\n\nYour configuration contains an import block with a \"to\" address of %s. This resource instance points to a configuration inside of a module. Config generation is only supported for resource in the root module.", address)
-			}
-
 			// Create a node with the exact resource and import target, whether we have config generation enabled or not
 			// If config generation is enabled, then it will be applied during execution
 			// If it is not, an error will be thrown and handled from the node


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Related to https://github.com/opentofu/opentofu/issues/1033

Current plan for implementing `for_each` for the `import` block:
1. Prepare `ImportTarget` types and codebase for more dynamic addresses (addresses that are not fully known from the get-go) **<--- You are here**
2. Allow for having a more dynamic address in the `to` field of an `import` block
3. Add `for_each` field for `import` block, and adapt the code for resolving multiple import targets from the same import configuration

### Background - What this PR does
Once we implement `for_each` for `import`, there are a couple of things that will not be the same for `ImportTarget`, as they are today:
- The address of the import target is not necessarily fully known from the get go (as it could rely on data that would only be evaluated later on)
- A single import block could result in multiple import targets

This PR starts to adapt `ImportTarget`s and the rest of the code for when the addresses might be more dynamic, and for when the number of actual targets to import could not be determined from the get-go

### In detail

- Create a better separation between import targets originating from a `tofu import` command vs import targets originating from an `import` block - See `ImportTarget` and `CommandLineImportTarget`, alongside `EvaluatedConfigImportTarget`
- In order to preserve the validation that all `import` blocks have targeted an actual resource - Store all import targets as they are resolved when walking the graph in `ResolvedImports`, and use these in `postPlanValidateImports`
- For imports originating from the `tofu import` - remove `legacyImportMode`, as there is now no need for it
- Validations
  - Added a validation to make sure all imports are pointing to modules that are actually in the configuration (these imports were simply ignored in 1.6.0)
  - Align all "configuration missing" validation errors with Terraform
## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.0
