### PR TITLE
Add support for GOCOVERDIR to e2e tests

### DIFF
--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -247,7 +247,9 @@ func GoBuild(pkgPath, tmpPrefix string) string {
 
 	cmd := exec.Command(
 		"go", "build",
+		"-cover",
 		"-o", tmpFilename,
+		"-coverpkg=github.com/opentofu/opentofu/...",
 		pkgPath,
 	)
 	cmd.Stderr = os.Stderr

--- a/internal/e2e/e2e.go
+++ b/internal/e2e/e2e.go
@@ -245,13 +245,24 @@ func GoBuild(pkgPath, tmpPrefix string) string {
 		panic(err)
 	}
 
-	cmd := exec.Command(
-		"go", "build",
-		"-cover",
+	args := []string{
+		"go",
+		"build",
+	}
+
+	if len(os.Getenv("GOCOVERDIR")) != 0 {
+		args = append(args,
+			"-cover",
+			"-coverpkg=github.com/opentofu/opentofu/...",
+		)
+	}
+
+	args = append(args,
 		"-o", tmpFilename,
-		"-coverpkg=github.com/opentofu/opentofu/...",
 		pkgPath,
 	)
+
+	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 


### PR DESCRIPTION
Example usage:
`TF_ACC=1 GOCOVERDIR=$PWD/covdir go test -count=1 -run TestEncryptionFlow ./internal/command/e2etest/`

Part of  #1536

## Target Release


1.8.0
