### PR TITLE
Fix 1201 initwd package

### DIFF
--- a/internal/initwd/from_module_test.go
+++ b/internal/initwd/from_module_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -281,6 +282,7 @@ func TestDirFromModule_rel_submodules(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		os.Chdir(oldDir)
+		runtime.GC()
 	})
 
 	hooks := &testInstallHooks{}

--- a/internal/modsdir/manifest.go
+++ b/internal/modsdir/manifest.go
@@ -180,5 +180,7 @@ func (m Manifest) WriteSnapshotToDir(dir string) error {
 	if err != nil {
 		return err
 	}
+	defer w.Close()
+
 	return m.WriteSnapshot(w)
 }


### PR DESCRIPTION

## Target Release

1.8.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

Related to #1201 

This PR helps resolves the initwd package tests failing on Windows. The errors included Windows filepath errors and a Tempdir Cleanup RemoveAll error. The solution for TempDir RemoveAll Cleanup error was to do `runtime.GC()` which runs a garbage collection and blocks other processes. This worked because it most likely released the open file handles that were not needed anymore. In the `WriteSnapshotToDir` function I also closed the file after creating it.

## Important
Another test was failing which was `TestModuleInstaller_symlink` and I was getting this error:
```
--- FAIL: TestModuleInstaller_symlink (0.01s)
    module_install_test.go:377: failed to copy fixture to temporary directory: symlink ..\child_a\ C:\Users\ED\AppData\Local\Temp\terraform-configload2464638177\modules\child_a: A required privilege is not held by the client.
```
What I had to do is enable developer mode on Windows (11), see https://github.com/Schniz/fnm/issues/338Bbut. If it's not possible to enable developer mode in the production environment then we could skip this test for Windows runtime only.
```
if runtime.GOOS == "windows" {
    t.Skip("Skipping symlinks test on Windows")
}
```

Tests in this package are passing on Windows and Linux machine
![initwd pass](https://github.com/opentofu/opentofu/assets/100037959/04041bd4-3a2e-4632-85e4-ac12a452d94e)
