### PR TITLE
WIP - Introduce telemetry for debugging and profiling the planning phase

### DIFF
--- a/cmd/tofu/main.go
+++ b/cmd/tofu/main.go
@@ -83,7 +83,7 @@ func realMain() int {
 	var ctx context.Context
 	var otelSpan trace.Span
 	{
-		// At minimum we emit a span covering the entire command execution.
+		// At a minimum we emit a span covering the entire command execution.
 		_, displayArgs := shquot.POSIXShellSplit(os.Args)
 		ctx, otelSpan = tracer.Start(context.Background(), fmt.Sprintf("tofu %s", displayArgs))
 		defer otelSpan.End()
@@ -140,7 +140,7 @@ func realMain() int {
 	// path in the TERRAFORM_CONFIG_FILE environment variable (though probably
 	// ill-advised) will be resolved relative to the true working directory,
 	// not the overridden one.
-	config, diags := cliconfig.LoadConfig()
+	config, diags := cliconfig.LoadConfig(ctx)
 
 	if len(diags) > 0 {
 		// Since we haven't instantiated a command.Meta yet, we need to do

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -17,6 +17,8 @@ import (
 
 	svchost "github.com/hashicorp/terraform-svchost"
 	"github.com/mitchellh/go-homedir"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/command/clistate"
 	"github.com/opentofu/opentofu/internal/command/views"
@@ -31,7 +33,6 @@ import (
 	"github.com/opentofu/opentofu/internal/states/statemgr"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/opentofu/opentofu/internal/tofu"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // DefaultStateName is the name of the default, initial state that every
@@ -169,7 +170,7 @@ type Local interface {
 	// backend's implementations of this to understand what this actually
 	// does, because this operation has no well-defined contract aside from
 	// "whatever it already does".
-	LocalRun(*Operation) (*LocalRun, statemgr.Full, tfdiags.Diagnostics)
+	LocalRun(context.Context, *Operation) (*LocalRun, statemgr.Full, tfdiags.Diagnostics)
 }
 
 // LocalRun represents the assortment of objects that we can collect or

--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -15,6 +15,8 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/backend"
 	"github.com/opentofu/opentofu/internal/command/views"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
@@ -23,7 +25,6 @@ import (
 	"github.com/opentofu/opentofu/internal/states/statemgr"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/opentofu/opentofu/internal/tofu"
-	"github.com/zclconf/go-cty/cty"
 )
 
 const (
@@ -289,7 +290,7 @@ func (b *Local) Operation(ctx context.Context, op *backend.Operation) (*backend.
 	}
 
 	// Determine the function to call for our operation
-	var f func(context.Context, context.Context, *backend.Operation, *backend.RunningOperation)
+	var f func(context.Context, context.Context, context.Context, *backend.Operation, *backend.RunningOperation)
 	switch op.Type {
 	case backend.OperationTypeRefresh:
 		f = b.opRefresh
@@ -336,7 +337,7 @@ func (b *Local) Operation(ctx context.Context, op *backend.Operation) (*backend.
 		defer cancel()
 
 		defer b.opLock.Unlock()
-		f(stopCtx, cancelCtx, op, runningOp)
+		f(ctx, stopCtx, cancelCtx, op, runningOp)
 	}()
 
 	// Return

--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -330,15 +330,16 @@ func (b *Local) Operation(ctx context.Context, op *backend.Operation) (*backend.
 	panicHandler := logging.PanicHandlerWithTraceFn()
 
 	// Do it
-	go func() {
+	go func(ctx context.Context) {
 		defer panicHandler()
 		defer done()
 		defer stop()
 		defer cancel()
 
 		defer b.opLock.Unlock()
+
 		f(ctx, stopCtx, cancelCtx, op, runningOp)
-	}()
+	}(ctx)
 
 	// Return
 	return runningOp, nil

--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/zclconf/go-cty/cty"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/opentofu/opentofu/internal/backend"
 	"github.com/opentofu/opentofu/internal/configs"
@@ -42,6 +43,10 @@ func (b *Local) LocalRun(ctx context.Context, op *backend.Operation) (*backend.L
 
 func (b *Local) localRun(ctx context.Context, op *backend.Operation) (*backend.LocalRun, *configload.Snapshot, statemgr.Full, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
+
+	var span trace.Span
+	ctx, span = tracer.Start(ctx, "Local.localRun")
+	defer span.End()
 
 	// Get the latest state.
 	log.Printf("[TRACE] backend/local: requesting state manager for workspace %q", op.Workspace)
@@ -97,7 +102,7 @@ func (b *Local) localRun(ctx context.Context, op *backend.Operation) (*backend.L
 			stateMeta = &m
 		}
 		log.Printf("[TRACE] backend/local: populating backend.LocalRun from plan file")
-		ret, configSnap, ctxDiags = b.localRunForPlanFile(op, lp, ret, &coreOpts, stateMeta)
+		ret, configSnap, ctxDiags = b.localRunForPlanFile(ctx, op, lp, ret, &coreOpts, stateMeta)
 		if ctxDiags.HasErrors() {
 			diags = diags.Append(ctxDiags)
 			return nil, nil, nil, diags
@@ -108,7 +113,7 @@ func (b *Local) localRun(ctx context.Context, op *backend.Operation) (*backend.L
 		op.ConfigLoader.ImportSourcesFromSnapshot(configSnap)
 	} else {
 		log.Printf("[TRACE] backend/local: populating backend.LocalRun for current working directory")
-		ret, configSnap, ctxDiags = b.localRunDirect(op, ret, &coreOpts, s)
+		ret, configSnap, ctxDiags = b.localRunDirect(ctx, op, ret, &coreOpts, s)
 	}
 	diags = diags.Append(ctxDiags)
 	if diags.HasErrors() {
@@ -141,7 +146,7 @@ func (b *Local) localRun(ctx context.Context, op *backend.Operation) (*backend.L
 	return ret, configSnap, s, diags
 }
 
-func (b *Local) localRunDirect(op *backend.Operation, run *backend.LocalRun, coreOpts *tofu.ContextOpts, s statemgr.Full) (*backend.LocalRun, *configload.Snapshot, tfdiags.Diagnostics) {
+func (b *Local) localRunDirect(ctx context.Context, op *backend.Operation, run *backend.LocalRun, coreOpts *tofu.ContextOpts, s statemgr.Full) (*backend.LocalRun, *configload.Snapshot, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	// Load the configuration using the caller-provided configuration loader.
@@ -152,7 +157,7 @@ func (b *Local) localRunDirect(op *backend.Operation, run *backend.LocalRun, cor
 	}
 	run.Config = config
 
-	if errs := config.VerifyDependencySelections(op.DependencyLocks); len(errs) > 0 {
+	if errs := config.VerifyDependencySelections(ctx, op.DependencyLocks); len(errs) > 0 {
 		var buf strings.Builder
 		for _, err := range errs {
 			fmt.Fprintf(&buf, "\n  - %s", err.Error())
@@ -213,7 +218,7 @@ func (b *Local) localRunDirect(op *backend.Operation, run *backend.LocalRun, cor
 	// snapshot, from the previous run.
 	state := s.State()
 	if state != nil {
-		migratedState, migrateDiags := tofumigrate.MigrateStateProviderAddresses(config, state)
+		migratedState, migrateDiags := tofumigrate.MigrateStateProviderAddresses(ctx, config, state)
 		diags = diags.Append(migrateDiags)
 		if migrateDiags.HasErrors() {
 			return nil, nil, diags
@@ -231,7 +236,7 @@ func (b *Local) localRunDirect(op *backend.Operation, run *backend.LocalRun, cor
 	return run, configSnap, diags
 }
 
-func (b *Local) localRunForPlanFile(op *backend.Operation, pf *planfile.Reader, run *backend.LocalRun, coreOpts *tofu.ContextOpts, currentStateMeta *statemgr.SnapshotMeta) (*backend.LocalRun, *configload.Snapshot, tfdiags.Diagnostics) {
+func (b *Local) localRunForPlanFile(ctx context.Context, op *backend.Operation, pf *planfile.Reader, run *backend.LocalRun, coreOpts *tofu.ContextOpts, currentStateMeta *statemgr.SnapshotMeta) (*backend.LocalRun, *configload.Snapshot, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	const errSummary = "Invalid plan file"
@@ -262,7 +267,7 @@ func (b *Local) localRunForPlanFile(op *backend.Operation, pf *planfile.Reader, 
 	// in coreOpts below. However, we'll also separately check that the
 	// plan file has identical locked plugins below, and thus we're effectively
 	// checking consistency with both here.
-	if errs := config.VerifyDependencySelections(op.DependencyLocks); len(errs) > 0 {
+	if errs := config.VerifyDependencySelections(ctx, op.DependencyLocks); len(errs) > 0 {
 		var buf strings.Builder
 		for _, err := range errs {
 			fmt.Fprintf(&buf, "\n  - %s", err.Error())

--- a/internal/backend/local/backend_refresh.go
+++ b/internal/backend/local/backend_refresh.go
@@ -41,7 +41,7 @@ func (b *Local) opRefresh(
 					"Cannot read state file",
 					fmt.Sprintf("Failed to read %s: %s", b.StatePath, err),
 				))
-				op.ReportResult(runningOp, diags)
+				op.ReportResult(traceCtx, runningOp, diags)
 				return
 			}
 		}
@@ -54,7 +54,7 @@ func (b *Local) opRefresh(
 	lr, _, opState, contextDiags := b.localRun(traceCtx, op)
 	diags = diags.Append(contextDiags)
 	if contextDiags.HasErrors() {
-		op.ReportResult(runningOp, diags)
+		op.ReportResult(traceCtx, runningOp, diags)
 		return
 	}
 
@@ -83,7 +83,7 @@ func (b *Local) opRefresh(
 	schemas, moreDiags := lr.Core.Schemas(traceCtx, lr.Config, lr.InputState)
 	diags = diags.Append(moreDiags)
 	if moreDiags.HasErrors() {
-		op.ReportResult(runningOp, diags)
+		op.ReportResult(traceCtx, runningOp, diags)
 		return
 	}
 
@@ -107,17 +107,17 @@ func (b *Local) opRefresh(
 	runningOp.State = newState
 	diags = diags.Append(refreshDiags)
 	if refreshDiags.HasErrors() {
-		op.ReportResult(runningOp, diags)
+		op.ReportResult(traceCtx, runningOp, diags)
 		return
 	}
 
 	err := statemgr.WriteAndPersist(opState, newState, schemas)
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("failed to write state: %w", err))
-		op.ReportResult(runningOp, diags)
+		op.ReportResult(traceCtx, runningOp, diags)
 		return
 	}
 
 	// Show any remaining warnings before exiting
-	op.ReportResult(runningOp, diags)
+	op.ReportResult(traceCtx, runningOp, diags)
 }

--- a/internal/backend/local/backend_refresh.go
+++ b/internal/backend/local/backend_refresh.go
@@ -19,6 +19,7 @@ import (
 )
 
 func (b *Local) opRefresh(
+	traceCtx context.Context,
 	stopCtx context.Context,
 	cancelCtx context.Context,
 	op *backend.Operation,
@@ -50,7 +51,7 @@ func (b *Local) opRefresh(
 	op.PlanRefresh = true
 
 	// Get our context
-	lr, _, opState, contextDiags := b.localRun(op)
+	lr, _, opState, contextDiags := b.localRun(traceCtx, op)
 	diags = diags.Append(contextDiags)
 	if contextDiags.HasErrors() {
 		op.ReportResult(runningOp, diags)
@@ -79,7 +80,7 @@ func (b *Local) opRefresh(
 	}
 
 	// get schemas before writing state
-	schemas, moreDiags := lr.Core.Schemas(lr.Config, lr.InputState)
+	schemas, moreDiags := lr.Core.Schemas(traceCtx, lr.Config, lr.InputState)
 	diags = diags.Append(moreDiags)
 	if moreDiags.HasErrors() {
 		op.ReportResult(runningOp, diags)
@@ -94,7 +95,7 @@ func (b *Local) opRefresh(
 	go func() {
 		defer panicHandler()
 		defer close(doneCh)
-		newState, refreshDiags = lr.Core.Refresh(lr.Config, lr.InputState, lr.PlanOpts)
+		newState, refreshDiags = lr.Core.Refresh(traceCtx, lr.Config, lr.InputState, lr.PlanOpts)
 		log.Printf("[INFO] backend/local: refresh calling Refresh")
 	}()
 

--- a/internal/backend/local/telemetry.go
+++ b/internal/backend/local/telemetry.go
@@ -1,0 +1,12 @@
+package local
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+var tracer trace.Tracer
+
+func init() {
+	tracer = otel.Tracer("github.com/opentofu/opentofu/internal/backend/local")
+}

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -23,6 +23,8 @@ import (
 	"github.com/hashicorp/terraform-svchost/disco"
 	"github.com/mitchellh/cli"
 	"github.com/mitchellh/colorstring"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/backend"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/encryption"
@@ -33,7 +35,6 @@ import (
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/opentofu/opentofu/internal/tofu"
 	tfversion "github.com/opentofu/opentofu/version"
-	"github.com/zclconf/go-cty/cty"
 
 	backendLocal "github.com/opentofu/opentofu/internal/backend/local"
 )
@@ -839,7 +840,7 @@ func (b *Remote) Operation(ctx context.Context, op *backend.Operation) (*backend
 		if opErr != nil && opErr != context.Canceled {
 			var diags tfdiags.Diagnostics
 			diags = diags.Append(opErr)
-			op.ReportResult(runningOp, diags)
+			op.ReportResult(ctx, runningOp, diags)
 			return
 		}
 
@@ -854,7 +855,7 @@ func (b *Remote) Operation(ctx context.Context, op *backend.Operation) (*backend
 			if err != nil {
 				var diags tfdiags.Diagnostics
 				diags = diags.Append(generalError("Failed to retrieve run", err))
-				op.ReportResult(runningOp, diags)
+				op.ReportResult(ctx, runningOp, diags)
 				return
 			}
 
@@ -865,7 +866,7 @@ func (b *Remote) Operation(ctx context.Context, op *backend.Operation) (*backend
 				if err := b.cancel(cancelCtx, op, r); err != nil {
 					var diags tfdiags.Diagnostics
 					diags = diags.Append(generalError("Failed to retrieve run", err))
-					op.ReportResult(runningOp, diags)
+					op.ReportResult(ctx, runningOp, diags)
 					return
 				}
 			}

--- a/internal/backend/remote/backend_context.go
+++ b/internal/backend/remote/backend_context.go
@@ -14,16 +14,17 @@ import (
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/backend"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/states/statemgr"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/opentofu/opentofu/internal/tofu"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // Context implements backend.Local.
-func (b *Remote) LocalRun(op *backend.Operation) (*backend.LocalRun, statemgr.Full, tfdiags.Diagnostics) {
+func (b *Remote) LocalRun(ctx context.Context, op *backend.Operation) (*backend.LocalRun, statemgr.Full, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	ret := &backend.LocalRun{
 		PlanOpts: &tofu.PlanOpts{

--- a/internal/backend/remote/backend_context_test.go
+++ b/internal/backend/remote/backend_context_test.go
@@ -214,7 +214,7 @@ func TestRemoteContextWithVars(t *testing.T) {
 			}
 			b.client.Variables.Create(context.TODO(), workspaceID, *v)
 
-			_, _, diags := b.LocalRun(op)
+			_, _, diags := b.LocalRun(context.TODO(), op)
 
 			if test.WantError != "" {
 				if !diags.HasErrors() {
@@ -435,7 +435,7 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 				b.client.Variables.Create(context.TODO(), workspaceID, *v)
 			}
 
-			lr, _, diags := b.LocalRun(op)
+			lr, _, diags := b.LocalRun(context.TODO(), op)
 
 			if diags.HasErrors() {
 				t.Fatalf("unexpected error\ngot:  %s\nwant: <no error>", diags.Err().Error())

--- a/internal/backend/telemetry.go
+++ b/internal/backend/telemetry.go
@@ -1,0 +1,12 @@
+package backend
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+var tracer trace.Tracer
+
+func init() {
+	tracer = otel.Tracer("github.com/opentofu/opentofu/internal/backend")
+}

--- a/internal/builtin/providers/tf/provider.go
+++ b/internal/builtin/providers/tf/provider.go
@@ -46,7 +46,7 @@ func (p *Provider) ValidateProviderConfig(ctx context.Context, req providers.Val
 }
 
 // ValidateDataResourceConfig is used to validate the data source configuration values.
-func (p *Provider) ValidateDataResourceConfig(req providers.ValidateDataResourceConfigRequest) providers.ValidateDataResourceConfigResponse {
+func (p *Provider) ValidateDataResourceConfig(ctx context.Context, req providers.ValidateDataResourceConfigRequest) providers.ValidateDataResourceConfigResponse {
 	// FIXME: move the backend configuration validate call that's currently
 	// inside the read method  into here so that we can catch provider configuration
 	// errors in tofu validate as well as during tofu plan.
@@ -73,7 +73,7 @@ func (p *Provider) ConfigureProvider(context.Context, providers.ConfigureProvide
 }
 
 // ReadDataSource returns the data source's current state.
-func (p *Provider) ReadDataSource(req providers.ReadDataSourceRequest) providers.ReadDataSourceResponse {
+func (p *Provider) ReadDataSource(ctx context.Context, req providers.ReadDataSourceRequest) providers.ReadDataSourceResponse {
 	panic("Should not be called directly, special case for terraform_remote_state")
 }
 
@@ -125,25 +125,25 @@ func (p *Provider) Stop() error {
 // instance state whose schema version is less than the one reported by the
 // currently-used version of the corresponding provider, and the upgraded
 // result is used for any further processing.
-func (p *Provider) UpgradeResourceState(req providers.UpgradeResourceStateRequest) providers.UpgradeResourceStateResponse {
+func (p *Provider) UpgradeResourceState(ctx context.Context, req providers.UpgradeResourceStateRequest) providers.UpgradeResourceStateResponse {
 	return upgradeDataStoreResourceState(req)
 }
 
 // ReadResource refreshes a resource and returns its current state.
-func (p *Provider) ReadResource(req providers.ReadResourceRequest) providers.ReadResourceResponse {
+func (p *Provider) ReadResource(ctx context.Context, req providers.ReadResourceRequest) providers.ReadResourceResponse {
 	return readDataStoreResourceState(req)
 }
 
 // PlanResourceChange takes the current state and proposed state of a
 // resource, and returns the planned final state.
-func (p *Provider) PlanResourceChange(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+func (p *Provider) PlanResourceChange(ctx context.Context, req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
 	return planDataStoreResourceChange(req)
 }
 
 // ApplyResourceChange takes the planned state for a resource, which may
 // yet contain unknown computed values, and applies the changes returning
 // the final state.
-func (p *Provider) ApplyResourceChange(req providers.ApplyResourceChangeRequest) providers.ApplyResourceChangeResponse {
+func (p *Provider) ApplyResourceChange(ctx context.Context, req providers.ApplyResourceChangeRequest) providers.ApplyResourceChangeResponse {
 	return applyDataStoreResourceChange(req)
 }
 
@@ -157,7 +157,7 @@ func (p *Provider) ImportResourceState(req providers.ImportResourceStateRequest)
 }
 
 // ValidateResourceConfig is used to to validate the resource configuration values.
-func (p *Provider) ValidateResourceConfig(req providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
+func (p *Provider) ValidateResourceConfig(ctx context.Context, req providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
 	return validateDataStoreResourceConfig(req)
 }
 

--- a/internal/builtin/providers/tf/provider.go
+++ b/internal/builtin/providers/tf/provider.go
@@ -6,6 +6,7 @@
 package tf
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -24,7 +25,7 @@ func NewProvider() providers.Interface {
 }
 
 // GetSchema returns the complete schema for the provider.
-func (p *Provider) GetProviderSchema() providers.GetProviderSchemaResponse {
+func (p *Provider) GetProviderSchema(context.Context) providers.GetProviderSchemaResponse {
 	return providers.GetProviderSchemaResponse{
 		DataSources: map[string]providers.Schema{
 			"terraform_remote_state": dataSourceRemoteStateGetSchema(),
@@ -36,7 +37,7 @@ func (p *Provider) GetProviderSchema() providers.GetProviderSchemaResponse {
 }
 
 // ValidateProviderConfig is used to validate the configuration values.
-func (p *Provider) ValidateProviderConfig(req providers.ValidateProviderConfigRequest) providers.ValidateProviderConfigResponse {
+func (p *Provider) ValidateProviderConfig(ctx context.Context, req providers.ValidateProviderConfigRequest) providers.ValidateProviderConfigResponse {
 	// At this moment there is nothing to configure for the tofu provider,
 	// so we will happily return without taking any action
 	var res providers.ValidateProviderConfigResponse
@@ -64,7 +65,7 @@ func (p *Provider) ValidateDataResourceConfig(req providers.ValidateDataResource
 }
 
 // Configure configures and initializes the provider.
-func (p *Provider) ConfigureProvider(providers.ConfigureProviderRequest) providers.ConfigureProviderResponse {
+func (p *Provider) ConfigureProvider(context.Context, providers.ConfigureProviderRequest) providers.ConfigureProviderResponse {
 	// At this moment there is nothing to configure for the terraform provider,
 	// so we will happily return without taking any action
 	var res providers.ConfigureProviderResponse
@@ -164,7 +165,7 @@ func (p *Provider) GetFunctions() providers.GetFunctionsResponse {
 	panic("unimplemented - terraform provider has no functions")
 }
 
-func (p *Provider) CallFunction(r providers.CallFunctionRequest) providers.CallFunctionResponse {
+func (p *Provider) CallFunction(ctx context.Context, r providers.CallFunctionRequest) providers.CallFunctionResponse {
 	panic("unimplemented - terraform provider has no functions")
 }
 

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -867,7 +867,7 @@ func (b *Cloud) Operation(ctx context.Context, op *backend.Operation) (*backend.
 		if opErr != nil && opErr != context.Canceled {
 			var diags tfdiags.Diagnostics
 			diags = diags.Append(opErr)
-			op.ReportResult(runningOp, diags)
+			op.ReportResult(ctx, runningOp, diags)
 			return
 		}
 
@@ -882,7 +882,7 @@ func (b *Cloud) Operation(ctx context.Context, op *backend.Operation) (*backend.
 			if err != nil {
 				var diags tfdiags.Diagnostics
 				diags = diags.Append(generalError("Failed to retrieve run", err))
-				op.ReportResult(runningOp, diags)
+				op.ReportResult(ctx, runningOp, diags)
 				return
 			}
 
@@ -893,7 +893,7 @@ func (b *Cloud) Operation(ctx context.Context, op *backend.Operation) (*backend.
 				if err := b.cancel(cancelCtx, op, r); err != nil {
 					var diags tfdiags.Diagnostics
 					diags = diags.Append(generalError("Failed to retrieve run", err))
-					op.ReportResult(runningOp, diags)
+					op.ReportResult(ctx, runningOp, diags)
 					return
 				}
 			}

--- a/internal/cloud/backend_context.go
+++ b/internal/cloud/backend_context.go
@@ -14,16 +14,17 @@ import (
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/backend"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/states/statemgr"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/opentofu/opentofu/internal/tofu"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // LocalRun implements backend.Local
-func (b *Cloud) LocalRun(op *backend.Operation) (*backend.LocalRun, statemgr.Full, tfdiags.Diagnostics) {
+func (b *Cloud) LocalRun(ctx context.Context, op *backend.Operation) (*backend.LocalRun, statemgr.Full, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	ret := &backend.LocalRun{
 		PlanOpts: &tofu.PlanOpts{

--- a/internal/cloud/backend_context_test.go
+++ b/internal/cloud/backend_context_test.go
@@ -213,7 +213,7 @@ func TestRemoteContextWithVars(t *testing.T) {
 			}
 			b.client.Variables.Create(context.TODO(), workspaceID, *v)
 
-			_, _, diags := b.LocalRun(op)
+			_, _, diags := b.LocalRun(context.TODO(), op)
 
 			if test.WantError != "" {
 				if !diags.HasErrors() {
@@ -434,7 +434,7 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 				b.client.Variables.Create(context.TODO(), workspaceID, *v)
 			}
 
-			lr, _, diags := b.LocalRun(op)
+			lr, _, diags := b.LocalRun(context.TODO(), op)
 
 			if diags.HasErrors() {
 				t.Fatalf("unexpected error\ngot:  %s\nwant: <no error>", diags.Err().Error())

--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -29,6 +30,8 @@ type ApplyCommand struct {
 
 func (c *ApplyCommand) Run(rawArgs []string) int {
 	var diags tfdiags.Diagnostics
+
+	ctx := context.Background()
 
 	// Parse and apply global view arguments
 	common, rawArgs := arguments.ParseView(rawArgs)
@@ -108,7 +111,7 @@ func (c *ApplyCommand) Run(rawArgs []string) int {
 
 	// Prepare the backend, passing the plan file if present, and the
 	// backend-specific arguments
-	be, beDiags := c.PrepareBackend(planFile, args.State, args.ViewType, enc.State())
+	be, beDiags := c.PrepareBackend(ctx, planFile, args.State, args.ViewType, enc.State())
 	diags = diags.Append(beDiags)
 	if diags.HasErrors() {
 		view.Diagnostics(diags)
@@ -132,7 +135,7 @@ func (c *ApplyCommand) Run(rawArgs []string) int {
 	diags = nil
 
 	// Run the operation
-	op, err := c.RunOperation(be, opReq)
+	op, err := c.RunOperation(ctx, be, opReq)
 	if err != nil {
 		diags = diags.Append(err)
 		view.Diagnostics(diags)
@@ -205,7 +208,7 @@ func (c *ApplyCommand) LoadPlanFile(path string, enc encryption.Encryption) (*pl
 	return planFile, diags
 }
 
-func (c *ApplyCommand) PrepareBackend(planFile *planfile.WrappedPlanFile, args *arguments.State, viewType arguments.ViewType, enc encryption.StateEncryption) (backend.Enhanced, tfdiags.Diagnostics) {
+func (c *ApplyCommand) PrepareBackend(ctx context.Context, planFile *planfile.WrappedPlanFile, args *arguments.State, viewType arguments.ViewType, enc encryption.StateEncryption) (backend.Enhanced, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	// FIXME: we need to apply the state arguments to the meta object here
@@ -245,7 +248,7 @@ func (c *ApplyCommand) PrepareBackend(planFile *planfile.WrappedPlanFile, args *
 			return nil, diags
 		}
 
-		be, beDiags = c.Backend(&BackendOpts{
+		be, beDiags = c.Backend(ctx, &BackendOpts{
 			Config:   backendConfig,
 			ViewType: viewType,
 		}, enc)

--- a/internal/command/autocomplete.go
+++ b/internal/command/autocomplete.go
@@ -6,6 +6,8 @@
 package command
 
 import (
+	"context"
+
 	"github.com/posener/complete"
 )
 
@@ -55,7 +57,7 @@ func (m *Meta) completePredictWorkspaceName() complete.Predictor {
 			return nil
 		}
 
-		b, diags := m.Backend(&BackendOpts{
+		b, diags := m.Backend(context.TODO(), &BackendOpts{
 			Config: backendConfig,
 		}, nil) // Don't need state encryption here.
 		if diags.HasErrors() {

--- a/internal/command/cliconfig/telemetry.go
+++ b/internal/command/cliconfig/telemetry.go
@@ -1,1 +1,17 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package cliconfig
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+var tracer trace.Tracer
+
+func init() {
+	tracer = otel.Tracer("github.com/opentofu/opentofu/internal/command/cliconfig")
+}

--- a/internal/command/cliconfig/telemetry.go
+++ b/internal/command/cliconfig/telemetry.go
@@ -1,0 +1,1 @@
+package cliconfig

--- a/internal/command/console.go
+++ b/internal/command/console.go
@@ -174,17 +174,17 @@ func (c *ConsoleCommand) Run(args []string) int {
 
 	// Determine if stdin is a pipe. If so, we evaluate directly.
 	if c.StdinPiped() {
-		return c.modePiped(session, ui)
+		return c.modePiped(ctx, session, ui)
 	}
 
-	return c.modeInteractive(session, ui)
+	return c.modeInteractive(ctx, session, ui)
 }
 
-func (c *ConsoleCommand) modePiped(session *repl.Session, ui cli.Ui) int {
+func (c *ConsoleCommand) modePiped(ctx context.Context, session *repl.Session, ui cli.Ui) int {
 	var lastResult string
 	scanner := bufio.NewScanner(os.Stdin)
 	for scanner.Scan() {
-		result, exit, diags := session.Handle(strings.TrimSpace(scanner.Text()))
+		result, exit, diags := session.Handle(ctx, strings.TrimSpace(scanner.Text()))
 		if diags.HasErrors() {
 			// In piped mode we'll exit immediately on error.
 			c.showDiagnostics(diags)

--- a/internal/command/console_interactive.go
+++ b/internal/command/console_interactive.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -16,7 +17,7 @@ import (
 	"github.com/mitchellh/cli"
 )
 
-func (c *ConsoleCommand) modeInteractive(session *repl.Session, ui cli.Ui) int {
+func (c *ConsoleCommand) modeInteractive(ctx context.Context, session *repl.Session, ui cli.Ui) int {
 	// Configure input
 	l, err := readline.NewEx(&readline.Config{
 		Prompt:            "> ",
@@ -48,7 +49,7 @@ func (c *ConsoleCommand) modeInteractive(session *repl.Session, ui cli.Ui) int {
 			break
 		}
 
-		out, exit, diags := session.Handle(line)
+		out, exit, diags := session.Handle(ctx, line)
 		if diags.HasErrors() {
 			c.showDiagnostics(diags)
 		}

--- a/internal/command/graph.go
+++ b/internal/command/graph.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -84,7 +85,7 @@ func (c *GraphCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(&BackendOpts{
+	b, backendDiags := c.Backend(context.TODO(), &BackendOpts{
 		Config: backendConfig,
 	}, enc.State())
 	diags = diags.Append(backendDiags)
@@ -117,7 +118,7 @@ func (c *GraphCommand) Run(args []string) int {
 	}
 
 	// Get the context
-	lr, _, ctxDiags := local.LocalRun(opReq)
+	lr, _, ctxDiags := local.LocalRun(context.TODO(), opReq)
 	diags = diags.Append(ctxDiags)
 	if ctxDiags.HasErrors() {
 		c.showDiagnostics(diags)

--- a/internal/command/graph.go
+++ b/internal/command/graph.go
@@ -84,8 +84,11 @@ func (c *GraphCommand) Run(args []string) int {
 		return 1
 	}
 
+	// TODO: Fetch the context from the executable, propagate it here
+	ctx := context.Background()
+
 	// Load the backend
-	b, backendDiags := c.Backend(context.TODO(), &BackendOpts{
+	b, backendDiags := c.Backend(ctx, &BackendOpts{
 		Config: backendConfig,
 	}, enc.State())
 	diags = diags.Append(backendDiags)
@@ -118,7 +121,7 @@ func (c *GraphCommand) Run(args []string) int {
 	}
 
 	// Get the context
-	lr, _, ctxDiags := local.LocalRun(context.TODO(), opReq)
+	lr, _, ctxDiags := local.LocalRun(ctx, opReq)
 	diags = diags.Append(ctxDiags)
 	if ctxDiags.HasErrors() {
 		c.showDiagnostics(diags)
@@ -138,11 +141,11 @@ func (c *GraphCommand) Run(args []string) int {
 	var graphDiags tfdiags.Diagnostics
 	switch graphTypeStr {
 	case "plan":
-		g, graphDiags = lr.Core.PlanGraphForUI(lr.Config, lr.InputState, plans.NormalMode)
+		g, graphDiags = lr.Core.PlanGraphForUI(ctx, lr.Config, lr.InputState, plans.NormalMode)
 	case "plan-refresh-only":
-		g, graphDiags = lr.Core.PlanGraphForUI(lr.Config, lr.InputState, plans.RefreshOnlyMode)
+		g, graphDiags = lr.Core.PlanGraphForUI(ctx, lr.Config, lr.InputState, plans.RefreshOnlyMode)
 	case "plan-destroy":
-		g, graphDiags = lr.Core.PlanGraphForUI(lr.Config, lr.InputState, plans.DestroyMode)
+		g, graphDiags = lr.Core.PlanGraphForUI(ctx, lr.Config, lr.InputState, plans.DestroyMode)
 	case "apply":
 		plan := lr.Plan
 

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -281,7 +281,7 @@ func (c *InitCommand) Run(args []string) int {
 	// the configuration declare that they don't support this OpenTofu
 	// version, so we can produce a version-related error message rather than
 	// potentially-confusing downstream errors.
-	versionDiags := tofu.CheckCoreVersionRequirements(config)
+	versionDiags := tofu.CheckCoreVersionRequirements(ctx, config)
 	if versionDiags.HasErrors() {
 		c.showDiagnostics(versionDiags)
 		return 1
@@ -330,7 +330,7 @@ func (c *InitCommand) Run(args []string) int {
 	if state != nil {
 		// Since we now have the full configuration loaded, we can use it to migrate the in-memory state view
 		// prior to fetching providers.
-		migratedState, migrateDiags := tofumigrate.MigrateStateProviderAddresses(config, state)
+		migratedState, migrateDiags := tofumigrate.MigrateStateProviderAddresses(ctx, config, state)
 		diags = diags.Append(migrateDiags)
 		if migrateDiags.HasErrors() {
 			c.showDiagnostics(diags)
@@ -560,7 +560,7 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 
 	// First we'll collect all the provider dependencies we can see in the
 	// configuration and the state.
-	reqs, hclDiags := config.ProviderRequirements()
+	reqs, hclDiags := config.ProviderRequirements(ctx)
 	diags = diags.Append(hclDiags)
 	if hclDiags.HasErrors() {
 		return false, true, diags

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -458,7 +458,7 @@ func (c *InitCommand) initCloud(ctx context.Context, root *configs.Module, extra
 		Init:   true,
 	}
 
-	back, backDiags := c.Backend(opts, enc.State())
+	back, backDiags := c.Backend(ctx, opts, enc.State())
 	diags = diags.Append(backDiags)
 	return back, true, diags
 }
@@ -541,7 +541,7 @@ the backend configuration is present and valid.
 		Init:           true,
 	}
 
-	back, backDiags := c.Backend(opts, enc.State())
+	back, backDiags := c.Backend(context.TODO(), opts, enc.State())
 	diags = diags.Append(backDiags)
 	return back, true, diags
 }

--- a/internal/command/jsonformat/state_test.go
+++ b/internal/command/jsonformat/state_test.go
@@ -159,7 +159,7 @@ func testSchemas() *tofu.Schemas {
 	provider := testProvider()
 	return &tofu.Schemas{
 		Providers: map[addrs.Provider]providers.ProviderSchema{
-			addrs.NewDefaultProvider("test"): provider.GetProviderSchema(),
+			addrs.NewDefaultProvider("test"): provider.GetProviderSchema(nil),
 		},
 	}
 }

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -471,7 +471,7 @@ func (m *Meta) CommandContext() context.Context {
 // If the operation runs to completion then no error is returned even if the
 // operation itself is unsuccessful. Use the "Result" field of the
 // returned operation object to recognize operation-level failure.
-func (m *Meta) RunOperation(b backend.Enhanced, opReq *backend.Operation) (*backend.RunningOperation, error) {
+func (m *Meta) RunOperation(ctx context.Context, b backend.Enhanced, opReq *backend.Operation) (*backend.RunningOperation, error) {
 	if opReq.View == nil {
 		panic("RunOperation called with nil View")
 	}
@@ -479,7 +479,7 @@ func (m *Meta) RunOperation(b backend.Enhanced, opReq *backend.Operation) (*back
 		opReq.ConfigDir = m.normalizePath(opReq.ConfigDir)
 	}
 
-	op, err := b.Operation(context.Background(), opReq)
+	op, err := b.Operation(ctx, opReq)
 	if err != nil {
 		return nil, fmt.Errorf("error starting operation: %w", err)
 	}
@@ -857,7 +857,7 @@ func (m *Meta) checkRequiredVersion() tfdiags.Diagnostics {
 // it could potentially return nil without errors. It is the
 // responsibility of the caller to handle the lack of schema
 // information accordingly
-func (c *Meta) MaybeGetSchemas(state *states.State, config *configs.Config) (*tofu.Schemas, tfdiags.Diagnostics) {
+func (c *Meta) MaybeGetSchemas(ctx context.Context, state *states.State, config *configs.Config) (*tofu.Schemas, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	path, err := os.Getwd()
@@ -886,7 +886,7 @@ func (c *Meta) MaybeGetSchemas(state *states.State, config *configs.Config) (*to
 			return nil, diags
 		}
 		var schemaDiags tfdiags.Diagnostics
-		schemas, schemaDiags := tfCtx.Schemas(config, state)
+		schemas, schemaDiags := tfCtx.Schemas(ctx, config, state)
 		diags = diags.Append(schemaDiags)
 		if schemaDiags.HasErrors() {
 			return nil, diags

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -92,7 +92,7 @@ type BackendWithRemoteTerraformVersion interface {
 // A side-effect of this method is the population of m.backendState, recording
 // the final resolved backend configuration after dealing with overrides from
 // the "tofu init" command line, etc.
-func (m *Meta) Backend(opts *BackendOpts, enc encryption.StateEncryption) (backend.Enhanced, tfdiags.Diagnostics) {
+func (m *Meta) Backend(ctx context.Context, opts *BackendOpts, enc encryption.StateEncryption) (backend.Enhanced, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	// If no opts are set, then initialize
@@ -902,7 +902,7 @@ func (m *Meta) backend_c_r_S(
 	}
 
 	// Grab a purely local backend to get the local state if it exists
-	localB, moreDiags := m.Backend(&BackendOpts{ForceLocal: true, Init: true}, enc)
+	localB, moreDiags := m.Backend(context.TODO(), &BackendOpts{ForceLocal: true, Init: true}, enc)
 	diags = diags.Append(moreDiags)
 	if moreDiags.HasErrors() {
 		return nil, diags
@@ -961,7 +961,7 @@ func (m *Meta) backend_C_r_s(c *configs.Backend, cHash int, sMgr *clistate.Local
 	}
 
 	// Grab a purely local backend to get the local state if it exists
-	localB, localBDiags := m.Backend(&BackendOpts{ForceLocal: true, Init: true}, enc)
+	localB, localBDiags := m.Backend(context.TODO(), &BackendOpts{ForceLocal: true, Init: true}, enc)
 	if localBDiags.HasErrors() {
 		diags = diags.Append(localBDiags)
 		return nil, diags

--- a/internal/command/output.go
+++ b/internal/command/output.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -74,7 +75,7 @@ func (c *OutputCommand) Outputs(statePath string, enc encryption.Encryption) (ma
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(nil, enc.State())
+	b, backendDiags := c.Backend(context.TODO(), nil, enc.State())
 	diags = diags.Append(backendDiags)
 	if diags.HasErrors() {
 		return nil, diags

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -111,7 +111,7 @@ func (c *PlanCommand) Run(rawArgs []string) int {
 	view.Diagnostics(diags)
 	diags = nil
 
-	// TODO: Propagate the context from the main.go nicely to here
+	// TODO: Propagate the context from the main entrypoint nicely to here
 	var ctx context.Context
 	var otelSpan trace.Span
 	{

--- a/internal/command/plugins_test.go
+++ b/internal/command/plugins_test.go
@@ -41,7 +41,7 @@ func TestInternalProviders(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	schema := tfProvider.GetProviderSchema()
+	schema := tfProvider.GetProviderSchema(nil)
 	_, found := schema.DataSources["terraform_remote_state"]
 	if !found {
 		t.Errorf("didn't find terraform_remote_state in internal \"terraform\" provider")

--- a/internal/command/providers.go
+++ b/internal/command/providers.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -91,7 +92,7 @@ func (c *ProvidersCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(&BackendOpts{
+	b, backendDiags := c.Backend(context.TODO(), &BackendOpts{
 		Config: config.Module.Backend,
 	}, enc.State())
 	diags = diags.Append(backendDiags)

--- a/internal/command/providers_lock.go
+++ b/internal/command/providers_lock.go
@@ -123,7 +123,7 @@ func (c *ProvidersLockCommand) Run(args []string) int {
 
 	config, confDiags := c.loadConfig(".")
 	diags = diags.Append(confDiags)
-	reqs, hclDiags := config.ProviderRequirements()
+	reqs, hclDiags := config.ProviderRequirements(ctx)
 	diags = diags.Append(hclDiags)
 
 	// If we have explicit provider selections on the command line then

--- a/internal/command/providers_mirror.go
+++ b/internal/command/providers_mirror.go
@@ -82,7 +82,7 @@ func (c *ProvidersMirrorCommand) Run(args []string) int {
 
 	config, confDiags := c.loadConfig(".")
 	diags = diags.Append(confDiags)
-	reqs, moreDiags := config.ProviderRequirements()
+	reqs, moreDiags := config.ProviderRequirements(ctx)
 	diags = diags.Append(moreDiags)
 
 	// Read lock file
@@ -97,7 +97,7 @@ func (c *ProvidersMirrorCommand) Run(args []string) int {
 
 	// If lock file is present, validate it against configuration
 	if !lockedDeps.Empty() {
-		if errs := config.VerifyDependencySelections(lockedDeps); len(errs) > 0 {
+		if errs := config.VerifyDependencySelections(ctx, lockedDeps); len(errs) > 0 {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
 				"Inconsistent dependency lock file",

--- a/internal/command/providers_schema.go
+++ b/internal/command/providers_schema.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -58,7 +59,7 @@ func (c *ProvidersSchemaCommand) Run(args []string) int {
 	var diags tfdiags.Diagnostics
 
 	// Load the backend
-	b, backendDiags := c.Backend(nil, nil) // Encryption not needed here
+	b, backendDiags := c.Backend(context.TODO(), nil, nil) // Encryption not needed here
 	diags = diags.Append(backendDiags)
 	if backendDiags.HasErrors() {
 		c.showDiagnostics(diags)
@@ -95,14 +96,14 @@ func (c *ProvidersSchemaCommand) Run(args []string) int {
 	}
 
 	// Get the context
-	lr, _, ctxDiags := local.LocalRun(opReq)
+	lr, _, ctxDiags := local.LocalRun(context.TODO(), opReq)
 	diags = diags.Append(ctxDiags)
 	if ctxDiags.HasErrors() {
 		c.showDiagnostics(diags)
 		return 1
 	}
 
-	schemas, moreDiags := lr.Core.Schemas(lr.Config, lr.InputState)
+	schemas, moreDiags := lr.Core.Schemas(context.TODO(), lr.Config, lr.InputState)
 	diags = diags.Append(moreDiags)
 	if moreDiags.HasErrors() {
 		c.showDiagnostics(diags)

--- a/internal/command/refresh.go
+++ b/internal/command/refresh.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -107,7 +108,7 @@ func (c *RefreshCommand) Run(rawArgs []string) int {
 	diags = nil
 
 	// Perform the operation
-	op, err := c.RunOperation(be, opReq)
+	op, err := c.RunOperation(context.TODO(), be, opReq)
 	if err != nil {
 		diags = diags.Append(err)
 		view.Diagnostics(diags)
@@ -134,7 +135,7 @@ func (c *RefreshCommand) PrepareBackend(args *arguments.State, viewType argument
 	}
 
 	// Load the backend
-	be, beDiags := c.Backend(&BackendOpts{
+	be, beDiags := c.Backend(context.TODO(), &BackendOpts{
 		Config:   backendConfig,
 		ViewType: viewType,
 	}, enc.State())

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -86,8 +86,11 @@ func (c *ShowCommand) Run(rawArgs []string) int {
 		return 1
 	}
 
+	// TODO: Get a context from the main application and propagate it here
+	ctx := context.Background()
+
 	// Get the data we need to display
-	plan, jsonPlan, stateFile, config, schemas, showDiags := c.show(args.Path, enc)
+	plan, jsonPlan, stateFile, config, schemas, showDiags := c.show(ctx, args.Path, enc)
 	diags = diags.Append(showDiags)
 	if showDiags.HasErrors() {
 		view.Diagnostics(diags)
@@ -119,7 +122,7 @@ func (c *ShowCommand) Synopsis() string {
 	return "Show the current state or a saved plan"
 }
 
-func (c *ShowCommand) show(path string, enc encryption.Encryption) (*plans.Plan, *cloudplan.RemotePlanJSON, *statefile.File, *configs.Config, *tofu.Schemas, tfdiags.Diagnostics) {
+func (c *ShowCommand) show(ctx context.Context, path string, enc encryption.Encryption) (*plans.Plan, *cloudplan.RemotePlanJSON, *statefile.File, *configs.Config, *tofu.Schemas, tfdiags.Diagnostics) {
 	var diags, showDiags, migrateDiags tfdiags.Diagnostics
 	var plan *plans.Plan
 	var jsonPlan *cloudplan.RemotePlanJSON
@@ -149,7 +152,7 @@ func (c *ShowCommand) show(path string, enc encryption.Encryption) (*plans.Plan,
 	}
 
 	if stateFile != nil {
-		stateFile.State, migrateDiags = tofumigrate.MigrateStateProviderAddresses(config, stateFile.State)
+		stateFile.State, migrateDiags = tofumigrate.MigrateStateProviderAddresses(ctx, config, stateFile.State)
 		diags = diags.Append(migrateDiags)
 		if migrateDiags.HasErrors() {
 			return plan, jsonPlan, stateFile, config, schemas, diags

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -158,7 +158,7 @@ func (c *ShowCommand) show(path string, enc encryption.Encryption) (*plans.Plan,
 
 	// Get schemas, if possible
 	if config != nil || stateFile != nil {
-		schemas, diags = c.MaybeGetSchemas(stateFile.State, config)
+		schemas, diags = c.MaybeGetSchemas(context.TODO(), stateFile.State, config)
 		if diags.HasErrors() {
 			return plan, jsonPlan, stateFile, config, schemas, diags
 		}
@@ -170,7 +170,7 @@ func (c *ShowCommand) showFromLatestStateSnapshot(enc encryption.Encryption) (*s
 	var diags tfdiags.Diagnostics
 
 	// Load the backend
-	b, backendDiags := c.Backend(nil, enc.State())
+	b, backendDiags := c.Backend(context.TODO(), nil, enc.State())
 	diags = diags.Append(backendDiags)
 	if backendDiags.HasErrors() {
 		return nil, diags
@@ -298,7 +298,7 @@ func (c *ShowCommand) getPlanFromPath(path string, enc encryption.Encryption) (*
 
 func (c *ShowCommand) getDataFromCloudPlan(plan *cloudplan.SavedPlanBookmark, redacted bool, enc encryption.Encryption) (*cloudplan.RemotePlanJSON, error) {
 	// Set up the backend
-	b, backendDiags := c.Backend(nil, enc.State())
+	b, backendDiags := c.Backend(context.TODO(), nil, enc.State())
 	if backendDiags.HasErrors() {
 		return nil, errUnusable(backendDiags.Err(), "cloud plan")
 	}

--- a/internal/command/state_list.go
+++ b/internal/command/state_list.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -47,7 +48,7 @@ func (c *StateListCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(nil, enc.State())
+	b, backendDiags := c.Backend(context.TODO(), nil, enc.State())
 	if backendDiags.HasErrors() {
 		c.showDiagnostics(backendDiags)
 		return 1

--- a/internal/command/state_meta.go
+++ b/internal/command/state_meta.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"time"
@@ -38,7 +39,7 @@ func (c *StateMeta) State(enc encryption.Encryption) (statemgr.Full, error) {
 		realState = statemgr.NewFilesystem(c.statePath, encryption.StateEncryptionDisabled()) // User specified state file should not be encrypted
 	} else {
 		// Load the backend
-		b, backendDiags := c.Backend(nil, enc.State())
+		b, backendDiags := c.Backend(context.TODO(), nil, enc.State())
 		if backendDiags.HasErrors() {
 			return nil, backendDiags.Err()
 		}
@@ -62,7 +63,7 @@ func (c *StateMeta) State(enc encryption.Encryption) (statemgr.Full, error) {
 		}
 
 		// Get a local backend
-		localRaw, backendDiags := c.Backend(&BackendOpts{ForceLocal: true}, enc.State())
+		localRaw, backendDiags := c.Backend(context.TODO(), &BackendOpts{ForceLocal: true}, enc.State())
 		if backendDiags.HasErrors() {
 			// This should never fail
 			panic(backendDiags.Err())

--- a/internal/command/state_mv.go
+++ b/internal/command/state_mv.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -399,7 +400,7 @@ func (c *StateMvCommand) Run(args []string) int {
 		return 0 // This is as far as we go in dry-run mode
 	}
 
-	b, backendDiags := c.Backend(nil, enc.State())
+	b, backendDiags := c.Backend(context.TODO(), nil, enc.State())
 	diags = diags.Append(backendDiags)
 	if backendDiags.HasErrors() {
 		c.showDiagnostics(diags)
@@ -410,7 +411,7 @@ func (c *StateMvCommand) Run(args []string) int {
 	var schemas *tofu.Schemas
 	if isCloudMode(b) {
 		var schemaDiags tfdiags.Diagnostics
-		schemas, schemaDiags = c.MaybeGetSchemas(stateTo, nil)
+		schemas, schemaDiags = c.MaybeGetSchemas(context.TODO(), stateTo, nil)
 		diags = diags.Append(schemaDiags)
 	}
 

--- a/internal/command/state_mv.go
+++ b/internal/command/state_mv.go
@@ -51,7 +51,10 @@ func (c *StateMvCommand) Run(args []string) int {
 		return cli.RunResultHelp
 	}
 
-	if diags := c.Meta.checkRequiredVersion(); diags != nil {
+	// TODO: Pull the context from the parent application, and propagate it here
+	ctx := context.Background()
+
+	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {
 		c.showDiagnostics(diags)
 		return 1
 	}

--- a/internal/command/state_pull.go
+++ b/internal/command/state_pull.go
@@ -30,7 +30,10 @@ func (c *StatePullCommand) Run(args []string) int {
 		return 1
 	}
 
-	if diags := c.Meta.checkRequiredVersion(); diags != nil {
+	// TODO: Pull the context from the parent application, and propagate it here
+	ctx := context.Background()
+
+	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {
 		c.showDiagnostics(diags)
 		return 1
 	}

--- a/internal/command/state_pull.go
+++ b/internal/command/state_pull.go
@@ -7,6 +7,7 @@ package command
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strings"
 
@@ -42,7 +43,7 @@ func (c *StatePullCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(nil, enc.State())
+	b, backendDiags := c.Backend(context.TODO(), nil, enc.State())
 	if backendDiags.HasErrors() {
 		c.showDiagnostics(backendDiags)
 		return 1

--- a/internal/command/state_push.go
+++ b/internal/command/state_push.go
@@ -48,7 +48,10 @@ func (c *StatePushCommand) Run(args []string) int {
 		return cli.RunResultHelp
 	}
 
-	if diags := c.Meta.checkRequiredVersion(); diags != nil {
+	// TODO: Pull the context from the parent application, and propagate it here
+	ctx := context.Background()
+
+	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {
 		c.showDiagnostics(diags)
 		return 1
 	}

--- a/internal/command/state_push.go
+++ b/internal/command/state_push.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -87,7 +88,7 @@ func (c *StatePushCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(nil, enc.State())
+	b, backendDiags := c.Backend(context.TODO(), nil, enc.State())
 	if backendDiags.HasErrors() {
 		c.showDiagnostics(backendDiags)
 		return 1
@@ -147,7 +148,7 @@ func (c *StatePushCommand) Run(args []string) int {
 	var schemas *tofu.Schemas
 	var diags tfdiags.Diagnostics
 	if isCloudMode(b) {
-		schemas, diags = c.MaybeGetSchemas(srcStateFile.State, nil)
+		schemas, diags = c.MaybeGetSchemas(context.TODO(), srcStateFile.State, nil)
 	}
 
 	if err := stateMgr.WriteState(srcStateFile.State); err != nil {

--- a/internal/command/state_replace_provider.go
+++ b/internal/command/state_replace_provider.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -175,7 +176,7 @@ func (c *StateReplaceProviderCommand) Run(args []string) int {
 		resource.ProviderConfig.Provider = to
 	}
 
-	b, backendDiags := c.Backend(nil, enc.State())
+	b, backendDiags := c.Backend(context.TODO(), nil, enc.State())
 	diags = diags.Append(backendDiags)
 	if backendDiags.HasErrors() {
 		c.showDiagnostics(diags)
@@ -186,7 +187,7 @@ func (c *StateReplaceProviderCommand) Run(args []string) int {
 	var schemas *tofu.Schemas
 	if isCloudMode(b) {
 		var schemaDiags tfdiags.Diagnostics
-		schemas, schemaDiags = c.MaybeGetSchemas(state, nil)
+		schemas, schemaDiags = c.MaybeGetSchemas(context.TODO(), state, nil)
 		diags = diags.Append(schemaDiags)
 	}
 

--- a/internal/command/state_replace_provider.go
+++ b/internal/command/state_replace_provider.go
@@ -50,7 +50,10 @@ func (c *StateReplaceProviderCommand) Run(args []string) int {
 		return cli.RunResultHelp
 	}
 
-	if diags := c.Meta.checkRequiredVersion(); diags != nil {
+	// TODO: Pull the context from the parent application, and propagate it here
+	ctx := context.Background()
+
+	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {
 		c.showDiagnostics(diags)
 		return 1
 	}

--- a/internal/command/state_rm.go
+++ b/internal/command/state_rm.go
@@ -45,7 +45,10 @@ func (c *StateRmCommand) Run(args []string) int {
 		return cli.RunResultHelp
 	}
 
-	if diags := c.Meta.checkRequiredVersion(); diags != nil {
+	// TODO: Pull the context from the parent application, and propagate it here
+	ctx := context.Background()
+
+	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {
 		c.showDiagnostics(diags)
 		return 1
 	}

--- a/internal/command/state_rm.go
+++ b/internal/command/state_rm.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -124,7 +125,7 @@ func (c *StateRmCommand) Run(args []string) int {
 		return 0 // This is as far as we go in dry-run mode
 	}
 
-	b, backendDiags := c.Backend(nil, enc.State())
+	b, backendDiags := c.Backend(context.TODO(), nil, enc.State())
 	diags = diags.Append(backendDiags)
 	if backendDiags.HasErrors() {
 		c.showDiagnostics(diags)
@@ -135,7 +136,7 @@ func (c *StateRmCommand) Run(args []string) int {
 	var schemas *tofu.Schemas
 	if isCloudMode(b) {
 		var schemaDiags tfdiags.Diagnostics
-		schemas, schemaDiags = c.MaybeGetSchemas(state, nil)
+		schemas, schemaDiags = c.MaybeGetSchemas(context.TODO(), state, nil)
 		diags = diags.Append(schemaDiags)
 	}
 

--- a/internal/command/state_show.go
+++ b/internal/command/state_show.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -58,7 +59,7 @@ func (c *StateShowCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(nil, enc.State())
+	b, backendDiags := c.Backend(context.TODO(), nil, enc.State())
 	if backendDiags.HasErrors() {
 		c.showDiagnostics(backendDiags)
 		return 1
@@ -99,15 +100,17 @@ func (c *StateShowCommand) Run(args []string) int {
 		return 1
 	}
 
+	ctx := context.TODO()
+
 	// Get the context (required to get the schemas)
-	lr, _, ctxDiags := local.LocalRun(opReq)
+	lr, _, ctxDiags := local.LocalRun(ctx, opReq)
 	if ctxDiags.HasErrors() {
 		c.View.Diagnostics(ctxDiags)
 		return 1
 	}
 
 	// Get the schemas from the context
-	schemas, diags := lr.Core.Schemas(lr.Config, lr.InputState)
+	schemas, diags := lr.Core.Schemas(ctx, lr.Config, lr.InputState)
 	if diags.HasErrors() {
 		c.View.Diagnostics(diags)
 		return 1

--- a/internal/command/state_show.go
+++ b/internal/command/state_show.go
@@ -137,7 +137,7 @@ func (c *StateShowCommand) Run(args []string) int {
 		c.Streams.Eprintln(errStateNotFound)
 		return 1
 	}
-	migratedState, migrateDiags := tofumigrate.MigrateStateProviderAddresses(lr.Config, state)
+	migratedState, migrateDiags := tofumigrate.MigrateStateProviderAddresses(ctx, lr.Config, state)
 	diags = diags.Append(migrateDiags)
 	if migrateDiags.HasErrors() {
 		c.View.Diagnostics(diags)

--- a/internal/command/taint.go
+++ b/internal/command/taint.go
@@ -63,7 +63,10 @@ func (c *TaintCommand) Run(args []string) int {
 		return 1
 	}
 
-	if diags := c.Meta.checkRequiredVersion(); diags != nil {
+	// TODO: Pull the context from the parent application, and propagate it here
+	ctx := context.Background()
+
+	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {
 		c.showDiagnostics(diags)
 		return 1
 	}

--- a/internal/command/taint.go
+++ b/internal/command/taint.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -75,7 +76,7 @@ func (c *TaintCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(nil, enc.State())
+	b, backendDiags := c.Backend(context.TODO(), nil, enc.State())
 	diags = diags.Append(backendDiags)
 	if backendDiags.HasErrors() {
 		c.showDiagnostics(diags)
@@ -142,7 +143,7 @@ func (c *TaintCommand) Run(args []string) int {
 	var schemas *tofu.Schemas
 	if isCloudMode(b) {
 		var schemaDiags tfdiags.Diagnostics
-		schemas, schemaDiags = c.MaybeGetSchemas(state, nil)
+		schemas, schemaDiags = c.MaybeGetSchemas(context.TODO(), state, nil)
 		diags = diags.Append(schemaDiags)
 	}
 

--- a/internal/command/test.go
+++ b/internal/command/test.go
@@ -545,7 +545,7 @@ func (runner *TestFileRunner) ExecuteTestRun(ctx context.Context, run *moduletes
 			run.Diagnostics = run.Diagnostics.Append(diags)
 		}
 
-		planCtx.TestContext(config, plan.PlannedState, plan, variables).EvaluateAgainstPlan(run)
+		planCtx.TestContext(config, plan.PlannedState, plan, variables).EvaluateAgainstPlan(ctx, run)
 		return state, false
 	}
 
@@ -618,7 +618,7 @@ func (runner *TestFileRunner) ExecuteTestRun(ctx context.Context, run *moduletes
 		run.Diagnostics = run.Diagnostics.Append(diags)
 	}
 
-	applyCtx.TestContext(config, updated, plan, variables).EvaluateAgainstState(run)
+	applyCtx.TestContext(config, updated, plan, variables).EvaluateAgainstState(ctx, run)
 	return updated, true
 }
 

--- a/internal/command/unlock.go
+++ b/internal/command/unlock.go
@@ -62,7 +62,7 @@ func (c *UnlockCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(&BackendOpts{
+	b, backendDiags := c.Backend(context.TODO(), &BackendOpts{
 		Config: backendConfig,
 	}, nil) // Should not be needed for an unlock
 	diags = diags.Append(backendDiags)

--- a/internal/command/untaint.go
+++ b/internal/command/untaint.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -66,7 +67,7 @@ func (c *UntaintCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(nil, enc.State())
+	b, backendDiags := c.Backend(context.TODO(), nil, enc.State())
 	diags = diags.Append(backendDiags)
 	if backendDiags.HasErrors() {
 		c.showDiagnostics(diags)
@@ -182,7 +183,7 @@ func (c *UntaintCommand) Run(args []string) int {
 	var schemas *tofu.Schemas
 	if isCloudMode(b) {
 		var schemaDiags tfdiags.Diagnostics
-		schemas, schemaDiags = c.MaybeGetSchemas(state, nil)
+		schemas, schemaDiags = c.MaybeGetSchemas(context.TODO(), state, nil)
 		diags = diags.Append(schemaDiags)
 	}
 

--- a/internal/command/validate.go
+++ b/internal/command/validate.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -56,7 +57,10 @@ func (c *ValidateCommand) Run(rawArgs []string) int {
 		return view.Results(diags)
 	}
 
-	validateDiags := c.validate(dir, args.TestDirectory, args.NoTests)
+	// TODO: propagate the context from the entry point to here
+	ctx := context.Background()
+
+	validateDiags := c.validate(ctx, dir, args.TestDirectory, args.NoTests)
 	diags = diags.Append(validateDiags)
 
 	// Validating with dev overrides in effect means that the result might
@@ -68,7 +72,7 @@ func (c *ValidateCommand) Run(rawArgs []string) int {
 	return view.Results(diags)
 }
 
-func (c *ValidateCommand) validate(dir, testDir string, noTests bool) tfdiags.Diagnostics {
+func (c *ValidateCommand) validate(ctx context.Context, dir, testDir string, noTests bool) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 	var cfg *configs.Config
 
@@ -96,7 +100,7 @@ func (c *ValidateCommand) validate(dir, testDir string, noTests bool) tfdiags.Di
 			return diags
 		}
 
-		return diags.Append(tfCtx.Validate(cfg))
+		return diags.Append(tfCtx.Validate(ctx, cfg))
 	}
 
 	diags = diags.Append(validate(cfg))

--- a/internal/command/views/plan_test.go
+++ b/internal/command/views/plan_test.go
@@ -136,7 +136,7 @@ func testSchemas() *tofu.Schemas {
 	provider := testProvider()
 	return &tofu.Schemas{
 		Providers: map[addrs.Provider]providers.ProviderSchema{
-			addrs.NewDefaultProvider("test"): provider.GetProviderSchema(),
+			addrs.NewDefaultProvider("test"): provider.GetProviderSchema(nil),
 		},
 	}
 }

--- a/internal/command/workspace_delete.go
+++ b/internal/command/workspace_delete.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -72,7 +73,7 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(&BackendOpts{
+	b, backendDiags := c.Backend(context.TODO(), &BackendOpts{
 		Config: backendConfig,
 	}, enc.State())
 	diags = diags.Append(backendDiags)

--- a/internal/command/workspace_list.go
+++ b/internal/command/workspace_list.go
@@ -7,6 +7,7 @@ package command
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strings"
 
@@ -48,7 +49,7 @@ func (c *WorkspaceListCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(&BackendOpts{
+	b, backendDiags := c.Backend(context.TODO(), &BackendOpts{
 		Config: backendConfig,
 	}, nil)
 	diags = diags.Append(backendDiags)

--- a/internal/command/workspace_new.go
+++ b/internal/command/workspace_new.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -88,7 +89,7 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(&BackendOpts{
+	b, backendDiags := c.Backend(context.TODO(), &BackendOpts{
 		Config: backendConfig,
 	}, enc.State())
 	diags = diags.Append(backendDiags)

--- a/internal/command/workspace_select.go
+++ b/internal/command/workspace_select.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -69,7 +70,7 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(&BackendOpts{
+	b, backendDiags := c.Backend(context.TODO(), &BackendOpts{
 		Config: backendConfig,
 	}, enc.State())
 	diags = diags.Append(backendDiags)

--- a/internal/configs/telemetry.go
+++ b/internal/configs/telemetry.go
@@ -1,0 +1,12 @@
+package configs
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+var tracer trace.Tracer
+
+func init() {
+	tracer = otel.Tracer("github.com/opentofu/opentofu/internal/configs")
+}

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -6,6 +6,7 @@
 package dag
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -21,7 +22,7 @@ type AcyclicGraph struct {
 }
 
 // WalkFunc is the callback used for walking the graph.
-type WalkFunc func(Vertex) tfdiags.Diagnostics
+type WalkFunc func(context.Context, Vertex) tfdiags.Diagnostics
 
 // DepthWalkFunc is a walk function that also receives the current depth of the
 // walk as an argument
@@ -164,9 +165,9 @@ func (g *AcyclicGraph) Cycles() [][]Vertex {
 // Walk walks the graph, calling your callback as each node is visited.
 // This will walk nodes in parallel if it can. The resulting diagnostics
 // contains problems from all graphs visited, in no particular order.
-func (g *AcyclicGraph) Walk(cb WalkFunc) tfdiags.Diagnostics {
+func (g *AcyclicGraph) Walk(ctx context.Context, cb WalkFunc) tfdiags.Diagnostics {
 	w := &Walker{Callback: cb, Reverse: true}
-	w.Update(g)
+	w.Update(ctx, g)
 	return w.Wait()
 }
 

--- a/internal/getproviders/telemetry.go
+++ b/internal/getproviders/telemetry.go
@@ -1,1 +1,17 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package getproviders
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+var tracer trace.Tracer
+
+func init() {
+	tracer = otel.Tracer("github.com/opentofu/opentofu/internal/getproviders")
+}

--- a/internal/getproviders/telemetry.go
+++ b/internal/getproviders/telemetry.go
@@ -1,0 +1,1 @@
+package getproviders

--- a/internal/grpcwrap/provider6.go
+++ b/internal/grpcwrap/provider6.go
@@ -162,7 +162,8 @@ func (p *provider6) UpgradeResourceState(_ context.Context, req *tfplugin6.Upgra
 	return resp, nil
 }
 
-func (p *provider6) ConfigureProvider(_ context.Context, req *tfplugin6.ConfigureProvider_Request) (*tfplugin6.ConfigureProvider_Response, error) {
+func (p *provider6) ConfigureProvider(ctx context.Context, req *tfplugin6.ConfigureProvider_Request) (*tfplugin6.ConfigureProvider_Response, error) {
+	ConfigureProvider
 	resp := &tfplugin6.ConfigureProvider_Response{}
 	ty := p.schema.Provider.Block.ImpliedType()
 
@@ -172,7 +173,7 @@ func (p *provider6) ConfigureProvider(_ context.Context, req *tfplugin6.Configur
 		return resp, nil
 	}
 
-	configureResp := p.provider.ConfigureProvider(nil, providers.ConfigureProviderRequest{
+	configureResp := p.provider.ConfigureProvider(ctx, providers.ConfigureProviderRequest{
 		TerraformVersion: req.TerraformVersion,
 		Config:           configVal,
 	})

--- a/internal/grpcwrap/provider6.go
+++ b/internal/grpcwrap/provider6.go
@@ -8,12 +8,13 @@ package grpcwrap
 import (
 	"context"
 
-	"github.com/opentofu/opentofu/internal/plugin6/convert"
-	"github.com/opentofu/opentofu/internal/providers"
-	"github.com/opentofu/opentofu/internal/tfplugin6"
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 	"github.com/zclconf/go-cty/cty/msgpack"
+
+	"github.com/opentofu/opentofu/internal/plugin6/convert"
+	"github.com/opentofu/opentofu/internal/providers"
+	"github.com/opentofu/opentofu/internal/tfplugin6"
 )
 
 // New wraps a providers.Interface to implement a grpc ProviderServer using
@@ -22,7 +23,7 @@ import (
 func Provider6(p providers.Interface) tfplugin6.ProviderServer {
 	return &provider6{
 		provider: p,
-		schema:   p.GetProviderSchema(),
+		schema:   p.GetProviderSchema(nil),
 	}
 }
 
@@ -78,7 +79,7 @@ func (p *provider6) GetProviderSchema(_ context.Context, req *tfplugin6.GetProvi
 	return resp, nil
 }
 
-func (p *provider6) ValidateProviderConfig(_ context.Context, req *tfplugin6.ValidateProviderConfig_Request) (*tfplugin6.ValidateProviderConfig_Response, error) {
+func (p *provider6) ValidateProviderConfig(ctx context.Context, req *tfplugin6.ValidateProviderConfig_Request) (*tfplugin6.ValidateProviderConfig_Response, error) {
 	resp := &tfplugin6.ValidateProviderConfig_Response{}
 	ty := p.schema.Provider.Block.ImpliedType()
 
@@ -88,7 +89,7 @@ func (p *provider6) ValidateProviderConfig(_ context.Context, req *tfplugin6.Val
 		return resp, nil
 	}
 
-	prepareResp := p.provider.ValidateProviderConfig(providers.ValidateProviderConfigRequest{
+	prepareResp := p.provider.ValidateProviderConfig(ctx, providers.ValidateProviderConfigRequest{
 		Config: configVal,
 	})
 
@@ -171,7 +172,7 @@ func (p *provider6) ConfigureProvider(_ context.Context, req *tfplugin6.Configur
 		return resp, nil
 	}
 
-	configureResp := p.provider.ConfigureProvider(providers.ConfigureProviderRequest{
+	configureResp := p.provider.ConfigureProvider(nil, providers.ConfigureProviderRequest{
 		TerraformVersion: req.TerraformVersion,
 		Config:           configVal,
 	})

--- a/internal/lang/data.go
+++ b/internal/lang/data.go
@@ -6,6 +6,8 @@
 package lang
 
 import (
+	"context"
+
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -26,11 +28,11 @@ import (
 // cases where it's not possible to even determine a suitable result type,
 // cty.DynamicVal is returned along with errors describing the problem.
 type Data interface {
-	StaticValidateReferences(refs []*addrs.Reference, self addrs.Referenceable, source addrs.Referenceable) tfdiags.Diagnostics
+	StaticValidateReferences(ctx context.Context, refs []*addrs.Reference, self addrs.Referenceable, source addrs.Referenceable) tfdiags.Diagnostics
 
 	GetCountAttr(addrs.CountAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetForEachAttr(addrs.ForEachAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
-	GetResource(addrs.Resource, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
+	GetResource(context.Context, addrs.Resource, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetLocalValue(addrs.LocalValue, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetModule(addrs.ModuleCall, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 	GetPathAttr(addrs.PathAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)

--- a/internal/lang/data_test.go
+++ b/internal/lang/data_test.go
@@ -6,6 +6,8 @@
 package lang
 
 import (
+	"context"
+
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -27,7 +29,7 @@ type dataForTests struct {
 
 var _ Data = &dataForTests{}
 
-func (d *dataForTests) StaticValidateReferences(refs []*addrs.Reference, self addrs.Referenceable, source addrs.Referenceable) tfdiags.Diagnostics {
+func (d *dataForTests) StaticValidateReferences(ctx context.Context, refs []*addrs.Reference, self addrs.Referenceable, source addrs.Referenceable) tfdiags.Diagnostics {
 	return nil // does nothing in this stub implementation
 }
 
@@ -39,7 +41,7 @@ func (d *dataForTests) GetForEachAttr(addr addrs.ForEachAttr, rng tfdiags.Source
 	return d.ForEachAttrs[addr.Name], nil
 }
 
-func (d *dataForTests) GetResource(addr addrs.Resource, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+func (d *dataForTests) GetResource(ctx context.Context, addr addrs.Resource, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	return d.Resources[addr.String()], nil
 }
 

--- a/internal/lang/eval.go
+++ b/internal/lang/eval.go
@@ -311,7 +311,7 @@ func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceabl
 	// First we'll do static validation of the references. This catches things
 	// early that might otherwise not get caught due to unknown values being
 	// present in the scope during planning.
-	staticDiags := s.Data.StaticValidateReferences(refs, selfAddr, s.SourceAddr)
+	staticDiags := s.Data.StaticValidateReferences(nil, refs, selfAddr, s.SourceAddr)
 	diags = diags.Append(staticDiags)
 	if staticDiags.HasErrors() {
 		return ctx, diags
@@ -365,7 +365,7 @@ func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceabl
 			// self can only be used within a resource instance
 			subj := selfAddr.(addrs.ResourceInstance)
 
-			val, valDiags := normalizeRefValue(s.Data.GetResource(subj.ContainingResource(), rng))
+			val, valDiags := normalizeRefValue(s.Data.GetResource(nil, subj.ContainingResource(), rng))
 
 			diags = diags.Append(valDiags)
 
@@ -412,7 +412,7 @@ func (s *Scope) evalContext(refs []*addrs.Reference, selfAddr addrs.Referenceabl
 				panic(fmt.Errorf("unsupported ResourceMode %s", subj.Mode))
 			}
 
-			val, valDiags := normalizeRefValue(s.Data.GetResource(subj, rng))
+			val, valDiags := normalizeRefValue(s.Data.GetResource(nil, subj, rng))
 			diags = diags.Append(valDiags)
 
 			r := subj

--- a/internal/legacy/tofu/context_components.go
+++ b/internal/legacy/tofu/context_components.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -19,7 +20,7 @@ import (
 // a Context. This information is used for debugging.
 type contextComponentFactory interface {
 	// ResourceProvider creates a new ResourceProvider with the given type.
-	ResourceProvider(typ addrs.Provider) (providers.Interface, error)
+	ResourceProvider(ctx context.Context, typ addrs.Provider) (providers.Interface, error)
 	ResourceProviders() []string
 
 	// ResourceProvisioner creates a new ResourceProvisioner with the given
@@ -51,13 +52,13 @@ func (c *basicComponentFactory) ResourceProvisioners() []string {
 	return result
 }
 
-func (c *basicComponentFactory) ResourceProvider(typ addrs.Provider) (providers.Interface, error) {
+func (c *basicComponentFactory) ResourceProvider(ctx context.Context, typ addrs.Provider) (providers.Interface, error) {
 	f, ok := c.providers[typ]
 	if !ok {
 		return nil, fmt.Errorf("unknown provider %q", typ.String())
 	}
 
-	return f()
+	return f(ctx)
 }
 
 func (c *basicComponentFactory) ResourceProvisioner(typ string) (provisioners.Interface, error) {

--- a/internal/legacy/tofu/provider_mock.go
+++ b/internal/legacy/tofu/provider_mock.go
@@ -142,7 +142,7 @@ func (p *MockProvider) ValidateProviderConfig(ctx context.Context, r providers.V
 	return p.ValidateProviderConfigResponse
 }
 
-func (p *MockProvider) ValidateResourceConfig(r providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
+func (p *MockProvider) ValidateResourceConfig(ctx context.Context, r providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
 	p.Lock()
 	defer p.Unlock()
 
@@ -156,7 +156,7 @@ func (p *MockProvider) ValidateResourceConfig(r providers.ValidateResourceConfig
 	return p.ValidateResourceConfigResponse
 }
 
-func (p *MockProvider) ValidateDataResourceConfig(r providers.ValidateDataResourceConfigRequest) providers.ValidateDataResourceConfigResponse {
+func (p *MockProvider) ValidateDataResourceConfig(ctx context.Context, r providers.ValidateDataResourceConfigRequest) providers.ValidateDataResourceConfigResponse {
 	p.Lock()
 	defer p.Unlock()
 
@@ -170,7 +170,7 @@ func (p *MockProvider) ValidateDataResourceConfig(r providers.ValidateDataResour
 	return p.ValidateDataResourceConfigResponse
 }
 
-func (p *MockProvider) UpgradeResourceState(r providers.UpgradeResourceStateRequest) providers.UpgradeResourceStateResponse {
+func (p *MockProvider) UpgradeResourceState(ctx context.Context, r providers.UpgradeResourceStateRequest) providers.UpgradeResourceStateResponse {
 	p.Lock()
 	defer p.Unlock()
 
@@ -237,7 +237,7 @@ func (p *MockProvider) Stop() error {
 	return p.StopResponse
 }
 
-func (p *MockProvider) ReadResource(r providers.ReadResourceRequest) providers.ReadResourceResponse {
+func (p *MockProvider) ReadResource(ctx context.Context, r providers.ReadResourceRequest) providers.ReadResourceResponse {
 	p.Lock()
 	defer p.Unlock()
 
@@ -265,7 +265,7 @@ func (p *MockProvider) ReadResource(r providers.ReadResourceRequest) providers.R
 	return resp
 }
 
-func (p *MockProvider) PlanResourceChange(r providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+func (p *MockProvider) PlanResourceChange(ctx context.Context, r providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
 	p.Lock()
 	defer p.Unlock()
 
@@ -279,7 +279,7 @@ func (p *MockProvider) PlanResourceChange(r providers.PlanResourceChangeRequest)
 	return p.PlanResourceChangeResponse
 }
 
-func (p *MockProvider) ApplyResourceChange(r providers.ApplyResourceChangeRequest) providers.ApplyResourceChangeResponse {
+func (p *MockProvider) ApplyResourceChange(ctx context.Context, r providers.ApplyResourceChangeRequest) providers.ApplyResourceChangeResponse {
 	p.Lock()
 	p.ApplyResourceChangeCalled = true
 	p.ApplyResourceChangeRequest = r
@@ -349,7 +349,7 @@ func (p *MockProvider) ImportResourceState(r providers.ImportResourceStateReques
 	return p.ImportResourceStateResponse
 }
 
-func (p *MockProvider) ReadDataSource(r providers.ReadDataSourceRequest) providers.ReadDataSourceResponse {
+func (p *MockProvider) ReadDataSource(ctx context.Context, r providers.ReadDataSourceRequest) providers.ReadDataSourceResponse {
 	p.Lock()
 	defer p.Unlock()
 

--- a/internal/legacy/tofu/provider_mock.go
+++ b/internal/legacy/tofu/provider_mock.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"encoding/json"
 	"sync"
 
@@ -93,7 +94,7 @@ type MockProvider struct {
 	CloseError  error
 }
 
-func (p *MockProvider) GetProviderSchema() providers.GetProviderSchemaResponse {
+func (p *MockProvider) GetProviderSchema(context.Context) providers.GetProviderSchemaResponse {
 	p.Lock()
 	defer p.Unlock()
 	p.GetSchemaCalled = true
@@ -129,7 +130,7 @@ func (p *MockProvider) getSchema() providers.GetProviderSchemaResponse {
 	return ret
 }
 
-func (p *MockProvider) ValidateProviderConfig(r providers.ValidateProviderConfigRequest) providers.ValidateProviderConfigResponse {
+func (p *MockProvider) ValidateProviderConfig(ctx context.Context, r providers.ValidateProviderConfigRequest) providers.ValidateProviderConfigResponse {
 	p.Lock()
 	defer p.Unlock()
 
@@ -208,7 +209,7 @@ func (p *MockProvider) UpgradeResourceState(r providers.UpgradeResourceStateRequ
 	return resp
 }
 
-func (p *MockProvider) ConfigureProvider(r providers.ConfigureProviderRequest) providers.ConfigureProviderResponse {
+func (p *MockProvider) ConfigureProvider(ctx context.Context, r providers.ConfigureProviderRequest) providers.ConfigureProviderResponse {
 	p.Lock()
 	defer p.Unlock()
 
@@ -366,7 +367,7 @@ func (p *MockProvider) GetFunctions() providers.GetFunctionsResponse {
 	panic("Not Implemented")
 }
 
-func (p *MockProvider) CallFunction(r providers.CallFunctionRequest) providers.CallFunctionResponse {
+func (p *MockProvider) CallFunction(ctx context.Context, r providers.CallFunctionRequest) providers.CallFunctionResponse {
 	panic("Not Implemented")
 }
 

--- a/internal/legacy/tofu/schemas.go
+++ b/internal/legacy/tofu/schemas.go
@@ -120,7 +120,7 @@ func loadProviderSchemas(ctx context.Context, schemas map[addrs.Provider]*Provid
 			provider.Close()
 		}()
 
-		resp := provider.GetProviderSchema(nil)
+		resp := provider.GetProviderSchema(ctx)
 		if resp.Diagnostics.HasErrors() {
 			// We'll put a stub in the map so we won't re-attempt this on
 			// future calls.

--- a/internal/legacy/tofu/schemas.go
+++ b/internal/legacy/tofu/schemas.go
@@ -119,7 +119,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]*ProviderSchema, config *con
 			provider.Close()
 		}()
 
-		resp := provider.GetProviderSchema()
+		resp := provider.GetProviderSchema(nil)
 		if resp.Diagnostics.HasErrors() {
 			// We'll put a stub in the map so we won't re-attempt this on
 			// future calls.

--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -187,7 +187,7 @@ func (p *GRPCProvider) GetProviderSchema(traceCtx context.Context) (resp provide
 func (p *GRPCProvider) ValidateProviderConfig(ctx context.Context, r providers.ValidateProviderConfigRequest) (resp providers.ValidateProviderConfigResponse) {
 	logger.Trace("GRPCProvider: ValidateProviderConfig")
 
-	schema := p.GetProviderSchema(nil)
+	schema := p.GetProviderSchema(ctx)
 	if schema.Diagnostics.HasErrors() {
 		resp.Diagnostics = schema.Diagnostics
 		return resp
@@ -222,10 +222,10 @@ func (p *GRPCProvider) ValidateProviderConfig(ctx context.Context, r providers.V
 	return resp
 }
 
-func (p *GRPCProvider) ValidateResourceConfig(r providers.ValidateResourceConfigRequest) (resp providers.ValidateResourceConfigResponse) {
+func (p *GRPCProvider) ValidateResourceConfig(ctx context.Context, r providers.ValidateResourceConfigRequest) (resp providers.ValidateResourceConfigResponse) {
 	logger.Trace("GRPCProvider: ValidateResourceConfig")
 
-	schema := p.GetProviderSchema(nil)
+	schema := p.GetProviderSchema(ctx)
 	if schema.Diagnostics.HasErrors() {
 		resp.Diagnostics = schema.Diagnostics
 		return resp
@@ -258,10 +258,10 @@ func (p *GRPCProvider) ValidateResourceConfig(r providers.ValidateResourceConfig
 	return resp
 }
 
-func (p *GRPCProvider) ValidateDataResourceConfig(r providers.ValidateDataResourceConfigRequest) (resp providers.ValidateDataResourceConfigResponse) {
+func (p *GRPCProvider) ValidateDataResourceConfig(ctx context.Context, r providers.ValidateDataResourceConfigRequest) (resp providers.ValidateDataResourceConfigResponse) {
 	logger.Trace("GRPCProvider: ValidateDataResourceConfig")
 
-	schema := p.GetProviderSchema(nil)
+	schema := p.GetProviderSchema(ctx)
 	if schema.Diagnostics.HasErrors() {
 		resp.Diagnostics = schema.Diagnostics
 		return resp
@@ -293,10 +293,13 @@ func (p *GRPCProvider) ValidateDataResourceConfig(r providers.ValidateDataResour
 	return resp
 }
 
-func (p *GRPCProvider) UpgradeResourceState(r providers.UpgradeResourceStateRequest) (resp providers.UpgradeResourceStateResponse) {
+func (p *GRPCProvider) UpgradeResourceState(ctx context.Context, r providers.UpgradeResourceStateRequest) (resp providers.UpgradeResourceStateResponse) {
 	logger.Trace("GRPCProvider: UpgradeResourceState")
+	var span trace.Span
+	_, span = tracer.Start(ctx, "GRPCProvider UpgradeResourceState")
+	defer span.End()
 
-	schema := p.GetProviderSchema(nil)
+	schema := p.GetProviderSchema(ctx)
 	if schema.Diagnostics.HasErrors() {
 		resp.Diagnostics = schema.Diagnostics
 		return resp
@@ -343,7 +346,7 @@ func (p *GRPCProvider) UpgradeResourceState(r providers.UpgradeResourceStateRequ
 func (p *GRPCProvider) ConfigureProvider(ctx context.Context, r providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 	logger.Trace("GRPCProvider: ConfigureProvider")
 
-	schema := p.GetProviderSchema(nil)
+	schema := p.GetProviderSchema(ctx)
 	if schema.Diagnostics.HasErrors() {
 		resp.Diagnostics = schema.Diagnostics
 		return resp
@@ -388,10 +391,14 @@ func (p *GRPCProvider) Stop() error {
 	return nil
 }
 
-func (p *GRPCProvider) ReadResource(r providers.ReadResourceRequest) (resp providers.ReadResourceResponse) {
+func (p *GRPCProvider) ReadResource(ctx context.Context, r providers.ReadResourceRequest) (resp providers.ReadResourceResponse) {
 	logger.Trace("GRPCProvider: ReadResource")
 
-	schema := p.GetProviderSchema(nil)
+	var span trace.Span
+	_, span = tracer.Start(ctx, "GRPCProvider ReadResource")
+	defer span.End()
+
+	schema := p.GetProviderSchema(ctx)
 	if schema.Diagnostics.HasErrors() {
 		resp.Diagnostics = schema.Diagnostics
 		return resp
@@ -444,10 +451,10 @@ func (p *GRPCProvider) ReadResource(r providers.ReadResourceRequest) (resp provi
 	return resp
 }
 
-func (p *GRPCProvider) PlanResourceChange(r providers.PlanResourceChangeRequest) (resp providers.PlanResourceChangeResponse) {
+func (p *GRPCProvider) PlanResourceChange(ctx context.Context, r providers.PlanResourceChangeRequest) (resp providers.PlanResourceChangeResponse) {
 	logger.Trace("GRPCProvider: PlanResourceChange")
 
-	schema := p.GetProviderSchema(nil)
+	schema := p.GetProviderSchema(ctx)
 	if schema.Diagnostics.HasErrors() {
 		resp.Diagnostics = schema.Diagnostics
 		return resp
@@ -530,10 +537,10 @@ func (p *GRPCProvider) PlanResourceChange(r providers.PlanResourceChangeRequest)
 	return resp
 }
 
-func (p *GRPCProvider) ApplyResourceChange(r providers.ApplyResourceChangeRequest) (resp providers.ApplyResourceChangeResponse) {
+func (p *GRPCProvider) ApplyResourceChange(ctx context.Context, r providers.ApplyResourceChangeRequest) (resp providers.ApplyResourceChangeResponse) {
 	logger.Trace("GRPCProvider: ApplyResourceChange")
 
-	schema := p.GetProviderSchema(nil)
+	schema := p.GetProviderSchema(ctx)
 	if schema.Diagnostics.HasErrors() {
 		resp.Diagnostics = schema.Diagnostics
 		return resp
@@ -646,10 +653,10 @@ func (p *GRPCProvider) ImportResourceState(r providers.ImportResourceStateReques
 	return resp
 }
 
-func (p *GRPCProvider) ReadDataSource(r providers.ReadDataSourceRequest) (resp providers.ReadDataSourceResponse) {
+func (p *GRPCProvider) ReadDataSource(ctx context.Context, r providers.ReadDataSourceRequest) (resp providers.ReadDataSourceResponse) {
 	logger.Trace("GRPCProvider: ReadDataSource")
 
-	schema := p.GetProviderSchema(nil)
+	schema := p.GetProviderSchema(ctx)
 	if schema.Diagnostics.HasErrors() {
 		resp.Diagnostics = schema.Diagnostics
 		return resp

--- a/internal/plugin/grpc_provider_test.go
+++ b/internal/plugin/grpc_provider_test.go
@@ -14,10 +14,11 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/configs/hcl2shim"
 	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 
 	mockproto "github.com/opentofu/opentofu/internal/plugin/mock_proto"
 	proto "github.com/opentofu/opentofu/internal/tfplugin5"
@@ -123,7 +124,7 @@ func TestGRPCProvider_GetSchema(t *testing.T) {
 		client: mockProviderClient(t),
 	}
 
-	resp := p.GetProviderSchema()
+	resp := p.GetProviderSchema(nil)
 	checkDiags(t, resp.Diagnostics)
 }
 
@@ -143,7 +144,7 @@ func TestGRPCProvider_GetSchema_GRPCError(t *testing.T) {
 		client: client,
 	}
 
-	resp := p.GetProviderSchema()
+	resp := p.GetProviderSchema(nil)
 
 	checkDiagsHasError(t, resp.Diagnostics)
 }
@@ -176,7 +177,7 @@ func TestGRPCProvider_GetSchema_GlobalCacheEnabled(t *testing.T) {
 		client: client,
 		Addr:   providerAddr,
 	}
-	resp := p.GetProviderSchema()
+	resp := p.GetProviderSchema(nil)
 
 	checkDiags(t, resp.Diagnostics)
 	if !cmp.Equal(resp.Provider.Version, mockedProviderResponse.Version) {
@@ -187,7 +188,7 @@ func TestGRPCProvider_GetSchema_GlobalCacheEnabled(t *testing.T) {
 		client: client,
 		Addr:   providerAddr,
 	}
-	resp = p.GetProviderSchema()
+	resp = p.GetProviderSchema(nil)
 
 	checkDiags(t, resp.Diagnostics)
 	if !cmp.Equal(resp.Provider.Version, mockedProviderResponse.Version) {
@@ -223,7 +224,7 @@ func TestGRPCProvider_GetSchema_GlobalCacheDisabled(t *testing.T) {
 		client: client,
 		Addr:   providerAddr,
 	}
-	resp := p.GetProviderSchema()
+	resp := p.GetProviderSchema(nil)
 
 	checkDiags(t, resp.Diagnostics)
 	if !cmp.Equal(resp.Provider.Version, mockedProviderResponse.Version) {
@@ -234,7 +235,7 @@ func TestGRPCProvider_GetSchema_GlobalCacheDisabled(t *testing.T) {
 		client: client,
 		Addr:   providerAddr,
 	}
-	resp = p.GetProviderSchema()
+	resp = p.GetProviderSchema(nil)
 
 	checkDiags(t, resp.Diagnostics)
 	if !cmp.Equal(resp.Provider.Version, mockedProviderResponse.Version) {
@@ -268,7 +269,7 @@ func TestGRPCProvider_GetSchema_ResponseErrorDiagnostic(t *testing.T) {
 		client: client,
 	}
 
-	resp := p.GetProviderSchema()
+	resp := p.GetProviderSchema(nil)
 
 	checkDiagsHasError(t, resp.Diagnostics)
 }
@@ -285,7 +286,7 @@ func TestGRPCProvider_PrepareProviderConfig(t *testing.T) {
 	).Return(&proto.PrepareProviderConfig_Response{}, nil)
 
 	cfg := hcl2shim.HCL2ValueFromConfigValue(map[string]interface{}{"attr": "value"})
-	resp := p.ValidateProviderConfig(providers.ValidateProviderConfigRequest{Config: cfg})
+	resp := p.ValidateProviderConfig(nil, providers.ValidateProviderConfigRequest{Config: cfg})
 	checkDiags(t, resp.Diagnostics)
 }
 
@@ -400,7 +401,7 @@ func TestGRPCProvider_Configure(t *testing.T) {
 		gomock.Any(),
 	).Return(&proto.Configure_Response{}, nil)
 
-	resp := p.ConfigureProvider(providers.ConfigureProviderRequest{
+	resp := p.ConfigureProvider(nil, providers.ConfigureProviderRequest{
 		Config: cty.ObjectVal(map[string]cty.Value{
 			"attr": cty.StringVal("foo"),
 		}),
@@ -909,7 +910,7 @@ func TestGRPCProvider_CallFunction(t *testing.T) {
 		Result: &proto.DynamicValue{Json: []byte(`"foo"`)},
 	}, nil)
 
-	resp := p.CallFunction(providers.CallFunctionRequest{
+	resp := p.CallFunction(nil, providers.CallFunctionRequest{
 		Name:      "fn",
 		Arguments: []cty.Value{cty.StringVal("bar"), cty.NilVal},
 	})

--- a/internal/plugin/grpc_provider_test.go
+++ b/internal/plugin/grpc_provider_test.go
@@ -302,7 +302,7 @@ func TestGRPCProvider_ValidateResourceConfig(t *testing.T) {
 	).Return(&proto.ValidateResourceTypeConfig_Response{}, nil)
 
 	cfg := hcl2shim.HCL2ValueFromConfigValue(map[string]interface{}{"attr": "value"})
-	resp := p.ValidateResourceConfig(providers.ValidateResourceConfigRequest{
+	resp := p.ValidateResourceConfig(nil, providers.ValidateResourceConfigRequest{
 		TypeName: "resource",
 		Config:   cfg,
 	})
@@ -321,7 +321,7 @@ func TestGRPCProvider_ValidateDataSourceConfig(t *testing.T) {
 	).Return(&proto.ValidateDataSourceConfig_Response{}, nil)
 
 	cfg := hcl2shim.HCL2ValueFromConfigValue(map[string]interface{}{"attr": "value"})
-	resp := p.ValidateDataResourceConfig(providers.ValidateDataResourceConfigRequest{
+	resp := p.ValidateDataResourceConfig(nil, providers.ValidateDataResourceConfigRequest{
 		TypeName: "data",
 		Config:   cfg,
 	})
@@ -343,7 +343,7 @@ func TestGRPCProvider_UpgradeResourceState(t *testing.T) {
 		},
 	}, nil)
 
-	resp := p.UpgradeResourceState(providers.UpgradeResourceStateRequest{
+	resp := p.UpgradeResourceState(nil, providers.UpgradeResourceStateRequest{
 		TypeName:     "resource",
 		Version:      0,
 		RawStateJSON: []byte(`{"old_attr":"bar"}`),
@@ -374,7 +374,7 @@ func TestGRPCProvider_UpgradeResourceStateJSON(t *testing.T) {
 		},
 	}, nil)
 
-	resp := p.UpgradeResourceState(providers.UpgradeResourceStateRequest{
+	resp := p.UpgradeResourceState(nil, providers.UpgradeResourceStateRequest{
 		TypeName:     "resource",
 		Version:      0,
 		RawStateJSON: []byte(`{"old_attr":"bar"}`),
@@ -442,7 +442,7 @@ func TestGRPCProvider_ReadResource(t *testing.T) {
 		},
 	}, nil)
 
-	resp := p.ReadResource(providers.ReadResourceRequest{
+	resp := p.ReadResource(nil, providers.ReadResourceRequest{
 		TypeName: "resource",
 		PriorState: cty.ObjectVal(map[string]cty.Value{
 			"attr": cty.StringVal("foo"),
@@ -475,7 +475,7 @@ func TestGRPCProvider_ReadResourceJSON(t *testing.T) {
 		},
 	}, nil)
 
-	resp := p.ReadResource(providers.ReadResourceRequest{
+	resp := p.ReadResource(nil, providers.ReadResourceRequest{
 		TypeName: "resource",
 		PriorState: cty.ObjectVal(map[string]cty.Value{
 			"attr": cty.StringVal("foo"),
@@ -511,7 +511,7 @@ func TestGRPCProvider_ReadEmptyJSON(t *testing.T) {
 	obj := cty.ObjectVal(map[string]cty.Value{
 		"attr": cty.StringVal("foo"),
 	})
-	resp := p.ReadResource(providers.ReadResourceRequest{
+	resp := p.ReadResource(nil, providers.ReadResourceRequest{
 		TypeName:   "resource",
 		PriorState: obj,
 	})
@@ -554,7 +554,7 @@ func TestGRPCProvider_PlanResourceChange(t *testing.T) {
 		PlannedPrivate: expectedPrivate,
 	}, nil)
 
-	resp := p.PlanResourceChange(providers.PlanResourceChangeRequest{
+	resp := p.PlanResourceChange(nil, providers.PlanResourceChangeRequest{
 		TypeName: "resource",
 		PriorState: cty.ObjectVal(map[string]cty.Value{
 			"attr": cty.StringVal("foo"),
@@ -617,7 +617,7 @@ func TestGRPCProvider_PlanResourceChangeJSON(t *testing.T) {
 		PlannedPrivate: expectedPrivate,
 	}, nil)
 
-	resp := p.PlanResourceChange(providers.PlanResourceChangeRequest{
+	resp := p.PlanResourceChange(nil, providers.PlanResourceChangeRequest{
 		TypeName: "resource",
 		PriorState: cty.ObjectVal(map[string]cty.Value{
 			"attr": cty.StringVal("foo"),
@@ -669,7 +669,7 @@ func TestGRPCProvider_ApplyResourceChange(t *testing.T) {
 		Private: expectedPrivate,
 	}, nil)
 
-	resp := p.ApplyResourceChange(providers.ApplyResourceChangeRequest{
+	resp := p.ApplyResourceChange(nil, providers.ApplyResourceChangeRequest{
 		TypeName: "resource",
 		PriorState: cty.ObjectVal(map[string]cty.Value{
 			"attr": cty.StringVal("foo"),
@@ -715,7 +715,7 @@ func TestGRPCProvider_ApplyResourceChangeJSON(t *testing.T) {
 		Private: expectedPrivate,
 	}, nil)
 
-	resp := p.ApplyResourceChange(providers.ApplyResourceChangeRequest{
+	resp := p.ApplyResourceChange(nil, providers.ApplyResourceChangeRequest{
 		TypeName: "resource",
 		PriorState: cty.ObjectVal(map[string]cty.Value{
 			"attr": cty.StringVal("foo"),
@@ -846,7 +846,7 @@ func TestGRPCProvider_ReadDataSource(t *testing.T) {
 		},
 	}, nil)
 
-	resp := p.ReadDataSource(providers.ReadDataSourceRequest{
+	resp := p.ReadDataSource(nil, providers.ReadDataSourceRequest{
 		TypeName: "data",
 		Config: cty.ObjectVal(map[string]cty.Value{
 			"attr": cty.StringVal("foo"),
@@ -879,7 +879,7 @@ func TestGRPCProvider_ReadDataSourceJSON(t *testing.T) {
 		},
 	}, nil)
 
-	resp := p.ReadDataSource(providers.ReadDataSourceRequest{
+	resp := p.ReadDataSource(nil, providers.ReadDataSourceRequest{
 		TypeName: "data",
 		Config: cty.ObjectVal(map[string]cty.Value{
 			"attr": cty.StringVal("foo"),

--- a/internal/plugin/telemetry.go
+++ b/internal/plugin/telemetry.go
@@ -1,0 +1,12 @@
+package plugin
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+var tracer trace.Tracer
+
+func init() {
+	tracer = otel.Tracer("github.com/opentofu/opentofu/internal/plugin")
+}

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -226,10 +226,10 @@ func (p *GRPCProvider) ValidateProviderConfig(ctx context.Context, r providers.V
 	return resp
 }
 
-func (p *GRPCProvider) ValidateResourceConfig(r providers.ValidateResourceConfigRequest) (resp providers.ValidateResourceConfigResponse) {
+func (p *GRPCProvider) ValidateResourceConfig(ctx context.Context, r providers.ValidateResourceConfigRequest) (resp providers.ValidateResourceConfigResponse) {
 	logger.Trace("GRPCProvider.v6: ValidateResourceConfig")
 
-	schema := p.GetProviderSchema(nil)
+	schema := p.GetProviderSchema(ctx)
 	if schema.Diagnostics.HasErrors() {
 		resp.Diagnostics = schema.Diagnostics
 		return resp
@@ -262,10 +262,10 @@ func (p *GRPCProvider) ValidateResourceConfig(r providers.ValidateResourceConfig
 	return resp
 }
 
-func (p *GRPCProvider) ValidateDataResourceConfig(r providers.ValidateDataResourceConfigRequest) (resp providers.ValidateDataResourceConfigResponse) {
+func (p *GRPCProvider) ValidateDataResourceConfig(ctx context.Context, r providers.ValidateDataResourceConfigRequest) (resp providers.ValidateDataResourceConfigResponse) {
 	logger.Trace("GRPCProvider.v6: ValidateDataResourceConfig")
 
-	schema := p.GetProviderSchema(nil)
+	schema := p.GetProviderSchema(ctx)
 	if schema.Diagnostics.HasErrors() {
 		resp.Diagnostics = schema.Diagnostics
 		return resp
@@ -297,10 +297,13 @@ func (p *GRPCProvider) ValidateDataResourceConfig(r providers.ValidateDataResour
 	return resp
 }
 
-func (p *GRPCProvider) UpgradeResourceState(r providers.UpgradeResourceStateRequest) (resp providers.UpgradeResourceStateResponse) {
+func (p *GRPCProvider) UpgradeResourceState(ctx context.Context, r providers.UpgradeResourceStateRequest) (resp providers.UpgradeResourceStateResponse) {
 	logger.Trace("GRPCProvider.v6: UpgradeResourceState")
+	var span trace.Span
+	_, span = tracer.Start(ctx, "GRPCProvider6 UpgradeResourceState")
+	defer span.End()
 
-	schema := p.GetProviderSchema(nil)
+	schema := p.GetProviderSchema(ctx)
 	if schema.Diagnostics.HasErrors() {
 		resp.Diagnostics = schema.Diagnostics
 		return resp
@@ -392,10 +395,14 @@ func (p *GRPCProvider) Stop() error {
 	return nil
 }
 
-func (p *GRPCProvider) ReadResource(r providers.ReadResourceRequest) (resp providers.ReadResourceResponse) {
+func (p *GRPCProvider) ReadResource(ctx context.Context, r providers.ReadResourceRequest) (resp providers.ReadResourceResponse) {
 	logger.Trace("GRPCProvider.v6: ReadResource")
 
-	schema := p.GetProviderSchema(nil)
+	var span trace.Span
+	_, span = tracer.Start(ctx, "GRPCProvider6 ReadResource")
+	defer span.End()
+
+	schema := p.GetProviderSchema(ctx)
 	if schema.Diagnostics.HasErrors() {
 		resp.Diagnostics = schema.Diagnostics
 		return resp
@@ -448,10 +455,10 @@ func (p *GRPCProvider) ReadResource(r providers.ReadResourceRequest) (resp provi
 	return resp
 }
 
-func (p *GRPCProvider) PlanResourceChange(r providers.PlanResourceChangeRequest) (resp providers.PlanResourceChangeResponse) {
+func (p *GRPCProvider) PlanResourceChange(ctx context.Context, r providers.PlanResourceChangeRequest) (resp providers.PlanResourceChangeResponse) {
 	logger.Trace("GRPCProvider.v6: PlanResourceChange")
 
-	schema := p.GetProviderSchema(nil)
+	schema := p.GetProviderSchema(ctx)
 	if schema.Diagnostics.HasErrors() {
 		resp.Diagnostics = schema.Diagnostics
 		return resp
@@ -534,7 +541,7 @@ func (p *GRPCProvider) PlanResourceChange(r providers.PlanResourceChangeRequest)
 	return resp
 }
 
-func (p *GRPCProvider) ApplyResourceChange(r providers.ApplyResourceChangeRequest) (resp providers.ApplyResourceChangeResponse) {
+func (p *GRPCProvider) ApplyResourceChange(ctx context.Context, r providers.ApplyResourceChangeRequest) (resp providers.ApplyResourceChangeResponse) {
 	logger.Trace("GRPCProvider.v6: ApplyResourceChange")
 
 	schema := p.GetProviderSchema(nil)
@@ -650,7 +657,7 @@ func (p *GRPCProvider) ImportResourceState(r providers.ImportResourceStateReques
 	return resp
 }
 
-func (p *GRPCProvider) ReadDataSource(r providers.ReadDataSourceRequest) (resp providers.ReadDataSourceResponse) {
+func (p *GRPCProvider) ReadDataSource(ctx context.Context, r providers.ReadDataSourceRequest) (resp providers.ReadDataSourceResponse) {
 	logger.Trace("GRPCProvider.v6: ReadDataSource")
 
 	schema := p.GetProviderSchema(nil)
@@ -713,7 +720,7 @@ func (p *GRPCProvider) GetFunctions() (resp providers.GetFunctionsResponse) {
 	span.SetAttributes(attribute.String("provider", p.Addr.String()))
 
 	logger.Trace("GRPCProvider6: GetFunctions")
-	
+
 	protoReq := &proto6.GetFunctions_Request{}
 
 	protoResp, err := p.client.GetFunctions(ctx, protoReq)

--- a/internal/plugin6/grpc_provider_test.go
+++ b/internal/plugin6/grpc_provider_test.go
@@ -310,7 +310,7 @@ func TestGRPCProvider_ValidateResourceConfig(t *testing.T) {
 	).Return(&proto.ValidateResourceConfig_Response{}, nil)
 
 	cfg := hcl2shim.HCL2ValueFromConfigValue(map[string]interface{}{"attr": "value"})
-	resp := p.ValidateResourceConfig(providers.ValidateResourceConfigRequest{
+	resp := p.ValidateResourceConfig(nil, providers.ValidateResourceConfigRequest{
 		TypeName: "resource",
 		Config:   cfg,
 	})
@@ -329,7 +329,7 @@ func TestGRPCProvider_ValidateDataResourceConfig(t *testing.T) {
 	).Return(&proto.ValidateDataResourceConfig_Response{}, nil)
 
 	cfg := hcl2shim.HCL2ValueFromConfigValue(map[string]interface{}{"attr": "value"})
-	resp := p.ValidateDataResourceConfig(providers.ValidateDataResourceConfigRequest{
+	resp := p.ValidateDataResourceConfig(nil, providers.ValidateDataResourceConfigRequest{
 		TypeName: "data",
 		Config:   cfg,
 	})
@@ -351,7 +351,7 @@ func TestGRPCProvider_UpgradeResourceState(t *testing.T) {
 		},
 	}, nil)
 
-	resp := p.UpgradeResourceState(providers.UpgradeResourceStateRequest{
+	resp := p.UpgradeResourceState(nil, providers.UpgradeResourceStateRequest{
 		TypeName:     "resource",
 		Version:      0,
 		RawStateJSON: []byte(`{"old_attr":"bar"}`),
@@ -382,7 +382,7 @@ func TestGRPCProvider_UpgradeResourceStateJSON(t *testing.T) {
 		},
 	}, nil)
 
-	resp := p.UpgradeResourceState(providers.UpgradeResourceStateRequest{
+	resp := p.UpgradeResourceState(nil, providers.UpgradeResourceStateRequest{
 		TypeName:     "resource",
 		Version:      0,
 		RawStateJSON: []byte(`{"old_attr":"bar"}`),
@@ -450,7 +450,7 @@ func TestGRPCProvider_ReadResource(t *testing.T) {
 		},
 	}, nil)
 
-	resp := p.ReadResource(providers.ReadResourceRequest{
+	resp := p.ReadResource(nil, providers.ReadResourceRequest{
 		TypeName: "resource",
 		PriorState: cty.ObjectVal(map[string]cty.Value{
 			"attr": cty.StringVal("foo"),
@@ -483,7 +483,7 @@ func TestGRPCProvider_ReadResourceJSON(t *testing.T) {
 		},
 	}, nil)
 
-	resp := p.ReadResource(providers.ReadResourceRequest{
+	resp := p.ReadResource(nil, providers.ReadResourceRequest{
 		TypeName: "resource",
 		PriorState: cty.ObjectVal(map[string]cty.Value{
 			"attr": cty.StringVal("foo"),
@@ -519,7 +519,7 @@ func TestGRPCProvider_ReadEmptyJSON(t *testing.T) {
 	obj := cty.ObjectVal(map[string]cty.Value{
 		"attr": cty.StringVal("foo"),
 	})
-	resp := p.ReadResource(providers.ReadResourceRequest{
+	resp := p.ReadResource(nil, providers.ReadResourceRequest{
 		TypeName:   "resource",
 		PriorState: obj,
 	})
@@ -562,7 +562,7 @@ func TestGRPCProvider_PlanResourceChange(t *testing.T) {
 		PlannedPrivate: expectedPrivate,
 	}, nil)
 
-	resp := p.PlanResourceChange(providers.PlanResourceChangeRequest{
+	resp := p.PlanResourceChange(nil, providers.PlanResourceChangeRequest{
 		TypeName: "resource",
 		PriorState: cty.ObjectVal(map[string]cty.Value{
 			"attr": cty.StringVal("foo"),
@@ -625,7 +625,7 @@ func TestGRPCProvider_PlanResourceChangeJSON(t *testing.T) {
 		PlannedPrivate: expectedPrivate,
 	}, nil)
 
-	resp := p.PlanResourceChange(providers.PlanResourceChangeRequest{
+	resp := p.PlanResourceChange(nil, providers.PlanResourceChangeRequest{
 		TypeName: "resource",
 		PriorState: cty.ObjectVal(map[string]cty.Value{
 			"attr": cty.StringVal("foo"),
@@ -677,7 +677,7 @@ func TestGRPCProvider_ApplyResourceChange(t *testing.T) {
 		Private: expectedPrivate,
 	}, nil)
 
-	resp := p.ApplyResourceChange(providers.ApplyResourceChangeRequest{
+	resp := p.ApplyResourceChange(nil, providers.ApplyResourceChangeRequest{
 		TypeName: "resource",
 		PriorState: cty.ObjectVal(map[string]cty.Value{
 			"attr": cty.StringVal("foo"),
@@ -723,7 +723,7 @@ func TestGRPCProvider_ApplyResourceChangeJSON(t *testing.T) {
 		Private: expectedPrivate,
 	}, nil)
 
-	resp := p.ApplyResourceChange(providers.ApplyResourceChangeRequest{
+	resp := p.ApplyResourceChange(nil, providers.ApplyResourceChangeRequest{
 		TypeName: "resource",
 		PriorState: cty.ObjectVal(map[string]cty.Value{
 			"attr": cty.StringVal("foo"),
@@ -854,7 +854,7 @@ func TestGRPCProvider_ReadDataSource(t *testing.T) {
 		},
 	}, nil)
 
-	resp := p.ReadDataSource(providers.ReadDataSourceRequest{
+	resp := p.ReadDataSource(nil, providers.ReadDataSourceRequest{
 		TypeName: "data",
 		Config: cty.ObjectVal(map[string]cty.Value{
 			"attr": cty.StringVal("foo"),
@@ -887,7 +887,7 @@ func TestGRPCProvider_ReadDataSourceJSON(t *testing.T) {
 		},
 	}, nil)
 
-	resp := p.ReadDataSource(providers.ReadDataSourceRequest{
+	resp := p.ReadDataSource(nil, providers.ReadDataSourceRequest{
 		TypeName: "data",
 		Config: cty.ObjectVal(map[string]cty.Value{
 			"attr": cty.StringVal("foo"),

--- a/internal/plugin6/telemetry.go
+++ b/internal/plugin6/telemetry.go
@@ -1,0 +1,12 @@
+package plugin6
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+var tracer trace.Tracer
+
+func init() {
+	tracer = otel.Tracer("github.com/opentofu/opentofu/internal/plugin6")
+}

--- a/internal/provider-simple-v6/main/main.go
+++ b/internal/provider-simple-v6/main/main.go
@@ -6,6 +6,8 @@
 package main
 
 import (
+	"context"
+
 	"github.com/opentofu/opentofu/internal/grpcwrap"
 	plugin "github.com/opentofu/opentofu/internal/plugin6"
 	simple "github.com/opentofu/opentofu/internal/provider-simple-v6"
@@ -15,7 +17,7 @@ import (
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
 		GRPCProviderFunc: func() tfplugin6.ProviderServer {
-			return grpcwrap.Provider6(simple.Provider())
+			return grpcwrap.Provider6(context.TODO(), simple.Provider())
 		},
 	})
 }

--- a/internal/provider-simple-v6/provider.go
+++ b/internal/provider-simple-v6/provider.go
@@ -7,14 +7,16 @@
 package simple
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
 
-	"github.com/opentofu/opentofu/internal/configs/configschema"
-	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
+
+	"github.com/opentofu/opentofu/internal/configs/configschema"
+	"github.com/opentofu/opentofu/internal/providers"
 )
 
 type simple struct {
@@ -55,11 +57,11 @@ func Provider() providers.Interface {
 	}
 }
 
-func (s simple) GetProviderSchema() providers.GetProviderSchemaResponse {
+func (s simple) GetProviderSchema(context.Context) providers.GetProviderSchemaResponse {
 	return s.schema
 }
 
-func (s simple) ValidateProviderConfig(req providers.ValidateProviderConfigRequest) (resp providers.ValidateProviderConfigResponse) {
+func (s simple) ValidateProviderConfig(ctx context.Context, req providers.ValidateProviderConfigRequest) (resp providers.ValidateProviderConfigResponse) {
 	return resp
 }
 
@@ -79,7 +81,7 @@ func (p simple) UpgradeResourceState(req providers.UpgradeResourceStateRequest) 
 	return resp
 }
 
-func (s simple) ConfigureProvider(providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
+func (s simple) ConfigureProvider(context.Context, providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 	return resp
 }
 
@@ -151,7 +153,7 @@ func (s simple) GetFunctions() providers.GetFunctionsResponse {
 	panic("Not Implemented")
 }
 
-func (s simple) CallFunction(r providers.CallFunctionRequest) providers.CallFunctionResponse {
+func (s simple) CallFunction(ctx context.Context, r providers.CallFunctionRequest) providers.CallFunctionResponse {
 	panic("Not Implemented")
 }
 

--- a/internal/provider-simple-v6/provider.go
+++ b/internal/provider-simple-v6/provider.go
@@ -65,15 +65,15 @@ func (s simple) ValidateProviderConfig(ctx context.Context, req providers.Valida
 	return resp
 }
 
-func (s simple) ValidateResourceConfig(req providers.ValidateResourceConfigRequest) (resp providers.ValidateResourceConfigResponse) {
+func (s simple) ValidateResourceConfig(ctx context.Context, req providers.ValidateResourceConfigRequest) (resp providers.ValidateResourceConfigResponse) {
 	return resp
 }
 
-func (s simple) ValidateDataResourceConfig(req providers.ValidateDataResourceConfigRequest) (resp providers.ValidateDataResourceConfigResponse) {
+func (s simple) ValidateDataResourceConfig(ctx context.Context, req providers.ValidateDataResourceConfigRequest) (resp providers.ValidateDataResourceConfigResponse) {
 	return resp
 }
 
-func (p simple) UpgradeResourceState(req providers.UpgradeResourceStateRequest) (resp providers.UpgradeResourceStateResponse) {
+func (p simple) UpgradeResourceState(ctx context.Context, req providers.UpgradeResourceStateRequest) (resp providers.UpgradeResourceStateResponse) {
 	ty := p.schema.ResourceTypes[req.TypeName].Block.ImpliedType()
 	val, err := ctyjson.Unmarshal(req.RawStateJSON, ty)
 	resp.Diagnostics = resp.Diagnostics.Append(err)
@@ -89,13 +89,13 @@ func (s simple) Stop() error {
 	return nil
 }
 
-func (s simple) ReadResource(req providers.ReadResourceRequest) (resp providers.ReadResourceResponse) {
+func (s simple) ReadResource(ctx context.Context, req providers.ReadResourceRequest) (resp providers.ReadResourceResponse) {
 	// just return the same state we received
 	resp.NewState = req.PriorState
 	return resp
 }
 
-func (s simple) PlanResourceChange(req providers.PlanResourceChangeRequest) (resp providers.PlanResourceChangeResponse) {
+func (s simple) PlanResourceChange(ctx context.Context, req providers.PlanResourceChangeRequest) (resp providers.PlanResourceChangeResponse) {
 	if req.ProposedNewState.IsNull() {
 		// destroy op
 		resp.PlannedState = req.ProposedNewState
@@ -116,7 +116,7 @@ func (s simple) PlanResourceChange(req providers.PlanResourceChangeRequest) (res
 	return resp
 }
 
-func (s simple) ApplyResourceChange(req providers.ApplyResourceChangeRequest) (resp providers.ApplyResourceChangeResponse) {
+func (s simple) ApplyResourceChange(ctx context.Context, req providers.ApplyResourceChangeRequest) (resp providers.ApplyResourceChangeResponse) {
 	if req.PlannedState.IsNull() {
 		// make sure this was transferred from the plan action
 		if string(req.PlannedPrivate) != "destroy planned" {
@@ -142,7 +142,7 @@ func (s simple) ImportResourceState(providers.ImportResourceStateRequest) (resp 
 	return resp
 }
 
-func (s simple) ReadDataSource(req providers.ReadDataSourceRequest) (resp providers.ReadDataSourceResponse) {
+func (s simple) ReadDataSource(ctx context.Context, req providers.ReadDataSourceRequest) (resp providers.ReadDataSourceResponse) {
 	m := req.Config.AsValueMap()
 	m["id"] = cty.StringVal("static_id")
 	resp.State = cty.ObjectVal(m)

--- a/internal/provider-simple/main/main.go
+++ b/internal/provider-simple/main/main.go
@@ -6,6 +6,8 @@
 package main
 
 import (
+	"context"
+
 	"github.com/opentofu/opentofu/internal/grpcwrap"
 	"github.com/opentofu/opentofu/internal/plugin"
 	simple "github.com/opentofu/opentofu/internal/provider-simple"
@@ -15,7 +17,7 @@ import (
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
 		GRPCProviderFunc: func() tfplugin5.ProviderServer {
-			return grpcwrap.Provider(simple.Provider())
+			return grpcwrap.Provider(context.TODO(), simple.Provider())
 		},
 	})
 }

--- a/internal/provider-simple/provider.go
+++ b/internal/provider-simple/provider.go
@@ -7,13 +7,15 @@
 package simple
 
 import (
+	"context"
 	"errors"
 	"time"
 
-	"github.com/opentofu/opentofu/internal/configs/configschema"
-	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
+
+	"github.com/opentofu/opentofu/internal/configs/configschema"
+	"github.com/opentofu/opentofu/internal/providers"
 )
 
 type simple struct {
@@ -54,11 +56,11 @@ func Provider() providers.Interface {
 	}
 }
 
-func (s simple) GetProviderSchema() providers.GetProviderSchemaResponse {
+func (s simple) GetProviderSchema(context.Context) providers.GetProviderSchemaResponse {
 	return s.schema
 }
 
-func (s simple) ValidateProviderConfig(req providers.ValidateProviderConfigRequest) (resp providers.ValidateProviderConfigResponse) {
+func (s simple) ValidateProviderConfig(ctx context.Context, req providers.ValidateProviderConfigRequest) (resp providers.ValidateProviderConfigResponse) {
 	return resp
 }
 
@@ -78,7 +80,7 @@ func (p simple) UpgradeResourceState(req providers.UpgradeResourceStateRequest) 
 	return resp
 }
 
-func (s simple) ConfigureProvider(providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
+func (s simple) ConfigureProvider(context.Context, providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 	return resp
 }
 
@@ -142,7 +144,7 @@ func (s simple) GetFunctions() providers.GetFunctionsResponse {
 	panic("Not Implemented")
 }
 
-func (s simple) CallFunction(r providers.CallFunctionRequest) providers.CallFunctionResponse {
+func (s simple) CallFunction(ctx context.Context, r providers.CallFunctionRequest) providers.CallFunctionResponse {
 	panic("Not Implemented")
 }
 

--- a/internal/provider-simple/provider.go
+++ b/internal/provider-simple/provider.go
@@ -64,15 +64,15 @@ func (s simple) ValidateProviderConfig(ctx context.Context, req providers.Valida
 	return resp
 }
 
-func (s simple) ValidateResourceConfig(req providers.ValidateResourceConfigRequest) (resp providers.ValidateResourceConfigResponse) {
+func (s simple) ValidateResourceConfig(ctx context.Context, req providers.ValidateResourceConfigRequest) (resp providers.ValidateResourceConfigResponse) {
 	return resp
 }
 
-func (s simple) ValidateDataResourceConfig(req providers.ValidateDataResourceConfigRequest) (resp providers.ValidateDataResourceConfigResponse) {
+func (s simple) ValidateDataResourceConfig(ctx context.Context, req providers.ValidateDataResourceConfigRequest) (resp providers.ValidateDataResourceConfigResponse) {
 	return resp
 }
 
-func (p simple) UpgradeResourceState(req providers.UpgradeResourceStateRequest) (resp providers.UpgradeResourceStateResponse) {
+func (p simple) UpgradeResourceState(ctx context.Context, req providers.UpgradeResourceStateRequest) (resp providers.UpgradeResourceStateResponse) {
 	ty := p.schema.ResourceTypes[req.TypeName].Block.ImpliedType()
 	val, err := ctyjson.Unmarshal(req.RawStateJSON, ty)
 	resp.Diagnostics = resp.Diagnostics.Append(err)
@@ -88,13 +88,13 @@ func (s simple) Stop() error {
 	return nil
 }
 
-func (s simple) ReadResource(req providers.ReadResourceRequest) (resp providers.ReadResourceResponse) {
+func (s simple) ReadResource(ctx context.Context, req providers.ReadResourceRequest) (resp providers.ReadResourceResponse) {
 	// just return the same state we received
 	resp.NewState = req.PriorState
 	return resp
 }
 
-func (s simple) PlanResourceChange(req providers.PlanResourceChangeRequest) (resp providers.PlanResourceChangeResponse) {
+func (s simple) PlanResourceChange(ctx context.Context, req providers.PlanResourceChangeRequest) (resp providers.PlanResourceChangeResponse) {
 	if req.ProposedNewState.IsNull() {
 		// destroy op
 		resp.PlannedState = req.ProposedNewState
@@ -112,7 +112,7 @@ func (s simple) PlanResourceChange(req providers.PlanResourceChangeRequest) (res
 	return resp
 }
 
-func (s simple) ApplyResourceChange(req providers.ApplyResourceChangeRequest) (resp providers.ApplyResourceChangeResponse) {
+func (s simple) ApplyResourceChange(ctx context.Context, req providers.ApplyResourceChangeRequest) (resp providers.ApplyResourceChangeResponse) {
 	if req.PlannedState.IsNull() {
 		resp.NewState = req.PlannedState
 		return resp
@@ -133,7 +133,7 @@ func (s simple) ImportResourceState(providers.ImportResourceStateRequest) (resp 
 	return resp
 }
 
-func (s simple) ReadDataSource(req providers.ReadDataSourceRequest) (resp providers.ReadDataSourceResponse) {
+func (s simple) ReadDataSource(ctx context.Context, req providers.ReadDataSourceRequest) (resp providers.ReadDataSourceResponse) {
 	m := req.Config.AsValueMap()
 	m["id"] = cty.StringVal("static_id")
 	resp.State = cty.ObjectVal(m)

--- a/internal/providercache/cached_provider.go
+++ b/internal/providercache/cached_provider.go
@@ -6,10 +6,13 @@
 package providercache
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/getproviders"
@@ -105,7 +108,11 @@ func (cp *CachedProvider) HashV1() (getproviders.Hash, error) {
 // so that the results are consistent between platforms. Windows accepts both
 // slashes and backslashes as long as the separators are consistent within a
 // particular path string.
-func (cp *CachedProvider) ExecutableFile() (string, error) {
+func (cp *CachedProvider) ExecutableFile(ctx context.Context) (string, error) {
+	var span trace.Span
+	ctx, span = tracer.Start(ctx, "CachedProvider.ExecutableFile")
+	defer span.End()
+
 	infos, err := os.ReadDir(cp.PackageDir)
 	if err != nil {
 		// If the directory itself doesn't exist or isn't readable then we

--- a/internal/providercache/dir_modify.go
+++ b/internal/providercache/dir_modify.go
@@ -11,6 +11,7 @@ import (
 	"log"
 
 	"github.com/opentofu/opentofu/internal/getproviders"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // InstallPackage takes a metadata object describing a package available for
@@ -22,6 +23,10 @@ import (
 // hashes match then the returned error message assumes that the hashes came
 // from a lock file.
 func (d *Dir) InstallPackage(ctx context.Context, meta getproviders.PackageMeta, allowedHashes []getproviders.Hash) (*getproviders.PackageAuthenticationResult, error) {
+	var span trace.Span
+	ctx, span = tracer.Start(ctx, "install package")
+	defer span.End()
+
 	if meta.TargetPlatform != d.targetPlatform {
 		return nil, fmt.Errorf("can't install %s package into cache directory expecting %s", meta.TargetPlatform, d.targetPlatform)
 	}

--- a/internal/providercache/installer.go
+++ b/internal/providercache/installer.go
@@ -468,7 +468,7 @@ NeedProvider:
 					if cb := evts.LinkFromCacheBegin; cb != nil {
 						cb(provider, version, i.globalCacheDir.baseDir)
 					}
-					if _, err := cached.ExecutableFile(); err != nil {
+					if _, err := cached.ExecutableFile(ctx); err != nil {
 						err := fmt.Errorf("provider binary not found: %w", err)
 						errs[provider] = err
 						if cb := evts.LinkFromCacheFailure; cb != nil {
@@ -625,7 +625,7 @@ NeedProvider:
 			providerSpan.End()
 			continue
 		}
-		if _, err := new.ExecutableFile(); err != nil {
+		if _, err := new.ExecutableFile(ctx); err != nil {
 			err := fmt.Errorf("provider binary not found: %w", err)
 			errs[provider] = err
 			if cb := evts.FetchPackageFailure; cb != nil {
@@ -665,7 +665,7 @@ NeedProvider:
 				providerSpan.End()
 				continue
 			}
-			if _, err := new.ExecutableFile(); err != nil {
+			if _, err := new.ExecutableFile(ctx); err != nil {
 				err := fmt.Errorf("provider binary not found: %w", err)
 				errs[provider] = err
 				if cb := evts.FetchPackageFailure; cb != nil {

--- a/internal/providercache/telemetry.go
+++ b/internal/providercache/telemetry.go
@@ -1,1 +1,17 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package providercache
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+var tracer trace.Tracer
+
+func init() {
+	tracer = otel.Tracer("github.com/opentofu/opentofu/internal/providercache")
+}

--- a/internal/providercache/telemetry.go
+++ b/internal/providercache/telemetry.go
@@ -1,0 +1,1 @@
+package providercache

--- a/internal/providers/factory.go
+++ b/internal/providers/factory.go
@@ -5,9 +5,11 @@
 
 package providers
 
+import "context"
+
 // Factory is a function type that creates a new instance of a resource
 // provider, or returns an error if that is impossible.
-type Factory func() (Interface, error)
+type Factory func(ctx context.Context) (Interface, error)
 
 // FactoryFixed is a helper that creates a Factory that just returns some given
 // single provider.
@@ -18,7 +20,7 @@ type Factory func() (Interface, error)
 // or to mutate it in ways that will not cause unexpected behavior for others
 // holding the same reference.
 func FactoryFixed(p Interface) Factory {
-	return func() (Interface, error) {
+	return func(ctx context.Context) (Interface, error) {
 		return p, nil
 	}
 }

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -6,6 +6,8 @@
 package providers
 
 import (
+	"context"
+
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/configs/configschema"
@@ -21,14 +23,14 @@ type Interface interface {
 	// for initial validation.  This could result in some potential
 	// memory savings.
 
-	// GetSchema returns the complete schema for the provider.
-	GetProviderSchema() GetProviderSchemaResponse
+	// GetProviderSchema returns the complete schema for the provider.
+	GetProviderSchema(traceCtx context.Context) GetProviderSchemaResponse
 
 	// ValidateProviderConfig allows the provider to validate the configuration.
 	// The ValidateProviderConfigResponse.PreparedConfig field is unused. The
 	// final configuration is not stored in the state, and any modifications
 	// that need to be made must be made during the Configure method call.
-	ValidateProviderConfig(ValidateProviderConfigRequest) ValidateProviderConfigResponse
+	ValidateProviderConfig(context.Context, ValidateProviderConfigRequest) ValidateProviderConfigResponse
 
 	// ValidateResourceConfig allows the provider to validate the resource
 	// configuration values.
@@ -44,8 +46,8 @@ type Interface interface {
 	// result is used for any further processing.
 	UpgradeResourceState(UpgradeResourceStateRequest) UpgradeResourceStateResponse
 
-	// Configure configures and initialized the provider.
-	ConfigureProvider(ConfigureProviderRequest) ConfigureProviderResponse
+	// ConfigureProvider configures and initialized the provider.
+	ConfigureProvider(context.Context, ConfigureProviderRequest) ConfigureProviderResponse
 
 	// Stop is called when the provider should halt any in-flight actions.
 	//
@@ -82,7 +84,7 @@ type Interface interface {
 	GetFunctions() GetFunctionsResponse
 
 	// CallFunction requests that the given function is called and response returned.
-	CallFunction(CallFunctionRequest) CallFunctionResponse
+	CallFunction(context.Context, CallFunctionRequest) CallFunctionResponse
 
 	// Close shuts down the plugin process if applicable.
 	Close() error

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -34,17 +34,17 @@ type Interface interface {
 
 	// ValidateResourceConfig allows the provider to validate the resource
 	// configuration values.
-	ValidateResourceConfig(ValidateResourceConfigRequest) ValidateResourceConfigResponse
+	ValidateResourceConfig(context.Context, ValidateResourceConfigRequest) ValidateResourceConfigResponse
 
 	// ValidateDataResourceConfig allows the provider to validate the data source
 	// configuration values.
-	ValidateDataResourceConfig(ValidateDataResourceConfigRequest) ValidateDataResourceConfigResponse
+	ValidateDataResourceConfig(context.Context, ValidateDataResourceConfigRequest) ValidateDataResourceConfigResponse
 
 	// UpgradeResourceState is called when the state loader encounters an
 	// instance state whose schema version is less than the one reported by the
 	// currently-used version of the corresponding provider, and the upgraded
 	// result is used for any further processing.
-	UpgradeResourceState(UpgradeResourceStateRequest) UpgradeResourceStateResponse
+	UpgradeResourceState(context.Context, UpgradeResourceStateRequest) UpgradeResourceStateResponse
 
 	// ConfigureProvider configures and initialized the provider.
 	ConfigureProvider(context.Context, ConfigureProviderRequest) ConfigureProviderResponse
@@ -62,22 +62,22 @@ type Interface interface {
 	Stop() error
 
 	// ReadResource refreshes a resource and returns its current state.
-	ReadResource(ReadResourceRequest) ReadResourceResponse
+	ReadResource(context.Context, ReadResourceRequest) ReadResourceResponse
 
 	// PlanResourceChange takes the current state and proposed state of a
 	// resource, and returns the planned final state.
-	PlanResourceChange(PlanResourceChangeRequest) PlanResourceChangeResponse
+	PlanResourceChange(context.Context, PlanResourceChangeRequest) PlanResourceChangeResponse
 
 	// ApplyResourceChange takes the planned state for a resource, which may
 	// yet contain unknown computed values, and applies the changes returning
 	// the final state.
-	ApplyResourceChange(ApplyResourceChangeRequest) ApplyResourceChangeResponse
+	ApplyResourceChange(context.Context, ApplyResourceChangeRequest) ApplyResourceChangeResponse
 
 	// ImportResourceState requests that the given resource be imported.
 	ImportResourceState(ImportResourceStateRequest) ImportResourceStateResponse
 
 	// ReadDataSource returns the data source's current state.
-	ReadDataSource(ReadDataSourceRequest) ReadDataSourceResponse
+	ReadDataSource(context.Context, ReadDataSourceRequest) ReadDataSourceResponse
 
 	// GetFunctions returns a full list of functions defined in this provider.  It should be a super
 	// set of the functions returned in GetProviderSchema()

--- a/internal/tofu/context.go
+++ b/internal/tofu/context.go
@@ -12,6 +12,8 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/encryption"
@@ -20,7 +22,6 @@ import (
 	"github.com/opentofu/opentofu/internal/provisioners"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // InputMode defines what sort of input will be asked for when Input
@@ -153,10 +154,10 @@ func NewContext(opts *ContextOpts) (*Context, tfdiags.Diagnostics) {
 	}, diags
 }
 
-func (c *Context) Schemas(config *configs.Config, state *states.State) (*Schemas, tfdiags.Diagnostics) {
+func (c *Context) Schemas(ctx context.Context, config *configs.Config, state *states.State) (*Schemas, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	ret, err := loadSchemas(config, state, c.plugins)
+	ret, err := loadSchemas(ctx, config, state, c.plugins)
 	if err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,

--- a/internal/tofu/context_apply.go
+++ b/internal/tofu/context_apply.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -26,7 +27,7 @@ import (
 //
 // Even if the returned diagnostics contains errors, Apply always returns the
 // resulting state which is likely to have been partially-updated.
-func (c *Context) Apply(plan *plans.Plan, config *configs.Config) (*states.State, tfdiags.Diagnostics) {
+func (c *Context) Apply(ctx context.Context, plan *plans.Plan, config *configs.Config) (*states.State, tfdiags.Diagnostics) {
 	defer c.acquireRun("apply")()
 
 	log.Printf("[DEBUG] Building and walking apply graph for %s plan", plan.UIMode)
@@ -60,7 +61,7 @@ func (c *Context) Apply(plan *plans.Plan, config *configs.Config) (*states.State
 	}
 
 	workingState := plan.PriorState.DeepCopy()
-	walker, walkDiags := c.walk(graph, operation, &graphWalkOpts{
+	walker, walkDiags := c.walk(ctx, graph, operation, &graphWalkOpts{
 		Config:     config,
 		InputState: workingState,
 		Changes:    plan.Changes,

--- a/internal/tofu/context_eval.go
+++ b/internal/tofu/context_eval.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"log"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -37,7 +38,7 @@ type EvalOpts struct {
 // the returned scope may be nil. If it is not nil then it may still be used
 // to attempt expression evaluation or other analysis, but some expressions
 // may not behave as expected.
-func (c *Context) Eval(config *configs.Config, state *states.State, moduleAddr addrs.ModuleInstance, opts *EvalOpts) (*lang.Scope, tfdiags.Diagnostics) {
+func (c *Context) Eval(ctx context.Context, config *configs.Config, state *states.State, moduleAddr addrs.ModuleInstance, opts *EvalOpts) (*lang.Scope, tfdiags.Diagnostics) {
 	// This is intended for external callers such as the "tofu console"
 	// command. Internally, we create an evaluator in c.walk before walking
 	// the graph, and create scopes in ContextGraphWalker.
@@ -80,7 +81,7 @@ func (c *Context) Eval(config *configs.Config, state *states.State, moduleAddr a
 		Config:     config,
 	}
 
-	walker, moreDiags = c.walk(graph, walkEval, walkOpts)
+	walker, moreDiags = c.walk(ctx, graph, walkEval, walkOpts)
 	diags = diags.Append(moreDiags)
 	if walker != nil {
 		diags = diags.Append(walker.NonFatalDiagnostics)
@@ -97,5 +98,5 @@ func (c *Context) Eval(config *configs.Config, state *states.State, moduleAddr a
 	// caches its contexts, so we should get hold of the context that was
 	// previously used for evaluation here, unless we skipped walking.
 	evalCtx := walker.EnterPath(moduleAddr)
-	return evalCtx.EvaluationScope(nil, nil, EvalDataForNoInstanceKey), diags
+	return evalCtx.EvaluationScope(nil, nil, nil, EvalDataForNoInstanceKey), diags
 }

--- a/internal/tofu/context_functions.go
+++ b/internal/tofu/context_functions.go
@@ -147,7 +147,8 @@ func providerFunction(ctx context.Context, name string, spec providers.FunctionS
 	}
 
 	impl := func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-		// TODO: Nicely propagate the ctx, dont grab it from the parent function
+		// TODO: Nicely pass the the ctx into this function call, don't grab it from the parent function
+		// this causes separated traces right now but we're backed into a corner with the impl type coming from go-cty
 		resp := provider.CallFunction(ctx, providers.CallFunctionRequest{
 			Name:      name,
 			Arguments: args,

--- a/internal/tofu/context_functions.go
+++ b/internal/tofu/context_functions.go
@@ -1,22 +1,29 @@
 package tofu
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
-	"github.com/zclconf/go-cty/cty/function"
 )
 
 // This builds a provider function using an EvalContext and some additional information
 // This is split out of BuiltinEvalContext for testing
-func evalContextProviderFunction(ctx EvalContext, mc *configs.Config, op walkOperation, pf addrs.ProviderFunction, rng tfdiags.SourceRange) (*function.Function, tfdiags.Diagnostics) {
+func evalContextProviderFunction(traceCtx context.Context, ctx EvalContext, mc *configs.Config, op walkOperation, pf addrs.ProviderFunction, rng tfdiags.SourceRange) (*function.Function, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
+
+	var span trace.Span
+	traceCtx, span = tracer.Start(traceCtx, "evalContextProviderFunction")
+	defer span.End()
 
 	pr, ok := mc.Module.ProviderRequirements.RequiredProviders[pf.ProviderName]
 	if !ok {
@@ -72,7 +79,7 @@ func evalContextProviderFunction(ctx EvalContext, mc *configs.Config, op walkOpe
 	}
 
 	// First try to look up the function from provider schema
-	schema := provider.GetProviderSchema()
+	schema := provider.GetProviderSchema(traceCtx)
 	if schema.Diagnostics.HasErrors() {
 		return nil, schema.Diagnostics
 	}
@@ -118,7 +125,7 @@ func evalContextProviderFunction(ctx EvalContext, mc *configs.Config, op walkOpe
 		}
 	}
 
-	fn := providerFunction(pf.Function, spec, provider)
+	fn := providerFunction(traceCtx, pf.Function, spec, provider)
 
 	return &fn, nil
 
@@ -127,7 +134,7 @@ func evalContextProviderFunction(ctx EvalContext, mc *configs.Config, op walkOpe
 // Turn a provider function spec into a cty callable function
 // This will use the instance factory to get a provider to support the
 // function call.
-func providerFunction(name string, spec providers.FunctionSpec, provider providers.Interface) function.Function {
+func providerFunction(ctx context.Context, name string, spec providers.FunctionSpec, provider providers.Interface) function.Function {
 	params := make([]function.Parameter, len(spec.Parameters))
 	for i, param := range spec.Parameters {
 		params[i] = providerFunctionParameter(param)
@@ -140,7 +147,8 @@ func providerFunction(name string, spec providers.FunctionSpec, provider provide
 	}
 
 	impl := func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-		resp := provider.CallFunction(providers.CallFunctionRequest{
+		// TODO: Nicely propagate the ctx, dont grab it from the parent function
+		resp := provider.CallFunction(ctx, providers.CallFunctionRequest{
 			Name:      name,
 			Arguments: args,
 		})

--- a/internal/tofu/context_import.go
+++ b/internal/tofu/context_import.go
@@ -6,11 +6,13 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"sync"
 
 	"github.com/hashicorp/hcl/v2"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/instances"
@@ -235,7 +237,7 @@ func (ri *ImportResolver) GetImport(address addrs.AbsResourceInstance) *Evaluate
 // Further, this operation also gracefully handles partial state. If during
 // an import there is a failure, all previously imported resources remain
 // imported.
-func (c *Context) Import(config *configs.Config, prevRunState *states.State, opts *ImportOpts) (*states.State, tfdiags.Diagnostics) {
+func (c *Context) Import(ctx context.Context, config *configs.Config, prevRunState *states.State, opts *ImportOpts) (*states.State, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	// Hold a lock since we can modify our own state here
@@ -266,7 +268,7 @@ func (c *Context) Import(config *configs.Config, prevRunState *states.State, opt
 	}
 
 	// Walk it
-	walker, walkDiags := c.walk(graph, walkImport, &graphWalkOpts{
+	walker, walkDiags := c.walk(ctx, graph, walkImport, &graphWalkOpts{
 		Config:     config,
 		InputState: state,
 	})

--- a/internal/tofu/context_input.go
+++ b/internal/tofu/context_input.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/zclconf/go-cty/cty"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
@@ -46,6 +47,10 @@ func (c *Context) Input(ctx context.Context, config *configs.Config, mode InputM
 	// (Hopefully in future the remaining functionality here can move to the
 	// CLI layer too in order to avoid this odd situation where core code
 	// produces UI input prompts.)
+
+	var span trace.Span
+	ctx, span = tracer.Start(ctx, "Context.Input")
+	defer span.End()
 
 	var diags tfdiags.Diagnostics
 	defer c.acquireRun("input")()

--- a/internal/tofu/context_input.go
+++ b/internal/tofu/context_input.go
@@ -36,7 +36,7 @@ import (
 // any other Context method with a different config, because the aforementioned
 // modified internal state won't match. Again, this is an architectural wart
 // that we'll hopefully resolve in future.
-func (c *Context) Input(config *configs.Config, mode InputMode) tfdiags.Diagnostics {
+func (c *Context) Input(ctx context.Context, config *configs.Config, mode InputMode) tfdiags.Diagnostics {
 	// This function used to be responsible for more than it is now, so its
 	// interface is more general than its current functionality requires.
 	// It now exists only to handle interactive prompts for provider
@@ -50,7 +50,7 @@ func (c *Context) Input(config *configs.Config, mode InputMode) tfdiags.Diagnost
 	var diags tfdiags.Diagnostics
 	defer c.acquireRun("input")()
 
-	schemas, moreDiags := c.Schemas(config, nil)
+	schemas, moreDiags := c.Schemas(ctx, config, nil)
 	diags = diags.Append(moreDiags)
 	if moreDiags.HasErrors() {
 		return diags
@@ -60,8 +60,6 @@ func (c *Context) Input(config *configs.Config, mode InputMode) tfdiags.Diagnost
 		log.Printf("[TRACE] Context.Input: uiInput is nil, so skipping")
 		return diags
 	}
-
-	ctx := context.Background()
 
 	if mode&InputModeProvider != 0 {
 		log.Printf("[TRACE] Context.Input: Prompting for provider arguments")
@@ -165,7 +163,7 @@ func (c *Context) Input(config *configs.Config, mode InputMode) tfdiags.Diagnost
 				}
 
 				log.Printf("[TRACE] Context.Input: Prompting for %s argument %s", pa, key)
-				rawVal, err := input.Input(ctx, &InputOpts{
+				rawVal, err := input.Input(context.Background(), &InputOpts{
 					Id:          key,
 					Query:       key,
 					Description: attrS.Description,

--- a/internal/tofu/context_plugins.go
+++ b/internal/tofu/context_plugins.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -66,7 +67,7 @@ func (cp *contextPlugins) NewProvisionerInstance(typ string) (provisioners.Inter
 // ProviderSchema memoizes results by unique provider address, so it's fine
 // to repeatedly call this method with the same address if various different
 // parts of OpenTofu all need the same schema information.
-func (cp *contextPlugins) ProviderSchema(addr addrs.Provider) (providers.ProviderSchema, error) {
+func (cp *contextPlugins) ProviderSchema(ctx context.Context, addr addrs.Provider) (providers.ProviderSchema, error) {
 	// Check the global schema cache first.
 	// This cache is only written by the provider client, and transparently
 	// used by GetProviderSchema, but we check it here because at this point we
@@ -90,14 +91,14 @@ func (cp *contextPlugins) ProviderSchema(addr addrs.Provider) (providers.Provide
 	}
 	defer provider.Close()
 
-	resp := provider.GetProviderSchema()
+	resp := provider.GetProviderSchema(ctx)
 	if resp.Diagnostics.HasErrors() {
 		return resp, fmt.Errorf("failed to retrieve schema from provider %q: %w", addr, resp.Diagnostics.Err())
 	}
 
 	if resp.Provider.Version < 0 {
 		// We're not using the version numbers here yet, but we'll check
-		// for validity anyway in case we start using them in future.
+		// for validity anyway in case we start using them in the future.
 		return resp, fmt.Errorf("provider %s has invalid negative schema version for its configuration blocks,which is a bug in the provider ", addr)
 	}
 
@@ -128,8 +129,8 @@ func (cp *contextPlugins) ProviderSchema(addr addrs.Provider) (providers.Provide
 // reads the full schema of the given provider and then extracts just the
 // provider's configuration schema, which defines what's expected in a
 // "provider" block in the configuration when configuring this provider.
-func (cp *contextPlugins) ProviderConfigSchema(providerAddr addrs.Provider) (*configschema.Block, error) {
-	providerSchema, err := cp.ProviderSchema(providerAddr)
+func (cp *contextPlugins) ProviderConfigSchema(ctx context.Context, providerAddr addrs.Provider) (*configschema.Block, error) {
+	providerSchema, err := cp.ProviderSchema(ctx, providerAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +150,7 @@ func (cp *contextPlugins) ProviderConfigSchema(providerAddr addrs.Provider) (*co
 // is the current schema version number for the requested resource. The version
 // is irrelevant for other resource modes.
 func (cp *contextPlugins) ResourceTypeSchema(providerAddr addrs.Provider, resourceMode addrs.ResourceMode, resourceType string) (*configschema.Block, uint64, error) {
-	providerSchema, err := cp.ProviderSchema(providerAddr)
+	providerSchema, err := cp.ProviderSchema(context.TODO(), providerAddr)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/tofu/context_plugins.go
+++ b/internal/tofu/context_plugins.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"log"
 
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/providers"
@@ -37,13 +39,17 @@ func (cp *contextPlugins) HasProvider(addr addrs.Provider) bool {
 	return ok
 }
 
-func (cp *contextPlugins) NewProviderInstance(addr addrs.Provider) (providers.Interface, error) {
+func (cp *contextPlugins) NewProviderInstance(ctx context.Context, addr addrs.Provider) (providers.Interface, error) {
+	var span trace.Span
+	ctx, span = tracer.Start(ctx, "contextPlugins.NewProviderInstance")
+	defer span.End()
+
 	f, ok := cp.providerFactories[addr]
 	if !ok {
 		return nil, fmt.Errorf("unavailable provider %q", addr.String())
 	}
 
-	return f()
+	return f(ctx)
 
 }
 
@@ -68,6 +74,10 @@ func (cp *contextPlugins) NewProvisionerInstance(typ string) (provisioners.Inter
 // to repeatedly call this method with the same address if various different
 // parts of OpenTofu all need the same schema information.
 func (cp *contextPlugins) ProviderSchema(ctx context.Context, addr addrs.Provider) (providers.ProviderSchema, error) {
+	var span trace.Span
+	ctx, span = tracer.Start(ctx, "contextPlugins.ProviderSchema")
+	defer span.End()
+
 	// Check the global schema cache first.
 	// This cache is only written by the provider client, and transparently
 	// used by GetProviderSchema, but we check it here because at this point we
@@ -80,12 +90,13 @@ func (cp *contextPlugins) ProviderSchema(ctx context.Context, addr addrs.Provide
 	// BUG This SHORT CIRCUITS the logic below and is not the only code which inserts provider schemas into the cache!!
 	schemas, ok := providers.SchemaCache.Get(addr)
 	if ok {
+		span.AddEvent("Serving provider schema from global schema cache")
 		log.Printf("[TRACE] tofu.contextPlugins: Serving provider %q schema from global schema cache", addr)
 		return schemas, nil
 	}
 
 	log.Printf("[TRACE] tofu.contextPlugins: Initializing provider %q to read its schema", addr)
-	provider, err := cp.NewProviderInstance(addr)
+	provider, err := cp.NewProviderInstance(ctx, addr)
 	if err != nil {
 		return schemas, fmt.Errorf("failed to instantiate provider %q to obtain schema: %w", addr, err)
 	}
@@ -130,6 +141,10 @@ func (cp *contextPlugins) ProviderSchema(ctx context.Context, addr addrs.Provide
 // provider's configuration schema, which defines what's expected in a
 // "provider" block in the configuration when configuring this provider.
 func (cp *contextPlugins) ProviderConfigSchema(ctx context.Context, providerAddr addrs.Provider) (*configschema.Block, error) {
+	var span trace.Span
+	ctx, span = tracer.Start(ctx, "contextPlugins.ProviderConfigSchema")
+	defer span.End()
+
 	providerSchema, err := cp.ProviderSchema(ctx, providerAddr)
 	if err != nil {
 		return nil, err
@@ -149,8 +164,12 @@ func (cp *contextPlugins) ProviderConfigSchema(ctx context.Context, providerAddr
 // Managed resource types have versioned schemas, so the second return value
 // is the current schema version number for the requested resource. The version
 // is irrelevant for other resource modes.
-func (cp *contextPlugins) ResourceTypeSchema(providerAddr addrs.Provider, resourceMode addrs.ResourceMode, resourceType string) (*configschema.Block, uint64, error) {
-	providerSchema, err := cp.ProviderSchema(context.TODO(), providerAddr)
+func (cp *contextPlugins) ResourceTypeSchema(ctx context.Context, providerAddr addrs.Provider, resourceMode addrs.ResourceMode, resourceType string) (*configschema.Block, uint64, error) {
+	var span trace.Span
+	ctx, span = tracer.Start(ctx, "contextPlugins.ResourceTypeSchema")
+	defer span.End()
+
+	providerSchema, err := cp.ProviderSchema(ctx, providerAddr)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/tofu/context_plugins.go
+++ b/internal/tofu/context_plugins.go
@@ -74,9 +74,10 @@ func (cp *contextPlugins) NewProvisionerInstance(typ string) (provisioners.Inter
 // to repeatedly call this method with the same address if various different
 // parts of OpenTofu all need the same schema information.
 func (cp *contextPlugins) ProviderSchema(ctx context.Context, addr addrs.Provider) (providers.ProviderSchema, error) {
-	var span trace.Span
-	ctx, span = tracer.Start(ctx, "contextPlugins.ProviderSchema")
-	defer span.End()
+	// Commented this out as it's WAY too noisy
+	//var span trace.Span
+	//ctx, span = tracer.Start(ctx, "contextPlugins.ProviderSchema")
+	//defer span.End()
 
 	// Check the global schema cache first.
 	// This cache is only written by the provider client, and transparently
@@ -90,7 +91,7 @@ func (cp *contextPlugins) ProviderSchema(ctx context.Context, addr addrs.Provide
 	// BUG This SHORT CIRCUITS the logic below and is not the only code which inserts provider schemas into the cache!!
 	schemas, ok := providers.SchemaCache.Get(addr)
 	if ok {
-		span.AddEvent("Serving provider schema from global schema cache")
+		//span.AddEvent("Serving provider schema from global schema cache")
 		log.Printf("[TRACE] tofu.contextPlugins: Serving provider %q schema from global schema cache", addr)
 		return schemas, nil
 	}
@@ -141,9 +142,10 @@ func (cp *contextPlugins) ProviderSchema(ctx context.Context, addr addrs.Provide
 // provider's configuration schema, which defines what's expected in a
 // "provider" block in the configuration when configuring this provider.
 func (cp *contextPlugins) ProviderConfigSchema(ctx context.Context, providerAddr addrs.Provider) (*configschema.Block, error) {
-	var span trace.Span
-	ctx, span = tracer.Start(ctx, "contextPlugins.ProviderConfigSchema")
-	defer span.End()
+	// Commented out as it's WAY too noisy
+	//var span trace.Span
+	//ctx, span = tracer.Start(ctx, "contextPlugins.ProviderConfigSchema")
+	//defer span.End()
 
 	providerSchema, err := cp.ProviderSchema(ctx, providerAddr)
 	if err != nil {
@@ -165,9 +167,13 @@ func (cp *contextPlugins) ProviderConfigSchema(ctx context.Context, providerAddr
 // is the current schema version number for the requested resource. The version
 // is irrelevant for other resource modes.
 func (cp *contextPlugins) ResourceTypeSchema(ctx context.Context, providerAddr addrs.Provider, resourceMode addrs.ResourceMode, resourceType string) (*configschema.Block, uint64, error) {
-	var span trace.Span
-	ctx, span = tracer.Start(ctx, "contextPlugins.ResourceTypeSchema")
-	defer span.End()
+	if ctx == nil {
+		panic("JAMES2")
+	}
+	// commented out as it's WAY too noisy
+	//var span trace.Span
+	//ctx, span = tracer.Start(ctx, "contextPlugins.ResourceTypeSchema")
+	//defer span.End()
 
 	providerSchema, err := cp.ProviderSchema(ctx, providerAddr)
 	if err != nil {

--- a/internal/tofu/context_refresh.go
+++ b/internal/tofu/context_refresh.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"log"
 
 	"github.com/opentofu/opentofu/internal/configs"
@@ -21,7 +22,7 @@ import (
 // automation relying on the "tofu refresh" subcommand. The modern way
 // to get this effect is to create and then apply a plan in the refresh-only
 // mode.
-func (c *Context) Refresh(config *configs.Config, prevRunState *states.State, opts *PlanOpts) (*states.State, tfdiags.Diagnostics) {
+func (c *Context) Refresh(ctx context.Context, config *configs.Config, prevRunState *states.State, opts *PlanOpts) (*states.State, tfdiags.Diagnostics) {
 	if opts == nil {
 		// This fallback is only here for tests, not for real code.
 		opts = &PlanOpts{
@@ -33,7 +34,7 @@ func (c *Context) Refresh(config *configs.Config, prevRunState *states.State, op
 	}
 
 	log.Printf("[DEBUG] Refresh is really just plan now, so creating a %s plan", opts.Mode)
-	p, diags := c.Plan(config, prevRunState, opts)
+	p, diags := c.Plan(ctx, config, prevRunState, opts)
 	if diags.HasErrors() {
 		return nil, diags
 	}

--- a/internal/tofu/context_validate.go
+++ b/internal/tofu/context_validate.go
@@ -6,13 +6,15 @@
 package tofu
 
 import (
+	"context"
 	"log"
+
+	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // Validate performs semantic validation of a configuration, and returns
@@ -26,7 +28,7 @@ import (
 // such as root module input variables. However, the Plan function includes
 // all of the same checks as Validate, in addition to the other work it does
 // to consider the previous run state and the planning options.
-func (c *Context) Validate(config *configs.Config) tfdiags.Diagnostics {
+func (c *Context) Validate(ctx context.Context, config *configs.Config) tfdiags.Diagnostics {
 	defer c.acquireRun("validate")()
 
 	var diags tfdiags.Diagnostics
@@ -72,7 +74,7 @@ func (c *Context) Validate(config *configs.Config) tfdiags.Diagnostics {
 		return diags
 	}
 
-	walker, walkDiags := c.walk(graph, walkValidate, &graphWalkOpts{
+	walker, walkDiags := c.walk(ctx, graph, walkValidate, &graphWalkOpts{
 		Config: config,
 	})
 	diags = diags.Append(walker.NonFatalDiagnostics)

--- a/internal/tofu/context_walk.go
+++ b/internal/tofu/context_walk.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"log"
 	"time"
 
@@ -46,16 +47,16 @@ type graphWalkOpts struct {
 	MoveResults refactoring.MoveResults
 }
 
-func (c *Context) walk(graph *Graph, operation walkOperation, opts *graphWalkOpts) (*ContextGraphWalker, tfdiags.Diagnostics) {
+func (c *Context) walk(traceCtx context.Context, graph *Graph, operation walkOperation, opts *graphWalkOpts) (*ContextGraphWalker, tfdiags.Diagnostics) {
 	log.Printf("[DEBUG] Starting graph walk: %s", operation.String())
 
 	walker := c.graphWalker(operation, opts)
 
-	// Watch for a stop so we can call the provider Stop() API.
+	// Watch for a stop, so we can call the provider Stop() API.
 	watchStop, watchWait := c.watchStop(walker)
 
 	// Walk the real graph, this will block until it completes
-	diags := graph.Walk(walker)
+	diags := graph.Walk(traceCtx, walker)
 
 	// Close the channel so the watcher stops, and wait for it to return.
 	close(watchStop)

--- a/internal/tofu/eval_conditions.go
+++ b/internal/tofu/eval_conditions.go
@@ -104,7 +104,7 @@ func validateCheckRule(traceCtx context.Context, addr addrs.CheckRule, rule *con
 	}
 	scope := ctx.EvaluationScope(traceCtx, selfReference, sourceReference, keyData)
 
-	hclCtx, moreDiags := scope.EvalContext(refs)
+	hclCtx, moreDiags := scope.EvalContext(traceCtx, refs)
 	diags = diags.Append(moreDiags)
 
 	errorMessage, moreDiags := evalCheckErrorMessage(rule.ErrorMessage, hclCtx)

--- a/internal/tofu/eval_conditions.go
+++ b/internal/tofu/eval_conditions.go
@@ -101,7 +101,7 @@ func validateCheckRule(addr addrs.CheckRule, rule *configs.CheckRule, ctx EvalCo
 			panic(fmt.Sprintf("Invalid source reference type %t", addr.Container))
 		}
 	}
-	scope := ctx.EvaluationScope(selfReference, sourceReference, keyData)
+	scope := ctx.EvaluationScope(nil, selfReference, sourceReference, keyData)
 
 	hclCtx, moreDiags := scope.EvalContext(refs)
 	diags = diags.Append(moreDiags)

--- a/internal/tofu/eval_context.go
+++ b/internal/tofu/eval_context.go
@@ -6,7 +6,11 @@
 package tofu
 
 import (
+	"context"
+
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/checks"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
@@ -19,7 +23,6 @@ import (
 	"github.com/opentofu/opentofu/internal/refactoring"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // EvalContext is the interface that is given to eval nodes to execute.
@@ -60,7 +63,7 @@ type EvalContext interface {
 	//
 	// This method expects an _absolute_ provider configuration address, since
 	// resources in one module are able to use providers from other modules.
-	ProviderSchema(addrs.AbsProviderConfig) (providers.ProviderSchema, error)
+	ProviderSchema(context.Context, addrs.AbsProviderConfig) (providers.ProviderSchema, error)
 
 	// CloseProvider closes provider connections that aren't needed anymore.
 	//
@@ -75,7 +78,7 @@ type EvalContext interface {
 	//
 	// This method will panic if the module instance address of the given
 	// provider configuration does not match the Path() of the EvalContext.
-	ConfigureProvider(addrs.AbsProviderConfig, cty.Value) tfdiags.Diagnostics
+	ConfigureProvider(context.Context, addrs.AbsProviderConfig, cty.Value) tfdiags.Diagnostics
 
 	// ProviderInput and SetProviderInput are used to configure providers
 	// from user input.
@@ -122,7 +125,7 @@ type EvalContext interface {
 	// The "self" argument is optional. If given, it is the referenceable
 	// address that the name "self" should behave as an alias for when
 	// evaluating. Set this to nil if the "self" object should not be available.
-	EvaluateExpr(expr hcl.Expression, wantType cty.Type, self addrs.Referenceable) (cty.Value, tfdiags.Diagnostics)
+	EvaluateExpr(ctx context.Context, expr hcl.Expression, wantType cty.Type, self addrs.Referenceable) (cty.Value, tfdiags.Diagnostics)
 
 	// EvaluateReplaceTriggeredBy takes the raw reference expression from the
 	// config, and returns the evaluated *addrs.Reference along with a boolean
@@ -135,7 +138,7 @@ type EvalContext interface {
 
 	// EvaluationScope returns a scope that can be used to evaluate reference
 	// addresses in this context.
-	EvaluationScope(self addrs.Referenceable, source addrs.Referenceable, keyData InstanceKeyEvalData) *lang.Scope
+	EvaluationScope(ctx context.Context, self addrs.Referenceable, source addrs.Referenceable, keyData InstanceKeyEvalData) *lang.Scope
 
 	// SetRootModuleArgument defines the value for one variable of the root
 	// module. The caller must ensure that given value is a suitable

--- a/internal/tofu/eval_context.go
+++ b/internal/tofu/eval_context.go
@@ -47,7 +47,7 @@ type EvalContext interface {
 	// It is an error to initialize the same provider more than once. This
 	// method will panic if the module instance address of the given provider
 	// configuration does not match the Path() of the EvalContext.
-	InitProvider(addr addrs.AbsProviderConfig) (providers.Interface, error)
+	InitProvider(ctx context.Context, addr addrs.AbsProviderConfig) (providers.Interface, error)
 
 	// Provider gets the provider instance with the given address (already
 	// initialized) or returns nil if the provider isn't initialized.
@@ -117,7 +117,7 @@ type EvalContext interface {
 	// "dynamic" blocks replaced with zero or more static blocks. This can be
 	// used to extract correct source location information about attributes of
 	// the returned object value.
-	EvaluateBlock(body hcl.Body, schema *configschema.Block, self addrs.Referenceable, keyData InstanceKeyEvalData) (cty.Value, hcl.Body, tfdiags.Diagnostics)
+	EvaluateBlock(traceCtx context.Context, body hcl.Body, schema *configschema.Block, self addrs.Referenceable, keyData InstanceKeyEvalData) (cty.Value, hcl.Body, tfdiags.Diagnostics)
 
 	// EvaluateExpr takes the given HCL expression and evaluates it to produce
 	// a value.
@@ -130,11 +130,11 @@ type EvalContext interface {
 	// EvaluateReplaceTriggeredBy takes the raw reference expression from the
 	// config, and returns the evaluated *addrs.Reference along with a boolean
 	// indicating if that reference forces replacement.
-	EvaluateReplaceTriggeredBy(expr hcl.Expression, repData instances.RepetitionData) (*addrs.Reference, bool, tfdiags.Diagnostics)
+	EvaluateReplaceTriggeredBy(ctx context.Context, expr hcl.Expression, repData instances.RepetitionData) (*addrs.Reference, bool, tfdiags.Diagnostics)
 
 	// EvaluateImportAddress takes the raw reference expression of the import address
 	// from the config, and returns the evaluated address addrs.AbsResourceInstance
-	EvaluateImportAddress(expr hcl.Expression, keyData instances.RepetitionData) (addrs.AbsResourceInstance, tfdiags.Diagnostics)
+	EvaluateImportAddress(traceCtx context.Context, expr hcl.Expression, keyData instances.RepetitionData) (addrs.AbsResourceInstance, tfdiags.Diagnostics)
 
 	// EvaluationScope returns a scope that can be used to evaluate reference
 	// addresses in this context.

--- a/internal/tofu/eval_context_builtin.go
+++ b/internal/tofu/eval_context_builtin.go
@@ -130,7 +130,7 @@ func (ctx *BuiltinEvalContext) Input() UIInput {
 	return ctx.InputValue
 }
 
-func (ctx *BuiltinEvalContext) InitProvider(addr addrs.AbsProviderConfig) (providers.Interface, error) {
+func (ctx *BuiltinEvalContext) InitProvider(traceCtx context.Context, addr addrs.AbsProviderConfig) (providers.Interface, error) {
 	ctx.ProviderLock.Lock()
 	defer ctx.ProviderLock.Unlock()
 
@@ -141,7 +141,7 @@ func (ctx *BuiltinEvalContext) InitProvider(addr addrs.AbsProviderConfig) (provi
 		return nil, fmt.Errorf("%s is already initialized", addr)
 	}
 
-	p, err := ctx.Plugins.NewProviderInstance(addr.Provider)
+	p, err := ctx.Plugins.NewProviderInstance(traceCtx, addr.Provider)
 	if err != nil {
 		return nil, err
 	}
@@ -159,8 +159,12 @@ func (ctx *BuiltinEvalContext) Provider(addr addrs.AbsProviderConfig) providers.
 	return ctx.ProviderCache[addr.String()]
 }
 
-func (ctx *BuiltinEvalContext) ProviderSchema(c context.Context, addr addrs.AbsProviderConfig) (providers.ProviderSchema, error) {
-	return ctx.Plugins.ProviderSchema(c, addr.Provider)
+func (ctx *BuiltinEvalContext) ProviderSchema(traceCtx context.Context, addr addrs.AbsProviderConfig) (providers.ProviderSchema, error) {
+	var span trace.Span
+	traceCtx, span = tracer.Start(traceCtx, "BuiltinEvalContext.ProviderSchema")
+	defer span.End()
+
+	return ctx.Plugins.ProviderSchema(traceCtx, addr.Provider)
 }
 
 func (ctx *BuiltinEvalContext) CloseProvider(addr addrs.AbsProviderConfig) error {
@@ -269,9 +273,9 @@ func (ctx *BuiltinEvalContext) CloseProvisioners() error {
 	return diags.Err()
 }
 
-func (ctx *BuiltinEvalContext) EvaluateBlock(body hcl.Body, schema *configschema.Block, self addrs.Referenceable, keyData InstanceKeyEvalData) (cty.Value, hcl.Body, tfdiags.Diagnostics) {
+func (ctx *BuiltinEvalContext) EvaluateBlock(traceCtx context.Context, body hcl.Body, schema *configschema.Block, self addrs.Referenceable, keyData InstanceKeyEvalData) (cty.Value, hcl.Body, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	scope := ctx.EvaluationScope(nil, self, nil, keyData)
+	scope := ctx.EvaluationScope(traceCtx, self, nil, keyData)
 	body, evalDiags := scope.ExpandBlock(body, schema)
 	diags = diags.Append(evalDiags)
 	val, evalDiags := scope.EvalBlock(body, schema)
@@ -288,8 +292,7 @@ func (ctx *BuiltinEvalContext) EvaluateExpr(traceCtx context.Context, expr hcl.E
 	return scope.EvalExpr(expr, wantType)
 }
 
-func (ctx *BuiltinEvalContext) EvaluateReplaceTriggeredBy(expr hcl.Expression, repData instances.RepetitionData) (*addrs.Reference, bool, tfdiags.Diagnostics) {
-
+func (ctx *BuiltinEvalContext) EvaluateReplaceTriggeredBy(traceCtx context.Context, expr hcl.Expression, repData instances.RepetitionData) (*addrs.Reference, bool, tfdiags.Diagnostics) {
 	// get the reference to lookup changes in the plan
 	ref, diags := evalReplaceTriggeredByExpr(expr, repData)
 	if diags.HasErrors() {
@@ -366,7 +369,7 @@ func (ctx *BuiltinEvalContext) EvaluateReplaceTriggeredBy(expr hcl.Expression, r
 	// Since we have a traversal after the resource reference, we will need to
 	// decode the changes, which means we need a schema.
 	providerAddr := change.ProviderAddr
-	schema, err := ctx.ProviderSchema(context.TODO(), providerAddr)
+	schema, err := ctx.ProviderSchema(traceCtx, providerAddr)
 	if err != nil {
 		diags = diags.Append(err)
 		return nil, false, diags
@@ -409,8 +412,8 @@ func (ctx *BuiltinEvalContext) EvaluateReplaceTriggeredBy(expr hcl.Expression, r
 // in the indexes of expressions. If we encounter a hclsyntax.IndexExpr, we can evaluate the Key expression and create
 // an Index Traversal, adding it to the Traverser
 // TODO move this function into eval_import.go
-func (ctx *BuiltinEvalContext) EvaluateImportAddress(expr hcl.Expression, keyData instances.RepetitionData) (addrs.AbsResourceInstance, tfdiags.Diagnostics) {
-	traversal, diags := ctx.traversalForImportExpr(expr, keyData)
+func (ctx *BuiltinEvalContext) EvaluateImportAddress(traceCtx context.Context, expr hcl.Expression, keyData instances.RepetitionData) (addrs.AbsResourceInstance, tfdiags.Diagnostics) {
+	traversal, diags := ctx.traversalForImportExpr(traceCtx, expr, keyData)
 	if diags.HasErrors() {
 		return addrs.AbsResourceInstance{}, diags
 	}
@@ -418,18 +421,18 @@ func (ctx *BuiltinEvalContext) EvaluateImportAddress(expr hcl.Expression, keyDat
 	return addrs.ParseAbsResourceInstance(traversal)
 }
 
-func (ctx *BuiltinEvalContext) traversalForImportExpr(expr hcl.Expression, keyData instances.RepetitionData) (traversal hcl.Traversal, diags tfdiags.Diagnostics) {
+func (ctx *BuiltinEvalContext) traversalForImportExpr(traceCtx context.Context, expr hcl.Expression, keyData instances.RepetitionData) (traversal hcl.Traversal, diags tfdiags.Diagnostics) {
 	switch e := expr.(type) {
 	case *hclsyntax.IndexExpr:
-		t, d := ctx.traversalForImportExpr(e.Collection, keyData)
+		t, d := ctx.traversalForImportExpr(traceCtx, e.Collection, keyData)
 		diags = diags.Append(d)
 		traversal = append(traversal, t...)
 
-		tIndex, dIndex := ctx.parseImportIndexKeyExpr(e.Key, keyData)
+		tIndex, dIndex := ctx.parseImportIndexKeyExpr(traceCtx, e.Key, keyData)
 		diags = diags.Append(dIndex)
 		traversal = append(traversal, tIndex)
 	case *hclsyntax.RelativeTraversalExpr:
-		t, d := ctx.traversalForImportExpr(e.Source, keyData)
+		t, d := ctx.traversalForImportExpr(traceCtx, e.Source, keyData)
 		diags = diags.Append(d)
 		traversal = append(traversal, t...)
 		traversal = append(traversal, e.Traversal...)
@@ -451,13 +454,13 @@ func (ctx *BuiltinEvalContext) traversalForImportExpr(expr hcl.Expression, keyDa
 // import target address, into a traversal of type hcl.TraverseIndex.
 // After evaluation, the expression must be known, not null, not sensitive, and must be a string (for_each) or a number
 // (count)
-func (ctx *BuiltinEvalContext) parseImportIndexKeyExpr(expr hcl.Expression, keyData instances.RepetitionData) (hcl.TraverseIndex, tfdiags.Diagnostics) {
+func (ctx *BuiltinEvalContext) parseImportIndexKeyExpr(traceCtx context.Context, expr hcl.Expression, keyData instances.RepetitionData) (hcl.TraverseIndex, tfdiags.Diagnostics) {
 	idx := hcl.TraverseIndex{
 		SrcRange: expr.Range(),
 	}
 
 	// evaluate and take into consideration the for_each key (if exists)
-	val, diags := evaluateExprWithRepetitionData(ctx, expr, cty.DynamicPseudoType, keyData)
+	val, diags := evaluateExprWithRepetitionData(traceCtx, ctx, expr, cty.DynamicPseudoType, keyData)
 	if diags.HasErrors() {
 		return idx, diags
 	}
@@ -507,6 +510,10 @@ func (ctx *BuiltinEvalContext) parseImportIndexKeyExpr(expr hcl.Expression, keyD
 }
 
 func (ctx *BuiltinEvalContext) EvaluationScope(traceCtx context.Context, self addrs.Referenceable, source addrs.Referenceable, keyData InstanceKeyEvalData) *lang.Scope {
+	// TODO: REMOVE BEFORE MERGING
+	if traceCtx == nil {
+		panic("JAMES")
+	}
 	var span trace.Span
 	traceCtx, span = tracer.Start(traceCtx, "BuiltinEvalContext.EvaluationScope")
 	defer span.End()

--- a/internal/tofu/eval_context_builtin.go
+++ b/internal/tofu/eval_context_builtin.go
@@ -160,9 +160,10 @@ func (ctx *BuiltinEvalContext) Provider(addr addrs.AbsProviderConfig) providers.
 }
 
 func (ctx *BuiltinEvalContext) ProviderSchema(traceCtx context.Context, addr addrs.AbsProviderConfig) (providers.ProviderSchema, error) {
-	var span trace.Span
-	traceCtx, span = tracer.Start(traceCtx, "BuiltinEvalContext.ProviderSchema")
-	defer span.End()
+	// Commented this out as it's WAY too noisy
+	//var span trace.Span
+	//traceCtx, span = tracer.Start(traceCtx, "BuiltinEvalContext.ProviderSchema")
+	//defer span.End()
 
 	return ctx.Plugins.ProviderSchema(traceCtx, addr.Provider)
 }
@@ -276,9 +277,9 @@ func (ctx *BuiltinEvalContext) CloseProvisioners() error {
 func (ctx *BuiltinEvalContext) EvaluateBlock(traceCtx context.Context, body hcl.Body, schema *configschema.Block, self addrs.Referenceable, keyData InstanceKeyEvalData) (cty.Value, hcl.Body, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	scope := ctx.EvaluationScope(traceCtx, self, nil, keyData)
-	body, evalDiags := scope.ExpandBlock(body, schema)
+	body, evalDiags := scope.ExpandBlock(traceCtx, body, schema)
 	diags = diags.Append(evalDiags)
-	val, evalDiags := scope.EvalBlock(body, schema)
+	val, evalDiags := scope.EvalBlock(traceCtx, body, schema)
 	diags = diags.Append(evalDiags)
 	return val, body, diags
 }
@@ -289,7 +290,7 @@ func (ctx *BuiltinEvalContext) EvaluateExpr(traceCtx context.Context, expr hcl.E
 	defer span.End()
 
 	scope := ctx.EvaluationScope(traceCtx, self, nil, EvalDataForNoInstanceKey)
-	return scope.EvalExpr(expr, wantType)
+	return scope.EvalExpr(traceCtx, expr, wantType)
 }
 
 func (ctx *BuiltinEvalContext) EvaluateReplaceTriggeredBy(traceCtx context.Context, expr hcl.Expression, repData instances.RepetitionData) (*addrs.Reference, bool, tfdiags.Diagnostics) {

--- a/internal/tofu/eval_context_mock.go
+++ b/internal/tofu/eval_context_mock.go
@@ -6,8 +6,13 @@
 package tofu
 
 import (
+	"context"
+
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hcldec"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/checks"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
@@ -20,8 +25,6 @@ import (
 	"github.com/opentofu/opentofu/internal/refactoring"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
-	"github.com/zclconf/go-cty/cty/convert"
 )
 
 // MockEvalContext is a mock version of EvalContext that can be used
@@ -196,7 +199,7 @@ func (c *MockEvalContext) Provider(addr addrs.AbsProviderConfig) providers.Inter
 	return c.ProviderProvider
 }
 
-func (c *MockEvalContext) ProviderSchema(addr addrs.AbsProviderConfig) (providers.ProviderSchema, error) {
+func (c *MockEvalContext) ProviderSchema(_ context.Context, addr addrs.AbsProviderConfig) (providers.ProviderSchema, error) {
 	c.ProviderSchemaCalled = true
 	c.ProviderSchemaAddr = addr
 	return c.ProviderSchemaSchema, c.ProviderSchemaError
@@ -208,7 +211,7 @@ func (c *MockEvalContext) CloseProvider(addr addrs.AbsProviderConfig) error {
 	return nil
 }
 
-func (c *MockEvalContext) ConfigureProvider(addr addrs.AbsProviderConfig, cfg cty.Value) tfdiags.Diagnostics {
+func (c *MockEvalContext) ConfigureProvider(ctx context.Context, addr addrs.AbsProviderConfig, cfg cty.Value) tfdiags.Diagnostics {
 
 	c.ConfigureProviderCalled = true
 	c.ConfigureProviderAddr = addr
@@ -260,7 +263,7 @@ func (c *MockEvalContext) EvaluateBlock(body hcl.Body, schema *configschema.Bloc
 	return c.EvaluateBlockResult, c.EvaluateBlockExpandedBody, c.EvaluateBlockDiags
 }
 
-func (c *MockEvalContext) EvaluateExpr(expr hcl.Expression, wantType cty.Type, self addrs.Referenceable) (cty.Value, tfdiags.Diagnostics) {
+func (c *MockEvalContext) EvaluateExpr(ctx context.Context, expr hcl.Expression, wantType cty.Type, self addrs.Referenceable) (cty.Value, tfdiags.Diagnostics) {
 	c.EvaluateExprCalled = true
 	c.EvaluateExprExpr = expr
 	c.EvaluateExprWantType = wantType
@@ -332,7 +335,7 @@ func (c *MockEvalContext) installSimpleEval() {
 	}
 }
 
-func (c *MockEvalContext) EvaluationScope(self addrs.Referenceable, source addrs.Referenceable, keyData InstanceKeyEvalData) *lang.Scope {
+func (c *MockEvalContext) EvaluationScope(ctx context.Context, self addrs.Referenceable, source addrs.Referenceable, keyData InstanceKeyEvalData) *lang.Scope {
 	c.EvaluationScopeCalled = true
 	c.EvaluationScopeSelf = self
 	c.EvaluationScopeKeyData = keyData

--- a/internal/tofu/eval_context_mock.go
+++ b/internal/tofu/eval_context_mock.go
@@ -291,16 +291,16 @@ func (c *MockEvalContext) EvaluateImportAddress(traceCtx context.Context, expr h
 //
 // This function overwrites any existing functions installed in fields
 // EvaluateBlockResultFunc and EvaluateExprResultFunc.
-func (c *MockEvalContext) installSimpleEval() {
+func (c *MockEvalContext) installSimpleEval(ctx context.Context) {
 	c.EvaluateBlockResultFunc = func(body hcl.Body, schema *configschema.Block, self addrs.Referenceable, keyData InstanceKeyEvalData) (cty.Value, hcl.Body, tfdiags.Diagnostics) {
 		if scope := c.EvaluationScopeScope; scope != nil {
 			// Fully-functional codepath.
 			var diags tfdiags.Diagnostics
-			body, diags = scope.ExpandBlock(body, schema)
+			body, diags = scope.ExpandBlock(ctx, body, schema)
 			if diags.HasErrors() {
 				return cty.DynamicVal, body, diags
 			}
-			val, evalDiags := c.EvaluationScopeScope.EvalBlock(body, schema)
+			val, evalDiags := c.EvaluationScopeScope.EvalBlock(ctx, body, schema)
 			diags = diags.Append(evalDiags)
 			if evalDiags.HasErrors() {
 				return cty.DynamicVal, body, diags
@@ -315,7 +315,7 @@ func (c *MockEvalContext) installSimpleEval() {
 	c.EvaluateExprResultFunc = func(expr hcl.Expression, wantType cty.Type, self addrs.Referenceable) (cty.Value, tfdiags.Diagnostics) {
 		if scope := c.EvaluationScopeScope; scope != nil {
 			// Fully-functional codepath.
-			return scope.EvalExpr(expr, wantType)
+			return scope.EvalExpr(ctx, expr, wantType)
 		}
 
 		// Fallback codepath supporting constant values only.

--- a/internal/tofu/eval_context_mock.go
+++ b/internal/tofu/eval_context_mock.go
@@ -186,7 +186,7 @@ func (c *MockEvalContext) Input() UIInput {
 	return c.InputInput
 }
 
-func (c *MockEvalContext) InitProvider(addr addrs.AbsProviderConfig) (providers.Interface, error) {
+func (c *MockEvalContext) InitProvider(ctx context.Context, addr addrs.AbsProviderConfig) (providers.Interface, error) {
 	c.InitProviderCalled = true
 	c.InitProviderType = addr.String()
 	c.InitProviderAddr = addr
@@ -251,7 +251,7 @@ func (c *MockEvalContext) CloseProvisioners() error {
 	return nil
 }
 
-func (c *MockEvalContext) EvaluateBlock(body hcl.Body, schema *configschema.Block, self addrs.Referenceable, keyData InstanceKeyEvalData) (cty.Value, hcl.Body, tfdiags.Diagnostics) {
+func (c *MockEvalContext) EvaluateBlock(traceCtx context.Context, body hcl.Body, schema *configschema.Block, self addrs.Referenceable, keyData InstanceKeyEvalData) (cty.Value, hcl.Body, tfdiags.Diagnostics) {
 	c.EvaluateBlockCalled = true
 	c.EvaluateBlockBody = body
 	c.EvaluateBlockSchema = schema
@@ -274,11 +274,11 @@ func (c *MockEvalContext) EvaluateExpr(ctx context.Context, expr hcl.Expression,
 	return c.EvaluateExprResult, c.EvaluateExprDiags
 }
 
-func (c *MockEvalContext) EvaluateReplaceTriggeredBy(hcl.Expression, instances.RepetitionData) (*addrs.Reference, bool, tfdiags.Diagnostics) {
+func (c *MockEvalContext) EvaluateReplaceTriggeredBy(context.Context, hcl.Expression, instances.RepetitionData) (*addrs.Reference, bool, tfdiags.Diagnostics) {
 	return nil, false, nil
 }
 
-func (c *MockEvalContext) EvaluateImportAddress(expression hcl.Expression, keyData instances.RepetitionData) (addrs.AbsResourceInstance, tfdiags.Diagnostics) {
+func (c *MockEvalContext) EvaluateImportAddress(traceCtx context.Context, expr hcl.Expression, keyData instances.RepetitionData) (addrs.AbsResourceInstance, tfdiags.Diagnostics) {
 	return addrs.AbsResourceInstance{}, nil
 }
 

--- a/internal/tofu/eval_count.go
+++ b/internal/tofu/eval_count.go
@@ -9,9 +9,10 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
-	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
+
+	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
 // evaluateCountExpression is our standard mechanism for interpreting an
@@ -63,7 +64,7 @@ func evaluateCountExpressionValue(expr hcl.Expression, ctx EvalContext) (cty.Val
 		return nullCount, nil
 	}
 
-	countVal, countDiags := ctx.EvaluateExpr(expr, cty.Number, nil)
+	countVal, countDiags := ctx.EvaluateExpr(nil, expr, cty.Number, nil)
 	diags = diags.Append(countDiags)
 	if diags.HasErrors() {
 		return nullCount, diags

--- a/internal/tofu/eval_for_each.go
+++ b/internal/tofu/eval_for_each.go
@@ -52,7 +52,7 @@ func evaluateForEachExpressionValue(expr hcl.Expression, ctx EvalContext, allowU
 
 	refs, moreDiags := lang.ReferencesInExpr(addrs.ParseRef, expr)
 	diags = diags.Append(moreDiags)
-	scope := ctx.EvaluationScope(nil, nil, EvalDataForNoInstanceKey)
+	scope := ctx.EvaluationScope(nil, nil, nil, EvalDataForNoInstanceKey)
 	var hclCtx *hcl.EvalContext
 	if scope != nil {
 		hclCtx, moreDiags = scope.EvalContext(refs)

--- a/internal/tofu/eval_for_each.go
+++ b/internal/tofu/eval_for_each.go
@@ -56,7 +56,7 @@ func evaluateForEachExpressionValue(traceCtx context.Context, expr hcl.Expressio
 	scope := ctx.EvaluationScope(traceCtx, nil, nil, EvalDataForNoInstanceKey)
 	var hclCtx *hcl.EvalContext
 	if scope != nil {
-		hclCtx, moreDiags = scope.EvalContext(refs)
+		hclCtx, moreDiags = scope.EvalContext(traceCtx, refs)
 	} else {
 		// This shouldn't happen in real code, but it can unfortunately arise
 		// in unit tests due to incompletely-implemented mocks. :(

--- a/internal/tofu/eval_import.go
+++ b/internal/tofu/eval_import.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
@@ -17,7 +18,7 @@ import (
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
-func evaluateImportIdExpression(expr hcl.Expression, ctx EvalContext, keyData instances.RepetitionData) (string, tfdiags.Diagnostics) {
+func evaluateImportIdExpression(tracedCtx context.Context, expr hcl.Expression, ctx EvalContext, keyData instances.RepetitionData) (string, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	if expr == nil {
@@ -30,7 +31,7 @@ func evaluateImportIdExpression(expr hcl.Expression, ctx EvalContext, keyData in
 	}
 
 	// evaluate the import ID and take into consideration the for_each key (if exists)
-	importIdVal, evalDiags := evaluateExprWithRepetitionData(ctx, expr, cty.String, keyData)
+	importIdVal, evalDiags := evaluateExprWithRepetitionData(tracedCtx, ctx, expr, cty.String, keyData)
 	diags = diags.Append(evalDiags)
 
 	if importIdVal.IsNull() {
@@ -81,7 +82,7 @@ func evaluateImportIdExpression(expr hcl.Expression, ctx EvalContext, keyData in
 // it to produce a value, while taking into consideration any repetition key
 // (a single combination of each.key and each.value of a for_each argument)
 // that should be a part of the scope.
-func evaluateExprWithRepetitionData(ctx EvalContext, expr hcl.Expression, wantType cty.Type, keyData instances.RepetitionData) (cty.Value, tfdiags.Diagnostics) {
-	scope := ctx.EvaluationScope(nil, nil, nil, keyData)
+func evaluateExprWithRepetitionData(traceCtx context.Context, ctx EvalContext, expr hcl.Expression, wantType cty.Type, keyData instances.RepetitionData) (cty.Value, tfdiags.Diagnostics) {
+	scope := ctx.EvaluationScope(traceCtx, nil, nil, keyData)
 	return scope.EvalExpr(expr, wantType)
 }

--- a/internal/tofu/eval_import.go
+++ b/internal/tofu/eval_import.go
@@ -9,11 +9,12 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/gocty"
+
 	"github.com/opentofu/opentofu/internal/instances"
 	"github.com/opentofu/opentofu/internal/lang/marks"
 	"github.com/opentofu/opentofu/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
-	"github.com/zclconf/go-cty/cty/gocty"
 )
 
 func evaluateImportIdExpression(expr hcl.Expression, ctx EvalContext, keyData instances.RepetitionData) (string, tfdiags.Diagnostics) {
@@ -81,6 +82,6 @@ func evaluateImportIdExpression(expr hcl.Expression, ctx EvalContext, keyData in
 // (a single combination of each.key and each.value of a for_each argument)
 // that should be a part of the scope.
 func evaluateExprWithRepetitionData(ctx EvalContext, expr hcl.Expression, wantType cty.Type, keyData instances.RepetitionData) (cty.Value, tfdiags.Diagnostics) {
-	scope := ctx.EvaluationScope(nil, nil, keyData)
+	scope := ctx.EvaluationScope(nil, nil, nil, keyData)
 	return scope.EvalExpr(expr, wantType)
 }

--- a/internal/tofu/eval_import.go
+++ b/internal/tofu/eval_import.go
@@ -84,5 +84,5 @@ func evaluateImportIdExpression(tracedCtx context.Context, expr hcl.Expression, 
 // that should be a part of the scope.
 func evaluateExprWithRepetitionData(traceCtx context.Context, ctx EvalContext, expr hcl.Expression, wantType cty.Type, keyData instances.RepetitionData) (cty.Value, tfdiags.Diagnostics) {
 	scope := ctx.EvaluationScope(traceCtx, nil, nil, keyData)
-	return scope.EvalExpr(expr, wantType)
+	return scope.EvalExpr(traceCtx, expr, wantType)
 }

--- a/internal/tofu/eval_provider.go
+++ b/internal/tofu/eval_provider.go
@@ -46,7 +46,7 @@ func buildProviderConfig(ctx EvalContext, addr addrs.AbsProviderConfig, config *
 }
 
 // getProvider returns the providers.Interface and schema for a given provider.
-func getProvider(ctx EvalContext, addr addrs.AbsProviderConfig) (providers.Interface, providers.ProviderSchema, error) {
+func getProvider(traceCtx context.Context, ctx EvalContext, addr addrs.AbsProviderConfig) (providers.Interface, providers.ProviderSchema, error) {
 	if addr.Provider.Type == "" {
 		// Should never happen
 		panic("GetProvider used with uninitialized provider configuration address")
@@ -57,7 +57,7 @@ func getProvider(ctx EvalContext, addr addrs.AbsProviderConfig) (providers.Inter
 	}
 	// Not all callers require a schema, so we will leave checking for a nil
 	// schema to the callers.
-	schema, err := ctx.ProviderSchema(context.TODO(), addr)
+	schema, err := ctx.ProviderSchema(traceCtx, addr)
 	if err != nil {
 		return nil, providers.ProviderSchema{}, fmt.Errorf("failed to read schema for provider %s: %w", addr, err)
 	}

--- a/internal/tofu/eval_provider.go
+++ b/internal/tofu/eval_provider.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -56,7 +57,7 @@ func getProvider(ctx EvalContext, addr addrs.AbsProviderConfig) (providers.Inter
 	}
 	// Not all callers require a schema, so we will leave checking for a nil
 	// schema to the callers.
-	schema, err := ctx.ProviderSchema(addr)
+	schema, err := ctx.ProviderSchema(context.TODO(), addr)
 	if err != nil {
 		return nil, providers.ProviderSchema{}, fmt.Errorf("failed to read schema for provider %s: %w", addr, err)
 	}

--- a/internal/tofu/eval_variable.go
+++ b/internal/tofu/eval_variable.go
@@ -240,7 +240,7 @@ func evalVariableValidations(addr addrs.AbsInputVariableInstance, config *config
 				config.Name: val,
 			}),
 		},
-		Functions: ctx.EvaluationScope(nil, nil, EvalDataForNoInstanceKey).Functions(),
+		Functions: ctx.EvaluationScope(nil, nil, nil, EvalDataForNoInstanceKey).Functions(),
 	}
 
 	for ix, validation := range config.Validations {

--- a/internal/tofu/eval_variable.go
+++ b/internal/tofu/eval_variable.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -199,7 +200,7 @@ func prepareFinalInputVariableValue(addr addrs.AbsInputVariableInstance, raw *In
 // This must be used only after any side-effects that make the value of the
 // variable available for use in expression evaluation, such as
 // EvalModuleCallArgument for variables in descendent modules.
-func evalVariableValidations(addr addrs.AbsInputVariableInstance, config *configs.Variable, expr hcl.Expression, ctx EvalContext) (diags tfdiags.Diagnostics) {
+func evalVariableValidations(traceCtx context.Context, addr addrs.AbsInputVariableInstance, config *configs.Variable, expr hcl.Expression, ctx EvalContext) (diags tfdiags.Diagnostics) {
 	if config == nil || len(config.Validations) == 0 {
 		log.Printf("[TRACE] evalVariableValidations: no validation rules declared for %s, so skipping", addr)
 		return nil
@@ -240,7 +241,7 @@ func evalVariableValidations(addr addrs.AbsInputVariableInstance, config *config
 				config.Name: val,
 			}),
 		},
-		Functions: ctx.EvaluationScope(nil, nil, nil, EvalDataForNoInstanceKey).Functions(),
+		Functions: ctx.EvaluationScope(traceCtx, nil, nil, EvalDataForNoInstanceKey).Functions(),
 	}
 
 	for ix, validation := range config.Validations {

--- a/internal/tofu/evaluate.go
+++ b/internal/tofu/evaluate.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -642,7 +643,7 @@ func (d *evaluationStateData) GetPathAttr(addr addrs.PathAttr, rng tfdiags.Sourc
 	}
 }
 
-func (d *evaluationStateData) GetResource(addr addrs.Resource, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+func (d *evaluationStateData) GetResource(ctx context.Context, addr addrs.Resource, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	// First we'll consult the configuration to see if an resource of this
 	// name is declared at all.
@@ -669,7 +670,7 @@ func (d *evaluationStateData) GetResource(addr addrs.Resource, rng tfdiags.Sourc
 	// state available in all cases.
 	// We need to build an abs provider address, but we can use a default
 	// instance since we're only interested in the schema.
-	schema := d.getResourceSchema(addr, config.Provider)
+	schema := d.getResourceSchema(ctx, addr, config.Provider)
 	if schema == nil {
 		// This shouldn't happen, since validation before we get here should've
 		// taken care of it, but we'll show a reasonable error message anyway.
@@ -902,8 +903,8 @@ func (d *evaluationStateData) GetResource(addr addrs.Resource, rng tfdiags.Sourc
 	return ret, diags
 }
 
-func (d *evaluationStateData) getResourceSchema(addr addrs.Resource, providerAddr addrs.Provider) *configschema.Block {
-	schema, _, err := d.Evaluator.Plugins.ResourceTypeSchema(providerAddr, addr.Mode, addr.Type)
+func (d *evaluationStateData) getResourceSchema(ctx context.Context, addr addrs.Resource, providerAddr addrs.Provider) *configschema.Block {
+	schema, _, err := d.Evaluator.Plugins.ResourceTypeSchema(ctx, providerAddr, addr.Mode, addr.Type)
 	if err != nil {
 		// We have plently other codepaths that will detect and report
 		// schema lookup errors before we'd reach this point, so we'll just

--- a/internal/tofu/evaluate_test.go
+++ b/internal/tofu/evaluate_test.go
@@ -381,7 +381,7 @@ func TestEvaluatorGetResource(t *testing.T) {
 		Type: "test_resource",
 		Name: "foo",
 	}
-	got, diags := scope.Data.GetResource(addr, tfdiags.SourceRange{})
+	got, diags := scope.Data.GetResource(nil, addr, tfdiags.SourceRange{})
 
 	if len(diags) != 0 {
 		t.Errorf("unexpected diagnostics %s", spew.Sdump(diags))
@@ -521,7 +521,7 @@ func TestEvaluatorGetResource_changes(t *testing.T) {
 		}).Mark(marks.Sensitive),
 	})
 
-	got, diags := scope.Data.GetResource(addr, tfdiags.SourceRange{})
+	got, diags := scope.Data.GetResource(nil, addr, tfdiags.SourceRange{})
 
 	if len(diags) != 0 {
 		t.Errorf("unexpected diagnostics %s", spew.Sdump(diags))

--- a/internal/tofu/execute.go
+++ b/internal/tofu/execute.go
@@ -5,10 +5,14 @@
 
 package tofu
 
-import "github.com/opentofu/opentofu/internal/tfdiags"
+import (
+	"context"
+
+	"github.com/opentofu/opentofu/internal/tfdiags"
+)
 
 // GraphNodeExecutable is the interface that graph nodes must implement to
 // enable execution.
 type GraphNodeExecutable interface {
-	Execute(EvalContext, walkOperation) tfdiags.Diagnostics
+	Execute(context.Context, EvalContext, walkOperation) tfdiags.Diagnostics
 }

--- a/internal/tofu/graph.go
+++ b/internal/tofu/graph.go
@@ -100,7 +100,7 @@ func (g *Graph) walk(traceCtx context.Context, walker GraphWalker) tfdiags.Diagn
 		if ev, ok := v.(GraphNodeDynamicExpandable); ok {
 			log.Printf("[TRACE] vertex %q: expanding dynamic subgraph", dag.VertexName(v))
 
-			g, err := ev.DynamicExpand(vertexCtx)
+			g, err := ev.DynamicExpand(nil, vertexCtx)
 			diags = diags.Append(err)
 			if diags.HasErrors() {
 				log.Printf("[TRACE] vertex %q: failed expanding dynamic subgraph: %s", dag.VertexName(v), err)

--- a/internal/tofu/graph.go
+++ b/internal/tofu/graph.go
@@ -100,7 +100,7 @@ func (g *Graph) walk(traceCtx context.Context, walker GraphWalker) tfdiags.Diagn
 		if ev, ok := v.(GraphNodeDynamicExpandable); ok {
 			log.Printf("[TRACE] vertex %q: expanding dynamic subgraph", dag.VertexName(v))
 
-			g, err := ev.DynamicExpand(nil, vertexCtx)
+			g, err := ev.DynamicExpand(traceCtx, vertexCtx)
 			diags = diags.Append(err)
 			if diags.HasErrors() {
 				log.Printf("[TRACE] vertex %q: failed expanding dynamic subgraph: %s", dag.VertexName(v), err)

--- a/internal/tofu/graph_builder_apply.go
+++ b/internal/tofu/graph_builder_apply.go
@@ -6,6 +6,10 @@
 package tofu
 
 import (
+	"context"
+
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/dag"
@@ -62,11 +66,15 @@ type ApplyGraphBuilder struct {
 }
 
 // See GraphBuilder
-func (b *ApplyGraphBuilder) Build(path addrs.ModuleInstance) (*Graph, tfdiags.Diagnostics) {
+func (b *ApplyGraphBuilder) Build(ctx context.Context, path addrs.ModuleInstance) (*Graph, tfdiags.Diagnostics) {
+	var span trace.Span
+	ctx, span = tracer.Start(ctx, "ApplyGraphBuilder.Build")
+	defer span.End()
+
 	return (&BasicGraphBuilder{
 		Steps: b.Steps(),
 		Name:  "ApplyGraphBuilder",
-	}).Build(path)
+	}).Build(ctx, path)
 }
 
 // See GraphBuilder

--- a/internal/tofu/graph_builder_apply_test.go
+++ b/internal/tofu/graph_builder_apply_test.go
@@ -59,7 +59,7 @@ func TestApplyGraphBuilder(t *testing.T) {
 		Plugins: simpleMockPluginLibrary(),
 	}
 
-	g, err := b.Build(addrs.RootModuleInstance)
+	g, err := b.Build(nil, addrs.RootModuleInstance)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -122,7 +122,7 @@ func TestApplyGraphBuilder_depCbd(t *testing.T) {
 		State:   state,
 	}
 
-	g, err := b.Build(addrs.RootModuleInstance)
+	g, err := b.Build(nil, addrs.RootModuleInstance)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -194,7 +194,7 @@ func TestApplyGraphBuilder_doubleCBD(t *testing.T) {
 		Plugins: simpleMockPluginLibrary(),
 	}
 
-	g, err := b.Build(addrs.RootModuleInstance)
+	g, err := b.Build(nil, addrs.RootModuleInstance)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -288,7 +288,7 @@ func TestApplyGraphBuilder_destroyStateOnly(t *testing.T) {
 		Plugins: simpleMockPluginLibrary(),
 	}
 
-	g, diags := b.Build(addrs.RootModuleInstance)
+	g, diags := b.Build(nil, addrs.RootModuleInstance)
 	if diags.HasErrors() {
 		t.Fatalf("err: %s", diags.Err())
 	}
@@ -350,7 +350,7 @@ func TestApplyGraphBuilder_destroyCount(t *testing.T) {
 		State:   state,
 	}
 
-	g, err := b.Build(addrs.RootModuleInstance)
+	g, err := b.Build(nil, addrs.RootModuleInstance)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -412,7 +412,7 @@ func TestApplyGraphBuilder_moduleDestroy(t *testing.T) {
 		State:   state,
 	}
 
-	g, err := b.Build(addrs.RootModuleInstance)
+	g, err := b.Build(nil, addrs.RootModuleInstance)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -451,7 +451,7 @@ func TestApplyGraphBuilder_targetModule(t *testing.T) {
 		},
 	}
 
-	g, err := b.Build(addrs.RootModuleInstance)
+	g, err := b.Build(nil, addrs.RootModuleInstance)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -545,7 +545,7 @@ func TestApplyGraphBuilder_updateFromOrphan(t *testing.T) {
 		State:   state,
 	}
 
-	g, err := b.Build(addrs.RootModuleInstance)
+	g, err := b.Build(nil, addrs.RootModuleInstance)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -645,7 +645,7 @@ func TestApplyGraphBuilder_updateFromCBDOrphan(t *testing.T) {
 		State:   state,
 	}
 
-	g, err := b.Build(addrs.RootModuleInstance)
+	g, err := b.Build(nil, addrs.RootModuleInstance)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -695,7 +695,7 @@ func TestApplyGraphBuilder_orphanedWithProvider(t *testing.T) {
 		State:   state,
 	}
 
-	g, err := b.Build(addrs.RootModuleInstance)
+	g, err := b.Build(nil, addrs.RootModuleInstance)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -744,7 +744,7 @@ func TestApplyGraphBuilder_withChecks(t *testing.T) {
 		Operation: walkApply,
 	}
 
-	g, err := b.Build(addrs.RootModuleInstance)
+	g, err := b.Build(nil, addrs.RootModuleInstance)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/internal/tofu/graph_builder_eval.go
+++ b/internal/tofu/graph_builder_eval.go
@@ -6,6 +6,10 @@
 package tofu
 
 import (
+	"context"
+
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/dag"
@@ -46,11 +50,15 @@ type EvalGraphBuilder struct {
 }
 
 // See GraphBuilder
-func (b *EvalGraphBuilder) Build(path addrs.ModuleInstance) (*Graph, tfdiags.Diagnostics) {
+func (b *EvalGraphBuilder) Build(ctx context.Context, path addrs.ModuleInstance) (*Graph, tfdiags.Diagnostics) {
+	var span trace.Span
+	ctx, span = tracer.Start(ctx, "EvalGraphBuilder.Build")
+	defer span.End()
+
 	return (&BasicGraphBuilder{
 		Steps: b.Steps(),
 		Name:  "EvalGraphBuilder",
-	}).Build(path)
+	}).Build(ctx, path)
 }
 
 // See GraphBuilder

--- a/internal/tofu/graph_builder_plan.go
+++ b/internal/tofu/graph_builder_plan.go
@@ -6,7 +6,10 @@
 package tofu
 
 import (
+	"context"
 	"log"
+
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
@@ -95,12 +98,16 @@ type PlanGraphBuilder struct {
 }
 
 // See GraphBuilder
-func (b *PlanGraphBuilder) Build(path addrs.ModuleInstance) (*Graph, tfdiags.Diagnostics) {
+func (b *PlanGraphBuilder) Build(ctx context.Context, path addrs.ModuleInstance) (*Graph, tfdiags.Diagnostics) {
+	var span trace.Span
+	ctx, span = tracer.Start(ctx, "PlanGraphBuilder.Build")
+	defer span.End()
+
 	log.Printf("[TRACE] building graph for %s", b.Operation)
 	return (&BasicGraphBuilder{
 		Steps: b.Steps(),
 		Name:  "PlanGraphBuilder",
-	}).Build(path)
+	}).Build(ctx, path)
 }
 
 // See GraphBuilder

--- a/internal/tofu/graph_builder_plan_test.go
+++ b/internal/tofu/graph_builder_plan_test.go
@@ -44,7 +44,7 @@ func TestPlanGraphBuilder(t *testing.T) {
 		Operation: walkPlan,
 	}
 
-	g, err := b.Build(addrs.RootModuleInstance)
+	g, err := b.Build(nil, addrs.RootModuleInstance)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -87,7 +87,7 @@ func TestPlanGraphBuilder_dynamicBlock(t *testing.T) {
 		Operation: walkPlan,
 	}
 
-	g, err := b.Build(addrs.RootModuleInstance)
+	g, err := b.Build(nil, addrs.RootModuleInstance)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -143,7 +143,7 @@ func TestPlanGraphBuilder_attrAsBlocks(t *testing.T) {
 		Operation: walkPlan,
 	}
 
-	g, err := b.Build(addrs.RootModuleInstance)
+	g, err := b.Build(nil, addrs.RootModuleInstance)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -184,7 +184,7 @@ func TestPlanGraphBuilder_targetModule(t *testing.T) {
 		Operation: walkPlan,
 	}
 
-	g, err := b.Build(addrs.RootModuleInstance)
+	g, err := b.Build(nil, addrs.RootModuleInstance)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -208,7 +208,7 @@ func TestPlanGraphBuilder_forEach(t *testing.T) {
 		Operation: walkPlan,
 	}
 
-	g, err := b.Build(addrs.RootModuleInstance)
+	g, err := b.Build(nil, addrs.RootModuleInstance)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/internal/tofu/graph_builder_test.go
+++ b/internal/tofu/graph_builder_test.go
@@ -25,7 +25,7 @@ func TestBasicGraphBuilder(t *testing.T) {
 		},
 	}
 
-	g, err := b.Build(addrs.RootModuleInstance)
+	g, err := b.Build(nil, addrs.RootModuleInstance)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -49,7 +49,7 @@ func TestBasicGraphBuilder_validate(t *testing.T) {
 		},
 	}
 
-	_, err := b.Build(addrs.RootModuleInstance)
+	_, err := b.Build(nil, addrs.RootModuleInstance)
 	if err == nil {
 		t.Fatal("should error")
 	}
@@ -59,7 +59,7 @@ type testBasicGraphBuilderTransform struct {
 	V dag.Vertex
 }
 
-func (t *testBasicGraphBuilderTransform) Transform(g *Graph) error {
+func (t *testBasicGraphBuilderTransform) Transform(ctx context.Context, g *Graph) error {
 	g.Add(t.V)
 	return nil
 }

--- a/internal/tofu/graph_walk.go
+++ b/internal/tofu/graph_walk.go
@@ -6,6 +6,8 @@
 package tofu
 
 import (
+	"context"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
@@ -16,7 +18,7 @@ type GraphWalker interface {
 	EvalContext() EvalContext
 	EnterPath(addrs.ModuleInstance) EvalContext
 	ExitPath(addrs.ModuleInstance)
-	Execute(EvalContext, GraphNodeExecutable) tfdiags.Diagnostics
+	Execute(context.Context, EvalContext, GraphNodeExecutable) tfdiags.Diagnostics
 }
 
 // NullGraphWalker is a GraphWalker implementation that does nothing.
@@ -24,7 +26,9 @@ type GraphWalker interface {
 // implementing all the required functions.
 type NullGraphWalker struct{}
 
-func (NullGraphWalker) EvalContext() EvalContext                                     { return new(MockEvalContext) }
-func (NullGraphWalker) EnterPath(addrs.ModuleInstance) EvalContext                   { return new(MockEvalContext) }
-func (NullGraphWalker) ExitPath(addrs.ModuleInstance)                                {}
-func (NullGraphWalker) Execute(EvalContext, GraphNodeExecutable) tfdiags.Diagnostics { return nil }
+func (NullGraphWalker) EvalContext() EvalContext                   { return new(MockEvalContext) }
+func (NullGraphWalker) EnterPath(addrs.ModuleInstance) EvalContext { return new(MockEvalContext) }
+func (NullGraphWalker) ExitPath(addrs.ModuleInstance)              {}
+func (NullGraphWalker) Execute(context.Context, EvalContext, GraphNodeExecutable) tfdiags.Diagnostics {
+	return nil
+}

--- a/internal/tofu/graph_walk_context.go
+++ b/internal/tofu/graph_walk_context.go
@@ -7,10 +7,12 @@ package tofu
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
 	"github.com/zclconf/go-cty/cty"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -142,7 +144,7 @@ func (w *ContextGraphWalker) init() {
 
 func (w *ContextGraphWalker) Execute(traceCtx context.Context, ctx EvalContext, n GraphNodeExecutable) tfdiags.Diagnostics {
 	var span trace.Span
-	traceCtx, span = tracer.Start(traceCtx, "ContextGraphWalker.Execute")
+	traceCtx, span = tracer.Start(traceCtx, "ContextGraphWalker.Execute", trace.WithAttributes(attribute.String("node type", fmt.Sprintf("%T", n))))
 	defer span.End()
 
 	// Acquire a lock on the semaphore

--- a/internal/tofu/node_check.go
+++ b/internal/tofu/node_check.go
@@ -82,7 +82,7 @@ func (n *nodeExpandCheck) ModulePath() addrs.Module {
 	return n.addr.Module
 }
 
-func (n *nodeExpandCheck) DynamicExpand(ctx EvalContext) (*Graph, error) {
+func (n *nodeExpandCheck) DynamicExpand(traceCtx context.Context, ctx EvalContext) (*Graph, error) {
 	exp := ctx.InstanceExpander()
 	modInsts := exp.ExpandModule(n.ModulePath())
 
@@ -164,6 +164,7 @@ func (n *nodeCheckAssert) Execute(traceCtx context.Context, ctx EvalContext, _ w
 		}
 
 		return evalCheckRules(
+			traceCtx,
 			addrs.CheckAssertion,
 			n.config.Asserts,
 			ctx,
@@ -177,7 +178,7 @@ func (n *nodeCheckAssert) Execute(traceCtx context.Context, ctx EvalContext, _ w
 	// diagnostics if references do not exist etc.
 	var diags tfdiags.Diagnostics
 	for ix, assert := range n.config.Asserts {
-		_, _, moreDiags := validateCheckRule(addrs.NewCheckRule(n.addr, addrs.CheckAssertion, ix), assert, ctx, EvalDataForNoInstanceKey)
+		_, _, moreDiags := validateCheckRule(traceCtx, addrs.NewCheckRule(n.addr, addrs.CheckAssertion, ix), assert, ctx, EvalDataForNoInstanceKey)
 		diags = diags.Append(moreDiags)
 	}
 	return diags

--- a/internal/tofu/node_check.go
+++ b/internal/tofu/node_check.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"log"
 
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -40,7 +41,7 @@ func (n *nodeReportCheck) ModulePath() addrs.Module {
 	return n.addr.Module
 }
 
-func (n *nodeReportCheck) Execute(ctx EvalContext, _ walkOperation) tfdiags.Diagnostics {
+func (n *nodeReportCheck) Execute(traceCtx context.Context, ctx EvalContext, _ walkOperation) tfdiags.Diagnostics {
 	exp := ctx.InstanceExpander()
 	modInsts := exp.ExpandModule(n.ModulePath())
 
@@ -150,7 +151,7 @@ func (n *nodeCheckAssert) Path() addrs.ModuleInstance {
 	return n.addr.Module
 }
 
-func (n *nodeCheckAssert) Execute(ctx EvalContext, _ walkOperation) tfdiags.Diagnostics {
+func (n *nodeCheckAssert) Execute(traceCtx context.Context, ctx EvalContext, _ walkOperation) tfdiags.Diagnostics {
 
 	// We only want to actually execute the checks during specific
 	// operations, such as plan and applies.
@@ -195,7 +196,7 @@ var (
 // dependency that can enforce this ordering.
 type nodeCheckStart struct{}
 
-func (n *nodeCheckStart) Execute(context EvalContext, operation walkOperation) tfdiags.Diagnostics {
+func (n *nodeCheckStart) Execute(ctx context.Context, context EvalContext, operation walkOperation) tfdiags.Diagnostics {
 	// This node doesn't actually do anything, except simplify the underlying
 	// graph structure.
 	return nil

--- a/internal/tofu/node_data_destroy.go
+++ b/internal/tofu/node_data_destroy.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"log"
 
 	"github.com/opentofu/opentofu/internal/tfdiags"
@@ -22,7 +23,7 @@ var (
 )
 
 // GraphNodeExecutable
-func (n *NodeDestroyableDataResourceInstance) Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
+func (n *NodeDestroyableDataResourceInstance) Execute(traceCtx context.Context, ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
 	log.Printf("[TRACE] NodeDestroyableDataResourceInstance: removing state object for %s", n.Addr)
 	ctx.State().SetResourceInstanceCurrent(n.Addr, nil, n.ResolvedProvider)
 	return nil

--- a/internal/tofu/node_data_destroy_test.go
+++ b/internal/tofu/node_data_destroy_test.go
@@ -41,7 +41,7 @@ func TestNodeDataDestroyExecute(t *testing.T) {
 		}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
 	}}
 
-	diags := node.Execute(ctx, walkApply)
+	diags := node.Execute(nil, ctx, walkApply)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %v", diags.Err())
 	}

--- a/internal/tofu/node_local.go
+++ b/internal/tofu/node_local.go
@@ -70,7 +70,7 @@ func (n *nodeExpandLocal) References() []*addrs.Reference {
 	return refs
 }
 
-func (n *nodeExpandLocal) DynamicExpand(ctx EvalContext) (*Graph, error) {
+func (n *nodeExpandLocal) DynamicExpand(traceCtx context.Context, ctx EvalContext) (*Graph, error) {
 	var g Graph
 	expander := ctx.InstanceExpander()
 	for _, module := range expander.ExpandModule(n.Module) {
@@ -141,7 +141,7 @@ func (n *NodeLocal) Execute(traceCtx context.Context, ctx EvalContext, op walkOp
 	var span trace.Span
 	traceCtx, span = tracer.Start(traceCtx, "NodeLocal.Execute")
 	defer span.End()
-	
+
 	expr := n.Config.Expr
 	addr := n.Addr.LocalValue
 

--- a/internal/tofu/node_local_test.go
+++ b/internal/tofu/node_local_test.go
@@ -62,7 +62,7 @@ func TestNodeLocalExecute(t *testing.T) {
 				EvaluateExprResult: hcl2shim.HCL2ValueFromConfigValue(test.Want),
 			}
 
-			err := n.Execute(ctx, walkApply)
+			err := n.Execute(nil, ctx, walkApply)
 			if (err != nil) != test.Err {
 				if err != nil {
 					t.Errorf("unexpected error: %s", err)

--- a/internal/tofu/node_module_expand.go
+++ b/internal/tofu/node_module_expand.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"log"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -104,7 +105,7 @@ func (n *nodeExpandModule) ReferenceOutside() (selfPath, referencePath addrs.Mod
 }
 
 // GraphNodeExecutable
-func (n *nodeExpandModule) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *nodeExpandModule) Execute(traceCtx context.Context, ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	expander := ctx.InstanceExpander()
 	_, call := n.Addr.Call()
 
@@ -180,7 +181,7 @@ func (n *nodeCloseModule) Name() string {
 	return n.Addr.String() + " (close)"
 }
 
-func (n *nodeCloseModule) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *nodeCloseModule) Execute(traceCtx context.Context, ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	if !n.Addr.IsRoot() {
 		return
 	}
@@ -223,7 +224,7 @@ type nodeValidateModule struct {
 var _ GraphNodeExecutable = (*nodeValidateModule)(nil)
 
 // GraphNodeEvalable
-func (n *nodeValidateModule) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *nodeValidateModule) Execute(traceCtx context.Context, ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	_, call := n.Addr.Call()
 	expander := ctx.InstanceExpander()
 

--- a/internal/tofu/node_module_expand.go
+++ b/internal/tofu/node_module_expand.go
@@ -124,7 +124,7 @@ func (n *nodeExpandModule) Execute(traceCtx context.Context, ctx EvalContext, op
 			expander.SetModuleCount(module, call, count)
 
 		case n.ModuleCall.ForEach != nil:
-			forEach, feDiags := evaluateForEachExpression(n.ModuleCall.ForEach, ctx)
+			forEach, feDiags := evaluateForEachExpression(traceCtx, n.ModuleCall.ForEach, ctx)
 			diags = diags.Append(feDiags)
 			if diags.HasErrors() {
 				return diags
@@ -244,11 +244,11 @@ func (n *nodeValidateModule) Execute(traceCtx context.Context, ctx EvalContext, 
 			diags = diags.Append(countDiags)
 
 		case n.ModuleCall.ForEach != nil:
-			_, forEachDiags := evaluateForEachExpressionValue(n.ModuleCall.ForEach, ctx, true, false)
+			_, forEachDiags := evaluateForEachExpressionValue(traceCtx, n.ModuleCall.ForEach, ctx, true, false)
 			diags = diags.Append(forEachDiags)
 		}
 
-		diags = diags.Append(validateDependsOn(ctx, n.ModuleCall.DependsOn))
+		diags = diags.Append(validateDependsOn(traceCtx, ctx, n.ModuleCall.DependsOn))
 
 		// now set our own mode to single
 		expander.SetModuleSingle(module, call)

--- a/internal/tofu/node_module_expand_test.go
+++ b/internal/tofu/node_module_expand_test.go
@@ -9,11 +9,12 @@ import (
 	"testing"
 
 	"github.com/hashicorp/hcl/v2/hcltest"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/instances"
 	"github.com/opentofu/opentofu/internal/states"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func TestNodeExpandModuleExecute(t *testing.T) {
@@ -29,7 +30,7 @@ func TestNodeExpandModuleExecute(t *testing.T) {
 		},
 	}
 
-	err := node.Execute(ctx, walkApply)
+	err := node.Execute(nil, ctx, walkApply)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -47,7 +48,7 @@ func TestNodeCloseModuleExecute(t *testing.T) {
 			StateState: state.SyncWrapper(),
 		}
 		node := nodeCloseModule{addrs.Module{"child"}}
-		diags := node.Execute(ctx, walkApply)
+		diags := node.Execute(nil, ctx, walkApply)
 		if diags.HasErrors() {
 			t.Fatalf("unexpected error: %s", diags.Err())
 		}
@@ -59,7 +60,7 @@ func TestNodeCloseModuleExecute(t *testing.T) {
 
 		// the root module should do all the module cleanup
 		node = nodeCloseModule{addrs.RootModule}
-		diags = node.Execute(ctx, walkApply)
+		diags = node.Execute(nil, ctx, walkApply)
 		if diags.HasErrors() {
 			t.Fatalf("unexpected error: %s", diags.Err())
 		}
@@ -79,7 +80,7 @@ func TestNodeCloseModuleExecute(t *testing.T) {
 		}
 		node := nodeCloseModule{addrs.Module{"child"}}
 
-		diags := node.Execute(ctx, walkImport)
+		diags := node.Execute(nil, ctx, walkImport)
 		if diags.HasErrors() {
 			t.Fatalf("unexpected error: %s", diags.Err())
 		}
@@ -104,7 +105,7 @@ func TestNodeValidateModuleExecute(t *testing.T) {
 			},
 		}
 
-		diags := node.Execute(ctx, walkApply)
+		diags := node.Execute(nil, ctx, walkApply)
 		if diags.HasErrors() {
 			t.Fatalf("unexpected error: %v", diags.Err())
 		}
@@ -124,7 +125,7 @@ func TestNodeValidateModuleExecute(t *testing.T) {
 			},
 		}
 
-		err := node.Execute(ctx, walkApply)
+		err := node.Execute(nil, ctx, walkApply)
 		if err == nil {
 			t.Fatal("expected error, got success")
 		}

--- a/internal/tofu/node_module_variable.go
+++ b/internal/tofu/node_module_variable.go
@@ -45,7 +45,7 @@ func (n *nodeExpandModuleVariable) temporaryValue() bool {
 	return true
 }
 
-func (n *nodeExpandModuleVariable) DynamicExpand(ctx EvalContext) (*Graph, error) {
+func (n *nodeExpandModuleVariable) DynamicExpand(traceCtx context.Context, ctx EvalContext) (*Graph, error) {
 	var g Graph
 
 	// If this variable has preconditions, we need to report these checks now.
@@ -177,10 +177,10 @@ func (n *nodeModuleVariable) Execute(traceCtx context.Context, ctx EvalContext, 
 
 	switch op {
 	case walkValidate:
-		val, err = n.evalModuleVariable(ctx, true)
+		val, err = n.evalModuleVariable(traceCtx, ctx, true)
 		diags = diags.Append(err)
 	default:
-		val, err = n.evalModuleVariable(ctx, false)
+		val, err = n.evalModuleVariable(traceCtx, ctx, false)
 		diags = diags.Append(err)
 	}
 	if diags.HasErrors() {
@@ -192,7 +192,7 @@ func (n *nodeModuleVariable) Execute(traceCtx context.Context, ctx EvalContext, 
 	_, call := n.Addr.Module.CallInstance()
 	ctx.SetModuleCallArgument(call, n.Addr.Variable, val)
 
-	return evalVariableValidations(n.Addr, n.Config, n.Expr, ctx)
+	return evalVariableValidations(traceCtx, n.Addr, n.Config, n.Expr, ctx)
 }
 
 // dag.GraphNodeDotter impl.
@@ -218,7 +218,7 @@ func (n *nodeModuleVariable) DotNode(name string, opts *dag.DotOpts) *dag.DotNod
 // validateOnly indicates that this evaluation is only for config
 // validation, and we will not have any expansion module instance
 // repetition data.
-func (n *nodeModuleVariable) evalModuleVariable(ctx EvalContext, validateOnly bool) (cty.Value, error) {
+func (n *nodeModuleVariable) evalModuleVariable(traceCtx context.Context, ctx EvalContext, validateOnly bool) (cty.Value, error) {
 	var diags tfdiags.Diagnostics
 	var givenVal cty.Value
 	var errSourceRange tfdiags.SourceRange
@@ -241,7 +241,7 @@ func (n *nodeModuleVariable) evalModuleVariable(ctx EvalContext, validateOnly bo
 			moduleInstanceRepetitionData = ctx.InstanceExpander().GetModuleInstanceRepetitionData(n.ModuleInstance)
 		}
 
-		scope := ctx.EvaluationScope(nil, nil, nil, moduleInstanceRepetitionData)
+		scope := ctx.EvaluationScope(traceCtx, nil, nil, moduleInstanceRepetitionData)
 		val, moreDiags := scope.EvalExpr(expr, cty.DynamicPseudoType)
 		diags = diags.Append(moreDiags)
 		if moreDiags.HasErrors() {

--- a/internal/tofu/node_module_variable.go
+++ b/internal/tofu/node_module_variable.go
@@ -242,7 +242,7 @@ func (n *nodeModuleVariable) evalModuleVariable(traceCtx context.Context, ctx Ev
 		}
 
 		scope := ctx.EvaluationScope(traceCtx, nil, nil, moduleInstanceRepetitionData)
-		val, moreDiags := scope.EvalExpr(expr, cty.DynamicPseudoType)
+		val, moreDiags := scope.EvalExpr(traceCtx, expr, cty.DynamicPseudoType)
 		diags = diags.Append(moreDiags)
 		if moreDiags.HasErrors() {
 			return cty.DynamicVal, diags.ErrWithWarnings()

--- a/internal/tofu/node_module_variable.go
+++ b/internal/tofu/node_module_variable.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -168,7 +169,7 @@ func (n *nodeModuleVariable) ModulePath() addrs.Module {
 }
 
 // GraphNodeExecutable
-func (n *nodeModuleVariable) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *nodeModuleVariable) Execute(traceCtx context.Context, ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	log.Printf("[TRACE] nodeModuleVariable: evaluating %s", n.Addr)
 
 	var val cty.Value
@@ -240,7 +241,7 @@ func (n *nodeModuleVariable) evalModuleVariable(ctx EvalContext, validateOnly bo
 			moduleInstanceRepetitionData = ctx.InstanceExpander().GetModuleInstanceRepetitionData(n.ModuleInstance)
 		}
 
-		scope := ctx.EvaluationScope(nil, nil, moduleInstanceRepetitionData)
+		scope := ctx.EvaluationScope(nil, nil, nil, moduleInstanceRepetitionData)
 		val, moreDiags := scope.EvalExpr(expr, cty.DynamicPseudoType)
 		diags = diags.Append(moreDiags)
 		if moreDiags.HasErrors() {

--- a/internal/tofu/node_output.go
+++ b/internal/tofu/node_output.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -302,7 +303,7 @@ func (n *NodeApplyableOutput) References() []*addrs.Reference {
 }
 
 // GraphNodeExecutable
-func (n *NodeApplyableOutput) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *NodeApplyableOutput) Execute(traceCtx context.Context, ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	state := ctx.State()
 	if state == nil {
 		return
@@ -347,7 +348,7 @@ func (n *NodeApplyableOutput) Execute(ctx EvalContext, op walkOperation) (diags 
 		// This has to run before we have a state lock, since evaluation also
 		// reads the state
 		var evalDiags tfdiags.Diagnostics
-		val, evalDiags = ctx.EvaluateExpr(n.Config.Expr, cty.DynamicPseudoType, nil)
+		val, evalDiags = ctx.EvaluateExpr(nil, n.Config.Expr, cty.DynamicPseudoType, nil)
 		diags = diags.Append(evalDiags)
 
 		// We'll handle errors below, after we have loaded the module.
@@ -451,7 +452,7 @@ func (n *NodeDestroyableOutput) temporaryValue() bool {
 }
 
 // GraphNodeExecutable
-func (n *NodeDestroyableOutput) Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
+func (n *NodeDestroyableOutput) Execute(traceCtx context.Context, ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
 	state := ctx.State()
 	if state == nil {
 		return nil

--- a/internal/tofu/node_output.go
+++ b/internal/tofu/node_output.go
@@ -57,7 +57,7 @@ func (n *nodeExpandOutput) temporaryValue() bool {
 	return !n.Module.IsRoot()
 }
 
-func (n *nodeExpandOutput) DynamicExpand(ctx EvalContext) (*Graph, error) {
+func (n *nodeExpandOutput) DynamicExpand(traceCtx context.Context, ctx EvalContext) (*Graph, error) {
 	expander := ctx.InstanceExpander()
 	changes := ctx.Changes()
 
@@ -331,6 +331,7 @@ func (n *NodeApplyableOutput) Execute(traceCtx context.Context, ctx EvalContext,
 			checkRuleSeverity = tfdiags.Warning
 		}
 		checkDiags := evalCheckRules(
+			traceCtx,
 			addrs.OutputPrecondition,
 			n.Config.Preconditions,
 			ctx, n.Addr, EvalDataForNoInstanceKey,
@@ -354,7 +355,7 @@ func (n *NodeApplyableOutput) Execute(traceCtx context.Context, ctx EvalContext,
 		// We'll handle errors below, after we have loaded the module.
 		// Outputs don't have a separate mode for validation, so validate
 		// depends_on expressions here too
-		diags = diags.Append(validateDependsOn(ctx, n.Config.DependsOn))
+		diags = diags.Append(validateDependsOn(traceCtx, ctx, n.Config.DependsOn))
 
 		// For root module outputs in particular, an output value must be
 		// statically declared as sensitive in order to dynamically return

--- a/internal/tofu/node_output_test.go
+++ b/internal/tofu/node_output_test.go
@@ -33,7 +33,7 @@ func TestNodeApplyableOutputExecute_knownValue(t *testing.T) {
 	})
 	ctx.EvaluateExprResult = val
 
-	err := node.Execute(ctx, walkApply)
+	err := node.Execute(nil, ctx, walkApply)
 	if err != nil {
 		t.Fatalf("unexpected execute error: %s", err)
 	}
@@ -63,7 +63,7 @@ func TestNodeApplyableOutputExecute_noState(t *testing.T) {
 	})
 	ctx.EvaluateExprResult = val
 
-	err := node.Execute(ctx, walkApply)
+	err := node.Execute(nil, ctx, walkApply)
 	if err != nil {
 		t.Fatalf("unexpected execute error: %s", err)
 	}
@@ -91,7 +91,7 @@ func TestNodeApplyableOutputExecute_invalidDependsOn(t *testing.T) {
 	})
 	ctx.EvaluateExprResult = val
 
-	diags := node.Execute(ctx, walkApply)
+	diags := node.Execute(nil, ctx, walkApply)
 	if !diags.HasErrors() {
 		t.Fatal("expected execute error, but there was none")
 	}
@@ -113,7 +113,7 @@ func TestNodeApplyableOutputExecute_sensitiveValueNotOutput(t *testing.T) {
 	})
 	ctx.EvaluateExprResult = val
 
-	diags := node.Execute(ctx, walkApply)
+	diags := node.Execute(nil, ctx, walkApply)
 	if !diags.HasErrors() {
 		t.Fatal("expected execute error, but there was none")
 	}
@@ -138,7 +138,7 @@ func TestNodeApplyableOutputExecute_sensitiveValueAndOutput(t *testing.T) {
 	})
 	ctx.EvaluateExprResult = val
 
-	err := node.Execute(ctx, walkApply)
+	err := node.Execute(nil, ctx, walkApply)
 	if err != nil {
 		t.Fatalf("unexpected execute error: %s", err)
 	}
@@ -163,7 +163,7 @@ func TestNodeDestroyableOutputExecute(t *testing.T) {
 	}
 	node := NodeDestroyableOutput{Addr: outputAddr}
 
-	diags := node.Execute(ctx, walkApply)
+	diags := node.Execute(nil, ctx, walkApply)
 	if diags.HasErrors() {
 		t.Fatalf("Unexpected error: %s", diags.Err())
 	}
@@ -182,7 +182,7 @@ func TestNodeDestroyableOutputExecute_notInState(t *testing.T) {
 	}
 	node := NodeDestroyableOutput{Addr: outputAddr}
 
-	diags := node.Execute(ctx, walkApply)
+	diags := node.Execute(nil, ctx, walkApply)
 	if diags.HasErrors() {
 		t.Fatalf("Unexpected error: %s", diags.Err())
 	}

--- a/internal/tofu/node_provider.go
+++ b/internal/tofu/node_provider.go
@@ -29,12 +29,13 @@ var (
 
 // GraphNodeExecutable
 func (n *NodeApplyableProvider) Execute(traceCtx context.Context, ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
-	_, err := ctx.InitProvider(n.Addr)
+
+	_, err := ctx.InitProvider(traceCtx, n.Addr)
 	diags = diags.Append(err)
 	if diags.HasErrors() {
 		return diags
 	}
-	provider, _, err := getProvider(ctx, n.Addr)
+	provider, _, err := getProvider(traceCtx, ctx, n.Addr)
 	diags = diags.Append(err)
 	if diags.HasErrors() {
 		return diags
@@ -79,7 +80,7 @@ func (n *NodeApplyableProvider) ValidateProvider(traceCtx context.Context, ctx E
 		configSchema = &configschema.Block{}
 	}
 
-	configVal, _, evalDiags := ctx.EvaluateBlock(configBody, configSchema, nil, EvalDataForNoInstanceKey)
+	configVal, _, evalDiags := ctx.EvaluateBlock(traceCtx, configBody, configSchema, nil, EvalDataForNoInstanceKey)
 	if evalDiags.HasErrors() {
 		return diags.Append(evalDiags)
 	}
@@ -114,7 +115,7 @@ func (n *NodeApplyableProvider) ConfigureProvider(traceCtx context.Context, ctx 
 	}
 
 	configSchema := resp.Provider.Block
-	configVal, configBody, evalDiags := ctx.EvaluateBlock(configBody, configSchema, nil, EvalDataForNoInstanceKey)
+	configVal, configBody, evalDiags := ctx.EvaluateBlock(traceCtx, configBody, configSchema, nil, EvalDataForNoInstanceKey)
 	diags = diags.Append(evalDiags)
 	if evalDiags.HasErrors() {
 		return diags

--- a/internal/tofu/node_provider.go
+++ b/internal/tofu/node_provider.go
@@ -6,14 +6,16 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // NodeApplyableProvider represents a provider during an apply.
@@ -26,7 +28,7 @@ var (
 )
 
 // GraphNodeExecutable
-func (n *NodeApplyableProvider) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *NodeApplyableProvider) Execute(traceCtx context.Context, ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	_, err := ctx.InitProvider(n.Addr)
 	diags = diags.Append(err)
 	if diags.HasErrors() {
@@ -41,19 +43,18 @@ func (n *NodeApplyableProvider) Execute(ctx EvalContext, op walkOperation) (diag
 	switch op {
 	case walkValidate:
 		log.Printf("[TRACE] NodeApplyableProvider: validating configuration for %s", n.Addr)
-		return diags.Append(n.ValidateProvider(ctx, provider))
+		return diags.Append(n.ValidateProvider(traceCtx, ctx, provider))
 	case walkPlan, walkPlanDestroy, walkApply, walkDestroy:
 		log.Printf("[TRACE] NodeApplyableProvider: configuring %s", n.Addr)
-		return diags.Append(n.ConfigureProvider(ctx, provider, false))
+		return diags.Append(n.ConfigureProvider(traceCtx, ctx, provider, false))
 	case walkImport:
 		log.Printf("[TRACE] NodeApplyableProvider: configuring %s (requiring that configuration is wholly known)", n.Addr)
-		return diags.Append(n.ConfigureProvider(ctx, provider, true))
+		return diags.Append(n.ConfigureProvider(traceCtx, ctx, provider, true))
 	}
 	return diags
 }
 
-func (n *NodeApplyableProvider) ValidateProvider(ctx EvalContext, provider providers.Interface) (diags tfdiags.Diagnostics) {
-
+func (n *NodeApplyableProvider) ValidateProvider(traceCtx context.Context, ctx EvalContext, provider providers.Interface) (diags tfdiags.Diagnostics) {
 	configBody := buildProviderConfig(ctx, n.Addr, n.ProviderConfig())
 
 	// if a provider config is empty (only an alias), return early and don't continue
@@ -64,7 +65,7 @@ func (n *NodeApplyableProvider) ValidateProvider(ctx EvalContext, provider provi
 		return nil
 	}
 
-	schemaResp := provider.GetProviderSchema()
+	schemaResp := provider.GetProviderSchema(nil)
 	diags = diags.Append(schemaResp.Diagnostics.InConfigBody(configBody, n.Addr.String()))
 	if diags.HasErrors() {
 		return diags
@@ -92,7 +93,7 @@ func (n *NodeApplyableProvider) ValidateProvider(ctx EvalContext, provider provi
 		Config: unmarkedConfigVal,
 	}
 
-	validateResp := provider.ValidateProviderConfig(req)
+	validateResp := provider.ValidateProviderConfig(traceCtx, req)
 	diags = diags.Append(validateResp.Diagnostics.InConfigBody(configBody, n.Addr.String()))
 
 	return diags
@@ -101,12 +102,12 @@ func (n *NodeApplyableProvider) ValidateProvider(ctx EvalContext, provider provi
 // ConfigureProvider configures a provider that is already initialized and retrieved.
 // If verifyConfigIsKnown is true, ConfigureProvider will return an error if the
 // provider configVal is not wholly known and is meant only for use during import.
-func (n *NodeApplyableProvider) ConfigureProvider(ctx EvalContext, provider providers.Interface, verifyConfigIsKnown bool) (diags tfdiags.Diagnostics) {
+func (n *NodeApplyableProvider) ConfigureProvider(traceCtx context.Context, ctx EvalContext, provider providers.Interface, verifyConfigIsKnown bool) (diags tfdiags.Diagnostics) {
 	config := n.ProviderConfig()
 
 	configBody := buildProviderConfig(ctx, n.Addr, config)
 
-	resp := provider.GetProviderSchema()
+	resp := provider.GetProviderSchema(traceCtx)
 	diags = diags.Append(resp.Diagnostics.InConfigBody(configBody, n.Addr.String()))
 	if diags.HasErrors() {
 		return diags
@@ -141,7 +142,7 @@ func (n *NodeApplyableProvider) ConfigureProvider(ctx EvalContext, provider prov
 
 	// ValidateProviderConfig is only used for validation. We are intentionally
 	// ignoring the PreparedConfig field to maintain existing behavior.
-	validateResp := provider.ValidateProviderConfig(req)
+	validateResp := provider.ValidateProviderConfig(traceCtx, req)
 	diags = diags.Append(validateResp.Diagnostics.InConfigBody(configBody, n.Addr.String()))
 	if diags.HasErrors() && config == nil {
 		// If there isn't an explicit "provider" block in the configuration,
@@ -165,7 +166,7 @@ func (n *NodeApplyableProvider) ConfigureProvider(ctx EvalContext, provider prov
 		log.Printf("[WARN] ValidateProviderConfig from %q changed the config value, but that value is unused", n.Addr)
 	}
 
-	configDiags := ctx.ConfigureProvider(n.Addr, unmarkedConfigVal)
+	configDiags := ctx.ConfigureProvider(traceCtx, n.Addr, unmarkedConfigVal)
 	diags = diags.Append(configDiags.InConfigBody(configBody, n.Addr.String()))
 	if diags.HasErrors() && config == nil {
 		// If there isn't an explicit "provider" block in the configuration,

--- a/internal/tofu/node_provider_eval.go
+++ b/internal/tofu/node_provider_eval.go
@@ -5,7 +5,11 @@
 
 package tofu
 
-import "github.com/opentofu/opentofu/internal/tfdiags"
+import (
+	"context"
+
+	"github.com/opentofu/opentofu/internal/tfdiags"
+)
 
 // NodeEvalableProvider represents a provider during an "eval" walk.
 // This special provider node type just initializes a provider and
@@ -18,7 +22,7 @@ type NodeEvalableProvider struct {
 var _ GraphNodeExecutable = (*NodeEvalableProvider)(nil)
 
 // GraphNodeExecutable
-func (n *NodeEvalableProvider) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *NodeEvalableProvider) Execute(traceCtx context.Context, ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	_, err := ctx.InitProvider(n.Addr)
 	return diags.Append(err)
 }

--- a/internal/tofu/node_provider_eval.go
+++ b/internal/tofu/node_provider_eval.go
@@ -23,6 +23,6 @@ var _ GraphNodeExecutable = (*NodeEvalableProvider)(nil)
 
 // GraphNodeExecutable
 func (n *NodeEvalableProvider) Execute(traceCtx context.Context, ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
-	_, err := ctx.InitProvider(n.Addr)
+	_, err := ctx.InitProvider(traceCtx, n.Addr)
 	return diags.Append(err)
 }

--- a/internal/tofu/node_provider_test.go
+++ b/internal/tofu/node_provider_test.go
@@ -57,7 +57,7 @@ func TestNodeApplyableProviderExecute(t *testing.T) {
 		"pw": cty.StringVal("so secret"),
 	}
 
-	if diags := n.Execute(ctx, walkApply); diags.HasErrors() {
+	if diags := n.Execute(nil, ctx, walkApply); diags.HasErrors() {
 		t.Fatalf("err: %s", diags.Err())
 	}
 
@@ -101,7 +101,7 @@ func TestNodeApplyableProviderExecute_unknownImport(t *testing.T) {
 	ctx := &MockEvalContext{ProviderProvider: provider}
 	ctx.installSimpleEval()
 
-	diags := n.Execute(ctx, walkImport)
+	diags := n.Execute(nil, ctx, walkImport)
 	if !diags.HasErrors() {
 		t.Fatal("expected error, got success")
 	}
@@ -135,7 +135,7 @@ func TestNodeApplyableProviderExecute_unknownApply(t *testing.T) {
 	ctx := &MockEvalContext{ProviderProvider: provider}
 	ctx.installSimpleEval()
 
-	if err := n.Execute(ctx, walkApply); err != nil {
+	if err := n.Execute(nil, ctx, walkApply); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -172,7 +172,7 @@ func TestNodeApplyableProviderExecute_sensitive(t *testing.T) {
 
 	ctx := &MockEvalContext{ProviderProvider: provider}
 	ctx.installSimpleEval()
-	if err := n.Execute(ctx, walkApply); err != nil {
+	if err := n.Execute(nil, ctx, walkApply); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -209,7 +209,7 @@ func TestNodeApplyableProviderExecute_sensitiveValidate(t *testing.T) {
 
 	ctx := &MockEvalContext{ProviderProvider: provider}
 	ctx.installSimpleEval()
-	if err := n.Execute(ctx, walkValidate); err != nil {
+	if err := n.Execute(nil, ctx, walkValidate); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -251,7 +251,7 @@ func TestNodeApplyableProviderExecute_emptyValidate(t *testing.T) {
 
 	ctx := &MockEvalContext{ProviderProvider: provider}
 	ctx.installSimpleEval()
-	if err := n.Execute(ctx, walkValidate); err != nil {
+	if err := n.Execute(nil, ctx, walkValidate); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -503,7 +503,7 @@ func (n *NodeAbstractResource) readResourceInstanceState(traceCtx context.Contex
 		// Shouldn't happen since we should've failed long ago if no schema is present
 		return nil, diags.Append(fmt.Errorf("no schema available for %s while reading state; this is a bug in OpenTofu and should be reported", addr))
 	}
-	src, upgradeDiags := upgradeResourceState(addr, provider, src, schema, currentVersion)
+	src, upgradeDiags := upgradeResourceState(traceCtx, addr, provider, src, schema, currentVersion)
 	if n.Config != nil {
 		upgradeDiags = upgradeDiags.InConfigBody(n.Config.Config, addr.String())
 	}
@@ -550,7 +550,7 @@ func (n *NodeAbstractResource) readResourceInstanceStateDeposed(traceCtx context
 
 	}
 
-	src, upgradeDiags := upgradeResourceState(addr, provider, src, schema, currentVersion)
+	src, upgradeDiags := upgradeResourceState(traceCtx, addr, provider, src, schema, currentVersion)
 	if n.Config != nil {
 		upgradeDiags = upgradeDiags.InConfigBody(n.Config.Config, addr.String())
 	}

--- a/internal/tofu/node_resource_abstract_instance.go
+++ b/internal/tofu/node_resource_abstract_instance.go
@@ -2220,7 +2220,7 @@ func (n *NodeAbstractResourceInstance) evalDestroyProvisionerConfig(ctx EvalCont
 	// destroy-time provisioners.
 	keyData := EvalDataForInstanceKey(n.ResourceInstanceAddr().Resource.Key, nil)
 
-	evalScope := ctx.EvaluationScope(n.ResourceInstanceAddr().Resource, nil, keyData)
+	evalScope := ctx.EvaluationScope(nil, n.ResourceInstanceAddr().Resource, nil, keyData)
 	config, evalDiags := evalScope.EvalSelfBlock(body, self, schema, keyData)
 	diags = diags.Append(evalDiags)
 

--- a/internal/tofu/node_resource_abstract_instance.go
+++ b/internal/tofu/node_resource_abstract_instance.go
@@ -745,7 +745,7 @@ func (n *NodeAbstractResourceInstance) plan(
 		return plannedChange, currentState.DeepCopy(), keyData, diags
 	}
 
-	origConfigVal, _, configDiags := ctx.EvaluateBlock(nil, config.Config, schema, nil, keyData)
+	origConfigVal, _, configDiags := ctx.EvaluateBlock(traceCtx, config.Config, schema, nil, keyData)
 	diags = diags.Append(configDiags)
 	if configDiags.HasErrors() {
 		return nil, nil, keyData, diags
@@ -1580,7 +1580,7 @@ func (n *NodeAbstractResourceInstance) providerMetas(traceCtx context.Context, c
 				})
 			} else {
 				var configDiags tfdiags.Diagnostics
-				metaConfigVal, _, configDiags = ctx.EvaluateBlock(nil, m.Config, providerSchema.ProviderMeta.Block, nil, EvalDataForNoInstanceKey)
+				metaConfigVal, _, configDiags = ctx.EvaluateBlock(traceCtx, m.Config, providerSchema.ProviderMeta.Block, nil, EvalDataForNoInstanceKey)
 				diags = diags.Append(configDiags)
 			}
 		}
@@ -1634,7 +1634,7 @@ func (n *NodeAbstractResourceInstance) planDataSource(traceCtx context.Context, 
 	}
 
 	var configDiags tfdiags.Diagnostics
-	configVal, _, configDiags = ctx.EvaluateBlock(nil, config.Config, schema, nil, keyData)
+	configVal, _, configDiags = ctx.EvaluateBlock(traceCtx, config.Config, schema, nil, keyData)
 	diags = diags.Append(configDiags)
 	if configDiags.HasErrors() {
 		return nil, nil, keyData, diags
@@ -1924,7 +1924,7 @@ func (n *NodeAbstractResourceInstance) applyDataSource(traceCtx context.Context,
 		return nil, keyData, diags
 	}
 
-	configVal, _, configDiags := ctx.EvaluateBlock(nil, config.Config, schema, nil, keyData)
+	configVal, _, configDiags := ctx.EvaluateBlock(traceCtx, config.Config, schema, nil, keyData)
 	diags = diags.Append(configDiags)
 	if configDiags.HasErrors() {
 		return nil, keyData, diags
@@ -2273,7 +2273,7 @@ func (n *NodeAbstractResourceInstance) apply(
 	configVal := cty.NullVal(cty.DynamicPseudoType)
 	if applyConfig != nil {
 		var configDiags tfdiags.Diagnostics
-		configVal, _, configDiags = ctx.EvaluateBlock(nil, applyConfig.Config, schema, nil, keyData)
+		configVal, _, configDiags = ctx.EvaluateBlock(traceCtx, applyConfig.Config, schema, nil, keyData)
 		diags = diags.Append(configDiags)
 		if configDiags.HasErrors() {
 			return nil, diags

--- a/internal/tofu/node_resource_abstract_instance_test.go
+++ b/internal/tofu/node_resource_abstract_instance_test.go
@@ -173,7 +173,7 @@ func TestNodeAbstractResourceInstance_WriteResourceInstanceState(t *testing.T) {
 		},
 	}
 	ctx.ProviderProvider = mockProvider
-	ctx.ProviderSchemaSchema = mockProvider.GetProviderSchema()
+	ctx.ProviderSchemaSchema = mockProvider.GetProviderSchema(nil)
 
 	err := node.writeResourceInstanceState(ctx, obj, workingState)
 	if err != nil {

--- a/internal/tofu/node_resource_abstract_test.go
+++ b/internal/tofu/node_resource_abstract_test.go
@@ -232,7 +232,7 @@ func TestNodeAbstractResource_ReadResourceInstanceState(t *testing.T) {
 			ctx := new(MockEvalContext)
 			ctx.StateState = test.State.SyncWrapper()
 			ctx.PathPath = addrs.RootModuleInstance
-			ctx.ProviderSchemaSchema = mockProvider.GetProviderSchema()
+			ctx.ProviderSchemaSchema = mockProvider.GetProviderSchema(nil)
 
 			ctx.ProviderProvider = providers.Interface(mockProvider)
 
@@ -297,7 +297,7 @@ func TestNodeAbstractResource_ReadResourceInstanceStateDeposed(t *testing.T) {
 			ctx := new(MockEvalContext)
 			ctx.StateState = test.State.SyncWrapper()
 			ctx.PathPath = addrs.RootModuleInstance
-			ctx.ProviderSchemaSchema = mockProvider.GetProviderSchema()
+			ctx.ProviderSchemaSchema = mockProvider.GetProviderSchema(nil)
 			ctx.ProviderProvider = providers.Interface(mockProvider)
 
 			key := states.DeposedKey("00000001") // shim from legacy state assigns 0th deposed index this key

--- a/internal/tofu/node_resource_apply.go
+++ b/internal/tofu/node_resource_apply.go
@@ -56,7 +56,7 @@ func (n *nodeExpandApplyableResource) Execute(traceCtx context.Context, ctx Eval
 	moduleInstances := expander.ExpandModule(n.Addr.Module)
 	for _, module := range moduleInstances {
 		ctx = ctx.WithPath(module)
-		diags = diags.Append(n.writeResourceState(ctx, n.Addr.Resource.Absolute(module)))
+		diags = diags.Append(n.writeResourceState(traceCtx, ctx, n.Addr.Resource.Absolute(module)))
 	}
 
 	return diags

--- a/internal/tofu/node_resource_apply.go
+++ b/internal/tofu/node_resource_apply.go
@@ -6,6 +6,8 @@
 package tofu
 
 import (
+	"context"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
@@ -48,7 +50,7 @@ func (n *nodeExpandApplyableResource) Name() string {
 	return n.NodeAbstractResource.Name() + " (expand)"
 }
 
-func (n *nodeExpandApplyableResource) Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
+func (n *nodeExpandApplyableResource) Execute(traceCtx context.Context, ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 	expander := ctx.InstanceExpander()
 	moduleInstances := expander.ExpandModule(n.Addr.Module)

--- a/internal/tofu/node_resource_apply_instance.go
+++ b/internal/tofu/node_resource_apply_instance.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -116,7 +117,7 @@ func (n *NodeApplyableResourceInstance) AttachDependencies(deps []addrs.ConfigRe
 }
 
 // GraphNodeExecutable
-func (n *NodeApplyableResourceInstance) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *NodeApplyableResourceInstance) Execute(traceCtx context.Context, ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	addr := n.ResourceInstanceAddr()
 
 	if n.Config == nil {

--- a/internal/tofu/node_resource_apply_test.go
+++ b/internal/tofu/node_resource_apply_test.go
@@ -28,7 +28,7 @@ func TestNodeExpandApplyableResourceExecute(t *testing.T) {
 				Config: nil,
 			},
 		}
-		diags := node.Execute(ctx, walkApply)
+		diags := node.Execute(nil, ctx, walkApply)
 		if diags.HasErrors() {
 			t.Fatalf("unexpected error: %s", diags.Err())
 		}
@@ -59,7 +59,7 @@ func TestNodeExpandApplyableResourceExecute(t *testing.T) {
 				},
 			},
 		}
-		diags := node.Execute(ctx, walkApply)
+		diags := node.Execute(nil, ctx, walkApply)
 		if diags.HasErrors() {
 			t.Fatalf("unexpected error: %s", diags.Err())
 		}

--- a/internal/tofu/node_resource_deposed.go
+++ b/internal/tofu/node_resource_deposed.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -84,7 +85,7 @@ func (n *NodePlanDeposedResourceInstanceObject) References() []*addrs.Reference 
 }
 
 // GraphNodeEvalable impl.
-func (n *NodePlanDeposedResourceInstanceObject) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *NodePlanDeposedResourceInstanceObject) Execute(traceCtx context.Context, ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	log.Printf("[TRACE] NodePlanDeposedResourceInstanceObject: planning %s deposed object %s", n.Addr, n.DeposedKey)
 
 	// Read the state for the deposed resource instance
@@ -249,7 +250,7 @@ func (n *NodeDestroyDeposedResourceInstanceObject) ModifyCreateBeforeDestroy(v b
 }
 
 // GraphNodeExecutable impl.
-func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *NodeDestroyDeposedResourceInstanceObject) Execute(traceCtx context.Context, ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	var change *plans.ResourceInstanceChange
 
 	// Read the state for the deposed resource instance
@@ -398,7 +399,7 @@ func (n *NodeForgetDeposedResourceInstanceObject) References() []*addrs.Referenc
 }
 
 // GraphNodeExecutable impl.
-func (n *NodeForgetDeposedResourceInstanceObject) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *NodeForgetDeposedResourceInstanceObject) Execute(traceCtx context.Context, ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	// Read the state for the deposed resource instance
 	state, err := n.readResourceInstanceStateDeposed(ctx, n.Addr, n.DeposedKey)
 	if err != nil {

--- a/internal/tofu/node_resource_deposed_test.go
+++ b/internal/tofu/node_resource_deposed_test.go
@@ -8,12 +8,13 @@ package tofu
 import (
 	"testing"
 
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/plans"
 	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/states"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func TestNodePlanDeposedResourceInstanceObject_Execute(t *testing.T) {
@@ -103,7 +104,7 @@ func TestNodePlanDeposedResourceInstanceObject_Execute(t *testing.T) {
 			EndpointsToRemove: test.nodeEndpointsToRemove,
 		}
 
-		err := node.Execute(ctx, walkPlan)
+		err := node.Execute(nil, ctx, walkPlan)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -138,7 +139,7 @@ func TestNodeDestroyDeposedResourceInstanceObject_Execute(t *testing.T) {
 		},
 		DeposedKey: deposedKey,
 	}
-	err := node.Execute(ctx, walkApply)
+	err := node.Execute(nil, ctx, walkApply)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -163,7 +164,7 @@ func TestNodeDestroyDeposedResourceInstanceObject_WriteResourceInstanceState(t *
 		},
 	})
 	ctx.ProviderProvider = mockProvider
-	ctx.ProviderSchemaSchema = mockProvider.GetProviderSchema()
+	ctx.ProviderSchemaSchema = mockProvider.GetProviderSchema(nil)
 
 	obj := &states.ResourceInstanceObject{
 		Value: cty.ObjectVal(map[string]cty.Value{
@@ -198,7 +199,7 @@ func TestNodeDestroyDeposedResourceInstanceObject_ExecuteMissingState(t *testing
 	ctx := &MockEvalContext{
 		StateState:           states.NewState().SyncWrapper(),
 		ProviderProvider:     simpleMockProvider(),
-		ProviderSchemaSchema: p.GetProviderSchema(),
+		ProviderSchemaSchema: p.GetProviderSchema(nil),
 		ChangesChanges:       plans.NewChanges().SyncWrapper(),
 	}
 
@@ -211,7 +212,7 @@ func TestNodeDestroyDeposedResourceInstanceObject_ExecuteMissingState(t *testing
 		},
 		DeposedKey: states.NewDeposedKey(),
 	}
-	err := node.Execute(ctx, walkApply)
+	err := node.Execute(nil, ctx, walkApply)
 
 	if err == nil {
 		t.Fatal("expected error")
@@ -234,7 +235,7 @@ func TestNodeForgetDeposedResourceInstanceObject_Execute(t *testing.T) {
 		},
 		DeposedKey: deposedKey,
 	}
-	err := node.Execute(ctx, walkApply)
+	err := node.Execute(nil, ctx, walkApply)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -279,7 +280,7 @@ func initMockEvalContext(resourceAddrs string, deposedKey states.DeposedKey) (*M
 	}
 
 	p := testProvider("test")
-	p.ConfigureProvider(providers.ConfigureProviderRequest{})
+	p.ConfigureProvider(nil, providers.ConfigureProviderRequest{})
 	p.GetProviderSchemaResponse = &schema
 
 	p.UpgradeResourceStateResponse = &providers.UpgradeResourceStateResponse{

--- a/internal/tofu/node_resource_destroy.go
+++ b/internal/tofu/node_resource_destroy.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -137,7 +138,7 @@ func (n *NodeDestroyResourceInstance) References() []*addrs.Reference {
 }
 
 // GraphNodeExecutable
-func (n *NodeDestroyResourceInstance) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *NodeDestroyResourceInstance) Execute(traceCtx context.Context, ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	addr := n.ResourceInstanceAddr()
 
 	// Eval info is different depending on what kind of resource this is

--- a/internal/tofu/node_resource_forget.go
+++ b/internal/tofu/node_resource_forget.go
@@ -56,7 +56,7 @@ func (n *NodeForgetResourceInstance) Execute(traceCtx context.Context, ctx EvalC
 
 	var state *states.ResourceInstanceObject
 
-	state, readDiags := n.readResourceInstanceState(ctx, addr)
+	state, readDiags := n.readResourceInstanceState(traceCtx, ctx, addr)
 	diags = diags.Append(readDiags)
 	if diags.HasErrors() {
 		return diags

--- a/internal/tofu/node_resource_forget.go
+++ b/internal/tofu/node_resource_forget.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -44,7 +45,7 @@ func (n *NodeForgetResourceInstance) Name() string {
 }
 
 // GraphNodeExecutable
-func (n *NodeForgetResourceInstance) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *NodeForgetResourceInstance) Execute(traceCtx context.Context, ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	addr := n.ResourceInstanceAddr()
 
 	// Get our state

--- a/internal/tofu/node_resource_import.go
+++ b/internal/tofu/node_resource_import.go
@@ -269,7 +269,7 @@ func (n *graphNodeImportStateSub) Execute(traceCtx context.Context, ctx EvalCont
 	// Insert marks from configuration
 	if n.Config != nil {
 		// Since the import command allow import resource with incomplete configuration, we ignore diagnostics here
-		valueWithConfigurationSchemaMarks, _, _ := ctx.EvaluateBlock(nil, n.Config.Config, n.Schema, nil, EvalDataForNoInstanceKey)
+		valueWithConfigurationSchemaMarks, _, _ := ctx.EvaluateBlock(traceCtx, n.Config.Config, n.Schema, nil, EvalDataForNoInstanceKey)
 		state.Value = copyMarksFromValue(state.Value, valueWithConfigurationSchemaMarks)
 	}
 

--- a/internal/tofu/node_resource_import.go
+++ b/internal/tofu/node_resource_import.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -77,7 +78,7 @@ func (n *graphNodeImportState) ModulePath() addrs.Module {
 }
 
 // GraphNodeExecutable impl.
-func (n *graphNodeImportState) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *graphNodeImportState) Execute(traceCtx context.Context, ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	// Reset our states
 	n.states = nil
 
@@ -224,7 +225,7 @@ func (n *graphNodeImportStateSub) Path() addrs.ModuleInstance {
 }
 
 // GraphNodeExecutable impl.
-func (n *graphNodeImportStateSub) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *graphNodeImportStateSub) Execute(traceCtx context.Context, ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	// If the Ephemeral type isn't set, then it is an error
 	if n.State.TypeName == "" {
 		diags = diags.Append(fmt.Errorf("import of %s didn't set type", n.TargetAddr.String()))

--- a/internal/tofu/node_resource_import.go
+++ b/internal/tofu/node_resource_import.go
@@ -82,7 +82,7 @@ func (n *graphNodeImportState) Execute(traceCtx context.Context, ctx EvalContext
 	// Reset our states
 	n.states = nil
 
-	provider, _, err := getProvider(ctx, n.ResolvedProvider)
+	provider, _, err := getProvider(traceCtx, ctx, n.ResolvedProvider)
 	diags = diags.Append(err)
 	if diags.HasErrors() {
 		return diags
@@ -127,7 +127,7 @@ func (n *graphNodeImportState) Execute(traceCtx context.Context, ctx EvalContext
 // and state inserts we need to do for our import state. Since they're new
 // resources they don't depend on anything else and refreshes are isolated
 // so this is nearly a perfect use case for dynamic expand.
-func (n *graphNodeImportState) DynamicExpand(ctx EvalContext) (*Graph, error) {
+func (n *graphNodeImportState) DynamicExpand(traceCtx context.Context, ctx EvalContext) (*Graph, error) {
 	var diags tfdiags.Diagnostics
 
 	g := &Graph{Path: ctx.Path()}
@@ -241,7 +241,7 @@ func (n *graphNodeImportStateSub) Execute(traceCtx context.Context, ctx EvalCont
 			ResolvedProvider: n.ResolvedProvider,
 		},
 	}
-	state, refreshDiags := riNode.refresh(ctx, states.NotDeposed, state)
+	state, refreshDiags := riNode.refresh(traceCtx, ctx, states.NotDeposed, state)
 	diags = diags.Append(refreshDiags)
 	if diags.HasErrors() {
 		return diags
@@ -269,10 +269,10 @@ func (n *graphNodeImportStateSub) Execute(traceCtx context.Context, ctx EvalCont
 	// Insert marks from configuration
 	if n.Config != nil {
 		// Since the import command allow import resource with incomplete configuration, we ignore diagnostics here
-		valueWithConfigurationSchemaMarks, _, _ := ctx.EvaluateBlock(n.Config.Config, n.Schema, nil, EvalDataForNoInstanceKey)
+		valueWithConfigurationSchemaMarks, _, _ := ctx.EvaluateBlock(nil, n.Config.Config, n.Schema, nil, EvalDataForNoInstanceKey)
 		state.Value = copyMarksFromValue(state.Value, valueWithConfigurationSchemaMarks)
 	}
 
-	diags = diags.Append(riNode.writeResourceInstanceState(ctx, state, workingState))
+	diags = diags.Append(riNode.writeResourceInstanceState(traceCtx, ctx, state, workingState))
 	return diags
 }

--- a/internal/tofu/node_resource_plan_destroy.go
+++ b/internal/tofu/node_resource_plan_destroy.go
@@ -51,15 +51,15 @@ func (n *NodePlanDestroyableResourceInstance) Execute(traceCtx context.Context, 
 
 	switch addr.Resource.Resource.Mode {
 	case addrs.ManagedResourceMode:
-		return n.managedResourceExecute(ctx, op)
+		return n.managedResourceExecute(traceCtx, ctx, op)
 	case addrs.DataResourceMode:
-		return n.dataResourceExecute(ctx, op)
+		return n.dataResourceExecute(traceCtx, ctx, op)
 	default:
 		panic(fmt.Errorf("unsupported resource mode %s", n.Config.Mode))
 	}
 }
 
-func (n *NodePlanDestroyableResourceInstance) managedResourceExecute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *NodePlanDestroyableResourceInstance) managedResourceExecute(traceCtx context.Context, ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	addr := n.ResourceInstanceAddr()
 
 	// Declare a bunch of variables that are used for state during
@@ -68,7 +68,7 @@ func (n *NodePlanDestroyableResourceInstance) managedResourceExecute(ctx EvalCon
 	var change *plans.ResourceInstanceChange
 	var state *states.ResourceInstanceObject
 
-	state, err := n.readResourceInstanceState(ctx, addr)
+	state, err := n.readResourceInstanceState(traceCtx, ctx, addr)
 	diags = diags.Append(err)
 	if diags.HasErrors() {
 		return diags
@@ -84,23 +84,23 @@ func (n *NodePlanDestroyableResourceInstance) managedResourceExecute(ctx EvalCon
 	// conditionals must agree (be exactly opposite) in order to get the
 	// correct behavior in both cases.
 	if n.skipRefresh {
-		diags = diags.Append(n.writeResourceInstanceState(ctx, state, prevRunState))
+		diags = diags.Append(n.writeResourceInstanceState(traceCtx, ctx, state, prevRunState))
 		if diags.HasErrors() {
 			return diags
 		}
-		diags = diags.Append(n.writeResourceInstanceState(ctx, state, refreshState))
+		diags = diags.Append(n.writeResourceInstanceState(traceCtx, ctx, state, refreshState))
 		if diags.HasErrors() {
 			return diags
 		}
 	}
 
-	change, destroyPlanDiags := n.planDestroy(ctx, state, "")
+	change, destroyPlanDiags := n.planDestroy(traceCtx, ctx, state, "")
 	diags = diags.Append(destroyPlanDiags)
 	if diags.HasErrors() {
 		return diags
 	}
 
-	diags = diags.Append(n.writeChange(ctx, change, ""))
+	diags = diags.Append(n.writeChange(traceCtx, ctx, change, ""))
 	if diags.HasErrors() {
 		return diags
 	}
@@ -109,7 +109,7 @@ func (n *NodePlanDestroyableResourceInstance) managedResourceExecute(ctx EvalCon
 	return diags
 }
 
-func (n *NodePlanDestroyableResourceInstance) dataResourceExecute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *NodePlanDestroyableResourceInstance) dataResourceExecute(traceCtx context.Context, ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 
 	// We may not be able to read a prior data source from the state if the
 	// schema was upgraded and we are destroying before ever refreshing that
@@ -125,5 +125,5 @@ func (n *NodePlanDestroyableResourceInstance) dataResourceExecute(ctx EvalContex
 		},
 		ProviderAddr: n.ResolvedProvider,
 	}
-	return diags.Append(n.writeChange(ctx, change, ""))
+	return diags.Append(n.writeChange(traceCtx, ctx, change, ""))
 }

--- a/internal/tofu/node_resource_plan_destroy.go
+++ b/internal/tofu/node_resource_plan_destroy.go
@@ -6,13 +6,15 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
+
+	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/plans"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // NodePlanDestroyableResourceInstance represents a resource that is ready
@@ -44,7 +46,7 @@ func (n *NodePlanDestroyableResourceInstance) DestroyAddr() *addrs.AbsResourceIn
 }
 
 // GraphNodeEvalable
-func (n *NodePlanDestroyableResourceInstance) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *NodePlanDestroyableResourceInstance) Execute(traceCtx context.Context, ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	addr := n.ResourceInstanceAddr()
 
 	switch addr.Resource.Resource.Mode {

--- a/internal/tofu/node_resource_plan_instance.go
+++ b/internal/tofu/node_resource_plan_instance.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
@@ -99,6 +100,10 @@ func (n *NodePlannableResourceInstance) Execute(traceCtx context.Context, ctx Ev
 }
 
 func (n *NodePlannableResourceInstance) dataResourceExecute(traceCtx context.Context, ctx EvalContext) (diags tfdiags.Diagnostics) {
+	var span trace.Span
+	traceCtx, span = tracer.Start(traceCtx, "NodePlannableResourceInstance.dataResourceExecute")
+	defer span.End()
+
 	config := n.Config
 	addr := n.ResourceInstanceAddr()
 
@@ -156,6 +161,10 @@ func (n *NodePlannableResourceInstance) dataResourceExecute(traceCtx context.Con
 }
 
 func (n *NodePlannableResourceInstance) managedResourceExecute(traceCtx context.Context, ctx EvalContext) (diags tfdiags.Diagnostics) {
+	var span trace.Span
+	traceCtx, span = tracer.Start(traceCtx, "NodePlannableResourceInstance.managedResourceExecute")
+	defer span.End()
+
 	config := n.Config
 	addr := n.ResourceInstanceAddr()
 

--- a/internal/tofu/node_resource_plan_instance.go
+++ b/internal/tofu/node_resource_plan_instance.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"path/filepath"
@@ -83,7 +84,7 @@ var (
 )
 
 // GraphNodeEvalable
-func (n *NodePlannableResourceInstance) Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
+func (n *NodePlannableResourceInstance) Execute(traceCtx context.Context, ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
 	addr := n.ResourceInstanceAddr()
 
 	// Eval info is different depending on what kind of resource this is

--- a/internal/tofu/node_resource_plan_orphan.go
+++ b/internal/tofu/node_resource_plan_orphan.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -51,7 +52,7 @@ func (n *NodePlannableResourceInstanceOrphan) Name() string {
 }
 
 // GraphNodeExecutable
-func (n *NodePlannableResourceInstanceOrphan) Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
+func (n *NodePlannableResourceInstanceOrphan) Execute(traceCtx context.Context, ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
 	addr := n.ResourceInstanceAddr()
 
 	// Eval info is different depending on what kind of resource this is

--- a/internal/tofu/node_resource_plan_orphan_test.go
+++ b/internal/tofu/node_resource_plan_orphan_test.go
@@ -10,12 +10,13 @@ import (
 
 	"github.com/opentofu/opentofu/internal/configs/configschema"
 
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/instances"
 	"github.com/opentofu/opentofu/internal/plans"
 	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/states"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func TestNodeResourcePlanOrphan_Execute(t *testing.T) {
@@ -126,7 +127,7 @@ func TestNodeResourcePlanOrphan_Execute(t *testing.T) {
 		}
 
 		p := simpleMockProvider()
-		p.ConfigureProvider(providers.ConfigureProviderRequest{})
+		p.ConfigureProvider(nil, providers.ConfigureProviderRequest{})
 		p.GetProviderSchemaResponse = &schema
 
 		ctx := &MockEvalContext{
@@ -152,7 +153,7 @@ func TestNodeResourcePlanOrphan_Execute(t *testing.T) {
 			EndpointsToRemove: test.nodeEndpointsToRemove,
 		}
 
-		err := node.Execute(ctx, walkPlan)
+		err := node.Execute(nil, ctx, walkPlan)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -194,7 +195,7 @@ func TestNodeResourcePlanOrphanExecute_alreadyDeleted(t *testing.T) {
 	changes := plans.NewChanges()
 
 	p := simpleMockProvider()
-	p.ConfigureProvider(providers.ConfigureProviderRequest{})
+	p.ConfigureProvider(nil, providers.ConfigureProviderRequest{})
 	p.ReadResourceResponse = &providers.ReadResourceResponse{
 		NewState: cty.NullVal(p.GetProviderSchemaResponse.ResourceTypes["test_string"].Block.ImpliedType()),
 	}
@@ -225,7 +226,7 @@ func TestNodeResourcePlanOrphanExecute_alreadyDeleted(t *testing.T) {
 			Addr: mustResourceInstanceAddr("test_object.foo"),
 		},
 	}
-	diags := node.Execute(ctx, walkPlan)
+	diags := node.Execute(nil, ctx, walkPlan)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}
@@ -276,7 +277,7 @@ func TestNodeResourcePlanOrphanExecute_deposed(t *testing.T) {
 	changes := plans.NewChanges()
 
 	p := simpleMockProvider()
-	p.ConfigureProvider(providers.ConfigureProviderRequest{})
+	p.ConfigureProvider(nil, providers.ConfigureProviderRequest{})
 	p.ReadResourceResponse = &providers.ReadResourceResponse{
 		NewState: cty.NullVal(p.GetProviderSchemaResponse.ResourceTypes["test_string"].Block.ImpliedType()),
 	}
@@ -307,7 +308,7 @@ func TestNodeResourcePlanOrphanExecute_deposed(t *testing.T) {
 			Addr: mustResourceInstanceAddr("test_object.foo"),
 		},
 	}
-	diags := node.Execute(ctx, walkPlan)
+	diags := node.Execute(nil, ctx, walkPlan)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}

--- a/internal/tofu/node_resource_validate.go
+++ b/internal/tofu/node_resource_validate.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -46,7 +47,7 @@ func (n *NodeValidatableResource) Path() addrs.ModuleInstance {
 }
 
 // GraphNodeEvalable
-func (n *NodeValidatableResource) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *NodeValidatableResource) Execute(traceCtx context.Context, ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	if n.Config == nil {
 		return diags
 	}
@@ -480,7 +481,7 @@ func (n *NodeValidatableResource) evaluateExpr(ctx EvalContext, expr hcl.Express
 	refs, refDiags := lang.ReferencesInExpr(addrs.ParseRef, expr)
 	diags = diags.Append(refDiags)
 
-	scope := ctx.EvaluationScope(self, nil, keyData)
+	scope := ctx.EvaluationScope(nil, self, nil, keyData)
 
 	hclCtx, moreDiags := scope.EvalContext(refs)
 	diags = diags.Append(moreDiags)
@@ -596,7 +597,7 @@ func validateDependsOn(ctx EvalContext, dependsOn []hcl.Traversal) (diags tfdiag
 		// we'll just eval it and count on the fact that our evaluator will
 		// detect references to non-existent objects.
 		if !diags.HasErrors() {
-			scope := ctx.EvaluationScope(nil, nil, EvalDataForNoInstanceKey)
+			scope := ctx.EvaluationScope(nil, nil, nil, EvalDataForNoInstanceKey)
 			if scope != nil { // sometimes nil in tests, due to incomplete mocks
 				_, refDiags = scope.EvalReference(ref, cty.DynamicPseudoType)
 				diags = diags.Append(refDiags)

--- a/internal/tofu/node_resource_validate.go
+++ b/internal/tofu/node_resource_validate.go
@@ -381,7 +381,7 @@ func (n *NodeValidatableResource) validateResource(traceCtx context.Context, ctx
 			return diags
 		}
 
-		configVal, _, valDiags := ctx.EvaluateBlock(nil, n.Config.Config, schema, nil, keyData)
+		configVal, _, valDiags := ctx.EvaluateBlock(traceCtx, n.Config.Config, schema, nil, keyData)
 		diags = diags.Append(valDiags)
 		if valDiags.HasErrors() {
 			return diags
@@ -427,7 +427,7 @@ func (n *NodeValidatableResource) validateResource(traceCtx context.Context, ctx
 			Config:   unmarkedConfigVal,
 		}
 
-		resp := provider.ValidateResourceConfig(req)
+		resp := provider.ValidateResourceConfig(traceCtx, req)
 		diags = diags.Append(resp.Diagnostics.InConfigBody(n.Config.Config, n.Addr.String()))
 
 	case addrs.DataResourceMode:
@@ -455,7 +455,7 @@ func (n *NodeValidatableResource) validateResource(traceCtx context.Context, ctx
 			return diags
 		}
 
-		configVal, _, valDiags := ctx.EvaluateBlock(nil, n.Config.Config, schema, nil, keyData)
+		configVal, _, valDiags := ctx.EvaluateBlock(traceCtx, n.Config.Config, schema, nil, keyData)
 		diags = diags.Append(valDiags)
 		if valDiags.HasErrors() {
 			return diags
@@ -468,7 +468,7 @@ func (n *NodeValidatableResource) validateResource(traceCtx context.Context, ctx
 			Config:   unmarkedConfigVal,
 		}
 
-		resp := provider.ValidateDataResourceConfig(req)
+		resp := provider.ValidateDataResourceConfig(traceCtx, req)
 		diags = diags.Append(resp.Diagnostics.InConfigBody(n.Config.Config, n.Addr.String()))
 	}
 
@@ -483,7 +483,7 @@ func (n *NodeValidatableResource) evaluateExpr(traceCtx context.Context, ctx Eva
 
 	scope := ctx.EvaluationScope(traceCtx, self, nil, keyData)
 
-	hclCtx, moreDiags := scope.EvalContext(refs)
+	hclCtx, moreDiags := scope.EvalContext(traceCtx, refs)
 	diags = diags.Append(moreDiags)
 
 	result, hclDiags := expr.Value(hclCtx)
@@ -599,7 +599,7 @@ func validateDependsOn(traceCtx context.Context, ctx EvalContext, dependsOn []hc
 		if !diags.HasErrors() {
 			scope := ctx.EvaluationScope(traceCtx, nil, nil, EvalDataForNoInstanceKey)
 			if scope != nil { // sometimes nil in tests, due to incomplete mocks
-				_, refDiags = scope.EvalReference(ref, cty.DynamicPseudoType)
+				_, refDiags = scope.EvalReference(traceCtx, ref, cty.DynamicPseudoType)
 				diags = diags.Append(refDiags)
 			}
 		}

--- a/internal/tofu/node_resource_validate_test.go
+++ b/internal/tofu/node_resource_validate_test.go
@@ -195,7 +195,7 @@ func TestNodeValidatableResource_ValidateResource_managedResource(t *testing.T) 
 
 	ctx := &MockEvalContext{}
 	ctx.installSimpleEval()
-	ctx.ProviderSchemaSchema = mp.GetProviderSchema()
+	ctx.ProviderSchemaSchema = mp.GetProviderSchema(nil)
 	ctx.ProviderProvider = p
 
 	err := node.validateResource(ctx)
@@ -225,7 +225,7 @@ func TestNodeValidatableResource_ValidateResource_managedResourceCount(t *testin
 
 	ctx := &MockEvalContext{}
 	ctx.installSimpleEval()
-	ctx.ProviderSchemaSchema = mp.GetProviderSchema()
+	ctx.ProviderSchemaSchema = mp.GetProviderSchema(nil)
 	ctx.ProviderProvider = p
 
 	tests := []struct {
@@ -309,7 +309,7 @@ func TestNodeValidatableResource_ValidateResource_dataSource(t *testing.T) {
 
 	ctx := &MockEvalContext{}
 	ctx.installSimpleEval()
-	ctx.ProviderSchemaSchema = mp.GetProviderSchema()
+	ctx.ProviderSchemaSchema = mp.GetProviderSchema(nil)
 	ctx.ProviderProvider = p
 
 	diags := node.validateResource(ctx)
@@ -345,7 +345,7 @@ func TestNodeValidatableResource_ValidateResource_valid(t *testing.T) {
 
 	ctx := &MockEvalContext{}
 	ctx.installSimpleEval()
-	ctx.ProviderSchemaSchema = mp.GetProviderSchema()
+	ctx.ProviderSchemaSchema = mp.GetProviderSchema(nil)
 	ctx.ProviderProvider = p
 
 	diags := node.validateResource(ctx)
@@ -382,7 +382,7 @@ func TestNodeValidatableResource_ValidateResource_warningsAndErrorsPassedThrough
 
 	ctx := &MockEvalContext{}
 	ctx.installSimpleEval()
-	ctx.ProviderSchemaSchema = mp.GetProviderSchema()
+	ctx.ProviderSchemaSchema = mp.GetProviderSchema(nil)
 	ctx.ProviderProvider = p
 
 	diags := node.validateResource(ctx)
@@ -445,7 +445,7 @@ func TestNodeValidatableResource_ValidateResource_invalidDependsOn(t *testing.T)
 	ctx := &MockEvalContext{}
 	ctx.installSimpleEval()
 
-	ctx.ProviderSchemaSchema = mp.GetProviderSchema()
+	ctx.ProviderSchemaSchema = mp.GetProviderSchema(nil)
 	ctx.ProviderProvider = p
 
 	diags := node.validateResource(ctx)
@@ -529,7 +529,7 @@ func TestNodeValidatableResource_ValidateResource_invalidIgnoreChangesNonexisten
 	ctx := &MockEvalContext{}
 	ctx.installSimpleEval()
 
-	ctx.ProviderSchemaSchema = mp.GetProviderSchema()
+	ctx.ProviderSchemaSchema = mp.GetProviderSchema(nil)
 	ctx.ProviderProvider = p
 
 	diags := node.validateResource(ctx)
@@ -612,7 +612,7 @@ func TestNodeValidatableResource_ValidateResource_invalidIgnoreChangesComputed(t
 	ctx := &MockEvalContext{}
 	ctx.installSimpleEval()
 
-	ctx.ProviderSchemaSchema = mp.GetProviderSchema()
+	ctx.ProviderSchemaSchema = mp.GetProviderSchema(nil)
 	ctx.ProviderProvider = p
 
 	diags := node.validateResource(ctx)

--- a/internal/tofu/node_root_variable.go
+++ b/internal/tofu/node_root_variable.go
@@ -107,6 +107,7 @@ func (n *NodeRootVariable) Execute(traceCtx context.Context, ctx EvalContext, op
 	ctx.SetRootModuleArgument(addr.Variable, finalVal)
 
 	moreDiags = evalVariableValidations(
+		traceCtx,
 		addrs.RootModuleInstance.InputVariable(n.Addr.Name),
 		n.Config,
 		nil, // not set for root module variables

--- a/internal/tofu/node_root_variable.go
+++ b/internal/tofu/node_root_variable.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"log"
 
 	"github.com/zclconf/go-cty/cty"
@@ -53,7 +54,7 @@ func (n *NodeRootVariable) ReferenceableAddrs() []addrs.Referenceable {
 }
 
 // GraphNodeExecutable
-func (n *NodeRootVariable) Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
+func (n *NodeRootVariable) Execute(traceCtx context.Context, ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
 	// Root module variables are special in that they are provided directly
 	// by the caller (usually, the CLI layer) and so we don't really need to
 	// evaluate them in the usual sense, but we do need to process the raw

--- a/internal/tofu/node_root_variable_test.go
+++ b/internal/tofu/node_root_variable_test.go
@@ -43,7 +43,7 @@ func TestNodeRootVariableExecute(t *testing.T) {
 			},
 		})
 
-		diags := n.Execute(ctx, walkApply)
+		diags := n.Execute(nil, ctx, walkApply)
 		if diags.HasErrors() {
 			t.Fatalf("unexpected error: %s", diags.Err())
 		}
@@ -136,7 +136,7 @@ func TestNodeRootVariableExecute(t *testing.T) {
 			},
 		})
 
-		diags := n.Execute(ctx, walkApply)
+		diags := n.Execute(nil, ctx, walkApply)
 		if diags.HasErrors() {
 			t.Fatalf("unexpected error: %s", diags.Err())
 		}

--- a/internal/tofu/provider_mock.go
+++ b/internal/tofu/provider_mock.go
@@ -141,7 +141,7 @@ func (p *MockProvider) ValidateProviderConfig(ctx context.Context, r providers.V
 	return resp
 }
 
-func (p *MockProvider) ValidateResourceConfig(r providers.ValidateResourceConfigRequest) (resp providers.ValidateResourceConfigResponse) {
+func (p *MockProvider) ValidateResourceConfig(ctx context.Context, r providers.ValidateResourceConfigRequest) (resp providers.ValidateResourceConfigResponse) {
 	p.Lock()
 	defer p.Unlock()
 
@@ -173,7 +173,7 @@ func (p *MockProvider) ValidateResourceConfig(r providers.ValidateResourceConfig
 	return resp
 }
 
-func (p *MockProvider) ValidateDataResourceConfig(r providers.ValidateDataResourceConfigRequest) (resp providers.ValidateDataResourceConfigResponse) {
+func (p *MockProvider) ValidateDataResourceConfig(ctx context.Context, r providers.ValidateDataResourceConfigRequest) (resp providers.ValidateDataResourceConfigResponse) {
 	p.Lock()
 	defer p.Unlock()
 
@@ -203,7 +203,7 @@ func (p *MockProvider) ValidateDataResourceConfig(r providers.ValidateDataResour
 	return resp
 }
 
-func (p *MockProvider) UpgradeResourceState(r providers.UpgradeResourceStateRequest) (resp providers.UpgradeResourceStateResponse) {
+func (p *MockProvider) UpgradeResourceState(ctx context.Context, r providers.UpgradeResourceStateRequest) (resp providers.UpgradeResourceStateResponse) {
 	p.Lock()
 	defer p.Unlock()
 
@@ -284,7 +284,7 @@ func (p *MockProvider) Stop() error {
 	return p.StopResponse
 }
 
-func (p *MockProvider) ReadResource(r providers.ReadResourceRequest) (resp providers.ReadResourceResponse) {
+func (p *MockProvider) ReadResource(ctx context.Context, r providers.ReadResourceRequest) (resp providers.ReadResourceResponse) {
 	p.Lock()
 	defer p.Unlock()
 
@@ -325,7 +325,7 @@ func (p *MockProvider) ReadResource(r providers.ReadResourceRequest) (resp provi
 	return resp
 }
 
-func (p *MockProvider) PlanResourceChange(r providers.PlanResourceChangeRequest) (resp providers.PlanResourceChangeResponse) {
+func (p *MockProvider) PlanResourceChange(ctx context.Context, r providers.PlanResourceChangeRequest) (resp providers.PlanResourceChangeResponse) {
 	p.Lock()
 	defer p.Unlock()
 
@@ -405,7 +405,7 @@ func (p *MockProvider) PlanResourceChange(r providers.PlanResourceChangeRequest)
 	return resp
 }
 
-func (p *MockProvider) ApplyResourceChange(r providers.ApplyResourceChangeRequest) (resp providers.ApplyResourceChangeResponse) {
+func (p *MockProvider) ApplyResourceChange(ctx context.Context, r providers.ApplyResourceChangeRequest) (resp providers.ApplyResourceChangeResponse) {
 	p.Lock()
 	defer p.Unlock()
 	p.ApplyResourceChangeCalled = true
@@ -503,7 +503,7 @@ func (p *MockProvider) ImportResourceState(r providers.ImportResourceStateReques
 	return resp
 }
 
-func (p *MockProvider) ReadDataSource(r providers.ReadDataSourceRequest) (resp providers.ReadDataSourceResponse) {
+func (p *MockProvider) ReadDataSource(ctx context.Context, r providers.ReadDataSourceRequest) (resp providers.ReadDataSourceResponse) {
 	p.Lock()
 	defer p.Unlock()
 

--- a/internal/tofu/provider_mock.go
+++ b/internal/tofu/provider_mock.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -100,7 +101,7 @@ type MockProvider struct {
 	CloseError  error
 }
 
-func (p *MockProvider) GetProviderSchema() providers.GetProviderSchemaResponse {
+func (p *MockProvider) GetProviderSchema(context.Context) providers.GetProviderSchemaResponse {
 	p.Lock()
 	defer p.Unlock()
 	p.GetProviderSchemaCalled = true
@@ -122,7 +123,7 @@ func (p *MockProvider) getProviderSchema() providers.GetProviderSchemaResponse {
 	}
 }
 
-func (p *MockProvider) ValidateProviderConfig(r providers.ValidateProviderConfigRequest) (resp providers.ValidateProviderConfigResponse) {
+func (p *MockProvider) ValidateProviderConfig(ctx context.Context, r providers.ValidateProviderConfigRequest) (resp providers.ValidateProviderConfigResponse) {
 	p.Lock()
 	defer p.Unlock()
 
@@ -251,7 +252,7 @@ func (p *MockProvider) UpgradeResourceState(r providers.UpgradeResourceStateRequ
 	return resp
 }
 
-func (p *MockProvider) ConfigureProvider(r providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
+func (p *MockProvider) ConfigureProvider(ctx context.Context, r providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
 	p.Lock()
 	defer p.Unlock()
 
@@ -541,7 +542,7 @@ func (p *MockProvider) GetFunctions() (resp providers.GetFunctionsResponse) {
 	return resp
 }
 
-func (p *MockProvider) CallFunction(r providers.CallFunctionRequest) (resp providers.CallFunctionResponse) {
+func (p *MockProvider) CallFunction(ctx context.Context, r providers.CallFunctionRequest) (resp providers.CallFunctionResponse) {
 	p.Lock()
 	defer p.Unlock()
 

--- a/internal/tofu/schemas.go
+++ b/internal/tofu/schemas.go
@@ -10,6 +10,9 @@ import (
 	"fmt"
 	"log"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
@@ -74,6 +77,10 @@ func (ss *Schemas) ProvisionerConfig(name string) *configschema.Block {
 // protocol itself. When returned with errors, the returned schemas object is
 // still valid but may be incomplete.
 func loadSchemas(ctx context.Context, config *configs.Config, state *states.State, plugins *contextPlugins) (*Schemas, error) {
+	var span trace.Span
+	ctx, span = tracer.Start(ctx, "loadSchemas")
+	defer span.End()
+
 	schemas := &Schemas{
 		Providers:    map[addrs.Provider]providers.ProviderSchema{},
 		Provisioners: map[string]*configschema.Block{},
@@ -82,7 +89,7 @@ func loadSchemas(ctx context.Context, config *configs.Config, state *states.Stat
 
 	newDiags := loadProviderSchemas(ctx, schemas.Providers, config, state, plugins)
 	diags = diags.Append(newDiags)
-	newDiags = loadProvisionerSchemas(schemas.Provisioners, config, plugins)
+	newDiags = loadProvisionerSchemas(ctx, schemas.Provisioners, config, plugins)
 	diags = diags.Append(newDiags)
 
 	return schemas, diags.Err()
@@ -91,7 +98,15 @@ func loadSchemas(ctx context.Context, config *configs.Config, state *states.Stat
 func loadProviderSchemas(ctx context.Context, schemas map[addrs.Provider]providers.ProviderSchema, config *configs.Config, state *states.State, plugins *contextPlugins) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
-	ensure := func(fqn addrs.Provider) {
+	var span trace.Span
+	ctx, span = tracer.Start(ctx, "loadProviderSchemas")
+	defer span.End()
+
+	ensure := func(innerCtx context.Context, fqn addrs.Provider) {
+		var innerSpan trace.Span
+		innerCtx, innerSpan = tracer.Start(innerCtx, "loadProviderSchema", trace.WithAttributes(attribute.String("provider", fqn.String())))
+		defer innerSpan.End()
+
 		name := fqn.String()
 
 		if _, exists := schemas[fqn]; exists {
@@ -99,7 +114,7 @@ func loadProviderSchemas(ctx context.Context, schemas map[addrs.Provider]provide
 		}
 
 		log.Printf("[TRACE] LoadSchemas: retrieving schema for provider type %q", name)
-		schema, err := plugins.ProviderSchema(ctx, fqn)
+		schema, err := plugins.ProviderSchema(innerCtx, fqn)
 		if err != nil {
 			// We'll put a stub in the map so we won't re-attempt this on
 			// future calls, which would then repeat the same error message
@@ -119,23 +134,26 @@ func loadProviderSchemas(ctx context.Context, schemas map[addrs.Provider]provide
 	}
 
 	if config != nil {
-		for _, fqn := range config.ProviderTypes() {
-			ensure(fqn)
+		for _, fqn := range config.ProviderTypes(ctx) {
+			ensure(ctx, fqn)
 		}
 	}
 
 	if state != nil {
 		needed := providers.AddressedTypesAbs(state.ProviderAddrs())
 		for _, typeAddr := range needed {
-			ensure(typeAddr)
+			ensure(ctx, typeAddr)
 		}
 	}
 
 	return diags
 }
 
-func loadProvisionerSchemas(schemas map[string]*configschema.Block, config *configs.Config, plugins *contextPlugins) tfdiags.Diagnostics {
+func loadProvisionerSchemas(ctx context.Context, schemas map[string]*configschema.Block, config *configs.Config, plugins *contextPlugins) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
+	var span trace.Span
+	ctx, span = tracer.Start(ctx, "loadProvisionerSchemas")
+	defer span.End()
 
 	ensure := func(name string) {
 		if _, exists := schemas[name]; exists {
@@ -171,7 +189,7 @@ func loadProvisionerSchemas(schemas map[string]*configschema.Block, config *conf
 
 		// Must also visit our child modules, recursively.
 		for _, cc := range config.Children {
-			childDiags := loadProvisionerSchemas(schemas, cc, plugins)
+			childDiags := loadProvisionerSchemas(ctx, schemas, cc, plugins)
 			diags = diags.Append(childDiags)
 		}
 	}

--- a/internal/tofu/schemas_test.go
+++ b/internal/tofu/schemas_test.go
@@ -19,7 +19,7 @@ func simpleTestSchemas() *Schemas {
 
 	return &Schemas{
 		Providers: map[addrs.Provider]providers.ProviderSchema{
-			addrs.NewDefaultProvider("test"): provider.GetProviderSchema(),
+			addrs.NewDefaultProvider("test"): provider.GetProviderSchema(nil),
 		},
 		Provisioners: map[string]*configschema.Block{
 			"test": provisioner.GetSchemaResponse.Provisioner,

--- a/internal/tofu/telemetry.go
+++ b/internal/tofu/telemetry.go
@@ -1,0 +1,12 @@
+package tofu
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+var tracer trace.Tracer
+
+func init() {
+	tracer = otel.Tracer("github.com/opentofu/opentofu/internal/tofu")
+}

--- a/internal/tofu/transform.go
+++ b/internal/tofu/transform.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"log"
 
 	"github.com/opentofu/opentofu/internal/dag"
@@ -15,7 +16,7 @@ import (
 // GraphTransformer is the interface that transformers implement. This
 // interface is only for transforms that need entire graph visibility.
 type GraphTransformer interface {
-	Transform(*Graph) error
+	Transform(context.Context, *Graph) error
 }
 
 // GraphVertexTransformer is an interface that transforms a single
@@ -32,11 +33,11 @@ type graphTransformerMulti struct {
 	Transforms []GraphTransformer
 }
 
-func (t *graphTransformerMulti) Transform(g *Graph) error {
+func (t *graphTransformerMulti) Transform(ctx context.Context, g *Graph) error {
 	var lastStepStr string
 	for _, t := range t.Transforms {
 		log.Printf("[TRACE] (graphTransformerMulti) Executing graph transform %T", t)
-		if err := t.Transform(g); err != nil {
+		if err := t.Transform(ctx, g); err != nil {
 			return err
 		}
 		if thisStepStr := g.StringWithNodeTypes(); thisStepStr != lastStepStr {

--- a/internal/tofu/transform_attach_config_resource.go
+++ b/internal/tofu/transform_attach_config_resource.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"log"
 
 	"github.com/opentofu/opentofu/internal/configs"
@@ -31,7 +32,7 @@ type AttachResourceConfigTransformer struct {
 	Config *configs.Config // Config is the root node in the config tree
 }
 
-func (t *AttachResourceConfigTransformer) Transform(g *Graph) error {
+func (t *AttachResourceConfigTransformer) Transform(ctx context.Context, g *Graph) error {
 
 	// Go through and find GraphNodeAttachResource
 	for _, v := range g.Vertices() {

--- a/internal/tofu/transform_attach_schema.go
+++ b/internal/tofu/transform_attach_schema.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -81,7 +82,7 @@ func (t *AttachSchemaTransformer) Transform(g *Graph) error {
 
 		if tv, ok := v.(GraphNodeAttachProviderConfigSchema); ok {
 			providerAddr := tv.ProviderAddr()
-			schema, err := t.Plugins.ProviderConfigSchema(providerAddr.Provider)
+			schema, err := t.Plugins.ProviderConfigSchema(context.TODO(), providerAddr.Provider)
 			if err != nil {
 				return fmt.Errorf("failed to read provider configuration schema for %s: %w", providerAddr.Provider, err)
 			}

--- a/internal/tofu/transform_attach_schema.go
+++ b/internal/tofu/transform_attach_schema.go
@@ -53,7 +53,7 @@ type AttachSchemaTransformer struct {
 	Config  *configs.Config
 }
 
-func (t *AttachSchemaTransformer) Transform(g *Graph) error {
+func (t *AttachSchemaTransformer) Transform(ctx context.Context, g *Graph) error {
 	if t.Plugins == nil {
 		// Should never happen with a reasonable caller, but we'll return a
 		// proper error here anyway so that we'll fail gracefully.
@@ -68,7 +68,7 @@ func (t *AttachSchemaTransformer) Transform(g *Graph) error {
 			typeName := addr.Resource.Type
 			providerFqn := tv.Provider()
 
-			schema, version, err := t.Plugins.ResourceTypeSchema(providerFqn, mode, typeName)
+			schema, version, err := t.Plugins.ResourceTypeSchema(ctx, providerFqn, mode, typeName)
 			if err != nil {
 				return fmt.Errorf("failed to read schema for %s in %s: %w", addr, providerFqn, err)
 			}
@@ -82,7 +82,7 @@ func (t *AttachSchemaTransformer) Transform(g *Graph) error {
 
 		if tv, ok := v.(GraphNodeAttachProviderConfigSchema); ok {
 			providerAddr := tv.ProviderAddr()
-			schema, err := t.Plugins.ProviderConfigSchema(context.TODO(), providerAddr.Provider)
+			schema, err := t.Plugins.ProviderConfigSchema(ctx, providerAddr.Provider)
 			if err != nil {
 				return fmt.Errorf("failed to read provider configuration schema for %s: %w", providerAddr.Provider, err)
 			}

--- a/internal/tofu/transform_attach_state.go
+++ b/internal/tofu/transform_attach_state.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"log"
 
 	"github.com/opentofu/opentofu/internal/dag"
@@ -34,7 +35,7 @@ type AttachStateTransformer struct {
 	State *states.State // State is the root state
 }
 
-func (t *AttachStateTransformer) Transform(g *Graph) error {
+func (t *AttachStateTransformer) Transform(ctx context.Context, g *Graph) error {
 	// If no state, then nothing to do
 	if t.State == nil {
 		log.Printf("[DEBUG] Not attaching any node states: overall state is nil")

--- a/internal/tofu/transform_check.go
+++ b/internal/tofu/transform_check.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"log"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -23,7 +24,7 @@ type checkTransformer struct {
 
 var _ GraphTransformer = (*checkTransformer)(nil)
 
-func (t *checkTransformer) Transform(graph *Graph) error {
+func (t *checkTransformer) Transform(ctx context.Context, graph *Graph) error {
 	return t.transform(graph, t.Config, graph.Vertices())
 }
 

--- a/internal/tofu/transform_check_starter.go
+++ b/internal/tofu/transform_check_starter.go
@@ -6,6 +6,8 @@
 package tofu
 
 import (
+	"context"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/dag"
@@ -25,7 +27,7 @@ type checkStartTransformer struct {
 	Operation walkOperation
 }
 
-func (s *checkStartTransformer) Transform(graph *Graph) error {
+func (s *checkStartTransformer) Transform(ctx context.Context, graph *Graph) error {
 	if s.Operation != walkApply && s.Operation != walkPlan {
 		// We only actually execute the checks during plan apply operations
 		// so if we are doing something else we can just skip this and

--- a/internal/tofu/transform_config.go
+++ b/internal/tofu/transform_config.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"log"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -51,7 +52,7 @@ type ConfigTransformer struct {
 	generateConfigPathForImportTargets string
 }
 
-func (t *ConfigTransformer) Transform(g *Graph) error {
+func (t *ConfigTransformer) Transform(ctx context.Context, g *Graph) error {
 	if t.skip {
 		return nil
 	}

--- a/internal/tofu/transform_config_test.go
+++ b/internal/tofu/transform_config_test.go
@@ -15,7 +15,7 @@ import (
 func TestConfigTransformer_nilModule(t *testing.T) {
 	g := Graph{Path: addrs.RootModuleInstance}
 	tf := &ConfigTransformer{}
-	if err := tf.Transform(&g); err != nil {
+	if err := tf.Transform(; err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -27,7 +27,7 @@ func TestConfigTransformer_nilModule(t *testing.T) {
 func TestConfigTransformer(t *testing.T) {
 	g := Graph{Path: addrs.RootModuleInstance}
 	tf := &ConfigTransformer{Config: testModule(t, "graph-basic")}
-	if err := tf.Transform(&g); err != nil {
+	if err := tf.Transform(; err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -45,7 +45,7 @@ func TestConfigTransformer_mode(t *testing.T) {
 		ModeFilter: true,
 		Mode:       addrs.DataResourceMode,
 	}
-	if err := tf.Transform(&g); err != nil {
+	if err := tf.Transform(; err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -66,7 +66,7 @@ func TestConfigTransformer_nonUnique(t *testing.T) {
 		),
 	))
 	tf := &ConfigTransformer{Config: testModule(t, "graph-basic")}
-	if err := tf.Transform(&g); err != nil {
+	if err := tf.Transform(; err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/internal/tofu/transform_destroy_cbd.go
+++ b/internal/tofu/transform_destroy_cbd.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -39,7 +40,7 @@ type GraphNodeDestroyerCBD interface {
 type ForcedCBDTransformer struct {
 }
 
-func (t *ForcedCBDTransformer) Transform(g *Graph) error {
+func (t *ForcedCBDTransformer) Transform(ctx context.Context, g *Graph) error {
 	for _, v := range g.Vertices() {
 		dn, ok := v.(GraphNodeDestroyerCBD)
 		if !ok {
@@ -122,7 +123,7 @@ type CBDEdgeTransformer struct {
 	State  *states.State
 }
 
-func (t *CBDEdgeTransformer) Transform(g *Graph) error {
+func (t *CBDEdgeTransformer) Transform(ctx context.Context, g *Graph) error {
 	// Go through and reverse any destroy edges
 	for _, v := range g.Vertices() {
 		dn, ok := v.(GraphNodeDestroyerCBD)

--- a/internal/tofu/transform_destroy_cbd_test.go
+++ b/internal/tofu/transform_destroy_cbd_test.go
@@ -28,7 +28,7 @@ func cbdTestGraph(t *testing.T, mod string, changes *plans.Changes, state *state
 	g, err := (&BasicGraphBuilder{
 		Steps: cbdTestSteps(applyBuilder.Steps()),
 		Name:  "ApplyGraphBuilder",
-	}).Build(addrs.RootModuleInstance)
+	}).Build(nil, addrs.RootModuleInstance)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/internal/tofu/transform_destroy_edge.go
+++ b/internal/tofu/transform_destroy_edge.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"log"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -138,7 +139,7 @@ func (t *DestroyEdgeTransformer) tryInterProviderDestroyEdge(g *Graph, from, to 
 	}
 }
 
-func (t *DestroyEdgeTransformer) Transform(g *Graph) error {
+func (t *DestroyEdgeTransformer) Transform(ctx context.Context, g *Graph) error {
 	// Build a map of what is being destroyed (by address string) to
 	// the list of destroyers.
 	destroyers := make(map[string][]GraphNodeDestroyer)
@@ -288,7 +289,7 @@ type pruneUnusedNodesTransformer struct {
 	skip bool
 }
 
-func (t *pruneUnusedNodesTransformer) Transform(g *Graph) error {
+func (t *pruneUnusedNodesTransformer) Transform(ctx context.Context, g *Graph) error {
 	if t.skip {
 		return nil
 	}

--- a/internal/tofu/transform_destroy_edge_test.go
+++ b/internal/tofu/transform_destroy_edge_test.go
@@ -43,12 +43,12 @@ func TestDestroyEdgeTransformer_basic(t *testing.T) {
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
 	)
-	if err := (&AttachStateTransformer{State: state}).Transform(&g); err != nil {
+	if err := (&AttachStateTransformer{State: state}).Transform(; err != nil {
 		t.Fatal(err)
 	}
 
 	tf := &DestroyEdgeTransformer{}
-	if err := tf.Transform(&g); err != nil {
+	if err := tf.Transform(; err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -97,12 +97,12 @@ func TestDestroyEdgeTransformer_multi(t *testing.T) {
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
 	)
 
-	if err := (&AttachStateTransformer{State: state}).Transform(&g); err != nil {
+	if err := (&AttachStateTransformer{State: state}).Transform(; err != nil {
 		t.Fatal(err)
 	}
 
 	tf := &DestroyEdgeTransformer{}
-	if err := tf.Transform(&g); err != nil {
+	if err := tf.Transform(; err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -117,7 +117,7 @@ func TestDestroyEdgeTransformer_selfRef(t *testing.T) {
 	g := Graph{Path: addrs.RootModuleInstance}
 	g.Add(testDestroyNode("test_object.A"))
 	tf := &DestroyEdgeTransformer{}
-	if err := tf.Transform(&g); err != nil {
+	if err := tf.Transform(; err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -153,12 +153,12 @@ func TestDestroyEdgeTransformer_module(t *testing.T) {
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
 	)
 
-	if err := (&AttachStateTransformer{State: state}).Transform(&g); err != nil {
+	if err := (&AttachStateTransformer{State: state}).Transform(; err != nil {
 		t.Fatal(err)
 	}
 
 	tf := &DestroyEdgeTransformer{}
-	if err := tf.Transform(&g); err != nil {
+	if err := tf.Transform(; err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -212,12 +212,12 @@ func TestDestroyEdgeTransformer_moduleOnly(t *testing.T) {
 		)
 	}
 
-	if err := (&AttachStateTransformer{State: state}).Transform(&g); err != nil {
+	if err := (&AttachStateTransformer{State: state}).Transform(; err != nil {
 		t.Fatal(err)
 	}
 
 	tf := &DestroyEdgeTransformer{}
-	if err := tf.Transform(&g); err != nil {
+	if err := tf.Transform(; err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -280,12 +280,12 @@ func TestDestroyEdgeTransformer_destroyThenUpdate(t *testing.T) {
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
 	)
 
-	if err := (&AttachStateTransformer{State: state}).Transform(&g); err != nil {
+	if err := (&AttachStateTransformer{State: state}).Transform(; err != nil {
 		t.Fatal(err)
 	}
 
 	tf := &DestroyEdgeTransformer{}
-	if err := tf.Transform(&g); err != nil {
+	if err := tf.Transform(; err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -401,7 +401,7 @@ func TestPruneUnusedNodesTransformer_rootModuleOutputValues(t *testing.T) {
 			&CloseRootModuleTransformer{},
 		},
 	}
-	graph, diags := builder.Build(addrs.RootModuleInstance)
+	graph, diags := builder.Build(nil, addrs.RootModuleInstance)
 	assertNoDiagnostics(t, diags)
 
 	// At this point, thanks to pruneUnusedNodesTransformer, we should still
@@ -482,7 +482,7 @@ func TestDestroyEdgeTransformer_noOp(t *testing.T) {
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
 	)
 
-	if err := (&AttachStateTransformer{State: state}).Transform(&g); err != nil {
+	if err := (&AttachStateTransformer{State: state}).Transform(; err != nil {
 		t.Fatal(err)
 	}
 
@@ -498,7 +498,7 @@ func TestDestroyEdgeTransformer_noOp(t *testing.T) {
 			},
 		},
 	}
-	if err := tf.Transform(&g); err != nil {
+	if err := tf.Transform(; err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -542,12 +542,12 @@ func TestDestroyEdgeTransformer_dataDependsOn(t *testing.T) {
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
 	)
 
-	if err := (&AttachStateTransformer{State: state}).Transform(&g); err != nil {
+	if err := (&AttachStateTransformer{State: state}).Transform(; err != nil {
 		t.Fatal(err)
 	}
 
 	tf := &DestroyEdgeTransformer{}
-	if err := tf.Transform(&g); err != nil {
+	if err := tf.Transform(; err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/internal/tofu/transform_diff.go
+++ b/internal/tofu/transform_diff.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -47,7 +48,7 @@ func (t *DiffTransformer) hasConfigConditions(addr addrs.AbsResourceInstance) bo
 	return len(res.Preconditions) > 0 || len(res.Postconditions) > 0
 }
 
-func (t *DiffTransformer) Transform(g *Graph) error {
+func (t *DiffTransformer) Transform(ctx context.Context, g *Graph) error {
 	if t.Changes == nil || len(t.Changes.Resources) == 0 {
 		// Nothing to do!
 		return nil

--- a/internal/tofu/transform_diff_test.go
+++ b/internal/tofu/transform_diff_test.go
@@ -18,7 +18,7 @@ import (
 func TestDiffTransformer_nilDiff(t *testing.T) {
 	g := Graph{Path: addrs.RootModuleInstance}
 	tf := &DiffTransformer{}
-	if err := tf.Transform(&g); err != nil {
+	if err := tf.Transform(; err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -61,7 +61,7 @@ func TestDiffTransformer(t *testing.T) {
 			},
 		},
 	}
-	if err := tf.Transform(&g); err != nil {
+	if err := tf.Transform(; err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -156,7 +156,7 @@ resource "aws_instance" "foo" {
 			},
 		},
 	}
-	if err := tf.Transform(&g); err != nil {
+	if err := tf.Transform(; err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/internal/tofu/transform_expand.go
+++ b/internal/tofu/transform_expand.go
@@ -5,6 +5,8 @@
 
 package tofu
 
+import "context"
+
 // GraphNodeDynamicExpandable is an interface that nodes can implement
 // to signal that they can be expanded at eval-time (hence dynamic).
 // These nodes are given the eval context and are expected to return
@@ -18,5 +20,5 @@ type GraphNodeDynamicExpandable interface {
 	// of calling ErrWithWarnings on a tfdiags.Diagnostics value instead,
 	// in which case the caller will unwrap it and gather the individual
 	// diagnostics.
-	DynamicExpand(EvalContext) (*Graph, error)
+	DynamicExpand(context.Context, EvalContext) (*Graph, error)
 }

--- a/internal/tofu/transform_external_reference.go
+++ b/internal/tofu/transform_external_reference.go
@@ -5,7 +5,11 @@
 
 package tofu
 
-import "github.com/opentofu/opentofu/internal/addrs"
+import (
+	"context"
+
+	"github.com/opentofu/opentofu/internal/addrs"
+)
 
 // ExternalReferenceTransformer will add a GraphNodeReferencer into the graph
 // that makes no changes to the graph itself but, by referencing the addresses
@@ -16,7 +20,7 @@ type ExternalReferenceTransformer struct {
 	ExternalReferences []*addrs.Reference
 }
 
-func (t *ExternalReferenceTransformer) Transform(g *Graph) error {
+func (t *ExternalReferenceTransformer) Transform(ctx context.Context, g *Graph) error {
 	if len(t.ExternalReferences) == 0 {
 		return nil
 	}

--- a/internal/tofu/transform_import_state_test.go
+++ b/internal/tofu/transform_import_state_test.go
@@ -9,11 +9,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/states"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func TestGraphNodeImportStateExecute(t *testing.T) {
@@ -29,7 +30,7 @@ func TestGraphNodeImportStateExecute(t *testing.T) {
 			},
 		},
 	}
-	provider.ConfigureProvider(providers.ConfigureProviderRequest{})
+	provider.ConfigureProvider(nil, providers.ConfigureProviderRequest{})
 
 	ctx := &MockEvalContext{
 		StateState:       state.SyncWrapper(),
@@ -52,7 +53,7 @@ func TestGraphNodeImportStateExecute(t *testing.T) {
 		},
 	}
 
-	diags := node.Execute(ctx, walkImport)
+	diags := node.Execute(nil, ctx, walkImport)
 	if diags.HasErrors() {
 		t.Fatalf("Unexpected error: %s", diags.Err())
 	}
@@ -70,7 +71,7 @@ func TestGraphNodeImportStateExecute(t *testing.T) {
 func TestGraphNodeImportStateSubExecute(t *testing.T) {
 	state := states.NewState()
 	provider := testProvider("aws")
-	provider.ConfigureProvider(providers.ConfigureProviderRequest{})
+	provider.ConfigureProvider(nil, providers.ConfigureProviderRequest{})
 	ctx := &MockEvalContext{
 		StateState:       state.SyncWrapper(),
 		ProviderProvider: provider,
@@ -107,7 +108,7 @@ func TestGraphNodeImportStateSubExecute(t *testing.T) {
 			Module:   addrs.RootModule,
 		},
 	}
-	diags := node.Execute(ctx, walkImport)
+	diags := node.Execute(nil, ctx, walkImport)
 	if diags.HasErrors() {
 		t.Fatalf("Unexpected error: %s", diags.Err())
 	}
@@ -169,7 +170,7 @@ func TestGraphNodeImportStateSubExecuteNull(t *testing.T) {
 			Module:   addrs.RootModule,
 		},
 	}
-	diags := node.Execute(ctx, walkImport)
+	diags := node.Execute(nil, ctx, walkImport)
 	if !diags.HasErrors() {
 		t.Fatal("expected error for non-existent resource")
 	}

--- a/internal/tofu/transform_local.go
+++ b/internal/tofu/transform_local.go
@@ -6,6 +6,8 @@
 package tofu
 
 import (
+	"context"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 )
@@ -16,7 +18,7 @@ type LocalTransformer struct {
 	Config *configs.Config
 }
 
-func (t *LocalTransformer) Transform(g *Graph) error {
+func (t *LocalTransformer) Transform(ctx context.Context, g *Graph) error {
 	return t.transformModule(g, t.Config)
 }
 

--- a/internal/tofu/transform_module_expansion.go
+++ b/internal/tofu/transform_module_expansion.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"log"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -31,7 +32,7 @@ type ModuleExpansionTransformer struct {
 	closers map[string]*nodeCloseModule
 }
 
-func (t *ModuleExpansionTransformer) Transform(g *Graph) error {
+func (t *ModuleExpansionTransformer) Transform(ctx context.Context, g *Graph) error {
 	t.closers = make(map[string]*nodeCloseModule)
 	// The root module is always a singleton and so does not need expansion
 	// processing, but any descendent modules do. We'll process them

--- a/internal/tofu/transform_module_variable.go
+++ b/internal/tofu/transform_module_variable.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/zclconf/go-cty/cty"
@@ -32,7 +33,7 @@ type ModuleVariableTransformer struct {
 	Config *configs.Config
 }
 
-func (t *ModuleVariableTransformer) Transform(g *Graph) error {
+func (t *ModuleVariableTransformer) Transform(ctx context.Context, g *Graph) error {
 	return t.transform(g, nil, t.Config)
 }
 

--- a/internal/tofu/transform_module_variable_test.go
+++ b/internal/tofu/transform_module_variable_test.go
@@ -18,14 +18,14 @@ func TestModuleVariableTransformer(t *testing.T) {
 
 	{
 		tf := &RootVariableTransformer{Config: module}
-		if err := tf.Transform(&g); err != nil {
+		if err := tf.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
 
 	{
 		tf := &ModuleVariableTransformer{Config: module}
-		if err := tf.Transform(&g); err != nil {
+		if err := tf.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
@@ -43,14 +43,14 @@ func TestModuleVariableTransformer_nested(t *testing.T) {
 
 	{
 		tf := &RootVariableTransformer{Config: module}
-		if err := tf.Transform(&g); err != nil {
+		if err := tf.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
 
 	{
 		tf := &ModuleVariableTransformer{Config: module}
-		if err := tf.Transform(&g); err != nil {
+		if err := tf.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}

--- a/internal/tofu/transform_orphan_count.go
+++ b/internal/tofu/transform_orphan_count.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"log"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -28,7 +29,7 @@ type OrphanResourceInstanceCountTransformer struct {
 	State         *states.State               // Full global state
 }
 
-func (t *OrphanResourceInstanceCountTransformer) Transform(g *Graph) error {
+func (t *OrphanResourceInstanceCountTransformer) Transform(ctx context.Context, g *Graph) error {
 	rs := t.State.Resource(t.Addr)
 	if rs == nil {
 		return nil // Resource doesn't exist in state, so nothing to do!

--- a/internal/tofu/transform_orphan_count_test.go
+++ b/internal/tofu/transform_orphan_count_test.go
@@ -52,7 +52,7 @@ func TestOrphanResourceCountTransformer(t *testing.T) {
 			InstanceAddrs: []addrs.AbsResourceInstance{mustResourceInstanceAddr("aws_instance.foo[0]")},
 			State:         state,
 		}
-		if err := tf.Transform(&g); err != nil {
+		if err := tf.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
@@ -103,7 +103,7 @@ func TestOrphanResourceCountTransformer_zero(t *testing.T) {
 			InstanceAddrs: []addrs.AbsResourceInstance{},
 			State:         state,
 		}
-		if err := tf.Transform(&g); err != nil {
+		if err := tf.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
@@ -154,7 +154,7 @@ func TestOrphanResourceCountTransformer_oneIndex(t *testing.T) {
 			InstanceAddrs: []addrs.AbsResourceInstance{mustResourceInstanceAddr("aws_instance.foo[0]")},
 			State:         state,
 		}
-		if err := tf.Transform(&g); err != nil {
+		if err := tf.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
@@ -214,7 +214,7 @@ func TestOrphanResourceCountTransformer_deposed(t *testing.T) {
 			InstanceAddrs: []addrs.AbsResourceInstance{mustResourceInstanceAddr("aws_instance.foo[0]")},
 			State:         state,
 		}
-		if err := tf.Transform(&g); err != nil {
+		if err := tf.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
@@ -276,7 +276,7 @@ func TestOrphanResourceCountTransformer_ForEachEdgesAdded(t *testing.T) {
 			InstanceAddrs: []addrs.AbsResourceInstance{},
 			State:         state,
 		}
-		if err := tf.Transform(&g); err != nil {
+		if err := tf.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}

--- a/internal/tofu/transform_orphan_output.go
+++ b/internal/tofu/transform_orphan_output.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"log"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -22,7 +23,7 @@ type OrphanOutputTransformer struct {
 	Planning bool
 }
 
-func (t *OrphanOutputTransformer) Transform(g *Graph) error {
+func (t *OrphanOutputTransformer) Transform(ctx context.Context, g *Graph) error {
 	if t.State == nil {
 		log.Printf("[DEBUG] No state, no orphan outputs")
 		return nil

--- a/internal/tofu/transform_orphan_resource.go
+++ b/internal/tofu/transform_orphan_resource.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"log"
 
 	"github.com/opentofu/opentofu/internal/configs"
@@ -36,7 +37,7 @@ type OrphanResourceInstanceTransformer struct {
 	skip bool
 }
 
-func (t *OrphanResourceInstanceTransformer) Transform(g *Graph) error {
+func (t *OrphanResourceInstanceTransformer) Transform(ctx context.Context, g *Graph) error {
 	if t.skip {
 		return nil
 	}

--- a/internal/tofu/transform_orphan_resource_test.go
+++ b/internal/tofu/transform_orphan_resource_test.go
@@ -80,7 +80,7 @@ func TestOrphanResourceInstanceTransformer(t *testing.T) {
 	g := Graph{Path: addrs.RootModuleInstance}
 	{
 		tf := &ConfigTransformer{Config: mod}
-		if err := tf.Transform(&g); err != nil {
+		if err := tf.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
@@ -91,7 +91,7 @@ func TestOrphanResourceInstanceTransformer(t *testing.T) {
 			State:    state,
 			Config:   mod,
 		}
-		if err := tf.Transform(&g); err != nil {
+		if err := tf.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
@@ -146,7 +146,7 @@ func TestOrphanResourceInstanceTransformer_countGood(t *testing.T) {
 	g := Graph{Path: addrs.RootModuleInstance}
 	{
 		tf := &ConfigTransformer{Config: mod}
-		if err := tf.Transform(&g); err != nil {
+		if err := tf.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
@@ -157,7 +157,7 @@ func TestOrphanResourceInstanceTransformer_countGood(t *testing.T) {
 			State:    state,
 			Config:   mod,
 		}
-		if err := tf.Transform(&g); err != nil {
+		if err := tf.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
@@ -211,7 +211,7 @@ func TestOrphanResourceInstanceTransformer_countBad(t *testing.T) {
 	g := Graph{Path: addrs.RootModuleInstance}
 	{
 		tf := &ConfigTransformer{Config: mod}
-		if err := tf.Transform(&g); err != nil {
+		if err := tf.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
@@ -222,7 +222,7 @@ func TestOrphanResourceInstanceTransformer_countBad(t *testing.T) {
 			State:    state,
 			Config:   mod,
 		}
-		if err := tf.Transform(&g); err != nil {
+		if err := tf.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
@@ -276,7 +276,7 @@ func TestOrphanResourceInstanceTransformer_modules(t *testing.T) {
 	g := Graph{Path: addrs.RootModuleInstance}
 	{
 		tf := &ConfigTransformer{Config: mod}
-		if err := tf.Transform(&g); err != nil {
+		if err := tf.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
@@ -287,7 +287,7 @@ func TestOrphanResourceInstanceTransformer_modules(t *testing.T) {
 			State:    state,
 			Config:   mod,
 		}
-		if err := tf.Transform(&g); err != nil {
+		if err := tf.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}

--- a/internal/tofu/transform_output.go
+++ b/internal/tofu/transform_output.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"log"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -34,7 +35,7 @@ type OutputTransformer struct {
 	Destroying bool
 }
 
-func (t *OutputTransformer) Transform(g *Graph) error {
+func (t *OutputTransformer) Transform(ctx context.Context, g *Graph) error {
 	return t.transform(g, t.Config)
 }
 

--- a/internal/tofu/transform_provider.go
+++ b/internal/tofu/transform_provider.go
@@ -96,7 +96,7 @@ type ProviderTransformer struct {
 	Config *configs.Config
 }
 
-func (t *ProviderTransformer) Transform(g *Graph) error {
+func (t *ProviderTransformer) Transform(ctx context.Context, g *Graph) error {
 	// We need to find a provider configuration address for each resource
 	// either directly represented by a node or referenced by a node in
 	// the graph, and then create graph edges from provider to provider user
@@ -257,7 +257,7 @@ type ProviderFunctionTransformer struct {
 	Config *configs.Config
 }
 
-func (t *ProviderFunctionTransformer) Transform(g *Graph) error {
+func (t *ProviderFunctionTransformer) Transform(ctx context.Context, g *Graph) error {
 	var diags tfdiags.Diagnostics
 
 	if t.Config == nil {
@@ -381,7 +381,7 @@ func (t *ProviderFunctionTransformer) Transform(g *Graph) error {
 // in the graph are evaluated.
 type CloseProviderTransformer struct{}
 
-func (t *CloseProviderTransformer) Transform(g *Graph) error {
+func (t *CloseProviderTransformer) Transform(ctx context.Context, g *Graph) error {
 	pm := providerVertexMap(g)
 	cpm := make(map[string]*graphNodeCloseProvider)
 	var err error
@@ -440,7 +440,7 @@ type MissingProviderTransformer struct {
 	Concrete ConcreteProviderNodeFunc
 }
 
-func (t *MissingProviderTransformer) Transform(g *Graph) error {
+func (t *MissingProviderTransformer) Transform(ctx context.Context, g *Graph) error {
 	// Initialize factory
 	if t.Concrete == nil {
 		t.Concrete = func(a *NodeAbstractProvider) dag.Vertex {
@@ -493,7 +493,7 @@ func (t *MissingProviderTransformer) Transform(g *Graph) error {
 // configuration may imply initialization which may require auth.
 type PruneProviderTransformer struct{}
 
-func (t *PruneProviderTransformer) Transform(g *Graph) error {
+func (t *PruneProviderTransformer) Transform(ctx context.Context, g *Graph) error {
 	for _, v := range g.Vertices() {
 		// We only care about providers
 		_, ok := v.(GraphNodeProvider)
@@ -622,7 +622,7 @@ type ProviderConfigTransformer struct {
 	Config *configs.Config
 }
 
-func (t *ProviderConfigTransformer) Transform(g *Graph) error {
+func (t *ProviderConfigTransformer) Transform(ctx context.Context, g *Graph) error {
 	// If no configuration is given, we don't do anything
 	if t.Config == nil {
 		return nil

--- a/internal/tofu/transform_provider.go
+++ b/internal/tofu/transform_provider.go
@@ -6,10 +6,12 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 
 	"github.com/hashicorp/hcl/v2"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/dag"
@@ -546,7 +548,7 @@ func (n *graphNodeCloseProvider) ModulePath() addrs.Module {
 }
 
 // GraphNodeExecutable impl.
-func (n *graphNodeCloseProvider) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *graphNodeCloseProvider) Execute(traceCtx context.Context, ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	return diags.Append(ctx.CloseProvider(n.Addr))
 }
 

--- a/internal/tofu/transform_provider_test.go
+++ b/internal/tofu/transform_provider_test.go
@@ -20,11 +20,11 @@ func testProviderTransformerGraph(t *testing.T, cfg *configs.Config) *Graph {
 
 	g := &Graph{Path: addrs.RootModuleInstance}
 	ct := &ConfigTransformer{Config: cfg}
-	if err := ct.Transform(g); err != nil {
+	if err := ct.Transform(; err != nil {
 		t.Fatal(err)
 	}
 	arct := &AttachResourceConfigTransformer{Config: cfg}
-	if err := arct.Transform(g); err != nil {
+	if err := arct.Transform(; err != nil {
 		t.Fatal(err)
 	}
 
@@ -61,13 +61,13 @@ func TestProviderTransformer(t *testing.T) {
 	g := testProviderTransformerGraph(t, mod)
 	{
 		transform := &MissingProviderTransformer{}
-		if err := transform.Transform(g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
 
 	transform := &ProviderTransformer{}
-	if err := transform.Transform(g); err != nil {
+	if err := transform.Transform(; err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -86,13 +86,13 @@ func TestProviderTransformer_fqns(t *testing.T) {
 		g := testProviderTransformerGraph(t, mod)
 		{
 			transform := &MissingProviderTransformer{Config: mod}
-			if err := transform.Transform(g); err != nil {
+			if err := transform.Transform(; err != nil {
 				t.Fatalf("err: %s", err)
 			}
 		}
 
 		transform := &ProviderTransformer{Config: mod}
-		if err := transform.Transform(g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 
@@ -110,21 +110,21 @@ func TestCloseProviderTransformer(t *testing.T) {
 
 	{
 		transform := &MissingProviderTransformer{}
-		if err := transform.Transform(g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
 
 	{
 		transform := &ProviderTransformer{}
-		if err := transform.Transform(g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
 
 	{
 		transform := &CloseProviderTransformer{}
-		if err := transform.Transform(g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
@@ -154,7 +154,7 @@ func TestCloseProviderTransformer_withTargets(t *testing.T) {
 	}
 
 	for _, tr := range transforms {
-		if err := tr.Transform(g); err != nil {
+		if err := tr.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
@@ -172,21 +172,21 @@ func TestMissingProviderTransformer(t *testing.T) {
 	g := testProviderTransformerGraph(t, mod)
 	{
 		transform := &MissingProviderTransformer{}
-		if err := transform.Transform(g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
 
 	{
 		transform := &ProviderTransformer{}
-		if err := transform.Transform(g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
 
 	{
 		transform := &CloseProviderTransformer{}
-		if err := transform.Transform(g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
@@ -206,13 +206,13 @@ func TestMissingProviderTransformer_grandchildMissing(t *testing.T) {
 	g := testProviderTransformerGraph(t, mod)
 	{
 		transform := testTransformProviders(concrete, mod)
-		if err := transform.Transform(g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
 	{
 		transform := &TransitiveReductionTransformer{}
-		if err := transform.Transform(g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
@@ -230,28 +230,28 @@ func TestPruneProviderTransformer(t *testing.T) {
 	g := testProviderTransformerGraph(t, mod)
 	{
 		transform := &MissingProviderTransformer{}
-		if err := transform.Transform(g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
 
 	{
 		transform := &ProviderTransformer{}
-		if err := transform.Transform(g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
 
 	{
 		transform := &CloseProviderTransformer{}
-		if err := transform.Transform(g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
 
 	{
 		transform := &PruneProviderTransformer{}
-		if err := transform.Transform(g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
@@ -271,7 +271,7 @@ func TestProviderConfigTransformer_parentProviders(t *testing.T) {
 	g := testProviderTransformerGraph(t, mod)
 	{
 		tf := testTransformProviders(concrete, mod)
-		if err := tf.Transform(g); err != nil {
+		if err := tf.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
@@ -291,7 +291,7 @@ func TestProviderConfigTransformer_grandparentProviders(t *testing.T) {
 	g := testProviderTransformerGraph(t, mod)
 	{
 		tf := testTransformProviders(concrete, mod)
-		if err := tf.Transform(g); err != nil {
+		if err := tf.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
@@ -325,7 +325,7 @@ resource "test_object" "a" {
 	g := testProviderTransformerGraph(t, mod)
 	{
 		tf := testTransformProviders(concrete, mod)
-		if err := tf.Transform(g); err != nil {
+		if err := tf.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
@@ -403,7 +403,7 @@ resource "test_object" "a" {
 	g := testProviderTransformerGraph(t, mod)
 	{
 		tf := testTransformProviders(concrete, mod)
-		if err := tf.Transform(g); err != nil {
+		if err := tf.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
@@ -447,7 +447,7 @@ provider "test" {
 		Config:   mod,
 		Concrete: concrete,
 	}
-	if err := tf.Transform(g); err != nil {
+	if err := tf.Transform(; err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/internal/tofu/transform_reference.go
+++ b/internal/tofu/transform_reference.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"sort"
@@ -116,7 +117,7 @@ type GraphNodeReferenceOutside interface {
 // nodes that reference each other in order to form the proper ordering.
 type ReferenceTransformer struct{}
 
-func (t *ReferenceTransformer) Transform(g *Graph) error {
+func (t *ReferenceTransformer) Transform(ctx context.Context, g *Graph) error {
 	// Build a reference map so we can efficiently look up the references
 	vs := g.Vertices()
 	m := NewReferenceMap(vs)
@@ -185,7 +186,7 @@ func (m depMap) add(v dag.Vertex) {
 type attachDataResourceDependsOnTransformer struct {
 }
 
-func (t attachDataResourceDependsOnTransformer) Transform(g *Graph) error {
+func (t attachDataResourceDependsOnTransformer) Transform(ctx context.Context, g *Graph) error {
 	// First we need to make a map of referenceable addresses to their vertices.
 	// This is very similar to what's done in ReferenceTransformer, but we keep
 	// implementation separate as they may need to change independently.
@@ -230,7 +231,7 @@ func (t attachDataResourceDependsOnTransformer) Transform(g *Graph) error {
 type AttachDependenciesTransformer struct {
 }
 
-func (t AttachDependenciesTransformer) Transform(g *Graph) error {
+func (t AttachDependenciesTransformer) Transform(ctx context.Context, g *Graph) error {
 	for _, v := range g.Vertices() {
 		attacher, ok := v.(GraphNodeAttachDependencies)
 		if !ok {

--- a/internal/tofu/transform_reference_test.go
+++ b/internal/tofu/transform_reference_test.go
@@ -27,7 +27,7 @@ func TestReferenceTransformer_simple(t *testing.T) {
 	})
 
 	tf := &ReferenceTransformer{}
-	if err := tf.Transform(&g); err != nil {
+	if err := tf.Transform(; err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -50,7 +50,7 @@ func TestReferenceTransformer_self(t *testing.T) {
 	})
 
 	tf := &ReferenceTransformer{}
-	if err := tf.Transform(&g); err != nil {
+	if err := tf.Transform(; err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -83,7 +83,7 @@ func TestReferenceTransformer_path(t *testing.T) {
 	})
 
 	tf := &ReferenceTransformer{}
-	if err := tf.Transform(&g); err != nil {
+	if err := tf.Transform(; err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -157,7 +157,7 @@ func TestReferenceTransformer_resourceInstances(t *testing.T) {
 	})
 
 	tf := &ReferenceTransformer{}
-	if err := tf.Transform(&g); err != nil {
+	if err := tf.Transform(; err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 

--- a/internal/tofu/transform_removed_modules.go
+++ b/internal/tofu/transform_removed_modules.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"log"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -20,7 +21,7 @@ type RemovedModuleTransformer struct {
 	State  *states.State
 }
 
-func (t *RemovedModuleTransformer) Transform(g *Graph) error {
+func (t *RemovedModuleTransformer) Transform(ctx context.Context, g *Graph) error {
 	// nothing to remove if there's no state!
 	if t.State == nil {
 		return nil

--- a/internal/tofu/transform_resource_count.go
+++ b/internal/tofu/transform_resource_count.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"log"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -25,7 +26,7 @@ type ResourceCountTransformer struct {
 	InstanceAddrs []addrs.AbsResourceInstance
 }
 
-func (t *ResourceCountTransformer) Transform(g *Graph) error {
+func (t *ResourceCountTransformer) Transform(ctx context.Context, g *Graph) error {
 	for _, addr := range t.InstanceAddrs {
 		abstract := NewNodeAbstractResourceInstance(addr)
 		abstract.Schema = t.Schema

--- a/internal/tofu/transform_root.go
+++ b/internal/tofu/transform_root.go
@@ -6,6 +6,8 @@
 package tofu
 
 import (
+	"context"
+
 	"github.com/opentofu/opentofu/internal/dag"
 )
 
@@ -14,7 +16,7 @@ const rootNodeName = "root"
 // RootTransformer is a GraphTransformer that adds a root to the graph.
 type RootTransformer struct{}
 
-func (t *RootTransformer) Transform(g *Graph) error {
+func (t *RootTransformer) Transform(ctx context.Context, g *Graph) error {
 	addRootNodeToGraph(g)
 	return nil
 }
@@ -64,7 +66,7 @@ func (n graphNodeRoot) Name() string {
 // CloseRootModuleTransformer is a GraphTransformer that adds a root to the graph.
 type CloseRootModuleTransformer struct{}
 
-func (t *CloseRootModuleTransformer) Transform(g *Graph) error {
+func (t *CloseRootModuleTransformer) Transform(ctx context.Context, g *Graph) error {
 	// close the root module
 	closeRoot := &nodeCloseModule{}
 	g.Add(closeRoot)

--- a/internal/tofu/transform_root_test.go
+++ b/internal/tofu/transform_root_test.go
@@ -19,28 +19,28 @@ func TestRootTransformer(t *testing.T) {
 		g := Graph{Path: addrs.RootModuleInstance}
 		{
 			tf := &ConfigTransformer{Config: mod}
-			if err := tf.Transform(&g); err != nil {
+			if err := tf.Transform(; err != nil {
 				t.Fatalf("err: %s", err)
 			}
 		}
 
 		{
 			transform := &MissingProviderTransformer{}
-			if err := transform.Transform(&g); err != nil {
+			if err := transform.Transform(; err != nil {
 				t.Fatalf("err: %s", err)
 			}
 		}
 
 		{
 			transform := &ProviderTransformer{}
-			if err := transform.Transform(&g); err != nil {
+			if err := transform.Transform(; err != nil {
 				t.Fatalf("err: %s", err)
 			}
 		}
 
 		{
 			transform := &RootTransformer{}
-			if err := transform.Transform(&g); err != nil {
+			if err := transform.Transform(; err != nil {
 				t.Fatalf("err: %s", err)
 			}
 		}

--- a/internal/tofu/transform_state.go
+++ b/internal/tofu/transform_state.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"log"
 
 	"github.com/opentofu/opentofu/internal/states"
@@ -30,7 +31,7 @@ type StateTransformer struct {
 	State *states.State
 }
 
-func (t *StateTransformer) Transform(g *Graph) error {
+func (t *StateTransformer) Transform(ctx context.Context, g *Graph) error {
 	if t.State == nil {
 		log.Printf("[TRACE] StateTransformer: state is nil, so nothing to do")
 		return nil

--- a/internal/tofu/transform_targets.go
+++ b/internal/tofu/transform_targets.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"log"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -29,7 +30,7 @@ type TargetsTransformer struct {
 	Targets []addrs.Targetable
 }
 
-func (t *TargetsTransformer) Transform(g *Graph) error {
+func (t *TargetsTransformer) Transform(ctx context.Context, g *Graph) error {
 	if len(t.Targets) > 0 {
 		targetedNodes, err := t.selectTargetedNodes(g, t.Targets)
 		if err != nil {

--- a/internal/tofu/transform_targets_test.go
+++ b/internal/tofu/transform_targets_test.go
@@ -18,21 +18,21 @@ func TestTargetsTransformer(t *testing.T) {
 	g := Graph{Path: addrs.RootModuleInstance}
 	{
 		tf := &ConfigTransformer{Config: mod}
-		if err := tf.Transform(&g); err != nil {
+		if err := tf.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
 
 	{
 		transform := &AttachResourceConfigTransformer{Config: mod}
-		if err := transform.Transform(&g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
 
 	{
 		transform := &ReferenceTransformer{}
-		if err := transform.Transform(&g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
@@ -45,7 +45,7 @@ func TestTargetsTransformer(t *testing.T) {
 				),
 			},
 		}
-		if err := transform.Transform(&g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
@@ -69,35 +69,35 @@ func TestTargetsTransformer_downstream(t *testing.T) {
 	g := Graph{Path: addrs.RootModuleInstance}
 	{
 		transform := &ConfigTransformer{Config: mod}
-		if err := transform.Transform(&g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("%T failed: %s", transform, err)
 		}
 	}
 
 	{
 		transform := &AttachResourceConfigTransformer{Config: mod}
-		if err := transform.Transform(&g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("%T failed: %s", transform, err)
 		}
 	}
 
 	{
 		transform := &AttachResourceConfigTransformer{Config: mod}
-		if err := transform.Transform(&g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("%T failed: %s", transform, err)
 		}
 	}
 
 	{
 		transform := &OutputTransformer{Config: mod}
-		if err := transform.Transform(&g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("%T failed: %s", transform, err)
 		}
 	}
 
 	{
 		transform := &ReferenceTransformer{}
-		if err := transform.Transform(&g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
@@ -113,7 +113,7 @@ func TestTargetsTransformer_downstream(t *testing.T) {
 					),
 			},
 		}
-		if err := transform.Transform(&g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("%T failed: %s", transform, err)
 		}
 	}
@@ -143,35 +143,35 @@ func TestTargetsTransformer_wholeModule(t *testing.T) {
 	g := Graph{Path: addrs.RootModuleInstance}
 	{
 		transform := &ConfigTransformer{Config: mod}
-		if err := transform.Transform(&g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("%T failed: %s", transform, err)
 		}
 	}
 
 	{
 		transform := &AttachResourceConfigTransformer{Config: mod}
-		if err := transform.Transform(&g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("%T failed: %s", transform, err)
 		}
 	}
 
 	{
 		transform := &AttachResourceConfigTransformer{Config: mod}
-		if err := transform.Transform(&g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("%T failed: %s", transform, err)
 		}
 	}
 
 	{
 		transform := &OutputTransformer{Config: mod}
-		if err := transform.Transform(&g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("%T failed: %s", transform, err)
 		}
 	}
 
 	{
 		transform := &ReferenceTransformer{}
-		if err := transform.Transform(&g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
@@ -184,7 +184,7 @@ func TestTargetsTransformer_wholeModule(t *testing.T) {
 					Child("grandchild"),
 			},
 		}
-		if err := transform.Transform(&g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("%T failed: %s", transform, err)
 		}
 	}

--- a/internal/tofu/transform_transitive_reduction.go
+++ b/internal/tofu/transform_transitive_reduction.go
@@ -5,12 +5,14 @@
 
 package tofu
 
+import "context"
+
 // TransitiveReductionTransformer is a GraphTransformer that
 // finds the transitive reduction of the graph. For a definition of
 // transitive reduction, see [Wikipedia](https://en.wikipedia.org/wiki/Transitive_reduction).
 type TransitiveReductionTransformer struct{}
 
-func (t *TransitiveReductionTransformer) Transform(g *Graph) error {
+func (t *TransitiveReductionTransformer) Transform(ctx context.Context, g *Graph) error {
 	// If the graph isn't valid, skip the transitive reduction.
 	// We don't error here because OpenTofu itself handles graph
 	// validation in a better way, or we assume it does.

--- a/internal/tofu/transform_transitive_reduction_test.go
+++ b/internal/tofu/transform_transitive_reduction_test.go
@@ -21,7 +21,7 @@ func TestTransitiveReductionTransformer(t *testing.T) {
 	g := Graph{Path: addrs.RootModuleInstance}
 	{
 		tf := &ConfigTransformer{Config: mod}
-		if err := tf.Transform(&g); err != nil {
+		if err := tf.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 		t.Logf("graph after ConfigTransformer:\n%s", g.String())
@@ -29,7 +29,7 @@ func TestTransitiveReductionTransformer(t *testing.T) {
 
 	{
 		transform := &AttachResourceConfigTransformer{Config: mod}
-		if err := transform.Transform(&g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
@@ -57,14 +57,14 @@ func TestTransitiveReductionTransformer(t *testing.T) {
 				},
 			}, t),
 		}
-		if err := transform.Transform(&g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}
 
 	{
 		transform := &ReferenceTransformer{}
-		if err := transform.Transform(&g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 		t.Logf("graph after ReferenceTransformer:\n%s", g.String())
@@ -72,7 +72,7 @@ func TestTransitiveReductionTransformer(t *testing.T) {
 
 	{
 		transform := &TransitiveReductionTransformer{}
-		if err := transform.Transform(&g); err != nil {
+		if err := transform.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 		t.Logf("graph after TransitiveReductionTransformer:\n%s", g.String())

--- a/internal/tofu/transform_variable.go
+++ b/internal/tofu/transform_variable.go
@@ -6,6 +6,8 @@
 package tofu
 
 import (
+	"context"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 )
@@ -22,7 +24,7 @@ type RootVariableTransformer struct {
 	RawValues InputValues
 }
 
-func (t *RootVariableTransformer) Transform(g *Graph) error {
+func (t *RootVariableTransformer) Transform(ctx context.Context, g *Graph) error {
 	// We can have no variables if we have no config.
 	if t.Config == nil {
 		return nil

--- a/internal/tofu/transform_vertex.go
+++ b/internal/tofu/transform_vertex.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/opentofu/opentofu/internal/dag"
@@ -19,7 +20,7 @@ type VertexTransformer struct {
 	Transforms []GraphVertexTransformer
 }
 
-func (t *VertexTransformer) Transform(g *Graph) error {
+func (t *VertexTransformer) Transform(ctx context.Context, g *Graph) error {
 	for _, v := range g.Vertices() {
 		for _, vt := range t.Transforms {
 			newV, err := vt.Transform(v)

--- a/internal/tofu/transform_vertex_test.go
+++ b/internal/tofu/transform_vertex_test.go
@@ -30,7 +30,7 @@ func TestVertexTransformer(t *testing.T) {
 				&testVertexTransform{Source: 2, Target: 42},
 			},
 		}
-		if err := tf.Transform(&g); err != nil {
+		if err := tf.Transform(; err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}

--- a/internal/tofu/upgrade_resource_state.go
+++ b/internal/tofu/upgrade_resource_state.go
@@ -6,16 +6,18 @@
 package tofu
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
+
+	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // upgradeResourceState will, if necessary, run the provider-defined upgrade
@@ -25,7 +27,7 @@ import (
 //
 // If any errors occur during upgrade, error diagnostics are returned. In that
 // case it is not safe to proceed with using the original state object.
-func upgradeResourceState(addr addrs.AbsResourceInstance, provider providers.Interface, src *states.ResourceInstanceObjectSrc, currentSchema *configschema.Block, currentVersion uint64) (*states.ResourceInstanceObjectSrc, tfdiags.Diagnostics) {
+func upgradeResourceState(ctx context.Context, addr addrs.AbsResourceInstance, provider providers.Interface, src *states.ResourceInstanceObjectSrc, currentSchema *configschema.Block, currentVersion uint64) (*states.ResourceInstanceObjectSrc, tfdiags.Diagnostics) {
 	if addr.Resource.Resource.Mode != addrs.ManagedResourceMode {
 		// We only do state upgrading for managed resources.
 		// This was a part of the normal workflow in older versions and
@@ -92,7 +94,7 @@ func upgradeResourceState(addr addrs.AbsResourceInstance, provider providers.Int
 		req.RawStateJSON = src.AttrsJSON
 	}
 
-	resp := provider.UpgradeResourceState(req)
+	resp := provider.UpgradeResourceState(ctx, req)
 	diags := resp.Diagnostics
 	if diags.HasErrors() {
 		return nil, diags

--- a/internal/tofu/variables.go
+++ b/internal/tofu/variables.go
@@ -6,9 +6,11 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/zclconf/go-cty/cty"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/tfdiags"
@@ -284,8 +286,12 @@ func (vv InputValues) Identical(other InputValues) bool {
 // The set of values is considered valid only if the returned diagnostics
 // does not contain errors. A valid set of values may still produce warnings,
 // which should be returned to the user.
-func checkInputVariables(vcs map[string]*configs.Variable, vs InputValues) tfdiags.Diagnostics {
+func checkInputVariables(ctx context.Context, vcs map[string]*configs.Variable, vs InputValues) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
+
+	var span trace.Span
+	ctx, span = tracer.Start(ctx, "checkInputVariables")
+	defer span.End()
 
 	for name := range vcs {
 		_, isSet := vs[name]

--- a/internal/tofu/version_required.go
+++ b/internal/tofu/version_required.go
@@ -6,6 +6,10 @@
 package tofu
 
 import (
+	"context"
+
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/opentofu/opentofu/internal/tfdiags"
 
 	"github.com/opentofu/opentofu/internal/configs"
@@ -18,7 +22,11 @@ import (
 // The returned diagnostics will contain errors if any constraints do not match.
 // The returned diagnostics might also return warnings, which should be
 // displayed to the user.
-func CheckCoreVersionRequirements(config *configs.Config) tfdiags.Diagnostics {
+func CheckCoreVersionRequirements(ctx context.Context, config *configs.Config) tfdiags.Diagnostics {
+	var span trace.Span
+	ctx, span = tracer.Start(ctx, "CheckCoreVersionRequirements")
+	defer span.End()
+
 	if config == nil {
 		return nil
 	}

--- a/internal/tofumigrate/tofumigrate.go
+++ b/internal/tofumigrate/tofumigrate.go
@@ -6,6 +6,7 @@
 package tofumigrate
 
 import (
+	"context"
 	"os"
 
 	"github.com/hashicorp/hcl/v2"
@@ -39,7 +40,7 @@ import (
 //	}
 //
 // then we keep the old address.
-func MigrateStateProviderAddresses(config *configs.Config, state *states.State) (*states.State, tfdiags.Diagnostics) {
+func MigrateStateProviderAddresses(ctx context.Context, config *configs.Config, state *states.State) (*states.State, tfdiags.Diagnostics) {
 	if os.Getenv("OPENTOFU_STATEFILE_PROVIDER_ADDRESS_TRANSLATION") == "0" {
 		return state, nil
 	}
@@ -56,7 +57,7 @@ func MigrateStateProviderAddresses(config *configs.Config, state *states.State) 
 	// config could be nil when we're e.g. showing a statefile without the configuration present
 	if config != nil {
 		var hclDiags hcl.Diagnostics
-		providers, hclDiags = config.ProviderRequirements()
+		providers, hclDiags = config.ProviderRequirements(ctx)
 		diags = diags.Append(hclDiags)
 		if hclDiags.HasErrors() {
 			return nil, diags


### PR DESCRIPTION
This PR is mainly to add opentelemetry throughout the planning phase. The initial aim for this was to make a "small PR" to instrument some of the process around planning and provider-defined function invocation. However it turned into a mess of "Let's add context.Context here too!".

It does produce a very comprehensive trace though! 
![image](https://github.com/opentofu/opentofu/assets/237469/b638a727-71bd-48fa-bfa0-2c89ec0246c0)


Related to #1519 