### PR TITLE
Improve panic handling within go-routines

### DIFF
--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"sort"
 	"sync"
 
@@ -326,9 +327,11 @@ func (b *Local) Operation(ctx context.Context, op *backend.Operation) (*backend.
 
 	op.StateLocker = op.StateLocker.WithContext(stopCtx)
 
+	trace := debug.Stack()
+
 	// Do it
 	go func() {
-		defer logging.PanicHandler()
+		defer logging.PanicHandlerWithTrace(trace)
 		defer done()
 		defer stop()
 		defer cancel()

--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -12,7 +12,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"runtime/debug"
 	"sort"
 	"sync"
 
@@ -327,11 +326,11 @@ func (b *Local) Operation(ctx context.Context, op *backend.Operation) (*backend.
 
 	op.StateLocker = op.StateLocker.WithContext(stopCtx)
 
-	trace := debug.Stack()
+	panicHandler := logging.PanicHandlerWithTraceFn()
 
 	// Do it
 	go func() {
-		defer logging.PanicHandlerWithTrace(trace)
+		defer panicHandler()
 		defer done()
 		defer stop()
 		defer cancel()

--- a/internal/backend/local/backend_apply.go
+++ b/internal/backend/local/backend_apply.go
@@ -233,8 +233,9 @@ func (b *Local) opApply(
 	var applyState *states.State
 	var applyDiags tfdiags.Diagnostics
 	doneCh := make(chan struct{})
+	panicHandler := logging.PanicHandlerWithTraceFn()
 	go func() {
-		defer logging.PanicHandler()
+		defer panicHandler()
 		defer close(doneCh)
 		log.Printf("[INFO] backend/local: apply calling Apply")
 		applyState, applyDiags = lr.Core.Apply(plan, lr.Config)

--- a/internal/backend/local/backend_plan.go
+++ b/internal/backend/local/backend_plan.go
@@ -103,8 +103,9 @@ func (b *Local) opPlan(
 	var plan *plans.Plan
 	var planDiags tfdiags.Diagnostics
 	doneCh := make(chan struct{})
+	panicHandler := logging.PanicHandlerWithTraceFn()
 	go func() {
-		defer logging.PanicHandler()
+		defer panicHandler()
 		defer close(doneCh)
 		log.Printf("[INFO] backend/local: plan calling Plan")
 		plan, planDiags = lr.Core.Plan(lr.Config, lr.InputState, lr.PlanOpts)

--- a/internal/backend/local/backend_refresh.go
+++ b/internal/backend/local/backend_refresh.go
@@ -90,8 +90,9 @@ func (b *Local) opRefresh(
 	var newState *states.State
 	var refreshDiags tfdiags.Diagnostics
 	doneCh := make(chan struct{})
+	panicHandler := logging.PanicHandlerWithTraceFn()
 	go func() {
-		defer logging.PanicHandler()
+		defer panicHandler()
 		defer close(doneCh)
 		newState, refreshDiags = lr.Core.Refresh(lr.Config, lr.InputState, lr.PlanOpts)
 		log.Printf("[INFO] backend/local: refresh calling Refresh")

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -821,9 +821,11 @@ func (b *Remote) Operation(ctx context.Context, op *backend.Operation) (*backend
 	cancelCtx, cancel := context.WithCancel(context.Background())
 	runningOp.Cancel = cancel
 
+	panicHandler := logging.PanicHandlerWithTraceFn()
+
 	// Do it.
 	go func() {
-		defer logging.PanicHandler()
+		defer panicHandler()
 		defer done()
 		defer stop()
 		defer cancel()

--- a/internal/backend/remote/backend_common.go
+++ b/internal/backend/remote/backend_common.go
@@ -467,8 +467,10 @@ func (b *Remote) confirm(stopCtx context.Context, op *backend.Operation, opts *t
 	doneCtx, cancel := context.WithCancel(stopCtx)
 	result := make(chan error, 2)
 
+	panicHandler := logging.PanicHandlerWithTraceFn()
+
 	go func() {
-		defer logging.PanicHandler()
+		defer panicHandler()
 
 		// Make sure we cancel doneCtx before we return
 		// so the input command is also canceled.

--- a/internal/backend/remote/backend_plan.go
+++ b/internal/backend/remote/backend_plan.go
@@ -329,11 +329,13 @@ in order to capture the filesystem context the remote workspace expects:
 		return r, generalError("Failed to create run", err)
 	}
 
+	panicHandler := logging.PanicHandlerWithTraceFn()
+
 	// When the lock timeout is set, if the run is still pending and
 	// cancellable after that period, we attempt to cancel it.
 	if lockTimeout := op.StateLocker.Timeout(); lockTimeout > 0 {
 		go func() {
-			defer logging.PanicHandler()
+			defer panicHandler()
 
 			select {
 			case <-stopCtx.Done():

--- a/internal/command/login.go
+++ b/internal/command/login.go
@@ -454,8 +454,9 @@ func (c *LoginCommand) interactiveGetTokenByCode(hostname svchost.Hostname, cred
 			resp.Write([]byte(callbackSuccessMessage))
 		}),
 	}
+	panicHandler := logging.PanicHandlerWithTraceFn()
 	go func() {
-		defer logging.PanicHandler()
+		defer panicHandler()
 		err := server.Serve(listener)
 		if err != nil && err != http.ErrServerClosed {
 			diags = diags.Append(tfdiags.Sourceless(

--- a/internal/command/test.go
+++ b/internal/command/test.go
@@ -256,8 +256,9 @@ func (c *TestCommand) Run(rawArgs []string) int {
 
 	view.Abstract(&suite)
 
+	panicHandler := logging.PanicHandlerWithTraceFn()
 	go func() {
-		defer logging.PanicHandler()
+		defer panicHandler()
 		defer done()
 		defer stop()
 		defer cancel()
@@ -635,8 +636,9 @@ func (runner *TestFileRunner) validate(config *configs.Config, run *moduletest.R
 	runningCtx, done := context.WithCancel(context.Background())
 
 	var validateDiags tfdiags.Diagnostics
+	panicHandler := logging.PanicHandlerWithTraceFn()
 	go func() {
-		defer logging.PanicHandler()
+		defer panicHandler()
 		defer done()
 
 		log.Printf("[DEBUG] TestFileRunner: starting validate for %s/%s", file.Name, run.Name)
@@ -688,8 +690,9 @@ func (runner *TestFileRunner) destroy(config *configs.Config, state *states.Stat
 
 	var plan *plans.Plan
 	var planDiags tfdiags.Diagnostics
+	panicHandler := logging.PanicHandlerWithTraceFn()
 	go func() {
-		defer logging.PanicHandler()
+		defer panicHandler()
 		defer done()
 
 		log.Printf("[DEBUG] TestFileRunner: starting destroy plan for %s/%s", file.Name, run.Name)
@@ -761,8 +764,9 @@ func (runner *TestFileRunner) plan(config *configs.Config, state *states.State, 
 
 	var plan *plans.Plan
 	var planDiags tfdiags.Diagnostics
+	panicHandler := logging.PanicHandlerWithTraceFn()
 	go func() {
-		defer logging.PanicHandler()
+		defer panicHandler()
 		defer done()
 
 		log.Printf("[DEBUG] TestFileRunner: starting plan for %s/%s", file.Name, run.Name)
@@ -816,8 +820,9 @@ func (runner *TestFileRunner) apply(plan *plans.Plan, state *states.State, confi
 	var updated *states.State
 	var applyDiags tfdiags.Diagnostics
 
+	panicHandler := logging.PanicHandlerWithTraceFn()
 	go func() {
-		defer logging.PanicHandler()
+		defer panicHandler()
 		defer done()
 		log.Printf("[DEBUG] TestFileRunner: starting apply for %s/%s", file.Name, run.Name)
 		updated, applyDiags = tfCtx.Apply(plan, config)

--- a/internal/logging/panic.go
+++ b/internal/logging/panic.go
@@ -53,10 +53,13 @@ func PanicHandler() {
 
 // PanicHandlerWithTraceFn returns a function similar to PanicHandler which is
 // called to recover from an internal panic in OpenTofu, and augments the
-// standard stack trace with a more user friendly error message.
+// standard stack trace with a more complete stack trace.
 // The calling stack trace is captured before returing the augmented panicHandler
 // The returned panicHandler must be called as a defered function, and must be the
 // first defer called at the start of a new goroutine.
+//
+// Callers of this function should create the panicHandler before any tight looping
+// as there may be a performance impact if called excessively.
 //
 // This only is a partial solution to the problem of panics within deeply nested
 // go-routines.  It only works between the go-routine being called and the calling

--- a/internal/logging/panic.go
+++ b/internal/logging/panic.go
@@ -40,6 +40,10 @@ var panicMutex sync.Mutex
 // PanicHandler must be called as a defered function, and must be the first
 // defer called at the start of a new goroutine.
 func PanicHandler() {
+	PanicHandlerWithTrace(nil)
+}
+
+func PanicHandlerWithTrace(trace []byte) {
 	// Have all managed goroutines checkin here, and prevent them from exiting
 	// if there's a panic in progress. While this can't lock the entire runtime
 	// to block progress, we can prevent some cases where OpenTofu may return
@@ -58,6 +62,10 @@ func PanicHandler() {
 	// When called from a deferred function, debug.PrintStack will include the
 	// full stack from the point of the pending panic.
 	debug.PrintStack()
+	if trace != nil {
+		fmt.Fprint(os.Stderr, "With go-routine called from:\n")
+		os.Stderr.Write(trace)
+	}
 
 	// An exit code of 11 keeps us out of the way of the detailed exitcodes
 	// from plan, and also happens to be the same code as SIGSEGV which is

--- a/internal/logging/panic.go
+++ b/internal/logging/panic.go
@@ -40,10 +40,6 @@ var panicMutex sync.Mutex
 // PanicHandler must be called as a defered function, and must be the first
 // defer called at the start of a new goroutine.
 func PanicHandler() {
-	PanicHandlerWithTrace(nil)
-}
-
-func PanicHandlerWithTrace(trace []byte) {
 	// Have all managed goroutines checkin here, and prevent them from exiting
 	// if there's a panic in progress. While this can't lock the entire runtime
 	// to block progress, we can prevent some cases where OpenTofu may return
@@ -52,6 +48,39 @@ func PanicHandlerWithTrace(trace []byte) {
 	defer panicMutex.Unlock()
 
 	recovered := recover()
+	panicHandler(recovered, nil)
+}
+
+// PanicHandlerWithTraceFn returns a function similar to PanicHandler which is
+// called to recover from an internal panic in OpenTofu, and augments the
+// standard stack trace with a more user friendly error message.
+// The calling stack trace is captured before returing the augmented panicHandler
+// The returned panicHandler must be called as a defered function, and must be the
+// first defer called at the start of a new goroutine.
+//
+// This only is a partial solution to the problem of panics within deeply nested
+// go-routines.  It only works between the go-routine being called and the calling
+// go-routine.  If you have multiple nested go-rotuines, it will only preserve the
+// calling stack and the called panic stack.  Idealy we would be able to use context
+// or a similar construct to build a more comprehensive panic handler, but this
+// is a significant step in the right direction that will dramatically improve crash
+// debugging
+func PanicHandlerWithTraceFn() func() {
+	trace := debug.Stack()
+	return func() {
+		// Have all managed goroutines checkin here, and prevent them from exiting
+		// if there's a panic in progress. While this can't lock the entire runtime
+		// to block progress, we can prevent some cases where OpenTofu may return
+		// early before the panic has been printed out.
+		panicMutex.Lock()
+		defer panicMutex.Unlock()
+
+		recovered := recover()
+		panicHandler(recovered, trace)
+	}
+}
+
+func panicHandler(recovered interface{}, trace []byte) {
 	if recovered == nil {
 		return
 	}

--- a/internal/tofu/context.go
+++ b/internal/tofu/context.go
@@ -272,8 +272,9 @@ func (c *Context) watchStop(walker *ContextGraphWalker) (chan struct{}, <-chan s
 	// write to the runContext field.
 	done := c.runContext.Done()
 
+	panicHandler := logging.PanicHandlerWithTraceFn()
 	go func() {
-		defer logging.PanicHandler()
+		defer panicHandler()
 
 		defer close(wait)
 		// Wait for a stop or completion

--- a/internal/tofu/graph.go
+++ b/internal/tofu/graph.go
@@ -44,6 +44,10 @@ func (g *Graph) walk(walker GraphWalker) tfdiags.Diagnostics {
 	// The callbacks for enter/exiting a graph
 	ctx := walker.EvalContext()
 
+	// We explicitly create the panicHandler before
+	// spawning many go routines for vertex evaluation
+	// to minimize the performance impact of capturing
+	// the stack trace.
 	panicHandler := logging.PanicHandlerWithTraceFn()
 
 	// Walk the graph.

--- a/internal/tofu/graph.go
+++ b/internal/tofu/graph.go
@@ -44,11 +44,13 @@ func (g *Graph) walk(walker GraphWalker) tfdiags.Diagnostics {
 	// The callbacks for enter/exiting a graph
 	ctx := walker.EvalContext()
 
+	panicHandler := logging.PanicHandlerWithTraceFn()
+
 	// Walk the graph.
 	walkFn := func(v dag.Vertex) (diags tfdiags.Diagnostics) {
 		// the walkFn is called asynchronously, and needs to be recovered
 		// separately in the case of a panic.
-		defer logging.PanicHandler()
+		defer panicHandler()
 
 		log.Printf("[TRACE] vertex %q: starting visit (%T)", dag.VertexName(v), v)
 


### PR DESCRIPTION
I've introduced a new panic handler which captures the calling stack trace.  It is a fairly small modification to the codebase which provides a much better view into the stack during a panic.  It does make a additional call to debug.Stack() before go-routines are spawned, but this is not deeply nested in any loops and should not incur any significant performance penalty.

This only is a partial solution to the problem of panics within deeply nested go-routines.  It only works between the go-routine being called and the calling go-routine.  If you have multiple nested go-rotuines, it will only preserve the
calling stack and the called panic stack.  Idealy we would be able to use context or a similar construct to build a more comprehensive panic handler, but this is a significant step in the right direction that will dramatically improve crash
debugging.

One of the scenarios which is not completely solved by this PR is `main() -spawn> operation() -spawn> graph_walk()`.  If `graph_walk` panics, it will only include the stack trace from `graph_walk` and `operation` and will not include the main stack trace.  This is still a big improvement, but as before mentioned there is still room for improvement.

Resolves #1424, may be worth creating a followup issue to discuss the deeper improvements mentioned above.

## Target Release

1.7.0
