### PR TITLE
Fix #1407: Pass through metadata fields in state encryption

### DIFF
--- a/internal/encryption/base.go
+++ b/internal/encryption/base.go
@@ -87,7 +87,7 @@ func IsEncryptionPayload(data []byte) (bool, error) {
 	return es.Version != "", nil
 }
 
-func (s *baseEncryption) encrypt(data []byte) ([]byte, error) {
+func (s *baseEncryption) encrypt(data []byte, enhance func(basedata) interface{}) ([]byte, error) {
 	// No configuration provided, don't do anything
 	if s.target == nil {
 		return data, nil
@@ -117,7 +117,7 @@ func (s *baseEncryption) encrypt(data []byte) ([]byte, error) {
 		Meta:    s.encMeta,
 		Data:    encd,
 	}
-	jsond, err := json.Marshal(es)
+	jsond, err := json.Marshal(enhance(es))
 	if err != nil {
 		return nil, fmt.Errorf("unable to encode encrypted data as json: %w", err)
 	}

--- a/internal/encryption/example_test.go
+++ b/internal/encryption/example_test.go
@@ -65,13 +65,13 @@ func Example() {
 
 	// Encrypt the data, for this example we will be using the string "test",
 	// but in a real world scenario this would be the plan file.
-	sourceData := []byte("test")
+	sourceData := []byte(`{"serial": 42}`)
 	encrypted, err := sfe.EncryptState(sourceData)
 	if err != nil {
 		panic(err)
 	}
 
-	if string(encrypted) == "test" {
+	if string(encrypted) == `{"serial": 42}` {
 		panic("The data has not been encrypted!")
 	}
 
@@ -82,7 +82,7 @@ func Example() {
 	}
 
 	fmt.Printf("%s\n", decryptedState)
-	// Output: test
+	// Output: {"serial": 42}
 }
 
 func handleDiags(diags hcl.Diagnostics) {

--- a/internal/encryption/example_test.go
+++ b/internal/encryption/example_test.go
@@ -63,15 +63,15 @@ func Example() {
 
 	sfe := enc.State()
 
-	// Encrypt the data, for this example we will be using the string "test",
+	// Encrypt the data, for this example we will be using the string `{"serial": 42, "lineage": "magic"}`,
 	// but in a real world scenario this would be the plan file.
-	sourceData := []byte(`{"serial": 42}`)
+	sourceData := []byte(`{"serial": 42, "lineage": "magic"}`)
 	encrypted, err := sfe.EncryptState(sourceData)
 	if err != nil {
 		panic(err)
 	}
 
-	if string(encrypted) == `{"serial": 42}` {
+	if string(encrypted) == `{"serial": 42, "lineage": "magic"}` {
 		panic("The data has not been encrypted!")
 	}
 
@@ -82,7 +82,7 @@ func Example() {
 	}
 
 	fmt.Printf("%s\n", decryptedState)
-	// Output: {"serial": 42}
+	// Output: {"serial": 42, "lineage": "magic"}
 }
 
 func handleDiags(diags hcl.Diagnostics) {

--- a/internal/encryption/plan.go
+++ b/internal/encryption/plan.go
@@ -55,7 +55,7 @@ func newPlanEncryption(enc *encryption, target *config.TargetConfig, enforced bo
 }
 
 func (p planEncryption) EncryptPlan(data []byte) ([]byte, error) {
-	return p.base.encrypt(data)
+	return p.base.encrypt(data, func(base basedata) interface{} { return base })
 }
 
 func (p planEncryption) DecryptPlan(data []byte) ([]byte, error) {

--- a/internal/encryption/state.go
+++ b/internal/encryption/state.go
@@ -63,7 +63,8 @@ func newStateEncryption(enc *encryption, target *config.TargetConfig, enforced b
 }
 
 type statedata struct {
-	Serial *int `json:"serial"`
+	Serial  *int   `json:"serial"`
+	Lineage string `json:"lineage"`
 }
 
 func (s *stateEncryption) EncryptState(plainState []byte) ([]byte, error) {
@@ -121,6 +122,11 @@ func (s *stateEncryption) DecryptState(encryptedState []byte) ([]byte, error) {
 	// TODO make encrypted.Serial non-optional.  This is only for supporting alpha1 states!
 	if encrypted.Serial != nil && state.Serial != nil && *state.Serial != *encrypted.Serial {
 		return nil, fmt.Errorf("invalid state metadata, serial field mismatch %v vs %v", *encrypted.Serial, *state.Serial)
+	}
+
+	// TODO make encrypted.Lineage non-optional.  This is only for supporting alpha1 states!
+	if encrypted.Lineage != "" && state.Lineage != encrypted.Lineage {
+		return nil, fmt.Errorf("invalid state metadata, linage field mismatch %v vs %v", encrypted.Lineage, state.Lineage)
 	}
 
 	return decryptedState, nil


### PR DESCRIPTION
Some backends require certain fields like "serial" in order to function. It is relatively safe to keep some of these metadata fields in the encrypted state json payload.

Long term, we should remove this metadata, but this provides a better user experience for the initial migration to encrypted state as different backends take time to adjust their expectations.

Currently only "serial" and "linage" are passed through.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #1407 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.0
