### PR TITLE
300: Add InstanceKeys to providers instead of mapping to alias [WIP]

### DIFF
--- a/internal/addrs/provider_config_test.go
+++ b/internal/addrs/provider_config_test.go
@@ -47,6 +47,20 @@ func TestParseAbsProviderConfig(t *testing.T) {
 			``,
 		},
 		{
+			`provider["registry.opentofu.org/hashicorp/aws"].foo[4]`,
+			AbsProviderConfig{
+				Module: RootModule,
+				Provider: Provider{
+					Type:      "aws",
+					Namespace: "hashicorp",
+					Hostname:  "registry.opentofu.org",
+				},
+				Alias: "foo",
+				Key:   IntKey(4),
+			},
+			``,
+		},
+		{
 			`module.baz.provider["registry.opentofu.org/hashicorp/aws"]`,
 			AbsProviderConfig{
 				Module: Module{"baz"},
@@ -68,6 +82,20 @@ func TestParseAbsProviderConfig(t *testing.T) {
 					Hostname:  "registry.opentofu.org",
 				},
 				Alias: "foo",
+			},
+			``,
+		},
+		{
+			`module.baz.provider["registry.opentofu.org/hashicorp/aws"].foo["bar"]`,
+			AbsProviderConfig{
+				Module: Module{"baz"},
+				Provider: Provider{
+					Type:      "aws",
+					Namespace: "hashicorp",
+					Hostname:  "registry.opentofu.org",
+				},
+				Alias: "foo",
+				Key:   StringKey("bar"),
 			},
 			``,
 		},
@@ -102,7 +130,7 @@ func TestParseAbsProviderConfig(t *testing.T) {
 			`Provider address must begin with "provider.", followed by a provider type name.`,
 		},
 		{
-			`provider.aws.foo.bar`,
+			`provider["aws"].foo.bar.baz`,
 			AbsProviderConfig{},
 			`Extraneous operators after provider configuration alias.`,
 		},
@@ -147,7 +175,7 @@ func TestParseAbsProviderConfig(t *testing.T) {
 				return
 			} else {
 				if len(diags) != 0 {
-					t.Fatalf("got %d diagnostics; want 0", len(diags))
+					t.Fatalf("got %q diagnostics; want 0", diags.Err())
 				}
 			}
 

--- a/internal/configs/module.go
+++ b/internal/configs/module.go
@@ -69,8 +69,8 @@ type Module struct {
 }
 
 // GetProviderConfig uses name and alias to find the respective Provider configuration.
-func (m *Module) GetProviderConfig(name, alias string) (*Provider, bool) {
-	tp := &Provider{ProviderCommon: ProviderCommon{Name: name}, Alias: alias}
+func (m *Module) GetProviderConfig(name, alias string, key addrs.InstanceKey) (*Provider, bool) {
+	tp := &Provider{ProviderCommon: ProviderCommon{Name: name, Alias: alias}, Key: key}
 	p, ok := m.ProviderConfigs[tp.Addr().StringCompact()]
 	return p, ok
 }
@@ -500,6 +500,7 @@ func (m *Module) appendFile(file *File) hcl.Diagnostics {
 			i.Provider = m.ProviderForLocalConfig(addrs.LocalProviderConfig{
 				LocalName: i.ProviderConfigRef.Name,
 				Alias:     i.ProviderConfigRef.Alias,
+				Key:       i.ProviderConfigRef.Key,
 			})
 		} else {
 			implied, err := addrs.ParseProviderPart(i.StaticTo.Resource.ImpliedProvider())

--- a/internal/configs/provider_test.go
+++ b/internal/configs/provider_test.go
@@ -59,6 +59,15 @@ func TestParseProviderConfigCompact(t *testing.T) {
 			``,
 		},
 		{
+			`aws.foo[5]`,
+			addrs.LocalProviderConfig{
+				LocalName: "aws",
+				Alias:     "foo",
+				Key:       IntKey(5),
+			},
+			``,
+		},
+		{
 			`aws["foo"]`,
 			addrs.LocalProviderConfig{},
 			`The provider type name must either stand alone or be followed by an alias name separated with a dot.`,

--- a/internal/configs/provider_validation.go
+++ b/internal/configs/provider_validation.go
@@ -189,6 +189,7 @@ func validateProviderConfigsForTests(cfg *Config) (diags hcl.Diagnostics) {
 										Name:         requirement.Name,
 										NameRange:    requirement.DeclRange,
 										Alias:        alias.Alias,
+										Key:          alias.Key,
 										providerType: requirement.Type,
 									},
 									InParentMapping: providerToConfigRefMapping(provider),
@@ -375,6 +376,7 @@ func validateProviderConfigs(parentCall *ModuleCall, cfg *Config, noProviderConf
 					Module:   cfg.Path,
 					Provider: req.Type,
 					Alias:    alias.Alias,
+					Key:      alias.Key,
 				}
 				configAliases[providerName(alias.LocalName, alias.Alias)] = addr
 			}
@@ -458,7 +460,7 @@ func validateProviderConfigs(parentCall *ModuleCall, cfg *Config, noProviderConf
 			// aliased providers are handled more strictly, and are never
 			// inherited, so they are validated within modules further down.
 			// Skip these checks to prevent redundant diagnostics.
-			if passed.InParentMapping.HasAlias() {
+			if passed.InParentMapping.HasAlias() || passed.InParentMapping.HasKeys() {
 				continue
 			}
 
@@ -471,6 +473,7 @@ func validateProviderConfigs(parentCall *ModuleCall, cfg *Config, noProviderConf
 			// configuration. We ignore empty configs, because they will
 			// already produce a warning.
 			if !(confOK || localOK) {
+				fmt.Printf("Parent: %#v\n", passed.InParentMapping)
 				defAddr := addrs.NewDefaultProvider(name)
 				diags = append(diags, &hcl.Diagnostic{
 					Severity: hcl.DiagWarning,
@@ -579,6 +582,7 @@ func validateProviderConfigs(parentCall *ModuleCall, cfg *Config, noProviderConf
 			Module:   cfg.Path,
 			Provider: childTy,
 			Alias:    passed.InChild.Alias,
+			Key:      passed.InChild.Key,
 		}
 
 		localAddr, localName := localNames[name]

--- a/internal/configs/test_file.go
+++ b/internal/configs/test_file.go
@@ -102,12 +102,13 @@ func (file *TestFile) getTestProviderOrMock(addr string) (*Provider, bool) {
 		p := &Provider{
 			ProviderCommon: ProviderCommon{
 				Name:          mockProvider.Name,
+				Alias:         mockProvider.Alias,
+				AliasRange:    mockProvider.AliasRange,
 				NameRange:     mockProvider.NameRange,
 				DeclRange:     mockProvider.DeclRange,
 				IsMocked:      true,
 				MockResources: mockProvider.MockResources,
 			},
-			Alias: mockProvider.Alias,
 		}
 
 		return p, true

--- a/internal/states/statefile/version4.go
+++ b/internal/states/statefile/version4.go
@@ -96,7 +96,7 @@ func prepareStateV4(sV4 *stateV4) (*File, tfdiags.Diagnostics) {
 			// Looks like it is set on the resource level
 			var addrDiags tfdiags.Diagnostics
 			resourceProviderAddr, addrDiags = addrs.ParseAbsProviderConfigStr(rsV4.ProviderConfig)
-			diags.Append(addrDiags)
+			diags = diags.Append(addrDiags)
 			if addrDiags.HasErrors() {
 				// If ParseAbsProviderConfigStr returns an error, the state may have
 				// been written before Provider FQNs were introduced and the

--- a/internal/tofu/context_input.go
+++ b/internal/tofu/context_input.go
@@ -189,6 +189,7 @@ func (c *Context) Input(config *configs.Config, mode InputMode) tfdiags.Diagnost
 			absConfigAddr := addrs.AbsProviderConfig{
 				Provider: providerFqn,
 				Alias:    pa.Alias,
+				Key:      pa.Key,
 				Module:   config.Path,
 			}
 			c.providerInputConfig[absConfigAddr.String()] = vals

--- a/internal/tofu/eval_context_builtin.go
+++ b/internal/tofu/eval_context_builtin.go
@@ -146,7 +146,7 @@ func (ctx *BuiltinEvalContext) InitProvider(addr addrs.AbsProviderConfig) (provi
 	if ctx.Evaluator != nil && ctx.Evaluator.Config != nil && ctx.Evaluator.Config.Module != nil {
 		// If an aliased provider is mocked, we use providerForTest wrapper.
 		// We cannot wrap providers.Factory itself, because factories don't support aliases.
-		pc, ok := ctx.Evaluator.Config.Module.GetProviderConfig(addr.Provider.Type, addr.Alias)
+		pc, ok := ctx.Evaluator.Config.Module.GetProviderConfig(addr.Provider.Type, addr.Alias, addr.Key)
 		if ok && pc.IsMocked {
 			p, err = newProviderForTest(p, pc.MockResources)
 			if err != nil {

--- a/internal/tofu/node_resource_plan_instance.go
+++ b/internal/tofu/node_resource_plan_instance.go
@@ -675,6 +675,7 @@ func (n *NodePlannableResourceInstance) generateHCLStringAttributes(addr addrs.A
 	providerAddr := addrs.LocalProviderConfig{
 		LocalName: n.ResolvedProvider.Provider.Type,
 		Alias:     n.ResolvedProvider.Alias,
+		Key:       n.ResolvedProvider.Key,
 	}
 
 	return genconfig.GenerateResourceContents(addr, filteredSchema, providerAddr, state.Value)

--- a/internal/tofu/transform_attach_state.go
+++ b/internal/tofu/transform_attach_state.go
@@ -8,6 +8,7 @@ package tofu
 import (
 	"log"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/opentofu/opentofu/internal/dag"
 	"github.com/opentofu/opentofu/internal/states"
 )
@@ -61,12 +62,14 @@ func (t *AttachStateTransformer) Transform(g *Graph) error {
 
 		rs := t.State.Resource(addr.ContainingResource())
 		if rs == nil {
+			spew.Dump(t.State)
 			log.Printf("[DEBUG] Resource state not found for node %q, instance %s", dag.VertexName(v), addr)
 			continue
 		}
 
 		is := rs.Instance(addr.Resource.Key)
 		if is == nil {
+			spew.Dump(rs)
 			// We don't actually need this here, since we'll attach the whole
 			// resource state, but we still check because it'd be weird
 			// for the specific instance we're attaching to not to exist.

--- a/internal/tofu/transform_destroy_edge.go
+++ b/internal/tofu/transform_destroy_edge.go
@@ -103,11 +103,11 @@ func (t *DestroyEdgeTransformer) tryInterProviderDestroyEdge(g *Graph, from, to 
 	getComparableProvider := func(pc GraphNodeProviderConsumer) []string {
 		req := pc.ProvidedBy()
 		var ps []string
-		for _, alias := range req.Local {
+		for _, lc := range req.Local {
 			// We used to only compare the LocalName + Alias across instances. That was probably bug
 			// that was infrequently hit. We now mirror the logic of TransformProvider to construct
 			// the AbsProviderConfig based off of the vertex and the alias
-			ps = append(ps, addrs.AbsProviderConfig{Provider: pc.Provider(), Module: pc.ModulePath(), Alias: alias}.String())
+			ps = append(ps, addrs.AbsProviderConfig{Provider: pc.Provider(), Module: pc.ModulePath(), Alias: lc.Alias, Key: lc.Key}.String())
 		}
 		for _, p := range req.Exact {
 			ps = append(ps, p.Provider.String())


### PR DESCRIPTION
PR'd into #1911 
Main PR: #2054

Based on the discussion around https://github.com/opentofu/opentofu/pull/2088:
* `[*]` syntax not added for configured_aliases yet
* for_each allowed without aliases
* Split out Instance variants of configs
* See if Key in ProviderConfigRef is needed / makes sense
* Support for `count` in provider config block

## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
