### PR TITLE
Fix issues with and cleanup Static Provider Mapping

### DIFF
--- a/internal/backend/testing.go
+++ b/internal/backend/testing.go
@@ -159,7 +159,6 @@ func TestBackendStates(t *testing.T, b Backend) {
 				Provider: addrs.NewDefaultProvider("test"),
 				Module:   addrs.RootModule,
 			},
-			addrs.AbsProviderConfig{},
 		)
 
 		// write a distinct known state to bar

--- a/internal/command/jsonstate/state.go
+++ b/internal/command/jsonstate/state.go
@@ -367,7 +367,7 @@ func marshalResources(resources map[string]*states.Resource, module addrs.Module
 				Address:      r.Addr.Instance(k).String(),
 				Type:         resAddr.Type,
 				Name:         resAddr.Name,
-				ProviderName: r.ProviderConfig.Provider.String(),
+				ProviderName: ri.Current.InstanceProvider.Provider.String(),
 			}
 
 			if k != nil {
@@ -390,7 +390,7 @@ func marshalResources(resources map[string]*states.Resource, module addrs.Module
 			}
 
 			schema, version := schemas.ResourceTypeConfig(
-				r.ProviderConfig.Provider,
+				ri.Current.InstanceProvider.Provider, // TODO inspect current and deposed to find this value
 				resAddr.Mode,
 				resAddr.Type,
 			)
@@ -404,7 +404,7 @@ func marshalResources(resources map[string]*states.Resource, module addrs.Module
 				current.SchemaVersion = ri.Current.SchemaVersion
 
 				if schema == nil {
-					return nil, fmt.Errorf("no schema found for %s (in provider %s)", resAddr.String(), r.ProviderConfig.Provider)
+					return nil, fmt.Errorf("no schema found for %s (in provider %s)", resAddr.String(), ri.Current.InstanceProvider.Provider)
 				}
 				riObj, err := ri.Current.Decode(schema.ImpliedType())
 				if err != nil {

--- a/internal/command/jsonstate/state.go
+++ b/internal/command/jsonstate/state.go
@@ -367,7 +367,7 @@ func marshalResources(resources map[string]*states.Resource, module addrs.Module
 				Address:      r.Addr.Instance(k).String(),
 				Type:         resAddr.Type,
 				Name:         resAddr.Name,
-				ProviderName: ri.Current.InstanceProvider.Provider.String(),
+				ProviderName: ri.InstanceProvider.Provider.String(),
 			}
 
 			if k != nil {
@@ -390,7 +390,7 @@ func marshalResources(resources map[string]*states.Resource, module addrs.Module
 			}
 
 			schema, version := schemas.ResourceTypeConfig(
-				ri.Current.InstanceProvider.Provider, // TODO inspect current and deposed to find this value
+				ri.InstanceProvider.Provider,
 				resAddr.Mode,
 				resAddr.Type,
 			)
@@ -404,7 +404,7 @@ func marshalResources(resources map[string]*states.Resource, module addrs.Module
 				current.SchemaVersion = ri.Current.SchemaVersion
 
 				if schema == nil {
-					return nil, fmt.Errorf("no schema found for %s (in provider %s)", resAddr.String(), ri.Current.InstanceProvider.Provider)
+					return nil, fmt.Errorf("no schema found for %s (in provider %s)", resAddr.String(), ri.InstanceProvider.Provider)
 				}
 				riObj, err := ri.Current.Decode(schema.ImpliedType())
 				if err != nil {

--- a/internal/command/state_mv.go
+++ b/internal/command/state_mv.go
@@ -339,8 +339,6 @@ func (c *StateMvCommand) Run(args []string) int {
 			c.Ui.Output(fmt.Sprintf("%s %q to %q", prefix, addrFrom.String(), args[1]))
 			if !dryRun {
 				fromResourceAddr := addrFrom.ContainingResource()
-				fromResource := ssFrom.Resource(fromResourceAddr)
-				fromProviderAddr := fromResource.ProviderConfig
 				ssFrom.ForgetResourceInstanceAll(addrFrom)
 				ssFrom.RemoveResourceIfEmpty(fromResourceAddr)
 
@@ -352,9 +350,8 @@ func (c *StateMvCommand) Run(args []string) int {
 					// address covers both). If there's an index in the
 					// target then allow creating the new instance here.
 					resourceAddr := addrTo.ContainingResource()
-					stateTo.SyncWrapper().SetResourceProvider(
+					stateTo.SyncWrapper().EnsureResourceExists(
 						resourceAddr,
-						fromProviderAddr, // in this case, we bring the provider along as if we were moving the whole resource
 					)
 					rs = stateTo.Resource(resourceAddr)
 				}

--- a/internal/command/state_replace_provider.go
+++ b/internal/command/state_replace_provider.go
@@ -127,19 +127,18 @@ func (c *StateReplaceProviderCommand) Run(args []string) int {
 	}
 
 	var willReplace []*states.Resource
-	var willReplaceInstances []*states.ResourceInstanceObjectSrc
+	var willReplaceInstances []*states.ResourceInstance
 
 	// Update all matching resources with new provider
 	for _, resource := range resources {
 		hasMarked := false
 		for _, instance := range resource.Instances {
-			if instance.Current.InstanceProvider.Provider.Equals(from) {
+			if instance.InstanceProvider.Provider.Equals(from) {
 				if !hasMarked {
 					willReplace = append(willReplace, resource)
 					hasMarked = true
 				}
-				willReplaceInstances = append(willReplaceInstances, instance.Current)
-				// TODO deposed
+				willReplaceInstances = append(willReplaceInstances, instance)
 			}
 		}
 	}

--- a/internal/command/state_show.go
+++ b/internal/command/state_show.go
@@ -162,8 +162,8 @@ func (c *StateShowCommand) Run(args []string) int {
 
 	// check if the resource has a configured provider, otherwise this will use the default provider
 	absInstanceProvider := addrs.AbsProviderConfig{
-		Provider: is.Current.InstanceProvider.Provider,
-		Alias:    is.Current.InstanceProvider.Alias,
+		Provider: is.InstanceProvider.Provider,
+		Alias:    is.InstanceProvider.Alias,
 		Module:   addrs.RootModule,
 	}
 

--- a/internal/command/state_show.go
+++ b/internal/command/state_show.go
@@ -161,13 +161,6 @@ func (c *StateShowCommand) Run(args []string) int {
 	}
 
 	// check if the resource has a configured provider, otherwise this will use the default provider
-	rs := state.Resource(addr.ContainingResource())
-	absResourceProvider := addrs.AbsProviderConfig{
-		Provider: rs.ProviderConfig.Provider,
-		Alias:    rs.ProviderConfig.Alias,
-		Module:   addrs.RootModule,
-	}
-
 	absInstanceProvider := addrs.AbsProviderConfig{
 		Provider: is.Current.InstanceProvider.Provider,
 		Alias:    is.Current.InstanceProvider.Alias,
@@ -178,7 +171,6 @@ func (c *StateShowCommand) Run(args []string) int {
 	singleInstance.EnsureModule(addr.Module).SetResourceInstanceCurrent(
 		addr.Resource,
 		is.Current,
-		absResourceProvider,
 		absInstanceProvider,
 	)
 

--- a/internal/command/taint.go
+++ b/internal/command/taint.go
@@ -185,7 +185,7 @@ func (c *TaintCommand) Run(args []string) int {
 	}
 
 	obj.Status = states.ObjectTainted
-	ss.SetResourceInstanceCurrent(addr, obj, is.Current.InstanceProvider)
+	ss.SetResourceInstanceCurrent(addr, obj, is.InstanceProvider)
 
 	if err := stateMgr.WriteState(state); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error writing state file: %s", err))

--- a/internal/command/taint.go
+++ b/internal/command/taint.go
@@ -149,7 +149,6 @@ func (c *TaintCommand) Run(args []string) int {
 	ss := state.SyncWrapper()
 
 	// Get the resource and instance we're going to taint
-	rs := ss.Resource(addr.ContainingResource())
 	is := ss.ResourceInstance(addr)
 	if is == nil {
 		if allowMissing {
@@ -186,7 +185,7 @@ func (c *TaintCommand) Run(args []string) int {
 	}
 
 	obj.Status = states.ObjectTainted
-	ss.SetResourceInstanceCurrent(addr, obj, rs.ProviderConfig, is.Current.InstanceProvider)
+	ss.SetResourceInstanceCurrent(addr, obj, is.Current.InstanceProvider)
 
 	if err := stateMgr.WriteState(state); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error writing state file: %s", err))

--- a/internal/command/untaint.go
+++ b/internal/command/untaint.go
@@ -186,7 +186,7 @@ func (c *UntaintCommand) Run(args []string) int {
 	}
 
 	obj.Status = states.ObjectReady
-	ss.SetResourceInstanceCurrent(addr, obj, is.Current.InstanceProvider)
+	ss.SetResourceInstanceCurrent(addr, obj, is.InstanceProvider)
 
 	if err := stateMgr.WriteState(state); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error writing state file: %s", err))

--- a/internal/command/untaint.go
+++ b/internal/command/untaint.go
@@ -132,7 +132,6 @@ func (c *UntaintCommand) Run(args []string) int {
 	ss := state.SyncWrapper()
 
 	// Get the resource and instance we're going to taint
-	rs := ss.Resource(addr.ContainingResource())
 	is := ss.ResourceInstance(addr)
 	if is == nil {
 		if allowMissing {
@@ -187,7 +186,7 @@ func (c *UntaintCommand) Run(args []string) int {
 	}
 
 	obj.Status = states.ObjectReady
-	ss.SetResourceInstanceCurrent(addr, obj, rs.ProviderConfig, is.Current.InstanceProvider)
+	ss.SetResourceInstanceCurrent(addr, obj, is.Current.InstanceProvider)
 
 	if err := stateMgr.WriteState(state); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error writing state file: %s", err))

--- a/internal/states/instance_object.go
+++ b/internal/states/instance_object.go
@@ -49,11 +49,6 @@ type ResourceInstanceObject struct {
 	// destroy operations, we need to record the status to ensure a resource
 	// removed from the config will still be destroyed in the same manner.
 	CreateBeforeDestroy bool
-
-	// InstanceProvider, if set, this instance has a specific provider different
-	// from the whole resource's provider. Happens in cases when we have a
-	// for_each or count in provider reference of the resource / module
-	InstanceProvider addrs.AbsProviderConfig
 }
 
 // ObjectStatus represents the status of a RemoteObject.
@@ -140,7 +135,6 @@ func (o *ResourceInstanceObject) Encode(ty cty.Type, schemaVersion uint64) (*Res
 		Status:              o.Status,
 		Dependencies:        dependencies,
 		CreateBeforeDestroy: o.CreateBeforeDestroy,
-		InstanceProvider:    o.InstanceProvider,
 	}, nil
 }
 

--- a/internal/states/instance_object_src.go
+++ b/internal/states/instance_object_src.go
@@ -64,11 +64,6 @@ type ResourceInstanceObjectSrc struct {
 	Status              ObjectStatus
 	Dependencies        []addrs.ConfigResource
 	CreateBeforeDestroy bool
-
-	// InstanceProvider, if set, this instance has a specific provider different
-	// from the whole resource's provider. Happens in cases when we have a
-	// for_each or count in provider reference of the resource / module
-	InstanceProvider addrs.AbsProviderConfig
 }
 
 // Decode unmarshals the raw representation of the object attributes. Pass the
@@ -107,7 +102,6 @@ func (os *ResourceInstanceObjectSrc) Decode(ty cty.Type) (*ResourceInstanceObjec
 		Dependencies:        os.Dependencies,
 		Private:             os.Private,
 		CreateBeforeDestroy: os.CreateBeforeDestroy,
-		InstanceProvider:    os.InstanceProvider,
 	}, nil
 }
 

--- a/internal/states/module.go
+++ b/internal/states/module.go
@@ -136,7 +136,7 @@ func (ms *Module) SetResourceInstanceCurrent(addr addrs.ResourceInstance, obj *R
 		is = rs.CreateInstance(addr.Key)
 	}
 
-	obj.InstanceProvider = instanceProvider
+	is.InstanceProvider = instanceProvider
 	is.Current = obj
 }
 
@@ -164,7 +164,7 @@ func (ms *Module) SetResourceInstanceDeposed(addr addrs.ResourceInstance, key De
 
 	// If the instanceProvider is not empty, populate the obj with its value
 	if instanceProvider.IsSet() {
-		obj.InstanceProvider = instanceProvider
+		is.InstanceProvider = instanceProvider
 	}
 
 	if obj != nil {

--- a/internal/states/module.go
+++ b/internal/states/module.go
@@ -108,6 +108,7 @@ func (ms *Module) SetResourceInstanceCurrent(addr addrs.ResourceInstance, obj *R
 			return
 		}
 		// if we have an instance, update the current
+		is.InstanceProvider = instanceProvider
 		is.Current = obj
 		if !is.HasObjects() {
 			// If we have no objects at all then we'll clean up.

--- a/internal/states/module.go
+++ b/internal/states/module.go
@@ -6,7 +6,6 @@
 package states
 
 import (
-	"fmt"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -60,7 +59,7 @@ func (ms *Module) ResourceInstance(addr addrs.ResourceInstance) *ResourceInstanc
 // SetResourceProvider updates the resource-level metadata for the resource
 // with the given address, creating the resource state for it if it doesn't
 // already exist. Also sets the provider on the resource level (if not empty).
-func (ms *Module) SetResourceProvider(addr addrs.Resource, provider addrs.AbsProviderConfig) {
+func (ms *Module) EnsureResourceExists(addr addrs.Resource) {
 	rs := ms.Resource(addr)
 	if rs == nil {
 		rs = &Resource{
@@ -68,10 +67,6 @@ func (ms *Module) SetResourceProvider(addr addrs.Resource, provider addrs.AbsPro
 			Instances: map[addrs.InstanceKey]*ResourceInstance{},
 		}
 		ms.Resources[addr.String()] = rs
-	}
-
-	if provider.IsSet() {
-		rs.ProviderConfig = provider
 	}
 }
 
@@ -92,7 +87,7 @@ func (ms *Module) RemoveResource(addr addrs.Resource) {
 //
 // The provider address can be either a resource-wide settings or set for the
 // specific instance, and it depends on the given resourceProvider / instanceProvider
-func (ms *Module) SetResourceInstanceCurrent(addr addrs.ResourceInstance, obj *ResourceInstanceObjectSrc, resourceProvider, instanceProvider addrs.AbsProviderConfig) {
+func (ms *Module) SetResourceInstanceCurrent(addr addrs.ResourceInstance, obj *ResourceInstanceObjectSrc, instanceProvider addrs.AbsProviderConfig) {
 	rs := ms.Resource(addr.Resource)
 	// if the resource is nil and the object is nil, don't do anything!
 	// you'll probably just cause issues
@@ -129,7 +124,7 @@ func (ms *Module) SetResourceInstanceCurrent(addr addrs.ResourceInstance, obj *R
 
 	if rs == nil && obj != nil {
 		// We don't have have a resource so make one, which is a side effect of setResourceMeta
-		ms.SetResourceProvider(addr.Resource, resourceProvider)
+		ms.EnsureResourceExists(addr.Resource)
 
 		// now we have a resource! so update the rs value to point to it
 		rs = ms.Resource(addr.Resource)
@@ -139,36 +134,9 @@ func (ms *Module) SetResourceInstanceCurrent(addr addrs.ResourceInstance, obj *R
 	if is == nil {
 		// if we don't have a resource, create one and add to the instances
 		is = rs.CreateInstance(addr.Key)
-		// update the resource meta because we have a new
-		ms.SetResourceProvider(addr.Resource, resourceProvider)
 	}
 
-	// Update the resource's ProviderConfig, in case the provider has updated
-	if resourceProvider.IsSet() {
-		rs.ProviderConfig = resourceProvider
-	}
-
-	// If the instanceProvider is not empty, populate the obj with its value
-	if instanceProvider.IsSet() {
-		obj.InstanceProvider = instanceProvider
-	}
-
-	var stringInstanceKey string
-
-	if addr.Key == nil {
-		stringInstanceKey = "nil"
-	} else {
-		stringInstanceKey = addr.Key.String()
-	}
-
-	if !resourceProvider.IsSet() && !instanceProvider.IsSet() {
-		panic(fmt.Sprintf("SetResourceInstanceCurrent for %s (instance key %s) cannot find a provider (resourceProvider / instanceProvider) to write in state", addr, stringInstanceKey))
-	}
-
-	if resourceProvider.IsSet() && instanceProvider.IsSet() {
-		panic(fmt.Sprintf("SetResourceInstanceCurrent for %s (instance key %s) got two providers (resourceProvider & instanceProvider) to write in state", addr, stringInstanceKey))
-	}
-
+	obj.InstanceProvider = instanceProvider
 	is.Current = obj
 }
 
@@ -188,8 +156,8 @@ func (ms *Module) SetResourceInstanceCurrent(addr addrs.ResourceInstance, obj *R
 // is overwritten. Set obj to nil to remove the deposed object altogether. If
 // the instance is left with no objects after this operation then it will
 // be removed from its containing resource altogether.
-func (ms *Module) SetResourceInstanceDeposed(addr addrs.ResourceInstance, key DeposedKey, obj *ResourceInstanceObjectSrc, resourceProvider addrs.AbsProviderConfig, instanceProvider addrs.AbsProviderConfig) {
-	ms.SetResourceProvider(addr.Resource, resourceProvider)
+func (ms *Module) SetResourceInstanceDeposed(addr addrs.ResourceInstance, key DeposedKey, obj *ResourceInstanceObjectSrc, instanceProvider addrs.AbsProviderConfig) {
+	ms.EnsureResourceExists(addr.Resource)
 
 	rs := ms.Resource(addr.Resource)
 	is := rs.EnsureInstance(addr.Key)
@@ -197,22 +165,6 @@ func (ms *Module) SetResourceInstanceDeposed(addr addrs.ResourceInstance, key De
 	// If the instanceProvider is not empty, populate the obj with its value
 	if instanceProvider.IsSet() {
 		obj.InstanceProvider = instanceProvider
-	}
-
-	var stringInstanceKey string
-
-	if addr.Key == nil {
-		stringInstanceKey = "nil"
-	} else {
-		stringInstanceKey = addr.Key.String()
-	}
-
-	if !resourceProvider.IsSet() && !instanceProvider.IsSet() {
-		panic(fmt.Sprintf("SetResourceInstanceDeposed for %s (instance key %s, deposed key %s) cannot find a provider (resourceProvider / instanceProvider) to write in state", addr, stringInstanceKey, key))
-	}
-
-	if resourceProvider.IsSet() && instanceProvider.IsSet() {
-		panic(fmt.Sprintf("SetResourceInstanceDeposed for %s (instance key %s, deposed key %s) got two providers (resourceProvider & instanceProvider) to write in state", addr, stringInstanceKey, key))
 	}
 
 	if obj != nil {

--- a/internal/states/module.go
+++ b/internal/states/module.go
@@ -56,9 +56,9 @@ func (ms *Module) ResourceInstance(addr addrs.ResourceInstance) *ResourceInstanc
 	return rs.Instance(addr.Key)
 }
 
-// SetResourceProvider updates the resource-level metadata for the resource
+// EnsureResourceExists updates the resource-level metadata for the resource
 // with the given address, creating the resource state for it if it doesn't
-// already exist. Also sets the provider on the resource level (if not empty).
+// already exists.
 func (ms *Module) EnsureResourceExists(addr addrs.Resource) {
 	rs := ms.Resource(addr)
 	if rs == nil {
@@ -84,9 +84,6 @@ func (ms *Module) RemoveResource(addr addrs.Resource) {
 // Any existing current instance object for the given resource is overwritten.
 // Set obj to nil to remove the primary generation object altogether. If there
 // are no deposed objects then the instance will be removed altogether.
-//
-// The provider address can be either a resource-wide settings or set for the
-// specific instance, and it depends on the given resourceProvider / instanceProvider
 func (ms *Module) SetResourceInstanceCurrent(addr addrs.ResourceInstance, obj *ResourceInstanceObjectSrc, instanceProvider addrs.AbsProviderConfig) {
 	rs := ms.Resource(addr.Resource)
 	// if the resource is nil and the object is nil, don't do anything!

--- a/internal/states/resource.go
+++ b/internal/states/resource.go
@@ -63,6 +63,11 @@ type ResourceInstance struct {
 	// replaced and are pending destruction due to the create_before_destroy
 	// lifecycle mode.
 	Deposed map[DeposedKey]*ResourceInstanceObjectSrc
+
+	// InstanceProvider, if set, this instance has a specific provider different
+	// from the whole resource's provider. Happens in cases when we have a
+	// for_each or count in provider reference of the resource / module
+	InstanceProvider addrs.AbsProviderConfig
 }
 
 // NewResourceInstance constructs and returns a new ResourceInstance, ready to

--- a/internal/states/state.go
+++ b/internal/states/state.go
@@ -331,8 +331,7 @@ func (s *State) ProviderAddrs() []addrs.AbsProviderConfig {
 	for _, ms := range s.Modules {
 		for _, rc := range ms.Resources {
 			for _, instance := range rc.Instances {
-				// TODO should we check deposed as well just in case?
-				m[instance.Current.InstanceProvider.String()] = instance.Current.InstanceProvider
+				m[instance.InstanceProvider.String()] = instance.InstanceProvider
 			}
 		}
 	}

--- a/internal/states/state_deepcopy.go
+++ b/internal/states/state_deepcopy.go
@@ -178,7 +178,6 @@ func (os *ResourceInstanceObjectSrc) DeepCopy() *ResourceInstanceObjectSrc {
 		AttrSensitivePaths:  attrPaths,
 		Dependencies:        dependencies,
 		CreateBeforeDestroy: os.CreateBeforeDestroy,
-		InstanceProvider:    os.InstanceProvider,
 	}
 }
 

--- a/internal/states/state_deepcopy.go
+++ b/internal/states/state_deepcopy.go
@@ -117,8 +117,9 @@ func (i *ResourceInstance) DeepCopy() *ResourceInstance {
 	}
 
 	return &ResourceInstance{
-		Current: i.Current.DeepCopy(),
-		Deposed: deposed,
+		Current:          i.Current.DeepCopy(),
+		Deposed:          deposed,
+		InstanceProvider: i.InstanceProvider,
 	}
 }
 

--- a/internal/states/state_deepcopy.go
+++ b/internal/states/state_deepcopy.go
@@ -93,9 +93,8 @@ func (rs *Resource) DeepCopy() *Resource {
 	}
 
 	return &Resource{
-		Addr:           rs.Addr,
-		Instances:      instances,
-		ProviderConfig: rs.ProviderConfig, // technically mutable, but immutable by convention
+		Addr:      rs.Addr,
+		Instances: instances,
 	}
 }
 

--- a/internal/states/state_string.go
+++ b/internal/states/state_string.go
@@ -99,7 +99,6 @@ func (ms *Module) testString() string {
 
 	for _, fakeAbsAddr := range addrsOrder {
 		addr := fakeAbsAddr.Resource
-		rs := ms.Resource(addr.ContainingResource())
 		is := ms.ResourceInstance(addr)
 
 		// Here we need to fake up a legacy-style address as the old state
@@ -133,7 +132,7 @@ func (ms *Module) testString() string {
 
 		buf.WriteString(fmt.Sprintf("%s:%s%s\n", k, taintStr, deposedStr))
 		buf.WriteString(fmt.Sprintf("  ID = %s\n", id))
-		buf.WriteString(fmt.Sprintf("  provider = %s\n", rs.ProviderConfig.String()))
+		// TODO buf.WriteString(fmt.Sprintf("  provider = %s\n", rs.ProviderConfig.String()))
 
 		// Attributes were a flatmap before, but are not anymore. To preserve
 		// our old output as closely as possible we need to do a conversion

--- a/internal/states/statefile/version4.go
+++ b/internal/states/statefile/version4.go
@@ -174,7 +174,6 @@ func prepareStateV4(sV4 *stateV4) (*File, tfdiags.Diagnostics) {
 			obj := &states.ResourceInstanceObjectSrc{
 				SchemaVersion:       isV4.SchemaVersion,
 				CreateBeforeDestroy: isV4.CreateBeforeDestroy,
-				InstanceProvider:    instanceProviderAddr,
 			}
 
 			{
@@ -418,19 +417,10 @@ func writeStateV4(file *File, w io.Writer, enc encryption.StateEncryption) tfdia
 			var providerConfigValue string
 			identicalProviderConfigValue := true
 			for _, is := range rs.Instances {
-				if is.HasCurrent() {
-					if providerConfigValue == "" {
-						providerConfigValue = is.Current.InstanceProvider.String()
-					} else {
-						identicalProviderConfigValue = identicalProviderConfigValue && providerConfigValue == is.Current.InstanceProvider.String()
-					}
-				}
-				for _, obj := range is.Deposed {
-					if providerConfigValue == "" {
-						providerConfigValue = obj.InstanceProvider.String()
-					} else {
-						identicalProviderConfigValue = identicalProviderConfigValue && providerConfigValue == obj.InstanceProvider.String()
-					}
+				if providerConfigValue == "" {
+					providerConfigValue = is.InstanceProvider.String()
+				} else {
+					identicalProviderConfigValue = identicalProviderConfigValue && providerConfigValue == is.InstanceProvider.String()
 				}
 			}
 
@@ -556,8 +546,8 @@ func appendInstanceObjectStateV4(rs *states.Resource, is *states.ResourceInstanc
 	diags = diags.Append(pathsDiags)
 
 	instanceProviderValue := ""
-	if obj.InstanceProvider.IsSet() && useInstanceProvider {
-		instanceProviderValue = obj.InstanceProvider.String()
+	if is.InstanceProvider.IsSet() && useInstanceProvider {
+		instanceProviderValue = is.InstanceProvider.String()
 	}
 
 	return append(isV4s, instanceObjectStateV4{

--- a/internal/states/statemgr/testing.go
+++ b/internal/states/statemgr/testing.go
@@ -155,11 +155,12 @@ func TestFullInitialState() *states.State {
 		Type: "null_resource",
 		Name: "foo",
 	}
+	/* TODO this does not actually create a resource, instances are required
 	providerAddr := addrs.AbsProviderConfig{
 		Provider: addrs.NewDefaultProvider(rAddr.ImpliedProvider()),
 		Module:   addrs.RootModule,
-	}
-	childMod.SetResourceProvider(rAddr, providerAddr)
+	}*/
+	childMod.EnsureResourceExists(rAddr)
 
 	state.RootModule().SetOutputValue("sensitive_output", cty.StringVal("it's a secret"), true)
 	state.RootModule().SetOutputValue("nonsensitive_output", cty.StringVal("hello, world!"), false)

--- a/internal/states/statemgr/testing.go
+++ b/internal/states/statemgr/testing.go
@@ -155,11 +155,6 @@ func TestFullInitialState() *states.State {
 		Type: "null_resource",
 		Name: "foo",
 	}
-	/* TODO this does not actually create a resource, instances are required
-	providerAddr := addrs.AbsProviderConfig{
-		Provider: addrs.NewDefaultProvider(rAddr.ImpliedProvider()),
-		Module:   addrs.RootModule,
-	}*/
 	childMod.EnsureResourceExists(rAddr)
 
 	state.RootModule().SetOutputValue("sensitive_output", cty.StringVal("it's a secret"), true)

--- a/internal/states/sync.go
+++ b/internal/states/sync.go
@@ -203,12 +203,12 @@ func (s *SyncState) ResourceInstanceObject(addr addrs.AbsResourceInstance, gen G
 // SetResourceProvider updates the resource-level metadata for the resource at
 // the given address, creating the containing module state and resource state
 // as a side-effect if not already present.
-func (s *SyncState) SetResourceProvider(addr addrs.AbsResource, provider addrs.AbsProviderConfig) {
+func (s *SyncState) EnsureResourceExists(addr addrs.AbsResource) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
 	ms := s.state.EnsureModule(addr.Module)
-	ms.SetResourceProvider(addr.Resource, provider)
+	ms.EnsureResourceExists(addr.Resource)
 }
 
 // RemoveResource removes the entire state for the given resource, taking with
@@ -274,12 +274,12 @@ func (s *SyncState) RemoveResourceIfEmpty(addr addrs.AbsResource) bool {
 // If the containing module for this resource or the resource itself are not
 // already tracked in state then they will be added as a side-effect.
 // SetResourceInstanceCurrent
-func (s *SyncState) SetResourceInstanceCurrent(addr addrs.AbsResourceInstance, obj *ResourceInstanceObjectSrc, resourceProvider addrs.AbsProviderConfig, instanceProvider addrs.AbsProviderConfig) {
+func (s *SyncState) SetResourceInstanceCurrent(addr addrs.AbsResourceInstance, obj *ResourceInstanceObjectSrc, instanceProvider addrs.AbsProviderConfig) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
 	ms := s.state.EnsureModule(addr.Module)
-	ms.SetResourceInstanceCurrent(addr.Resource, obj.DeepCopy(), resourceProvider, instanceProvider)
+	ms.SetResourceInstanceCurrent(addr.Resource, obj.DeepCopy(), instanceProvider)
 	s.maybePruneModule(addr.Module)
 }
 
@@ -306,12 +306,12 @@ func (s *SyncState) SetResourceInstanceCurrent(addr addrs.AbsResourceInstance, o
 //
 // If the containing module for this resource or the resource itself are not
 // already tracked in state then they will be added as a side-effect.
-func (s *SyncState) SetResourceInstanceDeposed(addr addrs.AbsResourceInstance, key DeposedKey, obj *ResourceInstanceObjectSrc, resourceProvider addrs.AbsProviderConfig, instanceProvider addrs.AbsProviderConfig) {
+func (s *SyncState) SetResourceInstanceDeposed(addr addrs.AbsResourceInstance, key DeposedKey, obj *ResourceInstanceObjectSrc, instanceProvider addrs.AbsProviderConfig) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
 	ms := s.state.EnsureModule(addr.Module)
-	ms.SetResourceInstanceDeposed(addr.Resource, key, obj.DeepCopy(), resourceProvider, instanceProvider)
+	ms.SetResourceInstanceDeposed(addr.Resource, key, obj.DeepCopy(), instanceProvider)
 	s.maybePruneModule(addr.Module)
 }
 
@@ -444,7 +444,7 @@ func (s *SyncState) RemovePlannedResourceInstanceObjects() {
 				if is.Current != nil && is.Current.Status == ObjectPlanned {
 					// Setting the current instance to nil removes it from the
 					// state altogether if there are not also deposed instances.
-					ms.SetResourceInstanceCurrent(instAddr, nil, rs.ProviderConfig, is.Current.InstanceProvider)
+					ms.SetResourceInstanceCurrent(instAddr, nil, is.Current.InstanceProvider)
 				}
 
 				for dk, obj := range is.Deposed {

--- a/internal/states/sync.go
+++ b/internal/states/sync.go
@@ -444,7 +444,7 @@ func (s *SyncState) RemovePlannedResourceInstanceObjects() {
 				if is.Current != nil && is.Current.Status == ObjectPlanned {
 					// Setting the current instance to nil removes it from the
 					// state altogether if there are not also deposed instances.
-					ms.SetResourceInstanceCurrent(instAddr, nil, is.Current.InstanceProvider)
+					ms.SetResourceInstanceCurrent(instAddr, nil, is.InstanceProvider)
 				}
 
 				for dk, obj := range is.Deposed {

--- a/internal/states/sync.go
+++ b/internal/states/sync.go
@@ -200,7 +200,7 @@ func (s *SyncState) ResourceInstanceObject(addr addrs.AbsResourceInstance, gen G
 	return inst.GetGeneration(gen).DeepCopy()
 }
 
-// SetResourceProvider updates the resource-level metadata for the resource at
+// EnsureResourceExists updates the resource-level metadata for the resource at
 // the given address, creating the containing module state and resource state
 // as a side-effect if not already present.
 func (s *SyncState) EnsureResourceExists(addr addrs.AbsResource) {
@@ -267,9 +267,6 @@ func (s *SyncState) RemoveResourceIfEmpty(addr addrs.AbsResource) bool {
 // The caller must ensure that the given ResourceInstanceObject is not
 // concurrently mutated during this call, but may be freely used again once
 // this function returns.
-//
-// The provider address can be either a resource-wide settings or set for the
-// specific instance, and it depends on the given resourceProvider / instanceProvider
 //
 // If the containing module for this resource or the resource itself are not
 // already tracked in state then they will be added as a side-effect.

--- a/internal/tofu/context_plan.go
+++ b/internal/tofu/context_plan.go
@@ -849,10 +849,8 @@ func (c *Context) driftedResources(config *configs.Config, oldState, newState *s
 
 				newIS := newState.ResourceInstance(addr)
 
-				provider, _ := rs.InstanceProvider(key)
-
 				schema, _ := schemas.ResourceTypeConfig(
-					provider.Provider,
+					oldIS.Current.InstanceProvider.Provider,
 					addr.Resource.Resource.Mode,
 					addr.Resource.Resource.Type,
 				)
@@ -925,7 +923,7 @@ func (c *Context) driftedResources(config *configs.Config, oldState, newState *s
 				change := &plans.ResourceInstanceChange{
 					Addr:         addr,
 					PrevRunAddr:  prevRunAddr,
-					ProviderAddr: rs.ProviderConfig,
+					ProviderAddr: oldIS.Current.InstanceProvider,
 					Change: plans.Change{
 						Action: action,
 						Before: oldVal,

--- a/internal/tofu/context_plan.go
+++ b/internal/tofu/context_plan.go
@@ -850,7 +850,7 @@ func (c *Context) driftedResources(config *configs.Config, oldState, newState *s
 				newIS := newState.ResourceInstance(addr)
 
 				schema, _ := schemas.ResourceTypeConfig(
-					oldIS.Current.InstanceProvider.Provider,
+					oldIS.InstanceProvider.Provider,
 					addr.Resource.Resource.Mode,
 					addr.Resource.Resource.Type,
 				)
@@ -923,7 +923,7 @@ func (c *Context) driftedResources(config *configs.Config, oldState, newState *s
 				change := &plans.ResourceInstanceChange{
 					Addr:         addr,
 					PrevRunAddr:  prevRunAddr,
-					ProviderAddr: oldIS.Current.InstanceProvider,
+					ProviderAddr: oldIS.InstanceProvider,
 					Change: plans.Change{
 						Action: action,
 						Before: oldVal,

--- a/internal/tofu/node_data_destroy.go
+++ b/internal/tofu/node_data_destroy.go
@@ -24,6 +24,6 @@ var (
 // GraphNodeExecutable
 func (n *NodeDestroyableDataResourceInstance) Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
 	log.Printf("[TRACE] NodeDestroyableDataResourceInstance: removing state object for %s", n.Addr)
-	ctx.State().SetResourceInstanceCurrent(n.Addr, nil, n.NodeAbstractResource.ResolvedResourceProvider, n.ResolvedInstanceProvider)
+	ctx.State().SetResourceInstanceCurrent(n.Addr, nil, n.ResolvedInstanceProvider)
 	return nil
 }

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -321,17 +321,9 @@ func (n *NodeAbstractResource) SetProvider(provider addrs.AbsProviderConfig, isR
 }
 
 func (n *NodeAbstractResource) ProvidedBy() (map[addrs.InstanceKey]addrs.ProviderConfig, ExactProvider) {
-	return n.ProvidedByImpl(addrs.AbsProviderConfig{})
-}
-
-// GraphNodeProviderConsumer
-func (n *NodeAbstractResource) ProvidedByImpl(resolvedInstanceProvider addrs.AbsProviderConfig) (map[addrs.InstanceKey]addrs.ProviderConfig, ExactProvider) {
 	// Once the provider is fully resolved, we can return the known value.
 	if n.ResolvedResourceProvider.IsSet() {
-		return map[addrs.InstanceKey]addrs.ProviderConfig{}, ExactProvider{provider: n.ResolvedResourceProvider, isResourceProvider: true}
-	} else if resolvedInstanceProvider.IsSet() {
-		return map[addrs.InstanceKey]addrs.ProviderConfig{}, ExactProvider{provider: resolvedInstanceProvider, isResourceProvider: false}
-
+		return nil, ExactProvider{provider: n.ResolvedResourceProvider, isResourceProvider: true}
 	}
 
 	// If we have a config we prefer that above all else

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -340,8 +340,6 @@ func (n *NodeAbstractResource) ProvidedBy() ProvidedBy {
 		}
 
 		if len(n.Config.ProviderConfigRef.Aliases) > 0 {
-			result.Relative = make(map[addrs.InstanceKey]addrs.AbsProviderConfig)
-
 			// If we have aliases set in ProviderConfigRef, we'll calculate a LocalProviderConfig for each one
 			for key, alias := range n.Config.ProviderConfigRef.Aliases {
 				result.Relative[key] = addrs.AbsProviderConfig{

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -83,7 +83,7 @@ type NodeAbstractResource struct {
 	// calculate its provider.
 	// If the potentialProviders is populated, it means the ResolvedResourceProvider is empty and the provider will be
 	// defined per resource instance and not on the whole resource.
-	potentialProviders []distinguishableProvider
+	potentialProviders ResourceInstanceProviderResolver
 
 	// storedProviderConfig is the provider address retrieved from the state of the resource,
 	// with a bool indication on whether this provider is se on the Resource level or on the instance level.
@@ -301,7 +301,7 @@ func (n *NodeAbstractResource) DependsOn() []*addrs.Reference {
 	return result
 }
 
-func (n *NodeAbstractResource) SetPotentialProviders(potentialProviders []distinguishableProvider) {
+func (n *NodeAbstractResource) SetPotentialProviders(potentialProviders ResourceInstanceProviderResolver) {
 	n.potentialProviders = potentialProviders
 }
 
@@ -309,15 +309,7 @@ func (n *NodeAbstractResource) SetPotentialProviders(potentialProviders []distin
 // InstanceProvider if a few potential providers exist. A few potential providers might exist if the resource
 // configuration, or one of the containing module's configuration, contains a for_each or count in the provider reference.
 func (n *NodeAbstractResource) resolveInstanceProvider(instance addrs.AbsResourceInstance) addrs.AbsProviderConfig {
-	for _, potentialProvider := range n.potentialProviders {
-		if potentialProvider.IsResourceInstanceMatching(instance) {
-			return potentialProvider.concreteProvider.ProviderAddr()
-		}
-	}
-
-	// Can happen if ResolvedResourceProvider is already set for the whole resource, and we don't have a specific
-	// provider set for the instances
-	return addrs.AbsProviderConfig{}
+	return n.potentialProviders.Resolve(instance)
 }
 
 func (n *NodeAbstractResource) SetProvider(provider addrs.AbsProviderConfig, isResourceProvider bool) {

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -308,7 +308,9 @@ func (n *NodeAbstractResource) resolveInstanceProvider(instance addrs.AbsResourc
 }
 
 func (n *NodeAbstractResource) ProvidedBy() ProvidedBy {
-	var result ProvidedBy
+	result := ProvidedBy{
+		Relative: make(map[addrs.InstanceKey]addrs.AbsProviderConfig),
+	}
 
 	// Make sure orphans are properly accounted for
 	// TODO this could introduce some funkiness in the
@@ -329,7 +331,6 @@ func (n *NodeAbstractResource) ProvidedBy() ProvidedBy {
 	// If we have a config we prefer that above all else
 	if n.Config != nil {
 		if n.Config.ProviderConfigRef == nil {
-			result.Relative = make(map[addrs.InstanceKey]addrs.AbsProviderConfig)
 
 			// If no specific "provider" argument is given, we want to look up the
 			// provider config where the local name matches the implied provider

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -85,6 +85,8 @@ type NodeAbstractResource struct {
 	// generateConfigPath tells this node which file to write generated config
 	// into. If empty, then config should not be generated.
 	generateConfigPath string
+
+	knownResourceStates []*states.Resource
 }
 
 var (
@@ -99,6 +101,7 @@ var (
 	_ GraphNodeAttachProviderMetaConfigs   = (*NodeAbstractResource)(nil)
 	_ GraphNodeTargetable                  = (*NodeAbstractResource)(nil)
 	_ graphNodeAttachDataResourceDependsOn = (*NodeAbstractResource)(nil)
+	_ GraphNodeAttachResourceStates        = (*NodeAbstractResource)(nil)
 	_ dag.GraphNodeDotter                  = (*NodeAbstractResource)(nil)
 )
 
@@ -289,6 +292,10 @@ func (n *NodeAbstractResource) DependsOn() []*addrs.Reference {
 	return result
 }
 
+func (n *NodeAbstractResource) AttachResourceStates(known []*states.Resource) {
+	n.knownResourceStates = known
+}
+
 func (n *NodeAbstractResource) SetPotentialProviders(potentialProviders ResourceInstanceProviderResolver) {
 	n.potentialProviders = potentialProviders
 }
@@ -300,10 +307,25 @@ func (n *NodeAbstractResource) resolveInstanceProvider(instance addrs.AbsResourc
 	return n.potentialProviders.Resolve(instance)
 }
 
-func (n *NodeAbstractResource) ProvidedBy() (map[addrs.InstanceKey]addrs.ProviderConfig, bool) {
-	return n.ProvidedByImpl(addrs.NoKey, addrs.AbsProviderConfig{})
-}
-func (n *NodeAbstractResource) ProvidedByImpl(instanceKey addrs.InstanceKey, storedProviderConfig addrs.AbsProviderConfig) (map[addrs.InstanceKey]addrs.ProviderConfig, bool) {
+func (n *NodeAbstractResource) ProvidedBy() ProvidedBy {
+	var result ProvidedBy
+
+	// Make sure orphans are properly accounted for
+	// TODO this could introduce some funkiness in the
+	// execution, where providers that are no longer
+	// needed due to provider alias changes are still
+	// required.  I don't know if there is a way to
+	// determine the orphans ahead of time and prune
+	// this list down to the essentials.
+	for _, rs := range n.knownResourceStates {
+		for key, inst := range rs.Instances {
+			result.Absolute = append(result.Absolute, ResourceProvidedBy{
+				Provider: inst.Current.InstanceProvider,
+				Resource: rs.Addr.Instance(key),
+			})
+		}
+	}
+
 	// If we have a config we prefer that above all else
 	if n.Config != nil {
 		if n.Config.ProviderConfigRef == nil {
@@ -311,42 +333,33 @@ func (n *NodeAbstractResource) ProvidedByImpl(instanceKey addrs.InstanceKey, sto
 			// provider config where the local name matches the implied provider
 			// from the resource type. This may be different from the resource's
 			// provider type.
-			return map[addrs.InstanceKey]addrs.ProviderConfig{
-				instanceKey: addrs.LocalProviderConfig{
-					LocalName: n.Config.Addr().ImpliedProvider(),
-				},
-			}, false
+			result.Relative[addrs.NoKey] = addrs.AbsProviderConfig{
+				Provider: n.Provider(),
+				Module:   n.ModulePath(),
+			}
+			return result
 		}
 
-		result := make(map[addrs.InstanceKey]addrs.ProviderConfig)
-
 		if len(n.Config.ProviderConfigRef.Aliases) > 0 {
+			result.Relative = make(map[addrs.InstanceKey]addrs.AbsProviderConfig)
+
 			// If we have aliases set in ProviderConfigRef, we'll calculate a LocalProviderConfig for each one
 			for key, alias := range n.Config.ProviderConfigRef.Aliases {
-				// TODO consider filtering InstanceKey
-				result[key] = addrs.LocalProviderConfig{
-					LocalName: n.Config.ProviderConfigRef.Name,
-					Alias:     alias,
+				result.Relative[key] = addrs.AbsProviderConfig{
+					Provider: n.Provider(),
+					Module:   n.ModulePath(),
+					Alias:    alias,
 				}
 			}
 		} else {
 			// If we have no aliases in ProviderConfigRef, we still need to calculate a single LocalProviderConfig
-			result[instanceKey] = addrs.LocalProviderConfig{
-				LocalName: n.Config.ProviderConfigRef.Name,
+			result.Relative[addrs.NoKey] = addrs.AbsProviderConfig{
+				Provider: n.Provider(),
+				Module:   n.ModulePath(),
 			}
 		}
 
-		return result, false
-	}
-
-	// See if we have a valid provider config from the state.
-	if storedProviderConfig.IsSet() {
-		// An address from the state must match exactly, since we must ensure
-		// we refresh/destroy a resource with the same provider configuration
-		// that created it.
-		return map[addrs.InstanceKey]addrs.ProviderConfig{
-			instanceKey: storedProviderConfig,
-		}, true
+		return result
 	}
 
 	// We might have an import target that is providing a specific provider,
@@ -357,21 +370,21 @@ func (n *NodeAbstractResource) ProvidedByImpl(instanceKey addrs.InstanceKey, sto
 		// of them should be. They should also all have the same provider, so it
 		// shouldn't matter which we check here, as they'll all give the same.
 		if n.importTargets[0].Config != nil && n.importTargets[0].Config.ProviderConfigRef != nil {
-			return map[addrs.InstanceKey]addrs.ProviderConfig{
-				instanceKey: addrs.LocalProviderConfig{
-					LocalName: n.importTargets[0].Config.ProviderConfigRef.Name,
-					Alias:     n.importTargets[0].Config.ProviderConfigRef.Alias,
-				},
-			}, false
+			result.Relative[addrs.NoKey] = addrs.AbsProviderConfig{
+				Provider: n.Provider(),
+				Module:   n.ModulePath(),
+				//LocalName: n.importTargets[0].Config.ProviderConfigRef.Name,
+				Alias: n.importTargets[0].Config.ProviderConfigRef.Alias,
+			}
+			return result
 		}
 	}
 	// No provider configuration found; return a default address
-	return map[addrs.InstanceKey]addrs.ProviderConfig{
-		instanceKey: addrs.AbsProviderConfig{
-			Provider: n.Provider(),
-			Module:   n.ModulePath(),
-		},
-	}, false
+	result.Relative[addrs.NoKey] = addrs.AbsProviderConfig{
+		Provider: n.Provider(),
+		Module:   n.ModulePath(),
+	}
+	return result
 }
 
 // GraphNodeProviderConsumer

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -329,6 +329,8 @@ func (n *NodeAbstractResource) ProvidedBy() ProvidedBy {
 	// If we have a config we prefer that above all else
 	if n.Config != nil {
 		if n.Config.ProviderConfigRef == nil {
+			result.Relative = make(map[addrs.InstanceKey]addrs.AbsProviderConfig)
+
 			// If no specific "provider" argument is given, we want to look up the
 			// provider config where the local name matches the implied provider
 			// from the resource type. This may be different from the resource's

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -317,7 +317,7 @@ func (n *NodeAbstractResource) ProvidedBy() ProvidedBy {
 	for _, rs := range n.knownResourceStates {
 		for key, inst := range rs.Instances {
 			result.Absolute = append(result.Absolute, ResourceProvidedBy{
-				Provider: inst.Current.InstanceProvider,
+				Provider: inst.InstanceProvider,
 				Resource: rs.Addr.Instance(key),
 				Optional: true,
 			})

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -312,18 +312,14 @@ func (n *NodeAbstractResource) ProvidedBy() ProvidedBy {
 		Relative: make(map[addrs.InstanceKey]addrs.AbsProviderConfig),
 	}
 
-	// Make sure orphans are properly accounted for
-	// TODO this could introduce some funkiness in the
-	// execution, where providers that are no longer
-	// needed due to provider alias changes are still
-	// required.  I don't know if there is a way to
-	// determine the orphans ahead of time and prune
-	// this list down to the essentials.
+	// Make sure orphans are properly accounted for.  TODO better comment that the
+	// checking of exists can happen outside the transformer as it may not be needed.
 	for _, rs := range n.knownResourceStates {
 		for key, inst := range rs.Instances {
 			result.Absolute = append(result.Absolute, ResourceProvidedBy{
 				Provider: inst.Current.InstanceProvider,
 				Resource: rs.Addr.Instance(key),
+				Optional: true,
 			})
 		}
 	}

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -73,23 +73,11 @@ type NodeAbstractResource struct {
 	dependsOn      []addrs.ConfigResource
 	forceDependsOn bool
 
-	// The address of the provider this resource will use.
-	// Can be empty if the provider is not set on the resource level but in the resource instance instead. In this case,
-	// the potentialProviders property will be populated.
-	// It can happen when we have a for_each or count on the providers in the resource or containing module.
-	ResolvedResourceProvider addrs.AbsProviderConfig
-
 	// potentialProviders is a list of provider and their identifiers, meant to be resolved per each instance to
 	// calculate its provider.
 	// If the potentialProviders is populated, it means the ResolvedResourceProvider is empty and the provider will be
 	// defined per resource instance and not on the whole resource.
 	potentialProviders ResourceInstanceProviderResolver
-
-	// storedProviderConfig is the provider address retrieved from the state of the resource,
-	// with a bool indication on whether this provider is se on the Resource level or on the instance level.
-	// This is defined here for access within the ProvidedBy method, but will be set from the embedding
-	// instance type when the state is attached.
-	storedProviderConfig addrs.AbsProviderConfig
 
 	// This resource may expand into instances which need to be imported.
 	importTargets []*ImportTarget
@@ -313,6 +301,9 @@ func (n *NodeAbstractResource) resolveInstanceProvider(instance addrs.AbsResourc
 }
 
 func (n *NodeAbstractResource) ProvidedBy() (map[addrs.InstanceKey]addrs.ProviderConfig, bool) {
+	return n.ProvidedByImpl(addrs.NoKey, addrs.AbsProviderConfig{})
+}
+func (n *NodeAbstractResource) ProvidedByImpl(instanceKey addrs.InstanceKey, storedProviderConfig addrs.AbsProviderConfig) (map[addrs.InstanceKey]addrs.ProviderConfig, bool) {
 	// If we have a config we prefer that above all else
 	if n.Config != nil {
 		if n.Config.ProviderConfigRef == nil {
@@ -321,7 +312,7 @@ func (n *NodeAbstractResource) ProvidedBy() (map[addrs.InstanceKey]addrs.Provide
 			// from the resource type. This may be different from the resource's
 			// provider type.
 			return map[addrs.InstanceKey]addrs.ProviderConfig{
-				addrs.NoKey: addrs.LocalProviderConfig{
+				instanceKey: addrs.LocalProviderConfig{
 					LocalName: n.Config.Addr().ImpliedProvider(),
 				},
 			}, false
@@ -332,6 +323,7 @@ func (n *NodeAbstractResource) ProvidedBy() (map[addrs.InstanceKey]addrs.Provide
 		if len(n.Config.ProviderConfigRef.Aliases) > 0 {
 			// If we have aliases set in ProviderConfigRef, we'll calculate a LocalProviderConfig for each one
 			for key, alias := range n.Config.ProviderConfigRef.Aliases {
+				// TODO consider filtering InstanceKey
 				result[key] = addrs.LocalProviderConfig{
 					LocalName: n.Config.ProviderConfigRef.Name,
 					Alias:     alias,
@@ -339,7 +331,7 @@ func (n *NodeAbstractResource) ProvidedBy() (map[addrs.InstanceKey]addrs.Provide
 			}
 		} else {
 			// If we have no aliases in ProviderConfigRef, we still need to calculate a single LocalProviderConfig
-			result[addrs.NoKey] = addrs.LocalProviderConfig{
+			result[instanceKey] = addrs.LocalProviderConfig{
 				LocalName: n.Config.ProviderConfigRef.Name,
 			}
 		}
@@ -348,12 +340,12 @@ func (n *NodeAbstractResource) ProvidedBy() (map[addrs.InstanceKey]addrs.Provide
 	}
 
 	// See if we have a valid provider config from the state.
-	if n.storedProviderConfig.IsSet() {
+	if storedProviderConfig.IsSet() {
 		// An address from the state must match exactly, since we must ensure
 		// we refresh/destroy a resource with the same provider configuration
 		// that created it.
 		return map[addrs.InstanceKey]addrs.ProviderConfig{
-			addrs.NoKey: n.storedProviderConfig,
+			instanceKey: storedProviderConfig,
 		}, true
 	}
 
@@ -366,7 +358,7 @@ func (n *NodeAbstractResource) ProvidedBy() (map[addrs.InstanceKey]addrs.Provide
 		// shouldn't matter which we check here, as they'll all give the same.
 		if n.importTargets[0].Config != nil && n.importTargets[0].Config.ProviderConfigRef != nil {
 			return map[addrs.InstanceKey]addrs.ProviderConfig{
-				addrs.NoKey: addrs.LocalProviderConfig{
+				instanceKey: addrs.LocalProviderConfig{
 					LocalName: n.importTargets[0].Config.ProviderConfigRef.Name,
 					Alias:     n.importTargets[0].Config.ProviderConfigRef.Alias,
 				},
@@ -375,7 +367,7 @@ func (n *NodeAbstractResource) ProvidedBy() (map[addrs.InstanceKey]addrs.Provide
 	}
 	// No provider configuration found; return a default address
 	return map[addrs.InstanceKey]addrs.ProviderConfig{
-		addrs.NoKey: addrs.AbsProviderConfig{
+		instanceKey: addrs.AbsProviderConfig{
 			Provider: n.Provider(),
 			Module:   n.ModulePath(),
 		},
@@ -384,11 +376,14 @@ func (n *NodeAbstractResource) ProvidedBy() (map[addrs.InstanceKey]addrs.Provide
 
 // GraphNodeProviderConsumer
 func (n *NodeAbstractResource) Provider() addrs.Provider {
+	return n.ProviderImpl(addrs.AbsProviderConfig{})
+}
+func (n *NodeAbstractResource) ProviderImpl(storedProviderConfig addrs.AbsProviderConfig) addrs.Provider {
 	if n.Config != nil {
 		return n.Config.Provider
 	}
-	if n.storedProviderConfig.IsSet() {
-		return n.storedProviderConfig.Provider
+	if storedProviderConfig.IsSet() {
+		return storedProviderConfig.Provider
 	}
 
 	if len(n.importTargets) > 0 {
@@ -495,7 +490,7 @@ func (n *NodeAbstractResource) writeResourceState(ctx EvalContext, addr addrs.Ab
 			return diags
 		}
 
-		state.SetResourceProvider(addr, n.ResolvedResourceProvider)
+		state.EnsureResourceExists(addr)
 		expander.SetResourceCount(addr.Module, n.Addr.Resource, count)
 
 	case n.Config != nil && n.Config.ForEach != nil:
@@ -507,11 +502,11 @@ func (n *NodeAbstractResource) writeResourceState(ctx EvalContext, addr addrs.Ab
 
 		// This method takes care of all of the business logic of updating this
 		// while ensuring that any existing instances are preserved, etc.
-		state.SetResourceProvider(addr, n.ResolvedResourceProvider)
+		state.EnsureResourceExists(addr)
 		expander.SetResourceForEach(addr.Module, n.Addr.Resource, forEach)
 
 	default:
-		state.SetResourceProvider(addr, n.ResolvedResourceProvider)
+		state.EnsureResourceExists(addr)
 		expander.SetResourceSingle(addr.Module, n.Addr.Resource)
 	}
 

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -89,7 +89,7 @@ type NodeAbstractResource struct {
 	// with a bool indication on whether this provider is se on the Resource level or on the instance level.
 	// This is defined here for access within the ProvidedBy method, but will be set from the embedding
 	// instance type when the state is attached.
-	storedProviderConfig ExactProvider
+	storedProviderConfig addrs.AbsProviderConfig
 
 	// This resource may expand into instances which need to be imported.
 	importTargets []*ImportTarget
@@ -312,20 +312,7 @@ func (n *NodeAbstractResource) resolveInstanceProvider(instance addrs.AbsResourc
 	return n.potentialProviders.Resolve(instance)
 }
 
-func (n *NodeAbstractResource) SetProvider(provider addrs.AbsProviderConfig, isResourceProvider bool) {
-	if isResourceProvider {
-		n.ResolvedResourceProvider = provider
-	} else {
-		panic(fmt.Sprintf("SetProvider for %s cannot set an instance provider on a NodeAbstractResource", n.Addr))
-	}
-}
-
-func (n *NodeAbstractResource) ProvidedBy() (map[addrs.InstanceKey]addrs.ProviderConfig, ExactProvider) {
-	// Once the provider is fully resolved, we can return the known value.
-	if n.ResolvedResourceProvider.IsSet() {
-		return nil, ExactProvider{provider: n.ResolvedResourceProvider, isResourceProvider: true}
-	}
-
+func (n *NodeAbstractResource) ProvidedBy() (map[addrs.InstanceKey]addrs.ProviderConfig, bool) {
 	// If we have a config we prefer that above all else
 	if n.Config != nil {
 		if n.Config.ProviderConfigRef == nil {
@@ -337,7 +324,7 @@ func (n *NodeAbstractResource) ProvidedBy() (map[addrs.InstanceKey]addrs.Provide
 				addrs.NoKey: addrs.LocalProviderConfig{
 					LocalName: n.Config.Addr().ImpliedProvider(),
 				},
-			}, ExactProvider{}
+			}, false
 		}
 
 		result := make(map[addrs.InstanceKey]addrs.ProviderConfig)
@@ -354,19 +341,20 @@ func (n *NodeAbstractResource) ProvidedBy() (map[addrs.InstanceKey]addrs.Provide
 			// If we have no aliases in ProviderConfigRef, we still need to calculate a single LocalProviderConfig
 			result[addrs.NoKey] = addrs.LocalProviderConfig{
 				LocalName: n.Config.ProviderConfigRef.Name,
-				Alias:     "",
 			}
 		}
 
-		return result, ExactProvider{}
+		return result, false
 	}
 
 	// See if we have a valid provider config from the state.
-	if n.storedProviderConfig.provider.IsSet() {
+	if n.storedProviderConfig.IsSet() {
 		// An address from the state must match exactly, since we must ensure
 		// we refresh/destroy a resource with the same provider configuration
 		// that created it.
-		return map[addrs.InstanceKey]addrs.ProviderConfig{}, ExactProvider{provider: n.storedProviderConfig.provider, isResourceProvider: n.storedProviderConfig.isResourceProvider}
+		return map[addrs.InstanceKey]addrs.ProviderConfig{
+			addrs.NoKey: n.storedProviderConfig,
+		}, true
 	}
 
 	// We might have an import target that is providing a specific provider,
@@ -382,7 +370,7 @@ func (n *NodeAbstractResource) ProvidedBy() (map[addrs.InstanceKey]addrs.Provide
 					LocalName: n.importTargets[0].Config.ProviderConfigRef.Name,
 					Alias:     n.importTargets[0].Config.ProviderConfigRef.Alias,
 				},
-			}, ExactProvider{}
+			}, false
 		}
 	}
 	// No provider configuration found; return a default address
@@ -391,7 +379,7 @@ func (n *NodeAbstractResource) ProvidedBy() (map[addrs.InstanceKey]addrs.Provide
 			Provider: n.Provider(),
 			Module:   n.ModulePath(),
 		},
-	}, ExactProvider{}
+	}, false
 }
 
 // GraphNodeProviderConsumer
@@ -399,8 +387,8 @@ func (n *NodeAbstractResource) Provider() addrs.Provider {
 	if n.Config != nil {
 		return n.Config.Provider
 	}
-	if n.storedProviderConfig.provider.IsSet() {
-		return n.storedProviderConfig.provider.Provider
+	if n.storedProviderConfig.IsSet() {
+		return n.storedProviderConfig.Provider
 	}
 
 	if len(n.importTargets) > 0 {

--- a/internal/tofu/node_resource_abstract_instance.go
+++ b/internal/tofu/node_resource_abstract_instance.go
@@ -70,7 +70,10 @@ func NewNodeAbstractResourceInstance(addr addrs.AbsResourceInstance) *NodeAbstra
 }
 
 func (n *NodeAbstractResourceInstance) ProvidedBy() (map[addrs.InstanceKey]addrs.ProviderConfig, ExactProvider) {
-	return n.NodeAbstractResource.ProvidedByImpl(n.ResolvedInstanceProvider)
+	if n.ResolvedInstanceProvider.IsSet() {
+		return nil, ExactProvider{provider: resolvedInstanceProvider, isResourceProvider: false}
+	}
+	return n.NodeAbstractResource.ProvidedBy()
 }
 
 func (n *NodeAbstractResourceInstance) SetProvider(provider addrs.AbsProviderConfig, isResourceProvider bool) {

--- a/internal/tofu/node_resource_abstract_instance.go
+++ b/internal/tofu/node_resource_abstract_instance.go
@@ -76,10 +76,22 @@ func NewNodeAbstractResourceInstance(addr addrs.AbsResourceInstance) *NodeAbstra
 
 func (n *NodeAbstractResourceInstance) ProvidedBy() ProviderRequest {
 	// Once the provider is fully resolved, we can return the known value.
+	// In practice, this should be the only path that is commonly hit.
 	if n.ResolvedInstanceProvider.IsSet() {
 		return ProviderRequest{
 			Exact: []ProviderResourceInstanceRequest{{
 				Provider: n.ResolvedInstanceProvider,
+				Resource: n.Addr,
+			}},
+		}
+	}
+
+	// If there is no overwriting config, we should use the storedProviderConfig
+	// This is usually an orphaned instance (by count)
+	if n.Config == nil && n.storedProviderConfig.IsSet() {
+		return ProviderRequest{
+			Exact: []ProviderResourceInstanceRequest{{
+				Provider: n.storedProviderConfig,
 				Resource: n.Addr,
 			}},
 		}

--- a/internal/tofu/node_resource_abstract_instance.go
+++ b/internal/tofu/node_resource_abstract_instance.go
@@ -74,15 +74,18 @@ func NewNodeAbstractResourceInstance(addr addrs.AbsResourceInstance) *NodeAbstra
 	}
 }
 
-func (n *NodeAbstractResourceInstance) ProvidedBy() (map[addrs.InstanceKey]addrs.ProviderConfig, bool) {
+func (n *NodeAbstractResourceInstance) ProvidedBy() ProvidedBy {
 	// Once the provider is fully resolved, we can return the known value.
 	if n.ResolvedInstanceProvider.IsSet() {
-		return map[addrs.InstanceKey]addrs.ProviderConfig{
-			n.Addr.Resource.Key: n.ResolvedInstanceProvider,
-		}, true
+		return ProvidedBy{
+			Absolute: []ResourceProvidedBy{{
+				Provider: n.ResolvedInstanceProvider,
+				Resource: n.Addr,
+			}},
+		}
 	}
 	// TODO consider filtering out only the providers that apply to this instance to simplify the expanded graph
-	return n.NodeAbstractResource.ProvidedByImpl(n.Addr.Resource.Key, n.storedProviderConfig)
+	return n.NodeAbstractResource.ProvidedBy()
 }
 
 func (n *NodeAbstractResourceInstance) Provider() addrs.Provider {

--- a/internal/tofu/node_resource_abstract_instance.go
+++ b/internal/tofu/node_resource_abstract_instance.go
@@ -181,7 +181,7 @@ func (n *NodeAbstractResourceInstance) AttachResourceState(s *states.Resource) {
 
 	log.Printf("[TRACE] NodeAbstractResourceInstance.AttachResourceState for %s", n.Addr)
 	n.instanceState = s.Instance(n.Addr.Resource.Key)
-	n.storedProviderConfig = n.instanceState.Current.InstanceProvider
+	n.storedProviderConfig = n.instanceState.InstanceProvider
 }
 
 // readDiff returns the planned change for a particular resource instance

--- a/internal/tofu/node_resource_abstract_instance.go
+++ b/internal/tofu/node_resource_abstract_instance.go
@@ -74,11 +74,11 @@ func NewNodeAbstractResourceInstance(addr addrs.AbsResourceInstance) *NodeAbstra
 	}
 }
 
-func (n *NodeAbstractResourceInstance) ProvidedBy() ProvidedBy {
+func (n *NodeAbstractResourceInstance) ProvidedBy() ProviderRequest {
 	// Once the provider is fully resolved, we can return the known value.
 	if n.ResolvedInstanceProvider.IsSet() {
-		return ProvidedBy{
-			Absolute: []ResourceProvidedBy{{
+		return ProviderRequest{
+			Exact: []ProviderResourceInstanceRequest{{
 				Provider: n.ResolvedInstanceProvider,
 				Resource: n.Addr,
 			}},

--- a/internal/tofu/node_resource_abstract_test.go
+++ b/internal/tofu/node_resource_abstract_test.go
@@ -127,13 +127,13 @@ func TestNodeAbstractResourceResolveInstanceProvider(t *testing.T) {
 	tests := []struct {
 		name               string
 		instanceAddr       addrs.AbsResourceInstance
-		potentialProviders []distinguishableProvider
+		potentialProviders []ModuleInstancePotentialProvider
 		Want               addrs.AbsProviderConfig
 	}{
 		{
 			name:         "potential provider pointing to a resource instance with an instance key",
 			instanceAddr: mustResourceInstanceAddr("null_resource.resource[\"first\"]"),
-			potentialProviders: []distinguishableProvider{{
+			potentialProviders: []ModuleInstancePotentialProvider{{
 				concreteProvider:   applyableProvider,
 				resourceIdentifier: addrs.StringKey("first")}},
 			Want: addrs.AbsProviderConfig{Provider: addrs.Provider{
@@ -145,7 +145,7 @@ func TestNodeAbstractResourceResolveInstanceProvider(t *testing.T) {
 		{
 			name:         "potential provider pointing to a resource instance under a child module with an instance key",
 			instanceAddr: mustResourceInstanceAddr("module.child_module[\"first\"].null_resource.resource"),
-			potentialProviders: []distinguishableProvider{{
+			potentialProviders: []ModuleInstancePotentialProvider{{
 				concreteProvider: applyableProvider,
 				moduleIdentifier: []addrs.ModuleInstanceStep{
 					{
@@ -162,7 +162,7 @@ func TestNodeAbstractResourceResolveInstanceProvider(t *testing.T) {
 		{
 			name:         "potential provider pointing to a resource instance with an instance key under a child module with an instance key",
 			instanceAddr: mustResourceInstanceAddr("module.child_module[\"first\"].null_resource.resource[\"first\"]"),
-			potentialProviders: []distinguishableProvider{{
+			potentialProviders: []ModuleInstancePotentialProvider{{
 				concreteProvider:   applyableProvider,
 				resourceIdentifier: addrs.StringKey("first"),
 				moduleIdentifier: []addrs.ModuleInstanceStep{
@@ -180,7 +180,7 @@ func TestNodeAbstractResourceResolveInstanceProvider(t *testing.T) {
 		{
 			name:         "potential provider pointing to a resource instance with an instance key under a nested child module with an instance key on the nested module",
 			instanceAddr: mustResourceInstanceAddr("module.child_module.module.nested_module[\"first\"].null_resource.resource[\"first\"]"),
-			potentialProviders: []distinguishableProvider{{
+			potentialProviders: []ModuleInstancePotentialProvider{{
 				concreteProvider:   applyableProvider,
 				resourceIdentifier: addrs.StringKey("first"),
 				moduleIdentifier: []addrs.ModuleInstanceStep{
@@ -201,7 +201,7 @@ func TestNodeAbstractResourceResolveInstanceProvider(t *testing.T) {
 		{
 			name:         "potential provider pointing to a resource instance with an instance key under a nested child module with an instance key on the nested module (with the instance key on the child module ignored)",
 			instanceAddr: mustResourceInstanceAddr("module.child_module[\"ignored\"].module.nested_module[\"first\"].null_resource.resource[\"first\"]"),
-			potentialProviders: []distinguishableProvider{{
+			potentialProviders: []ModuleInstancePotentialProvider{{
 				concreteProvider:   applyableProvider,
 				resourceIdentifier: addrs.StringKey("first"),
 				moduleIdentifier: []addrs.ModuleInstanceStep{
@@ -222,7 +222,7 @@ func TestNodeAbstractResourceResolveInstanceProvider(t *testing.T) {
 		{
 			name:         "potential provider pointing to a resource instance with an instance key under a nested child module with an instance key on both modules",
 			instanceAddr: mustResourceInstanceAddr("module.child_module[\"first\"].module.nested_module[\"first\"].null_resource.resource[\"first\"]"),
-			potentialProviders: []distinguishableProvider{{
+			potentialProviders: []ModuleInstancePotentialProvider{{
 				concreteProvider:   applyableProvider,
 				resourceIdentifier: addrs.StringKey("first"),
 				moduleIdentifier: []addrs.ModuleInstanceStep{

--- a/internal/tofu/node_resource_deposed.go
+++ b/internal/tofu/node_resource_deposed.go
@@ -328,7 +328,7 @@ func (n *NodeDestroyDeposedResourceInstanceObject) writeResourceInstanceState(ct
 
 	if obj == nil {
 		// No need to encode anything: we'll just write it directly.
-		state.SetResourceInstanceDeposed(absAddr, key, nil, n.ResolvedResourceProvider, n.ResolvedInstanceProvider)
+		state.SetResourceInstanceDeposed(absAddr, key, nil, n.ResolvedInstanceProvider)
 		log.Printf("[TRACE] writeResourceInstanceStateDeposed: removing state object for %s deposed %s", absAddr, key)
 		return nil
 	}
@@ -351,7 +351,7 @@ func (n *NodeDestroyDeposedResourceInstanceObject) writeResourceInstanceState(ct
 	}
 
 	log.Printf("[TRACE] writeResourceInstanceStateDeposed: writing state object for %s deposed %s", absAddr, key)
-	state.SetResourceInstanceDeposed(absAddr, key, src, n.ResolvedResourceProvider, n.ResolvedInstanceProvider)
+	state.SetResourceInstanceDeposed(absAddr, key, src, n.ResolvedInstanceProvider)
 	return nil
 }
 

--- a/internal/tofu/node_resource_destroy.go
+++ b/internal/tofu/node_resource_destroy.go
@@ -49,10 +49,10 @@ func (n *NodeDestroyResourceInstance) Name() string {
 	return n.ResourceInstanceAddr().String() + " (destroy)"
 }
 
-func (n *NodeDestroyResourceInstance) ProvidedBy() (addr map[addrs.InstanceKey]addrs.ProviderConfig, exactProvider ExactProvider) {
+func (n *NodeDestroyResourceInstance) ProvidedBy() (map[addrs.InstanceKey]addrs.ProviderConfig, bool) {
 	if n.Addr.Resource.Resource.Mode == addrs.DataResourceMode {
 		// indicate that this node does not require a configured provider
-		return nil, ExactProvider{}
+		return nil, true
 	}
 	return n.NodeAbstractResourceInstance.ProvidedBy()
 }

--- a/internal/tofu/node_resource_destroy.go
+++ b/internal/tofu/node_resource_destroy.go
@@ -49,10 +49,10 @@ func (n *NodeDestroyResourceInstance) Name() string {
 	return n.ResourceInstanceAddr().String() + " (destroy)"
 }
 
-func (n *NodeDestroyResourceInstance) ProvidedBy() ProvidedBy {
+func (n *NodeDestroyResourceInstance) ProvidedBy() ProviderRequest {
 	if n.Addr.Resource.Resource.Mode == addrs.DataResourceMode {
 		// indicate that this node does not require a configured provider
-		return ProvidedBy{}
+		return ProviderRequest{}
 	}
 	return n.NodeAbstractResourceInstance.ProvidedBy()
 }

--- a/internal/tofu/node_resource_destroy.go
+++ b/internal/tofu/node_resource_destroy.go
@@ -234,6 +234,6 @@ func (n *NodeDestroyResourceInstance) managedResourceExecute(ctx EvalContext) (d
 
 func (n *NodeDestroyResourceInstance) dataResourceExecute(ctx EvalContext) (diags tfdiags.Diagnostics) {
 	log.Printf("[TRACE] NodeDestroyResourceInstance: removing state object for %s", n.Addr)
-	ctx.State().SetResourceInstanceCurrent(n.Addr, nil, n.ResolvedResourceProvider, n.ResolvedInstanceProvider)
+	ctx.State().SetResourceInstanceCurrent(n.Addr, nil, n.ResolvedInstanceProvider)
 	return diags.Append(updateStateHook(ctx))
 }

--- a/internal/tofu/node_resource_destroy.go
+++ b/internal/tofu/node_resource_destroy.go
@@ -49,10 +49,10 @@ func (n *NodeDestroyResourceInstance) Name() string {
 	return n.ResourceInstanceAddr().String() + " (destroy)"
 }
 
-func (n *NodeDestroyResourceInstance) ProvidedBy() (map[addrs.InstanceKey]addrs.ProviderConfig, bool) {
+func (n *NodeDestroyResourceInstance) ProvidedBy() ProvidedBy {
 	if n.Addr.Resource.Resource.Mode == addrs.DataResourceMode {
 		// indicate that this node does not require a configured provider
-		return nil, true
+		return ProvidedBy{}
 	}
 	return n.NodeAbstractResourceInstance.ProvidedBy()
 }

--- a/internal/tofu/node_resource_import.go
+++ b/internal/tofu/node_resource_import.go
@@ -259,10 +259,7 @@ func (n *graphNodeImportStateSub) Execute(ctx EvalContext, op walkOperation) (di
 
 	// Refresh
 	riNode := &NodeAbstractResourceInstance{
-		Addr: n.TargetAddr,
-		NodeAbstractResource: NodeAbstractResource{
-			ResolvedResourceProvider: n.ResolvedResourceProvider,
-		},
+		Addr:                     n.TargetAddr,
 		ResolvedInstanceProvider: n.ResolvedInstanceProvider,
 	}
 	state, refreshDiags := riNode.refresh(ctx, states.NotDeposed, state)

--- a/internal/tofu/node_resource_import.go
+++ b/internal/tofu/node_resource_import.go
@@ -49,13 +49,17 @@ func (n *graphNodeImportState) Name() string {
 }
 
 // GraphNodeProviderConsumer
-func (n *graphNodeImportState) ProvidedBy() (map[addrs.InstanceKey]addrs.ProviderConfig, bool) {
+func (n *graphNodeImportState) ProvidedBy() ProvidedBy {
 	// We assume that n.ProviderAddr has been properly populated here.
 	// It's the responsibility of the code creating a graphNodeImportState
 	// to populate this, possibly by calling DefaultProviderConfig() on the
 	// resource address to infer an implied provider from the resource type
 	// name.
-	return map[addrs.InstanceKey]addrs.ProviderConfig{addrs.NoKey: n.ProviderAddr}, false
+	return ProvidedBy{
+		Relative: map[addrs.InstanceKey]addrs.AbsProviderConfig{
+			addrs.NoKey: n.ProviderAddr,
+		},
+	}
 }
 
 // GraphNodeProviderConsumer

--- a/internal/tofu/node_resource_import.go
+++ b/internal/tofu/node_resource_import.go
@@ -18,23 +18,15 @@ import (
 )
 
 type graphNodeImportState struct {
-	Addr                     addrs.AbsResourceInstance // Addr is the resource address to import into
-	ID                       string                    // ID is the ID to import as
-	ProviderAddr             addrs.AbsProviderConfig   // Provider address given by the user, or implied by the resource type
-	ResolvedResourceProvider addrs.AbsProviderConfig   // provider node address after resolution for the whole resource
-	ResolvedInstanceProvider addrs.AbsProviderConfig   // provider node address after resolution for instance
+	Addr             addrs.AbsResourceInstance // Addr is the resource address to import into
+	ID               string                    // ID is the ID to import as
+	ResolvedProvider addrs.AbsProviderConfig   // provider node address after resolution
 
 	Schema        *configschema.Block // Schema for processing the configuration body
 	SchemaVersion uint64              // Schema version of "Schema", as decided by the provider
 	Config        *configs.Resource   // Config is the resource in the config
 
 	states []providers.ImportedResource
-}
-
-func (n *graphNodeImportState) SetPotentialProviders(potentialProviders ResourceInstanceProviderResolver) {
-	// Technically we shouldn't get here as we don't support import with for_each on providers in resources / modules.
-	// We should panic here since we validated provider match between import/resource previously on configuration parsing.
-	panic("implement me")
 }
 
 var (
@@ -49,27 +41,22 @@ func (n *graphNodeImportState) Name() string {
 }
 
 // GraphNodeProviderConsumer
-func (n *graphNodeImportState) ProvidedBy() ProvidedBy {
-	// We assume that n.ProviderAddr has been properly populated here.
-	// It's the responsibility of the code creating a graphNodeImportState
-	// to populate this, possibly by calling DefaultProviderConfig() on the
-	// resource address to infer an implied provider from the resource type
-	// name.
-	return ProvidedBy{
-		Relative: map[addrs.InstanceKey]addrs.AbsProviderConfig{
-			addrs.NoKey: n.ProviderAddr,
-		},
+func (n *graphNodeImportState) ProvidedBy() ProviderRequest {
+	return ProviderRequest{
+		Exact: []ProviderResourceInstanceRequest{{
+			Resource: n.Addr,
+			Provider: n.ResolvedProvider,
+		}},
 	}
 }
 
 // GraphNodeProviderConsumer
 func (n *graphNodeImportState) Provider() addrs.Provider {
-	// We assume that n.ProviderAddr has been properly populated here.
-	// It's the responsibility of the code creating a graphNodeImportState
-	// to populate this, possibly by calling DefaultProviderConfig() on the
-	// resource address to infer an implied provider from the resource type
-	// name.
-	return n.ProviderAddr.Provider
+	return n.ResolvedProvider.Provider
+}
+
+func (n *graphNodeImportState) SetPotentialProviders(potentialProviders ResourceInstanceProviderResolver) {
+	// We already have a resolved provider and do not need this additional resolver
 }
 
 // GraphNodeModuleInstance
@@ -82,32 +69,12 @@ func (n *graphNodeImportState) ModulePath() addrs.Module {
 	return n.Addr.Module.Module()
 }
 
-func (n *graphNodeImportState) ResolvedProvider() addrs.AbsProviderConfig {
-	var result addrs.AbsProviderConfig
-	if n.ResolvedResourceProvider.IsSet() {
-		result = n.ResolvedResourceProvider
-	} else {
-		result = n.ResolvedInstanceProvider
-	}
-
-	if !result.IsSet() {
-		panic(fmt.Sprintf("ResolvedProvider for graphNodeImportState of %s cannot get a provider", n.Addr))
-	}
-
-	// Throw an error if ResolvedResourceProvider and ResolvedInstanceProvider exists at the same time.
-	if n.ResolvedInstanceProvider.IsSet() && n.ResolvedResourceProvider.IsSet() {
-		panic(fmt.Sprintf("ResolvedProvider for graphNodeImportState of %s has a provider set for both the resource and the resource's instance", n.Addr))
-	}
-
-	return result
-}
-
 // GraphNodeExecutable impl.
 func (n *graphNodeImportState) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	// Reset our states
 	n.states = nil
 
-	provider, _, err := getProvider(ctx, n.ResolvedProvider())
+	provider, _, err := getProvider(ctx, n.ResolvedProvider)
 	diags = diags.Append(err)
 	if diags.HasErrors() {
 		return diags
@@ -207,13 +174,12 @@ func (n *graphNodeImportState) DynamicExpand(ctx EvalContext) (*Graph, error) {
 	// safe.
 	for i, state := range n.states {
 		g.Add(&graphNodeImportStateSub{
-			TargetAddr:               addrs[i],
-			State:                    state,
-			ResolvedResourceProvider: n.ResolvedResourceProvider,
-			ResolvedInstanceProvider: n.ResolvedInstanceProvider,
-			Schema:                   n.Schema,
-			SchemaVersion:            n.SchemaVersion,
-			Config:                   n.Config,
+			TargetAddr:       addrs[i],
+			State:            state,
+			ResolvedProvider: n.ResolvedProvider,
+			Schema:           n.Schema,
+			SchemaVersion:    n.SchemaVersion,
+			Config:           n.Config,
 		})
 	}
 
@@ -227,10 +193,9 @@ func (n *graphNodeImportState) DynamicExpand(ctx EvalContext) (*Graph, error) {
 // and is part of the subgraph. This node is responsible for refreshing
 // and adding a resource to the state once it is imported.
 type graphNodeImportStateSub struct {
-	TargetAddr               addrs.AbsResourceInstance
-	State                    providers.ImportedResource
-	ResolvedResourceProvider addrs.AbsProviderConfig // provider node address after resolution for the whole resource
-	ResolvedInstanceProvider addrs.AbsProviderConfig // provider node address after resolution for instance
+	TargetAddr       addrs.AbsResourceInstance
+	State            providers.ImportedResource
+	ResolvedProvider addrs.AbsProviderConfig // provider node address after resolution
 
 	Schema        *configschema.Block // Schema for processing the configuration body
 	SchemaVersion uint64              // Schema version of "Schema", as decided by the provider
@@ -264,7 +229,7 @@ func (n *graphNodeImportStateSub) Execute(ctx EvalContext, op walkOperation) (di
 	// Refresh
 	riNode := &NodeAbstractResourceInstance{
 		Addr:                     n.TargetAddr,
-		ResolvedInstanceProvider: n.ResolvedInstanceProvider,
+		ResolvedInstanceProvider: n.ResolvedProvider,
 	}
 	state, refreshDiags := riNode.refresh(ctx, states.NotDeposed, state)
 	diags = diags.Append(refreshDiags)

--- a/internal/tofu/node_resource_import.go
+++ b/internal/tofu/node_resource_import.go
@@ -31,7 +31,7 @@ type graphNodeImportState struct {
 	states []providers.ImportedResource
 }
 
-func (n *graphNodeImportState) SetPotentialProviders(potentialProviders []distinguishableProvider) {
+func (n *graphNodeImportState) SetPotentialProviders(potentialProviders ResourceInstanceProviderResolver) {
 	// Technically we shouldn't get here as we don't support import with for_each on providers in resources / modules.
 	// We should panic here since we validated provider match between import/resource previously on configuration parsing.
 	panic("implement me")

--- a/internal/tofu/node_resource_import.go
+++ b/internal/tofu/node_resource_import.go
@@ -49,13 +49,13 @@ func (n *graphNodeImportState) Name() string {
 }
 
 // GraphNodeProviderConsumer
-func (n *graphNodeImportState) ProvidedBy() (map[addrs.InstanceKey]addrs.ProviderConfig, ExactProvider) {
+func (n *graphNodeImportState) ProvidedBy() (map[addrs.InstanceKey]addrs.ProviderConfig, bool) {
 	// We assume that n.ProviderAddr has been properly populated here.
 	// It's the responsibility of the code creating a graphNodeImportState
 	// to populate this, possibly by calling DefaultProviderConfig() on the
 	// resource address to infer an implied provider from the resource type
 	// name.
-	return map[addrs.InstanceKey]addrs.ProviderConfig{addrs.NoKey: n.ProviderAddr}, ExactProvider{}
+	return map[addrs.InstanceKey]addrs.ProviderConfig{addrs.NoKey: n.ProviderAddr}, false
 }
 
 // GraphNodeProviderConsumer
@@ -66,15 +66,6 @@ func (n *graphNodeImportState) Provider() addrs.Provider {
 	// resource address to infer an implied provider from the resource type
 	// name.
 	return n.ProviderAddr.Provider
-}
-
-// GraphNodeProviderConsumer
-func (n *graphNodeImportState) SetProvider(provider addrs.AbsProviderConfig, isResourceProvider bool) {
-	if isResourceProvider {
-		n.ResolvedResourceProvider = provider
-	} else {
-		n.ResolvedInstanceProvider = provider
-	}
 }
 
 // GraphNodeModuleInstance

--- a/internal/tofu/node_resource_plan.go
+++ b/internal/tofu/node_resource_plan.go
@@ -127,7 +127,6 @@ func (n *nodeExpandPlannableResource) DynamicExpand(ctx EvalContext) (*Graph, er
 	concreteResourceOrphan := func(a *NodeAbstractResourceInstance) *NodePlannableResourceInstanceOrphan {
 		// Add the config and state since we don't do that via transforms
 		a.Config = n.Config
-		a.ResolvedResourceProvider = n.ResolvedResourceProvider
 		a.ResolvedInstanceProvider = n.resolveInstanceProvider(a.Addr)
 		a.Schema = n.Schema
 		a.ProvisionerSchemas = n.ProvisionerSchemas
@@ -337,7 +336,6 @@ func (n *nodeExpandPlannableResource) resourceInstanceSubgraph(ctx EvalContext, 
 				return &graphNodeImportState{
 					Addr:                     c.Addr,
 					ID:                       c.ID,
-					ResolvedResourceProvider: n.ResolvedResourceProvider,
 					ResolvedInstanceProvider: n.resolveInstanceProvider(a.Addr),
 					Schema:                   n.Schema,
 					SchemaVersion:            n.SchemaVersion,
@@ -348,7 +346,6 @@ func (n *nodeExpandPlannableResource) resourceInstanceSubgraph(ctx EvalContext, 
 
 		// Add the config and state since we don't do that via transforms
 		a.Config = n.Config
-		a.ResolvedResourceProvider = n.ResolvedResourceProvider
 		a.ResolvedInstanceProvider = n.resolveInstanceProvider(a.Addr)
 		a.Schema = n.Schema
 		a.ProvisionerSchemas = n.ProvisionerSchemas
@@ -382,7 +379,6 @@ func (n *nodeExpandPlannableResource) resourceInstanceSubgraph(ctx EvalContext, 
 	concreteResourceOrphan := func(a *NodeAbstractResourceInstance) dag.Vertex {
 		// Add the config and state since we don't do that via transforms
 		a.Config = n.Config
-		a.ResolvedResourceProvider = n.ResolvedResourceProvider
 		a.ResolvedInstanceProvider = n.resolveInstanceProvider(a.Addr)
 		a.Schema = n.Schema
 		a.ProvisionerSchemas = n.ProvisionerSchemas

--- a/internal/tofu/node_resource_plan.go
+++ b/internal/tofu/node_resource_plan.go
@@ -334,12 +334,12 @@ func (n *nodeExpandPlannableResource) resourceInstanceSubgraph(ctx EvalContext, 
 		for _, c := range commandLineImportTargets {
 			if c.Addr.Equal(a.Addr) {
 				return &graphNodeImportState{
-					Addr:                     c.Addr,
-					ID:                       c.ID,
-					ResolvedInstanceProvider: n.resolveInstanceProvider(a.Addr),
-					Schema:                   n.Schema,
-					SchemaVersion:            n.SchemaVersion,
-					Config:                   n.Config,
+					Addr:             c.Addr,
+					ID:               c.ID,
+					ResolvedProvider: n.resolveInstanceProvider(a.Addr),
+					Schema:           n.Schema,
+					SchemaVersion:    n.SchemaVersion,
+					Config:           n.Config,
 				}
 			}
 		}

--- a/internal/tofu/node_resource_plan_instance.go
+++ b/internal/tofu/node_resource_plan_instance.go
@@ -528,10 +528,8 @@ func (n *NodePlannableResourceInstance) importState(ctx EvalContext, addr addrs.
 
 	// refresh
 	riNode := &NodeAbstractResourceInstance{
-		Addr: n.Addr,
-		NodeAbstractResource: NodeAbstractResource{
-			ResolvedResourceProvider: n.ResolvedProvider(),
-		},
+		Addr:                     n.Addr,
+		ResolvedInstanceProvider: n.resolveInstanceProvider(n.Addr),
 	}
 	instanceRefreshState, refreshDiags := riNode.refresh(ctx, states.NotDeposed, importedState)
 	diags = diags.Append(refreshDiags)

--- a/internal/tofu/node_resource_plan_orphan.go
+++ b/internal/tofu/node_resource_plan_orphan.go
@@ -65,10 +65,10 @@ func (n *NodePlannableResourceInstanceOrphan) Execute(ctx EvalContext, op walkOp
 	}
 }
 
-func (n *NodePlannableResourceInstanceOrphan) ProvidedBy() ProvidedBy {
+func (n *NodePlannableResourceInstanceOrphan) ProvidedBy() ProviderRequest {
 	if n.Addr.Resource.Resource.Mode == addrs.DataResourceMode {
 		// indicate that this node does not require a configured provider
-		return ProvidedBy{}
+		return ProviderRequest{}
 	}
 	return n.NodeAbstractResourceInstance.ProvidedBy()
 }

--- a/internal/tofu/node_resource_plan_orphan.go
+++ b/internal/tofu/node_resource_plan_orphan.go
@@ -80,10 +80,10 @@ func (n *NodePlannableResourceInstanceOrphan) dataResourceExecute(ctx EvalContex
 	// we need to update both the refresh state to refresh the current data
 	// source, and the working state for plan-time evaluations.
 	refreshState := ctx.RefreshState()
-	refreshState.SetResourceInstanceCurrent(n.Addr, nil, n.NodeAbstractResource.ResolvedResourceProvider, n.ResolvedInstanceProvider)
+	refreshState.SetResourceInstanceCurrent(n.Addr, nil, n.ResolvedInstanceProvider)
 
 	workingState := ctx.State()
-	workingState.SetResourceInstanceCurrent(n.Addr, nil, n.NodeAbstractResource.ResolvedResourceProvider, n.ResolvedInstanceProvider)
+	workingState.SetResourceInstanceCurrent(n.Addr, nil, n.ResolvedInstanceProvider)
 	return nil
 }
 

--- a/internal/tofu/node_resource_plan_orphan.go
+++ b/internal/tofu/node_resource_plan_orphan.go
@@ -65,10 +65,10 @@ func (n *NodePlannableResourceInstanceOrphan) Execute(ctx EvalContext, op walkOp
 	}
 }
 
-func (n *NodePlannableResourceInstanceOrphan) ProvidedBy() (addr map[addrs.InstanceKey]addrs.ProviderConfig, exact ExactProvider) {
+func (n *NodePlannableResourceInstanceOrphan) ProvidedBy() (addr map[addrs.InstanceKey]addrs.ProviderConfig, exact bool) {
 	if n.Addr.Resource.Resource.Mode == addrs.DataResourceMode {
 		// indicate that this node does not require a configured provider
-		return nil, ExactProvider{}
+		return nil, true
 	}
 	return n.NodeAbstractResourceInstance.ProvidedBy()
 }

--- a/internal/tofu/node_resource_plan_orphan.go
+++ b/internal/tofu/node_resource_plan_orphan.go
@@ -65,10 +65,10 @@ func (n *NodePlannableResourceInstanceOrphan) Execute(ctx EvalContext, op walkOp
 	}
 }
 
-func (n *NodePlannableResourceInstanceOrphan) ProvidedBy() (addr map[addrs.InstanceKey]addrs.ProviderConfig, exact bool) {
+func (n *NodePlannableResourceInstanceOrphan) ProvidedBy() ProvidedBy {
 	if n.Addr.Resource.Resource.Mode == addrs.DataResourceMode {
 		// indicate that this node does not require a configured provider
-		return nil, true
+		return ProvidedBy{}
 	}
 	return n.NodeAbstractResourceInstance.ProvidedBy()
 }

--- a/internal/tofu/node_resource_validate.go
+++ b/internal/tofu/node_resource_validate.go
@@ -282,13 +282,7 @@ var connectionBlockSupersetSchema = &configschema.Block{
 func (n *NodeValidatableResource) validateResource(ctx EvalContext) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
-	var absProvider addrs.AbsProviderConfig
-
-	if len(n.potentialProviders) > 0 {
-		// If the provider has yet to be resolved (will be resolved at the expansion on instance level), we can use any
-		// of the potentialProviders instead, as the interface and schema will be the same for all potential providers
-		absProvider = n.potentialProviders.Any()
-	}
+	absProvider := n.potentialProviders.Any()
 
 	provider, providerSchema, err := getProvider(ctx, absProvider)
 	diags = diags.Append(err)

--- a/internal/tofu/node_resource_validate.go
+++ b/internal/tofu/node_resource_validate.go
@@ -288,7 +288,7 @@ func (n *NodeValidatableResource) validateResource(ctx EvalContext) tfdiags.Diag
 	} else if len(n.potentialProviders) > 0 {
 		// If the provider has yet to be resolved (will be resolved at the expansion on instance level), we can use any
 		// of the potentialProviders instead, as the interface and schema will be the same for all potential providers
-		absProvider = n.potentialProviders[0].concreteProvider.ProviderAddr()
+		absProvider = n.potentialProviders.Any()
 	}
 
 	provider, providerSchema, err := getProvider(ctx, absProvider)

--- a/internal/tofu/node_resource_validate.go
+++ b/internal/tofu/node_resource_validate.go
@@ -283,9 +283,8 @@ func (n *NodeValidatableResource) validateResource(ctx EvalContext) tfdiags.Diag
 	var diags tfdiags.Diagnostics
 
 	var absProvider addrs.AbsProviderConfig
-	if n.ResolvedResourceProvider.IsSet() {
-		absProvider = n.ResolvedResourceProvider
-	} else if len(n.potentialProviders) > 0 {
+
+	if len(n.potentialProviders) > 0 {
 		// If the provider has yet to be resolved (will be resolved at the expansion on instance level), we can use any
 		// of the potentialProviders instead, as the interface and schema will be the same for all potential providers
 		absProvider = n.potentialProviders.Any()

--- a/internal/tofu/node_resource_validate_test.go
+++ b/internal/tofu/node_resource_validate_test.go
@@ -378,7 +378,7 @@ func TestNodeValidatableResource_ValidateResource_validWithPotentialProviderSet(
 		NodeAbstractResource: &NodeAbstractResource{
 			Addr:   mustConfigResourceAddr("test_object.foo"),
 			Config: rc,
-			potentialProviders: []distinguishableProvider{{
+			potentialProviders: []ModuleInstancePotentialProvider{{
 				concreteProvider: applyableProvider}},
 		},
 	}

--- a/internal/tofu/transform_attach_state.go
+++ b/internal/tofu/transform_attach_state.go
@@ -28,6 +28,12 @@ type GraphNodeAttachResourceState interface {
 	AttachResourceState(*states.Resource)
 }
 
+type GraphNodeAttachResourceStates interface {
+	GraphNodeConfigResource
+
+	AttachResourceStates([]*states.Resource)
+}
+
 // AttachStateTransformer goes through the graph and attaches
 // state to nodes that implement the interfaces above.
 type AttachStateTransformer struct {
@@ -42,6 +48,10 @@ func (t *AttachStateTransformer) Transform(g *Graph) error {
 	}
 
 	for _, v := range g.Vertices() {
+		if an, ok := v.(GraphNodeAttachResourceStates); ok {
+			an.AttachResourceStates(t.State.Resources(an.ResourceAddr()))
+		}
+
 		// Nodes implement this interface to request state attachment.
 		an, ok := v.(GraphNodeAttachResourceState)
 		if !ok {

--- a/internal/tofu/transform_destroy_edge.go
+++ b/internal/tofu/transform_destroy_edge.go
@@ -102,10 +102,7 @@ func (t *DestroyEdgeTransformer) tryInterProviderDestroyEdge(g *Graph, from, to 
 	// from the same provider instance.
 	getComparableProvider := func(pc GraphNodeProviderConsumer) []string {
 
-		pmap, exact := pc.ProvidedBy()
-		if exact.provider.IsSet() {
-			return []string{exact.provider.String()}
-		}
+		pmap, _ := pc.ProvidedBy()
 		if len(pmap) == 0 {
 			return []string{pc.Provider().String()}
 		}

--- a/internal/tofu/transform_destroy_edge.go
+++ b/internal/tofu/transform_destroy_edge.go
@@ -103,13 +103,14 @@ func (t *DestroyEdgeTransformer) tryInterProviderDestroyEdge(g *Graph, from, to 
 	getComparableProvider := func(pc GraphNodeProviderConsumer) []string {
 
 		// TODO more checks
-		pmap := pc.ProvidedBy().Relative
+		// TODO this is probably bugged on main as well!
+		pmap := pc.ProvidedBy().Local
 		if len(pmap) == 0 {
 			return []string{pc.Provider().String()}
 		}
 		var ps []string
 		for _, p := range pmap {
-			ps = append(ps, p.String())
+			ps = append(ps, p)
 		}
 		return ps
 

--- a/internal/tofu/transform_destroy_edge.go
+++ b/internal/tofu/transform_destroy_edge.go
@@ -102,18 +102,14 @@ func (t *DestroyEdgeTransformer) tryInterProviderDestroyEdge(g *Graph, from, to 
 	// from the same provider instance.
 	getComparableProvider := func(pc GraphNodeProviderConsumer) []string {
 
-		pmap, _ := pc.ProvidedBy()
+		// TODO more checks
+		pmap := pc.ProvidedBy().Relative
 		if len(pmap) == 0 {
 			return []string{pc.Provider().String()}
 		}
 		var ps []string
 		for _, p := range pmap {
-			switch p := p.(type) {
-			case addrs.AbsProviderConfig:
-				ps = append(ps, p.String())
-			case addrs.LocalProviderConfig:
-				ps = append(ps, p.String())
-			}
+			ps = append(ps, p.String())
 		}
 		return ps
 

--- a/internal/tofu/transform_provider.go
+++ b/internal/tofu/transform_provider.go
@@ -592,18 +592,25 @@ func (r ResourceInstanceProviderResolver) Resolve(addr addrs.AbsResourceInstance
 	}
 	// First check for an exact match on the resource instance key
 	if p, ok := r.ByResourceKey[addr.Resource.Key]; ok {
-		return p.Resolve(addr.Module)
+		if resolved := p.Resolve(addr.Module); resolved.IsSet() {
+			return resolved
+		}
 	}
 	// If the resource instance key is not an exact match, the other possibility is that there is no
 	// alternate mapping to ModuleInstanceProviderResovlers based on the provider key
 	if p, ok := r.ByResourceKey[addrs.NoKey]; ok {
-		return p.Resolve(addr.Module)
+		if resolved := p.Resolve(addr.Module); resolved.IsSet() {
+			return resolved
+		}
 	}
 	for _, m := range r.Absolute {
 		if addr.Equal(m.Resource) && m.Optional {
 			return m.Provider
 		}
 	}
+	spew.Dump(addr)
+	println("=========")
+	spew.Dump(r)
 	panic("TODO better message here")
 }
 
@@ -619,10 +626,7 @@ func (m ModuleInstanceProviderResolver) Resolve(addr addrs.ModuleInstance) addrs
 			return pr.concreteProvider.ProviderAddr()
 		}
 	}
-	spew.Dump(m)
-	println("====")
-	spew.Dump(addr)
-	panic("TODO better message here")
+	return addrs.AbsProviderConfig{}
 }
 
 // ModuleInstancePotentialProvider is a representation of a concrete provider and identifiers that match the provider to a

--- a/internal/tofu/transform_provider.go
+++ b/internal/tofu/transform_provider.go
@@ -723,12 +723,19 @@ func (n *graphNodeProxyProvider) Expanded() []ModuleInstancePotentialProvider {
 			targetConcrete = append(targetConcrete, providers...)
 		} else {
 			// We hit a concrete provider
-			modulePath := addrs.ModuleInstanceStep{
-				Name:        n.ModulePath()[len(n.ModulePath())-1],
-				InstanceKey: ik,
+			// Build a path that matches the existing module path directly
+			path := make([]addrs.ModuleInstanceStep, len(n.ModulePath()))
+			for i, step := range n.ModulePath() {
+				path[i] = addrs.ModuleInstanceStep{
+					Name:        step,
+					InstanceKey: addrs.NoKey,
+				}
 			}
+			// Overwrite the last instance key with the current key
+			path[len(path)-1].InstanceKey = ik
+
 			targetConcrete = []ModuleInstancePotentialProvider{{
-				moduleIdentifier: []addrs.ModuleInstanceStep{modulePath},
+				moduleIdentifier: path,
 				concreteProvider: target,
 			}}
 		}

--- a/internal/tofu/transform_provider.go
+++ b/internal/tofu/transform_provider.go
@@ -83,13 +83,10 @@ type GraphNodeProviderConsumer interface {
 	// * addrs.AbsProviderConfig + empty ExactProvider{}: no config or state; the returned
 	//   value is a default provider configuration address for the resource's
 	//   Provider
-	ProvidedBy() (addr map[addrs.InstanceKey]addrs.ProviderConfig, exactProvider ExactProvider)
+	ProvidedBy() (addr map[addrs.InstanceKey]addrs.ProviderConfig, exact bool)
 
 	// Provider returns the Provider FQN for the node.
 	Provider() (provider addrs.Provider)
-
-	// SetProvider Set the resolved provider address for the resource / instance
-	SetProvider(provider addrs.AbsProviderConfig, isResourceProvider bool)
 
 	// SetPotentialProviders sets the potential providers to be resolved later, after the expansion of instances.
 	// Sometimes we won't know the exact provider, and will have a list of potential providers that can be resolved once
@@ -118,76 +115,58 @@ func (t *ProviderTransformer) Transform(g *Graph) error {
 	// Our "requested" map is from graph vertices to string representations of
 	// provider config addresses (for deduping) to requests.
 	type ProviderRequest struct {
-		Addr        addrs.AbsProviderConfig
-		Exact       ExactProvider // If populated, inheritance from parent modules is not attempted
-		instanceKey addrs.InstanceKey
+		Addr  addrs.AbsProviderConfig
+		Exact bool // If true, inheritance from parent modules is not attempted
 	}
-	requested := map[dag.Vertex]map[string]ProviderRequest{}
-	needConfigured := map[string]addrs.AbsProviderConfig{}
+	requested := make(map[dag.Vertex]map[addrs.InstanceKey]ProviderRequest)
 	for _, v := range g.Vertices() {
 		// Does the vertex _directly_ use a provider?
 		if pv, ok := v.(GraphNodeProviderConsumer); ok {
-			providerAddrs, exactProvider := pv.ProvidedBy()
+			providerAddrs, exact := pv.ProvidedBy()
 
-			if providerAddrs == nil && !exactProvider.provider.IsSet() {
+			if providerAddrs == nil && !exact {
 				// no provider is required
 				continue
 			}
 
-			requested[v] = make(map[string]ProviderRequest)
+			requested[v] = make(map[addrs.InstanceKey]ProviderRequest)
 
-			if exactProvider.provider.IsSet() {
-				providerAddr := exactProvider.provider
-				log.Printf("[TRACE] ProviderTransformer: %s is provided by %s exactly", dag.VertexName(v), providerAddr)
+			for ik, providerAddr := range providerAddrs {
+				var absPc addrs.AbsProviderConfig
 
-				requested[v][providerAddr.String()] = ProviderRequest{
-					Addr:  addrs.AbsProviderConfig{},
-					Exact: exactProvider,
-					// If we are providing an exact provider, we won't need to use the instanceKey prop on the request.
-					// That's why we can set addrs.NoKey as the instanceKey.
-					instanceKey: addrs.NoKey,
-				}
+				switch p := providerAddr.(type) {
+				case addrs.AbsProviderConfig:
+					// ProvidedBy() returns an AbsProviderConfig when the provider
+					// configuration is implied from the resource, so we do not need to verify
+					// the FQN matches.
+					absPc = p
 
-				// Direct references need the provider configured as well as initialized
-				needConfigured[providerAddr.String()] = providerAddr
-			} else {
-				for ik, providerAddr := range providerAddrs {
-					var absPc addrs.AbsProviderConfig
+					if exact {
+						log.Printf("[TRACE] ProviderTransformer: %s is provided by %s exactly", dag.VertexName(v), absPc)
+					}
 
-					switch p := providerAddr.(type) {
-					case addrs.AbsProviderConfig:
-						// ProvidedBy() returns an AbsProviderConfig when the provider
-						// configuration is implied from the resource, so we do not need to verify
-						// the FQN matches.
-						absPc = p
-
-					case addrs.LocalProviderConfig:
-						// ProvidedBy() return a LocalProviderConfig when the resource
-						// contains a `provider` attribute
-						absPc.Provider = pv.Provider()
-						modPath := pv.ModulePath()
-						if t.Config == nil {
-							absPc.Module = modPath
-							absPc.Alias = p.Alias
-							break
-						}
-
+				case addrs.LocalProviderConfig:
+					// ProvidedBy() return a LocalProviderConfig when the resource
+					// contains a `provider` attribute
+					absPc.Provider = pv.Provider()
+					modPath := pv.ModulePath()
+					if t.Config == nil {
 						absPc.Module = modPath
 						absPc.Alias = p.Alias
-
-					default:
-						// This should never happen; the case statements are meant to be exhaustive
-						panic(fmt.Sprintf("%s: provider for %s couldn't be determined", dag.VertexName(v), absPc))
+						break
 					}
 
-					requested[v][absPc.String()] = ProviderRequest{
-						Addr:        absPc,
-						Exact:       ExactProvider{},
-						instanceKey: ik,
-					}
+					absPc.Module = modPath
+					absPc.Alias = p.Alias
 
-					// Direct references need the provider configured as well as initialized
-					needConfigured[absPc.String()] = absPc
+				default:
+					// This should never happen; the case statements are meant to be exhaustive
+					panic(fmt.Sprintf("%s: provider for %s couldn't be determined", dag.VertexName(v), absPc))
+				}
+
+				requested[v][ik] = ProviderRequest{
+					Addr:  absPc,
+					Exact: exact,
 				}
 			}
 		}
@@ -201,9 +180,9 @@ func (t *ProviderTransformer) Transform(g *Graph) error {
 		// Mapping from resource.InstanceKey to one of many ModuleInstancePotentialProvider
 		potentialTargets := make(ResourceInstanceProviderResolver)
 
-		for key, req := range reqs {
+		for resourceKey, req := range reqs {
 			p := req.Addr
-			target := m[key]
+			target := m[p.String()]
 
 			_, ok := v.(GraphNodeModulePath)
 			if !ok && target == nil {
@@ -217,11 +196,9 @@ func (t *ProviderTransformer) Transform(g *Graph) error {
 				log.Printf("[TRACE] ProviderTransformer: exact match for %s serving %s", p, dag.VertexName(v))
 			}
 
-			isRequestedExactProvider := req.Exact.provider.IsSet()
-
 			// if we don't have a provider at this level, walk up the path looking for one,
 			// unless we were told to be exact.
-			if target == nil && !isRequestedExactProvider {
+			if target == nil && !req.Exact {
 				for pp, ok := p.Inherited(); ok; pp, ok = pp.Inherited() {
 					key := pp.String()
 					target = m[key]
@@ -231,25 +208,6 @@ func (t *ProviderTransformer) Transform(g *Graph) error {
 					}
 					log.Printf("[TRACE] ProviderTransformer: looking for %s to serve %s", pp, dag.VertexName(v))
 				}
-			}
-
-			// If this provider doesn't need to be configured then we can just
-			// stub it out with an init-only provider node, which will just
-			// start up the provider and fetch its schema.
-			if _, exists := needConfigured[key]; target == nil && !exists {
-				stubAddr := addrs.AbsProviderConfig{
-					Module:   addrs.RootModule,
-					Provider: p.Provider,
-				}
-				stub := &NodeEvalableProvider{
-					&NodeAbstractProvider{
-						Addr: stubAddr,
-					},
-				}
-				m[stubAddr.String()] = stub
-				log.Printf("[TRACE] ProviderTransformer: creating init-only node for %s", stubAddr)
-				target = stub
-				g.Add(target)
 			}
 
 			if target == nil {
@@ -264,61 +222,30 @@ func (t *ProviderTransformer) Transform(g *Graph) error {
 				break
 			}
 
-			// If exact is true, it means we are in one in two scenarios:
-			// 1. The provider transformer is running after the resources were expanded to instances, and the instances
-			// already resolved their providers and the provider level (provider is set for the resource or for the
-			// instance).
-			// 2. This resource is not in the configuration, so the providers were taken from the state.
-			//
-			// In both of those cases, as the providers were previously resolved, we don't need to go through the whole
-			// process of resolving them again. We'll set them straight on the resource and use the given
-			// "isResourceProvider", to set the provider on the already known provider level.
-			// We are also breaking the loop and stopping to process this request, as we don't need to proceed and
-			// calculate the potentialTargets, as we already know the resolved provider.
-			if isRequestedExactProvider {
-				if pv, ok := v.(GraphNodeProviderConsumer); ok {
-					log.Printf("[DEBUG] ProviderTransformer: %q (%T) needs %s", dag.VertexName(v), v, dag.VertexName(target))
-
-					if _, ok := target.(*graphNodeProxyProvider); ok {
-						panic(fmt.Sprintf("%s: exact provider target cannot be from type graphNodeProxyProvider, it should have already been a concrete provider", dag.VertexName(v)))
-					}
-
-					log.Printf("[DEBUG] ProviderTransformer: %q (%T) needs the exact provider %s", dag.VertexName(v), v, dag.VertexName(target))
-					g.Connect(dag.BasicEdge(v, target))
-					pv.SetProvider(target.ProviderAddr(), req.Exact.isResourceProvider)
-
-					break
-				}
-
-			}
-
 			// Module expansions for this particular resource InstanceKey
 			var moduleExpansionProviders []ModuleInstancePotentialProvider
 
 			// see if this is a proxy provider pointing to another concrete config
 			if p, ok := target.(*graphNodeProxyProvider); ok {
-				g.Remove(p)
-
 				moduleExpansionProviders = p.Expanded()
 				for _, pp := range moduleExpansionProviders {
-					log.Printf("[DEBUG] ProviderTransformer: %q (%T) needs the potential provider %s", dag.VertexName(v), v, dag.VertexName(pp))
+					log.Printf("[DEBUG] ProviderTransformer: %q (%T) needs the provider %s", dag.VertexName(v), v, dag.VertexName(pp.concreteProvider))
 					g.Connect(dag.BasicEdge(v, pp.concreteProvider))
 				}
 			} else {
-				log.Printf("[DEBUG] ProviderTransformer: %q (%T) needs the potential provider %s", dag.VertexName(v), v, dag.VertexName(target))
+				log.Printf("[DEBUG] ProviderTransformer: %q (%T) needs the provider %s", dag.VertexName(v), v, dag.VertexName(target))
 				moduleExpansionProviders = []ModuleInstancePotentialProvider{{
-					moduleIdentifier: nil, // TODO should this construct the actual module path here?
+					moduleIdentifier: nil, // Special case in ModuleInstancePotentialProvider
 					concreteProvider: target,
 				}}
 				g.Connect(dag.BasicEdge(v, target))
 			}
 
-			potentialTargets[req.instanceKey] = moduleExpansionProviders
+			potentialTargets[resourceKey] = moduleExpansionProviders
 		}
 
 		if pv, ok := v.(GraphNodeProviderConsumer); ok {
 			pv.SetPotentialProviders(potentialTargets)
-
 		}
 	}
 
@@ -587,6 +514,7 @@ func (t *PruneProviderTransformer) Transform(g *Graph) error {
 		if _, ok := v.(*graphNodeProxyProvider); ok {
 			log.Printf("[DEBUG] pruning proxy %s", dag.VertexName(v))
 			g.Remove(v)
+			continue
 		}
 
 		// Remove providers with no dependencies.
@@ -679,6 +607,10 @@ func (r ResourceInstanceProviderResolver) Resolve(addr addrs.AbsResourceInstance
 type ModuleInstanceProviderResolver []ModuleInstancePotentialProvider
 
 func (m ModuleInstanceProviderResolver) Resolve(addr addrs.ModuleInstance) addrs.AbsProviderConfig {
+	if len(m) == 1 && m[0].moduleIdentifier == nil {
+		// Special case, see transformer above
+		return m[0].concreteProvider.ProviderAddr()
+	}
 	for _, pr := range m {
 		if pr.ModuleInstanceMatches(addr) {
 			return pr.concreteProvider.ProviderAddr()
@@ -702,6 +634,9 @@ func (d *ModuleInstancePotentialProvider) AddModuleIdentifierToTheEnd(step addrs
 }
 
 func (d *ModuleInstancePotentialProvider) ModuleInstanceMatches(moduleInstance addrs.ModuleInstance) bool {
+	if len(moduleInstance) != len(d.moduleIdentifier) {
+		panic("TODO better message")
+	}
 	for i, moduleInstanceStep := range d.moduleIdentifier {
 		parallelResourceModuleAddress := moduleInstance[i]
 

--- a/internal/tofu/transform_provider.go
+++ b/internal/tofu/transform_provider.go
@@ -62,22 +62,28 @@ type GraphNodeCloseProvider interface {
 	CloseProviderAddr() addrs.AbsProviderConfig
 }
 
-type ResourceProvidedBy struct {
+type ProviderResourceInstanceRequest struct {
 	Resource addrs.AbsResourceInstance
 	Provider addrs.AbsProviderConfig
 	Optional bool
 }
 
-type ProvidedBy struct {
-	// Relative to the containing module
-	Relative map[addrs.InstanceKey]addrs.AbsProviderConfig
+type ProviderRequest struct {
+	// Local: the provider should be looked up in
+	//   the current module path. Only the Alias field is used, the LocalName
+	//   is ignored and Provider() is preferred instead.
+	//   Examples: config, default
+	Local map[addrs.InstanceKey]string
 
-	// Usually from state
-	Absolute []ResourceProvidedBy
+	// Exact: the exact provider configuration has been
+	//   resolved elsewhere and must be referenced directly. No inheritence
+	//   logic is allowed.
+	//   Examples: state, resource instance (resolved)
+	Exact []ProviderResourceInstanceRequest
 }
 
-func (p ProvidedBy) IsSet() bool {
-	return len(p.Absolute) != 0 || len(p.Relative) != 0
+func (p ProviderRequest) IsSet() bool {
+	return len(p.Exact) != 0 || len(p.Local) != 0
 }
 
 // GraphNodeProviderConsumer is an interface that nodes that require
@@ -89,7 +95,7 @@ type GraphNodeProviderConsumer interface {
 	GraphNodeModulePath
 	// ProvidedBy returns the address of the provider configuration the node
 	// refers to, if available.
-	ProvidedBy() ProvidedBy
+	ProvidedBy() ProviderRequest
 
 	// Provider returns the Provider FQN for the node.
 	Provider() (provider addrs.Provider)
@@ -132,26 +138,35 @@ func (t *ProviderTransformer) Transform(g *Graph) error {
 		}
 
 		resolver := ResourceInstanceProviderResolver{
-			Absolute:      providedBy.Absolute,
+			Absolute:      providedBy.Exact,
 			ByResourceKey: make(map[addrs.InstanceKey]ModuleInstanceProviderResolver),
 		}
 
 		// Handle Absolute providers
 		// These come from state or are pre-computed
 		// They should never require additional graph traversal
-		for _, abs := range providedBy.Absolute {
+		for _, abs := range providedBy.Exact {
 			provider, ok := m[abs.Provider.String()]
 			if !ok {
 				if abs.Optional {
 					log.Printf("[TRACE] ProviderTransformer: optional provider for %s serving %s not found, orphaned node may fail", abs.Provider, dag.VertexName(v))
 				} else {
-					diags = diags.Append(fmt.Errorf("%s: provider %s couldn't be found", dag.VertexName(v), abs.Provider))
+					diags = diags.Append(tfdiags.Sourceless(
+						tfdiags.Error,
+						"Provider configuration not present",
+						fmt.Sprintf(
+							"To work with %s its original provider configuration at %s is required, but it has been removed. This occurs when a provider configuration is removed while objects created by that provider still exist in the state. Re-add the provider configuration to destroy %s, after which you can remove the provider configuration again.",
+							dag.VertexName(v), abs, dag.VertexName(v),
+						),
+					))
 				}
 				continue
 			}
 
+			// QUESTION: should proxies be allowed here?
+			// Potential historical bug
 			if _, isProxy := provider.(*graphNodeProxyProvider); isProxy {
-				panic("todo error message")
+				panic("TODO error message")
 			}
 
 			log.Printf("[TRACE] ProviderTransformer: exact absolute match for %s serving %s", abs.Provider, dag.VertexName(v))
@@ -159,27 +174,24 @@ func (t *ProviderTransformer) Transform(g *Graph) error {
 			g.Connect(dag.BasicEdge(v, provider))
 		}
 
-		// Handle relative resources with keys, usually from config
-		// They point to an AbsProviderConfig that either exists
-		// directly, or which can be used to walk up the module tree
-		// to locate a matching declaration in a parent module
-		// This breaks in *fun* ways when a provider's Name != Type
-		for resourceKey, p := range providedBy.Relative {
-			target := m[p.String()]
-
-			_, ok := v.(GraphNodeModulePath)
-			if !ok && target == nil {
-				// No target and no path to traverse up from
-				diags = diags.Append(fmt.Errorf("%s: provider %s couldn't be found", dag.VertexName(v), p))
-				continue
+		for resourceKey, alias := range providedBy.Local {
+			// We assume that the value returned from Provider() has already been
+			// properly checked during the provider validation logic in the
+			// config package and can use that Provider Type directly instead
+			// of duplicating provider LocalNames logic.
+			fullProviderAddr := addrs.AbsProviderConfig{
+				Provider: pv.Provider(),
+				Module:   pv.ModulePath(),
+				Alias:    alias,
 			}
+			target := m[fullProviderAddr.String()]
 
 			if target != nil {
 				// Providers with configuration will already exist within the graph and can be directly referenced
-				log.Printf("[TRACE] ProviderTransformer: exact match for %s serving %s", p, dag.VertexName(v))
+				log.Printf("[TRACE] ProviderTransformer: exact match for %s serving %s", fullProviderAddr, dag.VertexName(v))
 			} else {
 				// if we don't have a provider at this level, walk up the path looking for one,
-				for pp, ok := p.Inherited(); ok; pp, ok = pp.Inherited() {
+				for pp, ok := fullProviderAddr.Inherited(); ok; pp, ok = pp.Inherited() {
 					key := pp.String()
 					target = m[key]
 					if target != nil {
@@ -191,12 +203,13 @@ func (t *ProviderTransformer) Transform(g *Graph) error {
 			}
 
 			if target == nil {
+				// TODO this error message is possibly misleading
 				diags = diags.Append(tfdiags.Sourceless(
 					tfdiags.Error,
 					"Provider configuration not present",
 					fmt.Sprintf(
 						"To work with %s its original provider configuration at %s is required, but it has been removed. This occurs when a provider configuration is removed while objects created by that provider still exist in the state. Re-add the provider configuration to destroy %s, after which you can remove the provider configuration again.",
-						dag.VertexName(v), p, dag.VertexName(v),
+						dag.VertexName(v), fullProviderAddr, dag.VertexName(v),
 					),
 				))
 				break
@@ -224,9 +237,7 @@ func (t *ProviderTransformer) Transform(g *Graph) error {
 			resolver.ByResourceKey[resourceKey] = moduleExpansionProviders
 		}
 
-		if pv, ok := v.(GraphNodeProviderConsumer); ok {
-			pv.SetPotentialProviders(resolver)
-		}
+		pv.SetPotentialProviders(resolver)
 	}
 
 	return diags.Err()
@@ -561,7 +572,7 @@ func (n *graphNodeCloseProvider) DotNode(name string, opts *dag.DotOpts) *dag.Do
 }
 
 type ResourceInstanceProviderResolver struct {
-	Absolute      []ResourceProvidedBy
+	Absolute      []ProviderResourceInstanceRequest
 	ByResourceKey map[addrs.InstanceKey]ModuleInstanceProviderResolver
 }
 

--- a/internal/tofu/transform_provider.go
+++ b/internal/tofu/transform_provider.go
@@ -619,10 +619,8 @@ func (r ResourceInstanceProviderResolver) Resolve(addr addrs.AbsResourceInstance
 			return m.Provider
 		}
 	}
-	spew.Dump(addr)
-	println("=========")
-	spew.Dump(r)
-	panic("TODO better message here")
+
+	panic(fmt.Sprintf("Bug in provider resolution: \n%s\n\n\n%s\n", spew.Sdump(addr), spew.Sdump(r)))
 }
 
 type ModuleInstanceProviderResolver []ModuleInstancePotentialProvider
@@ -656,7 +654,7 @@ func (d *ModuleInstancePotentialProvider) AddModuleIdentifierToTheEnd(step addrs
 
 func (d *ModuleInstancePotentialProvider) ModuleInstanceMatches(moduleInstance addrs.ModuleInstance) bool {
 	if len(moduleInstance) != len(d.moduleIdentifier) {
-		panic("TODO better message")
+		panic(fmt.Sprintf("Unable to resolve %s in context of %s: %s\n", moduleInstance, d.moduleIdentifier, spew.Sdump(d)))
 	}
 	for i, moduleInstanceStep := range d.moduleIdentifier {
 		parallelResourceModuleAddress := moduleInstance[i]

--- a/internal/tofu/transform_provider.go
+++ b/internal/tofu/transform_provider.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
@@ -616,6 +617,9 @@ func (m ModuleInstanceProviderResolver) Resolve(addr addrs.ModuleInstance) addrs
 			return pr.concreteProvider.ProviderAddr()
 		}
 	}
+	spew.Dump(m)
+	println("====")
+	spew.Dump(addr)
 	panic("TODO better message here")
 }
 

--- a/internal/tofu/transform_provider.go
+++ b/internal/tofu/transform_provider.go
@@ -65,6 +65,7 @@ type GraphNodeCloseProvider interface {
 type ResourceProvidedBy struct {
 	Resource addrs.AbsResourceInstance
 	Provider addrs.AbsProviderConfig
+	Optional bool
 }
 
 type ProvidedBy struct {
@@ -141,7 +142,11 @@ func (t *ProviderTransformer) Transform(g *Graph) error {
 		for _, abs := range providedBy.Absolute {
 			provider, ok := m[abs.Provider.String()]
 			if !ok {
-				diags = diags.Append(fmt.Errorf("%s: provider %s couldn't be found", dag.VertexName(v), abs.Provider))
+				if abs.Optional {
+					log.Printf("[TRACE] ProviderTransformer: optional provider for %s serving %s not found, orphaned node may fail", abs.Provider, dag.VertexName(v))
+				} else {
+					diags = diags.Append(fmt.Errorf("%s: provider %s couldn't be found", dag.VertexName(v), abs.Provider))
+				}
 				continue
 			}
 
@@ -562,11 +567,18 @@ type ResourceInstanceProviderResolver struct {
 
 func (r ResourceInstanceProviderResolver) Any() addrs.AbsProviderConfig {
 	for _, m := range r.Absolute {
-		return m.Provider
+		if !m.Optional {
+			return m.Provider
+		}
 	}
 	for _, m := range r.ByResourceKey {
 		for _, p := range m {
 			return p.concreteProvider.ProviderAddr()
+		}
+	}
+	for _, m := range r.Absolute {
+		if m.Optional {
+			return m.Provider
 		}
 	}
 	panic("unreachable")
@@ -574,7 +586,7 @@ func (r ResourceInstanceProviderResolver) Any() addrs.AbsProviderConfig {
 
 func (r ResourceInstanceProviderResolver) Resolve(addr addrs.AbsResourceInstance) addrs.AbsProviderConfig {
 	for _, m := range r.Absolute {
-		if addr.Equal(m.Resource) {
+		if addr.Equal(m.Resource) && !m.Optional {
 			return m.Provider
 		}
 	}
@@ -586,6 +598,11 @@ func (r ResourceInstanceProviderResolver) Resolve(addr addrs.AbsResourceInstance
 	// alternate mapping to ModuleInstanceProviderResovlers based on the provider key
 	if p, ok := r.ByResourceKey[addrs.NoKey]; ok {
 		return p.Resolve(addr.Module)
+	}
+	for _, m := range r.Absolute {
+		if addr.Equal(m.Resource) && m.Optional {
+			return m.Provider
+		}
 	}
 	panic("TODO better message here")
 }

--- a/internal/tofu/transform_provider_test.go
+++ b/internal/tofu/transform_provider_test.go
@@ -539,7 +539,7 @@ func Test_graphNodeProxyProvider_Expanded_noForEachOnModules(t *testing.T) {
 		targets: map[addrs.InstanceKey]GraphNodeProvider{addrs.NoKey: &SecondLevelProxy},
 	}
 
-	want := []distinguishableProvider{
+	want := []ModuleInstancePotentialProvider{
 		{
 			moduleIdentifier: []addrs.ModuleInstanceStep{
 				{
@@ -598,7 +598,7 @@ func Test_graphNodeProxyProvider_Expanded_ForEachInSecondModule(t *testing.T) {
 		targets: map[addrs.InstanceKey]GraphNodeProvider{addrs.StringKey("first"): &SecondLevelProxyFirst, addrs.StringKey("second"): &SecondLevelProxySecond},
 	}
 
-	want := []distinguishableProvider{
+	want := []ModuleInstancePotentialProvider{
 		{
 			moduleIdentifier: []addrs.ModuleInstanceStep{
 				{
@@ -675,7 +675,7 @@ func Test_graphNodeProxyProvider_Expanded_ForEachInRootModule(t *testing.T) {
 		targets: map[addrs.InstanceKey]GraphNodeProvider{addrs.NoKey: &SecondLevelProxy},
 	}
 
-	want := []distinguishableProvider{
+	want := []ModuleInstancePotentialProvider{
 		{
 			moduleIdentifier: []addrs.ModuleInstanceStep{
 				{
@@ -727,7 +727,7 @@ func Test_graphNodeProxyProvider_Expanded_ForEachInRootModule(t *testing.T) {
 	})
 }
 
-func isDistinguishableProviderEqual(got distinguishableProvider, want distinguishableProvider) bool {
+func isDistinguishableProviderEqual(got ModuleInstancePotentialProvider, want ModuleInstancePotentialProvider) bool {
 	return !reflect.DeepEqual(got.moduleIdentifier, want.moduleIdentifier) ||
 		!reflect.DeepEqual(got.resourceIdentifier, want.resourceIdentifier) ||
 		got.concreteProvider.Name() != want.concreteProvider.Name()

--- a/internal/tofumigrate/tofumigrate.go
+++ b/internal/tofumigrate/tofumigrate.go
@@ -66,10 +66,9 @@ func MigrateStateProviderAddresses(config *configs.Config, state *states.State) 
 	for _, module := range stateCopy.Modules {
 		for _, resource := range module.Resources {
 			for _, instance := range resource.Instances {
-				// TODO deposed
-				_, referencedInConfig := providers[instance.Current.InstanceProvider.Provider]
-				if instance.Current.InstanceProvider.Provider.Hostname == "registry.terraform.io" && !referencedInConfig {
-					instance.Current.InstanceProvider.Provider.Hostname = tfaddr.DefaultProviderRegistryHost
+				_, referencedInConfig := providers[instance.InstanceProvider.Provider]
+				if instance.InstanceProvider.Provider.Hostname == "registry.terraform.io" && !referencedInConfig {
+					instance.InstanceProvider.Provider.Hostname = tfaddr.DefaultProviderRegistryHost
 				}
 			}
 		}

--- a/internal/tofumigrate/tofumigrate.go
+++ b/internal/tofumigrate/tofumigrate.go
@@ -65,9 +65,12 @@ func MigrateStateProviderAddresses(config *configs.Config, state *states.State) 
 
 	for _, module := range stateCopy.Modules {
 		for _, resource := range module.Resources {
-			_, referencedInConfig := providers[resource.ProviderConfig.Provider]
-			if resource.ProviderConfig.Provider.Hostname == "registry.terraform.io" && !referencedInConfig {
-				resource.ProviderConfig.Provider.Hostname = tfaddr.DefaultProviderRegistryHost
+			for _, instance := range resource.Instances {
+				// TODO deposed
+				_, referencedInConfig := providers[instance.Current.InstanceProvider.Provider]
+				if instance.Current.InstanceProvider.Provider.Hostname == "registry.terraform.io" && !referencedInConfig {
+					instance.Current.InstanceProvider.Provider.Hostname = tfaddr.DefaultProviderRegistryHost
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Part of #300

In debugging preliminary issues reported in #2054, @ollevche and I stumbled upon some interesting edge cases in the existing provider resolution code.  We did some refactoring in e73c28e1b527fe9d45bc1b8e8fe4df263362cebd that made it easier to spot issues like the ones reported.

From there, I started experimenting with some edge cases to try to try to hit other failure scenarios and found a few. In the end, I refactoring and expanding on the core pieces that @Evi1Pumpkin wrote previously and took a really hard look at the *quirky* behaviors in the ProviderTransformer, even before these changes.

## Changes From @Evi1Pumpkin's Implementation:
* ProviderConfig on the Resource State object (internal representation, not V4 serializer)  is *moved* to the Instance instead of existing in two places.
  * Conceptually this is much easier to grok.
  * It removes a lot of panic(*) calls in the code
  * Harder to hold it wrong
  * Translated between resource/instance at the V4 encode/decode functions.
  * This also implies the movement of storedProviderConfig and ResolvedResourceProvider to `NodeAbstractResourceInstance` from `NodeAbstractResource
* Attaching resource instance states to `NodeResourceAbstract` for orphaned nodes
  * When dealing with resources that are partially removed from the config (orphaned instances, with others remaining), we need to be able to attach the providers required by those orphaned instances.
  * The solution I found (with large comment / question) is to hook into the `AttachStateTransformer` and attach resource instance states to `NodeResourceAbstract`
  * When `NodeResourceAbstract` is queried about what providers it may perhaps require, it returns the usual information from the ProvidedBy function (config, imports, etc...).  It additionally loops through the resource instances that were in the state and adds them to the "absolute" mapping as it knows explicitly which `NodeResourceAbstractInstance` will require it.

## Changes From main branch:
If requested, these could be broken out into their own PR against main to ease the burden of reviewing the massive PR that is #2054.  The changes here are not specific to #300.  See https://github.com/opentofu/opentofu/pull/2069
### ProviderTransformer Logic
Man, where to begin on this one...  This code has undergone a *lot* of refactoring over the years, and there are a variety of odd quirks to it and dead code.

* The `GraphNodeProviderConsumer`s  return either a LocalProviderConfig or an AbsProviderConfig, with a flag for if an exact match is required.
  * The Transformer *does not care* about the *provider name field* of the LocalProviderConfig.  It completely ignores it and asks the vertex for it's addrs.Provider directly.  This in of itself is quite confusing.
  * Instead of relying on a type check and an ambiguous boolean, we should return a struct with explicit fields.  That both clarifies the returned value and removes a lot of code (with odd vestigial components) from the ProviderTransformer.  The node should know what it provider wants, and in what module path.
  * The struct returned by ProvidedBy should be as clear as possible for what provider it needs, and if it should be looked up directly (config block in the same module [aka exact]).
  * This takes a slightly different form in this branch due to additional constraints placed on it by #300
  * With this change in place, about half of the code can be removed from the ProviderTransformer...
  
* `ProviderTransformer`s needConfigured flag is a vestige of some old refactoring.
  * https://github.com/opentofu/opentofu/blob/7fddff6ba4f6e2338361fcd9b33587eae6d09709/internal/tofu/transform_provider.go#L165
  * Regardless of what those intentions were at the time, any lookups from that field are always true.
  * https://github.com/opentofu/opentofu/blob/7fddff6ba4f6e2338361fcd9b33587eae6d09709/internal/tofu/transform_provider.go#L207-L221
  * That concept can be removed altogether with no ill effects.  @apparentlymart may be able to provide more context on this change as he poked at it a few years ago.  He also might have a good reason why this should be kept or at least documented.
  
*  `ProviderTransformer` Removal of proxy nodes from the graph
  * https://github.com/opentofu/opentofu/blob/7fddff6ba4f6e2338361fcd9b33587eae6d09709/internal/tofu/transform_provider.go#L237
  * This is already done by the `PruneProviderTransformer` later on
  * This also breaks the `ProviderFunctionTransformer` and will be fixed on main before this feature branch makes it in.
  

## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

As per usual, I suck at naming things and am more than happy for any suggestions here.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
