### PR TITLE
Added support to use .tfvars files from tests folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ NEW FEATURES:
 * Add support for a `removed` block that allows users to remove resources or modules from the state without destroying them. ([#1158](https://github.com/opentofu/opentofu/pull/1158))
 
 ENHANCEMENTS:
+* Added support to use `.tfvars` files from tests folder. ([#1386](https://github.com/opentofu/opentofu/pull/1386))
 * Added `templatestring` function that takes a string and renders it as a template using a supplied set of template variables. ([#1223](https://github.com/opentofu/opentofu/pull/1223))
 * Added `base64gunzip` function that takes a base64 encoded gzip string and returns the decompressed data as a string. ([#800](https://github.com/opentofu/opentofu/issues/800))
 * Added `cidrcontains` function that determines if an address belongs to a certain prefix. ([#366](https://github.com/opentofu/opentofu/issues/366))

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -161,6 +161,14 @@ func TestTest(t *testing.T) {
 			expected: "1 passed, 0 failed.",
 			code:     0,
 		},
+		"pass_with_tests_dir_variables": {
+			expected: "1 passed, 0 failed.",
+			code:     0,
+		},
+		"override_with_tests_dir_variables": {
+			expected: "1 passed, 0 failed.",
+			code:     0,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {

--- a/internal/command/testdata/test/override_with_tests_dir_variables/main.tf
+++ b/internal/command/testdata/test/override_with_tests_dir_variables/main.tf
@@ -1,0 +1,7 @@
+variable "testVar" {
+  type=string
+}
+
+resource "test_resource" "testRes" {
+  value = var.testVar
+}

--- a/internal/command/testdata/test/override_with_tests_dir_variables/main.tf
+++ b/internal/command/testdata/test/override_with_tests_dir_variables/main.tf
@@ -1,5 +1,5 @@
 variable "testVar" {
-  type=string
+  type = string
 }
 
 resource "test_resource" "testRes" {

--- a/internal/command/testdata/test/override_with_tests_dir_variables/terraform.tfvars
+++ b/internal/command/testdata/test/override_with_tests_dir_variables/terraform.tfvars
@@ -1,0 +1,1 @@
+testVar = "ValueFROM./tfvars"

--- a/internal/command/testdata/test/override_with_tests_dir_variables/tests/main.tftest.hcl
+++ b/internal/command/testdata/test/override_with_tests_dir_variables/tests/main.tftest.hcl
@@ -1,0 +1,6 @@
+run "validate_test_resource" {
+  assert {
+    condition = test_resource.testRes.value == "ValueFROMtests/tfvars"
+    error_message = "invalid value"
+  }
+}

--- a/internal/command/testdata/test/override_with_tests_dir_variables/tests/main.tftest.hcl
+++ b/internal/command/testdata/test/override_with_tests_dir_variables/tests/main.tftest.hcl
@@ -1,6 +1,6 @@
 run "validate_test_resource" {
   assert {
-    condition = test_resource.testRes.value == "ValueFROMtests/tfvars"
+    condition     = test_resource.testRes.value == "ValueFROMtests/tfvars"
     error_message = "invalid value"
   }
 }

--- a/internal/command/testdata/test/override_with_tests_dir_variables/tests/terraform.tfvars
+++ b/internal/command/testdata/test/override_with_tests_dir_variables/tests/terraform.tfvars
@@ -1,0 +1,1 @@
+testVar="ValueFROMtests/tfvars"

--- a/internal/command/testdata/test/override_with_tests_dir_variables/tests/terraform.tfvars
+++ b/internal/command/testdata/test/override_with_tests_dir_variables/tests/terraform.tfvars
@@ -1,1 +1,1 @@
-testVar="ValueFROMtests/tfvars"
+testVar = "ValueFROMtests/tfvars"

--- a/internal/command/testdata/test/pass_with_tests_dir_variables/main.tf
+++ b/internal/command/testdata/test/pass_with_tests_dir_variables/main.tf
@@ -1,0 +1,7 @@
+variable "testVar" {
+  type=string
+}
+
+resource "test_resource" "testRes" {
+  value = var.testVar
+}

--- a/internal/command/testdata/test/pass_with_tests_dir_variables/main.tf
+++ b/internal/command/testdata/test/pass_with_tests_dir_variables/main.tf
@@ -1,5 +1,5 @@
 variable "testVar" {
-  type=string
+  type = string
 }
 
 resource "test_resource" "testRes" {

--- a/internal/command/testdata/test/pass_with_tests_dir_variables/tests/main.tftest.hcl
+++ b/internal/command/testdata/test/pass_with_tests_dir_variables/tests/main.tftest.hcl
@@ -1,0 +1,6 @@
+run "validate_test_resource" {
+  assert {
+    condition = test_resource.testRes.value == "ValueFROMtests/tfvars"
+    error_message = "invalid value"
+  }
+}

--- a/internal/command/testdata/test/pass_with_tests_dir_variables/tests/main.tftest.hcl
+++ b/internal/command/testdata/test/pass_with_tests_dir_variables/tests/main.tftest.hcl
@@ -1,6 +1,6 @@
 run "validate_test_resource" {
   assert {
-    condition = test_resource.testRes.value == "ValueFROMtests/tfvars"
+    condition     = test_resource.testRes.value == "ValueFROMtests/tfvars"
     error_message = "invalid value"
   }
 }

--- a/internal/command/testdata/test/pass_with_tests_dir_variables/tests/terraform.tfvars
+++ b/internal/command/testdata/test/pass_with_tests_dir_variables/tests/terraform.tfvars
@@ -1,0 +1,1 @@
+testVar="ValueFROMtests/tfvars"

--- a/internal/command/testdata/test/pass_with_tests_dir_variables/tests/terraform.tfvars
+++ b/internal/command/testdata/test/pass_with_tests_dir_variables/tests/terraform.tfvars
@@ -1,1 +1,1 @@
-testVar="ValueFROMtests/tfvars"
+testVar = "ValueFROMtests/tfvars"

--- a/website/docs/cli/commands/test/index.mdx
+++ b/website/docs/cli/commands/test/index.mdx
@@ -244,10 +244,11 @@ can provide variables to your test run using any of the following methods:
 | Order  | Source                                                                                                                         |
 |:------:|:-------------------------------------------------------------------------------------------------------------------------------|
 |   1    | Environment variables with the `TF_VAR_` prefix.                                                                               |
-|   2    | tfvar files specified: `terraform.tfvars` and `*.auto.tfvars`.                                                                 |
-|   3    | Commandline variables defined using the flag `-var`, and the variables defined in the files specified by the flag `-var-file`. |
-|   4    | The variables from the `variables` block in a test file.                                                                       |
-|   5    | The variables from the `variables` block in `run` block.                                                                       |
+|   2    | tfvar files specified in the current directory: `terraform.tfvars` and `*.auto.tfvars`.                                        |
+|   3    | tfvar files specified in the tests directory: `tests/terraform.tfvars` and `tests/*.auto.tfvars`.                              |
+|   4    | Commandline variables defined using the flag `-var`, and the variables defined in the files specified by the flag `-var-file`. |
+|   5    | The variables from the `variables` block in a test file.                                                                       |
+|   6    | The variables from the `variables` block in `run` block.                                                                       |
 
 OpenTofu evaluates the variables in the order listed above, so you can use it to override the previously set variable.
 For example:


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->
## Objective
To enhance the functionality of tofu tests by extending support for `.tfvars` files located in the tests folder. Currently, tofu tests only pick up variables from `.tfvars` files in the root configuration folder. By implementing this, users will have the flexibility to use variables from `.tfvars` files in the tests folder as well. Also, if a variable appears both in a `.tfvars` file in the root configuration and in the tests folder, the one in the tests folder will take precedence. 

## Changes

- Modified `meta_vars.go` file to incorporate the logic for including `.tfvars` files from the tests folder.
- Created two new folders, `override_with_tests_dir_variables` and `pass_with_tests_dir_variables`, to contain `.tf` test files and modified `test_test.go` for testing the changes.
- Added a description of this functionality to the tofu test's documentation.

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #1367 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.0
