### PR TITLE
Fix for setting the env variable on Unix/Linux

### DIFF
--- a/website/docs/language/state/examples/encryption/configuration.sh
+++ b/website/docs/language/state/examples/encryption/configuration.sh
@@ -1,4 +1,4 @@
-read -d '' TF_ENCRYPTION << EOF
+TF_ENCRYPTION=$(cat <<EOF
 terraform {
   encryption {
     key_provider "some_key_provider" "some_name" {
@@ -25,4 +25,4 @@ terraform {
     }
   }
 }
-EOF
+EOF)


### PR DESCRIPTION
# Description

When using the shell built in read, as in the previous example, the exit code would always return `1`.

This can be really inconvenient on a CI, where every command is expected to exit with `0`, otherwise it shows the build as broken.

Resorted to using `cat(1)`, to work around this issue.

## Why am I proposing this change?

Because of this issue: https://github.com/opentofu/opentofu/issues/1462

Resolves #1462

This issue: https://github.com/opentofu/opentofu/issues/1462

## Target Release

Technically: 1.7.0

But really, it's more of a documentation fix.
