### PR TITLE
Create-before-destroy issue when refresh=false fix

### DIFF
--- a/internal/tofu/context_apply2_test.go
+++ b/internal/tofu/context_apply2_test.go
@@ -1247,10 +1247,10 @@ output "out" {
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			Provider: providers.Schema{Block: simpleTestSchema()},
 			ResourceTypes: map[string]providers.Schema{
-				"test_object": {Block: simpleTestSchema()},
+				"test_object": providers.Schema{Block: simpleTestSchema()},
 			},
 			DataSources: map[string]providers.Schema{
-				"test_object": {
+				"test_object": providers.Schema{
 					Block: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"test_string": {
@@ -1302,7 +1302,7 @@ output "out" {
 				},
 			},
 			ResourceTypes: map[string]providers.Schema{
-				"other_object": {Block: simpleTestSchema()},
+				"other_object": providers.Schema{Block: simpleTestSchema()},
 			},
 		},
 	}


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves #1806

## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

This PR solves https://github.com/opentofu/opentofu/issues/1806
There is an issue when changing create-before-destroy and not updating the state (tofu apply refresh=false).
This is solved by making sure the state and config have no discrepancy for what they think the value of `create-before-destroy` is. So the solution is to update the state if there is a change in `create-before-destroy` even if you are skipping refreshing. 

I came to the solution by thinking of this problem uisng this analogy I made:
### Building bridge analogy
This is the logic represented in terms of building a bridge.

I own a massive city which has a river running through it. 
On Monday I have an idea and write it on my phone notes: Let's build a new bridge, called foo, over this river and on this land we must *always create a new bridge before destroying the old one* to continue traffic flow.
I share this idea to my builders and they create their plan based on this idea.
I also write this exact idea on a whiteboard on-site as a reminder for them when they actually apply it.
I tell my builders to build the bridge called foo.

I don't like the bridge and on Tuesday I change my mind and I write it on my phone notes: Let's build a new bridge, called bar, and on this land we must *destroy the old bridge before creating a new one*. 
I share this idea to my builders and they create their plan based on this idea. 
The builders see that my idea states: **the last stage of this project is when a bridge is created** (we are following destroy-then-create).
I forget to update the whiteboard on-site.

The builders arrive at the site, read the outdated whiteboard, and follow the old rule they see there. Since the whiteboard says they must create a new bridge before destroying the old one, they proceed by first building the new bridge bar. And according to the plan they set previously, the last stage of the project is when a bridge is built, so they go home. At the end of Tuesday there are two bridges standing.

analogy - real life
me - developer
city - instance
bridge - text file
builders - Opentofu
phone notes - config
whiteboard - state
Monday - first plan and apply
Tuesday - second plan and apply with refresh=false


So the specific reason 2 files are being created and the older file is not being destroyed is because tofu thinks the last operation is create (from destroy-before-create) even though it applies create-before-destroy). So we must update the whiteboard (state) so both `create-before-destroy` values on the config and the state match. 

### Tests
I added a test for this specific case. I also fixed a random new test that was failing on Windows.
