### PR TITLE
fix panic when encryption enabled for remote and cloud backends

### DIFF
--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -378,7 +378,7 @@ func (b *Remote) Configure(obj cty.Value) tfdiags.Diagnostics {
 	}
 
 	// Configure a local backend for when we need to run operations locally.
-	b.local = backendLocal.NewWithBackend(b, nil)
+	b.local = backendLocal.NewWithBackend(b, b.encryption)
 	b.forceLocal = b.forceLocal || !entitlements.Operations
 
 	// Enable retries for server errors as the backend is now fully configured.

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -641,6 +641,7 @@ func (b *Remote) DeleteWorkspace(name string, _ bool) error {
 		workspace: &tfe.Workspace{
 			Name: name,
 		},
+		encryption: b.encryption,
 	}
 
 	return client.Delete()
@@ -706,6 +707,8 @@ func (b *Remote) StateMgr(name string) (statemgr.Full, error) {
 
 		// This is optionally set during OpenTofu Enterprise runs.
 		runID: os.Getenv("TFE_RUN_ID"),
+
+		encryption: b.encryption,
 	}
 
 	state := remote.NewState(client, b.encryption)

--- a/internal/backend/remote/backend_state.go
+++ b/internal/backend/remote/backend_state.go
@@ -32,6 +32,7 @@ type remoteClient struct {
 	stateUploadErr bool
 	workspace      *tfe.Workspace
 	forcePush      bool
+	encryption     encryption.StateEncryption
 }
 
 // Get the remote state.
@@ -96,8 +97,7 @@ func (r *remoteClient) Put(state []byte) error {
 	ctx := context.Background()
 
 	// Read the raw state into a OpenTofu state.
-	// State Encryption is not supported for the remote backend
-	stateFile, err := statefile.Read(bytes.NewReader(state), encryption.StateEncryptionDisabled())
+	stateFile, err := statefile.Read(bytes.NewReader(state), r.encryption)
 	if err != nil {
 		return fmt.Errorf("error reading state: %w", err)
 	}

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -413,7 +413,7 @@ func (b *Cloud) Configure(obj cty.Value) tfdiags.Diagnostics {
 	}
 
 	// Configure a local backend for when we need to run operations locally.
-	b.local = backendLocal.NewWithBackend(b, nil)
+	b.local = backendLocal.NewWithBackend(b, b.encryption)
 	b.forceLocal = b.forceLocal || !entitlements.Operations
 
 	// Enable retries for server errors as the backend is now fully configured.


### PR DESCRIPTION
Resolves #1426 issue.

~~This PR fixes the panic described in #1426, but doesn't entirely resolve the issue. There is still a problem with the disabled encryption configuration for remoteClient ([code reference](https://github.com/opentofu/opentofu/blame/main/internal/backend/remote/backend_state.go#L100)).~~

This PR adds the needed encryption configuration for cases when remote backend is used. Also, it adds encryption to `remoteClient` to properly read the encrypted state file to pass metadata to the remote API.

Note: I didn't test the fix for cloud backend, but I believe there was a panic as well. 

## Target Release

1.7.0
