### PR TITLE
gcs backend: fix race condition on locking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ BUG FIXES:
 * `tofu test` now supports accessing module outputs when the module has no resources. ([#1409](https://github.com/opentofu/opentofu/pull/1409))
 * Fixed support for provider functions in tests ([#1603](https://github.com/opentofu/opentofu/pull/1603))
 * Added a better error message on `for_each` block with sensitive value of unsuitable type. ([#1485](https://github.com/opentofu/opentofu/pull/1485))
+* Fix race condition on locking in gcs backend ([#1342](https://github.com/opentofu/opentofu/pull/1342))
 
 ## Previous Releases
 

--- a/internal/states/statemgr/locker.go
+++ b/internal/states/statemgr/locker.go
@@ -89,14 +89,17 @@ func LockWithContext(ctx context.Context, s Locker, info *LockInfo) (string, err
 			return "", err
 		}
 
-		if le == nil || le.Info == nil || le.Info.ID == "" {
-			// If we don't have a complete LockError then there's something
-			// wrong with the lock.
+		if !le.Retriable() {
 			return "", err
 		}
 
 		if postLockHook != nil {
 			postLockHook()
+		}
+
+		// Lock() can be repeated without sleep
+		if le.RetriableWithoutDelay() {
+			continue
 		}
 
 		// there's an existing lock, wait and try again
@@ -214,6 +217,10 @@ func (l *LockInfo) String() string {
 type LockError struct {
 	Info *LockInfo
 	Err  error
+
+	// Set when writing of lock file fails because of conflict and
+	// then reading fails because file doesn't exist (removed by other process)
+	InconsistentRead bool
 }
 
 func (e *LockError) Error() string {
@@ -226,4 +233,20 @@ func (e *LockError) Error() string {
 		out = append(out, e.Info.String())
 	}
 	return strings.Join(out, "\n")
+}
+
+// Retriable returns true when locking should be retried
+func (e *LockError) Retriable() bool {
+	// If we don't have a complete LockError then there's something
+	// wrong with the lock.
+	if e == nil {
+		return false
+	}
+
+	return e.InconsistentRead || (e.Info != nil && e.Info.ID != "")
+}
+
+// RetriableWithoutDelay returns true when delaying can be avoided
+func (e *LockError) RetriableWithoutDelay() bool {
+	return e != nil && e.InconsistentRead
 }


### PR DESCRIPTION
- handles situation when Lock() fails because lock file exists, and then lockInfo() fails because file was deleted by concurrent process
- try to fix #1341

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->
Details: 
- when [Lock](https://github.com/opentofu/opentofu/blob/36eb93f95862c9f1e8a270f6a6e31f8818b0bfa5/internal/backend/remote-state/gcs/client.go#L91) can't  [write lock file](https://github.com/opentofu/opentofu/blob/36eb93f95862c9f1e8a270f6a6e31f8818b0bfa5/internal/backend/remote-state/gcs/client.go#L104) it tries to [read exists lock file](https://github.com/opentofu/opentofu/blob/36eb93f95862c9f1e8a270f6a6e31f8818b0bfa5/internal/backend/remote-state/gcs/client.go#L149) via [lockError()](https://github.com/opentofu/opentofu/blob/36eb93f95862c9f1e8a270f6a6e31f8818b0bfa5/internal/backend/remote-state/gcs/client.go#L111) and [lockInfo()](https://github.com/opentofu/opentofu/blob/36eb93f95862c9f1e8a270f6a6e31f8818b0bfa5/internal/backend/remote-state/gcs/client.go#L137)
- there is some probability that there already no file (deleted by other process) and lockInfo() and lockError() returns error without filled Info field and info.ID 
- but [LockWithContext()](https://github.com/opentofu/opentofu/blob/36eb93f95862c9f1e8a270f6a6e31f8818b0bfa5/internal/states/statemgr/locker.go#L92) expects either no error or filled err.Info.ID  
- for such a case the patch returns dummy err.Info.ID so waiting for real lock continues


<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #1341

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.0
