### PR TITLE
Added aliases for `state list`, `state mv`, and `state rm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ BUG FIXES:
 * Fix Global Schema Cache not working in provider acceptance tests ([#1054](https://github.com/opentofu/opentofu/pull/1054))
 * Fix `tofu show` and `tofu state show` not working with state files referencing Terraform registry providers in some instances ([#1141](https://github.com/opentofu/opentofu/pull/1141))
 * Improved stability on 32-bit architectures ([#1154](https://github.com/opentofu/opentofu/pull/1154))
+* Added aliases for `state list`, `state mv`, and `state rm` ([#1220](https://github.com/opentofu/opentofu/pull/1220))
 
 ## Previous Releases
 

--- a/cmd/tofu/commands.go
+++ b/cmd/tofu/commands.go
@@ -370,6 +370,14 @@ func initCommands(
 			}, nil
 		},
 
+		"state ls": func() (cli.Command, error) {
+			return &command.AliasCommand{
+				Command: &command.StateListCommand{
+					Meta: meta,
+				},
+			}, nil
+		},
+
 		"state rm": func() (cli.Command, error) {
 			return &command.StateRmCommand{
 				StateMeta: command.StateMeta{
@@ -378,10 +386,30 @@ func initCommands(
 			}, nil
 		},
 
+		"state remove": func() (cli.Command, error) {
+			return &command.AliasCommand{
+				Command: &command.StateRmCommand{
+					StateMeta: command.StateMeta{
+						Meta: meta,
+					},
+				},
+			}, nil
+		},
+
 		"state mv": func() (cli.Command, error) {
 			return &command.StateMvCommand{
 				StateMeta: command.StateMeta{
 					Meta: meta,
+				},
+			}, nil
+		},
+
+		"state move": func() (cli.Command, error) {
+			return &command.AliasCommand{
+				Command: &command.StateMvCommand{
+					StateMeta: command.StateMeta{
+						Meta: meta,
+					},
 				},
 			}, nil
 		},
@@ -457,4 +485,16 @@ func makeShutdownCh() <-chan struct{} {
 func credentialsSource(config *cliconfig.Config) (auth.CredentialsSource, error) {
 	helperPlugins := pluginDiscovery.FindPlugins("credentials", globalPluginDirs())
 	return config.CredentialsSource(helperPlugins)
+}
+
+func getAliasCommandKeys() []string {
+	keys := []string{}
+	for key, cmdFact := range commands {
+		cmd, _ := cmdFact()
+		_, ok := cmd.(*command.AliasCommand)
+		if ok {
+			keys = append(keys, key)
+		}
+	}
+	return keys
 }

--- a/cmd/tofu/main.go
+++ b/cmd/tofu/main.go
@@ -299,11 +299,12 @@ func realMain() int {
 	// Rebuild the CLI with any modified args.
 	log.Printf("[INFO] CLI command args: %#v", args)
 	cliRunner = &cli.CLI{
-		Name:       binName,
-		Args:       args,
-		Commands:   commands,
-		HelpFunc:   helpFunc,
-		HelpWriter: os.Stdout,
+		Name:           binName,
+		Args:           args,
+		Commands:       commands,
+		HiddenCommands: getAliasCommandKeys(),
+		HelpFunc:       helpFunc,
+		HelpWriter:     os.Stdout,
 
 		Autocomplete:          true,
 		AutocompleteInstall:   "install-autocomplete",

--- a/internal/command/alias.go
+++ b/internal/command/alias.go
@@ -1,0 +1,22 @@
+package command
+
+import (
+	"github.com/mitchellh/cli"
+)
+
+// AliasCommand is a Command implementation that wraps another Command for the purpose of aliasing.
+type AliasCommand struct {
+	cli.Command
+}
+
+func (c *AliasCommand) Run(args []string) int {
+	return c.Command.Run(args)
+}
+
+func (c *AliasCommand) Help() string {
+	return c.Command.Help()
+}
+
+func (c *AliasCommand) Synopsis() string {
+	return c.Command.Synopsis()
+}

--- a/internal/command/state_list.go
+++ b/internal/command/state_list.go
@@ -96,7 +96,7 @@ func (c *StateListCommand) Run(args []string) int {
 
 func (c *StateListCommand) Help() string {
 	helpText := `
-Usage: tofu [global options] state list [options] [address...]
+Usage: tofu [global options] state (list|ls) [options] [address...]
 
   List resources in the OpenTofu state.
 

--- a/internal/command/state_mv.go
+++ b/internal/command/state_mv.go
@@ -519,7 +519,7 @@ func (c *StateMvCommand) validateResourceMove(addrFrom, addrTo addrs.AbsResource
 
 func (c *StateMvCommand) Help() string {
 	helpText := `
-Usage: tofu [global options] state mv [options] SOURCE DESTINATION
+Usage: tofu [global options] state (mv|move) [options] SOURCE DESTINATION
 
  This command will move an item matched by the address given to the
  destination address. This command can also move to a destination address

--- a/internal/command/state_rm.go
+++ b/internal/command/state_rm.go
@@ -159,7 +159,7 @@ func (c *StateRmCommand) Run(args []string) int {
 
 func (c *StateRmCommand) Help() string {
 	helpText := `
-Usage: tofu [global options] state rm [options] ADDRESS...
+Usage: tofu [global options] state (rm|remove) [options] ADDRESS...
 
   Remove one or more items from the OpenTofu state, causing OpenTofu to
   "forget" those items without first destroying them in the remote system.


### PR DESCRIPTION
Adds alias commands for `state list`, `state mv`, and `state rm`. Aliases don't show when listing `state`'s subcommands, and are denoted in each subcommand's help text.

Resolves #1136 

## Target Release
1.7.0