### PR TITLE
[PROTOTYPE] Experimenting with allowing wildcards in ignore_changes

### DIFF
--- a/internal/configs/resource_test.go
+++ b/internal/configs/resource_test.go
@@ -1,0 +1,310 @@
+package configs
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/json"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestDecodeIgnoreChangesPatterns(t *testing.T) {
+	// This is a narrow test covering only the unexported decodeIgnoreChangesPatterns
+	// helper function. This function is used only when ignore_changes has a static
+	// list expression assigned to it. This function does not deal with other
+	// ignore_changes situations such as the special "all" keyword.
+
+	type TestCase struct {
+		inputExpr string
+		want      []IgnoreChangesPattern
+	}
+
+	nativeSyntaxTests := map[string]TestCase{
+		"empty": {
+			`[]`,
+			nil,
+		},
+		"just root attribute": {
+			`[
+				foo,
+			]`,
+			[]IgnoreChangesPattern{
+				{
+					traversal: hcl.Traversal{
+						hcl.TraverseAttr{
+							Name: "foo",
+							SrcRange: hcl.Range{
+								Start: hcl.Pos{Line: 2, Column: 5, Byte: 6},
+								End:   hcl.Pos{Line: 2, Column: 8, Byte: 9},
+							},
+						},
+					},
+				},
+			},
+		},
+		"two root attributes": {
+			`[
+				foo,
+				bar,
+			]`,
+			[]IgnoreChangesPattern{
+				{
+					traversal: hcl.Traversal{
+						hcl.TraverseAttr{
+							Name: "foo",
+							SrcRange: hcl.Range{
+								Start: hcl.Pos{Line: 2, Column: 5, Byte: 6},
+								End:   hcl.Pos{Line: 2, Column: 8, Byte: 9},
+							},
+						},
+					},
+				},
+				{
+					traversal: hcl.Traversal{
+						hcl.TraverseAttr{
+							Name: "bar",
+							SrcRange: hcl.Range{
+								Start: hcl.Pos{Line: 3, Column: 5, Byte: 15},
+								End:   hcl.Pos{Line: 3, Column: 8, Byte: 18},
+							},
+						},
+					},
+				},
+			},
+		},
+		"attribute in nested object": {
+			`[
+				foo.bar,
+			]`,
+			[]IgnoreChangesPattern{
+				{
+					traversal: hcl.Traversal{
+						hcl.TraverseAttr{
+							Name: "foo",
+							SrcRange: hcl.Range{
+								Start: hcl.Pos{Line: 2, Column: 5, Byte: 6},
+								End:   hcl.Pos{Line: 2, Column: 8, Byte: 9},
+							},
+						},
+						hcl.TraverseAttr{
+							Name: "bar",
+							SrcRange: hcl.Range{
+								Start: hcl.Pos{Line: 2, Column: 8, Byte: 9},
+								End:   hcl.Pos{Line: 2, Column: 12, Byte: 13},
+							},
+						},
+					},
+				},
+			},
+		},
+		"element in nested list": {
+			`[
+				foo[0],
+			]`,
+			[]IgnoreChangesPattern{
+				{
+					traversal: hcl.Traversal{
+						hcl.TraverseAttr{
+							Name: "foo",
+							SrcRange: hcl.Range{
+								Start: hcl.Pos{Line: 2, Column: 5, Byte: 6},
+								End:   hcl.Pos{Line: 2, Column: 8, Byte: 9},
+							},
+						},
+						hcl.TraverseIndex{
+							Key: cty.Zero,
+							SrcRange: hcl.Range{
+								Start: hcl.Pos{Line: 2, Column: 8, Byte: 9},
+								End:   hcl.Pos{Line: 2, Column: 11, Byte: 12},
+							},
+						},
+					},
+				},
+			},
+		},
+		"element in nested map": {
+			`[
+				foo["bar"],
+			]`,
+			[]IgnoreChangesPattern{
+				{
+					traversal: hcl.Traversal{
+						hcl.TraverseAttr{
+							Name: "foo",
+							SrcRange: hcl.Range{
+								Start: hcl.Pos{Line: 2, Column: 5, Byte: 6},
+								End:   hcl.Pos{Line: 2, Column: 8, Byte: 9},
+							},
+						},
+						hcl.TraverseIndex{
+							Key: cty.StringVal("bar"),
+							SrcRange: hcl.Range{
+								Start: hcl.Pos{Line: 2, Column: 8, Byte: 9},
+								End:   hcl.Pos{Line: 2, Column: 15, Byte: 16},
+							},
+						},
+					},
+				},
+			},
+		},
+		"attribute of element in nested list": {
+			`[
+				foo[0].bar,
+			]`,
+			[]IgnoreChangesPattern{
+				{
+					traversal: hcl.Traversal{
+						hcl.TraverseAttr{
+							Name: "foo",
+							SrcRange: hcl.Range{
+								Start: hcl.Pos{Line: 2, Column: 5, Byte: 6},
+								End:   hcl.Pos{Line: 2, Column: 8, Byte: 9},
+							},
+						},
+						hcl.TraverseIndex{
+							Key: cty.Zero,
+							SrcRange: hcl.Range{
+								Start: hcl.Pos{Line: 2, Column: 8, Byte: 9},
+								End:   hcl.Pos{Line: 2, Column: 11, Byte: 12},
+							},
+						},
+						hcl.TraverseAttr{
+							Name: "bar",
+							SrcRange: hcl.Range{
+								Start: hcl.Pos{Line: 2, Column: 11, Byte: 12},
+								End:   hcl.Pos{Line: 2, Column: 15, Byte: 16},
+							},
+						},
+					},
+				},
+			},
+		},
+		"attribute of all elements in nested collection": {
+			`[
+				foo[*].bar,
+			]`,
+			[]IgnoreChangesPattern{
+				{
+					traversal: hcl.Traversal{
+						hcl.TraverseAttr{
+							Name: "foo",
+							SrcRange: hcl.Range{
+								Start: hcl.Pos{Line: 2, Column: 5, Byte: 6},
+								End:   hcl.Pos{Line: 2, Column: 8, Byte: 9},
+							},
+						},
+						hcl.TraverseSplat{
+							SrcRange: hcl.Range{
+								Start: hcl.Pos{Line: 2, Column: 8, Byte: 9},
+								End:   hcl.Pos{Line: 2, Column: 11, Byte: 12},
+							},
+						},
+						hcl.TraverseAttr{
+							Name: "bar",
+							SrcRange: hcl.Range{
+								Start: hcl.Pos{Line: 2, Column: 11, Byte: 12},
+								End:   hcl.Pos{Line: 2, Column: 15, Byte: 16},
+							},
+						},
+					},
+				},
+			},
+		},
+		// TODO: If we decide to move forward with this prototype, there are
+		// plenty more situations to test.
+	}
+	jsonSyntaxTests := map[string]TestCase{
+		"empty": {
+			`[]`,
+			nil,
+		},
+		"attribute of all elements in nested collection": {
+			`[
+				"foo[*].bar"
+			]`,
+			[]IgnoreChangesPattern{
+				{
+					traversal: hcl.Traversal{
+						hcl.TraverseAttr{
+							Name: "foo",
+							SrcRange: hcl.Range{
+								Start: hcl.Pos{Line: 2, Column: 9, Byte: 6},
+								End:   hcl.Pos{Line: 2, Column: 12, Byte: 9},
+							},
+						},
+						hcl.TraverseSplat{
+							SrcRange: hcl.Range{
+								Start: hcl.Pos{Line: 2, Column: 12, Byte: 9},
+								End:   hcl.Pos{Line: 2, Column: 15, Byte: 12},
+							},
+						},
+						hcl.TraverseAttr{
+							Name: "bar",
+							SrcRange: hcl.Range{
+								Start: hcl.Pos{Line: 2, Column: 15, Byte: 12},
+								End:   hcl.Pos{Line: 2, Column: 19, Byte: 16},
+							},
+						},
+					},
+				},
+			},
+		},
+		// TODO: If we decide to move forward with this prototype, there are
+		// plenty more situations to test.
+	}
+
+	runTests := func(t *testing.T, tests map[string]TestCase, parse func(*testing.T, string) hcl.Expression) {
+		for name, test := range tests {
+			t.Run(name, func(t *testing.T) {
+				fullExpr := parse(t, test.inputExpr)
+				exprs, diags := hcl.ExprList(fullExpr)
+				if diags.HasErrors() {
+					t.Fatalf("cannot interpret expression as static list:\n%s", diags.Error())
+				}
+
+				got, diags := decodeIgnoreChangesPatterns(exprs)
+				if diags.HasErrors() {
+					t.Fatalf("invalid patterns:\n%s", diags.Error())
+				}
+
+				cmpOpts := cmp.Options{
+					cmp.AllowUnexported(IgnoreChangesPattern{}),
+					cmpopts.IgnoreUnexported(
+						hcl.TraverseAttr{},
+						hcl.TraverseIndex{},
+						hcl.TraverseSplat{},
+					),
+					ctydebug.CmpOptions,
+				}
+				if diff := cmp.Diff(test.want, got, cmpOpts); diff != "" {
+					t.Errorf("wrong result\n%s", diff)
+				}
+			})
+		}
+	}
+	parseNativeSyntax := func(t *testing.T, inputExpr string) hcl.Expression {
+		fullExpr, diags := hclsyntax.ParseExpression([]byte(inputExpr), "", hcl.InitialPos)
+		if diags.HasErrors() {
+			t.Fatalf("invalid expression syntax:\n%s", diags.Error())
+		}
+		return fullExpr
+	}
+	parseJSONSyntax := func(t *testing.T, inputExpr string) hcl.Expression {
+		fullExpr, diags := json.ParseExpression([]byte(inputExpr), "")
+		if diags.HasErrors() {
+			t.Fatalf("invalid expression syntax:\n%s", diags.Error())
+		}
+		return fullExpr
+	}
+
+	t.Run("native_syntax", func(t *testing.T) {
+		runTests(t, nativeSyntaxTests, parseNativeSyntax)
+	})
+	t.Run("json_syntax", func(t *testing.T) {
+		runTests(t, jsonSyntaxTests, parseJSONSyntax)
+	})
+}

--- a/internal/tofu/node_resource_abstract_instance.go
+++ b/internal/tofu/node_resource_abstract_instance.go
@@ -1198,7 +1198,7 @@ func (n *NodeAbstractResource) processIgnoreChanges(prior, config cty.Value, sch
 		return config, nil
 	}
 
-	ignoreChanges := traversalsToPaths(n.Config.Managed.IgnoreChanges)
+	ignoreChanges := n.Config.Managed.IgnoreChanges
 	ignoreAll := n.Config.Managed.IgnoreAllChanges
 
 	if len(ignoreChanges) == 0 && !ignoreAll {
@@ -1274,7 +1274,7 @@ func traversalToPath(traversal hcl.Traversal) cty.Path {
 	return path
 }
 
-func processIgnoreChangesIndividual(prior, config cty.Value, ignoreChangesPath []cty.Path) (cty.Value, tfdiags.Diagnostics) {
+func processIgnoreChangesIndividual(prior, config cty.Value, ignoreChangesPath []configs.IgnoreChangesPattern) (cty.Value, tfdiags.Diagnostics) {
 	type ignoreChange struct {
 		// Path is the full path, minus any trailing map index
 		path cty.Path


### PR DESCRIPTION
This PR is not intended to ever be merged. Instead, it's just a staging area that I'm using to experiment with what it might look like to support wildcard-matching in `ignore_changes`, using the `[*]` syntax borrowed from the splat operator to represent "any element of a collection".

This is motivated by https://github.com/opentofu/opentofu/issues/1933 but not intended to actually close it. If this prototype is successful then I intend to write an RFC describing it, and then write a "real" implementation only if that RFC is accepted.
