### PR TITLE
ignore any lock file on license header check

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -14,7 +14,7 @@ project {
   header_ignore = [
     "**/*.tf",
     "**/*.tftest.hcl",
-    "testing/equivalence-tests/**/.terraform.lock.hcl",
+    "**/*.terraform.lock.hcl",
     "website/docs/**/examples/**",
     "**/testdata/**",
     "**/*.pb.go",


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
When testing different configurations locally, I usually have git ignored dirs with lock files. It is annoying to see errors from the license checker when running locally in that setup.

So I believe any lock file should be ignored.

## Target Release

1.8.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [X] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [X] I have not used an AI coding assistant to create this PR.
- [X] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
