### PR TITLE
website: Initial documentation updates for dynamic provider instances

### DIFF
--- a/website/docs/language/meta-arguments/examples/resource-provider-dynamic-instances.tf
+++ b/website/docs/language/meta-arguments/examples/resource-provider-dynamic-instances.tf
@@ -1,0 +1,25 @@
+variable "aws_regions" {
+  type = map(object({
+    vpc_cidr_block = string
+  }))
+}
+
+provider "aws" {
+  alias    = "by_region"
+  for_each = var.aws_regions
+
+  region = each.key
+}
+
+resource "aws_vpc" "private" {
+  # This expression filters var.aws_regions to include only
+  # the elements whose value is not null. Refer to the
+  # warning in the text below for more information.
+  for_each = {
+    for region, config in var.aws_regions : region => config
+    if config != null
+  }
+  provider = aws.by_region[each.key]
+
+  cidr_block = each.value.vpc_cidr_block
+}

--- a/website/docs/language/meta-arguments/module-providers.mdx
+++ b/website/docs/language/meta-arguments/module-providers.mdx
@@ -35,26 +35,36 @@ module "example" {
 }
 ```
 
+Each module in an OpenTofu configuration has its own separate namespace of
+provider configurations, but a child module's namespace is populated with
+configurations from the root module, either inheriting the default provider
+configurations automatically or explicitly passing them from the parent
+using the `providers` argument.
+
 ## Default Behavior: Inherit Default Providers
 
 If the child module does not declare any [configuration aliases](../../language/modules/develop/providers.mdx#provider-aliases-within-modules),
 the `providers` argument is optional. If you omit it, a child module inherits
-all of the _default_ provider configurations from its parent module. (Default
-provider configurations are ones that don't use the `alias` argument.)
+all of the
+[default provider configurations](../../language/providers/configuration.mdx#default-provider-configurations)
+from its parent module. (Default provider configurations are any that don't
+use the `alias` argument.)
 
 If you specify a `providers` argument, it cancels this default behavior, and the
-child module will _only_ have access to the provider configurations you specify.
+child module will only have access to the provider configurations you specify.
 
 ## Usage and Behavior
 
-The value of `providers` is a map, where:
+The `providers` argument uses a map-like syntax delimited by braces (`{`, `}`).
+In the given mapping:
 
-- The keys are the provider configuration names used inside the child module.
-- The values are provider configuration names from the parent module.
+- The keys are the provider configuration addresses that will be used inside the
+  child module.
+- The values are provider instance addresses from the parent module.
 
-Both keys and values should be unquoted references to provider configurations.
-For default configurations, this is the local name of the provider; for
-alternate configurations, this is a `<PROVIDER>.<ALIAS>` reference.
+Both parts use
+[provider instance reference syntax](../../language/providers/configuration.mdx#referring-to-provider-instances),
+which for alternative provider configurations appears as `<PROVIDER NAME>.<ALIAS>`.
 
 Within a child module, resources are assigned to provider configurations as
 normal — either OpenTofu chooses a default based on the name of the resource
@@ -117,6 +127,82 @@ Non-default provider configurations are never automatically inherited, so any
 module that works like this will always need a `providers` argument. The
 documentation for the module should specify all of the provider configuration
 names it needs.
+
+### Module instances with differing provider instances
+
+When you write a `provider` block using
+[the `for_each` meta-argument](../../language/providers/configuration.mdx#for_each-multiple-instances-of-a-provider-configuration)
+the provider configuration dynamically declares zero or more provider instances.
+
+If you also write a `module` block that uses `for_each` you can set its provider
+configuration addresses to refer to dynamically-chosen instances of a multi-instance
+provider configuration, which allows instantiating a module once per provider
+instance.
+
+For example, you might instantiate a module for each of a number of different AWS
+regions, declaring foundational infrastructure across all of the regions you use,
+with the module itself using only one default provider configuration that differs
+for each module instance:
+
+```hcl
+variable "aws_regions" {
+  type = map(object({
+    vpc_cidr_block = string
+  }))
+}
+
+provider "aws" {
+  alias    = "by_region"
+  for_each = var.aws_regions
+
+  region = each.key
+}
+
+module "per_region" {
+  source = "./per-region"
+  # This expression filters var.aws_regions to include only
+  # the elements whose value is not null. Refer to the
+  # warning in the text below for more information.
+  for_each = {
+    for region, config in var.aws_regions : region => config
+    if config != null
+  }
+  providers = {
+    aws = aws.by_region[each.key]
+  }
+
+  region_name    = each.key
+  vpc_cidr_block = each.value.vpc_cidr_block
+}
+```
+
+The module in `./per-region` should be written so that all of its AWS resources
+are bound to that module's default configuration for the AWS provider. The
+`providers` argument in the `module` block ensures that each instance of the
+module has its default configuration for the AWS provider bound to a different
+instance of `aws.by_region`.
+
+All instances of the module must refer to instances of the same provider
+configuration: only the expression in brackets (`each.key` in the above example)
+can vary between the instances of the module.
+
+:::warning
+**The `for_each` expression for a resource must not exactly match the
+`for_each` expression for its associated provider configuration.**
+
+OpenTofu uses a provider instance to plan and apply _all_ actions related
+to a resource instance, including destroying a resource instance that
+has been removed from the configuration.
+
+Therefore a provider instance passed into a child module that will declare
+resources associated with that provider instance must always remain in the
+configuration for at least one more plan/apply round after the module instance
+has been removed, or OpenTofu will fail to plan to destroy the resource instances
+declared in the module.
+
+You can find more information on this constraint in
+[Referring to Provider Instances](../../language/providers/configuration.mdx#referring-to-provider-instances).
+:::
 
 ## More Information for Module Developers
 

--- a/website/docs/language/meta-arguments/resource-provider.mdx
+++ b/website/docs/language/meta-arguments/resource-provider.mdx
@@ -4,26 +4,29 @@ description: >-
   should use for a resource, overriding OpenTofu's default behavior.
 ---
 
+import CodeBlock from '@theme/CodeBlock';
+import ExampleDynamicInstances from '!!raw-loader!./examples/resource-provider-dynamic-instances.tf'
+
 # The Resource `provider` Meta-Argument
 
-The `provider` meta-argument specifies which provider configuration to use for a resource,
-overriding OpenTofu's default behavior of selecting one based on the resource
-type name. Its value should be an unquoted `<PROVIDER>.<ALIAS>` reference.
+The `provider` meta-argument specifies which provider instance is responsible for managing
+each instance of a resource, overriding OpenTofu's default behavior of
+[automatically selecting a default provider configuration](../../language/providers/configuration.mdx#default-provider-configurations).
 
-As described in [Provider Configuration](../../language/providers/configuration.mdx), you can optionally
-create multiple configurations for a single provider (usually to manage
-resources in different regions of multi-region services). Each provider can have
-one default configuration, and any number of alternate configurations that
-include an extra name segment (or "alias").
+As described in [Provider Configuration](../../language/providers/configuration.mdx), you
+can optionally declare multiple configurations for a single provider, or multiple dynamic
+instances of a single provider configuration, such as when managing resources across
+different regions when using a provider which forces only a single region per provider
+instance.
 
-By default, OpenTofu interprets the initial word in the resource type name
-(separated by underscores) as the local name of a provider, and uses that
-provider's default configuration. For example, the resource type
-`google_compute_instance` is associated automatically with the default
-configuration for the provider named `google`.
+By default, OpenTofu interprets the initial word in the resource type name (separated by
+underscores) as the local name of a provider, and uses that provider's default
+configuration. For example, the resource type `google_compute_instance` is associated
+automatically with the default configuration for the provider whose local name
+in the current module is `google`.
 
-By using the `provider` meta-argument, you can select an alternate provider
-configuration for a resource:
+Using the `provider` meta-argument you can select an alternate provider configuration
+for a resource:
 
 ```hcl
 # default configuration
@@ -47,12 +50,31 @@ resource "google_compute_instance" "example" {
 }
 ```
 
-A resource always has an implicit dependency on its associated provider, to
-ensure that the provider is fully configured before any resource actions
-are taken.
+If you select a provider configuration that uses `for_each` then you
+must also dynamically select a different instance of the provider configuration for
+each instance of the resource by including an instance key expression in brackets:
 
-The `provider` meta-argument expects
-[a `<PROVIDER>.<ALIAS>` reference](../../language/providers/configuration.mdx#referring-to-alternate-provider-configurations),
-which does not need to be quoted. Arbitrary expressions are not permitted for
-`provider` because it must be resolved while OpenTofu is constructing the
-dependency graph, before it is safe to evaluate expressions.
+<CodeBlock language="hcl">{ExampleDynamicInstances}</CodeBlock>
+
+{/* NOTE: The above example is shared with ../providers/configuration.mdx
+    and its text refers to specific declarations in the example. */}
+
+You can find more detail on the syntax used with the `provider` argument in
+[Referring to Provider Instances](../../language/providers/configuration.mdx#referring-to-provider-instances).
+
+:::warning
+**The `for_each` expression for a resource must not exactly match the
+`for_each` expression for its associated provider configuration.**
+
+OpenTofu uses a provider instance to plan and apply _all_ actions related
+to a resource instance, including destroying a resource instance that
+has been removed from the configuration.
+
+Therefore the provider instance associated with any resource instance must
+always remain in the configuration for at least one more plan/apply round
+after the resource instance has been removed, or OpenTofu will fail to
+plan to destroy the resource instance.
+
+You can find more information on this constraint in
+[Referring to Provider Instances](../../language/providers/configuration.mdx#referring-to-provider-instances).
+:::

--- a/website/docs/language/modules/develop/providers.mdx
+++ b/website/docs/language/modules/develop/providers.mdx
@@ -21,22 +21,24 @@ following sections.
 
 A module intended to be called by one or more other modules must not contain
 any `provider` blocks. A module containing its own provider configurations is
-not compatible with the `for_each`, `count`, and `depends_on` arguments.
+not compatible with the `for_each`, `count`, and `depends_on` meta-arguments.
 
 Provider configurations are used for all operations on associated resources,
 including destroying remote objects and refreshing state. OpenTofu retains, as
 part of its state, a reference to the provider configuration that was most
 recently used to apply changes to each resource. When a `resource` block is
-removed from the configuration, this record in the state will be used to locate
-the appropriate configuration because the resource's `provider` argument
-(if any) will no longer be present in the configuration.
+removed from the configuration, or a dynamic instance of a resource is removed
+by modifying the value assigned to the `count` or `for_each` meta-argument,
+this record in the state will be used to locate the appropriate configuration
+because the resource instance's `provider` argument (if any) will no longer be
+present in the configuration.
 
 As a consequence, you must ensure that all resources that belong to a
-particular provider configuration are destroyed before you can remove that
-provider configuration's block from your configuration. If OpenTofu finds
-a resource instance tracked in the state whose provider configuration block is
-no longer available then it will return an error during planning, prompting you
-to reintroduce the provider configuration.
+particular provider instance are destroyed before you can remove that
+provider instance from your configuration. If OpenTofu finds a resource instance
+tracked in the state whose provider instance is no longer declared in the
+configuration then it will return an error during planning, prompting you
+to reintroduce the provider instance.
 
 ## Provider Version Constraints in Modules
 
@@ -95,6 +97,11 @@ required provider version using a `>=` constraint. This should specify the
 minimum version containing the features your module relies on, and thus allow a
 user of your module to potentially select a newer provider version if other
 features are needed by other parts of their overall configuration.
+
+It is not currently possible to pass a provider configuration with multiple
+instances (that was declared using `for_each`) as a whole to a child module,
+although it is valid for the parent module to assign a single dynamic instance
+of a provider configuration to each instance of the module.
 
 ## Implicit Provider Inheritance
 
@@ -170,9 +177,10 @@ module "example" {
 }
 ```
 
-The `providers` argument within a `module` block is similar to
-[the `provider` argument](../../../language/meta-arguments/resource-provider.mdx)
-within a resource, but is a map rather than a single string because a module may
+[The `providers` argument within a `module` block](../../../language/meta-arguments/module-providers.mdx)
+is similar to
+[the `provider` argument within a `resource` block](../../../language/meta-arguments/resource-provider.mdx),
+but is a mapping rather than a single string because a module may
 contain resources from many different providers.
 
 The keys of the `providers` map are provider configuration names as expected by

--- a/website/docs/language/providers/configuration.mdx
+++ b/website/docs/language/providers/configuration.mdx
@@ -4,6 +4,9 @@ description: >-
   specify multiple configurations for a single provider.
 ---
 
+import CodeBlock from '@theme/CodeBlock';
+import ExampleDynamicProviderInstances from '!!raw-loader!../meta-arguments/examples/resource-provider-dynamic-instances.tf'
+
 # Provider Configuration
 
 Providers allow OpenTofu to interact with cloud providers, SaaS providers, and
@@ -26,7 +29,7 @@ more information, see
 [The Module `providers` Meta-Argument](../../language/meta-arguments/module-providers.mdx)
 and [Module Development: Providers Within Modules](../../language/modules/develop/providers.mdx).)
 
-A provider configuration is created using a `provider` block:
+A provider configuration is defined using a `provider` block:
 
 ```hcl
 provider "google" {
@@ -37,8 +40,8 @@ provider "google" {
 
 The name given in the block header (`"google"` in this example) is the
 [local name](../../language/providers/requirements.mdx#local-names) of the provider to
-configure. This provider should already be included in a `required_providers`
-block.
+configure. Each module has its own namespace of provider local names,
+defined in its `required_providers` block.
 
 The body of the block (between `{` and `}`) contains configuration arguments for
 the provider. Most arguments in this section are defined by the provider itself;
@@ -46,10 +49,10 @@ in this example both `project` and `region` are specific to the `google`
 provider.
 
 You can use [expressions](../../language/expressions/index.mdx) in the values of these
-configuration arguments, but can only reference values that are known before the
+configuration arguments, but can only refer to values that are known before the
 configuration is applied. This means you can safely reference input variables,
-but not attributes exported by resources (with an exception for resource
-arguments that are specified directly in the configuration).
+but not attributes exported by resources unless they are defined directly in
+the configuration or documented as being available during the planning phase.
 
 A provider's documentation should list which configuration arguments it expects.
 For providers distributed on the
@@ -65,7 +68,8 @@ version-controlled OpenTofu code.
 There are also two "meta-arguments" that are defined by OpenTofu itself
 and available for all `provider` blocks:
 
-- [`alias`, for using the same provider with different configurations for different resources][inpage-alias]
+- [`alias`, for defining additional configurations for the same provider][inpage-alias]
+- [`for_each`, for defining multiple dynamic instances of a provider configuration][inpage-for_each]
 - [`version`, which we no longer recommend][inpage-versions] (use
   [provider requirements](../../language/providers/requirements.mdx) instead)
 
@@ -85,6 +89,7 @@ examples include targeting multiple Docker hosts, multiple Consul hosts, etc.
 To create multiple configurations for a given provider, include multiple
 `provider` blocks with the same provider name. For each additional non-default
 configuration, use the `alias` meta-argument to provide an extra name segment.
+A provider configuration with an alias is called an _alternate provider configuration_.
 For example:
 
 ```hcl
@@ -94,7 +99,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-# Additional provider configuration for west coast region; resources can
+# Alternate provider configuration for west coast region; resources can
 # reference this as `aws.west`.
 provider "aws" {
   alias  = "west"
@@ -120,7 +125,7 @@ terraform {
 }
 ```
 
-### Default Provider Configurations
+## Default Provider Configurations
 
 A `provider` block without an `alias` argument is the _default_ configuration
 for that provider. Resources that don't set the `provider` meta-argument will
@@ -128,29 +133,102 @@ use the default provider configuration that matches the first word of the
 resource type name. (For example, an `aws_instance` resource uses the default
 `aws` provider configuration unless otherwise stated.)
 
-If every explicit configuration of a provider has an alias, OpenTofu uses the
-implied empty configuration as that provider's default configuration. (If the
-provider has any required configuration arguments, OpenTofu will raise an error
-when resources default to the empty configuration.)
+If there is no `provider` block defining the default configuration for a
+provider, OpenTofu automatically infers an empty default provider configuration
+for that provider. If the provider's configuration schema includes any required
+arguments then the empty configuration would be invalid, and so an explicit
+`provider` block is required.
 
-### Referring to Alternate Provider Configurations
+A default provider configuration is not required nor inferred if all resources
+in a module explicitly select a different provider configuration using the
+`provider` meta-argument in their `resource` or `data` blocks.
 
-When OpenTofu needs the name of a provider configuration, it expects a
-reference of the form `<PROVIDER NAME>.<ALIAS>`. In the example above,
-`aws.west` would refer to the provider with the `us-west-2` region.
+## `for_each`: Multiple instances of a provider configuration
 
-These references are special expressions. Like references to other named
-entities (for example, `var.image_id`), they aren't strings and don't need to be
-quoted. But they are only valid in specific meta-arguments of `resource`,
-`data`, and `module` blocks, and can't be used in arbitrary expressions.
+[inpage-for_each]: #for_each-multiple-instances-of-a-provider-configuration
 
-### Selecting Alternate Provider Configurations
+Sometimes it's necessary to declare multiple instances of a provider dynamically
+based on some other data available in your configuration, such as an input
+variable.
 
-By default, resources use a default provider configuration (one without an
-`alias` argument) inferred from the first word of the resource type name.
+For example, a configuration that declares a foundational set of infrastructure
+for each AWS region that an organization is using might offer an input variable
+for specifying those regions, but the `hashicorp/aws` provider supports only
+one region per instance of the provider and so it would not be possible to
+declare infrastructure across a dynamic set of regions using only static
+provider configurations.
 
-To use an alternate provider configuration for a resource or data source, set
-its `provider` meta-argument to a `<PROVIDER NAME>.<ALIAS>` reference:
+Any alternate provider configuration (declared using the `alias` argument)
+can optionally also include the `for_each` argument to declare that the
+configuration should be instantiated multiple times based on a collection
+value:
+
+```hcl
+variable "aws_regions" {
+  type = map(object({
+    vpc_cidr_block = string
+  }))
+}
+
+provider "aws" {
+  alias    = "by_region"
+  for_each = var.aws_regions
+
+  region = each.key
+}
+```
+
+Without the `for_each` argument, a `provider` block always declares only
+a single instance of the corresponding provider. A provider configuration
+which includes the `for_each` argument instead declares _zero or more_
+provider instances where each corresponds to one element from the `for_each`
+collection, each configured systematically based on the same configuration
+block.
+
+Each instance has an _instance key_ which uniquely identifies the instance
+among all instances belonging to the same provider configuration.
+The value assigned to `for_each` must be of either a map type, an object
+type, or be a set of strings. For a map or object type, the element key or
+attribute name becomes the instance key. For a set of strings, the element
+value itself becomes the instance key.
+
+An operator of this configuration must provide a map value for the `aws_regions`
+input variable, where each element's key is a valid AWS region name and its
+value is an object describing the unique settings for that region. For example,
+in a `terraform.tfvars` file:
+
+```hcl
+aws_regions = {
+  eu-central-2 = {
+    vpc_cidr_block = "10.1.0.0/16"
+  }
+  ap-northeast-1 = {
+    vpc_cidr_block = "10.2.0.0/16"
+  }
+}
+```
+
+The `for_each` argument can only be used in combination with `alias`, because
+the default configuration for each provider must always have exactly one
+instance so that OpenTofu can select it automatically when appropriate.
+
+## Selecting Alternate Provider Configurations
+
+Each resource in your OpenTofu configuration must be bound to one
+provider configuration.
+
+By default, each resource is bound to a
+[default provider configuration](#default-provider-configurations)
+chosen automatically based on the first segment of the resource type
+name. For example, a `resource "azurerm_subnet" "example"` block would
+be bound to the default configuration for whichever provider has the
+local name "azurerm" in the module where the resource is declared.
+
+To use an alternate provider configuration, a `resource` or `data`
+block must include
+[the `provider` Meta-Argument](../../language/meta-arguments/resource-provider.mdx),
+with a [provider instance reference](#referring-to-provider-instances)
+that includes the selected configuration's alias:
 
 ```hcl
 resource "aws_instance" "foo" {
@@ -160,24 +238,114 @@ resource "aws_instance" "foo" {
 }
 ```
 
-To select alternate provider configurations for a child module, use its
-`providers` meta-argument to specify which provider configurations should be
-mapped to which local provider names inside the module:
+If the selected configuration uses the `for_each` argument to declare
+multiple instances then the `provider` argument must also include
+an instance key expression to select one instance of the provider
+configuration per resource instance as described in the next section.
+
+Omitting the `provider` argument is equivalent to setting it to
+choose the default configuration for the provider whose local name
+matches the resource type name's prefix:
 
 ```hcl
-module "aws_vpc" {
-  source = "./aws_vpc"
-  providers = {
-    aws = aws.west
-  }
+resource "aws_instance" "foo" {
+  provider = aws
+
+  # ...
 }
 ```
 
-Modules have some special requirements when passing in providers; see
-[The Module `providers` Meta-Argument](../../language/meta-arguments/module-providers.mdx)
-for more details. In most cases, only _root modules_ should define provider
-configurations, with all child modules obtaining their provider configurations
-from their parents.
+## Referring to Provider Instances
+
+{/* old section anchor to preserve existing external links */}
+<a id="referring-to-alternate-provider-configurations"></a>
+
+To explicitly refer to provider configurations, OpenTofu uses a
+provider-configuration-specific reference syntax of the form
+`<PROVIDER NAME>.<ALIAS>`. For example, `aws.west` refers to the
+`provider "aws"` block with `alias = "west"`.
+
+This syntax uses similar symbols to a normal
+[expression reference](../../language/expressions/references.mdx), but
+provider references are not normal expressions and can only be used
+in some special locations:
+
+- [The `provider` meta-argument of a `resource` or `data` block](../../language/meta-arguments/resource-provider.mdx)
+- [The `providers` meta-argument of a `module` block](../../language/meta-arguments/module-providers.mdx)
+
+For a provider configuration that does not include `for_each`, the same
+syntax used to refer to the configuration is also a reference to its
+single provider instance, so in most cases you can think of a provider
+configuration reference and a provider instance reference as equivalent.
+
+However, when a provider configuration declares zero or more dynamic
+instances using `for_each` the reference syntax grows to include an
+additional component which specifies which instance to select using
+the configuration's instance keys. For example, `aws.by_region["eu-west-1"]`
+refers to whichever instance of `aws.by_region` has the instance
+key `"eu-west-1"`.
+
+The expression in square brackets uses [normal expression syntax](../../language/expressions/index.mdx),
+and typically the instance key would be selected dynamically for each
+instance of a resource rather than hard-coded. For example:
+
+<CodeBlock language="hcl">{ExampleDynamicProviderInstances}</CodeBlock>
+
+{/* NOTE: The above example is shared with ../meta-arguments/resource-provider.mdx */}
+
+The `resource "aws_vpc" "private"` block uses `for_each` to declare one
+instance of the resource for each non-null element of `var.aws_regions`.
+The `provider` argument then uses `each.key` to select a different
+instance of `aws.by_region` for each instance of the resource, so that
+each would be declared in a different region.
+
+You can also choose a dynamic instance from a provider configuration for
+all resources in a child module as part of a `module` block. Refer to
+[Module instances with differing provider instances](../../language/meta-arguments/module-providers.mdx#module-instances-with-differing-provider-instances)
+for more information.
+
+Although the instance key expression in square brackets is dynamic, the
+provider configuration reference is static so that OpenTofu can infer the
+dependencies between `resource` blocks and `provider` blocks before
+evaluating any expressions. The dependencies then ensure that OpenTofu
+can resolve dynamic expressions in the correct order. This means that
+all instances of a particular resource must be bound to instances of the
+same provider configuration block, but can they each be bound to a different
+instance.
+
+:::warning
+**The `for_each` expression for a resource must not exactly match the
+`for_each` expression for its associated provider configuration.**
+
+OpenTofu uses a provider instance to plan and apply _all_ actions related
+to a resource instance, including destroying a resource instance that
+has been removed from the configuration.
+
+Therefore the provider instance associated with any resource instance must
+always remain in the configuration for at least one more plan/apply round
+after the resource instance has been removed, or OpenTofu will fail to
+plan to destroy the resource instance.
+
+The above example uses a null element in `var.aws_regions` to represent
+that a provider instance is needed but no resource instances should be
+associated with it.
+
+Setting a particular region's element to `null` would therefore cause
+OpenTofu to propose to destroy the `aws_vpc.private` instance for that
+region while retaining the provider instance needed to plan and apply that
+action. You can then remove the element altogether on the next round, once
+all of the associated resource instances have been destroyed.
+:::
+
+### Passing provider configurations between modules
+
+Each module has its own separate namespace of provider configurations, but
+it's possible for a parent module to pass some or all of its provider
+configurations into provider configuration addresses declared in a
+child module.
+
+For more information, refer to
+[The `providers` Meta-Argument in `module` blocks](../../language/meta-arguments/module-providers.mdx).
 
 <a id="provider-versions"></a>
 

--- a/website/docs/language/providers/index.mdx
+++ b/website/docs/language/providers/index.mdx
@@ -31,18 +31,19 @@ generating random numbers for unique resource names.
 Providers are distributed separately from OpenTofu itself, and each provider
 has its own release cadence and version numbers.
 
-The [Public OpenTofu Registry](https://github.com/opentofu/registry/tree/main/providers)
+The [Public OpenTofu Registry](https://registry.opentofu.org/)
 is the main directory of publicly available providers, and hosts
 providers for most major infrastructure platforms.
 
 ## Provider Documentation
 
 Each provider has its own documentation, describing its resource
-types and their arguments. This documentation can be found in the provider's
-github repository.
+types and their arguments. This documentation can be found in each provider's
+GitHub repository, and the documentation for many providers is also
+mirrored on [the Providers index in the Public OpenTofu Registry](https://search.opentofu.org/providers).
 
-Provider documentation is versioned, make sure you are referring to the correct
-tag/release.
+Provider documentation is versioned, so it's important to refer to the tag or
+release matching the version you are using.
 
 ## How to Use Providers
 


### PR DESCRIPTION
This is an initial round of documentation updates for the new feature that allows an alternate provider configuration to declare multiple dynamic instances, using the `for_each` argument in a `provider` block.

This initial work is intended to provide a starting point to support those who wish to experiment with this feature during the v1.9.0 prerelease period. We will continue iterating on this documentation throughout the prerelease period, especially if prerelease feedback suggests that any part of the feature is difficult to understand.

Along with directly documenting the new features, this also includes some general adjustments of terminology to try to draw a distinction between provider _configurations_ (`provider` blocks) and provider _instances_, since this new feature means that they are no longer always directly synonymous as they were before. There are probably other parts of the documentation in need of similar tweaks, but to start I focused only on the sections that are primarily related provider configurations, instances, and references.

Before final release we also intend to create some preemptive feature request issues for capabilities we've intentionally excluded from the first round of this feature, so that there will be a clear place to share use-cases and votes for those enhancements. Once we've created those issues a subsequent draft of this documentation will link to them in appropriate
places, but that information is intentionally excluded from the first draft because we want to focus on the already-implemented capabilities for the first round of beta testing.

This is part of https://github.com/opentofu/opentofu/issues/2123 .

## Target Release

1.9.0-beta1

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
