### PR TITLE
Fix plan static variable injection

### DIFF
--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/backend"
@@ -248,8 +249,49 @@ func (b *Local) localRunForPlanFile(op *backend.Operation, pf *planfile.Reader, 
 		))
 		return nil, snap, diags
 	}
+
+	plan, err := pf.ReadPlan()
+	if err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			errSummary,
+			fmt.Sprintf("Failed to read plan from plan file: %s.", err),
+		))
+		return nil, snap, diags
+	}
+	// When we're applying a saved plan, we populate Plan instead of PlanOpts,
+	// because a plan object incorporates the subset of data from PlanOps that
+	// we need to apply the plan.
+	run.Plan = plan
+
+	subCall := op.RootCall.WithVariables(func(variable *configs.Variable) (cty.Value, hcl.Diagnostics) {
+		var diags hcl.Diagnostics
+
+		name := variable.Name
+		v, ok := plan.VariableValues[name]
+		if !ok {
+			if variable.Required() {
+				// This should not happen...
+				return cty.DynamicVal, diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Missing plan variable " + variable.Name,
+				})
+			}
+			return variable.Default, nil
+		}
+
+		parsed, parsedErr := v.Decode(variable.Type)
+		if parsedErr != nil {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  parsedErr.Error(),
+			})
+		}
+		return parsed, diags
+	})
+
 	loader := configload.NewLoaderFromSnapshot(snap)
-	config, configDiags := loader.LoadConfig(snap.Modules[""].Dir, op.RootCall)
+	config, configDiags := loader.LoadConfig(snap.Modules[""].Dir, subCall)
 	diags = diags.Append(configDiags)
 	if configDiags.HasErrors() {
 		return nil, snap, diags
@@ -341,20 +383,6 @@ func (b *Local) localRunForPlanFile(op *backend.Operation, pf *planfile.Reader, 
 	// recorded in the plan, which incorporates the result of all of the
 	// refreshing we did while building the plan.
 	run.InputState = priorStateFile.State
-
-	plan, err := pf.ReadPlan()
-	if err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			errSummary,
-			fmt.Sprintf("Failed to read plan from plan file: %s.", err),
-		))
-		return nil, snap, diags
-	}
-	// When we're applying a saved plan, we populate Plan instead of PlanOpts,
-	// because a plan object incorporates the subset of data from PlanOps that
-	// we need to apply the plan.
-	run.Plan = plan
 
 	tfCtx, moreDiags := tofu.NewContext(coreOpts)
 	diags = diags.Append(moreDiags)

--- a/internal/command/e2etest/static_plan_test.go
+++ b/internal/command/e2etest/static_plan_test.go
@@ -1,3 +1,8 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package e2etest
 
 import (

--- a/internal/command/e2etest/static_plan_test.go
+++ b/internal/command/e2etest/static_plan_test.go
@@ -1,0 +1,40 @@
+package e2etest
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/opentofu/opentofu/internal/e2e"
+)
+
+// This is an e2e test as it relies on very specific configuration
+// within the meta object that is currently very hard to mock out.
+func TestStaticPlanVariables(t *testing.T) {
+	fixturePath := filepath.Join("testdata", "static_plan_variables")
+	tf := e2e.NewBinary(t, tofuBin, fixturePath)
+
+	run := func(args ...string) tofuResult {
+		stdout, stderr, err := tf.Run(args...)
+		return tofuResult{t, stdout, stderr, err}
+	}
+
+	statePath := "custom.tfstate"
+	stateVar := "-var=state_path=" + statePath
+	modVar := "-var=src=./mod"
+	planfile := "static.plan"
+
+	// Init without static variable
+	run("init").Failure()
+
+	// Init with static variable
+	run("init", stateVar, modVar).Success()
+
+	// Plan with static variable
+	run("plan", stateVar, modVar, "-out="+planfile).Success()
+
+	// Show plan without static variable (embedded)
+	run("show", planfile).Success()
+
+	// Apply plan without static variable (embedded)
+	run("apply", planfile).Success()
+}

--- a/internal/command/e2etest/testdata/static_plan_variables/main.tf
+++ b/internal/command/e2etest/testdata/static_plan_variables/main.tf
@@ -1,0 +1,17 @@
+variable "state_path" {}
+
+variable "src" {}
+
+terraform {
+	backend "local" {
+		path = var.state_path
+	}
+}
+
+module "mod" {
+	source = var.src
+}
+
+output "out" {
+	value = module.mod.out
+}

--- a/internal/command/e2etest/testdata/static_plan_variables/mod/mod.tf
+++ b/internal/command/e2etest/testdata/static_plan_variables/mod/mod.tf
@@ -1,0 +1,3 @@
+output "out" {
+	value = "placeholder"
+}

--- a/internal/command/meta_config.go
+++ b/internal/command/meta_config.go
@@ -93,7 +93,7 @@ func (m *Meta) loadConfigWithTests(rootDir, testDir string) (*configs.Config, tf
 // initialization use-cases where the root module must be inspected in order
 // to determine what else needs to be installed before the full configuration
 // can be used.
-func (m *Meta) loadSingleModule(dir string) (*configs.Module, tfdiags.Diagnostics) {
+func (m *Meta) loadSingleModule(dir string, load configs.SelectiveLoader) (*configs.Module, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	dir = m.normalizePath(dir)
 
@@ -109,7 +109,7 @@ func (m *Meta) loadSingleModule(dir string) (*configs.Module, tfdiags.Diagnostic
 		return nil, diags
 	}
 
-	module, hclDiags := loader.Parser().LoadConfigDir(dir, call)
+	module, hclDiags := loader.Parser().LoadConfigDirSelective(dir, call, load)
 	diags = diags.Append(hclDiags)
 	return module, diags
 }
@@ -205,7 +205,7 @@ func (m *Meta) dirIsConfigPath(dir string) bool {
 // that a call to loadSingleModule or loadConfig could fail on the same
 // directory even if loadBackendConfig succeeded.)
 func (m *Meta) loadBackendConfig(rootDir string) (*configs.Backend, tfdiags.Diagnostics) {
-	mod, diags := m.loadSingleModule(rootDir)
+	mod, diags := m.loadSingleModule(rootDir, configs.SelectiveLoadBackend)
 
 	// Only return error diagnostics at this point. Any warnings will be caught
 	// again later and duplicated in the output.

--- a/internal/command/meta_encryption.go
+++ b/internal/command/meta_encryption.go
@@ -29,7 +29,7 @@ func (m *Meta) Encryption() (encryption.Encryption, tfdiags.Diagnostics) {
 func (m *Meta) EncryptionFromPath(path string) (encryption.Encryption, tfdiags.Diagnostics) {
 	// This is not ideal, but given how fragmented the command package is, loading the root module here is our best option
 	// See other meta commands like version check which do that same.
-	module, diags := m.loadSingleModule(path)
+	module, diags := m.loadSingleModule(path, configs.SelectiveLoadEncryption)
 	if diags.HasErrors() {
 		return nil, diags
 	}

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/opentofu/opentofu/internal/backend"
 	"github.com/opentofu/opentofu/internal/cloud"
 	"github.com/opentofu/opentofu/internal/cloud/cloudplan"
@@ -26,6 +27,7 @@ import (
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/opentofu/opentofu/internal/tofu"
 	"github.com/opentofu/opentofu/internal/tofumigrate"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // Many of the methods we get data from can emit special error types if they're
@@ -355,8 +357,34 @@ func getDataFromPlanfileReader(planReader *planfile.Reader, rootCall configs.Sta
 		return nil, nil, nil, err
 	}
 
+	subCall := rootCall.WithVariables(func(variable *configs.Variable) (cty.Value, hcl.Diagnostics) {
+		var diags hcl.Diagnostics
+
+		name := variable.Name
+		v, ok := plan.VariableValues[name]
+		if !ok {
+			if variable.Required() {
+				// This should not happen...
+				return cty.DynamicVal, diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Missing plan variable " + variable.Name,
+				})
+			}
+			return variable.Default, nil
+		}
+
+		parsed, parsedErr := v.Decode(variable.Type)
+		if parsedErr != nil {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  parsedErr.Error(),
+			})
+		}
+		return parsed, diags
+	})
+
 	// Get config
-	config, diags := planReader.ReadConfig(rootCall)
+	config, diags := planReader.ReadConfig(subCall)
 	if diags.HasErrors() {
 		return nil, nil, nil, errUnusable(diags.Err(), "local plan")
 	}

--- a/internal/configs/module.go
+++ b/internal/configs/module.go
@@ -13,7 +13,6 @@ import (
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/encryption/config"
 	"github.com/opentofu/opentofu/internal/experiments"
-
 	tfversion "github.com/opentofu/opentofu/version"
 )
 
@@ -108,7 +107,7 @@ type File struct {
 	Checks []*Check
 }
 
-// Only load and validate the portions of files needed for the given operations/contexts
+// SelectiveLoader allows the consumer to only load and validate the portions of files needed for the given operations/contexts
 type SelectiveLoader int
 
 const (
@@ -131,7 +130,7 @@ func (s SelectiveLoader) filter(input []*File) []*File {
 		}
 
 		switch s {
-		case SelectiveLoadBackend:
+		case SelectiveLoadBackend: //nolint:exhaustive
 			outFile.Backends = inFile.Backends
 			outFile.CloudConfigs = inFile.CloudConfigs
 		case SelectiveLoadEncryption:

--- a/internal/configs/module.go
+++ b/internal/configs/module.go
@@ -129,8 +129,8 @@ func (s SelectiveLoader) filter(input []*File) []*File {
 			Locals:    inFile.Locals,
 		}
 
-		switch s {
-		case SelectiveLoadBackend: //nolint:exhaustive
+		switch s { //nolint:exhaustive // SelectiveLoadAll handled above
+		case SelectiveLoadBackend:
 			outFile.Backends = inFile.Backends
 			outFile.CloudConfigs = inFile.CloudConfigs
 		case SelectiveLoadEncryption:

--- a/internal/configs/parser_config_dir.go
+++ b/internal/configs/parser_config_dir.go
@@ -52,6 +52,9 @@ const (
 // .tf files are parsed using the HCL native syntax while .tf.json files are
 // parsed using the HCL JSON syntax.
 func (p *Parser) LoadConfigDir(path string, call StaticModuleCall) (*Module, hcl.Diagnostics) {
+	return p.LoadConfigDirSelective(path, call, SelectiveLoadAll)
+}
+func (p *Parser) LoadConfigDirSelective(path string, call StaticModuleCall, load SelectiveLoader) (*Module, hcl.Diagnostics) {
 	primaryPaths, overridePaths, _, diags := p.dirFiles(path, "")
 	if diags.HasErrors() {
 		return nil, diags
@@ -62,7 +65,7 @@ func (p *Parser) LoadConfigDir(path string, call StaticModuleCall) (*Module, hcl
 	override, fDiags := p.loadFiles(overridePaths, true)
 	diags = append(diags, fDiags...)
 
-	mod, modDiags := NewModule(primary, override, call, path)
+	mod, modDiags := NewModule(primary, override, call, path, load)
 	diags = append(diags, modDiags...)
 
 	return mod, diags

--- a/internal/configs/parser_test.go
+++ b/internal/configs/parser_test.go
@@ -48,7 +48,7 @@ func testParser(files map[string]string) *Parser {
 func testModuleConfigFromFile(filename string) (*Config, hcl.Diagnostics) {
 	parser := NewParser(nil)
 	f, diags := parser.LoadConfigFile(filename)
-	mod, modDiags := NewModule([]*File{f}, nil, RootModuleCallForTesting(), filename)
+	mod, modDiags := NewModule([]*File{f}, nil, RootModuleCallForTesting(), filename, SelectiveLoadAll)
 	diags = append(diags, modDiags...)
 	cfg, moreDiags := BuildConfig(mod, nil)
 	return cfg, append(diags, moreDiags...)

--- a/internal/configs/static_evaluator.go
+++ b/internal/configs/static_evaluator.go
@@ -48,6 +48,15 @@ func NewStaticModuleCall(addr addrs.Module, vars StaticModuleVariables, rootPath
 	}
 }
 
+func (s StaticModuleCall) WithVariables(vars StaticModuleVariables) StaticModuleCall {
+	return StaticModuleCall{
+		addr:      s.addr,
+		vars:      vars,
+		rootPath:  s.rootPath,
+		workspace: s.workspace,
+	}
+}
+
 // only used in testing
 func RootModuleCallForTesting() StaticModuleCall {
 	return NewStaticModuleCall(addrs.RootModule, func(_ *Variable) (cty.Value, hcl.Diagnostics) {

--- a/internal/configs/static_evaluator_test.go
+++ b/internal/configs/static_evaluator_test.go
@@ -96,7 +96,7 @@ resource "foo" "bar" {}
 	dummyIdentifier := StaticIdentifier{Subject: "local.test"}
 
 	t.Run("Empty Eval", func(t *testing.T) {
-		mod, _ := NewModule([]*File{file}, nil, RootModuleCallForTesting(), "dir")
+		mod, _ := NewModule([]*File{file}, nil, RootModuleCallForTesting(), "dir", SelectiveLoadAll)
 		emptyEval := StaticEvaluator{}
 
 		// Expr with no traversals shouldn't access any fields
@@ -119,7 +119,7 @@ resource "foo" "bar" {}
 	})
 
 	t.Run("Simple static cases", func(t *testing.T) {
-		mod, _ := NewModule([]*File{file}, nil, RootModuleCallForTesting(), "dir")
+		mod, _ := NewModule([]*File{file}, nil, RootModuleCallForTesting(), "dir", SelectiveLoadAll)
 		eval := NewStaticEvaluator(mod, RootModuleCallForTesting())
 
 		locals := []struct {
@@ -156,7 +156,7 @@ resource "foo" "bar" {}
 			}
 			return v.Default, nil
 		}, "<testing>", "")
-		mod, _ := NewModule([]*File{file}, nil, call, "dir")
+		mod, _ := NewModule([]*File{file}, nil, call, "dir", SelectiveLoadAll)
 		eval := NewStaticEvaluator(mod, call)
 
 		locals := []struct {
@@ -182,7 +182,7 @@ resource "foo" "bar" {}
 	})
 
 	t.Run("Bad References", func(t *testing.T) {
-		mod, _ := NewModule([]*File{file}, nil, RootModuleCallForTesting(), "dir")
+		mod, _ := NewModule([]*File{file}, nil, RootModuleCallForTesting(), "dir", SelectiveLoadAll)
 		eval := NewStaticEvaluator(mod, RootModuleCallForTesting())
 
 		locals := []struct {
@@ -202,7 +202,7 @@ resource "foo" "bar" {}
 	})
 
 	t.Run("Circular References", func(t *testing.T) {
-		mod, _ := NewModule([]*File{file}, nil, RootModuleCallForTesting(), "dir")
+		mod, _ := NewModule([]*File{file}, nil, RootModuleCallForTesting(), "dir", SelectiveLoadAll)
 		eval := NewStaticEvaluator(mod, RootModuleCallForTesting())
 
 		locals := []struct {
@@ -239,7 +239,7 @@ resource "foo" "bar" {}
 				Subject:  v.DeclRange.Ptr(),
 			}}
 		}, "<testing>", "")
-		mod, _ := NewModule([]*File{file}, nil, call, "dir")
+		mod, _ := NewModule([]*File{file}, nil, call, "dir", SelectiveLoadAll)
 		eval := NewStaticEvaluator(mod, call)
 
 		badref := mod.Locals["ref_c"]
@@ -253,7 +253,7 @@ resource "foo" "bar" {}
 	})
 
 	t.Run("Missing References", func(t *testing.T) {
-		mod, _ := NewModule([]*File{file}, nil, RootModuleCallForTesting(), "dir")
+		mod, _ := NewModule([]*File{file}, nil, RootModuleCallForTesting(), "dir", SelectiveLoadAll)
 		eval := NewStaticEvaluator(mod, RootModuleCallForTesting())
 
 		locals := []struct {
@@ -274,7 +274,7 @@ resource "foo" "bar" {}
 
 	t.Run("Workspace", func(t *testing.T) {
 		call := NewStaticModuleCall(nil, nil, "<testing>", "my-workspace")
-		mod, _ := NewModule([]*File{file}, nil, call, "dir")
+		mod, _ := NewModule([]*File{file}, nil, call, "dir", SelectiveLoadAll)
 		eval := NewStaticEvaluator(mod, call)
 
 		value, diags := eval.Evaluate(mod.Locals["ws"].Expr, dummyIdentifier)
@@ -287,7 +287,7 @@ resource "foo" "bar" {}
 	})
 
 	t.Run("Functions", func(t *testing.T) {
-		mod, _ := NewModule([]*File{file}, nil, RootModuleCallForTesting(), "dir")
+		mod, _ := NewModule([]*File{file}, nil, RootModuleCallForTesting(), "dir", SelectiveLoadAll)
 		eval := NewStaticEvaluator(mod, RootModuleCallForTesting())
 
 		value, diags := eval.Evaluate(mod.Locals["func"].Expr, dummyIdentifier)
@@ -312,7 +312,7 @@ func TestStaticEvaluator_DecodeExpression(t *testing.T) {
 	if fileDiags.HasErrors() {
 		t.Fatal(fileDiags)
 	}
-	mod, _ := NewModule([]*File{file}, nil, RootModuleCallForTesting(), "dir")
+	mod, _ := NewModule([]*File{file}, nil, RootModuleCallForTesting(), "dir", SelectiveLoadAll)
 	eval := NewStaticEvaluator(mod, RootModuleCallForTesting())
 
 	cases := []struct {
@@ -382,7 +382,7 @@ terraform {
 				t.Fatal(fileDiags)
 			}
 
-			mod, _ := NewModule([]*File{file}, nil, RootModuleCallForTesting(), "dir")
+			mod, _ := NewModule([]*File{file}, nil, RootModuleCallForTesting(), "dir", SelectiveLoadAll)
 			_, diags := mod.Backend.Decode(&configschema.Block{
 				Attributes: map[string]*configschema.Attribute{
 					"thing": &configschema.Attribute{


### PR DESCRIPTION
Fixes scenarios where static variables are stored in a plan (show/apply).  It also addresses encryption loading for those scenarios by only loading the required configuration data at that point in time (the cause of the reported issue).

Resolves #1768

## Target Release

1.8.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
