### PR TITLE
docs: update nonsensitive docs to not show error

### DIFF
--- a/website/docs/language/functions/nonsensitive.mdx
+++ b/website/docs/language/functions/nonsensitive.mdx
@@ -98,11 +98,7 @@ the local value `mixed_content`, with a valid JSON string assigned to
 > nonsensitive(local.mixed_content["username"])
 "zqb"
 > nonsensitive("clear")
-
-Error: Invalid function argument
-
-Invalid value for "value" parameter: the given value is not sensitive, so this
-call is redundant.
+"clear"
 ```
 
 Note though that it's always your responsibility to use `nonsensitive` only


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

The docs for the `nonsensitive` function showing console output seems to not reflect the changes made in #369, this fixes that.

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.0
