### PR TITLE
Fix more tests on Windows

### DIFF
--- a/internal/builtin/provisioners/remote-exec/resource_provisioner_test.go
+++ b/internal/builtin/provisioners/remote-exec/resource_provisioner_test.go
@@ -145,7 +145,9 @@ func TestResourceProvider_CollectScripts_script(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	if out.String() != expectedScriptOut {
+	expectedOutput := normaliseNewlines(expectedScriptOut)
+	actualOutput := normaliseNewlines(out.String())
+	if actualOutput != expectedOutput {
 		t.Fatalf("bad: %v", out.String())
 	}
 }
@@ -181,7 +183,9 @@ func TestResourceProvider_CollectScripts_scripts(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 
-		if out.String() != expectedScriptOut {
+		expectedOutput := normaliseNewlines(expectedScriptOut)
+		actualOutput := normaliseNewlines(out.String())
+		if actualOutput != expectedOutput {
 			t.Fatalf("bad: %v", out.String())
 		}
 	}
@@ -322,4 +326,8 @@ func TestResourceProvisioner_nullsInOptionals(t *testing.T) {
 			})
 		})
 	}
+}
+
+func normaliseNewlines(input string) string {
+	return strings.ReplaceAll(input, "\r\n", "\n")
 }

--- a/internal/cloud/e2e/main_test.go
+++ b/internal/cloud/e2e/main_test.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -197,7 +198,8 @@ func setupBinary() func() {
 		os.Exit(1)
 	}
 	// Getting top level dir
-	dirPaths := strings.Split(currentDir, "/")
+	newDir := filepath.ToSlash(currentDir)
+	dirPaths := strings.Split(newDir, "/")
 	log.Println(currentDir)
 	topLevel := len(dirPaths) - 3
 	topDir := strings.Join(dirPaths[0:topLevel], "/")

--- a/internal/command/views/json/diagnostic_test.go
+++ b/internal/command/views/json/diagnostic_test.go
@@ -918,14 +918,19 @@ func TestNewDiagnostic(t *testing.T) {
 			}
 
 			// Don't care about leading or trailing whitespace
-			gotString := strings.TrimSpace(string(gotBytes))
-			wantString := strings.TrimSpace(string(wantBytes))
+			gotString := normaliseNewlines(strings.TrimSpace(string(gotBytes)))
+			wantString := normaliseNewlines(strings.TrimSpace(string(wantBytes)))
 
 			if !cmp.Equal(wantString, gotString) {
 				t.Fatalf("wrong result\n:%s", cmp.Diff(wantString, gotString))
 			}
 		})
 	}
+}
+
+// Function to normalise newlines in a string for Windows
+func normaliseNewlines(s string) string {
+	return strings.ReplaceAll(s, "\r\n", "\n")
 }
 
 // Helper function to make constructing literal Diagnostics easier. There

--- a/internal/command/views/test_test.go
+++ b/internal/command/views/test_test.go
@@ -8,6 +8,7 @@ package views
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -3564,6 +3565,11 @@ func runTestSaveErroredStateFile(t *testing.T, tc map[string]struct {
 			if _, err := os.Stat(tempStateFilePath); os.IsNotExist(err) {
 				// File does not exist
 				t.Errorf("Expected state file 'errored_test.tfstate' to exist in: %s, but it does not.", tempDir)
+			}
+			// Trigger garbage collection to ensure that all open file handles are closed.
+			// This prevents TempDir RemoveAll cleanup errors on Windows.
+			if runtime.GOOS == "windows" {
+				runtime.GC()
 			}
 		})
 	}

--- a/internal/configs/configload/loader_snapshot_test.go
+++ b/internal/configs/configload/loader_snapshot_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -46,6 +47,9 @@ func TestLoadConfigWithSnapshot(t *testing.T) {
 			"child_b.child_d": "testdata/already-installed/.terraform/modules/child_b.child_d",
 		}
 
+		for key, module := range wantModuleDirs {
+			wantModuleDirs[key] = filepath.Join(module)
+		}
 		problems := deep.Equal(wantModuleDirs, gotModuleDirs)
 		for _, problem := range problems {
 			t.Errorf(problem)
@@ -57,7 +61,7 @@ func TestLoadConfigWithSnapshot(t *testing.T) {
 
 	gotRoot := got.Modules[""]
 	wantRoot := &SnapshotModule{
-		Dir: "testdata/already-installed",
+		Dir: filepath.Join("testdata/already-installed"),
 		Files: map[string][]byte{
 			"root.tf": []byte(`
 module "child_a" {
@@ -71,6 +75,10 @@ module "child_b" {
 }
 `),
 		},
+	}
+	// Normalise line endings and file paths for Windows
+	for k, v := range gotRoot.Files {
+		gotRoot.Files[k] = []byte(strings.ReplaceAll(string(v), "\r\n", "\n"))
 	}
 	if !reflect.DeepEqual(gotRoot, wantRoot) {
 		t.Errorf("wrong root module snapshot\ngot: %swant: %s", spew.Sdump(gotRoot), spew.Sdump(wantRoot))
@@ -126,7 +134,7 @@ func TestSnapshotRoundtrip(t *testing.T) {
 	if config.Module == nil {
 		t.Fatalf("config has no root module")
 	}
-	if got, want := config.Module.SourceDir, "testdata/already-installed"; got != want {
+	if got, want := config.Module.SourceDir, filepath.Clean("testdata/already-installed"); got != want {
 		t.Errorf("wrong root module sourcedir %q; want %q", got, want)
 	}
 	if got, want := len(config.Module.ModuleCalls), 2; got != want {
@@ -139,7 +147,7 @@ func TestSnapshotRoundtrip(t *testing.T) {
 	if childA.Module == nil {
 		t.Fatalf("child_a config has no module")
 	}
-	if got, want := childA.Module.SourceDir, "testdata/already-installed/.terraform/modules/child_a"; got != want {
+	if got, want := childA.Module.SourceDir, filepath.Clean("testdata/already-installed/.terraform/modules/child_a"); got != want {
 		t.Errorf("wrong child_a sourcedir %q; want %q", got, want)
 	}
 	if got, want := len(childA.Module.ModuleCalls), 1; got != want {

--- a/internal/configs/configload/loader_snapshot_test.go
+++ b/internal/configs/configload/loader_snapshot_test.go
@@ -48,7 +48,7 @@ func TestLoadConfigWithSnapshot(t *testing.T) {
 		}
 
 		for key, module := range wantModuleDirs {
-			wantModuleDirs[key] = filepath.Join(module)
+			wantModuleDirs[key] = filepath.Clean(module)
 		}
 		problems := deep.Equal(wantModuleDirs, gotModuleDirs)
 		for _, problem := range problems {
@@ -61,7 +61,7 @@ func TestLoadConfigWithSnapshot(t *testing.T) {
 
 	gotRoot := got.Modules[""]
 	wantRoot := &SnapshotModule{
-		Dir: filepath.Join("testdata/already-installed"),
+		Dir: filepath.Join("testdata", "already-installed"),
 		Files: map[string][]byte{
 			"root.tf": []byte(`
 module "child_a" {

--- a/internal/plans/planfile/planfile_test.go
+++ b/internal/plans/planfile/planfile_test.go
@@ -7,6 +7,7 @@ package planfile
 
 import (
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -189,10 +190,15 @@ func TestWrappedError(t *testing.T) {
 	}
 
 	// Open something that doesn't exist: should error
-	missingFile := "no such file or directory"
+	var missingFileError string
+	if runtime.GOOS == "windows" {
+		missingFileError = "The system cannot find the file specified"
+	} else {
+		missingFileError = "no such file or directory"
+	}
 	_, err = OpenWrapped(filepath.Join("testdata", "absent.tfplan"), encryption.PlanEncryptionDisabled())
-	if !strings.Contains(err.Error(), missingFile) {
-		t.Fatalf("expected  %q, got %q", missingFile, err)
+	if !strings.Contains(err.Error(), missingFileError) {
+		t.Fatalf("expected  %q, got %q", missingFileError, err)
 	}
 }
 

--- a/internal/refactoring/move_statement_test.go
+++ b/internal/refactoring/move_statement_test.go
@@ -32,7 +32,7 @@ func normaliseLineEndings(filename string) ([]byte, error) {
 	normalisedContent := bytes.ReplaceAll(originalContent, []byte("\r\n"), []byte("\n"))
 
 	if !bytes.Equal(originalContent, normalisedContent) {
-		err = os.WriteFile(filename, normalisedContent, 0644)
+		err = os.WriteFile(filename, normalisedContent, 0600)
 		if err != nil {
 			return nil, fmt.Errorf("error writing file %s: %w", filename, err)
 		}
@@ -57,11 +57,11 @@ func TestImpliedMoveStatements(t *testing.T) {
 
 		// Restore original file content after test completion
 		t.Cleanup(func() {
-			err1 := os.WriteFile(file1, originalContent, 0644)
+			err1 := os.WriteFile(file1, originalContent, 0600)
 			if err1 != nil {
 				t.Error()
 			}
-			err = os.WriteFile(file2, originalContentChild, 0644)
+			err = os.WriteFile(file2, originalContentChild, 0600)
 			if err != nil {
 				t.Error()
 			}

--- a/internal/refactoring/move_statement_test.go
+++ b/internal/refactoring/move_statement_test.go
@@ -6,6 +6,11 @@
 package refactoring
 
 import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
 	"sort"
 	"testing"
 
@@ -16,7 +21,54 @@ import (
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
+// Changes line endings from Windows-style ('\r\n') to Unix-style ('\n').
+func normaliseLineEndings(filename string) ([]byte, error) {
+	originalContent, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("error reading file %s: %w", filename, err)
+	}
+
+	// Replace all occurrences of '\r\n' with '\n'
+	normalisedContent := bytes.ReplaceAll(originalContent, []byte("\r\n"), []byte("\n"))
+
+	if !bytes.Equal(originalContent, normalisedContent) {
+		err = os.WriteFile(filename, normalisedContent, 0644)
+		if err != nil {
+			return nil, fmt.Errorf("error writing file %s: %w", filename, err)
+		}
+	}
+
+	return originalContent, nil
+}
+
 func TestImpliedMoveStatements(t *testing.T) {
+	// Normalise file content for cross-platform compatibility
+	if runtime.GOOS == "windows" {
+		file1 := "testdata/move-statement-implied/move-statement-implied.tf"
+		file2 := "testdata/move-statement-implied/child/move-statement-implied.tf"
+		originalContent, err := normaliseLineEndings(file1)
+		if err != nil {
+			t.Errorf("Error normalising line endings %v", err)
+		}
+		originalContentChild, err := normaliseLineEndings(file2)
+		if err != nil {
+			t.Errorf("Error normalising line endings %v", err)
+		}
+
+		// Restore original file content after test completion
+		t.Cleanup(func() {
+			err1 := os.WriteFile(file1, originalContent, 0644)
+			if err1 != nil {
+				t.Error()
+			}
+			err = os.WriteFile(file2, originalContentChild, 0644)
+			if err != nil {
+				t.Error()
+			}
+		},
+		)
+	}
+
 	resourceAddr := func(name string) addrs.AbsResource {
 		return addrs.Resource{
 			Mode: addrs.ManagedResourceMode,
@@ -124,7 +176,7 @@ func TestImpliedMoveStatements(t *testing.T) {
 			To:      addrs.ImpliedMoveStatementEndpoint(resourceAddr("formerly_count").Instance(addrs.NoKey), tfdiags.SourceRange{}),
 			Implied: true,
 			DeclRange: tfdiags.SourceRange{
-				Filename: "testdata/move-statement-implied/move-statement-implied.tf",
+				Filename: filepath.Join("testdata", "move-statement-implied", "move-statement-implied.tf"),
 				Start:    tfdiags.SourcePos{Line: 5, Column: 1, Byte: 180},
 				End:      tfdiags.SourcePos{Line: 5, Column: 32, Byte: 211},
 			},
@@ -136,7 +188,7 @@ func TestImpliedMoveStatements(t *testing.T) {
 			To:      addrs.ImpliedMoveStatementEndpoint(nestedResourceAddr("child", "formerly_count").Instance(addrs.NoKey), tfdiags.SourceRange{}),
 			Implied: true,
 			DeclRange: tfdiags.SourceRange{
-				Filename: "testdata/move-statement-implied/child/move-statement-implied.tf",
+				Filename: filepath.Join("testdata", "move-statement-implied", "child", "move-statement-implied.tf"),
 				Start:    tfdiags.SourcePos{Line: 5, Column: 1, Byte: 180},
 				End:      tfdiags.SourcePos{Line: 5, Column: 32, Byte: 211},
 			},
@@ -147,7 +199,7 @@ func TestImpliedMoveStatements(t *testing.T) {
 			To:      addrs.ImpliedMoveStatementEndpoint(resourceAddr("now_count").Instance(addrs.IntKey(0)), tfdiags.SourceRange{}),
 			Implied: true,
 			DeclRange: tfdiags.SourceRange{
-				Filename: "testdata/move-statement-implied/move-statement-implied.tf",
+				Filename: filepath.Join("testdata", "move-statement-implied", "move-statement-implied.tf"),
 				Start:    tfdiags.SourcePos{Line: 10, Column: 11, Byte: 282},
 				End:      tfdiags.SourcePos{Line: 10, Column: 12, Byte: 283},
 			},
@@ -159,7 +211,7 @@ func TestImpliedMoveStatements(t *testing.T) {
 			To:      addrs.ImpliedMoveStatementEndpoint(nestedResourceAddr("child", "now_count").Instance(addrs.IntKey(0)), tfdiags.SourceRange{}),
 			Implied: true,
 			DeclRange: tfdiags.SourceRange{
-				Filename: "testdata/move-statement-implied/child/move-statement-implied.tf",
+				Filename: filepath.Join("testdata", "move-statement-implied", "child", "move-statement-implied.tf"),
 				Start:    tfdiags.SourcePos{Line: 10, Column: 11, Byte: 282},
 				End:      tfdiags.SourcePos{Line: 10, Column: 12, Byte: 283},
 			},
@@ -175,7 +227,7 @@ func TestImpliedMoveStatements(t *testing.T) {
 			To:      addrs.ImpliedMoveStatementEndpoint(resourceAddr("ambiguous").Instance(addrs.NoKey), tfdiags.SourceRange{}),
 			Implied: true,
 			DeclRange: tfdiags.SourceRange{
-				Filename: "testdata/move-statement-implied/move-statement-implied.tf",
+				Filename: filepath.Join("testdata", "move-statement-implied", "move-statement-implied.tf"),
 				Start:    tfdiags.SourcePos{Line: 46, Column: 1, Byte: 806},
 				End:      tfdiags.SourcePos{Line: 46, Column: 27, Byte: 832},
 			},

--- a/internal/refactoring/move_validate_test.go
+++ b/internal/refactoring/move_validate_test.go
@@ -7,6 +7,7 @@ package refactoring
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -517,7 +518,8 @@ A chain of move statements must end with an address that doesn't appear in any o
 				if !gotDiags.HasErrors() {
 					t.Fatalf("unexpected success\nwant error: %s", test.WantError)
 				}
-				if got, want := gotDiags.Err().Error(), test.WantError; got != want {
+				normalisedErr := filepath.ToSlash(gotDiags.Err().Error())
+				if got, want := normalisedErr, test.WantError; got != want {
 					t.Fatalf("wrong error\ngot error:  %s\nwant error: %s", got, want)
 				}
 			default:

--- a/internal/tofu/context_plan_test.go
+++ b/internal/tofu/context_plan_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"strings"
@@ -3417,9 +3418,9 @@ func TestContext2Plan_pathVar(t *testing.T) {
 				t.Fatalf("resource %s should be created", i)
 			}
 			checkVals(t, objectVal(t, schema, map[string]cty.Value{
-				"cwd":    cty.StringVal(cwd + "/barpath"),
-				"module": cty.StringVal(m.Module.SourceDir + "/foopath"),
-				"root":   cty.StringVal(m.Module.SourceDir + "/barpath"),
+				"cwd":    cty.StringVal(filepath.ToSlash(cwd + "/barpath")),
+				"module": cty.StringVal(filepath.ToSlash(m.Module.SourceDir + "/foopath")),
+				"root":   cty.StringVal(filepath.ToSlash(m.Module.SourceDir + "/barpath")),
 			}), ric.After)
 		default:
 			t.Fatal("unknown instance:", i)


### PR DESCRIPTION
## Target Release

1.8.0


## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.


Related to #1201 

In this PR I have included the small changes which fix tests for Windows across many packages. Most of the issues were to do with filepaths and 1 issue was a TempDir one.

See the tests output below:
<details>
<summary>Windows tests output</summary>

gotestsum ./...
✓  internal/backend/init (258ms)
✓  cmd/tofu (489ms)
✓  internal/addrs (603ms)
✖  internal/backend (924ms)
✖  internal/backend/remote (13.836s)
✓  internal/backend/remote-state/consul (249ms)
✓  internal/backend/remote-state/azure (281ms)
✓  internal/backend/remote-state/cos (305ms)
✓  internal/backend/remote-state/gcs (137ms)
✓  internal/backend/remote-state/oss (255ms)
✓  internal/backend/remote-state/kubernetes (280ms)
✓  internal/backend/remote-state/inmem (313ms)
✓  internal/backend/remote-state/pg (128ms)
✖  internal/backend/remote-state/http (8.508s)
✖  internal/backend/remote-state/s3 (405ms)
✓  internal/builtin/provisioners/file (138ms)
✓  internal/builtin/providers/tf (333ms)
✓  internal/builtin/provisioners/remote-exec (2.225s)
✓  internal/checks (384ms)
✓  internal/builtin/provisioners/local-exec (3.339s)
∅  internal/cloudplugin (1ms)
∅  internal/cloudplugin/cloudproto1 (1ms)
∅  internal/cloudplugin/mock_cloudproto1
✓  internal/cloudplugin/cloudplugin1 (114ms)
✓  internal/cloud/cloudplan (260ms)
✓  internal/cloud (275ms)
✓  internal/collections (cached)
✖  internal/backend/local (1m11.419s)
✓  internal/command/arguments (206ms)
✓  internal/command/clistate (291ms)
✓  internal/command/cliconfig (487ms)
✓  internal/command/jsonchecks (253ms)
✓  internal/command/format (326ms)
✓  internal/command/jsonconfig (381ms)
∅  internal/command/jsonformat/collections
∅  internal/command/jsonformat/computed
✓  internal/command/jsonformat (500ms)
✓  internal/command/jsonformat/computed/renderers (134ms)
∅  internal/command/jsonformat/jsondiff (2ms)
∅  internal/command/jsonformat/structured (10ms)
✓  internal/command/jsonformat/differ (160ms)
✓  internal/command/jsonformat/structured/attribute_path (cached)
✓  internal/command/jsonfunction (148ms)
✓  internal/command/jsonplan (149ms)
✓  internal/command/jsonprovider (164ms)
∅  internal/command/testing
✓  internal/command/jsonstate (175ms)
✓  internal/command/webbrowser (183ms)
✓  internal/command/views/json (574ms)
✓  internal/command/workdir (cached)
✓  internal/command/views (3.814s)
∅  internal/communicator/remote (cached)
✓  internal/communicator/shared (99ms)
✓  internal/communicator (1.576s)
✓  internal/communicator/winrm (141ms)
✓  internal/communicator/ssh (2.608s)
✓  internal/configs/configload (593ms)
✓  internal/configs/configschema (120ms)
✓  internal/copy (cached)
✓  internal/configs/hcl2shim (193ms)
✖  internal/configs (4.725s)
✓  internal/dag (1.116s)
✓  internal/didyoumean (cached)
∅  internal/e2e (1ms)
✓  internal/depsfile (223ms)
∅  internal/encryption/compliancetest
✓  internal/encryption/config (137ms)
✓  internal/encryption (197ms)
∅  internal/encryption/enctest
✓  internal/encryption/keyprovider (92ms)
∅  internal/encryption/keyprovider/compliancetest
✓  internal/encryption/keyprovider/aws_kms (190ms)
✓  internal/encryption/keyprovider/gcp_kms (145ms)
✓  internal/encryption/keyprovider/openbao (256ms)
∅  internal/encryption/method
✓  internal/encryption/keyprovider/static (232ms)
∅  internal/encryption/method/compliancetest
∅  internal/encryption/method/unencrypted
∅  internal/encryption/registry
✓  internal/encryption/method/aesgcm (145ms)
∅  internal/encryption/registry/compliancetest (1ms)
∅  internal/experiments (1ms)
✓  internal/encryption/registry/lockingencryptionregistry (126ms)
✓  internal/encryption/keyprovider/pbkdf2 (5.187s)
∅  internal/getmodules
✓  internal/genconfig (222ms)
∅  internal/grpcwrap
✓  internal/gohcl (94ms)
✓  internal/helper/slowmessage (cached)
✓  internal/httpclient (81ms)
✓  internal/instances (96ms)
✓  internal/ipaddr (cached)
✖  internal/getproviders (4.334s)
✓  internal/initwd (2.019s)
✓  internal/lang/blocktoattr (122ms)
✓  internal/lang (612ms)
✖  internal/lang/funcs (669ms)
∅  internal/lang/marks
∅  internal/lang/types
✓  internal/lang/globalref (364ms)
✓  internal/legacy/helper/hashcode (cached)
✓  internal/legacy/helper/acctest (153ms)
✓  internal/legacy/helper/schema (263ms)
∅  internal/modsdir
✓  internal/logging (91ms)
✓  internal/legacy/tofu (155ms)
✓  internal/moduledeps (825ms)
∅  internal/plans/internal/planproto
✓  internal/moduletest (161ms)
✓  internal/plans (173ms)
✓  internal/plans/objchange (1.407s)
✓  internal/plans/planfile (1.509s)
✓  internal/plugin (128ms)
∅  internal/plugin/mock_proto
✓  internal/plugin/discovery (cached)
✓  internal/plugin/convert (190ms)
✓  internal/plugin6 (111ms)
∅  internal/plugin6/mock_proto
∅  internal/provider-simple
✓  internal/plugin6/convert (134ms)
∅  internal/provider-simple/main
∅  internal/provider-simple-v6 (1ms)
∅  internal/provider-simple-v6/main
∅  internal/provisioner-local-exec/main (1ms)
∅  internal/provisioners
✓  internal/providers (161ms)
✖  internal/providercache (995ms)
✓  internal/registry/regsrc (116ms)
✓  internal/refactoring (498ms)
✓  internal/registry/response (cached)
∅  internal/registry/test (1ms)
✓  internal/registry (2.373s)
∅  internal/replacefile
✓  internal/states (114ms)
✓  internal/repl (811ms)
✓  internal/states/remote (256ms)
✓  internal/states/statefile (912ms)
✓  internal/terminal (126ms)
∅  internal/tfplugin5
∅  internal/tfplugin6
✓  internal/tfdiags (171ms)
✓  internal/tofumigrate (106ms)
∅  tools/loggraphdiff
∅  tools/protobuf-compile
✓  version (41ms)
✖  internal/tofu (15.885s)
✓  internal/states/statemgr (50.656s)
✖  internal/command (5m3.457s)
✓  internal/cloud/e2e (7m56.795s)
✖  internal/command/e2etest (8m42.69s)

</details>
