### PR TITLE
fix: internal/config unit test for windows

### DIFF
--- a/internal/configs/config_build_test.go
+++ b/internal/configs/config_build_test.go
@@ -101,7 +101,7 @@ func TestBuildConfigDiags(t *testing.T) {
 		},
 	))
 
-	wantDiag := `testdata/nested-errors/child_c/child_c.tf:5,1-8: ` +
+	wantDiag := filepath.FromSlash(`testdata/nested-errors/child_c/child_c.tf:5,1-8: `) +
 		`Unsupported block type; Blocks of type "invalid" are not expected here.`
 	assertExactDiagnostics(t, diags, []string{wantDiag})
 
@@ -190,6 +190,14 @@ func TestBuildConfigInvalidModules(t *testing.T) {
 				for _, s := range strings.Split(string(data), "\n") {
 					msg := strings.TrimSpace(s)
 					msg = strings.ReplaceAll(msg, `\n`, "\n")
+					// The filepath preset in testdata with unix-style slash.
+					// We should from slash to adapt to Linux, Windows and others OS.
+					msgSplit := strings.SplitN(msg, ":", 2)
+					if len(msgSplit) == 2 {
+						msgSplit[0] = filepath.FromSlash(msgSplit[0])
+						msg = strings.Join(msgSplit, ":")
+					}
+
 					if msg != "" {
 						expected = append(expected, msg)
 					}

--- a/internal/configs/config_test.go
+++ b/internal/configs/config_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -323,7 +324,7 @@ func TestConfigProviderRequirementsByModule(t *testing.T) {
 			"kinder": {
 				Name:       "kinder",
 				SourceAddr: addrs.ModuleSourceLocal("./child"),
-				SourceDir:  "testdata/provider-reqs/child",
+				SourceDir:  filepath.FromSlash("testdata/provider-reqs/child"),
 				Requirements: getproviders.Requirements{
 					nullProvider:       getproviders.MustParseVersionConstraints("= 2.0.1"),
 					happycloudProvider: nil,
@@ -332,7 +333,7 @@ func TestConfigProviderRequirementsByModule(t *testing.T) {
 					"nested": {
 						Name:       "nested",
 						SourceAddr: addrs.ModuleSourceLocal("./grandchild"),
-						SourceDir:  "testdata/provider-reqs/child/grandchild",
+						SourceDir:  filepath.FromSlash("testdata/provider-reqs/child/grandchild"),
 						Requirements: getproviders.Requirements{
 							grandchildProvider: nil,
 						},
@@ -393,7 +394,7 @@ func TestConfigProviderRequirementsByModuleInclTests(t *testing.T) {
 					"setup": {
 						Name:       "setup",
 						SourceAddr: addrs.ModuleSourceLocal("./setup"),
-						SourceDir:  "testdata/provider-reqs-with-tests/setup",
+						SourceDir:  filepath.FromSlash("testdata/provider-reqs-with-tests/setup"),
 						Requirements: getproviders.Requirements{
 							nullProvider:   getproviders.MustParseVersionConstraints("~> 2.0.0"),
 							randomProvider: getproviders.MustParseVersionConstraints("~> 1.2.0"),

--- a/internal/configs/experiments_test.go
+++ b/internal/configs/experiments_test.go
@@ -6,6 +6,7 @@
 package configs
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -38,7 +39,7 @@ func TestExperimentsConfig(t *testing.T) {
 			Summary:  `Experimental feature "current" is active`,
 			Detail:   "Experimental features are available only in alpha releases of OpenTofu and are subject to breaking changes or total removal in later versions, based on feedback. We recommend against using experimental features in production.\n\nIf you have feedback on the design of this feature, please open a GitHub issue to discuss it.",
 			Subject: &hcl.Range{
-				Filename: "testdata/experiments/current/current_experiment.tf",
+				Filename: filepath.FromSlash("testdata/experiments/current/current_experiment.tf"),
 				Start:    hcl.Pos{Line: 2, Column: 18, Byte: 29},
 				End:      hcl.Pos{Line: 2, Column: 25, Byte: 36},
 			},
@@ -66,7 +67,7 @@ func TestExperimentsConfig(t *testing.T) {
 			Summary:  `Experiment has concluded`,
 			Detail:   `Experiment "concluded" is no longer available. Reticulate your splines.`,
 			Subject: &hcl.Range{
-				Filename: "testdata/experiments/concluded/concluded_experiment.tf",
+				Filename: filepath.FromSlash("testdata/experiments/concluded/concluded_experiment.tf"),
 				Start:    hcl.Pos{Line: 2, Column: 18, Byte: 29},
 				End:      hcl.Pos{Line: 2, Column: 27, Byte: 38},
 			},
@@ -88,7 +89,7 @@ func TestExperimentsConfig(t *testing.T) {
 			Summary:  `Unknown experiment keyword`,
 			Detail:   `There is no current experiment with the keyword "unknown".`,
 			Subject: &hcl.Range{
-				Filename: "testdata/experiments/unknown/unknown_experiment.tf",
+				Filename: filepath.FromSlash("testdata/experiments/unknown/unknown_experiment.tf"),
 				Start:    hcl.Pos{Line: 2, Column: 18, Byte: 29},
 				End:      hcl.Pos{Line: 2, Column: 25, Byte: 36},
 			},
@@ -110,7 +111,7 @@ func TestExperimentsConfig(t *testing.T) {
 			Summary:  `Invalid expression`,
 			Detail:   `A static list expression is required.`,
 			Subject: &hcl.Range{
-				Filename: "testdata/experiments/invalid/invalid_experiments.tf",
+				Filename: filepath.FromSlash("testdata/experiments/invalid/invalid_experiments.tf"),
 				Start:    hcl.Pos{Line: 2, Column: 17, Byte: 28},
 				End:      hcl.Pos{Line: 2, Column: 24, Byte: 35},
 			},
@@ -132,7 +133,7 @@ func TestExperimentsConfig(t *testing.T) {
 			Summary:  `Module uses experimental features`,
 			Detail:   `Experimental features are intended only for gathering early feedback on new language designs, and so are available only in alpha releases of OpenTofu.`,
 			Subject: &hcl.Range{
-				Filename: "testdata/experiments/current/current_experiment.tf",
+				Filename: filepath.FromSlash("testdata/experiments/current/current_experiment.tf"),
 				Start:    hcl.Pos{Line: 2, Column: 3, Byte: 14},
 				End:      hcl.Pos{Line: 2, Column: 14, Byte: 25},
 			},

--- a/internal/configs/module_call_test.go
+++ b/internal/configs/module_call_test.go
@@ -7,6 +7,7 @@ package configs
 
 import (
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -151,6 +152,11 @@ func TestLoadModuleCall(t *testing.T) {
 }
 
 func TestModuleSourceAddrEntersNewPackage(t *testing.T) {
+	absolutePath := "/absolute/path"
+	if runtime.GOOS == "windows" {
+		absolutePath = "C:\\absolute\\path"
+	}
+
 	tests := []struct {
 		Addr string
 		Want bool
@@ -164,7 +170,7 @@ func TestModuleSourceAddrEntersNewPackage(t *testing.T) {
 			false,
 		},
 		{
-			"/absolute/path",
+			absolutePath,
 			true,
 		},
 		{

--- a/internal/configs/module_merge_test.go
+++ b/internal/configs/module_merge_test.go
@@ -7,6 +7,7 @@ package configs
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
@@ -35,7 +36,7 @@ func TestModuleOverrideVariable(t *testing.T) {
 			ConstraintType: cty.String,
 			ParsingMode:    VariableParseLiteral,
 			DeclRange: hcl.Range{
-				Filename: "testdata/valid-modules/override-variable/primary.tf",
+				Filename: filepath.FromSlash("testdata/valid-modules/override-variable/primary.tf"),
 				Start: hcl.Pos{
 					Line:   1,
 					Column: 1,
@@ -59,7 +60,7 @@ func TestModuleOverrideVariable(t *testing.T) {
 			ConstraintType: cty.String,
 			ParsingMode:    VariableParseLiteral,
 			DeclRange: hcl.Range{
-				Filename: "testdata/valid-modules/override-variable/primary.tf",
+				Filename: filepath.FromSlash("testdata/valid-modules/override-variable/primary.tf"),
 				Start: hcl.Pos{
 					Line:   7,
 					Column: 1,
@@ -96,7 +97,7 @@ func TestModuleOverrideModule(t *testing.T) {
 		SourceAddr:    addrs.ModuleSourceLocal("./example2-a_override"),
 		SourceAddrRaw: "./example2-a_override",
 		SourceAddrRange: hcl.Range{
-			Filename: "testdata/valid-modules/override-module/a_override.tf",
+			Filename: filepath.FromSlash("testdata/valid-modules/override-module/a_override.tf"),
 			Start: hcl.Pos{
 				Line:   3,
 				Column: 12,
@@ -110,7 +111,7 @@ func TestModuleOverrideModule(t *testing.T) {
 		},
 		SourceSet: true,
 		DeclRange: hcl.Range{
-			Filename: "testdata/valid-modules/override-module/primary.tf",
+			Filename: filepath.FromSlash("testdata/valid-modules/override-module/primary.tf"),
 			Start: hcl.Pos{
 				Line:   2,
 				Column: 1,
@@ -127,7 +128,7 @@ func TestModuleOverrideModule(t *testing.T) {
 				hcl.TraverseRoot{
 					Name: "null_resource",
 					SrcRange: hcl.Range{
-						Filename: "testdata/valid-modules/override-module/primary.tf",
+						Filename: filepath.FromSlash("testdata/valid-modules/override-module/primary.tf"),
 						Start:    hcl.Pos{Line: 11, Column: 17, Byte: 149},
 						End:      hcl.Pos{Line: 11, Column: 30, Byte: 162},
 					},
@@ -135,7 +136,7 @@ func TestModuleOverrideModule(t *testing.T) {
 				hcl.TraverseAttr{
 					Name: "test",
 					SrcRange: hcl.Range{
-						Filename: "testdata/valid-modules/override-module/primary.tf",
+						Filename: filepath.FromSlash("testdata/valid-modules/override-module/primary.tf"),
 						Start:    hcl.Pos{Line: 11, Column: 30, Byte: 162},
 						End:      hcl.Pos{Line: 11, Column: 35, Byte: 167},
 					},
@@ -147,7 +148,7 @@ func TestModuleOverrideModule(t *testing.T) {
 				InChild: &ProviderConfigRef{
 					Name: "test",
 					NameRange: hcl.Range{
-						Filename: "testdata/valid-modules/override-module/b_override.tf",
+						Filename: filepath.FromSlash("testdata/valid-modules/override-module/b_override.tf"),
 						Start:    hcl.Pos{Line: 7, Column: 5, Byte: 97},
 						End:      hcl.Pos{Line: 7, Column: 9, Byte: 101},
 					},
@@ -155,13 +156,13 @@ func TestModuleOverrideModule(t *testing.T) {
 				InParent: &ProviderConfigRef{
 					Name: "test",
 					NameRange: hcl.Range{
-						Filename: "testdata/valid-modules/override-module/b_override.tf",
+						Filename: filepath.FromSlash("testdata/valid-modules/override-module/b_override.tf"),
 						Start:    hcl.Pos{Line: 7, Column: 12, Byte: 104},
 						End:      hcl.Pos{Line: 7, Column: 16, Byte: 108},
 					},
 					Alias: "b_override",
 					AliasRange: &hcl.Range{
-						Filename: "testdata/valid-modules/override-module/b_override.tf",
+						Filename: filepath.FromSlash("testdata/valid-modules/override-module/b_override.tf"),
 						Start:    hcl.Pos{Line: 7, Column: 16, Byte: 108},
 						End:      hcl.Pos{Line: 7, Column: 27, Byte: 119},
 					},
@@ -324,7 +325,7 @@ func TestModuleOverrideResourceFQNs(t *testing.T) {
 	wantProviderCfg := &ProviderConfigRef{
 		Name: "bar-test",
 		NameRange: hcl.Range{
-			Filename: "testdata/valid-modules/override-resource-provider/a_override.tf",
+			Filename: filepath.FromSlash("testdata/valid-modules/override-resource-provider/a_override.tf"),
 			Start:    hcl.Pos{Line: 2, Column: 14, Byte: 51},
 			End:      hcl.Pos{Line: 2, Column: 22, Byte: 59},
 		},


### PR DESCRIPTION
In windows machine, some filepaths filled by OpenTofu have windows style slash
Fix the expected data in unit test to pass in different OS.

Part of https://github.com/opentofu/opentofu/issues/1201
