### PR TITLE
lower golangci-lint requirements

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,17 @@ linters-settings:
     require-explanation: true
     require-specific: true
 
+  cyclop:
+    max-complexity: 15
+
+issues:
+  exclude-rules:
+    - path: (.+)_test.go
+      linters:
+        - funlen
+        - dupl
+        - cyclop
+
 linters:
   disable-all: true
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,7 +33,6 @@ issues:
       linters:
         - funlen
         - dupl
-        - cyclop
 
 linters:
   disable-all: true


### PR DESCRIPTION
This PR lowers golangci-lint requirements for code:
* increases complexity limit (cyclop linter)
* removes issues reported by some linters for `_test.go` files

See rule violation examples in https://github.com/opentofu/opentofu/pull/1499