### PR TITLE
Fix inmem backend crash due to missing struct field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ ENHANCEMENTS:
 
 BUG FIXES:
 * Fixed crash in gcs backend when using certain commands ([#1618](https://github.com/opentofu/opentofu/pull/1618))
+* Fix inmem backend crash due to missing struct field ([#1619](https://github.com/opentofu/opentofu/pull/1619))
 * Added a check in the `tofu test` to validate that the names of test run blocks do not contain spaces. ([#1489](https://github.com/opentofu/opentofu/pull/1489))
 * `tofu test` now supports accessing module outputs when the module has no resources. ([#1409](https://github.com/opentofu/opentofu/pull/1409))
 

--- a/internal/backend/remote-state/inmem/backend.go
+++ b/internal/backend/remote-state/inmem/backend.go
@@ -76,9 +76,7 @@ func (b *Backend) configure(ctx context.Context) error {
 		Name: backend.DefaultStateName,
 	}
 
-	states.m[backend.DefaultStateName] = &remote.State{
-		Client: defaultClient,
-	}
+	states.m[backend.DefaultStateName] = remote.NewState(defaultClient, b.encryption)
 
 	// set the default client lock info per the test config
 	data := schema.FromContextBackendConfig(ctx)


### PR DESCRIPTION
This was the last remaining location outside of tests which used the struct initializer for remote.State instead of the constructor.  The constructor was refactored to include the state encryption parameter recently, which I had incorrectly assumed was used in all required locations.

Resolves #1613

## Target Release

1.7.1, 1.8.0
