### PR TITLE
Changing release number in docs

### DIFF
--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -10,7 +10,7 @@ import DocVersionBadge from "@theme/DocVersionBadge";
 
 ### OpenTofu Documentation <DocVersionBadge />
 
-Welcome to OpenTofu 1.7! This version brings you a host of new features like state encryption, loop-able import blocks, provider defined functions and more. If you are coming from a previous OpenTofu or Terraform version you can [read the details about the new features here &raquo;](intro/whats-new.mdx)
+Welcome to OpenTofu 1.8! This version brings you a host of new features like state encryption, loop-able import blocks, provider defined functions and more. If you are coming from a previous OpenTofu or Terraform version you can [read the details about the new features here &raquo;](intro/whats-new.mdx)
 
 <DocCardList
     items={[


### PR DESCRIPTION
Using previous release number (1.7) in latest docs.

## Target Release

1.8.0,
1.8.x

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
