### PR TITLE
Fix destroy/orphan path with provider instances

### DIFF
--- a/internal/tofu/context_apply2_test.go
+++ b/internal/tofu/context_apply2_test.go
@@ -4152,7 +4152,7 @@ func TestContext2Apply_excludedModuleRecursive(t *testing.T) {
 	`)
 }
 
-func TestContext2_providerResourceIteration(t *testing.T) {
+func TestContext2Apply_providerResourceIteration(t *testing.T) {
 	localComplete := `
 locals {
 	providers = { "primary": "eu-west-1", "secondary": "eu-west-2" }
@@ -4297,7 +4297,7 @@ resource "test_instance" "a" {
 	})
 }
 
-func TestContext2_providerModuleIteration(t *testing.T) {
+func TestContext2Apply_providerModuleIteration(t *testing.T) {
 	localComplete := `
 locals {
 	providers = { "primary": "eu-west-1", "secondary": "eu-west-2" }

--- a/internal/tofu/context_apply2_test.go
+++ b/internal/tofu/context_apply2_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/checks"
+	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/encryption"
 	"github.com/opentofu/opentofu/internal/lang/marks"
@@ -4149,4 +4150,266 @@ func TestContext2Apply_excludedModuleRecursive(t *testing.T) {
 	checkStateString(t, state, `
 <no state>
 	`)
+}
+
+func TestContext2_providerResourceIteration(t *testing.T) {
+	localComplete := `
+locals {
+	providers = { "primary": "eu-west-1", "secondary": "eu-west-2" }
+	resources = ["primary", "secondary"]
+}
+`
+	localPartial := `
+locals {
+	providers = { "primary": "eu-west-1", "secondary": "eu-west-2" }
+	resources = ["primary"]
+}
+`
+	providerConfig := `
+provider "test" {
+  alias = "al"
+  for_each = local.providers
+  region = each.value
+}
+`
+	resourceConfig := `
+resource "test_instance" "a" {
+  for_each = toset(local.resources)
+  provider = test.al[each.key]
+}
+`
+	complete := testModuleInline(t, map[string]string{
+		"locals.tofu":    localComplete,
+		"providers.tofu": providerConfig,
+		"resources.tofu": resourceConfig,
+	})
+	partial := testModuleInline(t, map[string]string{
+		"locals.tofu":    localPartial,
+		"providers.tofu": providerConfig,
+		"resources.tofu": resourceConfig,
+	})
+
+	provider := testProvider("test")
+	provider.ReadDataSourceResponse = &providers.ReadDataSourceResponse{
+		State: cty.ObjectVal(map[string]cty.Value{
+			"id": cty.StringVal("data_source"),
+		}),
+	}
+	provider.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) providers.ConfigureProviderResponse {
+		var resp providers.ConfigureProviderResponse
+
+		region := req.Config.GetAttr("region")
+		if region.AsString() != "eu-west-1" && region.AsString() != "eu-west-2" {
+			resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("incorrect config val: %#v\n", region))
+		}
+		return resp
+	}
+	ps := map[addrs.Provider]providers.Factory{
+		addrs.NewDefaultProvider("test"): testProviderFuncFixed(provider),
+	}
+
+	apply := func(t *testing.T, m *configs.Config, prevState *states.State) *states.State {
+		t.Helper()
+		ctx := testContext2(t, &ContextOpts{
+			Providers: ps,
+		})
+
+		plan, diags := ctx.Plan(m, prevState, DefaultPlanOpts)
+		if diags.HasErrors() {
+			t.Fatal(diags.Err())
+		}
+
+		newState, diags := ctx.Apply(plan, m)
+		if diags.HasErrors() {
+			t.Fatal(diags.Err())
+		}
+		return newState
+	}
+
+	destroy := func(t *testing.T, m *configs.Config, prevState *states.State) *states.State {
+		ctx := testContext2(t, &ContextOpts{
+			Providers: ps,
+		})
+
+		plan, diags := ctx.Plan(m, prevState, &PlanOpts{
+			Mode: plans.DestroyMode,
+		})
+		if diags.HasErrors() {
+			t.Fatal(diags.Err())
+		}
+
+		newState, diags := ctx.Apply(plan, m)
+		if diags.HasErrors() {
+			t.Fatal(diags.Err())
+		}
+		return newState
+	}
+
+	primaryResource := mustResourceInstanceAddr(`test_instance.a["primary"]`)
+	secondaryResource := mustResourceInstanceAddr(`test_instance.a["secondary"]`)
+
+	t.Run("apply_destroy", func(t *testing.T) {
+		state := apply(t, complete, states.NewState())
+
+		if state.ResourceInstance(primaryResource).ProviderKey != addrs.StringKey("primary") {
+			t.Fatal("Wrong provider key")
+		}
+		if state.ResourceInstance(secondaryResource).ProviderKey != addrs.StringKey("secondary") {
+			t.Fatal("Wrong provider key")
+		}
+
+		destroy(t, complete, state)
+	})
+
+	t.Run("apply_orphan_destroy", func(t *testing.T) {
+		state := apply(t, complete, states.NewState())
+
+		state = apply(t, partial, state)
+
+		// Expect primary
+		if state.ResourceInstance(primaryResource) == nil {
+			t.Fatal(primaryResource.String())
+		}
+		// Missing secondary
+		if state.ResourceInstance(secondaryResource) != nil {
+			t.Fatal(secondaryResource.String())
+		}
+
+		destroy(t, partial, state)
+	})
+}
+
+func TestContext2_providerModuleIteration(t *testing.T) {
+	localComplete := `
+locals {
+	providers = { "primary": "eu-west-1", "secondary": "eu-west-2" }
+	mods = ["primary", "secondary"]
+}
+`
+	localPartial := `
+locals {
+	providers = { "primary": "eu-west-1", "secondary": "eu-west-2" }
+	mods = ["primary"]
+}
+`
+	providerConfig := `
+provider "test" {
+  alias = "al"
+  for_each = local.providers
+  region = each.value
+}
+`
+	moduleCall := `
+module "mod" {
+  source = "./mod"
+  for_each = toset(local.mods)
+  providers = {
+    test = test.al[each.key]
+  }
+}
+`
+	resourceConfig := `
+resource "test_instance" "a" {
+}
+`
+	complete := testModuleInline(t, map[string]string{
+		"locals.tofu":        localComplete,
+		"providers.tofu":     providerConfig,
+		"modules.tofu":       moduleCall,
+		"mod/resources.tofu": resourceConfig,
+	})
+	partial := testModuleInline(t, map[string]string{
+		"locals.tofu":        localPartial,
+		"providers.tofu":     providerConfig,
+		"modules.tofu":       moduleCall,
+		"mod/resources.tofu": resourceConfig,
+	})
+
+	provider := testProvider("test")
+	provider.ReadDataSourceResponse = &providers.ReadDataSourceResponse{
+		State: cty.ObjectVal(map[string]cty.Value{
+			"id": cty.StringVal("data_source"),
+		}),
+	}
+	provider.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) providers.ConfigureProviderResponse {
+		var resp providers.ConfigureProviderResponse
+		region := req.Config.GetAttr("region")
+		if region.AsString() != "eu-west-1" && region.AsString() != "eu-west-2" {
+			resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("incorrect config val: %#v\n", region))
+		}
+		return resp
+	}
+	ps := map[addrs.Provider]providers.Factory{
+		addrs.NewDefaultProvider("test"): testProviderFuncFixed(provider),
+	}
+
+	apply := func(t *testing.T, m *configs.Config, prevState *states.State) *states.State {
+		t.Helper()
+		ctx := testContext2(t, &ContextOpts{
+			Providers: ps,
+		})
+
+		plan, diags := ctx.Plan(m, prevState, DefaultPlanOpts)
+		if diags.HasErrors() {
+			t.Fatal(diags.Err())
+		}
+
+		newState, diags := ctx.Apply(plan, m)
+		if diags.HasErrors() {
+			t.Fatal(diags.Err())
+		}
+		return newState
+	}
+
+	destroy := func(t *testing.T, m *configs.Config, prevState *states.State) *states.State {
+		ctx := testContext2(t, &ContextOpts{
+			Providers: ps,
+		})
+
+		plan, diags := ctx.Plan(m, prevState, &PlanOpts{
+			Mode: plans.DestroyMode,
+		})
+		if diags.HasErrors() {
+			t.Fatal(diags.Err())
+		}
+
+		newState, diags := ctx.Apply(plan, m)
+		if diags.HasErrors() {
+			t.Fatal(diags.Err())
+		}
+		return newState
+	}
+
+	primaryResource := mustResourceInstanceAddr(`module.mod["primary"].test_instance.a`)
+	secondaryResource := mustResourceInstanceAddr(`module.mod["secondary"].test_instance.a`)
+
+	t.Run("apply_destroy", func(t *testing.T) {
+		state := apply(t, complete, states.NewState())
+
+		if state.ResourceInstance(primaryResource).ProviderKey != addrs.StringKey("primary") {
+			t.Fatal("Wrong provider key")
+		}
+		if state.ResourceInstance(secondaryResource).ProviderKey != addrs.StringKey("secondary") {
+			t.Fatal("Wrong provider key")
+		}
+
+		destroy(t, complete, state)
+	})
+
+	t.Run("apply_orphan_destroy", func(t *testing.T) {
+		state := apply(t, complete, states.NewState())
+
+		state = apply(t, partial, state)
+
+		// Expect primary
+		if state.ResourceInstance(primaryResource) == nil {
+			t.Fatal(primaryResource.String())
+		}
+		// Missing secondary
+		if state.ResourceInstance(secondaryResource) != nil {
+			t.Fatal(secondaryResource.String())
+		}
+
+		destroy(t, partial, state)
+	})
 }

--- a/internal/tofu/context_apply2_test.go
+++ b/internal/tofu/context_apply2_test.go
@@ -4188,6 +4188,10 @@ resource "test_instance" "a" {
 		"providers.tofu": providerConfig,
 		"resources.tofu": resourceConfig,
 	})
+	removed := testModuleInline(t, map[string]string{
+		"locals.tofu":    localPartial,
+		"providers.tofu": providerConfig,
+	})
 
 	provider := testProvider("test")
 	provider.ReadDataSourceResponse = &providers.ReadDataSourceResponse{
@@ -4261,6 +4265,20 @@ resource "test_instance" "a" {
 		destroy(t, complete, state)
 	})
 
+	t.Run("apply_removed", func(t *testing.T) {
+		state := apply(t, complete, states.NewState())
+
+		state = apply(t, removed, state)
+
+		// Expect destroyed
+		if state.ResourceInstance(primaryResource) != nil {
+			t.Fatal(primaryResource.String())
+		}
+		if state.ResourceInstance(secondaryResource) != nil {
+			t.Fatal(secondaryResource.String())
+		}
+	})
+
 	t.Run("apply_orphan_destroy", func(t *testing.T) {
 		state := apply(t, complete, states.NewState())
 
@@ -4323,6 +4341,10 @@ resource "test_instance" "a" {
 		"providers.tofu":     providerConfig,
 		"modules.tofu":       moduleCall,
 		"mod/resources.tofu": resourceConfig,
+	})
+	removed := testModuleInline(t, map[string]string{
+		"locals.tofu":    localPartial,
+		"providers.tofu": providerConfig,
 	})
 
 	provider := testProvider("test")
@@ -4394,6 +4416,20 @@ resource "test_instance" "a" {
 		}
 
 		destroy(t, complete, state)
+	})
+
+	t.Run("apply_removed", func(t *testing.T) {
+		state := apply(t, complete, states.NewState())
+
+		state = apply(t, removed, state)
+
+		// Expect destroyed
+		if state.ResourceInstance(primaryResource) != nil {
+			t.Fatal(primaryResource.String())
+		}
+		if state.ResourceInstance(secondaryResource) != nil {
+			t.Fatal(secondaryResource.String())
+		}
 	})
 
 	t.Run("apply_orphan_destroy", func(t *testing.T) {

--- a/internal/tofu/node_resource_abstract_instance.go
+++ b/internal/tofu/node_resource_abstract_instance.go
@@ -118,6 +118,7 @@ func (n *NodeAbstractResourceInstance) resolveProvider(ctx EvalContext, hasExpan
 
 	useStateFallback := false
 
+	//nolint:nestif // complexity
 	if n.ResolvedProvider.KeyExact != nil {
 		// Pass through from state
 		n.ResolvedProviderKey = n.ResolvedProvider.KeyExact

--- a/internal/tofu/node_resource_apply_instance.go
+++ b/internal/tofu/node_resource_apply_instance.go
@@ -141,7 +141,7 @@ func (n *NodeApplyableResourceInstance) Execute(ctx EvalContext, op walkOperatio
 		return diags
 	}
 
-	diags = n.resolveProvider(ctx)
+	diags = n.resolveProvider(ctx, true)
 	if diags.HasErrors() {
 		return diags
 	}

--- a/internal/tofu/node_resource_destroy.go
+++ b/internal/tofu/node_resource_destroy.go
@@ -143,7 +143,7 @@ func (n *NodeDestroyResourceInstance) Execute(ctx EvalContext, op walkOperation)
 	// Eval info is different depending on what kind of resource this is
 	switch addr.Resource.Resource.Mode {
 	case addrs.ManagedResourceMode:
-		diags = n.resolveProvider(ctx)
+		diags = n.resolveProvider(ctx, false)
 		if diags.HasErrors() {
 			return diags
 		}

--- a/internal/tofu/node_resource_import.go
+++ b/internal/tofu/node_resource_import.go
@@ -92,7 +92,7 @@ func (n *graphNodeImportState) Execute(ctx EvalContext, op walkOperation) (diags
 			ResolvedProvider: n.ResolvedProvider,
 		},
 	}
-	diags = diags.Append(asAbsNode.resolveProvider(ctx))
+	diags = diags.Append(asAbsNode.resolveProvider(ctx, true))
 	if diags.HasErrors() {
 		return diags
 	}

--- a/internal/tofu/node_resource_plan_destroy.go
+++ b/internal/tofu/node_resource_plan_destroy.go
@@ -60,6 +60,11 @@ func (n *NodePlanDestroyableResourceInstance) Execute(ctx EvalContext, op walkOp
 func (n *NodePlanDestroyableResourceInstance) managedResourceExecute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	addr := n.ResourceInstanceAddr()
 
+	diags = diags.Append(n.resolveProvider(ctx, false))
+	if diags.HasErrors() {
+		return diags
+	}
+
 	// Declare a bunch of variables that are used for state during
 	// evaluation. These are written to by address in the EvalNodes we
 	// declare below.

--- a/internal/tofu/node_resource_plan_instance.go
+++ b/internal/tofu/node_resource_plan_instance.go
@@ -86,7 +86,7 @@ var (
 func (n *NodePlannableResourceInstance) Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
 	addr := n.ResourceInstanceAddr()
 
-	diags := n.resolveProvider(ctx)
+	diags := n.resolveProvider(ctx, true)
 	if diags.HasErrors() {
 		return diags
 	}

--- a/internal/tofu/node_resource_plan_orphan.go
+++ b/internal/tofu/node_resource_plan_orphan.go
@@ -57,7 +57,7 @@ func (n *NodePlannableResourceInstanceOrphan) Execute(ctx EvalContext, op walkOp
 	// Eval info is different depending on what kind of resource this is
 	switch addr.Resource.Resource.Mode {
 	case addrs.ManagedResourceMode:
-		diags := n.resolveProvider(ctx)
+		diags := n.resolveProvider(ctx, true)
 		if diags.HasErrors() {
 			return diags
 		}


### PR DESCRIPTION
As reported in the linked issue, the destroy path was broken in the alpha due to https://github.com/opentofu/opentofu/pull/2105.  I additionally noticed that we had some related issues with orphaned instances.

For the destroy scenario, I realized that `NodeDestroyResourceInstance`s are created without a corresponding expansion data.  In that scenario, we are unable to use the configuration to determine the correct provider instance keys and should instead rely on the state.

In the `NodePlanResourceInstanceOrphaned` scenario, only the `NodePlanResourceInstance`s have corresponding expansion data from the configuration.  If provider keys are in use and expansion data can't be determined, we should try to default to the state.

Overall this mixes in some logic from the ProviderTransformer attempting to deal with nodes missing configuration, but can really only be fixed when we re-design the provider reference system from the ground up.

<!-- If your PR resolves an issue, please add it here. -->
Resolves #2149

## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
