### PR TITLE
Fix function refs in variable validation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,6 +41,7 @@ issues:
       linters:
         - funlen
         - dupl
+        - revive
 
 linters:
   disable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,10 @@ issues:
         - funlen
         - dupl
         - revive
+    - path: (.+)_test.go
+      text: "ST1003"
+    - path: (.+)_test.go
+      text: "var-naming: don't use underscores in Go names"
 
 linters:
   disable-all: true

--- a/internal/tofu/context_validate_test.go
+++ b/internal/tofu/context_validate_test.go
@@ -2453,7 +2453,6 @@ resource "aws_instance" "test" {
 	}
 }
 
-//nolint:var-naming // existing pattern
 func TestContext2Validate_deprecatedAttr(t *testing.T) {
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
@@ -2489,6 +2488,7 @@ locals {
 	}
 }
 
+//nolint:var-naming // existing pattern
 func TextContext2Validate_providerFunctions(t *testing.T) {
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
@@ -2508,27 +2508,27 @@ func TextContext2Validate_providerFunctions(t *testing.T) {
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 terraform {
-        required_providers {
-                aws = ">=5.70.0"
-        }
+  required_providers {
+    aws = ">=5.70.0"
+  }
 }
 
 provider "aws" {
-        region="us-east-1"
+  region="us-east-1"
 }
 
 module "mod" {
-        source = "./mod"
-        providers = {
-                aws = aws
-        }
+  source = "./mod"
+  providers = {
+    aws = aws
+  }
 }
  `,
 		"mod/mod.tf": `
-	terraform {
-        required_providers {
-                aws = ">=5.70.0"
-        }
+  terraform {
+    required_providers {
+      aws = ">=5.70.0"
+    }
 }
 
 variable "obfmod" {
@@ -2545,9 +2545,9 @@ variable "obfmod" {
   }
 
   default = {
-        arns = [
-          "arn:partition:service:region:account-id:resource-id",
-        ]
+    arns = [
+      "arn:partition:service:region:account-id:resource-id",
+    ]
   }
 }
 `,

--- a/internal/tofu/context_validate_test.go
+++ b/internal/tofu/context_validate_test.go
@@ -2487,3 +2487,84 @@ locals {
 		t.Fatalf("expected deprecated warning, got: %q\n", warn)
 	}
 }
+
+func TextContext2Validate_providerFunctions(t *testing.T) {
+	p := testProvider("aws")
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
+		Functions: map[string]providers.FunctionSpec{
+			"arn_parse": providers.FunctionSpec{
+				Parameters: []providers.FunctionParameterSpec{{
+					Name: "arn",
+					Type: cty.String,
+				}},
+				Return: cty.Bool,
+			},
+		},
+	}
+	p.CallFunctionResponse = &providers.CallFunctionResponse{
+		Result: cty.True,
+	}
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+terraform {
+        required_providers {
+                aws = ">=5.70.0"
+        }
+}
+
+provider "aws" {
+        region="us-east-1"
+}
+
+module "mod" {
+        source = "./mod"
+        providers = {
+                aws = aws
+        }
+}
+ `,
+		"mod/mod.tf": `
+	terraform {
+        required_providers {
+                aws = ">=5.70.0"
+        }
+}
+
+variable "obfmod" {
+  type = object({
+    arns = optional(list(string))
+  })
+  description = "Configuration for xxx."
+
+  validation {
+    condition = alltrue([
+      for arn in var.obfmod.arns: can(provider::aws::arn_parse(arn))
+    ])
+    error_message = "All arns MUST BE a valid AWS ARN format."
+  }
+
+  default = {
+        arns = [
+          "arn:partition:service:region:account-id:resource-id",
+        ]
+  }
+}
+`,
+	})
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
+		},
+	})
+
+	diags := ctx.Validate(m)
+	warn := diags.ErrWithWarnings().Error()
+	if !strings.Contains(warn, `The attribute "foo" is deprecated`) {
+		t.Fatalf("expected deprecated warning, got: %q\n", warn)
+	}
+
+	if !p.CallFunctionCalled {
+		t.Fatalf("Expected function call")
+	}
+}

--- a/internal/tofu/context_validate_test.go
+++ b/internal/tofu/context_validate_test.go
@@ -2453,6 +2453,7 @@ resource "aws_instance" "test" {
 	}
 }
 
+//nolint:var-naming // existing pattern
 func TestContext2Validate_deprecatedAttr(t *testing.T) {
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{

--- a/internal/tofu/context_validate_test.go
+++ b/internal/tofu/context_validate_test.go
@@ -2488,7 +2488,6 @@ locals {
 	}
 }
 
-//nolint:var-naming // existing pattern
 func TextContext2Validate_providerFunctions(t *testing.T) {
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{

--- a/internal/tofu/node_module_variable.go
+++ b/internal/tofu/node_module_variable.go
@@ -91,16 +91,27 @@ func (n *nodeExpandModuleVariable) ModulePath() addrs.Module {
 
 // GraphNodeReferencer
 func (n *nodeExpandModuleVariable) References() []*addrs.Reference {
+	var refs []*addrs.Reference
+	if n.Config != nil {
+		// These references will ignore GraphNodeReferenceOutside and are used by the ProviderFunctionTransformer and lang.Scope.evalContext
+		// It's an odd pattern, but it works
+		for _, validation := range n.Config.Validations {
+			condFuncs, _ := lang.ProviderFunctionsInExpr(addrs.ParseRef, validation.Condition)
+			refs = append(refs, condFuncs...)
+			errFuncs, _ := lang.ProviderFunctionsInExpr(addrs.ParseRef, validation.ErrorMessage)
+			refs = append(refs, errFuncs...)
+		}
+	}
 
 	// If we have no value expression, we cannot depend on anything.
 	if n.Expr == nil {
-		return nil
+		return refs
 	}
 
 	// Variables in the root don't depend on anything, because their values
 	// are gathered prior to the graph walk and recorded in the context.
 	if len(n.Module) == 0 {
-		return nil
+		return refs
 	}
 
 	// Otherwise, we depend on anything referenced by our value expression.
@@ -113,7 +124,9 @@ func (n *nodeExpandModuleVariable) References() []*addrs.Reference {
 	// where our associated variable was declared, which is correct because
 	// our value expression is assigned within a "module" block in the parent
 	// module.
-	refs, _ := lang.ReferencesInExpr(addrs.ParseRef, n.Expr)
+	outerRefs, _ := lang.ReferencesInExpr(addrs.ParseRef, n.Expr)
+	refs = append(refs, outerRefs...)
+
 	return refs
 }
 
@@ -165,23 +178,6 @@ func (n *nodeModuleVariable) Path() addrs.ModuleInstance {
 // GraphNodeModulePath
 func (n *nodeModuleVariable) ModulePath() addrs.Module {
 	return n.Addr.Module.Module()
-}
-
-// GraphNodeReferencer
-func (n *nodeModuleVariable) References() []*addrs.Reference {
-	// This is identical to NodeRootVariable.References
-	var refs []*addrs.Reference
-
-	if n.Config != nil {
-		for _, validation := range n.Config.Validations {
-			condFuncs, _ := lang.ProviderFunctionsInExpr(addrs.ParseRef, validation.Condition)
-			refs = append(refs, condFuncs...)
-			errFuncs, _ := lang.ProviderFunctionsInExpr(addrs.ParseRef, validation.ErrorMessage)
-			refs = append(refs, errFuncs...)
-		}
-	}
-
-	return refs
 }
 
 // GraphNodeExecutable


### PR DESCRIPTION
The nodeModuleVariable.References() function is not called within the function transformer as it is on an expanded object.  Instead these references are determined pre-expansion and provided to the provider function transformer

I still need to try to find a test case that explicitly triggers this, instead of the race condition in the issue.

<!-- If your PR resolves an issue, please add it here. -->
Resolves #2051

## Target Release

1.9.0,1.8.4,1.7.4

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
