### PR TITLE
Better handling of key_provider references

### DIFF
--- a/internal/encryption/targets_test.go
+++ b/internal/encryption/targets_test.go
@@ -131,6 +131,22 @@ func TestBaseEncryption_buildTargetMethods(t *testing.T) {
 				aesgcm.Is,
 			},
 		},
+		"key-from-complex-vars": {
+			rawConfig: `
+				key_provider "static" "basic" {
+					key = var.obj[0].key
+				}
+				method "aes_gcm" "example" {
+					keys = key_provider.static.basic
+				}
+				state {
+					method = method.aes_gcm.example
+				}
+			`,
+			wantMethods: []func(method.Method) bool{
+				aesgcm.Is,
+			},
+		},
 		"undefined-key-from-vars": {
 			rawConfig: `
 				key_provider "static" "basic" {
@@ -178,6 +194,10 @@ func TestBaseEncryption_buildTargetMethods(t *testing.T) {
 				Name:    "key",
 				Default: cty.StringVal("6f6f706830656f67686f6834616872756f3751756165686565796f6f72653169"),
 				Type:    cty.String,
+			},
+			"obj": {
+				Name:    "obj",
+				Default: cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{"key": cty.StringVal("6f6f706830656f67686f6834616872756f3751756165686565796f6f72653169")})}),
 			},
 		},
 	}

--- a/internal/encryption/targets_test.go
+++ b/internal/encryption/targets_test.go
@@ -145,6 +145,20 @@ func TestBaseEncryption_buildTargetMethods(t *testing.T) {
 			`,
 			wantErr: "Test Config Source:3,12-28: Undefined variable; Undefined variable var.undefinedkey",
 		},
+		"bad-keyprovider-format": {
+			rawConfig: `
+				key_provider "static" "basic" {
+					key = key_provider.static[0]
+				}
+				method "aes_gcm" "example" {
+					keys = key_provider.static.basic
+				}
+				state {
+					method = method.aes_gcm.example
+				}
+			`,
+			wantErr: "Test Config Source:3,12-34: Invalid Key Provider expression format; Expected key_provider.<type>.<name>",
+		},
 	}
 
 	reg := lockingencryptionregistry.New()


### PR DESCRIPTION
Fixes detection of key_provider vs variable/local and adds guard-rails around bad key_provider formats

<!-- If your PR resolves an issue, please add it here. -->
Resolves #1918  

## Target Release

1.9.0, 1.8.x

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

