### PR TITLE
Docs: add Fedora section and minor changes in rpm doc

### DIFF
--- a/website/docs/intro/install/fedora.mdx
+++ b/website/docs/intro/install/fedora.mdx
@@ -1,0 +1,20 @@
+---
+sidebar_position: 6
+sidebar_label: Fedora
+description: |-
+  Install OpenTofu on Fedora.
+---
+
+import CodeBlock from '@theme/CodeBlock';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Installing OpenTofu on Fedora
+
+OpenTofu is available in the [Fedora repository](https://src.fedoraproject.org/rpms/opentofu) as an `.rpm` package.
+
+## Installing the .rpm package
+
+```bash
+dnf install opentofu
+```

--- a/website/docs/intro/install/index.mdx
+++ b/website/docs/intro/install/index.mdx
@@ -31,7 +31,14 @@ You can install OpenTofu via a wide range of methods. Please select your operati
             href: "/docs/intro/install/rpm",
             label: "RHEL and derivatives (.rpm)",
             description:
-                "Install OpenTofu on RHEL, Fedora, openSUSE, or any other .rpm-based Linux distribution using your package manager.",
+                "Install OpenTofu on RHEL, openSUSE, AlmaLinux or any other .rpm-based Linux distribution using your package manager.",
+        },
+        {
+            type: "link",
+            href: "/docs/intro/install/fedora",
+            label: "Fedora",
+            description:
+                "Install OpenTofu on Fedora using your package manager.",
         },
         {
             type: "link",

--- a/website/docs/intro/install/rpm.mdx
+++ b/website/docs/intro/install/rpm.mdx
@@ -1,8 +1,8 @@
 ---
 sidebar_position: 3
-sidebar_label: .rpm-based Linux (RHEL, openSUSE, Fedora)
+sidebar_label: .rpm-based Linux (RHEL, openSUSE, AlmaLinux)
 description: |-
-  Install OpenTofu on Red Hat Enterprise Linux.
+  Install OpenTofu on Red Hat Enterprise Linux (RHEL), openSUSE, AlmaLinux.
 ---
 
 import Tabs from '@theme/Tabs';
@@ -15,7 +15,7 @@ import YumInstallScript from '!!raw-loader!./install-yum.sh'
 import ZypperInstallScript from '!!raw-loader!./install-zypper.sh'
 import Buildkite from "./buildkite";
 
-# Installing OpenTofu on RHEL, Fedora, openSUSE, and other RPM-based distributions
+# Installing OpenTofu on RHEL, openSUSE, AlmaLinux and other RPM-based distributions
 
 <Buildkite />
 
@@ -34,7 +34,7 @@ The following steps explain how to set up the OpenTofu RPM repositories. These i
 ### Adding the OpenTofu repository
 
 <Tabs>
-    <TabItem value="redhat" label="Yum (RHEL/Fedora/etc.)" default>
+    <TabItem value="redhat" label="Yum (RHEL/AlmaLinux/etc.)" default>
         Create the <code>/etc/yum.repos.d/opentofu.repo</code> file by running the following command:
         <CodeBlock language={"bash"}>{YumRepoScript}</CodeBlock>
     </TabItem>
@@ -49,7 +49,7 @@ The following steps explain how to set up the OpenTofu RPM repositories. These i
 Now you install OpenTofu by running:
 
 <Tabs>
-    <TabItem value="redhat" label="Yum (RHEL/Fedora/etc)" default>
+    <TabItem value="redhat" label="Yum (RHEL/AlmaLinux/etc)" default>
         <CodeBlock language={"bash"}>{YumInstallScript}</CodeBlock>
     </TabItem>
     <TabItem value="opensuse-leap" label="Zypper (openSUSE)">


### PR DESCRIPTION
Since last week OpenTofu is available to be installed in Fedora directly. It took a few more days than I said at FOSDEM ;)

I'm creating this PR with updated doc adding a new section and modifying the rpm doc a bit. I can create an issue if we want to discuss if this is the correct approach.
