### PR TITLE
feat: Add support for `tofu.workspace` which will be resolved in the same way as `terraform.workspace`

### DIFF
--- a/internal/addrs/parse_ref.go
+++ b/internal/addrs/parse_ref.go
@@ -328,10 +328,18 @@ func parseRef(traversal hcl.Traversal) (*Reference, tfdiags.Diagnostics) {
 	case "terraform":
 		name, rng, remain, diags := parseSingleAttrRef(traversal)
 		return &Reference{
-			Subject:     TerraformAttr{Name: name},
+			Subject:     NewTerraformAttr(IdentTerraform, name),
 			SourceRange: tfdiags.SourceRangeFromHCL(rng),
 			Remaining:   remain,
 		}, diags
+
+	case "tofu":
+		name, rng, remain, parsedDiags := parseSingleAttrRef(traversal)
+		return &Reference{
+			Subject:     NewTerraformAttr(IdentTofu, name),
+			SourceRange: tfdiags.SourceRangeFromHCL(rng),
+			Remaining:   remain,
+		}, parsedDiags
 
 	case "var":
 		name, rng, remain, diags := parseSingleAttrRef(traversal)

--- a/internal/addrs/parse_ref_test.go
+++ b/internal/addrs/parse_ref_test.go
@@ -606,9 +606,7 @@ func TestParseRef(t *testing.T) {
 		{
 			`terraform.workspace`,
 			&Reference{
-				Subject: TerraformAttr{
-					Name: "workspace",
-				},
+				Subject: NewTerraformAttr("terraform", "workspace"),
 				SourceRange: tfdiags.SourceRange{
 					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
 					End:   tfdiags.SourcePos{Line: 1, Column: 20, Byte: 19},
@@ -619,9 +617,7 @@ func TestParseRef(t *testing.T) {
 		{
 			`terraform.workspace.blah`,
 			&Reference{
-				Subject: TerraformAttr{
-					Name: "workspace",
-				},
+				Subject: NewTerraformAttr("terraform", "workspace"),
 				SourceRange: tfdiags.SourceRange{
 					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
 					End:   tfdiags.SourcePos{Line: 1, Column: 20, Byte: 19},
@@ -647,6 +643,49 @@ func TestParseRef(t *testing.T) {
 			`terraform["workspace"]`,
 			nil,
 			`The "terraform" object does not support this operation.`,
+		},
+
+		// tofu
+		{
+			`tofu.workspace`,
+			&Reference{
+				Subject: NewTerraformAttr("tofu", "workspace"),
+				SourceRange: tfdiags.SourceRange{
+					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
+					End:   tfdiags.SourcePos{Line: 1, Column: 15, Byte: 14},
+				},
+			},
+			``,
+		},
+		{
+			`tofu.workspace.blah`,
+			&Reference{
+				Subject: NewTerraformAttr("tofu", "workspace"),
+				SourceRange: tfdiags.SourceRange{
+					Start: tfdiags.SourcePos{Line: 1, Column: 1, Byte: 0},
+					End:   tfdiags.SourcePos{Line: 1, Column: 15, Byte: 14},
+				},
+				Remaining: hcl.Traversal{
+					hcl.TraverseAttr{
+						Name: "blah",
+						SrcRange: hcl.Range{
+							Start: hcl.Pos{Line: 1, Column: 15, Byte: 14},
+							End:   hcl.Pos{Line: 1, Column: 20, Byte: 19},
+						},
+					},
+				},
+			},
+			``, // valid at this layer, but will fail during eval because "workspace" is a string
+		},
+		{
+			`tofu`,
+			nil,
+			`The "tofu" object cannot be accessed directly. Instead, access one of its attributes.`,
+		},
+		{
+			`tofu["workspace"]`,
+			nil,
+			`The "tofu" object does not support this operation.`,
 		},
 
 		// var

--- a/internal/addrs/tf_attr.go
+++ b/internal/addrs/tf_attr.go
@@ -5,15 +5,28 @@
 
 package addrs
 
-// TerraformAttr is the address of an attribute of the "terraform" object in
-// the interpolation scope, like "terraform.workspace".
+const (
+	IdentTerraform = "terraform"
+	IdentTofu      = "tofu"
+)
+
+func NewTerraformAttr(alias, name string) TerraformAttr {
+	return TerraformAttr{
+		Name:  name,
+		Alias: alias,
+	}
+}
+
+// TerraformAttr is the address of an attribute of the "terraform" and "tofu" object in
+// the interpolation scope, like "terraform.workspace" and "tofu.workspace".
 type TerraformAttr struct {
 	referenceable
-	Name string
+	Name  string
+	Alias string
 }
 
 func (ta TerraformAttr) String() string {
-	return "terraform." + ta.Name
+	return ta.Alias + "." + ta.Name
 }
 
 func (ta TerraformAttr) UniqueKey() UniqueKey {

--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -1735,8 +1735,44 @@ func TestApply_disableBackup(t *testing.T) {
 	}
 }
 
+func TestApply_tfWorkspace(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("apply-tf-workspace"), td)
+	defer testChdir(t, td)()
+
+	statePath := testTempFile(t)
+
+	p := testProvider()
+	view, done := testView(t)
+	c := &ApplyCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(p),
+			View:             view,
+		},
+	}
+
+	args := []string{
+		"-auto-approve",
+		"-state", statePath,
+	}
+	code := c.Run(args)
+	output := done(t)
+	if code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, output.Stderr())
+	}
+
+	expected := strings.TrimSpace(`
+<no state>
+Outputs:
+
+output = default
+	`)
+	testStateOutput(t, statePath, expected)
+}
+
 // Test that the OpenTofu env is passed through
-func TestApply_tofuEnv(t *testing.T) {
+func TestApply_tofuWorkspace(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-tofu-workspace"), td)
@@ -1772,8 +1808,69 @@ output = default
 	testStateOutput(t, statePath, expected)
 }
 
+func TestApply_tfWorkspaceNonDefault(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("apply-tf-workspace"), td)
+	defer testChdir(t, td)()
+
+	// Create new env
+	{
+		ui := new(cli.MockUi)
+		newCmd := &WorkspaceNewCommand{
+			Meta: Meta{
+				Ui: ui,
+			},
+		}
+		if code := newCmd.Run([]string{"test"}); code != 0 {
+			t.Fatal("error creating workspace")
+		}
+	}
+
+	// Switch to it
+	{
+		args := []string{"test"}
+		ui := new(cli.MockUi)
+		selCmd := &WorkspaceSelectCommand{
+			Meta: Meta{
+				Ui: ui,
+			},
+		}
+		if code := selCmd.Run(args); code != 0 {
+			t.Fatal("error switching workspace")
+		}
+	}
+
+	p := testProvider()
+	view, done := testView(t)
+	c := &ApplyCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(p),
+			View:             view,
+		},
+	}
+
+	args := []string{
+		"-auto-approve",
+	}
+	code := c.Run(args)
+	output := done(t)
+	if code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, output.Stderr())
+	}
+
+	statePath := filepath.Join("terraform.tfstate.d", "test", "terraform.tfstate")
+	expected := strings.TrimSpace(`
+<no state>
+Outputs:
+
+output = test
+	`)
+	testStateOutput(t, statePath, expected)
+}
+
 // Test that the OpenTofu env is passed through
-func TestApply_tofuEnvNonDefault(t *testing.T) {
+func TestApply_tofuWorkspaceNonDefault(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-tofu-workspace"), td)

--- a/internal/command/testdata/apply-tf-workspace/main.tf
+++ b/internal/command/testdata/apply-tf-workspace/main.tf
@@ -1,0 +1,3 @@
+output "output" {
+  value = terraform.workspace
+}

--- a/internal/command/testdata/apply-tofu-workspace/main.tf
+++ b/internal/command/testdata/apply-tofu-workspace/main.tf
@@ -1,3 +1,3 @@
 output "output" {
-  value = terraform.workspace
+  value = tofu.workspace
 }

--- a/internal/configs/provisioner.go
+++ b/internal/configs/provisioner.go
@@ -163,7 +163,7 @@ func onlySelfRefs(body hcl.Body) hcl.Diagnostics {
 		for _, v := range attr.Expr.Variables() {
 			valid := false
 			switch v.RootName() {
-			case "self", "path", "terraform":
+			case "self", "path", "terraform", "tofu":
 				valid = true
 			case "count":
 				// count must use "index"

--- a/internal/configs/provisioner_test.go
+++ b/internal/configs/provisioner_test.go
@@ -1,0 +1,123 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package configs
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hcltest"
+)
+
+func TestProvisionerBlock_decode(t *testing.T) {
+	tests := map[string]struct {
+		input *hcl.Block
+		want  *Provisioner
+		err   string
+	}{
+		"refer terraform.workspace when destroy": {
+			input: &hcl.Block{
+				Type:   "provisioner",
+				Labels: []string{"local-exec"},
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"when": {
+							Name: "when",
+							Expr: hcltest.MockExprTraversalSrc("destroy"),
+						},
+						"command": {
+							Name: "command",
+							Expr: hcltest.MockExprTraversalSrc("terraform.workspace"),
+						},
+					},
+				}),
+				DefRange:    blockRange,
+				LabelRanges: []hcl.Range{hcl.Range{}},
+			},
+			want: &Provisioner{
+				Type:      "local-exec",
+				When:      ProvisionerWhenDestroy,
+				OnFailure: ProvisionerOnFailureFail,
+				DeclRange: blockRange,
+			},
+		},
+		"refer tofu.workspace when destroy": {
+			input: &hcl.Block{
+				Type:   "provisioner",
+				Labels: []string{"local-exec"},
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"when": {
+							Name: "when",
+							Expr: hcltest.MockExprTraversalSrc("destroy"),
+						},
+						"command": {
+							Name: "command",
+							Expr: hcltest.MockExprTraversalSrc("tofu.workspace"),
+						},
+					},
+				}),
+				DefRange:    blockRange,
+				LabelRanges: []hcl.Range{hcl.Range{}},
+			},
+			want: &Provisioner{
+				Type:      "local-exec",
+				When:      ProvisionerWhenDestroy,
+				OnFailure: ProvisionerOnFailureFail,
+				DeclRange: blockRange,
+			},
+		},
+		"refer unknown.workspace when destroy": {
+			input: &hcl.Block{
+				Type:   "provisioner",
+				Labels: []string{"local-exec"},
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"when": {
+							Name: "when",
+							Expr: hcltest.MockExprTraversalSrc("destroy"),
+						},
+						"command": {
+							Name: "command",
+							Expr: hcltest.MockExprTraversalSrc("unknown.workspace"),
+						},
+					},
+				}),
+				DefRange:    blockRange,
+				LabelRanges: []hcl.Range{hcl.Range{}},
+			},
+			want: &Provisioner{
+				Type:      "local-exec",
+				When:      ProvisionerWhenDestroy,
+				OnFailure: ProvisionerOnFailureFail,
+				DeclRange: blockRange,
+			},
+			err: "Invalid reference from destroy provisioner",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, diags := decodeProvisionerBlock(test.input)
+
+			if diags.HasErrors() {
+				if test.err == "" {
+					t.Fatalf("unexpected error: %s", diags.Errs())
+				}
+				if gotErr := diags[0].Summary; gotErr != test.err {
+					t.Errorf("wrong error, got %q, want %q", gotErr, test.err)
+				}
+			} else if test.err != "" {
+				t.Fatal("expected error")
+			}
+
+			if !cmp.Equal(got, test.want, cmpopts.IgnoreInterfaces(struct{ hcl.Body }{})) {
+				t.Fatalf("wrong result: %s", cmp.Diff(got, test.want))
+			}
+		})
+	}
+}

--- a/internal/configs/static_scope.go
+++ b/internal/configs/static_scope.go
@@ -11,11 +11,12 @@ import (
 	"path/filepath"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/didyoumean"
 	"github.com/opentofu/opentofu/internal/lang"
 	"github.com/opentofu/opentofu/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // newStaticScope creates a lang.Scope that's backed by the static view of the module represented by the StaticEvaluator

--- a/internal/lang/eval.go
+++ b/internal/lang/eval.go
@@ -146,6 +146,7 @@ func (s *Scope) EvalSelfBlock(body hcl.Body, self cty.Value, schema *configschem
 
 	vals["path"] = cty.ObjectVal(pathAttrs)
 	vals["terraform"] = cty.ObjectVal(terraformAttrs)
+	vals["tofu"] = cty.ObjectVal(terraformAttrs)
 
 	ctx := &hcl.EvalContext{
 		Variables: vals,
@@ -557,6 +558,7 @@ func (b *evalVarBuilder) buildAllVariablesInto(vals map[string]cty.Value) {
 	vals["local"] = cty.ObjectVal(b.localValues)
 	vals["path"] = cty.ObjectVal(b.pathAttrs)
 	vals["terraform"] = cty.ObjectVal(b.terraformAttrs)
+	vals["tofu"] = cty.ObjectVal(b.terraformAttrs)
 	vals["count"] = cty.ObjectVal(b.countAttrs)
 	vals["each"] = cty.ObjectVal(b.forEachAttrs)
 

--- a/internal/lang/eval_test.go
+++ b/internal/lang/eval_test.go
@@ -349,6 +349,20 @@ func TestScopeEvalContext(t *testing.T) {
 				"terraform": cty.ObjectVal(map[string]cty.Value{
 					"workspace": cty.StringVal("default"),
 				}),
+				"tofu": cty.ObjectVal(map[string]cty.Value{
+					"workspace": cty.StringVal("default"),
+				}),
+			},
+		},
+		{
+			`tofu.workspace`,
+			map[string]cty.Value{
+				"terraform": cty.ObjectVal(map[string]cty.Value{
+					"workspace": cty.StringVal("default"),
+				}),
+				"tofu": cty.ObjectVal(map[string]cty.Value{
+					"workspace": cty.StringVal("default"),
+				}),
 			},
 		},
 		{
@@ -882,6 +896,13 @@ func TestScopeEvalSelfBlock(t *testing.T) {
 		},
 		{
 			Config: `attr = terraform.workspace`,
+			Want: map[string]cty.Value{
+				"attr": cty.StringVal("default"),
+				"num":  cty.NullVal(cty.Number),
+			},
+		},
+		{
+			Config: `attr = tofu.workspace`,
 			Want: map[string]cty.Value{
 				"attr": cty.StringVal("default"),
 				"num":  cty.NullVal(cty.Number),

--- a/internal/tfdiags/diagnostics.go
+++ b/internal/tfdiags/diagnostics.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/errwrap"
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hcl/v2"
 )
 
@@ -191,6 +191,10 @@ func (diags Diagnostics) NonFatalErr() error {
 // Diagnostics that do not differ by any of these sortable characteristics
 // will remain in the same relative order after this method returns.
 func (diags Diagnostics) Sort() {
+	sort.Stable(sortDiagnostics(diags))
+}
+
+func (diags Diagnostics) TrimDuplicated() {
 	sort.Stable(sortDiagnostics(diags))
 }
 

--- a/internal/tofu/evaluate.go
+++ b/internal/tofu/evaluate.go
@@ -916,7 +916,6 @@ func (d *evaluationStateData) getResourceSchema(addr addrs.Resource, providerAdd
 func (d *evaluationStateData) GetTerraformAttr(addr addrs.TerraformAttr, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	switch addr.Name {
-
 	case "workspace":
 		workspaceName := d.Evaluator.Meta.Env
 		return cty.StringVal(workspaceName), diags
@@ -927,8 +926,8 @@ func (d *evaluationStateData) GetTerraformAttr(addr addrs.TerraformAttr, rng tfd
 		// removed.
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
-			Summary:  `Invalid "terraform" attribute`,
-			Detail:   `The terraform.env attribute was deprecated in v0.10 and removed in v0.12. The "state environment" concept was renamed to "workspace" in v0.12, and so the workspace name can now be accessed using the terraform.workspace attribute.`,
+			Summary:  fmt.Sprintf("Invalid %q attribute", addr.Alias),
+			Detail:   fmt.Sprintf(`The %s.env attribute was deprecated in v0.10 and removed in v0.12. The "state environment" concept was renamed to "workspace" in v0.12, and so the workspace name can now be accessed using the %s.workspace attribute.`, addr.Alias, addr.Alias),
 			Subject:  rng.ToHCL().Ptr(),
 		})
 		return cty.DynamicVal, diags
@@ -936,8 +935,8 @@ func (d *evaluationStateData) GetTerraformAttr(addr addrs.TerraformAttr, rng tfd
 	default:
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
-			Summary:  `Invalid "terraform" attribute`,
-			Detail:   fmt.Sprintf(`The "terraform" object does not have an attribute named %q. The only supported attribute is terraform.workspace, the name of the currently-selected workspace.`, addr.Name),
+			Summary:  fmt.Sprintf("Invalid %q attribute", addr.Alias),
+			Detail:   fmt.Sprintf(`The %q object does not have an attribute named %q. The only supported attribute is %s.workspace, the name of the currently-selected workspace.`, addr.Alias, addr.Name, addr.Alias),
 			Subject:  rng.ToHCL().Ptr(),
 		})
 		return cty.DynamicVal, diags

--- a/internal/tofu/evaluate_test.go
+++ b/internal/tofu/evaluate_test.go
@@ -33,11 +33,20 @@ func TestEvaluatorGetTerraformAttr(t *testing.T) {
 	}
 	scope := evaluator.Scope(data, nil, nil, nil)
 
-	t.Run("workspace", func(t *testing.T) {
+	t.Run("terraform.workspace", func(t *testing.T) {
 		want := cty.StringVal("foo")
-		got, diags := scope.Data.GetTerraformAttr(addrs.TerraformAttr{
-			Name: "workspace",
-		}, tfdiags.SourceRange{})
+		got, diags := scope.Data.GetTerraformAttr(addrs.NewTerraformAttr("terraform", "workspace"), tfdiags.SourceRange{})
+		if len(diags) != 0 {
+			t.Errorf("unexpected diagnostics %s", spew.Sdump(diags))
+		}
+		if !got.RawEquals(want) {
+			t.Errorf("wrong result %q; want %q", got, want)
+		}
+	})
+
+	t.Run("tofu.workspace", func(t *testing.T) {
+		want := cty.StringVal("foo")
+		got, diags := scope.Data.GetTerraformAttr(addrs.NewTerraformAttr("tofu", "workspace"), tfdiags.SourceRange{})
 		if len(diags) != 0 {
 			t.Errorf("unexpected diagnostics %s", spew.Sdump(diags))
 		}

--- a/internal/tofu/testdata/apply-tf-workspace/main.tf
+++ b/internal/tofu/testdata/apply-tf-workspace/main.tf
@@ -1,0 +1,3 @@
+output "output" {
+    value = terraform.workspace
+}

--- a/internal/tofu/testdata/apply-tofu-workspace/main.tf
+++ b/internal/tofu/testdata/apply-tofu-workspace/main.tf
@@ -1,3 +1,3 @@
 output "output" {
-    value = "${terraform.workspace}"
+    value = tofu.workspace
 }


### PR DESCRIPTION
Resolves #1156 

This PR reuse the `TerraformAttr` struct, and add a `alias` property in it. 

Also, adding the logic for parsing `tofu.workspace` on ParseRef and evalContext function.

Here are the details on how `tofu.workspace` or `terraform.workspace` be evaluated.

## Details

I don't have a lot of background on tf syntax parsing.

But it seems that a graph will be built and walk validate in every tofu operation (like `plan`,`apply`,`validate` etc.)

So I checked the trace log and found `(*BuiltinEvalContext)EvaluateExpr` will be called when tofu want to evaluate the value of `terraform.workspace`.

Therefore, I implemented the parsing logic of `tofu.workspace` by referring to the parsing logic of `terraform.workspace`.

## Additional Information

### Unit Test

I noticed some unit test about `terraform.workspace` is named with tofu.

I do some refactor on them. 

Now, the test about `terraform.workspace` will be named `tf-workspace` or `tfWorkspace`. (alias `terraform` to `tf` to avoid some legal risk)
And the test about `tofu.workspace` will be named `tofu-workspace` or `tofuWorkspace`

### Cloud E2E Test

Also I noticed some e2e test at [internal/cloud/e2e](https://github.com/opentofu/opentofu/tree/main/internal/cloud/e2e) is using `terraform.workspace`. But it seems that all test will be skipped. So I did't add some test about `tofu.workspace` here.

**If you have a different opinion about this, please let me know.**

## TODO

* Change the word on document. (Janos will change it)
* <del>Throw some warning diagnostic when user are using `terraform.workspace` **(I'm not sure. Should be discuss)**</del> (not accept, throw warning will make for a bad user experience for people who just migrated.)

## Target Release

1.7.0


