### PR TITLE
Partially unknown provider functions arguments fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ BUG FIXES:
 * Fixed function references in variable validation ([#2052](https://github.com/opentofu/opentofu/pull/2052))
 * Fixed potential leaking of secret variable with static evaluation ([#2045](https://github.com/opentofu/opentofu/pull/2045))
 * Fixed a providers mirror crash with bad lock file ([#1985](https://github.com/opentofu/opentofu/pull/1985))
+* Provider functions will now handle partially unknown arguments per the tfplugin spec ([#2127](https://github.com/opentofu/opentofu/pull/2127))
 
 
 ## Previous Releases

--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -766,7 +766,20 @@ func (p *GRPCProvider) CallFunction(r providers.CallFunctionRequest) (resp provi
 			} else {
 				// This should be unreachable
 				resp.Error = fmt.Errorf("invalid CallFunctionRequest: too many arguments passed to non-variadic function %s", r.Name)
+				return resp
 			}
+		}
+
+		if !paramSpec.AllowUnknownValues && !arg.IsWhollyKnown() {
+			// Unlike the standard in cty, AllowUnknownValues == false does not just apply to
+			// the root of the value (IsKnown) and instead also applies to values inside collections
+			// and structures (IsWhollyKnown).
+			// This is documented in the tfplugin proto file comments.
+			//
+			// The standard cty logic can be found in:
+			// https://github.com/zclconf/go-cty/blob/ea922e7a95ba2be57897697117f318670e066d22/cty/function/function.go#L288-L290
+			resp.Result = cty.UnknownVal(spec.Return)
+			return resp
 		}
 
 		if arg.IsNull() {

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -170,7 +170,10 @@ type FunctionParameterSpec struct {
 	// Null values allowed for the parameter
 	AllowNullValue bool
 	// Unknown Values allowed for the parameter
-	// Implies the Return type of the function is also Unknown
+	// Individual provider implementations may interpret this as a
+	// check using IsWhollyKnown instead cty's default of IsKnown.
+	// If the input is not wholly known, the result should be
+	// cty.UnknownVal(spec.returnType)
 	AllowUnknownValues bool
 	// Human-readable documentation for the parameter
 	Description string


### PR DESCRIPTION
Provider function arguments now respect the protocol's definition that function inputs should be checked against IsWhollyKnown in addition to the standard IsKnown.

This is different than the cty convention and has been documented as such

Resolves #2126

## Target Release

1.9.0, 1.8.x, 1.7.x

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
