### PR TITLE
HTTP backend client cleanup

### DIFF
--- a/internal/backend/remote-state/http/client.go
+++ b/internal/backend/remote-state/http/client.go
@@ -42,14 +42,13 @@ type httpClient struct {
 }
 
 func (c *httpClient) httpRequest(method string, url *url.URL, data *[]byte, what string) (*http.Response, error) {
-	// If we have data we need a reader
-	var reader io.Reader = nil
+	var body interface{}
 	if data != nil {
-		reader = bytes.NewReader(*data)
+		body = *data
 	}
 
 	// Create the request
-	req, err := retryablehttp.NewRequest(method, url.String(), reader)
+	req, err := retryablehttp.NewRequest(method, url.String(), body)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to make %s HTTP request: %w", what, err)
 	}
@@ -101,7 +100,6 @@ func (c *httpClient) Lock(info *statemgr.LockInfo) (string, error) {
 	case http.StatusForbidden:
 		return "", fmt.Errorf("HTTP remote state endpoint invalid auth")
 	case http.StatusConflict, http.StatusLocked:
-		defer resp.Body.Close()
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return "", &statemgr.LockError{

--- a/internal/backend/remote-state/http/client.go
+++ b/internal/backend/remote-state/http/client.go
@@ -41,10 +41,10 @@ type httpClient struct {
 	jsonLockInfo []byte
 }
 
-func (c *httpClient) httpRequest(method string, url *url.URL, data *[]byte, what string) (*http.Response, error) {
+func (c *httpClient) httpRequest(method string, url *url.URL, data []byte, what string) (*http.Response, error) {
 	var body interface{}
-	if data != nil {
-		body = *data
+	if len(data) > 0 {
+		body = data
 	}
 
 	// Create the request
@@ -58,12 +58,12 @@ func (c *httpClient) httpRequest(method string, url *url.URL, data *[]byte, what
 	}
 
 	// Work with data/body
-	if data != nil {
+	if len(data) > 0 {
 		req.Header.Set("Content-Type", "application/json")
-		req.ContentLength = int64(len(*data))
+		req.ContentLength = int64(len(data))
 
 		// Generate the MD5
-		hash := md5.Sum(*data)
+		hash := md5.Sum(data)
 		b64 := base64.StdEncoding.EncodeToString(hash[:])
 		req.Header.Set("Content-MD5", b64)
 	}
@@ -84,7 +84,7 @@ func (c *httpClient) Lock(info *statemgr.LockInfo) (string, error) {
 	c.lockID = ""
 
 	jsonLockInfo := info.Marshal()
-	resp, err := c.httpRequest(c.LockMethod, c.LockURL, &jsonLockInfo, "lock")
+	resp, err := c.httpRequest(c.LockMethod, c.LockURL, jsonLockInfo, "lock")
 	if err != nil {
 		return "", err
 	}
@@ -129,7 +129,7 @@ func (c *httpClient) Unlock(id string) error {
 		return nil
 	}
 
-	resp, err := c.httpRequest(c.UnlockMethod, c.UnlockURL, &c.jsonLockInfo, "unlock")
+	resp, err := c.httpRequest(c.UnlockMethod, c.UnlockURL, c.jsonLockInfo, "unlock")
 	if err != nil {
 		return err
 	}
@@ -225,7 +225,7 @@ func (c *httpClient) Put(data []byte) error {
 	if c.UpdateMethod != "" {
 		method = c.UpdateMethod
 	}
-	resp, err := c.httpRequest(method, &base, &data, "upload state")
+	resp, err := c.httpRequest(method, &base, data, "upload state")
 	if err != nil {
 		return err
 	}

--- a/internal/backend/remote-state/http/client.go
+++ b/internal/backend/remote-state/http/client.go
@@ -60,7 +60,6 @@ func (c *httpClient) httpRequest(method string, url *url.URL, data []byte, what 
 	// Work with data/body
 	if len(data) > 0 {
 		req.Header.Set("Content-Type", "application/json")
-		req.ContentLength = int64(len(data))
 
 		// Generate the MD5
 		hash := md5.Sum(data)

--- a/internal/backend/remote-state/http/client.go
+++ b/internal/backend/remote-state/http/client.go
@@ -144,7 +144,7 @@ func (c *httpClient) Unlock(id string) error {
 }
 
 func (c *httpClient) Get() (*remote.Payload, error) {
-	resp, err := c.httpRequest("GET", c.URL, nil, "get state")
+	resp, err := c.httpRequest(http.MethodGet, c.URL, nil, "get state")
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +242,7 @@ func (c *httpClient) Put(data []byte) error {
 
 func (c *httpClient) Delete() error {
 	// Make the request
-	resp, err := c.httpRequest("DELETE", c.URL, nil, "delete state")
+	resp, err := c.httpRequest(http.MethodDelete, c.URL, nil, "delete state")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
1. Don't need to close response body twice
2. Pass data as `[]byte`, no need to wrap in a reader

This is a copy of https://github.com/hashicorp/terraform/pull/24639.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.0
