### PR TITLE
Prevents providers mirror from crashing with bad lock file

### DIFF
--- a/internal/command/e2etest/testdata/tofu-providers-mirror-with-bad-lock-file/.terraform.lock.hcl
+++ b/internal/command/e2etest/testdata/tofu-providers-mirror-with-bad-lock-file/.terraform.lock.hcl
@@ -1,0 +1,8 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/tfcoremocka" {
+  version = "0.2.0"
+  hashes = ["zh:"
+  ]
+}

--- a/internal/command/e2etest/testdata/tofu-providers-mirror-with-bad-lock-file/main.tf
+++ b/internal/command/e2etest/testdata/tofu-providers-mirror-with-bad-lock-file/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    tfcoremock = {
+      source  = "tfcoremock"
+    }
+  }
+}

--- a/internal/command/providers_mirror.go
+++ b/internal/command/providers_mirror.go
@@ -164,6 +164,14 @@ func (c *ProvidersMirrorCommand) Run(args []string) int {
 		}
 		selected := candidates.Newest()
 		if !lockedDeps.Empty() {
+			if lockedDeps.Provider(provider) == nil {
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Provider not found in lockfile",
+					fmt.Sprintf("Failed to find %s in the lock file", provider.String()),
+				))
+				continue
+			}
 			selected = lockedDeps.Provider(provider).Version()
 			c.Ui.Output(fmt.Sprintf("  - Selected v%s to match dependency lock file", selected.String()))
 		} else if len(constraintsStr) > 0 {


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves https://github.com/opentofu/opentofu/issues/1800

Prevents bad lock file from causing tofu to panic

## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
