### PR TITLE
add trace log level warning to docs

### DIFF
--- a/website/docs/internals/debugging.mdx
+++ b/website/docs/internals/debugging.mdx
@@ -12,7 +12,7 @@ OpenTofu has detailed logs that you can enable by setting the `TF_LOG` environme
 You can set `TF_LOG` to one of the log levels (in order of decreasing verbosity) `TRACE`, `DEBUG`, `INFO`, `WARN` or `ERROR` to change the verbosity of the logs.
 
 :::warning
-Logs produced with `TRACE` level set should be considered as potentially sensitive.
+Logs produced with the `TRACE` level may contain sensitive details such as credentials and should be treated with care.
 :::
 
 Setting `TF_LOG` to `JSON` outputs logs at the `TRACE` level or higher, and uses a parseable JSON encoding as the formatting.

--- a/website/docs/internals/debugging.mdx
+++ b/website/docs/internals/debugging.mdx
@@ -11,6 +11,10 @@ OpenTofu has detailed logs that you can enable by setting the `TF_LOG` environme
 
 You can set `TF_LOG` to one of the log levels (in order of decreasing verbosity) `TRACE`, `DEBUG`, `INFO`, `WARN` or `ERROR` to change the verbosity of the logs.
 
+:::warning
+Logs produced with `TRACE` level set should be considered as potentially sensitive.
+:::
+
 Setting `TF_LOG` to `JSON` outputs logs at the `TRACE` level or higher, and uses a parseable JSON encoding as the formatting.
 
 :::warning


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->

This PR adds a warning to docs to clearly state that `TRACE` log level can produce sensitive output.

## Target Release

1.8.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [X] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [X] I have not used an AI coding assistant to create this PR.
- [X] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [X] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
