### PR TITLE
Add provider functions to provider.Interface with GRPC implementation

### DIFF
--- a/internal/builtin/providers/tf/provider.go
+++ b/internal/builtin/providers/tf/provider.go
@@ -160,6 +160,10 @@ func (p *Provider) ValidateResourceConfig(req providers.ValidateResourceConfigRe
 	return validateDataStoreResourceConfig(req)
 }
 
+func (p *Provider) CallFunction(r providers.CallFunctionRequest) providers.CallFunctionResponse {
+	panic("unimplemented - terraform provider has no functions")
+}
+
 // Close is a noop for this provider, since it's run in-process.
 func (p *Provider) Close() error {
 	return nil

--- a/internal/legacy/tofu/provider_mock.go
+++ b/internal/legacy/tofu/provider_mock.go
@@ -362,6 +362,10 @@ func (p *MockProvider) ReadDataSource(r providers.ReadDataSourceRequest) provide
 	return p.ReadDataSourceResponse
 }
 
+func (p *MockProvider) CallFunction(r providers.CallFunctionRequest) providers.CallFunctionResponse {
+	panic("Not Implemented")
+}
+
 func (p *MockProvider) Close() error {
 	p.CloseCalled = true
 	return p.CloseError

--- a/internal/plugin/convert/function.go
+++ b/internal/plugin/convert/function.go
@@ -1,0 +1,64 @@
+package convert
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/opentofu/opentofu/internal/providers"
+	"github.com/opentofu/opentofu/internal/tfplugin5"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func ProtoToCtyType(in []byte) cty.Type {
+	var out cty.Type
+	if err := json.Unmarshal(in, &out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func ProtoToTextFormatting(proto tfplugin5.StringKind) providers.TextFormatting {
+	switch proto {
+	case tfplugin5.StringKind_PLAIN:
+		return providers.TextFormattingPlain
+	case tfplugin5.StringKind_MARKDOWN:
+		return providers.TextFormattingMarkdown
+	default:
+		panic(fmt.Sprintf("Invalid text tfplugin5.StringKind %v", proto))
+	}
+}
+
+func ProtoToFunctionParameterSpec(proto *tfplugin5.Function_Parameter) providers.FunctionParameterSpec {
+	return providers.FunctionParameterSpec{
+		Name:               proto.Name,
+		Type:               ProtoToCtyType(proto.Type),
+		AllowNullValue:     proto.AllowNullValue,
+		AllowUnknownValues: proto.AllowUnknownValues,
+		Description:        proto.Description,
+		DescriptionFormat:  ProtoToTextFormatting(proto.DescriptionKind),
+	}
+}
+
+func ProtoToFunctionSpec(proto *tfplugin5.Function) providers.FunctionSpec {
+	params := make([]providers.FunctionParameterSpec, len(proto.Parameters))
+	for i, param := range proto.Parameters {
+		params[i] = ProtoToFunctionParameterSpec(param)
+	}
+
+	var varParam *providers.FunctionParameterSpec
+	if proto.VariadicParameter != nil {
+		param := ProtoToFunctionParameterSpec(proto.VariadicParameter)
+		varParam = &param
+	}
+
+	// *FunctionParameterSpec
+	return providers.FunctionSpec{
+		Parameters:         params,
+		VariadicParameter:  varParam,
+		Return:             ProtoToCtyType(proto.Return.Type),
+		Summary:            proto.Summary,
+		Description:        proto.Description,
+		DescriptionFormat:  ProtoToTextFormatting(proto.DescriptionKind),
+		DeprecationMessage: proto.DeprecationMessage,
+	}
+}

--- a/internal/plugin/convert/function.go
+++ b/internal/plugin/convert/function.go
@@ -51,7 +51,6 @@ func ProtoToFunctionSpec(proto *tfplugin5.Function) providers.FunctionSpec {
 		varParam = &param
 	}
 
-	// *FunctionParameterSpec
 	return providers.FunctionSpec{
 		Parameters:         params,
 		VariadicParameter:  varParam,

--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -76,6 +76,8 @@ type GRPCProvider struct {
 	schema providers.GetProviderSchemaResponse
 }
 
+var _ providers.Interface = new(GRPCProvider)
+
 func (p *GRPCProvider) GetProviderSchema() (resp providers.GetProviderSchemaResponse) {
 	logger.Trace("GRPCProvider: GetProviderSchema")
 	p.mu.Lock()
@@ -684,6 +686,10 @@ func (p *GRPCProvider) ReadDataSource(r providers.ReadDataSourceRequest) (resp p
 	resp.State = state
 
 	return resp
+}
+
+func (p *GRPCProvider) CallFunction(r providers.CallFunctionRequest) providers.CallFunctionResponse {
+	panic("TODO - implement me")
 }
 
 // closing the grpc connection is final, and tofu will call it at the end of every phase.

--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -104,6 +104,7 @@ func (p *GRPCProvider) GetProviderSchema() (resp providers.GetProviderSchemaResp
 
 	resp.ResourceTypes = make(map[string]providers.Schema)
 	resp.DataSources = make(map[string]providers.Schema)
+	resp.Functions = make(map[string]providers.FunctionSpec)
 
 	// Some providers may generate quite large schemas, and the internal default
 	// grpc response size limit is 4MB. 64MB should cover most any use case, and
@@ -144,6 +145,10 @@ func (p *GRPCProvider) GetProviderSchema() (resp providers.GetProviderSchemaResp
 
 	for name, data := range protoResp.DataSourceSchemas {
 		resp.DataSources[name] = convert.ProtoToProviderSchema(data)
+	}
+
+	for name, fn := range protoResp.Functions {
+		resp.Functions[name] = convert.ProtoToFunctionSpec(fn)
 	}
 
 	if protoResp.ServerCapabilities != nil {

--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -716,7 +716,7 @@ func (p *GRPCProvider) CallFunction(r providers.CallFunctionRequest) (resp provi
 	}
 
 	// Translate the arguments
-	// As this is functionallity is always sitting behind cty/function.Function, we skip some validation
+	// As this is functionality is always sitting behind cty/function.Function, we skip some validation
 	// checks of from the function and param spec.  We still include basic validation to prevent panics,
 	// just in case there are bugs in cty
 	if len(r.Arguments) < len(spec.Parameters) {

--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -714,15 +714,18 @@ func (p *GRPCProvider) CallFunction(r providers.CallFunctionRequest) (resp provi
 		Name:      r.Name,
 		Arguments: make([]*proto.DynamicValue, len(r.Arguments)),
 	}
+
+	// Translate the arguments
+	// As this is functionallity is always sitting behind cty/function.Function, we skip some validation
+	// checks of from the function and param spec.  We still include basic validation to prevent panics,
+	// just in case there are bugs in cty
 	if len(r.Arguments) < len(spec.Parameters) {
 		// This should be unreachable
 		resp.Error = fmt.Errorf("invalid CallFunctionRequest: function %s expected %d parameters and got %d instead", r.Name, len(spec.Parameters), len(r.Arguments))
 		return resp
 	}
 
-	// Translate the arguments
 	for i, arg := range r.Arguments {
-		// Most of the validation we do here should have already happened, but it does not hurt to be extra safe
 		var paramSpec providers.FunctionParameterSpec
 		if i < len(spec.Parameters) {
 			paramSpec = spec.Parameters[i]

--- a/internal/plugin/grpc_provider_test.go
+++ b/internal/plugin/grpc_provider_test.go
@@ -96,6 +96,25 @@ func providerProtoSchema() *proto.GetProviderSchema_Response {
 				},
 			},
 		},
+		Functions: map[string]*proto.Function{
+			"fn": &proto.Function{
+				Parameters: []*proto.Function_Parameter{{
+					Name:               "par_a",
+					Type:               []byte(`"string"`),
+					AllowNullValue:     false,
+					AllowUnknownValues: false,
+				}},
+				VariadicParameter: &proto.Function_Parameter{
+					Name:               "par_var",
+					Type:               []byte(`"string"`),
+					AllowNullValue:     true,
+					AllowUnknownValues: false,
+				},
+				Return: &proto.Function_Return{
+					Type: []byte(`"string"`),
+				},
+			},
+		},
 	}
 }
 
@@ -874,5 +893,31 @@ func TestGRPCProvider_ReadDataSourceJSON(t *testing.T) {
 
 	if !cmp.Equal(expected, resp.State, typeComparer, valueComparer, equateEmpty) {
 		t.Fatal(cmp.Diff(expected, resp.State, typeComparer, valueComparer, equateEmpty))
+	}
+}
+
+func TestGRPCProvider_CallFunction(t *testing.T) {
+	client := mockProviderClient(t)
+	p := &GRPCProvider{
+		client: client,
+	}
+
+	client.EXPECT().CallFunction(
+		gomock.Any(),
+		gomock.Any(),
+	).Return(&proto.CallFunction_Response{
+		Result: &proto.DynamicValue{Json: []byte(`"foo"`)},
+	}, nil)
+
+	resp := p.CallFunction(providers.CallFunctionRequest{
+		Name:      "fn",
+		Arguments: []cty.Value{cty.StringVal("bar"), cty.NilVal},
+	})
+
+	if resp.Error != nil {
+		t.Fatal(resp.Error)
+	}
+	if resp.Result != cty.StringVal("foo") {
+		t.Fatalf("%v", resp.Result)
 	}
 }

--- a/internal/plugin6/convert/function.go
+++ b/internal/plugin6/convert/function.go
@@ -10,7 +10,6 @@ import (
 )
 
 func ProtoToCtyType(in []byte) cty.Type {
-	println(string(in))
 	var out cty.Type
 	if err := json.Unmarshal(in, &out); err != nil {
 		panic(err)

--- a/internal/plugin6/convert/function.go
+++ b/internal/plugin6/convert/function.go
@@ -1,0 +1,64 @@
+package convert
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/opentofu/opentofu/internal/providers"
+	"github.com/opentofu/opentofu/internal/tfplugin6"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func ProtoToCtyType(in []byte) cty.Type {
+	var out cty.Type
+	if err := json.Unmarshal(in, &out); err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func ProtoToTextFormatting(proto tfplugin6.StringKind) providers.TextFormatting {
+	switch proto {
+	case tfplugin6.StringKind_PLAIN:
+		return providers.TextFormattingPlain
+	case tfplugin6.StringKind_MARKDOWN:
+		return providers.TextFormattingMarkdown
+	default:
+		panic(fmt.Sprintf("Invalid text tfplugin6.StringKind %v", proto))
+	}
+}
+
+func ProtoToFunctionParameterSpec(proto *tfplugin6.Function_Parameter) providers.FunctionParameterSpec {
+	return providers.FunctionParameterSpec{
+		Name:               proto.Name,
+		Type:               ProtoToCtyType(proto.Type),
+		AllowNullValue:     proto.AllowNullValue,
+		AllowUnknownValues: proto.AllowUnknownValues,
+		Description:        proto.Description,
+		DescriptionFormat:  ProtoToTextFormatting(proto.DescriptionKind),
+	}
+}
+
+func ProtoToFunctionSpec(proto *tfplugin6.Function) providers.FunctionSpec {
+	params := make([]providers.FunctionParameterSpec, len(proto.Parameters))
+	for i, param := range proto.Parameters {
+		params[i] = ProtoToFunctionParameterSpec(param)
+	}
+
+	var varParam *providers.FunctionParameterSpec
+	if proto.VariadicParameter != nil {
+		param := ProtoToFunctionParameterSpec(proto.VariadicParameter)
+		varParam = &param
+	}
+
+	// *FunctionParameterSpec
+	return providers.FunctionSpec{
+		Parameters:         params,
+		VariadicParameter:  varParam,
+		Return:             ProtoToCtyType(proto.Return.Type),
+		Summary:            proto.Summary,
+		Description:        proto.Description,
+		DescriptionFormat:  ProtoToTextFormatting(proto.DescriptionKind),
+		DeprecationMessage: proto.DeprecationMessage,
+	}
+}

--- a/internal/plugin6/convert/function.go
+++ b/internal/plugin6/convert/function.go
@@ -10,6 +10,7 @@ import (
 )
 
 func ProtoToCtyType(in []byte) cty.Type {
+	println(string(in))
 	var out cty.Type
 	if err := json.Unmarshal(in, &out); err != nil {
 		panic(err)

--- a/internal/plugin6/convert/function.go
+++ b/internal/plugin6/convert/function.go
@@ -51,7 +51,6 @@ func ProtoToFunctionSpec(proto *tfplugin6.Function) providers.FunctionSpec {
 		varParam = &param
 	}
 
-	// *FunctionParameterSpec
 	return providers.FunctionSpec{
 		Parameters:         params,
 		VariadicParameter:  varParam,

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -703,11 +703,19 @@ func (p *GRPCProvider) CallFunction(r providers.CallFunctionRequest) (resp provi
 		Name:      r.Name,
 		Arguments: make([]*proto6.DynamicValue, len(r.Arguments)),
 	}
+	if len(r.Arguments) < len(spec.Parameters) {
+		// This should be unreachable
+		resp.Error = fmt.Errorf("invalid CallFunctionRequest: function %s expected %d parameters and got %d instead", r.Name, len(spec.Parameters), len(r.Arguments))
+		return resp
+	}
+
 	// Translate the arguments
 	for i, arg := range r.Arguments {
 		// Most of the validation we do here should have already happened, but it does not hurt to be extra safe
 		var paramSpec providers.FunctionParameterSpec
-		if i >= len(spec.Parameters) {
+		if i < len(spec.Parameters) {
+			paramSpec = spec.Parameters[i]
+		} else {
 			// We are past the end of spec.Parameters, this is either variadic or an error
 			if spec.VariadicParameter != nil {
 				paramSpec = *spec.VariadicParameter
@@ -715,6 +723,18 @@ func (p *GRPCProvider) CallFunction(r providers.CallFunctionRequest) (resp provi
 				// This should be unreachable
 				resp.Error = fmt.Errorf("invalid CallFunctionRequest: too many arguments passed to non-variadic function %s", r.Name)
 			}
+		}
+
+		if arg.IsNull() {
+			if paramSpec.AllowNullValue {
+				continue
+			} else {
+				resp.Error = &providers.CallFunctionArgumentError{
+					Text:             fmt.Sprintf("parameter %s is null, which is not allowed for function %s", paramSpec.Name, r.Name),
+					FunctionArgument: i,
+				}
+			}
+
 		}
 
 		encodedArg, err := msgpack.Marshal(arg, paramSpec.Type)
@@ -739,8 +759,7 @@ func (p *GRPCProvider) CallFunction(r providers.CallFunctionRequest) (resp provi
 			Text: protoResp.Error.Text,
 		}
 		if protoResp.Error.FunctionArgument != nil {
-			arg := int(*protoResp.Error.FunctionArgument)
-			err.FunctionArgument = &arg
+			err.FunctionArgument = int(*protoResp.Error.FunctionArgument)
 		}
 		resp.Error = err
 		return

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -682,8 +682,72 @@ func (p *GRPCProvider) ReadDataSource(r providers.ReadDataSourceRequest) (resp p
 	return resp
 }
 
-func (p *GRPCProvider) CallFunction(r providers.CallFunctionRequest) providers.CallFunctionResponse {
-	panic("TODO - implement me")
+func (p *GRPCProvider) CallFunction(r providers.CallFunctionRequest) (resp providers.CallFunctionResponse) {
+	logger.Trace("GRPCProvider6: CallFunction")
+
+	schema := p.GetProviderSchema()
+	if schema.Diagnostics.HasErrors() {
+		// This should be unreachable
+		resp.Error = schema.Diagnostics.Err()
+		return resp
+	}
+
+	spec, ok := schema.Functions[r.Name]
+	if !ok {
+		// This should be unreachable
+		resp.Error = fmt.Errorf("invalid CallFunctionRequest: function %s not defined in provider schema", r.Name)
+		return resp
+	}
+
+	protoReq := &proto6.CallFunction_Request{
+		Name:      r.Name,
+		Arguments: make([]*proto6.DynamicValue, len(r.Arguments)),
+	}
+	// Translate the arguments
+	for i, arg := range r.Arguments {
+		// Most of the validation we do here should have already happened, but it does not hurt to be extra safe
+		var paramSpec providers.FunctionParameterSpec
+		if i >= len(spec.Parameters) {
+			// We are past the end of spec.Parameters, this is either variadic or an error
+			if spec.VariadicParameter != nil {
+				paramSpec = *spec.VariadicParameter
+			} else {
+				// This should be unreachable
+				resp.Error = fmt.Errorf("invalid CallFunctionRequest: too many arguments passed to non-variadic function %s", r.Name)
+			}
+		}
+
+		encodedArg, err := msgpack.Marshal(arg, paramSpec.Type)
+		if err != nil {
+			resp.Error = err
+			return
+		}
+
+		protoReq.Arguments[i] = &proto6.DynamicValue{
+			Msgpack: encodedArg,
+		}
+	}
+
+	protoResp, err := p.client.CallFunction(p.ctx, protoReq)
+	if err != nil {
+		resp.Error = err
+		return
+	}
+
+	if protoResp.Error != nil {
+		err := &providers.CallFunctionArgumentError{
+			Text: protoResp.Error.Text,
+		}
+		if protoResp.Error.FunctionArgument != nil {
+			arg := int(*protoResp.Error.FunctionArgument)
+			err.FunctionArgument = &arg
+		}
+		resp.Error = err
+		return
+	}
+
+	resp.Result, resp.Error = decodeDynamicValue(protoResp.Result, spec.Return)
+	return
 }
 
 // closing the grpc connection is final, and tofu will call it at the end of every phase.

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -104,6 +104,7 @@ func (p *GRPCProvider) GetProviderSchema() (resp providers.GetProviderSchemaResp
 
 	resp.ResourceTypes = make(map[string]providers.Schema)
 	resp.DataSources = make(map[string]providers.Schema)
+	resp.Functions = make(map[string]providers.FunctionSpec)
 
 	// Some providers may generate quite large schemas, and the internal default
 	// grpc response size limit is 4MB. 64MB should cover most any use case, and
@@ -144,6 +145,10 @@ func (p *GRPCProvider) GetProviderSchema() (resp providers.GetProviderSchemaResp
 
 	for name, data := range protoResp.DataSourceSchemas {
 		resp.DataSources[name] = convert.ProtoToProviderSchema(data)
+	}
+
+	for name, fn := range protoResp.Functions {
+		resp.Functions[name] = convert.ProtoToFunctionSpec(fn)
 	}
 
 	if protoResp.ServerCapabilities != nil {

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -76,6 +76,8 @@ type GRPCProvider struct {
 	schema providers.GetProviderSchemaResponse
 }
 
+var _ providers.Interface = new(GRPCProvider)
+
 func (p *GRPCProvider) GetProviderSchema() (resp providers.GetProviderSchemaResponse) {
 	logger.Trace("GRPCProvider.v6: GetProviderSchema")
 	p.mu.Lock()
@@ -673,6 +675,10 @@ func (p *GRPCProvider) ReadDataSource(r providers.ReadDataSourceRequest) (resp p
 	resp.State = state
 
 	return resp
+}
+
+func (p *GRPCProvider) CallFunction(r providers.CallFunctionRequest) providers.CallFunctionResponse {
+	panic("TODO - implement me")
 }
 
 // closing the grpc connection is final, and tofu will call it at the end of every phase.

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -703,15 +703,18 @@ func (p *GRPCProvider) CallFunction(r providers.CallFunctionRequest) (resp provi
 		Name:      r.Name,
 		Arguments: make([]*proto6.DynamicValue, len(r.Arguments)),
 	}
+
+	// Translate the arguments
+	// As this is functionallity is always sitting behind cty/function.Function, we skip some validation
+	// checks of from the function and param spec.  We still include basic validation to prevent panics,
+	// just in case there are bugs in cty
 	if len(r.Arguments) < len(spec.Parameters) {
 		// This should be unreachable
 		resp.Error = fmt.Errorf("invalid CallFunctionRequest: function %s expected %d parameters and got %d instead", r.Name, len(spec.Parameters), len(r.Arguments))
 		return resp
 	}
 
-	// Translate the arguments
 	for i, arg := range r.Arguments {
-		// Most of the validation we do here should have already happened, but it does not hurt to be extra safe
 		var paramSpec providers.FunctionParameterSpec
 		if i < len(spec.Parameters) {
 			paramSpec = spec.Parameters[i]

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -705,7 +705,7 @@ func (p *GRPCProvider) CallFunction(r providers.CallFunctionRequest) (resp provi
 	}
 
 	// Translate the arguments
-	// As this is functionallity is always sitting behind cty/function.Function, we skip some validation
+	// As this is functionality is always sitting behind cty/function.Function, we skip some validation
 	// checks of from the function and param spec.  We still include basic validation to prevent panics,
 	// just in case there are bugs in cty
 	if len(r.Arguments) < len(spec.Parameters) {

--- a/internal/plugin6/grpc_provider_test.go
+++ b/internal/plugin6/grpc_provider_test.go
@@ -103,6 +103,25 @@ func providerProtoSchema() *proto.GetProviderSchema_Response {
 				},
 			},
 		},
+		Functions: map[string]*proto.Function{
+			"fn": &proto.Function{
+				Parameters: []*proto.Function_Parameter{{
+					Name:               "par_a",
+					Type:               []byte(`"string"`),
+					AllowNullValue:     false,
+					AllowUnknownValues: false,
+				}},
+				VariadicParameter: &proto.Function_Parameter{
+					Name:               "par_var",
+					Type:               []byte(`"string"`),
+					AllowNullValue:     true,
+					AllowUnknownValues: false,
+				},
+				Return: &proto.Function_Return{
+					Type: []byte(`"string"`),
+				},
+			},
+		},
 	}
 }
 
@@ -881,5 +900,31 @@ func TestGRPCProvider_ReadDataSourceJSON(t *testing.T) {
 
 	if !cmp.Equal(expected, resp.State, typeComparer, valueComparer, equateEmpty) {
 		t.Fatal(cmp.Diff(expected, resp.State, typeComparer, valueComparer, equateEmpty))
+	}
+}
+
+func TestGRPCProvider_CallFunction(t *testing.T) {
+	client := mockProviderClient(t)
+	p := &GRPCProvider{
+		client: client,
+	}
+
+	client.EXPECT().CallFunction(
+		gomock.Any(),
+		gomock.Any(),
+	).Return(&proto.CallFunction_Response{
+		Result: &proto.DynamicValue{Json: []byte(`"foo"`)},
+	}, nil)
+
+	resp := p.CallFunction(providers.CallFunctionRequest{
+		Name:      "fn",
+		Arguments: []cty.Value{cty.StringVal("bar"), cty.NilVal},
+	})
+
+	if resp.Error != nil {
+		t.Fatal(resp.Error)
+	}
+	if resp.Result != cty.StringVal("foo") {
+		t.Fatalf("%v", resp.Result)
 	}
 }

--- a/internal/provider-simple-v6/provider.go
+++ b/internal/provider-simple-v6/provider.go
@@ -147,6 +147,10 @@ func (s simple) ReadDataSource(req providers.ReadDataSourceRequest) (resp provid
 	return resp
 }
 
+func (s simple) CallFunction(r providers.CallFunctionRequest) providers.CallFunctionResponse {
+	panic("Not Implemented")
+}
+
 func (s simple) Close() error {
 	return nil
 }

--- a/internal/provider-simple/provider.go
+++ b/internal/provider-simple/provider.go
@@ -138,6 +138,10 @@ func (s simple) ReadDataSource(req providers.ReadDataSourceRequest) (resp provid
 	return resp
 }
 
+func (s simple) CallFunction(r providers.CallFunctionRequest) providers.CallFunctionResponse {
+	panic("Not Implemented")
+}
+
 func (s simple) Close() error {
 	return nil
 }

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -487,7 +487,7 @@ type CallFunctionResponse struct {
 
 type CallFunctionArgumentError struct {
 	Text             string
-	FunctionArgument *int
+	FunctionArgument int
 }
 
 func (err *CallFunctionArgumentError) Error() string {

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -476,12 +476,20 @@ type ReadDataSourceResponse struct {
 }
 
 type CallFunctionRequest struct {
-	Name    string
-	Args    []cty.Value
-	RetType cty.Type // This could be done by looking at the metadata instead
+	Name      string
+	Arguments []cty.Value
 }
 
 type CallFunctionResponse struct {
 	Result cty.Value
 	Error  error
+}
+
+type CallFunctionArgumentError struct {
+	Text             string
+	FunctionArgument *int
+}
+
+func (err *CallFunctionArgumentError) Error() string {
+	return err.Text
 }

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -175,7 +175,7 @@ type FunctionParameterSpec struct {
 	// Human-readable documentation for the parameter
 	Description string
 	// Formatting type of the Description field
-	DescriptionKind TextFormatting
+	DescriptionFormat TextFormatting
 }
 
 type TextFormatting string

--- a/internal/tofu/provider_mock.go
+++ b/internal/tofu/provider_mock.go
@@ -516,6 +516,10 @@ func (p *MockProvider) ReadDataSource(r providers.ReadDataSourceRequest) (resp p
 	return resp
 }
 
+func (p *MockProvider) CallFunction(r providers.CallFunctionRequest) providers.CallFunctionResponse {
+	panic("Not Implemented")
+}
+
 func (p *MockProvider) Close() error {
 	p.Lock()
 	defer p.Unlock()


### PR DESCRIPTION
This PR takes another step closer to supporting provider functions.  This initial implementation is based on lessons learned from https://github.com/opentofu/opentofu/pull/1334.

All panics introduced are either only hit during test code or are invalid code paths that should never be hit.

Part of #1326 

## Target Release

1.7.0
