### PR TITLE
Add page about official OpenTofu Docker image

### DIFF
--- a/website/docs/intro/install/docker-pull.sh
+++ b/website/docs/intro/install/docker-pull.sh
@@ -1,0 +1,1 @@
+docker pull ghcr.io/opentofu/opentofu:latest

--- a/website/docs/intro/install/docker-run.sh
+++ b/website/docs/intro/install/docker-run.sh
@@ -1,0 +1,5 @@
+docker run \
+    --workdir=/srv/workspace \
+    --mount type=bind,source=.,target=/srv/workspace \
+    ghcr.io/opentofu/opentofu:latest \
+    init

--- a/website/docs/intro/install/docker.mdx
+++ b/website/docs/intro/install/docker.mdx
@@ -1,0 +1,48 @@
+---
+sidebar_position: 99
+sidebar_label: OCI container image
+description: |-
+  Use official OCI container image available on GitHub Container Registry.
+---
+
+import CodeBlock from '@theme/CodeBlock';
+import DockerPullScript from '!!raw-loader!./docker-pull.sh'
+import DockerRunScript from '!!raw-loader!./docker-run.sh'
+
+# Use OpenTofu as Docker Image
+
+OpenTofu is available as [OCI container images](https://github.com/opentofu/opentofu/pkgs/container/opentofu),
+and distributed via public GitHub Packages registry.
+
+## Versions
+
+Images are hosted as packages in opentofy GitHub organization. See the list
+of available versions [here](https://github.com/opentofu/opentofu/pkgs/container/opentofu/versions?filters%5Bversion_type%5D=tagged).
+
+The multi platform images are available using the following tags:
+
+- `latest`: latest overall version of OpenTofu,
+- `Major`: a specific major version of OpenTofu,
+- `Major`.`Minor`: a specific minor version of OpenTofu,
+- `Major`.`Minor`.`Patch`: a specific patch version of OpenTofu.
+
+To pull platform-specific images (`amd64`, `arm`, `arm64`, `386`) use:
+
+- `<Version>`-`<Platform>`: a platform specific version of OpenTofu.
+
+## Usage
+
+To pull the image from GitHub Packages registry:
+
+<CodeBlock language="bash">{DockerPullScript}</CodeBlock>
+
+To run OpenTofu as a Docker container:
+
+<CodeBlock language="bash">{DockerRunScript}</CodeBlock>
+
+:::tip
+If you run into rate limiting issues with GitHub, create a
+[Personal Access Token](https://github.com/settings/tokens) and
+[log in](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry)
+to the registry.
+:::

--- a/website/docs/intro/install/docker.mdx
+++ b/website/docs/intro/install/docker.mdx
@@ -41,8 +41,10 @@ To run OpenTofu as a Docker container:
 <CodeBlock language="bash">{DockerRunScript}</CodeBlock>
 
 :::tip
+
 If you run into rate limiting issues with GitHub, create a
 [Personal Access Token](https://github.com/settings/tokens) and
 [log in](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry)
 to the registry.
+
 :::

--- a/website/docs/intro/install/index.mdx
+++ b/website/docs/intro/install/index.mdx
@@ -59,5 +59,12 @@ You can install OpenTofu via a wide range of methods. Please select your operati
       description:
         "Use OpenTofu without installation on Linux, MacOS, Windows or FreeBSD.",
     },
+    {
+        type: "link",
+        href: "/docs/intro/install/docker",
+        label: "OCI container image",
+        description:
+            "Use official OCI container image available on GitHub Container Registry.",
+    },
   ]}
 />


### PR DESCRIPTION
Documentation website was lacking a mention of official OpenTofu Docker image.
So I've added it.

See https://opentofucommunity.slack.com/archives/C05R0FD0VRU/p1708027559842219
