### PR TITLE
#300 - Support in graph for each on providers in resources and modules: Fix UT

### DIFF
--- a/internal/backend/local/backend_plan_test.go
+++ b/internal/backend/local/backend_plan_test.go
@@ -369,6 +369,7 @@ func TestLocal_planDeposedOnly(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	}))
 	outDir := t.TempDir()
@@ -765,6 +766,7 @@ func testPlanState() *states.State {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	return state
 }
@@ -792,6 +794,7 @@ func testPlanState_withDataSource() *states.State {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	rootModule.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -809,6 +812,7 @@ func testPlanState_withDataSource() *states.State {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	return state
 }
@@ -836,6 +840,7 @@ func testPlanState_tainted() *states.State {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	return state
 }

--- a/internal/backend/local/backend_refresh_test.go
+++ b/internal/backend/local/backend_refresh_test.go
@@ -300,6 +300,7 @@ func testRefreshState() *states.State {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	return state
 }

--- a/internal/command/apply_destroy_test.go
+++ b/internal/command/apply_destroy_test.go
@@ -43,6 +43,7 @@ func TestApply_destroy(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, originalState)
@@ -148,6 +149,7 @@ func TestApply_destroyApproveNo(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, originalState)
@@ -216,6 +218,7 @@ func TestApply_destroyApproveYes(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, originalState)
@@ -286,6 +289,7 @@ func TestApply_destroyLockedState(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, originalState)
@@ -410,6 +414,7 @@ func TestApply_destroyTargetedDependencies(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -426,6 +431,7 @@ func TestApply_destroyTargetedDependencies(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, originalState)
@@ -544,6 +550,7 @@ func TestApply_destroyTargeted(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -560,6 +567,7 @@ func TestApply_destroyTargeted(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	wantState := states.BuildState(func(s *states.SyncState) {
@@ -577,6 +585,7 @@ func TestApply_destroyTargeted(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, originalState)

--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -1000,6 +1000,7 @@ func TestApply_refresh(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, originalState)
@@ -1067,6 +1068,7 @@ func TestApply_refreshFalse(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, originalState)
@@ -1204,6 +1206,7 @@ func TestApply_state(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, originalState)
@@ -1601,6 +1604,7 @@ func TestApply_backup(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, originalState)
@@ -2040,6 +2044,7 @@ func TestApply_replace(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, originalState)

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -311,6 +311,7 @@ func testState() *states.State {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		// DeepCopy is used here to ensure our synthetic state matches exactly
 		// with a state that will have been copied during the command

--- a/internal/command/jsonformat/state_test.go
+++ b/internal/command/jsonformat/state_test.go
@@ -271,6 +271,7 @@ func basicState(t *testing.T) *states.State {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	rootModule.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -287,6 +288,7 @@ func basicState(t *testing.T) *states.State {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	return state
 }
@@ -323,6 +325,7 @@ func stateWithMoreOutputs(t *testing.T) *states.State {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	return state
 }
@@ -350,6 +353,7 @@ func nestedState(t *testing.T) *states.State {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	return state
 }
@@ -373,6 +377,7 @@ func deposedState(t *testing.T) *states.State {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	return state
 }
@@ -402,6 +407,7 @@ func onlyDeposedState(t *testing.T) *states.State {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	rootModule.SetResourceInstanceDeposed(
 		addrs.Resource{
@@ -419,6 +425,7 @@ func onlyDeposedState(t *testing.T) *states.State {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	return state
 }

--- a/internal/command/jsonstate/state_test.go
+++ b/internal/command/jsonstate/state_test.go
@@ -631,6 +631,7 @@ func TestMarshalModules_basic(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -646,6 +647,7 @@ func TestMarshalModules_basic(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   childModule.Module(),
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -661,6 +663,7 @@ func TestMarshalModules_basic(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   subModule.Module(),
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	moduleMap := make(map[string][]addrs.ModuleInstance)
@@ -700,6 +703,7 @@ func TestMarshalModules_nested(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -715,6 +719,7 @@ func TestMarshalModules_nested(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   childModule.Module(),
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -730,6 +735,7 @@ func TestMarshalModules_nested(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   subModule.Module(),
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	moduleMap := make(map[string][]addrs.ModuleInstance)
@@ -772,6 +778,7 @@ func TestMarshalModules_parent_no_resources(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -787,6 +794,7 @@ func TestMarshalModules_parent_no_resources(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   subModule.Module(),
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	got, err := marshalRootModule(testState, testSchemas())

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -153,6 +153,7 @@ func TestPlan_destroy(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	outPath := testTempFile(t)
@@ -316,6 +317,7 @@ func TestPlan_outPathNoChange(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, originalState)
@@ -417,6 +419,7 @@ func TestPlan_outBackend(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 
@@ -1386,6 +1389,7 @@ func TestPlan_replace(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, originalState)

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -148,6 +148,7 @@ func TestShow_argsWithStateAliasedProvider(t *testing.T) {
 				Dependencies: []addrs.ConfigResource{},
 			},
 			addrs.RootModuleInstance.ProviderConfigAliased(addrs.NewDefaultProvider("test"), "alias"),
+			addrs.AbsProviderConfig{},
 		)
 	})
 

--- a/internal/command/state_mv_test.go
+++ b/internal/command/state_mv_test.go
@@ -35,6 +35,7 @@ func TestStateMv(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -51,6 +52,7 @@ func TestStateMv(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -171,6 +173,7 @@ func TestStateMv_backupAndBackupOutOptionsWithNonLocalBackend(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 
@@ -418,6 +421,7 @@ func TestStateMv_resourceToInstance(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -434,6 +438,7 @@ func TestStateMv_resourceToInstance(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceProvider(
 			addrs.Resource{
@@ -509,6 +514,7 @@ func TestStateMv_resourceToInstanceErr(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceProvider(
 			addrs.Resource{
@@ -578,6 +584,7 @@ func TestStateMv_resourceToInstanceErrInAutomation(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceProvider(
 			addrs.Resource{
@@ -648,6 +655,7 @@ func TestStateMv_instanceToResource(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -663,6 +671,7 @@ func TestStateMv_instanceToResource(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -738,6 +747,7 @@ func TestStateMv_instanceToNewResource(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -811,6 +821,7 @@ func TestStateMv_differentResourceTypes(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -873,6 +884,7 @@ func TestStateMv_explicitWithBackend(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -888,6 +900,7 @@ func TestStateMv_explicitWithBackend(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -951,6 +964,7 @@ func TestStateMv_backupExplicit(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -967,6 +981,7 @@ func TestStateMv_backupExplicit(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -1018,6 +1033,7 @@ func TestStateMv_stateOutNew(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -1074,6 +1090,7 @@ func TestStateMv_stateOutExisting(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, stateSrc)
@@ -1093,6 +1110,7 @@ func TestStateMv_stateOutExisting(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	stateOutPath := testStateFile(t, stateDst)
@@ -1176,6 +1194,7 @@ func TestStateMv_stateOutNew_count(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -1191,6 +1210,7 @@ func TestStateMv_stateOutNew_count(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -1206,6 +1226,7 @@ func TestStateMv_stateOutNew_count(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -1266,6 +1287,7 @@ func TestStateMv_stateOutNew_largeCount(t *testing.T) {
 					Provider: addrs.NewDefaultProvider("test"),
 					Module:   addrs.RootModule,
 				},
+				addrs.AbsProviderConfig{},
 			)
 		}
 		s.SetResourceInstanceCurrent(
@@ -1282,6 +1304,7 @@ func TestStateMv_stateOutNew_largeCount(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -1338,6 +1361,7 @@ func TestStateMv_stateOutNew_nestedModule(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -1353,6 +1377,7 @@ func TestStateMv_stateOutNew_nestedModule(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 
@@ -1410,6 +1435,7 @@ func TestStateMv_toNewModule(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 
@@ -1484,6 +1510,7 @@ func TestStateMv_withinBackend(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -1500,6 +1527,7 @@ func TestStateMv_withinBackend(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 
@@ -1559,6 +1587,7 @@ func TestStateMv_fromBackendToLocal(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	state.Module(addrs.RootModuleInstance).SetResourceInstanceCurrent(
 		mustResourceAddr("test_instance.baz").Resource.Instance(addrs.NoKey),
@@ -1570,6 +1599,7 @@ func TestStateMv_fromBackendToLocal(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 
 	// the local backend state file is "foo"
@@ -1635,6 +1665,7 @@ func TestStateMv_onlyResourceInModule(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 
@@ -1730,6 +1761,7 @@ func TestStateMv_checkRequiredVersion(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -1746,6 +1778,7 @@ func TestStateMv_checkRequiredVersion(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)

--- a/internal/command/state_replace_provider_test.go
+++ b/internal/command/state_replace_provider_test.go
@@ -33,6 +33,7 @@ func TestStateReplaceProvider(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("aws"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -48,6 +49,7 @@ func TestStateReplaceProvider(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("aws"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -63,6 +65,7 @@ func TestStateReplaceProvider(t *testing.T) {
 				Provider: addrs.NewLegacyProvider("azurerm"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 
@@ -320,6 +323,7 @@ func TestStateReplaceProvider_checkRequiredVersion(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("aws"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -335,6 +339,7 @@ func TestStateReplaceProvider_checkRequiredVersion(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("aws"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -350,6 +355,7 @@ func TestStateReplaceProvider_checkRequiredVersion(t *testing.T) {
 				Provider: addrs.NewLegacyProvider("azurerm"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 

--- a/internal/command/state_rm_test.go
+++ b/internal/command/state_rm_test.go
@@ -33,6 +33,7 @@ func TestStateRm(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -48,6 +49,7 @@ func TestStateRm(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -100,6 +102,7 @@ func TestStateRmNotChildModule(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		// This second instance has the same local address as the first but
 		// is in a child module. Older versions of Terraform would incorrectly
@@ -118,6 +121,7 @@ func TestStateRmNotChildModule(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -191,6 +195,7 @@ func TestStateRmNoArgs(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -206,6 +211,7 @@ func TestStateRmNoArgs(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -252,6 +258,7 @@ func TestStateRmNonExist(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -267,6 +274,7 @@ func TestStateRmNonExist(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -309,6 +317,7 @@ func TestStateRm_backupExplicit(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -324,6 +333,7 @@ func TestStateRm_backupExplicit(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -428,6 +438,7 @@ func TestStateRm_backendState(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -443,6 +454,7 @@ func TestStateRm_backendState(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 
@@ -509,6 +521,7 @@ func TestStateRm_checkRequiredVersion(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -524,6 +537,7 @@ func TestStateRm_checkRequiredVersion(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)

--- a/internal/command/state_show_test.go
+++ b/internal/command/state_show_test.go
@@ -34,6 +34,7 @@ func TestStateShow(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -96,6 +97,7 @@ func TestStateShow_multi(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -111,6 +113,7 @@ func TestStateShow_multi(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   submod.Module(),
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -222,6 +225,7 @@ func TestStateShow_configured_provider(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test-beta"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -364,6 +368,7 @@ func stateWithSensitiveValueForStateShow() *states.State {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 

--- a/internal/command/taint_test.go
+++ b/internal/command/taint_test.go
@@ -33,6 +33,7 @@ func TestTaint(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -73,6 +74,7 @@ func TestTaint_lockedState(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -125,6 +127,7 @@ func TestTaint_backup(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	testStateFileDefault(t, state)
@@ -169,6 +172,7 @@ func TestTaint_backupDisable(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	testStateFileDefault(t, state)
@@ -236,6 +240,7 @@ func TestTaint_defaultState(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	testStateFileDefault(t, state)
@@ -278,6 +283,7 @@ func TestTaint_defaultWorkspaceState(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	testWorkspace := "development"
@@ -317,6 +323,7 @@ func TestTaint_missing(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -355,6 +362,7 @@ func TestTaint_missingAllow(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -411,6 +419,7 @@ func TestTaint_stateOut(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	testStateFileDefault(t, state)
@@ -452,6 +461,7 @@ func TestTaint_module(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -467,6 +477,7 @@ func TestTaint_module(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -513,6 +524,7 @@ func TestTaint_checkRequiredVersion(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	path := testStateFile(t, state)

--- a/internal/command/untaint_test.go
+++ b/internal/command/untaint_test.go
@@ -32,6 +32,7 @@ func TestUntaint(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -77,6 +78,7 @@ func TestUntaint_lockedState(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -129,6 +131,7 @@ func TestUntaint_backup(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	testStateFileDefault(t, state)
@@ -184,6 +187,7 @@ func TestUntaint_backupDisable(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	testStateFileDefault(t, state)
@@ -255,6 +259,7 @@ func TestUntaint_defaultState(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	testStateFileDefault(t, state)
@@ -302,6 +307,7 @@ func TestUntaint_defaultWorkspaceState(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	testWorkspace := "development"
@@ -345,6 +351,7 @@ func TestUntaint_missing(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -383,6 +390,7 @@ func TestUntaint_missingAllow(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)
@@ -439,6 +447,7 @@ func TestUntaint_stateOut(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	testStateFileDefault(t, state)
@@ -488,6 +497,7 @@ func TestUntaint_module(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -503,6 +513,7 @@ func TestUntaint_module(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	statePath := testStateFile(t, state)

--- a/internal/command/views/operation_test.go
+++ b/internal/command/views/operation_test.go
@@ -309,6 +309,7 @@ func TestOperation_planNoChanges(t *testing.T) {
 								AttrsJSON: []byte(`{}`),
 							},
 							addrs.RootModuleInstance.ProviderConfigDefault(addrs.NewDefaultProvider("test")),
+							addrs.AbsProviderConfig{},
 						)
 					}),
 					PriorState: states.NewState(),

--- a/internal/command/views/show_test.go
+++ b/internal/command/views/show_test.go
@@ -233,6 +233,7 @@ func testState() *states.State {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		// DeepCopy is used here to ensure our synthetic state matches exactly
 		// with a state that will have been copied during the command

--- a/internal/command/views/test_test.go
+++ b/internal/command/views/test_test.go
@@ -665,7 +665,8 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 									Namespace: "hashicorp",
 									Type:      "test",
 								},
-							})
+							},
+							addrs.AbsProviderConfig{})
 					}),
 					Config: &configs.Config{},
 					Providers: map[addrs.Provider]providers.ProviderSchema{
@@ -812,7 +813,8 @@ this time it is very bad
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("test"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 				state.SetResourceInstanceCurrent(
 					addrs.Resource{
 						Mode: addrs.ManagedResourceMode,
@@ -825,7 +827,8 @@ this time it is very bad
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("test"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 				state.SetResourceInstanceDeposed(
 					addrs.Resource{
 						Mode: addrs.ManagedResourceMode,
@@ -839,7 +842,8 @@ this time it is very bad
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("test"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 			}),
 			stdout: `
 Warning: first warning
@@ -880,7 +884,8 @@ up manually:
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("test"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 				state.SetResourceInstanceCurrent(
 					addrs.Resource{
 						Mode: addrs.ManagedResourceMode,
@@ -893,7 +898,8 @@ up manually:
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("test"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 				state.SetResourceInstanceDeposed(
 					addrs.Resource{
 						Mode: addrs.ManagedResourceMode,
@@ -907,7 +913,8 @@ up manually:
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("test"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 			}),
 			stdout: `
 Warning: first warning
@@ -954,7 +961,9 @@ up manually:
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("null"),
-					})
+					},
+					addrs.AbsProviderConfig{},
+				)
 				state.SetResourceInstanceCurrent(
 					addrs.Resource{
 						Mode: addrs.ManagedResourceMode,
@@ -978,7 +987,8 @@ up manually:
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("null"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 			}),
 			stdout: `
 Warning: first warning
@@ -1096,6 +1106,10 @@ OpenTofu was in the process of creating the following resources for
 							},
 						},
 						&states.ResourceInstanceObjectSrc{},
+						addrs.AbsProviderConfig{
+							Module:   addrs.RootModule,
+							Provider: addrs.NewDefaultProvider("test"),
+						},
 						addrs.AbsProviderConfig{})
 
 					state.SetResourceInstanceCurrent(
@@ -1110,6 +1124,10 @@ OpenTofu was in the process of creating the following resources for
 							},
 						},
 						&states.ResourceInstanceObjectSrc{},
+						addrs.AbsProviderConfig{
+							Module:   addrs.RootModule,
+							Provider: addrs.NewDefaultProvider("test"),
+						},
 						addrs.AbsProviderConfig{})
 				}),
 			},
@@ -1146,6 +1164,10 @@ test:
 							},
 						},
 						&states.ResourceInstanceObjectSrc{},
+						addrs.AbsProviderConfig{
+							Module:   addrs.RootModule,
+							Provider: addrs.NewDefaultProvider("test"),
+						},
 						addrs.AbsProviderConfig{})
 
 					state.SetResourceInstanceCurrent(
@@ -1160,6 +1182,10 @@ test:
 							},
 						},
 						&states.ResourceInstanceObjectSrc{},
+						addrs.AbsProviderConfig{
+							Module:   addrs.RootModule,
+							Provider: addrs.NewDefaultProvider("test"),
+						},
 						addrs.AbsProviderConfig{})
 				}),
 			},
@@ -1196,6 +1222,10 @@ OpenTofu has already created the following resources for "setup_block" from
 							},
 						},
 						&states.ResourceInstanceObjectSrc{},
+						addrs.AbsProviderConfig{
+							Module:   addrs.RootModule,
+							Provider: addrs.NewDefaultProvider("test"),
+						},
 						addrs.AbsProviderConfig{})
 
 					state.SetResourceInstanceCurrent(
@@ -1210,6 +1240,10 @@ OpenTofu has already created the following resources for "setup_block" from
 							},
 						},
 						&states.ResourceInstanceObjectSrc{},
+						addrs.AbsProviderConfig{
+							Module:   addrs.RootModule,
+							Provider: addrs.NewDefaultProvider("test"),
+						},
 						addrs.AbsProviderConfig{})
 				}),
 				nil: states.BuildState(func(state *states.SyncState) {
@@ -1225,6 +1259,10 @@ OpenTofu has already created the following resources for "setup_block" from
 							},
 						},
 						&states.ResourceInstanceObjectSrc{},
+						addrs.AbsProviderConfig{
+							Module:   addrs.RootModule,
+							Provider: addrs.NewDefaultProvider("test"),
+						},
 						addrs.AbsProviderConfig{})
 
 					state.SetResourceInstanceCurrent(
@@ -1239,6 +1277,10 @@ OpenTofu has already created the following resources for "setup_block" from
 							},
 						},
 						&states.ResourceInstanceObjectSrc{},
+						addrs.AbsProviderConfig{
+							Module:   addrs.RootModule,
+							Provider: addrs.NewDefaultProvider("test"),
+						},
 						addrs.AbsProviderConfig{})
 				}),
 			},
@@ -2021,7 +2063,8 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("test"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 			}),
 			want: []map[string]interface{}{
 				{
@@ -2060,7 +2103,8 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("test"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 				state.SetResourceInstanceCurrent(
 					addrs.Resource{
 						Mode: addrs.ManagedResourceMode,
@@ -2073,7 +2117,8 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("test"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 				state.SetResourceInstanceDeposed(
 					addrs.Resource{
 						Mode: addrs.ManagedResourceMode,
@@ -2087,7 +2132,8 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("test"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 			}),
 			want: []map[string]interface{}{
 				{
@@ -2157,7 +2203,8 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("test"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 				state.SetResourceInstanceCurrent(
 					addrs.Resource{
 						Mode: addrs.ManagedResourceMode,
@@ -2170,7 +2217,8 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("test"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 				state.SetResourceInstanceDeposed(
 					addrs.Resource{
 						Mode: addrs.ManagedResourceMode,
@@ -2184,7 +2232,8 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("test"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 			}),
 			want: []map[string]interface{}{
 				{
@@ -2266,7 +2315,8 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("null"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 				state.SetResourceInstanceCurrent(
 					addrs.Resource{
 						Mode: addrs.ManagedResourceMode,
@@ -2290,7 +2340,8 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("null"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 			}), want: []map[string]interface{}{
 				{
 					"@level":    "error",
@@ -2864,7 +2915,8 @@ func TestTestJSON_Run(t *testing.T) {
 									Namespace: "hashicorp",
 									Type:      "test",
 								},
-							})
+							},
+							addrs.AbsProviderConfig{})
 					}),
 					Config: &configs.Config{
 						Module: &configs.Module{},
@@ -3021,6 +3073,10 @@ func TestTestJSON_FatalInterruptSummary(t *testing.T) {
 							},
 						},
 						&states.ResourceInstanceObjectSrc{},
+						addrs.AbsProviderConfig{
+							Provider: addrs.NewDefaultProvider("test"),
+							Module:   addrs.RootModule,
+						},
 						addrs.AbsProviderConfig{})
 
 					state.SetResourceInstanceCurrent(
@@ -3035,6 +3091,10 @@ func TestTestJSON_FatalInterruptSummary(t *testing.T) {
 							},
 						},
 						&states.ResourceInstanceObjectSrc{},
+						addrs.AbsProviderConfig{
+							Provider: addrs.NewDefaultProvider("test"),
+							Module:   addrs.RootModule,
+						},
 						addrs.AbsProviderConfig{})
 				}),
 			},
@@ -3074,6 +3134,10 @@ func TestTestJSON_FatalInterruptSummary(t *testing.T) {
 							},
 						},
 						&states.ResourceInstanceObjectSrc{},
+						addrs.AbsProviderConfig{
+							Provider: addrs.NewDefaultProvider("test"),
+							Module:   addrs.RootModule,
+						},
 						addrs.AbsProviderConfig{})
 
 					state.SetResourceInstanceCurrent(
@@ -3088,6 +3152,10 @@ func TestTestJSON_FatalInterruptSummary(t *testing.T) {
 							},
 						},
 						&states.ResourceInstanceObjectSrc{},
+						addrs.AbsProviderConfig{
+							Provider: addrs.NewDefaultProvider("test"),
+							Module:   addrs.RootModule,
+						},
 						addrs.AbsProviderConfig{})
 				}),
 			},
@@ -3129,6 +3197,10 @@ func TestTestJSON_FatalInterruptSummary(t *testing.T) {
 							},
 						},
 						&states.ResourceInstanceObjectSrc{},
+						addrs.AbsProviderConfig{
+							Provider: addrs.NewDefaultProvider("test"),
+							Module:   addrs.RootModule,
+						},
 						addrs.AbsProviderConfig{})
 
 					state.SetResourceInstanceCurrent(
@@ -3143,6 +3215,10 @@ func TestTestJSON_FatalInterruptSummary(t *testing.T) {
 							},
 						},
 						&states.ResourceInstanceObjectSrc{},
+						addrs.AbsProviderConfig{
+							Provider: addrs.NewDefaultProvider("test"),
+							Module:   addrs.RootModule,
+						},
 						addrs.AbsProviderConfig{})
 				}),
 				nil: states.BuildState(func(state *states.SyncState) {
@@ -3158,6 +3234,10 @@ func TestTestJSON_FatalInterruptSummary(t *testing.T) {
 							},
 						},
 						&states.ResourceInstanceObjectSrc{},
+						addrs.AbsProviderConfig{
+							Provider: addrs.NewDefaultProvider("test"),
+							Module:   addrs.RootModule,
+						},
 						addrs.AbsProviderConfig{})
 
 					state.SetResourceInstanceCurrent(
@@ -3172,6 +3252,10 @@ func TestTestJSON_FatalInterruptSummary(t *testing.T) {
 							},
 						},
 						&states.ResourceInstanceObjectSrc{},
+						addrs.AbsProviderConfig{
+							Provider: addrs.NewDefaultProvider("test"),
+							Module:   addrs.RootModule,
+						},
 						addrs.AbsProviderConfig{})
 				}),
 			},
@@ -3279,7 +3363,8 @@ func TestSaveErroredStateFile(t *testing.T) {
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("test"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 				state.SetResourceInstanceCurrent(
 					addrs.Resource{
 						Mode: addrs.ManagedResourceMode,
@@ -3292,7 +3377,8 @@ func TestSaveErroredStateFile(t *testing.T) {
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("test"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 				state.SetResourceInstanceDeposed(
 					addrs.Resource{
 						Mode: addrs.ManagedResourceMode,
@@ -3306,7 +3392,8 @@ func TestSaveErroredStateFile(t *testing.T) {
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("test"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 			}),
 			stderr: `
 Writing state to file: errored_test.tfstate
@@ -3328,7 +3415,8 @@ Writing state to file: errored_test.tfstate
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("null"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 				state.SetResourceInstanceCurrent(
 					addrs.Resource{
 						Mode: addrs.ManagedResourceMode,
@@ -3352,7 +3440,8 @@ Writing state to file: errored_test.tfstate
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("null"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 			}),
 			stderr: `
 Writing state to file: errored_test.tfstate
@@ -3384,7 +3473,8 @@ Writing state to file: errored_test.tfstate
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("test"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 			}),
 			stderr: "",
 			want: []map[string]interface{}{
@@ -3410,7 +3500,8 @@ Writing state to file: errored_test.tfstate
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("test"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 				state.SetResourceInstanceCurrent(
 					addrs.Resource{
 						Mode: addrs.ManagedResourceMode,
@@ -3423,7 +3514,8 @@ Writing state to file: errored_test.tfstate
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("test"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 				state.SetResourceInstanceDeposed(
 					addrs.Resource{
 						Mode: addrs.ManagedResourceMode,
@@ -3437,7 +3529,8 @@ Writing state to file: errored_test.tfstate
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("test"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 			}),
 			stderr: "",
 			want: []map[string]interface{}{
@@ -3463,7 +3556,8 @@ Writing state to file: errored_test.tfstate
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("null"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 				state.SetResourceInstanceCurrent(
 					addrs.Resource{
 						Mode: addrs.ManagedResourceMode,
@@ -3487,7 +3581,8 @@ Writing state to file: errored_test.tfstate
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("null"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 			}),
 			stderr: "",
 			want: []map[string]interface{}{

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -251,6 +251,7 @@ func TestWorkspace_createWithState(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 

--- a/internal/refactoring/move_execute_test.go
+++ b/internal/refactoring/move_execute_test.go
@@ -59,6 +59,7 @@ func TestApplyMoves(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					providerAddr,
+					addrs.AbsProviderConfig{},
 				)
 			}),
 			emptyResults,
@@ -78,6 +79,7 @@ func TestApplyMoves(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					providerAddr,
+					addrs.AbsProviderConfig{},
 				)
 			}),
 			MoveResults{
@@ -105,6 +107,7 @@ func TestApplyMoves(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					providerAddr,
+					addrs.AbsProviderConfig{},
 				)
 			}),
 			MoveResults{
@@ -133,6 +136,7 @@ func TestApplyMoves(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					providerAddr,
+					addrs.AbsProviderConfig{},
 				)
 			}),
 			MoveResults{
@@ -161,6 +165,7 @@ func TestApplyMoves(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					providerAddr,
+					addrs.AbsProviderConfig{},
 				)
 			}),
 			MoveResults{
@@ -189,6 +194,7 @@ func TestApplyMoves(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					providerAddr,
+					addrs.AbsProviderConfig{},
 				)
 			}),
 			MoveResults{
@@ -217,6 +223,7 @@ func TestApplyMoves(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					providerAddr,
+					addrs.AbsProviderConfig{},
 				)
 				s.SetResourceInstanceCurrent(
 					mustParseInstAddr("module.boo.module.hoo.foo.from"),
@@ -225,6 +232,7 @@ func TestApplyMoves(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					providerAddr,
+					addrs.AbsProviderConfig{},
 				)
 			}),
 			MoveResults{
@@ -258,6 +266,7 @@ func TestApplyMoves(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					providerAddr,
+					addrs.AbsProviderConfig{},
 				)
 			}),
 			MoveResults{
@@ -287,6 +296,7 @@ func TestApplyMoves(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					providerAddr,
+					addrs.AbsProviderConfig{},
 				)
 			}),
 			MoveResults{
@@ -316,6 +326,7 @@ func TestApplyMoves(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					providerAddr,
+					addrs.AbsProviderConfig{},
 				)
 			}),
 			MoveResults{
@@ -344,6 +355,7 @@ func TestApplyMoves(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					providerAddr,
+					addrs.AbsProviderConfig{},
 				)
 				s.SetResourceInstanceCurrent(
 					mustParseInstAddr("module.boo.foo.to[0]"),
@@ -352,6 +364,7 @@ func TestApplyMoves(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					providerAddr,
+					addrs.AbsProviderConfig{},
 				)
 			}),
 			MoveResults{
@@ -386,6 +399,7 @@ func TestApplyMoves(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					providerAddr,
+					addrs.AbsProviderConfig{},
 				)
 				s.SetResourceInstanceCurrent(
 					mustParseInstAddr("foo.to"),
@@ -394,6 +408,7 @@ func TestApplyMoves(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					providerAddr,
+					addrs.AbsProviderConfig{},
 				)
 			}),
 			MoveResults{
@@ -428,6 +443,7 @@ func TestApplyMoves(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					providerAddr,
+					addrs.AbsProviderConfig{},
 				)
 				s.SetResourceInstanceCurrent(
 					mustParseInstAddr("foo.to[0]"),
@@ -436,6 +452,7 @@ func TestApplyMoves(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					providerAddr,
+					addrs.AbsProviderConfig{},
 				)
 			}),
 			MoveResults{
@@ -470,6 +487,7 @@ func TestApplyMoves(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					providerAddr,
+					addrs.AbsProviderConfig{},
 				)
 			}),
 			MoveResults{
@@ -499,6 +517,7 @@ func TestApplyMoves(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					providerAddr,
+					addrs.AbsProviderConfig{},
 				)
 				s.SetResourceInstanceCurrent(
 					mustParseInstAddr("foo.from"),
@@ -507,6 +526,7 @@ func TestApplyMoves(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					providerAddr,
+					addrs.AbsProviderConfig{},
 				)
 			}),
 			MoveResults{
@@ -542,6 +562,7 @@ func TestApplyMoves(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					providerAddr,
+					addrs.AbsProviderConfig{},
 				)
 				s.SetResourceInstanceCurrent(
 					mustParseInstAddr("bar.from"),
@@ -550,6 +571,7 @@ func TestApplyMoves(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					providerAddr,
+					addrs.AbsProviderConfig{},
 				)
 			}),
 			MoveResults{
@@ -584,6 +606,7 @@ func TestApplyMoves(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					providerAddr,
+					addrs.AbsProviderConfig{},
 				)
 				s.SetResourceInstanceCurrent(
 					mustParseInstAddr("foo.from"),
@@ -592,6 +615,7 @@ func TestApplyMoves(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					providerAddr,
+					addrs.AbsProviderConfig{},
 				)
 			}),
 			MoveResults{

--- a/internal/refactoring/move_statement_test.go
+++ b/internal/refactoring/move_statement_test.go
@@ -99,41 +99,49 @@ func TestImpliedMoveStatements(t *testing.T) {
 			resourceAddr("formerly_count").Instance(addrs.IntKey(0)),
 			instObjState(),
 			providerAddr,
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			resourceAddr("formerly_count").Instance(addrs.IntKey(1)),
 			instObjState(),
 			providerAddr,
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			resourceAddr("now_count").Instance(addrs.NoKey),
 			instObjState(),
 			providerAddr,
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			resourceAddr("formerly_count_explicit").Instance(addrs.IntKey(0)),
 			instObjState(),
 			providerAddr,
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			resourceAddr("formerly_count_explicit").Instance(addrs.IntKey(1)),
 			instObjState(),
 			providerAddr,
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			resourceAddr("now_count_explicit").Instance(addrs.NoKey),
 			instObjState(),
 			providerAddr,
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			resourceAddr("now_for_each_formerly_count").Instance(addrs.IntKey(0)),
 			instObjState(),
 			providerAddr,
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			resourceAddr("now_for_each_formerly_no_count").Instance(addrs.NoKey),
 			instObjState(),
 			providerAddr,
+			addrs.AbsProviderConfig{},
 		)
 
 		// This "ambiguous" resource is representing a rare but possible
@@ -147,11 +155,13 @@ func TestImpliedMoveStatements(t *testing.T) {
 			resourceAddr("ambiguous").Instance(addrs.NoKey),
 			instObjState(),
 			providerAddr,
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			resourceAddr("ambiguous").Instance(addrs.IntKey(0)),
 			instObjState(),
 			providerAddr,
+			addrs.AbsProviderConfig{},
 		)
 
 		// Add two resource nested in a module to ensure we find these
@@ -160,11 +170,13 @@ func TestImpliedMoveStatements(t *testing.T) {
 			nestedResourceAddr("child", "formerly_count").Instance(addrs.IntKey(0)),
 			instObjState(),
 			providerAddr,
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			nestedResourceAddr("child", "now_count").Instance(addrs.NoKey),
 			instObjState(),
 			providerAddr,
+			addrs.AbsProviderConfig{},
 		)
 	})
 

--- a/internal/repl/session_test.go
+++ b/internal/repl/session_test.go
@@ -45,6 +45,7 @@ func TestSession_basicState(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -60,6 +61,7 @@ func TestSession_basicState(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 

--- a/internal/states/module_test.go
+++ b/internal/states/module_test.go
@@ -1,0 +1,151 @@
+package states
+
+import (
+	"fmt"
+	"github.com/opentofu/opentofu/internal/addrs"
+	"testing"
+)
+
+func TestModule_SetResourceInstanceCurrent_setProviders(t *testing.T) {
+	var (
+		resourceInstance, _ = addrs.ParseAbsResourceInstanceStr("null_resource.resource")
+		mockAddr            = resourceInstance.Resource
+		provider, _         = addrs.ParseAbsProviderConfigStr("provider[\"registry.opentofu.org/hashicorp/aws\"]")
+		mockObject          = &ResourceInstanceObjectSrc{
+			SchemaVersion: 1,
+			AttrsJSON:     []byte(`{"hello": "world"}`),
+		}
+	)
+
+	module := &Module{
+		Resources: make(map[string]*Resource),
+	}
+
+	t.Run("valid - resourceProvider set, instanceProvider not set", func(t *testing.T) {
+		module.Resources = make(map[string]*Resource)
+		module.SetResourceInstanceCurrent(mockAddr, mockObject, provider, addrs.AbsProviderConfig{})
+
+		resource := module.Resources[mockAddr.Resource.String()]
+		if resource == nil {
+			t.Errorf("Expected resource to be created")
+		} else if !resource.ProviderConfig.IsSet() || resource.ProviderConfig.String() != provider.String() {
+			t.Errorf("Expected resourceProvider to be set correctly, got %+v", resource.ProviderConfig)
+		}
+
+		if mockObject.InstanceProvider.IsSet() {
+			t.Errorf("Expected instanceProvider to be not set, got %+v", mockObject.InstanceProvider)
+		}
+	})
+
+	t.Run("valid - instanceProvider set, resourceProvider not set", func(t *testing.T) {
+		module.Resources = make(map[string]*Resource)
+		module.SetResourceInstanceCurrent(mockAddr, mockObject, addrs.AbsProviderConfig{}, provider)
+
+		resource := module.Resources[mockAddr.Resource.String()]
+		if resource == nil {
+			t.Errorf("Expected resource to be created")
+		} else if resource.ProviderConfig.IsSet() {
+			t.Errorf("Expected resourceProvider to be not set, got %+v", resource.ProviderConfig)
+		}
+
+		if !mockObject.InstanceProvider.IsSet() || mockObject.InstanceProvider.String() != provider.String() {
+			t.Errorf("Expected instanceProvider to be set correctly, got %+v", mockObject.InstanceProvider)
+		}
+	})
+
+	t.Run("both providers set should panic", func(t *testing.T) {
+		module.Resources = make(map[string]*Resource)
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("Expected panic when both providers are set")
+			} else if r != fmt.Sprintf("SetResourceInstanceCurrent for %s (instance key nil) got two providers (resourceProvider & instanceProvider) to write in state", mockAddr.Resource) {
+				t.Errorf("Unexpected panic message: got %v", r)
+			}
+		}()
+		module.SetResourceInstanceCurrent(mockAddr, mockObject, provider, provider)
+	})
+
+	t.Run("neither provider set should panic", func(t *testing.T) {
+		module.Resources = make(map[string]*Resource)
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("Expected panic when neither provider is set")
+			} else if r != fmt.Sprintf("SetResourceInstanceCurrent for %s (instance key nil) cannot find a provider (resourceProvider / instanceProvider) to write in state", mockAddr.Resource) {
+				t.Errorf("Unexpected panic message: got %v", r)
+			}
+		}()
+		module.SetResourceInstanceCurrent(mockAddr, mockObject, addrs.AbsProviderConfig{}, addrs.AbsProviderConfig{})
+	})
+}
+
+func TestModule_SetResourceInstanceDeposed_setProviders(t *testing.T) {
+	var (
+		resourceInstance, _ = addrs.ParseAbsResourceInstanceStr("null_resource.resource")
+		mockAddr            = resourceInstance.Resource
+		provider, _         = addrs.ParseAbsProviderConfigStr("provider[\"registry.opentofu.org/hashicorp/aws\"]")
+		mockObject          = &ResourceInstanceObjectSrc{
+			SchemaVersion: 1,
+			AttrsJSON:     []byte(`{"hello": "world"}`),
+		}
+	)
+
+	module := &Module{
+		Resources: make(map[string]*Resource),
+	}
+
+	t.Run("valid - resourceProvider set, instanceProvider not set", func(t *testing.T) {
+		module.Resources = make(map[string]*Resource)
+		module.SetResourceInstanceDeposed(mockAddr, "deposedKey", mockObject, provider, addrs.AbsProviderConfig{})
+
+		resource := module.Resources[mockAddr.Resource.String()]
+		if resource == nil {
+			t.Errorf("Expected resource to be created")
+		} else if !resource.ProviderConfig.IsSet() || resource.ProviderConfig.String() != provider.String() {
+			t.Errorf("Expected resourceProvider to be set correctly, got %+v", resource.ProviderConfig)
+		}
+
+		if mockObject.InstanceProvider.IsSet() {
+			t.Errorf("Expected instanceProvider to be not set, got %+v", mockObject.InstanceProvider)
+		}
+	})
+
+	t.Run("valid - instanceProvider set, resourceProvider not set", func(t *testing.T) {
+		module.Resources = make(map[string]*Resource)
+		module.SetResourceInstanceDeposed(mockAddr, "deposedKey", mockObject, addrs.AbsProviderConfig{}, provider)
+
+		resource := module.Resources[mockAddr.Resource.String()]
+		if resource == nil {
+			t.Errorf("Expected resource to be created")
+		} else if resource.ProviderConfig.IsSet() {
+			t.Errorf("Expected resourceProvider to be not set, got %+v", resource.ProviderConfig)
+		}
+
+		if !mockObject.InstanceProvider.IsSet() || mockObject.InstanceProvider.String() != provider.String() {
+			t.Errorf("Expected instanceProvider to be set correctly, got %+v", mockObject.InstanceProvider)
+		}
+	})
+
+	t.Run("both providers set should panic", func(t *testing.T) {
+		module.Resources = make(map[string]*Resource)
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("Expected panic when both providers are set")
+			} else if r != fmt.Sprintf("SetResourceInstanceDeposed for %s (instance key nil, deposed key deposedKey) got two providers (resourceProvider & instanceProvider) to write in state", mockAddr.Resource) {
+				t.Errorf("Unexpected panic message: got %v", r)
+			}
+		}()
+		module.SetResourceInstanceDeposed(mockAddr, "deposedKey", mockObject, provider, provider)
+	})
+
+	t.Run("neither provider set should panic", func(t *testing.T) {
+		module.Resources = make(map[string]*Resource)
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("Expected panic when neither provider is set")
+			} else if r != fmt.Sprintf("SetResourceInstanceDeposed for %s (instance key nil, deposed key deposedKey) cannot find a provider (resourceProvider / instanceProvider) to write in state", mockAddr.Resource) {
+				t.Errorf("Unexpected panic message: got %v", r)
+			}
+		}()
+		module.SetResourceInstanceDeposed(mockAddr, "deposedKey", mockObject, addrs.AbsProviderConfig{}, addrs.AbsProviderConfig{})
+	})
+}

--- a/internal/states/remote/state_test.go
+++ b/internal/states/remote/state_test.go
@@ -97,8 +97,11 @@ func TestStatePersist(t *testing.T) {
 						Status: states.ObjectReady,
 					},
 					addrs.AbsProviderConfig{
-						Provider: tfaddr.Provider{Namespace: "local"},
+						Provider: tfaddr.Provider{
+							Type:      "local",
+							Namespace: "namespace"},
 					},
+					addrs.AbsProviderConfig{},
 				)
 				return s, func() {}
 			},
@@ -135,7 +138,7 @@ func TestStatePersist(t *testing.T) {
 								},
 								"mode":     "managed",
 								"name":     "myfile",
-								"provider": `provider["/local/"]`,
+								"provider": `provider["/namespace/local"]`,
 								"type":     "local_file",
 							},
 						},
@@ -173,7 +176,7 @@ func TestStatePersist(t *testing.T) {
 								},
 								"mode":     "managed",
 								"name":     "myfile",
-								"provider": `provider["/local/"]`,
+								"provider": `provider["/namespace/local"]`,
 								"type":     "local_file",
 							},
 						},

--- a/internal/states/resource_test.go
+++ b/internal/states/resource_test.go
@@ -6,6 +6,8 @@
 package states
 
 import (
+	"fmt"
+	"github.com/opentofu/opentofu/internal/addrs"
 	"testing"
 )
 
@@ -58,4 +60,119 @@ func TestResourceInstanceDeposeCurrentObject(t *testing.T) {
 			t.Errorf("wrong len(deposedkey) %d; want %d", got, want)
 		}
 	})
+}
+
+func TestResolveInstanceProvider(t *testing.T) {
+	ik := addrs.StringKey("first")
+	absResourceAddr := mustAbsResourceAddr("null_resource.resource")
+	provider, _ := addrs.ParseAbsProviderConfigStr("provider[\"registry.opentofu.org/hashicorp/aws\"]")
+	providerSecond, _ := addrs.ParseAbsProviderConfigStr("provider[\"registry.opentofu.org/hashicorp/aws\"].second")
+	emptyProvider := addrs.AbsProviderConfig{}
+
+	// Test cases for the method
+	tests := []struct {
+		name                    string
+		resourceProvider        addrs.AbsProviderConfig
+		currentInstanceProvider addrs.AbsProviderConfig
+		deposedInstanceProvider addrs.AbsProviderConfig
+		expectPanic             bool
+		expectedPanicMessage    string
+		expectFromResource      bool
+	}{
+		{
+			name:                    "should return resourceProvider if set",
+			resourceProvider:        provider,
+			currentInstanceProvider: emptyProvider,
+			expectPanic:             false,
+			expectFromResource:      true,
+		},
+		{
+			name:                    "should return instanceProvider if resourceProvider is not set",
+			resourceProvider:        emptyProvider,
+			currentInstanceProvider: provider,
+			expectPanic:             false,
+			expectFromResource:      false,
+		},
+		{
+			name:                    "should return resourceProvider if set (even when deposed has deposedInstanceProvider set)",
+			resourceProvider:        provider,
+			currentInstanceProvider: emptyProvider,
+			deposedInstanceProvider: providerSecond,
+			expectPanic:             false,
+			expectFromResource:      true,
+		},
+		{
+			name:                    "should return current instanceProvider if resourceProvider is not set (even when deposed has deposedInstanceProvider set)",
+			resourceProvider:        emptyProvider,
+			currentInstanceProvider: provider,
+			deposedInstanceProvider: providerSecond,
+			expectPanic:             false,
+			expectFromResource:      false,
+		},
+		{
+			name:                    "should return instanceProvider from deposed instances",
+			resourceProvider:        emptyProvider,
+			currentInstanceProvider: emptyProvider,
+			deposedInstanceProvider: provider,
+			expectPanic:             false,
+			expectFromResource:      false,
+		},
+		{
+			name:                    "should panic if neither resourceProvider nor instanceProvider is set and no deposed instance provider found",
+			resourceProvider:        emptyProvider,
+			currentInstanceProvider: emptyProvider,
+			deposedInstanceProvider: emptyProvider,
+			expectPanic:             true,
+			expectedPanicMessage:    fmt.Sprintf("InstanceProvider for %s (instance key %s) failed to read provider from the state", absResourceAddr, ik),
+		},
+		{
+			name:                    "should panic if both resourceProvider and instanceProvider are set",
+			resourceProvider:        provider,
+			currentInstanceProvider: providerSecond,
+			expectPanic:             true,
+			expectedPanicMessage:    fmt.Sprintf("InstanceProvider for %s (instance key %s) found two providers in state for the instance", absResourceAddr, ik),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := &ResourceInstance{
+				Current: &ResourceInstanceObjectSrc{
+					InstanceProvider: tt.currentInstanceProvider,
+				},
+				Deposed: map[DeposedKey]*ResourceInstanceObjectSrc{"deposedKey": {
+					InstanceProvider: tt.deposedInstanceProvider,
+				}},
+			}
+
+			rs := &Resource{
+				Addr:           absResourceAddr,
+				ProviderConfig: tt.resourceProvider,
+				Instances:      map[addrs.InstanceKey]*ResourceInstance{ik: instance},
+			}
+
+			if tt.expectPanic {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("Expected panic, but got none")
+					} else if r != tt.expectedPanicMessage {
+						t.Errorf("Expected panic message '%s', but got '%v'", tt.expectedPanicMessage, r)
+					}
+				}()
+				rs.InstanceProvider(ik)
+			} else {
+				resultProvider, fromResource := rs.InstanceProvider(ik)
+
+				if !resultProvider.IsSet() {
+					t.Errorf("Expected provider to be set, but it was not")
+				}
+				if resultProvider.String() != provider.String() {
+					t.Errorf("Expected provider %v, but got %v", provider, resultProvider)
+				}
+				if fromResource != tt.expectFromResource {
+					t.Errorf("Expected fromResource to be %v, but got %v", tt.expectFromResource, fromResource)
+				}
+			}
+		})
+	}
 }

--- a/internal/states/state_test.go
+++ b/internal/states/state_test.go
@@ -47,6 +47,7 @@ func TestState(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 
 	childModule := state.EnsureModule(addrs.RootModuleInstance.Child("child", addrs.NoKey))
@@ -254,6 +255,7 @@ func TestStateDeepCopy(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	rootModule.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -288,6 +290,7 @@ func TestStateDeepCopy(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 
 	childModule := state.EnsureModule(addrs.RootModuleInstance.Child("child", addrs.NoKey))
@@ -326,6 +329,7 @@ func TestStateHasResourceInstanceObjects(t *testing.T) {
 						Status:    ObjectReady,
 					},
 					providerConfig,
+					addrs.AbsProviderConfig{},
 				)
 			},
 			true,
@@ -339,6 +343,7 @@ func TestStateHasResourceInstanceObjects(t *testing.T) {
 						Status:    ObjectReady,
 					},
 					childModuleProviderConfig,
+					addrs.AbsProviderConfig{},
 				)
 			},
 			true,
@@ -352,6 +357,7 @@ func TestStateHasResourceInstanceObjects(t *testing.T) {
 						Status:    ObjectTainted,
 					},
 					providerConfig,
+					addrs.AbsProviderConfig{},
 				)
 			},
 			true,
@@ -366,6 +372,7 @@ func TestStateHasResourceInstanceObjects(t *testing.T) {
 						Status:    ObjectTainted,
 					},
 					providerConfig,
+					addrs.AbsProviderConfig{},
 				)
 			},
 			true,
@@ -384,6 +391,7 @@ func TestStateHasResourceInstanceObjects(t *testing.T) {
 						Status:    ObjectTainted,
 					},
 					providerConfig,
+					addrs.AbsProviderConfig{},
 				)
 				s := ss.Lock()
 				delete(s.Modules[""].Resources["test.foo"].Instances, addrs.NoKey)
@@ -400,6 +408,7 @@ func TestStateHasResourceInstanceObjects(t *testing.T) {
 						Status:    ObjectReady,
 					},
 					providerConfig,
+					addrs.AbsProviderConfig{},
 				)
 			},
 			false, // data resources aren't managed resources, so they don't count
@@ -437,6 +446,7 @@ func TestState_MoveAbsResource(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	src := addrs.Resource{Mode: addrs.ManagedResourceMode, Type: "test_thing", Name: "foo"}.Absolute(addrs.RootModuleInstance)
 
@@ -504,6 +514,7 @@ func TestState_MoveAbsResource(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		cm.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -520,6 +531,7 @@ func TestState_MoveAbsResource(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 
 		src := addrs.Resource{Mode: addrs.ManagedResourceMode, Type: "test_thing", Name: "child"}.Absolute(srcModule)
@@ -569,6 +581,7 @@ func TestState_MoveAbsResource(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 
 		src := addrs.Resource{Mode: addrs.ManagedResourceMode, Type: "test_thing", Name: "child"}.Absolute(srcModule)
@@ -615,6 +628,7 @@ func TestState_MoveAbsResource(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 
 		src := addrs.Resource{Mode: addrs.ManagedResourceMode, Type: "test_thing", Name: "child"}.Absolute(srcModule)
@@ -660,6 +674,7 @@ func TestState_MaybeMoveAbsResource(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 
 	src := addrs.Resource{Mode: addrs.ManagedResourceMode, Type: "test_thing", Name: "foo"}.Absolute(addrs.RootModuleInstance)
@@ -700,6 +715,7 @@ func TestState_MoveAbsResourceInstance(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	// src resource from the state above
 	src := addrs.Resource{Mode: addrs.ManagedResourceMode, Type: "test_thing", Name: "foo"}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance)
@@ -770,6 +786,7 @@ func TestState_MaybeMoveAbsResourceInstance(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 
 	// For a little extra fun, let's go from a resource to a resource instance: test_thing.foo to test_thing.bar[1]
@@ -816,6 +833,7 @@ func TestState_MoveModuleInstance(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 
 	dstModule := addrs.RootModuleInstance.Child("child", addrs.IntKey(3))
@@ -863,6 +881,7 @@ func TestState_MaybeMoveModuleInstance(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 
 	dst := addrs.RootModuleInstance.Child("kinder", addrs.StringKey("b"))
@@ -905,6 +924,7 @@ func TestState_MoveModule(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 
 	moduleInstance := addrs.RootModuleInstance.Child("kinder", addrs.StringKey("a"))
@@ -924,6 +944,7 @@ func TestState_MoveModule(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 
 	_, mc := srcModule.Call()
@@ -977,6 +998,7 @@ func TestState_MoveModule(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 
 		_, dstMC := addrs.RootModule.Child("child").Call()

--- a/internal/tofu/context_apply.go
+++ b/internal/tofu/context_apply.go
@@ -54,7 +54,7 @@ func (c *Context) Apply(plan *plans.Plan, config *configs.Config) (*states.State
 		}
 	}
 
-	graph, operation, diags := c.applyGraph(plan, config, true)
+	graph, operation, diags := c.applyGraph(plan, config)
 	if diags.HasErrors() {
 		return nil, diags
 	}
@@ -119,7 +119,7 @@ Note that the -target option is not suitable for routine use, and is provided on
 	return newState, diags
 }
 
-func (c *Context) applyGraph(plan *plans.Plan, config *configs.Config, validate bool) (*Graph, walkOperation, tfdiags.Diagnostics) {
+func (c *Context) applyGraph(plan *plans.Plan, config *configs.Config) (*Graph, walkOperation, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	variables := InputValues{}
@@ -204,7 +204,7 @@ func (c *Context) ApplyGraphForUI(plan *plans.Plan, config *configs.Config) (*Gr
 
 	var diags tfdiags.Diagnostics
 
-	graph, _, moreDiags := c.applyGraph(plan, config, false)
+	graph, _, moreDiags := c.applyGraph(plan, config)
 	diags = diags.Append(moreDiags)
 	return graph, diags
 }

--- a/internal/tofu/context_apply2_test.go
+++ b/internal/tofu/context_apply2_test.go
@@ -46,6 +46,7 @@ func TestContext2Apply_createBeforeDestroy_deposedKeyPreApply(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceDeposed(
 		mustResourceInstanceAddr("aws_instance.bar").Resource,
@@ -55,6 +56,7 @@ func TestContext2Apply_createBeforeDestroy_deposedKeyPreApply(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	hook := new(MockHook)
@@ -229,7 +231,8 @@ resource "test_instance" "a" {
 		s.SetResourceInstanceCurrent(addrA, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{"id":"a","value":"old","type":"test"}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 
 		// test_instance.b depended on test_instance.a, and therefor should be
 		// destroyed before any changes to test_instance.a
@@ -237,7 +240,8 @@ resource "test_instance" "a" {
 			AttrsJSON:    []byte(`{"id":"b"}`),
 			Status:       states.ObjectReady,
 			Dependencies: []addrs.ConfigResource{addrA.ContainingResource().Config()},
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	ctx := testContext2(t, &ContextOpts{
@@ -279,6 +283,7 @@ func TestApply_updateDependencies(t *testing.T) {
 			},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		binAddr.Resource,
@@ -290,6 +295,7 @@ func TestApply_updateDependencies(t *testing.T) {
 			},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		bazAddr.Resource,
@@ -302,6 +308,7 @@ func TestApply_updateDependencies(t *testing.T) {
 			},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		barAddr.Resource,
@@ -310,6 +317,7 @@ func TestApply_updateDependencies(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","foo":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	m := testModuleInline(t, map[string]string{
@@ -429,6 +437,7 @@ resource "test_resource" "b" {
 				},
 				Status: states.ObjectReady,
 			}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{},
 		)
 	})
 
@@ -587,6 +596,7 @@ resource "test_object" "x" {
 			AttrsJSON: []byte(`{"test_string":"deposed"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -715,6 +725,7 @@ resource "test_object" "b" {
 			AttrsJSON: []byte(`{"test_string":"ok"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.b").Resource,
@@ -723,6 +734,7 @@ resource "test_object" "b" {
 			AttrsJSON: []byte(`{"test_string":"ok"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -1425,6 +1437,7 @@ resource "test_object" "x" {
 			AttrsJSON: []byte(`{"test_string":"ok"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -1475,6 +1488,7 @@ resource "test_object" "y" {
 			AttrsJSON: []byte(`{"test_string":"x"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -1631,6 +1645,7 @@ output "from_resource" {
 			AttrsJSON: []byte(`{"test_string":"wrong_val"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -1686,6 +1701,7 @@ output "from_resource" {
 			AttrsJSON: []byte(`{"test_string":"wrong val"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	mod.SetOutputValue("from_resource", cty.StringVal("wrong val"), false)
 
@@ -1756,6 +1772,7 @@ resource "test_object" "y" {
 			AttrsJSON: []byte(`{"test_string":"y"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -2268,6 +2285,7 @@ func TestContext2Apply_forgetOrphanAndDeposed(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceDeposed(
 		mustResourceInstanceAddr(addr).Resource,
@@ -2278,6 +2296,7 @@ func TestContext2Apply_forgetOrphanAndDeposed(t *testing.T) {
 			Dependencies: []addrs.ConfigResource{},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	ctx := testContext2(t, &ContextOpts{
 		Providers: map[addrs.Provider]providers.Factory{

--- a/internal/tofu/context_apply_checks_test.go
+++ b/internal/tofu/context_apply_checks_test.go
@@ -472,7 +472,8 @@ check "error" {
 					addrs.AbsProviderConfig{
 						Provider: addrs.NewDefaultProvider("test"),
 						Module:   addrs.RootModule,
-					})
+					},
+					addrs.AbsProviderConfig{})
 			}),
 			plan: map[string]checksTestingStatus{
 				"error": {
@@ -572,7 +573,8 @@ check "passing" {
 					addrs.AbsProviderConfig{
 						Provider: addrs.NewDefaultProvider("test"),
 						Module:   addrs.RootModule,
-					})
+					},
+					addrs.AbsProviderConfig{})
 			}),
 			plan: map[string]checksTestingStatus{
 				"passing": {

--- a/internal/tofu/context_apply_test.go
+++ b/internal/tofu/context_apply_test.go
@@ -462,6 +462,7 @@ func TestContext2Apply_resourceDependsOnModuleStateOnly(t *testing.T) {
 			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("module.child.aws_instance.child")},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	child := state.EnsureModule(addrs.RootModuleInstance.Child("child", addrs.NoKey))
 	child.SetResourceInstanceCurrent(
@@ -471,6 +472,7 @@ func TestContext2Apply_resourceDependsOnModuleStateOnly(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"child"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	{
@@ -944,6 +946,7 @@ func TestContext2Apply_createBeforeDestroy(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar", "require_new": "abc"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	ctx := testContext2(t, &ContextOpts{
 		Providers: map[addrs.Provider]providers.Factory{
@@ -1013,6 +1016,7 @@ func TestContext2Apply_createBeforeDestroyUpdate(t *testing.T) {
 			CreateBeforeDestroy: true,
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.bar").Resource,
@@ -1023,6 +1027,7 @@ func TestContext2Apply_createBeforeDestroyUpdate(t *testing.T) {
 			Dependencies:        []addrs.ConfigResource{fooAddr.ContainingResource().Config()},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -1072,6 +1077,7 @@ func TestContext2Apply_createBeforeDestroy_dependsNonCBD(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar", "require_new": "abc"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo").Resource,
@@ -1080,6 +1086,7 @@ func TestContext2Apply_createBeforeDestroy_dependsNonCBD(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo", "require_new": "abc"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -1133,6 +1140,7 @@ func TestContext2Apply_createBeforeDestroy_hook(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar", "require_new": "abc"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	var actual []cty.Value
@@ -1194,6 +1202,7 @@ func TestContext2Apply_createBeforeDestroy_deposedCount(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceDeposed(
 		mustResourceInstanceAddr("aws_instance.bar[0]").Resource,
@@ -1203,6 +1212,7 @@ func TestContext2Apply_createBeforeDestroy_deposedCount(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.bar[1]").Resource,
@@ -1211,6 +1221,7 @@ func TestContext2Apply_createBeforeDestroy_deposedCount(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceDeposed(
 		mustResourceInstanceAddr("aws_instance.bar[1]").Resource,
@@ -1220,6 +1231,7 @@ func TestContext2Apply_createBeforeDestroy_deposedCount(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -1271,6 +1283,7 @@ func TestContext2Apply_createBeforeDestroy_deposedOnly(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceDeposed(
 		mustResourceInstanceAddr("aws_instance.bar").Resource,
@@ -1280,6 +1293,7 @@ func TestContext2Apply_createBeforeDestroy_deposedOnly(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -1321,6 +1335,7 @@ func TestContext2Apply_destroyComputed(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo", "output": "value"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	ctx := testContext2(t, &ContextOpts{
 		Providers: map[addrs.Provider]providers.Factory{
@@ -1367,6 +1382,7 @@ func testContext2Apply_destroyDependsOn(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo").Resource,
@@ -1376,6 +1392,7 @@ func testContext2Apply_destroyDependsOn(t *testing.T) {
 			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("aws_instance.bar")},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	// Record the order we see Apply
@@ -1432,6 +1449,7 @@ func TestContext2Apply_destroyDependsOnStateOnly(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("aws"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -1457,6 +1475,7 @@ func TestContext2Apply_destroyDependsOnStateOnly(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("aws"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 
 	// It is possible for this to be racy, so we loop a number of times
@@ -1526,6 +1545,7 @@ func TestContext2Apply_destroyDependsOnStateOnlyModule(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("aws"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	child.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -1551,6 +1571,7 @@ func TestContext2Apply_destroyDependsOnStateOnlyModule(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("aws"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 
 	// It is possible for this to be racy, so we loop a number of times
@@ -1663,6 +1684,7 @@ func TestContext2Apply_destroyData(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"-"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/null"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	hook := &testHook{}
@@ -1722,6 +1744,7 @@ func TestContext2Apply_destroySkipsCBD(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.bar").Resource,
@@ -1730,6 +1753,7 @@ func TestContext2Apply_destroySkipsCBD(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -1768,6 +1792,7 @@ func TestContext2Apply_destroyModuleVarProviderConfig(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	ctx := testContext2(t, &ContextOpts{
 		Providers: map[addrs.Provider]providers.Factory{
@@ -1844,6 +1869,7 @@ func getContextForApply_destroyCrossProviders(t *testing.T, m *configs.Config, p
 			AttrsJSON: []byte(`{"id":"test"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	child := state.EnsureModule(addrs.RootModuleInstance.Child("child", addrs.NoKey))
 	child.SetResourceInstanceCurrent(
@@ -1853,6 +1879,7 @@ func getContextForApply_destroyCrossProviders(t *testing.T, m *configs.Config, p
 			AttrsJSON: []byte(`{"id": "vpc-aaabbb12", "value":"test"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -2199,6 +2226,7 @@ func TestContext2Apply_countDecrease(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","foo": "foo","type": "aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo[1]").Resource,
@@ -2207,6 +2235,7 @@ func TestContext2Apply_countDecrease(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","foo": "foo","type": "aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo[2]").Resource,
@@ -2215,6 +2244,7 @@ func TestContext2Apply_countDecrease(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar", "foo": "foo", "type": "aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -2249,6 +2279,7 @@ func TestContext2Apply_countDecreaseToOneX(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar", "foo": "foo", "type": "aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo[1]").Resource,
@@ -2257,6 +2288,7 @@ func TestContext2Apply_countDecreaseToOneX(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo[2]").Resource,
@@ -2265,6 +2297,7 @@ func TestContext2Apply_countDecreaseToOneX(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -2319,6 +2352,7 @@ func TestContext2Apply_countDecreaseToOneCorrupted(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar", "foo": "foo", "type": "aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo[0]").Resource,
@@ -2327,6 +2361,7 @@ func TestContext2Apply_countDecreaseToOneCorrupted(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"baz", "type": "aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -2395,6 +2430,7 @@ func TestContext2Apply_countTainted(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar", "type": "aws_instance", "foo": "foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	ctx := testContext2(t, &ContextOpts{
 		Providers: map[addrs.Provider]providers.Factory{
@@ -2652,6 +2688,7 @@ func TestContext2Apply_moduleDestroyOrder(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"a"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root := state.EnsureModule(addrs.RootModuleInstance)
 	root.SetResourceInstanceCurrent(
@@ -2662,6 +2699,7 @@ func TestContext2Apply_moduleDestroyOrder(t *testing.T) {
 			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("module.child.aws_instance.a")},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -2787,7 +2825,8 @@ func TestContext2Apply_orphanResource(t *testing.T) {
 		s.SetResourceInstanceCurrent(oneAddr.Instance(addrs.IntKey(0)), &states.ResourceInstanceObjectSrc{
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"foo"}`),
-		}, providerAddr)
+		}, providerAddr,
+			addrs.AbsProviderConfig{})
 	})
 
 	if state.String() != want.String() {
@@ -2859,6 +2898,7 @@ func TestContext2Apply_moduleOrphanInheritAlias(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -2922,6 +2962,7 @@ func TestContext2Apply_moduleOrphanProvider(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -2962,6 +3003,7 @@ func TestContext2Apply_moduleOrphanGrandchildProvider(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -3131,6 +3173,7 @@ func TestContext2Apply_moduleProviderCloseNested(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -3168,6 +3211,7 @@ func TestContext2Apply_moduleVarRefExisting(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo","foo":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -4453,6 +4497,7 @@ func TestContext2Apply_provisionerFail_createBeforeDestroy(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","require_new":"abc"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -4492,6 +4537,7 @@ func TestContext2Apply_error_createBeforeDestroy(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar", "require_new": "abc","type":"aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -4538,6 +4584,7 @@ func TestContext2Apply_errorDestroy_createBeforeDestroy(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar", "require_new": "abc"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -4596,6 +4643,7 @@ func TestContext2Apply_multiDepose_createBeforeDestroy(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	p.PlanResourceChangeFn = testDiffFn
@@ -4885,6 +4933,7 @@ func TestContext2Apply_provisionerDestroy(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","foo":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -4932,6 +4981,7 @@ func TestContext2Apply_provisionerDestroyFail(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","foo":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -4996,6 +5046,7 @@ func TestContext2Apply_provisionerDestroyFailContinue(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -5063,6 +5114,7 @@ func TestContext2Apply_provisionerDestroyFailContinueFail(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -5129,6 +5181,7 @@ func TestContext2Apply_provisionerDestroyTainted(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -5575,6 +5628,7 @@ func TestContext2Apply_outputDiffVars(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -5796,6 +5850,7 @@ func TestContext2Apply_destroyNestedModule(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -5834,6 +5889,7 @@ func TestContext2Apply_destroyDeeplyNestedModule(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -6233,6 +6289,7 @@ func TestContext2Apply_destroyOrphan(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	ctx := testContext2(t, &ContextOpts{
 		Providers: map[addrs.Provider]providers.Factory{
@@ -6271,6 +6328,7 @@ func TestContext2Apply_destroyTaintedProvisioner(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -6391,6 +6449,7 @@ func TestContext2Apply_errorDestroy(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
@@ -6523,6 +6582,7 @@ func TestContext2Apply_errorUpdateNullNew(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("aws"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
@@ -6573,6 +6633,7 @@ func TestContext2Apply_errorPartial(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","type":"aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -6657,6 +6718,7 @@ func TestContext2Apply_hookOrphan(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -6896,6 +6958,7 @@ func TestContext2Apply_taintX(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"baz","num": "2", "type": "aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -6942,6 +7005,7 @@ func TestContext2Apply_taintDep(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"baz","num": "2", "type": "aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.bar").Resource,
@@ -6951,6 +7015,7 @@ func TestContext2Apply_taintDep(t *testing.T) {
 			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("aws_instance.foo")},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -6993,6 +7058,7 @@ func TestContext2Apply_taintDepRequiresNew(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"baz","num": "2", "type": "aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.bar").Resource,
@@ -7002,6 +7068,7 @@ func TestContext2Apply_taintDepRequiresNew(t *testing.T) {
 			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("aws_instance.foo")},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -7159,6 +7226,7 @@ func TestContext2Apply_targetedDestroy(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetOutputValue("out", cty.StringVal("bar"), false)
 
@@ -7170,6 +7238,7 @@ func TestContext2Apply_targetedDestroy(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"i-bcd345"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -7244,6 +7313,7 @@ func TestContext2Apply_targetedDestroyCountDeps(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"i-bcd345"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.bar").Resource,
@@ -7253,6 +7323,7 @@ func TestContext2Apply_targetedDestroyCountDeps(t *testing.T) {
 			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("aws_instance.foo")},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -7294,6 +7365,7 @@ func TestContext2Apply_targetedDestroyModule(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"i-bcd345"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.bar").Resource,
@@ -7302,6 +7374,7 @@ func TestContext2Apply_targetedDestroyModule(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"i-abc123"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	child := state.EnsureModule(addrs.RootModuleInstance.Child("child", addrs.NoKey))
 	child.SetResourceInstanceCurrent(
@@ -7311,6 +7384,7 @@ func TestContext2Apply_targetedDestroyModule(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"i-bcd345"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	child.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.bar").Resource,
@@ -7319,6 +7393,7 @@ func TestContext2Apply_targetedDestroyModule(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"i-abc123"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -7377,31 +7452,37 @@ func TestContext2Apply_targetedDestroyCountIndex(t *testing.T) {
 		mustResourceInstanceAddr("aws_instance.foo[0]").Resource,
 		foo,
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo[1]").Resource,
 		foo,
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo[2]").Resource,
 		foo,
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.bar[0]").Resource,
 		bar,
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.bar[1]").Resource,
 		bar,
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.bar[2]").Resource,
 		bar,
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -7653,6 +7734,7 @@ func TestContext2Apply_targetedResourceOrphanModule(t *testing.T) {
 			AttrsJSON: []byte(`{"type":"aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -7873,6 +7955,7 @@ func TestContext2Apply_createBefore_depends(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("aws"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 
 	root.SetResourceInstanceCurrent(
@@ -7899,6 +7982,7 @@ func TestContext2Apply_createBefore_depends(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("aws"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -8001,6 +8085,7 @@ func TestContext2Apply_singleDestroy(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("aws"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 
 	root.SetResourceInstanceCurrent(
@@ -8027,6 +8112,7 @@ func TestContext2Apply_singleDestroy(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("aws"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -8211,6 +8297,7 @@ func TestContext2Apply_targetedWithTaintedInState(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"ifailedprovisioners"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -8344,6 +8431,7 @@ func TestContext2Apply_ignoreChangesWithDep(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"i-abc123","ami":"ami-abcd1234"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo[1]").Resource,
@@ -8352,6 +8440,7 @@ func TestContext2Apply_ignoreChangesWithDep(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"i-bcd234","ami":"i-bcd234"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_eip.foo[0]").Resource,
@@ -8370,6 +8459,7 @@ func TestContext2Apply_ignoreChangesWithDep(t *testing.T) {
 			},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_eip.foo[1]").Resource,
@@ -8388,6 +8478,7 @@ func TestContext2Apply_ignoreChangesWithDep(t *testing.T) {
 			},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -8814,6 +8905,7 @@ func TestContext2Apply_destroyWithLocals(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetOutputValue("name", cty.StringVal("test-bar"), false)
 
@@ -8909,6 +9001,7 @@ func TestContext2Apply_destroyWithProviders(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"].baz`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -8963,6 +9056,7 @@ func TestContext2Apply_providersFromState(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	aliasedProviderState := states.NewState()
@@ -8974,6 +9068,7 @@ func TestContext2Apply_providersFromState(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"].bar`),
+		addrs.AbsProviderConfig{},
 	)
 
 	moduleProviderState := states.NewState()
@@ -8985,6 +9080,7 @@ func TestContext2Apply_providersFromState(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`module.child.provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	for _, tc := range []struct {
@@ -9064,6 +9160,7 @@ func TestContext2Apply_plannedInterpolatedCount(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -9114,6 +9211,7 @@ func TestContext2Apply_plannedDestroyInterpolatedCount(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.a[1]").Resource,
@@ -9122,6 +9220,7 @@ func TestContext2Apply_plannedDestroyInterpolatedCount(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetOutputValue("out", cty.ListVal([]cty.Value{cty.StringVal("foo"), cty.StringVal("foo")}), false)
 
@@ -9177,6 +9276,7 @@ func TestContext2Apply_scaleInMultivarRef(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.two").Resource,
@@ -9185,6 +9285,7 @@ func TestContext2Apply_scaleInMultivarRef(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -9340,6 +9441,7 @@ func TestContext2Apply_issue19908(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 
@@ -9457,6 +9559,7 @@ func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("aws"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 
 		modB := state.EnsureModule(addrs.RootModuleInstance.Child("b", addrs.NoKey))
@@ -9474,6 +9577,7 @@ func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("aws"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 
 		aBefore, _ := plans.NewDynamicValue(
@@ -9596,6 +9700,7 @@ func TestContext2Apply_destroyDataCycle(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("null"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -9621,6 +9726,7 @@ func TestContext2Apply_destroyDataCycle(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -9636,6 +9742,7 @@ func TestContext2Apply_destroyDataCycle(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("null"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 
 	Providers := map[addrs.Provider]providers.Factory{
@@ -9743,6 +9850,7 @@ func TestContext2Apply_taintedDestroyFailure(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -9758,6 +9866,7 @@ func TestContext2Apply_taintedDestroyFailure(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -9773,6 +9882,7 @@ func TestContext2Apply_taintedDestroyFailure(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 
 	Providers := map[addrs.Provider]providers.Factory{
@@ -9948,6 +10058,7 @@ func TestContext2Apply_cbdCycle(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -9973,6 +10084,7 @@ func TestContext2Apply_cbdCycle(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -9988,6 +10100,7 @@ func TestContext2Apply_cbdCycle(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 
 	Providers := map[addrs.Provider]providers.Factory{
@@ -11220,7 +11333,8 @@ locals {
 			Dependencies:        []addrs.ConfigResource{},
 			CreateBeforeDestroy: true,
 		},
-		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_instance.a[1]").Resource,
@@ -11230,7 +11344,8 @@ locals {
 			Dependencies:        []addrs.ConfigResource{},
 			CreateBeforeDestroy: true,
 		},
-		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_instance.b").Resource,
@@ -11240,7 +11355,8 @@ locals {
 			Dependencies:        []addrs.ConfigResource{mustConfigResourceAddr("test_instance.a")},
 			CreateBeforeDestroy: true,
 		},
-		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_instance.c").Resource,
@@ -11253,7 +11369,8 @@ locals {
 			},
 			CreateBeforeDestroy: true,
 		},
-		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	p := testProvider("test")
@@ -12165,6 +12282,7 @@ resource "test_resource" "foo" {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 
@@ -12708,7 +12826,8 @@ func TestContext2Apply_errorRestorePrivateData(t *testing.T) {
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"foo"}`),
 			Private:   []byte("private"),
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	ctx := testContext2(t, &ContextOpts{
@@ -12753,7 +12872,8 @@ func TestContext2Apply_errorRestoreStatus(t *testing.T) {
 			AttrsJSON:    []byte(`{"test_string":"foo"}`),
 			Private:      []byte("private"),
 			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("test_object.b")},
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	ctx := testContext2(t, &ContextOpts{

--- a/internal/tofu/context_import_test.go
+++ b/internal/tofu/context_import_test.go
@@ -218,6 +218,7 @@ func TestContextImport_collision(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("aws"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 

--- a/internal/tofu/context_input_test.go
+++ b/internal/tofu/context_input_test.go
@@ -446,6 +446,7 @@ func TestContext2Input_dataSourceRequiresRefresh(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("null"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 

--- a/internal/tofu/context_plan.go
+++ b/internal/tofu/context_plan.go
@@ -277,7 +277,7 @@ func (c *Context) checkApplyGraph(plan *plans.Plan, config *configs.Config) tfdi
 		return nil
 	}
 	log.Println("[DEBUG] building apply graph to check for errors")
-	_, _, diags := c.applyGraph(plan, config, true)
+	_, _, diags := c.applyGraph(plan, config)
 	return diags
 }
 

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -80,7 +80,8 @@ resource "test_object" "a" {
 		s.SetResourceInstanceCurrent(addr, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{"arg":"previous_run"}`),
 			Status:    states.ObjectTainted,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	ctx := testContext2(t, &ContextOpts{
@@ -209,6 +210,7 @@ data "test_data_source" "foo" {
 			},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -251,7 +253,8 @@ output "out" {
 		s.SetResourceInstanceCurrent(mustResourceInstanceAddr(`data.test_object.a["old"]`), &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{"test_string":"foo"}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	ctx := testContext2(t, &ContextOpts{
@@ -375,6 +378,7 @@ resource "test_resource" "b" {
 				AttrsJSON: []byte(`{"id":"a"}`),
 				Status:    states.ObjectReady,
 			}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			mustResourceInstanceAddr(`module.mod["old"].test_resource.b`),
@@ -382,6 +386,7 @@ resource "test_resource" "b" {
 				AttrsJSON: []byte(`{"id":"b","value":"d"}`),
 				Status:    states.ObjectReady,
 			}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			oldDataAddr,
@@ -389,6 +394,7 @@ resource "test_resource" "b" {
 				AttrsJSON: []byte(`{"id":"d"}`),
 				Status:    states.ObjectReady,
 			}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{},
 		)
 	})
 
@@ -674,6 +680,7 @@ data "test_data_source" "a" {
 				AttrsJSON: []byte(`{"id":"boop","valid":false}`),
 				Status:    states.ObjectReady,
 			}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{},
 		)
 	})
 
@@ -886,6 +893,7 @@ resource "test_resource" "b" {
 				AttrsJSON: []byte(`{"id":"main","valid":false}`),
 				Status:    states.ObjectReady,
 			}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			managedAddrB,
@@ -893,6 +901,7 @@ resource "test_resource" "b" {
 				AttrsJSON: []byte(`{"id":"checker","valid":true}`),
 				Status:    states.ObjectReady,
 			}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{},
 		)
 	})
 
@@ -986,7 +995,10 @@ resource "test_object" "a" {
 		s.SetResourceInstanceCurrent(addr, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{"arg":"before"}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{},
+		)
+
 	})
 
 	ctx := testContext2(t, &ContextOpts{
@@ -1086,7 +1098,9 @@ resource "test_object" "a" {
 		s.SetResourceInstanceCurrent(addr, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{"arg":"before"}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{},
+		)
 	})
 
 	ctx := testContext2(t, &ContextOpts{
@@ -1226,7 +1240,8 @@ provider "test" {
 		s.SetResourceInstanceCurrent(addr, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{"test_string":"foo"}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	ctx := testContext2(t, &ContextOpts{
@@ -1262,7 +1277,8 @@ func TestContext2Plan_movedResourceBasic(t *testing.T) {
 		s.SetResourceInstanceCurrent(addrA, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	p := simpleMockProvider()
@@ -1326,11 +1342,13 @@ func TestContext2Plan_movedResourceCollision(t *testing.T) {
 		s.SetResourceInstanceCurrent(addrNoKey, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 		s.SetResourceInstanceCurrent(addrZeroKey, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	p := simpleMockProvider()
@@ -1432,11 +1450,13 @@ func TestContext2Plan_movedResourceCollisionDestroy(t *testing.T) {
 		s.SetResourceInstanceCurrent(addrNoKey, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 		s.SetResourceInstanceCurrent(addrZeroKey, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	p := simpleMockProvider()
@@ -1544,7 +1564,8 @@ func TestContext2Plan_movedResourceUntargeted(t *testing.T) {
 		s.SetResourceInstanceCurrent(addrA, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	p := simpleMockProvider()
@@ -1732,12 +1753,14 @@ resource "test_object" "b" {
 		s.SetResourceInstanceCurrent(addrA, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 		s.SetResourceInstanceCurrent(addrB, &states.ResourceInstanceObjectSrc{
 			// old_list is no longer in the schema
 			AttrsJSON: []byte(`{"old_list":["used to be","a list here"]}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	p := simpleMockProvider()
@@ -1790,7 +1813,8 @@ func TestContext2Plan_movedResourceRefreshOnly(t *testing.T) {
 		s.SetResourceInstanceCurrent(addrA, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	p := simpleMockProvider()
@@ -1862,7 +1886,8 @@ func TestContext2Plan_refreshOnlyMode(t *testing.T) {
 		s.SetResourceInstanceCurrent(addr, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{"arg":"before"}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	p := simpleMockProvider()
@@ -1998,7 +2023,8 @@ func TestContext2Plan_refreshOnlyMode_deposed(t *testing.T) {
 		s.SetResourceInstanceDeposed(addr, deposedKey, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{"arg":"before"}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	p := simpleMockProvider()
@@ -2135,11 +2161,13 @@ func TestContext2Plan_refreshOnlyMode_orphan(t *testing.T) {
 		s.SetResourceInstanceCurrent(addr.Instance(addrs.IntKey(0)), &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{"arg":"before"}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 		s.SetResourceInstanceCurrent(addr.Instance(addrs.IntKey(1)), &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{"arg":"before"}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	p := simpleMockProvider()
@@ -2352,6 +2380,7 @@ data "test_data_source" "foo" {
 			},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_instance.bar").Resource,
@@ -2366,6 +2395,7 @@ data "test_data_source" "foo" {
 			},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -2409,11 +2439,13 @@ func TestContext2Plan_forceReplace(t *testing.T) {
 		s.SetResourceInstanceCurrent(addrA, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 		s.SetResourceInstanceCurrent(addrB, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	p := simpleMockProvider()
@@ -2477,11 +2509,13 @@ func TestContext2Plan_forceReplaceIncompleteAddr(t *testing.T) {
 		s.SetResourceInstanceCurrent(addr0, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 		s.SetResourceInstanceCurrent(addr1, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	p := simpleMockProvider()
@@ -2597,6 +2631,7 @@ output "output" {
 			AttrsJSON: []byte(`{"id":"foo","value":"a"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	one.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr(`data.test_data_source.d`).Resource,
@@ -2605,6 +2640,7 @@ output "output" {
 			AttrsJSON: []byte(`{"id":"data"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	two.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr(`test_resource.x`).Resource,
@@ -2613,6 +2649,7 @@ output "output" {
 			AttrsJSON: []byte(`{"id":"foo","value":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	two.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr(`data.test_data_source.d`).Resource,
@@ -2621,6 +2658,7 @@ output "output" {
 			AttrsJSON: []byte(`{"id":"data"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -2688,7 +2726,8 @@ func TestContext2Plan_moduleExpandOrphansResourceInstance(t *testing.T) {
 		s.SetResourceInstanceCurrent(addrNoKey, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	p := simpleMockProvider()
@@ -2863,7 +2902,8 @@ resource "test_resource" "a" {
 			s.SetResourceInstanceCurrent(mustResourceInstanceAddr("test_resource.a"), &states.ResourceInstanceObjectSrc{
 				AttrsJSON: []byte(`{"value":"boop","output":"blorp"}`),
 				Status:    states.ObjectReady,
-			}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+			}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+				addrs.AbsProviderConfig{})
 		})
 		_, diags := ctx.Plan(m, state, &PlanOpts{
 			Mode: plans.RefreshOnlyMode,
@@ -2932,7 +2972,8 @@ resource "test_resource" "a" {
 			s.SetResourceInstanceCurrent(mustResourceInstanceAddr("test_resource.a"), &states.ResourceInstanceObjectSrc{
 				AttrsJSON: []byte(`{"value":"boop","output":"blorp"}`),
 				Status:    states.ObjectReady,
-			}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+			}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+				addrs.AbsProviderConfig{})
 		})
 		p.ReadResourceFn = func(req providers.ReadResourceRequest) (resp providers.ReadResourceResponse) {
 			newVal, err := cty.Transform(req.PriorState, func(path cty.Path, v cty.Value) (cty.Value, error) {
@@ -2985,7 +3026,8 @@ resource "test_resource" "a" {
 			s.SetResourceInstanceCurrent(mustResourceInstanceAddr("test_resource.a"), &states.ResourceInstanceObjectSrc{
 				AttrsJSON: []byte(`{"value":"boop","output":"blorp"}`),
 				Status:    states.ObjectReady,
-			}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+			}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+				addrs.AbsProviderConfig{})
 		})
 		p.ReadResourceFn = func(req providers.ReadResourceRequest) (resp providers.ReadResourceResponse) {
 			newVal, err := cty.Transform(req.PriorState, func(path cty.Path, v cty.Value) (cty.Value, error) {
@@ -3657,6 +3699,7 @@ resource "test_object" "b" {
 				Status:    states.ObjectReady,
 			},
 			mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			mustResourceInstanceAddr("test_object.b[0]"),
@@ -3665,6 +3708,7 @@ resource "test_object" "b" {
 				Status:    states.ObjectReady,
 			},
 			mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{},
 		)
 	})
 	for _, configuration := range configurations {
@@ -3746,7 +3790,8 @@ data "test_object" "a" {
 		s.SetResourceInstanceCurrent(mustResourceInstanceAddr(`data.test_object.a`), &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{"id":"old","obj":[{"args":["string"]}]}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	ctx := testContext2(t, &ContextOpts{
@@ -3787,6 +3832,7 @@ resource "test_object" "b" {
 			Dependencies: []addrs.ConfigResource{mustResourceInstanceAddr("test_object.b").ContainingResource().Config()},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.b").Resource,
@@ -3795,6 +3841,7 @@ resource "test_object" "b" {
 			AttrsJSON: []byte(`{"test_string":"b"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -3908,6 +3955,7 @@ resource "test_object" "b" {
 			Dependencies: []addrs.ConfigResource{},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.a[0]").Resource,
@@ -3917,6 +3965,7 @@ resource "test_object" "b" {
 			Dependencies: []addrs.ConfigResource{},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -4087,6 +4136,7 @@ output "out" {
 			Dependencies: []addrs.ConfigResource{},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	mod.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.a[1]").Resource,
@@ -4096,6 +4146,7 @@ output "out" {
 			Dependencies: []addrs.ConfigResource{},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -4230,6 +4281,7 @@ resource "test_object" "a" {
 			Dependencies: []addrs.ConfigResource{},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	ctx := testContext2(t, &ContextOpts{
 		Providers: map[addrs.Provider]providers.Factory{
@@ -5344,6 +5396,7 @@ import {
 			AttrsJSON: []byte(`{"test_string":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
@@ -6781,7 +6834,8 @@ func TestContext2Plan_removedResourceBasic(t *testing.T) {
 		s.SetResourceInstanceCurrent(addr, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 		s.SetResourceInstanceDeposed(
 			mustResourceInstanceAddr(addr.String()),
 			desposedKey,
@@ -6791,6 +6845,7 @@ func TestContext2Plan_removedResourceBasic(t *testing.T) {
 				Dependencies: []addrs.ConfigResource{},
 			},
 			mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{},
 		)
 	})
 
@@ -6861,7 +6916,8 @@ func TestContext2Plan_removedModuleBasic(t *testing.T) {
 		s.SetResourceInstanceCurrent(addr, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 		s.SetResourceInstanceDeposed(
 			mustResourceInstanceAddr(addr.String()),
 			desposedKey,
@@ -6871,6 +6927,7 @@ func TestContext2Plan_removedModuleBasic(t *testing.T) {
 				Dependencies: []addrs.ConfigResource{},
 			},
 			mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{},
 		)
 	})
 
@@ -6943,11 +7000,13 @@ func TestContext2Plan_removedModuleForgetsAllInstances(t *testing.T) {
 		s.SetResourceInstanceCurrent(addrFirst, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 		s.SetResourceInstanceCurrent(addrSecond, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	p := simpleMockProvider()
@@ -7009,11 +7068,13 @@ func TestContext2Plan_removedResourceForgetsAllInstances(t *testing.T) {
 		s.SetResourceInstanceCurrent(addrFirst, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 		s.SetResourceInstanceCurrent(addrSecond, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	p := simpleMockProvider()
@@ -7077,7 +7138,8 @@ func TestContext2Plan_removedResourceInChildModuleFromParentModule(t *testing.T)
 		s.SetResourceInstanceCurrent(addr, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	p := simpleMockProvider()
@@ -7139,7 +7201,8 @@ func TestContext2Plan_removedResourceInChildModuleFromChildModule(t *testing.T) 
 		s.SetResourceInstanceCurrent(addr, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	p := simpleMockProvider()
@@ -7202,7 +7265,8 @@ func TestContext2Plan_removedResourceInGrandchildModuleFromRootModule(t *testing
 		s.SetResourceInstanceCurrent(addr, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	p := simpleMockProvider()
@@ -7265,7 +7329,8 @@ func TestContext2Plan_removedChildModuleForgetsResourceInGrandchildModule(t *tes
 		s.SetResourceInstanceCurrent(addr, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	p := simpleMockProvider()
@@ -7333,7 +7398,8 @@ func TestContext2Plan_movedAndRemovedResourceAtTheSameTime(t *testing.T) {
 		s.SetResourceInstanceCurrent(addrA, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	p := simpleMockProvider()
@@ -7398,7 +7464,8 @@ func TestContext2Plan_removedResourceButResourceBlockStillExists(t *testing.T) {
 		s.SetResourceInstanceCurrent(addr, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	p := simpleMockProvider()
@@ -7447,7 +7514,8 @@ func TestContext2Plan_removedResourceButResourceBlockStillExistsInChildModule(t 
 		s.SetResourceInstanceCurrent(addr, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	p := simpleMockProvider()
@@ -7496,7 +7564,8 @@ func TestContext2Plan_removedModuleButModuleBlockStillExists(t *testing.T) {
 		s.SetResourceInstanceCurrent(addr, &states.ResourceInstanceObjectSrc{
 			AttrsJSON: []byte(`{}`),
 			Status:    states.ObjectReady,
-		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`))
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{})
 	})
 
 	p := simpleMockProvider()

--- a/internal/tofu/context_plan_test.go
+++ b/internal/tofu/context_plan_test.go
@@ -95,6 +95,8 @@ func TestContext2Plan_createBefore_deposed(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"baz","type":"aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceDeposed(
 		mustResourceInstanceAddr("aws_instance.foo").Resource,
@@ -104,6 +106,8 @@ func TestContext2Plan_createBefore_deposed(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -810,6 +814,7 @@ func TestContext2Plan_moduleOrphans(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"baz"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -882,6 +887,7 @@ func TestContext2Plan_moduleOrphansWithProvisioner(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"top","type":"aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	child1 := state.EnsureModule(addrs.RootModuleInstance.Child("parent", addrs.NoKey).Child("child1", addrs.NoKey))
 	child1.SetResourceInstanceCurrent(
@@ -891,6 +897,7 @@ func TestContext2Plan_moduleOrphansWithProvisioner(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"baz","type":"aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	child2 := state.EnsureModule(addrs.RootModuleInstance.Child("parent", addrs.NoKey).Child("child2", addrs.NoKey))
 	child2.SetResourceInstanceCurrent(
@@ -900,6 +907,7 @@ func TestContext2Plan_moduleOrphansWithProvisioner(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"baz","type":"aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -1376,6 +1384,7 @@ func TestContext2Plan_preventDestroy_bad(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"i-abc123"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -1415,6 +1424,7 @@ func TestContext2Plan_preventDestroy_good(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"i-abc123","type":"aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -1446,6 +1456,8 @@ func TestContext2Plan_preventDestroy_countBad(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"i-abc123"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo[1]").Resource,
@@ -1454,6 +1466,8 @@ func TestContext2Plan_preventDestroy_countBad(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"i-abc345"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -1502,6 +1516,8 @@ func TestContext2Plan_preventDestroy_countGood(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"i-abc123"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo[1]").Resource,
@@ -1510,6 +1526,8 @@ func TestContext2Plan_preventDestroy_countGood(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"i-abc345"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -1553,6 +1571,8 @@ func TestContext2Plan_preventDestroy_countGoodNoChange(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"i-abc123","current":"0","type":"aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -1584,6 +1604,8 @@ func TestContext2Plan_preventDestroy_destroyPlan(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"i-abc123"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -1981,6 +2003,8 @@ func TestContext2Plan_dataResourceBecomesComputed(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"i-abc123","foo":"baz"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -2603,6 +2627,8 @@ func TestContext2Plan_countDecreaseToOne(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","foo":"foo","type":"aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo[1]").Resource,
@@ -2611,6 +2637,8 @@ func TestContext2Plan_countDecreaseToOne(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo[2]").Resource,
@@ -2619,6 +2647,8 @@ func TestContext2Plan_countDecreaseToOne(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -2703,6 +2733,8 @@ func TestContext2Plan_countIncreaseFromNotSet(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","type":"aws_instance","foo":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -2780,6 +2812,8 @@ func TestContext2Plan_countIncreaseFromOne(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","foo":"foo","type":"aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -2863,6 +2897,8 @@ func TestContext2Plan_countIncreaseFromOneCorrupted(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","foo":"foo","type":"aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo[0]").Resource,
@@ -2871,6 +2907,8 @@ func TestContext2Plan_countIncreaseFromOneCorrupted(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","foo":"foo","type":"aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -2971,6 +3009,8 @@ func TestContext2Plan_countIncreaseWithSplatReference(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","name":"foo 0"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo[1]").Resource,
@@ -2979,6 +3019,8 @@ func TestContext2Plan_countIncreaseWithSplatReference(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","name":"foo 1"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.bar[0]").Resource,
@@ -2987,6 +3029,8 @@ func TestContext2Plan_countIncreaseWithSplatReference(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","foo_name":"foo 0"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.bar[1]").Resource,
@@ -2995,6 +3039,8 @@ func TestContext2Plan_countIncreaseWithSplatReference(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","foo_name":"foo 1"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -3135,6 +3181,8 @@ func TestContext2Plan_destroy(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.two").Resource,
@@ -3143,6 +3191,8 @@ func TestContext2Plan_destroy(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"baz"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -3196,6 +3246,8 @@ func TestContext2Plan_moduleDestroy(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 	child := state.EnsureModule(addrs.RootModuleInstance.Child("child", addrs.NoKey))
 	child.SetResourceInstanceCurrent(
@@ -3205,6 +3257,8 @@ func TestContext2Plan_moduleDestroy(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -3258,6 +3312,8 @@ func TestContext2Plan_moduleDestroyCycle(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"a"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 	bModule := state.EnsureModule(addrs.RootModuleInstance.Child("b_module", addrs.NoKey))
 	bModule.SetResourceInstanceCurrent(
@@ -3267,6 +3323,8 @@ func TestContext2Plan_moduleDestroyCycle(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"b"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -3320,6 +3378,8 @@ func TestContext2Plan_moduleDestroyMultivar(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar0"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 	child.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo[1]").Resource,
@@ -3328,6 +3388,8 @@ func TestContext2Plan_moduleDestroyMultivar(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar1"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -3441,6 +3503,8 @@ func TestContext2Plan_diffVar(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","num":"2","type":"aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -3556,6 +3620,8 @@ func TestContext2Plan_orphan(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -3638,6 +3704,8 @@ func TestContext2Plan_state(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 	ctx := testContext2(t, &ContextOpts{
 		Providers: map[addrs.Provider]providers.Factory{
@@ -3740,6 +3808,7 @@ func TestContext2Plan_requiresReplace(t *testing.T) {
 			AttrsJSON: []byte(`{"v":"hello"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -3798,6 +3867,8 @@ func TestContext2Plan_taint(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","num":"2","type":"aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.bar").Resource,
@@ -3806,6 +3877,8 @@ func TestContext2Plan_taint(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"baz"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -3884,6 +3957,8 @@ func TestContext2Plan_taintIgnoreChanges(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo","vars":"foo","type":"aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -3948,6 +4023,8 @@ func TestContext2Plan_taintDestroyInterpolatedCountRace(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","type":"aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo[1]").Resource,
@@ -3956,6 +4033,8 @@ func TestContext2Plan_taintDestroyInterpolatedCountRace(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","type":"aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo[2]").Resource,
@@ -3964,6 +4043,8 @@ func TestContext2Plan_taintDestroyInterpolatedCountRace(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","type":"aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	for i := 0; i < 100; i++ {
@@ -4186,6 +4267,8 @@ func TestContext2Plan_targetedOrphan(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"i-789xyz"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.nottargeted").Resource,
@@ -4194,6 +4277,8 @@ func TestContext2Plan_targetedOrphan(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"i-abc123"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -4252,6 +4337,8 @@ func TestContext2Plan_targetedModuleOrphan(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"i-789xyz"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 	child.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.nottargeted").Resource,
@@ -4260,6 +4347,8 @@ func TestContext2Plan_targetedModuleOrphan(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"i-abc123"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -4408,6 +4497,8 @@ func TestContext2Plan_targetedOverTen(t *testing.T) {
 				AttrsJSON: []byte(attrs),
 			},
 			mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+			addrs.AbsProviderConfig{},
 		)
 	}
 
@@ -4506,6 +4597,8 @@ func TestContext2Plan_ignoreChanges(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","ami":"ami-abcd1234","type":"aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -4578,6 +4671,8 @@ func TestContext2Plan_ignoreChangesWildcard(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","ami":"ami-abcd1234","instance":"t2.micro","type":"aws_instance","foo":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -4643,6 +4738,7 @@ func TestContext2Plan_ignoreChangesInMap(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	m := testModule(t, "plan-ignore-changes-in-map")
@@ -4700,6 +4796,8 @@ func TestContext2Plan_ignoreChangesSensitive(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"bar","ami":"ami-abcd1234","type":"aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -5091,6 +5189,8 @@ func TestContext2Plan_ignoreChangesWithFlatmaps(t *testing.T) {
 			}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -5162,6 +5262,8 @@ func TestContext2Plan_resourceNestedCount(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo0","type":"aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo[1]").Resource,
@@ -5170,6 +5272,8 @@ func TestContext2Plan_resourceNestedCount(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo1","type":"aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.bar[0]").Resource,
@@ -5179,6 +5283,8 @@ func TestContext2Plan_resourceNestedCount(t *testing.T) {
 			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("aws_instance.foo")},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.bar[1]").Resource,
@@ -5188,6 +5294,8 @@ func TestContext2Plan_resourceNestedCount(t *testing.T) {
 			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("aws_instance.foo")},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.baz[0]").Resource,
@@ -5197,6 +5305,8 @@ func TestContext2Plan_resourceNestedCount(t *testing.T) {
 			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("aws_instance.bar")},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.baz[1]").Resource,
@@ -5206,6 +5316,8 @@ func TestContext2Plan_resourceNestedCount(t *testing.T) {
 			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("aws_instance.bar")},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 	ctx := testContext2(t, &ContextOpts{
 		Providers: map[addrs.Provider]providers.Factory{
@@ -5827,6 +5939,8 @@ resource "aws_instance" "foo" {
 			AttrsJSON: []byte(`{"id":"child","type":"aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 	state.EnsureModule(addrs.RootModuleInstance.Child("mod", addrs.IntKey(1))).SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo").Resource,
@@ -5835,6 +5949,8 @@ resource "aws_instance" "foo" {
 			AttrsJSON: []byte(`{"id":"child","type":"aws_instance"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	p := testProvider("aws")
@@ -6113,7 +6229,9 @@ data "test_data_source" "foo" {}
 			Status:    states.ObjectReady,
 			AttrsJSON: []byte(`{"id":"data_id", "foo":"foo"}`),
 		},
-		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -6162,7 +6280,9 @@ resource "test_instance" "b" {
 			AttrsJSON:    []byte(`{"id":"a0"}`),
 			Dependencies: []addrs.ConfigResource{},
 		},
-		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_instance.b").Resource,
@@ -6171,7 +6291,9 @@ resource "test_instance" "b" {
 			AttrsJSON:    []byte(`{"id":"b"}`),
 			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("test_instance.a")},
 		},
-		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -6458,7 +6580,9 @@ resource "test_instance" "a" {
 			AttrsJSON:    []byte(`{"id":"a","type":"test_instance"}`),
 			Dependencies: []addrs.ConfigResource{},
 		},
-		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -6630,7 +6754,9 @@ resource "test_instance" "a" {
 			AttrsJSON:    []byte(`{"id":"a","data":"foo"}`),
 			Dependencies: []addrs.ConfigResource{},
 		},
-		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -6693,7 +6819,9 @@ resource "test_instance" "a" {
 			AttrsJSON:    []byte(`{"id":"a","data":"foo"}`),
 			Dependencies: []addrs.ConfigResource{},
 		},
-		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -6751,7 +6879,9 @@ resource "test_instance" "a" {
 			AttrsJSON:    []byte(`{"id":"orig","data":"orig"}`),
 			Dependencies: []addrs.ConfigResource{},
 		},
-		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -6790,7 +6920,9 @@ resource "test_instance" "a" {
 			AttrsJSON:    []byte(`{"id":"a","data":"foo"}`),
 			Dependencies: []addrs.ConfigResource{},
 		},
-		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+
+		addrs.AbsProviderConfig{},
 	)
 
 	// the provider for this data source is no longer in the config, but that
@@ -6803,6 +6935,7 @@ resource "test_instance" "a" {
 			Dependencies: []addrs.ConfigResource{},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/local/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -6860,6 +6993,7 @@ resource "test_resource" "foo" {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 	plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))

--- a/internal/tofu/context_refresh_test.go
+++ b/internal/tofu/context_refresh_test.go
@@ -36,6 +36,7 @@ func TestContext2Refresh(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo","foo":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{
@@ -98,6 +99,7 @@ func TestContext2Refresh_dynamicAttr(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 
@@ -1166,6 +1168,7 @@ func TestContext2Refresh_orphanModule(t *testing.T) {
 			},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	child := state.EnsureModule(addrs.RootModuleInstance.Child("child", addrs.NoKey))
 	child.SetResourceInstanceCurrent(
@@ -1176,6 +1179,7 @@ func TestContext2Refresh_orphanModule(t *testing.T) {
 			Dependencies: []addrs.ConfigResource{{Module: addrs.Module{"module.grandchild"}}},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	grandchild := state.EnsureModule(addrs.RootModuleInstance.Child("child", addrs.NoKey).Child("grandchild", addrs.NoKey))
 	testSetResourceInstanceCurrent(grandchild, "aws_instance.baz", `{"id":"i-cde345"}`, `provider["registry.opentofu.org/hashicorp/aws"]`)
@@ -1305,6 +1309,7 @@ func TestContext2Refresh_schemaUpgradeFlatmap(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 
@@ -1387,6 +1392,7 @@ func TestContext2Refresh_schemaUpgradeJSON(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 
@@ -1524,6 +1530,7 @@ func TestRefresh_updateLifecycle(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("aws"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 
 	m := testModuleInline(t, map[string]string{
@@ -1577,6 +1584,7 @@ func TestContext2Refresh_dataSourceOrphan(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	p := testProvider("test")
 	p.ReadDataSourceFn = func(req providers.ReadDataSourceRequest) (resp providers.ReadDataSourceResponse) {
@@ -1667,6 +1675,7 @@ resource "test_resource" "foo" {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 
 	ctx := testContext2(t, &ContextOpts{

--- a/internal/tofu/evaluate_test.go
+++ b/internal/tofu/evaluate_test.go
@@ -246,6 +246,7 @@ func TestEvaluatorGetResource(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	}).SyncWrapper()
 
@@ -420,6 +421,7 @@ func TestEvaluatorGetResource_changes(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	}).SyncWrapper()
 

--- a/internal/tofu/graph_builder_apply_test.go
+++ b/internal/tofu/graph_builder_apply_test.go
@@ -104,6 +104,7 @@ func TestApplyGraphBuilder_depCbd(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"A"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.B").Resource,
@@ -113,6 +114,7 @@ func TestApplyGraphBuilder_depCbd(t *testing.T) {
 			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("test_object.A")},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	b := &ApplyGraphBuilder{
@@ -270,6 +272,7 @@ func TestApplyGraphBuilder_destroyStateOnly(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	child.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.B").Resource,
@@ -279,6 +282,7 @@ func TestApplyGraphBuilder_destroyStateOnly(t *testing.T) {
 			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("module.child.test_object.A")},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	b := &ApplyGraphBuilder{
@@ -332,6 +336,7 @@ func TestApplyGraphBuilder_destroyCount(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"B"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.B").Resource,
@@ -341,6 +346,7 @@ func TestApplyGraphBuilder_destroyCount(t *testing.T) {
 			Dependencies: []addrs.ConfigResource{addrA.ContainingResource().Config()},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	b := &ApplyGraphBuilder{
@@ -393,6 +399,7 @@ func TestApplyGraphBuilder_moduleDestroy(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	modB := state.EnsureModule(addrs.RootModuleInstance.Child("B", addrs.NoKey))
 	modB.SetResourceInstanceCurrent(
@@ -403,6 +410,7 @@ func TestApplyGraphBuilder_moduleDestroy(t *testing.T) {
 			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("module.A.test_object.foo")},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	b := &ApplyGraphBuilder{
@@ -511,6 +519,7 @@ func TestApplyGraphBuilder_updateFromOrphan(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -536,6 +545,7 @@ func TestApplyGraphBuilder_updateFromOrphan(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 
 	b := &ApplyGraphBuilder{
@@ -614,6 +624,7 @@ func TestApplyGraphBuilder_updateFromCBDOrphan(t *testing.T) {
 			CreateBeforeDestroy: true,
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		addrs.Resource{
@@ -636,6 +647,7 @@ func TestApplyGraphBuilder_updateFromCBDOrphan(t *testing.T) {
 			},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	b := &ApplyGraphBuilder{
@@ -686,6 +698,7 @@ func TestApplyGraphBuilder_orphanedWithProvider(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"A"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"].foo`),
+		addrs.AbsProviderConfig{},
 	)
 
 	b := &ApplyGraphBuilder{

--- a/internal/tofu/node_data_destroy_test.go
+++ b/internal/tofu/node_data_destroy_test.go
@@ -28,6 +28,7 @@ func TestNodeDataDestroyExecute(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	ctx := &MockEvalContext{
 		StateState: state.SyncWrapper(),

--- a/internal/tofu/node_resource_abstract_instance_test.go
+++ b/internal/tofu/node_resource_abstract_instance_test.go
@@ -131,9 +131,9 @@ func TestNodeAbstractResourceInstanceProvider(t *testing.T) {
 				// function. (This would not be valid for some other functions.)
 				Addr: test.Addr,
 				NodeAbstractResource: NodeAbstractResource{
-					Addr:                         test.Addr.ConfigResource(),
-					Config:                       test.Config,
-					storedResourceProviderConfig: test.StoredProviderConfig,
+					Addr:                 test.Addr.ConfigResource(),
+					Config:               test.Config,
+					storedProviderConfig: ExactProvider{isResourceProvider: true, provider: test.StoredProviderConfig},
 				},
 			}
 			got := node.Provider()

--- a/internal/tofu/node_resource_abstract_instance_test.go
+++ b/internal/tofu/node_resource_abstract_instance_test.go
@@ -187,3 +187,71 @@ aws_instance.foo:
   provider = provider["registry.opentofu.org/hashicorp/aws"]
 	`)
 }
+
+func TestNodeAbstractResourceInstance_ResolvedProvider(t *testing.T) {
+	provider := mustProviderConfig(`provider["registry.opentofu.org/hashicorp/null"]`)
+
+	tests := []struct {
+		name                     string
+		ResolvedResourceProvider addrs.AbsProviderConfig
+		ResolvedInstanceProvider addrs.AbsProviderConfig
+		expectPanic              bool
+		expectedPanicMessage     string
+	}{
+		{
+			name:                     "ResolvedResourceProvider is set",
+			ResolvedResourceProvider: provider,
+			ResolvedInstanceProvider: addrs.AbsProviderConfig{},
+		},
+		{
+			name:                     "ResolvedInstanceProvider is set",
+			ResolvedResourceProvider: addrs.AbsProviderConfig{},
+			ResolvedInstanceProvider: provider,
+		},
+		{
+			name:                     "Panic if both providers are set",
+			ResolvedResourceProvider: provider,
+			ResolvedInstanceProvider: provider,
+			expectPanic:              true,
+			expectedPanicMessage:     "ResolvedProvider for null_resource.resource has a provider set for the resource and the resource's instance",
+		},
+		{
+			name:                     "Panic if no provider set",
+			ResolvedResourceProvider: addrs.AbsProviderConfig{},
+			ResolvedInstanceProvider: addrs.AbsProviderConfig{},
+			expectPanic:              true,
+			expectedPanicMessage:     "ResolvedProvider for null_resource.resource cannot get a provider",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			n := &NodeAbstractResourceInstance{
+				NodeAbstractResource: NodeAbstractResource{
+					ResolvedResourceProvider: test.ResolvedResourceProvider,
+				},
+				ResolvedInstanceProvider: test.ResolvedInstanceProvider,
+				Addr:                     mustResourceInstanceAddr("null_resource.resource"),
+			}
+
+			if test.expectPanic {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("Expected panic, but got none")
+					} else if r != test.expectedPanicMessage {
+						t.Errorf("Expected panic message '%s', but got '%v'", test.expectedPanicMessage, r)
+					}
+				}()
+				n.ResolvedProvider()
+			} else {
+				result := n.ResolvedProvider()
+				if !result.IsSet() {
+					t.Errorf("Expected provider to be set, but it was not")
+				}
+				if result.String() != provider.String() {
+					t.Errorf("Expected provider %v, but got %v", provider, result)
+				}
+			}
+		})
+	}
+}

--- a/internal/tofu/node_resource_deposed_test.go
+++ b/internal/tofu/node_resource_deposed_test.go
@@ -261,6 +261,7 @@ func initMockEvalContext(resourceAddrs string, deposedKey states.DeposedKey) (*M
 			AttrsJSON: []byte(`{"id":"bar"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	schema := providers.ProviderSchema{

--- a/internal/tofu/node_resource_plan_orphan_test.go
+++ b/internal/tofu/node_resource_plan_orphan_test.go
@@ -108,6 +108,7 @@ func TestNodeResourcePlanOrphan_Execute(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 
 		schema := providers.ProviderSchema{
@@ -188,6 +189,7 @@ func TestNodeResourcePlanOrphanExecute_alreadyDeleted(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	refreshState := state.DeepCopy()
 	prevRunState := state.DeepCopy()
@@ -270,6 +272,7 @@ func TestNodeResourcePlanOrphanExecute_deposed(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
+		addrs.AbsProviderConfig{},
 	)
 	refreshState := state.DeepCopy()
 	prevRunState := state.DeepCopy()

--- a/internal/tofu/opentf_test.go
+++ b/internal/tofu/opentf_test.go
@@ -155,6 +155,7 @@ func testSetResourceInstanceCurrent(module *states.Module, resource, attrsJson, 
 			AttrsJSON: []byte(attrsJson),
 		},
 		mustProviderConfig(provider),
+		addrs.AbsProviderConfig{},
 	)
 }
 
@@ -168,6 +169,7 @@ func testSetResourceInstanceTainted(module *states.Module, resource, attrsJson, 
 			AttrsJSON: []byte(attrsJson),
 		},
 		mustProviderConfig(provider),
+		addrs.AbsProviderConfig{},
 	)
 }
 

--- a/internal/tofu/test_context_test.go
+++ b/internal/tofu/test_context_test.go
@@ -65,7 +65,8 @@ run "test_case" {
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("test"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 			}),
 			provider: &MockProvider{
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
@@ -123,7 +124,8 @@ run "test_case" {
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("test"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 			}),
 			provider: &MockProvider{
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
@@ -183,7 +185,8 @@ run "test_case" {
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("test"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 			}),
 			variables: InputValues{
 				"value": {
@@ -240,7 +243,8 @@ run "test_case" {
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("test"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 			}),
 			provider: &MockProvider{
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
@@ -303,7 +307,8 @@ run "test_case" {
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("test"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 			}),
 			provider: &MockProvider{
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
@@ -403,7 +408,8 @@ run "test_case" {
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("test"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 			}),
 			plan: &plans.Plan{
 				Changes: &plans.Changes{
@@ -479,7 +485,8 @@ run "test_case" {
 					addrs.AbsProviderConfig{
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("test"),
-					})
+					},
+					addrs.AbsProviderConfig{})
 			}),
 			plan: &plans.Plan{
 				Changes: &plans.Changes{

--- a/internal/tofu/transform_destroy_cbd_test.go
+++ b/internal/tofu/transform_destroy_cbd_test.go
@@ -105,6 +105,7 @@ func TestCBDEdgeTransformer(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"A"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.B").Resource,
@@ -114,6 +115,7 @@ func TestCBDEdgeTransformer(t *testing.T) {
 			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("test_object.A")},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	g := cbdTestGraph(t, "transform-destroy-cbd-edge-basic", changes, state)
@@ -166,6 +168,7 @@ func TestCBDEdgeTransformerMulti(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"A"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.B").Resource,
@@ -174,6 +177,7 @@ func TestCBDEdgeTransformerMulti(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"B"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.C").Resource,
@@ -186,6 +190,7 @@ func TestCBDEdgeTransformerMulti(t *testing.T) {
 			},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	g := cbdTestGraph(t, "transform-destroy-cbd-edge-multi", changes, state)
@@ -242,6 +247,7 @@ func TestCBDEdgeTransformer_depNonCBDCount(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"A"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.B[0]").Resource,
@@ -251,6 +257,7 @@ func TestCBDEdgeTransformer_depNonCBDCount(t *testing.T) {
 			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("test_object.A")},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.B[1]").Resource,
@@ -260,6 +267,7 @@ func TestCBDEdgeTransformer_depNonCBDCount(t *testing.T) {
 			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("test_object.A")},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	g := cbdTestGraph(t, "transform-cbd-destroy-edge-count", changes, state)
@@ -319,6 +327,7 @@ func TestCBDEdgeTransformer_depNonCBDCountBoth(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"A"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.A[1]").Resource,
@@ -327,6 +336,7 @@ func TestCBDEdgeTransformer_depNonCBDCountBoth(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"A"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.B[0]").Resource,
@@ -336,6 +346,7 @@ func TestCBDEdgeTransformer_depNonCBDCountBoth(t *testing.T) {
 			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("test_object.A")},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.B[1]").Resource,
@@ -345,6 +356,7 @@ func TestCBDEdgeTransformer_depNonCBDCountBoth(t *testing.T) {
 			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("test_object.A")},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	g := cbdTestGraph(t, "transform-cbd-destroy-edge-both-count", changes, state)

--- a/internal/tofu/transform_destroy_edge_test.go
+++ b/internal/tofu/transform_destroy_edge_test.go
@@ -33,6 +33,7 @@ func TestDestroyEdgeTransformer_basic(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"A"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.B").Resource,
@@ -42,6 +43,7 @@ func TestDestroyEdgeTransformer_basic(t *testing.T) {
 			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("test_object.A")},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	if err := (&AttachStateTransformer{State: state}).Transform(&g); err != nil {
 		t.Fatal(err)
@@ -74,6 +76,7 @@ func TestDestroyEdgeTransformer_multi(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"A"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.B").Resource,
@@ -83,6 +86,7 @@ func TestDestroyEdgeTransformer_multi(t *testing.T) {
 			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("test_object.A")},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.C").Resource,
@@ -95,6 +99,7 @@ func TestDestroyEdgeTransformer_multi(t *testing.T) {
 			},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	if err := (&AttachStateTransformer{State: state}).Transform(&g); err != nil {
@@ -143,6 +148,7 @@ func TestDestroyEdgeTransformer_module(t *testing.T) {
 			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("module.child.test_object.b")},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	child.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.b").Resource,
@@ -151,6 +157,7 @@ func TestDestroyEdgeTransformer_module(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"b","test_string":"x"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	if err := (&AttachStateTransformer{State: state}).Transform(&g); err != nil {
@@ -186,6 +193,7 @@ func TestDestroyEdgeTransformer_moduleOnly(t *testing.T) {
 				AttrsJSON: []byte(`{"id":"a"}`),
 			},
 			mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{},
 		)
 		child.SetResourceInstanceCurrent(
 			mustResourceInstanceAddr("test_object.b").Resource,
@@ -197,6 +205,7 @@ func TestDestroyEdgeTransformer_moduleOnly(t *testing.T) {
 				},
 			},
 			mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{},
 		)
 		child.SetResourceInstanceCurrent(
 			mustResourceInstanceAddr("test_object.c").Resource,
@@ -209,6 +218,7 @@ func TestDestroyEdgeTransformer_moduleOnly(t *testing.T) {
 				},
 			},
 			mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+			addrs.AbsProviderConfig{},
 		)
 	}
 
@@ -269,6 +279,7 @@ func TestDestroyEdgeTransformer_destroyThenUpdate(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"A","test_string":"old"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.B").Resource,
@@ -278,6 +289,7 @@ func TestDestroyEdgeTransformer_destroyThenUpdate(t *testing.T) {
 			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("test_object.A")},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	if err := (&AttachStateTransformer{State: state}).Transform(&g); err != nil {
@@ -367,6 +379,7 @@ func TestPruneUnusedNodesTransformer_rootModuleOutputValues(t *testing.T) {
 				AttrsJSON: []byte(`{}`),
 			},
 			providerCfgAddr,
+			addrs.AbsProviderConfig{},
 		)
 	})
 	changes := plans.NewChanges()
@@ -461,6 +474,7 @@ func TestDestroyEdgeTransformer_noOp(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"A"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.B").Resource,
@@ -470,6 +484,7 @@ func TestDestroyEdgeTransformer_noOp(t *testing.T) {
 			Dependencies: []addrs.ConfigResource{mustConfigResourceAddr("test_object.A")},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("test_object.C").Resource,
@@ -480,6 +495,7 @@ func TestDestroyEdgeTransformer_noOp(t *testing.T) {
 				mustConfigResourceAddr("test_object.B")},
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	if err := (&AttachStateTransformer{State: state}).Transform(&g); err != nil {
@@ -540,6 +556,7 @@ func TestDestroyEdgeTransformer_dataDependsOn(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"A"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	if err := (&AttachStateTransformer{State: state}).Transform(&g); err != nil {

--- a/internal/tofu/transform_import_state_test.go
+++ b/internal/tofu/transform_import_state_test.go
@@ -102,7 +102,7 @@ func TestGraphNodeImportStateSubExecute(t *testing.T) {
 			Name: "foo",
 		}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
 		State: importedResource,
-		ResolvedProvider: addrs.AbsProviderConfig{
+		ResolvedResourceProvider: addrs.AbsProviderConfig{
 			Provider: addrs.NewDefaultProvider("aws"),
 			Module:   addrs.RootModule,
 		},
@@ -164,7 +164,7 @@ func TestGraphNodeImportStateSubExecuteNull(t *testing.T) {
 			Name: "foo",
 		}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
 		State: importedResource,
-		ResolvedProvider: addrs.AbsProviderConfig{
+		ResolvedResourceProvider: addrs.AbsProviderConfig{
 			Provider: addrs.NewDefaultProvider("aws"),
 			Module:   addrs.RootModule,
 		},

--- a/internal/tofu/transform_orphan_count_test.go
+++ b/internal/tofu/transform_orphan_count_test.go
@@ -23,6 +23,7 @@ func TestOrphanResourceCountTransformer(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo[0]").Resource,
@@ -31,6 +32,7 @@ func TestOrphanResourceCountTransformer(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo[2]").Resource,
@@ -39,6 +41,7 @@ func TestOrphanResourceCountTransformer(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	g := Graph{Path: addrs.RootModuleInstance}
@@ -74,6 +77,7 @@ func TestOrphanResourceCountTransformer_zero(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo[0]").Resource,
@@ -82,6 +86,7 @@ func TestOrphanResourceCountTransformer_zero(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo[2]").Resource,
@@ -90,6 +95,7 @@ func TestOrphanResourceCountTransformer_zero(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	g := Graph{Path: addrs.RootModuleInstance}
@@ -125,6 +131,7 @@ func TestOrphanResourceCountTransformer_oneIndex(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo[0]").Resource,
@@ -133,6 +140,7 @@ func TestOrphanResourceCountTransformer_oneIndex(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo[1]").Resource,
@@ -141,6 +149,7 @@ func TestOrphanResourceCountTransformer_oneIndex(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	g := Graph{Path: addrs.RootModuleInstance}
@@ -176,6 +185,7 @@ func TestOrphanResourceCountTransformer_deposed(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo[0]").Resource,
@@ -184,6 +194,7 @@ func TestOrphanResourceCountTransformer_deposed(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceCurrent(
 		mustResourceInstanceAddr("aws_instance.foo[1]").Resource,
@@ -192,6 +203,7 @@ func TestOrphanResourceCountTransformer_deposed(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 	root.SetResourceInstanceDeposed(
 		mustResourceInstanceAddr("aws_instance.foo[2]").Resource,
@@ -201,6 +213,7 @@ func TestOrphanResourceCountTransformer_deposed(t *testing.T) {
 			AttrsJSON: []byte(`{"id":"foo"}`),
 		},
 		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+		addrs.AbsProviderConfig{},
 	)
 
 	g := Graph{Path: addrs.RootModuleInstance}
@@ -246,6 +259,7 @@ func TestOrphanResourceCountTransformer_ForEachEdgesAdded(t *testing.T) {
 				Status: states.ObjectReady,
 			},
 			mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+			addrs.AbsProviderConfig{},
 		)
 
 		// NoKey'd resource
@@ -262,6 +276,7 @@ func TestOrphanResourceCountTransformer_ForEachEdgesAdded(t *testing.T) {
 				Status: states.ObjectReady,
 			},
 			mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+			addrs.AbsProviderConfig{},
 		)
 	})
 

--- a/internal/tofu/transform_orphan_resource_test.go
+++ b/internal/tofu/transform_orphan_resource_test.go
@@ -35,6 +35,7 @@ func TestOrphanResourceInstanceTransformer(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("aws"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 
 		// The orphan
@@ -54,6 +55,7 @@ func TestOrphanResourceInstanceTransformer(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("aws"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 
 		// A deposed orphan should not be handled by this transformer
@@ -74,6 +76,7 @@ func TestOrphanResourceInstanceTransformer(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 
@@ -123,6 +126,7 @@ func TestOrphanResourceInstanceTransformer_countGood(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("aws"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -140,6 +144,7 @@ func TestOrphanResourceInstanceTransformer_countGood(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("aws"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 
@@ -188,6 +193,7 @@ func TestOrphanResourceInstanceTransformer_countBad(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("aws"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -205,6 +211,7 @@ func TestOrphanResourceInstanceTransformer_countBad(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("aws"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 
@@ -253,6 +260,7 @@ func TestOrphanResourceInstanceTransformer_modules(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("aws"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 		s.SetResourceInstanceCurrent(
 			addrs.Resource{
@@ -270,6 +278,7 @@ func TestOrphanResourceInstanceTransformer_modules(t *testing.T) {
 				Provider: addrs.NewDefaultProvider("aws"),
 				Module:   addrs.RootModule,
 			},
+			addrs.AbsProviderConfig{},
 		)
 	})
 

--- a/internal/tofu/transform_provider_test.go
+++ b/internal/tofu/transform_provider_test.go
@@ -7,6 +7,7 @@ package tofu
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -518,3 +519,216 @@ module.child.module.grandchild.aws_instance.baz
   provider["registry.opentofu.org/hashicorp/aws"].foo
 provider["registry.opentofu.org/hashicorp/aws"].foo
 `
+
+func Test_graphNodeProxyProvider_Expanded_noForEachOnModules(t *testing.T) {
+	// This test describes the simplest scenario, where we don't have for_each on the providers in none of the modules:
+	// root provider -> second provider -> third provider
+	rootProvider := NodeApplyableProvider{
+		NodeAbstractProvider: &NodeAbstractProvider{
+			Addr: mustProviderConfig(`provider["registry.opentofu.org/hashicorp/null"]`),
+		},
+	}
+
+	SecondLevelProxy := graphNodeProxyProvider{
+		addr:    mustProviderConfig(`module.second.provider["registry.opentofu.org/hashicorp/null"]`),
+		targets: map[addrs.InstanceKey]GraphNodeProvider{addrs.NoKey: &rootProvider},
+	}
+
+	thirdLevelProxy := graphNodeProxyProvider{
+		addr:    mustProviderConfig(`module.second.module.third.provider["registry.opentofu.org/hashicorp/null"]`),
+		targets: map[addrs.InstanceKey]GraphNodeProvider{addrs.NoKey: &SecondLevelProxy},
+	}
+
+	want := []distinguishableProvider{
+		{
+			moduleIdentifier: []addrs.ModuleInstanceStep{
+				{
+					Name: "second",
+				},
+				{
+					Name: "third",
+				},
+			},
+			resourceIdentifier: addrs.NoKey,
+			concreteProvider:   rootProvider,
+		},
+	}
+
+	t.Run("graphNodeProxyProvider_Expanded - no for_each on providers at all", func(t *testing.T) {
+		n := thirdLevelProxy
+		got := n.Expanded()
+
+		if len(got) != 1 {
+			t.Errorf("expected to get a single provider as a result")
+		}
+
+		if isDistinguishableProviderEqual(got[0], want[0]) {
+			t.Errorf("Got DistinguishableProvider %v, want %v", got[0], want[0])
+		}
+	})
+}
+
+func Test_graphNodeProxyProvider_Expanded_ForEachInSecondModule(t *testing.T) {
+	// This test describes the scenario where we have a for_each on the providers in the second module:
+	// root provider.first, provider.second -> second provider.first, provider.second (for_each) -> third.first / third.second
+	rootProviderFirst := NodeApplyableProvider{
+		NodeAbstractProvider: &NodeAbstractProvider{
+			Addr: mustProviderConfig(`provider["registry.opentofu.org/hashicorp/null"].first`),
+		},
+	}
+
+	rootProviderSecond := NodeApplyableProvider{
+		NodeAbstractProvider: &NodeAbstractProvider{
+			Addr: mustProviderConfig(`provider["registry.opentofu.org/hashicorp/null"].second`),
+		},
+	}
+
+	SecondLevelProxyFirst := graphNodeProxyProvider{
+		addr:    mustProviderConfig(`module.second.provider["registry.opentofu.org/hashicorp/null"].first`),
+		targets: map[addrs.InstanceKey]GraphNodeProvider{addrs.NoKey: &rootProviderFirst},
+	}
+
+	SecondLevelProxySecond := graphNodeProxyProvider{
+		addr:    mustProviderConfig(`module.second.provider["registry.opentofu.org/hashicorp/null"].second`),
+		targets: map[addrs.InstanceKey]GraphNodeProvider{addrs.NoKey: &rootProviderSecond},
+	}
+
+	thirdLevelProxy := graphNodeProxyProvider{
+		addr:    mustProviderConfig(`module.second.module.third.provider["registry.opentofu.org/hashicorp/null"]`),
+		targets: map[addrs.InstanceKey]GraphNodeProvider{addrs.StringKey("first"): &SecondLevelProxyFirst, addrs.StringKey("second"): &SecondLevelProxySecond},
+	}
+
+	want := []distinguishableProvider{
+		{
+			moduleIdentifier: []addrs.ModuleInstanceStep{
+				{
+					Name: "second",
+				},
+				{
+					Name:        "third",
+					InstanceKey: addrs.StringKey("first"),
+				},
+			},
+			resourceIdentifier: addrs.NoKey,
+			concreteProvider:   rootProviderFirst,
+		},
+		{
+			moduleIdentifier: []addrs.ModuleInstanceStep{
+				{
+					Name: "second",
+				},
+				{
+					Name:        "third",
+					InstanceKey: addrs.StringKey("second"),
+				},
+			},
+			resourceIdentifier: addrs.NoKey,
+			concreteProvider:   rootProviderSecond,
+		},
+	}
+
+	t.Run("graphNodeProxyProvider_Expanded - for_each on providers in the second module", func(t *testing.T) {
+		n := thirdLevelProxy
+		got := n.Expanded()
+
+		if len(got) != 2 {
+			t.Errorf("expected to get a single provider as a result")
+		}
+
+		matchingCounter := 0
+		for _, resultProvider := range got {
+			for _, wantProvider := range want {
+				if isDistinguishableProviderEqual(resultProvider, wantProvider) {
+					matchingCounter = matchingCounter + 1
+				}
+			}
+		}
+
+		if matchingCounter != 2 {
+			t.Errorf("recieved providers are not matching to the expected providers")
+		}
+	})
+}
+
+func Test_graphNodeProxyProvider_Expanded_ForEachInRootModule(t *testing.T) {
+	// This test describes the scenario where we have a for_each on the providers in the third module:
+	// root provider.first, provider.second (for_each) -> second provider.first / provider.second  -> third.first / third.second
+	rootProviderFirst := NodeApplyableProvider{
+		NodeAbstractProvider: &NodeAbstractProvider{
+			Addr: mustProviderConfig(`provider["registry.opentofu.org/hashicorp/null"].first`),
+		},
+	}
+
+	rootProviderSecond := NodeApplyableProvider{
+		NodeAbstractProvider: &NodeAbstractProvider{
+			Addr: mustProviderConfig(`provider["registry.opentofu.org/hashicorp/null"].second`),
+		},
+	}
+
+	SecondLevelProxy := graphNodeProxyProvider{
+		addr:    mustProviderConfig(`module.second.provider["registry.opentofu.org/hashicorp/null"].first`),
+		targets: map[addrs.InstanceKey]GraphNodeProvider{addrs.StringKey("first"): &rootProviderFirst, addrs.StringKey("second"): &rootProviderSecond},
+	}
+
+	thirdLevelProxy := graphNodeProxyProvider{
+		addr:    mustProviderConfig(`module.second.module.third.provider["registry.opentofu.org/hashicorp/null"]`),
+		targets: map[addrs.InstanceKey]GraphNodeProvider{addrs.NoKey: &SecondLevelProxy},
+	}
+
+	want := []distinguishableProvider{
+		{
+			moduleIdentifier: []addrs.ModuleInstanceStep{
+				{
+					Name:        "second",
+					InstanceKey: addrs.StringKey("first"),
+				},
+				{
+					Name: "third",
+				},
+			},
+			resourceIdentifier: addrs.NoKey,
+			concreteProvider:   rootProviderFirst,
+		},
+		{
+			moduleIdentifier: []addrs.ModuleInstanceStep{
+				{
+					Name:        "second",
+					InstanceKey: addrs.StringKey("second"),
+				},
+				{
+					Name: "third",
+				},
+			},
+			resourceIdentifier: addrs.NoKey,
+			concreteProvider:   rootProviderSecond,
+		},
+	}
+
+	t.Run("graphNodeProxyProvider_Expanded - for_each on providers in the root module", func(t *testing.T) {
+		n := thirdLevelProxy
+		got := n.Expanded()
+
+		if len(got) != 2 {
+			t.Errorf("expected to get a single provider as a result")
+		}
+
+		matchingCounter := 0
+		for _, resultProvider := range got {
+			for _, wantProvider := range want {
+				if isDistinguishableProviderEqual(resultProvider, wantProvider) {
+					matchingCounter = matchingCounter + 1
+				}
+			}
+		}
+
+		if matchingCounter != 2 {
+			t.Errorf("recieved providers are not matching to the expected providers")
+		}
+	})
+}
+
+func isDistinguishableProviderEqual(got distinguishableProvider, want distinguishableProvider) bool {
+	return !reflect.DeepEqual(got.moduleIdentifier, want.moduleIdentifier) ||
+		!reflect.DeepEqual(got.resourceIdentifier, want.resourceIdentifier) ||
+		got.concreteProvider.Name() != want.concreteProvider.Name()
+}

--- a/internal/tofumigrate/tofumigrate_test.go
+++ b/internal/tofumigrate/tofumigrate_test.go
@@ -57,6 +57,7 @@ func TestMigrateStateProviderAddresses(t *testing.T) {
 							AttrsJSON: []byte(`{}`),
 						},
 						makeRootProviderAddr("registry.terraform.io/hashicorp/random"),
+						addrs.AbsProviderConfig{},
 					)
 					s.SetResourceInstanceCurrent(
 						mustParseInstAddr("aws_instance.example"),
@@ -65,6 +66,7 @@ func TestMigrateStateProviderAddresses(t *testing.T) {
 							AttrsJSON: []byte(`{}`),
 						},
 						makeRootProviderAddr("registry.terraform.io/hashicorp/aws"),
+						addrs.AbsProviderConfig{},
 					)
 				}),
 			},
@@ -76,6 +78,7 @@ func TestMigrateStateProviderAddresses(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					makeRootProviderAddr("registry.opentofu.org/hashicorp/random"),
+					addrs.AbsProviderConfig{},
 				)
 				s.SetResourceInstanceCurrent(
 					mustParseInstAddr("aws_instance.example"),
@@ -84,6 +87,7 @@ func TestMigrateStateProviderAddresses(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					makeRootProviderAddr("registry.opentofu.org/hashicorp/aws"),
+					addrs.AbsProviderConfig{},
 				)
 			}),
 		},
@@ -99,6 +103,7 @@ func TestMigrateStateProviderAddresses(t *testing.T) {
 							AttrsJSON: []byte(`{}`),
 						},
 						makeRootProviderAddr("registry.terraform.io/hashicorp/random"),
+						addrs.AbsProviderConfig{},
 					)
 					s.SetResourceInstanceCurrent(
 						mustParseInstAddr("aws_instance.example"),
@@ -107,6 +112,7 @@ func TestMigrateStateProviderAddresses(t *testing.T) {
 							AttrsJSON: []byte(`{}`),
 						},
 						makeRootProviderAddr("registry.terraform.io/hashicorp/aws"),
+						addrs.AbsProviderConfig{},
 					)
 				}),
 			},
@@ -118,6 +124,7 @@ func TestMigrateStateProviderAddresses(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					makeRootProviderAddr("registry.opentofu.org/hashicorp/random"),
+					addrs.AbsProviderConfig{},
 				)
 				s.SetResourceInstanceCurrent(
 					mustParseInstAddr("aws_instance.example"),
@@ -126,6 +133,7 @@ func TestMigrateStateProviderAddresses(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					makeRootProviderAddr("registry.terraform.io/hashicorp/aws"),
+					addrs.AbsProviderConfig{},
 				)
 			}),
 		},
@@ -141,6 +149,7 @@ func TestMigrateStateProviderAddresses(t *testing.T) {
 							AttrsJSON: []byte(`{}`),
 						},
 						makeRootProviderAddr("registry.opentofu.org/hashicorp/random"),
+						addrs.AbsProviderConfig{},
 					)
 					s.SetResourceInstanceCurrent(
 						mustParseInstAddr("aws_instance.example"),
@@ -149,6 +158,7 @@ func TestMigrateStateProviderAddresses(t *testing.T) {
 							AttrsJSON: []byte(`{}`),
 						},
 						makeRootProviderAddr("registry.opentofu.org/hashicorp/aws"),
+						addrs.AbsProviderConfig{},
 					)
 				}),
 			},
@@ -160,6 +170,7 @@ func TestMigrateStateProviderAddresses(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					makeRootProviderAddr("registry.opentofu.org/hashicorp/random"),
+					addrs.AbsProviderConfig{},
 				)
 				s.SetResourceInstanceCurrent(
 					mustParseInstAddr("aws_instance.example"),
@@ -168,6 +179,7 @@ func TestMigrateStateProviderAddresses(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					makeRootProviderAddr("registry.opentofu.org/hashicorp/aws"),
+					addrs.AbsProviderConfig{},
 				)
 			}),
 		},
@@ -183,6 +195,7 @@ func TestMigrateStateProviderAddresses(t *testing.T) {
 							AttrsJSON: []byte(`{}`),
 						},
 						makeRootProviderAddr("registry.terraform.io/hashicorp/random"),
+						addrs.AbsProviderConfig{},
 					)
 					s.SetResourceInstanceCurrent(
 						mustParseInstAddr("aws_instance.example"),
@@ -191,6 +204,7 @@ func TestMigrateStateProviderAddresses(t *testing.T) {
 							AttrsJSON: []byte(`{}`),
 						},
 						makeRootProviderAddr("registry.terraform.io/hashicorp/aws"),
+						addrs.AbsProviderConfig{},
 					)
 				}),
 			},
@@ -202,6 +216,7 @@ func TestMigrateStateProviderAddresses(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					makeRootProviderAddr("registry.opentofu.org/hashicorp/random"),
+					addrs.AbsProviderConfig{},
 				)
 				s.SetResourceInstanceCurrent(
 					mustParseInstAddr("aws_instance.example"),
@@ -210,6 +225,7 @@ func TestMigrateStateProviderAddresses(t *testing.T) {
 						AttrsJSON: []byte(`{}`),
 					},
 					makeRootProviderAddr("registry.opentofu.org/hashicorp/aws"),
+					addrs.AbsProviderConfig{},
 				)
 			}),
 		},


### PR DESCRIPTION
Fixing breaking UT for https://github.com/opentofu/opentofu/pull/1963
Most of the changes are related to changing the `SetResourceInstanceCurrent()` function.

## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [ ] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [ ] I have not used an AI coding assistant to create this PR.
- [ ] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [ ] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
