### PR TITLE
chore: add failing testvar override test

### DIFF
--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -169,6 +169,10 @@ func TestTest(t *testing.T) {
 			expected: "1 passed, 0 failed.",
 			code:     0,
 		},
+		"no_override_in_tests_dir_when_not_testing": {
+			expected: "1 passed, 0 failed.",
+			code:     0,
+		},
 	}
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {

--- a/internal/command/testdata/test/no_override_in_tests_dir_when_not_testing/main.tf
+++ b/internal/command/testdata/test/no_override_in_tests_dir_when_not_testing/main.tf
@@ -1,0 +1,7 @@
+variable "testVar" {
+  type = string
+}
+
+resource "test_resource" "testRes" {
+  value = var.testVar
+}

--- a/internal/command/testdata/test/no_override_in_tests_dir_when_not_testing/terraform.tfvars
+++ b/internal/command/testdata/test/no_override_in_tests_dir_when_not_testing/terraform.tfvars
@@ -1,0 +1,1 @@
+testVar = "ValueFROMmain/tfvars"

--- a/internal/command/testdata/test/no_override_in_tests_dir_when_not_testing/tests/main.tftest.hcl
+++ b/internal/command/testdata/test/no_override_in_tests_dir_when_not_testing/tests/main.tftest.hcl
@@ -1,0 +1,7 @@
+run "validate_test_resource" {
+  command = plan
+  assert {
+    condition     = test_resource.testRes.value == "ValueFROMmain/tfvars"
+    error_message = "invalid value"
+  }
+}

--- a/internal/command/testdata/test/no_override_in_tests_dir_when_not_testing/tests/terraform.tfvars
+++ b/internal/command/testdata/test/no_override_in_tests_dir_when_not_testing/tests/terraform.tfvars
@@ -1,0 +1,1 @@
+testVar = "ValueFROMtests/tfvars"


### PR DESCRIPTION
This is a draft PR to represent a potential bug in that test vars should not be used when running a normal `plan` command

I expect the variable `testVar` to equal the variable defined in the main `terraform.tfvars` file eg. `ValueFROMmain/tfvars`
Instead, the `testVar` takes on the value defined in `tests/terraform.tfvars` eg. `valueFROMtests/tfvars`

## Target Release

N/A

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
