### PR TITLE
command/init: Support static eval for backend config migration check [v1.8 backport]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.8.4 (Unreleased)
+
+BUG FIXES:
+
+* `tofu init` will no longer return a supurious "Backend configuration changed" error when re-initializing a working directory with identical settings, backend configuration contains references to variables or local values, and when the `-backend-config` command line option is used. That combination previously caused OpenTofu to incorrectly treat the backend configuration as invalid. ([#2055](https://github.com/opentofu/opentofu/pull/2055))
+
 ## 1.8.3
 
 SECURITY:

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 
@@ -1363,8 +1362,7 @@ func (m *Meta) backendConfigNeedsMigration(c *configs.Backend, s *legacy.Backend
 	b := f(nil) // We don't need encryption here as it's only used for config/schema
 
 	schema := b.ConfigSchema()
-	decSpec := schema.NoneRequired().DecoderSpec()
-	givenVal, diags := hcldec.Decode(c.Config, decSpec, nil)
+	givenVal, diags := c.Decode(schema)
 	if diags.HasErrors() {
 		log.Printf("[TRACE] backendConfigNeedsMigration: failed to decode given config; migration codepath must handle problem: %s", diags.Error())
 		return true // let the migration codepath deal with these errors

--- a/internal/command/testdata/backend-unchanged-vars/.terraform/terraform.tfstate
+++ b/internal/command/testdata/backend-unchanged-vars/.terraform/terraform.tfstate
@@ -1,0 +1,23 @@
+{
+    "version": 3,
+    "serial": 1,
+    "lineage": "666f9301-7e65-4b19-ae23-71184bb19b03",
+    "backend": {
+        "type": "local",
+        "config": {
+            "path": "local-state.tfstate",
+            "workspace_dir": "doesnt-actually-matter-what-this-is"
+        },
+        "hash": 4282859327
+    },
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {},
+            "resources": {},
+            "depends_on": []
+        }
+    ]
+}

--- a/internal/command/testdata/backend-unchanged-vars/local-state.tfstate
+++ b/internal/command/testdata/backend-unchanged-vars/local-state.tfstate
@@ -1,0 +1,12 @@
+{
+    "version": 4,
+    "terraform_version": "0.14.0",
+    "serial": 7,
+    "lineage": "configuredUnchanged",
+    "outputs": {
+        "foo": {
+            "type": "string",
+            "value": "This is only here so that the state snapshot isn't 'empty' and so can't enter a no-migration-needed fast path."
+        }
+    }
+}

--- a/internal/command/testdata/backend-unchanged-vars/main.tf
+++ b/internal/command/testdata/backend-unchanged-vars/main.tf
@@ -1,0 +1,10 @@
+variable "state_filename" {
+  type    = string
+  default = "local-state.tfstate"
+}
+
+terraform {
+  backend "local" {
+    path = var.state_filename
+  }
+}


### PR DESCRIPTION
This is a direct backport of https://github.com/opentofu/opentofu/pull/2055 to the v1.8 branch, for inclusion in a forthcoming patch release.

Resolves #2024

## Target Release

1.8.x

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
