### PR TITLE
fix: commands.go location in architecture docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,7 +26,7 @@ transfers immediately into one of the "command" implementations in
 [the `command` package](https://pkg.go.dev/github.com/opentofu/opentofu/internal/command).
 The mapping between the user-facing command names and
 their corresponding `command` package types can be found in the `commands.go`
-file in the root of the repository.
+file under the `cmd/tofu` directory (package `main`).
 
 The full flow illustrated above does not actually apply to _all_ commands,
 but it applies to the main OpenTofu workflow commands `tofu plan` and


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Just a minor fix for documentation: `commands.go` is in `cmd/tofu` directory and not in the root.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.0
