### PR TITLE
Enhancement: Introduce .tar.gz Archive Format for Additional Download Option

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,11 +63,11 @@ builds:
 
 archives:
   - format: tar.gz
-    id: tar.gz format 
+    id: targz
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{- .Os }}_{{- .Arch }}"
   
   - format: zip
-    id: zip format
+    id: zip 
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{- .Os }}_{{- .Arch }}"
 
 dockers:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -62,7 +62,12 @@ builds:
         goarch: arm
 
 archives:
+  - format: tar.gz
+    id: tar.gz format 
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{- .Os }}_{{- .Arch }}"
+  
   - format: zip
+    id: zip format
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{- .Os }}_{{- .Arch }}"
 
 dockers:


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->
**Addition of Tar.gz Archive Format:** The proposal suggests shipping .tar.gz archives alongside the existing .zip archives. This change aims to provide users with an alternative archive format for downloading and using the project.

When introducing multiple archive formats, such as .zip and .tar.gz, it's crucial to provide identifiers(id) for each format to distinguish between them. This ensures clarity and prevents errors when generating archives.

To check if the files are being generated as desired, try running "goreleaser release --snapshot" in terminal. 
<!--
Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them
-->

Resolves #1097 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.0
