### PR TITLE
[backport 1.7] fix: slack link and `BuildKite` component (#1681)

### DIFF
--- a/website/docs/intro/install/buildkite.jsx
+++ b/website/docs/intro/install/buildkite.jsx
@@ -8,8 +8,21 @@
 import React from 'react';
 import BuildKiteSVG from './buildkite.svg'
 
-export default ({children, color}) => (
-    <p style={{textAlign: "center", padding: "1.5rem"}}><a href={"https://buildkite.com"} style={{display: "block", color: "#fff", textDecoration: "none"}}>
-        Thank you to <BuildKiteSVG style={{maxWidth: "50%", marginLeft: "auto", marginRight: "auto"}}/> for sponsoring the OpenTofu package hosting.
-    </a></p>
-);
+const BuildKite = () => {
+    return (
+      <p style={{ textAlign: "center", padding: "1.5rem" }}>
+        <a
+          href={"https://buildkite.com"}
+          style={{ display: "block", color: "#fff", textDecoration: "none" }}
+        >
+          Thank you to{" "}
+          <BuildKiteSVG
+            style={{ maxWidth: "50%", marginLeft: "auto", marginRight: "auto" }}
+          />{" "}
+          for sponsoring the OpenTofu package hosting.
+        </a>
+      </p>
+    );
+};
+
+export default BuildKite;

--- a/website/docs/intro/migration/terraform-1.5-or-lower.mdx
+++ b/website/docs/intro/migration/terraform-1.5-or-lower.mdx
@@ -121,7 +121,7 @@ If you encountered a bug, [please report it on GitHub](https://github.com/opento
 
 ## Troubleshooting
 
-If you encounter any issues during the migration to OpenTofu, you can join the [OpenTofu Slack](/slack) or ask on
+If you encounter any issues during the migration to OpenTofu, you can join the <a href="/slack/">OpenTofu Slack</a> or ask on
 [GitHub Discussions](https://github.com/orgs/opentofu/discussions).
 
 ### Error: Failed to query available provider packages

--- a/website/docs/intro/migration/terraform-1.6.mdx
+++ b/website/docs/intro/migration/terraform-1.6.mdx
@@ -136,7 +136,7 @@ If you encountered a bug, [please report it on GitHub](https://github.com/opento
 
 ## Troubleshooting
 
-If you encounter any issues during the migration to OpenTofu, you can join the [OpenTofu Slack](/slack) or ask on
+If you encounter any issues during the migration to OpenTofu, you can join the <a href="/slack/">OpenTofu Slack</a> or ask on
 [GitHub Discussions](https://github.com/orgs/opentofu/discussions).
 
 ### Error: Failed to query available provider packages

--- a/website/docs/intro/migration/terraform-1.7.mdx
+++ b/website/docs/intro/migration/terraform-1.7.mdx
@@ -148,7 +148,7 @@ If you encountered a bug, [please report it on GitHub](https://github.com/opento
 
 ## Troubleshooting
 
-If you encounter any issues during the migration to OpenTofu, you can join the [OpenTofu Slack](/slack) or ask on
+If you encounter any issues during the migration to OpenTofu, you can join the <a href="/slack/">OpenTofu Slack</a> or ask on
 [GitHub Discussions](https://github.com/orgs/opentofu/discussions).
 
 ### Error: Failed to query available provider packages

--- a/website/docs/intro/migration/terraform-1.8.mdx
+++ b/website/docs/intro/migration/terraform-1.8.mdx
@@ -147,7 +147,7 @@ If you encountered a bug, [please report it on GitHub](https://github.com/opento
 
 ## Troubleshooting
 
-If you encounter any issues during the migration to OpenTofu, you can join the [OpenTofu Slack](/slack) or ask on
+If you encounter any issues during the migration to OpenTofu, you can join the <a href="/slack/">OpenTofu Slack</a> or ask on
 [GitHub Discussions](https://github.com/orgs/opentofu/discussions).
 
 ### Error: Failed to query available provider packages

--- a/website/docs/intro/upgrading.mdx
+++ b/website/docs/intro/upgrading.mdx
@@ -100,7 +100,7 @@ If you encountered a bug, [please report it on GitHub](https://github.com/opento
 
 ## Troubleshooting
 
-If you encounter any issues during the migration to OpenTofu, you can join the [OpenTofu Slack](/slack) or ask on
+If you encounter any issues during the migration to OpenTofu, you can join the <a href="/slack/">OpenTofu Slack</a> or ask on
 [GitHub Discussions](https://github.com/orgs/opentofu/discussions).
 
 ### Error: Failed to query available provider packages


### PR DESCRIPTION
Backport of #1681