### PR TITLE
fix e2e init test for windows

### DIFF
--- a/internal/command/e2etest/init_test.go
+++ b/internal/command/e2etest/init_test.go
@@ -466,13 +466,10 @@ func TestInitProviderNotFound(t *testing.T) {
 			t.Fatal("expected error, got success")
 		}
 
-		escapedPluginDir, err := json.Marshal(pluginDir)
-		if err != nil {
-			panic("failed to marshal plugin dir: " + pluginDir)
-		}
+		escapedPluginDir := escapeStringJSON(pluginDir)
 
-		if !strings.Contains(stdout, `"diagnostic":{"severity":"error","summary":"Failed to query available provider packages","detail":"Could not retrieve the list of available versions for provider hashicorp/nonexist: provider registry.opentofu.org/hashicorp/nonexist was not found in any of the search locations\n\n  - `+string(escapedPluginDir)+`"},"type":"diagnostic"}`) {
-			t.Errorf("expected error message is missing from output (pluginDir = '%s'):\n%s", pluginDir, stdout)
+		if !strings.Contains(stdout, `"diagnostic":{"severity":"error","summary":"Failed to query available provider packages","detail":"Could not retrieve the list of available versions for provider hashicorp/nonexist: provider registry.opentofu.org/hashicorp/nonexist was not found in any of the search locations\n\n  - `+escapedPluginDir+`"},"type":"diagnostic"}`) {
+			t.Errorf("expected error message is missing from output (pluginDir = '%s'):\n%s", escapedPluginDir, stdout)
 		}
 	})
 
@@ -528,3 +525,24 @@ func TestInitProviderNotFound(t *testing.T) {
 //	}
 //
 //}
+
+func escapeStringJSON(v string) string {
+	b := &strings.Builder{}
+
+	enc := json.NewEncoder(b)
+
+	enc.SetEscapeHTML(false)
+
+	if err := enc.Encode(v); err != nil {
+		panic("failed to escapeStringJSON: " + v)
+	}
+
+	marshaledV := b.String()
+
+	// shouldn't happen
+	if len(marshaledV) < 2 {
+		return string(marshaledV)
+	}
+
+	return string(marshaledV[1 : len(marshaledV)-1])
+}

--- a/internal/command/e2etest/init_test.go
+++ b/internal/command/e2etest/init_test.go
@@ -7,6 +7,7 @@ package e2etest
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -465,8 +466,13 @@ func TestInitProviderNotFound(t *testing.T) {
 			t.Fatal("expected error, got success")
 		}
 
-		if !strings.Contains(stdout, `"diagnostic":{"severity":"error","summary":"Failed to query available provider packages","detail":"Could not retrieve the list of available versions for provider hashicorp/nonexist: provider registry.opentofu.org/hashicorp/nonexist was not found in any of the search locations\n\n  - `+pluginDir+`"},"type":"diagnostic"}`) {
-			t.Errorf("expected error message is missing from output:\n%s", stdout)
+		escapedPluginDir, err := json.Marshal(pluginDir)
+		if err != nil {
+			panic("failed to marshal plugin dir: " + pluginDir)
+		}
+
+		if !strings.Contains(stdout, `"diagnostic":{"severity":"error","summary":"Failed to query available provider packages","detail":"Could not retrieve the list of available versions for provider hashicorp/nonexist: provider registry.opentofu.org/hashicorp/nonexist was not found in any of the search locations\n\n  - `+string(escapedPluginDir)+`"},"type":"diagnostic"}`) {
+			t.Errorf("expected error message is missing from output (pluginDir = '%s'):\n%s", pluginDir, stdout)
 		}
 	})
 

--- a/internal/command/e2etest/init_test.go
+++ b/internal/command/e2etest/init_test.go
@@ -544,5 +544,5 @@ func escapeStringJSON(v string) string {
 		return string(marshaledV)
 	}
 
-	return string(marshaledV[1 : len(marshaledV)-1])
+	return string(marshaledV[1 : len(marshaledV)-2])
 }


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Part of #1373.

This PR adds a tiny bug fix for windows e2e test.

We need to escape `\` in windows directory path before comparing it to json output.

https://github.com/opentofu/opentofu/actions/runs/8554520116

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.0
