### PR TITLE
test: use regex for expected value in `TestUiHookPreApply_periodicTimer`

### DIFF
--- a/internal/command/views/hook_ui_test.go
+++ b/internal/command/views/hook_ui_test.go
@@ -126,15 +126,15 @@ func TestUiHookPreApply_periodicTimer(t *testing.T) {
 	close(uiState.DoneCh)
 	<-uiState.done
 
-	expectedOutput := `test_instance.foo: Modifying... [id=test]
-test_instance.foo: Still modifying... [id=test, 1s elapsed]
-test_instance.foo: Still modifying... [id=test, 2s elapsed]
-test_instance.foo: Still modifying... [id=test, 3s elapsed]
+	expectedRegexp := `test_instance\.foo: Modifying... \[id=test\]
+test_instance\.foo: Still modifying... \[id=test, \ds elapsed\]
+test_instance\.foo: Still modifying... \[id=test, \ds elapsed\]
+test_instance\.foo: Still modifying... \[id=test, \ds elapsed\]
 `
 	result := done(t)
 	output := result.Stdout()
-	if output != expectedOutput {
-		t.Fatalf("Output didn't match.\nExpected: %q\nGiven: %q", expectedOutput, output)
+	if matched, _ := regexp.MatchString(expectedRegexp, output); !matched {
+		t.Fatalf("Output didn't match.\nExpected: %q\nGiven: %q", expectedRegexp, output)
 	}
 
 	expectedErrOutput := ""


### PR DESCRIPTION
Resolve flaky test by using regex for expected value of `TestUiHookPreApply_periodicTimer`. Match any single digit for the number of seconds vs. hard-coding. This seems less fragile to me.

I could look into separately asserting on the total elapsed time, and / or use a smaller range of numbers in the regex if there's concern about this starting to take unexpectedly more time, but I'm assuming that's not mostly what this test is trying to check.

Example failure:
https://github.com/opentofu/opentofu/actions/runs/11072397888/job/30766524726


Note: I do get one golangci-lint failure within that specific function, but as best I can tell, it's not related to my changes.

## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
