### PR TITLE
#300: allow square brackets syntax and pass aliases map to graph

### DIFF
--- a/internal/configs/config.go
+++ b/internal/configs/config.go
@@ -484,8 +484,7 @@ func (c *Config) addProviderRequirements(reqs getproviders.Requirements, recurse
 					})
 					continue
 				}
-				// TODO Ronny: Fix to run this validation with multiple providers
-				if i.ProviderConfigRef.Name != target.ProviderConfigRef.Name || i.ProviderConfigRef.Alias != target.ProviderConfigRef.Aliases[addrs.NoKey] {
+				if i.ProviderConfigRef.Name != target.ProviderConfigRef.Name || i.ProviderConfigRef.Alias != target.ProviderConfigRef.GetNoKeyAlias() {
 					// This means we have a provider specified in both the
 					// import block and the resource block, and they disagree.
 					// This is bad as OpenTofu now has different instructions

--- a/internal/configs/module.go
+++ b/internal/configs/module.go
@@ -250,6 +250,16 @@ func NewModule(primaryFiles, overrideFiles []*File, call StaticModuleCall, sourc
 		diags = append(diags, mDiags...)
 	}
 
+	// Process all resources now that we have the static context
+	for _, res := range mod.ManagedResources {
+		mDiags := res.decodeStaticFields(mod.StaticEvaluator)
+		diags = append(diags, mDiags...)
+	}
+	for _, res := range mod.DataResources {
+		mDiags := res.decodeStaticFields(mod.StaticEvaluator)
+		diags = append(diags, mDiags...)
+	}
+
 	diags = append(diags, checkModuleExperiments(mod)...)
 
 	// Generate the FQN -> LocalProviderName map

--- a/internal/configs/module_call.go
+++ b/internal/configs/module_call.go
@@ -300,7 +300,6 @@ func (c *PassedProviderConfig) InParentTODO() *ProviderConfigRef {
 	return c.InParent(addrs.NoKey)
 }
 
-// TODO/Oleksandr: check InParent calls to ensure it expects functions instead of a field
 func (c *PassedProviderConfig) InParent(k addrs.InstanceKey) *ProviderConfigRef {
 	if c.InParentMapping == nil {
 		return nil
@@ -333,7 +332,7 @@ func decodePassedProviderConfigs(attr *hcl.Attribute) ([]PassedProviderConfig, h
 	for _, pair := range pairs {
 		key, keyDiags := decodeProviderConfigRef(pair.Key, "providers")
 		diags = append(diags, keyDiags...)
-		value, valueDiags := decodeProviderConfigRef(pair.Value, "providers")
+		value, valueDiags := decodeProviderConfigRefMapping(pair.Value, "providers")
 		diags = append(diags, valueDiags...)
 		if keyDiags.HasErrors() || valueDiags.HasErrors() {
 			continue
@@ -355,7 +354,7 @@ func decodePassedProviderConfigs(attr *hcl.Attribute) ([]PassedProviderConfig, h
 
 		providers = append(providers, PassedProviderConfig{
 			InChild:         key,
-			InParentMapping: NewProviderConfigMappingFromRef(value),
+			InParentMapping: value,
 		})
 	}
 	return providers, diags

--- a/internal/configs/provider_validation.go
+++ b/internal/configs/provider_validation.go
@@ -681,7 +681,7 @@ func validateProviderConfigs(parentCall *ModuleCall, cfg *Config, noProviderConf
 					Summary:  errSummary,
 					Detail: fmt.Sprintf(
 						"The local name %q in %s represents provider %q, but %q in %s represents %q.\n\nEach provider has its own distinct configuration schema and provider types, so this module's %q can be assigned only a configuration for %s, which is not required by %s.",
-						passed.InParent, parentModuleText, parentAddr.Provider.ForDisplay(),
+						passed.InParentTODO(), parentModuleText, parentAddr.Provider.ForDisplay(),
 						passed.InChild, moduleText, providerAddr.Provider.ForDisplay(),
 						passed.InChild, providerAddr.Provider.ForDisplay(),
 						moduleText,

--- a/internal/configs/resource.go
+++ b/internal/configs/resource.go
@@ -696,26 +696,6 @@ func NewProviderConfigRefMapping(p *Provider) *ProviderConfigRefMapping {
 	return m
 }
 
-// TODO/Oleksandr: review the calls and provide a proper mapping
-func NewProviderConfigMappingFromRef(ref *ProviderConfigRef) *ProviderConfigRefMapping {
-	m := &ProviderConfigRefMapping{
-		Name:         ref.Name,
-		NameRange:    ref.NameRange,
-		providerType: ref.providerType,
-	}
-
-	if ref.Alias == "" {
-		return m
-	}
-
-	m.Aliases = map[addrs.InstanceKey]string{
-		addrs.NoKey: ref.Alias,
-	}
-	m.AliasRange = ref.AliasRange
-
-	return m
-}
-
 // TODO/Oleksandr: review calls and provide a proper alias
 func (m *ProviderConfigRefMapping) GetNoKeyAlias() string {
 	return m.Aliases[addrs.NoKey]
@@ -723,12 +703,25 @@ func (m *ProviderConfigRefMapping) GetNoKeyAlias() string {
 
 // TODO/Oleksandr: properly decode ProviderConfigRefMapping
 func decodeProviderConfigRefMapping(expr hcl.Expression, argName string) (*ProviderConfigRefMapping, hcl.Diagnostics) {
-	r, diags := decodeProviderConfigRef(expr, argName)
+	ref, diags := decodeProviderConfigRef(expr, argName)
 	if diags.HasErrors() {
 		return nil, diags
 	}
 
-	return NewProviderConfigMappingFromRef(r), diags
+	m := &ProviderConfigRefMapping{
+		Name:         ref.Name,
+		NameRange:    ref.NameRange,
+		providerType: ref.providerType,
+	}
+
+	if ref.Alias != "" {
+		m.Aliases = map[addrs.InstanceKey]string{
+			addrs.NoKey: ref.Alias,
+		}
+		m.AliasRange = ref.AliasRange
+	}
+
+	return m, diags
 }
 
 func decodeProviderConfigRef(expr hcl.Expression, argName string) (*ProviderConfigRef, hcl.Diagnostics) {


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Part of #300 

This PR is not meant to be merged to main directly. There is also lots of TODOs left.

Main purpose of the PR is to allow using square brackets with `each.value` / `each.key` when referencing providers:

```hcl
provider random {
  alias = "a"
}

provider random {
  alias = "b"
}

provider random {
  alias = "c"
}

module "mod" {
  for_each = toset(["a", "b", "c"])

  source = "./mod"
  providers = {
    random.moda = random[each.value]
    random.modb = random[each.value]
  }
}

resource "random_id" "all" {
  byte_length = 10

  for_each = toset(["a", "b", "c"])

  provider = random[each.value]
}
```

With such configuration, proper list of `PassedProviderConfig` with `ProviderConfigRefMapping` will be passed to graph transformers. Also, `ProviderConfigRefMapping` will be passed for configuration of `data` and `resource` blocks.

## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [X] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [X] I have not used an AI coding assistant to create this PR.
- [X] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.