### PR TITLE
Add tests for AttachResourceConfigTransformer

### DIFF
--- a/internal/tofu/testdata/transform-attach-config/child/main.tf
+++ b/internal/tofu/testdata/transform-attach-config/child/main.tf
@@ -1,0 +1,6 @@
+data "aws_instance" "child_data_instance" {
+	data_config = 30
+}
+resource "aws_instance" "child_resource_instance" {
+	data_config = 40
+}

--- a/internal/tofu/testdata/transform-attach-config/main.tf
+++ b/internal/tofu/testdata/transform-attach-config/main.tf
@@ -1,0 +1,9 @@
+data "aws_instance" "data_instance" {
+	data_config = 10
+}
+resource "aws_instance" "resource_instance" {
+	resource_config = 20
+}
+module "child" {
+	source = "./child"	
+}

--- a/internal/tofu/transform_attach_config_resource_test.go
+++ b/internal/tofu/transform_attach_config_resource_test.go
@@ -1,0 +1,66 @@
+package tofu
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/zclconf/go-cty/cty/gocty"
+)
+
+func TestModuleTransformAttachConfigTransformer(t *testing.T) {
+	g := Graph{Path: addrs.RootModuleInstance}
+	module := testModule(t, "transform-attach-config")
+
+	err := (&ConfigTransformer{Config: module}).Transform(&g)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = (&AttachResourceConfigTransformer{Config: module}).Transform(&g)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	verts := g.Vertices()
+
+	if len(verts) != 4 {
+		t.Fatalf("Expected 4 vertices, got %v", len(verts))
+	}
+
+	expected := map[string]map[string]int{
+		"data.aws_instance.data_instance": map[string]int{
+			"data_config": 10,
+		},
+		"aws_instance.resource_instance": map[string]int{
+			"resource_config": 20,
+		},
+		"module.child.data.aws_instance.child_data_instance": map[string]int{
+			"data_config": 30,
+		},
+		"module.child.aws_instance.child_resource_instance": map[string]int{
+			"data_config": 40,
+		},
+	}
+
+	got := make(map[string]map[string]int)
+	for _, v := range verts {
+		ar := v.(*NodeAbstractResource)
+		attrs, _ := ar.Config.Config.JustAttributes()
+
+		values := make(map[string]int)
+		for _, attr := range attrs {
+			val, _ := attr.Expr.Value(nil)
+			var target int
+			gocty.FromCtyValue(val, &target)
+			values[attr.Name] = target
+		}
+
+		got[ar.ResourceAddr().String()] = values
+	}
+
+	if !reflect.DeepEqual(expected, got) {
+		t.Fatalf("Expected %s, got %s", spew.Sdump(expected), spew.Sdump(got))
+	}
+}


### PR DESCRIPTION
This simulates loading a module with resource and data blocks, and a child with the same, and ensures that the correct config is applied to the corresponding nodes.

Related to #1558 

## Target Release

1.8.0
