### PR TITLE
Change migration path to and from encrypted state/plans

### DIFF
--- a/internal/command/e2etest/encryption_test.go
+++ b/internal/command/e2etest/encryption_test.go
@@ -143,7 +143,7 @@ func TestEncryptionFlow(t *testing.T) {
 
 	with("required.tf", func() {
 		// Can't switch directly to encryption, need to migrate
-		apply().Failure().StderrContains("decrypted payload provided without fallback specified")
+		apply().Failure().StderrContains("decrypted payload provided without \"migrate_to_encrypted")
 		requireUnencryptedState()
 	})
 
@@ -177,7 +177,7 @@ func TestEncryptionFlow(t *testing.T) {
 		requireEncryptedState()
 
 		// Can't apply unencrypted plan
-		applyPlan(unencryptedPlan).Failure().StderrContains("decrypted payload provided without fallback specified")
+		applyPlan(unencryptedPlan).Failure().StderrContains("decrypted payload provided without \"migrate_to_encrypted")
 		requireEncryptedState()
 
 		// Apply encrypted plan

--- a/internal/command/e2etest/testdata/encryption-flow/migratefrom.tf.disabled
+++ b/internal/command/e2etest/testdata/encryption-flow/migratefrom.tf.disabled
@@ -11,14 +11,12 @@ terraform {
       keys = key_provider.pbkdf2.basic
     }
     state {
-      fallback {
-        method = method.aes_gcm.example
-      }
+      migrate_to_unencrypted = true
+      method = method.aes_gcm.example
     }
     plan {
-      fallback {
-        method = method.aes_gcm.example
-      }
+      migrate_to_unencrypted = true
+      method = method.aes_gcm.example
     }
   }
 }

--- a/internal/command/e2etest/testdata/encryption-flow/migrateto.tf.disabled
+++ b/internal/command/e2etest/testdata/encryption-flow/migrateto.tf.disabled
@@ -12,11 +12,11 @@ terraform {
     }
     state {
       method = method.aes_gcm.example
-      fallback {}
+      migrate_to_encrypted = true
     }
     plan {
       method = method.aes_gcm.example
-      fallback {}
+      migrate_to_encrypted = true
     }
   }
 }

--- a/internal/encryption/base.go
+++ b/internal/encryption/base.go
@@ -21,21 +21,23 @@ const (
 )
 
 type baseEncryption struct {
-	enc        *encryption
-	target     *config.TargetConfig
-	enforced   bool
-	name       string
-	encMethods []method.Method
-	encMeta    map[keyprovider.Addr][]byte
+	enc                  *encryption
+	target               *config.TargetConfig
+	migrateToEncrypted   bool
+	migrateToUnencrypted bool
+	name                 string
+	encMethods           []method.Method
+	encMeta              map[keyprovider.Addr][]byte
 }
 
-func newBaseEncryption(enc *encryption, target *config.TargetConfig, enforced bool, name string) (*baseEncryption, hcl.Diagnostics) {
+func newBaseEncryption(enc *encryption, target *config.TargetConfig, migrateToEncrypted bool, migrateToUnencrypted bool, name string) (*baseEncryption, hcl.Diagnostics) {
 	base := &baseEncryption{
-		enc:      enc,
-		target:   target,
-		enforced: enforced,
-		name:     name,
-		encMeta:  make(map[keyprovider.Addr][]byte),
+		enc:                  enc,
+		target:               target,
+		migrateToEncrypted:   migrateToEncrypted,
+		migrateToUnencrypted: migrateToUnencrypted,
+		name:                 name,
+		encMeta:              make(map[keyprovider.Addr][]byte),
 	}
 	// Setup the encryptor
 	//
@@ -89,7 +91,7 @@ func IsEncryptionPayload(data []byte) (bool, error) {
 
 func (s *baseEncryption) encrypt(data []byte, enhance func(basedata) interface{}) ([]byte, error) {
 	// No configuration provided, don't do anything
-	if s.target == nil {
+	if s.migrateToUnencrypted {
 		return data, nil
 	}
 
@@ -97,14 +99,6 @@ func (s *baseEncryption) encrypt(data []byte, enhance func(basedata) interface{}
 	if len(s.encMethods) != 0 {
 		// Use the pre-configured encryption method
 		encryptor = s.encMethods[0]
-	}
-
-	if encryptor == nil {
-		// ensure that the method is defined when Enforced is true
-		if s.enforced {
-			return nil, fmt.Errorf("encryption of %q is enforced, and therefore requires a method to be provided", s.name)
-		}
-		return data, nil
 	}
 
 	encd, err := encryptor.Encrypt(data)
@@ -127,10 +121,6 @@ func (s *baseEncryption) encrypt(data []byte, enhance func(basedata) interface{}
 
 // TODO Find a way to make these errors actionable / clear
 func (s *baseEncryption) decrypt(data []byte, validator func([]byte) error) ([]byte, error) {
-	if s.target == nil {
-		return data, nil
-	}
-
 	es := basedata{}
 	err := json.Unmarshal(data, &es)
 
@@ -149,20 +139,11 @@ func (s *baseEncryption) decrypt(data []byte, validator func([]byte) error) ([]b
 			return nil, fmt.Errorf("unable to determine data structure during decryption: %w", verr)
 		}
 
-		methods, diags := s.buildTargetMethods(make(map[keyprovider.Addr][]byte))
-		if diags.HasErrors() {
-			// This cast to error here is safe as we know that at least one error exists
-			// This is also quite unlikely to happen as the constructor already has checked this code path
-			return nil, diags
+		// Yep, it's already decrypted and we are in the process of migration
+		if s.migrateToEncrypted || s.migrateToUnencrypted {
+			return data, nil
 		}
-		// Yep, it's already decrypted
-		for _, method := range methods {
-			if method == nil {
-				// fallback allowed
-				return data, nil
-			}
-		}
-		return data, fmt.Errorf("decrypted payload provided without fallback specified")
+		return data, fmt.Errorf("decrypted payload provided without \"migrate_to_encrypted = true\"")
 	}
 
 	if es.Version != encryptionVersion {
@@ -177,28 +158,8 @@ func (s *baseEncryption) decrypt(data []byte, validator func([]byte) error) ([]b
 		return nil, diags
 	}
 
-	if len(methods) == 0 {
-		err = validator(data)
-		if err != nil {
-			// TODO improve this error message
-			return nil, err
-		}
-		// No methods/fallbacks specified and data is valid payload
-		return data, nil
-	}
-
 	errs := make([]error, 0)
 	for _, method := range methods {
-		if method == nil {
-			// No method specified for this target
-			err = validator(data)
-			if err == nil {
-				return data, nil
-			}
-			// TODO improve this error message
-			errs = append(errs, fmt.Errorf("payload is not already decrypted: %w", err))
-			continue
-		}
 		uncd, err := method.Decrypt(es.Data)
 		if err == nil {
 			// Success

--- a/internal/encryption/config/config.go
+++ b/internal/encryption/config/config.go
@@ -73,9 +73,12 @@ type TargetConfig struct {
 //
 // Note: This struct is copied because gohcl does not support embedding.
 type EnforcableTargetConfig struct {
-	Enforced bool           `hcl:"enforced,optional"`
-	Method   hcl.Expression `hcl:"method,optional"`
-	Fallback *TargetConfig  `hcl:"fallback,block"`
+	//TODO if a state{} or plan{} block is defined it implies enforced
+	Enforced             bool           `hcl:"enforced,optional"`
+	Method               hcl.Expression `hcl:"method"`
+	Fallback             *TargetConfig  `hcl:"fallback,block"`
+	MigrateToUnencrypted bool           `hcl:"migrate_to_unencrypted,optional"`
+	MigrateToEncrypted   bool           `hcl:"migrate_to_encrypted,optional"`
 }
 
 // AsTargetConfig converts the struct into its parent TargetConfig.

--- a/internal/encryption/config/config_merge.go
+++ b/internal/encryption/config/config_merge.go
@@ -115,9 +115,11 @@ func mergeEnforcableTargetConfigs(cfg *EnforcableTargetConfig, override *Enforca
 
 	mergeTarget := mergeTargetConfigs(cfg.AsTargetConfig(), override.AsTargetConfig())
 	return &EnforcableTargetConfig{
-		Enforced: cfg.Enforced || override.Enforced,
-		Method:   mergeTarget.Method,
-		Fallback: mergeTarget.Fallback,
+		Enforced:             cfg.Enforced || override.Enforced,
+		Method:               mergeTarget.Method,
+		Fallback:             mergeTarget.Fallback,
+		MigrateToUnencrypted: cfg.MigrateToUnencrypted || override.MigrateToUnencrypted,
+		MigrateToEncrypted:   cfg.MigrateToEncrypted || override.MigrateToEncrypted,
 	}
 }
 

--- a/internal/encryption/config/config_parse.go
+++ b/internal/encryption/config/config_parse.go
@@ -68,6 +68,61 @@ func DecodeConfig(body hcl.Body, rng hcl.Range) (*EncryptionConfig, hcl.Diagnost
 		}
 	}
 
+	if cfg.Plan != nil {
+		if cfg.Plan.MigrateToUnencrypted && cfg.Plan.MigrateToEncrypted {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Field conflict in encryption",
+				Detail:   "Only one of migrate_to_encrypted or migrate_to_unencrypted may be specified",
+				Subject:  rng.Ptr(),
+			})
+		} else {
+			if cfg.Plan.MigrateToUnencrypted {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagWarning,
+					Summary:  "Plan Encryption Migration Enabled",
+					Detail:   "plan > migrate_to_unencrypted is enabled and should be disabled once the migration is complete",
+					Subject:  rng.Ptr(),
+				})
+			}
+			if cfg.Plan.MigrateToEncrypted {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagWarning,
+					Summary:  "Plan Encryption Migration Enabled",
+					Detail:   "plan > migrate_to_encrypted is enabled and should be disabled once the migration is complete",
+					Subject:  rng.Ptr(),
+				})
+			}
+		}
+	}
+	if cfg.State != nil {
+		if cfg.State.MigrateToUnencrypted && cfg.State.MigrateToEncrypted {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Field conflict in encryption",
+				Detail:   "Only one of migrate_to_encrypted or migrate_to_unencrypted may be specified",
+				Subject:  rng.Ptr(),
+			})
+		} else {
+			if cfg.State.MigrateToUnencrypted {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagWarning,
+					Summary:  "State Encryption Migration Enabled",
+					Detail:   "plan > migrate_to_unencrypted is enabled and should be disabled once the migration is complete",
+					Subject:  rng.Ptr(),
+				})
+			}
+			if cfg.State.MigrateToEncrypted {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagWarning,
+					Summary:  "State Encryption Migration Enabled",
+					Detail:   "plan > migrate_to_encrypted is enabled and should be disabled once the migration is complete",
+					Subject:  rng.Ptr(),
+				})
+			}
+		}
+	}
+
 	if diags.HasErrors() {
 		return nil, diags
 	}

--- a/internal/encryption/encryption.go
+++ b/internal/encryption/encryption.go
@@ -66,7 +66,7 @@ func New(reg registry.Registry, cfg *config.EncryptionConfig) (Encryption, hcl.D
 	}
 
 	if cfg.Remote != nil && cfg.Remote.Default != nil {
-		enc.remoteDefault, encDiags = newStateEncryption(enc, cfg.Remote.Default, false, false, "remote.default")
+		enc.remoteDefault, encDiags = newStateEncryption(enc, cfg.Remote.Default.AsTargetConfig(), false, cfg.Remote.Default.AllowUnencrypted, "remote.default")
 		diags = append(diags, encDiags...)
 	} else {
 		enc.remoteDefault = StateEncryptionDisabled()
@@ -76,7 +76,7 @@ func New(reg registry.Registry, cfg *config.EncryptionConfig) (Encryption, hcl.D
 		for _, remoteTarget := range cfg.Remote.Targets {
 			// TODO the addr here should be generated in one place.
 			addr := "remote.remote_state_datasource." + remoteTarget.Name
-			enc.remotes[remoteTarget.Name], encDiags = newStateEncryption(enc, remoteTarget.AsTargetConfig(), false, false, addr)
+			enc.remotes[remoteTarget.Name], encDiags = newStateEncryption(enc, remoteTarget.AsTargetConfig(), false, remoteTarget.AllowUnencrypted, addr)
 			diags = append(diags, encDiags...)
 		}
 	}

--- a/internal/encryption/encryption.go
+++ b/internal/encryption/encryption.go
@@ -52,21 +52,21 @@ func New(reg registry.Registry, cfg *config.EncryptionConfig) (Encryption, hcl.D
 	var encDiags hcl.Diagnostics
 
 	if cfg.State != nil {
-		enc.state, encDiags = newStateEncryption(enc, cfg.State.AsTargetConfig(), cfg.State.Enforced, "state")
+		enc.state, encDiags = newStateEncryption(enc, cfg.State.AsTargetConfig(), cfg.State.MigrateToEncrypted, cfg.State.MigrateToUnencrypted, "state")
 		diags = append(diags, encDiags...)
 	} else {
 		enc.state = StateEncryptionDisabled()
 	}
 
 	if cfg.Plan != nil {
-		enc.plan, encDiags = newPlanEncryption(enc, cfg.Plan.AsTargetConfig(), cfg.Plan.Enforced, "plan")
+		enc.plan, encDiags = newPlanEncryption(enc, cfg.Plan.AsTargetConfig(), cfg.Plan.MigrateToEncrypted, cfg.Plan.MigrateToUnencrypted, "plan")
 		diags = append(diags, encDiags...)
 	} else {
 		enc.plan = PlanEncryptionDisabled()
 	}
 
 	if cfg.Remote != nil && cfg.Remote.Default != nil {
-		enc.remoteDefault, encDiags = newStateEncryption(enc, cfg.Remote.Default, false, "remote.default")
+		enc.remoteDefault, encDiags = newStateEncryption(enc, cfg.Remote.Default, false, false, "remote.default")
 		diags = append(diags, encDiags...)
 	} else {
 		enc.remoteDefault = StateEncryptionDisabled()
@@ -76,7 +76,7 @@ func New(reg registry.Registry, cfg *config.EncryptionConfig) (Encryption, hcl.D
 		for _, remoteTarget := range cfg.Remote.Targets {
 			// TODO the addr here should be generated in one place.
 			addr := "remote.remote_state_datasource." + remoteTarget.Name
-			enc.remotes[remoteTarget.Name], encDiags = newStateEncryption(enc, remoteTarget.AsTargetConfig(), false, addr)
+			enc.remotes[remoteTarget.Name], encDiags = newStateEncryption(enc, remoteTarget.AsTargetConfig(), false, false, addr)
 			diags = append(diags, encDiags...)
 		}
 	}

--- a/internal/encryption/plan.go
+++ b/internal/encryption/plan.go
@@ -49,8 +49,8 @@ type planEncryption struct {
 	base *baseEncryption
 }
 
-func newPlanEncryption(enc *encryption, target *config.TargetConfig, enforced bool, name string) (PlanEncryption, hcl.Diagnostics) {
-	base, diags := newBaseEncryption(enc, target, enforced, name)
+func newPlanEncryption(enc *encryption, target *config.TargetConfig, migrateToEncrypted bool, migrateToUnencrypted bool, name string) (PlanEncryption, hcl.Diagnostics) {
+	base, diags := newBaseEncryption(enc, target, migrateToEncrypted, migrateToUnencrypted, name)
 	return &planEncryption{base}, diags
 }
 

--- a/internal/encryption/state.go
+++ b/internal/encryption/state.go
@@ -57,8 +57,8 @@ type stateEncryption struct {
 	base *baseEncryption
 }
 
-func newStateEncryption(enc *encryption, target *config.TargetConfig, enforced bool, name string) (StateEncryption, hcl.Diagnostics) {
-	base, diags := newBaseEncryption(enc, target, enforced, name)
+func newStateEncryption(enc *encryption, target *config.TargetConfig, migrateToEncrypted bool, migrateToUnencrypted bool, name string) (StateEncryption, hcl.Diagnostics) {
+	base, diags := newBaseEncryption(enc, target, migrateToEncrypted, migrateToUnencrypted, name)
 	return &stateEncryption{base}, diags
 }
 

--- a/internal/encryption/targets.go
+++ b/internal/encryption/targets.go
@@ -68,28 +68,22 @@ func (e *targetBuilder) build(target *config.TargetConfig, targetName string) (m
 	// https://github.com/hashicorp/hcl/blob/main/gohcl/decode.go#L112-L118
 
 	// Descriptor referenced by this target
-	var methodIdent *string
+	var methodIdent string
 	decodeDiags := gohcl.DecodeExpression(target.Method, e.ctx, &methodIdent)
 	diags = append(diags, decodeDiags...)
 
 	// Only attempt to fetch the method if the decoding was successful
 	if !decodeDiags.HasErrors() {
-
-		if methodIdent != nil {
-			if method, ok := e.methods[method.Addr(*methodIdent)]; ok {
-				methods = append(methods, method)
-			} else {
-				// We can't continue if the method is not found
-				diags = append(diags, &hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  "Undefined encryption method",
-					Detail:   fmt.Sprintf("Can not find %q for %q", *methodIdent, targetName),
-					Subject:  target.Method.Range().Ptr(),
-				})
-			}
+		if method, ok := e.methods[method.Addr(methodIdent)]; ok {
+			methods = append(methods, method)
 		} else {
-			// nil is a nop method
-			methods = append(methods, nil)
+			// We can't continue if the method is not found
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Undefined encryption method",
+				Detail:   fmt.Sprintf("Can not find %q for %q", methodIdent, targetName),
+				Subject:  target.Method.Range().Ptr(),
+			})
 		}
 	}
 


### PR DESCRIPTION
Added migrate_to_[un]encrypted fields and remove empty fallback logic.

This implements #1365 and #1366, with a few minor changes.

~~Additionally, it removes the need for enforced.  If a state{} or plan{} block is defined, it is automatically enforced.  We will probably remove the field.~~ See conversation below.

Migration enabled:
![image](https://github.com/opentofu/opentofu/assets/892136/1af25d6b-0c77-47a2-b0cd-611201a0ab69)

Trying to use encryption on an existing project without migration:
![image](https://github.com/opentofu/opentofu/assets/892136/119822c4-6f1f-46fa-b8a9-fdae3b80671d)



Resolves #1365 
Resolves #1366

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.0
