### PR TITLE
GCP KMS for Key Provider for Encryption

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.3.1
+	github.com/googleapis/gax-go/v2 v2.11.0
 	github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.43
 	github.com/hashicorp/consul/api v1.13.0
 	github.com/hashicorp/consul/sdk v0.8.0
@@ -180,7 +181,6 @@ require (
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/s2a-go v0.1.4 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
-	github.com/googleapis/gax-go/v2 v2.11.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.0.0 // indirect

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -419,7 +419,7 @@ func (r OperationResult) ExitStatus() int {
 	return int(r)
 }
 
-// If the argument is a path, Read loads it and returns the contents,
+// If the argument is a path, ReadPathOrContents loads it and returns the contents,
 // otherwise the argument is assumed to be the desired contents and is simply
 // returned.
 func ReadPathOrContents(poc string) (string, error) {

--- a/internal/encryption/default_registry.go
+++ b/internal/encryption/default_registry.go
@@ -7,6 +7,7 @@ package encryption
 
 import (
 	"github.com/opentofu/opentofu/internal/encryption/keyprovider/aws_kms"
+	"github.com/opentofu/opentofu/internal/encryption/keyprovider/gcp_kms"
 	"github.com/opentofu/opentofu/internal/encryption/keyprovider/pbkdf2"
 	"github.com/opentofu/opentofu/internal/encryption/method/aesgcm"
 	"github.com/opentofu/opentofu/internal/encryption/registry/lockingencryptionregistry"
@@ -22,6 +23,9 @@ func init() {
 		panic(err)
 	}
 	if err := DefaultRegistry.RegisterKeyProvider(aws_kms.New()); err != nil {
+		panic(err)
+	}
+	if err := DefaultRegistry.RegisterKeyProvider(gcp_kms.New()); err != nil {
 		panic(err)
 	}
 }

--- a/internal/encryption/keyprovider/gcp_kms/compliance_test.go
+++ b/internal/encryption/keyprovider/gcp_kms/compliance_test.go
@@ -1,0 +1,139 @@
+package gcp_kms
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/opentofu/opentofu/internal/encryption/keyprovider/compliancetest"
+)
+
+// skipCheck checks if the test should be skipped or not based on environment variables
+func skipCheckGetKey(t *testing.T) string {
+	// check if TF_ACC and TF_KMS_TEST are unset
+	// if so, skip the test
+	if os.Getenv("TF_ACC") == "" && os.Getenv("TF_KMS_TEST") == "" {
+		t.Log("Skipping test because TF_ACC or TF_KMS_TEST is not set")
+		t.Skip()
+	}
+	key := os.Getenv("TF_GCP_KMS_KEY")
+	if key == "" {
+		t.Log("Skipping test because TF_AWS_GCP_KEY is not set")
+		t.Skip()
+	}
+	return key
+}
+
+func TestKeyProvider(t *testing.T) {
+	testKeyId := skipCheckGetKey(t)
+
+	compliancetest.ComplianceTest(
+		t,
+		compliancetest.TestConfiguration[*descriptor, *Config, *keyMeta, *keyProvider]{
+			Descriptor: New().(*descriptor),
+			HCLParseTestCases: map[string]compliancetest.HCLParseTestCase[*Config, *keyProvider]{
+				"success": {
+					HCL: fmt.Sprintf(`key_provider "gcp_kms" "foo" {
+							kms_encryption_key = "%s"
+							key_size = 32
+						}`, testKeyId),
+					ValidHCL:   true,
+					ValidBuild: true,
+					Validate: func(config *Config, keyProvider *keyProvider) error {
+						if config.KMSKeyName != testKeyId {
+							return fmt.Errorf("incorrect key ID returned")
+						}
+						return nil
+					},
+				},
+				"empty": {
+					HCL:        `key_provider "gcp_kms" "foo" {}`,
+					ValidHCL:   false,
+					ValidBuild: false,
+				},
+				"invalid-key-size": {
+					HCL: fmt.Sprintf(`key_provider "gcp_kms" "foo" {
+							kms_encryption_key = "%s"
+							key_size = -1
+							}`, testKeyId),
+					ValidHCL:   true,
+					ValidBuild: false,
+				},
+				"empty-key-id": {
+					HCL: `key_provider "gcp_kms" "foo" {
+							kms_encryption_key = ""
+							key_size = 32
+							}`,
+					ValidHCL:   true,
+					ValidBuild: false,
+				},
+				"large-key-size": {
+					HCL: `key_provider "gcp_kms" "foo" {
+							kms_encryption_key = "alias/temp"
+							key_size = 999999999999
+							}`,
+					ValidHCL:   true,
+					ValidBuild: false,
+				},
+				"unknown-property": {
+					HCL: fmt.Sprintf(`key_provider "gcp_kms" "foo" {
+							kms_encryption_key = "%s"	
+							key_size = 32	
+							unknown_property = "foo"
+				}`, testKeyId),
+					ValidHCL:   false,
+					ValidBuild: false,
+				},
+			},
+			ConfigStructTestCases: map[string]compliancetest.ConfigStructTestCase[*Config, *keyProvider]{
+				"success": {
+					Config: &Config{
+						KMSKeyName: testKeyId,
+						KeySize:    32,
+					},
+					ValidBuild: true,
+					Validate:   nil,
+				},
+				"empty": {
+					Config: &Config{
+						KMSKeyName: "",
+						KeySize:    0,
+					},
+					ValidBuild: false,
+					Validate:   nil,
+				},
+			},
+			MetadataStructTestCases: map[string]compliancetest.MetadataStructTestCase[*Config, *keyMeta]{
+				"empty": {
+					ValidConfig: &Config{
+						KMSKeyName: testKeyId,
+						KeySize:    32,
+					},
+					Meta:      &keyMeta{},
+					IsPresent: false,
+					IsValid:   false,
+				},
+			},
+			ProvideTestCase: compliancetest.ProvideTestCase[*Config, *keyMeta]{
+				ValidConfig: &Config{
+					KMSKeyName: testKeyId,
+					KeySize:    32,
+				},
+				ValidateKeys: func(dec []byte, enc []byte) error {
+					if len(dec) == 0 {
+						return fmt.Errorf("decryption key is empty")
+					}
+					if len(enc) == 0 {
+						return fmt.Errorf("encryption key is empty")
+					}
+					return nil
+				},
+				ValidateMetadata: func(meta *keyMeta) error {
+					if len(meta.Ciphertext) == 0 {
+						return fmt.Errorf("ciphertext is empty")
+					}
+					return nil
+				},
+			},
+		})
+}

--- a/internal/encryption/keyprovider/gcp_kms/compliance_test.go
+++ b/internal/encryption/keyprovider/gcp_kms/compliance_test.go
@@ -49,7 +49,7 @@ func TestKeyProvider(t *testing.T) {
 				"success": {
 					HCL: fmt.Sprintf(`key_provider "gcp_kms" "foo" {
 							kms_encryption_key = "%s"
-							key_size = 32
+							key_length = 32
 						}`, testKeyId),
 					ValidHCL:   true,
 					ValidBuild: true,
@@ -68,7 +68,7 @@ func TestKeyProvider(t *testing.T) {
 				"invalid-key-size": {
 					HCL: fmt.Sprintf(`key_provider "gcp_kms" "foo" {
 							kms_encryption_key = "%s"
-							key_size = -1
+							key_length = -1
 							}`, testKeyId),
 					ValidHCL:   true,
 					ValidBuild: false,
@@ -76,7 +76,7 @@ func TestKeyProvider(t *testing.T) {
 				"empty-key-id": {
 					HCL: `key_provider "gcp_kms" "foo" {
 							kms_encryption_key = ""
-							key_size = 32
+							key_length = 32
 							}`,
 					ValidHCL:   true,
 					ValidBuild: false,
@@ -84,7 +84,7 @@ func TestKeyProvider(t *testing.T) {
 				"large-key-size": {
 					HCL: `key_provider "gcp_kms" "foo" {
 							kms_encryption_key = "alias/temp"
-							key_size = 999999999999
+							key_length = 999999999999
 							}`,
 					ValidHCL:   true,
 					ValidBuild: false,
@@ -92,7 +92,7 @@ func TestKeyProvider(t *testing.T) {
 				"unknown-property": {
 					HCL: fmt.Sprintf(`key_provider "gcp_kms" "foo" {
 							kms_encryption_key = "%s"	
-							key_size = 32	
+							key_length = 32	
 							unknown_property = "foo"
 				}`, testKeyId),
 					ValidHCL:   false,
@@ -101,7 +101,7 @@ func TestKeyProvider(t *testing.T) {
 				"with-access-token": {
 					HCL: `key_provider "gcp_kms" "foo" {
 							kms_encryption_key = "alias/temp"
-							key_size = 32
+							key_length = 32
 							access_token = "my-access-token"
 							}`,
 					ValidHCL:   true,
@@ -110,7 +110,7 @@ func TestKeyProvider(t *testing.T) {
 				"bad-credentials": {
 					HCL: `key_provider "gcp_kms" "foo" {
 							kms_encryption_key = "alias/temp"
-							key_size = 32
+							key_length = 32
 							credentials = "AS{DU*@#8UQDD*a"
 							}`,
 					ValidHCL:   true,
@@ -119,7 +119,7 @@ func TestKeyProvider(t *testing.T) {
 				"impersonation": {
 					HCL: `key_provider "gcp_kms" "foo" {
 							kms_encryption_key = "alias/temp"
-							key_size = 32
+							key_length = 32
 							impersonate_service_account = "batman"
 							}`,
 					ValidHCL:   true,
@@ -130,7 +130,7 @@ func TestKeyProvider(t *testing.T) {
 				"success": {
 					Config: &Config{
 						KMSKeyName: testKeyId,
-						KeySize:    32,
+						KeyLength:  32,
 					},
 					ValidBuild: true,
 					Validate:   nil,
@@ -138,7 +138,7 @@ func TestKeyProvider(t *testing.T) {
 				"empty": {
 					Config: &Config{
 						KMSKeyName: "",
-						KeySize:    0,
+						KeyLength:  0,
 					},
 					ValidBuild: false,
 					Validate:   nil,
@@ -148,7 +148,7 @@ func TestKeyProvider(t *testing.T) {
 				"empty": {
 					ValidConfig: &Config{
 						KMSKeyName: testKeyId,
-						KeySize:    32,
+						KeyLength:  32,
 					},
 					Meta:      &keyMeta{},
 					IsPresent: false,
@@ -158,7 +158,7 @@ func TestKeyProvider(t *testing.T) {
 			ProvideTestCase: compliancetest.ProvideTestCase[*Config, *keyMeta]{
 				ValidConfig: &Config{
 					KMSKeyName: testKeyId,
-					KeySize:    32,
+					KeyLength:  32,
 				},
 				ValidateKeys: func(dec []byte, enc []byte) error {
 					if len(dec) == 0 {

--- a/internal/encryption/keyprovider/gcp_kms/compliance_test.go
+++ b/internal/encryption/keyprovider/gcp_kms/compliance_test.go
@@ -84,6 +84,33 @@ func TestKeyProvider(t *testing.T) {
 					ValidHCL:   false,
 					ValidBuild: false,
 				},
+				"with-access-token": {
+					HCL: `key_provider "gcp_kms" "foo" {
+							kms_encryption_key = "alias/temp"
+							key_size = 32
+							access_token = "my-access-token"
+							}`,
+					ValidHCL:   true,
+					ValidBuild: true,
+				},
+				"bad-credentials": {
+					HCL: `key_provider "gcp_kms" "foo" {
+							kms_encryption_key = "alias/temp"
+							key_size = 32
+							credentials = "AS{DU*@#8UQDD*a"
+							}`,
+					ValidHCL:   true,
+					ValidBuild: false,
+				},
+				"impersonation": {
+					HCL: `key_provider "gcp_kms" "foo" {
+							kms_encryption_key = "alias/temp"
+							key_size = 32
+							impersonate_service_account = "batman"
+							}`,
+					ValidHCL:   true,
+					ValidBuild: true,
+				},
 			},
 			ConfigStructTestCases: map[string]compliancetest.ConfigStructTestCase[*Config, *keyProvider]{
 				"success": {

--- a/internal/encryption/keyprovider/gcp_kms/config.go
+++ b/internal/encryption/keyprovider/gcp_kms/config.go
@@ -122,6 +122,10 @@ func (c Config) Build() (keyprovider.KeyProvider, keyprovider.KeyMeta, error) {
 		return nil, nil, &keyprovider.ErrInvalidConfiguration{Cause: err}
 	}
 
+	if c.KMSKeyName == "" {
+		return nil, nil, &keyprovider.ErrInvalidConfiguration{Message: "kms_key_name must be provided"}
+	}
+
 	if c.KeySize < 1 {
 		return nil, nil, &keyprovider.ErrInvalidConfiguration{Message: "key_size must be at least 1"}
 	}

--- a/internal/encryption/keyprovider/gcp_kms/config.go
+++ b/internal/encryption/keyprovider/gcp_kms/config.go
@@ -16,8 +16,10 @@ import (
 	kms "cloud.google.com/go/kms/apiv1"
 )
 
+type keyManagementClientInit func(ctx context.Context, opts ...option.ClientOption) (keyManagementClient, error)
+
 // Can be overridden for test mocking
-var newKeyManagementClient func(ctx context.Context, opts ...option.ClientOption) (keyManagementClient, error) = func(ctx context.Context, opts ...option.ClientOption) (keyManagementClient, error) {
+var newKeyManagementClient keyManagementClientInit = func(ctx context.Context, opts ...option.ClientOption) (keyManagementClient, error) {
 	return kms.NewKeyManagementClient(ctx, opts...)
 }
 

--- a/internal/encryption/keyprovider/gcp_kms/config.go
+++ b/internal/encryption/keyprovider/gcp_kms/config.go
@@ -42,7 +42,7 @@ func stringAttrEnvFallback(val string, env string) string {
 }
 
 // TODO This is copied in from the backend packge to prevent a circular dependency loop
-// If the argument is a path, Read loads it and returns the contents,
+// If the argument is a path, ReadPathOrContents loads it and returns the contents,
 // otherwise the argument is assumed to be the desired contents and is simply
 // returned.
 func ReadPathOrContents(poc string) (string, error) {

--- a/internal/encryption/keyprovider/gcp_kms/config.go
+++ b/internal/encryption/keyprovider/gcp_kms/config.go
@@ -1,0 +1,138 @@
+package gcp_kms
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/opentofu/opentofu/internal/encryption/keyprovider"
+	"github.com/opentofu/opentofu/internal/httpclient"
+	"github.com/opentofu/opentofu/version"
+	"golang.org/x/oauth2"
+	"google.golang.org/api/impersonate"
+	"google.golang.org/api/option"
+
+	kms "cloud.google.com/go/kms/apiv1"
+)
+
+type Config struct {
+	Credentials string `hcl:"credentials,optional"`
+	AccessToken string `hcl:"access_token,optional"`
+
+	ImpersonateServiceAccount          string   `hcl:"impersonate_service_account,optional"`
+	ImpersonateServiceAccountDelegates []string `hcl:"impersonate_service_account_delegates,optional"`
+
+	KMSKeyName string `hcl:"kms_encryption_key"`
+	KeySize    int    `hcl:"key_size"`
+}
+
+func stringAttrEnvFallback(val string, env string) string {
+	if val != "" {
+		return val
+	}
+	return os.Getenv(env)
+}
+
+// TODO This is copied in from the backend packge to prevent a circular dependency loop
+// If the argument is a path, Read loads it and returns the contents,
+// otherwise the argument is assumed to be the desired contents and is simply
+// returned.
+func ReadPathOrContents(poc string) (string, error) {
+	if len(poc) == 0 {
+		return poc, nil
+	}
+
+	path := poc
+	if path[0] == '~' {
+		var err error
+		path, err = homedir.Expand(path)
+		if err != nil {
+			return path, err
+		}
+	}
+
+	if _, err := os.Stat(path); err == nil {
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			return string(contents), err
+		}
+		return string(contents), nil
+	}
+
+	return poc, nil
+}
+
+func (c Config) Build() (keyprovider.KeyProvider, keyprovider.KeyMeta, error) {
+	// This mirrors the gcp remote state backend
+
+	// Apply env defaults if nessesary
+	c.Credentials = stringAttrEnvFallback(c.Credentials, "GOOGLE_CREDENTIALS")
+	c.AccessToken = stringAttrEnvFallback(c.AccessToken, "GOOGLE_OAUTH_ACCESS_TOKEN")
+	c.ImpersonateServiceAccount = stringAttrEnvFallback(c.ImpersonateServiceAccount, "GOOGLE_BACKEND_IMPERSONATE_SERVICE_ACCOUNT")
+	c.ImpersonateServiceAccount = stringAttrEnvFallback(c.ImpersonateServiceAccount, "GOOGLE_IMPERSONATE_SERVICE_ACCOUNT")
+	c.KMSKeyName = stringAttrEnvFallback(c.KMSKeyName, "GOOGLE_KMS_ENCRYPTION_KEY")
+
+	ctx := context.Background()
+
+	var opts []option.ClientOption
+	var credOptions []option.ClientOption
+
+	if c.AccessToken != "" {
+		tokenSource := oauth2.StaticTokenSource(&oauth2.Token{
+			AccessToken: c.AccessToken,
+		})
+		credOptions = append(credOptions, option.WithTokenSource(tokenSource))
+	} else if c.Credentials != "" {
+		// to mirror how the provider works, we accept the file path or the contents
+		contents, err := ReadPathOrContents(c.Credentials)
+		if err != nil {
+			return nil, nil, &keyprovider.ErrInvalidConfiguration{Message: "Error loading credentials", Cause: err}
+		}
+
+		if !json.Valid([]byte(contents)) {
+			return nil, nil, &keyprovider.ErrInvalidConfiguration{Message: "the string provided in credentials is neither valid json nor a valid file path"}
+		}
+
+		credOptions = append(credOptions, option.WithCredentialsJSON([]byte(contents)))
+	}
+
+	// Service Account Impersonation
+	if c.ImpersonateServiceAccount != "" {
+		ts, err := impersonate.CredentialsTokenSource(ctx, impersonate.CredentialsConfig{
+			TargetPrincipal: c.ImpersonateServiceAccount,
+			Scopes:          []string{"https://www.googleapis.com/auth/cloudkms"}, // I can't find a smaller scope than this...
+			Delegates:       c.ImpersonateServiceAccountDelegates,
+		}, credOptions...)
+
+		if err != nil {
+			return nil, nil, &keyprovider.ErrInvalidConfiguration{Cause: err}
+		}
+
+		opts = append(opts, option.WithTokenSource(ts))
+
+	} else {
+		opts = append(opts, credOptions...)
+	}
+
+	opts = append(opts, option.WithUserAgent(httpclient.OpenTofuUserAgent(version.Version)))
+
+	svc, err := kms.NewKeyManagementClient(ctx, opts...)
+	if err != nil {
+		return nil, nil, &keyprovider.ErrInvalidConfiguration{Cause: err}
+	}
+
+	if c.KeySize < 1 {
+		return nil, nil, &keyprovider.ErrInvalidConfiguration{Message: "key_size must be at least 1"}
+	}
+	if c.KeySize > 1024 {
+		return nil, nil, &keyprovider.ErrInvalidConfiguration{Message: "key_size must be less than the GCP limit of 1024"}
+	}
+
+	return &keyProvider{
+		svc:     svc,
+		ctx:     ctx,
+		keyName: c.KMSKeyName,
+		keySize: c.KeySize,
+	}, new(keyMeta), nil
+}

--- a/internal/encryption/keyprovider/gcp_kms/config.go
+++ b/internal/encryption/keyprovider/gcp_kms/config.go
@@ -16,6 +16,11 @@ import (
 	kms "cloud.google.com/go/kms/apiv1"
 )
 
+// Can be overridden for test mocking
+var newKeyManagementClient func(ctx context.Context, opts ...option.ClientOption) (keyManagementClient, error) = func(ctx context.Context, opts ...option.ClientOption) (keyManagementClient, error) {
+	return kms.NewKeyManagementClient(ctx, opts...)
+}
+
 type Config struct {
 	Credentials string `hcl:"credentials,optional"`
 	AccessToken string `hcl:"access_token,optional"`
@@ -117,7 +122,7 @@ func (c Config) Build() (keyprovider.KeyProvider, keyprovider.KeyMeta, error) {
 
 	opts = append(opts, option.WithUserAgent(httpclient.OpenTofuUserAgent(version.Version)))
 
-	svc, err := kms.NewKeyManagementClient(ctx, opts...)
+	svc, err := newKeyManagementClient(ctx, opts...)
 	if err != nil {
 		return nil, nil, &keyprovider.ErrInvalidConfiguration{Cause: err}
 	}

--- a/internal/encryption/keyprovider/gcp_kms/config.go
+++ b/internal/encryption/keyprovider/gcp_kms/config.go
@@ -31,7 +31,7 @@ type Config struct {
 	ImpersonateServiceAccountDelegates []string `hcl:"impersonate_service_account_delegates,optional"`
 
 	KMSKeyName string `hcl:"kms_encryption_key"`
-	KeySize    int    `hcl:"key_size"`
+	KeyLength  int    `hcl:"key_length"`
 }
 
 func stringAttrEnvFallback(val string, env string) string {
@@ -133,17 +133,17 @@ func (c Config) Build() (keyprovider.KeyProvider, keyprovider.KeyMeta, error) {
 		return nil, nil, &keyprovider.ErrInvalidConfiguration{Message: "kms_key_name must be provided"}
 	}
 
-	if c.KeySize < 1 {
-		return nil, nil, &keyprovider.ErrInvalidConfiguration{Message: "key_size must be at least 1"}
+	if c.KeyLength < 1 {
+		return nil, nil, &keyprovider.ErrInvalidConfiguration{Message: "key_length must be at least 1"}
 	}
-	if c.KeySize > 1024 {
-		return nil, nil, &keyprovider.ErrInvalidConfiguration{Message: "key_size must be less than the GCP limit of 1024"}
+	if c.KeyLength > 1024 {
+		return nil, nil, &keyprovider.ErrInvalidConfiguration{Message: "key_length must be less than the GCP limit of 1024"}
 	}
 
 	return &keyProvider{
-		svc:     svc,
-		ctx:     ctx,
-		keyName: c.KMSKeyName,
-		keySize: c.KeySize,
+		svc:       svc,
+		ctx:       ctx,
+		keyName:   c.KMSKeyName,
+		keyLength: c.KeyLength,
 	}, new(keyMeta), nil
 }

--- a/internal/encryption/keyprovider/gcp_kms/descriptor.go
+++ b/internal/encryption/keyprovider/gcp_kms/descriptor.go
@@ -1,0 +1,20 @@
+package gcp_kms
+
+import (
+	"github.com/opentofu/opentofu/internal/encryption/keyprovider"
+)
+
+func New() keyprovider.Descriptor {
+	return &descriptor{}
+}
+
+type descriptor struct {
+}
+
+func (f descriptor) ID() keyprovider.ID {
+	return "gcp_kms"
+}
+
+func (f descriptor) ConfigStruct() keyprovider.Config {
+	return &Config{}
+}

--- a/internal/encryption/keyprovider/gcp_kms/mock_test.go
+++ b/internal/encryption/keyprovider/gcp_kms/mock_test.go
@@ -1,0 +1,27 @@
+package gcp_kms
+
+import (
+	"context"
+
+	"cloud.google.com/go/kms/apiv1/kmspb"
+	"github.com/googleapis/gax-go/v2"
+	"google.golang.org/api/option"
+)
+
+type mockKMC struct {
+	encrypt func(*kmspb.EncryptRequest) (*kmspb.EncryptResponse, error)
+	decrypt func(*kmspb.DecryptRequest) (*kmspb.DecryptResponse, error)
+}
+
+func (m *mockKMC) Encrypt(ctx context.Context, req *kmspb.EncryptRequest, opts ...gax.CallOption) (*kmspb.EncryptResponse, error) {
+	return m.encrypt(req)
+}
+func (m *mockKMC) Decrypt(ctx context.Context, req *kmspb.DecryptRequest, opts ...gax.CallOption) (*kmspb.DecryptResponse, error) {
+	return m.decrypt(req)
+}
+
+func injectMock(m *mockKMC) {
+	newKeyManagementClient = func(ctx context.Context, opts ...option.ClientOption) (keyManagementClient, error) {
+		return m, nil
+	}
+}

--- a/internal/encryption/keyprovider/gcp_kms/provider.go
+++ b/internal/encryption/keyprovider/gcp_kms/provider.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"crypto/rand"
 
-	kms "cloud.google.com/go/kms/apiv1"
 	"cloud.google.com/go/kms/apiv1/kmspb"
+	"github.com/googleapis/gax-go/v2"
 	"github.com/opentofu/opentofu/internal/encryption/keyprovider"
 )
 
@@ -17,8 +17,13 @@ func (m keyMeta) isPresent() bool {
 	return len(m.Ciphertext) != 0
 }
 
+type keyManagementClient interface {
+	Encrypt(ctx context.Context, req *kmspb.EncryptRequest, opts ...gax.CallOption) (*kmspb.EncryptResponse, error)
+	Decrypt(ctx context.Context, req *kmspb.DecryptRequest, opts ...gax.CallOption) (*kmspb.DecryptResponse, error)
+}
+
 type keyProvider struct {
-	svc     *kms.KeyManagementClient
+	svc     keyManagementClient
 	ctx     context.Context
 	keyName string
 	keySize int

--- a/internal/encryption/keyprovider/gcp_kms/provider.go
+++ b/internal/encryption/keyprovider/gcp_kms/provider.go
@@ -1,0 +1,73 @@
+package gcp_kms
+
+import (
+	"context"
+	"crypto/rand"
+
+	kms "cloud.google.com/go/kms/apiv1"
+	"cloud.google.com/go/kms/apiv1/kmspb"
+	"github.com/opentofu/opentofu/internal/encryption/keyprovider"
+)
+
+type keyMeta struct {
+	Ciphertext []byte `json:"ciphertext"`
+}
+
+func (m keyMeta) isPresent() bool {
+	return len(m.Ciphertext) != 0
+}
+
+type keyProvider struct {
+	svc     *kms.KeyManagementClient
+	ctx     context.Context
+	keyName string
+	keySize int
+}
+
+func (p keyProvider) Provide(rawMeta keyprovider.KeyMeta) (keyprovider.Output, keyprovider.KeyMeta, error) {
+	if rawMeta == nil {
+		return keyprovider.Output{}, nil, keyprovider.ErrInvalidMetadata{Message: "bug: no metadata struct provided"}
+	}
+	inMeta := rawMeta.(*keyMeta)
+
+	outMeta := &keyMeta{}
+	out := keyprovider.Output{}
+
+	// Generate new key
+	out.EncryptionKey = make([]byte, p.keySize)
+	_, err := rand.Read(out.EncryptionKey)
+	if err != nil {
+		return out, outMeta, &keyprovider.ErrKeyProviderFailure{
+			Message: "failed to generate key",
+			Cause:   err,
+		}
+	}
+
+	// Encrypt new encryption key using kms
+	encryptedKeyData, err := p.svc.Encrypt(p.ctx, &kmspb.EncryptRequest{
+		Name:      p.keyName,
+		Plaintext: out.EncryptionKey,
+	})
+
+	outMeta.Ciphertext = encryptedKeyData.Ciphertext
+
+	// We do not set the DecryptionKey here as we should only be setting the decryption key if we are decrypting
+	// and that is handled below when we check if the inMeta has a CiphertextBlob
+
+	if inMeta.isPresent() {
+		// We have an existing decryption key to decrypt, so we should now populate the DecryptionKey
+		decryptedKeyData, decryptErr := p.svc.Decrypt(p.ctx, &kmspb.DecryptRequest{
+			Name:       p.keyName,
+			Ciphertext: inMeta.Ciphertext,
+		})
+
+		if decryptErr != nil {
+			return out, outMeta, decryptErr
+		}
+
+		// Set decryption key on the output
+		out.DecryptionKey = decryptedKeyData.Plaintext
+	}
+
+	return out, outMeta, nil
+}

--- a/internal/encryption/keyprovider/gcp_kms/provider.go
+++ b/internal/encryption/keyprovider/gcp_kms/provider.go
@@ -23,10 +23,10 @@ type keyManagementClient interface {
 }
 
 type keyProvider struct {
-	svc     keyManagementClient
-	ctx     context.Context
-	keyName string
-	keySize int
+	svc       keyManagementClient
+	ctx       context.Context
+	keyName   string
+	keyLength int
 }
 
 func (p keyProvider) Provide(rawMeta keyprovider.KeyMeta) (keyprovider.Output, keyprovider.KeyMeta, error) {
@@ -42,7 +42,7 @@ func (p keyProvider) Provide(rawMeta keyprovider.KeyMeta) (keyprovider.Output, k
 	out := keyprovider.Output{}
 
 	// Generate new key
-	out.EncryptionKey = make([]byte, p.keySize)
+	out.EncryptionKey = make([]byte, p.keyLength)
 	_, err := rand.Read(out.EncryptionKey)
 	if err != nil {
 		return out, outMeta, &keyprovider.ErrKeyProviderFailure{


### PR DESCRIPTION
Initial manual testing performed, unit tests required, potential storage of AAD in metadata.

Resolves #1173 


Example:
```hcl
terraform {
        encryption {
                key_provider "gcp_kms" "basic" {
                        kms_encryption_key = "projects/local-vehicle-redacted/locations/global/keyRings/opentofu-test/cryptoKeys/opentofu-keytest"
                        credentials = "/path/to/creds.json"
                        key_size = 32
                }
                method "aes_gcm" "example" {
                        keys = key_provider.gcp_kms.basic
                }
                state {
                        method = method.aes_gcm.example
                }
        }
}

resource "tfcoremock_simple_resource" "simple" {
        string = "helloworld changes! 5"
}

```

## Target Release

1.7.0
