### PR TITLE
Implement Gitlab Remote State Backend

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/packer-community/winrmcp v0.0.0-20180921211025-c76d91c1e7db
 	github.com/pkg/errors v0.9.1
 	github.com/posener/complete v1.2.3
+	github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466
 	github.com/spf13/afero v1.9.3
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.588
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sts v1.0.588

--- a/go.sum
+++ b/go.sum
@@ -982,6 +982,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
+github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466 h1:17JxqqJY66GmZVHkmAsGEkcIu0oCe3AM420QDgGwZx0=
+github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466/go.mod h1:9dIRpgIY7hVhoqfe0/FcYp0bpInZaT7dc3BYOprrIUE=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=

--- a/internal/backend/init/init.go
+++ b/internal/backend/init/init.go
@@ -22,6 +22,7 @@ import (
 	backendConsul "github.com/opentofu/opentofu/internal/backend/remote-state/consul"
 	backendCos "github.com/opentofu/opentofu/internal/backend/remote-state/cos"
 	backendGCS "github.com/opentofu/opentofu/internal/backend/remote-state/gcs"
+	backendGitlab "github.com/opentofu/opentofu/internal/backend/remote-state/gitlab"
 	backendHTTP "github.com/opentofu/opentofu/internal/backend/remote-state/http"
 	backendInmem "github.com/opentofu/opentofu/internal/backend/remote-state/inmem"
 	backendKubernetes "github.com/opentofu/opentofu/internal/backend/remote-state/kubernetes"
@@ -63,6 +64,7 @@ func Init(services *disco.Disco) {
 		"consul":     func(enc encryption.StateEncryption) backend.Backend { return backendConsul.New(enc) },
 		"cos":        func(enc encryption.StateEncryption) backend.Backend { return backendCos.New(enc) },
 		"gcs":        func(enc encryption.StateEncryption) backend.Backend { return backendGCS.New(enc) },
+		"gitlab":     func(enc encryption.StateEncryption) backend.Backend { return backendGitlab.New(enc) },
 		"http":       func(enc encryption.StateEncryption) backend.Backend { return backendHTTP.New(enc) },
 		"inmem":      func(enc encryption.StateEncryption) backend.Backend { return backendInmem.New(enc) },
 		"kubernetes": func(enc encryption.StateEncryption) backend.Backend { return backendKubernetes.New(enc) },

--- a/internal/backend/remote-state/gitlab/backend.go
+++ b/internal/backend/remote-state/gitlab/backend.go
@@ -1,0 +1,169 @@
+package gitlab
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/opentofu/opentofu/internal/backend"
+	"github.com/opentofu/opentofu/internal/encryption"
+	"github.com/opentofu/opentofu/internal/legacy/helper/schema"
+	"github.com/opentofu/opentofu/internal/logging"
+	"golang.org/x/oauth2"
+)
+
+func New(enc encryption.StateEncryption) backend.Backend {
+	var (
+		defaultAddressEnvVars = []string{"TF_GITLAB_ADDRESS", "CI_SERVER_URL"}
+		defaultProjectEnvVars = []string{"TF_GITLAB_PROJECT", "CI_PROJECT_ID"}
+		defaultTokenEnvVars   = []string{"TF_GITLAB_TOKEN", "CI_JOB_TOKEN"}
+	)
+
+	const (
+		defaultRetryMax     = 2
+		defaultRetryWaitMin = 1
+		defaultRetryWaitMax = 30
+	)
+
+	s := &schema.Backend{
+		Schema: map[string]*schema.Schema{
+			"address": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.MultiEnvDefaultFunc(defaultAddressEnvVars, nil),
+				Description: "The Gitlab URL.",
+			},
+			"project": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.MultiEnvDefaultFunc(defaultProjectEnvVars, nil),
+				Description: "The Gitlab project path or ID number.",
+			},
+			"token": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				DefaultFunc: schema.MultiEnvDefaultFunc(defaultTokenEnvVars, nil),
+				Description: "The Gitlab access token to manage remote state.",
+			},
+			"skip_cert_verification": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Whether to skip TLS verification.",
+			},
+			"retry_max": &schema.Schema{
+				Type:        schema.TypeInt,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("TF_GITLAB_RETRY_MAX", defaultRetryMax),
+				Description: "The number of HTTP request retries.",
+			},
+			"retry_wait_min": &schema.Schema{
+				Type:        schema.TypeInt,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("TF_GITLAB_RETRY_WAIT_MIN", defaultRetryWaitMin),
+				Description: "The minimum time in seconds to wait between HTTP request attempts.",
+			},
+			"retry_wait_max": &schema.Schema{
+				Type:        schema.TypeInt,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("TF_GITLAB_RETRY_WAIT_MAX", defaultRetryWaitMax),
+				Description: "The maximum time in seconds to wait between HTTP request attempts.",
+			},
+		},
+	}
+
+	b := &Backend{Backend: s, encryption: enc}
+	b.Backend.ConfigureFunc = b.configure
+	return b
+}
+
+type Backend struct {
+	encryption encryption.StateEncryption
+	client     *RemoteClient
+
+	address *url.URL
+	project string
+	token   string
+
+	httpClient *retryablehttp.Client
+
+	*schema.Backend
+}
+
+func (b *Backend) configure(ctx context.Context) error {
+	data := schema.FromContextBackendConfig(ctx)
+	var err error
+
+	var (
+		address      = data.Get("address").(string)
+		project      = data.Get("project").(string)
+		token        = data.Get("token").(string)
+		retryMax     = data.Get("retry_max").(int)
+		retryWaitMin = data.Get("retry_wait_min").(int)
+		retryWaitMax = data.Get("retry_wait_max").(int)
+
+		skipCertVerification = data.Get("skip_cert_verification").(bool)
+	)
+
+	if b.address, err = url.Parse(address); err != nil {
+		return fmt.Errorf("could not to parse gitlab address %s: %w", address, err)
+	} else if b.address.Scheme != "http" && b.address.Scheme != "https" {
+		return fmt.Errorf("scheme must be http or https")
+	}
+
+	if b.project = project; project == "" {
+		return fmt.Errorf("project must not be empty")
+	}
+
+	if b.token = token; token == "" {
+		return fmt.Errorf("token must not be empty")
+	}
+
+	b.httpClient = retryablehttp.NewClient()
+
+	// get original transport so we can add authentication
+	originalTransport := b.httpClient.HTTPClient.Transport
+
+	// optionally skip tls certificate validation
+	if transport, ok := originalTransport.(*http.Transport); ok {
+		if skipCertVerification {
+			transport.TLSClientConfig.InsecureSkipVerify = true
+		}
+	}
+
+	// build an http client with retries and authentication
+	b.httpClient.HTTPClient.Transport = &oauth2.Transport{
+		Base: originalTransport,
+		Source: oauth2.StaticTokenSource(&oauth2.Token{
+			TokenType:   "Bearer",
+			AccessToken: b.token,
+		}),
+	}
+
+	// set up logging to match the configured log level and flags
+	b.httpClient.Logger = log.New(logging.LogOutput(), "", log.Flags())
+
+	// set up retries like the http backend
+	b.httpClient.RetryMax = retryMax
+	b.httpClient.RetryWaitMin = time.Duration(retryWaitMin) * time.Second
+	b.httpClient.RetryWaitMax = time.Duration(retryWaitMax) * time.Second
+
+	// build a remote client for the default state
+	b.client = b.remoteClientFor(backend.DefaultStateName)
+
+	return nil
+}
+
+func (b *Backend) remoteClientFor(stateName string) *RemoteClient {
+	return &RemoteClient{
+		HTTPClient: b.httpClient,
+		BaseURL:    b.address,
+		Project:    b.project,
+		StateName:  stateName,
+	}
+}

--- a/internal/backend/remote-state/gitlab/backend_state.go
+++ b/internal/backend/remote-state/gitlab/backend_state.go
@@ -1,0 +1,62 @@
+package gitlab
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/opentofu/opentofu/internal/backend"
+	"github.com/opentofu/opentofu/internal/states/remote"
+	"github.com/opentofu/opentofu/internal/states/statemgr"
+	"github.com/shurcooL/graphql"
+)
+
+// Workspaces returns a list of names for the workspaces found in Gitlab.
+// The default workspace is always returned as the first element in the slice.
+func (b *Backend) Workspaces() ([]string, error) {
+	graphqlEndpoint := b.address.JoinPath("api", "graphql").String()
+	graphqlClient := graphql.NewClient(graphqlEndpoint, b.httpClient.StandardClient())
+
+	var query struct {
+		Project struct {
+			TerraformStates struct {
+				Nodes []struct {
+					Name string
+				}
+			}
+		} `graphql:"project(fullPath: $projectPath)"`
+	}
+
+	variables := map[string]interface{}{
+		"projectPath": b.project,
+	}
+
+	if err := graphqlClient.Query(context.Background(), &query, variables); err != nil {
+		return nil, fmt.Errorf("unable to execute graphql query: %w", err)
+	}
+
+	states := []string{backend.DefaultStateName}
+
+	for _, v := range query.Project.TerraformStates.Nodes {
+		if v.Name != backend.DefaultStateName {
+			states = append(states, v.Name)
+		}
+	}
+
+	// The default state always comes first.
+	sort.Strings(states[1:])
+
+	return states, nil
+}
+
+func (b *Backend) StateMgr(stateName string) (statemgr.Full, error) {
+	return remote.NewState(b.remoteClientFor(stateName), b.encryption), nil
+}
+
+func (b *Backend) DeleteWorkspace(stateName string, _ bool) error {
+	if stateName == backend.DefaultStateName || stateName == "" {
+		return fmt.Errorf("can't delete default state")
+	}
+
+	return b.remoteClientFor(stateName).Delete()
+}

--- a/internal/backend/remote-state/gitlab/backend_test.go
+++ b/internal/backend/remote-state/gitlab/backend_test.go
@@ -1,0 +1,109 @@
+package gitlab
+
+import (
+	"testing"
+	"time"
+
+	"github.com/opentofu/opentofu/internal/configs"
+	"github.com/opentofu/opentofu/internal/encryption"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/opentofu/opentofu/internal/backend"
+)
+
+func TestBackendContract(_ *testing.T) {
+	var _ backend.Backend = new(Backend)
+}
+
+func TestGitlabClientFactoryStatic(t *testing.T) {
+	vars := map[string]cty.Value{
+		"address":        cty.StringVal("http://127.0.0.1:8080"),
+		"project":        cty.StringVal("namespace/project"),
+		"token":          cty.StringVal("access-token"),
+		"retry_max":      cty.StringVal("999"),
+		"retry_wait_min": cty.StringVal("15"),
+		"retry_wait_max": cty.StringVal("150"),
+	}
+
+	config := configs.SynthBody("synth", vars)
+
+	b := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), config).(*Backend)
+	client := b.client
+
+	if client == nil {
+		t.Fatal("Unexpected failure: invalid config")
+	}
+
+	if client.BaseURL.String() != "http://127.0.0.1:8080" {
+		t.Fatalf("Expected address \"%s\", got \"%s\"", vars["address"], client.BaseURL.String())
+	}
+
+	if client.Project != "namespace/project" {
+		t.Fatalf("Expected project \"%s\", got \"%s\"", vars["project"], client.Project)
+	}
+
+	if client.StateName != backend.DefaultStateName {
+		t.Fatalf("Expected state name \"%s\", got \"%s\"", client.StateName, backend.DefaultStateName)
+	}
+
+	if client.HTTPClient.RetryMax != 999 {
+		t.Fatalf("Expected retry_max \"%d\", got \"%d\"", 999, client.HTTPClient.RetryMax)
+	}
+
+	if client.HTTPClient.RetryWaitMin != 15*time.Second {
+		t.Fatalf("Expected retry_wait_min \"%s\", got \"%s\"", 15*time.Second, client.HTTPClient.RetryWaitMin)
+	}
+
+	if client.HTTPClient.RetryWaitMax != 150*time.Second {
+		t.Fatalf("Expected retry_wait_max \"%s\", got \"%s\"", 150*time.Second, client.HTTPClient.RetryWaitMax)
+	}
+}
+
+func TestGitlabClientFactoryFromEnv(t *testing.T) {
+	conf := map[string]string{
+		"address":        "http://127.0.0.1:8080",
+		"project":        "namespace/project",
+		"token":          "access-token",
+		"retry_max":      "999",
+		"retry_wait_min": "15",
+		"retry_wait_max": "150",
+	}
+
+	t.Setenv("TF_GITLAB_ADDRESS", conf["address"])
+	t.Setenv("TF_GITLAB_PROJECT", conf["project"])
+	t.Setenv("TF_GITLAB_TOKEN", conf["token"])
+	t.Setenv("TF_GITLAB_RETRY_MAX", conf["retry_max"])
+	t.Setenv("TF_GITLAB_RETRY_WAIT_MIN", conf["retry_wait_min"])
+	t.Setenv("TF_GITLAB_RETRY_WAIT_MAX", conf["retry_wait_max"])
+
+	b := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), nil).(*Backend)
+	client := b.client
+
+	if client == nil {
+		t.Fatal("Unexpected failure: no config from env")
+	}
+
+	if client.BaseURL.String() != "http://127.0.0.1:8080" {
+		t.Fatalf("Expected address \"%s\", got \"%s\"", conf["address"], client.BaseURL.String())
+	}
+
+	if client.Project != "namespace/project" {
+		t.Fatalf("Expected project \"%s\", got \"%s\"", conf["project"], client.Project)
+	}
+
+	if client.StateName != backend.DefaultStateName {
+		t.Fatalf("Expected state name \"%s\", got \"%s\"", client.StateName, backend.DefaultStateName)
+	}
+
+	if client.HTTPClient.RetryMax != 999 {
+		t.Fatalf("Expected retry_max \"%d\", got \"%d\"", 999, client.HTTPClient.RetryMax)
+	}
+
+	if client.HTTPClient.RetryWaitMin != 15*time.Second {
+		t.Fatalf("Expected retry_wait_min \"%s\", got \"%s\"", 15*time.Second, client.HTTPClient.RetryWaitMin)
+	}
+
+	if client.HTTPClient.RetryWaitMax != 150*time.Second {
+		t.Fatalf("Expected retry_wait_max \"%s\", got \"%s\"", 150*time.Second, client.HTTPClient.RetryWaitMax)
+	}
+}

--- a/internal/backend/remote-state/gitlab/client.go
+++ b/internal/backend/remote-state/gitlab/client.go
@@ -1,0 +1,253 @@
+package gitlab
+
+import (
+	"bytes"
+	"crypto/md5"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/opentofu/opentofu/internal/states/remote"
+	"github.com/opentofu/opentofu/internal/states/statemgr"
+)
+
+type RemoteClient struct {
+	HTTPClient *retryablehttp.Client
+	BaseURL    *url.URL
+	Project    string
+	StateName  string
+
+	lockID       string
+	jsonLockInfo []byte
+}
+
+func (client *RemoteClient) buildStateURL(extra ...string) *url.URL {
+	// Escape the project and state names as URL path components.
+	projectName := url.PathEscape(client.Project)
+	stateName := url.PathEscape(client.StateName)
+
+	// /api/v4/projects/{projectName}/terraform/state/{stateName}
+	pathComponents := []string{
+		"api", "v4",
+		"projects", projectName,
+		"terraform", "state", stateName,
+	}
+
+	// Append additional path components (ie: lock)
+	pathComponents = append(pathComponents, extra...)
+
+	return client.BaseURL.JoinPath(pathComponents...)
+}
+
+func (client *RemoteClient) httpRequest(method string, url *url.URL, data []byte, what string) (*http.Response, error) {
+	req, err := retryablehttp.NewRequest(method, url.String(), data)
+
+	if err != nil {
+		return nil, fmt.Errorf("%s failed: create request failed: %w", what, err)
+	}
+
+	if len(data) > 0 {
+		req.Header.Set("Content-Type", "application/json")
+
+		hash := md5.Sum(data)
+		digest := base64.StdEncoding.EncodeToString(hash[:])
+
+		req.Header.Set("Content-MD5", digest)
+	}
+
+	resp, err := client.HTTPClient.Do(req)
+
+	if err != nil {
+		return nil, fmt.Errorf("%s failed: could not create request: %w", what, err)
+	}
+
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+
+	if err != nil {
+		return nil, fmt.Errorf("%s failed: cannot read body: %w", what, err)
+	}
+
+	// Backfill a Content-MD5 header so we don't have to do it later.
+	if raw := resp.Header.Get("Content-MD5"); raw == "" {
+		hash := md5.Sum(body)
+		digest := base64.StdEncoding.EncodeToString(hash[:])
+
+		resp.Header.Set("Content-MD5", digest)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusUnauthorized:
+		return nil, fmt.Errorf("%s failed: requires auth", what)
+	case http.StatusForbidden:
+		return nil, fmt.Errorf("%s failed: not authorized", what)
+	case http.StatusBadRequest, http.StatusUnprocessableEntity:
+		return nil, fmt.Errorf("%s failed: request not understood", what)
+	case http.StatusInternalServerError:
+		return nil, fmt.Errorf("%s failed: internal server error", what)
+	}
+
+	// Reassign the response body with a new reader.
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+
+	return resp, nil
+}
+
+func (client *RemoteClient) Get() (*remote.Payload, error) {
+	stateURL := client.buildStateURL()
+
+	resp, err := client.httpRequest(http.MethodGet, stateURL, nil, "get state")
+
+	if err != nil {
+		return nil, fmt.Errorf("gitlab remote state get failed: %w", err)
+	}
+
+	defer resp.Body.Close()
+
+	// If there was no state or the state was empty then we're starting fresh.
+	if resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("gitlab remote state get failed: http response code %d", resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to read remote state: %w", err)
+	}
+
+	// Empty data means fresh state.
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	raw := resp.Header.Get("Content-MD5")
+	hash, err := base64.StdEncoding.DecodeString(raw)
+
+	if err != nil {
+		return nil, fmt.Errorf("could not decode Content-MD5 '%s': %w", raw, err)
+	}
+
+	payload := &remote.Payload{
+		Data: data,
+		MD5:  hash,
+	}
+
+	return payload, nil
+}
+
+func (client *RemoteClient) Put(data []byte) error {
+	stateURL := client.buildStateURL()
+
+	if client.lockID != "" {
+		query := stateURL.Query()
+		query.Set("ID", client.lockID)
+		stateURL.RawQuery = query.Encode()
+	}
+
+	resp, err := client.httpRequest(http.MethodPost, stateURL, data, "put state")
+
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	// One of: created, updated, or nothing has changed.
+	case http.StatusCreated, http.StatusOK, http.StatusNoContent:
+		return nil
+	}
+
+	return fmt.Errorf("gitlab remote state delete failed: http response code %d", resp.StatusCode)
+}
+
+func (client *RemoteClient) Delete() error {
+	resp, err := client.httpRequest(http.MethodDelete, client.buildStateURL(), nil, "delete state")
+
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+
+	return fmt.Errorf("gitlab remote state delete failed: http response code %d", resp.StatusCode)
+}
+
+func (client *RemoteClient) Lock(info *statemgr.LockInfo) (string, error) {
+	client.lockID = ""
+	jsonLockInfo := info.Marshal()
+	lockURL := client.buildStateURL("lock")
+
+	resp, err := client.httpRequest(http.MethodPost, lockURL, jsonLockInfo, "lock state")
+
+	if err != nil {
+		return "", err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		client.lockID = info.ID
+		client.jsonLockInfo = jsonLockInfo
+		return info.ID, nil
+	}
+
+	if resp.StatusCode == http.StatusConflict || resp.StatusCode == http.StatusLocked {
+		body, err := io.ReadAll(resp.Body)
+
+		if err != nil {
+			return "", &statemgr.LockError{
+				Info: info,
+				Err:  fmt.Errorf("gitlab remote state already locked; failed to read body"),
+			}
+		}
+
+		existing := statemgr.LockInfo{}
+		err = json.Unmarshal(body, &existing)
+
+		if err != nil {
+			return "", &statemgr.LockError{
+				Info: info,
+				Err:  fmt.Errorf("gitlab remote state already locked; failed to unmarshal body"),
+			}
+		}
+
+		return "", &statemgr.LockError{
+			Info: info,
+			Err:  fmt.Errorf("gitlab remote state already locked: id=%s", existing.ID),
+		}
+	}
+
+	return "", fmt.Errorf("gitlab remote state lock failed: http response code %d", resp.StatusCode)
+}
+
+func (client *RemoteClient) Unlock(_ string) error {
+	lockURL := client.buildStateURL("lock")
+
+	resp, err := client.httpRequest(http.MethodDelete, lockURL, client.jsonLockInfo, "unlock state")
+
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+
+	return fmt.Errorf("gitlab remote state unlock failed: http response code %d", resp.StatusCode)
+}

--- a/internal/backend/remote-state/gitlab/client_test.go
+++ b/internal/backend/remote-state/gitlab/client_test.go
@@ -1,0 +1,181 @@
+package gitlab
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/opentofu/opentofu/internal/backend"
+	"github.com/opentofu/opentofu/internal/states/remote"
+)
+
+func TestRemoteClientContract(_ *testing.T) {
+	var _ remote.Client = new(RemoteClient)
+	var _ remote.ClientLocker = new(RemoteClient)
+}
+
+func stateKeyFromRequest(r *http.Request) (string, bool, error) {
+	// Parse the raw URL path to extract path segments.
+	segments := strings.SplitN(r.URL.RawPath, "/", 9)[1:]
+
+	// /api/v4/projects/{state}/terraform/state/{default}[/lock]
+	lengthMatches := len(segments) >= 7 && len(segments) <= 8
+	isProjectPath := slices.Equal(segments[0:3], []string{"api", "v4", "projects"})
+	isStatePath := slices.Equal(segments[4:6], []string{"terraform", "state"})
+	isLockRequest := segments[len(segments)-1] == "lock"
+
+	// Only ever match Gitlab Terraform state paths.
+	if !(lengthMatches && isProjectPath && isStatePath) {
+		return "", false, fmt.Errorf("not a valid gitlab terraform state path")
+	}
+
+	projectName, _ := url.PathUnescape(segments[3])
+	stateName, _ := url.PathUnescape(segments[6])
+
+	// Generate a unique key to represent this project/state.
+	key := fmt.Sprintf("%s:%s", projectName, stateName)
+
+	return key, isLockRequest, nil
+}
+
+func gitlabStateValueHandler() http.HandlerFunc {
+	valueStorage := map[string][]byte{}
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Always close request body.
+		defer r.Body.Close()
+
+		stateKey, lockRequest, err := stateKeyFromRequest(r)
+
+		if lockRequest || err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		switch r.Method {
+		// Retrieve state.
+		case http.MethodGet:
+			currentValue, exists := valueStorage[stateKey]
+			if exists {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(currentValue)
+			} else {
+				w.WriteHeader(http.StatusNoContent)
+				_, _ = w.Write([]byte{})
+			}
+		// Update state.
+		case http.MethodPost:
+			currentValue, exists := valueStorage[stateKey]
+			stateValue, _ := io.ReadAll(r.Body)
+
+			if !exists {
+				valueStorage[stateKey] = stateValue
+				w.WriteHeader(http.StatusCreated)
+			} else {
+				// Check if the existing state matches what was sent.
+				if bytes.Equal(currentValue, stateValue) {
+					w.WriteHeader(http.StatusNoContent)
+				} else {
+					valueStorage[stateKey] = stateValue
+					w.WriteHeader(http.StatusOK)
+				}
+			}
+		// Delete state.
+		case http.MethodDelete:
+			delete(valueStorage, stateKey)
+			w.WriteHeader(http.StatusOK)
+		}
+	}
+}
+
+func TestRemoteClientOperations(t *testing.T) {
+	testServer := httptest.NewServer(gitlabStateValueHandler())
+	defer testServer.Close()
+
+	url, err := url.Parse(testServer.URL)
+
+	if err != nil {
+		t.Fatalf("Parse: %s", err)
+	}
+
+	client := &RemoteClient{
+		HTTPClient: retryablehttp.NewClient(),
+		StateName:  backend.DefaultStateName,
+		BaseURL:    url,
+		Project:    "test/with/slashes",
+	}
+
+	remote.TestClient(t, client)
+}
+
+func gitlabLockStateHandler() http.HandlerFunc {
+	lockStorage := map[string][]byte{}
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Always close request body.
+		defer r.Body.Close()
+
+		stateKey, lockRequest, err := stateKeyFromRequest(r)
+
+		if !lockRequest || err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		lockValue, _ := io.ReadAll(r.Body)
+
+		switch r.Method {
+		// Acquire lock.
+		case http.MethodPost:
+			currentLock, locked := lockStorage[stateKey]
+			if locked {
+				w.WriteHeader(http.StatusLocked)
+				_, _ = w.Write(currentLock)
+			} else {
+				lockStorage[stateKey] = lockValue
+				w.WriteHeader(http.StatusOK)
+			}
+		// Relinquish lock.
+		case http.MethodDelete:
+			currentLock := lockStorage[stateKey]
+			if !bytes.Equal(lockValue, currentLock) {
+				w.WriteHeader(http.StatusConflict)
+			} else {
+				delete(lockStorage, stateKey)
+				w.WriteHeader(http.StatusOK)
+			}
+		}
+	}
+}
+
+func TestRemoteClientLocks(t *testing.T) {
+	testServer := httptest.NewServer(gitlabLockStateHandler())
+	defer testServer.Close()
+
+	url, err := url.Parse(testServer.URL)
+
+	if err != nil {
+		t.Fatalf("Parse: %s", err)
+	}
+
+	firstClient := &RemoteClient{
+		HTTPClient: retryablehttp.NewClient(),
+		BaseURL:    url,
+		Project:    "test/with/slashes",
+		StateName:  backend.DefaultStateName,
+	}
+
+	secondClient := &RemoteClient{
+		HTTPClient: retryablehttp.NewClient(),
+		BaseURL:    url,
+		Project:    "test/with/slashes",
+		StateName:  backend.DefaultStateName,
+	}
+
+	remote.TestRemoteLocks(t, firstClient, secondClient)
+}

--- a/website/docs/language/settings/backends/gitlab.mdx
+++ b/website/docs/language/settings/backends/gitlab.mdx
@@ -1,0 +1,49 @@
+---
+sidebar_label: gitlab
+description: OpenTofu can store state remotely in a Gitlab project with locking.
+---
+
+# Backend Type: gitlab
+
+Stores the state in [Gitlab-managed Terraform State](https://docs.gitlab.com/ee/user/infrastructure/iac/terraform_state.html).
+
+This backend supports [state locking](../../../language/state/locking.mdx).
+
+## Example Usage
+
+```hcl
+terraform {
+  backend "gitlab" {
+    address = "https://gitlab.com"
+    project = "group/project"
+  }
+}
+```
+
+## Data Source Configuration
+
+```hcl
+data "terraform_remote_state" "foo" {
+  backend = "gitlab"
+  config = {
+    address = "https://gitlab.com"
+    project = "group/project"
+  }
+}
+```
+
+## Configuration Variables
+
+:::danger Warning
+We recommend using environment variables to supply credentials and other sensitive data. If you use `-backend-config` or hardcode these values directly in your configuration, OpenTofu will include these values in both the `.terraform` subdirectory and in plan files. Refer to [Credentials and Sensitive Data](../../../language/settings/backends/configuration.mdx#credentials-and-sensitive-data) for details.
+:::
+
+The following configuration options / environment variables are supported:
+
+- `address` / `TF_GITLAB_ADDRESS` / `CI_SERVER_URL` - (Required) The address of the Gitlab server.
+- `project` / `TF_GITLAB_PROJECT` / `CI_PROJECT_ID` - (Required) The address of the Gitlab project.
+- `token`  / `TF_GITLAB_TOKEN` / `CI_JOB_TOKEN` - (Optional) The authorization token to access Gitlab.
+- `skip_cert_verification` - (Optional) Whether to skip TLS verification. Defaults to `false`.
+- `retry_max` / `TF_GITLAB_RETRY_MAX` – (Optional) The number of HTTP request retries. Defaults to `2`.
+- `retry_wait_min` / `TF_GITLAB_RETRY_WAIT_MIN` – (Optional) The minimum time in seconds to wait between HTTP request attempts. Defaults to `1`.
+- `retry_wait_max` / `TF_GITLAB_RETRY_WAIT_MAX` – (Optional) The maximum time in seconds to wait between HTTP request attempts. Defaults to `30`.

--- a/website/docs/language/state/remote.mdx
+++ b/website/docs/language/state/remote.mdx
@@ -15,7 +15,7 @@ OpenTofu at the same time.
 With _remote_ state, OpenTofu writes the state data to a remote data store,
 which can then be shared between all members of a team. OpenTofu supports
 storing state in [TACOS](../../intro/tacos.mdx) (TF Automation and Collaboration Software),
-[HashiCorp Consul](https://www.consul.io/), Amazon S3, Azure Blob Storage, Google Cloud Storage, Alibaba Cloud OSS, and more.
+[HashiCorp Consul](https://www.consul.io/), Amazon S3, Azure Blob Storage, Google Cloud Storage, Gitlab, Alibaba Cloud OSS, and more.
 
 Remote state is implemented by a [backend](../../language/settings/backends/configuration.mdx) or by
 [TACOS](../../intro/tacos.mdx) (TF Automation and Collaboration Software), both of which you can configure in your configuration's root module.

--- a/website/docs/language/state/workspaces.mdx
+++ b/website/docs/language/state/workspaces.mdx
@@ -19,6 +19,7 @@ You can use multiple workspaces with the following backends:
 - [Consul](../../language/settings/backends/consul.mdx)
 - [COS](../../language/settings/backends/cos.mdx)
 - [GCS](../../language/settings/backends/gcs.mdx)
+- [Gitlab](../../language/settings/backends/gitlab.mdx)
 - [Kubernetes](../../language/settings/backends/kubernetes.mdx)
 - [Local](../../language/settings/backends/local.mdx)
 - [OSS](../../language/settings/backends/oss.mdx)


### PR DESCRIPTION
## Description

This PR implements a backend for [Gitlab-managed Terraform State](https://docs.gitlab.com/ee/user/infrastructure/iac/terraform_state.html) including workspace support.

This provides better integration with Gitlab than the standard `http` backend and is relatively small.

## Target Release

1.9.0

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
