### PR TITLE
Adding `removed` block docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ UPGRADE NOTES:
 
 
 NEW FEATURES:
+* Add support for a `removed` block that allows users to remove resources or modules from the state without destroying them. ([#1158](https://github.com/opentofu/opentofu/pull/1158))
 
 ENHANCEMENTS:
 * Added `templatestring` function that takes a string and renders it as a template using a supplied set of template variables. ([#1223](https://github.com/opentofu/opentofu/pull/1223))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ ENHANCEMENTS:
 * Allow test run blocks to reference previous run block's module outputs ([#1129](https://github.com/opentofu/opentofu/pull/1129))
 * Support the XDG Base Directory Specification ([#1200](https://github.com/opentofu/opentofu/pull/1200))
 * Allow referencing the output from a test run in the local variables block of another run (tofu test). ([#1254](https://github.com/opentofu/opentofu/pull/1254))
-* Add support for a `removed` block that allows users to remove resources or modules from the state without destroying them. ([#1158](https://github.com/opentofu/opentofu/pull/1158))
+* Add documentation for the `removed` block. ([#1332](https://github.com/opentofu/opentofu/pull/1332))
 
 BUG FIXES:
 * `tofu test` resources cleanup at the end of tests changed to use simple reverse run block order. ([#1043](https://github.com/opentofu/opentofu/pull/1043))

--- a/website/docs/language/resources/behavior.mdx
+++ b/website/docs/language/resources/behavior.mdx
@@ -29,6 +29,7 @@ In summary, applying an OpenTofu configuration will:
 
 - _Create_ resources that exist in the configuration but are not associated with a real infrastructure object in the state.
 - _Destroy_ resources that exist in the state but no longer exist in the configuration.
+- _Forget_ resources that exist in the state but no longer in the configuration and are referenced in a `removed` block within the configuration.
 - _Update in-place_ resources whose arguments have changed.
 - _Destroy and re-create_ resources whose arguments have changed but which cannot be updated in-place due to remote API limitations.
 

--- a/website/docs/language/resources/syntax.mdx
+++ b/website/docs/language/resources/syntax.mdx
@@ -119,8 +119,7 @@ configuration, see
 
 ## Removing Resources
 
-By default, deleting a resource block from your configuration will result in a plan to destroy it, effectively removing
-the infrastructure object described by the resource.
+If you remove a resource block from your configuration, OpenTofu will destroy it as a default behavior.
 
 However, there are instances when you want to remove a resource from your configuration without destroying the
 corresponding infrastructure object. In such cases, you can remove it from the [OpenTofu state](/docs/language/state)
@@ -137,6 +136,11 @@ removed {
   from = aws_instance.web
 }
 ```
+
+:::note
+The address in the `from` attribute cannot include instance keys (for example, "aws_instance.web[0]").
+:::
+
 
 Upon executing `tofu plan`, OpenTofu will indicate that the resource is slated for removal from the state but will not
 be destroyed.

--- a/website/docs/language/resources/syntax.mdx
+++ b/website/docs/language/resources/syntax.mdx
@@ -137,7 +137,9 @@ removed {
 ```
 
 :::note
+
 The address in the `from` attribute cannot include instance keys (for example, "aws_instance.web[0]").
+
 :::
 
 Upon executing `tofu plan`, OpenTofu will indicate that the resource is slated for removal from the state but will not

--- a/website/docs/language/resources/syntax.mdx
+++ b/website/docs/language/resources/syntax.mdx
@@ -140,7 +140,6 @@ removed {
 The address in the `from` attribute cannot include instance keys (for example, "aws_instance.web[0]").
 :::
 
-
 Upon executing `tofu plan`, OpenTofu will indicate that the resource is slated for removal from the state but will not
 be destroyed.
 

--- a/website/docs/language/resources/syntax.mdx
+++ b/website/docs/language/resources/syntax.mdx
@@ -127,8 +127,7 @@ while allowing it to persist in the remote system.
 
 To achieve this, follow these steps:
 1. Delete the resource from your configuration.
-2. Add a removed block instead, specifying the resource address you want to "forget" in the `from` attribute. Note that
-the address cannot include instance keys (for example, "aws_instance.web[0]").
+2. Add a removed block instead, specifying the resource address you want to "forget" in the `from` attribute.
 
 For example:
 ```hcl

--- a/website/docs/language/resources/syntax.mdx
+++ b/website/docs/language/resources/syntax.mdx
@@ -117,6 +117,37 @@ For more information about how OpenTofu manages resources when applying a
 configuration, see
 [Resource Behavior](/docs/language/resources/behavior).
 
+## Removing Resources
+
+By default, deleting a resource block from your configuration will result in a plan to destroy it, effectively removing
+the infrastructure object described by the resource.
+
+However, there are instances when you want to remove a resource from your configuration without destroying the
+corresponding infrastructure object. In such cases, you can remove it from the [OpenTofu state](/docs/language/state)
+while allowing it to persist in the remote system.
+
+To achieve this, follow these steps:
+1. Delete the resource from your configuration.
+2. Add a removed block instead, specifying the resource address you want to "forget" in the `from` attribute. Note that
+the address cannot include instance keys (for example, "aws_instance.web[0]").
+
+For example:
+```hcl
+removed {
+  from = aws_instance.web
+}
+```
+
+Upon executing `tofu plan`, OpenTofu will indicate that the resource is slated for removal from the state but will not
+be destroyed.
+
+The `removed` block can be used to remove specific resources or modules containing multiple resources. For example:
+```hcl
+removed {
+  from = module.some_module
+}
+```
+
 ## Meta-Arguments
 
 The OpenTofu language defines several meta-arguments, which can be used with


### PR DESCRIPTION
Adding the documentation for the `removed` block introduced in https://github.com/opentofu/opentofu/pull/1158

**Possible sections to add explanations about the `removed` block:**
1. [Language -> Resources -> Resource Blocks](https://opentofu.org/docs/language/resources/syntax/) - added here the main explanation. 
2. [Language -> Resources -> Resource Behavior](https://opentofu.org/docs/language/resources/behavior/) - added an explanation about the new `forget` action.
3. [Language -> Modules -> Refactoring](https://opentofu.org/docs/language/modules/develop/refactoring/) - I initially considered putting the main explanation here, as this section mainly discusses the `moved` block. But the `removed` block forgets resources and doesn't specifically belong to modules. So, I decided not to include it here. However, I am still considering putting a reference to 1.
4. [Language -> State](https://opentofu.org/docs/language/state/) - We have the '[Importing Existing Resources](https://opentofu.org/docs/language/state/import/)' page, so I considered adding a similar page about removing existing resources. Ultimately, it would not benefit this location, as people will most likely search for how to remove resources in the 'Resources' section and not in the 'State' section.

**More considerations:**
1. Since we still don't have docs per OpenTofu version, should we mention that this feature is supported from the 1.7.0 version onwards?
2. Should we also mention the `tofu state rm` command here, as it is a similar way to do the same thing?

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.0
