### PR TITLE
Allow unconfigured provider functions in test context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ BUG FIXES:
 * Fix inmem backend crash due to missing struct field ([#1619](https://github.com/opentofu/opentofu/pull/1619))
 * Added a check in the `tofu test` to validate that the names of test run blocks do not contain spaces. ([#1489](https://github.com/opentofu/opentofu/pull/1489))
 * `tofu test` now supports accessing module outputs when the module has no resources. ([#1409](https://github.com/opentofu/opentofu/pull/1409))
+* Fixed support for provider functions in tests ([#1603](https://github.com/opentofu/opentofu/pull/1603))
 
 ## Previous Releases
 

--- a/internal/tofu/context_functions.go
+++ b/internal/tofu/context_functions.go
@@ -15,7 +15,7 @@ import (
 
 // This builds a provider function using an EvalContext and some additional information
 // This is split out of BuiltinEvalContext for testing
-func evalContextProviderFunction(ctx EvalContext, mc *configs.Config, op walkOperation, pf addrs.ProviderFunction, rng tfdiags.SourceRange) (*function.Function, tfdiags.Diagnostics) {
+func evalContextProviderFunction(providers func(addrs.AbsProviderConfig) providers.Interface, mc *configs.Config, op walkOperation, pf addrs.ProviderFunction, rng tfdiags.SourceRange) (*function.Function, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	pr, ok := mc.Module.ProviderRequirements.RequiredProviders[pf.ProviderName]
@@ -35,7 +35,7 @@ func evalContextProviderFunction(ctx EvalContext, mc *configs.Config, op walkOpe
 		Alias:    pf.ProviderAlias,
 	}
 
-	provider := ctx.Provider(absPc)
+	provider := providers(absPc)
 
 	if provider == nil {
 		// Configured provider (NodeApplyableProvider) not required via transform_provider.go.  Instead we should use the unconfigured instance (NodeEvalableProvider) in the root.
@@ -59,7 +59,7 @@ func evalContextProviderFunction(ctx EvalContext, mc *configs.Config, op walkOpe
 			}
 		}
 
-		provider = ctx.Provider(addrs.AbsProviderConfig{Provider: pr.Type})
+		provider = providers(addrs.AbsProviderConfig{Provider: pr.Type})
 		if provider == nil {
 			// This should not be possible
 			return nil, diags.Append(&hcl.Diagnostic{

--- a/internal/tofu/context_functions_test.go
+++ b/internal/tofu/context_functions_test.go
@@ -134,7 +134,7 @@ func TestFunctions(t *testing.T) {
 	}
 
 	// Provider missing
-	_, diags := evalContextProviderFunction(mockCtx, cfg, walkValidate, providerFunc("provider::invalid::unknown"), rng)
+	_, diags := evalContextProviderFunction(mockCtx.Provider, cfg, walkValidate, providerFunc("provider::invalid::unknown"), rng)
 	if !diags.HasErrors() {
 		t.Fatal("expected unknown function provider")
 	}
@@ -143,7 +143,7 @@ func TestFunctions(t *testing.T) {
 	}
 
 	// Provider not initialized
-	_, diags = evalContextProviderFunction(mockCtx, cfg, walkValidate, providerFunc("provider::mockname::missing"), rng)
+	_, diags = evalContextProviderFunction(mockCtx.Provider, cfg, walkValidate, providerFunc("provider::mockname::missing"), rng)
 	if !diags.HasErrors() {
 		t.Fatal("expected unknown function provider")
 	}
@@ -156,7 +156,7 @@ func TestFunctions(t *testing.T) {
 
 	// Function missing (validate)
 	mockProvider.GetFunctionsCalled = false
-	_, diags = evalContextProviderFunction(mockCtx, cfg, walkValidate, providerFunc("provider::mockname::missing"), rng)
+	_, diags = evalContextProviderFunction(mockCtx.Provider, cfg, walkValidate, providerFunc("provider::mockname::missing"), rng)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -166,7 +166,7 @@ func TestFunctions(t *testing.T) {
 
 	// Function missing (Non-validate)
 	mockProvider.GetFunctionsCalled = false
-	_, diags = evalContextProviderFunction(mockCtx, cfg, walkPlan, providerFunc("provider::mockname::missing"), rng)
+	_, diags = evalContextProviderFunction(mockCtx.Provider, cfg, walkPlan, providerFunc("provider::mockname::missing"), rng)
 	if !diags.HasErrors() {
 		t.Fatal("expected unknown function")
 	}
@@ -188,7 +188,7 @@ func TestFunctions(t *testing.T) {
 	// Load functions into ctx
 	for _, fn := range []string{"echo", "concat", "coalesce", "unknown_param", "error_param"} {
 		pf := providerFunc("provider::mockname::" + fn)
-		impl, diags := evalContextProviderFunction(mockCtx, cfg, walkPlan, pf, rng)
+		impl, diags := evalContextProviderFunction(mockCtx.Provider, cfg, walkPlan, pf, rng)
 		if diags.HasErrors() {
 			t.Fatal(diags.Err())
 		}

--- a/internal/tofu/eval_context_builtin.go
+++ b/internal/tofu/eval_context_builtin.go
@@ -526,7 +526,7 @@ func (ctx *BuiltinEvalContext) EvaluationScope(self addrs.Referenceable, source 
 	}
 
 	scope := ctx.Evaluator.Scope(data, self, source, func(pf addrs.ProviderFunction, rng tfdiags.SourceRange) (*function.Function, tfdiags.Diagnostics) {
-		return evalContextProviderFunction(ctx, mc, ctx.Evaluator.Operation, pf, rng)
+		return evalContextProviderFunction(ctx.Provider, mc, ctx.Evaluator.Operation, pf, rng)
 	})
 	scope.SetActiveExperiments(mc.Module.ActiveExperiments)
 

--- a/internal/tofu/test_context.go
+++ b/internal/tofu/test_context.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
+	"github.com/zclconf/go-cty/cty/function"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
@@ -104,6 +105,14 @@ func (ctx *TestContext) evaluate(state *states.SyncState, changes *plans.Changes
 		BaseDir:       ".",
 		PureOnly:      operation != walkApply,
 		PlanTimestamp: ctx.Plan.Timestamp,
+		ProviderFunctions: func(pf addrs.ProviderFunction, rng tfdiags.SourceRange) (*function.Function, tfdiags.Diagnostics) {
+			return nil, tfdiags.Diagnostics(nil).Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Provider functions not available",
+				Detail:   fmt.Sprintf("Providers are unable to supply functions within the test context (%s)", pf),
+				Subject:  rng.ToHCL().Ptr(),
+			})
+		},
 	}
 
 	// We're going to assume the run has passed, and then if anything fails this


### PR DESCRIPTION
When implementing provider functions, I failed to consider how functions would be used in test checks.  This spins up a provider instance for evaluating functions within a test context.  It does not have access to configuration and will only support unconfigured (not dynamic) functions.

Resolves #1600

## Target Release


1.7.1, 1.8.0
