### PR TITLE
Refactor: Use uuid.NewRandom() for LockInfo ID generation

### DIFF
--- a/internal/states/statemgr/locker.go
+++ b/internal/states/statemgr/locker.go
@@ -18,7 +18,7 @@ import (
 	"text/template"
 	"time"
 
-	uuid "github.com/hashicorp/go-uuid"
+	"github.com/google/uuid"
 	"github.com/opentofu/opentofu/version"
 )
 
@@ -145,13 +145,7 @@ type LockInfo struct {
 // NewLockInfo creates a LockInfo object and populates many of its fields
 // with suitable default values.
 func NewLockInfo() *LockInfo {
-	// this doesn't need to be cryptographically secure, just unique.
-	// Using math/rand alleviates the need to check handle the read error.
-	// Use a uuid format to match other IDs used throughout OpenTofu.
-	buf := make([]byte, 16)
-	rngSource.Read(buf)
-
-	id, err := uuid.FormatUUID(buf)
+	id, err := uuid.NewRandom()
 	if err != nil {
 		// this of course shouldn't happen
 		panic(err)
@@ -165,7 +159,7 @@ func NewLockInfo() *LockInfo {
 	host, _ := os.Hostname()
 
 	info := &LockInfo{
-		ID:      id,
+		ID:      id.String(),
 		Who:     fmt.Sprintf("%s@%s", userName, host),
 		Version: version.Version,
 		Created: time.Now().UTC(),


### PR DESCRIPTION
This commit updates the LockInfo ID generation in the statemgr package to use `uuid.NewRandom()` from the `github.com/google/uuid` package instead of the previous approach using `uuid.FormatUUID(buf)` from `github.com/hashicorp/go-uuid`. The new method generates UUIDs in a more performant manner, even though cryptographic security isn't a requirement for this specific use case. This change improves efficiency without sacrificing reliability and ensures consistency with other UUID generation practices in the codebase.

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #1523

## Target Release

1.7.0
