### PR TITLE
CHANGELOG: Prepare for the v1.9.0 prerelease period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,39 +2,64 @@
 
 UPGRADE NOTES:
 
-* Using the `ghcr.io/opentofu/opentofu` image as a base image for custom images is deprecated and this will be removed in OpenTofu 1.10. Please see https://opentofu.org/docs/intro/install/docker/ for instructions on building your own image.
+* Using the `ghcr.io/opentofu/opentofu` image as a base image for custom images is deprecated and this will be removed in OpenTofu 1.10.
+
+    Please refer to https://opentofu.org/docs/intro/install/docker/ for instructions on building your own image.
 
 NEW FEATURES:
-* Add support for `-exclude` flag, to allow excluding specific resources and modules with resource targeting ([#426](https://github.com/opentofu/opentofu/issues/426))
+
+* **`for_each` in provider configuration blocks:** An alternate (aka "aliased") provider configuration can now have multiple dynamically-chosen instances using the `for_each` argument:
+
+    ```hcl
+    provider "aws" {
+      alias    = "by_region"
+      for_each = var.aws_regions
+
+      region = each.key
+    }
+    ```
+
+    Each instance of a resource can also potentially select a different instance of the associated provider configuration, making it easier to declare infrastructure that ought to be duplicated for each region.
+
+* **`-exclude` planning option:** similar to `-target`, this allows operators to tell OpenTofu to work on only a subset of the objects declared in the configuration or tracked in the state.
+
+    ```shell
+    tofu plan -exclude=kubernetes_manifest.crds
+    ```
+
+    While `-target` specifies the objects to _include_ and skips everything not needed for the selected objects, `-exclude` instead specifies objects to skip. OpenTofu will exclude the selected objects and everything that depends on them.
 
 ENHANCEMENTS:
-* State encryption key providers now support customizing the metadata key via `encrypted_metadata_alias` ([#1605](https://github.com/opentofu/opentofu/issues/1605))
-* Added user input prompt for static variables. ([#1792](https://github.com/opentofu/opentofu/issues/1792))
-* Added `-show-sensitive` flag to tofu plan, apply, state-show and output commands to display sensitive data in output. ([#1554](https://github.com/opentofu/opentofu/pull/1554))
+* `provider` blocks now support `for_each`. ([#2123](https://github.com/opentofu/opentofu/issues/2123))
+* The new `-exclude` planning option complements `-target`, specifying what to exclude rather than what to include. ([#1900](https://github.com/opentofu/opentofu/pull/1900))
+* State encryption key providers now support customizing the metadata key via `encrypted_metadata_alias`. ([#2080](https://github.com/opentofu/opentofu/pull/2080))
+* OpenTofu will now prompt for values for input variables needed for early evaluation. ([#2047](https://github.com/opentofu/opentofu/pull/2047))
+* Various commands now accept `-consolidate-warnings` and `-consolidate-errors` options to enable or disable OpenTofu's summarization of diagnostic messages. ([#1894](https://github.com/opentofu/opentofu/pull/1894))
+* `-show-sensitive` option causes `tofu plan`, `tofu apply`, and other commands that can return data from the configuration or state to unmask sensitive values. ([#1554](https://github.com/opentofu/opentofu/pull/1554))
+* `tofu console` now accepts expressions split over multiple lines, when the newline characters appear inside bracketing pairs or when they are escaped using a backslash. ([#1875](https://github.com/opentofu/opentofu/pull/1875))
 * Improved performance for large graphs when debug logs are not enabled. ([#1810](https://github.com/opentofu/opentofu/pull/1810))
 * Improved performance for large graphs with many submodules. ([#1809](https://github.com/opentofu/opentofu/pull/1809))
-* Added multi-line support to the `tofu console` command. ([#1307](https://github.com/opentofu/opentofu/issues/1307))
-* Added a help target to the Makefile. ([#1925](https://github.com/opentofu/opentofu/pull/1925))
-* Added a simplified Build Process with a Makefile Target ([#1926](https://github.com/opentofu/opentofu/issues/1926))
-* Ensures that the Makefile adheres to POSIX standards ([#1811](https://github.com/opentofu/opentofu/pull/1928))
-* Added for-each support to providers ([#300](https://github.com/opentofu/opentofu/issues/300))
-* Added consolidate warnings and errors flags ([#1894](https://github.com/opentofu/opentofu/pull/1894))
 
 BUG FIXES:
-* Ensure that using a sensitive path for templatefile that it doesn't panic([#1801](https://github.com/opentofu/opentofu/issues/1801))
-* Fixed crash when module source is not present ([#1888](https://github.com/opentofu/opentofu/pull/1888))
-* Added error handling for `force-unlock` command when locking is disabled for S3, HTTP, and OSS backends. [#1977](https://github.com/opentofu/opentofu/pull/1977)
-* Ensured that using a sensitive path for templatefile that it doesn't panic([#1801](https://github.com/opentofu/opentofu/issues/1801))
-* Fixed a crash when module source is not present ([#1888](https://github.com/opentofu/opentofu/pull/1888))
-* Fixed a crash when importing an empty optional sensitive string ([#1986](https://github.com/opentofu/opentofu/pull/1986))
-* Fixed autoloaded test tfvar files being used in non-test scenarios ([#2039](https://github.com/opentofu/opentofu/pull/2039))
-* Fixed a config generation crash when importing sensitive values ([#2077](https://github.com/opentofu/opentofu/pull/2077))
-* Fixed exit command in console interactive mode ([#2086](https://github.com/opentofu/opentofu/pull/2086))
-* Fixed function references in variable validation ([#2052](https://github.com/opentofu/opentofu/pull/2052))
-* Fixed potential leaking of secret variable with static evaluation ([#2045](https://github.com/opentofu/opentofu/pull/2045))
-* Fixed a providers mirror crash with bad lock file ([#1985](https://github.com/opentofu/opentofu/pull/1985))
-* Provider functions will now handle partially unknown arguments per the tfplugin spec ([#2127](https://github.com/opentofu/opentofu/pull/2127))
+* `templatefile` no longer crashes if the given filename is derived from a sensitive value. ([#1801](https://github.com/opentofu/opentofu/issues/1801))
+* Configuration loading no longer crashes when a `module` block lacks the required `source` argument. ([#1888](https://github.com/opentofu/opentofu/pull/1888))
+* The `tofu force-unlock` command now returns a relevant error when used with a backend that is not configured to support locking. ([#1977](https://github.com/opentofu/opentofu/pull/1977))
+* Configuration generation during import no longer crashes if an imported object includes sensitive values. ([#1986](https://github.com/opentofu/opentofu/pull/1986), [#2077](https://github.com/opentofu/opentofu/pull/2077))
+* `.tfvars` files from the `tests` directly are no longer incorrectly loaded for non-test commands. ([#2039](https://github.com/opentofu/opentofu/pull/2039))
+* `tofu console`'s interactive mode now handles the special `exit` command correctly. ([#2086](https://github.com/opentofu/opentofu/pull/2086))
+* Provider-contributed functions are now called correctly when used in the `validation` block of an input variable declaration. ([#2052](https://github.com/opentofu/opentofu/pull/2052))
+* Sensitive values are now prohibited in early evaluation of backend configuration and module source locations, because otherwise they would be exposed as a side-effect of initializing the backend or installing a module. ([#2045](https://github.com/opentofu/opentofu/pull/2045))
+* `tofu providers mirror` no longer crashes when the dependency lock file has missing or invalid entries. ([#1985](https://github.com/opentofu/opentofu/pull/1985))
+* OpenTofu now respects a provider-contributed functions' request to be called only when its arguments are fully known, for compatibility with functions that cannot handle unknown values themselves. ([#2127](https://github.com/opentofu/opentofu/pull/2127))
+* `tofu init` no longer duplicates diagnostic messages produced when evaluating early-evaluation expressions. ([#1890](https://github.com/opentofu/opentofu/pull/1890))
+* `tofu plan` change description now includes information about configuration blocks generated using a `dynamic` block with an unknown `for_each` value. ([#1948](https://github.com/opentofu/opentofu/pull/1948))
+* Error message about a provider type mismatch now correctly identifies which module contains the problem. ([#1991](https://github.com/opentofu/opentofu/pull/1991))
+* The `yamldecode` function's interpretation of scalars as numbers now conforms to the YAML 1.2 specification. In particular, the scalar value `+` is now interpreted as the string `"+"` rather than returning a parse error trying to interpret it as an integer. ([#2044](https://github.com/opentofu/opentofu/pull/2044))
 
+INTERNAL CHANGES:
+
+* The Makefile now includes `build` and `help` targets. ([#1925](https://github.com/opentofu/opentofu/pull/1925), [#1927](https://github.com/opentofu/opentofu/pull/1927))
+* The Makefile is now configured to allow only POSIX standard make syntax, without implementation-specific extensions. ([#1811](https://github.com/opentofu/opentofu/pull/1928))
 
 ## Previous Releases
 


### PR DESCRIPTION
This includes various adjustments and additions to the changelog in preparation for the imminent start of the v1.9.0 prerelease testing period.

[The rendered version](https://github.com/opentofu/opentofu/blob/changelog-catchup-v1.9/CHANGELOG.md) is probably the easiest way to review this, since the diff is quite noisy.

In particular:
- The "NEW FEATURES" section highlights the two most significant additions in this release, including brief examples to help readers understand what they represent. (Fuller content about these will be included in release announcement content later.)
- Some changes were previously missing from the changelog altogether, and so I've added them here for the first time.
- The links associated with each change are now consistent in linking to the pull request that implemented the change, whereas before some were linking to feature request or bug report issues instead.

  The one notable exception is that provider for_each links to our RFC tracking issue instead, because that was a larger change implemented over several pull requests and so the tracking issue is the best overview of that work.
- The "ENHANCEMENTS" and "BUG FIXES" entries are all full sentences with more consistent structure and punctuation. In particular, avoided having a huge set of items that all start with "Added" and "Fixed" because that is (subjectively) harder to scan for relevant items. Instead, as far as possible the items try to lead with which component they relate to so that a reader can more easily skim for changes that might be relevant to their concerns.
- Reordered the items in each section in a best effort to list the most broadly impactful changes first, although of course that's highly subjective. The two new features are also included under ENHANCEMENTS to make sure that section is comprehensive while still being able to draw attention to them under NEW FEATURES in a more end-user-oriented presentation.
- The two development-environment-only changes (to the Makefile) are now in a separate section "INTERNAL CHANGES", because they are not relevant to end-users.

We will continue adding items to the changelog if we accept other bug reports or enhancements before the v1.9.0 final release, but this is hopefully a good starting point to inform those who intend to participate in the prerelease testing period.
