### PR TITLE
Rewrite outdated doc of function call with sensitive data

### DIFF
--- a/website/docs/language/expressions/function-calls.mdx
+++ b/website/docs/language/expressions/function-calls.mdx
@@ -51,11 +51,11 @@ The expansion symbol is three periods (`...`), not a Unicode ellipsis character
 
 When using sensitive data, such as [an input variable](../../language/values/variables.mdx#suppressing-values-in-cli-output)
 or [an output defined](../../language/values/outputs.mdx#sensitive-suppressing-values-in-cli-output) as sensitive
-as function arguments, the result of the function call will be marked as sensitive.
+as function arguments, the sensitive information in the arguments will be tracked during the function call.
 
-This is a conservative behavior that is true irrespective of the function being
-called. For example, passing an object containing a sensitive input variable to
-the `keys()` function will result in a list that is sensitive:
+For example, passing an object containing a sensitive input variable to the `keys()` function
+will return a list with all keys we expected, but the `values()` function will result in
+a list with first item as sensitive, because the value of key "a" is sensitive.
 
 ```shell
 > local.baz
@@ -64,7 +64,15 @@ the `keys()` function will result in a list that is sensitive:
   "b" = "dog"
 }
 > keys(local.baz)
-(sensitive value)
+[
+  "a",
+  "b",
+]
+> values(local.baz)
+[
+  (sensitive value),
+  "dog",
+]
 ```
 
 ## When OpenTofu Calls Functions


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->
During I working on #1485, I tried a lot function calls to reproduce the conservative behavior described in doc but failed, the example mayab outdated, and I tend to remove it.

```
locals {
  baz = {
    "a" = sensitive("cat")
    "b" = "dog"
  }
}
```
```
> local.baz
{
  "a" = (sensitive value)
  "b" = "dog"
}
> keys(local.baz)
[
  "a",
  "b",
]
>
```





related to #1485 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.0
