### PR TITLE
Fix: don't panic when both source and content of file provisioner are null

### DIFF
--- a/internal/builtin/provisioners/file/resource_provisioner.go
+++ b/internal/builtin/provisioners/file/resource_provisioner.go
@@ -149,7 +149,7 @@ func getSrc(v cty.Value) (string, bool, error) {
 		return expansion, false, err
 
 	default:
-		panic("source and content cannot both be null")
+		return "", false, errors.New("source and content cannot both be null")
 	}
 }
 

--- a/internal/builtin/provisioners/file/resource_provisioner_test.go
+++ b/internal/builtin/provisioners/file/resource_provisioner_test.go
@@ -121,3 +121,28 @@ func TestResourceProvisioner_connectionRequired(t *testing.T) {
 		t.Fatalf("expected 'Missing connection' error: got %q", got)
 	}
 }
+
+func TestResourceProvisioner_nullSrcVars(t *testing.T) {
+	conn := cty.ObjectVal(map[string]cty.Value{
+		"type": cty.StringVal(""),
+		"host": cty.StringVal("localhost"),
+	})
+	config := cty.ObjectVal(map[string]cty.Value{
+		"source":      cty.NilVal,
+		"content":     cty.NilVal,
+		"destination": cty.StringVal("/tmp/bar"),
+	})
+	p := New()
+	resp := p.ProvisionResource(provisioners.ProvisionResourceRequest{
+		Connection: conn,
+		Config:     config,
+	})
+	if !resp.Diagnostics.HasErrors() {
+		t.Fatal("expected error")
+	}
+
+	got := resp.Diagnostics.Err().Error()
+	if !strings.Contains(got, "file provisioner error: source and content cannot both be null") {
+		t.Fatalf("file provisioner error: source and content cannot both be null' error: got %q", got)
+	}
+}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->
If file provisioner using dynamic value(such as vars) as source, we can not validate if it is empty in walkValidate operation 
Then the source will be null when apply the provisioner and make OpenTofu crash.
So we should not panic when both source and content of provisioner are empty

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #1360

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.0
