### PR TITLE
Fix extra file generated in tests of #1554

### DIFF
--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -1001,6 +1001,9 @@ func TestShow_corruptStatefile(t *testing.T) {
 }
 
 func TestShow_showSensitiveArg(t *testing.T) {
+	td := t.TempDir()
+	defer testChdir(t, td)()
+
 	originalState := stateWithSensitiveValueForShow()
 
 	testStateFileDefault(t, originalState)
@@ -1030,6 +1033,9 @@ func TestShow_showSensitiveArg(t *testing.T) {
 }
 
 func TestShow_withoutShowSensitiveArg(t *testing.T) {
+	td := t.TempDir()
+	defer testChdir(t, td)()
+
 	originalState := stateWithSensitiveValueForShow()
 
 	testStateFileDefault(t, originalState)


### PR DESCRIPTION
https://github.com/opentofu/opentofu/pull/1554/files#diff-b93fa3444a62d34548671197812ac5b0111974901a88f2610f5420d1139daf3dR1003

That writes a statefile to the current test directory of ./internal/command/

## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
