### PR TITLE
Don't do a DeepCopy in the remote state backend to avoid double copying

### DIFF
--- a/internal/states/remote/state.go
+++ b/internal/states/remote/state.go
@@ -101,10 +101,8 @@ func (s *State) WriteState(state *states.State) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// We create a deep copy of the state here, because the caller also has
-	// a reference to the given object and can potentially go on to mutate
-	// it after we return, but we want the snapshot at this point in time.
-	s.state = state.DeepCopy()
+	// We don't create a DeepCopy because it's already created in the `update_state_hook`
+	s.state = state
 
 	return nil
 }


### PR DESCRIPTION
The `updateStateHook` performs `DeepCopy` to create a `state` object that is then pushed to the `StateMgr.WriteState`.  If we use remote state backend, then it's doing `DeepCopy` again leading to increased pressure on the garbage collection in case of big states (couple of hundreds megabytes).

<!--

Describe in detail the changes you are proposing, and the rationale.

See the contributing guide:

https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

-->

Resolves #1580

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.8.0
