### PR TITLE
Fallback to reading the x-terraform-get header if the module registry returns an empty json body

### DIFF
--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 	svchost "github.com/hashicorp/terraform-svchost"
 	"github.com/hashicorp/terraform-svchost/disco"
+
 	"github.com/opentofu/opentofu/internal/httpclient"
 	"github.com/opentofu/opentofu/internal/logging"
 	"github.com/opentofu/opentofu/internal/registry/regsrc"
@@ -245,6 +246,11 @@ func (c *Client) ModuleLocation(ctx context.Context, module *regsrc.Module, vers
 		}
 
 		location = v.Location
+
+		// if the location is empty, we will fallback to the header
+		if location == "" {
+			location = resp.Header.Get(xTerraformGet)
+		}
 
 	case http.StatusNoContent:
 		// FALLBACK: set the found location from the header


### PR DESCRIPTION
Resolves #2078 

Right now the `tofu` command will attempt to read the json body of a module registry response if the http statuscode is 200, and read the header if it returns a 201. 

This code introduces a change to fall back to checking the header. This means the module registry can return either json body or a http header to point to the location of the module.

## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
