### PR TITLE
use dynamic types when handling variables during plan and show static evaluation

### DIFF
--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -280,7 +280,7 @@ func (b *Local) localRunForPlanFile(op *backend.Operation, pf *planfile.Reader, 
 			return variable.Default, nil
 		}
 
-		parsed, parsedErr := v.Decode(variable.Type)
+		parsed, parsedErr := v.Decode(cty.DynamicPseudoType)
 		if parsedErr != nil {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,

--- a/internal/command/e2etest/static_plan_test.go
+++ b/internal/command/e2etest/static_plan_test.go
@@ -21,7 +21,6 @@ func TestStaticPlanVariables(t *testing.T) {
 		"static_plan_typed_variables",
 	}
 	for _, fixture := range fixtures {
-
 		t.Run(fmt.Sprintf("TestStaticPlanVariables/%s", fixture), func(t *testing.T) {
 			fixturePath := filepath.Join("testdata", fixture)
 			tf := e2e.NewBinary(t, tofuBin, fixturePath)

--- a/internal/command/e2etest/static_plan_test.go
+++ b/internal/command/e2etest/static_plan_test.go
@@ -6,6 +6,7 @@
 package e2etest
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -15,121 +16,130 @@ import (
 // This is an e2e test as it relies on very specific configuration
 // within the meta object that is currently very hard to mock out.
 func TestStaticPlanVariables(t *testing.T) {
-	fixturePath := filepath.Join("testdata", "static_plan_variables")
-	tf := e2e.NewBinary(t, tofuBin, fixturePath)
-
-	run := func(args ...string) tofuResult {
-		stdout, stderr, err := tf.Run(args...)
-		return tofuResult{t, stdout, stderr, err}
+	fixtures := []string{
+		"static_plan_variables",
+		"static_plan_typed_variables",
 	}
+	for _, fixture := range fixtures {
 
-	statePath := "custom.tfstate"
-	stateVar := "-var=state_path=" + statePath
-	modVar := "-var=src=./mod"
-	planfile := "static.plan"
+		t.Run(fmt.Sprintf("TestStaticPlanVariables/%s", fixture), func(t *testing.T) {
+			fixturePath := filepath.Join("testdata", fixture)
+			tf := e2e.NewBinary(t, tofuBin, fixturePath)
 
-	modErr := "module.mod.source depends on var.src which is not available"
-	backendErr := "backend.local depends on var.state_path which is not available"
+			run := func(args ...string) tofuResult {
+				stdout, stderr, err := tf.Run(args...)
+				return tofuResult{t, stdout, stderr, err}
+			}
 
-	// Init
-	run("init").Failure().StderrContains(modErr)
-	run("init", stateVar, modVar).Success()
+			statePath := "custom.tfstate"
+			stateVar := "-var=state_path=" + statePath
+			modVar := "-var=src=./mod"
+			planfile := "static.plan"
 
-	// Get
-	run("get").Failure().StderrContains(modErr)
-	run("get", stateVar, modVar).Success()
+			modErr := "module.mod.source depends on var.src which is not available"
+			backendErr := "backend.local depends on var.state_path which is not available"
 
-	// Validate
-	run("validate").Failure().StderrContains(modErr)
-	run("validate", stateVar, modVar).Success()
+			// Init
+			run("init").Failure().StderrContains(modErr)
+			run("init", stateVar, modVar).Success()
 
-	// Providers
-	run("providers").Failure().StderrContains(modErr)
-	run("providers", stateVar, modVar).Success()
-	run("providers", "lock").Failure().StderrContains(modErr)
-	run("providers", "lock", stateVar, modVar).Success()
-	run("providers", "mirror", "./tempproviders").Failure().StderrContains(modErr)
-	run("providers", "mirror", stateVar, modVar, "./tempproviders").Failure().StderrContains("Could not scan the output directory to get package metadata for the JSON")
-	run("providers", "schema", "-json").Failure().StderrContains(backendErr)
-	run("providers", "schema", "-json", stateVar, modVar).Success()
+			// Get
+			run("get").Failure().StderrContains(modErr)
+			run("get", stateVar, modVar).Success()
 
-	// Check console init (early exits due to stdin setup)
-	run("console").Failure().StderrContains(backendErr)
-	run("console", stateVar, modVar).Success()
+			// Validate
+			run("validate").Failure().StderrContains(modErr)
+			run("validate", stateVar, modVar).Success()
 
-	// Check graph (without plan)
-	run("graph").Failure().StderrContains(backendErr)
-	run("graph", stateVar, modVar).Success()
+			// Providers
+			run("providers").Failure().StderrContains(modErr)
+			run("providers", stateVar, modVar).Success()
+			run("providers", "lock").Failure().StderrContains(modErr)
+			run("providers", "lock", stateVar, modVar).Success()
+			run("providers", "mirror", "./tempproviders").Failure().StderrContains(modErr)
+			run("providers", "mirror", stateVar, modVar, "./tempproviders").Failure().StderrContains("Could not scan the output directory to get package metadata for the JSON")
+			run("providers", "schema", "-json").Failure().StderrContains(backendErr)
+			run("providers", "schema", "-json", stateVar, modVar).Success()
 
-	// Plan with static variable
-	run("plan", stateVar, modVar, "-out="+planfile).Success()
+			// Check console init (early exits due to stdin setup)
+			run("console").Failure().StderrContains(backendErr)
+			run("console", stateVar, modVar).Success()
 
-	// Show plan without static variable (embedded)
-	run("show", planfile).Success()
+			// Check graph (without plan)
+			run("graph").Failure().StderrContains(backendErr)
+			run("graph", stateVar, modVar).Success()
 
-	// Check graph (without plan)
-	run("graph", "-plan="+planfile).Success()
+			// Plan with static variable
+			run("plan", stateVar, modVar, "-out="+planfile).Success()
 
-	// Apply plan without static variable (embedded)
-	run("apply", planfile).Success()
+			// Show plan without static variable (embedded)
+			run("show", planfile).Success()
 
-	// Show State
-	run("show", statePath).Failure().StderrContains(modErr)
-	run("show", stateVar, modVar, statePath).Success().Contains(`out = "placeholder"`)
+			// Check graph (without plan)
+			run("graph", "-plan="+planfile).Success()
 
-	// Force Unlock
-	run("force-unlock", "ident").Failure().StderrContains(backendErr)
-	run("force-unlock", stateVar, modVar, "ident").Failure().StderrContains("Local state cannot be unlocked by another process")
+			// Apply plan without static variable (embedded)
+			run("apply", planfile).Success()
 
-	// Output values
-	run("output").Failure().StderrContains(backendErr)
-	run("output", stateVar, modVar).Success().Contains(`out = "placeholder"`)
+			// Show State
+			run("show", statePath).Failure().StderrContains(modErr)
+			run("show", stateVar, modVar, statePath).Success().Contains(`out = "placeholder"`)
 
-	// Refresh
-	run("refresh").Failure().StderrContains(backendErr)
-	run("refresh", stateVar, modVar).Success().Contains("There are currently no remote objects tracked in the state")
+			// Force Unlock
+			run("force-unlock", "ident").Failure().StderrContains(backendErr)
+			run("force-unlock", stateVar, modVar, "ident").Failure().StderrContains("Local state cannot be unlocked by another process")
 
-	// Import
-	run("import", "resource.addr", "id").Failure().StderrContains(modErr)
-	run("import", stateVar, modVar, "resource.addr", "id").Failure().StderrContains("Before importing this resource, please create its configuration in the root module.")
+			// Output values
+			run("output").Failure().StderrContains(backendErr)
+			run("output", stateVar, modVar).Success().Contains(`out = "placeholder"`)
 
-	// Taint
-	run("taint", "resource.addr").Failure().StderrContains(modErr)
-	run("taint", stateVar, modVar, "resource.addr").Failure().StderrContains("There is no resource instance in the state with the address resource.addr.")
-	run("untaint", "resource.addr").Failure().StderrContains(backendErr)
-	run("untaint", stateVar, modVar, "resource.addr").Failure().StderrContains("There is no resource instance in the state with the address resource.addr.")
+			// Refresh
+			run("refresh").Failure().StderrContains(backendErr)
+			run("refresh", stateVar, modVar).Success().Contains("There are currently no remote objects tracked in the state")
 
-	// State
-	run("state", "list").Failure().StderrContains(backendErr)
-	run("state", "list", stateVar, modVar).Success()
-	run("state", "mv", "foo.bar", "foo.baz").Failure().StderrContains(modErr)
-	run("state", "mv", stateVar, modVar, "foo.bar", "foo.baz").Failure().StderrContains("Cannot move foo.bar: does not match anything in the current state.")
-	run("state", "pull").Failure().StderrContains(modErr)
-	run("state", "pull", stateVar, modVar).Success().Contains(`"outputs":{"out":{"value":"placeholder","type":"string"}}`)
-	run("state", "push", statePath).Failure().StderrContains(modErr)
-	run("state", "push", stateVar, modVar, statePath).Success()
-	run("state", "replace-provider", "foo", "bar").Failure().StderrContains(modErr)
-	run("state", "replace-provider", stateVar, modVar, "foo", "bar").Success().Contains("No matching resources found.")
-	run("state", "rm", "foo.bar").Failure().StderrContains(modErr)
-	run("state", "rm", stateVar, modVar, "foo.bar").Failure().StderrContains("No matching objects found.")
-	run("state", "show", "out").Failure().StderrContains(backendErr)
-	run("state", "show", stateVar, modVar, "invalid.resource").Failure().StderrContains("No instance found for the given address!")
+			// Import
+			run("import", "resource.addr", "id").Failure().StderrContains(modErr)
+			run("import", stateVar, modVar, "resource.addr", "id").Failure().StderrContains("Before importing this resource, please create its configuration in the root module.")
 
-	// Workspace
-	run("workspace", "list").Failure().StderrContains(backendErr)
-	run("workspace", "list", stateVar, modVar).Success().Contains(`default`)
-	run("workspace", "new", "foo").Failure().StderrContains(backendErr)
-	run("workspace", "new", stateVar, modVar, "foo").Success().Contains(`foo`)
-	run("workspace", "select", "default").Failure().StderrContains(backendErr)
-	run("workspace", "select", stateVar, modVar, "default").Success().Contains(`default`)
-	run("workspace", "delete", "foo").Failure().StderrContains(backendErr)
-	run("workspace", "delete", stateVar, modVar, "foo").Success().Contains(`foo`)
+			// Taint
+			run("taint", "resource.addr").Failure().StderrContains(modErr)
+			run("taint", stateVar, modVar, "resource.addr").Failure().StderrContains("There is no resource instance in the state with the address resource.addr.")
+			run("untaint", "resource.addr").Failure().StderrContains(backendErr)
+			run("untaint", stateVar, modVar, "resource.addr").Failure().StderrContains("There is no resource instance in the state with the address resource.addr.")
 
-	// Test
-	run("test").Failure().StderrContains(modErr)
-	run("test", stateVar, modVar).Success().Contains(`Success!`)
+			// State
+			run("state", "list").Failure().StderrContains(backendErr)
+			run("state", "list", stateVar, modVar).Success()
+			run("state", "mv", "foo.bar", "foo.baz").Failure().StderrContains(modErr)
+			run("state", "mv", stateVar, modVar, "foo.bar", "foo.baz").Failure().StderrContains("Cannot move foo.bar: does not match anything in the current state.")
+			run("state", "pull").Failure().StderrContains(modErr)
+			run("state", "pull", stateVar, modVar).Success().Contains(`"outputs":{"out":{"value":"placeholder","type":"string"}}`)
+			run("state", "push", statePath).Failure().StderrContains(modErr)
+			run("state", "push", stateVar, modVar, statePath).Success()
+			run("state", "replace-provider", "foo", "bar").Failure().StderrContains(modErr)
+			run("state", "replace-provider", stateVar, modVar, "foo", "bar").Success().Contains("No matching resources found.")
+			run("state", "rm", "foo.bar").Failure().StderrContains(modErr)
+			run("state", "rm", stateVar, modVar, "foo.bar").Failure().StderrContains("No matching objects found.")
+			run("state", "show", "out").Failure().StderrContains(backendErr)
+			run("state", "show", stateVar, modVar, "invalid.resource").Failure().StderrContains("No instance found for the given address!")
 
-	// Destroy
-	run("destroy", "-auto-approve").Failure().StderrContains(backendErr)
-	run("destroy", stateVar, modVar, "-auto-approve").Success().Contains("You can apply this plan to save these new output values")
+			// Workspace
+			run("workspace", "list").Failure().StderrContains(backendErr)
+			run("workspace", "list", stateVar, modVar).Success().Contains(`default`)
+			run("workspace", "new", "foo").Failure().StderrContains(backendErr)
+			run("workspace", "new", stateVar, modVar, "foo").Success().Contains(`foo`)
+			run("workspace", "select", "default").Failure().StderrContains(backendErr)
+			run("workspace", "select", stateVar, modVar, "default").Success().Contains(`default`)
+			run("workspace", "delete", "foo").Failure().StderrContains(backendErr)
+			run("workspace", "delete", stateVar, modVar, "foo").Success().Contains(`foo`)
+
+			// Test
+			run("test").Failure().StderrContains(modErr)
+			run("test", stateVar, modVar).Success().Contains(`Success!`)
+
+			// Destroy
+			run("destroy", "-auto-approve").Failure().StderrContains(backendErr)
+			run("destroy", stateVar, modVar, "-auto-approve").Success().Contains("You can apply this plan to save these new output values")
+		})
+	}
 }

--- a/internal/command/e2etest/testdata/static_plan_typed_variables/main.tf
+++ b/internal/command/e2etest/testdata/static_plan_typed_variables/main.tf
@@ -1,0 +1,19 @@
+variable "state_path" {}
+
+variable "src" {
+	type = string
+}
+
+terraform {
+	backend "local" {
+		path = var.state_path
+	}
+}
+
+module "mod" {
+	source = var.src
+}
+
+output "out" {
+	value = module.mod.out
+}

--- a/internal/command/e2etest/testdata/static_plan_typed_variables/mod/mod.tf
+++ b/internal/command/e2etest/testdata/static_plan_typed_variables/mod/mod.tf
@@ -1,0 +1,3 @@
+output "out" {
+	value = "placeholder"
+}

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -383,7 +383,7 @@ func getDataFromPlanfileReader(planReader *planfile.Reader, rootCall configs.Sta
 			return variable.Default, nil
 		}
 
-		parsed, parsedErr := v.Decode(variable.Type)
+		parsed, parsedErr := v.Decode(cty.DynamicPseudoType)
 		if parsedErr != nil {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/backend"
 	"github.com/opentofu/opentofu/internal/cloud"
 	"github.com/opentofu/opentofu/internal/cloud/cloudplan"
@@ -27,7 +29,6 @@ import (
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/opentofu/opentofu/internal/tofu"
 	"github.com/opentofu/opentofu/internal/tofumigrate"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // Many of the methods we get data from can emit special error types if they're


### PR DESCRIPTION
This PR solves an issue where when we were showing a planfile, we were attempting to be too strict with typing. The typing of the variables is stored as dynamic and so we should use that instead of the type of the variable in the config.

<!-- If your PR resolves an issue, please add it here. -->
Resolves #1825

## Target Release

1.8.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
