### PR TITLE
fix tofu installation tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -258,13 +258,13 @@ jobs:
           path: ".licensei.cache"
           key: licensei-cache-${{ hashFiles('go.sum') }}
  
- installation-instructions:
-   name: "Test Installation Instructions"
-   runs-on: ubuntu-latest
+  installation-instructions:
+    name: "Test Installation Instructions"
+    runs-on: ubuntu-latest
 
-   steps:
-     - name: "Fetch source code"
-       uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+    steps:
+      - name: "Fetch source code"
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
-     - name: "Run Installation Instructions Test"
-       run: make test-linux-install-instructions
+      - name: "Run Installation Instructions Test"
+        run: make test-linux-install-instructions

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -257,13 +257,14 @@ jobs:
         with:
           path: ".licensei.cache"
           key: licensei-cache-${{ hashFiles('go.sum') }}
-#  installation-instructions:
-#    name: "Test Installation Instructions"
-#    runs-on: ubuntu-latest
-#
-#    steps:
-#      - name: "Fetch source code"
-#        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-#
-#      - name: "Run Installation Instructions Test"
-#        run: make test-linux-install-instructions
+ 
+ installation-instructions:
+   name: "Test Installation Instructions"
+   runs-on: ubuntu-latest
+
+   steps:
+     - name: "Fetch source code"
+       uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+
+     - name: "Run Installation Instructions Test"
+       run: make test-linux-install-instructions

--- a/website/docs/intro/install/alpine-convenience.sh
+++ b/website/docs/intro/install/alpine-convenience.sh
@@ -11,4 +11,4 @@ chmod +x install-opentofu.sh
 ./install-opentofu.sh --install-method apk
 
 # Remove the installer:
-rm install-opentofu.sh
+rm -f install-opentofu.sh

--- a/website/docs/intro/install/deb-convenience.sh
+++ b/website/docs/intro/install/deb-convenience.sh
@@ -11,4 +11,4 @@ chmod +x install-opentofu.sh
 ./install-opentofu.sh --install-method deb
 
 # Remove the installer:
-rm install-opentofu.sh
+rm -f install-opentofu.sh

--- a/website/docs/intro/install/rpm-convenience.sh
+++ b/website/docs/intro/install/rpm-convenience.sh
@@ -11,4 +11,4 @@ chmod +x install-opentofu.sh
 ./install-opentofu.sh --install-method rpm
 
 # Remove the installer:
-rm install-opentofu.sh
+rm -f install-opentofu.sh

--- a/website/docs/intro/install/standalone-install.sh
+++ b/website/docs/intro/install/standalone-install.sh
@@ -11,4 +11,4 @@ chmod +x install-opentofu.sh
 ./install-opentofu.sh --install-method standalone
 
 # Remove the installer:
-rm install-opentofu.sh
+rm -f install-opentofu.sh

--- a/website/docs/intro/install/test-install-instructions.sh
+++ b/website/docs/intro/install/test-install-instructions.sh
@@ -28,7 +28,7 @@ for SERVICE in $SERVICES; do
     echo -e "::group::\033[0;32m✅  ${SERVICE}\033[0m"
   else
     echo -e "::group::\033[0;31m❌  ${SERVICE}\033[0m"
-    FAILED=$(("${FAILED}"+1))
+    FAILED=$((${FAILED}+1))
   fi
   cat $TEMPFILE | grep -a -E "^[a-zA-Z]+-${SERVICE}-1\s+\| " | sed -E "s/^[a-zA-Z]+-${SERVICE}-1\s+\| //"
   echo "::endgroup::"


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
This PR fixes tests for installation scripts.

1. `test-install-instructions.sh` reports success status for test group even if there are fails. Syntax error in bash script.

2. Tests randomly fail due to non-OK exit code from `rm`, when there is no `install-opentofu.sh`. Due to the parent folder being shared and concurrent execution, it's possible for other tests to remove this script. Fixed by adding `-f` to `rm` in examples. 

PS I didn't check the brew test due to mismatched supported processors. Running docker with ubuntu image on Apple M2 chip (ARM) produces the following error: `Homebrew on Linux is not supported on ARM processors`.

## Target Release

1.8.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [X] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [X] I have not used an AI coding assistant to create this PR.
- [X] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [X] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
