### PR TITLE
fix: providers block shouldn't be merged with file mocks in tofu test

### DIFF
--- a/internal/command/e2etest/test_test.go
+++ b/internal/command/e2etest/test_test.go
@@ -76,7 +76,7 @@ func TestMocksAndOverrides(t *testing.T) {
 	if stderr != "" {
 		t.Errorf("unexpected stderr output on 'test':\n%s", stderr)
 	}
-	if !strings.Contains(stdout, "12 passed, 0 failed") {
+	if !strings.Contains(stdout, "13 passed, 0 failed") {
 		t.Errorf("output doesn't have expected success string:\n%s", stdout)
 	}
 }

--- a/internal/command/e2etest/testdata/overrides-in-tests/main.tf
+++ b/internal/command/e2etest/testdata/overrides-in-tests/main.tf
@@ -82,3 +82,19 @@ data "local_file" "maintf" {
 }
 
 resource "random_pet" "cat" {}
+
+provider random {
+  alias = "aliased"
+}
+
+resource "random_integer" "aliased" {
+  provider = random.aliased
+
+  # helps create a new value when test with mocked pet runs
+  keepers = {
+    pet = random_pet.cat.id
+  }
+
+  min = 1
+  max = 10
+}

--- a/internal/command/e2etest/testdata/overrides-in-tests/main.tftest.hcl
+++ b/internal/command/e2etest/testdata/overrides-in-tests/main.tftest.hcl
@@ -255,6 +255,16 @@ mock_provider "random" {
   }
 }
 
+mock_provider "random" {
+  alias = "aliased"
+
+  mock_resource "random_integer" {
+    defaults = {
+      id = "11"
+    }
+  }
+}
+
 run "check_mock_providers" {
   assert {
     condition     = resource.aws_s3_bucket.test.arn == "arn:aws:s3:::mocked"
@@ -276,12 +286,26 @@ run "check_mock_providers" {
     error_message = "file should not be read due to provider being mocked"
   }
 
+  assert {
+    condition     = resource.random_integer.aliased.id == "11"
+    error_message = "random integer should be 11 due to provider being mocked"
+  }
+}
+
+run "check_providers_block" {
   providers = {
-    random = random.for_pets
+    aws           = aws
+    local.aliased = local.aliased
+    random        = random.for_pets
   }
 
   assert {
     condition     = resource.random_pet.cat.id == "my lovely cat"
     error_message = "providers block in run should allow replacing real providers by mocked"
+  }
+
+  assert {
+    condition     = resource.random_integer.aliased.id != "11"
+    error_message = "random integer should not be mocked if providers block present"
   }
 }

--- a/internal/configs/config.go
+++ b/internal/configs/config.go
@@ -926,7 +926,7 @@ func (c *Config) transformProviderConfigsForTest(run *TestRun, file *TestFile) (
 	//       doing this we ensure to preserve the name and alias from the
 	//       original config.
 	//   3b. If the run has no override configuration, we copy all the providers
-	//       (with mocks) from the test file into `next`, overriding all providers
+	//       (including mocks) from the test file into `next`, overriding all providers
 	//       with name collisions from the original config.
 	//   4. We then modify the original configuration so that the providers it
 	//      holds are the combination specified by the original config, the test

--- a/internal/configs/config.go
+++ b/internal/configs/config.go
@@ -926,10 +926,8 @@ func (c *Config) transformProviderConfigsForTest(run *TestRun, file *TestFile) (
 	//       doing this we ensure to preserve the name and alias from the
 	//       original config.
 	//   3b. If the run has no override configuration, we copy all the providers
-	//       from the test file into `next`, overriding all providers with name
-	//       collisions from the original config.
-	//   3c. Copy all mock providers from the test file to the `next`, overriding
-	//       providers with name collisions from the original config.
+	//       (with mocks) from the test file into `next`, overriding all providers
+	//       with name collisions from the original config.
 	//   4. We then modify the original configuration so that the providers it
 	//      holds are the combination specified by the original config, the test
 	//      file and the run file.
@@ -986,17 +984,16 @@ func (c *Config) transformProviderConfigsForTest(run *TestRun, file *TestFile) (
 		for key, provider := range file.Providers {
 			next[key] = provider
 		}
-	}
-
-	for _, mp := range file.MockProviders {
-		next[mp.moduleUniqueKey()] = &Provider{
-			Name:          mp.Name,
-			NameRange:     mp.NameRange,
-			Alias:         mp.Alias,
-			AliasRange:    mp.AliasRange,
-			DeclRange:     mp.DeclRange,
-			IsMocked:      true,
-			MockResources: mp.MockResources,
+		for _, mp := range file.MockProviders {
+			next[mp.moduleUniqueKey()] = &Provider{
+				Name:          mp.Name,
+				NameRange:     mp.NameRange,
+				Alias:         mp.Alias,
+				AliasRange:    mp.AliasRange,
+				DeclRange:     mp.DeclRange,
+				IsMocked:      true,
+				MockResources: mp.MockResources,
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Part of #1155.

This PR makes `providers` block ignore any non-referenced `mock_provider` definitions. The same way it behaves with other `provider` definitions in a test file.

## Target Release

1.8.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [X] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [X] I have not used an AI coding assistant to create this PR.
- [X] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [X] I have run golangci-lint on my change and receive no errors relevant to my code.
- [X] I have run existing tests to ensure my code doesn't break anything.
- [X] I have added tests for all relevant use cases of my code, and those tests are passing.
- [X] I have only exported functions, variables and structs that should be used from other packages.
- [X] I have added meaningful comments to all exported functions, variables, and structs.
