### PR TITLE
Do not run top issues workflow on forks

### DIFF
--- a/.github/workflows/update-top-issues-ranking.yml
+++ b/.github/workflows/update-top-issues-ranking.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   update:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'opentofu'
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
This workflow is exclusively used in the OpenTofu repository. Disabled for all forks and avoid the daily failure notifications.

Fix #1602

