### PR TITLE
Fix: import block might cause a destroy action to attempt destruction of an already-destroyed resource #1803

### DIFF
--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -3911,8 +3911,8 @@ func TestContext2Plan_destroyWithImportedResources(t *testing.T) {
 		},
 	}
 
-	// When attempting to destroy the configuration, 
-	// after test_object.a has been destroyed as part of a targeted destroy, 
+	// When attempting to destroy the configuration,
+	// after test_object.a has been destroyed as part of a targeted destroy,
 	// OpenTofu should attempt to only destroy test_object.b
 	state := states.NewState()
 	root := state.EnsureModule(addrs.RootModuleInstance)
@@ -3922,7 +3922,7 @@ func TestContext2Plan_destroyWithImportedResources(t *testing.T) {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"test_string":"foo"}`),
 		},
-		mustProviderConfig(`provider["registry.terraform.io/hashicorp/test"]`),
+		mustProviderConfig(`provider["registry.opentofu.io/local/test"]`),
 	)
 
 	ctx := testContext2(t, &ContextOpts{

--- a/internal/tofu/node_resource_plan_instance.go
+++ b/internal/tofu/node_resource_plan_instance.go
@@ -641,7 +641,7 @@ func (n *NodePlannableResourceInstance) importState(ctx EvalContext, addr addrs.
 }
 
 func (n *NodePlannableResourceInstance) shouldImport(ctx EvalContext) bool {
-	if n.importTarget.ID == "" {
+	if n.importTarget.ID == "" || n.preDestroyRefresh {
 		return false
 	}
 


### PR DESCRIPTION
Fix: import block might cause a destroy action to attempt destruction of an already-destroyed resource

<!-- If your PR resolves an issue, please add it here. -->
Resolves #1803 

## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [ ] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [ ] I have not used an AI coding assistant to create this PR.
- [ ] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
