### PR TITLE
allow GCP KMS key to be set as env only

### DIFF
--- a/internal/encryption/keyprovider/gcp_kms/config.go
+++ b/internal/encryption/keyprovider/gcp_kms/config.go
@@ -30,7 +30,7 @@ type Config struct {
 	ImpersonateServiceAccount          string   `hcl:"impersonate_service_account,optional"`
 	ImpersonateServiceAccountDelegates []string `hcl:"impersonate_service_account_delegates,optional"`
 
-	KMSKeyName string `hcl:"kms_encryption_key"`
+	KMSKeyName string `hcl:"kms_encryption_key,optional"`
 	KeyLength  int    `hcl:"key_length"`
 }
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

This PR allows GCP KMS key to be set as env only. Previously, it was required in HCL configuration.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.0
