### PR TITLE
docs: Add Community Supported Architectures Section to Install Docs - ppc64le

### DIFF
--- a/website/docs/intro/install/standalone.mdx
+++ b/website/docs/intro/install/standalone.mdx
@@ -40,7 +40,13 @@ You can run OpenTofu without installation as a standalone binary. You can [downl
 
 ### Community-supported Architectures
 
-Download the latest binary for [ppc64le here.](https://ftp2.osuosl.org/pub/ppc64el/opentofu/).
+:::note
+
+These are builds for architectures that OpenTofu does not officially support. Please raise issues about these builds with their maintainers.
+
+:::
+
+Download the latest binary for [ppc64le here.](https://ftp2.osuosl.org/pub/ppc64el/opentofu/). [Contact the ppc64le maintainer](mick@linux.vnet.ibm.com) for issues related to this binary.
 
 ## Verify the file integrity
 

--- a/website/docs/intro/install/standalone.mdx
+++ b/website/docs/intro/install/standalone.mdx
@@ -38,6 +38,10 @@ import Admonition from '@theme/Admonition';
 
 You can run OpenTofu without installation as a standalone binary. You can [download the latest release](https://github.com/opentofu/opentofu/releases/latest/) for your operating system from the [GitHub releases page](https://github.com/opentofu/opentofu/releases/latest/), unpack the zip and start using it. For easier updates, we recommend using the **non-portable packaged versions for your operating system**.
 
+### Community-supported Architectures
+
+Download the latest binary for [ppc64le here.](https://ftp2.osuosl.org/pub/ppc64el/opentofu/).
+
 ## Verify the file integrity
 
 Please download the `tofu_YOURVERSION_SHA256SUMS` file from the release. This file contains the SHA256 checksums for all files. You can verify the integrity of your file by running:


### PR DESCRIPTION
Please add a link to the Linux install docs pointing to the binary hosted at OSU OSL for ppc64le. Newer binaries for ppc64le will be uploaded to this [2] location once a Release is added to the OpenTofu repo. This is in reply to the RFC discussion started here [3]. Thank you :) 


[1] https://osuosl.org/services/powerdev/
[2] https://ftp2.osuosl.org/pub/ppc64el/opentofu/
[3] https://github.com/opentofu/opentofu/issues/1130
