### PR TITLE
Resolve more inconsistencies in 32-bit systems

### DIFF
--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -933,7 +933,7 @@ func configureAssumeRole(obj cty.Value) *awsbase.AssumeRole {
 	assumeRole := awsbase.AssumeRole{}
 
 	assumeRole.RoleARN = stringAttr(obj, "role_arn")
-	assumeRole.Duration = time.Duration(intAttr(obj, "assume_role_duration_seconds") * int(time.Second))
+	assumeRole.Duration = time.Duration(int64(intAttr(obj, "assume_role_duration_seconds")) * int64(time.Second))
 	assumeRole.ExternalID = stringAttr(obj, "external_id")
 	assumeRole.Policy = stringAttr(obj, "assume_role_policy")
 	assumeRole.SessionName = stringAttr(obj, "session_name")


### PR DESCRIPTION
This issue fixes the 2 failing tests in 386 and arm based systems in the alpine build pipelines.

- Resolves issue with integer overflow when constructing the s3 assume role timeout in the backend logic
- Resolves issue where TestEncodePaths was comparing the order of slices, when the order returned from go-cty is non-deterministic (Due to hashing on 32 bit systems dropping half the data).

Resolves #1069 

## Target Release
1.7.0, 1.6.1
