### PR TITLE
Change link for missing module or missing provider

### DIFF
--- a/internal/command/e2etest/init_test.go
+++ b/internal/command/e2etest/init_test.go
@@ -432,7 +432,7 @@ func TestInitProviderNotFound(t *testing.T) {
 		}
 
 		oneLineStdout := strings.ReplaceAll(stdout, "\n", " ")
-		if !strings.Contains(oneLineStdout, `"diagnostic":{"severity":"error","summary":"Failed to query available provider packages","detail":"Could not retrieve the list of available versions for provider hashicorp/nonexist: provider registry registry.opentofu.org does not have a provider named registry.opentofu.org/hashicorp/nonexist\n\nAll modules should specify their required_providers so that external consumers will get the correct providers when using a module. To see which modules are currently depending on hashicorp/nonexist, run the following command:\n    tofu providers\n\nIf you believe this provider is missing from the registry, please submit a issue on the OpenTofu Registry https://github.com/opentofu/registry/issues/"},"type":"diagnostic"}`) {
+		if !strings.Contains(oneLineStdout, `"diagnostic":{"severity":"error","summary":"Failed to query available provider packages","detail":"Could not retrieve the list of available versions for provider hashicorp/nonexist: provider registry registry.opentofu.org does not have a provider named registry.opentofu.org/hashicorp/nonexist\n\nAll modules should specify their required_providers so that external consumers will get the correct providers when using a module. To see which modules are currently depending on hashicorp/nonexist, run the following command:\n    tofu providers\n\nIf you believe this provider is missing from the registry, please submit a issue on the OpenTofu Registry https://github.com/opentofu/registry/issues/new/choose"},"type":"diagnostic"}`) {
 			t.Errorf("expected error message is missing from output:\n%s", stdout)
 		}
 	})
@@ -493,7 +493,8 @@ func TestInitProviderNotFound(t *testing.T) {
 │     tofu providers
 │ 
 │ If you believe this provider is missing from the registry, please submit a
-│ issue on the OpenTofu Registry https://github.com/opentofu/registry/issues/
+│ issue on the OpenTofu Registry
+│ https://github.com/opentofu/registry/issues/new/choose
 ╵
 
 `

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -703,7 +703,7 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 				}
 
 				if provider.Hostname == addrs.DefaultProviderRegistryHost {
-					suggestion += "\n\nIf you believe this provider is missing from the registry, please submit a issue on the OpenTofu Registry https://github.com/opentofu/registry/issues/"
+					suggestion += "\n\nIf you believe this provider is missing from the registry, please submit a issue on the OpenTofu Registry https://github.com/opentofu/registry/issues/new/choose"
 				}
 
 				diags = diags.Append(tfdiags.Sourceless(

--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -440,7 +440,7 @@ func (i *ModuleInstaller) installRegistryModule(ctx context.Context, req *config
 			if registry.IsModuleNotFound(err) {
 				suggestion := ""
 				if hostname == addrs.DefaultModuleRegistryHost {
-					suggestion = "\n\nIf you believe this module is missing from the registry, please submit a issue on the OpenTofu Registry https://github.com/opentofu/registry/issues/"
+					suggestion = "\n\nIf you believe this module is missing from the registry, please submit a issue on the OpenTofu Registry https://github.com/opentofu/registry/issues/new/choose"
 				}
 
 				diags = diags.Append(&hcl.Diagnostic{


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

When running `tofu init` with a missing provider/module, the error message links to publish a new provider or module with the `https://github.com/opentofu/registry/issues` link. This link just goes to the list of issues

I changed the link to be `https://github.com/opentofu/registry/issues/new/choose`, letting you pick what kind of issue you'd like to open

## Target Release

1.8.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
