### PR TITLE
fix broken link

### DIFF
--- a/website/docs/language/settings/tf-cloud.mdx
+++ b/website/docs/language/settings/tf-cloud.mdx
@@ -5,7 +5,7 @@ description: >-
 
 # Cloud Configuration
 
-The main module of an OpenTofu configuration can integrate with a cloud backend to enable CLI-driven run workflow (if supported by your cloud backend). You only need to configure these settings when you want to use OpenTofu CLI to interact with a cloud backend.
+The main module of an OpenTofu configuration can integrate with a cloud backend to enable its [CLI-driven run workflow](docs/cli/cloud) (if supported by your cloud backend). You only need to configure these settings when you want to use OpenTofu CLI to interact with a cloud backend.
 A cloud backend ignores them when interacting with OpenTofu through version control or the API.
 
 ## Usage Example

--- a/website/docs/language/settings/tf-cloud.mdx
+++ b/website/docs/language/settings/tf-cloud.mdx
@@ -5,7 +5,7 @@ description: >-
 
 # Cloud Configuration
 
-The main module of an OpenTofu configuration can integrate with a cloud backend to enable its [CLI-driven run workflow](docs/cli/cloud) (if supported by your cloud backend). You only need to configure these settings when you want to use OpenTofu CLI to interact with a cloud backend.
+The main module of an OpenTofu configuration can integrate with a cloud backend to enable its [CLI-driven run workflow](/docs/cli/cloud) (if supported by your cloud backend). You only need to configure these settings when you want to use OpenTofu CLI to interact with a cloud backend.
 A cloud backend ignores them when interacting with OpenTofu through version control or the API.
 
 ## Usage Example


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

## Current Behaviour

On the [Cloud Configuration](https://opentofu.org/docs/language/settings/tf-cloud/) page, the "CLI-driven run workflow" text contains a broken link to <https://opentofu.org/docs/cloud-docs/run/cli>.

## Expected Behaviour

I assume that it's meant to link to [Using the Cloud Backend with OpenTofu CLI](https://opentofu.org/docs/cli/cloud/) page instead.

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #1285

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.6.0
