### PR TITLE
Fix Docusaurus "broken link" warnings on main branch of docs

### DIFF
--- a/website/docs/intro/tacos.mdx
+++ b/website/docs/intro/tacos.mdx
@@ -11,7 +11,7 @@ TF Automation and Collaboration Software (TACOS) are platforms which allow teams
 
 # What are some examples?
 
-There are a variety of platforms which offer OpenTofu support, both Open Source and Commercial. Many of these organizations support OpenTofu directly and can be found on our [supporters](../../../supporters) page.
+There are a variety of platforms which offer OpenTofu support, both Open Source and Commercial. Many of these organizations support OpenTofu directly and can be found on our [supporters](/supporters) page.
 
 
 

--- a/website/docs/language/expressions/references.mdx
+++ b/website/docs/language/expressions/references.mdx
@@ -179,9 +179,9 @@ where they appear. Some of most common local names are:
 
 :::note
 Local names are often referred to as _variables_ or
-_temporary variables_ in their documentation. These are not [input
-variables](../../language/values/variables.mdx); they are just arbitrary names
-that temporarily represent a value.
+_temporary variables_ in their documentation. These are not
+[input variables](../../language/values/variables.mdx); they are just
+arbitrary names that temporarily represent a value.
 :::
 
 The names in this section relate to top-level configuration blocks only.

--- a/website/docs/language/providers/requirements.mdx
+++ b/website/docs/language/providers/requirements.mdx
@@ -12,9 +12,9 @@ OpenTofu can install and use them. This page documents how to declare providers
 so OpenTofu can install them.
 
 Additionally, some providers require configuration (like endpoint URLs or cloud
-regions) before they can be used. The [Provider
-Configuration](../../language/providers/configuration.mdx) page documents how
-to configure settings for providers.
+regions) before they can be used. The
+[Provider Configuration](../../language/providers/configuration.mdx) page
+documents how to configure settings for providers.
 
 ## Requiring Providers
 

--- a/website/docs/language/settings/backends/oss.mdx
+++ b/website/docs/language/settings/backends/oss.mdx
@@ -36,8 +36,7 @@ OpenTofu state will be written into the file `path/mystate/version-1.tfstate`. T
 ## Data Source Configuration
 
 To make use of the OSS remote state in another configuration, use the
-[`terraform_remote_state` data
-source](../../../language/state/remote-state-data/index.mdx).
+[`terraform_remote_state` data source](../../../language/state/remote-state-data.mdx).
 
 ```hcl
 terraform {

--- a/website/docs/language/settings/index.mdx
+++ b/website/docs/language/settings/index.mdx
@@ -40,8 +40,8 @@ following sections.
 
 The nested `backend` block configures which state backend OpenTofu should use.
 
-The syntax and behavior of the `backend` block is described in [Backend
-Configuration](../../language/settings/backends/configuration.mdx).
+The syntax and behavior of the `backend` block is described in
+[Backend Configuration](../../language/settings/backends/configuration.mdx).
 
 ## Specifying a Required OpenTofu Version
 


### PR DESCRIPTION
Works towards a fix to https://github.com/opentofu/opentofu/issues/1863, by partially fixing blockers for https://github.com/opentofu/opentofu.org/issues/85

## Target Release

1.9.0 (website)

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.


### Website/documentation checklist

- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
