### PR TITLE
#300 - Support in graph for each on providers in resources and modules: Add UT

### DIFF
--- a/internal/states/module_test.go
+++ b/internal/states/module_test.go
@@ -1,0 +1,151 @@
+package states
+
+import (
+	"fmt"
+	"github.com/opentofu/opentofu/internal/addrs"
+	"testing"
+)
+
+func TestModule_SetResourceInstanceCurrent_setProviders(t *testing.T) {
+	var (
+		resourceInstance, _ = addrs.ParseAbsResourceInstanceStr("null_resource.resource")
+		mockAddr            = resourceInstance.Resource
+		provider, _         = addrs.ParseAbsProviderConfigStr("provider[\"registry.opentofu.org/hashicorp/aws\"]")
+		mockObject          = &ResourceInstanceObjectSrc{
+			SchemaVersion: 1,
+			AttrsJSON:     []byte(`{"hello": "world"}`),
+		}
+	)
+
+	module := &Module{
+		Resources: make(map[string]*Resource),
+	}
+
+	t.Run("valid - resourceProvider set, instanceProvider not set", func(t *testing.T) {
+		module.Resources = make(map[string]*Resource)
+		module.SetResourceInstanceCurrent(mockAddr, mockObject, provider, addrs.AbsProviderConfig{})
+
+		resource := module.Resources[mockAddr.Resource.String()]
+		if resource == nil {
+			t.Errorf("Expected resource to be created")
+		} else if !resource.ProviderConfig.IsSet() || resource.ProviderConfig.String() != provider.String() {
+			t.Errorf("Expected resourceProvider to be set correctly, got %+v", resource.ProviderConfig)
+		}
+
+		if mockObject.InstanceProvider.IsSet() {
+			t.Errorf("Expected instanceProvider to be not set, got %+v", mockObject.InstanceProvider)
+		}
+	})
+
+	t.Run("valid - instanceProvider set, resourceProvider not set", func(t *testing.T) {
+		module.Resources = make(map[string]*Resource)
+		module.SetResourceInstanceCurrent(mockAddr, mockObject, addrs.AbsProviderConfig{}, provider)
+
+		resource := module.Resources[mockAddr.Resource.String()]
+		if resource == nil {
+			t.Errorf("Expected resource to be created")
+		} else if resource.ProviderConfig.IsSet() {
+			t.Errorf("Expected resourceProvider to be not set, got %+v", resource.ProviderConfig)
+		}
+
+		if !mockObject.InstanceProvider.IsSet() || mockObject.InstanceProvider.String() != provider.String() {
+			t.Errorf("Expected instanceProvider to be set correctly, got %+v", mockObject.InstanceProvider)
+		}
+	})
+
+	t.Run("both providers set should panic", func(t *testing.T) {
+		module.Resources = make(map[string]*Resource)
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("Expected panic when both providers are set")
+			} else if r != fmt.Sprintf("SetResourceInstanceCurrent for %s (instance key nil) got two providers (resourceProvider & instanceProvider) to write in state", mockAddr.Resource) {
+				t.Errorf("Unexpected panic message: got %v", r)
+			}
+		}()
+		module.SetResourceInstanceCurrent(mockAddr, mockObject, provider, provider)
+	})
+
+	t.Run("neither provider set should panic", func(t *testing.T) {
+		module.Resources = make(map[string]*Resource)
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("Expected panic when neither provider is set")
+			} else if r != fmt.Sprintf("SetResourceInstanceCurrent for %s (instance key nil) cannot find a provider (resourceProvider / instanceProvider) to write in state", mockAddr.Resource) {
+				t.Errorf("Unexpected panic message: got %v", r)
+			}
+		}()
+		module.SetResourceInstanceCurrent(mockAddr, mockObject, addrs.AbsProviderConfig{}, addrs.AbsProviderConfig{})
+	})
+}
+
+func TestModule_SetResourceInstanceDeposed_setProviders(t *testing.T) {
+	var (
+		resourceInstance, _ = addrs.ParseAbsResourceInstanceStr("null_resource.resource")
+		mockAddr            = resourceInstance.Resource
+		provider, _         = addrs.ParseAbsProviderConfigStr("provider[\"registry.opentofu.org/hashicorp/aws\"]")
+		mockObject          = &ResourceInstanceObjectSrc{
+			SchemaVersion: 1,
+			AttrsJSON:     []byte(`{"hello": "world"}`),
+		}
+	)
+
+	module := &Module{
+		Resources: make(map[string]*Resource),
+	}
+
+	t.Run("valid - resourceProvider set, instanceProvider not set", func(t *testing.T) {
+		module.Resources = make(map[string]*Resource)
+		module.SetResourceInstanceDeposed(mockAddr, "deposedKey", mockObject, provider, addrs.AbsProviderConfig{})
+
+		resource := module.Resources[mockAddr.Resource.String()]
+		if resource == nil {
+			t.Errorf("Expected resource to be created")
+		} else if !resource.ProviderConfig.IsSet() || resource.ProviderConfig.String() != provider.String() {
+			t.Errorf("Expected resourceProvider to be set correctly, got %+v", resource.ProviderConfig)
+		}
+
+		if mockObject.InstanceProvider.IsSet() {
+			t.Errorf("Expected instanceProvider to be not set, got %+v", mockObject.InstanceProvider)
+		}
+	})
+
+	t.Run("valid - instanceProvider set, resourceProvider not set", func(t *testing.T) {
+		module.Resources = make(map[string]*Resource)
+		module.SetResourceInstanceDeposed(mockAddr, "deposedKey", mockObject, addrs.AbsProviderConfig{}, provider)
+
+		resource := module.Resources[mockAddr.Resource.String()]
+		if resource == nil {
+			t.Errorf("Expected resource to be created")
+		} else if resource.ProviderConfig.IsSet() {
+			t.Errorf("Expected resourceProvider to be not set, got %+v", resource.ProviderConfig)
+		}
+
+		if !mockObject.InstanceProvider.IsSet() || mockObject.InstanceProvider.String() != provider.String() {
+			t.Errorf("Expected instanceProvider to be set correctly, got %+v", mockObject.InstanceProvider)
+		}
+	})
+
+	t.Run("both providers set should panic", func(t *testing.T) {
+		module.Resources = make(map[string]*Resource)
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("Expected panic when both providers are set")
+			} else if r != fmt.Sprintf("SetResourceInstanceDeposed for %s (instance key nil, deposed key deposedKey) got two providers (resourceProvider & instanceProvider) to write in state", mockAddr.Resource) {
+				t.Errorf("Unexpected panic message: got %v", r)
+			}
+		}()
+		module.SetResourceInstanceDeposed(mockAddr, "deposedKey", mockObject, provider, provider)
+	})
+
+	t.Run("neither provider set should panic", func(t *testing.T) {
+		module.Resources = make(map[string]*Resource)
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("Expected panic when neither provider is set")
+			} else if r != fmt.Sprintf("SetResourceInstanceDeposed for %s (instance key nil, deposed key deposedKey) cannot find a provider (resourceProvider / instanceProvider) to write in state", mockAddr.Resource) {
+				t.Errorf("Unexpected panic message: got %v", r)
+			}
+		}()
+		module.SetResourceInstanceDeposed(mockAddr, "deposedKey", mockObject, addrs.AbsProviderConfig{}, addrs.AbsProviderConfig{})
+	})
+}

--- a/internal/states/resource_test.go
+++ b/internal/states/resource_test.go
@@ -6,6 +6,8 @@
 package states
 
 import (
+	"fmt"
+	"github.com/opentofu/opentofu/internal/addrs"
 	"testing"
 )
 
@@ -58,4 +60,119 @@ func TestResourceInstanceDeposeCurrentObject(t *testing.T) {
 			t.Errorf("wrong len(deposedkey) %d; want %d", got, want)
 		}
 	})
+}
+
+func TestResolveInstanceProvider(t *testing.T) {
+	ik := addrs.StringKey("first")
+	absResourceAddr := mustAbsResourceAddr("null_resource.resource")
+	provider, _ := addrs.ParseAbsProviderConfigStr("provider[\"registry.opentofu.org/hashicorp/aws\"]")
+	providerSecond, _ := addrs.ParseAbsProviderConfigStr("provider[\"registry.opentofu.org/hashicorp/aws\"].second")
+	emptyProvider := addrs.AbsProviderConfig{}
+
+	// Test cases for the method
+	tests := []struct {
+		name                    string
+		resourceProvider        addrs.AbsProviderConfig
+		currentInstanceProvider addrs.AbsProviderConfig
+		deposedInstanceProvider addrs.AbsProviderConfig
+		expectPanic             bool
+		expectedPanicMessage    string
+		expectFromResource      bool
+	}{
+		{
+			name:                    "should return resourceProvider if set",
+			resourceProvider:        provider,
+			currentInstanceProvider: emptyProvider,
+			expectPanic:             false,
+			expectFromResource:      true,
+		},
+		{
+			name:                    "should return instanceProvider if resourceProvider is not set",
+			resourceProvider:        emptyProvider,
+			currentInstanceProvider: provider,
+			expectPanic:             false,
+			expectFromResource:      false,
+		},
+		{
+			name:                    "should return resourceProvider if set (even when deposed has deposedInstanceProvider set)",
+			resourceProvider:        provider,
+			currentInstanceProvider: emptyProvider,
+			deposedInstanceProvider: providerSecond,
+			expectPanic:             false,
+			expectFromResource:      true,
+		},
+		{
+			name:                    "should return current instanceProvider if resourceProvider is not set (even when deposed has deposedInstanceProvider set)",
+			resourceProvider:        emptyProvider,
+			currentInstanceProvider: provider,
+			deposedInstanceProvider: providerSecond,
+			expectPanic:             false,
+			expectFromResource:      false,
+		},
+		{
+			name:                    "should return instanceProvider from deposed instances",
+			resourceProvider:        emptyProvider,
+			currentInstanceProvider: emptyProvider,
+			deposedInstanceProvider: provider,
+			expectPanic:             false,
+			expectFromResource:      false,
+		},
+		{
+			name:                    "should panic if neither resourceProvider nor instanceProvider is set and no deposed instance provider found",
+			resourceProvider:        emptyProvider,
+			currentInstanceProvider: emptyProvider,
+			deposedInstanceProvider: emptyProvider,
+			expectPanic:             true,
+			expectedPanicMessage:    fmt.Sprintf("InstanceProvider for %s (instance key %s) failed to read provider from the state", absResourceAddr, ik),
+		},
+		{
+			name:                    "should panic if both resourceProvider and instanceProvider are set",
+			resourceProvider:        provider,
+			currentInstanceProvider: providerSecond,
+			expectPanic:             true,
+			expectedPanicMessage:    fmt.Sprintf("InstanceProvider for %s (instance key %s) found two providers in state for the instance", absResourceAddr, ik),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := &ResourceInstance{
+				Current: &ResourceInstanceObjectSrc{
+					InstanceProvider: tt.currentInstanceProvider,
+				},
+				Deposed: map[DeposedKey]*ResourceInstanceObjectSrc{"deposedKey": {
+					InstanceProvider: tt.deposedInstanceProvider,
+				}},
+			}
+
+			rs := &Resource{
+				Addr:           absResourceAddr,
+				ProviderConfig: tt.resourceProvider,
+				Instances:      map[addrs.InstanceKey]*ResourceInstance{ik: instance},
+			}
+
+			if tt.expectPanic {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("Expected panic, but got none")
+					} else if r != tt.expectedPanicMessage {
+						t.Errorf("Expected panic message '%s', but got '%v'", tt.expectedPanicMessage, r)
+					}
+				}()
+				rs.InstanceProvider(ik)
+			} else {
+				resultProvider, fromResource := rs.InstanceProvider(ik)
+
+				if !resultProvider.IsSet() {
+					t.Errorf("Expected provider to be set, but it was not")
+				}
+				if resultProvider.String() != provider.String() {
+					t.Errorf("Expected provider %v, but got %v", provider, resultProvider)
+				}
+				if fromResource != tt.expectFromResource {
+					t.Errorf("Expected fromResource to be %v, but got %v", tt.expectFromResource, fromResource)
+				}
+			}
+		})
+	}
 }

--- a/internal/tofu/context_apply.go
+++ b/internal/tofu/context_apply.go
@@ -54,7 +54,7 @@ func (c *Context) Apply(plan *plans.Plan, config *configs.Config) (*states.State
 		}
 	}
 
-	graph, operation, diags := c.applyGraph(plan, config, true)
+	graph, operation, diags := c.applyGraph(plan, config)
 	if diags.HasErrors() {
 		return nil, diags
 	}
@@ -119,7 +119,7 @@ Note that the -target option is not suitable for routine use, and is provided on
 	return newState, diags
 }
 
-func (c *Context) applyGraph(plan *plans.Plan, config *configs.Config, validate bool) (*Graph, walkOperation, tfdiags.Diagnostics) {
+func (c *Context) applyGraph(plan *plans.Plan, config *configs.Config) (*Graph, walkOperation, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	variables := InputValues{}
@@ -204,7 +204,7 @@ func (c *Context) ApplyGraphForUI(plan *plans.Plan, config *configs.Config) (*Gr
 
 	var diags tfdiags.Diagnostics
 
-	graph, _, moreDiags := c.applyGraph(plan, config, false)
+	graph, _, moreDiags := c.applyGraph(plan, config)
 	diags = diags.Append(moreDiags)
 	return graph, diags
 }

--- a/internal/tofu/context_plan.go
+++ b/internal/tofu/context_plan.go
@@ -277,7 +277,7 @@ func (c *Context) checkApplyGraph(plan *plans.Plan, config *configs.Config) tfdi
 		return nil
 	}
 	log.Println("[DEBUG] building apply graph to check for errors")
-	_, _, diags := c.applyGraph(plan, config, true)
+	_, _, diags := c.applyGraph(plan, config)
 	return diags
 }
 

--- a/internal/tofu/node_resource_abstract_instance_test.go
+++ b/internal/tofu/node_resource_abstract_instance_test.go
@@ -187,3 +187,71 @@ aws_instance.foo:
   provider = provider["registry.opentofu.org/hashicorp/aws"]
 	`)
 }
+
+func TestNodeAbstractResourceInstance_ResolvedProvider(t *testing.T) {
+	provider := mustProviderConfig(`provider["registry.opentofu.org/hashicorp/null"]`)
+
+	tests := []struct {
+		name                     string
+		ResolvedResourceProvider addrs.AbsProviderConfig
+		ResolvedInstanceProvider addrs.AbsProviderConfig
+		expectPanic              bool
+		expectedPanicMessage     string
+	}{
+		{
+			name:                     "ResolvedResourceProvider is set",
+			ResolvedResourceProvider: provider,
+			ResolvedInstanceProvider: addrs.AbsProviderConfig{},
+		},
+		{
+			name:                     "ResolvedInstanceProvider is set",
+			ResolvedResourceProvider: addrs.AbsProviderConfig{},
+			ResolvedInstanceProvider: provider,
+		},
+		{
+			name:                     "Panic if both providers are set",
+			ResolvedResourceProvider: provider,
+			ResolvedInstanceProvider: provider,
+			expectPanic:              true,
+			expectedPanicMessage:     "ResolvedProvider for null_resource.resource has a provider set for the resource and the resource's instance",
+		},
+		{
+			name:                     "Panic if no provider set",
+			ResolvedResourceProvider: addrs.AbsProviderConfig{},
+			ResolvedInstanceProvider: addrs.AbsProviderConfig{},
+			expectPanic:              true,
+			expectedPanicMessage:     "ResolvedProvider for null_resource.resource cannot get a provider",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			n := &NodeAbstractResourceInstance{
+				NodeAbstractResource: NodeAbstractResource{
+					ResolvedResourceProvider: test.ResolvedResourceProvider,
+				},
+				ResolvedInstanceProvider: test.ResolvedInstanceProvider,
+				Addr:                     mustResourceInstanceAddr("null_resource.resource"),
+			}
+
+			if test.expectPanic {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("Expected panic, but got none")
+					} else if r != test.expectedPanicMessage {
+						t.Errorf("Expected panic message '%s', but got '%v'", test.expectedPanicMessage, r)
+					}
+				}()
+				n.ResolvedProvider()
+			} else {
+				result := n.ResolvedProvider()
+				if !result.IsSet() {
+					t.Errorf("Expected provider to be set, but it was not")
+				}
+				if result.String() != provider.String() {
+					t.Errorf("Expected provider %v, but got %v", provider, result)
+				}
+			}
+		})
+	}
+}

--- a/internal/tofu/transform_provider_test.go
+++ b/internal/tofu/transform_provider_test.go
@@ -7,6 +7,7 @@ package tofu
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -518,3 +519,216 @@ module.child.module.grandchild.aws_instance.baz
   provider["registry.opentofu.org/hashicorp/aws"].foo
 provider["registry.opentofu.org/hashicorp/aws"].foo
 `
+
+func Test_graphNodeProxyProvider_Expanded_noForEachOnModules(t *testing.T) {
+	// This test describes the simplest scenario, where we don't have for_each on the providers in none of the modules:
+	// root provider -> second provider -> third provider
+	rootProvider := NodeApplyableProvider{
+		NodeAbstractProvider: &NodeAbstractProvider{
+			Addr: mustProviderConfig(`provider["registry.opentofu.org/hashicorp/null"]`),
+		},
+	}
+
+	SecondLevelProxy := graphNodeProxyProvider{
+		addr:    mustProviderConfig(`module.second.provider["registry.opentofu.org/hashicorp/null"]`),
+		targets: map[addrs.InstanceKey]GraphNodeProvider{addrs.NoKey: &rootProvider},
+	}
+
+	thirdLevelProxy := graphNodeProxyProvider{
+		addr:    mustProviderConfig(`module.second.module.third.provider["registry.opentofu.org/hashicorp/null"]`),
+		targets: map[addrs.InstanceKey]GraphNodeProvider{addrs.NoKey: &SecondLevelProxy},
+	}
+
+	want := []distinguishableProvider{
+		{
+			moduleIdentifier: []addrs.ModuleInstanceStep{
+				{
+					Name: "second",
+				},
+				{
+					Name: "third",
+				},
+			},
+			resourceIdentifier: addrs.NoKey,
+			concreteProvider:   rootProvider,
+		},
+	}
+
+	t.Run("graphNodeProxyProvider_Expanded - no for_each on providers at all", func(t *testing.T) {
+		n := thirdLevelProxy
+		got := n.Expanded()
+
+		if len(got) != 1 {
+			t.Errorf("expected to get a single provider as a result")
+		}
+
+		if isDistinguishableProviderEqual(got[0], want[0]) {
+			t.Errorf("Got DistinguishableProvider %v, want %v", got[0], want[0])
+		}
+	})
+}
+
+func Test_graphNodeProxyProvider_Expanded_ForEachInSecondModule(t *testing.T) {
+	// This test describes the scenario where we have a for_each on the providers in the second module:
+	// root provider.first, provider.second -> second provider.first, provider.second (for_each) -> third.first / third.second
+	rootProviderFirst := NodeApplyableProvider{
+		NodeAbstractProvider: &NodeAbstractProvider{
+			Addr: mustProviderConfig(`provider["registry.opentofu.org/hashicorp/null"].first`),
+		},
+	}
+
+	rootProviderSecond := NodeApplyableProvider{
+		NodeAbstractProvider: &NodeAbstractProvider{
+			Addr: mustProviderConfig(`provider["registry.opentofu.org/hashicorp/null"].second`),
+		},
+	}
+
+	SecondLevelProxyFirst := graphNodeProxyProvider{
+		addr:    mustProviderConfig(`module.second.provider["registry.opentofu.org/hashicorp/null"].first`),
+		targets: map[addrs.InstanceKey]GraphNodeProvider{addrs.NoKey: &rootProviderFirst},
+	}
+
+	SecondLevelProxySecond := graphNodeProxyProvider{
+		addr:    mustProviderConfig(`module.second.provider["registry.opentofu.org/hashicorp/null"].second`),
+		targets: map[addrs.InstanceKey]GraphNodeProvider{addrs.NoKey: &rootProviderSecond},
+	}
+
+	thirdLevelProxy := graphNodeProxyProvider{
+		addr:    mustProviderConfig(`module.second.module.third.provider["registry.opentofu.org/hashicorp/null"]`),
+		targets: map[addrs.InstanceKey]GraphNodeProvider{addrs.StringKey("first"): &SecondLevelProxyFirst, addrs.StringKey("second"): &SecondLevelProxySecond},
+	}
+
+	want := []distinguishableProvider{
+		{
+			moduleIdentifier: []addrs.ModuleInstanceStep{
+				{
+					Name: "second",
+				},
+				{
+					Name:        "third",
+					InstanceKey: addrs.StringKey("first"),
+				},
+			},
+			resourceIdentifier: addrs.NoKey,
+			concreteProvider:   rootProviderFirst,
+		},
+		{
+			moduleIdentifier: []addrs.ModuleInstanceStep{
+				{
+					Name: "second",
+				},
+				{
+					Name:        "third",
+					InstanceKey: addrs.StringKey("second"),
+				},
+			},
+			resourceIdentifier: addrs.NoKey,
+			concreteProvider:   rootProviderSecond,
+		},
+	}
+
+	t.Run("graphNodeProxyProvider_Expanded - for_each on providers in the second module", func(t *testing.T) {
+		n := thirdLevelProxy
+		got := n.Expanded()
+
+		if len(got) != 2 {
+			t.Errorf("expected to get a single provider as a result")
+		}
+
+		matchingCounter := 0
+		for _, resultProvider := range got {
+			for _, wantProvider := range want {
+				if isDistinguishableProviderEqual(resultProvider, wantProvider) {
+					matchingCounter = matchingCounter + 1
+				}
+			}
+		}
+
+		if matchingCounter != 2 {
+			t.Errorf("recieved providers are not matching to the expected providers")
+		}
+	})
+}
+
+func Test_graphNodeProxyProvider_Expanded_ForEachInRootModule(t *testing.T) {
+	// This test describes the scenario where we have a for_each on the providers in the third module:
+	// root provider.first, provider.second (for_each) -> second provider.first / provider.second  -> third.first / third.second
+	rootProviderFirst := NodeApplyableProvider{
+		NodeAbstractProvider: &NodeAbstractProvider{
+			Addr: mustProviderConfig(`provider["registry.opentofu.org/hashicorp/null"].first`),
+		},
+	}
+
+	rootProviderSecond := NodeApplyableProvider{
+		NodeAbstractProvider: &NodeAbstractProvider{
+			Addr: mustProviderConfig(`provider["registry.opentofu.org/hashicorp/null"].second`),
+		},
+	}
+
+	SecondLevelProxy := graphNodeProxyProvider{
+		addr:    mustProviderConfig(`module.second.provider["registry.opentofu.org/hashicorp/null"].first`),
+		targets: map[addrs.InstanceKey]GraphNodeProvider{addrs.StringKey("first"): &rootProviderFirst, addrs.StringKey("second"): &rootProviderSecond},
+	}
+
+	thirdLevelProxy := graphNodeProxyProvider{
+		addr:    mustProviderConfig(`module.second.module.third.provider["registry.opentofu.org/hashicorp/null"]`),
+		targets: map[addrs.InstanceKey]GraphNodeProvider{addrs.NoKey: &SecondLevelProxy},
+	}
+
+	want := []distinguishableProvider{
+		{
+			moduleIdentifier: []addrs.ModuleInstanceStep{
+				{
+					Name:        "second",
+					InstanceKey: addrs.StringKey("first"),
+				},
+				{
+					Name: "third",
+				},
+			},
+			resourceIdentifier: addrs.NoKey,
+			concreteProvider:   rootProviderFirst,
+		},
+		{
+			moduleIdentifier: []addrs.ModuleInstanceStep{
+				{
+					Name:        "second",
+					InstanceKey: addrs.StringKey("second"),
+				},
+				{
+					Name: "third",
+				},
+			},
+			resourceIdentifier: addrs.NoKey,
+			concreteProvider:   rootProviderSecond,
+		},
+	}
+
+	t.Run("graphNodeProxyProvider_Expanded - for_each on providers in the root module", func(t *testing.T) {
+		n := thirdLevelProxy
+		got := n.Expanded()
+
+		if len(got) != 2 {
+			t.Errorf("expected to get a single provider as a result")
+		}
+
+		matchingCounter := 0
+		for _, resultProvider := range got {
+			for _, wantProvider := range want {
+				if isDistinguishableProviderEqual(resultProvider, wantProvider) {
+					matchingCounter = matchingCounter + 1
+				}
+			}
+		}
+
+		if matchingCounter != 2 {
+			t.Errorf("recieved providers are not matching to the expected providers")
+		}
+	})
+}
+
+func isDistinguishableProviderEqual(got distinguishableProvider, want distinguishableProvider) bool {
+	return !reflect.DeepEqual(got.moduleIdentifier, want.moduleIdentifier) ||
+		!reflect.DeepEqual(got.resourceIdentifier, want.resourceIdentifier) ||
+		got.concreteProvider.Name() != want.concreteProvider.Name()
+}


### PR DESCRIPTION
Addind UT for https://github.com/opentofu/opentofu/pull/1963
Based of https://github.com/opentofu/opentofu/pull/2030
We still have a single failing test that we need to fix `TestContext2Plan_destroyWithResourceConfiguredProvider`.

## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [ ] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [ ] I have not used an AI coding assistant to create this PR.
- [ ] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [ ] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
