### PR TITLE
Better wording on for_each block with unsuitable type value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ BUG FIXES:
 * Added a check in the `tofu test` to validate that the names of test run blocks do not contain spaces. ([#1489](https://github.com/opentofu/opentofu/pull/1489))
 * `tofu test` now supports accessing module outputs when the module has no resources. ([#1409](https://github.com/opentofu/opentofu/pull/1409))
 * Fixed support for provider functions in tests ([#1603](https://github.com/opentofu/opentofu/pull/1603))
-* Better error message on `for_each` block with sensitive value of unsuitable type. ([#1485](https://github.com/opentofu/opentofu/pull/1485))
+* Added a better error message on `for_each` block with sensitive value of unsuitable type. ([#1485](https://github.com/opentofu/opentofu/pull/1485))
 
 ## Previous Releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ BUG FIXES:
 * Added a check in the `tofu test` to validate that the names of test run blocks do not contain spaces. ([#1489](https://github.com/opentofu/opentofu/pull/1489))
 * `tofu test` now supports accessing module outputs when the module has no resources. ([#1409](https://github.com/opentofu/opentofu/pull/1409))
 * Fixed support for provider functions in tests ([#1603](https://github.com/opentofu/opentofu/pull/1603))
+* Better error message on `for_each` block with sensitive value of unsuitable type. ([#1485](https://github.com/opentofu/opentofu/pull/1485))
 
 ## Previous Releases
 

--- a/internal/tofu/eval_for_each.go
+++ b/internal/tofu/eval_for_each.go
@@ -83,9 +83,6 @@ func evaluateForEachExpressionValue(expr hcl.Expression, ctx EvalContext, allowU
 		})
 	}
 
-	if diags.HasErrors() {
-		return nullMap, diags
-	}
 	ty := forEachVal.Type()
 
 	var isAllowedType bool
@@ -96,6 +93,23 @@ func evaluateForEachExpressionValue(expr hcl.Expression, ctx EvalContext, allowU
 	} else {
 		isAllowedType = ty.IsMapType() || ty.IsSetType() || ty.IsObjectType()
 		allowedTypesMessage = "map, or set of strings"
+	}
+
+	// Check if the type is allowed whether the value is marked or not
+	if !(isAllowedType) {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity:    hcl.DiagError,
+			Summary:     "Invalid for_each argument",
+			Detail:      fmt.Sprintf(`The given "for_each" argument value is unsuitable: the "for_each" argument must be a %s, and you have provided a value of type %s.`, allowedTypesMessage, ty.FriendlyName()),
+			Subject:     expr.Range().Ptr(),
+			Expression:  expr,
+			EvalContext: hclCtx,
+		})
+	}
+
+	// Return it to avoid expose sensitive value by further check
+	if diags.HasErrors() {
+		return nullMap, diags
 	}
 
 	const errInvalidUnknownDetailMap = "The \"for_each\" map includes keys derived from resource attributes that cannot be determined until apply, and so OpenTofu cannot determine the full set of keys that will identify the instances of this resource.\n\nWhen working with unknown values in for_each, it's better to define the map keys statically in your configuration and place apply-time results only in the map values.\n\nAlternatively, you could use the -target planning option to first apply only the resources that the for_each value depends on, and then apply a second time to fully converge."
@@ -134,18 +148,6 @@ func evaluateForEachExpressionValue(expr hcl.Expression, ctx EvalContext, allowU
 		}
 		// ensure that we have a map, and not a DynamicValue
 		return cty.UnknownVal(cty.Map(cty.DynamicPseudoType)), diags
-
-	case !(isAllowedType):
-		diags = diags.Append(&hcl.Diagnostic{
-			Severity:    hcl.DiagError,
-			Summary:     "Invalid for_each argument",
-			Detail:      fmt.Sprintf(`The given "for_each" argument value is unsuitable: the "for_each" argument must be a %s, and you have provided a value of type %s.`, allowedTypesMessage, ty.FriendlyName()),
-			Subject:     expr.Range().Ptr(),
-			Expression:  expr,
-			EvalContext: hclCtx,
-		})
-		return nullMap, diags
-
 	case markSafeLengthInt(forEachVal) == 0:
 		// If the map is empty ({}), return an empty map, because cty will
 		// return nil when representing {} AsValueMap. This also covers an empty

--- a/internal/tofu/eval_for_each.go
+++ b/internal/tofu/eval_for_each.go
@@ -96,7 +96,7 @@ func evaluateForEachExpressionValue(expr hcl.Expression, ctx EvalContext, allowU
 	}
 
 	// Check if the type is allowed whether the value is marked or not
-	if !(isAllowedType) {
+	if forEachVal.IsKnown() && !isAllowedType {
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity:    hcl.DiagError,
 			Summary:     "Invalid for_each argument",

--- a/internal/tofu/eval_for_each_test.go
+++ b/internal/tofu/eval_for_each_test.go
@@ -213,6 +213,112 @@ func TestEvaluateForEachExpression_errors(t *testing.T) {
 	}
 }
 
+func TestEvaluateForEachExpression_multi_errors(t *testing.T) {
+	tests := map[string]struct {
+		Expr   hcl.Expression
+		Wanted []struct {
+			Summary           string
+			DetailSubstring   string
+			CausedBySensitive bool
+		}
+	}{
+		"marked list": {
+			hcltest.MockExprLiteral(cty.ListVal([]cty.Value{cty.StringVal("a"), cty.StringVal("a")}).Mark(marks.Sensitive)),
+			[]struct {
+				Summary           string
+				DetailSubstring   string
+				CausedBySensitive bool
+			}{
+				{
+					"Invalid for_each argument",
+					"Sensitive values, or values derived from sensitive values, cannot be used as for_each arguments. If used, the sensitive value could be exposed as a resource instance key.",
+					true,
+				},
+				{
+					"Invalid for_each argument",
+					"must be a map, or set of strings, and you have provided a value of type list",
+					false,
+				},
+			},
+		},
+		"marked tuple": {
+			hcltest.MockExprLiteral(cty.TupleVal([]cty.Value{cty.StringVal("a"), cty.StringVal("a")}).Mark(marks.Sensitive)),
+			[]struct {
+				Summary           string
+				DetailSubstring   string
+				CausedBySensitive bool
+			}{
+				{
+					"Invalid for_each argument",
+					"Sensitive values, or values derived from sensitive values, cannot be used as for_each arguments. If used, the sensitive value could be exposed as a resource instance key.",
+					true,
+				},
+				{
+					"Invalid for_each argument",
+					"must be a map, or set of strings, and you have provided a value of type tuple",
+					false,
+				},
+			},
+		},
+		"marked string": {
+			hcltest.MockExprLiteral(cty.StringVal("a").Mark(marks.Sensitive)),
+			[]struct {
+				Summary           string
+				DetailSubstring   string
+				CausedBySensitive bool
+			}{
+				{
+					"Invalid for_each argument",
+					"Sensitive values, or values derived from sensitive values, cannot be used as for_each arguments. If used, the sensitive value could be exposed as a resource instance key.",
+					true,
+				},
+				{
+					"Invalid for_each argument",
+					"must be a map, or set of strings, and you have provided a value of type string",
+					false,
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := &MockEvalContext{}
+			ctx.installSimpleEval()
+			_, diags := evaluateForEachExpression(test.Expr, ctx)
+			if len(diags) != len(test.Wanted) {
+				t.Errorf("unexpected diagnostics %s", spew.Sdump(diags))
+			}
+			for idx := range test.Wanted {
+				if got, want := diags[idx].Severity(), tfdiags.Error; got != want {
+					t.Errorf("wrong diagnostic severity %#v; want %#v", got, want)
+				}
+				if got, want := diags[idx].Description().Summary, test.Wanted[idx].Summary; got != want {
+					t.Errorf("wrong diagnostic summary\ngot:  %s\nwant: %s", got, want)
+				}
+				if got, want := diags[idx].Description().Detail, test.Wanted[idx].DetailSubstring; !strings.Contains(got, want) {
+					t.Errorf("wrong diagnostic detail\ngot: %s\nwant substring: %s", got, want)
+				}
+				if fromExpr := diags[idx].FromExpr(); fromExpr != nil {
+					if fromExpr.Expression == nil {
+						t.Errorf("diagnostic does not refer to an expression")
+					}
+					if fromExpr.EvalContext == nil {
+						t.Errorf("diagnostic does not refer to an EvalContext")
+					}
+				} else {
+					t.Errorf("diagnostic does not support FromExpr\ngot: %s", spew.Sdump(diags[idx]))
+				}
+
+				if got, want := tfdiags.DiagnosticCausedBySensitive(diags[idx]), test.Wanted[idx].CausedBySensitive; got != want {
+					t.Errorf("wrong result from tfdiags.DiagnosticCausedBySensitive\ngot:  %#v\nwant: %#v", got, want)
+				}
+			}
+
+		})
+	}
+}
+
 func TestEvaluateForEachExpressionKnown(t *testing.T) {
 	tests := map[string]hcl.Expression{
 		"unknown string set": hcltest.MockExprLiteral(cty.UnknownVal(cty.Set(cty.String))),

--- a/internal/tofu/eval_for_each_test.go
+++ b/internal/tofu/eval_for_each_test.go
@@ -133,6 +133,12 @@ func TestEvaluateForEachExpression_errors(t *testing.T) {
 			"map includes keys derived from resource attributes that cannot be determined until apply",
 			true, false,
 		},
+		"unknown pseudo-type": {
+			hcltest.MockExprLiteral(cty.UnknownVal(cty.DynamicPseudoType)),
+			"Invalid for_each argument",
+			"map includes keys derived from resource attributes that cannot be determined until apply",
+			true, false,
+		},
 		"marked map": {
 			hcltest.MockExprLiteral(cty.MapVal(map[string]cty.Value{
 				"a": cty.BoolVal(true),
@@ -321,9 +327,10 @@ func TestEvaluateForEachExpression_multi_errors(t *testing.T) {
 
 func TestEvaluateForEachExpressionKnown(t *testing.T) {
 	tests := map[string]hcl.Expression{
-		"unknown string set": hcltest.MockExprLiteral(cty.UnknownVal(cty.Set(cty.String))),
-		"unknown map":        hcltest.MockExprLiteral(cty.UnknownVal(cty.Map(cty.Bool))),
-		"unknown tuple":      hcltest.MockExprLiteral(cty.UnknownVal(cty.Tuple([]cty.Type{cty.String, cty.Number, cty.Bool}))),
+		"unknown string set":  hcltest.MockExprLiteral(cty.UnknownVal(cty.Set(cty.String))),
+		"unknown map":         hcltest.MockExprLiteral(cty.UnknownVal(cty.Map(cty.Bool))),
+		"unknown tuple":       hcltest.MockExprLiteral(cty.UnknownVal(cty.Tuple([]cty.Type{cty.String, cty.Number, cty.Bool}))),
+		"unknown pseudo-type": hcltest.MockExprLiteral(cty.UnknownVal(cty.DynamicPseudoType)),
 	}
 
 	for name, expr := range tests {


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->
The diags of eval_for_each  will also show type info if the input value is sensitive
But just the type info, diags will not expose the value itself, such as empty or null.

Resolves #1434

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.0
