### PR TITLE
Improve performance of `AttachResourceConfigTransformer` on big graphs

### DIFF
--- a/internal/tofu/transform_attach_config_resource.go
+++ b/internal/tofu/transform_attach_config_resource.go
@@ -56,17 +56,19 @@ func (t *AttachResourceConfigTransformer) Transform(g *Graph) error {
 			m = config.Module.ManagedResources
 		} else if addr.Resource.Mode == addrs.DataResourceMode {
 			m = config.Module.DataResources
+		} else {
+			panic("unknown resource mode: " + addr.Resource.Mode.String())
 		}
-		if m != nil {
-			coord := addr.Resource.String()
-			if r, ok := m[coord]; ok && r.Addr() == addr.Resource {
-				log.Printf("[TRACE] AttachResourceConfigTransformer: attaching to %q (%T) config from %#v", dag.VertexName(v), v, r.DeclRange)
-				arn.AttachResourceConfig(r)
-				if gnapmc, ok := v.(GraphNodeAttachProviderMetaConfigs); ok {
-					log.Printf("[TRACE] AttachResourceConfigTransformer: attaching provider meta configs to %s", dag.VertexName(v))
-					if config.Module != nil && config.Module.ProviderMetas != nil {
-						gnapmc.AttachProviderMetaConfigs(config.Module.ProviderMetas)
-					}
+		coord := addr.Resource.String()
+		if r, ok := m[coord]; ok && r.Addr() == addr.Resource {
+			log.Printf("[TRACE] AttachResourceConfigTransformer: attaching to %q (%T) config from %#v", dag.VertexName(v), v, r.DeclRange)
+			arn.AttachResourceConfig(r)
+			if gnapmc, ok := v.(GraphNodeAttachProviderMetaConfigs); ok {
+				log.Printf("[TRACE] AttachResourceConfigTransformer: attaching provider meta configs to %s", dag.VertexName(v))
+				if config.Module.ProviderMetas != nil {
+					gnapmc.AttachProviderMetaConfigs(config.Module.ProviderMetas)
+				} else {
+					log.Printf("[TRACE] AttachResourceConfigTransformer: no provider meta configs available to attach to %s", dag.VertexName(v))
 				}
 			}
 		}

--- a/internal/tofu/transform_attach_config_resource.go
+++ b/internal/tofu/transform_attach_config_resource.go
@@ -8,6 +8,7 @@ package tofu
 import (
 	"log"
 
+	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/dag"
 )
@@ -50,63 +51,23 @@ func (t *AttachResourceConfigTransformer) Transform(g *Graph) error {
 			log.Printf("[TRACE] AttachResourceConfigTransformer: %q (%T) has no configuration available", dag.VertexName(v), v)
 			continue
 		}
-
-		for _, r := range config.Module.ManagedResources {
-			rAddr := r.Addr()
-
-			if rAddr != addr.Resource {
-				// Not the same resource
-				continue
-			}
-
-			log.Printf("[TRACE] AttachResourceConfigTransformer: attaching to %q (%T) config from %s", dag.VertexName(v), v, r.DeclRange)
-			arn.AttachResourceConfig(r)
-
-			// attach the provider_meta info
-			if gnapmc, ok := v.(GraphNodeAttachProviderMetaConfigs); ok {
-				log.Printf("[TRACE] AttachResourceConfigTransformer: attaching provider meta configs to %s", dag.VertexName(v))
-				if config == nil {
-					log.Printf("[TRACE] AttachResourceConfigTransformer: no config set on the transformer for %s", dag.VertexName(v))
-					continue
-				}
-				if config.Module == nil {
-					log.Printf("[TRACE] AttachResourceConfigTransformer: no module in config for %s", dag.VertexName(v))
-					continue
-				}
-				if config.Module.ProviderMetas == nil {
-					log.Printf("[TRACE] AttachResourceConfigTransformer: no provider metas defined for %s", dag.VertexName(v))
-					continue
-				}
-				gnapmc.AttachProviderMetaConfigs(config.Module.ProviderMetas)
-			}
+		var m map[string]*configs.Resource
+		if addr.Resource.Mode == addrs.ManagedResourceMode {
+			m = config.Module.ManagedResources
+		} else if addr.Resource.Mode == addrs.DataResourceMode {
+			m = config.Module.DataResources
 		}
-		for _, r := range config.Module.DataResources {
-			rAddr := r.Addr()
-
-			if rAddr != addr.Resource {
-				// Not the same resource
-				continue
-			}
-
-			log.Printf("[TRACE] AttachResourceConfigTransformer: attaching to %q (%T) config from %#v", dag.VertexName(v), v, r.DeclRange)
-			arn.AttachResourceConfig(r)
-
-			// attach the provider_meta info
-			if gnapmc, ok := v.(GraphNodeAttachProviderMetaConfigs); ok {
-				log.Printf("[TRACE] AttachResourceConfigTransformer: attaching provider meta configs to %s", dag.VertexName(v))
-				if config == nil {
-					log.Printf("[TRACE] AttachResourceConfigTransformer: no config set on the transformer for %s", dag.VertexName(v))
-					continue
+		if m != nil {
+			coord := addr.Resource.String()
+			if r, ok := m[coord]; ok && r.Addr() == addr.Resource {
+				log.Printf("[TRACE] AttachResourceConfigTransformer: attaching to %q (%T) config from %#v", dag.VertexName(v), v, r.DeclRange)
+				arn.AttachResourceConfig(r)
+				if gnapmc, ok := v.(GraphNodeAttachProviderMetaConfigs); ok {
+					log.Printf("[TRACE] AttachResourceConfigTransformer: attaching provider meta configs to %s", dag.VertexName(v))
+					if config.Module != nil && config.Module.ProviderMetas != nil {
+						gnapmc.AttachProviderMetaConfigs(config.Module.ProviderMetas)
+					}
 				}
-				if config.Module == nil {
-					log.Printf("[TRACE] AttachResourceConfigTransformer: no module in config for %s", dag.VertexName(v))
-					continue
-				}
-				if config.Module.ProviderMetas == nil {
-					log.Printf("[TRACE] AttachResourceConfigTransformer: no provider metas defined for %s", dag.VertexName(v))
-					continue
-				}
-				gnapmc.AttachProviderMetaConfigs(config.Module.ProviderMetas)
 			}
 		}
 	}


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

The current implementation of `AttachResourceConfigTransformer` has performance of `O(N^2)` to the number of vertices in the graph, and this leads to significant performance degradation on huge graphs.

The given implementation decreases the complexity to `O(N)` by performing direct lookup of a resource in the `ManagedResources` or `DataResources` depending on the object type.

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #1559

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.8.0
