### PR TITLE
Fix setops not used in block set renderer

### DIFF
--- a/internal/command/jsonformat/computed/renderers/block.go
+++ b/internal/command/jsonformat/computed/renderers/block.go
@@ -79,7 +79,6 @@ func (renderer blockRenderer) RenderHuman(diff computed.Diff, indent int, opts c
 	for _, key := range attributeKeys {
 		attribute := renderer.attributes[key]
 		if importantAttribute(key) {
-
 			// Always display the important attributes.
 			for _, warning := range attribute.WarningsHuman(indent+1, importantAttributeOpts) {
 				buf.WriteString(fmt.Sprintf("%s%s\n", formatIndent(indent+1), warning))
@@ -104,10 +103,8 @@ func (renderer blockRenderer) RenderHuman(diff computed.Diff, indent int, opts c
 
 	blockKeys := renderer.blocks.GetAllKeys()
 	for _, key := range blockKeys {
-
 		foundChangedBlock := false
 		renderBlock := func(diff computed.Diff, mapKey string, opts computed.RenderHumanOpts) {
-
 			creatingSensitiveValue := diff.Action == plans.Create && renderer.blocks.AfterSensitiveBlocks[key]
 			deletingSensitiveValue := diff.Action == plans.Delete && renderer.blocks.BeforeSensitiveBlocks[key]
 			modifyingSensitiveValue := (diff.Action == plans.Update || diff.Action == plans.NoOp) && (renderer.blocks.AfterSensitiveBlocks[key] || renderer.blocks.BeforeSensitiveBlocks[key])
@@ -146,7 +143,6 @@ func (renderer blockRenderer) RenderHuman(diff computed.Diff, indent int, opts c
 				buf.WriteString(fmt.Sprintf("%s%s\n", formatIndent(indent+1), warning))
 			}
 			buf.WriteString(fmt.Sprintf("%s%s%s%s %s\n", formatIndent(indent+1), writeDiffActionSymbol(diff.Action, blockOpts), EnsureValidAttributeName(key), mapKey, diff.RenderHuman(indent+1, blockOpts)))
-
 		}
 
 		switch {
@@ -163,12 +159,11 @@ func (renderer blockRenderer) RenderHuman(diff computed.Diff, indent int, opts c
 				renderBlock(renderer.blocks.MapBlocks[key][innerKey], fmt.Sprintf(" %q", innerKey), opts)
 			}
 		case renderer.blocks.IsSetBlock(key):
-
 			setOpts := opts.Clone()
 			setOpts.OverrideForcesReplacement = diff.Replace
 
 			for _, block := range renderer.blocks.SetBlocks[key] {
-				renderBlock(block, "", opts)
+				renderBlock(block, "", setOpts)
 			}
 		case renderer.blocks.IsListBlock(key):
 			for _, block := range renderer.blocks.ListBlocks[key] {

--- a/internal/command/jsonformat/computed/renderers/renderer_test.go
+++ b/internal/command/jsonformat/computed/renderers/renderer_test.go
@@ -1989,6 +1989,56 @@ jsonencode(
         }
     }`,
 		},
+		"set_block_override_replacement": {
+			diff: computed.Diff{
+				Renderer: Block(
+					nil,
+					Blocks{
+						SetBlocks: map[string][]computed.Diff{
+							"set_blocks": {
+								{
+									Renderer: Block(map[string]computed.Diff{
+										"number": {
+											Renderer: Primitive(json.Number("1"), json.Number("2"), cty.Number),
+											Action:   plans.Update,
+										},
+										"string": {
+											Renderer: Primitive(nil, "new", cty.String),
+											Action:   plans.Create,
+										},
+									}, Blocks{}),
+									Action: plans.Update,
+								},
+								{
+									Renderer: Block(map[string]computed.Diff{
+										"number": {
+											Renderer: Primitive(json.Number("1"), nil, cty.Number),
+											Action:   plans.Delete,
+										},
+										"string": {
+											Renderer: Primitive("old", "new", cty.String),
+											Action:   plans.Update,
+										},
+									}, Blocks{}),
+									Action: plans.Update,
+								},
+							},
+						},
+					}),
+				Replace: true,
+			},
+			expected: `
+{ # forces replacement
+      ~ set_blocks {
+          ~ number = 1 -> 2
+          + string = "new"
+        }
+      ~ set_blocks {
+          - number = 1 -> null
+          ~ string = "old" -> "new"
+        }
+    }`,
+		},
 		"map_block_update": {
 			diff: computed.Diff{
 				Renderer: Block(


### PR DESCRIPTION
While implementing https://github.com/opentofu/opentofu/pull/1948 I have realized that `setOpts` is defined but is not used. I think this was a mistake and opened a PR for this. 

## Target Release

1.9.0

## Checklist
- [X] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [X] I have not used an AI coding assistant to create this PR.
- [X] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [X] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [X] I have run golangci-lint on my change and receive no errors relevant to my code.
- [X] I have run existing tests to ensure my code doesn't break anything.
- [X] I have added tests for all relevant use cases of my code, and those tests are passing.
- [X] I have only exported functions, variables and structs that should be used from other packages.
- [X] I have added meaningful comments to all exported functions, variables, and structs.

