### PR TITLE
Add liason email to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ The key features of OpenTofu are:
 ## Reporting security vulnerabilities
 If you've found a vulnerability or a potential vulnerability in OpenTofu please follow [Security Policy](https://github.com/opentofu/opentofu/security/policy). We'll send a confirmation email to acknowledge your report, and we'll send an additional email when we've identified the issue positively or negatively.
 
+## Reporting possible copyright issues
+
+If you beleive you have found any possible copyright or intellectual property issues, please contact liaison@opentofu.org. We'll send a confirmation email to acknowledge your report.
+
 ## License
 
 [Mozilla Public License v2.0](https://github.com/opentofu/opentofu/blob/main/LICENSE)
+


### PR DESCRIPTION
This PR adds our liason@opentofu.org email to our README so people know how to contact us regarding copyright or intellectual property issues.
