### PR TITLE
fix mock provider validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ BUG FIXES:
 * Error message about a provider type mismatch now correctly identifies which module contains the problem. ([#1991](https://github.com/opentofu/opentofu/pull/1991))
 * The `yamldecode` function's interpretation of scalars as numbers now conforms to the YAML 1.2 specification. In particular, the scalar value `+` is now interpreted as the string `"+"` rather than returning a parse error trying to interpret it as an integer. ([#2044](https://github.com/opentofu/opentofu/pull/2044))
 * A `module` block's `version` argument now accepts prerelease version selections using a "v" prefix before the version number. Previously this was accepted only for non-prerelease selections. ([#2124])(https://github.com/opentofu/opentofu/issues/2124)
+* The `tofu test` command doesn't try to validate mock provider definition by its underlying provider schema now. ([#2140](https://github.com/opentofu/opentofu/pull/2140))
 
 INTERNAL CHANGES:
 

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/opentofu/opentofu/internal/addrs"
 	testing_command "github.com/opentofu/opentofu/internal/command/testing"
 	"github.com/opentofu/opentofu/internal/command/views"
+	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/terminal"
 )
@@ -1394,5 +1395,68 @@ digits, underscores, and dashes.
 				t.Fatalf("expected status code 0 but got %d: %s", code, ui.ErrorWriter)
 			}
 		})
+	}
+}
+
+// TestTest_MockProviderValidation checks if tofu test runs proper validation for
+// mock_provider. Even if provider schema has required fields, tofu test should
+// ignore it completely, because the provider is mocked.
+func TestTest_MockProviderValidation(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("test/mock_provider_validation"), td)
+	defer testChdir(t, td)()
+
+	provider := testing_command.NewProvider(nil)
+	providerSource, close := newMockProviderSource(t, map[string][]string{
+		"test": {"1.0.0"},
+	})
+	defer close()
+
+	provider.Provider.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
+		Provider: providers.Schema{
+			Block: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"required_field": {
+						Type:     cty.String,
+						Required: true,
+					},
+				},
+			},
+		},
+		ResourceTypes: map[string]providers.Schema{
+			"test_resource": {
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"value": {
+							Type:     cty.String,
+							Optional: true,
+						},
+						"computed_value": {
+							Type:     cty.String,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	streams, _ := terminal.StreamsForTesting(t)
+	view := views.NewView(streams)
+	ui := new(cli.MockUi)
+	meta := Meta{
+		testingOverrides: metaOverridesForProvider(provider.Provider),
+		Ui:               ui,
+		View:             view,
+		Streams:          streams,
+		ProviderSource:   providerSource,
+	}
+
+	testCmd := &TestCommand{
+		Meta: meta,
+	}
+
+	if code := testCmd.Run(nil); code != 0 {
+		t.Fatalf("expected status code 0 but got %d: %s", code, ui.ErrorWriter)
 	}
 }

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -1407,10 +1407,10 @@ func TestTest_MockProviderValidation(t *testing.T) {
 	defer testChdir(t, td)()
 
 	provider := testing_command.NewProvider(nil)
-	providerSource, close := newMockProviderSource(t, map[string][]string{
+	providerSource, closePS := newMockProviderSource(t, map[string][]string{
 		"test": {"1.0.0"},
 	})
-	defer close()
+	defer closePS()
 
 	provider.Provider.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{

--- a/internal/command/testdata/test/mock_provider_validation/main.tf
+++ b/internal/command/testdata/test/mock_provider_validation/main.tf
@@ -1,0 +1,5 @@
+provider "test" {}
+
+resource "test_resource" "primary" {
+  value = "foo"
+}

--- a/internal/command/testdata/test/mock_provider_validation/main.tftest.hcl
+++ b/internal/command/testdata/test/mock_provider_validation/main.tftest.hcl
@@ -1,0 +1,14 @@
+mock_provider "test" {
+  mock_resource "test_resource" {
+    defaults = {
+      computed_value = "bar"      
+    }
+  }
+}
+
+run "test" {
+  assert {
+    condition = test_resource.primary.computed_value == "bar"
+    error_message = "Unexpected computed value"
+  }
+}

--- a/internal/tofu/provider_for_test_framework.go
+++ b/internal/tofu/provider_for_test_framework.go
@@ -104,7 +104,7 @@ func (p *providerForTest) ReadDataSource(r providers.ReadDataSourceRequest) prov
 }
 
 // ValidateProviderConfig is irrelevant when provider is mocked or overridden.
-func (p *providerForTest) ValidateProviderConfig(r providers.ValidateProviderConfigRequest) providers.ValidateProviderConfigResponse {
+func (p *providerForTest) ValidateProviderConfig(_ providers.ValidateProviderConfigRequest) providers.ValidateProviderConfigResponse {
 	return providers.ValidateProviderConfigResponse{}
 }
 

--- a/internal/tofu/provider_for_test_framework.go
+++ b/internal/tofu/provider_for_test_framework.go
@@ -110,7 +110,10 @@ func (p *providerForTest) ValidateProviderConfig(_ providers.ValidateProviderCon
 
 // GetProviderSchema is also used to perform additional validation outside of the provider
 // implementation. We are excluding parts of the schema related to provider since it is
-// irrelevant in the scope of mocking / overriding.
+// irrelevant in the scope of mocking / overriding. When running `tofu test` configuration
+// is being transformed for testing framework and original provider configuration is not
+// accessible so it is safe to wipe metadata as well. See Config.transformProviderConfigsForTest
+// for more details.
 func (p *providerForTest) GetProviderSchema() providers.GetProviderSchemaResponse {
 	providerSchema := p.internal.GetProviderSchema()
 	providerSchema.Provider = providers.Schema{}

--- a/internal/tofu/provider_for_test_framework.go
+++ b/internal/tofu/provider_for_test_framework.go
@@ -118,41 +118,9 @@ func (p *providerForTest) GetProviderSchema() providers.GetProviderSchemaRespons
 	return providerSchema
 }
 
-// Calling the internal provider ensures providerForTest has the same behaviour as if
-// it wasn't overridden or mocked. The only exception is ImportResourceState, which panics
-// if called via providerForTest because importing is not supported in testing framework.
-
-func (p *providerForTest) ValidateResourceConfig(r providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
-	return p.internal.ValidateResourceConfig(r)
-}
-
-func (p *providerForTest) ValidateDataResourceConfig(r providers.ValidateDataResourceConfigRequest) providers.ValidateDataResourceConfigResponse {
-	return p.internal.ValidateDataResourceConfig(r)
-}
-
-func (p *providerForTest) UpgradeResourceState(r providers.UpgradeResourceStateRequest) providers.UpgradeResourceStateResponse {
-	return p.internal.UpgradeResourceState(r)
-}
-
 // providerForTest doesn't configure its internal provider because it is mocked.
 func (p *providerForTest) ConfigureProvider(_ providers.ConfigureProviderRequest) providers.ConfigureProviderResponse {
 	return providers.ConfigureProviderResponse{}
-}
-
-func (p *providerForTest) Stop() error {
-	return p.internal.Stop()
-}
-
-func (p *providerForTest) GetFunctions() providers.GetFunctionsResponse {
-	return p.internal.GetFunctions()
-}
-
-func (p *providerForTest) CallFunction(r providers.CallFunctionRequest) providers.CallFunctionResponse {
-	return p.internal.CallFunction(r)
-}
-
-func (p *providerForTest) Close() error {
-	return p.internal.Close()
 }
 
 func (p *providerForTest) ImportResourceState(providers.ImportResourceStateRequest) providers.ImportResourceStateResponse {
@@ -195,6 +163,38 @@ func (p *providerForTest) addMockResources(mockResources []*configs.MockResource
 			overrideValues: mockRes.Defaults,
 		}
 	}
+}
+
+// Calling the internal provider ensures providerForTest has the same behaviour as if
+// it wasn't overridden or mocked. The only exception is ImportResourceState, which panics
+// if called via providerForTest because importing is not supported in testing framework.
+
+func (p *providerForTest) ValidateResourceConfig(r providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
+	return p.internal.ValidateResourceConfig(r)
+}
+
+func (p *providerForTest) ValidateDataResourceConfig(r providers.ValidateDataResourceConfigRequest) providers.ValidateDataResourceConfigResponse {
+	return p.internal.ValidateDataResourceConfig(r)
+}
+
+func (p *providerForTest) UpgradeResourceState(r providers.UpgradeResourceStateRequest) providers.UpgradeResourceStateResponse {
+	return p.internal.UpgradeResourceState(r)
+}
+
+func (p *providerForTest) Stop() error {
+	return p.internal.Stop()
+}
+
+func (p *providerForTest) GetFunctions() providers.GetFunctionsResponse {
+	return p.internal.GetFunctions()
+}
+
+func (p *providerForTest) CallFunction(r providers.CallFunctionRequest) providers.CallFunctionResponse {
+	return p.internal.CallFunction(r)
+}
+
+func (p *providerForTest) Close() error {
+	return p.internal.Close()
 }
 
 type resourceForTest struct {

--- a/internal/tofu/provider_for_test_framework.go
+++ b/internal/tofu/provider_for_test_framework.go
@@ -103,17 +103,24 @@ func (p *providerForTest) ReadDataSource(r providers.ReadDataSourceRequest) prov
 	return resp
 }
 
+// ValidateProviderConfig is irrelevant when provider is mocked or overridden.
+func (p *providerForTest) ValidateProviderConfig(r providers.ValidateProviderConfigRequest) providers.ValidateProviderConfigResponse {
+	return providers.ValidateProviderConfigResponse{}
+}
+
+// GetProviderSchema is also used to perform additional validation outside of the provider
+// implementation. We are excluding parts of the schema related to provider since it is
+// irrelevant in the scope of mocking / overriding.
+func (p *providerForTest) GetProviderSchema() providers.GetProviderSchemaResponse {
+	providerSchema := p.internal.GetProviderSchema()
+	providerSchema.Provider = providers.Schema{}
+	providerSchema.ProviderMeta = providers.Schema{}
+	return providerSchema
+}
+
 // Calling the internal provider ensures providerForTest has the same behaviour as if
 // it wasn't overridden or mocked. The only exception is ImportResourceState, which panics
 // if called via providerForTest because importing is not supported in testing framework.
-
-func (p *providerForTest) GetProviderSchema() providers.GetProviderSchemaResponse {
-	return p.internal.GetProviderSchema()
-}
-
-func (p *providerForTest) ValidateProviderConfig(r providers.ValidateProviderConfigRequest) providers.ValidateProviderConfigResponse {
-	return p.internal.ValidateProviderConfig(r)
-}
 
 func (p *providerForTest) ValidateResourceConfig(r providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
 	return p.internal.ValidateResourceConfig(r)


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves #2139
Resolves #2038 

In the initial implementation of mock providers, I missed that the validation of the provider block must also be skipped. In this PR I disable `ValidateProviderConfig` calls and remove provider-related schemas from `GetProviderSchema` call for any mocked provider.

## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
