### PR TITLE
Remove the recommendation to use cloud backends over remote state

### DIFF
--- a/website/docs/language/settings/backends/remote.mdx
+++ b/website/docs/language/settings/backends/remote.mdx
@@ -7,10 +7,6 @@ description: >-
 
 # Backend Type: remote
 
-:::note
-**We recommend using the [`cloud` built-in integration](../../../cli/cloud/settings.mdx)** instead of this backend. The `cloud` option includes an improved user experience and more features.
-:::
-
 The remote backend is unique among all other OpenTofu backends because it can both store state snapshots and execute CLI-driven run workflow operations for TF Automation and Collaboration Software ([TACOS](../../../intro/tacos.mdx)) backends. It used to be called an "enhanced" backend.
 
 If your [TACOS](../../../intro/tacos.mdx) provider enables full remote operations, you can execute commands such as `tofu plan` or `tofu apply` within the [TACOS](../../../intro/tacos.mdx) runtime environment, with log output streaming directly to your local terminal. Remote plans and applies use variable values from the associated remote workspace.


### PR DESCRIPTION
Remove the stale recommendation (it was carried over wholesale during the forkfrom terraform).

Cloud backends are not well supported in OpenTofu (as discussed in the OpenTofu Slack today).

## Target Release

1.9.0

## Checklist

 

- [X ] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [ X] I have not used an AI coding assistant to create this PR.
- [ X] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
 

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [X ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
