### PR TITLE
add changelog entries for s3 and twingate bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ BUG FIXES:
 * Don't show false update action when import resource with sensitive datasource([#1220](https://github.com/opentofu/opentofu/pull/1220))
 * Fix panic when provisioner source and content are both null ([#1376](https://github.com/opentofu/opentofu/pull/1376))
 * Fix large number will be truncated in plan ([#1382](https://github.com/opentofu/opentofu/pull/1382))
+* Fix S3 backend must have permissions to default 'env:' workspace prefix ([#1445](https://github.com/opentofu/opentofu/pull/1445))
+* Fix crash when using a conditional with Twingate resource ([1446](https://github.com/opentofu/opentofu/pull/1446))
 
 ## Previous Releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,8 @@ BUG FIXES:
 * Don't show false update action when import resource with sensitive datasource([#1220](https://github.com/opentofu/opentofu/pull/1220))
 * Fix panic when provisioner source and content are both null ([#1376](https://github.com/opentofu/opentofu/pull/1376))
 * Fix large number will be truncated in plan ([#1382](https://github.com/opentofu/opentofu/pull/1382))
-* Fix S3 backend must have permissions to default 'env:' workspace prefix ([#1445](https://github.com/opentofu/opentofu/pull/1445))
-* Fix crash when using a conditional with Twingate resource ([1446](https://github.com/opentofu/opentofu/pull/1446))
+* S3 backend no longer requires to have permissions to use the default 'env:' workspace prefix ([#1445](https://github.com/opentofu/opentofu/pull/1445))
+* Fixed a crash when using a conditional with Twingate resource ([1446](https://github.com/opentofu/opentofu/pull/1446))
 
 ## Previous Releases
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Related to #1380 and #1357.

This PR adds missing changelog entries for these issues:

* [Crash when using a conditional with Twingate resource](https://github.com/opentofu/opentofu/issues/1380)

* [Backend/S3: Regression in workspace-prefix - must have permission to default env: workspace prefix](https://github.com/opentofu/opentofu/issues/1357)

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.0
