### PR TITLE
Fix inverted entries in provider error message

### DIFF
--- a/internal/configs/provider_validation.go
+++ b/internal/configs/provider_validation.go
@@ -679,8 +679,8 @@ func validateProviderConfigs(parentCall *ModuleCall, cfg *Config, noProviderConf
 					Summary:  errSummary,
 					Detail: fmt.Sprintf(
 						"The assigned configuration is for provider %q, but local name %q in %s represents %q.\n\nTo pass this configuration to the child module, use the local name %q instead.",
-						parentAddr.Provider.ForDisplay(), passed.InChild.Name,
-						parentModuleText, providerAddr.Provider.ForDisplay(),
+						providerAddr.Provider.ForDisplay(), passed.InChild.Name,
+						parentModuleText, parentAddr.Provider.ForDisplay(),
 						otherLocalName,
 					),
 					Subject: &passed.InChild.NameRange,


### PR DESCRIPTION
Resolves #1913

## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
