### PR TITLE
Update CONTRIBUTING.md: Update 'docker run' example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,8 +112,12 @@ If you have Docker or a compatible alternative installed, you can run the entire
 docker run \
   --rm \
   -v "$PWD":/usr/src/opentofu\
-  -w /usr/src/opentofu golang:1.21.3\
-  GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o tofu -v -buildvcs=false ./cmd/tofu
+  -w /usr/src/opentofu\
+  -e GOOS=linux\
+  -e GOARCH=amd64\
+  -e CGO_ENABLED=0\
+  golang:1.21.3\
+  go build -o tofu -v -buildvcs=false ./cmd/tofu
 ```
 
 This will create the `tofu` binary in the current working directory, which you can test by running `./tofu --version`.


### PR DESCRIPTION
The current Docker example in CONTRIBUTING.md fails with the following error:

```
docker run   --rm   -v "$PWD":/usr/src/opentofu  -w /usr/src/opentofu golang:1.21.3  GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o tofu -v -buildvcs=false ./cmd/tofu; echo $?
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "GOOS=linux": executable file not found in $PATH: unknown.
127
```

This PR updates the example `docker run` command to pass the GO variables in as environment variables:
```
docker run   --rm   -v "$PWD":/usr/src/opentofu  -w /usr/src/opentofu  -e GOOS=linux  -e GOARCH=amd64  -e CGO_ENABLED=0  golang:1.21.3  go build -o tofu -v -buildvcs=false ./cmd/tofu; echo $?
<snip lots of GO output>
0
```

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [X] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [X] I have not used an AI coding assistant to create this PR.
- [X] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [X] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

N/A

### Website/documentation checklist

N/A (Please correct me if this file is displayed outside of github.com)
