### PR TITLE
doc: Add and Improve Security Notices for `filemd5`, `md5`, and `filesha1` functions

### DIFF
--- a/website/docs/language/functions/filemd5.mdx
+++ b/website/docs/language/functions/filemd5.mdx
@@ -13,3 +13,8 @@ that hashes the contents of a given file rather than a literal string.
 This is similar to `md5(file(filename))`, but
 because [`file`](/docs/language/functions/file) accepts only UTF-8 text it cannot be used to
 create hashes for binary files.
+
+Collision attacks have been successfully performed against this hashing
+function. Before using this function for anything security-sensitive, refer to
+[RFC 6151](https://tools.ietf.org/html/rfc6151) for updated security
+considerations applying to the MD5 algorithm.

--- a/website/docs/language/functions/filesha1.mdx
+++ b/website/docs/language/functions/filesha1.mdx
@@ -13,3 +13,7 @@ that hashes the contents of a given file rather than a literal string.
 This is similar to `sha1(file(filename))`, but
 because [`file`](/docs/language/functions/file) accepts only UTF-8 text it cannot be used to
 create hashes for binary files.
+
+Collision attacks have been successfully performed against this hashing
+function. Before using this function for anything security-sensitive, review
+relevant literature to understand the security implications.

--- a/website/docs/language/functions/md5.mdx
+++ b/website/docs/language/functions/md5.mdx
@@ -14,7 +14,8 @@ The given string is first encoded as UTF-8 and then the MD5 algorithm is applied
 as defined in [RFC 1321](https://tools.ietf.org/html/rfc1321). The raw hash is
 then encoded to lowercase hexadecimal digits before returning.
 
-Before using this function for anything security-sensitive, refer to
+Collision attacks have been successfully performed against this hashing
+function. Before using this function for anything security-sensitive, refer to
 [RFC 6151](https://tools.ietf.org/html/rfc6151) for updated security
 considerations applying to the MD5 algorithm.
 


### PR DESCRIPTION
Just a simple doc update to add/improve security notices for `filemd5`, `md5`, and `filesha1` functions.