### PR TITLE
ignore AccessDenied error on listing workspaces in S3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.25.5
 	github.com/aws/aws-sdk-go-v2/service/kms v1.26.5
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.46.0
+	github.com/aws/smithy-go v1.17.0
 	github.com/bgentry/speakeasy v0.1.0
 	github.com/bmatcuk/doublestar/v4 v4.6.0
 	github.com/chzyer/readline v1.5.1
@@ -154,7 +155,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.17.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.20.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.25.6 // indirect
-	github.com/aws/smithy-go v1.17.0 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bradleyfalzon/ghinstallation/v2 v2.1.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect


### PR DESCRIPTION
Resolves #1357.

Before the https://github.com/opentofu/opentofu/pull/701 PR, all the errors were ignored, except `ErrCodeNoSuchBucket`.

Ideally, we would want to ignore `AccessDenied` when (a) `default` workspace is used and (b) no other workspaces exist. But to assert (a) and (b), we still need to fetch workspaces regardless of their prefix. So it's ignored with no further conditions.

## Target Release

1.7.0
