### PR TITLE
Always use large instance for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on:
-      group: larger-runners
+    runs-on: larger-runners
     environment: gpg
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,8 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on:
+      group: larger-runners
     environment: gpg
     permissions:
       contents: write


### PR DESCRIPTION
This pulls in changes that @cube2222 made on the 1.7 branch.