### PR TITLE
Introduced consistent ordering of aliases in help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ BUG FIXES:
 * Fix Global Schema Cache not working in provider acceptance tests ([#1054](https://github.com/opentofu/opentofu/pull/1054))
 * Fix `tofu show` and `tofu state show` not working with state files referencing Terraform registry providers in some instances ([#1141](https://github.com/opentofu/opentofu/pull/1141))
 * Improved stability on 32-bit architectures ([#1154](https://github.com/opentofu/opentofu/pull/1154))
-* Added aliases for `state list`, `state mv`, and `state rm` ([#1220](https://github.com/opentofu/opentofu/pull/1220))
+* Added aliases for `state list` (`state ls`), `state mv` (`state move`), and `state rm` (`state remove`) ([#1220](https://github.com/opentofu/opentofu/pull/1220))
 
 ## Previous Releases
 

--- a/internal/command/state_mv.go
+++ b/internal/command/state_mv.go
@@ -521,7 +521,7 @@ func (c *StateMvCommand) validateResourceMove(addrFrom, addrTo addrs.AbsResource
 
 func (c *StateMvCommand) Help() string {
 	helpText := `
-Usage: tofu [global options] state (mv|move) [options] SOURCE DESTINATION
+Usage: tofu [global options] state (move|mv) [options] SOURCE DESTINATION
 
  This command will move an item matched by the address given to the
  destination address. This command can also move to a destination address

--- a/internal/command/state_rm.go
+++ b/internal/command/state_rm.go
@@ -161,7 +161,7 @@ func (c *StateRmCommand) Run(args []string) int {
 
 func (c *StateRmCommand) Help() string {
 	helpText := `
-Usage: tofu [global options] state (rm|remove) [options] ADDRESS...
+Usage: tofu [global options] state (remove|rm) [options] ADDRESS...
 
   Remove one or more items from the OpenTofu state, causing OpenTofu to
   "forget" those items without first destroying them in the remote system.


### PR DESCRIPTION
This change introduced 2 things

- Improved changelog entry to make it clear what we're adding
- Improved help text to be consistent in ordering (full|alias).

related to: #1220

## Target Release

1.7.0
