### PR TITLE
Insert configuration marks to state value when import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ BUG FIXES:
 * Fix Global Schema Cache not working in provider acceptance tests ([#1054](https://github.com/opentofu/opentofu/pull/1054))
 * Fix `tofu show` and `tofu state show` not working with state files referencing Terraform registry providers in some instances ([#1141](https://github.com/opentofu/opentofu/pull/1141))
 * Improved stability on 32-bit architectures ([#1154](https://github.com/opentofu/opentofu/pull/1154))
+* Don't show false update action when import resource with sensitive datasource([#1220](https://github.com/opentofu/opentofu/pull/1220))
 * Fix panic when provisioner source and content are both null ([#1376](https://github.com/opentofu/opentofu/pull/1376))
 
 ## Previous Releases

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -6168,3 +6168,111 @@ func TestContext2Plan_removedModuleButModuleBlockStillExists(t *testing.T) {
 		t.Fatalf("wrong error:\ngot:  %s\nwant: message containing %q", got, want)
 	}
 }
+
+func TestContext2Plan_importResourceWithSensitiveDataSource(t *testing.T) {
+	addr := mustResourceInstanceAddr("test_object.b")
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+			data "test_data_source" "a" {
+			}
+			resource "test_object" "b" {
+				test_string = data.test_data_source.a.test_string
+			}
+			import {
+			  to   = test_object.b
+			  id   = "123"
+			}
+		`,
+	})
+
+	p := &MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			Provider: providers.Schema{Block: simpleTestSchema()},
+			ResourceTypes: map[string]providers.Schema{
+				"test_object": {Block: simpleTestSchema()},
+			},
+			DataSources: map[string]providers.Schema{
+				"test_data_source": {Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"test_string": {
+							Type:      cty.String,
+							Computed:  true,
+							Sensitive: true,
+						},
+					},
+				}},
+			},
+		},
+	}
+	hook := new(MockHook)
+	ctx := testContext2(t, &ContextOpts{
+		Hooks: []Hook{hook},
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	p.ReadDataSourceResponse = &providers.ReadDataSourceResponse{
+		State: cty.ObjectVal(map[string]cty.Value{
+			"test_string": cty.StringVal("foo"),
+		}),
+	}
+
+	p.ReadResourceResponse = &providers.ReadResourceResponse{
+		NewState: cty.ObjectVal(map[string]cty.Value{
+			"test_string": cty.StringVal("foo"),
+		}),
+	}
+	p.ImportResourceStateResponse = &providers.ImportResourceStateResponse{
+		ImportedResources: []providers.ImportedResource{
+			{
+				TypeName: "test_object",
+				State: cty.ObjectVal(map[string]cty.Value{
+					"test_string": cty.StringVal("foo"),
+				}),
+			},
+		},
+	}
+
+	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+
+	t.Run(addr.String(), func(t *testing.T) {
+		instPlan := plan.Changes.ResourceInstance(addr)
+		if instPlan == nil {
+			t.Fatalf("no plan for %s at all", addr)
+		}
+
+		if got, want := instPlan.Addr, addr; !got.Equal(want) {
+			t.Errorf("wrong current address\ngot:  %s\nwant: %s", got, want)
+		}
+		if got, want := instPlan.PrevRunAddr, addr; !got.Equal(want) {
+			t.Errorf("wrong previous run address\ngot:  %s\nwant: %s", got, want)
+		}
+		if got, want := instPlan.Action, plans.NoOp; got != want {
+			t.Errorf("wrong planned action\ngot:  %s\nwant: %s", got, want)
+		}
+		if got, want := instPlan.ActionReason, plans.ResourceInstanceChangeNoReason; got != want {
+			t.Errorf("wrong action reason\ngot:  %s\nwant: %s", got, want)
+		}
+		if instPlan.Importing.ID != "123" {
+			t.Errorf("expected import change from \"123\", got non-import change")
+		}
+
+		if !hook.PrePlanImportCalled {
+			t.Fatalf("PostPlanImport hook not called")
+		}
+		if addr, wantAddr := hook.PrePlanImportAddr, instPlan.Addr; !addr.Equal(wantAddr) {
+			t.Errorf("expected addr to be %s, but was %s", wantAddr, addr)
+		}
+
+		if !hook.PostPlanImportCalled {
+			t.Fatalf("PostPlanImport hook not called")
+		}
+		if addr, wantAddr := hook.PostPlanImportAddr, instPlan.Addr; !addr.Equal(wantAddr) {
+			t.Errorf("expected addr to be %s, but was %s", wantAddr, addr)
+		}
+	})
+}

--- a/internal/tofu/context_test.go
+++ b/internal/tofu/context_test.go
@@ -672,6 +672,19 @@ func testProviderSchema(name string) *providers.GetProviderSchemaResponse {
 					},
 				},
 			},
+			name + "_sensitive_data_source": {
+				Attributes: map[string]*configschema.Attribute{
+					"id": {
+						Type:     cty.String,
+						Computed: true,
+					},
+					"value": {
+						Type:      cty.String,
+						Optional:  true,
+						Sensitive: true,
+					},
+				},
+			},
 		},
 	})
 }

--- a/internal/tofu/marks.go
+++ b/internal/tofu/marks.go
@@ -58,3 +58,11 @@ func marksEqual(a, b []cty.PathValueMarks) bool {
 
 	return true
 }
+
+func copyMarksFromValue(dst, src cty.Value) cty.Value {
+	_, pvm := src.UnmarkDeepWithPaths()
+	if len(pvm) == 0 {
+		return dst
+	}
+	return dst.MarkWithPaths(pvm)
+}

--- a/internal/tofu/node_resource_import.go
+++ b/internal/tofu/node_resource_import.go
@@ -268,9 +268,8 @@ func (n *graphNodeImportStateSub) Execute(ctx EvalContext, op walkOperation) (di
 	// Insert marks from configuration
 	if n.Config != nil {
 		// Since the import command allow import resource with incomplete configuration, we ignore diagnostics here
-		valueWithSchemaMarks, _, _ := ctx.EvaluateBlock(n.Config.Config, n.Schema, nil, EvalDataForNoInstanceKey)
-		_, pvm := valueWithSchemaMarks.UnmarkDeepWithPaths()
-		state.Value = state.Value.MarkWithPaths(pvm)
+		valueWithConfigurationSchemaMarks, _, _ := ctx.EvaluateBlock(n.Config.Config, n.Schema, nil, EvalDataForNoInstanceKey)
+		state.Value = copyMarksFromValue(state.Value, valueWithConfigurationSchemaMarks)
 	}
 
 	diags = diags.Append(riNode.writeResourceInstanceState(ctx, state, workingState))

--- a/internal/tofu/node_resource_import.go
+++ b/internal/tofu/node_resource_import.go
@@ -10,6 +10,8 @@ import (
 	"log"
 
 	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/configs"
+	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
@@ -20,6 +22,10 @@ type graphNodeImportState struct {
 	ID               string                    // ID is the ID to import as
 	ProviderAddr     addrs.AbsProviderConfig   // Provider address given by the user, or implied by the resource type
 	ResolvedProvider addrs.AbsProviderConfig   // provider node address after resolution
+
+	Schema        *configschema.Block // Schema for processing the configuration body
+	SchemaVersion uint64              // Schema version of "Schema", as decided by the provider
+	Config        *configs.Resource   // Config is the resource in the config
 
 	states []providers.ImportedResource
 }
@@ -178,6 +184,9 @@ func (n *graphNodeImportState) DynamicExpand(ctx EvalContext) (*Graph, error) {
 			TargetAddr:       addrs[i],
 			State:            state,
 			ResolvedProvider: n.ResolvedProvider,
+			Schema:           n.Schema,
+			SchemaVersion:    n.SchemaVersion,
+			Config:           n.Config,
 		})
 	}
 
@@ -194,6 +203,11 @@ type graphNodeImportStateSub struct {
 	TargetAddr       addrs.AbsResourceInstance
 	State            providers.ImportedResource
 	ResolvedProvider addrs.AbsProviderConfig
+
+	Schema        *configschema.Block // Schema for processing the configuration body
+	SchemaVersion uint64              // Schema version of "Schema", as decided by the provider
+	Config        *configs.Resource   // Config is the resource in the config
+
 }
 
 var (
@@ -249,6 +263,17 @@ func (n *graphNodeImportStateSub) Execute(ctx EvalContext, op walkOperation) (di
 			),
 		))
 		return diags
+	}
+
+	// Insert marks from configuration
+	if n.Config != nil {
+		valueWithSchemaMarks, _, configDiags := ctx.EvaluateBlock(n.Config.Config, n.Schema, nil, EvalDataForNoInstanceKey)
+		diags = diags.Append(configDiags)
+		if configDiags.HasErrors() {
+			return diags
+		}
+		_, pvm := valueWithSchemaMarks.UnmarkDeepWithPaths()
+		state.Value = state.Value.MarkWithPaths(pvm)
 	}
 
 	diags = diags.Append(riNode.writeResourceInstanceState(ctx, state, workingState))

--- a/internal/tofu/node_resource_import.go
+++ b/internal/tofu/node_resource_import.go
@@ -267,11 +267,8 @@ func (n *graphNodeImportStateSub) Execute(ctx EvalContext, op walkOperation) (di
 
 	// Insert marks from configuration
 	if n.Config != nil {
-		valueWithSchemaMarks, _, configDiags := ctx.EvaluateBlock(n.Config.Config, n.Schema, nil, EvalDataForNoInstanceKey)
-		diags = diags.Append(configDiags)
-		if configDiags.HasErrors() {
-			return diags
-		}
+		// Since the import command allow import resource with incomplete configuration, we ignore diagnostics here
+		valueWithSchemaMarks, _, _ := ctx.EvaluateBlock(n.Config.Config, n.Schema, nil, EvalDataForNoInstanceKey)
 		_, pvm := valueWithSchemaMarks.UnmarkDeepWithPaths()
 		state.Value = state.Value.MarkWithPaths(pvm)
 	}

--- a/internal/tofu/node_resource_plan.go
+++ b/internal/tofu/node_resource_plan.go
@@ -334,6 +334,9 @@ func (n *nodeExpandPlannableResource) resourceInstanceSubgraph(ctx EvalContext, 
 					Addr:             c.Addr,
 					ID:               c.ID,
 					ResolvedProvider: n.ResolvedProvider,
+					Schema:           n.Schema,
+					SchemaVersion:    n.SchemaVersion,
+					Config:           n.Config,
 				}
 			}
 		}

--- a/internal/tofu/node_resource_plan_instance.go
+++ b/internal/tofu/node_resource_plan_instance.go
@@ -554,7 +554,7 @@ func (n *NodePlannableResourceInstance) importState(ctx EvalContext, addr addrs.
 		return instanceRefreshState, diags
 	}
 
-	// insert marks from schema
+	// Insert marks from configuration
 	if n.Config != nil {
 		valueWithSchemaMarks, _, configDiags := ctx.EvaluateBlock(n.Config.Config, n.Schema, nil, EvalDataForNoInstanceKey)
 		diags = diags.Append(configDiags)

--- a/internal/tofu/node_resource_plan_instance.go
+++ b/internal/tofu/node_resource_plan_instance.go
@@ -554,6 +554,17 @@ func (n *NodePlannableResourceInstance) importState(ctx EvalContext, addr addrs.
 		return instanceRefreshState, diags
 	}
 
+	// insert marks from schema
+	if n.Config != nil {
+		valueWithSchemaMarks, _, configDiags := ctx.EvaluateBlock(n.Config.Config, n.Schema, nil, EvalDataForNoInstanceKey)
+		diags = diags.Append(configDiags)
+		if configDiags.HasErrors() {
+			return instanceRefreshState, diags
+		}
+		_, pvm := valueWithSchemaMarks.UnmarkDeepWithPaths()
+		instanceRefreshState.Value = instanceRefreshState.Value.MarkWithPaths(pvm)
+	}
+
 	// If we're importing and generating config, generate it now.
 	if len(n.generateConfigPath) > 0 {
 		if n.Config != nil {

--- a/internal/tofu/node_resource_plan_instance.go
+++ b/internal/tofu/node_resource_plan_instance.go
@@ -556,13 +556,12 @@ func (n *NodePlannableResourceInstance) importState(ctx EvalContext, addr addrs.
 
 	// Insert marks from configuration
 	if n.Config != nil {
-		valueWithSchemaMarks, _, configDiags := ctx.EvaluateBlock(n.Config.Config, n.Schema, nil, EvalDataForNoInstanceKey)
+		valueWithConfigurationSchemaMarks, _, configDiags := ctx.EvaluateBlock(n.Config.Config, n.Schema, nil, EvalDataForNoInstanceKey)
 		diags = diags.Append(configDiags)
 		if configDiags.HasErrors() {
 			return instanceRefreshState, diags
 		}
-		_, pvm := valueWithSchemaMarks.UnmarkDeepWithPaths()
-		instanceRefreshState.Value = instanceRefreshState.Value.MarkWithPaths(pvm)
+		instanceRefreshState.Value = copyMarksFromValue(instanceRefreshState.Value, valueWithConfigurationSchemaMarks)
 	}
 
 	// If we're importing and generating config, generate it now.


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

For resource import scenario, the instance refresh state should contains all the marks(include marks form configuration ) to avoid a update action caused by difference marks between planned value and refresh state(for example: write or delete sensitive paths is an update action).

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #1231

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.0
