### PR TITLE
Improve ModuleExpansionTransformer performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ NEW FEATURES:
 ENHANCEMENTS:
 * Added `-show-sensitive` flag to tofu plan, apply, state-show and output commands to display sensitive data in output. ([#1554](https://github.com/opentofu/opentofu/pull/1554))
 * Improved performance for large graphs when debug logs are not enabled. ([#1810](https://github.com/opentofu/opentofu/pull/1810))
+* Improved performance for large graphs with many submodules. ([#1809](https://github.com/opentofu/opentofu/pull/1809))
 
 BUG FIXES:
 * Ensure that using a sensitive path for templatefile that it doesn't panic([#1801](https://github.com/opentofu/opentofu/issues/1801))

--- a/internal/tofu/transform_module_expansion_test.go
+++ b/internal/tofu/transform_module_expansion_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tofu
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/opentofu/opentofu/internal/addrs"
+)
+
+func TestModuleExpansionTransformer(t *testing.T) {
+	g := Graph{Path: addrs.RootModuleInstance}
+	module := testModule(t, "transform-module-var-basic")
+
+	{
+		tf := &ModuleExpansionTransformer{Config: module}
+		if err := tf.Transform(&g); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+
+	actual := strings.TrimSpace(g.String())
+	expected := strings.TrimSpace(testTransformModuleExpBasicStr)
+	if actual != expected {
+		t.Fatalf("want:\n\n%s\n\ngot:\n\n%s", expected, actual)
+	}
+}
+
+func TestModuleExpansionTransformer_nested(t *testing.T) {
+	g := Graph{Path: addrs.RootModuleInstance}
+	module := testModule(t, "transform-module-var-nested")
+
+	{
+		tf := &ModuleExpansionTransformer{Config: module}
+		if err := tf.Transform(&g); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+
+	actual := strings.TrimSpace(g.String())
+	expected := strings.TrimSpace(testTransformModuleExpNestedStr)
+	if actual != expected {
+		t.Fatalf("want:\n\n%s\n\ngot:\n\n%s", expected, actual)
+	}
+}
+
+const testTransformModuleExpBasicStr = `
+module.child (close)
+  module.child (expand)
+module.child (expand)
+`
+
+const testTransformModuleExpNestedStr = `
+module.child (close)
+  module.child (expand)
+  module.child.module.child (close)
+module.child (expand)
+module.child.module.child (close)
+  module.child.module.child (expand)
+module.child.module.child (expand)
+  module.child (expand)
+`


### PR DESCRIPTION
The existing implementation took a very long time given a large number of Vertices or Modules in a graph.

This constructs a tree that can quickly return the set of vertices in a given module rather than iterating over every Vertex for every Module.

We have a fairly unusual graph with an obscene number of modules and vertices, so this change makes a fairly substantial impact on our performance.

Before: https://share.firefox.dev/3Y0qu9h
After: https://share.firefox.dev/4bHYBGd

Time spent in ModuleExpansionTransformer drops from ~27s to ~1s.

I haven't added any new tests because (in theory) this should not affect any functionality, just performance, but let me know if I should add some.

This `pathTree` implementation is not exposed to anything because I didn't want to change any interfaces, but it might make sense for [`tofu.Graph`](https://github.com/opentofu/opentofu/blob/f668c48ffd57d1f5f5dcd7543f179b373643081a/internal/tofu/graph.go#L23) to implement something like this? I would personally wait until we find other instances where we want vertex lookup by module before changing any APIs, but I'd defer to maintainers.

## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
