### PR TITLE
Fix GCS backend crash from encryption changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ENHANCEMENTS:
 * Added `tofu test -json` types to website Machine-Readable UI documentation ([1408](https://github.com/opentofu/opentofu/issues/1408))
 
 BUG FIXES:
+* Fixed crash in gcs backend when using certain commands ([#1618](https://github.com/opentofu/opentofu/pull/1618))
 * Added a check in the `tofu test` to validate that the names of test run blocks do not contain spaces. ([#1489](https://github.com/opentofu/opentofu/pull/1489))
 * `tofu test` now supports accessing module outputs when the module has no resources. ([#1409](https://github.com/opentofu/opentofu/pull/1409))
 

--- a/internal/command/autocomplete.go
+++ b/internal/command/autocomplete.go
@@ -55,9 +55,16 @@ func (m *Meta) completePredictWorkspaceName() complete.Predictor {
 			return nil
 		}
 
+		// Load the encryption configuration
+		enc, encDiags := m.Encryption()
+		if encDiags.HasErrors() {
+			m.showDiagnostics(encDiags)
+			return nil
+		}
+
 		b, diags := m.Backend(&BackendOpts{
 			Config: backendConfig,
-		}, nil) // Don't need state encryption here.
+		}, enc.State())
 		if diags.HasErrors() {
 			return nil
 		}

--- a/internal/command/providers_schema.go
+++ b/internal/command/providers_schema.go
@@ -57,8 +57,15 @@ func (c *ProvidersSchemaCommand) Run(args []string) int {
 
 	var diags tfdiags.Diagnostics
 
+	enc, encDiags := c.Encryption()
+	diags = diags.Append(encDiags)
+	if encDiags.HasErrors() {
+		c.showDiagnostics(diags)
+		return 1
+	}
+
 	// Load the backend
-	b, backendDiags := c.Backend(nil, nil) // Encryption not needed here
+	b, backendDiags := c.Backend(nil, enc.State())
 	diags = diags.Append(backendDiags)
 	if backendDiags.HasErrors() {
 		c.showDiagnostics(diags)
@@ -84,7 +91,7 @@ func (c *ProvidersSchemaCommand) Run(args []string) int {
 	}
 
 	// Build the operation
-	opReq := c.Operation(b, arguments.ViewJSON, nil) // Encryption not needed here
+	opReq := c.Operation(b, arguments.ViewJSON, enc)
 	opReq.ConfigDir = cwd
 	opReq.ConfigLoader, err = c.initConfigLoader()
 	opReq.AllowUnsetVariables = true

--- a/internal/command/unlock.go
+++ b/internal/command/unlock.go
@@ -52,6 +52,13 @@ func (c *UnlockCommand) Run(args []string) int {
 		return 1
 	}
 
+	// Load the encryption configuration
+	enc, encDiags := c.EncryptionFromPath(configPath)
+	if encDiags.HasErrors() {
+		c.showDiagnostics(encDiags)
+		return 1
+	}
+
 	var diags tfdiags.Diagnostics
 
 	backendConfig, backendDiags := c.loadBackendConfig(configPath)
@@ -64,7 +71,7 @@ func (c *UnlockCommand) Run(args []string) int {
 	// Load the backend
 	b, backendDiags := c.Backend(&BackendOpts{
 		Config: backendConfig,
-	}, nil) // Should not be needed for an unlock
+	}, enc.State())
 	diags = diags.Append(backendDiags)
 	if backendDiags.HasErrors() {
 		c.showDiagnostics(diags)

--- a/internal/command/workspace_list.go
+++ b/internal/command/workspace_list.go
@@ -38,6 +38,13 @@ func (c *WorkspaceListCommand) Run(args []string) int {
 		return 1
 	}
 
+	// Load the encryption configuration
+	enc, encDiags := c.EncryptionFromPath(configPath)
+	if encDiags.HasErrors() {
+		c.showDiagnostics(encDiags)
+		return 1
+	}
+
 	var diags tfdiags.Diagnostics
 
 	backendConfig, backendDiags := c.loadBackendConfig(configPath)
@@ -50,7 +57,7 @@ func (c *WorkspaceListCommand) Run(args []string) int {
 	// Load the backend
 	b, backendDiags := c.Backend(&BackendOpts{
 		Config: backendConfig,
-	}, nil)
+	}, enc.State())
 	diags = diags.Append(backendDiags)
 	if backendDiags.HasErrors() {
 		c.showDiagnostics(diags)


### PR DESCRIPTION
The GCS backend is more eager than other backends we tested during the state encryption work. Some of the more peripheral commands were assumed to not need state encryption (incorrectly) and were passed nil.

That nil was an explicit choice to pass an invalid value if accessed in case our assumptions around that code were wrong.  We decided early on that we would rather panic than incorrectly disable encryption.

The fix here is fairly straightforward, I've added the same encryption logic used by other commands into the commands I thought did not require explicit encryption configuration.

Resolves #1617 

## Target Release

<!--

In normal circumstances we only target changes at the upcoming minor
release, or as a patch to the current minor version. If you need to
port a security fix to an older release, highlight this here by listing
all targeted releases.

-->

1.7.1, 1.8.0
