### PR TITLE
Added a User-Agent header for remote-state http backend client

### DIFF
--- a/internal/backend/remote-state/http/client.go
+++ b/internal/backend/remote-state/http/client.go
@@ -61,6 +61,7 @@ func (c *httpClient) httpRequest(method string, url *url.URL, data *[]byte, what
 	// Work with data/body
 	if data != nil {
 		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Opentofu-http-client/1.1")
 		req.ContentLength = int64(len(*data))
 
 		// Generate the MD5


### PR DESCRIPTION
Added a User-Agent header for the http client to determine which client call to the http backend for change state.

Sometimes need to be able to send specially formatted state in different ways (for example, hiding sensitive data that will be shown in Swagger output but not hidden for terraform cli). In this case, would like to be able to identify which client sends the request for change state.

## Target release 

1.7.0


