### PR TITLE
Set maintainer to OpenTofu in Linux package builds

### DIFF
--- a/.github/workflows/build-opentofu-oss.yml
+++ b/.github/workflows/build-opentofu-oss.yml
@@ -80,7 +80,8 @@ jobs:
           description: "OpenTofu enables you to safely and predictably create, change, and improve infrastructure. It is an open source tool that codifies APIs into declarative configuration files that can be shared amongst team members, treated as code, edited, reviewed, and versioned."
           arch: ${{ inputs.goarch }}
           version: ${{ inputs.product-version }}
-          maintainer: "HashiCorp"
+          maintainer: "OpenTofu"
+          vendor: "OpenTofu"
           homepage: "https://opentofu.org/"
           license: "MPL-2.0"
           binary: "dist/tofu"


### PR DESCRIPTION
When building `.rpms` and `.debs` in the build pipeline, set the maintainer to `OpenTofu` instead of `HashiCorp`.

It appears this is not used for release builds (available from https://github.com/opentofu/opentofu/releases) but only used for CI built images (useful for testing purpose).

Downloading such an image today gives:

> ```
> $ rpm -qip opentofu-1.7.0~dev-1.x86_64.rpm
> ... snip ...
> Maintainer  : HashiCorp
> Vendor      : HashiCorp
> ... snip ...
> ```

when these should correctly point to OpenTofu instead.

---

I ran across this recently when setting up build pipelines for OpenBao and figured I'd be neighborly. :-)

## Target Release

1.7.0
