### PR TITLE
Remove `use_legacy_workflow` from the S3 backend configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.8.0 (Unreleased)
 
 UPGRADE NOTES:
-BREAKING CHANGE - `use_legacy_workflow` field has been removing from the S3 backend configuration. ([XXXX]())
+BREAKING CHANGE - `use_legacy_workflow` field has been removing from the S3 backend configuration. ([#1730](https://github.com/opentofu/opentofu/pull/1730))
 
 NEW FEATURES:
 * Added support for `override_resource`, `override_data` and `override_module` blocks in testing framework. ([1499](https://github.com/opentofu/opentofu/pull/1499))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.8.0 (Unreleased)
 
 UPGRADE NOTES:
+BREAKING CHANGE - `use_legacy_workflow` field has been removing from the S3 backend configuration. ([XXXX]())
 
 NEW FEATURES:
 * Added support for `override_resource`, `override_data` and `override_module` blocks in testing framework. ([1499](https://github.com/opentofu/opentofu/pull/1499))

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -288,12 +288,6 @@ func (b *Backend) ConfigSchema() *configschema.Block {
 				Optional:    true,
 				Description: "The maximum number of times an AWS API request is retried on retryable failure.",
 			},
-			"use_legacy_workflow": {
-				Type:        cty.Bool,
-				Optional:    true,
-				Description: "Use the legacy authentication workflow, preferring environment variables over backend configuration.",
-				Deprecated:  true,
-			},
 			"custom_ca_bundle": {
 				Type:        cty.String,
 				Optional:    true,
@@ -575,18 +569,6 @@ func (b *Backend) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) 
 			attrPath))
 	}
 
-	if val := obj.GetAttr("use_legacy_workflow"); !val.IsNull() {
-		attrPath := cty.GetAttrPath("use_legacy_workflow")
-		detail := fmt.Sprintf(
-			`Parameter "%s" is deprecated and will be removed in an upcoming minor version.`,
-			pathString(attrPath))
-
-		diags = diags.Append(attributeWarningDiag(
-			"Deprecated Parameter",
-			detail,
-			attrPath))
-	}
-
 	validateAttributesConflict(
 		cty.GetAttrPath("force_path_style"),
 		cty.GetAttrPath("use_path_style"),
@@ -765,8 +747,6 @@ func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
 		EC2MetadataServiceEndpointMode: stringAttrDefaultEnvVar(obj, "ec2_metadata_service_endpoint_mode", "AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE"),
 		Logger:                         baselog,
 	}
-
-	cfg.UseLegacyWorkflow = boolAttr(obj, "use_legacy_workflow")
 
 	if val, ok := boolAttrOk(obj, "skip_metadata_api_check"); ok {
 		if val {

--- a/internal/backend/remote-state/s3/backend_complete_test.go
+++ b/internal/backend/remote-state/s3/backend_complete_test.go
@@ -226,34 +226,6 @@ aws_secret_access_key = ProfileSharedCredentialsSecretKey
 			ValidateDiags: ExpectNoDiags,
 		},
 
-		"environment AWS_ACCESS_KEY_ID overrides config Profile": { // Legacy behavior
-			config: map[string]any{
-				"profile":             "SharedCredentialsProfile",
-				"use_legacy_workflow": true,
-			},
-			EnvironmentVariables: map[string]string{
-				"AWS_ACCESS_KEY_ID":     servicemocks.MockEnvAccessKey,
-				"AWS_SECRET_ACCESS_KEY": servicemocks.MockEnvSecretKey,
-			},
-			ExpectedCredentialsValue: mockdata.MockEnvCredentials,
-			MockStsEndpoints: []*servicemocks.MockEndpoint{
-				servicemocks.MockStsGetCallerIdentityValidEndpoint,
-			},
-			SharedCredentialsFile: `
-[default]
-aws_access_key_id = DefaultSharedCredentialsAccessKey
-aws_secret_access_key = DefaultSharedCredentialsSecretKey
-[SharedCredentialsProfile]
-aws_access_key_id = ProfileSharedCredentialsAccessKey
-aws_secret_access_key = ProfileSharedCredentialsSecretKey
-`,
-			ValidateDiags: ExpectDiagsMatching(
-				tfdiags.Warning,
-				equalsMatcher("Deprecated Parameter"),
-				noopMatcher{},
-			),
-		},
-
 		"environment AWS_ACCESS_KEY_ID does not override config Profile": {
 			config: map[string]any{
 				"profile": "SharedCredentialsProfile",

--- a/website/docs/intro/upgrading.mdx
+++ b/website/docs/intro/upgrading.mdx
@@ -1,21 +1,26 @@
 ---
 sidebar_position: 5
-sidebar_label: Upgrading from OpenTofu 1.6.x
+sidebar_label: Upgrading from OpenTofu 1.6.x/1.7.x
 description: |-
-    Learn how to upgrade OpenTofu from version 1.6.x to 1.7.1.
+    Learn how to upgrade OpenTofu from version 1.6.x/1.7.x to 1.8.0.
 ---
 
-# Upgrading from OpenTofu 1.6.x
+# Upgrading from OpenTofu 1.6.x/1.7.x
 
-OpenTofu 1.7.x is fully compatible with OpenTofu 1.6.x. This migration guide will take you through the process of
-upgrading OpenTofu to version 1.7.1.
+OpenTofu 1.8.x is mostly compatible with OpenTofu 1.6.x and 1.7.x (other than one minor breaking change in the S3 backend). This migration guide will take you through the process of
+upgrading OpenTofu to version 1.8.0.
 
 ## Step 0: Prepare a disaster recovery plan
 
-Although OpenTofu 1.7 is fully compatible with version 1.6, you should take the necessary precautions to prevent
+Although OpenTofu 1.8 is mostly compatible with version 1.6 and 1.7, you should take the necessary precautions to prevent
 accidents. Make sure you have an up to date and *tested* disaster recovery plan.
 
-## Step 1: Apply all changes with OpenTofu 1.6.x
+## Step 1: Remove any use of `use_legacy_workflow` from S3 backend configurations, if any
+
+If you are using the S3 backend, with `use_legacy_workflow` set, you'd have to remove it. This field has been deprecated in version 1.7.0, and has been changed to default to `false`.
+The legacy workflow of authentication is no longer supported. Please start using the new authentication method, which is more consistent with other AWS tools
+
+## Step 2: Apply all changes with OpenTofu 1.6.x/1.7.x
 
 Before proceeding, make sure that you apply all changes with `tofu apply`. Running `tofu plan` should result
 in no planned changes. While you can switch to OpenTofu with pending changes, it is not recommended.
@@ -31,14 +36,14 @@ OpenTofu has compared your real infrastructure against your
 configuration and found no differences, so no changes are needed.
 ```
 
-## Step 3: Install OpenTofu 1.7.x
+## Step 3: Install OpenTofu 1.8.x
 
 As a first step, please [follow the installation instructions for the OpenTofu CLI tool](intro/install/index.mdx). Please test
 if you can successfully execute the `tofu` command and receive the correct version:
 
 ```
 $ tofu --version
-OpenTofu v1.7.1
+OpenTofu v1.8.0
 on linux_amd64
 ```
 
@@ -50,7 +55,7 @@ a local state file, you can simply make a copy of your `terraform.tfstate` file 
 If you are using a remote backend such as an S3 bucket, make sure that you follow the backup procedures for the
 backend and that you exercise the restore procedure at least once.
 
-## Step 5: Initialize OpenTofu 1.7.x
+## Step 5: Initialize OpenTofu 1.8.x
 
 :::warning
 
@@ -67,7 +72,7 @@ any providers and modules referenced in your configuration from the OpenTofu reg
 ## Step 6: Inspect the plan
 
 Once initialized, run `tofu plan` and ensure that there are no pending changes similar to step 1 above. If there are
-unexpected changes in the plan, roll back to OpenTofu 1.6.x and troubleshoot your migration. (See the Troubleshooting
+unexpected changes in the plan, roll back to OpenTofu 1.6.x/1.7.x and troubleshoot your migration. (See the Troubleshooting
 section below.)
 
 ```
@@ -88,10 +93,10 @@ change.
 
 ## Rolling back and reporting issues
 
-If you have issues migrating to OpenTofu you can follow these steps to roll back to OpenTofu 1.6.x:
+If you have issues migrating to OpenTofu you can follow these steps to roll back to OpenTofu 1.6.x/1.7.x:
 
 1. Create another backup of your state file.
-2. Remove OpenTofu 1.7.x and verify that you are running OpenTofu 1.6.x.
+2. Remove OpenTofu 1.8.x and verify that you are running OpenTofu 1.6.x/1.7.x.
 3. Run `tofu init`.
 4. Run `tofu plan` and verify that no unexpected changes are in the plan.
 5. Test the rollback with a small, non-critical change.
@@ -106,11 +111,11 @@ If you encounter any issues during the migration to OpenTofu, you can join the <
 ### Error: Failed to query available provider packages
 
 This error happens when a provider you specified in your configuration is not available in the OpenTofu registry.
-Please roll back to OpenTofu 1.6.x and make sure your code works with that version. If your code works, please
+Please roll back to OpenTofu 1.6.x/1.7.x and make sure your code works with that version. If your code works, please
 [submit an issue to include the provider in the registry](https://github.com/opentofu/registry/issues/).
 
 ### Error: Module not found
 
 This error happens when a module you specified in your configuration is not available in the OpenTofu registry.
-Please roll back to OpenTofu 1.6.x and make sure your code works with that version. If your code works, please
+Please roll back to OpenTofu 1.6.x/1.7.x and make sure your code works with that version. If your code works, please
 [submit an issue to include the module in the registry](https://github.com/opentofu/registry/issues/).

--- a/website/docs/language/settings/backends/s3.mdx
+++ b/website/docs/language/settings/backends/s3.mdx
@@ -177,7 +177,6 @@ The following configuration is optional:
 * `token` - (Optional) Multi-Factor Authentication (MFA) token. This can also be sourced from the `AWS_SESSION_TOKEN` environment variable.
 * `allowed_account_ids` (Optional): A list of permitted AWS account IDs to safeguard against accidental disruption of a live environment. This option conflicts with `forbidden_account_ids`.
 * `forbidden_account_ids` (Optional): A list of prohibited AWS account IDs to prevent unintentional disruption of a live environment. This option conflicts with `allowed_account_ids`.
-* `use_legacy_workflow` - (Optional) **Deprecated** Prefer environment variables for legacy authentication; default is 'false'. This method doesn't match AWS CLI or SDK authentication and will be removed in the future.
 * `custom_ca_bundle` - File containing custom root and intermediate certificates. Can also be configured using the `AWS_CA_BUNDLE` environment variable.
 * `ec2_metadata_service_endpoint` - Address of the EC2 metadata service (IMDS) endpoint to use. This can also be sourced from the `AWS_EC2_METADATA_SERVICE_ENDPOINT` environment variable.
 * `ec2_metadata_service_endpoint_mode` - Mode to use in communicating with the metadata service. Valid values are `IPv4` and `IPv6`. This can also be sourced from the `AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE` environment variable.


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves https://github.com/opentofu/opentofu/issues/1368

Remove the `use_legacy_workflow` field, which has been deprecated already in version 1.7.0, from the S3 backend configuration.

## Target Release

1.8.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
