### PR TITLE
HTTP backend user-defined headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ BUG FIXES:
 * Fix large number will be truncated in plan ([#1382](https://github.com/opentofu/opentofu/pull/1382))
 * S3 backend no longer requires to have permissions to use the default 'env:' workspace prefix ([#1445](https://github.com/opentofu/opentofu/pull/1445))
 * Fixed a crash when using a conditional with Twingate resource ([1446](https://github.com/opentofu/opentofu/pull/1446))
+* Added support for user-defined headers when configuring the HTTP backend ([1427](https://github.com/opentofu/opentofu/pull/1487))
 
 ## Previous Releases
 

--- a/internal/backend/remote-state/http/backend.go
+++ b/internal/backend/remote-state/http/backend.go
@@ -127,7 +127,7 @@ func New(enc encryption.StateEncryption) backend.Backend {
 				Optional: true,
 				ValidateFunc: func(cv interface{}, ck string) ([]string, []error) {
 					nameRegex := regexp.MustCompile("[^a-zA-Z0-9-_]")
-					valueRegex := regexp.MustCompile("[^[:ascii:]]")
+					valueRegex := regexp.MustCompile("[^\\x00-\\x7F]")
 
 					headers := cv.(map[string]interface{})
 					err := make([]error, 0, len(headers))

--- a/internal/backend/remote-state/http/backend.go
+++ b/internal/backend/remote-state/http/backend.go
@@ -260,10 +260,10 @@ func (b *Backend) configure(ctx context.Context) error {
 			switch strings.ToLower(k) {
 			case "authorization":
 				if username != "" {
-					return fmt.Errorf("header \"%s\" cannot be set when providing username", k)
+					return fmt.Errorf("headers \"%s\" cannot be set when providing username", k)
 				}
 			case "content-type", "content-md5":
-				return fmt.Errorf("header \"%s\" is reserved", k)
+				return fmt.Errorf("headers \"%s\" is reserved", k)
 			default:
 				headers[k] = v.(string)
 			}

--- a/internal/backend/remote-state/http/backend.go
+++ b/internal/backend/remote-state/http/backend.go
@@ -130,12 +130,14 @@ func New(enc encryption.StateEncryption) backend.Backend {
 
 					ch := cv.(map[string]interface{})
 					err := make([]error, 0, len(ch))
-					for k, v := range ch {
-						if rk.MatchString(k) {
-							err = append(err, fmt.Errorf("%s name '%s' must only contain 'A-Za-z0-9-_' characters", ck, k))
+					for hk, hv := range ch {
+						if len(hk) == 0 || rk.MatchString(hk) {
+							err = append(err, fmt.Errorf("%s name '%s' must be contain 'A-Za-z0-9-_' characters", ck, hk))
 						}
-						if rv.MatchString(v.(string)) {
-							err = append(err, fmt.Errorf("%s value '%s' must only contain ascii characters", ck, k))
+
+						v := hv.(string)
+						if len(v) == 0 || rv.MatchString(v) {
+							err = append(err, fmt.Errorf("%s value '%s' must only contain ascii characters", ck, hk))
 						}
 					}
 					return nil, err

--- a/internal/backend/remote-state/http/backend.go
+++ b/internal/backend/remote-state/http/backend.go
@@ -134,13 +134,13 @@ func New(enc encryption.StateEncryption) backend.Backend {
 					for name, value := range headers {
 						if len(name) == 0 || nameRegex.MatchString(name) {
 							err = append(err, fmt.Errorf(
-								"%s '%s' name must not be empty and only contain 'A-Za-z0-9-_' characters", ck, name))
+								"%s \"%s\" name must not be empty and only contain \"A-Za-z0-9-_\" characters", ck, name))
 						}
 
 						v := value.(string)
 						if len(v) == 0 || valueRegex.MatchString(v) {
 							err = append(err, fmt.Errorf(
-								"%s '%s' value must not be empty and only contain ascii characters", ck, name))
+								"%s \"%s\" value must not be empty and only contain ascii characters", ck, name))
 						}
 					}
 					return nil, err
@@ -260,10 +260,10 @@ func (b *Backend) configure(ctx context.Context) error {
 			switch strings.ToLower(k) {
 			case "authorization":
 				if username != "" {
-					return fmt.Errorf("%s header cannot be set when providing username", k)
+					return fmt.Errorf("header \"%s\" cannot be set when providing username", k)
 				}
 			case "content-type", "content-md5":
-				return fmt.Errorf("%s header is reserved", k)
+				return fmt.Errorf("header \"%s\" is reserved", k)
 			default:
 				headers[k] = v.(string)
 			}

--- a/internal/backend/remote-state/http/backend.go
+++ b/internal/backend/remote-state/http/backend.go
@@ -260,12 +260,10 @@ func (b *Backend) configure(ctx context.Context) error {
 			switch strings.ToLower(k) {
 			case "authorization":
 				if username != "" {
-					return fmt.Errorf("authorization header cannot be set when providing username")
+					return fmt.Errorf("%s header cannot be set when providing username", k)
 				}
-			case "content-type":
-				return fmt.Errorf("content-type header is reserved")
-			case "content-md5":
-				return fmt.Errorf("content-md5 header is reserved")
+			case "content-type", "content-md5":
+				return fmt.Errorf("%s header is reserved", k)
 			default:
 				headers[k] = v.(string)
 			}

--- a/internal/backend/remote-state/http/backend.go
+++ b/internal/backend/remote-state/http/backend.go
@@ -125,21 +125,21 @@ func New(enc encryption.StateEncryption) backend.Backend {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
 				ValidateFunc: func(cv interface{}, ck string) ([]string, []error) {
-					rk := regexp.MustCompile("[^a-zA-Z0-9-_]")
-					rv := regexp.MustCompile("[^[:ascii:]]")
+					nameRegex := regexp.MustCompile("[^a-zA-Z0-9-_]")
+					valueRegex := regexp.MustCompile("[^[:ascii:]]")
 
-					ch := cv.(map[string]interface{})
-					err := make([]error, 0, len(ch))
-					for hk, hv := range ch {
-						if len(hk) == 0 || rk.MatchString(hk) {
+					headers := cv.(map[string]interface{})
+					err := make([]error, 0, len(headers))
+					for name, value := range headers {
+						if len(name) == 0 || nameRegex.MatchString(name) {
 							err = append(err, fmt.Errorf(
-								"%s '%s' name must not be empty and only contain 'A-Za-z0-9-_' characters", ck, hk))
+								"%s '%s' name must not be empty and only contain 'A-Za-z0-9-_' characters", ck, name))
 						}
 
-						v := hv.(string)
-						if len(v) == 0 || rv.MatchString(v) {
+						v := value.(string)
+						if len(v) == 0 || valueRegex.MatchString(v) {
 							err = append(err, fmt.Errorf(
-								"%s '%s' value must not be empty and only contain ascii characters", ck, hk))
+								"%s '%s' value must not be empty and only contain ascii characters", ck, name))
 						}
 					}
 					return nil, err

--- a/internal/backend/remote-state/http/backend.go
+++ b/internal/backend/remote-state/http/backend.go
@@ -132,12 +132,14 @@ func New(enc encryption.StateEncryption) backend.Backend {
 					err := make([]error, 0, len(ch))
 					for hk, hv := range ch {
 						if len(hk) == 0 || rk.MatchString(hk) {
-							err = append(err, fmt.Errorf("%s name '%s' must be contain 'A-Za-z0-9-_' characters", ck, hk))
+							err = append(err, fmt.Errorf(
+								"%s name '%s' must not be empty and only contain 'A-Za-z0-9-_' characters", ck, hk))
 						}
 
 						v := hv.(string)
 						if len(v) == 0 || rv.MatchString(v) {
-							err = append(err, fmt.Errorf("%s value '%s' must only contain ascii characters", ck, hk))
+							err = append(err, fmt.Errorf(
+								"%s value '%s' must not be empty and only contain ascii characters", ck, hk))
 						}
 					}
 					return nil, err

--- a/internal/backend/remote-state/http/backend.go
+++ b/internal/backend/remote-state/http/backend.go
@@ -140,7 +140,7 @@ func New(enc encryption.StateEncryption) backend.Backend {
 						v := value.(string)
 						if len(v) == 0 || valueRegex.MatchString(v) {
 							err = append(err, fmt.Errorf(
-								"%s \"%s\" value must not be empty and only contain ascii characters", ck, name))
+								"%s \"%s\" value must not be empty and only contain us-ascii characters", ck, name))
 						}
 					}
 					return nil, err

--- a/internal/backend/remote-state/http/backend.go
+++ b/internal/backend/remote-state/http/backend.go
@@ -134,7 +134,7 @@ func New(enc encryption.StateEncryption) backend.Backend {
 					for name, value := range headers {
 						if len(name) == 0 || nameRegex.MatchString(name) {
 							err = append(err, fmt.Errorf(
-								"%s \"%s\" name must not be empty and only contain \"A-Za-z0-9-_\" characters", ck, name))
+								"%s \"%s\" name must not be empty and only contain A-Za-z0-9-_ characters", ck, name))
 						}
 
 						v := value.(string)

--- a/internal/backend/remote-state/http/backend.go
+++ b/internal/backend/remote-state/http/backend.go
@@ -133,13 +133,13 @@ func New(enc encryption.StateEncryption) backend.Backend {
 					for hk, hv := range ch {
 						if len(hk) == 0 || rk.MatchString(hk) {
 							err = append(err, fmt.Errorf(
-								"%s name '%s' must not be empty and only contain 'A-Za-z0-9-_' characters", ck, hk))
+								"%s '%s' name must not be empty and only contain 'A-Za-z0-9-_' characters", ck, hk))
 						}
 
 						v := hv.(string)
 						if len(v) == 0 || rv.MatchString(v) {
 							err = append(err, fmt.Errorf(
-								"%s value '%s' must not be empty and only contain ascii characters", ck, hk))
+								"%s '%s' value must not be empty and only contain ascii characters", ck, hk))
 						}
 					}
 					return nil, err

--- a/internal/backend/remote-state/http/backend.go
+++ b/internal/backend/remote-state/http/backend.go
@@ -127,7 +127,7 @@ func New(enc encryption.StateEncryption) backend.Backend {
 				Optional: true,
 				ValidateFunc: func(cv interface{}, ck string) ([]string, []error) {
 					nameRegex := regexp.MustCompile("[^a-zA-Z0-9-_]")
-					valueRegex := regexp.MustCompile("[^\\x00-\\x7F]")
+					valueRegex := regexp.MustCompile("[^[:ascii:]]")
 
 					headers := cv.(map[string]interface{})
 					err := make([]error, 0, len(headers))
@@ -140,7 +140,7 @@ func New(enc encryption.StateEncryption) backend.Backend {
 						v := value.(string)
 						if len(strings.TrimSpace(v)) == 0 || valueRegex.MatchString(v) {
 							err = append(err, fmt.Errorf(
-								"%s \"%s\" value must not be empty and only contain us-ascii characters", ck, name))
+								"%s \"%s\" value must not be empty and only contain ascii characters", ck, name))
 						}
 					}
 					return nil, err

--- a/internal/backend/remote-state/http/backend.go
+++ b/internal/backend/remote-state/http/backend.go
@@ -257,11 +257,18 @@ func (b *Backend) configure(ctx context.Context) error {
 		headers = make(map[string]string, len(dh))
 
 		for k, v := range dh {
-			if strings.ToLower(k) == "authorization" && username != "" {
-				return fmt.Errorf("authorization header cannot be set when providing a username")
+			switch strings.ToLower(k) {
+			case "authorization":
+				if username != "" {
+					return fmt.Errorf("authorization header cannot be set when providing username")
+				}
+			case "content-type":
+				return fmt.Errorf("content-type header is reserved")
+			case "content-md5":
+				return fmt.Errorf("content-md5 header is reserved")
+			default:
+				headers[k] = v.(string)
 			}
-
-			headers[k] = v.(string)
 		}
 	}
 

--- a/internal/backend/remote-state/http/backend.go
+++ b/internal/backend/remote-state/http/backend.go
@@ -138,7 +138,7 @@ func New(enc encryption.StateEncryption) backend.Backend {
 						}
 
 						v := value.(string)
-						if len(v) == 0 || valueRegex.MatchString(v) {
+						if len(strings.TrimSpace(v)) == 0 || valueRegex.MatchString(v) {
 							err = append(err, fmt.Errorf(
 								"%s \"%s\" value must not be empty and only contain us-ascii characters", ck, name))
 						}

--- a/internal/backend/remote-state/http/backend_test.go
+++ b/internal/backend/remote-state/http/backend_test.go
@@ -66,7 +66,7 @@ func TestHTTPClientFactory(t *testing.T) {
 		"retry_wait_min": cty.StringVal("15"),
 		"retry_wait_max": cty.StringVal("150"),
 		"headers": cty.MapVal(map[string]cty.Value{
-			"authorization": cty.StringVal("auth"),
+			"user-defined": cty.StringVal("test"),
 		}),
 	}
 
@@ -101,8 +101,8 @@ func TestHTTPClientFactory(t *testing.T) {
 		t.Fatalf("Expected retry_wait_max \"%s\", got \"%s\"", 150*time.Second, client.Client.RetryWaitMax)
 	}
 
-	if len(client.Headers) != 1 || client.Headers["authorization"] != "auth" {
-		t.Fatalf("Expected headers['auth'], got \"%s\"", client.Headers)
+	if len(client.Headers) != 1 || client.Headers["user-defined"] != "test" {
+		t.Fatalf("Expected headers \"user-defined\" to be \"test\", got \"%s\"", client.Headers)
 	}
 }
 

--- a/internal/backend/remote-state/http/backend_test.go
+++ b/internal/backend/remote-state/http/backend_test.go
@@ -48,6 +48,10 @@ func TestHTTPClientFactory(t *testing.T) {
 		t.Fatal("Unexpected username or password")
 	}
 
+	if client.Headers != nil {
+		t.Fatal("Unexpected headers")
+	}
+
 	// custom
 	conf = map[string]cty.Value{
 		"address":        cty.StringVal("http://127.0.0.1:8888/foo"),
@@ -61,6 +65,9 @@ func TestHTTPClientFactory(t *testing.T) {
 		"retry_max":      cty.StringVal("999"),
 		"retry_wait_min": cty.StringVal("15"),
 		"retry_wait_max": cty.StringVal("150"),
+		"headers": cty.MapVal(map[string]cty.Value{
+			"authorization": cty.StringVal("auth"),
+		}),
 	}
 
 	b = backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), configs.SynthBody("synth", conf)).(*Backend)
@@ -92,6 +99,10 @@ func TestHTTPClientFactory(t *testing.T) {
 	}
 	if client.Client.RetryWaitMax != 150*time.Second {
 		t.Fatalf("Expected retry_wait_max \"%s\", got \"%s\"", 150*time.Second, client.Client.RetryWaitMax)
+	}
+
+	if len(client.Headers) != 1 || client.Headers["authorization"] != "auth" {
+		t.Fatalf("Expected headers['auth'], got \"%s\"", client.Headers)
 	}
 }
 

--- a/internal/backend/remote-state/http/client.go
+++ b/internal/backend/remote-state/http/client.go
@@ -66,8 +66,7 @@ func (c *httpClient) httpRequest(method string, url *url.URL, data *[]byte, what
 		req.Header.Set(n, strings.TrimSpace(v))
 	}
 
-	// Set up basic auth if we do not have an authorization header present
-	if c.Username != "" && req.Header.Get("Authorization") == "" {
+	if c.Username != "" {
 		req.SetBasicAuth(c.Username, c.Password)
 	}
 

--- a/internal/backend/remote-state/http/client.go
+++ b/internal/backend/remote-state/http/client.go
@@ -56,9 +56,14 @@ func (c *httpClient) httpRequest(method string, url *url.URL, data *[]byte, what
 		return nil, fmt.Errorf("Failed to make %s HTTP request: %w", what, err)
 	}
 
-	// Add user-defined headers first
+	// Add user-defined headers
 	for k, v := range c.Headers {
-		req.Header.Set(strings.ReplaceAll(k, " ", ""), strings.TrimSpace(v))
+		n := strings.ToLower(strings.ReplaceAll(k, " ", ""))
+		if n == "content-type" || n == "content-md5" {
+			// We don't allow content-type or content-md5 to be set by the user
+			continue
+		}
+		req.Header.Set(n, strings.TrimSpace(v))
 	}
 
 	// Set up basic auth if we do not have an authorization header present

--- a/internal/backend/remote-state/http/client.go
+++ b/internal/backend/remote-state/http/client.go
@@ -36,6 +36,7 @@ type httpClient struct {
 	Client   *retryablehttp.Client
 	Username string
 	Password string
+	Header   http.Header
 
 	lockID       string
 	jsonLockInfo []byte
@@ -53,8 +54,14 @@ func (c *httpClient) httpRequest(method string, url *url.URL, data *[]byte, what
 	if err != nil {
 		return nil, fmt.Errorf("Failed to make %s HTTP request: %w", what, err)
 	}
-	// Set up basic auth
-	if c.Username != "" {
+
+	// Baseline with custom headers if we have any
+	if c.Header != nil {
+		req.Header = c.Header
+	}
+
+	// Set up basic auth if we do not have an authorization header present
+	if c.Username != "" && req.Header.Get("Authorization") == "" {
 		req.SetBasicAuth(c.Username, c.Password)
 	}
 

--- a/internal/backend/remote-state/http/client.go
+++ b/internal/backend/remote-state/http/client.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/opentofu/opentofu/internal/states/remote"
@@ -34,9 +35,9 @@ type httpClient struct {
 
 	// HTTP
 	Client   *retryablehttp.Client
+	Headers  map[string]string
 	Username string
 	Password string
-	Header   http.Header
 
 	lockID       string
 	jsonLockInfo []byte
@@ -55,9 +56,9 @@ func (c *httpClient) httpRequest(method string, url *url.URL, data *[]byte, what
 		return nil, fmt.Errorf("Failed to make %s HTTP request: %w", what, err)
 	}
 
-	// Baseline with custom headers if we have any
-	if c.Header != nil {
-		req.Header = c.Header
+	// Add user-defined headers first
+	for k, v := range c.Headers {
+		req.Header.Set(strings.TrimSpace(k), strings.TrimSpace(v))
 	}
 
 	// Set up basic auth if we do not have an authorization header present

--- a/internal/backend/remote-state/http/client.go
+++ b/internal/backend/remote-state/http/client.go
@@ -11,12 +11,13 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/go-retryablehttp"
-	"github.com/opentofu/opentofu/internal/states/remote"
-	"github.com/opentofu/opentofu/internal/states/statemgr"
 	"io"
 	"net/http"
 	"net/url"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/opentofu/opentofu/internal/states/remote"
+	"github.com/opentofu/opentofu/internal/states/statemgr"
 )
 
 // httpClient is a remote client that stores data in Consul or HTTP REST.

--- a/internal/backend/remote-state/http/client.go
+++ b/internal/backend/remote-state/http/client.go
@@ -58,12 +58,12 @@ func (c *httpClient) httpRequest(method string, url *url.URL, data *[]byte, what
 
 	// Add user-defined headers
 	for k, v := range c.Headers {
-		n := strings.ToLower(strings.ReplaceAll(k, " ", ""))
+		n := strings.ToLower(k)
 		if n == "content-type" || n == "content-md5" {
 			// We don't allow content-type or content-md5 to be set by the user
 			continue
 		}
-		req.Header.Set(n, strings.TrimSpace(v))
+		req.Header.Set(k, strings.TrimSpace(v))
 	}
 
 	if c.Username != "" {

--- a/internal/backend/remote-state/http/client.go
+++ b/internal/backend/remote-state/http/client.go
@@ -11,14 +11,12 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
-	"net/url"
-	"strings"
-
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/opentofu/opentofu/internal/states/remote"
 	"github.com/opentofu/opentofu/internal/states/statemgr"
+	"io"
+	"net/http"
+	"net/url"
 )
 
 // httpClient is a remote client that stores data in Consul or HTTP REST.
@@ -58,12 +56,7 @@ func (c *httpClient) httpRequest(method string, url *url.URL, data *[]byte, what
 
 	// Add user-defined headers
 	for k, v := range c.Headers {
-		n := strings.ToLower(k)
-		if n == "content-type" || n == "content-md5" {
-			// We don't allow content-type or content-md5 to be set by the user
-			continue
-		}
-		req.Header.Set(k, strings.TrimSpace(v))
+		req.Header.Set(k, v)
 	}
 
 	if c.Username != "" {

--- a/internal/backend/remote-state/http/client.go
+++ b/internal/backend/remote-state/http/client.go
@@ -58,7 +58,7 @@ func (c *httpClient) httpRequest(method string, url *url.URL, data *[]byte, what
 
 	// Add user-defined headers first
 	for k, v := range c.Headers {
-		req.Header.Set(strings.TrimSpace(k), strings.TrimSpace(v))
+		req.Header.Set(strings.ReplaceAll(k, " ", ""), strings.TrimSpace(v))
 	}
 
 	// Set up basic auth if we do not have an authorization header present

--- a/internal/backend/remote-state/http/client_test.go
+++ b/internal/backend/remote-state/http/client_test.go
@@ -66,7 +66,6 @@ func TestHTTPClient(t *testing.T) {
 		Headers: map[string]string{
 			"user-defined": "test",
 			"content-type": "application/xml",
-			"content-md5":  "md5",
 		},
 		Client: c,
 	}

--- a/internal/backend/remote-state/http/client_test.go
+++ b/internal/backend/remote-state/http/client_test.go
@@ -46,6 +46,33 @@ func TestHTTPClient(t *testing.T) {
 	}
 	remote.TestClient(t, p)
 
+	// Test headers
+	c := retryablehttp.NewClient()
+	c.RequestLogHook = func(_ retryablehttp.Logger, req *http.Request, _ int) {
+		v := req.Header.Get("user-defined")
+		if v != "test" {
+			t.Fatalf("Expected header \"user-defined\" with value \"test\", got \"%s\"", v)
+		}
+
+		v = req.Header.Get("content-type")
+		if req.Method == "PUT" && v != "application/json" {
+			t.Fatalf("Expected header \"content-type\" with value \"application/json\", got \"%s\"", v)
+		}
+	}
+
+	p = &httpClient{
+		URL:          url,
+		UpdateMethod: "PUT",
+		Headers: map[string]string{
+			"user-defined": "test",
+			"content-type": "application/xml",
+			"content-md5":  "md5",
+		},
+		Client: c,
+	}
+
+	remote.TestClient(t, p)
+
 	// Test locking and alternative UpdateMethod
 	a := &httpClient{
 		URL:          url,

--- a/internal/backend/remote-state/http/client_test.go
+++ b/internal/backend/remote-state/http/client_test.go
@@ -55,7 +55,7 @@ func TestHTTPClient(t *testing.T) {
 			t.Fatalf("Expected header \"user-defined\" with value \"test\", got \"%s\"", v)
 		}
 
-		// Test the content-type header was not overridden (set when sending a request with data)
+		// Test the content-type header was not overridden
 		v = req.Header.Get("content-type")
 		if req.Method == "PUT" && v != "application/json" {
 			t.Fatalf("Expected header \"content-type\" with value \"application/json\", got \"%s\"", v)

--- a/internal/backend/remote-state/http/client_test.go
+++ b/internal/backend/remote-state/http/client_test.go
@@ -49,11 +49,13 @@ func TestHTTPClient(t *testing.T) {
 	// Test headers
 	c := retryablehttp.NewClient()
 	c.RequestLogHook = func(_ retryablehttp.Logger, req *http.Request, _ int) {
+		// Test user defined header is part of the request
 		v := req.Header.Get("user-defined")
 		if v != "test" {
 			t.Fatalf("Expected header \"user-defined\" with value \"test\", got \"%s\"", v)
 		}
 
+		// Test the content-type header was not overridden (set when sending a request with data)
 		v = req.Header.Get("content-type")
 		if req.Method == "PUT" && v != "application/json" {
 			t.Fatalf("Expected header \"content-type\" with value \"application/json\", got \"%s\"", v)

--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -837,6 +837,7 @@ func TestApply_plan_remoteState(t *testing.T) {
 		"client_ca_certificate_pem": cty.NullVal(cty.String),
 		"client_certificate_pem":    cty.NullVal(cty.String),
 		"client_private_key_pem":    cty.NullVal(cty.String),
+		"headers":                   cty.NullVal(cty.String),
 	})
 	backendConfigRaw, err := plans.NewDynamicValue(backendConfig, backendConfig.Type())
 	if err != nil {


### PR DESCRIPTION
Enables users to define headers on the HTTP backend configuration, when supplied the headers are attached to all HTTP requests to the HTTP remote backend.

Changes
- Added headers as a configuration item when creating the HTTP backend
- Added attaching user-defined headers to requests sent to the HTTP backend

Resolves #1427 

## Target Release

1.7.0
