### PR TITLE
Fix race when using `ResolvedImports`

### DIFF
--- a/internal/tofu/context_plan.go
+++ b/internal/tofu/context_plan.go
@@ -532,9 +532,9 @@ func (c *Context) postPlanValidateMoves(config *configs.Config, stmts []refactor
 // All import target addresses with a key must already exist in config.
 // When we are able to generate config for expanded resources, this rule can be
 // relaxed.
-func (c *Context) postPlanValidateImports(resolvedImports *ResolvedImports, allInst instances.Set) tfdiags.Diagnostics {
+func (c *Context) postPlanValidateImports(importResolver *ImportResolver, allInst instances.Set) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
-	for resolvedImport := range resolvedImports.imports {
+	for resolvedImport := range importResolver.imports {
 		// We only care about import target addresses that have a key.
 		// If the address does not have a key, we don't need it to be in config
 		// because are able to generate config.
@@ -621,7 +621,7 @@ func (c *Context) planWalk(config *configs.Config, prevRunState *states.State, o
 
 	allInsts := walker.InstanceExpander.AllInstances()
 
-	importValidateDiags := c.postPlanValidateImports(walker.ResolvedImports, allInsts)
+	importValidateDiags := c.postPlanValidateImports(walker.ImportResolver, allInsts)
 	if importValidateDiags.HasErrors() {
 		return nil, importValidateDiags
 	}

--- a/internal/tofu/context_walk.go
+++ b/internal/tofu/context_walk.go
@@ -149,7 +149,7 @@ func (c *Context) graphWalker(operation walkOperation, opts *graphWalkOpts) *Con
 		Checks:           checkState,
 		InstanceExpander: instances.NewExpander(),
 		MoveResults:      opts.MoveResults,
-		ResolvedImports:  &ResolvedImports{imports: make(map[ResolvedConfigImportsKey]bool)},
+		ImportResolver:   NewImportResolver(),
 		Operation:        operation,
 		StopContext:      c.runContext,
 		PlanTimestamp:    opts.PlanTimeTimestamp,

--- a/internal/tofu/eval_context.go
+++ b/internal/tofu/eval_context.go
@@ -203,13 +203,13 @@ type EvalContext interface {
 	// objects accessible through it.
 	MoveResults() refactoring.MoveResults
 
-	// ResolvedImports returns a map describing the resolved imports
+	// ImportResolver returns a map describing the resolved imports
 	// after evaluating the dynamic address of the import targets
 	//
 	// This data is created during the graph walk, as import target addresses are being resolved
 	// Its primary use is for validation at the end of a plan - To make sure all imports have been satisfied
 	// and have a configuration
-	ResolvedImports() *ResolvedImports
+	ImportResolver() *ImportResolver
 
 	// WithPath returns a copy of the context with the internal path set to the
 	// path argument.

--- a/internal/tofu/eval_context_builtin.go
+++ b/internal/tofu/eval_context_builtin.go
@@ -75,7 +75,7 @@ type BuiltinEvalContext struct {
 	PrevRunStateValue     *states.SyncState
 	InstanceExpanderValue *instances.Expander
 	MoveResultsValue      refactoring.MoveResults
-	ResolvedImportsValue  *ResolvedImports
+	ImportResolverValue   *ImportResolver
 }
 
 // BuiltinEvalContext implements EvalContext
@@ -512,6 +512,6 @@ func (ctx *BuiltinEvalContext) MoveResults() refactoring.MoveResults {
 	return ctx.MoveResultsValue
 }
 
-func (ctx *BuiltinEvalContext) ResolvedImports() *ResolvedImports {
-	return ctx.ResolvedImportsValue
+func (ctx *BuiltinEvalContext) ImportResolver() *ImportResolver {
+	return ctx.ImportResolverValue
 }

--- a/internal/tofu/eval_context_mock.go
+++ b/internal/tofu/eval_context_mock.go
@@ -151,8 +151,8 @@ type MockEvalContext struct {
 	MoveResultsCalled  bool
 	MoveResultsResults refactoring.MoveResults
 
-	ResolvedImportsCalled  bool
-	ResolvedImportsResults *ResolvedImports
+	ImportResolverCalled  bool
+	ImportResolverResults *ImportResolver
 
 	InstanceExpanderCalled   bool
 	InstanceExpanderExpander *instances.Expander
@@ -403,9 +403,9 @@ func (c *MockEvalContext) MoveResults() refactoring.MoveResults {
 	return c.MoveResultsResults
 }
 
-func (c *MockEvalContext) ResolvedImports() *ResolvedImports {
-	c.ResolvedImportsCalled = true
-	return c.ResolvedImportsResults
+func (c *MockEvalContext) ImportResolver() *ImportResolver {
+	c.ImportResolverCalled = true
+	return c.ImportResolverResults
 }
 
 func (c *MockEvalContext) InstanceExpander() *instances.Expander {

--- a/internal/tofu/graph_walk_context.go
+++ b/internal/tofu/graph_walk_context.go
@@ -38,7 +38,7 @@ type ContextGraphWalker struct {
 	Changes            *plans.ChangesSync      // Used for safe concurrent writes to changes
 	Checks             *checks.State           // Used for safe concurrent writes of checkable objects and their check results
 	InstanceExpander   *instances.Expander     // Tracks our gradual expansion of module and resource instances
-	ResolvedImports    *ResolvedImports        // Tracks import targets as they are being resolved
+	ImportResolver     *ImportResolver         // Tracks import targets as they are being resolved
 	MoveResults        refactoring.MoveResults // Read-only record of earlier processing of move statements
 	Operation          walkOperation
 	StopContext        context.Context
@@ -103,7 +103,7 @@ func (w *ContextGraphWalker) EvalContext() EvalContext {
 		InstanceExpanderValue: w.InstanceExpander,
 		Plugins:               w.Context.plugins,
 		MoveResultsValue:      w.MoveResults,
-		ResolvedImportsValue:  w.ResolvedImports,
+		ImportResolverValue:   w.ImportResolver,
 		ProviderCache:         w.providerCache,
 		ProviderInputConfig:   w.Context.providerInputConfig,
 		ProviderLock:          &w.providerLock,


### PR DESCRIPTION
Fix a race introduced in https://github.com/opentofu/opentofu/pull/1207 (example run [here](https://github.com/opentofu/opentofu/actions/runs/7950028478/job/21701859808?pr=1158))

Access to `imports` of `ResolvedImports` was not _technically_ safe, causing failures in the race tests (A race here shouldn't really have affected the code much for now, as the `ResolvedImports` was only used for validation that all import actions have been satisfied)

Here I fix the race by:
- Introducing a lock for accessing the `imports`
- Changed `ResolvedImports` to be `ImportResolver`, which has its own access functions for reading and writing the resolved imports (in preparation for https://github.com/opentofu/opentofu/pull/1270)

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.0
