### PR TITLE
Make persist interval for remote state backend configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ NEW FEATURES:
 ENHANCEMENTS:
 * Added `tofu test -json` types to website Machine-Readable UI documentation ([1408](https://github.com/opentofu/opentofu/issues/1408))
 * Made `tofu plan` with `generate-config-out` flag replace JSON strings with `jsonencode` functions calls. ([#1595](https://github.com/opentofu/opentofu/pull/1595))
+* Make state persistence interval configurable via `TF_STATE_PERSIST_INTERVAL` environment variable ([#1591](https://github.com/opentofu/opentofu/pull/1591))
 
 BUG FIXES:
 * Fixed crash in gcs backend when using certain commands ([#1618](https://github.com/opentofu/opentofu/pull/1618))

--- a/internal/backend/local/backend_apply.go
+++ b/internal/backend/local/backend_apply.go
@@ -31,7 +31,7 @@ var testHookStopPlanApply func()
 
 var (
 	defaultPersistInterval                 = 20
-	persistIntervalEnvironmentVariableName = "TF_BACKEND_PERSIST_INTERVAL_SECONDS"
+	persistIntervalEnvironmentVariableName = "TF_STATE_PERSIST_INTERVAL"
 )
 
 func getEnvAsInt(envName string, defaultValue int) int {

--- a/internal/backend/local/backend_apply.go
+++ b/internal/backend/local/backend_apply.go
@@ -103,8 +103,9 @@ func (b *Local) opApply(
 	// persistent storage backend.
 	stateHook.Schemas = schemas
 	persistInterval := getEnvAsInt(persistIntervalEnvironmentVariableName, defaultPersistInterval)
-	if persistInterval < 0 {
-		panic(fmt.Sprintf("Can't use negative value for %s: %d", persistIntervalEnvironmentVariableName, persistInterval))
+	if persistInterval < defaultPersistInterval {
+		panic(fmt.Sprintf("Can't use value lower than %d for env variable %s, got %d",
+			defaultPersistInterval, persistIntervalEnvironmentVariableName, persistInterval))
 	}
 	stateHook.PersistInterval = time.Duration(persistInterval) * time.Second
 

--- a/internal/backend/local/backend_apply.go
+++ b/internal/backend/local/backend_apply.go
@@ -29,7 +29,7 @@ import (
 // test hook called between plan+apply during opApply
 var testHookStopPlanApply func()
 
-var (
+const (
 	defaultPersistInterval                 = 20 // arbitrary interval that's hopefully a sweet spot
 	persistIntervalEnvironmentVariableName = "TF_STATE_PERSIST_INTERVAL"
 )

--- a/internal/backend/local/backend_apply.go
+++ b/internal/backend/local/backend_apply.go
@@ -30,7 +30,7 @@ import (
 var testHookStopPlanApply func()
 
 var (
-	defaultPersistInterval                 = 20
+	defaultPersistInterval                 = 20 // arbitrary interval that's hopefully a sweet spot
 	persistIntervalEnvironmentVariableName = "TF_STATE_PERSIST_INTERVAL"
 )
 
@@ -106,7 +106,7 @@ func (b *Local) opApply(
 	if persistInterval < 0 {
 		panic(fmt.Sprintf("Can't use negative value for %s: %d", persistIntervalEnvironmentVariableName, persistInterval))
 	}
-	stateHook.PersistInterval = time.Duration(persistInterval) * time.Second // arbitrary interval that's hopefully a sweet spot
+	stateHook.PersistInterval = time.Duration(persistInterval) * time.Second
 
 	var plan *plans.Plan
 	// If we weren't given a plan, then we refresh/plan

--- a/website/docs/cli/commands/apply.mdx
+++ b/website/docs/cli/commands/apply.mdx
@@ -93,6 +93,10 @@ For configurations using
 `tofu apply` also accepts the legacy options
 [`-state`, `-state-out`, and `-backup`](../../language/settings/backends/local.mdx#command-line-arguments).
 
+### Environment variables
+
+You can further customize behavior of `apply` command by using [environment variables](../config/environment-variables.mdx).  For example, the [TF_STATE_PERSIST_INTERVAL](../config/environment-variables.mdx##tf_state_persist_interval) environment variable allows to specify the interval between state persistence.
+
 ## Passing a Different Configuration Directory
 
 If your workflow relies on overriding the root module directory, use

--- a/website/docs/cli/commands/apply.mdx
+++ b/website/docs/cli/commands/apply.mdx
@@ -95,7 +95,7 @@ For configurations using
 
 ### Environment variables
 
-You can further customize behavior of `apply` command by using [environment variables](../config/environment-variables.mdx).  For example, the [TF_STATE_PERSIST_INTERVAL](../config/environment-variables.mdx##tf_state_persist_interval) environment variable allows to specify the interval between state persistence.
+You can further customize behavior of `apply` command by using [environment variables](../config/environment-variables.mdx).  For example, the [TF_STATE_PERSIST_INTERVAL](../config/environment-variables.mdx#tf_state_persist_interval) environment variable allows to specify the interval between state persistence.
 
 ## Passing a Different Configuration Directory
 

--- a/website/docs/cli/config/environment-variables.mdx
+++ b/website/docs/cli/config/environment-variables.mdx
@@ -176,7 +176,7 @@ For more details on `.terraformignore`, please see [Excluding Files from Upload 
 
 ## TF_STATE_PERSIST_INTERVAL
 
-Set `TF_STATE_PERSIST_INTERVAL` to configure the interval (in seconds) between state persistence.  Increased interval could be useful when working with huge states (> 100k resources) where upload to a cloud service could take a significant amount of time.  Default persistence interval is 20 seconds.  The following command sets persistence interval to 5 minutes (300 seconds):
+Set `TF_STATE_PERSIST_INTERVAL` to configure the interval (in seconds) between state persistence.  Increased interval could be useful when working with huge states (> 100k resources) where upload to a cloud service could take a significant amount of time.  Default persistence interval is 20 seconds (it also the lowest possible value for this parameter).  The following command sets persistence interval to 5 minutes (300 seconds):
 
 ```shell
 export TF_STATE_PERSIST_INTERVAL=300

--- a/website/docs/cli/config/environment-variables.mdx
+++ b/website/docs/cli/config/environment-variables.mdx
@@ -174,6 +174,14 @@ export TF_PROVIDER_DOWNLOAD_RETRY=3
 
 For more details on `.terraformignore`, please see [Excluding Files from Upload with .terraformignore](../../language/settings/backends/remote.mdx#excluding-files-from-upload-with-terraformignore).
 
+## TF_STATE_PERSIST_INTERVAL
+
+Set `TF_STATE_PERSIST_INTERVAL` to configure the interval (in seconds) between state persistence.  Increased interval could be useful when working with huge states (> 100k resources) where upload to a cloud service could take a significant amount of time.  Default persistence interval is 20 seconds.  The following command sets persistence interval to 5 minutes (300 seconds):
+
+```shell
+export TF_STATE_PERSIST_INTERVAL=300
+```
+
 ## Cloud Backend CLI Integration
 
 The CLI integration with cloud backends lets you use them on the command line. The integration requires including a `cloud` block in your OpenTofu configuration. You can define its arguments directly in your configuration file or supply them through environment variables, which can be useful for non-interactive workflows like Continuous Integration (CI).


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

By default, the remote state backend persists state to the remote storage every 20 seconds—this value is hardcoded. But when the state is big (> 100Mb), this operation takes a long time and consumes a significant portion of these 20 seconds. This PR allows to make the persist interval configurable via the `TF_STATE_PERSIST_INTERVAL` environment variable, which allows to specify how often persistence should happen.

Please guide what part of documentation needs to be updated to document it...

P.S. I thought about adding the ability to completely disable this persist interval like it's done when the remote execution backend is used - but this could be a topic for discussion.

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #1568

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.8.0
