### PR TITLE
Hardcode golangci-lint revision to fix build on main

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -213,7 +213,8 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.58
-          only-new-issues: true
+          # Only compare with changes from when we introduced linting.  Eventually we can get rid of this and lint the whole project
+          args: --new-from-rev dd5f9afe8948186c76fe6b8b1193d7a8f46919d8
       
       - name: "Copyright headers"
         run: |

--- a/internal/configs/static_evaluator_test.go
+++ b/internal/configs/static_evaluator_test.go
@@ -17,7 +17,7 @@ import (
 
 // This exercises most of the logic in StaticEvaluator and staticScopeData
 //
-//nolint:gocognit,cyclop // it's a test
+//nolint:cyclop // it's a test
 func TestStaticEvaluator_Evaluate(t *testing.T) {
 	// Synthetic file for building test components
 	testData := `

--- a/internal/tofu/eval_for_each_test.go
+++ b/internal/tofu/eval_for_each_test.go
@@ -320,7 +320,6 @@ func TestEvaluateForEachExpression_multi_errors(t *testing.T) {
 					t.Errorf("wrong result from tfdiags.DiagnosticCausedBySensitive\ngot:  %#v\nwant: %#v", got, want)
 				}
 			}
-
 		})
 	}
 }


### PR DESCRIPTION
The "new issue" detection was no longer working on main.  This approach simply tells golang-ci-lint what change revision to start at.  It also includes some fixes to the main branch.

## Target Release

1.8.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
