### PR TITLE
fix: large number are truncated in plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ BUG FIXES:
 * Fix `tofu show` and `tofu state show` not working with state files referencing Terraform registry providers in some instances ([#1141](https://github.com/opentofu/opentofu/pull/1141))
 * Improved stability on 32-bit architectures ([#1154](https://github.com/opentofu/opentofu/pull/1154))
 * Fix panic when provisioner source and content are both null ([#1376](https://github.com/opentofu/opentofu/pull/1376))
+* Fix large number will be truncated in plan ([#1382](https://github.com/opentofu/opentofu/pull/1382))
 
 ## Previous Releases
 

--- a/internal/command/jsonformat/computed/renderers/primitive.go
+++ b/internal/command/jsonformat/computed/renderers/primitive.go
@@ -6,8 +6,8 @@
 package renderers
 
 import (
+	"encoding/json"
 	"fmt"
-	"math/big"
 	"strings"
 
 	"github.com/zclconf/go-cty/cty"
@@ -69,8 +69,8 @@ func renderPrimitiveValue(value interface{}, t cty.Type, opts computed.RenderHum
 		}
 		return "false"
 	case t == cty.Number:
-		bf := big.NewFloat(value.(float64))
-		return bf.Text('f', -1)
+		num := value.(json.Number)
+		return num.String()
 	default:
 		panic("unrecognized primitive type: " + t.FriendlyName())
 	}

--- a/internal/command/jsonformat/computed/renderers/string.go
+++ b/internal/command/jsonformat/computed/renderers/string.go
@@ -6,6 +6,7 @@
 package renderers
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -33,7 +34,9 @@ func evaluatePrimitiveString(value interface{}, opts computed.RenderHumanOpts) e
 
 	if strings.HasPrefix(str, "{") || strings.HasPrefix(str, "[") {
 		var jv interface{}
-		if err := json.Unmarshal([]byte(str), &jv); err == nil {
+		decoder := json.NewDecoder(bytes.NewBufferString(str))
+		decoder.UseNumber()
+		if err := decoder.Decode(&jv); err == nil {
 			return evaluatedString{
 				String: str,
 				Json:   jv,

--- a/internal/command/jsonformat/differ/differ_test.go
+++ b/internal/command/jsonformat/differ/differ_test.go
@@ -1748,16 +1748,16 @@ func TestValue_PrimitiveAttributes(t *testing.T) {
 		"dynamic_type_change": {
 			input: structured.Change{
 				Before: "old",
-				After:  4.0,
+				After:  json.Number("4"),
 			},
 			attribute: cty.DynamicPseudoType,
 			validateDiff: renderers.ValidateTypeChange(
 				renderers.ValidatePrimitive("old", nil, plans.Delete, false),
-				renderers.ValidatePrimitive(nil, 4.0, plans.Create, false),
+				renderers.ValidatePrimitive(nil, json.Number("4"), plans.Create, false),
 				plans.Update, false),
 			validateSliceDiffs: []renderers.ValidateDiffFunction{
 				renderers.ValidatePrimitive("old", nil, plans.Delete, false),
-				renderers.ValidatePrimitive(nil, 4.0, plans.Create, false),
+				renderers.ValidatePrimitive(nil, json.Number("4"), plans.Create, false),
 			},
 		},
 	}
@@ -2170,12 +2170,12 @@ func TestValue_CollectionAttributes(t *testing.T) {
 			input: structured.Change{
 				Before: []interface{}{
 					"one",
-					2.0,
+					json.Number("2"),
 					"three",
 				},
 				After: []interface{}{
 					"one",
-					4.0,
+					json.Number("4"),
 					"three",
 				},
 			},
@@ -2184,7 +2184,7 @@ func TestValue_CollectionAttributes(t *testing.T) {
 			},
 			validateDiff: renderers.ValidateList([]renderers.ValidateDiffFunction{
 				renderers.ValidatePrimitive("one", "one", plans.NoOp, false),
-				renderers.ValidatePrimitive(2.0, 4.0, plans.Update, false),
+				renderers.ValidatePrimitive(json.Number("2"), json.Number("4"), plans.Update, false),
 				renderers.ValidatePrimitive("three", "three", plans.NoOp, false),
 			}, plans.Update, false),
 		},
@@ -2342,27 +2342,27 @@ func TestRelevantAttributes(t *testing.T) {
 			input: structured.Change{
 				Before: map[string]interface{}{
 					"list": []interface{}{
-						0, 1, 2, 3, 4,
+						json.Number("0"), json.Number("1"), json.Number("2"), json.Number("3"), json.Number("4"),
 					},
 				},
 				After: map[string]interface{}{
 					"list": []interface{}{
-						0, 5, 6, 7, 4,
+						json.Number("0"), json.Number("5"), json.Number("6"), json.Number("7"), json.Number("4"),
 					},
 				},
 				RelevantAttributes: &attribute_path.PathMatcher{
 					Paths: [][]interface{}{ // The list is actually just going to ignore this.
 						{
 							"list",
-							float64(0),
+							0.0,
 						},
 						{
 							"list",
-							float64(2),
+							2.0,
 						},
 						{
 							"list",
-							float64(4),
+							4.0,
 						},
 					},
 				},
@@ -2378,14 +2378,14 @@ func TestRelevantAttributes(t *testing.T) {
 				// The list validator below just ignores our relevant
 				// attributes. This is deliberate.
 				"list": renderers.ValidateList([]renderers.ValidateDiffFunction{
-					renderers.ValidatePrimitive(0, 0, plans.NoOp, false),
-					renderers.ValidatePrimitive(1, nil, plans.Delete, false),
-					renderers.ValidatePrimitive(2, nil, plans.Delete, false),
-					renderers.ValidatePrimitive(3, nil, plans.Delete, false),
-					renderers.ValidatePrimitive(nil, 5, plans.Create, false),
-					renderers.ValidatePrimitive(nil, 6, plans.Create, false),
-					renderers.ValidatePrimitive(nil, 7, plans.Create, false),
-					renderers.ValidatePrimitive(4, 4, plans.NoOp, false),
+					renderers.ValidatePrimitive(json.Number("0"), json.Number("0"), plans.NoOp, false),
+					renderers.ValidatePrimitive(json.Number("1"), nil, plans.Delete, false),
+					renderers.ValidatePrimitive(json.Number("2"), nil, plans.Delete, false),
+					renderers.ValidatePrimitive(json.Number("3"), nil, plans.Delete, false),
+					renderers.ValidatePrimitive(nil, json.Number("5"), plans.Create, false),
+					renderers.ValidatePrimitive(nil, json.Number("6"), plans.Create, false),
+					renderers.ValidatePrimitive(nil, json.Number("7"), plans.Create, false),
+					renderers.ValidatePrimitive(json.Number("4"), json.Number("4"), plans.NoOp, false),
 				}, plans.Update, false),
 			}, nil, nil, nil, nil, plans.Update, false),
 		},
@@ -2442,12 +2442,12 @@ func TestRelevantAttributes(t *testing.T) {
 			input: structured.Change{
 				Before: map[string]interface{}{
 					"set": []interface{}{
-						0, 1, 2, 3, 4,
+						json.Number("0"), json.Number("1"), json.Number("2"), json.Number("3"), json.Number("4"),
 					},
 				},
 				After: map[string]interface{}{
 					"set": []interface{}{
-						0, 2, 4, 5, 6,
+						json.Number("0"), json.Number("2"), json.Number("4"), json.Number("5"), json.Number("6"),
 					},
 				},
 				RelevantAttributes: &attribute_path.PathMatcher{
@@ -2468,13 +2468,13 @@ func TestRelevantAttributes(t *testing.T) {
 			},
 			validate: renderers.ValidateBlock(map[string]renderers.ValidateDiffFunction{
 				"set": renderers.ValidateSet([]renderers.ValidateDiffFunction{
-					renderers.ValidatePrimitive(0, 0, plans.NoOp, false),
-					renderers.ValidatePrimitive(1, nil, plans.Delete, false),
-					renderers.ValidatePrimitive(2, 2, plans.NoOp, false),
-					renderers.ValidatePrimitive(3, nil, plans.Delete, false),
-					renderers.ValidatePrimitive(4, 4, plans.NoOp, false),
-					renderers.ValidatePrimitive(nil, 5, plans.Create, false),
-					renderers.ValidatePrimitive(nil, 6, plans.Create, false),
+					renderers.ValidatePrimitive(json.Number("0"), json.Number("0"), plans.NoOp, false),
+					renderers.ValidatePrimitive(json.Number("1"), nil, plans.Delete, false),
+					renderers.ValidatePrimitive(json.Number("2"), json.Number("2"), plans.NoOp, false),
+					renderers.ValidatePrimitive(json.Number("3"), nil, plans.Delete, false),
+					renderers.ValidatePrimitive(json.Number("4"), json.Number("4"), plans.NoOp, false),
+					renderers.ValidatePrimitive(nil, json.Number("5"), plans.Create, false),
+					renderers.ValidatePrimitive(nil, json.Number("6"), plans.Create, false),
 				}, plans.Update, false),
 			}, nil, nil, nil, nil, plans.Update, false),
 		},
@@ -2761,14 +2761,14 @@ func TestSpecificCases(t *testing.T) {
 				Before: map[string]interface{}{
 					"list": []interface{}{
 						map[string]interface{}{
-							"number": -1,
+							"number": json.Number("-1"),
 						},
 					},
 				},
 				After: map[string]interface{}{
 					"list": []interface{}{
 						map[string]interface{}{
-							"number": 2,
+							"number": json.Number("2"),
 						},
 					},
 				},
@@ -2799,7 +2799,7 @@ func TestSpecificCases(t *testing.T) {
 			validate: renderers.ValidateBlock(map[string]renderers.ValidateDiffFunction{
 				"list": renderers.ValidateList([]renderers.ValidateDiffFunction{
 					renderers.ValidateObject(map[string]renderers.ValidateDiffFunction{
-						"number": renderers.ValidatePrimitive(-1, 2, plans.Update, false),
+						"number": renderers.ValidatePrimitive(json.Number("-1"), json.Number("2"), plans.Update, false),
 					}, plans.Update, false),
 				}, plans.Update, false),
 			}, nil, nil, nil, nil, plans.Update, false),
@@ -2810,14 +2810,14 @@ func TestSpecificCases(t *testing.T) {
 				Before: map[string]interface{}{
 					"list": []interface{}{
 						map[string]interface{}{
-							"number": -1,
+							"number": json.Number("-1"),
 						},
 					},
 				},
 				After: map[string]interface{}{
 					"list": []interface{}{
 						map[string]interface{}{
-							"number": 2,
+							"number": json.Number("2"),
 						},
 					},
 				},
@@ -2848,7 +2848,7 @@ func TestSpecificCases(t *testing.T) {
 			validate: renderers.ValidateBlock(map[string]renderers.ValidateDiffFunction{
 				"list": renderers.ValidateList([]renderers.ValidateDiffFunction{
 					renderers.ValidateObject(map[string]renderers.ValidateDiffFunction{
-						"number": renderers.ValidatePrimitive(-1, 2, plans.Update, false),
+						"number": renderers.ValidatePrimitive(json.Number("-1"), json.Number("2"), plans.Update, false),
 					}, plans.Update, false),
 				}, plans.Update, false),
 			}, nil, nil, nil, nil, plans.Update, false),

--- a/internal/command/jsonformat/jsondiff/types.go
+++ b/internal/command/jsonformat/jsondiff/types.go
@@ -5,7 +5,10 @@
 
 package jsondiff
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 type Type string
 
@@ -18,11 +21,13 @@ const (
 	Null   Type = "null"
 )
 
-func GetType(json interface{}) Type {
-	switch json.(type) {
+func GetType(val interface{}) Type {
+	switch val.(type) {
 	case []interface{}:
 		return Array
 	case float64:
+		return Number
+	case json.Number:
 		return Number
 	case string:
 		return String
@@ -33,6 +38,6 @@ func GetType(json interface{}) Type {
 	case map[string]interface{}:
 		return Object
 	default:
-		panic(fmt.Sprintf("unrecognized json type %T", json))
+		panic(fmt.Sprintf("unrecognized json type %T", val))
 	}
 }

--- a/internal/command/jsonformat/structured/change.go
+++ b/internal/command/jsonformat/structured/change.go
@@ -6,6 +6,7 @@
 package structured
 
 import (
+	"bytes"
 	"encoding/json"
 	"reflect"
 
@@ -266,8 +267,10 @@ func unmarshalGeneric(raw json.RawMessage) interface{} {
 		return nil
 	}
 
+	decoder := json.NewDecoder(bytes.NewBuffer(raw))
+	decoder.UseNumber()
 	var out interface{}
-	if err := json.Unmarshal(raw, &out); err != nil {
+	if err := decoder.Decode(&out); err != nil {
 		panic("unrecognized json type: " + err.Error())
 	}
 	return out


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #1361 

Large number will be truncated because the default number type in `json.Unmarshal` is float64.

Change it to use `json.Number` 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.0
