### PR TITLE
add changelog entry for GCP KMS and OpenBao; update bao doc domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ STATE ENCRYPTION
 * Available key providers:
   * Passphrase, via pbkdf2 ([#1310](https://github.com/opentofu/opentofu/pull/1310))
   * AWS KMS ([#1349](https://github.com/opentofu/opentofu/pull/1349))
+  * GCP KMS ([#1392](https://github.com/opentofu/opentofu/pull/1392))
+  * OpenBao ([#1436](https://github.com/opentofu/opentofu/pull/1436))
 
 NEW FEATURES:
 * Add support for a `removed` block that allows users to remove resources or modules from the state without destroying them. ([#1158](https://github.com/opentofu/opentofu/pull/1158))

--- a/website/docs/language/state/encryption.mdx
+++ b/website/docs/language/state/encryption.mdx
@@ -129,12 +129,12 @@ The following example illustrates a minimal configuration:
 
 ### OpenBao
 
-This key provider uses the [OpenBao Transit Secret Engine](https://janma.github.io/openbao/docs/secrets/transit) to generate data keys. You can configure it as follows:
+This key provider uses the [OpenBao Transit Secret Engine](https://openbao.org/docs/secrets/transit) to generate data keys. You can configure it as follows:
 
 | Option                | Description                                                                                                                                                                              | Min. | Default                |
 |-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------|------------------------|
-| key_name *(required)* | Name of the transit encryption key to use to encrypt/decrypt the datakey. It should be [pre-configured](https://janma.github.io/openbao/docs/secrets/transit/#setup) in OpenBao server. | N/A  | -                      |
-| token                 | [Authorization Token](https://janma.github.io/openbao/docs/concepts/tokens/) to use when accessing OpenBao API. Available as `BAO_TOKEN` environment variable.                           | N/A  | -                      |
+| key_name *(required)* | Name of the transit encryption key to use to encrypt/decrypt the datakey. It should be [pre-configured](https://openbao.org/docs/secrets/transit/#setup) in OpenBao server. | N/A  | -                      |
+| token                 | [Authorization Token](https://openbao.org/docs/concepts/tokens/) to use when accessing OpenBao API. Available as `BAO_TOKEN` environment variable.                           | N/A  | -                      |
 | address               | OpenBao server address to access the API. Available as `BAO_ADDR` environment variable.                                                                                                  | N/A  | https://127.0.0.1:8200 |
 | transit_engine_path   | Path at whick Transit Secret Engine enabled in OpenBao.                                                                                                                                  | N/A  | /transit               |
 | key_length            | Number of bytes to generate as a key. Available options are `16`, `32` or `64` bytes.                                                                                                    | 16   | 32                     |


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Part of https://github.com/opentofu/opentofu/issues/1173
Part of https://github.com/opentofu/opentofu/issues/1174

This PR adds missing changelog entry for GCP KMS and OpenBao key providers. Also, this PR updates the URL for OpenBao documentation website.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.0
