### PR TITLE
chore: use errors.New to replace fmt.Errorf with no parameters will much better

### DIFF
--- a/internal/getproviders/hash.go
+++ b/internal/getproviders/hash.go
@@ -7,6 +7,7 @@ package getproviders
 
 import (
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -53,7 +54,7 @@ const NilHash = Hash("")
 func ParseHash(s string) (Hash, error) {
 	colon := strings.Index(s, ":")
 	if colon < 1 { // 1 because a zero-length scheme is not allowed
-		return NilHash, fmt.Errorf("hash string must start with a scheme keyword followed by a colon")
+		return NilHash, errors.New("hash string must start with a scheme keyword followed by a colon")
 	}
 	return Hash(s), nil
 }
@@ -194,7 +195,7 @@ func PackageMatchesHash(loc PackageLocation, want Hash) (bool, error) {
 	case HashSchemeZip:
 		archiveLoc, ok := loc.(PackageLocalArchive)
 		if !ok {
-			return false, fmt.Errorf(`ziphash scheme ("zh:" prefix) is not supported for unpacked provider packages`)
+			return false, errors.New(`ziphash scheme ("zh:" prefix) is not supported for unpacked provider packages`)
 		}
 		got, err := PackageHashLegacyZipSHA(archiveLoc)
 		if err != nil {
@@ -202,7 +203,7 @@ func PackageMatchesHash(loc PackageLocation, want Hash) (bool, error) {
 		}
 		return got == want, nil
 	default:
-		return false, fmt.Errorf("unsupported hash format (this may require a newer version of OpenTofu)")
+		return false, errors.New("unsupported hash format (this may require a newer version of OpenTofu)")
 	}
 }
 

--- a/internal/getproviders/http_mirror_source.go
+++ b/internal/getproviders/http_mirror_source.go
@@ -8,6 +8,7 @@ package getproviders
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -53,7 +54,7 @@ func NewHTTPMirrorSource(baseURL *url.URL, creds svcauth.CredentialsSource) *HTT
 		// If we get redirected more than five times we'll assume we're
 		// in a redirect loop and bail out, rather than hanging forever.
 		if len(via) > 5 {
-			return fmt.Errorf("too many redirects")
+			return errors.New("too many redirects")
 		}
 		return nil
 	}
@@ -345,7 +346,7 @@ func (s *HTTPMirrorSource) get(ctx context.Context, relativePath string) (status
 			return 0, nil, finalURL, fmt.Errorf("response has invalid Content-Type: %w", err)
 		}
 		if mt != "application/json" {
-			return 0, nil, finalURL, fmt.Errorf("response has invalid Content-Type: must be application/json")
+			return 0, nil, finalURL, errors.New("response has invalid Content-Type: must be application/json")
 		}
 		for name := range params {
 			// The application/json content-type has no defined parameters,

--- a/internal/getproviders/package_authentication.go
+++ b/internal/getproviders/package_authentication.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 
 	"log"
@@ -218,7 +219,7 @@ func (a packageHashAuthentication) AuthenticatePackage(localLocation PackageLoca
 		// Indicates that none of the hashes given to
 		// NewPackageHashAuthentication were considered to be usable by this
 		// version of OpenTofu.
-		return nil, fmt.Errorf("this version of OpenTofu does not support any of the checksum formats given for this provider")
+		return nil, errors.New("this version of OpenTofu does not support any of the checksum formats given for this provider")
 	}
 
 	matches, err := PackageMatchesAnyHash(localLocation, a.RequiredHashes)
@@ -239,7 +240,7 @@ func (a packageHashAuthentication) AuthenticatePackage(localLocation PackageLoca
 	// above will prevail in that case. Maybe we'll improve on this somehow
 	// if the future introduction of a new hash scheme causes there to more
 	// commonly be multiple hashes.
-	return nil, fmt.Errorf("provider package doesn't match the any of the expected checksums")
+	return nil, errors.New("provider package doesn't match the any of the expected checksums")
 }
 
 func (a packageHashAuthentication) AcceptableHashes() []Hash {
@@ -525,7 +526,7 @@ func (s signatureAuthentication) findSigningKey() (*SigningKey, string, error) {
 
 	// If none of the provided keys issued the signature, this package is
 	// unsigned. This is currently a terminal authentication error.
-	return nil, "", fmt.Errorf("authentication signature from unknown issuer")
+	return nil, "", errors.New("authentication signature from unknown issuer")
 }
 
 // entityString extracts the key ID and identity name(s) from an openpgp.Entity

--- a/internal/getproviders/registry_client.go
+++ b/internal/getproviders/registry_client.go
@@ -288,7 +288,7 @@ func (c *registryClient) PackageMeta(ctx context.Context, provider addrs.Provide
 	}
 	downloadURL = resp.Request.URL.ResolveReference(downloadURL)
 	if downloadURL.Scheme != "http" && downloadURL.Scheme != "https" {
-		return PackageMeta{}, fmt.Errorf("registry response includes invalid download URL: must use http or https scheme")
+		return PackageMeta{}, errors.New("registry response includes invalid download URL: must use http or https scheme")
 	}
 
 	ret := PackageMeta{
@@ -326,7 +326,7 @@ func (c *registryClient) PackageMeta(ctx context.Context, provider addrs.Provide
 	}
 	shasumsURL = resp.Request.URL.ResolveReference(shasumsURL)
 	if shasumsURL.Scheme != "http" && shasumsURL.Scheme != "https" {
-		return PackageMeta{}, fmt.Errorf("registry response includes invalid SHASUMS URL: must use http or https scheme")
+		return PackageMeta{}, errors.New("registry response includes invalid SHASUMS URL: must use http or https scheme")
 	}
 	document, err := c.getFile(shasumsURL)
 	if err != nil {
@@ -341,7 +341,7 @@ func (c *registryClient) PackageMeta(ctx context.Context, provider addrs.Provide
 	}
 	signatureURL = resp.Request.URL.ResolveReference(signatureURL)
 	if signatureURL.Scheme != "http" && signatureURL.Scheme != "https" {
-		return PackageMeta{}, fmt.Errorf("registry response includes invalid SHASUMS signature URL: must use http or https scheme")
+		return PackageMeta{}, errors.New("registry response includes invalid SHASUMS signature URL: must use http or https scheme")
 	}
 	signature, err := c.getFile(signatureURL)
 	if err != nil {

--- a/internal/getproviders/types.go
+++ b/internal/getproviders/types.go
@@ -6,6 +6,7 @@
 package getproviders
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 	"sort"
@@ -144,15 +145,15 @@ func (p Platform) LessThan(other Platform) bool {
 func ParsePlatform(str string) (Platform, error) {
 	parts := strings.Split(str, "_")
 	if len(parts) != 2 {
-		return Platform{}, fmt.Errorf("must be two words separated by an underscore")
+		return Platform{}, errors.New("must be two words separated by an underscore")
 	}
 
 	os, arch := parts[0], parts[1]
 	if strings.ContainsAny(os, " \t\n\r") {
-		return Platform{}, fmt.Errorf("OS portion must not contain whitespace")
+		return Platform{}, errors.New("OS portion must not contain whitespace")
 	}
 	if strings.ContainsAny(arch, " \t\n\r") {
-		return Platform{}, fmt.Errorf("architecture portion must not contain whitespace")
+		return Platform{}, errors.New("architecture portion must not contain whitespace")
 	}
 
 	return Platform{


### PR DESCRIPTION
use errors.New to replace fmt.Errorf with no parameters will much better

Resolves[https://github.com/opentofu/opentofu/issues/1521](url)