### PR TITLE
fix config generation with optional empty sensitive string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ ENHANCEMENTS:
 * Added for-each support to providers. ([#300](https://github.com/opentofu/opentofu/issues/300))
 
 BUG FIXES:
-* Ensure that using a sensitive path for templatefile that it doesn't panic([#1801](https://github.com/opentofu/opentofu/issues/1801))
-* Fixed crash when module source is not present ([#1888](https://github.com/opentofu/opentofu/pull/1888))
+* Ensured that using a sensitive path for templatefile that it doesn't panic([#1801](https://github.com/opentofu/opentofu/issues/1801))
+* Fixed a crash when module source is not present ([#1888](https://github.com/opentofu/opentofu/pull/1888))
+* Fixed a crash when importing an empty optional sensitive string ([#1986](https://github.com/opentofu/opentofu/pull/1986))
 
 ## Previous Releases
 

--- a/internal/genconfig/generate_config.go
+++ b/internal/genconfig/generate_config.go
@@ -152,16 +152,17 @@ func writeConfigAttributesFromExisting(addr addrs.AbsResourceInstance, buf *stri
 			} else {
 				val = attrS.EmptyValue()
 			}
-			if val.Type() == cty.String {
-				// SHAMELESS HACK: If we have "" for an optional value, assume
-				// it is actually null, due to the legacy SDK.
-				if !val.IsNull() && attrS.Optional && len(val.AsString()) == 0 {
-					val = attrS.EmptyValue()
-				}
-			}
 			if attrS.Sensitive || val.IsMarked() {
 				buf.WriteString("null # sensitive")
 			} else {
+				if val.Type() == cty.String {
+					// SHAMELESS HACK: If we have "" for an optional value, assume
+					// it is actually null, due to the legacy SDK.
+					if !val.IsNull() && attrS.Optional && len(val.AsString()) == 0 {
+						val = attrS.EmptyValue()
+					}
+				}
+
 				tok := tryWrapAsJsonEncodeFunctionCall(val)
 				if _, err := tok.WriteTo(buf); err != nil {
 					diags = diags.Append(&hcl.Diagnostic{

--- a/internal/genconfig/generate_config_test.go
+++ b/internal/genconfig/generate_config_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
+	"github.com/opentofu/opentofu/internal/lang/marks"
 )
 
 func TestConfigGeneration(t *testing.T) {
@@ -490,6 +491,38 @@ resource "tfcoremock_simple_resource" "example" {
   juststr          = "{a=b}"
   secrets          = null # sensitive
   sensitivejsonobj = null # sensitive
+}`,
+		},
+		"optional_empty_sensitive_string": {
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"str": {
+						Type:      cty.String,
+						Optional:  true,
+						Sensitive: true,
+					},
+				},
+			},
+			addr: addrs.AbsResourceInstance{
+				Module: nil,
+				Resource: addrs.ResourceInstance{
+					Resource: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "tfcoremock_simple_resource",
+						Name: "example",
+					},
+					Key: nil,
+				},
+			},
+			provider: addrs.LocalProviderConfig{
+				LocalName: "tfcoremock",
+			},
+			value: cty.ObjectVal(map[string]cty.Value{
+				"str": cty.StringVal("").Mark(marks.Sensitive),
+			}),
+			expected: `
+resource "tfcoremock_simple_resource" "example" {
+  str = null # sensitive
 }`,
 		},
 	}


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves #1984

This PR fixes configuration generation on import when an empty string value is marked as sensitive.

## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [X] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [X] I have not used an AI coding assistant to create this PR.
- [X] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [X] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [X] I have run golangci-lint on my change and receive no errors relevant to my code.
- [X] I have run existing tests to ensure my code doesn't break anything.
- [X] I have added tests for all relevant use cases of my code, and those tests are passing.
- [X] I have only exported functions, variables and structs that should be used from other packages.
- [X] I have added meaningful comments to all exported functions, variables, and structs.
