### PR TITLE
Docs: there're more than two installation methods

### DIFF
--- a/website/docs/cli/config/config-file.mdx
+++ b/website/docs/cli/config/config-file.mdx
@@ -207,7 +207,7 @@ public OpenTofu Registry, even when using wildcards. For example,
 `*/*` is a shorthand for `registry.opentofu.org/*/*`, not for
 `*/*/*`.
 
-The following are the two supported installation method types:
+The following are the supported installation method types:
 
 * `direct`: request information about the provider directly from its origin
   registry and download over the network from the location that registry


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

The docs says "The following are the two supported installation method types" and then list three installation methods - fix it.

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #1240 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.0
