### PR TITLE
Fix bug in import 'to' parsing in json configurations

### DIFF
--- a/internal/configs/hcl2shim/util.go
+++ b/internal/configs/hcl2shim/util.go
@@ -66,3 +66,27 @@ func schemaWithDynamic(schema *hcl.BodySchema) *hcl.BodySchema {
 
 	return ret
 }
+
+// Sometimes, we manually parse an expression instead of using the hcl library
+// for parsing. In this case we need to handle json configs specially, as the
+// values will be json strings rather than hcl.
+func convertJSONExpressionToHCL(expr hcl.Expression) (hcl.Expression, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+	// We can abuse the hcl json api and rely on the fact that calling
+	// Value on a json expression with no EvalContext will return the
+	// raw string. We can then parse that as normal hcl syntax, and
+	// continue with the decoding.
+	value, ds := expr.Value(nil)
+	diags = append(diags, ds...)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	expr, ds = hclsyntax.ParseExpression([]byte(value.AsString()), expr.Range().Filename, expr.Range().Start)
+	diags = append(diags, ds...)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	return expr, diags
+}

--- a/internal/configs/hcl2shim/util.go
+++ b/internal/configs/hcl2shim/util.go
@@ -67,10 +67,12 @@ func schemaWithDynamic(schema *hcl.BodySchema) *hcl.BodySchema {
 	return ret
 }
 
+// ConvertJSONExpressionToHCL is used to convert HCL *json.expression into
+// regular hcl syntax.
 // Sometimes, we manually parse an expression instead of using the hcl library
 // for parsing. In this case we need to handle json configs specially, as the
 // values will be json strings rather than hcl.
-func convertJSONExpressionToHCL(expr hcl.Expression) (hcl.Expression, hcl.Diagnostics) {
+func ConvertJSONExpressionToHCL(expr hcl.Expression) (hcl.Expression, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 	// We can abuse the hcl json api and rely on the fact that calling
 	// Value on a json expression with no EvalContext will return the

--- a/internal/configs/hcl2shim/util_test.go
+++ b/internal/configs/hcl2shim/util_test.go
@@ -1,0 +1,62 @@
+package hcl2shim
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	hclJSON "github.com/hashicorp/hcl/v2/json"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestConvertJSONExpressionToHCL(t *testing.T) {
+	tests := []struct {
+		Input string
+		Want  hcl.Traversal
+	}{
+		{
+			Input: "hello",
+			Want: hcl.Traversal{
+				hcl.TraverseRoot{Name: "hello"}}},
+		{
+			Input: "resource.test_resource[0]",
+			Want: hcl.Traversal{
+				hcl.TraverseRoot{Name: "boop"},
+				hcl.TraverseAttr{Name: "test_resource"},
+				hcl.TraverseIndex{Key: cty.NumberIntVal(0)},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		JSONExpr, diags := hclJSON.ParseExpression([]byte(`"`+test.Input+`"`), "")
+		if diags.HasErrors() {
+			t.Errorf("got %d diagnostics; want 0", len(diags))
+			for _, d := range diags {
+				t.Logf("  - %s", d.Error())
+			}
+		}
+
+		want, diags := hclsyntax.ParseExpression([]byte(test.Input), "", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			t.Errorf("got %d diagnostics; want 0", len(diags))
+			for _, d := range diags {
+				t.Logf("  - %s", d.Error())
+			}
+		}
+
+		t.Run(test.Input, func(t *testing.T) {
+			resultExpr, diags := convertJSONExpressionToHCL(JSONExpr)
+			if diags.HasErrors() {
+				t.Errorf("got %d diagnostics; want 0", len(diags))
+				for _, d := range diags {
+					t.Logf("  - %s", d.Error())
+				}
+			}
+
+			if resultExpr == want {
+				t.Errorf("got %s, but want %s", resultExpr, want)
+			}
+		})
+	}
+}

--- a/internal/configs/hcl2shim/util_test.go
+++ b/internal/configs/hcl2shim/util_test.go
@@ -38,7 +38,7 @@ func TestConvertJSONExpressionToHCL(t *testing.T) {
 		}
 
 		t.Run(test.Input, func(t *testing.T) {
-			resultExpr, diags := convertJSONExpressionToHCL(JSONExpr)
+			resultExpr, diags := ConvertJSONExpressionToHCL(JSONExpr)
 			if diags.HasErrors() {
 				t.Errorf("got %d diagnostics; want 0", len(diags))
 				for _, d := range diags {

--- a/internal/configs/hcl2shim/util_test.go
+++ b/internal/configs/hcl2shim/util_test.go
@@ -6,25 +6,17 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	hclJSON "github.com/hashicorp/hcl/v2/json"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func TestConvertJSONExpressionToHCL(t *testing.T) {
 	tests := []struct {
 		Input string
-		Want  hcl.Traversal
 	}{
 		{
 			Input: "hello",
-			Want: hcl.Traversal{
-				hcl.TraverseRoot{Name: "hello"}}},
+		},
 		{
 			Input: "resource.test_resource[0]",
-			Want: hcl.Traversal{
-				hcl.TraverseRoot{Name: "boop"},
-				hcl.TraverseAttr{Name: "test_resource"},
-				hcl.TraverseIndex{Key: cty.NumberIntVal(0)},
-			},
 		},
 	}
 

--- a/internal/configs/hcl2shim/util_test.go
+++ b/internal/configs/hcl2shim/util_test.go
@@ -1,6 +1,7 @@
 package hcl2shim
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
@@ -46,7 +47,7 @@ func TestConvertJSONExpressionToHCL(t *testing.T) {
 				}
 			}
 
-			if resultExpr == want {
+			if !reflect.DeepEqual(resultExpr, want) {
 				t.Errorf("got %s, but want %s", resultExpr, want)
 			}
 		})

--- a/internal/configs/import.go
+++ b/internal/configs/import.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	hcljson "github.com/hashicorp/hcl/v2/json"
 	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/configs/hcl2shim"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
@@ -74,7 +75,7 @@ func decodeImportBlock(block *hcl.Block) (*Import, hcl.Diagnostics) {
 		isJSON := hcljson.IsJSONExpression(attr.Expr)
 
 		if isJSON {
-			convertedExpr, convertDiags := convertJSONExpressionToHCL(toExpr)
+			convertedExpr, convertDiags := hcl2shim.ConvertJSONExpressionToHCL(toExpr)
 			diags = append(diags, convertDiags...)
 
 			if diags.HasErrors() {

--- a/internal/configs/parser_config.go
+++ b/internal/configs/parser_config.go
@@ -7,7 +7,6 @@ package configs
 
 import (
 	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/opentofu/opentofu/internal/encryption/config"
 )
 
@@ -370,28 +369,4 @@ var configFileExperimentsSniffBlockSchema = &hcl.BodySchema{
 		{Name: "experiments"},
 		{Name: "language"},
 	},
-}
-
-// Sometimes, we manually parse an expression instead of using the hcl library
-// for parsing. In this case we need to handle json configs specially, as the
-// values will be json strings rather than hcl.
-func convertJSONExpressionToHCL(expr hcl.Expression) (hcl.Expression, hcl.Diagnostics) {
-	var diags hcl.Diagnostics
-	// We can abuse the hcl json api and rely on the fact that calling
-	// Value on a json expression with no EvalContext will return the
-	// raw string. We can then parse that as normal hcl syntax, and
-	// continue with the decoding.
-	value, ds := expr.Value(nil)
-	diags = append(diags, ds...)
-	if diags.HasErrors() {
-		return nil, diags
-	}
-
-	expr, ds = hclsyntax.ParseExpression([]byte(value.AsString()), expr.Range().Filename, expr.Range().Start)
-	diags = append(diags, ds...)
-	if diags.HasErrors() {
-		return nil, diags
-	}
-
-	return expr, diags
 }

--- a/internal/configs/parser_config.go
+++ b/internal/configs/parser_config.go
@@ -7,6 +7,7 @@ package configs
 
 import (
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/opentofu/opentofu/internal/encryption/config"
 )
 
@@ -369,4 +370,28 @@ var configFileExperimentsSniffBlockSchema = &hcl.BodySchema{
 		{Name: "experiments"},
 		{Name: "language"},
 	},
+}
+
+// Sometimes, we manually parse an expression instead of using the hcl library
+// for parsing. In this case we need to handle json configs specially, as the
+// values will be json strings rather than hcl.
+func convertJSONExpressionToHCL(expr hcl.Expression) (hcl.Expression, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+	// We can abuse the hcl json api and rely on the fact that calling
+	// Value on a json expression with no EvalContext will return the
+	// raw string. We can then parse that as normal hcl syntax, and
+	// continue with the decoding.
+	value, ds := expr.Value(nil)
+	diags = append(diags, ds...)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	expr, ds = hclsyntax.ParseExpression([]byte(value.AsString()), expr.Range().Filename, expr.Range().Start)
+	diags = append(diags, ds...)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	return expr, diags
 }

--- a/internal/configs/resource.go
+++ b/internal/configs/resource.go
@@ -551,18 +551,9 @@ func decodeReplaceTriggeredBy(expr hcl.Expression) ([]hcl.Expression, hcl.Diagno
 
 	for i, expr := range exprs {
 		if isJSON {
-			// We can abuse the hcl json api and rely on the fact that calling
-			// Value on a json expression with no EvalContext will return the
-			// raw string. We can then parse that as normal hcl syntax, and
-			// continue with the decoding.
-			v, ds := expr.Value(nil)
-			diags = diags.Extend(ds)
-			if diags.HasErrors() {
-				continue
-			}
-
-			expr, ds = hclsyntax.ParseExpression([]byte(v.AsString()), "", expr.Range().Start)
-			diags = diags.Extend(ds)
+			var convertDiags hcl.Diagnostics
+			expr, convertDiags = convertJSONExpressionToHCL(expr)
+			diags = diags.Extend(convertDiags)
 			if diags.HasErrors() {
 				continue
 			}

--- a/internal/configs/resource.go
+++ b/internal/configs/resource.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	hcljson "github.com/hashicorp/hcl/v2/json"
-
 	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/configs/hcl2shim"
 	"github.com/opentofu/opentofu/internal/lang"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
@@ -552,7 +552,7 @@ func decodeReplaceTriggeredBy(expr hcl.Expression) ([]hcl.Expression, hcl.Diagno
 	for i, expr := range exprs {
 		if isJSON {
 			var convertDiags hcl.Diagnostics
-			expr, convertDiags = convertJSONExpressionToHCL(expr)
+			expr, convertDiags = hcl2shim.ConvertJSONExpressionToHCL(expr)
 			diags = diags.Extend(convertDiags)
 			if diags.HasErrors() {
 				continue


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

When we introduced the `import for_each` feature in 1.7.0, we accidentally broke the parsing of `to` addresses in `import` blocks when using JSON configuration. This PR should fix this issue:
1. Now, if the `to` expression originates from a JSON configuration, it'll first be parsed to a regular HCL expression. I used an existing logic from `replace_trigger_by` decoding and extracted it to a shared function in `parser_config.go`.
2. Added tests for JSON configurations for `import` block and `replace_trigger_by` attribute.

<!-- If your PR resolves an issue, please add it here. -->
Resolves #1652

## Target Release

1.8.0 (and will be backported to 1.7.2)

## Checklist

<!-- This checklist is mandatory for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have marked any code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from. 

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
