### PR TITLE
Allow for templatefile recursion (up to 1024 depth default)

### DIFF
--- a/.github/workflows/compare-snapshots.yml
+++ b/.github/workflows/compare-snapshots.yml
@@ -18,9 +18,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+
       - name: Install Go
         uses: actions/setup-go@v2
-        with: { go-version: '1.20' }
+        with: { go-version: '1.21.3' }
 
       - name: Get the equivalence test binary
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ ENHANCEMENTS:
 * Support the XDG Base Directory Specification ([#1200](https://github.com/opentofu/opentofu/pull/1200))
 * Allow referencing the output from a test run in the local variables block of another run (tofu test). ([#1254](https://github.com/opentofu/opentofu/pull/1254))
 * Add documentation for the `removed` block. ([#1332](https://github.com/opentofu/opentofu/pull/1332))
+* Allow for templatefile function recursion (up to 1024 call depth default). ([#1250](https://github.com/opentofu/opentofu/pull/1250))
 
 BUG FIXES:
 * Fix view hooks unit test flakiness by deterministically waiting for heartbeats to execute ([$1153](https://github.com/opentofu/opentofu/issues/1153))

--- a/internal/lang/funcs/filesystem.go
+++ b/internal/lang/funcs/filesystem.go
@@ -82,7 +82,7 @@ func (err ErrorTemplateRecursionLimit) Error() string {
 	trace := make([]string, 0)
 	maxTrace := 16
 
-	// Look for repitition in the first N sources
+	// Look for repetition in the first N sources
 	for _, source := range err.sources[:min(maxTrace, len(err.sources))] {
 		looped := false
 		for _, st := range trace {

--- a/internal/lang/funcs/filesystem_test.go
+++ b/internal/lang/funcs/filesystem_test.go
@@ -151,7 +151,7 @@ func TestTemplateFile(t *testing.T) {
 			cty.StringVal("testdata/recursive.tmpl"),
 			cty.MapValEmpty(cty.String),
 			cty.NilVal,
-			`testdata/recursive.tmpl:1,3-16: Error in function call; Call to function "templatefile" failed: cannot recursively call templatefile from inside templatefile or templatestring.`,
+			`maximum recursion depth 1024 reached in testdata/recursive.tmpl:1,3-16, testdata/recursive.tmpl:1,3-16 ... `,
 		},
 		{
 			cty.StringVal("testdata/list.tmpl"),

--- a/internal/lang/funcs/filesystem_test.go
+++ b/internal/lang/funcs/filesystem_test.go
@@ -219,6 +219,50 @@ func TestTemplateFile(t *testing.T) {
 	}
 }
 
+func Test_templateMaxRecursionDepth(t *testing.T) {
+	tests := []struct {
+		Input string
+		Want  int
+		Err   string
+	}{
+		{
+			"",
+			1024,
+			``,
+		}, {
+			"4096",
+			4096,
+			``,
+		}, {
+			"apple",
+			-1,
+			`invalid value for TF_TEMPLATE_RECURSION_DEPTH: strconv.Atoi: parsing "apple": invalid syntax`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("templateMaxRecursion(%s)", test.Input), func(t *testing.T) {
+			os.Setenv("TF_TEMPLATE_RECURSION_DEPTH", test.Input)
+			got, err := templateMaxRecursionDepth()
+			if test.Err != "" {
+				if err == nil {
+					t.Fatal("succeeded; want error")
+				}
+				if got, want := err.Error(), test.Err; got != want {
+					t.Errorf("wrong error\ngot:  %s\nwant: %s", got, want)
+				}
+				return
+			} else if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if got != test.Want {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
+			}
+		})
+	}
+}
+
 func TestFileExists(t *testing.T) {
 	tests := []struct {
 		Path cty.Value

--- a/internal/lang/funcs/render_template_test.go
+++ b/internal/lang/funcs/render_template_test.go
@@ -88,9 +88,7 @@ func TestRenderTemplate(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 
-			got, err := renderTemplate(test.Expr, test.Vars, func() map[string]function.Function {
-				return map[string]function.Function{}
-			})
+			got, err := renderTemplate(test.Expr, test.Vars, map[string]function.Function{})
 
 			if err != nil {
 				if test.Err == "" {

--- a/internal/lang/funcs/string.go
+++ b/internal/lang/funcs/string.go
@@ -218,7 +218,7 @@ func MakeTemplateStringFunc(content string, funcsCb func() map[string]function.F
 
 			// This is safe even if args[1] contains unknowns because the HCL
 			// template renderer itself knows how to short-circuit those.
-			val, err := renderTemplate(expr, args[1], funcsCb)
+			val, err := renderTemplate(expr, args[1], funcsCb())
 			return val.Type(), err
 		},
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
@@ -227,7 +227,7 @@ func MakeTemplateStringFunc(content string, funcsCb func() map[string]function.F
 			if err != nil {
 				return cty.DynamicVal, err
 			}
-			result, err := renderTemplate(expr, args[1], funcsCb)
+			result, err := renderTemplate(expr, args[1], funcsCb())
 			return result.WithMarks(dataMarks), err
 		},
 	})

--- a/internal/lang/funcs/testdata/recursive.tmpl
+++ b/internal/lang/funcs/testdata/recursive.tmpl
@@ -1,1 +1,1 @@
-${templatefile("recursive.tmpl", {})}
+${templatefile("testdata/recursive.tmpl", {})}

--- a/website/docs/language/functions/templatefile.mdx
+++ b/website/docs/language/functions/templatefile.mdx
@@ -22,10 +22,9 @@ out into a separate file for readability.
 
 The "vars" argument must be an object. Within the template file, each of the
 keys in the map is available as a variable for interpolation. The template may
-also use any other function available in the OpenTofu language, except that
-recursive calls to `templatefile` are not permitted. Variable names must
-each start with a letter, followed by zero or more letters, digits, or
-underscores.
+also use any other function available in the OpenTofu language. Variable
+names must each start with a letter, followed by zero or more
+letters, digits, or underscores.
 
 Strings in the OpenTofu language are sequences of Unicode characters, so
 this function will interpret the file contents as UTF-8 encoded text and
@@ -41,6 +40,29 @@ dynamically during an OpenTofu operation.
 OpenTofu will not prevent you from using other names, but following this
 convention will help your editor understand the content and likely provide
 better editing experience as a result.
+
+## Recursion
+
+There are a few limitations to be aware of if recursion is used with templatefile.
+
+Any recursive calls to `templatefile` will have a limited call depth (1024 by default).
+This is to prevent crashes due to unintential infinite recursive calls and limit the chance
+of Out Of Memory crashes.
+
+As tail-recursion is not supported, all documents in a call stack must be loaded
+into memory before the stack can unwind. On most modern systems and configurations
+this will likely not be an issue, but it is worth being mindful of.
+
+If the maximum recursion depth is hit during execution, a concise error will be provided
+which describes the first few steps of the call stack to help you diagnose the issue.
+If you need the full call stack, setting `TF_LOG=debug` will cause the full templatefile
+callstack to be printed to the console.
+
+If your configuration requires a larger maximum recursion depth, you can override the
+default using the `TF_TEMPLATE_RECURSION_DEPTH` environment variable. This is not
+recommended and is only provided as an escape hatch. Additionally, setting it lower
+than the 1024 default has the potential to cause problems with modules that use
+the templatefile function.
 
 ## Examples
 
@@ -148,3 +170,5 @@ For more information, see the main documentation for
 
 * [`file`](/docs/language/functions/file) reads a file from disk and returns its literal contents
   without any template interpretation.
+* [`templatestring`](/docs/language/functions/templatestring) takes a string and renders it as a
+  template using a supplied set of template variables.


### PR DESCRIPTION
This changes templatefile to track call depth when building templatefile functions.  It works fine, even when nested inside other function calls.

As mentioned in #402, due to the lack of tail recursion it can be memory intensive during evaluation.  In my opinion this is a reasonable trade off and the default max depth should prevent most OOM crashes during reasonable use.

Example:
```hcl
main.tf 
locals {
        x = templatefile("rec.tmpl", {})
}

rec.tmpl 
${ base64encode(templatefile("other.tmpl", {})) }

other.tmpl 
${ templatefile("rec.tmpl", {}) }

```

![image](https://github.com/opentofu/opentofu/assets/892136/81891a1a-13c5-4112-a4df-532f4ff1ad8c)

With `TF_LOG=debug`
![image](https://github.com/opentofu/opentofu/assets/892136/83aae14c-ee4f-4528-8c00-ca420c9b88ab)

TODO:
* Documentation changes to templatefile
* Changelog entry

Resolves #402

## Target Release

1.7.0
