### PR TITLE
docs: Adding DNF as  install option for the Redhat based distributions

### DIFF
--- a/website/docs/intro/install/install-dnf.sh
+++ b/website/docs/intro/install/install-dnf.sh
@@ -1,0 +1,1 @@
+sudo dnf install -y tofu

--- a/website/docs/intro/install/install-opentofu.sh
+++ b/website/docs/intro/install/install-opentofu.sh
@@ -558,10 +558,17 @@ EOF
 # This function installs OpenTofu via the yum command line utility. It returns $TOFU_INSTALL_EXIT_CODE_INSTALL_REQUIREMENTS_NOT_MET
 # if yum is not available.
 install_yum() {
-  if ! command_exists "yum"; then
+  RPM_PACKAGE_MANAGER=""
+  if command_exists "dnf"; then
+    RPM_PACKAGE_MANAGER="dnf"
+  elif command_exists "yum"; then
+    RPM_PACKAGE_MANAGER="yum"
+  else
+    log_error "Neither yum nor dnf found. Unable to install OpenTofu."
     return "${TOFU_INSTALL_EXIT_CODE_INSTALL_REQUIREMENTS_NOT_MET}"
   fi
-  log_info "Installing OpenTofu using yum..."
+  
+  log_info "Installing OpenTofu using ${RPM_PACKAGE_MANAGER}..."
   if [ "${SKIP_VERIFY}" -ne "1" ]; then
     GPGCHECK=1
     GPG_URL="${RPM_GPG_URL}"
@@ -609,8 +616,8 @@ EOF
       return "${TOFU_INSTALL_EXIT_CODE_INSTALL_FAILED}"
     fi
   done
-  if ! as_root yum install -y tofu; then
-    log_error "Failed to install tofu via yum."
+  if ! as_root ${RPM_PACKAGE_MANAGER} install -y tofu; then
+    log_error "Failed to install tofu via ${RPM_PACKAGE_MANAGER}."
     return "${TOFU_INSTALL_EXIT_CODE_INSTALL_FAILED}"
   fi
   if ! tofu --version; then

--- a/website/docs/intro/install/rpm.mdx
+++ b/website/docs/intro/install/rpm.mdx
@@ -12,6 +12,7 @@ import RpmConvenienceScript from '!!raw-loader!./rpm-convenience.sh'
 import YumRepoScript from '!!raw-loader!./repo-yum.sh'
 import ZypperRepoScript from '!!raw-loader!./repo-zypper.sh'
 import YumInstallScript from '!!raw-loader!./install-yum.sh'
+import DNFInstallScript from '!!raw-loader!./install-dnf.sh'
 import ZypperInstallScript from '!!raw-loader!./install-zypper.sh'
 import Buildkite from "./buildkite";
 
@@ -34,7 +35,7 @@ The following steps explain how to set up the OpenTofu RPM repositories. These i
 ### Adding the OpenTofu repository
 
 <Tabs>
-    <TabItem value="redhat" label="Yum (RHEL/Fedora/etc.)" default>
+    <TabItem value="redhat" label="Yum/DNF (RHEL/Fedora/etc.)" default>
         Create the <code>/etc/yum.repos.d/opentofu.repo</code> file by running the following command:
         <CodeBlock language={"bash"}>{YumRepoScript}</CodeBlock>
     </TabItem>
@@ -49,7 +50,10 @@ The following steps explain how to set up the OpenTofu RPM repositories. These i
 Now you install OpenTofu by running:
 
 <Tabs>
-    <TabItem value="redhat" label="Yum (RHEL/Fedora/etc)" default>
+    <TabItem value="redhat-dnf" label="DNF (RHEL/Fedora/etc)" default>
+        <CodeBlock language={"bash"}>{DNFInstallScript}</CodeBlock>
+    </TabItem>
+    <TabItem value="redhat-yum" label="Yum (RHEL/Fedora/etc)">
         <CodeBlock language={"bash"}>{YumInstallScript}</CodeBlock>
     </TabItem>
     <TabItem value="opensuse-leap" label="Zypper (openSUSE)">

--- a/website/docs/intro/install/rpm.sh
+++ b/website/docs/intro/install/rpm.sh
@@ -2,13 +2,21 @@
 
 set -e
 
-if [ -f /usr/bin/zypper ]; then
+if command_exists "zypper"; then
   zypper install -y sudo
   if [ "$1" = "--convenience" ]; then
     bash -ex rpm-convenience.sh
   else
     bash -ex repo-zypper.sh
     bash -ex install-zypper.sh
+  fi
+elif command_exists "dnf"; then
+  dnf install -y sudo
+  if [ "$1" = "--convenience" ]; then
+    bash -ex rpm-convenience.sh
+  else
+    bash -ex repo-yum.sh
+    bash -ex install-dnf.sh
   fi
 else
   yum install -y sudo


### PR DESCRIPTION


Adding DNF as a installation option in the website installation guide. 
This PR adds a third tab, with DNF instead of replacing Yum completely.

Even though ```dnf``` is the default for the most recent versions of the major RedHat based distributions, yum is still a valid command for RHEL / CentOS 7 and below.

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #1205.