### PR TITLE
Fix docker building in goreleaser (by prerelease).

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -157,7 +157,7 @@ docker_manifests:
       - ghcr.io/opentofu/opentofu:{{ .Version }}-arm64
       - ghcr.io/opentofu/opentofu:{{ .Version }}-arm
       - ghcr.io/opentofu/opentofu:{{ .Version }}-386
-    skip_push: auto
+    skip_push: auto # Skips the push on pre-release versions, like 1.6.1-alpha1
 
   - name_template: ghcr.io/opentofu/opentofu:latest
     image_templates:
@@ -165,7 +165,7 @@ docker_manifests:
       - ghcr.io/opentofu/opentofu:{{ .Version }}-arm64
       - ghcr.io/opentofu/opentofu:{{ .Version }}-arm
       - ghcr.io/opentofu/opentofu:{{ .Version }}-386
-    skip_push: auto
+    skip_push: auto # Skips the push on pre-release versions, like 1.6.1-alpha1
 
 nfpms:
   - file_name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Arch }}'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -157,13 +157,7 @@ docker_manifests:
       - ghcr.io/opentofu/opentofu:{{ .Version }}-arm64
       - ghcr.io/opentofu/opentofu:{{ .Version }}-arm
       - ghcr.io/opentofu/opentofu:{{ .Version }}-386
-
-  - name_template: ghcr.io/opentofu/opentofu:{{ .Major }}
-    image_templates:
-      - ghcr.io/opentofu/opentofu:{{ .Version }}-amd64
-      - ghcr.io/opentofu/opentofu:{{ .Version }}-arm64
-      - ghcr.io/opentofu/opentofu:{{ .Version }}-arm
-      - ghcr.io/opentofu/opentofu:{{ .Version }}-386
+    skip_push: auto
 
   - name_template: ghcr.io/opentofu/opentofu:latest
     image_templates:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -157,7 +157,7 @@ docker_manifests:
       - ghcr.io/opentofu/opentofu:{{ .Version }}-arm64
       - ghcr.io/opentofu/opentofu:{{ .Version }}-arm
       - ghcr.io/opentofu/opentofu:{{ .Version }}-386
-    skip_push: auto # Skips the push on pre-release versions, like 1.6.1-alpha1
+    skip_push: auto # Skips the push on pre-release versions, like 1.6.1-alpha1. See https://goreleaser.com/customization/docker_manifest/#customization
 
   - name_template: ghcr.io/opentofu/opentofu:latest
     image_templates:
@@ -165,7 +165,7 @@ docker_manifests:
       - ghcr.io/opentofu/opentofu:{{ .Version }}-arm64
       - ghcr.io/opentofu/opentofu:{{ .Version }}-arm
       - ghcr.io/opentofu/opentofu:{{ .Version }}-386
-    skip_push: auto # Skips the push on pre-release versions, like 1.6.1-alpha1
+    skip_push: auto # Skips the push on pre-release versions, like 1.6.1-alpha1. See https://goreleaser.com/customization/docker_manifest/#customization
 
 nfpms:
   - file_name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Arch }}'


### PR DESCRIPTION
Stop building images with just x as the label from the x.y.z full version.

Only push :x.y labeled images on non-prerelease.

In other words, prereleases will only push docker images with the full version label.