### PR TITLE
wrap JSON strings as jsonencode calls on generate-config-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ UPGRADE NOTES:
 NEW FEATURES:
 
 ENHANCEMENTS:
+* Made `tofu plan` with `generate-config-out` flag replace JSON strings with `jsonencode` functions calls. ([#1595](https://github.com/opentofu/opentofu/pull/1595))
 
 BUG FIXES:
 * Added a check in the `tofu test` to validate that the names of test run blocks do not contain spaces. ([#1489](https://github.com/opentofu/opentofu/pull/1489))

--- a/internal/genconfig/generate_config_test.go
+++ b/internal/genconfig/generate_config_test.go
@@ -425,6 +425,53 @@ resource "tfcoremock_simple_resource" "empty" {
   single = null
 }`,
 		},
+		"jsonencode_wrapping": {
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"juststr": {
+						Type:     cty.String,
+						Optional: true,
+					},
+					"jsonobj": {
+						Type:     cty.String,
+						Optional: true,
+					},
+					"jsonarr": {
+						Type:     cty.String,
+						Optional: true,
+					},
+				},
+			},
+			addr: addrs.AbsResourceInstance{
+				Module: nil,
+				Resource: addrs.ResourceInstance{
+					Resource: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "tfcoremock_simple_resource",
+						Name: "example",
+					},
+					Key: nil,
+				},
+			},
+			provider: addrs.LocalProviderConfig{
+				LocalName: "tfcoremock",
+			},
+			value: cty.ObjectVal(map[string]cty.Value{
+				"juststr": cty.StringVal("{a=b}"),
+				"jsonobj": cty.StringVal(`{"SomeDate":"2012-10-17"}`),
+				"jsonarr": cty.StringVal(`[{"a": 1}]`),
+			}),
+			expected: `
+resource "tfcoremock_simple_resource" "example" {
+  jsonarr = jsonencode([{
+    a = 1
+  }])
+  jsonobj = jsonencode({
+    SomeDate = "2012-10-17"
+  })
+  juststr = "{a=b}"
+}`,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {

--- a/internal/genconfig/generate_config_test.go
+++ b/internal/genconfig/generate_config_test.go
@@ -440,6 +440,11 @@ resource "tfcoremock_simple_resource" "empty" {
 						Type:     cty.String,
 						Optional: true,
 					},
+					"sensitivejsonobj": {
+						Type:      cty.String,
+						Optional:  true,
+						Sensitive: true,
+					},
 				},
 			},
 			addr: addrs.AbsResourceInstance{
@@ -457,9 +462,10 @@ resource "tfcoremock_simple_resource" "empty" {
 				LocalName: "tfcoremock",
 			},
 			value: cty.ObjectVal(map[string]cty.Value{
-				"juststr": cty.StringVal("{a=b}"),
-				"jsonobj": cty.StringVal(`{"SomeDate":"2012-10-17"}`),
-				"jsonarr": cty.StringVal(`[{"a": 1}]`),
+				"juststr":          cty.StringVal("{a=b}"),
+				"jsonobj":          cty.StringVal(`{"SomeDate":"2012-10-17"}`),
+				"jsonarr":          cty.StringVal(`[{"a": 1}]`),
+				"sensitivejsonobj": cty.StringVal(`{"SomePassword":"dontstealplease"}`),
 			}),
 			expected: `
 resource "tfcoremock_simple_resource" "example" {
@@ -469,7 +475,8 @@ resource "tfcoremock_simple_resource" "example" {
   jsonobj = jsonencode({
     SomeDate = "2012-10-17"
   })
-  juststr = "{a=b}"
+  juststr          = "{a=b}"
+  sensitivejsonobj = null # sensitive
 }`,
 		},
 	}

--- a/internal/genconfig/generate_config_test.go
+++ b/internal/genconfig/generate_config_test.go
@@ -445,6 +445,14 @@ resource "tfcoremock_simple_resource" "empty" {
 						Optional:  true,
 						Sensitive: true,
 					},
+					"secrets": {
+						Type: cty.Object(map[string]cty.Type{
+							"main":      cty.String,
+							"secondary": cty.String,
+						}),
+						Optional:  true,
+						Sensitive: true,
+					},
 				},
 			},
 			addr: addrs.AbsResourceInstance{
@@ -466,6 +474,10 @@ resource "tfcoremock_simple_resource" "empty" {
 				"jsonobj":          cty.StringVal(`{"SomeDate":"2012-10-17"}`),
 				"jsonarr":          cty.StringVal(`[{"a": 1}]`),
 				"sensitivejsonobj": cty.StringVal(`{"SomePassword":"dontstealplease"}`),
+				"secrets": cty.ObjectVal(map[string]cty.Value{
+					"main":      cty.StringVal(`{"v":"mypass"}`),
+					"secondary": cty.StringVal(`{"v":"mybackup"}`),
+				}),
 			}),
 			expected: `
 resource "tfcoremock_simple_resource" "example" {
@@ -476,6 +488,7 @@ resource "tfcoremock_simple_resource" "example" {
     SomeDate = "2012-10-17"
   })
   juststr          = "{a=b}"
+  secrets          = null # sensitive
   sensitivejsonobj = null # sensitive
 }`,
 		},


### PR DESCRIPTION
Resolves #1371

This PR makes `tofu plan` with `generate-config-out` flag check for JSON strings and, if possible, replace them with `jsonencode` function call.

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.2
