### PR TITLE
Fixing link that was pointing to localhost in docs

### DIFF
--- a/website/docs/language/modules/develop/publish.mdx
+++ b/website/docs/language/modules/develop/publish.mdx
@@ -21,7 +21,7 @@ module "consul" {
 ```
 
 If you do not wish to publish your modules in the public registry, you can
-instead use a [private registry](http://localhost:3000/docs/internals/module-registry-protocol) to get
+instead use a [private registry](/docs/internals/module-registry-protocol) to get
 the same benefits.
 
 We welcome contributions of modules from our community members, partners, and customers. Our ecosystem is made richer by each new module created or an existing one updated, as they reflect the wide range of experience and technical requirements of the community that uses them. Our cloud provider partners often seek to develop specific modules for popular or challenging use cases on their platform and utilize them as valuable learning experiences to empathize with their users. Similarly, our community module developers incorporate a variety of opinions and use cases from the broader OpenTofu community. Both types of modules have their place in the registry, accessible to practitioners who can decide which modules best fit their requirements.


### PR DESCRIPTION
I noticed that the link to private module registry docs from the publishing modules page was hard coded to localhost.

Resolves #1465

## Target Release

1.7.0
