### PR TITLE
Only run check/tests workflow when relevant file paths are modified

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,16 +17,19 @@ name: Quick Checks
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'website/**'
   push:
     branches:
       - main
       - 'v[0-9]+.[0-9]+'
       - checks-workflow-dev/*
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+*'
     paths-ignore:
       - 'docs/**'
       - 'website/**'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 # This workflow runs for not-yet-reviewed external contributions and so it
 # intentionally has no write access and only limited read access to the

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,6 +24,8 @@ on:
       - checks-workflow-dev/*
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
+    paths-ignore:
+      - 'website/**'
 
 # This workflow runs for not-yet-reviewed external contributions and so it
 # intentionally has no write access and only limited read access to the

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -25,6 +25,7 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
     paths-ignore:
+      - 'docs/**'
       - 'website/**'
 
 # This workflow runs for not-yet-reviewed external contributions and so it

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -8,6 +8,8 @@ on:
       - 'v[0-9]+.[0-9]+'
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
+    paths:
+      - 'website/**'
 
 jobs:
   build:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -2,14 +2,16 @@ name: Website checks
 
 on:
   pull_request:
+    paths:
+      - 'website/**'
   push:
     branches:
       - main
       - 'v[0-9]+.[0-9]+'
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+*'
     paths:
       - 'website/**'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   build:


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

Currently, for any given PR on this repo, a whole host of tests are required by the checks.yml workflow.

When it comes to website/docs-only changes, this workflow requirement is particularly wasteful of GitHub Action runner minutes _and_ adds unnecessary friction to the PR review process.

[Per docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-paths), we can `paths` and `paths-ignore` to filter when the workflow is run depending on the file changes introduced by the PR.

While I've drafted a "broad stroke" approach of either include or excluding the `'website/**'` directory and its content, it's perfectly open/adaptable to both positive and negative matching of both files paths and (nested) directories.

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #1303

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.6.1
