### PR TITLE
Better var file type detection

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -32,8 +32,11 @@ const DefaultPluginVendorDir = "terraform.d/plugins/" + pluginMachineName
 // DefaultStateFilename is the default filename used for the state file.
 const DefaultStateFilename = "terraform.tfstate"
 
+// DefaultVarsExtension is the default file extension used for vars
+const DefaultVarsExtension = ".tfvars"
+
 // DefaultVarsFilename is the default filename used for vars
-const DefaultVarsFilename = "terraform.tfvars"
+const DefaultVarsFilename = "terraform" + DefaultVarsExtension
 
 // DefaultBackupExtension is added to the state file to form the path
 const DefaultBackupExtension = ".backup"

--- a/internal/command/meta_vars.go
+++ b/internal/command/meta_vars.go
@@ -182,7 +182,15 @@ func (m *Meta) addVarsFromFile(filename string, sourceType tofu.ValueSourceType,
 	loader.Parser().ForceFileSource(filename, src)
 
 	var f *hcl.File
-	if strings.HasSuffix(filename, ".json") {
+
+	extJSON := strings.HasSuffix(filename, ".json")
+	extTfvars := strings.HasSuffix(filename, DefaultVarsExtension)
+
+	// Only try json detection if ambiguous
+	// Ex: -var-file=<(./scripts/vars.sh)
+	detectJSON := !extJSON && !extTfvars && strings.HasPrefix(strings.TrimSpace(string(src)), "{")
+
+	if extJSON || detectJSON {
 		var hclDiags hcl.Diagnostics
 		f, hclDiags = hcljson.Parse(src, filename)
 		diags = diags.Append(hclDiags)

--- a/internal/command/meta_vars_test.go
+++ b/internal/command/meta_vars_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/opentofu/opentofu/internal/backend"
+	"github.com/opentofu/opentofu/internal/tofu"
+)
+
+func TestMeta_addVarsFromFile(t *testing.T) {
+	d := t.TempDir()
+	defer testChdir(t, d)()
+
+	hclData := `foo = "bar"`
+	jsonData := `{"foo": "bar"}`
+
+	cases := []struct {
+		filename string
+		contents string
+		errors   bool
+	}{
+		{
+			filename: "input.tfvars",
+			contents: hclData,
+			errors:   false,
+		},
+		{
+			filename: "input.json",
+			contents: jsonData,
+			errors:   false,
+		},
+		{
+			filename: "input_a.unknown",
+			contents: hclData,
+			errors:   false,
+		},
+		{
+			filename: "input_b.unknown",
+			contents: jsonData,
+			errors:   false,
+		},
+		{
+			filename: "mismatch.tfvars",
+			contents: jsonData,
+			errors:   true,
+		},
+		{
+			filename: "mismatch.json",
+			contents: hclData,
+			errors:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.filename, func(t *testing.T) {
+			target := filepath.Join(d, tc.filename)
+			err := os.WriteFile(target, []byte(tc.contents), 0600)
+			if err != nil {
+				t.Fatalf("err: %s", err)
+			}
+
+			m := new(Meta)
+			to := make(map[string]backend.UnparsedVariableValue)
+			diags := m.addVarsFromFile(target, tofu.ValueFromAutoFile, to)
+			if tc.errors != diags.HasErrors() {
+				t.Log(diags.Err())
+				t.Errorf("Expected: %v, got %v", tc.errors, diags.HasErrors())
+			}
+		})
+	}
+}


### PR DESCRIPTION
With special cases (like shell redirects), we currently default to hcl when no file type is detected.  This PR changes that logic slightly to try to detect json vs hcl *only if* the file extension is unknown.

<!-- If your PR resolves an issue, please add it here. -->
Resolves #1872

## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
