### PR TITLE
remove copyright headers from website examples and lock files

### DIFF
--- a/testing/equivalence-tests/tests/basic_json_string_update/.terraform.lock.hcl
+++ b/testing/equivalence-tests/tests/basic_json_string_update/.terraform.lock.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 # This file is maintained automatically by "opentf init".
 # Manual edits may be lost in future updates.
 

--- a/testing/equivalence-tests/tests/basic_multiline_string_update/.terraform.lock.hcl
+++ b/testing/equivalence-tests/tests/basic_multiline_string_update/.terraform.lock.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 # This file is maintained automatically by "opentf init".
 # Manual edits may be lost in future updates.
 

--- a/testing/equivalence-tests/tests/drift_refresh_only/.terraform.lock.hcl
+++ b/testing/equivalence-tests/tests/drift_refresh_only/.terraform.lock.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 # This file is maintained automatically by "opentf init".
 # Manual edits may be lost in future updates.
 

--- a/testing/equivalence-tests/tests/drift_relevant_attributes/.terraform.lock.hcl
+++ b/testing/equivalence-tests/tests/drift_relevant_attributes/.terraform.lock.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 # This file is maintained automatically by "opentf init".
 # Manual edits may be lost in future updates.
 

--- a/testing/equivalence-tests/tests/drift_simple/.terraform.lock.hcl
+++ b/testing/equivalence-tests/tests/drift_simple/.terraform.lock.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 # This file is maintained automatically by "opentf init".
 # Manual edits may be lost in future updates.
 

--- a/testing/equivalence-tests/tests/fully_populated_complex_destroy/.terraform.lock.hcl
+++ b/testing/equivalence-tests/tests/fully_populated_complex_destroy/.terraform.lock.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 # This file is maintained automatically by "opentf init".
 # Manual edits may be lost in future updates.
 

--- a/testing/equivalence-tests/tests/fully_populated_complex_update/.terraform.lock.hcl
+++ b/testing/equivalence-tests/tests/fully_populated_complex_update/.terraform.lock.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 # This file is maintained automatically by "opentf init".
 # Manual edits may be lost in future updates.
 

--- a/testing/equivalence-tests/tests/local_provider_delete/.terraform.lock.hcl
+++ b/testing/equivalence-tests/tests/local_provider_delete/.terraform.lock.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 # This file is maintained automatically by "opentf init".
 # Manual edits may be lost in future updates.
 

--- a/testing/equivalence-tests/tests/local_provider_update/.terraform.lock.hcl
+++ b/testing/equivalence-tests/tests/local_provider_update/.terraform.lock.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 # This file is maintained automatically by "opentf init".
 # Manual edits may be lost in future updates.
 

--- a/testing/equivalence-tests/tests/moved_simple/.terraform.lock.hcl
+++ b/testing/equivalence-tests/tests/moved_simple/.terraform.lock.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 # This file is maintained automatically by "opentf init".
 # Manual edits may be lost in future updates.
 

--- a/testing/equivalence-tests/tests/moved_with_drift/.terraform.lock.hcl
+++ b/testing/equivalence-tests/tests/moved_with_drift/.terraform.lock.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 # This file is maintained automatically by "opentf init".
 # Manual edits may be lost in future updates.
 

--- a/testing/equivalence-tests/tests/moved_with_refresh_only/.terraform.lock.hcl
+++ b/testing/equivalence-tests/tests/moved_with_refresh_only/.terraform.lock.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 # This file is maintained automatically by "opentf init".
 # Manual edits may be lost in future updates.
 

--- a/testing/equivalence-tests/tests/moved_with_update/.terraform.lock.hcl
+++ b/testing/equivalence-tests/tests/moved_with_update/.terraform.lock.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 # This file is maintained automatically by "opentf init".
 # Manual edits may be lost in future updates.
 

--- a/testing/equivalence-tests/tests/null_provider_delete/.terraform.lock.hcl
+++ b/testing/equivalence-tests/tests/null_provider_delete/.terraform.lock.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 # This file is maintained automatically by "opentf init".
 # Manual edits may be lost in future updates.
 

--- a/testing/equivalence-tests/tests/replace_within_list/.terraform.lock.hcl
+++ b/testing/equivalence-tests/tests/replace_within_list/.terraform.lock.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 # This file is maintained automatically by "opentf init".
 # Manual edits may be lost in future updates.
 

--- a/testing/equivalence-tests/tests/replace_within_map/.terraform.lock.hcl
+++ b/testing/equivalence-tests/tests/replace_within_map/.terraform.lock.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 # This file is maintained automatically by "opentf init".
 # Manual edits may be lost in future updates.
 

--- a/testing/equivalence-tests/tests/replace_within_object/.terraform.lock.hcl
+++ b/testing/equivalence-tests/tests/replace_within_object/.terraform.lock.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 # This file is maintained automatically by "opentf init".
 # Manual edits may be lost in future updates.
 

--- a/testing/equivalence-tests/tests/replace_within_set/.terraform.lock.hcl
+++ b/testing/equivalence-tests/tests/replace_within_set/.terraform.lock.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 # This file is maintained automatically by "opentf init".
 # Manual edits may be lost in future updates.
 

--- a/website/docs/cli/commands/test/examples/expect_failures_resources/main.tftest.hcl
+++ b/website/docs/cli/commands/test/examples/expect_failures_resources/main.tftest.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 run "test-failure" {
   variables {
     # This healthcheck endpoint won't exist:

--- a/website/docs/cli/commands/test/examples/expect_failures_variables/main.tftest.hcl
+++ b/website/docs/cli/commands/test/examples/expect_failures_variables/main.tftest.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 run "main" {
   command = plan
 

--- a/website/docs/cli/commands/test/examples/module/main.tftest.hcl
+++ b/website/docs/cli/commands/test/examples/module/main.tftest.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 run "http" {
   # Load the test helper instead of the main module:
   module {

--- a/website/docs/cli/commands/test/examples/nested-layout/main.tftest.hcl
+++ b/website/docs/cli/commands/test/examples/nested-layout/main.tftest.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 run "test" {
 
 }

--- a/website/docs/cli/commands/test/examples/nested-layout/module/tests/main.tftest.hcl
+++ b/website/docs/cli/commands/test/examples/nested-layout/module/tests/main.tftest.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 run "test" {
   module {
     source="../"

--- a/website/docs/cli/commands/test/examples/offline/main.tftest.hcl
+++ b/website/docs/cli/commands/test/examples/offline/main.tftest.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 // Configure the AWS provider to run fake credentials and without
 // any validations. Not all providers support this, but when they
 // do, you can run fully offline tests.

--- a/website/docs/cli/commands/test/examples/plan/Dockerfile
+++ b/website/docs/cli/commands/test/examples/plan/Dockerfile
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 FROM nginx
 
 # It doesn't really matter what we do here, it won't run anyway.

--- a/website/docs/cli/commands/test/examples/plan/main.tftest.hcl
+++ b/website/docs/cli/commands/test/examples/plan/main.tftest.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 run "test" {
   command = plan
   plan_options {

--- a/website/docs/cli/commands/test/examples/provider_alias/Dockerfile
+++ b/website/docs/cli/commands/test/examples/provider_alias/Dockerfile
@@ -1,6 +1,1 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 FROM nginx

--- a/website/docs/cli/commands/test/examples/provider_alias/main.tftest.hcl
+++ b/website/docs/cli/commands/test/examples/provider_alias/main.tftest.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 # This is the default "docker" provider for this file:
 provider "docker" {
   host = "tcp://0.0.0.0:2376"

--- a/website/docs/cli/commands/test/examples/simple/main.tftest.hcl
+++ b/website/docs/cli/commands/test/examples/simple/main.tftest.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 run "test" {
   assert {
     condition     = file(local_file.test.filename) == "Hello world!"

--- a/website/docs/cli/commands/test/examples/variables/main.tftest.hcl
+++ b/website/docs/cli/commands/test/examples/variables/main.tftest.hcl
@@ -1,8 +1,3 @@
-# Copyright (c) The OpenTofu Authors
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (c) 2023 HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 # First, set the variable here:
 variables {
   name = "OpenTofu"


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->

These copyright headers was mistakenly added in the following PR: https://github.com/opentofu/opentofu/pull/1232.

Part of https://github.com/opentofu/opentofu/issues/454 (original issue).

## Target Release

1.8.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [X] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [X] I have not used an AI coding assistant to create this PR.
- [X] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [X] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
