### PR TITLE
Change numbers to make tests work in i386

### DIFF
--- a/internal/command/testdata/backend-unchanged/.terraform/terraform.tfstate
+++ b/internal/command/testdata/backend-unchanged/.terraform/terraform.tfstate
@@ -1,6 +1,6 @@
 {
     "version": 3,
-    "serial": 0,
+    "serial": 1,
     "lineage": "666f9301-7e65-4b19-ae23-71184bb19b03",
     "backend": {
         "type": "local",
@@ -8,7 +8,7 @@
             "path": "local-state.tfstate",
             "workspace_dir": null
         },
-        "hash": 4282859327
+        "hash": 18446744073697443647
     },
     "modules": [
         {

--- a/internal/command/testdata/backend-unchanged/.terraform/terraform.tfstate
+++ b/internal/command/testdata/backend-unchanged/.terraform/terraform.tfstate
@@ -8,7 +8,7 @@
             "path": "local-state.tfstate",
             "workspace_dir": null
         },
-        "hash": 18446744073697443647
+        "hash": 4282859327
     },
     "modules": [
         {

--- a/internal/command/testdata/backend-unchanged/.terraform/terraform.tfstate
+++ b/internal/command/testdata/backend-unchanged/.terraform/terraform.tfstate
@@ -1,6 +1,6 @@
 {
     "version": 3,
-    "serial": 1,
+    "serial": 0,
     "lineage": "666f9301-7e65-4b19-ae23-71184bb19b03",
     "backend": {
         "type": "local",

--- a/internal/encryption/keyprovider/gcp_kms/compliance_test.go
+++ b/internal/encryption/keyprovider/gcp_kms/compliance_test.go
@@ -84,7 +84,7 @@ func TestKeyProvider(t *testing.T) {
 				"large-key-size": {
 					HCL: `key_provider "gcp_kms" "foo" {
 							kms_encryption_key = "alias/temp"
-							key_length = 999999999999
+							key_length = 99999999
 							}`,
 					ValidHCL:   true,
 					ValidBuild: false,


### PR DESCRIPTION
As a part of #1202  @cam72cam and I are working to get tests run on multiple OS environments like i386, AMD64 etc.

While running dry runs of tests in one of these environments, a number not supported by the 32 bit architecture was identified and fixed.

 