### PR TITLE
fix: Apply and Destroy cancelled vision

### DIFF
--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -164,12 +164,12 @@ func TestApply_approveNo(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("bad: %d\n\n%s", code, output.Stderr())
 	}
-	if got, want := output.Stdout(), "Apply cancelled"; !strings.Contains(got, want) {
+	if got, want := output.Stdout(), "Apply cancelled!\n"; !strings.Contains(got, want) {
 		t.Fatalf("expected output to include %q, but was:\n%s", want, got)
 	}
 
 	if _, err := os.Stat(statePath); err == nil || !os.IsNotExist(err) {
-		t.Fatalf("state file should not exist")
+		t.Fatalf("state file should not exist!\n")
 	}
 }
 

--- a/internal/command/views/operation.go
+++ b/internal/command/views/operation.go
@@ -78,9 +78,9 @@ func (v *OperationHuman) Stopping() {
 func (v *OperationHuman) Cancelled(planMode plans.Mode) {
 	switch planMode {
 	case plans.DestroyMode:
-		v.view.streams.Println("Destroy cancelled.")
+		v.view.streams.Println("Destroy cancelled!\n")
 	default:
-		v.view.streams.Println("Apply cancelled.")
+		v.view.streams.Println("Apply cancelled!\n")
 	}
 }
 
@@ -194,9 +194,9 @@ func (v *OperationJSON) Stopping() {
 func (v *OperationJSON) Cancelled(planMode plans.Mode) {
 	switch planMode {
 	case plans.DestroyMode:
-		v.view.Log("Destroy cancelled")
+		v.view.Log("Destroy cancelled!\n")
 	default:
-		v.view.Log("Apply cancelled")
+		v.view.Log("Apply cancelled!\n")
 	}
 }
 

--- a/internal/command/views/operation_test.go
+++ b/internal/command/views/operation_test.go
@@ -41,11 +41,11 @@ func TestOperation_cancelled(t *testing.T) {
 	}{
 		"apply": {
 			planMode: plans.NormalMode,
-			want:     "Apply cancelled.\n",
+			want:     "Apply cancelled!\n",
 		},
 		"destroy": {
 			planMode: plans.DestroyMode,
-			want:     "Destroy cancelled.\n",
+			want:     "Destroy cancelled!\n",
 		},
 	}
 	for name, tc := range testCases {


### PR DESCRIPTION
## Why

It's really hard to read when something is cancelled. We just need a new line and that's it.

## Target Release

1.8.0

## Checklist

- [+] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [+] I have not used an AI coding assistant to create this PR.
- [+] I have marked any code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from. 

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ +] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ +] I have run existing tests to ensure my code doesn't break anything.
- [ +] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ +] I have only exported functions, variables and structs that should be used from other packages.
- [ +] I have added meaningful comments to all exported functions, variables, and structs.

