### PR TITLE
Adding temporary feedback template for 1.7.0-alpha1 issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_7_0_alpha1_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/1_7_0_alpha1_feedback.yml
@@ -1,0 +1,118 @@
+# Copyright (c) The OpenTofu Authors
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2023 HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+name: 1.7.0-alpha1 feedback
+description: Provide feedback for the 1.7.0-alpha1 preview release.
+labels: ["preview-release-feedback"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Thank you for testing the [1.7.0-alpha1](https://github.com/opentofu/opentofu/releases/tag/v1.7.0-alpha1) release.
+  - type: markdown
+    attributes:
+      value: |
+        ## State encryption
+        
+        - [Documentation](https://1-7-0-alpha1.opentofu.pages.dev/docs/language/state/encryption/)
+  - type: dropdown
+    attributes:
+      label: Did you test this feature?
+      options:
+        - Did not test
+        - Tested, worked
+        - Tested, did not work / had problems
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional feedback / details
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Removed block
+        
+        - [Documentation](https://1-7-0-alpha1.opentofu.pages.dev/docs/language/resources/syntax/#removing-resources)
+  - type: dropdown
+    attributes:
+      label: Did you test this feature?
+      options:
+        - Did not test
+        - Tested, worked
+        - Tested, did not work / had problems
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional feedback / details
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Testing feature
+        
+        - `run{}` blocks now allow referencing previous block's module outputs.
+        - `run{}` blocks now allow referencing the output from a previous run in variables. 
+        - `tofu test` now dumps the state file if it fails to clean up test resources.
+  - type: dropdown
+    attributes:
+      label: Did you test these functions
+      options:
+        - Did not test
+        - Tested, worked
+        - Tested, did not work / had problems
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional feedback / details
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Built-in function changes
+        
+        - New function: [templatestring](https://1-7-0-alpha1.opentofu.pages.dev/docs/language/functions/templatestring/)
+        - New function: [base64gunzip](https://1-7-0-alpha1.opentofu.pages.dev/docs/language/functions/base64gunzip/)
+        - New function: [cidrcontains](https://1-7-0-alpha1.opentofu.pages.dev/docs/language/functions/cidrcontains/)
+        - New function: [urldecode](https://1-7-0-alpha1.opentofu.pages.dev/docs/language/functions/urldecode/)
+        - New function: [issensitive](https://1-7-0-alpha1.opentofu.pages.dev/docs/language/functions/issensitive/)
+        - [nonsensitive](https://1-7-0-alpha1.opentofu.pages.dev/docs/language/functions/nonsensitive/) no longer returns an error when the applied values are not sensitive.
+        - [templatefile](https://1-7-0-alpha1.opentofu.pages.dev/docs/language/functions/templatefile/) now supports recursion up to a depth of 1024.
+  - type: dropdown
+    attributes:
+      label: Did you test these functions
+      options:
+        - Did not test
+        - Tested, worked
+        - Tested, did not work / had problems
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional feedback / details
+
+  - type: markdown
+    attributes:
+      value: |
+        ## CLI changes
+        
+        - `tofu plan` now has a `-concise` flag to shorten the plan output.
+        - `tofu console` now works on Solaris and AIX.
+        - The CLI now supports the XDG directory specification.
+        - Aliases for `state list` &rarr; `state ls`, `state mv` &rarr; `state move`, `state rm` &rarr; `state remove`.
+  - type: dropdown
+    attributes:
+      label: Did you test these functions
+      options:
+        - Did not test
+        - Tested, worked
+        - Tested, did not work / had problems
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional feedback / details


### PR DESCRIPTION
This PR adds a new issue template for use with 1.7.0-alpha1 feedback issues. It will be removed when the next alpha/beta launches.

## Target Release

1.7.0
