### PR TITLE
Bug Fix #1403 - Set grade and channel correctly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,12 @@ on:
       tag:
         description: "Git tag (leave empty for dry run)"
         required: false
-      prerelease:
-        description: "Release as prerelease?"
-        required: true
-        type: boolean
       latest:
         description: "Release as latest?"
+        required: true
+        type: boolean
+      prerelease:
+        description: "Release as prerelease?"
         required: true
         type: boolean
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_TOKEN }}
           SNAPCRAFT_GRADE: ${{ inputs.prerelease && 'devel' || 'stable' }}
+          SNAPCRAFT_CHANNEL: ${{ inputs.prerelease && 'edge' || 'stable' }}
 
       - name: Remove GPG key
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,11 @@ on:
         description: "Git tag (leave empty for dry run)"
         required: false
       prerelease:
-        description: "Is this a pre-release?"
+        description: "Publish as prerelease?"
+        required: true
+        type: boolean
+      latest:
+        description: "Publish as latest?"
         required: true
         type: boolean
 
@@ -129,7 +133,8 @@ jobs:
           # goreleaser won't sign the packages.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_TOKEN }}
-          PRERELEASE_RELEASE: ${{ inputs.prerelease }}
+          RELEASE_FLAG_PRERELEASE: ${{ inputs.prerelease }}
+          RELEASE_FLAG_LATEST: ${{ inputs.latest }}
 
       - name: Remove GPG key
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,11 @@ on:
         description: "Git tag (leave empty for dry run)"
         required: false
       prerelease:
-        description: "Publish as prerelease?"
+        description: "Release as prerelease?"
         required: true
         type: boolean
       latest:
-        description: "Publish as latest?"
+        description: "Release as latest?"
         required: true
         type: boolean
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
           # goreleaser won't sign the packages.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_TOKEN }}
-          SNAPCRAFT_CHANNEL: ${{ inputs.prerelease &&  'edge' || 'stable' }}
+          SNAPCRAFT_GRADE: ${{ inputs.prerelease && 'devel' || 'stable' }}
 
       - name: Remove GPG key
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,8 +129,7 @@ jobs:
           # goreleaser won't sign the packages.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_TOKEN }}
-          SNAPCRAFT_GRADE: ${{ inputs.prerelease && 'devel' || 'stable' }}
-          SNAPCRAFT_CHANNEL: ${{ inputs.prerelease && 'edge' || 'stable' }}
+          PRERELEASE_RELEASE: ${{ inputs.prerelease }}
 
       - name: Remove GPG key
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ dist/
 
 # Licensei cache file
 .licensei.cache
+
+# Development temp folder
+tmp

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -208,8 +208,9 @@ snapcrafts:
       providers as well as custom in-house solutions.
     base: core22
     channel_templates:
-      - '{{ if eq .Env.PRERELEASE_RELEASE "true" }}edge{{ else }}stable{{ end }}'
-    grade: '{{ if eq .Env.PRERELEASE_RELEASE "true" }}devel{{ else }}stable{{ end }}'
+      - '{{ if eq .Env.RELEASE_FLAG_PRERELEASE "true" }}edge{{ else }}stable{{ end }}'
+      - '{{ .Major }}.{{ .Minor }}/{{ if eq .Env.RELEASE_FLAG_PRERELEASE "true" }}edge{{ else }}stable{{ end }}'
+    grade: '{{ if eq .Env.RELEASE_FLAG_PRERELEASE "true" }}devel{{ else }}stable{{ end }}'
     confinement: classic
     license: MPL-2.0
     apps:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -207,6 +207,7 @@ snapcrafts:
       safely and efficiently. OpenTofu can manage existing and popular service
       providers as well as custom in-house solutions.
     base: core22
+    grade: '{{ if eq .Env.RELEASE_FLAG_PRERELEASE "true" }}devel{{ else }}stable{{ end }}'
     channel_templates:
       - '{{ .Major }}.{{ .Minor }}/{{ if eq .Env.RELEASE_FLAG_PRERELEASE "true" }}edge{{ else }}stable{{ end }}'
       - >-
@@ -214,7 +215,6 @@ snapcrafts:
           {{- if eq .Env.RELEASE_FLAG_PRERELEASE "true" }}latest/edge{{- end }}
           {{- if eq .Env.RELEASE_FLAG_PRERELEASE "false" }}latest/stable{{- end }}
         {{- end }}
-    grade: '{{ if eq .Env.RELEASE_FLAG_PRERELEASE "true" }}devel{{ else }}stable{{ end }}'
     confinement: classic
     license: MPL-2.0
     apps:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -207,7 +207,10 @@ snapcrafts:
       safely and efficiently. OpenTofu can manage existing and popular service
       providers as well as custom in-house solutions.
     base: core22
-    grade: "{{ .Env.SNAPCRAFT_CHANNEL }}"
+    channel_templates:
+      - edge
+      - stable
+    grade: "{{ .Env.SNAPCRAFT_GRADE }}"
     confinement: classic
     license: MPL-2.0
     apps:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -209,8 +209,11 @@ snapcrafts:
     base: core22
     channel_templates:
       - '{{ .Major }}.{{ .Minor }}/{{ if eq .Env.RELEASE_FLAG_PRERELEASE "true" }}edge{{ else }}stable{{ end }}'
-      - '{{ if and (eq .Env.RELEASE_FLAG_LATEST "true") (eq .Env.RELEASE_FLAG_PRERELEASE "true") }}latest/edge{{ end }}'
-      - '{{ if and (eq .Env.RELEASE_FLAG_LATEST "true") (eq .Env.RELEASE_FLAG_PRERELEASE "false") }}latest/stable{{ end }}'
+      - >-
+        {{- if eq .Env.RELEASE_FLAG_LATEST "true" }}
+          {{- if eq .Env.RELEASE_FLAG_PRERELEASE "true" }}latest/edge{{- end }}
+          {{- if eq .Env.RELEASE_FLAG_PRERELEASE "false" }}latest/stable{{- end }}
+        {{- end }}
     grade: '{{ if eq .Env.RELEASE_FLAG_PRERELEASE "true" }}devel{{ else }}stable{{ end }}'
     confinement: classic
     license: MPL-2.0

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -208,8 +208,9 @@ snapcrafts:
       providers as well as custom in-house solutions.
     base: core22
     channel_templates:
-      - '{{ if eq .Env.RELEASE_FLAG_PRERELEASE "true" }}edge{{ else }}stable{{ end }}'
       - '{{ .Major }}.{{ .Minor }}/{{ if eq .Env.RELEASE_FLAG_PRERELEASE "true" }}edge{{ else }}stable{{ end }}'
+      - '{{ if and (eq .Env.RELEASE_FLAG_LATEST "true") (eq .Env.RELEASE_FLAG_PRERELEASE "true") }}latest/edge{{ end }}'
+      - '{{ if and (eq .Env.RELEASE_FLAG_LATEST "true") (eq .Env.RELEASE_FLAG_PRERELEASE "false") }}latest/stable{{ end }}'
     grade: '{{ if eq .Env.RELEASE_FLAG_PRERELEASE "true" }}devel{{ else }}stable{{ end }}'
     confinement: classic
     license: MPL-2.0

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -208,8 +208,7 @@ snapcrafts:
       providers as well as custom in-house solutions.
     base: core22
     channel_templates:
-      - edge
-      - stable
+      - "{{ .Env.SNAPCRAFT_CHANNEL }}"
     grade: "{{ .Env.SNAPCRAFT_GRADE }}"
     confinement: classic
     license: MPL-2.0

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -206,17 +206,13 @@ snapcrafts:
       OpenTofu is an OSS tool for building, changing, and versioning infrastructure
       safely and efficiently. OpenTofu can manage existing and popular service
       providers as well as custom in-house solutions.
-    base: core22
-    grade: '{{ if eq .Env.RELEASE_FLAG_PRERELEASE "true" }}devel{{ else }}stable{{ end }}'
+    disable: '{{ if eq .Env.RELEASE_FLAG_LATEST "false" }}true{{ else }}false{{ end }}'
     channel_templates:
-      - '{{ .Major }}.{{ .Minor }}/{{ if eq .Env.RELEASE_FLAG_PRERELEASE "true" }}edge{{ else }}stable{{ end }}'
-      - >-
-        {{- if eq .Env.RELEASE_FLAG_LATEST "true" }}
-          {{- if eq .Env.RELEASE_FLAG_PRERELEASE "true" }}latest/edge{{- end }}
-          {{- if eq .Env.RELEASE_FLAG_PRERELEASE "false" }}latest/stable{{- end }}
-        {{- end }}
+      - '{{ if eq .Env.RELEASE_FLAG_PRERELEASE "true" }}latest/edge{{ else }}latest/stable{{ end }}'
+    grade: '{{ if eq .Env.RELEASE_FLAG_PRERELEASE "true" }}devel{{ else }}stable{{ end }}'
     confinement: classic
     license: MPL-2.0
+    base: core22
     apps:
       tofu:
         command: tofu

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -208,8 +208,8 @@ snapcrafts:
       providers as well as custom in-house solutions.
     base: core22
     channel_templates:
-      - "{{ .Env.SNAPCRAFT_CHANNEL }}"
-    grade: "{{ .Env.SNAPCRAFT_GRADE }}"
+      - '{{ if eq .Env.PRERELEASE_RELEASE "true" }}edge{{ else }}stable{{ end }}'
+    grade: '{{ if eq .Env.PRERELEASE_RELEASE "true" }}devel{{ else }}stable{{ end }}'
     confinement: classic
     license: MPL-2.0
     apps:


### PR DESCRIPTION
Set snapcraft channel and grade based on pre-release release or stable release.

Changes
- Updated release workflow action to support release flags (prerelease and latest)
- Updated goreleaser to construct grade and channels based on workflow release flags enabled.

Resolves #1403 

## Target Release

1.7.0
