### PR TITLE
1078 prerelease vs release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
       tag:
         description: "Git tag (leave empty for dry run)"
         required: false
-    inputs:
       prerelease:
         description: "Is this a pre-release?"
         required: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: release
 on:
   workflow_dispatch:
     inputs:
-      ref:
-        description: "Git tag or branch (leave empty for dry run)"
+      tag:
+        description: "Git tag (leave empty for dry run)"
         required: false
       prerelease:
         description: "Is this a pre-release?"
@@ -16,8 +16,6 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     environment: gpg
-    env:
-      TRIGGER_PRERELEASE_FLOW: ${{ inputs.ref == 'main' || inputs.prerelease }}
     permissions:
       contents: write
       id-token: write
@@ -31,7 +29,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
-        if: startsWith(inputs.ref, 'v') || env.TRIGGER_PRERELEASE_FLOW
+        if: startsWith(inputs.tag, 'v')
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -41,16 +39,30 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.tag }}
 
       - name: Fetch tags
         run: git fetch --force --tags
 
       - name: Compare versions
-        if: startsWith(inputs.ref, 'v')
+        if: startsWith(inputs.tag, 'v')
         run: ./.github/scripts/compare-release-version.sh
         env:
-          TARGET_VERSION: ${{inputs.ref}}
+          TARGET_VERSION: ${{inputs.tag}}
+
+      - name: Check if tag is on main branch
+        id: validate_tag
+        run: |
+          IS_TAG_ON_MAIN=$(git branch --contains ${{inputs.tag}} | grep -q "main" && echo true || echo false)
+          echo "IS_TAG_ON_MAIN=${IS_TAG_ON_MAIN}" >> $GITHUB_OUTPUT
+
+      - name: Check if release is allowed or not
+        id: validate_release
+        run: |
+          if [[ !inputs.prerelease && steps.validate_tag.outputs.IS_TAG_ON_MAIN == true ]]; then
+            echo "ERROR: Creating stable release from a tag on main is not allowed."
+            exit 1
+          fi
 
       - name: Determine Go version
         id: go
@@ -80,7 +92,7 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_TOKEN }}
 
       - name: Import GPG key
-        if: startsWith(inputs.ref, 'v') || env.TRIGGER_PRERELEASE_FLOW
+        if: startsWith(inputs.tag, 'v')
         run: |
           GPG_KEY_FILE=/tmp/signing-key.gpg
           echo "${{ secrets.GPG_PRIVATE_KEY }}" | base64 --decode > "${GPG_KEY_FILE}"
@@ -97,7 +109,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: v1.21.2
-          args: release --clean --timeout=60m --snapshot=${{ !startsWith(inputs.ref, 'v') }}
+          args: release --clean --timeout=60m --snapshot=${{ !startsWith(inputs.tag, 'v') }}
         env:
           # Note: the GPG_FINGERPRINT and GPG_KEY_FILE are defined in the task above. If they are not set,
           # goreleaser won't sign the packages.
@@ -120,7 +132,7 @@ jobs:
           path: dist
 
       - name: Upload Debian packages to PackageCloud
-        if: startsWith(inputs.ref, 'v') && !inputs.prerelease
+        if: startsWith(inputs.tag, 'v') && !inputs.prerelease
         uses: computology/packagecloud-github-action@v0.6
         with:
                 PACKAGE-NAME: dist/*.deb
@@ -129,7 +141,7 @@ jobs:
                 PACKAGECLOUD-DISTRO: any/any
                 PACKAGECLOUD-TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
       - name: Upload RPM packages to PackageCloud
-        if: startsWith(inputs.ref, 'v') && !inputs.prerelease
+        if: startsWith(inputs.tag, 'v') && !inputs.prerelease
         uses: computology/packagecloud-github-action@v0.6
         with:
                 PACKAGE-NAME: dist/*.rpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
-        if: startsWith(inputs.ref, 'v') || env.ALLOW_MAIN_PRERELEASE
+        if: startsWith(inputs.ref, 'v') || env.TRIGGER_PRERELEASE_FLOW
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -80,7 +80,7 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_TOKEN }}
 
       - name: Import GPG key
-        if: startsWith(inputs.ref, 'v') || env.ALLOW_MAIN_PRERELEASE
+        if: startsWith(inputs.ref, 'v') || env.TRIGGER_PRERELEASE_FLOW
         run: |
           GPG_KEY_FILE=/tmp/signing-key.gpg
           echo "${{ secrets.GPG_PRIVATE_KEY }}" | base64 --decode > "${GPG_KEY_FILE}"
@@ -104,7 +104,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_TOKEN }}
           SNAPCRAFT_CHANNEL: ${{ inputs.prerelease &&  'edge' || 'stable' }}
-          STABLE_RELEASE: ${{ !inputs.prerelease }}
 
       - name: Remove GPG key
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,11 @@ on:
       tag:
         description: "Git tag (leave empty for dry run)"
         required: false
+    inputs:
+      prerelease:
+        description: "Is this a pre-release?"
+        required: true
+        type: boolean
 
 jobs:
   release:
@@ -97,6 +102,7 @@ jobs:
           # goreleaser won't sign the packages.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_TOKEN }}
+          SNAPCRAFT_CHANNEL: ${{!inputs.prerelease &&  'stable' || 'edge' }}
 
       - name: Remove GPG key
         if: always()
@@ -113,7 +119,7 @@ jobs:
           path: dist
 
       - name: Upload Debian packages to PackageCloud
-        if: startsWith(inputs.tag, 'v')
+        if: startsWith(inputs.tag, 'v') && !inputs.prerelease
         uses: computology/packagecloud-github-action@v0.6
         with:
                 PACKAGE-NAME: dist/*.deb
@@ -122,7 +128,7 @@ jobs:
                 PACKAGECLOUD-DISTRO: any/any
                 PACKAGECLOUD-TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
       - name: Upload RPM packages to PackageCloud
-        if: startsWith(inputs.tag, 'v')
+        if: startsWith(inputs.tag, 'v') && !inputs.prerelease
         uses: computology/packagecloud-github-action@v0.6
         with:
                 PACKAGE-NAME: dist/*.rpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: gpg
     env:
-      TRIGGER_PRERELEASE_FLOW: ${{ inputs.ref == 'main' && inputs.prerelease }}
+      TRIGGER_PRERELEASE_FLOW: ${{ inputs.ref == 'main' || inputs.prerelease }}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
-        if: startsWith(inputs.tag, 'v')
+        if: startsWith(inputs.tag, 'v') || (inputs.tag == 'main' && inputs.prerelease)
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -78,7 +78,7 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_TOKEN }}
 
       - name: Import GPG key
-        if: startsWith(inputs.tag, 'v')
+        if: startsWith(inputs.tag, 'v') || (inputs.tag == 'main' && inputs.prerelease)
         run: |
           GPG_KEY_FILE=/tmp/signing-key.gpg
           echo "${{ secrets.GPG_PRIVATE_KEY }}" | base64 --decode > "${GPG_KEY_FILE}"
@@ -101,7 +101,8 @@ jobs:
           # goreleaser won't sign the packages.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_TOKEN }}
-          SNAPCRAFT_CHANNEL: ${{!inputs.prerelease &&  'stable' || 'edge' }}
+          SNAPCRAFT_CHANNEL: ${{ !inputs.prerelease &&  'stable' || 'edge' }}
+          STABLE_RELEASE: ${{ !inputs.prerelease }}
 
       - name: Remove GPG key
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,19 +50,33 @@ jobs:
         env:
           TARGET_VERSION: ${{inputs.tag}}
 
-      - name: Check if tag is on main branch
+      - name: Check if tag is on main branch or version branch
         id: validate_tag
         run: |
-          IS_TAG_ON_MAIN=$(git branch --contains ${{inputs.tag}} | grep -q "main" && echo true || echo false)
+          IS_TAG_ON_MAIN=$(git branch -a --contains ${{inputs.tag}} | grep -q "main" && echo true || echo false)
+          IS_TAG_ON_VERSION=$(git branch -a --contains ${{inputs.tag}} | grep -E "^v[0-9]+\.[0-9]+" && echo true || echo false)
           echo "IS_TAG_ON_MAIN=${IS_TAG_ON_MAIN}" >> $GITHUB_OUTPUT
+          echo "IS_TAG_ON_VERSION=${IS_TAG_ON_VERSION}" >> $GITHUB_OUTPUT
 
       - name: Check if release is allowed or not
         id: validate_release
         run: |
-          if [[ !inputs.prerelease && steps.validate_tag.outputs.IS_TAG_ON_MAIN == true ]]; then
+          if [[ "${{ inputs.prerelease }}" == "false" && "${{ steps.validate_tag.outputs.IS_TAG_ON_MAIN }}" == "true" ]]; then
             echo "ERROR: Creating stable release from a tag on main is not allowed."
             exit 1
           fi
+
+      - name: Check eligibility for archive push
+        id: archive
+        run: |
+          PUSH_ARCHIVE=$(
+            [[ 
+              "${{ inputs.prerelease }}" == "true" && 
+              ("${{ steps.validate_tag.outputs.IS_TAG_ON_MAIN }}" == "true" || 
+              "${{ steps.validate_tag.outputs.IS_TAG_ON_VERSION }}" == "true") 
+            ]] && echo false || echo true
+          )
+          echo "PUSH_ARCHIVE=${PUSH_ARCHIVE}" >> $GITHUB_ENV
 
       - name: Determine Go version
         id: go
@@ -132,7 +146,7 @@ jobs:
           path: dist
 
       - name: Upload Debian packages to PackageCloud
-        if: startsWith(inputs.tag, 'v') && !inputs.prerelease
+        if: startsWith(inputs.tag, 'v') && steps.archive.outputs.PUSH_ARCHIVE
         uses: computology/packagecloud-github-action@v0.6
         with:
                 PACKAGE-NAME: dist/*.deb
@@ -141,7 +155,7 @@ jobs:
                 PACKAGECLOUD-DISTRO: any/any
                 PACKAGECLOUD-TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
       - name: Upload RPM packages to PackageCloud
-        if: startsWith(inputs.tag, 'v') && !inputs.prerelease
+        if: startsWith(inputs.tag, 'v') && steps.archive.outputs.PUSH_ARCHIVE
         uses: computology/packagecloud-github-action@v0.6
         with:
                 PACKAGE-NAME: dist/*.rpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: release
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: "Git tag (leave empty for dry run)"
+      ref:
+        description: "Git tag or branch (leave empty for dry run)"
         required: false
       prerelease:
         description: "Is this a pre-release?"
@@ -16,6 +16,8 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     environment: gpg
+    env:
+      TRIGGER_PRERELEASE_FLOW: ${{ inputs.ref == 'main' && inputs.prerelease }}
     permissions:
       contents: write
       id-token: write
@@ -29,7 +31,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
-        if: startsWith(inputs.tag, 'v') || (inputs.tag == 'main' && inputs.prerelease)
+        if: startsWith(inputs.ref, 'v') || env.ALLOW_MAIN_PRERELEASE
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -39,16 +41,16 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ inputs.tag }}
+          ref: ${{ inputs.ref }}
 
       - name: Fetch tags
         run: git fetch --force --tags
 
       - name: Compare versions
-        if: startsWith(inputs.tag, 'v')
+        if: startsWith(inputs.ref, 'v')
         run: ./.github/scripts/compare-release-version.sh
         env:
-          TARGET_VERSION: ${{inputs.tag}}
+          TARGET_VERSION: ${{inputs.ref}}
 
       - name: Determine Go version
         id: go
@@ -78,7 +80,7 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_TOKEN }}
 
       - name: Import GPG key
-        if: startsWith(inputs.tag, 'v') || (inputs.tag == 'main' && inputs.prerelease)
+        if: startsWith(inputs.ref, 'v') || env.ALLOW_MAIN_PRERELEASE
         run: |
           GPG_KEY_FILE=/tmp/signing-key.gpg
           echo "${{ secrets.GPG_PRIVATE_KEY }}" | base64 --decode > "${GPG_KEY_FILE}"
@@ -95,13 +97,13 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: v1.21.2
-          args: release --clean --timeout=60m --snapshot=${{ !startsWith(inputs.tag, 'v') }}
+          args: release --clean --timeout=60m --snapshot=${{ !startsWith(inputs.ref, 'v') }}
         env:
           # Note: the GPG_FINGERPRINT and GPG_KEY_FILE are defined in the task above. If they are not set,
           # goreleaser won't sign the packages.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_TOKEN }}
-          SNAPCRAFT_CHANNEL: ${{ !inputs.prerelease &&  'stable' || 'edge' }}
+          SNAPCRAFT_CHANNEL: ${{ inputs.prerelease &&  'edge' || 'stable' }}
           STABLE_RELEASE: ${{ !inputs.prerelease }}
 
       - name: Remove GPG key
@@ -119,7 +121,7 @@ jobs:
           path: dist
 
       - name: Upload Debian packages to PackageCloud
-        if: startsWith(inputs.tag, 'v') && !inputs.prerelease
+        if: startsWith(inputs.ref, 'v') && !inputs.prerelease
         uses: computology/packagecloud-github-action@v0.6
         with:
                 PACKAGE-NAME: dist/*.deb
@@ -128,7 +130,7 @@ jobs:
                 PACKAGECLOUD-DISTRO: any/any
                 PACKAGECLOUD-TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
       - name: Upload RPM packages to PackageCloud
-        if: startsWith(inputs.tag, 'v') && !inputs.prerelease
+        if: startsWith(inputs.ref, 'v') && !inputs.prerelease
         uses: computology/packagecloud-github-action@v0.6
         with:
                 PACKAGE-NAME: dist/*.rpm

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -189,7 +189,7 @@ nfpms:
 
 snapcrafts:
   - name: opentofu
-    publish: true
+    publish: "{{ .Env.STABLE_RELEASE }}"
     summary: OpenTofu lets you declaratively manage your cloud infrastructure.
     description: |
       OpenTofu is an OSS tool for building, changing, and versioning infrastructure

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -189,7 +189,7 @@ nfpms:
 
 snapcrafts:
   - name: opentofu
-    publish: "{{ .Env.STABLE_RELEASE }}"
+    publish: true
     summary: OpenTofu lets you declaratively manage your cloud infrastructure.
     description: |
       OpenTofu is an OSS tool for building, changing, and versioning infrastructure

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -161,6 +161,7 @@ docker_manifests:
       - ghcr.io/opentofu/opentofu:{{ .Version }}-arm64
       - ghcr.io/opentofu/opentofu:{{ .Version }}-arm
       - ghcr.io/opentofu/opentofu:{{ .Version }}-386
+    skip_push: auto
 
 nfpms:
   - file_name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Arch }}'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -196,7 +196,7 @@ snapcrafts:
       safely and efficiently. OpenTofu can manage existing and popular service
       providers as well as custom in-house solutions.
     base: core22
-    grade: "{{ .Env.SNAP_CHANNEL }}"
+    grade: "{{ .Env.SNAPCRAFT_CHANNEL }}"
     confinement: classic
     license: MPL-2.0
     apps:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -196,7 +196,7 @@ snapcrafts:
       safely and efficiently. OpenTofu can manage existing and popular service
       providers as well as custom in-house solutions.
     base: core22
-    grade: stable
+    grade: "{{ .Env.SNAP_CHANNEL }}"
     confinement: classic
     license: MPL-2.0
     apps:


### PR DESCRIPTION
Objective: 
The stable release flow should only be runnable from v1.x branches and should be the one we have today.

The pre-release flow (for alphas, betas, and release candidates) should be runnable from main and v1.x branches, and should not push linux archives (neither packagecloud nor snapcraft). Snapcraft does support separate edge/beta/candidate/stable channels, so eventually we could support that too.

Changes:

- Added new input variable `prerelease` in `workflow_dispatch` 
- Updated an existing variable in `workflow_dispatch` from `tag` to `ref` based on it's use case and for better code readability.
- Added a new variable `TRIGGER_PRERELEASE_FLOW`  and a conditional statement that stable release should be runnable for `v1.x` branch and pre-release flow should be runnable for `main` and `v1.x` branches.
- Added a new variable `SNAPCRAFT_CHANNEL` which is used to specify `grade` in **Snapcraft**. SNAPCRAFT_CHANNEL can be either **stable** or **edge**.

Resolves #1078 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.0
