### PR TITLE
Fix repetitive diagnosis output in init response

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -292,7 +292,7 @@ func (c *InitCommand) Run(args []string) int {
 
 	// Now, we can check the diagnostics from the early configuration and the
 	// backend.
-	diags = diags.Append(earlyConfDiags.Merge(backDiags))
+	diags = diags.Append(earlyConfDiags.StrictDeduplicateMerge(backDiags))
 	if earlyConfDiags.HasErrors() {
 		c.Ui.Error(strings.TrimSpace(errInitConfigError))
 		c.showDiagnostics(diags)

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -293,7 +293,6 @@ func (c *InitCommand) Run(args []string) int {
 	// Now, we can check the diagnostics from the early configuration and the
 	// backend.
 	diags = diags.Append(earlyConfDiags)
-	diags = diags.Append(backDiags)
 	if earlyConfDiags.HasErrors() {
 		c.Ui.Error(strings.TrimSpace(errInitConfigError))
 		c.showDiagnostics(diags)
@@ -303,6 +302,7 @@ func (c *InitCommand) Run(args []string) int {
 	// Now, we can show any errors from initializing the backend, but we won't
 	// show the errInitConfigError preamble as we didn't detect problems with
 	// the early configuration.
+	diags = diags.Append(backDiags)
 	if backDiags.HasErrors() {
 		c.showDiagnostics(diags)
 		return 1

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -292,7 +292,7 @@ func (c *InitCommand) Run(args []string) int {
 
 	// Now, we can check the diagnostics from the early configuration and the
 	// backend.
-	diags = diags.Append(earlyConfDiags)
+	diags = diags.Append(earlyConfDiags.Merge(backDiags))
 	if earlyConfDiags.HasErrors() {
 		c.Ui.Error(strings.TrimSpace(errInitConfigError))
 		c.showDiagnostics(diags)
@@ -302,7 +302,6 @@ func (c *InitCommand) Run(args []string) int {
 	// Now, we can show any errors from initializing the backend, but we won't
 	// show the errInitConfigError preamble as we didn't detect problems with
 	// the early configuration.
-	diags = diags.Append(backDiags)
 	if backDiags.HasErrors() {
 		c.showDiagnostics(diags)
 		return 1

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -2995,6 +2995,33 @@ func TestInit_moduleVersion(t *testing.T) {
 	})
 }
 
+func TestInit_invalidExtraLabel(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("init-syntax-invalid-extra-label"), td)
+	defer testChdir(t, td)()
+
+	ui := cli.NewMockUi()
+	view, _ := testView(t)
+	m := Meta{
+		Ui:   ui,
+		View: view,
+	}
+
+	c := &InitCommand{
+		Meta: m,
+	}
+
+	if code := c.Run(nil); code == 0 {
+		t.Fatalf("succeeded, but was expecting error\nstdout:\n%s\nstderr:\n%s", ui.OutputWriter, ui.ErrorWriter)
+	}
+
+	errStr := ui.ErrorWriter.String()
+	splitted := strings.Split(errStr, "Error: Unsupported block type")
+	if len(splitted) != 2 {
+		t.Fatalf("want exactly one unsupported block type erros but got: %d\nstderr:\n%s\n\nstdout:\n%s", len(splitted)-1, errStr, ui.OutputWriter.String())
+	}
+}
+
 // newMockProviderSource is a helper to succinctly construct a mock provider
 // source that contains a set of packages matching the given provider versions
 // that are available for installation (from temporary local files).

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -3018,7 +3018,7 @@ func TestInit_invalidExtraLabel(t *testing.T) {
 	errStr := ui.ErrorWriter.String()
 	splitted := strings.Split(errStr, "Error: Unsupported block type")
 	if len(splitted) != 2 {
-		t.Fatalf("want exactly one unsupported block type erros but got: %d\nstderr:\n%s\n\nstdout:\n%s", len(splitted)-1, errStr, ui.OutputWriter.String())
+		t.Fatalf("want exactly one unsupported block type errors but got: %d\nstderr:\n%s\n\nstdout:\n%s", len(splitted)-1, errStr, ui.OutputWriter.String())
 	}
 }
 

--- a/internal/command/testdata/init-syntax-invalid-extra-label/main.tf
+++ b/internal/command/testdata/init-syntax-invalid-extra-label/main.tf
@@ -1,0 +1,10 @@
+terraform {
+  extra_label{
+    required_providers {
+      azurerm = {
+        source  = "hashicorp/azurerm"
+        version = "~> 3.0.2"
+      }
+    }
+  }
+}

--- a/internal/tfdiags/diagnostic.go
+++ b/internal/tfdiags/diagnostic.go
@@ -58,9 +58,17 @@ type Description struct {
 	Detail  string
 }
 
+func (d Description) Equal(other Description) bool {
+	return d.Address == other.Address && d.Summary == other.Summary && d.Detail == other.Detail
+}
+
 type Source struct {
 	Subject *SourceRange
 	Context *SourceRange
+}
+
+func (s Source) Equal(other Source) bool {
+	return s.Subject.Equal(other.Subject) && s.Context.Equal(other.Context)
 }
 
 type FromExpr struct {

--- a/internal/tfdiags/diagnostics.go
+++ b/internal/tfdiags/diagnostics.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"fmt"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"strings"
 
@@ -102,17 +101,17 @@ func (diags Diagnostics) Append(new ...interface{}) Diagnostics {
 	return diags
 }
 
-func (diags Diagnostics) Merge(other Diagnostics) Diagnostics {
+func (diags Diagnostics) StrictDeduplicateMerge(other Diagnostics) Diagnostics {
 	if len(diags) == 0 {
 		return other
 	}
 
 	for _, d := range diags {
 		for _, o := range other {
-			if reflect.DeepEqual(d, o) {
-				continue
+			isEqual := d.Description().Equal(o.Description()) && d.Severity() == o.Severity() && d.Source().Equal(o.Source())
+			if DoNotConsolidateDiagnostic(d) || DoNotConsolidateDiagnostic(o) || !isEqual {
+				diags = append(diags, o)
 			}
-			diags = append(diags, o)
 		}
 	}
 

--- a/internal/tfdiags/diagnostics.go
+++ b/internal/tfdiags/diagnostics.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -96,6 +97,23 @@ func (diags Diagnostics) Append(new ...interface{}) Diagnostics {
 	// here, but we'll make sure of that so callers can rely on empty == nil
 	if len(diags) == 0 {
 		return nil
+	}
+
+	return diags
+}
+
+func (diags Diagnostics) Merge(other Diagnostics) Diagnostics {
+	if len(diags) == 0 {
+		return other
+	}
+
+	for _, d := range diags {
+		for _, o := range other {
+			if reflect.DeepEqual(d, o) {
+				continue
+			}
+			diags = append(diags, o)
+		}
 	}
 
 	return diags

--- a/internal/tfdiags/source_range.go
+++ b/internal/tfdiags/source_range.go
@@ -16,8 +16,20 @@ type SourceRange struct {
 	Start, End SourcePos
 }
 
+func (r *SourceRange) Equal(other *SourceRange) bool {
+	if r == nil || other == nil {
+		return r == other
+	}
+
+	return r.Filename == other.Filename && r.Start.Equal(other.Start) && r.End.Equal(other.End)
+}
+
 type SourcePos struct {
 	Line, Column, Byte int
+}
+
+func (p SourcePos) Equal(other SourcePos) bool {
+	return p.Line == other.Line && p.Column == other.Column && p.Byte == other.Byte
 }
 
 // StartString returns a string representation of the start of the range,


### PR DESCRIPTION
In the issue #1812 it was explained and demonstrated clearly that init response was outputting duplicate diagnosis error. I have added `Merge` method to diagnostics to not add exact equal diagnostics to prevent duplicates.

Resolves #1812 

## Target Release

1.9.0

## Checklist
- [X] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [X] I have not used an AI coding assistant to create this PR.
- [X] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.

### Go checklist
- [X] I have run golangci-lint on my change and receive no errors relevant to my code.
- [X] I have run existing tests to ensure my code doesn't break anything.
- [X] I have added tests for all relevant use cases of my code, and those tests are passing.
- [X] I have only exported functions, variables and structs that should be used from other packages.
- [X] I have added meaningful comments to all exported functions, variables, and structs.


