### PR TITLE
Assert that NodeRootVariable implements Execute

### DIFF
--- a/internal/tofu/node_root_variable.go
+++ b/internal/tofu/node_root_variable.go
@@ -31,6 +31,7 @@ type NodeRootVariable struct {
 }
 
 var (
+	_ GraphNodeExecutable     = (*NodeRootVariable)(nil)
 	_ GraphNodeModuleInstance = (*NodeRootVariable)(nil)
 	_ GraphNodeReferenceable  = (*NodeRootVariable)(nil)
 )


### PR DESCRIPTION
I was playing with the signature for GraphNodeExecutable (adding a context to add otel spans) and accidentally broke a few things because of dynamic type checks that weren't calling Execute on NodeRootVariable. This adds a compile time type assertion that NodeRootVariable indeed implements that interface such that if someone changes the interface in the future, they will have to change NodeRootVariable as well.

## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
