### PR TITLE
Cleanup and encode existing "bugs" in ProviderTransformer

### DIFF
--- a/internal/tofu/node_resource_abstract_test.go
+++ b/internal/tofu/node_resource_abstract_test.go
@@ -142,12 +142,13 @@ func TestNodeAbstractResourceSetProvider(t *testing.T) {
 		},
 	}
 
-	p, exact := node.ProvidedBy()
-	if exact {
+	p := node.ProvidedBy()
+	if p.Exact.Provider.Type != "" {
 		t.Fatalf("no exact provider should be found from this confniguration, got %q\n", p)
 	}
 
 	// the implied non-exact provider should be "terraform"
+	/* TODO this check does not matter given the current structure of the code
 	lpc, ok := p.(addrs.LocalProviderConfig)
 	if !ok {
 		t.Fatalf("expected LocalProviderConfig, got %#v\n", p)
@@ -155,7 +156,7 @@ func TestNodeAbstractResourceSetProvider(t *testing.T) {
 
 	if lpc.LocalName != "terraform" {
 		t.Fatalf("expected non-exact provider of 'terraform', got %q", lpc.LocalName)
-	}
+	}*/
 
 	// now set a resolved provider for the resource
 	resolved := addrs.AbsProviderConfig{
@@ -169,18 +170,19 @@ func TestNodeAbstractResourceSetProvider(t *testing.T) {
 	}
 
 	node.SetProvider(resolved)
-	p, exact = node.ProvidedBy()
-	if !exact {
+	p = node.ProvidedBy()
+	if p.Exact.Provider.Type == "" {
 		t.Fatalf("exact provider should be found, got %q\n", p)
 	}
 
+	/* TODO this check does not matter given the current structure of the code
 	apc, ok := p.(addrs.AbsProviderConfig)
 	if !ok {
 		t.Fatalf("expected AbsProviderConfig, got %#v\n", p)
-	}
+	}*/
 
-	if apc.String() != resolved.String() {
-		t.Fatalf("incorrect resolved config: got %#v, wanted %#v\n", apc, resolved)
+	if p.Exact.String() != resolved.String() {
+		t.Fatalf("incorrect resolved config: got %#v, wanted %#v\n", p.Exact, resolved)
 	}
 }
 

--- a/internal/tofu/node_resource_abstract_test.go
+++ b/internal/tofu/node_resource_abstract_test.go
@@ -143,12 +143,8 @@ func TestNodeAbstractResourceSetProvider(t *testing.T) {
 	}
 
 	p := node.ProvidedBy()
-	if p.Exact.Provider.Type != "" {
-		t.Fatalf("no exact provider should be found from this confniguration, got %q\n", p)
-	}
 
 	// the implied non-exact provider should be "terraform"
-	/* TODO this check does not matter given the current structure of the code
 	lpc, ok := p.(addrs.LocalProviderConfig)
 	if !ok {
 		t.Fatalf("expected LocalProviderConfig, got %#v\n", p)
@@ -156,7 +152,7 @@ func TestNodeAbstractResourceSetProvider(t *testing.T) {
 
 	if lpc.LocalName != "terraform" {
 		t.Fatalf("expected non-exact provider of 'terraform', got %q", lpc.LocalName)
-	}*/
+	}
 
 	// now set a resolved provider for the resource
 	resolved := addrs.AbsProviderConfig{
@@ -171,18 +167,14 @@ func TestNodeAbstractResourceSetProvider(t *testing.T) {
 
 	node.SetProvider(resolved)
 	p = node.ProvidedBy()
-	if p.Exact.Provider.Type == "" {
-		t.Fatalf("exact provider should be found, got %q\n", p)
-	}
 
-	/* TODO this check does not matter given the current structure of the code
 	apc, ok := p.(addrs.AbsProviderConfig)
 	if !ok {
 		t.Fatalf("expected AbsProviderConfig, got %#v\n", p)
-	}*/
+	}
 
-	if p.Exact.String() != resolved.String() {
-		t.Fatalf("incorrect resolved config: got %#v, wanted %#v\n", p.Exact, resolved)
+	if apc.String() != resolved.String() {
+		t.Fatalf("incorrect resolved config: got %#v, wanted %#v\n", apc, resolved)
 	}
 }
 

--- a/internal/tofu/node_resource_destroy.go
+++ b/internal/tofu/node_resource_destroy.go
@@ -49,10 +49,10 @@ func (n *NodeDestroyResourceInstance) Name() string {
 	return n.ResourceInstanceAddr().String() + " (destroy)"
 }
 
-func (n *NodeDestroyResourceInstance) ProvidedBy() ProvidedBy {
+func (n *NodeDestroyResourceInstance) ProvidedBy() ProviderRequest {
 	if n.Addr.Resource.Resource.Mode == addrs.DataResourceMode {
 		// indicate that this node does not require a configured provider
-		return ProvidedBy{}
+		return ProviderRequest{}
 	}
 	return n.NodeAbstractResourceInstance.ProvidedBy()
 }

--- a/internal/tofu/node_resource_destroy.go
+++ b/internal/tofu/node_resource_destroy.go
@@ -49,10 +49,10 @@ func (n *NodeDestroyResourceInstance) Name() string {
 	return n.ResourceInstanceAddr().String() + " (destroy)"
 }
 
-func (n *NodeDestroyResourceInstance) ProvidedBy() (addr addrs.ProviderConfig, exact bool) {
+func (n *NodeDestroyResourceInstance) ProvidedBy() ProvidedBy {
 	if n.Addr.Resource.Resource.Mode == addrs.DataResourceMode {
 		// indicate that this node does not require a configured provider
-		return nil, true
+		return ProvidedBy{}
 	}
 	return n.NodeAbstractResourceInstance.ProvidedBy()
 }

--- a/internal/tofu/node_resource_destroy.go
+++ b/internal/tofu/node_resource_destroy.go
@@ -49,10 +49,10 @@ func (n *NodeDestroyResourceInstance) Name() string {
 	return n.ResourceInstanceAddr().String() + " (destroy)"
 }
 
-func (n *NodeDestroyResourceInstance) ProvidedBy() ProviderRequest {
+func (n *NodeDestroyResourceInstance) ProvidedBy() addrs.ProviderConfig {
 	if n.Addr.Resource.Resource.Mode == addrs.DataResourceMode {
 		// indicate that this node does not require a configured provider
-		return ProviderRequest{}
+		return nil
 	}
 	return n.NodeAbstractResourceInstance.ProvidedBy()
 }

--- a/internal/tofu/node_resource_import.go
+++ b/internal/tofu/node_resource_import.go
@@ -42,13 +42,13 @@ func (n *graphNodeImportState) Name() string {
 }
 
 // GraphNodeProviderConsumer
-func (n *graphNodeImportState) ProvidedBy() ProvidedBy {
+func (n *graphNodeImportState) ProvidedBy() ProviderRequest {
 	// We assume that n.ProviderAddr has been properly populated here.
 	// It's the responsibility of the code creating a graphNodeImportState
 	// to populate this, possibly by calling DefaultProviderConfig() on the
 	// resource address to infer an implied provider from the resource type
 	// name.
-	return ProvidedBy{Local: n.ProviderAddr}
+	return ProviderRequest{Local: n.ProviderAddr}
 }
 
 // GraphNodeProviderConsumer

--- a/internal/tofu/node_resource_import.go
+++ b/internal/tofu/node_resource_import.go
@@ -20,7 +20,6 @@ import (
 type graphNodeImportState struct {
 	Addr             addrs.AbsResourceInstance // Addr is the resource address to import into
 	ID               string                    // ID is the ID to import as
-	ProviderAddr     addrs.AbsProviderConfig   // Provider address given by the user, or implied by the resource type
 	ResolvedProvider addrs.AbsProviderConfig   // provider node address after resolution
 
 	Schema        *configschema.Block // Schema for processing the configuration body
@@ -42,23 +41,15 @@ func (n *graphNodeImportState) Name() string {
 }
 
 // GraphNodeProviderConsumer
-func (n *graphNodeImportState) ProvidedBy() ProviderRequest {
-	// We assume that n.ProviderAddr has been properly populated here.
-	// It's the responsibility of the code creating a graphNodeImportState
-	// to populate this, possibly by calling DefaultProviderConfig() on the
-	// resource address to infer an implied provider from the resource type
-	// name.
-	return ProviderRequest{Local: n.ProviderAddr}
+func (n *graphNodeImportState) ProvidedBy() addrs.ProviderConfig {
+	// This has already been resolved by nodeExpandPlannableResource
+	return n.ResolvedProvider
 }
 
 // GraphNodeProviderConsumer
 func (n *graphNodeImportState) Provider() addrs.Provider {
-	// We assume that n.ProviderAddr has been properly populated here.
-	// It's the responsibility of the code creating a graphNodeImportState
-	// to populate this, possibly by calling DefaultProviderConfig() on the
-	// resource address to infer an implied provider from the resource type
-	// name.
-	return n.ProviderAddr.Provider
+	// This has already been resolved by nodeExpandPlannableResource
+	return n.ResolvedProvider.Provider
 }
 
 // GraphNodeProviderConsumer

--- a/internal/tofu/node_resource_import.go
+++ b/internal/tofu/node_resource_import.go
@@ -42,13 +42,13 @@ func (n *graphNodeImportState) Name() string {
 }
 
 // GraphNodeProviderConsumer
-func (n *graphNodeImportState) ProvidedBy() (addrs.ProviderConfig, bool) {
+func (n *graphNodeImportState) ProvidedBy() ProvidedBy {
 	// We assume that n.ProviderAddr has been properly populated here.
 	// It's the responsibility of the code creating a graphNodeImportState
 	// to populate this, possibly by calling DefaultProviderConfig() on the
 	// resource address to infer an implied provider from the resource type
 	// name.
-	return n.ProviderAddr, false
+	return ProvidedBy{Local: n.ProviderAddr}
 }
 
 // GraphNodeProviderConsumer

--- a/internal/tofu/node_resource_plan_orphan.go
+++ b/internal/tofu/node_resource_plan_orphan.go
@@ -65,10 +65,10 @@ func (n *NodePlannableResourceInstanceOrphan) Execute(ctx EvalContext, op walkOp
 	}
 }
 
-func (n *NodePlannableResourceInstanceOrphan) ProvidedBy() ProvidedBy {
+func (n *NodePlannableResourceInstanceOrphan) ProvidedBy() ProviderRequest {
 	if n.Addr.Resource.Resource.Mode == addrs.DataResourceMode {
 		// indicate that this node does not require a configured provider
-		return ProvidedBy{}
+		return ProviderRequest{}
 	}
 	return n.NodeAbstractResourceInstance.ProvidedBy()
 }

--- a/internal/tofu/node_resource_plan_orphan.go
+++ b/internal/tofu/node_resource_plan_orphan.go
@@ -65,10 +65,10 @@ func (n *NodePlannableResourceInstanceOrphan) Execute(ctx EvalContext, op walkOp
 	}
 }
 
-func (n *NodePlannableResourceInstanceOrphan) ProvidedBy() (addr addrs.ProviderConfig, exact bool) {
+func (n *NodePlannableResourceInstanceOrphan) ProvidedBy() ProvidedBy {
 	if n.Addr.Resource.Resource.Mode == addrs.DataResourceMode {
 		// indicate that this node does not require a configured provider
-		return nil, true
+		return ProvidedBy{}
 	}
 	return n.NodeAbstractResourceInstance.ProvidedBy()
 }

--- a/internal/tofu/node_resource_plan_orphan.go
+++ b/internal/tofu/node_resource_plan_orphan.go
@@ -65,10 +65,10 @@ func (n *NodePlannableResourceInstanceOrphan) Execute(ctx EvalContext, op walkOp
 	}
 }
 
-func (n *NodePlannableResourceInstanceOrphan) ProvidedBy() ProviderRequest {
+func (n *NodePlannableResourceInstanceOrphan) ProvidedBy() addrs.ProviderConfig {
 	if n.Addr.Resource.Resource.Mode == addrs.DataResourceMode {
 		// indicate that this node does not require a configured provider
-		return ProviderRequest{}
+		return nil
 	}
 	return n.NodeAbstractResourceInstance.ProvidedBy()
 }

--- a/internal/tofu/transform_destroy_edge.go
+++ b/internal/tofu/transform_destroy_edge.go
@@ -102,11 +102,11 @@ func (t *DestroyEdgeTransformer) tryInterProviderDestroyEdge(g *Graph, from, to 
 	// from the same provider instance.
 	getComparableProvider := func(pc GraphNodeProviderConsumer) string {
 		p := pc.ProvidedBy()
-		if p.Exact.Provider.Type != "" {
-			return p.Exact.String()
-		}
-		if p.Local.Provider.Type != "" {
-			return p.Local.String()
+		switch p := p.(type) {
+		case addrs.AbsProviderConfig:
+			return p.String()
+		case addrs.LocalProviderConfig:
+			return p.String()
 		}
 		return pc.Provider().String()
 	}

--- a/internal/tofu/transform_destroy_edge.go
+++ b/internal/tofu/transform_destroy_edge.go
@@ -101,19 +101,14 @@ func (t *DestroyEdgeTransformer) tryInterProviderDestroyEdge(g *Graph, from, to 
 	// description of the provider being used to help determine if 2 nodes are
 	// from the same provider instance.
 	getComparableProvider := func(pc GraphNodeProviderConsumer) string {
-		ps := pc.Provider().String()
-
-		// we don't care about `exact` here, since we're only looking for any
-		// clue that the providers may differ.
-		p, _ := pc.ProvidedBy()
-		switch p := p.(type) {
-		case addrs.AbsProviderConfig:
-			ps = p.String()
-		case addrs.LocalProviderConfig:
-			ps = p.String()
+		p := pc.ProvidedBy()
+		if p.Exact.Provider.Type != "" {
+			return p.Exact.String()
 		}
-
-		return ps
+		if p.Local.Provider.Type != "" {
+			return p.Local.String()
+		}
+		return pc.Provider().String()
 	}
 
 	pc, ok := from.(GraphNodeProviderConsumer)

--- a/internal/tofu/transform_provider.go
+++ b/internal/tofu/transform_provider.go
@@ -193,6 +193,8 @@ func (t *ProviderTransformer) Transform(g *Graph) error {
 			log.Printf("[DEBUG] ProviderTransformer: %q (%T) needs %s", dag.VertexName(v), v, dag.VertexName(target))
 			pv.SetProvider(target.ProviderAddr())
 			g.Connect(dag.BasicEdge(v, target))
+		default:
+			panic(fmt.Sprintf("BUG: Invalid provider address type %T for %#v", req, req))
 		}
 	}
 


### PR DESCRIPTION
Precursor to #300

When digging in to the `ProviderTransformer` and the `ProviderFunctionTransformer` (https://github.com/opentofu/opentofu/issues/2051), I found a mixture of dead an non-functional code.  That has been removed in this PR and the "quirks" around ignoring local provider names during `ProviderTransformer` have been made more explicit.

This has also been structured in a way that will make it easier to review and adopt #300

## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
