### PR TITLE
Backport: update nonsensitive docs to not show error

### DIFF
--- a/website/docs/language/functions/nonsensitive.mdx
+++ b/website/docs/language/functions/nonsensitive.mdx
@@ -99,11 +99,7 @@ the local value `mixed_content`, with a valid JSON string assigned to
 > nonsensitive(local.mixed_content["username"])
 "zqb"
 > nonsensitive("clear")
-
-Error: Invalid function argument
-
-Invalid value for "value" parameter: the given value is not sensitive, so this
-call is redundant.
+"clear"
 ```
 
 Note though that it's always your responsibility to use `nonsensitive` only


### PR DESCRIPTION
Backport #1391

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.6.2
