### PR TITLE
State Encryption Error Handling / Diagnostics

### DIFF
--- a/internal/encryption/example_test.go
+++ b/internal/encryption/example_test.go
@@ -64,11 +64,16 @@ func Example() {
 	// Construct the encryption object
 	enc := encryption.New(reg, cfg)
 
+	sfe, diags := enc.StateFile()
+	handleDiags(diags)
+
 	// Encrypt the data, for this example we will be using the string "test",
 	// but in a real world scenario this would be the plan file.
 	sourceData := []byte("test")
-	encrypted, diags := enc.StateFile().EncryptState(sourceData)
-	handleDiags(diags)
+	encrypted, err := sfe.EncryptState(sourceData)
+	if err != nil {
+		panic(err)
+	}
 
 	if string(encrypted) == "test" {
 		panic("The data has not been encrypted!")
@@ -77,7 +82,7 @@ func Example() {
 	println(string(encrypted))
 
 	// Decrypt
-	decryptedState, err := enc.StateFile().DecryptState(encrypted)
+	decryptedState, err := sfe.DecryptState(encrypted)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
A lot of the call sites seen in #1288 and #1292 only deal with errors, especially deep in the state serialization package.  By returning hcl.Diagnostics, we complicate each of those call sites, and the entire call tree thereof.  Although technically hcl.Diagnostics implements the error interface, it must be used carefuly.  In the case of `var err error; err = hcl.Diagnostics(nil)`, `err != nil` is a false statement as the type information does not match.

hcl.Diagnostics is primarily useful when decoding configuration or evaluating expressions.  We want to preserve the ability to return those from the encryption library where it makes sense, but simplify all other call sites as much as possible to the standard error interface.

Other than errors in the metadata, all of the hcl.Diagnostics should be known ahead of time when dealing with building encryption methods.   We can call that when the encryptor is constructed and return those diagnostics early.  This will primarily be called from packages that already are heavily dealing with hcl.Diagnostics and tfdiags.Diagnostics.

Once we know that the configuration/registry pair is valid for the given target, we can be confident that plain errors will suffice when calling the encrypt/decrypt actions.

This is a prerequisite of #1288 and #1292, though the code in those PRs won't change at all (other than 1 cleanup in planfile/reader.go)

Part of #1030 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.0
