### PR TITLE
Plumb context.Context from "package main" to the graph walk driver

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -169,7 +169,7 @@ type Local interface {
 	// backend's implementations of this to understand what this actually
 	// does, because this operation has no well-defined contract aside from
 	// "whatever it already does".
-	LocalRun(*Operation) (*LocalRun, statemgr.Full, tfdiags.Diagnostics)
+	LocalRun(context.Context, *Operation) (*LocalRun, statemgr.Full, tfdiags.Diagnostics)
 }
 
 // LocalRun represents the assortment of objects that we can collect or

--- a/internal/backend/local/backend_apply.go
+++ b/internal/backend/local/backend_apply.go
@@ -54,6 +54,15 @@ func (b *Local) opApply(
 
 	var diags, moreDiags tfdiags.Diagnostics
 
+	// For the moment we have a bit of a tangled mess of context.Context here, for
+	// historical reasons. Hopefully we'll clean this up one day, but here's the
+	// guide for now:
+	// - ctx is used only for its values, and should be connected to the top-level ctx
+	//   from "package main" so that we can obtain telemetry objects, etc from it.
+	// - stopCtx is cancelled to trigger a graceful shutdown.
+	// - cancelCtx is cancelled for a graceless shutdown.
+	ctx := context.WithoutCancel(stopCtx)
+
 	// If we have a nil module at this point, then set it to an empty tree
 	// to avoid any potential crashes.
 	if op.PlanFile == nil && op.PlanMode != plans.DestroyMode && !op.HasConfig() {
@@ -114,7 +123,7 @@ func (b *Local) opApply(
 	if op.PlanFile == nil {
 		// Perform the plan
 		log.Printf("[INFO] backend/local: apply calling Plan")
-		plan, moreDiags = lr.Core.Plan(lr.Config, lr.InputState, lr.PlanOpts)
+		plan, moreDiags = lr.Core.Plan(ctx, lr.Config, lr.InputState, lr.PlanOpts)
 		diags = diags.Append(moreDiags)
 		if moreDiags.HasErrors() {
 			// If OpenTofu Core generated a partial plan despite the errors

--- a/internal/backend/local/backend_apply.go
+++ b/internal/backend/local/backend_apply.go
@@ -270,7 +270,7 @@ func (b *Local) opApply(
 		defer panicHandler()
 		defer close(doneCh)
 		log.Printf("[INFO] backend/local: apply calling Apply")
-		applyState, applyDiags = lr.Core.Apply(plan, lr.Config)
+		applyState, applyDiags = lr.Core.Apply(ctx, plan, lr.Config)
 	}()
 
 	if b.opWait(doneCh, stopCtx, cancelCtx, lr.Core, opState, op.View) {

--- a/internal/backend/local/backend_apply.go
+++ b/internal/backend/local/backend_apply.go
@@ -81,7 +81,7 @@ func (b *Local) opApply(
 	op.Hooks = append(op.Hooks, stateHook)
 
 	// Get our context
-	lr, _, opState, contextDiags := b.localRun(op)
+	lr, _, opState, contextDiags := b.localRun(ctx, op)
 	diags = diags.Append(contextDiags)
 	if contextDiags.HasErrors() {
 		op.ReportResult(runningOp, diags)

--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -125,7 +125,7 @@ func (b *Local) localRun(ctx context.Context, op *backend.Operation) (*backend.L
 			mode := tofu.InputModeProvider
 
 			log.Printf("[TRACE] backend/local: requesting interactive input, if necessary")
-			inputDiags := ret.Core.Input(ret.Config, mode)
+			inputDiags := ret.Core.Input(ctx, ret.Config, mode)
 			diags = diags.Append(inputDiags)
 			if inputDiags.HasErrors() {
 				return nil, nil, nil, diags

--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -26,7 +26,7 @@ import (
 )
 
 // backend.Local implementation.
-func (b *Local) LocalRun(op *backend.Operation) (*backend.LocalRun, statemgr.Full, tfdiags.Diagnostics) {
+func (b *Local) LocalRun(ctx context.Context, op *backend.Operation) (*backend.LocalRun, statemgr.Full, tfdiags.Diagnostics) {
 	// Make sure the type is invalid. We use this as a way to know not
 	// to ask for input/validate. We're modifying this through a pointer,
 	// so we're mutating an object that belongs to the caller here, which
@@ -37,11 +37,12 @@ func (b *Local) LocalRun(op *backend.Operation) (*backend.LocalRun, statemgr.Ful
 
 	op.StateLocker = op.StateLocker.WithContext(context.Background())
 
-	lr, _, stateMgr, diags := b.localRun(op)
+	lr, _, stateMgr, diags := b.localRun(ctx, op)
 	return lr, stateMgr, diags
 }
 
-func (b *Local) localRun(op *backend.Operation) (*backend.LocalRun, *configload.Snapshot, statemgr.Full, tfdiags.Diagnostics) {
+//nolint:funlen // Historical function predates our complexity rules
+func (b *Local) localRun(ctx context.Context, op *backend.Operation) (*backend.LocalRun, *configload.Snapshot, statemgr.Full, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	// Get the latest state.
@@ -134,7 +135,7 @@ func (b *Local) localRun(op *backend.Operation) (*backend.LocalRun, *configload.
 		// If validation is enabled, validate
 		if b.OpValidation {
 			log.Printf("[TRACE] backend/local: running validation operation")
-			validateDiags := ret.Core.Validate(ret.Config)
+			validateDiags := ret.Core.Validate(ctx, ret.Config)
 			diags = diags.Append(validateDiags)
 		}
 	}

--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -6,6 +6,7 @@
 package local
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -49,7 +50,7 @@ func TestLocalRun(t *testing.T) {
 		StateLocker:  stateLocker,
 	}
 
-	_, _, diags := b.LocalRun(op)
+	_, _, diags := b.LocalRun(context.Background(), op)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %s", diags.Err().Error())
 	}
@@ -80,7 +81,7 @@ func TestLocalRun_error(t *testing.T) {
 		StateLocker:  stateLocker,
 	}
 
-	_, _, diags := b.LocalRun(op)
+	_, _, diags := b.LocalRun(context.Background(), op)
 	if !diags.HasErrors() {
 		t.Fatal("unexpected success")
 	}
@@ -115,7 +116,7 @@ func TestLocalRun_cloudPlan(t *testing.T) {
 		StateLocker:  stateLocker,
 	}
 
-	_, _, diags := b.LocalRun(op)
+	_, _, diags := b.LocalRun(context.Background(), op)
 	if !diags.HasErrors() {
 		t.Fatal("unexpected success")
 	}
@@ -201,7 +202,7 @@ func TestLocalRun_stalePlan(t *testing.T) {
 		StateLocker:  stateLocker,
 	}
 
-	_, _, diags := b.LocalRun(op)
+	_, _, diags := b.LocalRun(context.Background(), op)
 	if !diags.HasErrors() {
 		t.Fatal("unexpected success")
 	}

--- a/internal/backend/local/backend_plan.go
+++ b/internal/backend/local/backend_plan.go
@@ -88,7 +88,7 @@ func (b *Local) opPlan(
 	}
 
 	// Get our context
-	lr, configSnap, opState, ctxDiags := b.localRun(op)
+	lr, configSnap, opState, ctxDiags := b.localRun(ctx, op)
 	diags = diags.Append(ctxDiags)
 	if ctxDiags.HasErrors() {
 		op.ReportResult(runningOp, diags)

--- a/internal/backend/local/backend_plan.go
+++ b/internal/backend/local/backend_plan.go
@@ -32,6 +32,15 @@ func (b *Local) opPlan(
 
 	var diags tfdiags.Diagnostics
 
+	// For the moment we have a bit of a tangled mess of context.Context here, for
+	// historical reasons. Hopefully we'll clean this up one day, but here's the
+	// guide for now:
+	// - ctx is used only for its values, and should be connected to the top-level ctx
+	//   from "package main" so that we can obtain telemetry objects, etc from it.
+	// - stopCtx is cancelled to trigger a graceful shutdown.
+	// - cancelCtx is cancelled for a graceless shutdown.
+	ctx := context.WithoutCancel(stopCtx)
+
 	if op.PlanFile != nil {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
@@ -108,7 +117,7 @@ func (b *Local) opPlan(
 		defer panicHandler()
 		defer close(doneCh)
 		log.Printf("[INFO] backend/local: plan calling Plan")
-		plan, planDiags = lr.Core.Plan(lr.Config, lr.InputState, lr.PlanOpts)
+		plan, planDiags = lr.Core.Plan(ctx, lr.Config, lr.InputState, lr.PlanOpts)
 	}()
 
 	if b.opWait(doneCh, stopCtx, cancelCtx, lr.Core, opState, op.View) {

--- a/internal/backend/local/backend_refresh.go
+++ b/internal/backend/local/backend_refresh.go
@@ -59,7 +59,7 @@ func (b *Local) opRefresh(
 	op.PlanRefresh = true
 
 	// Get our context
-	lr, _, opState, contextDiags := b.localRun(op)
+	lr, _, opState, contextDiags := b.localRun(ctx, op)
 	diags = diags.Append(contextDiags)
 	if contextDiags.HasErrors() {
 		op.ReportResult(runningOp, diags)

--- a/internal/backend/local/backend_refresh.go
+++ b/internal/backend/local/backend_refresh.go
@@ -26,6 +26,15 @@ func (b *Local) opRefresh(
 
 	var diags tfdiags.Diagnostics
 
+	// For the moment we have a bit of a tangled mess of context.Context here, for
+	// historical reasons. Hopefully we'll clean this up one day, but here's the
+	// guide for now:
+	// - ctx is used only for its values, and should be connected to the top-level ctx
+	//   from "package main" so that we can obtain telemetry objects, etc from it.
+	// - stopCtx is cancelled to trigger a graceful shutdown.
+	// - cancelCtx is cancelled for a graceless shutdown.
+	ctx := context.WithoutCancel(stopCtx)
+
 	// Check if our state exists if we're performing a refresh operation. We
 	// only do this if we're managing state with this backend.
 	if b.Backend == nil {
@@ -94,7 +103,7 @@ func (b *Local) opRefresh(
 	go func() {
 		defer panicHandler()
 		defer close(doneCh)
-		newState, refreshDiags = lr.Core.Refresh(lr.Config, lr.InputState, lr.PlanOpts)
+		newState, refreshDiags = lr.Core.Refresh(ctx, lr.Config, lr.InputState, lr.PlanOpts)
 		log.Printf("[INFO] backend/local: refresh calling Refresh")
 	}()
 

--- a/internal/backend/remote/backend_context.go
+++ b/internal/backend/remote/backend_context.go
@@ -23,7 +23,9 @@ import (
 )
 
 // Context implements backend.Local.
-func (b *Remote) LocalRun(op *backend.Operation) (*backend.LocalRun, statemgr.Full, tfdiags.Diagnostics) {
+//
+//nolint:funlen,nestif // Historical function predates our complexity rules
+func (b *Remote) LocalRun(_ context.Context, op *backend.Operation) (*backend.LocalRun, statemgr.Full, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	ret := &backend.LocalRun{
 		PlanOpts: &tofu.PlanOpts{

--- a/internal/backend/remote/backend_context_test.go
+++ b/internal/backend/remote/backend_context_test.go
@@ -214,7 +214,7 @@ func TestRemoteContextWithVars(t *testing.T) {
 			}
 			b.client.Variables.Create(context.TODO(), workspaceID, *v)
 
-			_, _, diags := b.LocalRun(op)
+			_, _, diags := b.LocalRun(context.Background(), op)
 
 			if test.WantError != "" {
 				if !diags.HasErrors() {
@@ -435,7 +435,7 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 				b.client.Variables.Create(context.TODO(), workspaceID, *v)
 			}
 
-			lr, _, diags := b.LocalRun(op)
+			lr, _, diags := b.LocalRun(context.Background(), op)
 
 			if diags.HasErrors() {
 				t.Fatalf("unexpected error\ngot:  %s\nwant: <no error>", diags.Err().Error())

--- a/internal/cloud/backend_context.go
+++ b/internal/cloud/backend_context.go
@@ -23,7 +23,9 @@ import (
 )
 
 // LocalRun implements backend.Local
-func (b *Cloud) LocalRun(op *backend.Operation) (*backend.LocalRun, statemgr.Full, tfdiags.Diagnostics) {
+//
+//nolint:funlen,nestif // Historical function predates our complexity rules
+func (b *Cloud) LocalRun(_ context.Context, op *backend.Operation) (*backend.LocalRun, statemgr.Full, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	ret := &backend.LocalRun{
 		PlanOpts: &tofu.PlanOpts{

--- a/internal/cloud/backend_context_test.go
+++ b/internal/cloud/backend_context_test.go
@@ -213,7 +213,7 @@ func TestRemoteContextWithVars(t *testing.T) {
 			}
 			b.client.Variables.Create(context.TODO(), workspaceID, *v)
 
-			_, _, diags := b.LocalRun(op)
+			_, _, diags := b.LocalRun(context.Background(), op)
 
 			if test.WantError != "" {
 				if !diags.HasErrors() {
@@ -434,7 +434,7 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 				b.client.Variables.Create(context.TODO(), workspaceID, *v)
 			}
 
-			lr, _, diags := b.LocalRun(op)
+			lr, _, diags := b.LocalRun(context.Background(), op)
 
 			if diags.HasErrors() {
 				t.Fatalf("unexpected error\ngot:  %s\nwant: <no error>", diags.Err().Error())

--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -29,6 +29,7 @@ type ApplyCommand struct {
 
 func (c *ApplyCommand) Run(rawArgs []string) int {
 	var diags tfdiags.Diagnostics
+	ctx := c.CommandContext()
 
 	// Parse and apply global view arguments
 	common, rawArgs := arguments.ParseView(rawArgs)
@@ -134,7 +135,7 @@ func (c *ApplyCommand) Run(rawArgs []string) int {
 	diags = nil
 
 	// Run the operation
-	op, diags := c.RunOperation(be, opReq)
+	op, diags := c.RunOperation(ctx, be, opReq)
 	view.Diagnostics(diags)
 	if diags.HasErrors() {
 		return 1

--- a/internal/command/console.go
+++ b/internal/command/console.go
@@ -114,7 +114,7 @@ func (c *ConsoleCommand) Run(args []string) int {
 	}
 
 	// Get the context
-	lr, _, ctxDiags := local.LocalRun(opReq)
+	lr, _, ctxDiags := local.LocalRun(ctx, opReq)
 	diags = diags.Append(ctxDiags)
 	if ctxDiags.HasErrors() {
 		c.showDiagnostics(diags)

--- a/internal/command/console.go
+++ b/internal/command/console.go
@@ -28,6 +28,8 @@ type ConsoleCommand struct {
 }
 
 func (c *ConsoleCommand) Run(args []string) int {
+	ctx := c.CommandContext()
+
 	args = c.Meta.process(args)
 	cmdFlags := c.Meta.extendedFlagSet("console")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
@@ -144,7 +146,7 @@ func (c *ConsoleCommand) Run(args []string) int {
 	// Before we can evaluate expressions, we must compute and populate any
 	// derived values (input variables, local values, output values)
 	// that are not stored in the persistent state.
-	scope, scopeDiags := lr.Core.Eval(lr.Config, lr.InputState, addrs.RootModuleInstance, evalOpts)
+	scope, scopeDiags := lr.Core.Eval(ctx, lr.Config, lr.InputState, addrs.RootModuleInstance, evalOpts)
 	diags = diags.Append(scopeDiags)
 	if scope == nil {
 		// scope is nil if there are errors so bad that we can't even build a scope.

--- a/internal/command/graph.go
+++ b/internal/command/graph.go
@@ -33,6 +33,8 @@ func (c *GraphCommand) Run(args []string) int {
 	var verbose bool
 	var planPath string
 
+	ctx := c.CommandContext()
+
 	args = c.Meta.process(args)
 	cmdFlags := c.Meta.defaultFlagSet("graph")
 	c.Meta.varFlagSet(cmdFlags)
@@ -160,7 +162,7 @@ func (c *GraphCommand) Run(args []string) int {
 	}
 
 	// Get the context
-	lr, _, ctxDiags := local.LocalRun(opReq)
+	lr, _, ctxDiags := local.LocalRun(ctx, opReq)
 	diags = diags.Append(ctxDiags)
 	if ctxDiags.HasErrors() {
 		c.showDiagnostics(diags)

--- a/internal/command/import.go
+++ b/internal/command/import.go
@@ -227,7 +227,7 @@ func (c *ImportCommand) Run(args []string) int {
 	}
 
 	// Get the context
-	lr, state, ctxDiags := local.LocalRun(opReq)
+	lr, state, ctxDiags := local.LocalRun(ctx, opReq)
 	diags = diags.Append(ctxDiags)
 	if ctxDiags.HasErrors() {
 		c.showDiagnostics(diags)

--- a/internal/command/import.go
+++ b/internal/command/import.go
@@ -30,6 +30,8 @@ type ImportCommand struct {
 }
 
 func (c *ImportCommand) Run(args []string) int {
+	ctx := c.CommandContext()
+
 	// Get the pwd since its our default -config flag value
 	pwd, err := os.Getwd()
 	if err != nil {
@@ -243,7 +245,7 @@ func (c *ImportCommand) Run(args []string) int {
 	// Perform the import. Note that as you can see it is possible for this
 	// API to import more than one resource at once. For now, we only allow
 	// one while we stabilize this feature.
-	newState, importDiags := lr.Core.Import(lr.Config, lr.InputState, &tofu.ImportOpts{
+	newState, importDiags := lr.Core.Import(ctx, lr.Config, lr.InputState, &tofu.ImportOpts{
 		Targets: []*tofu.ImportTarget{
 			{
 				CommandLineImportTarget: &tofu.CommandLineImportTarget{

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -488,7 +488,7 @@ func (m *Meta) CommandContext() context.Context {
 // If the operation runs to completion then no error is returned even if the
 // operation itself is unsuccessful. Use the "Result" field of the
 // returned operation object to recognize operation-level failure.
-func (m *Meta) RunOperation(b backend.Enhanced, opReq *backend.Operation) (*backend.RunningOperation, tfdiags.Diagnostics) {
+func (m *Meta) RunOperation(ctx context.Context, b backend.Enhanced, opReq *backend.Operation) (*backend.RunningOperation, tfdiags.Diagnostics) {
 	if opReq.View == nil {
 		panic("RunOperation called with nil View")
 	}
@@ -505,7 +505,7 @@ func (m *Meta) RunOperation(b backend.Enhanced, opReq *backend.Operation) (*back
 		return nil, diags
 	}
 
-	op, err := b.Operation(context.Background(), opReq)
+	op, err := b.Operation(ctx, opReq)
 	if err != nil {
 		return nil, diags.Append(fmt.Errorf("error starting operation: %w", err))
 	}

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -23,6 +23,8 @@ type PlanCommand struct {
 }
 
 func (c *PlanCommand) Run(rawArgs []string) int {
+	ctx := c.CommandContext()
+
 	// Parse and apply global view arguments
 	common, rawArgs := arguments.ParseView(rawArgs)
 	c.View.Configure(common)
@@ -105,7 +107,7 @@ func (c *PlanCommand) Run(rawArgs []string) int {
 	diags = nil
 
 	// Perform the operation
-	op, diags := c.RunOperation(be, opReq)
+	op, diags := c.RunOperation(ctx, be, opReq)
 	view.Diagnostics(diags)
 	if diags.HasErrors() {
 		return 1

--- a/internal/command/providers_schema.go
+++ b/internal/command/providers_schema.go
@@ -30,6 +30,8 @@ func (c *ProvidersSchemaCommand) Synopsis() string {
 }
 
 func (c *ProvidersSchemaCommand) Run(args []string) int {
+	ctx := c.CommandContext()
+
 	args = c.Meta.process(args)
 	cmdFlags := c.Meta.defaultFlagSet("providers schema")
 	c.Meta.varFlagSet(cmdFlags)
@@ -111,7 +113,7 @@ func (c *ProvidersSchemaCommand) Run(args []string) int {
 	}
 
 	// Get the context
-	lr, _, ctxDiags := local.LocalRun(opReq)
+	lr, _, ctxDiags := local.LocalRun(ctx, opReq)
 	diags = diags.Append(ctxDiags)
 	if ctxDiags.HasErrors() {
 		c.showDiagnostics(diags)

--- a/internal/command/refresh.go
+++ b/internal/command/refresh.go
@@ -24,6 +24,7 @@ type RefreshCommand struct {
 
 func (c *RefreshCommand) Run(rawArgs []string) int {
 	var diags tfdiags.Diagnostics
+	ctx := c.CommandContext()
 
 	// Parse and apply global view arguments
 	common, rawArgs := arguments.ParseView(rawArgs)
@@ -103,7 +104,7 @@ func (c *RefreshCommand) Run(rawArgs []string) int {
 	diags = nil
 
 	// Perform the operation
-	op, diags := c.RunOperation(be, opReq)
+	op, diags := c.RunOperation(ctx, be, opReq)
 	view.Diagnostics(diags)
 	if diags.HasErrors() {
 		return 1

--- a/internal/command/state_show.go
+++ b/internal/command/state_show.go
@@ -31,6 +31,8 @@ type StateShowCommand struct {
 }
 
 func (c *StateShowCommand) Run(args []string) int {
+	ctx := c.CommandContext()
+
 	args = c.Meta.process(args)
 	cmdFlags := c.Meta.defaultFlagSet("state show")
 	c.Meta.varFlagSet(cmdFlags)
@@ -112,7 +114,7 @@ func (c *StateShowCommand) Run(args []string) int {
 	}
 
 	// Get the context (required to get the schemas)
-	lr, _, ctxDiags := local.LocalRun(opReq)
+	lr, _, ctxDiags := local.LocalRun(ctx, opReq)
 	if ctxDiags.HasErrors() {
 		c.View.Diagnostics(ctxDiags)
 		return 1

--- a/internal/command/validate.go
+++ b/internal/command/validate.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -24,6 +25,8 @@ type ValidateCommand struct {
 }
 
 func (c *ValidateCommand) Run(rawArgs []string) int {
+	ctx := c.CommandContext()
+
 	// Parse and apply global view arguments
 	common, rawArgs := arguments.ParseView(rawArgs)
 	c.View.Configure(common)
@@ -59,7 +62,7 @@ func (c *ValidateCommand) Run(rawArgs []string) int {
 	// Inject variables from args into meta for static evaluation
 	c.GatherVariables(args.Vars)
 
-	validateDiags := c.validate(dir, args.TestDirectory, args.NoTests)
+	validateDiags := c.validate(ctx, dir, args.TestDirectory, args.NoTests)
 	diags = diags.Append(validateDiags)
 
 	// Validating with dev overrides in effect means that the result might
@@ -88,7 +91,7 @@ func (c *ValidateCommand) GatherVariables(args *arguments.Vars) {
 	c.Meta.variableArgs = rawFlags{items: &items}
 }
 
-func (c *ValidateCommand) validate(dir, testDir string, noTests bool) tfdiags.Diagnostics {
+func (c *ValidateCommand) validate(ctx context.Context, dir, testDir string, noTests bool) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 	var cfg *configs.Config
 
@@ -116,7 +119,7 @@ func (c *ValidateCommand) validate(dir, testDir string, noTests bool) tfdiags.Di
 			return diags
 		}
 
-		return diags.Append(tfCtx.Validate(cfg))
+		return diags.Append(tfCtx.Validate(ctx, cfg))
 	}
 
 	diags = diags.Append(validate(cfg))

--- a/internal/repl/session_test.go
+++ b/internal/repl/session_test.go
@@ -6,6 +6,7 @@
 package repl
 
 import (
+	"context"
 	"flag"
 	"os"
 	"strings"
@@ -298,7 +299,7 @@ func testSession(t *testing.T, test testSessionTest) {
 	if state == nil {
 		state = states.NewState()
 	}
-	scope, diags := ctx.Eval(config, state, addrs.RootModuleInstance, &tofu.EvalOpts{})
+	scope, diags := ctx.Eval(context.Background(), config, state, addrs.RootModuleInstance, &tofu.EvalOpts{})
 	if diags.HasErrors() {
 		t.Fatalf("failed to create scope: %s", diags.Err())
 	}

--- a/internal/tofu/context_apply.go
+++ b/internal/tofu/context_apply.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -26,7 +27,7 @@ import (
 //
 // Even if the returned diagnostics contains errors, Apply always returns the
 // resulting state which is likely to have been partially-updated.
-func (c *Context) Apply(plan *plans.Plan, config *configs.Config) (*states.State, tfdiags.Diagnostics) {
+func (c *Context) Apply(ctx context.Context, plan *plans.Plan, config *configs.Config) (*states.State, tfdiags.Diagnostics) {
 	defer c.acquireRun("apply")()
 
 	log.Printf("[DEBUG] Building and walking apply graph for %s plan", plan.UIMode)

--- a/internal/tofu/context_apply.go
+++ b/internal/tofu/context_apply.go
@@ -63,7 +63,7 @@ func (c *Context) Apply(ctx context.Context, plan *plans.Plan, config *configs.C
 	}
 
 	workingState := plan.PriorState.DeepCopy()
-	walker, walkDiags := c.walk(graph, operation, &graphWalkOpts{
+	walker, walkDiags := c.walk(ctx, graph, operation, &graphWalkOpts{
 		Config:     config,
 		InputState: workingState,
 		Changes:    plan.Changes,

--- a/internal/tofu/context_apply2_test.go
+++ b/internal/tofu/context_apply2_test.go
@@ -3252,7 +3252,7 @@ func TestContext2Apply_excludedDestroy(t *testing.T) {
 		})
 
 		// First plan and apply a create operation
-		if diags := ctx.Validate(m); diags.HasErrors() {
+		if diags := ctx.Validate(context.Background(), m); diags.HasErrors() {
 			t.Fatalf("validate errors: %s", diags.Err())
 		}
 
@@ -3316,7 +3316,7 @@ func TestContext2Apply_excludedDestroyDependent(t *testing.T) {
 		})
 
 		// First plan and apply a create operation
-		if diags := ctx.Validate(m); diags.HasErrors() {
+		if diags := ctx.Validate(context.Background(), m); diags.HasErrors() {
 			t.Fatalf("validate errors: %s", diags.Err())
 		}
 

--- a/internal/tofu/context_apply2_test.go
+++ b/internal/tofu/context_apply2_test.go
@@ -79,7 +79,7 @@ func TestContext2Apply_createBeforeDestroy_deposedKeyPreApply(t *testing.T) {
 		t.Logf(legacyDiffComparisonString(plan.Changes))
 	}
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -171,7 +171,7 @@ output "data" {
 		t.Fatal(diags.Err())
 	}
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -194,7 +194,7 @@ output "data" {
 		return resp
 	}
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -256,7 +256,7 @@ resource "test_instance" "a" {
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -368,7 +368,7 @@ resource "aws_instance" "bin" {
 		t.Fatalf("baz should depend on bam after refresh, but got %s", baz.Current.Dependencies)
 	}
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -452,7 +452,7 @@ resource "test_resource" "b" {
 	plan, diags := ctx.Plan(context.Background(), m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -493,7 +493,7 @@ output "out" {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -556,7 +556,7 @@ resource "test_object" "y" {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	// FINAL PLAN:
@@ -614,7 +614,7 @@ resource "test_object" "x" {
 		t.Fatalf("plan: %s", diags.Err())
 	}
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("apply: %s", diags.Err())
 	}
@@ -629,7 +629,7 @@ func TestContext2Apply_nullableVariables(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("plan: %s", diags.Err())
 	}
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("apply: %s", diags.Err())
 	}
@@ -692,7 +692,7 @@ resource "test_object" "s" {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	// destroy only a single instance not included in the moved statements
@@ -742,7 +742,7 @@ resource "test_object" "s" {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	// destroy excluding the module in the moved statements
@@ -807,7 +807,7 @@ resource "test_object" "b" {
 	testObjA := plan.PriorState.Modules[""].Resources["test_object.a"].Instances[addrs.NoKey].Current
 	testObjA.Dependencies = append(testObjA.Dependencies, mustResourceInstanceAddr("test_object.b").ContainingResource().Config())
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	if !diags.HasErrors() {
 		t.Fatal("expected cycle error from apply")
 	}
@@ -893,7 +893,7 @@ resource "test_resource" "c" {
 			resp.NewState = cty.ObjectVal(m)
 			return resp
 		}
-		state, diags := ctx.Apply(plan, m)
+		state, diags := ctx.Apply(context.Background(), plan, m)
 		assertNoErrors(t, diags)
 
 		wantResourceAttrs := map[string]struct{ value, output string }{
@@ -949,7 +949,7 @@ resource "test_resource" "c" {
 			resp.NewState = cty.ObjectVal(m)
 			return resp
 		}
-		state, diags := ctx.Apply(plan, m)
+		state, diags := ctx.Apply(context.Background(), plan, m)
 		if !diags.HasErrors() {
 			t.Fatal("succeeded; want errors")
 		}
@@ -1054,7 +1054,7 @@ func TestContext2Apply_outputValuePrecondition(t *testing.T) {
 			}
 		}
 
-		state, diags := ctx.Apply(plan, m)
+		state, diags := ctx.Apply(context.Background(), plan, m)
 		assertNoDiagnostics(t, diags)
 		for _, addr := range checkableObjects {
 			result := state.CheckResults.GetObjectResult(addr)
@@ -1207,7 +1207,7 @@ func TestContext2Apply_resourceConditionApplyTimeFail(t *testing.T) {
 			t.Fatalf("incorrect initial plan for instance B\nwant a 'create' change\ngot: %s", spew.Sdump(planB))
 		}
 
-		state, diags := ctx.Apply(plan, m)
+		state, diags := ctx.Apply(context.Background(), plan, m)
 		assertNoErrors(t, diags)
 
 		stateA := state.ResourceInstance(instA)
@@ -1244,7 +1244,7 @@ func TestContext2Apply_resourceConditionApplyTimeFail(t *testing.T) {
 			t.Fatalf("incorrect initial plan for instance B\nwant a 'no-op' change\ngot: %s", spew.Sdump(planB))
 		}
 
-		_, diags = ctx.Apply(plan, m)
+		_, diags = ctx.Apply(context.Background(), plan, m)
 		if !diags.HasErrors() {
 			t.Fatal("final apply succeeded, but should've failed with a postcondition error")
 		}
@@ -1382,7 +1382,7 @@ output "out" {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), opts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	// Resource changes which have dependencies across providers which
@@ -1507,7 +1507,7 @@ resource "test_object" "x" {
 		t.Fatalf("plan: %s", diags.Err())
 	}
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("apply: %s", diags.Err())
 	}
@@ -1553,7 +1553,7 @@ resource "test_object" "y" {
 	plan, diags := ctx.Plan(context.Background(), m, state, opts)
 	assertNoErrors(t, diags)
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 }
 
@@ -1635,7 +1635,7 @@ output "data" {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), opts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	// and destroy
@@ -1643,7 +1643,7 @@ output "data" {
 	plan, diags = ctx.Plan(context.Background(), m, state, opts)
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	// and destroy again with no state
@@ -1655,7 +1655,7 @@ output "data" {
 	plan, diags = ctx.Plan(context.Background(), m, state, opts)
 	assertNoErrors(t, diags)
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 }
 
@@ -1710,7 +1710,7 @@ output "from_resource" {
 	plan, diags := ctx.Plan(context.Background(), m, state, opts)
 	assertNoErrors(t, diags)
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 }
 
@@ -1767,7 +1767,7 @@ output "from_resource" {
 	plan, diags := ctx.Plan(context.Background(), m, state, opts)
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	resCheck := state.CheckResults.GetObjectResult(mustResourceInstanceAddr("test_object.x"))
@@ -1855,7 +1855,7 @@ resource "test_object" "y" {
 		return resp
 	}
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 }
 
@@ -1903,7 +1903,7 @@ output "a" {
 		Mode: plans.NormalMode,
 	})
 	assertNoErrors(t, diags)
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 }
 
@@ -1950,7 +1950,7 @@ output "null_module_test" {
 		Mode: plans.NormalMode,
 	})
 	assertNoErrors(t, diags)
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	// now destroy
@@ -1958,7 +1958,7 @@ output "null_module_test" {
 		Mode: plans.DestroyMode,
 	})
 	assertNoErrors(t, diags)
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 }
 
@@ -2025,7 +2025,7 @@ output "resources" {
 		Mode: plans.NormalMode,
 	})
 	assertNoErrors(t, diags)
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 }
 
@@ -2113,7 +2113,7 @@ resource "test_resource" "b" {
 	})
 	assertNoErrors(t, diags)
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 }
 
@@ -2156,7 +2156,7 @@ resource "unused_resource" "test" {
 		Mode: plans.DestroyMode,
 	})
 	assertNoErrors(t, diags)
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 }
 
@@ -2216,7 +2216,7 @@ import {
 	})
 	assertNoErrors(t, diags)
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	if !hook.PreApplyImportCalled {
@@ -2259,7 +2259,7 @@ locals {
 		t.Errorf("expected no errors, but got %s", diags)
 	}
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Errorf("expected no errors, but got %s", diags)
 	}
@@ -2302,7 +2302,7 @@ locals {
 		t.Errorf("expected no errors, but got %s", diags)
 	}
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Errorf("expected no errors, but got %s", diags)
 	}
@@ -2361,7 +2361,7 @@ func TestContext2Apply_forgetOrphanAndDeposed(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	s, diags := ctx.Apply(plan, m)
+	s, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -2555,7 +2555,7 @@ func TestContext2Apply_providerExpandWithTargetOrExclude(t *testing.T) {
 			plan, diags := ctx.Plan(context.Background(), m, state, normalPlanOpts)
 			assertNoErrors(t, diags)
 
-			newState, diags := ctx.Apply(plan, m)
+			newState, diags := ctx.Apply(context.Background(), plan, m)
 			assertNoErrors(t, diags)
 
 			assertResourceInstanceProviderInstance(
@@ -2623,7 +2623,7 @@ func TestContext2Apply_providerExpandWithTargetOrExclude(t *testing.T) {
 			plan, diags := ctx.Plan(context.Background(), m, state, makeStep2PlanOpts(plans.NormalMode))
 			assertNoErrors(t, diags)
 
-			newState, diags := ctx.Apply(plan, m)
+			newState, diags := ctx.Apply(context.Background(), plan, m)
 			assertNoErrors(t, diags)
 
 			// Because makeStep2PlanOpts told us to retain at least one
@@ -2696,7 +2696,7 @@ func TestContext2Apply_providerExpandWithTargetOrExclude(t *testing.T) {
 			plan, diags := ctx.Plan(context.Background(), m, state, normalPlanOpts)
 			assertNoErrors(t, diags)
 
-			newState, diags := ctx.Apply(plan, m)
+			newState, diags := ctx.Apply(context.Background(), plan, m)
 			assertNoErrors(t, diags)
 
 			// The whole resource state for mock.first should've been removed now.
@@ -2773,7 +2773,7 @@ func TestContext2Apply_moduleProviderAliasExcludes(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -2813,7 +2813,7 @@ func TestContext2Apply_moduleProviderAliasExcludesNonExistent(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -2846,7 +2846,7 @@ func TestContext2Apply_moduleExclude(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -2882,7 +2882,7 @@ func TestContext2Apply_moduleExcludeDependent(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -2913,7 +2913,7 @@ func TestContext2Apply_moduleExcludeNonExistent(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -2960,7 +2960,7 @@ func TestContext2Apply_destroyExcludedNonExistentWithModuleVariableAndCount(t *t
 		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
-		state, diags = ctx.Apply(plan, m)
+		state, diags = ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("apply err: %s", diags.Err())
 		}
@@ -2994,7 +2994,7 @@ func TestContext2Apply_destroyExcludedNonExistentWithModuleVariableAndCount(t *t
 		}
 
 		// Destroy, excluding the module explicitly
-		state, diags = ctx.Apply(plan, m)
+		state, diags = ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("destroy apply err: %s", diags)
 		}
@@ -3049,7 +3049,7 @@ func TestContext2Apply_destroyExcludedWithModuleVariableAndCount(t *testing.T) {
 		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
-		state, diags = ctx.Apply(plan, m)
+		state, diags = ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("apply err: %s", diags.Err())
 		}
@@ -3083,7 +3083,7 @@ func TestContext2Apply_destroyExcludedWithModuleVariableAndCount(t *testing.T) {
 		}
 
 		// Destroy, excluding the module explicitly
-		state, diags = ctx.Apply(plan, m)
+		state, diags = ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("destroy apply err: %s", diags)
 		}
@@ -3127,7 +3127,7 @@ func TestContext2Apply_excluded(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -3167,7 +3167,7 @@ func TestContext2Apply_excludedCount(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -3209,7 +3209,7 @@ func TestContext2Apply_excludedCountIndex(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -3259,7 +3259,7 @@ func TestContext2Apply_excludedDestroy(t *testing.T) {
 		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
-		state, diags = ctx.Apply(plan, m)
+		state, diags = ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("apply err: %s", diags.Err())
 		}
@@ -3282,7 +3282,7 @@ func TestContext2Apply_excludedDestroy(t *testing.T) {
 		})
 		assertNoErrors(t, diags)
 
-		state, diags = ctx.Apply(plan, m)
+		state, diags = ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("diags: %s", diags.Err())
 		}
@@ -3323,7 +3323,7 @@ func TestContext2Apply_excludedDestroyDependent(t *testing.T) {
 		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
-		state, diags = ctx.Apply(plan, m)
+		state, diags = ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("apply err: %s", diags.Err())
 		}
@@ -3344,7 +3344,7 @@ func TestContext2Apply_excludedDestroyDependent(t *testing.T) {
 		})
 		assertNoErrors(t, diags)
 
-		state, diags = ctx.Apply(plan, m)
+		state, diags = ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("diags: %s", diags.Err())
 		}
@@ -3434,7 +3434,7 @@ func TestContext2Apply_excludedDestroyCountDeps(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -3512,7 +3512,7 @@ func TestContext2Apply_excludedDependentDestroyCountDeps(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -3596,7 +3596,7 @@ func TestContext2Apply_excludedDestroyModule(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -3681,7 +3681,7 @@ func TestContext2Apply_excludedDestroyCountIndex(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -3715,7 +3715,7 @@ func TestContext2Apply_excludedModule(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -3764,7 +3764,7 @@ func TestContext2Apply_excludedModuleResourceDep(t *testing.T) {
 		t.Logf("Diff: %s", legacyDiffComparisonString(plan.Changes))
 	}
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -3797,7 +3797,7 @@ func TestContext2Apply_excludedResourceDependentOnModule(t *testing.T) {
 		t.Logf("Diff: %s", legacyDiffComparisonString(plan.Changes))
 	}
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -3835,7 +3835,7 @@ func TestContext2Apply_excludedModuleDep(t *testing.T) {
 		t.Logf("Diff: %s", legacyDiffComparisonString(plan.Changes))
 	}
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -3868,7 +3868,7 @@ func TestContext2Apply_excludedModuleUnrelatedOutputs(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	s, diags := ctx.Apply(plan, m)
+	s, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -3916,7 +3916,7 @@ func TestContext2Apply_excludedModuleResource(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -3976,7 +3976,7 @@ func TestContext2Apply_excludedResourceOrphanModule(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
@@ -4027,7 +4027,7 @@ func TestContext2Apply_excludedOrphanModule(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
@@ -4097,7 +4097,7 @@ func TestContext2Apply_excludedWithTaintedInState(t *testing.T) {
 		t.Fatalf("err: %s", diags.Err())
 	}
 
-	s, diags := ctx.Apply(plan, m)
+	s, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("err: %s", diags.Err())
 	}
@@ -4136,7 +4136,7 @@ func TestContext2Apply_excludedModuleRecursive(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("err: %s", diags.Err())
 	}
@@ -4224,7 +4224,7 @@ resource "test_instance" "a" {
 			t.Fatal(diags.Err())
 		}
 
-		newState, diags := ctx.Apply(plan, m)
+		newState, diags := ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatal(diags.Err())
 		}
@@ -4243,7 +4243,7 @@ resource "test_instance" "a" {
 			t.Fatal(diags.Err())
 		}
 
-		newState, diags := ctx.Apply(plan, m)
+		newState, diags := ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatal(diags.Err())
 		}
@@ -4377,7 +4377,7 @@ resource "test_instance" "a" {
 			t.Fatal(diags.Err())
 		}
 
-		newState, diags := ctx.Apply(plan, m)
+		newState, diags := ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatal(diags.Err())
 		}
@@ -4396,7 +4396,7 @@ resource "test_instance" "a" {
 			t.Fatal(diags.Err())
 		}
 
-		newState, diags := ctx.Apply(plan, m)
+		newState, diags := ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatal(diags.Err())
 		}

--- a/internal/tofu/context_apply2_test.go
+++ b/internal/tofu/context_apply2_test.go
@@ -7,6 +7,7 @@ package tofu
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -71,7 +72,7 @@ func TestContext2Apply_createBeforeDestroy_deposedKeyPreApply(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	} else {
@@ -165,7 +166,7 @@ output "data" {
 		Providers: ps,
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -180,7 +181,7 @@ output "data" {
 		Providers: ps,
 	})
 
-	plan, diags = ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags = ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	if diags.HasErrors() {
@@ -252,7 +253,7 @@ resource "test_instance" "a" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m)
@@ -344,7 +345,7 @@ resource "aws_instance" "bin" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	bar := plan.PriorState.ResourceInstance(barAddr)
@@ -448,7 +449,7 @@ resource "test_resource" "b" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m)
@@ -489,7 +490,7 @@ output "out" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -502,7 +503,7 @@ output "out" {
 		t.Fatalf("Expected 1 sensitive mark for test_object.a, got %#v\n", obj.Current.AttrSensitivePaths)
 	}
 
-	plan, diags = ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags = ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	// make sure the same marks are compared in the next plan as well
@@ -552,14 +553,14 @@ resource "test_object" "y" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
 	assertNoErrors(t, diags)
 
 	// FINAL PLAN:
-	plan, diags = ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags = ctx.Plan(context.Background(), m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	// make sure the same marks are compared in the next plan as well
@@ -606,7 +607,7 @@ resource "test_object" "x" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	if diags.HasErrors() {
@@ -624,7 +625,7 @@ func TestContext2Apply_nullableVariables(t *testing.T) {
 	m := testModule(t, "apply-nullable-variables")
 	state := states.NewState()
 	ctx := testContext2(t, &ContextOpts{})
-	plan, diags := ctx.Plan(m, state, &PlanOpts{})
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{})
 	if diags.HasErrors() {
 		t.Fatalf("plan: %s", diags.Err())
 	}
@@ -688,14 +689,14 @@ resource "test_object" "s" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
 	assertNoErrors(t, diags)
 
 	// destroy only a single instance not included in the moved statements
-	_, diags = ctx.Plan(m, state, &PlanOpts{
+	_, diags = ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode:    plans.DestroyMode,
 		Targets: []addrs.Targetable{mustResourceInstanceAddr(`module.modb["a"].test_object.a`)},
 	})
@@ -738,14 +739,14 @@ resource "test_object" "s" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
 	assertNoErrors(t, diags)
 
 	// destroy excluding the module in the moved statements
-	_, diags = ctx.Plan(m, state, &PlanOpts{
+	_, diags = ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode:     plans.DestroyMode,
 		Excludes: []addrs.Targetable{addrs.Module{"sub"}},
 	})
@@ -794,7 +795,7 @@ resource "test_object" "b" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	if diags.HasErrors() {
@@ -871,7 +872,7 @@ resource "test_resource" "c" {
 	})
 
 	t.Run("condition pass", func(t *testing.T) {
-		plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 			Mode: plans.NormalMode,
 			SetVariables: InputValues{
 				"boop": &InputValue{
@@ -920,7 +921,7 @@ resource "test_resource" "c" {
 		}
 	})
 	t.Run("condition fail", func(t *testing.T) {
-		plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 			Mode: plans.NormalMode,
 			SetVariables: InputValues{
 				"boop": &InputValue{
@@ -1032,7 +1033,7 @@ func TestContext2Apply_outputValuePrecondition(t *testing.T) {
 
 	t.Run("pass", func(t *testing.T) {
 		ctx := testContext2(t, &ContextOpts{})
-		plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 			Mode: plans.NormalMode,
 			SetVariables: InputValues{
 				"input": &InputValue{
@@ -1072,7 +1073,7 @@ func TestContext2Apply_outputValuePrecondition(t *testing.T) {
 		// than an apply test but better to keep all of these
 		// thematically-related test cases together.
 		ctx := testContext2(t, &ContextOpts{})
-		_, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		_, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 			Mode: plans.NormalMode,
 			SetVariables: InputValues{
 				"input": &InputValue{
@@ -1187,7 +1188,7 @@ func TestContext2Apply_resourceConditionApplyTimeFail(t *testing.T) {
 	// subsequent plan and apply that we'll expect to fail.
 	var prevRunState *states.State
 	{
-		plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 			Mode: plans.NormalMode,
 			SetVariables: InputValues{
 				"input": &InputValue{
@@ -1224,7 +1225,7 @@ func TestContext2Apply_resourceConditionApplyTimeFail(t *testing.T) {
 	// var.input that should cause the test_resource.b condition to be unknown
 	// during planning and then fail during apply.
 	{
-		plan, diags := ctx.Plan(m, prevRunState, &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, prevRunState, &PlanOpts{
 			Mode: plans.NormalMode,
 			SetVariables: InputValues{
 				"input": &InputValue{
@@ -1378,7 +1379,7 @@ output "out" {
 	})
 
 	opts := SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables))
-	plan, diags := ctx.Plan(m, states.NewState(), opts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), opts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -1399,7 +1400,7 @@ output "out" {
 	testObjA := state.ResourceInstance(testObjAddr)
 	testObjA.Current.AttrsJSON = []byte(`{"test_bool":null,"test_list":null,"test_map":null,"test_number":null,"test_string":"changed"}`)
 
-	_, diags = ctx.Plan(m, state, opts)
+	_, diags = ctx.Plan(context.Background(), m, state, opts)
 	assertNoErrors(t, diags)
 	return
 	// TODO: unreachable code
@@ -1431,7 +1432,7 @@ got:      %#v`,
 	opts.SkipRefresh = true
 
 	// destroy only a single instance not included in the moved statements
-	_, diags = ctx.Plan(m, state, opts)
+	_, diags = ctx.Plan(context.Background(), m, state, opts)
 	assertNoErrors(t, diags)
 
 	if !otherProvider.ConfigureProviderCalled {
@@ -1497,7 +1498,7 @@ resource "test_object" "x" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 		// we don't want to refresh, because that actually runs a normal plan
 		SkipRefresh: true,
@@ -1549,7 +1550,7 @@ resource "test_object" "y" {
 	})
 
 	opts := SimplePlanOpts(plans.NormalMode, nil)
-	plan, diags := ctx.Plan(m, state, opts)
+	plan, diags := ctx.Plan(context.Background(), m, state, opts)
 	assertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m)
@@ -1631,7 +1632,7 @@ output "data" {
 
 	// apply the state
 	opts := SimplePlanOpts(plans.NormalMode, nil)
-	plan, diags := ctx.Plan(m, states.NewState(), opts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), opts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -1639,7 +1640,7 @@ output "data" {
 
 	// and destroy
 	opts = SimplePlanOpts(plans.DestroyMode, nil)
-	plan, diags = ctx.Plan(m, state, opts)
+	plan, diags = ctx.Plan(context.Background(), m, state, opts)
 	assertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m)
@@ -1651,7 +1652,7 @@ output "data" {
 	}
 
 	opts = SimplePlanOpts(plans.DestroyMode, nil)
-	plan, diags = ctx.Plan(m, state, opts)
+	plan, diags = ctx.Plan(context.Background(), m, state, opts)
 	assertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m)
@@ -1706,7 +1707,7 @@ output "from_resource" {
 	})
 
 	opts := SimplePlanOpts(plans.DestroyMode, nil)
-	plan, diags := ctx.Plan(m, state, opts)
+	plan, diags := ctx.Plan(context.Background(), m, state, opts)
 	assertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m)
@@ -1763,7 +1764,7 @@ output "from_resource" {
 	})
 
 	opts := SimplePlanOpts(plans.RefreshOnlyMode, nil)
-	plan, diags := ctx.Plan(m, state, opts)
+	plan, diags := ctx.Plan(context.Background(), m, state, opts)
 	assertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m)
@@ -1833,7 +1834,7 @@ resource "test_object" "y" {
 	})
 
 	opts := SimplePlanOpts(plans.NormalMode, nil)
-	plan, diags := ctx.Plan(m, state, opts)
+	plan, diags := ctx.Plan(context.Background(), m, state, opts)
 	assertNoErrors(t, diags)
 
 	for _, c := range plan.Changes.Resources {
@@ -1898,7 +1899,7 @@ output "a" {
 `,
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 	})
 	assertNoErrors(t, diags)
@@ -1945,7 +1946,7 @@ output "null_module_test" {
 	})
 
 	// verify plan and apply
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 	})
 	assertNoErrors(t, diags)
@@ -1953,7 +1954,7 @@ output "null_module_test" {
 	assertNoErrors(t, diags)
 
 	// now destroy
-	plan, diags = ctx.Plan(m, state, &PlanOpts{
+	plan, diags = ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	assertNoErrors(t, diags)
@@ -2020,7 +2021,7 @@ output "resources" {
 			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 		},
 	})
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 	})
 	assertNoErrors(t, diags)
@@ -2107,7 +2108,7 @@ resource "test_resource" "b" {
 			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 		},
 	})
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 	})
 	assertNoErrors(t, diags)
@@ -2151,7 +2152,7 @@ resource "unused_resource" "test" {
 `,
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	assertNoErrors(t, diags)
@@ -2210,7 +2211,7 @@ import {
 			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 		},
 	})
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 	})
 	assertNoErrors(t, diags)
@@ -2253,7 +2254,7 @@ locals {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), nil)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), nil)
 	if diags.HasErrors() {
 		t.Errorf("expected no errors, but got %s", diags)
 	}
@@ -2291,7 +2292,7 @@ locals {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		ExternalReferences: []*addrs.Reference{
 			mustReference("local.local_value"),
@@ -2357,7 +2358,7 @@ func TestContext2Apply_forgetOrphanAndDeposed(t *testing.T) {
 
 	p.PlanResourceChangeFn = testDiffFn
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	s, diags := ctx.Apply(plan, m)
@@ -2551,7 +2552,7 @@ func TestContext2Apply_providerExpandWithTargetOrExclude(t *testing.T) {
 					addrs.NewBuiltInProvider("mock"): testProviderFuncFixed(p),
 				},
 			})
-			plan, diags := ctx.Plan(m, state, normalPlanOpts)
+			plan, diags := ctx.Plan(context.Background(), m, state, normalPlanOpts)
 			assertNoErrors(t, diags)
 
 			newState, diags := ctx.Apply(plan, m)
@@ -2619,7 +2620,7 @@ func TestContext2Apply_providerExpandWithTargetOrExclude(t *testing.T) {
 					addrs.NewBuiltInProvider("mock"): testProviderFuncFixed(p),
 				},
 			})
-			plan, diags := ctx.Plan(m, state, makeStep2PlanOpts(plans.NormalMode))
+			plan, diags := ctx.Plan(context.Background(), m, state, makeStep2PlanOpts(plans.NormalMode))
 			assertNoErrors(t, diags)
 
 			newState, diags := ctx.Apply(plan, m)
@@ -2692,7 +2693,7 @@ func TestContext2Apply_providerExpandWithTargetOrExclude(t *testing.T) {
 					addrs.NewBuiltInProvider("mock"): testProviderFuncFixed(p),
 				},
 			})
-			plan, diags := ctx.Plan(m, state, normalPlanOpts)
+			plan, diags := ctx.Plan(context.Background(), m, state, normalPlanOpts)
 			assertNoErrors(t, diags)
 
 			newState, diags := ctx.Apply(plan, m)
@@ -2757,7 +2758,7 @@ func TestContext2Apply_moduleProviderAliasExcludes(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Excludes: []addrs.Targetable{
 			addrs.ConfigResource{
@@ -2797,7 +2798,7 @@ func TestContext2Apply_moduleProviderAliasExcludesNonExistent(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Excludes: []addrs.Targetable{
 			addrs.ConfigResource{
@@ -2837,7 +2838,7 @@ func TestContext2Apply_moduleExclude(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.Child("B", addrs.NoKey),
@@ -2873,7 +2874,7 @@ func TestContext2Apply_moduleExcludeDependent(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.Child("A", addrs.NoKey),
@@ -2904,7 +2905,7 @@ func TestContext2Apply_moduleExcludeNonExistent(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.Child("C", addrs.NoKey),
@@ -2956,7 +2957,7 @@ func TestContext2Apply_destroyExcludedNonExistentWithModuleVariableAndCount(t *t
 		})
 
 		// First plan and apply a create operation
-		plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
 		state, diags = ctx.Apply(plan, m)
@@ -2972,7 +2973,7 @@ func TestContext2Apply_destroyExcludedNonExistentWithModuleVariableAndCount(t *t
 			},
 		})
 
-		plan, diags := ctx.Plan(m, state, &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 			Mode: plans.DestroyMode,
 			Excludes: []addrs.Targetable{
 				addrs.RootModuleInstance.Child("child", addrs.NoKey),
@@ -3045,7 +3046,7 @@ func TestContext2Apply_destroyExcludedWithModuleVariableAndCount(t *testing.T) {
 		})
 
 		// First plan and apply a create operation
-		plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
 		state, diags = ctx.Apply(plan, m)
@@ -3061,7 +3062,7 @@ func TestContext2Apply_destroyExcludedWithModuleVariableAndCount(t *testing.T) {
 			},
 		})
 
-		plan, diags := ctx.Plan(m, state, &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 			Mode: plans.DestroyMode,
 			Excludes: []addrs.Targetable{
 				addrs.RootModuleInstance.Child("non-existent-child", addrs.NoKey),
@@ -3116,7 +3117,7 @@ func TestContext2Apply_excluded(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.Resource(
@@ -3156,7 +3157,7 @@ func TestContext2Apply_excludedCount(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.Resource(
@@ -3198,7 +3199,7 @@ func TestContext2Apply_excludedCountIndex(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.ResourceInstance(
@@ -3255,7 +3256,7 @@ func TestContext2Apply_excludedDestroy(t *testing.T) {
 			t.Fatalf("validate errors: %s", diags.Err())
 		}
 
-		plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
 		state, diags = ctx.Apply(plan, m)
@@ -3271,7 +3272,7 @@ func TestContext2Apply_excludedDestroy(t *testing.T) {
 			},
 		})
 
-		plan, diags := ctx.Plan(m, state, &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 			Mode: plans.DestroyMode,
 			Excludes: []addrs.Targetable{
 				addrs.RootModuleInstance.Resource(
@@ -3319,7 +3320,7 @@ func TestContext2Apply_excludedDestroyDependent(t *testing.T) {
 			t.Fatalf("validate errors: %s", diags.Err())
 		}
 
-		plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
 		state, diags = ctx.Apply(plan, m)
@@ -3335,7 +3336,7 @@ func TestContext2Apply_excludedDestroyDependent(t *testing.T) {
 			},
 		})
 
-		plan, diags := ctx.Plan(m, state, &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 			Mode: plans.DestroyMode,
 			Excludes: []addrs.Targetable{
 				addrs.RootModuleInstance.Child("child", addrs.NoKey),
@@ -3423,7 +3424,7 @@ func TestContext2Apply_excludedDestroyCountDeps(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.Resource(
@@ -3501,7 +3502,7 @@ func TestContext2Apply_excludedDependentDestroyCountDeps(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.Resource(
@@ -3585,7 +3586,7 @@ func TestContext2Apply_excludedDestroyModule(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.Child("child", addrs.NoKey).Resource(
@@ -3667,7 +3668,7 @@ func TestContext2Apply_excludedDestroyCountIndex(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.ResourceInstance(
@@ -3706,7 +3707,7 @@ func TestContext2Apply_excludedModule(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.Child("child", addrs.NoKey),
@@ -3749,7 +3750,7 @@ func TestContext2Apply_excludedModuleResourceDep(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.Child("child", addrs.NoKey).Resource(
@@ -3784,7 +3785,7 @@ func TestContext2Apply_excludedResourceDependentOnModule(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.Resource(addrs.ManagedResourceMode, "aws_instance", "foo"),
@@ -3822,7 +3823,7 @@ func TestContext2Apply_excludedModuleDep(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.Child("child", addrs.NoKey),
@@ -3858,7 +3859,7 @@ func TestContext2Apply_excludedModuleUnrelatedOutputs(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		Excludes: []addrs.Targetable{
 			// Excluding aws_instance.foo should also exclude module.child1, which is dependent on it
@@ -3905,7 +3906,7 @@ func TestContext2Apply_excludedModuleResource(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.Child("child", addrs.NoKey).Resource(
@@ -3965,7 +3966,7 @@ func TestContext2Apply_excludedResourceOrphanModule(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.Child("parent", addrs.NoKey).Resource(
@@ -4018,7 +4019,7 @@ func TestContext2Apply_excludedOrphanModule(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.Child("parent", addrs.NoKey),
@@ -4069,7 +4070,7 @@ func TestContext2Apply_excludedWithTaintedInState(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.Resource(
@@ -4127,7 +4128,7 @@ func TestContext2Apply_excludedModuleRecursive(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.Child("child", addrs.NoKey),
@@ -4218,7 +4219,7 @@ resource "test_instance" "a" {
 			Providers: ps,
 		})
 
-		plan, diags := ctx.Plan(m, prevState, DefaultPlanOpts)
+		plan, diags := ctx.Plan(context.Background(), m, prevState, DefaultPlanOpts)
 		if diags.HasErrors() {
 			t.Fatal(diags.Err())
 		}
@@ -4235,7 +4236,7 @@ resource "test_instance" "a" {
 			Providers: ps,
 		})
 
-		plan, diags := ctx.Plan(m, prevState, &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, prevState, &PlanOpts{
 			Mode: plans.DestroyMode,
 		})
 		if diags.HasErrors() {
@@ -4371,7 +4372,7 @@ resource "test_instance" "a" {
 			Providers: ps,
 		})
 
-		plan, diags := ctx.Plan(m, prevState, DefaultPlanOpts)
+		plan, diags := ctx.Plan(context.Background(), m, prevState, DefaultPlanOpts)
 		if diags.HasErrors() {
 			t.Fatal(diags.Err())
 		}
@@ -4388,7 +4389,7 @@ resource "test_instance" "a" {
 			Providers: ps,
 		})
 
-		plan, diags := ctx.Plan(m, prevState, &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, prevState, &PlanOpts{
 			Mode: plans.DestroyMode,
 		})
 		if diags.HasErrors() {

--- a/internal/tofu/context_apply_checks_test.go
+++ b/internal/tofu/context_apply_checks_test.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"testing"
 
 	"github.com/zclconf/go-cty/cty"
@@ -723,7 +724,7 @@ check "error" {
 				initialState = test.state
 			}
 
-			plan, diags := ctx.Plan(configs, initialState, &PlanOpts{
+			plan, diags := ctx.Plan(context.Background(), configs, initialState, &PlanOpts{
 				Mode: plans.NormalMode,
 			})
 			if validateCheckDiagnostics(t, "planning", test.planWarning, test.planError, diags) {

--- a/internal/tofu/context_apply_checks_test.go
+++ b/internal/tofu/context_apply_checks_test.go
@@ -738,7 +738,7 @@ check "error" {
 				test.providerHook(test.provider)
 			}
 
-			state, diags := ctx.Apply(plan, configs)
+			state, diags := ctx.Apply(context.Background(), plan, configs)
 			if validateCheckDiagnostics(t, "apply", test.applyWarning, test.applyError, diags) {
 				return
 			}

--- a/internal/tofu/context_apply_test.go
+++ b/internal/tofu/context_apply_test.go
@@ -7,6 +7,7 @@ package tofu
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -49,7 +50,7 @@ func TestContext2Apply_basic(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -144,7 +145,7 @@ func TestContext2Apply_stop(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	// We'll reset the hook events before we apply because we only care about
@@ -265,7 +266,7 @@ func TestContext2Apply_unstable(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error during Plan: %s", diags.Err())
 	}
@@ -321,7 +322,7 @@ func TestContext2Apply_escape(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -349,7 +350,7 @@ func TestContext2Apply_resourceCountOneList(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -377,7 +378,7 @@ func TestContext2Apply_resourceCountZeroList(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -430,7 +431,7 @@ func TestContext2Apply_resourceDependsOnModule(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -504,7 +505,7 @@ func TestContext2Apply_resourceDependsOnModuleStateOnly(t *testing.T) {
 			},
 		})
 
-		plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+		plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
 		state, diags := ctx.Apply(plan, m)
@@ -531,7 +532,7 @@ func TestContext2Apply_resourceDependsOnModuleDestroy(t *testing.T) {
 			},
 		})
 
-		plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
 		state, diags := ctx.Apply(plan, m)
@@ -572,7 +573,7 @@ func TestContext2Apply_resourceDependsOnModuleDestroy(t *testing.T) {
 			},
 		})
 
-		plan, diags := ctx.Plan(m, globalState, &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, globalState, &PlanOpts{
 			Mode: plans.DestroyMode,
 		})
 		assertNoErrors(t, diags)
@@ -625,7 +626,7 @@ func TestContext2Apply_resourceDependsOnModuleGrandchild(t *testing.T) {
 			},
 		})
 
-		plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
 		state, diags := ctx.Apply(plan, m)
@@ -676,7 +677,7 @@ func TestContext2Apply_resourceDependsOnModuleInModule(t *testing.T) {
 			},
 		})
 
-		plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
 		state, diags := ctx.Apply(plan, m)
@@ -703,7 +704,7 @@ func TestContext2Apply_mapVarBetweenModules(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -741,7 +742,7 @@ func TestContext2Apply_refCount(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -778,7 +779,7 @@ func TestContext2Apply_providerAlias(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -817,7 +818,7 @@ func TestContext2Apply_providerAliasConfigure(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	} else {
@@ -881,7 +882,7 @@ func TestContext2Apply_providerWarning(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -916,7 +917,7 @@ func TestContext2Apply_emptyModule(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -954,7 +955,7 @@ func TestContext2Apply_createBeforeDestroy(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	} else {
@@ -1036,7 +1037,7 @@ func TestContext2Apply_createBeforeDestroyUpdate(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	} else {
@@ -1095,7 +1096,7 @@ func TestContext2Apply_createBeforeDestroy_dependsNonCBD(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	} else {
@@ -1160,7 +1161,7 @@ func TestContext2Apply_createBeforeDestroy_hook(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	} else {
@@ -1240,7 +1241,7 @@ func TestContext2Apply_createBeforeDestroy_deposedCount(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	} else {
@@ -1302,7 +1303,7 @@ func TestContext2Apply_createBeforeDestroy_deposedOnly(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	} else {
@@ -1343,7 +1344,7 @@ func TestContext2Apply_destroyComputed(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	if diags.HasErrors() {
@@ -1414,7 +1415,7 @@ func testContext2Apply_destroyDependsOn(t *testing.T) {
 		Parallelism: 1, // To check ordering
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	assertNoErrors(t, diags)
@@ -1510,7 +1511,7 @@ func testContext2Apply_destroyDependsOnStateOnly(t *testing.T, state *states.Sta
 		Parallelism: 1, // To check ordering
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	assertNoErrors(t, diags)
@@ -1607,7 +1608,7 @@ func testContext2Apply_destroyDependsOnStateOnlyModule(t *testing.T, state *stat
 		Parallelism: 1, // To check ordering
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	assertNoErrors(t, diags)
@@ -1641,7 +1642,7 @@ func TestContext2Apply_dataBasic(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	} else {
@@ -1695,7 +1696,7 @@ func TestContext2Apply_destroyData(t *testing.T) {
 		Hooks: []Hook{hook},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	if diags.HasErrors() {
@@ -1762,7 +1763,7 @@ func TestContext2Apply_destroySkipsCBD(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	if diags.HasErrors() {
@@ -1800,7 +1801,7 @@ func TestContext2Apply_destroyModuleVarProviderConfig(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	assertNoErrors(t, diags)
@@ -1848,7 +1849,7 @@ func TestContext2Apply_destroyCrossProviders(t *testing.T) {
 
 	ctx, m, state := getContextForApply_destroyCrossProviders(t, m, providers)
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	assertNoErrors(t, diags)
@@ -1900,7 +1901,7 @@ func TestContext2Apply_minimal(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -1942,7 +1943,7 @@ func TestContext2Apply_cancel(t *testing.T) {
 	}
 	p.PlanResourceChangeFn = testDiffFn
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	// Start the Apply in a goroutine
@@ -2004,7 +2005,7 @@ func TestContext2Apply_cancelBlock(t *testing.T) {
 		return testApplyFn(req)
 	}
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	// Start the Apply in a goroutine
@@ -2101,7 +2102,7 @@ func TestContext2Apply_cancelProvisioner(t *testing.T) {
 		return nil
 	}
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	// Start the Apply in a goroutine
@@ -2190,7 +2191,7 @@ func TestContext2Apply_compute(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		SetVariables: InputValues{
 			"value": &InputValue{
 				Value:      cty.NumberIntVal(1),
@@ -2253,7 +2254,7 @@ func TestContext2Apply_countDecrease(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	s, diags := ctx.Apply(plan, m)
@@ -2306,7 +2307,7 @@ func TestContext2Apply_countDecreaseToOneX(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	s, diags := ctx.Apply(plan, m)
@@ -2370,7 +2371,7 @@ func TestContext2Apply_countDecreaseToOneCorrupted(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 	{
 		got := strings.TrimSpace(legacyPlanComparisonString(state, plan.Changes))
@@ -2438,7 +2439,7 @@ func TestContext2Apply_countTainted(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 	{
 		got := strings.TrimSpace(legacyDiffComparisonString(plan.Changes))
@@ -2489,7 +2490,7 @@ func TestContext2Apply_countVariable(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -2515,7 +2516,7 @@ func TestContext2Apply_countVariableRef(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -2554,7 +2555,7 @@ func TestContext2Apply_provisionerInterpCount(t *testing.T) {
 		Provisioners: provisioners,
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	// We'll marshal and unmarshal the plan here, to ensure that we have
@@ -2594,7 +2595,7 @@ func TestContext2Apply_foreachVariable(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"foo": &InputValue{
@@ -2627,7 +2628,7 @@ func TestContext2Apply_moduleBasic(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -2708,7 +2709,7 @@ func TestContext2Apply_moduleDestroyOrder(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	assertNoErrors(t, diags)
@@ -2758,7 +2759,7 @@ func TestContext2Apply_moduleInheritAlias(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -2804,7 +2805,7 @@ func TestContext2Apply_orphanResource(t *testing.T) {
 			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 		},
 	})
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 	state, diags := ctx.Apply(plan, m)
 	assertNoErrors(t, diags)
@@ -2839,7 +2840,7 @@ func TestContext2Apply_orphanResource(t *testing.T) {
 			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 		},
 	})
-	plan, diags = ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags = ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 	{
 		addr := mustResourceInstanceAddr("test_thing.one[0]")
@@ -2906,7 +2907,7 @@ func TestContext2Apply_moduleOrphanInheritAlias(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 	{
 		addr := mustResourceInstanceAddr("module.child.aws_instance.bar")
@@ -2970,7 +2971,7 @@ func TestContext2Apply_moduleOrphanProvider(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
@@ -3011,7 +3012,7 @@ func TestContext2Apply_moduleOrphanGrandchildProvider(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
@@ -3045,7 +3046,7 @@ func TestContext2Apply_moduleGrandchildProvider(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
@@ -3079,7 +3080,7 @@ func TestContext2Apply_moduleOnlyProvider(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -3105,7 +3106,7 @@ func TestContext2Apply_moduleProviderAlias(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -3130,7 +3131,7 @@ func TestContext2Apply_moduleProviderAliasTargets(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Targets: []addrs.Targetable{
 			addrs.ConfigResource{
@@ -3181,7 +3182,7 @@ func TestContext2Apply_moduleProviderCloseNested(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	assertNoErrors(t, diags)
@@ -3219,7 +3220,7 @@ func TestContext2Apply_moduleVarRefExisting(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m)
@@ -3244,7 +3245,7 @@ func TestContext2Apply_moduleVarResourceCount(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.DestroyMode,
 		SetVariables: InputValues{
 			"num": &InputValue{
@@ -3264,7 +3265,7 @@ func TestContext2Apply_moduleVarResourceCount(t *testing.T) {
 		},
 	})
 
-	plan, diags = ctx.Plan(m, state, &PlanOpts{
+	plan, diags = ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"num": &InputValue{
@@ -3292,7 +3293,7 @@ func TestContext2Apply_moduleBool(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -3320,7 +3321,7 @@ func TestContext2Apply_moduleTarget(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Targets: []addrs.Targetable{
 			addrs.RootModuleInstance.Child("B", addrs.NoKey),
@@ -3374,7 +3375,7 @@ func TestContext2Apply_multiProvider(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -3438,7 +3439,7 @@ func TestContext2Apply_multiProviderDestroy(t *testing.T) {
 			},
 		})
 
-		plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
 		s, diags := ctx.Apply(plan, m)
@@ -3485,7 +3486,7 @@ func TestContext2Apply_multiProviderDestroy(t *testing.T) {
 			},
 		})
 
-		plan, diags := ctx.Plan(m, state, &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 			Mode: plans.DestroyMode,
 		})
 		assertNoErrors(t, diags)
@@ -3551,7 +3552,7 @@ func TestContext2Apply_multiProviderDestroyChild(t *testing.T) {
 			},
 		})
 
-		plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
 		s, diags := ctx.Apply(plan, m)
@@ -3600,7 +3601,7 @@ func TestContext2Apply_multiProviderDestroyChild(t *testing.T) {
 			},
 		})
 
-		plan, diags := ctx.Plan(m, state, &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 			Mode: plans.DestroyMode,
 		})
 		assertNoErrors(t, diags)
@@ -3634,7 +3635,7 @@ func TestContext2Apply_multiVar(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"num": &InputValue{
@@ -3666,7 +3667,7 @@ func TestContext2Apply_multiVar(t *testing.T) {
 			},
 		})
 
-		plan, diags := ctx.Plan(m, state, &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 			Mode: plans.NormalMode,
 			SetVariables: InputValues{
 				"num": &InputValue{
@@ -3771,7 +3772,7 @@ func TestContext2Apply_multiVarComprehensive(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"num": &InputValue{
@@ -3917,7 +3918,7 @@ func TestContext2Apply_multiVarOrder(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -3948,7 +3949,7 @@ func TestContext2Apply_multiVarOrderInterp(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -3983,7 +3984,7 @@ func TestContext2Apply_multiVarCountDec(t *testing.T) {
 		})
 
 		log.Print("\n========\nStep 1 Plan\n========")
-		plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 			Mode: plans.NormalMode,
 			SetVariables: InputValues{
 				"num": &InputValue{
@@ -4047,7 +4048,7 @@ func TestContext2Apply_multiVarCountDec(t *testing.T) {
 		})
 
 		log.Print("\n========\nStep 2 Plan\n========")
-		plan, diags := ctx.Plan(m, s, &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, s, &PlanOpts{
 			Mode: plans.NormalMode,
 			SetVariables: InputValues{
 				"num": &InputValue{
@@ -4098,7 +4099,7 @@ func TestContext2Apply_multiVarMissingState(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	// Before the relevant bug was fixed, OpenTofu would panic during apply.
@@ -4125,7 +4126,7 @@ func TestContext2Apply_outputOrphan(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m)
@@ -4153,7 +4154,7 @@ func TestContext2Apply_outputOrphanModule(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	s, diags := ctx.Apply(plan, m)
@@ -4183,7 +4184,7 @@ func TestContext2Apply_outputOrphanModule(t *testing.T) {
 	// created "s" above as the result of the previous apply, but I've preserved
 	// it to avoid changing the flow of this test in case that's important
 	// for some reason.
-	plan, diags = ctx.Plan(emptyConfig, state.DeepCopy(), DefaultPlanOpts)
+	plan, diags = ctx.Plan(context.Background(), emptyConfig, state.DeepCopy(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, emptyConfig)
@@ -4221,7 +4222,7 @@ func TestContext2Apply_providerComputedVar(t *testing.T) {
 		return
 	}
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
@@ -4249,7 +4250,7 @@ func TestContext2Apply_providerConfigureDisabled(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
@@ -4286,7 +4287,7 @@ func TestContext2Apply_provisionerModule(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -4333,7 +4334,7 @@ func TestContext2Apply_Provisioner_compute(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"value": &InputValue{
@@ -4391,7 +4392,7 @@ func TestContext2Apply_provisionerCreateFail(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -4426,7 +4427,7 @@ func TestContext2Apply_provisionerCreateFailNoId(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -4461,7 +4462,7 @@ func TestContext2Apply_provisionerFail(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -4508,7 +4509,7 @@ func TestContext2Apply_provisionerFail_createBeforeDestroy(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m)
@@ -4550,7 +4551,7 @@ func TestContext2Apply_error_createBeforeDestroy(t *testing.T) {
 	}
 	p.PlanResourceChangeFn = testDiffFn
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m)
@@ -4603,7 +4604,7 @@ func TestContext2Apply_errorDestroy_createBeforeDestroy(t *testing.T) {
 	}
 	p.PlanResourceChangeFn = testDiffFn
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m)
@@ -4673,7 +4674,7 @@ func TestContext2Apply_multiDepose_createBeforeDestroy(t *testing.T) {
 		}
 	}
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"require_new": &InputValue{
@@ -4703,7 +4704,7 @@ aws_instance.web: (1 deposed)
 		Providers: ps,
 	})
 
-	plan, diags = ctx.Plan(m, state, &PlanOpts{
+	plan, diags = ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"require_new": &InputValue{
@@ -4768,7 +4769,7 @@ aws_instance.web: (1 deposed)
 	ctx = testContext2(t, &ContextOpts{
 		Providers: ps,
 	})
-	plan, diags = ctx.Plan(m, state, &PlanOpts{
+	plan, diags = ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"require_new": &InputValue{
@@ -4803,7 +4804,7 @@ aws_instance.web: (1 deposed)
 	ctx = testContext2(t, &ContextOpts{
 		Providers: ps,
 	})
-	plan, diags = ctx.Plan(m, state, &PlanOpts{
+	plan, diags = ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"require_new": &InputValue{
@@ -4849,7 +4850,7 @@ func TestContext2Apply_provisionerFailContinue(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -4894,7 +4895,7 @@ func TestContext2Apply_provisionerFailContinueHook(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
@@ -4944,7 +4945,7 @@ func TestContext2Apply_provisionerDestroy(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.DestroyMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, state, SimplePlanOpts(plans.DestroyMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m)
@@ -4992,7 +4993,7 @@ func TestContext2Apply_provisionerDestroyFail(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.DestroyMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, state, SimplePlanOpts(plans.DestroyMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m)
@@ -5057,7 +5058,7 @@ func TestContext2Apply_provisionerDestroyFailContinue(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	assertNoErrors(t, diags)
@@ -5125,7 +5126,7 @@ func TestContext2Apply_provisionerDestroyFailContinueFail(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	assertNoErrors(t, diags)
@@ -5192,7 +5193,7 @@ func TestContext2Apply_provisionerDestroyTainted(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"input": &InputValue{
@@ -5253,7 +5254,7 @@ func TestContext2Apply_provisionerResourceRef(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -5297,7 +5298,7 @@ func TestContext2Apply_provisionerSelfRef(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -5348,7 +5349,7 @@ func TestContext2Apply_provisionerMultiSelfRef(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -5406,7 +5407,7 @@ func TestContext2Apply_provisionerMultiSelfRefSingle(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -5458,7 +5459,7 @@ func TestContext2Apply_provisionerExplicitSelfRef(t *testing.T) {
 			},
 		})
 
-		plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		if diags.HasErrors() {
 			t.Fatalf("diags: %s", diags.Err())
 		}
@@ -5484,7 +5485,7 @@ func TestContext2Apply_provisionerExplicitSelfRef(t *testing.T) {
 			},
 		})
 
-		plan, diags := ctx.Plan(m, state, &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 			Mode: plans.DestroyMode,
 		})
 		if diags.HasErrors() {
@@ -5524,7 +5525,7 @@ func TestContext2Apply_provisionerForEachSelfRef(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m)
@@ -5549,7 +5550,7 @@ func TestContext2Apply_Provisioner_Diff(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -5594,7 +5595,7 @@ func TestContext2Apply_Provisioner_Diff(t *testing.T) {
 		},
 	})
 
-	plan, diags = ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags = ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state2, diags := ctx.Apply(plan, m)
@@ -5664,7 +5665,7 @@ func TestContext2Apply_outputDiffVars(t *testing.T) {
 	//    return d, nil
 	// }
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m)
@@ -5684,7 +5685,7 @@ func TestContext2Apply_destroyX(t *testing.T) {
 	})
 
 	// First plan and apply a create operation
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -5701,7 +5702,7 @@ func TestContext2Apply_destroyX(t *testing.T) {
 		},
 	})
 
-	plan, diags = ctx.Plan(m, state, &PlanOpts{
+	plan, diags = ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	assertNoErrors(t, diags)
@@ -5739,7 +5740,7 @@ func TestContext2Apply_destroyOrder(t *testing.T) {
 	})
 
 	// First plan and apply a create operation
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -5758,7 +5759,7 @@ func TestContext2Apply_destroyOrder(t *testing.T) {
 		},
 	})
 
-	plan, diags = ctx.Plan(m, state, &PlanOpts{
+	plan, diags = ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	assertNoErrors(t, diags)
@@ -5797,7 +5798,7 @@ func TestContext2Apply_destroyModulePrefix(t *testing.T) {
 	})
 
 	// First plan and apply a create operation
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -5819,7 +5820,7 @@ func TestContext2Apply_destroyModulePrefix(t *testing.T) {
 		},
 	})
 
-	plan, diags = ctx.Plan(m, state, &PlanOpts{
+	plan, diags = ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	assertNoErrors(t, diags)
@@ -5859,7 +5860,7 @@ func TestContext2Apply_destroyNestedModule(t *testing.T) {
 	})
 
 	// First plan and apply a create operation
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	s, diags := ctx.Apply(plan, m)
@@ -5898,7 +5899,7 @@ func TestContext2Apply_destroyDeeplyNestedModule(t *testing.T) {
 	})
 
 	// First plan and apply a create operation
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	s, diags := ctx.Apply(plan, m)
@@ -5927,7 +5928,7 @@ func TestContext2Apply_destroyModuleWithAttrsReferencingResource(t *testing.T) {
 		})
 
 		// First plan and apply a create operation
-		plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		if diags.HasErrors() {
 			t.Fatalf("plan diags: %s", diags.Err())
 		} else {
@@ -5954,7 +5955,7 @@ func TestContext2Apply_destroyModuleWithAttrsReferencingResource(t *testing.T) {
 		})
 
 		// First plan and apply a create operation
-		plan, diags := ctx.Plan(m, state, &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 			Mode: plans.DestroyMode,
 		})
 		if diags.HasErrors() {
@@ -6005,7 +6006,7 @@ func TestContext2Apply_destroyWithModuleVariableAndCount(t *testing.T) {
 		})
 
 		// First plan and apply a create operation
-		plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
 		state, diags = ctx.Apply(plan, m)
@@ -6026,7 +6027,7 @@ func TestContext2Apply_destroyWithModuleVariableAndCount(t *testing.T) {
 		})
 
 		// First plan and apply a create operation
-		plan, diags := ctx.Plan(m, state, &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 			Mode: plans.DestroyMode,
 		})
 		if diags.HasErrors() {
@@ -6077,7 +6078,7 @@ func TestContext2Apply_destroyTargetWithModuleVariableAndCount(t *testing.T) {
 		})
 
 		// First plan and apply a create operation
-		plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
 		state, diags = ctx.Apply(plan, m)
@@ -6093,7 +6094,7 @@ func TestContext2Apply_destroyTargetWithModuleVariableAndCount(t *testing.T) {
 			},
 		})
 
-		plan, diags := ctx.Plan(m, state, &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 			Mode: plans.DestroyMode,
 			Targets: []addrs.Targetable{
 				addrs.RootModuleInstance.Child("child", addrs.NoKey),
@@ -6151,7 +6152,7 @@ func TestContext2Apply_destroyWithModuleVariableAndCountNested(t *testing.T) {
 		})
 
 		// First plan and apply a create operation
-		plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 		assertNoErrors(t, diags)
 
 		state, diags = ctx.Apply(plan, m)
@@ -6172,7 +6173,7 @@ func TestContext2Apply_destroyWithModuleVariableAndCountNested(t *testing.T) {
 		})
 
 		// First plan and apply a create operation
-		plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.DestroyMode, testInputValuesUnset(m.Module.Variables)))
+		plan, diags := ctx.Plan(context.Background(), m, state, SimplePlanOpts(plans.DestroyMode, testInputValuesUnset(m.Module.Variables)))
 		if diags.HasErrors() {
 			t.Fatalf("destroy plan err: %s", diags.Err())
 		}
@@ -6229,7 +6230,7 @@ func TestContext2Apply_destroyOutputs(t *testing.T) {
 	})
 
 	// First plan and apply a create operation
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -6245,7 +6246,7 @@ func TestContext2Apply_destroyOutputs(t *testing.T) {
 		},
 	})
 
-	plan, diags = ctx.Plan(m, state, &PlanOpts{
+	plan, diags = ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	assertNoErrors(t, diags)
@@ -6266,7 +6267,7 @@ func TestContext2Apply_destroyOutputs(t *testing.T) {
 			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 		},
 	})
-	plan, diags = ctx.Plan(m, state, &PlanOpts{
+	plan, diags = ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	assertNoErrors(t, diags)
@@ -6298,7 +6299,7 @@ func TestContext2Apply_destroyOrphan(t *testing.T) {
 
 	p.PlanResourceChangeFn = testDiffFn
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	s, diags := ctx.Apply(plan, m)
@@ -6339,7 +6340,7 @@ func TestContext2Apply_destroyTaintedProvisioner(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	assertNoErrors(t, diags)
@@ -6383,7 +6384,7 @@ func TestContext2Apply_error(t *testing.T) {
 	}
 	p.PlanResourceChangeFn = testDiffFn
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -6451,7 +6452,7 @@ func TestContext2Apply_errorDestroy(t *testing.T) {
 			addrs.NoKey,
 		)
 	})
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m)
@@ -6508,7 +6509,7 @@ func TestContext2Apply_errorCreateInvalidNew(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -6584,7 +6585,7 @@ func TestContext2Apply_errorUpdateNullNew(t *testing.T) {
 			addrs.NoKey,
 		)
 	})
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m)
@@ -6652,7 +6653,7 @@ func TestContext2Apply_errorPartial(t *testing.T) {
 	}
 	p.PlanResourceChangeFn = testDiffFn
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	s, diags := ctx.Apply(plan, m)
@@ -6684,7 +6685,7 @@ func TestContext2Apply_hook(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
@@ -6727,7 +6728,7 @@ func TestContext2Apply_hookOrphan(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
@@ -6757,7 +6758,7 @@ func TestContext2Apply_idAttr(t *testing.T) {
 	p.PlanResourceChangeFn = testDiffFn
 	p.ApplyResourceChangeFn = testApplyFn
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -6791,7 +6792,7 @@ func TestContext2Apply_outputBasic(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -6817,7 +6818,7 @@ func TestContext2Apply_outputAdd(t *testing.T) {
 		},
 	})
 
-	plan1, diags := ctx1.Plan(m1, states.NewState(), DefaultPlanOpts)
+	plan1, diags := ctx1.Plan(context.Background(), m1, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state1, diags := ctx1.Apply(plan1, m1)
@@ -6835,7 +6836,7 @@ func TestContext2Apply_outputAdd(t *testing.T) {
 		},
 	})
 
-	plan2, diags := ctx1.Plan(m2, state1, DefaultPlanOpts)
+	plan2, diags := ctx1.Plan(context.Background(), m2, state1, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state2, diags := ctx2.Apply(plan2, m2)
@@ -6861,7 +6862,7 @@ func TestContext2Apply_outputList(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -6887,7 +6888,7 @@ func TestContext2Apply_outputMulti(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -6913,7 +6914,7 @@ func TestContext2Apply_outputMultiIndex(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -6966,7 +6967,7 @@ func TestContext2Apply_taintX(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	} else {
@@ -7023,7 +7024,7 @@ func TestContext2Apply_taintDep(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	} else {
@@ -7076,7 +7077,7 @@ func TestContext2Apply_taintDepRequiresNew(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	} else {
@@ -7106,7 +7107,7 @@ func TestContext2Apply_targeted(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Targets: []addrs.Targetable{
 			addrs.RootModuleInstance.Resource(
@@ -7146,7 +7147,7 @@ func TestContext2Apply_targetedCount(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Targets: []addrs.Targetable{
 			addrs.RootModuleInstance.Resource(
@@ -7188,7 +7189,7 @@ func TestContext2Apply_targetedCountIndex(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Targets: []addrs.Targetable{
 			addrs.RootModuleInstance.ResourceInstance(
@@ -7230,7 +7231,7 @@ func TestContext2Apply_targetedDestroy(t *testing.T) {
 			t.Fatalf("validate errors: %s", diags.Err())
 		}
 
-		plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
 		state, diags = ctx.Apply(plan, m)
@@ -7246,7 +7247,7 @@ func TestContext2Apply_targetedDestroy(t *testing.T) {
 			},
 		})
 
-		plan, diags := ctx.Plan(m, state, &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 			Mode: plans.DestroyMode,
 			Targets: []addrs.Targetable{
 				addrs.RootModuleInstance.Resource(
@@ -7328,7 +7329,7 @@ func TestContext2Apply_targetedDestroyCountDeps(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 		Targets: []addrs.Targetable{
 			addrs.RootModuleInstance.Resource(
@@ -7398,7 +7399,7 @@ func TestContext2Apply_targetedDestroyModule(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 		Targets: []addrs.Targetable{
 			addrs.RootModuleInstance.Child("child", addrs.NoKey).Resource(
@@ -7487,7 +7488,7 @@ func TestContext2Apply_targetedDestroyCountIndex(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 		Targets: []addrs.Targetable{
 			addrs.RootModuleInstance.ResourceInstance(
@@ -7532,7 +7533,7 @@ func TestContext2Apply_targetedModule(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Targets: []addrs.Targetable{
 			addrs.RootModuleInstance.Child("child", addrs.NoKey),
@@ -7581,7 +7582,7 @@ func TestContext2Apply_targetedModuleDep(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Targets: []addrs.Targetable{
 			addrs.RootModuleInstance.Resource(
@@ -7640,7 +7641,7 @@ func TestContext2Apply_targetedModuleUnrelatedOutputs(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		Targets: []addrs.Targetable{
 			addrs.RootModuleInstance.Child("child2", addrs.NoKey),
@@ -7686,7 +7687,7 @@ func TestContext2Apply_targetedModuleResource(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Targets: []addrs.Targetable{
 			addrs.RootModuleInstance.Child("child", addrs.NoKey).Resource(
@@ -7741,7 +7742,7 @@ func TestContext2Apply_targetedResourceOrphanModule(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		Targets: []addrs.Targetable{
 			addrs.RootModuleInstance.Resource(
@@ -7802,7 +7803,7 @@ func TestContext2Apply_unknownAttribute(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -7827,7 +7828,7 @@ func TestContext2Apply_unknownAttributeInterpolate(t *testing.T) {
 		},
 	})
 
-	if _, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts); diags == nil {
+	if _, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts); diags == nil {
 		t.Fatal("should error")
 	}
 }
@@ -7877,7 +7878,7 @@ func TestContext2Apply_vars(t *testing.T) {
 		},
 	}
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode:         plans.NormalMode,
 		SetVariables: variables,
 	})
@@ -7928,7 +7929,7 @@ func TestContext2Apply_varsEnv(t *testing.T) {
 		},
 	}
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode:         plans.NormalMode,
 		SetVariables: variables,
 	})
@@ -8005,7 +8006,7 @@ func TestContext2Apply_createBefore_depends(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		logDiagnostics(t, diags)
 		t.Fatal("plan failed")
@@ -8135,7 +8136,7 @@ func TestContext2Apply_singleDestroy(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	h.Active = true
@@ -8173,7 +8174,7 @@ func TestContext2Apply_issue7824(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatalf("err: %s", diags.Err())
 	}
@@ -8229,7 +8230,7 @@ func TestContext2Apply_issue5254(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatalf("err: %s", diags.Err())
 	}
@@ -8248,7 +8249,7 @@ func TestContext2Apply_issue5254(t *testing.T) {
 		},
 	})
 
-	plan, diags = ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags = ctx.Plan(context.Background(), m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatalf("err: %s", diags.Err())
 	}
@@ -8319,7 +8320,7 @@ func TestContext2Apply_targetedWithTaintedInState(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		Targets: []addrs.Targetable{
 			addrs.RootModuleInstance.Resource(
@@ -8386,7 +8387,7 @@ func TestContext2Apply_ignoreChangesCreate(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	} else {
@@ -8500,7 +8501,7 @@ func TestContext2Apply_ignoreChangesWithDep(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state.DeepCopy(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state.DeepCopy(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	s, diags := ctx.Apply(plan, m)
@@ -8531,7 +8532,7 @@ func TestContext2Apply_ignoreChangesAll(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		logDiagnostics(t, diags)
 		t.Fatal("plan failed")
@@ -8576,7 +8577,7 @@ func TestContext2Apply_destroyNestedModuleWithAttrsReferencingResource(t *testin
 		})
 
 		// First plan and apply a create operation
-		plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
 		state, diags = ctx.Apply(plan, m)
@@ -8592,7 +8593,7 @@ func TestContext2Apply_destroyNestedModuleWithAttrsReferencingResource(t *testin
 			},
 		})
 
-		plan, diags := ctx.Plan(m, state, &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 			Mode: plans.DestroyMode,
 		})
 		if diags.HasErrors() {
@@ -8671,7 +8672,7 @@ resource "null_instance" "depends" {
 		}
 	}
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -8698,7 +8699,7 @@ resource "null_instance" "depends" {
 	}
 
 	// run another plan to make sure the data source doesn't show as a change
-	plan, diags = ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags = ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	for _, c := range plan.Changes.Resources {
@@ -8737,7 +8738,7 @@ resource "null_instance" "depends" {
 		},
 	})
 
-	plan, diags = ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags = ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	expectedChanges := map[string]plans.Action{
@@ -8765,7 +8766,7 @@ func TestContext2Apply_tfWorkspace(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -8792,7 +8793,7 @@ func TestContext2Apply_tofuWorkspace(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -8818,7 +8819,7 @@ func TestContext2Apply_multiRef(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -8843,7 +8844,7 @@ func TestContext2Apply_targetedModuleRecursive(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Targets: []addrs.Targetable{
 			addrs.RootModuleInstance.Child("child", addrs.NoKey),
@@ -8883,7 +8884,7 @@ func TestContext2Apply_localVal(t *testing.T) {
 		Providers: map[addrs.Provider]providers.Factory{},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -8928,7 +8929,7 @@ func TestContext2Apply_destroyWithLocals(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	assertNoErrors(t, diags)
@@ -8967,7 +8968,7 @@ func TestContext2Apply_providerWithLocals(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -8981,7 +8982,7 @@ func TestContext2Apply_providerWithLocals(t *testing.T) {
 		},
 	})
 
-	plan, diags = ctx.Plan(m, state, &PlanOpts{
+	plan, diags = ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	assertNoErrors(t, diags)
@@ -9024,7 +9025,7 @@ func TestContext2Apply_destroyWithProviders(t *testing.T) {
 	})
 
 	// test that we can't destroy if the provider is missing
-	if _, diags := ctx.Plan(m, state, &PlanOpts{Mode: plans.DestroyMode}); diags == nil {
+	if _, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{Mode: plans.DestroyMode}); diags == nil {
 		t.Fatal("expected plan error, provider.aws.baz doesn't exist")
 	}
 
@@ -9037,7 +9038,7 @@ func TestContext2Apply_destroyWithProviders(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	assertNoErrors(t, diags)
@@ -9131,7 +9132,7 @@ func TestContext2Apply_providersFromState(t *testing.T) {
 				},
 			})
 
-			plan, diags := ctx.Plan(m, tc.state, DefaultPlanOpts)
+			plan, diags := ctx.Plan(context.Background(), m, tc.state, DefaultPlanOpts)
 			if tc.err {
 				if diags == nil {
 					t.Fatal("expected error")
@@ -9180,7 +9181,7 @@ func TestContext2Apply_plannedInterpolatedCount(t *testing.T) {
 		Providers: Providers,
 	})
 
-	plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatalf("plan failed: %s", diags.Err())
 	}
@@ -9241,7 +9242,7 @@ func TestContext2Apply_plannedDestroyInterpolatedCount(t *testing.T) {
 		Providers: providers,
 	})
 
-	plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.DestroyMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, state, SimplePlanOpts(plans.DestroyMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatalf("plan failed: %s", diags.Err())
 	}
@@ -9305,7 +9306,7 @@ func TestContext2Apply_scaleInMultivarRef(t *testing.T) {
 		Providers: Providers,
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"instance_count": {
@@ -9392,7 +9393,7 @@ func TestContext2Apply_inconsistentWithPlan(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m)
@@ -9458,7 +9459,7 @@ func TestContext2Apply_issue19908(t *testing.T) {
 		)
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m)
@@ -9516,7 +9517,7 @@ func TestContext2Apply_invalidIndexRef(t *testing.T) {
 	}
 
 	wantErr := `The given key does not identify an element in this collection value`
-	_, diags = c.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags = c.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 
 	if !diags.HasErrors() {
 		t.Fatalf("plan succeeded; want error")
@@ -9767,7 +9768,7 @@ func TestContext2Apply_destroyDataCycle(t *testing.T) {
 		Providers: Providers,
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	diags.HasErrors()
@@ -9907,7 +9908,7 @@ func TestContext2Apply_taintedDestroyFailure(t *testing.T) {
 		Hooks:     []Hook{&testHook{}},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	diags.HasErrors()
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
@@ -10020,7 +10021,7 @@ func TestContext2Apply_plannedConnectionRefs(t *testing.T) {
 		Hooks:        []Hook{hook},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	diags.HasErrors()
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
@@ -10126,7 +10127,7 @@ func TestContext2Apply_cbdCycle(t *testing.T) {
 		Hooks:     []Hook{hook},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	diags.HasErrors()
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
@@ -10189,7 +10190,7 @@ func TestContext2Apply_ProviderMeta_apply_set(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m)
@@ -10269,7 +10270,7 @@ func TestContext2Apply_ProviderMeta_apply_unset(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m)
@@ -10318,7 +10319,7 @@ func TestContext2Apply_ProviderMeta_plan_set(t *testing.T) {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	if !p.PlanResourceChangeCalled {
@@ -10385,7 +10386,7 @@ func TestContext2Apply_ProviderMeta_plan_unset(t *testing.T) {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	if !p.PlanResourceChangeCalled {
@@ -10415,7 +10416,7 @@ func TestContext2Apply_ProviderMeta_plan_setNoSchema(t *testing.T) {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if !diags.HasErrors() {
 		t.Fatalf("plan supposed to error, has no errors")
 	}
@@ -10463,7 +10464,7 @@ func TestContext2Apply_ProviderMeta_plan_setInvalid(t *testing.T) {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if !diags.HasErrors() {
 		t.Fatalf("plan supposed to error, has no errors")
 	}
@@ -10525,7 +10526,7 @@ func TestContext2Apply_ProviderMeta_refresh_set(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -10594,7 +10595,7 @@ func TestContext2Apply_ProviderMeta_refresh_setNoSchema(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -10659,7 +10660,7 @@ func TestContext2Apply_ProviderMeta_refresh_setInvalid(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -10760,7 +10761,7 @@ func TestContext2Apply_ProviderMeta_refreshdata_set(t *testing.T) {
 		}
 	}
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -10851,7 +10852,7 @@ func TestContext2Apply_ProviderMeta_refreshdata_unset(t *testing.T) {
 		}
 	}
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	_, diags = ctx.Apply(plan, m)
@@ -11014,7 +11015,7 @@ output "out" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -11073,7 +11074,7 @@ resource "aws_instance" "cbd" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -11145,7 +11146,7 @@ func TestContext2Apply_moduleDependsOn(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -11155,7 +11156,7 @@ func TestContext2Apply_moduleDependsOn(t *testing.T) {
 		t.Fatal(diags.ErrWithWarnings())
 	}
 
-	plan, diags = ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags = ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -11202,7 +11203,7 @@ output "c" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -11218,7 +11219,7 @@ output "c" {
 		},
 	})
 
-	plan, diags = ctx.Plan(m, state, &PlanOpts{
+	plan, diags = ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	if diags.HasErrors() {
@@ -11269,7 +11270,7 @@ output "myoutput" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -11285,7 +11286,7 @@ output "myoutput" {
 		},
 	})
 
-	plan, diags = ctx.Plan(m, state, &PlanOpts{
+	plan, diags = ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	if diags.HasErrors() {
@@ -11425,7 +11426,7 @@ locals {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"ct": &InputValue{
@@ -11488,7 +11489,7 @@ locals {
 		},
 	})
 
-	plan, diags = ctx.Plan(m, state, &PlanOpts{
+	plan, diags = ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"ct": &InputValue{
@@ -11631,7 +11632,7 @@ func TestContext2Apply_destroyProviderReference(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -11647,7 +11648,7 @@ func TestContext2Apply_destroyProviderReference(t *testing.T) {
 		Providers: providers,
 	})
 
-	plan, diags = ctx.Plan(m, state, &PlanOpts{
+	plan, diags = ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	assertNoErrors(t, diags)
@@ -11738,7 +11739,7 @@ output "outputs" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -11753,7 +11754,7 @@ output "outputs" {
 			},
 		})
 
-		plan, diags = ctx.Plan(m, state, &PlanOpts{
+		plan, diags = ctx.Plan(context.Background(), m, state, &PlanOpts{
 			Mode: plans.DestroyMode,
 		})
 		assertNoErrors(t, diags)
@@ -11818,7 +11819,7 @@ resource "test_resource" "a" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"v": &InputValue{
@@ -11839,7 +11840,7 @@ resource "test_resource" "a" {
 		},
 	})
 
-	plan, diags = ctx.Plan(m, state, &PlanOpts{
+	plan, diags = ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"v": &InputValue{
@@ -11881,7 +11882,7 @@ resource "test_instance" "b" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"v": &InputValue{
@@ -11902,7 +11903,7 @@ resource "test_instance" "b" {
 		},
 	})
 
-	plan, diags = ctx.Plan(m, state, &PlanOpts{
+	plan, diags = ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"v": &InputValue{
@@ -11942,7 +11943,7 @@ resource "test_resource" "c" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"ct": &InputValue{
@@ -11963,7 +11964,7 @@ resource "test_resource" "c" {
 		},
 	})
 
-	plan, diags = ctx.Plan(m, state, &PlanOpts{
+	plan, diags = ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"ct": &InputValue{
@@ -12042,7 +12043,7 @@ resource "test_resource" "foo" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -12057,7 +12058,7 @@ resource "test_resource" "foo" {
 		},
 	})
 
-	plan, diags = ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags = ctx.Plan(context.Background(), m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	state, diags = ctx.Apply(plan, m)
@@ -12072,7 +12073,7 @@ resource "test_resource" "foo" {
 		},
 	})
 
-	plan, diags = ctx.Plan(m, state, &PlanOpts{
+	plan, diags = ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"sensitive_id": &InputValue{Value: cty.NilVal},
@@ -12115,7 +12116,7 @@ resource "test_resource" "foo" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatalf("plan errors: %s", diags.Err())
 	}
@@ -12191,7 +12192,7 @@ resource "test_resource" "baz" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("plan errors: %s", diags.Err())
 	}
@@ -12299,7 +12300,7 @@ resource "test_resource" "foo" {
 		)
 	})
 
-	plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	addr := mustResourceInstanceAddr("test_resource.foo")
@@ -12357,7 +12358,7 @@ resource "test_resource" "foo" {
 		},
 	})
 
-	_, diags = newCtx.Plan(newModule, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	_, diags = newCtx.Plan(context.Background(), newModule, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 	stateWithoutSensitive, diags := newCtx.Apply(plan, newModule)
 	assertNoErrors(t, diags)
@@ -12404,7 +12405,7 @@ output "out" {
 
 	ctx := testContext2(t, &ContextOpts{})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"in": &InputValue{
@@ -12473,7 +12474,7 @@ output "out" {
 
 	// We don't specify a value for the variable here, relying on its defined
 	// default.
-	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -12523,7 +12524,7 @@ output "out" {
 
 	// We don't specify a value for the variable here, relying on its defined
 	// default.
-	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -12586,7 +12587,7 @@ output "out" {
 
 	// We don't specify a value for the variable here, relying on its defined
 	// default.
-	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -12640,7 +12641,7 @@ func TestContext2Apply_provisionerSensitive(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"password": &InputValue{
@@ -12706,7 +12707,7 @@ resource "test_resource" "foo" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	state, diags := ctx.Apply(plan, m)
@@ -12751,7 +12752,7 @@ resource "test_instance" "a" {
 			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 		},
 	})
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -12793,7 +12794,7 @@ func TestContext2Apply_dataSensitive(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	} else {
@@ -12848,7 +12849,7 @@ func TestContext2Apply_errorRestorePrivateData(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -12893,7 +12894,7 @@ func TestContext2Apply_errorRestoreStatus(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -12955,7 +12956,7 @@ resource "test_object" "a" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -12991,7 +12992,7 @@ resource "test_object" "a" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}

--- a/internal/tofu/context_apply_test.go
+++ b/internal/tofu/context_apply_test.go
@@ -10532,7 +10532,7 @@ func TestContext2Apply_ProviderMeta_refresh_set(t *testing.T) {
 	state, diags := ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
-	_, diags = ctx.Refresh(m, state, DefaultPlanOpts)
+	_, diags = ctx.Refresh(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	if !p.ReadResourceCalled {
@@ -10610,7 +10610,7 @@ func TestContext2Apply_ProviderMeta_refresh_setNoSchema(t *testing.T) {
 		},
 	})
 
-	_, diags = ctx.Refresh(m, state, DefaultPlanOpts)
+	_, diags = ctx.Refresh(context.Background(), m, state, DefaultPlanOpts)
 	if !diags.HasErrors() {
 		t.Fatalf("refresh supposed to error, has no errors")
 	}
@@ -10682,7 +10682,7 @@ func TestContext2Apply_ProviderMeta_refresh_setInvalid(t *testing.T) {
 		},
 	})
 
-	_, diags = ctx.Refresh(m, state, DefaultPlanOpts)
+	_, diags = ctx.Refresh(context.Background(), m, state, DefaultPlanOpts)
 	if !diags.HasErrors() {
 		t.Fatalf("refresh supposed to error, has no errors")
 	}
@@ -10767,7 +10767,7 @@ func TestContext2Apply_ProviderMeta_refreshdata_set(t *testing.T) {
 	state, diags := ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
-	_, diags = ctx.Refresh(m, state, DefaultPlanOpts)
+	_, diags = ctx.Refresh(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	if !p.ReadDataSourceCalled {
@@ -10891,7 +10891,7 @@ func TestContext2Apply_ProviderMeta_refreshdata_setNoSchema(t *testing.T) {
 		}),
 	}
 
-	_, diags := ctx.Refresh(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Refresh(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if !diags.HasErrors() {
 		t.Fatalf("refresh supposed to error, has no errors")
 	}
@@ -10945,7 +10945,7 @@ func TestContext2Apply_ProviderMeta_refreshdata_setInvalid(t *testing.T) {
 		}),
 	}
 
-	_, diags := ctx.Refresh(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Refresh(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if !diags.HasErrors() {
 		t.Fatalf("refresh supposed to error, has no errors")
 	}

--- a/internal/tofu/context_apply_test.go
+++ b/internal/tofu/context_apply_test.go
@@ -53,7 +53,7 @@ func TestContext2Apply_basic(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -155,7 +155,7 @@ func TestContext2Apply_stop(t *testing.T) {
 	// We'll apply in the background so that we can call Stop in the foreground.
 	stateCh := make(chan *states.State)
 	go func(plan *plans.Plan) {
-		state, _ := ctx.Apply(plan, m)
+		state, _ := ctx.Apply(context.Background(), plan, m)
 		stateCh <- state
 	}(plan)
 
@@ -286,7 +286,7 @@ func TestContext2Apply_unstable(t *testing.T) {
 		t.Fatalf("Attribute 'random' has known value %#v; should be unknown in plan", rd.After.GetAttr("random"))
 	}
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error during Apply: %s", diags.Err())
 	}
@@ -325,7 +325,7 @@ func TestContext2Apply_escape(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -353,7 +353,7 @@ func TestContext2Apply_resourceCountOneList(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	assertNoDiagnostics(t, diags)
 
 	got := strings.TrimSpace(state.String())
@@ -381,7 +381,7 @@ func TestContext2Apply_resourceCountZeroList(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -434,7 +434,7 @@ func TestContext2Apply_resourceDependsOnModule(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -508,7 +508,7 @@ func TestContext2Apply_resourceDependsOnModuleStateOnly(t *testing.T) {
 		plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
-		state, diags := ctx.Apply(plan, m)
+		state, diags := ctx.Apply(context.Background(), plan, m)
 		assertNoErrors(t, diags)
 
 		if !reflect.DeepEqual(order, []string{"child", "parent"}) {
@@ -535,7 +535,7 @@ func TestContext2Apply_resourceDependsOnModuleDestroy(t *testing.T) {
 		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
-		state, diags := ctx.Apply(plan, m)
+		state, diags := ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("diags: %s", diags.Err())
 		}
@@ -578,7 +578,7 @@ func TestContext2Apply_resourceDependsOnModuleDestroy(t *testing.T) {
 		})
 		assertNoErrors(t, diags)
 
-		state, diags := ctx.Apply(plan, m)
+		state, diags := ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("diags: %s", diags.Err())
 		}
@@ -629,7 +629,7 @@ func TestContext2Apply_resourceDependsOnModuleGrandchild(t *testing.T) {
 		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
-		state, diags := ctx.Apply(plan, m)
+		state, diags := ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("diags: %s", diags.Err())
 		}
@@ -680,7 +680,7 @@ func TestContext2Apply_resourceDependsOnModuleInModule(t *testing.T) {
 		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
-		state, diags := ctx.Apply(plan, m)
+		state, diags := ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("diags: %s", diags.Err())
 		}
@@ -707,7 +707,7 @@ func TestContext2Apply_mapVarBetweenModules(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -745,7 +745,7 @@ func TestContext2Apply_refCount(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -782,7 +782,7 @@ func TestContext2Apply_providerAlias(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -850,7 +850,7 @@ func TestContext2Apply_providerAliasConfigure(t *testing.T) {
 		},
 	})
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -885,7 +885,7 @@ func TestContext2Apply_providerWarning(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -920,7 +920,7 @@ func TestContext2Apply_emptyModule(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -962,7 +962,7 @@ func TestContext2Apply_createBeforeDestroy(t *testing.T) {
 		t.Logf(legacyDiffComparisonString(plan.Changes))
 	}
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -1044,7 +1044,7 @@ func TestContext2Apply_createBeforeDestroyUpdate(t *testing.T) {
 		t.Logf(legacyDiffComparisonString(plan.Changes))
 	}
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -1103,7 +1103,7 @@ func TestContext2Apply_createBeforeDestroy_dependsNonCBD(t *testing.T) {
 		t.Logf(legacyDiffComparisonString(plan.Changes))
 	}
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -1168,7 +1168,7 @@ func TestContext2Apply_createBeforeDestroy_hook(t *testing.T) {
 		t.Logf(legacyDiffComparisonString(plan.Changes))
 	}
 
-	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
+	if _, diags := ctx.Apply(context.Background(), plan, m); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
 
@@ -1248,7 +1248,7 @@ func TestContext2Apply_createBeforeDestroy_deposedCount(t *testing.T) {
 		t.Logf(legacyDiffComparisonString(plan.Changes))
 	}
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -1310,7 +1310,7 @@ func TestContext2Apply_createBeforeDestroy_deposedOnly(t *testing.T) {
 		t.Logf(legacyDiffComparisonString(plan.Changes))
 	}
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -1354,7 +1354,7 @@ func TestContext2Apply_destroyComputed(t *testing.T) {
 		t.Logf("plan:\n\n%s", legacyDiffComparisonString(plan.Changes))
 	}
 
-	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
+	if _, diags := ctx.Apply(context.Background(), plan, m); diags.HasErrors() {
 		logDiagnostics(t, diags)
 		t.Fatal("apply failed")
 	}
@@ -1420,7 +1420,7 @@ func testContext2Apply_destroyDependsOn(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
+	if _, diags := ctx.Apply(context.Background(), plan, m); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
 
@@ -1516,7 +1516,7 @@ func testContext2Apply_destroyDependsOnStateOnly(t *testing.T, state *states.Sta
 	})
 	assertNoErrors(t, diags)
 
-	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
+	if _, diags := ctx.Apply(context.Background(), plan, m); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
 
@@ -1613,7 +1613,7 @@ func testContext2Apply_destroyDependsOnStateOnlyModule(t *testing.T, state *stat
 	})
 	assertNoErrors(t, diags)
 
-	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
+	if _, diags := ctx.Apply(context.Background(), plan, m); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
 
@@ -1649,7 +1649,7 @@ func TestContext2Apply_dataBasic(t *testing.T) {
 		t.Logf(legacyDiffComparisonString(plan.Changes))
 	}
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	actual := strings.TrimSpace(state.String())
@@ -1705,7 +1705,7 @@ func TestContext2Apply_destroyData(t *testing.T) {
 		t.Logf(legacyDiffComparisonString(plan.Changes))
 	}
 
-	newState, diags := ctx.Apply(plan, m)
+	newState, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -1772,7 +1772,7 @@ func TestContext2Apply_destroySkipsCBD(t *testing.T) {
 		t.Logf(legacyDiffComparisonString(plan.Changes))
 	}
 
-	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
+	if _, diags := ctx.Apply(context.Background(), plan, m); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
 }
@@ -1806,7 +1806,7 @@ func TestContext2Apply_destroyModuleVarProviderConfig(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -1854,7 +1854,7 @@ func TestContext2Apply_destroyCrossProviders(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
+	if _, diags := ctx.Apply(context.Background(), plan, m); diags.HasErrors() {
 		logDiagnostics(t, diags)
 		t.Fatal("apply failed")
 	}
@@ -1904,7 +1904,7 @@ func TestContext2Apply_minimal(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -1950,7 +1950,7 @@ func TestContext2Apply_cancel(t *testing.T) {
 	var applyDiags tfdiags.Diagnostics
 	stateCh := make(chan *states.State)
 	go func() {
-		state, diags := ctx.Apply(plan, m)
+		state, diags := ctx.Apply(context.Background(), plan, m)
 		applyDiags = diags
 
 		stateCh <- state
@@ -2012,7 +2012,7 @@ func TestContext2Apply_cancelBlock(t *testing.T) {
 	var applyDiags tfdiags.Diagnostics
 	stateCh := make(chan *states.State)
 	go func() {
-		state, diags := ctx.Apply(plan, m)
+		state, diags := ctx.Apply(context.Background(), plan, m)
 		applyDiags = diags
 
 		stateCh <- state
@@ -2109,7 +2109,7 @@ func TestContext2Apply_cancelProvisioner(t *testing.T) {
 	var applyDiags tfdiags.Diagnostics
 	stateCh := make(chan *states.State)
 	go func() {
-		state, diags := ctx.Apply(plan, m)
+		state, diags := ctx.Apply(context.Background(), plan, m)
 		applyDiags = diags
 
 		stateCh <- state
@@ -2201,7 +2201,7 @@ func TestContext2Apply_compute(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -2257,7 +2257,7 @@ func TestContext2Apply_countDecrease(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	s, diags := ctx.Apply(plan, m)
+	s, diags := ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	actual := strings.TrimSpace(s.String())
@@ -2310,7 +2310,7 @@ func TestContext2Apply_countDecreaseToOneX(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	s, diags := ctx.Apply(plan, m)
+	s, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -2405,7 +2405,7 @@ func TestContext2Apply_countDecreaseToOneCorrupted(t *testing.T) {
 		}
 	}
 
-	s, diags := ctx.Apply(plan, m)
+	s, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -2458,7 +2458,7 @@ CREATE: aws_instance.foo[1]
 		}
 	}
 
-	s, diags := ctx.Apply(plan, m)
+	s, diags := ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	got := strings.TrimSpace(s.String())
@@ -2493,7 +2493,7 @@ func TestContext2Apply_countVariable(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -2519,7 +2519,7 @@ func TestContext2Apply_countVariableRef(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -2573,7 +2573,7 @@ func TestContext2Apply_provisionerInterpCount(t *testing.T) {
 	}
 
 	// Applying the plan should now succeed
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("apply failed unexpectedly: %s", diags.Err())
 	}
@@ -2605,7 +2605,7 @@ func TestContext2Apply_foreachVariable(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -2631,7 +2631,7 @@ func TestContext2Apply_moduleBasic(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -2714,7 +2714,7 @@ func TestContext2Apply_moduleDestroyOrder(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -2762,7 +2762,7 @@ func TestContext2Apply_moduleInheritAlias(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -2807,7 +2807,7 @@ func TestContext2Apply_orphanResource(t *testing.T) {
 	})
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	// At this point both resources should be recorded in the state, along
@@ -2856,7 +2856,7 @@ func TestContext2Apply_orphanResource(t *testing.T) {
 		}
 	}
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	// The state should now be _totally_ empty, with just an empty root module
@@ -2926,7 +2926,7 @@ func TestContext2Apply_moduleOrphanInheritAlias(t *testing.T) {
 		}
 	}
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -2974,7 +2974,7 @@ func TestContext2Apply_moduleOrphanProvider(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
+	if _, diags := ctx.Apply(context.Background(), plan, m); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
 }
@@ -3015,7 +3015,7 @@ func TestContext2Apply_moduleOrphanGrandchildProvider(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
+	if _, diags := ctx.Apply(context.Background(), plan, m); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
 }
@@ -3049,7 +3049,7 @@ func TestContext2Apply_moduleGrandchildProvider(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
+	if _, diags := ctx.Apply(context.Background(), plan, m); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
 
@@ -3083,7 +3083,7 @@ func TestContext2Apply_moduleOnlyProvider(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -3109,7 +3109,7 @@ func TestContext2Apply_moduleProviderAlias(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -3146,7 +3146,7 @@ func TestContext2Apply_moduleProviderAliasTargets(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -3187,7 +3187,7 @@ func TestContext2Apply_moduleProviderCloseNested(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
+	if _, diags := ctx.Apply(context.Background(), plan, m); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
 }
@@ -3223,7 +3223,7 @@ func TestContext2Apply_moduleVarRefExisting(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -3256,7 +3256,7 @@ func TestContext2Apply_moduleVarResourceCount(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	ctx = testContext2(t, &ContextOpts{
@@ -3276,7 +3276,7 @@ func TestContext2Apply_moduleVarResourceCount(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
+	if _, diags := ctx.Apply(context.Background(), plan, m); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
 }
@@ -3296,7 +3296,7 @@ func TestContext2Apply_moduleBool(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -3329,7 +3329,7 @@ func TestContext2Apply_moduleTarget(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -3378,7 +3378,7 @@ func TestContext2Apply_multiProvider(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -3442,7 +3442,7 @@ func TestContext2Apply_multiProviderDestroy(t *testing.T) {
 		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
-		s, diags := ctx.Apply(plan, m)
+		s, diags := ctx.Apply(context.Background(), plan, m)
 		assertNoErrors(t, diags)
 
 		state = s
@@ -3491,7 +3491,7 @@ func TestContext2Apply_multiProviderDestroy(t *testing.T) {
 		})
 		assertNoErrors(t, diags)
 
-		s, diags := ctx.Apply(plan, m)
+		s, diags := ctx.Apply(context.Background(), plan, m)
 		assertNoErrors(t, diags)
 
 		if !checked {
@@ -3555,7 +3555,7 @@ func TestContext2Apply_multiProviderDestroyChild(t *testing.T) {
 		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
-		s, diags := ctx.Apply(plan, m)
+		s, diags := ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("diags: %s", diags.Err())
 		}
@@ -3606,7 +3606,7 @@ func TestContext2Apply_multiProviderDestroyChild(t *testing.T) {
 		})
 		assertNoErrors(t, diags)
 
-		s, diags := ctx.Apply(plan, m)
+		s, diags := ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("diags: %s", diags.Err())
 		}
@@ -3646,7 +3646,7 @@ func TestContext2Apply_multiVar(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -3678,7 +3678,7 @@ func TestContext2Apply_multiVar(t *testing.T) {
 		})
 		assertNoErrors(t, diags)
 
-		state, diags := ctx.Apply(plan, m)
+		state, diags := ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("diags: %s", diags.Err())
 		}
@@ -3878,7 +3878,7 @@ func TestContext2Apply_multiVarComprehensive(t *testing.T) {
 	}))
 
 	t.Run("apply", func(t *testing.T) {
-		state, diags := ctx.Apply(plan, m)
+		state, diags := ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("error during apply: %s", diags.Err())
 		}
@@ -3921,7 +3921,7 @@ func TestContext2Apply_multiVarOrder(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -3952,7 +3952,7 @@ func TestContext2Apply_multiVarOrderInterp(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -3996,7 +3996,7 @@ func TestContext2Apply_multiVarCountDec(t *testing.T) {
 		assertNoErrors(t, diags)
 
 		log.Print("\n========\nStep 1 Apply\n========")
-		state, diags := ctx.Apply(plan, m)
+		state, diags := ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("diags: %s", diags.Err())
 		}
@@ -4062,7 +4062,7 @@ func TestContext2Apply_multiVarCountDec(t *testing.T) {
 		t.Logf("Step 2 plan:\n%s", legacyDiffComparisonString(plan.Changes))
 
 		log.Print("\n========\nStep 2 Apply\n========")
-		_, diags = ctx.Apply(plan, m)
+		_, diags = ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("apply errors: %s", diags.Err())
 		}
@@ -4103,7 +4103,7 @@ func TestContext2Apply_multiVarMissingState(t *testing.T) {
 	assertNoErrors(t, diags)
 
 	// Before the relevant bug was fixed, OpenTofu would panic during apply.
-	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
+	if _, diags := ctx.Apply(context.Background(), plan, m); diags.HasErrors() {
 		t.Fatalf("apply failed: %s", diags.Err())
 	}
 
@@ -4129,7 +4129,7 @@ func TestContext2Apply_outputOrphan(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -4157,7 +4157,7 @@ func TestContext2Apply_outputOrphanModule(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	s, diags := ctx.Apply(plan, m)
+	s, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -4187,7 +4187,7 @@ func TestContext2Apply_outputOrphanModule(t *testing.T) {
 	plan, diags = ctx.Plan(context.Background(), emptyConfig, state.DeepCopy(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, emptyConfig)
+	state, diags = ctx.Apply(context.Background(), plan, emptyConfig)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -4225,7 +4225,7 @@ func TestContext2Apply_providerComputedVar(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
+	if _, diags := ctx.Apply(context.Background(), plan, m); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
 }
@@ -4253,7 +4253,7 @@ func TestContext2Apply_providerConfigureDisabled(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
+	if _, diags := ctx.Apply(context.Background(), plan, m); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
 
@@ -4290,7 +4290,7 @@ func TestContext2Apply_provisionerModule(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -4345,7 +4345,7 @@ func TestContext2Apply_Provisioner_compute(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -4395,7 +4395,7 @@ func TestContext2Apply_provisionerCreateFail(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags == nil {
 		t.Fatal("should error")
 	}
@@ -4430,7 +4430,7 @@ func TestContext2Apply_provisionerCreateFailNoId(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags == nil {
 		t.Fatal("should error")
 	}
@@ -4465,7 +4465,7 @@ func TestContext2Apply_provisionerFail(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags == nil {
 		t.Fatal("should error")
 	}
@@ -4512,7 +4512,7 @@ func TestContext2Apply_provisionerFail_createBeforeDestroy(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if !diags.HasErrors() {
 		t.Fatal("should error")
 	}
@@ -4554,7 +4554,7 @@ func TestContext2Apply_error_createBeforeDestroy(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if !diags.HasErrors() {
 		t.Fatal("should have error")
 	}
@@ -4607,7 +4607,7 @@ func TestContext2Apply_errorDestroy_createBeforeDestroy(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if !diags.HasErrors() {
 		t.Fatal("should have error")
 	}
@@ -4686,7 +4686,7 @@ func TestContext2Apply_multiDepose_createBeforeDestroy(t *testing.T) {
 
 	// Destroy is broken, so even though CBD successfully replaces the instance,
 	// we'll have to save the Deposed instance to destroy later
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if !diags.HasErrors() {
 		t.Fatal("should have error")
 	}
@@ -4716,7 +4716,7 @@ aws_instance.web: (1 deposed)
 
 	// We're replacing the primary instance once again. Destroy is _still_
 	// broken, so the Deposed list gets longer
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if !diags.HasErrors() {
 		t.Fatal("should have error")
 	}
@@ -4779,7 +4779,7 @@ aws_instance.web: (1 deposed)
 	})
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	// Expect error because 1/2 of Deposed destroys failed
 	if !diags.HasErrors() {
 		t.Fatal("should have error")
@@ -4813,7 +4813,7 @@ aws_instance.web: (1 deposed)
 		},
 	})
 	assertNoErrors(t, diags)
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatal("should not have error:", diags.Err())
 	}
@@ -4853,7 +4853,7 @@ func TestContext2Apply_provisionerFailContinue(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -4898,7 +4898,7 @@ func TestContext2Apply_provisionerFailContinueHook(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
+	if _, diags := ctx.Apply(context.Background(), plan, m); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
 
@@ -4948,7 +4948,7 @@ func TestContext2Apply_provisionerDestroy(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, state, SimplePlanOpts(plans.DestroyMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -4996,7 +4996,7 @@ func TestContext2Apply_provisionerDestroyFail(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, state, SimplePlanOpts(plans.DestroyMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags == nil {
 		t.Fatal("should error")
 	}
@@ -5063,7 +5063,7 @@ func TestContext2Apply_provisionerDestroyFailContinue(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -5131,7 +5131,7 @@ func TestContext2Apply_provisionerDestroyFailContinueFail(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags == nil {
 		t.Fatal("apply succeeded; wanted error from second provisioner")
 	}
@@ -5206,7 +5206,7 @@ func TestContext2Apply_provisionerDestroyTainted(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -5257,7 +5257,7 @@ func TestContext2Apply_provisionerResourceRef(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -5301,7 +5301,7 @@ func TestContext2Apply_provisionerSelfRef(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -5352,7 +5352,7 @@ func TestContext2Apply_provisionerMultiSelfRef(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -5410,7 +5410,7 @@ func TestContext2Apply_provisionerMultiSelfRefSingle(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -5464,7 +5464,7 @@ func TestContext2Apply_provisionerExplicitSelfRef(t *testing.T) {
 			t.Fatalf("diags: %s", diags.Err())
 		}
 
-		state, diags = ctx.Apply(plan, m)
+		state, diags = ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("diags: %s", diags.Err())
 		}
@@ -5492,7 +5492,7 @@ func TestContext2Apply_provisionerExplicitSelfRef(t *testing.T) {
 			t.Fatalf("diags: %s", diags.Err())
 		}
 
-		state, diags = ctx.Apply(plan, m)
+		state, diags = ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("diags: %s", diags.Err())
 		}
@@ -5528,7 +5528,7 @@ func TestContext2Apply_provisionerForEachSelfRef(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -5553,7 +5553,7 @@ func TestContext2Apply_Provisioner_Diff(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		logDiagnostics(t, diags)
 		t.Fatal("apply failed")
@@ -5598,7 +5598,7 @@ func TestContext2Apply_Provisioner_Diff(t *testing.T) {
 	plan, diags = ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state2, diags := ctx.Apply(plan, m)
+	state2, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		logDiagnostics(t, diags)
 		t.Fatal("apply failed")
@@ -5668,7 +5668,7 @@ func TestContext2Apply_outputDiffVars(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 }
 
@@ -5688,7 +5688,7 @@ func TestContext2Apply_destroyX(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -5707,7 +5707,7 @@ func TestContext2Apply_destroyX(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -5743,7 +5743,7 @@ func TestContext2Apply_destroyOrder(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -5764,7 +5764,7 @@ func TestContext2Apply_destroyOrder(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -5801,7 +5801,7 @@ func TestContext2Apply_destroyModulePrefix(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -5825,7 +5825,7 @@ func TestContext2Apply_destroyModulePrefix(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -5863,7 +5863,7 @@ func TestContext2Apply_destroyNestedModule(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	s, diags := ctx.Apply(plan, m)
+	s, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -5902,7 +5902,7 @@ func TestContext2Apply_destroyDeeplyNestedModule(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	s, diags := ctx.Apply(plan, m)
+	s, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -5935,7 +5935,7 @@ func TestContext2Apply_destroyModuleWithAttrsReferencingResource(t *testing.T) {
 			t.Logf("Step 1 plan: %s", legacyDiffComparisonString(plan.Changes))
 		}
 
-		state, diags = ctx.Apply(plan, m)
+		state, diags = ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("apply errs: %s", diags.Err())
 		}
@@ -5978,7 +5978,7 @@ func TestContext2Apply_destroyModuleWithAttrsReferencingResource(t *testing.T) {
 			t.Fatalf("err: %s", diags.Err())
 		}
 
-		state, diags = ctx.Apply(plan, m)
+		state, diags = ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("destroy apply err: %s", diags.Err())
 		}
@@ -6009,7 +6009,7 @@ func TestContext2Apply_destroyWithModuleVariableAndCount(t *testing.T) {
 		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
-		state, diags = ctx.Apply(plan, m)
+		state, diags = ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("apply err: %s", diags.Err())
 		}
@@ -6049,7 +6049,7 @@ func TestContext2Apply_destroyWithModuleVariableAndCount(t *testing.T) {
 			t.Fatalf("err: %s", diags.Err())
 		}
 
-		state, diags = ctx.Apply(plan, m)
+		state, diags = ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("destroy apply err: %s", diags.Err())
 		}
@@ -6081,7 +6081,7 @@ func TestContext2Apply_destroyTargetWithModuleVariableAndCount(t *testing.T) {
 		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
-		state, diags = ctx.Apply(plan, m)
+		state, diags = ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("apply err: %s", diags.Err())
 		}
@@ -6115,7 +6115,7 @@ func TestContext2Apply_destroyTargetWithModuleVariableAndCount(t *testing.T) {
 		}
 
 		// Destroy, targeting the module explicitly
-		state, diags = ctx.Apply(plan, m)
+		state, diags = ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("destroy apply err: %s", diags)
 		}
@@ -6155,7 +6155,7 @@ func TestContext2Apply_destroyWithModuleVariableAndCountNested(t *testing.T) {
 		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 		assertNoErrors(t, diags)
 
-		state, diags = ctx.Apply(plan, m)
+		state, diags = ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("apply err: %s", diags.Err())
 		}
@@ -6193,7 +6193,7 @@ func TestContext2Apply_destroyWithModuleVariableAndCountNested(t *testing.T) {
 			t.Fatalf("err: %s", diags.Err())
 		}
 
-		state, diags = ctx.Apply(plan, m)
+		state, diags = ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("destroy apply err: %s", diags.Err())
 		}
@@ -6233,7 +6233,7 @@ func TestContext2Apply_destroyOutputs(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
@@ -6251,7 +6251,7 @@ func TestContext2Apply_destroyOutputs(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -6272,7 +6272,7 @@ func TestContext2Apply_destroyOutputs(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
+	if _, diags := ctx.Apply(context.Background(), plan, m); diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
 }
@@ -6302,7 +6302,7 @@ func TestContext2Apply_destroyOrphan(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	s, diags := ctx.Apply(plan, m)
+	s, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -6345,7 +6345,7 @@ func TestContext2Apply_destroyTaintedProvisioner(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	s, diags := ctx.Apply(plan, m)
+	s, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -6387,7 +6387,7 @@ func TestContext2Apply_error(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags == nil {
 		t.Fatal("should have error")
 	}
@@ -6455,7 +6455,7 @@ func TestContext2Apply_errorDestroy(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if !diags.HasErrors() {
 		t.Fatal("should have error")
 	}
@@ -6512,7 +6512,7 @@ func TestContext2Apply_errorCreateInvalidNew(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags == nil {
 		t.Fatal("should have error")
 	}
@@ -6588,7 +6588,7 @@ func TestContext2Apply_errorUpdateNullNew(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if !diags.HasErrors() {
 		t.Fatal("should have error")
 	}
@@ -6656,7 +6656,7 @@ func TestContext2Apply_errorPartial(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	s, diags := ctx.Apply(plan, m)
+	s, diags := ctx.Apply(context.Background(), plan, m)
 	if diags == nil {
 		t.Fatal("should have error")
 	}
@@ -6688,7 +6688,7 @@ func TestContext2Apply_hook(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
+	if _, diags := ctx.Apply(context.Background(), plan, m); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
 
@@ -6731,7 +6731,7 @@ func TestContext2Apply_hookOrphan(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
+	if _, diags := ctx.Apply(context.Background(), plan, m); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
 
@@ -6761,7 +6761,7 @@ func TestContext2Apply_idAttr(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
@@ -6795,7 +6795,7 @@ func TestContext2Apply_outputBasic(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -6821,7 +6821,7 @@ func TestContext2Apply_outputAdd(t *testing.T) {
 	plan1, diags := ctx1.Plan(context.Background(), m1, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state1, diags := ctx1.Apply(plan1, m1)
+	state1, diags := ctx1.Apply(context.Background(), plan1, m1)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -6839,7 +6839,7 @@ func TestContext2Apply_outputAdd(t *testing.T) {
 	plan2, diags := ctx1.Plan(context.Background(), m2, state1, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state2, diags := ctx2.Apply(plan2, m2)
+	state2, diags := ctx2.Apply(context.Background(), plan2, m2)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -6865,7 +6865,7 @@ func TestContext2Apply_outputList(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -6891,7 +6891,7 @@ func TestContext2Apply_outputMulti(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -6917,7 +6917,7 @@ func TestContext2Apply_outputMultiIndex(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -6974,7 +6974,7 @@ func TestContext2Apply_taintX(t *testing.T) {
 		t.Logf("plan: %s", legacyDiffComparisonString(plan.Changes))
 	}
 
-	s, diags := ctx.Apply(plan, m)
+	s, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -7031,7 +7031,7 @@ func TestContext2Apply_taintDep(t *testing.T) {
 		t.Logf("plan: %s", legacyDiffComparisonString(plan.Changes))
 	}
 
-	s, diags := ctx.Apply(plan, m)
+	s, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -7084,7 +7084,7 @@ func TestContext2Apply_taintDepRequiresNew(t *testing.T) {
 		t.Logf("plan: %s", legacyDiffComparisonString(plan.Changes))
 	}
 
-	s, diags := ctx.Apply(plan, m)
+	s, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -7117,7 +7117,7 @@ func TestContext2Apply_targeted(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -7157,7 +7157,7 @@ func TestContext2Apply_targetedCount(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -7199,7 +7199,7 @@ func TestContext2Apply_targetedCountIndex(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -7234,7 +7234,7 @@ func TestContext2Apply_targetedDestroy(t *testing.T) {
 		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
-		state, diags = ctx.Apply(plan, m)
+		state, diags = ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("apply err: %s", diags.Err())
 		}
@@ -7257,7 +7257,7 @@ func TestContext2Apply_targetedDestroy(t *testing.T) {
 		})
 		assertNoErrors(t, diags)
 
-		state, diags = ctx.Apply(plan, m)
+		state, diags = ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("diags: %s", diags.Err())
 		}
@@ -7339,7 +7339,7 @@ func TestContext2Apply_targetedDestroyCountDeps(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -7409,7 +7409,7 @@ func TestContext2Apply_targetedDestroyModule(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -7501,7 +7501,7 @@ func TestContext2Apply_targetedDestroyCountIndex(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -7541,7 +7541,7 @@ func TestContext2Apply_targetedModule(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -7596,7 +7596,7 @@ func TestContext2Apply_targetedModuleDep(t *testing.T) {
 		t.Logf("Diff: %s", legacyDiffComparisonString(plan.Changes))
 	}
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -7649,7 +7649,7 @@ func TestContext2Apply_targetedModuleUnrelatedOutputs(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	s, diags := ctx.Apply(plan, m)
+	s, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -7697,7 +7697,7 @@ func TestContext2Apply_targetedModuleResource(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -7752,7 +7752,7 @@ func TestContext2Apply_targetedResourceOrphanModule(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 
@@ -7806,7 +7806,7 @@ func TestContext2Apply_unknownAttribute(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if !diags.HasErrors() {
 		t.Error("should error, because attribute 'unknown' is still unknown after apply")
 	}
@@ -7884,7 +7884,7 @@ func TestContext2Apply_vars(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("err: %s", diags.Err())
 	}
@@ -7935,7 +7935,7 @@ func TestContext2Apply_varsEnv(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("err: %s", diags.Err())
 	}
@@ -8015,7 +8015,7 @@ func TestContext2Apply_createBefore_depends(t *testing.T) {
 	}
 
 	h.Active = true
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		logDiagnostics(t, diags)
 		t.Fatal("apply failed")
@@ -8140,7 +8140,7 @@ func TestContext2Apply_singleDestroy(t *testing.T) {
 	assertNoErrors(t, diags)
 
 	h.Active = true
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -8195,7 +8195,7 @@ func TestContext2Apply_issue7824(t *testing.T) {
 		t.Fatalf("err: %s", diags.Err())
 	}
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("err: %s", diags.Err())
 	}
@@ -8235,7 +8235,7 @@ func TestContext2Apply_issue5254(t *testing.T) {
 		t.Fatalf("err: %s", diags.Err())
 	}
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("err: %s", diags.Err())
 	}
@@ -8269,7 +8269,7 @@ func TestContext2Apply_issue5254(t *testing.T) {
 		t.Fatalf("err: %s", diags.Err())
 	}
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("err: %s", diags.Err())
 	}
@@ -8347,7 +8347,7 @@ func TestContext2Apply_targetedWithTaintedInState(t *testing.T) {
 		t.Fatalf("err: %s", diags.Err())
 	}
 
-	s, diags := ctx.Apply(plan, m)
+	s, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("err: %s", diags.Err())
 	}
@@ -8394,7 +8394,7 @@ func TestContext2Apply_ignoreChangesCreate(t *testing.T) {
 		t.Logf(legacyDiffComparisonString(plan.Changes))
 	}
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -8504,7 +8504,7 @@ func TestContext2Apply_ignoreChangesWithDep(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, state.DeepCopy(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	s, diags := ctx.Apply(plan, m)
+	s, diags := ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	actual := strings.TrimSpace(s.String())
@@ -8540,7 +8540,7 @@ func TestContext2Apply_ignoreChangesAll(t *testing.T) {
 		t.Logf(legacyDiffComparisonString(plan.Changes))
 	}
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	mod := state.RootModule()
@@ -8580,7 +8580,7 @@ func TestContext2Apply_destroyNestedModuleWithAttrsReferencingResource(t *testin
 		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		assertNoErrors(t, diags)
 
-		state, diags = ctx.Apply(plan, m)
+		state, diags = ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("apply err: %s", diags.Err())
 		}
@@ -8614,7 +8614,7 @@ func TestContext2Apply_destroyNestedModuleWithAttrsReferencingResource(t *testin
 			t.Fatalf("err: %s", diags.Err())
 		}
 
-		state, diags = ctx.Apply(plan, m)
+		state, diags = ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("destroy apply err: %s", diags.Err())
 		}
@@ -8675,7 +8675,7 @@ resource "null_instance" "depends" {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	root := state.Module(addrs.RootModuleInstance)
@@ -8769,7 +8769,7 @@ func TestContext2Apply_tfWorkspace(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -8796,7 +8796,7 @@ func TestContext2Apply_tofuWorkspace(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -8822,7 +8822,7 @@ func TestContext2Apply_multiRef(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("err: %s", diags.Err())
 	}
@@ -8852,7 +8852,7 @@ func TestContext2Apply_targetedModuleRecursive(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("err: %s", diags.Err())
 	}
@@ -8887,7 +8887,7 @@ func TestContext2Apply_localVal(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("error during apply: %s", diags.Err())
 	}
@@ -8934,7 +8934,7 @@ func TestContext2Apply_destroyWithLocals(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	s, diags := ctx.Apply(plan, m)
+	s, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("error during apply: %s", diags.Err())
 	}
@@ -8971,7 +8971,7 @@ func TestContext2Apply_providerWithLocals(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("err: %s", diags.Err())
 	}
@@ -8987,7 +8987,7 @@ func TestContext2Apply_providerWithLocals(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("err: %s", diags.Err())
 	}
@@ -9043,7 +9043,7 @@ func TestContext2Apply_destroyWithProviders(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("error during apply: %s", diags.Err())
 	}
@@ -9144,7 +9144,7 @@ func TestContext2Apply_providersFromState(t *testing.T) {
 				t.Fatal(diags.Err())
 			}
 
-			state, diags := ctx.Apply(plan, m)
+			state, diags := ctx.Apply(context.Background(), plan, m)
 			if diags.HasErrors() {
 				t.Fatalf("diags: %s", diags.Err())
 			}
@@ -9201,7 +9201,7 @@ func TestContext2Apply_plannedInterpolatedCount(t *testing.T) {
 	}
 
 	// Applying the plan should now succeed
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("apply failed: %s", diags.Err())
 	}
@@ -9262,7 +9262,7 @@ func TestContext2Apply_plannedDestroyInterpolatedCount(t *testing.T) {
 	}
 
 	// Applying the plan should now succeed
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("apply failed: %s", diags.Err())
 	}
@@ -9355,7 +9355,7 @@ func TestContext2Apply_scaleInMultivarRef(t *testing.T) {
 	}
 
 	// Applying the plan should now succeed
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 }
 
@@ -9396,7 +9396,7 @@ func TestContext2Apply_inconsistentWithPlan(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	if !diags.HasErrors() {
 		t.Fatalf("apply succeeded; want error")
 	}
@@ -9462,7 +9462,7 @@ func TestContext2Apply_issue19908(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if !diags.HasErrors() {
 		t.Fatalf("apply succeeded; want error")
 	}
@@ -9674,7 +9674,7 @@ func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
 		}
 
 		t.Run(mode, func(t *testing.T) {
-			_, diags := ctx.Apply(plan, m)
+			_, diags := ctx.Apply(context.Background(), plan, m)
 			if diags.HasErrors() {
 				t.Fatal(diags.Err())
 			}
@@ -9802,7 +9802,7 @@ func TestContext2Apply_destroyDataCycle(t *testing.T) {
 		return resp
 	}
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -9914,7 +9914,7 @@ func TestContext2Apply_taintedDestroyFailure(t *testing.T) {
 		t.Fatalf("diags: %s", diags.Err())
 	}
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if !diags.HasErrors() {
 		t.Fatal("expected error")
 	}
@@ -10027,7 +10027,7 @@ func TestContext2Apply_plannedConnectionRefs(t *testing.T) {
 		t.Fatalf("diags: %s", diags.Err())
 	}
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -10146,7 +10146,7 @@ func TestContext2Apply_cbdCycle(t *testing.T) {
 		t.Fatalf("failed to create context for plan: %s", diags.Err())
 	}
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -10193,7 +10193,7 @@ func TestContext2Apply_ProviderMeta_apply_set(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	if !p.ApplyResourceChangeCalled {
@@ -10273,7 +10273,7 @@ func TestContext2Apply_ProviderMeta_apply_unset(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	if !p.ApplyResourceChangeCalled {
@@ -10529,7 +10529,7 @@ func TestContext2Apply_ProviderMeta_refresh_set(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	_, diags = ctx.Refresh(m, state, DefaultPlanOpts)
@@ -10598,7 +10598,7 @@ func TestContext2Apply_ProviderMeta_refresh_setNoSchema(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	// drop the schema before refresh, to test that it errors
@@ -10663,7 +10663,7 @@ func TestContext2Apply_ProviderMeta_refresh_setInvalid(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	// change the schema before refresh, to test that it errors
@@ -10764,7 +10764,7 @@ func TestContext2Apply_ProviderMeta_refreshdata_set(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	_, diags = ctx.Refresh(m, state, DefaultPlanOpts)
@@ -10855,7 +10855,7 @@ func TestContext2Apply_ProviderMeta_refreshdata_unset(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	if !p.ReadDataSourceCalled {
@@ -11020,7 +11020,7 @@ output "out" {
 		t.Fatal(diags.ErrWithWarnings())
 	}
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -11079,7 +11079,7 @@ resource "aws_instance" "cbd" {
 		t.Fatal(diags.ErrWithWarnings())
 	}
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -11151,7 +11151,7 @@ func TestContext2Apply_moduleDependsOn(t *testing.T) {
 		t.Fatal(diags.ErrWithWarnings())
 	}
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -11208,7 +11208,7 @@ output "c" {
 		t.Fatal(diags.ErrWithWarnings())
 	}
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -11226,7 +11226,7 @@ output "c" {
 		t.Fatal(diags.ErrWithWarnings())
 	}
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -11275,7 +11275,7 @@ output "myoutput" {
 		t.Fatal(diags.ErrWithWarnings())
 	}
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -11293,7 +11293,7 @@ output "myoutput" {
 		t.Fatal(diags.ErrWithWarnings())
 	}
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -11471,7 +11471,7 @@ locals {
 		}
 	}
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		log.Fatal(diags.ErrWithWarnings())
 	}
@@ -11526,7 +11526,7 @@ locals {
 		}
 	}
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -11635,7 +11635,7 @@ func TestContext2Apply_destroyProviderReference(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
@@ -11666,7 +11666,7 @@ func TestContext2Apply_destroyProviderReference(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("failed to create context for plan: %s", diags.Err())
 	}
-	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
+	if _, diags := ctx.Apply(context.Background(), plan, m); diags.HasErrors() {
 		t.Fatalf("destroy apply errors: %s", diags.Err())
 	}
 }
@@ -11742,7 +11742,7 @@ output "outputs" {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
@@ -11759,7 +11759,7 @@ output "outputs" {
 		})
 		assertNoErrors(t, diags)
 
-		state, diags = ctx.Apply(plan, m)
+		state, diags = ctx.Apply(context.Background(), plan, m)
 		if diags.HasErrors() {
 			t.Fatalf("destroy apply errors: %s", diags.Err())
 		}
@@ -11829,7 +11829,7 @@ resource "test_resource" "a" {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
@@ -11850,7 +11850,7 @@ resource "test_resource" "a" {
 	})
 	assertNoErrors(t, diags)
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
@@ -11892,7 +11892,7 @@ resource "test_instance" "b" {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
@@ -11913,7 +11913,7 @@ resource "test_instance" "b" {
 	})
 	assertNoErrors(t, diags)
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
@@ -11953,7 +11953,7 @@ resource "test_resource" "c" {
 	})
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
@@ -11974,7 +11974,7 @@ resource "test_resource" "c" {
 	})
 	assertNoErrors(t, diags)
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
@@ -12046,7 +12046,7 @@ resource "test_resource" "foo" {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
@@ -12061,7 +12061,7 @@ resource "test_resource" "foo" {
 	plan, diags = ctx.Plan(context.Background(), m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
@@ -12084,7 +12084,7 @@ resource "test_resource" "foo" {
 	})
 	assertNoErrors(t, diags)
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
@@ -12151,7 +12151,7 @@ resource "test_resource" "foo" {
 	fooChangeSrc := plan.Changes.ResourceInstance(addr)
 	verifySensitiveValues(fooChangeSrc.AfterValMarks)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
@@ -12246,7 +12246,7 @@ resource "test_resource" "baz" {
 	bazChangeSrc := plan.Changes.ResourceInstance(bazAddr)
 	verifySensitiveValues(bazChangeSrc.AfterValMarks, wantedBazPaths)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
@@ -12305,7 +12305,7 @@ resource "test_resource" "foo" {
 
 	addr := mustResourceInstanceAddr("test_resource.foo")
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	fooState := state.ResourceInstance(addr)
@@ -12360,7 +12360,7 @@ resource "test_resource" "foo" {
 
 	_, diags = newCtx.Plan(context.Background(), newModule, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
-	stateWithoutSensitive, diags := newCtx.Apply(plan, newModule)
+	stateWithoutSensitive, diags := newCtx.Apply(context.Background(), plan, newModule)
 	assertNoErrors(t, diags)
 
 	newFooState := stateWithoutSensitive.ResourceInstance(addr)
@@ -12420,7 +12420,7 @@ output "out" {
 		t.Fatal(diags.ErrWithWarnings())
 	}
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -12479,7 +12479,7 @@ output "out" {
 		t.Fatal(diags.ErrWithWarnings())
 	}
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -12529,7 +12529,7 @@ output "out" {
 		t.Fatal(diags.ErrWithWarnings())
 	}
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -12592,7 +12592,7 @@ output "out" {
 		t.Fatal(diags.ErrWithWarnings())
 	}
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -12655,7 +12655,7 @@ func TestContext2Apply_provisionerSensitive(t *testing.T) {
 	// "restart" provisioner
 	pr.CloseCalled = false
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		logDiagnostics(t, diags)
 		t.Fatal("apply failed")
@@ -12710,7 +12710,7 @@ resource "test_resource" "foo" {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
 	}
@@ -12757,7 +12757,7 @@ resource "test_instance" "a" {
 		t.Fatal(diags.Err())
 	}
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -12801,7 +12801,7 @@ func TestContext2Apply_dataSensitive(t *testing.T) {
 		t.Logf(legacyDiffComparisonString(plan.Changes))
 	}
 
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	addr := mustResourceInstanceAddr("data.null_data_source.testing")
@@ -12854,7 +12854,7 @@ func TestContext2Apply_errorRestorePrivateData(t *testing.T) {
 		t.Fatal(diags.Err())
 	}
 
-	state, _ = ctx.Apply(plan, m)
+	state, _ = ctx.Apply(context.Background(), plan, m)
 	if string(state.ResourceInstance(addr).Current.Private) != "private" {
 		t.Fatal("missing private data in state")
 	}
@@ -12899,7 +12899,7 @@ func TestContext2Apply_errorRestoreStatus(t *testing.T) {
 		t.Fatal(diags.Err())
 	}
 
-	state, diags = ctx.Apply(plan, m)
+	state, diags = ctx.Apply(context.Background(), plan, m)
 
 	errString := diags.ErrWithWarnings().Error()
 	if !strings.Contains(errString, "oops") || !strings.Contains(errString, "warned") {
@@ -12961,7 +12961,7 @@ resource "test_object" "a" {
 		t.Fatal(diags.Err())
 	}
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	errString := diags.ErrWithWarnings().Error()
 	if !strings.Contains(errString, "oops") || !strings.Contains(errString, "warned") {
 		t.Fatalf("error missing expected info: %q", errString)
@@ -12997,7 +12997,7 @@ resource "test_object" "a" {
 		t.Fatal(diags.Err())
 	}
 
-	_, diags = ctx.Apply(plan, m)
+	_, diags = ctx.Apply(context.Background(), plan, m)
 	if !diags.HasErrors() {
 		t.Fatal("expected and error")
 	}

--- a/internal/tofu/context_apply_test.go
+++ b/internal/tofu/context_apply_test.go
@@ -7227,7 +7227,7 @@ func TestContext2Apply_targetedDestroy(t *testing.T) {
 		})
 
 		// First plan and apply a create operation
-		if diags := ctx.Validate(m); diags.HasErrors() {
+		if diags := ctx.Validate(context.Background(), m); diags.HasErrors() {
 			t.Fatalf("validate errors: %s", diags.Err())
 		}
 
@@ -7839,7 +7839,7 @@ func TestContext2Apply_vars(t *testing.T) {
 	ctx := testContext2(t, opts)
 	m := fixture.Config
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if len(diags) != 0 {
 		t.Fatalf("bad: %s", diags.ErrWithWarnings())
 	}
@@ -7902,7 +7902,7 @@ func TestContext2Apply_varsEnv(t *testing.T) {
 	ctx := testContext2(t, opts)
 	m := fixture.Config
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if len(diags) != 0 {
 		t.Fatalf("bad: %s", diags.ErrWithWarnings())
 	}
@@ -9511,7 +9511,7 @@ func TestContext2Apply_invalidIndexRef(t *testing.T) {
 			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 		},
 	})
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected validation failure: %s", diags.Err())
 	}

--- a/internal/tofu/context_eval.go
+++ b/internal/tofu/context_eval.go
@@ -85,7 +85,7 @@ func (c *Context) Eval(ctx context.Context, config *configs.Config, state *state
 		ProviderFunctionTracker: providerFunctionTracker,
 	}
 
-	walker, moreDiags = c.walk(graph, walkEval, walkOpts)
+	walker, moreDiags = c.walk(ctx, graph, walkEval, walkOpts)
 	diags = diags.Append(moreDiags)
 	if walker != nil {
 		diags = diags.Append(walker.NonFatalDiagnostics)

--- a/internal/tofu/context_eval.go
+++ b/internal/tofu/context_eval.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"log"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -37,7 +38,7 @@ type EvalOpts struct {
 // the returned scope may be nil. If it is not nil then it may still be used
 // to attempt expression evaluation or other analysis, but some expressions
 // may not behave as expected.
-func (c *Context) Eval(config *configs.Config, state *states.State, moduleAddr addrs.ModuleInstance, opts *EvalOpts) (*lang.Scope, tfdiags.Diagnostics) {
+func (c *Context) Eval(ctx context.Context, config *configs.Config, state *states.State, moduleAddr addrs.ModuleInstance, opts *EvalOpts) (*lang.Scope, tfdiags.Diagnostics) {
 	// This is intended for external callers such as the "tofu console"
 	// command. Internally, we create an evaluator in c.walk before walking
 	// the graph, and create scopes in ContextGraphWalker.

--- a/internal/tofu/context_eval_test.go
+++ b/internal/tofu/context_eval_test.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
@@ -59,7 +60,7 @@ func TestContextEval(t *testing.T) {
 		},
 	})
 
-	scope, diags := ctx.Eval(m, states.NewState(), addrs.RootModuleInstance, &EvalOpts{
+	scope, diags := ctx.Eval(context.Background(), m, states.NewState(), addrs.RootModuleInstance, &EvalOpts{
 		SetVariables: testInputValuesUnset(m.Module.Variables),
 	})
 	if diags.HasErrors() {
@@ -128,7 +129,7 @@ output "out" {
 		},
 	})
 
-	_, diags := ctx.Eval(m, states.NewState(), addrs.RootModuleInstance, &EvalOpts{
+	_, diags := ctx.Eval(context.Background(), m, states.NewState(), addrs.RootModuleInstance, &EvalOpts{
 		SetVariables: testInputValuesUnset(m.Module.Variables),
 	})
 	assertNoErrors(t, diags)

--- a/internal/tofu/context_functions_test.go
+++ b/internal/tofu/context_functions_test.go
@@ -362,7 +362,7 @@ variable "obfmod" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -443,7 +443,7 @@ variable "obfmod" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -536,7 +536,7 @@ variable "obfmod" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -728,7 +728,7 @@ variable "obfmod" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}

--- a/internal/tofu/context_functions_test.go
+++ b/internal/tofu/context_functions_test.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -455,7 +456,7 @@ variable "obfmod" {
 
 	p.GetFunctionsCalled = false
 	p.CallFunctionCalled = false
-	_, diags = ctx.Plan(m, nil, nil)
+	_, diags = ctx.Plan(context.Background(), m, nil, nil)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -552,7 +553,7 @@ variable "obfmod" {
 	p.GetProviderSchemaCalled = false
 	p.GetFunctionsCalled = false
 	p.CallFunctionCalled = false
-	_, diags = ctx.Plan(m, nil, nil)
+	_, diags = ctx.Plan(context.Background(), m, nil, nil)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -635,7 +636,7 @@ variable "obfmod" {
 		},
 	})
 
-	_, diags := ctx.Plan(m, nil, nil)
+	_, diags := ctx.Plan(context.Background(), m, nil, nil)
 	if !diags.HasErrors() {
 		t.Fatal("Expected error!")
 	}
@@ -744,7 +745,7 @@ variable "obfmod" {
 	p.GetProviderSchemaCalled = false
 	p.GetFunctionsCalled = false
 	p.CallFunctionCalled = false
-	_, diags = ctx.Plan(m, nil, nil)
+	_, diags = ctx.Plan(context.Background(), m, nil, nil)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}

--- a/internal/tofu/context_import.go
+++ b/internal/tofu/context_import.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"sync"
@@ -238,7 +239,7 @@ func (ri *ImportResolver) GetImport(address addrs.AbsResourceInstance) *Evaluate
 // Further, this operation also gracefully handles partial state. If during
 // an import there is a failure, all previously imported resources remain
 // imported.
-func (c *Context) Import(config *configs.Config, prevRunState *states.State, opts *ImportOpts) (*states.State, tfdiags.Diagnostics) {
+func (c *Context) Import(ctx context.Context, config *configs.Config, prevRunState *states.State, opts *ImportOpts) (*states.State, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	// Hold a lock since we can modify our own state here

--- a/internal/tofu/context_import.go
+++ b/internal/tofu/context_import.go
@@ -273,7 +273,7 @@ func (c *Context) Import(ctx context.Context, config *configs.Config, prevRunSta
 	}
 
 	// Walk it
-	walker, walkDiags := c.walk(graph, walkImport, &graphWalkOpts{
+	walker, walkDiags := c.walk(ctx, graph, walkImport, &graphWalkOpts{
 		Config:                  config,
 		InputState:              state,
 		ProviderFunctionTracker: providerFunctionTracker,

--- a/internal/tofu/context_import_test.go
+++ b/internal/tofu/context_import_test.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -43,7 +44,7 @@ func TestContextImport_basic(t *testing.T) {
 		},
 	}
 
-	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
+	state, diags := ctx.Import(context.Background(), m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
 				CommandLineImportTarget: &CommandLineImportTarget{
@@ -96,7 +97,7 @@ resource "aws_instance" "foo" {
 		},
 	}
 
-	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
+	state, diags := ctx.Import(context.Background(), m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
 				CommandLineImportTarget: &CommandLineImportTarget{
@@ -253,7 +254,7 @@ func TestContextImport_multiInstanceProviderConfig(t *testing.T) {
 	)
 	t.Logf("importing into %s, which should succeed because it's configured", existingInstanceAddr)
 	log.Printf("[TRACE] TestContextImport_multiInstanceProviderConfig: importing into %s, which should succeed because it's configured", existingInstanceAddr)
-	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
+	state, diags := ctx.Import(context.Background(), m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
 				CommandLineImportTarget: &CommandLineImportTarget{
@@ -349,7 +350,7 @@ resource "aws_instance" "foo" {
 		}),
 	}
 
-	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
+	state, diags := ctx.Import(context.Background(), m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
 				CommandLineImportTarget: &CommandLineImportTarget{
@@ -418,7 +419,7 @@ func TestContextImport_collision(t *testing.T) {
 		},
 	}
 
-	state, diags := ctx.Import(m, state, &ImportOpts{
+	state, diags := ctx.Import(context.Background(), m, state, &ImportOpts{
 		Targets: []*ImportTarget{
 			{
 				CommandLineImportTarget: &CommandLineImportTarget{
@@ -464,7 +465,7 @@ func TestContextImport_missingType(t *testing.T) {
 		},
 	})
 
-	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
+	state, diags := ctx.Import(context.Background(), m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
 				CommandLineImportTarget: &CommandLineImportTarget{
@@ -517,7 +518,7 @@ func TestContextImport_moduleProvider(t *testing.T) {
 		},
 	})
 
-	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
+	state, diags := ctx.Import(context.Background(), m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
 				CommandLineImportTarget: &CommandLineImportTarget{
@@ -574,7 +575,7 @@ func TestContextImport_providerModule(t *testing.T) {
 		return
 	}
 
-	_, diags := ctx.Import(m, states.NewState(), &ImportOpts{
+	_, diags := ctx.Import(context.Background(), m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
 				CommandLineImportTarget: &CommandLineImportTarget{
@@ -632,7 +633,7 @@ func TestContextImport_providerConfig(t *testing.T) {
 				},
 			}
 
-			state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
+			state, diags := ctx.Import(context.Background(), m, states.NewState(), &ImportOpts{
 				Targets: []*ImportTarget{
 					{
 						CommandLineImportTarget: &CommandLineImportTarget{
@@ -694,7 +695,7 @@ func TestContextImport_providerConfigResources(t *testing.T) {
 		},
 	}
 
-	_, diags := ctx.Import(m, states.NewState(), &ImportOpts{
+	_, diags := ctx.Import(context.Background(), m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
 				CommandLineImportTarget: &CommandLineImportTarget{
@@ -767,7 +768,7 @@ data "aws_data_source" "bar" {
 		}),
 	}
 
-	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
+	state, diags := ctx.Import(context.Background(), m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
 				CommandLineImportTarget: &CommandLineImportTarget{
@@ -820,7 +821,7 @@ func TestContextImport_refreshNil(t *testing.T) {
 		}
 	}
 
-	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
+	state, diags := ctx.Import(context.Background(), m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
 				CommandLineImportTarget: &CommandLineImportTarget{
@@ -863,7 +864,7 @@ func TestContextImport_module(t *testing.T) {
 		},
 	}
 
-	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
+	state, diags := ctx.Import(context.Background(), m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
 				CommandLineImportTarget: &CommandLineImportTarget{
@@ -906,7 +907,7 @@ func TestContextImport_moduleDepth2(t *testing.T) {
 		},
 	}
 
-	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
+	state, diags := ctx.Import(context.Background(), m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
 				CommandLineImportTarget: &CommandLineImportTarget{
@@ -949,7 +950,7 @@ func TestContextImport_moduleDiff(t *testing.T) {
 		},
 	}
 
-	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
+	state, diags := ctx.Import(context.Background(), m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
 				CommandLineImportTarget: &CommandLineImportTarget{
@@ -1019,7 +1020,7 @@ func TestContextImport_multiState(t *testing.T) {
 		},
 	})
 
-	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
+	state, diags := ctx.Import(context.Background(), m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
 				CommandLineImportTarget: &CommandLineImportTarget{
@@ -1095,7 +1096,7 @@ func TestContextImport_multiStateSame(t *testing.T) {
 		},
 	})
 
-	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
+	state, diags := ctx.Import(context.Background(), m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
 				CommandLineImportTarget: &CommandLineImportTarget{
@@ -1191,7 +1192,7 @@ resource "test_resource" "unused" {
 		},
 	})
 
-	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
+	state, diags := ctx.Import(context.Background(), m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
 				CommandLineImportTarget: &CommandLineImportTarget{
@@ -1263,7 +1264,7 @@ resource "test_resource" "test" {
 		},
 	})
 
-	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
+	state, diags := ctx.Import(context.Background(), m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
 				CommandLineImportTarget: &CommandLineImportTarget{
@@ -1310,7 +1311,7 @@ func TestContextImport_33572(t *testing.T) {
 		},
 	}
 
-	state, diags := ctx.Import(m, states.NewState(), &ImportOpts{
+	state, diags := ctx.Import(context.Background(), m, states.NewState(), &ImportOpts{
 		Targets: []*ImportTarget{
 			{
 				CommandLineImportTarget: &CommandLineImportTarget{

--- a/internal/tofu/context_input.go
+++ b/internal/tofu/context_input.go
@@ -36,7 +36,9 @@ import (
 // any other Context method with a different config, because the aforementioned
 // modified internal state won't match. Again, this is an architectural wart
 // that we'll hopefully resolve in future.
-func (c *Context) Input(config *configs.Config, mode InputMode) tfdiags.Diagnostics {
+//
+//nolint:cyclop,funlen,gocognit,nestif // Historical function predates our complexity rules
+func (c *Context) Input(ctx context.Context, config *configs.Config, mode InputMode) tfdiags.Diagnostics {
 	// This function used to be responsible for more than it is now, so its
 	// interface is more general than its current functionality requires.
 	// It now exists only to handle interactive prompts for provider
@@ -60,8 +62,6 @@ func (c *Context) Input(config *configs.Config, mode InputMode) tfdiags.Diagnost
 		log.Printf("[TRACE] Context.Input: uiInput is nil, so skipping")
 		return diags
 	}
-
-	ctx := context.Background()
 
 	if mode&InputModeProvider != 0 {
 		log.Printf("[TRACE] Context.Input: Prompting for provider arguments")
@@ -165,7 +165,15 @@ func (c *Context) Input(config *configs.Config, mode InputMode) tfdiags.Diagnost
 				}
 
 				log.Printf("[TRACE] Context.Input: Prompting for %s argument %s", pa, key)
-				rawVal, err := input.Input(ctx, &InputOpts{
+				// NOTE: Historically we were just passing a context.Background into
+				// this, because we didn't have any other context.Context to use.
+				// We're now passing in our given context but intentionally ignoring
+				// its cancellation because the main UIInput implementation (in
+				// package command) already/ had direct SIGINT handling and we want to
+				// preserve that behavior.
+				// FIXME: Remove the UIInput's own SIGINT handling and rely on the
+				// cancellation of ctx instead.
+				rawVal, err := input.Input(context.WithoutCancel(ctx), &InputOpts{
 					Id:          key,
 					Query:       key,
 					Description: attrS.Description,

--- a/internal/tofu/context_input_test.go
+++ b/internal/tofu/context_input_test.go
@@ -65,7 +65,7 @@ func TestContext2Input_provider(t *testing.T) {
 		return
 	}
 
-	if diags := ctx.Input(m, InputModeStd); diags.HasErrors() {
+	if diags := ctx.Input(context.Background(), m, InputModeStd); diags.HasErrors() {
 		t.Fatalf("input errors: %s", diags.Err())
 	}
 
@@ -143,7 +143,7 @@ func TestContext2Input_providerMulti(t *testing.T) {
 	var actual []interface{}
 	var lock sync.Mutex
 
-	if diags := ctx.Input(m, InputModeStd); diags.HasErrors() {
+	if diags := ctx.Input(context.Background(), m, InputModeStd); diags.HasErrors() {
 		t.Fatalf("input errors: %s", diags.Err())
 	}
 
@@ -181,7 +181,7 @@ func TestContext2Input_providerOnce(t *testing.T) {
 		},
 	})
 
-	if diags := ctx.Input(m, InputModeStd); diags.HasErrors() {
+	if diags := ctx.Input(context.Background(), m, InputModeStd); diags.HasErrors() {
 		t.Fatalf("input errors: %s", diags.Err())
 	}
 }
@@ -231,7 +231,7 @@ func TestContext2Input_providerId(t *testing.T) {
 		"provider.aws.foo": "bar",
 	}
 
-	if diags := ctx.Input(m, InputModeStd); diags.HasErrors() {
+	if diags := ctx.Input(context.Background(), m, InputModeStd); diags.HasErrors() {
 		t.Fatalf("input errors: %s", diags.Err())
 	}
 
@@ -289,7 +289,7 @@ func TestContext2Input_providerOnly(t *testing.T) {
 		return
 	}
 
-	if err := ctx.Input(m, InputModeProvider); err != nil {
+	if err := ctx.Input(context.Background(), m, InputModeProvider); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -348,7 +348,7 @@ func TestContext2Input_providerVars(t *testing.T) {
 		actual = req.Config.GetAttr("foo").AsString()
 		return
 	}
-	if diags := ctx.Input(m, InputModeStd); diags.HasErrors() {
+	if diags := ctx.Input(context.Background(), m, InputModeStd); diags.HasErrors() {
 		t.Fatalf("input errors: %s", diags.Err())
 	}
 
@@ -383,7 +383,7 @@ func TestContext2Input_providerVarsModuleInherit(t *testing.T) {
 		UIInput: input,
 	})
 
-	if diags := ctx.Input(m, InputModeStd); diags.HasErrors() {
+	if diags := ctx.Input(context.Background(), m, InputModeStd); diags.HasErrors() {
 		t.Fatalf("input errors: %s", diags.Err())
 	}
 }
@@ -400,7 +400,7 @@ func TestContext2Input_submoduleTriggersInvalidCount(t *testing.T) {
 		UIInput: input,
 	})
 
-	if diags := ctx.Input(m, InputModeStd); diags.HasErrors() {
+	if diags := ctx.Input(context.Background(), m, InputModeStd); diags.HasErrors() {
 		t.Fatalf("input errors: %s", diags.Err())
 	}
 }
@@ -458,7 +458,7 @@ func TestContext2Input_dataSourceRequiresRefresh(t *testing.T) {
 		UIInput: input,
 	})
 
-	if diags := ctx.Input(m, InputModeStd); diags.HasErrors() {
+	if diags := ctx.Input(context.Background(), m, InputModeStd); diags.HasErrors() {
 		t.Fatalf("input errors: %s", diags.Err())
 	}
 

--- a/internal/tofu/context_input_test.go
+++ b/internal/tofu/context_input_test.go
@@ -467,7 +467,7 @@ func TestContext2Input_dataSourceRequiresRefresh(t *testing.T) {
 	// a wrapper around plan anyway, but we're keeping it until we get a
 	// chance to review and check whether it's giving us any additional
 	// test coverage aside from what it's specifically intending to test.
-	if _, diags := ctx.Refresh(m, state, DefaultPlanOpts); diags.HasErrors() {
+	if _, diags := ctx.Refresh(context.Background(), m, state, DefaultPlanOpts); diags.HasErrors() {
 		t.Fatalf("refresh errors: %s", diags.Err())
 	}
 	if _, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts); diags.HasErrors() {

--- a/internal/tofu/context_input_test.go
+++ b/internal/tofu/context_input_test.go
@@ -79,7 +79,7 @@ func TestContext2Input_provider(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
+	if _, diags := ctx.Apply(context.Background(), plan, m); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
 
@@ -162,7 +162,7 @@ func TestContext2Input_providerMulti(t *testing.T) {
 		return p, nil
 	}
 
-	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
+	if _, diags := ctx.Apply(context.Background(), plan, m); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
 
@@ -238,7 +238,7 @@ func TestContext2Input_providerId(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
-	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
+	if _, diags := ctx.Apply(context.Background(), plan, m); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
 
@@ -312,7 +312,7 @@ func TestContext2Input_providerOnly(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	state, err := ctx.Apply(plan, m)
+	state, err := ctx.Apply(context.Background(), plan, m)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -363,7 +363,7 @@ func TestContext2Input_providerVars(t *testing.T) {
 	})
 	assertNoErrors(t, diags)
 
-	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
+	if _, diags := ctx.Apply(context.Background(), plan, m); diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
 	}
 

--- a/internal/tofu/context_input_test.go
+++ b/internal/tofu/context_input_test.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"reflect"
 	"strings"
 	"sync"
@@ -75,7 +76,7 @@ func TestContext2Input_provider(t *testing.T) {
 		t.Errorf("wrong description\ngot:  %q\nwant: %q", got, want)
 	}
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
@@ -146,7 +147,7 @@ func TestContext2Input_providerMulti(t *testing.T) {
 		t.Fatalf("input errors: %s", diags.Err())
 	}
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	providerFactory = func() (providers.Interface, error) {
@@ -234,7 +235,7 @@ func TestContext2Input_providerId(t *testing.T) {
 		t.Fatalf("input errors: %s", diags.Err())
 	}
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	if _, diags := ctx.Apply(plan, m); diags.HasErrors() {
@@ -300,7 +301,7 @@ func TestContext2Input_providerOnly(t *testing.T) {
 	// normal Input test, but we're preserving it until we have time to review
 	// and make sure this isn't inadvertently providing unique test coverage
 	// other than what it set out to test.
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"foo": &InputValue{
@@ -351,7 +352,7 @@ func TestContext2Input_providerVars(t *testing.T) {
 		t.Fatalf("input errors: %s", diags.Err())
 	}
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"foo": &InputValue{
@@ -469,7 +470,7 @@ func TestContext2Input_dataSourceRequiresRefresh(t *testing.T) {
 	if _, diags := ctx.Refresh(m, state, DefaultPlanOpts); diags.HasErrors() {
 		t.Fatalf("refresh errors: %s", diags.Err())
 	}
-	if _, diags := ctx.Plan(m, state, DefaultPlanOpts); diags.HasErrors() {
+	if _, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts); diags.HasErrors() {
 		t.Fatalf("plan errors: %s", diags.Err())
 	}
 }

--- a/internal/tofu/context_plan.go
+++ b/internal/tofu/context_plan.go
@@ -213,11 +213,11 @@ The -target and -exclude options are not for routine use, and are provided only 
 	var planDiags tfdiags.Diagnostics
 	switch opts.Mode {
 	case plans.NormalMode:
-		plan, planDiags = c.plan(config, prevRunState, opts)
+		plan, planDiags = c.plan(ctx, config, prevRunState, opts)
 	case plans.DestroyMode:
-		plan, planDiags = c.destroyPlan(config, prevRunState, opts)
+		plan, planDiags = c.destroyPlan(ctx, config, prevRunState, opts)
 	case plans.RefreshOnlyMode:
-		plan, planDiags = c.refreshOnlyPlan(config, prevRunState, opts)
+		plan, planDiags = c.refreshOnlyPlan(ctx, config, prevRunState, opts)
 	default:
 		panic(fmt.Sprintf("unsupported plan mode %s", opts.Mode))
 	}
@@ -318,7 +318,7 @@ func SimplePlanOpts(mode plans.Mode, setVariables InputValues) *PlanOpts {
 	}
 }
 
-func (c *Context) plan(config *configs.Config, prevRunState *states.State, opts *PlanOpts) (*plans.Plan, tfdiags.Diagnostics) {
+func (c *Context) plan(ctx context.Context, config *configs.Config, prevRunState *states.State, opts *PlanOpts) (*plans.Plan, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	if opts.Mode != plans.NormalMode {
@@ -340,20 +340,20 @@ func (c *Context) plan(config *configs.Config, prevRunState *states.State, opts 
 		return nil, diags
 	}
 
-	plan, walkDiags := c.planWalk(config, prevRunState, opts)
+	plan, walkDiags := c.planWalk(ctx, config, prevRunState, opts)
 	diags = diags.Append(walkDiags)
 
 	return plan, diags
 }
 
-func (c *Context) refreshOnlyPlan(config *configs.Config, prevRunState *states.State, opts *PlanOpts) (*plans.Plan, tfdiags.Diagnostics) {
+func (c *Context) refreshOnlyPlan(ctx context.Context, config *configs.Config, prevRunState *states.State, opts *PlanOpts) (*plans.Plan, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	if opts.Mode != plans.RefreshOnlyMode {
 		panic(fmt.Sprintf("called Context.refreshOnlyPlan with %s", opts.Mode))
 	}
 
-	plan, walkDiags := c.planWalk(config, prevRunState, opts)
+	plan, walkDiags := c.planWalk(ctx, config, prevRunState, opts)
 	diags = diags.Append(walkDiags)
 	if diags.HasErrors() {
 		// Non-nil plan along with errors indicates a non-applyable partial
@@ -390,7 +390,7 @@ func (c *Context) refreshOnlyPlan(config *configs.Config, prevRunState *states.S
 	return plan, diags
 }
 
-func (c *Context) destroyPlan(config *configs.Config, prevRunState *states.State, opts *PlanOpts) (*plans.Plan, tfdiags.Diagnostics) {
+func (c *Context) destroyPlan(ctx context.Context, config *configs.Config, prevRunState *states.State, opts *PlanOpts) (*plans.Plan, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	if opts.Mode != plans.DestroyMode {
@@ -422,7 +422,7 @@ func (c *Context) destroyPlan(config *configs.Config, prevRunState *states.State
 		// the destroy plan should take care of refreshing instances itself,
 		// where the special cases of evaluation and skipping condition checks
 		// can be done.
-		refreshPlan, refreshDiags := c.plan(config, prevRunState, &refreshOpts)
+		refreshPlan, refreshDiags := c.plan(ctx, config, prevRunState, &refreshOpts)
 		if refreshDiags.HasErrors() {
 			// NOTE: Normally we'd append diagnostics regardless of whether
 			// there are errors, just in case there are warnings we'd want to
@@ -451,7 +451,7 @@ func (c *Context) destroyPlan(config *configs.Config, prevRunState *states.State
 		log.Printf("[TRACE] Context.destroyPlan: now _really_ creating a destroy plan")
 	}
 
-	destroyPlan, walkDiags := c.planWalk(config, priorState, opts)
+	destroyPlan, walkDiags := c.planWalk(ctx, config, priorState, opts)
 	diags = diags.Append(walkDiags)
 	if walkDiags.HasErrors() {
 		// Non-nil plan along with errors indicates a non-applyable partial
@@ -741,7 +741,7 @@ func importResourceWithoutConfigDiags(addressStr string, config *configs.Import)
 	return &diag
 }
 
-func (c *Context) planWalk(config *configs.Config, prevRunState *states.State, opts *PlanOpts) (*plans.Plan, tfdiags.Diagnostics) {
+func (c *Context) planWalk(ctx context.Context, config *configs.Config, prevRunState *states.State, opts *PlanOpts) (*plans.Plan, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	log.Printf("[DEBUG] Building and walking plan graph for %s", opts.Mode)
 
@@ -770,7 +770,7 @@ func (c *Context) planWalk(config *configs.Config, prevRunState *states.State, o
 	// If we get here then we should definitely have a non-nil "graph", which
 	// we can now walk.
 	changes := plans.NewChanges()
-	walker, walkDiags := c.walk(graph, walkOp, &graphWalkOpts{
+	walker, walkDiags := c.walk(ctx, graph, walkOp, &graphWalkOpts{
 		Config:                  config,
 		InputState:              prevRunState,
 		Changes:                 changes,

--- a/internal/tofu/context_plan.go
+++ b/internal/tofu/context_plan.go
@@ -7,6 +7,7 @@ package tofu
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"sort"
@@ -123,7 +124,9 @@ type PlanOpts struct {
 // planned so far, which is not safe to apply but could potentially be used
 // by the UI layer to give extra context to support understanding of the
 // returned error messages.
-func (c *Context) Plan(config *configs.Config, prevRunState *states.State, opts *PlanOpts) (*plans.Plan, tfdiags.Diagnostics) {
+//
+//nolint:cyclop,funlen // Historical function predates our complexity rules
+func (c *Context) Plan(ctx context.Context, config *configs.Config, prevRunState *states.State, opts *PlanOpts) (*plans.Plan, tfdiags.Diagnostics) {
 	defer c.acquireRun("plan")()
 	var diags tfdiags.Diagnostics
 

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -7,6 +7,7 @@ package tofu
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -89,7 +90,7 @@ resource "test_object" "a" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	if !p.UpgradeResourceStateCalled {
@@ -218,7 +219,7 @@ data "test_data_source" "foo" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	assertNoErrors(t, diags)
 
 	for _, res := range plan.Changes.Resources {
@@ -261,7 +262,7 @@ output "out" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	change, err := plan.Changes.Outputs[0].Decode()
@@ -326,7 +327,7 @@ resource "test_object" "a" {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 }
 
@@ -402,7 +403,7 @@ resource "test_resource" "b" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	oldMod := oldDataAddr.Module
@@ -502,7 +503,7 @@ func TestContext2Plan_resourceChecksInExpandedModule(t *testing.T) {
 	})
 
 	priorState := states.NewState()
-	plan, diags := ctx.Plan(m, priorState, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, priorState, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	resourceInsts := []addrs.AbsResourceInstance{
@@ -688,7 +689,7 @@ data "test_data_source" "a" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, priorState, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, priorState, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	if rc := plan.Changes.ResourceInstance(dataAddr); rc != nil {
@@ -909,7 +910,7 @@ resource "test_resource" "b" {
 		},
 	})
 
-	_, diags := ctx.Plan(m, priorState, DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, priorState, DefaultPlanOpts)
 	if !diags.HasErrors() {
 		t.Fatalf("unexpected successful plan; should've failed with non-passing precondition")
 	}
@@ -1002,7 +1003,7 @@ resource "test_object" "a" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode:        plans.DestroyMode,
 		SkipRefresh: false, // the default
 	})
@@ -1102,7 +1103,7 @@ resource "test_object" "a" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode:        plans.DestroyMode,
 		SkipRefresh: true,
 	})
@@ -1195,7 +1196,7 @@ output "result" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	for _, res := range plan.Changes.Resources {
@@ -1242,7 +1243,7 @@ provider "test" {
 		},
 	})
 
-	_, diags := ctx.Plan(m, state, &PlanOpts{
+	_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	assertNoErrors(t, diags)
@@ -1279,7 +1280,7 @@ func TestContext2Plan_movedResourceBasic(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		ForceReplace: []addrs.AbsResourceInstance{
 			addrA,
@@ -1347,7 +1348,7 @@ func TestContext2Plan_movedResourceCollision(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 	})
 	if diags.HasErrors() {
@@ -1453,7 +1454,7 @@ func TestContext2Plan_movedResourceCollisionDestroy(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	if diags.HasErrors() {
@@ -1562,7 +1563,7 @@ func TestContext2Plan_movedResourceUntargeted(t *testing.T) {
 	})
 
 	t.Run("without targeting instance A", func(t *testing.T) {
-		_, diags := ctx.Plan(m, state, &PlanOpts{
+		_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 			Mode: plans.NormalMode,
 			Targets: []addrs.Targetable{
 				// NOTE: addrA isn't included here, but it's pending move to addrB
@@ -1602,7 +1603,7 @@ Note that adding these options may include further additional resource instances
 		}
 	})
 	t.Run("without targeting instance B", func(t *testing.T) {
-		_, diags := ctx.Plan(m, state, &PlanOpts{
+		_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 			Mode: plans.NormalMode,
 			Targets: []addrs.Targetable{
 				addrA,
@@ -1642,7 +1643,7 @@ Note that adding these options may include further additional resource instances
 		}
 	})
 	t.Run("without targeting either instance", func(t *testing.T) {
-		_, diags := ctx.Plan(m, state, &PlanOpts{
+		_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 			Mode: plans.NormalMode,
 			Targets: []addrs.Targetable{
 				mustResourceInstanceAddr("test_object.unrelated"),
@@ -1687,7 +1688,7 @@ Note that adding these options may include further additional resource instances
 		// addresses to the set of targets. This additional test makes sure that
 		// following that advice actually leads to a valid result.
 
-		_, diags := ctx.Plan(m, state, &PlanOpts{
+		_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 			Mode: plans.NormalMode,
 			Targets: []addrs.Targetable{
 				// This time we're including both addresses in the target,
@@ -1721,7 +1722,7 @@ The -target and -exclude options are not for routine use, and are provided only 
 		}
 	})
 	t.Run("excluding instance A", func(t *testing.T) {
-		_, diags := ctx.Plan(m, state, &PlanOpts{
+		_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 			Mode: plans.NormalMode,
 			Excludes: []addrs.Targetable{
 				// NOTE: addrA isn't excluded, and it's pending move to addrB
@@ -1761,7 +1762,7 @@ Note that removing these options may include further additional resource instanc
 		}
 	})
 	t.Run("excluding instance B", func(t *testing.T) {
-		_, diags := ctx.Plan(m, state, &PlanOpts{
+		_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 			Mode: plans.NormalMode,
 			Excludes: []addrs.Targetable{
 				addrB,
@@ -1801,7 +1802,7 @@ Note that removing these options may include further additional resource instanc
 		}
 	})
 	t.Run("excluding both addresses", func(t *testing.T) {
-		_, diags := ctx.Plan(m, state, &PlanOpts{
+		_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 			Mode: plans.NormalMode,
 			Excludes: []addrs.Targetable{
 				// NOTE: both addrA nor addrB are excluded here, but there's
@@ -1846,7 +1847,7 @@ Note that removing these options may include further additional resource instanc
 		// The error messages in the other subtests above suggest removing
 		// addresses to the set of excludes. This additional test makes sure that
 		// following that advice actually leads to a valid result.
-		_, diags := ctx.Plan(m, state, &PlanOpts{
+		_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 			Mode: plans.NormalMode,
 			Excludes: []addrs.Targetable{
 				mustResourceInstanceAddr("test_object.unrelated"),
@@ -1924,7 +1925,7 @@ resource "test_object" "b" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		Targets: []addrs.Targetable{
 			addrA,
@@ -1988,7 +1989,7 @@ resource "test_object" "b" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		Excludes: []addrs.Targetable{
 			addrB,
@@ -2038,7 +2039,7 @@ func TestContext2Plan_movedResourceRefreshOnly(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.RefreshOnlyMode,
 	})
 	if diags.HasErrors() {
@@ -2153,7 +2154,7 @@ func TestContext2Plan_refreshOnlyMode(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.RefreshOnlyMode,
 	})
 	if diags.HasErrors() {
@@ -2289,7 +2290,7 @@ func TestContext2Plan_refreshOnlyMode_deposed(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.RefreshOnlyMode,
 	})
 	if diags.HasErrors() {
@@ -2430,7 +2431,7 @@ func TestContext2Plan_refreshOnlyMode_orphan(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.RefreshOnlyMode,
 	})
 	if diags.HasErrors() {
@@ -2511,7 +2512,7 @@ output "root" {
 
 	ctx := testContext2(t, &ContextOpts{})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if !diags.HasErrors() {
 		t.Fatal("succeeded; want errors")
 	}
@@ -2614,7 +2615,7 @@ data "test_data_source" "foo" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	for _, res := range plan.Changes.Resources {
@@ -2663,7 +2664,7 @@ func TestContext2Plan_forceReplace(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		ForceReplace: []addrs.AbsResourceInstance{
 			addrA,
@@ -2731,7 +2732,7 @@ func TestContext2Plan_forceReplaceIncompleteAddr(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		ForceReplace: []addrs.AbsResourceInstance{
 			addrBare,
@@ -2873,7 +2874,7 @@ output "output" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	for _, res := range plan.Changes.Resources {
@@ -2942,7 +2943,7 @@ func TestContext2Plan_moduleExpandOrphansResourceInstance(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 	})
 	if diags.HasErrors() {
@@ -3047,7 +3048,7 @@ resource "test_resource" "a" {
 			resp.LegacyTypeSystem = true
 			return resp
 		}
-		plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 			Mode: plans.NormalMode,
 			SetVariables: InputValues{
 				"boop": &InputValue{
@@ -3076,7 +3077,7 @@ resource "test_resource" "a" {
 			},
 		})
 
-		_, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		_, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 			Mode: plans.NormalMode,
 			SetVariables: InputValues{
 				"boop": &InputValue{
@@ -3109,7 +3110,7 @@ resource "test_resource" "a" {
 				Status:    states.ObjectReady,
 			}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`), addrs.NoKey)
 		})
-		_, diags := ctx.Plan(m, state, &PlanOpts{
+		_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 			Mode: plans.RefreshOnlyMode,
 			SetVariables: InputValues{
 				"boop": &InputValue{
@@ -3145,7 +3146,7 @@ resource "test_resource" "a" {
 			resp.LegacyTypeSystem = true
 			return resp
 		}
-		_, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		_, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 			Mode: plans.NormalMode,
 			SetVariables: InputValues{
 				"boop": &InputValue{
@@ -3194,7 +3195,7 @@ resource "test_resource" "a" {
 				NewState: newVal,
 			}
 		}
-		_, diags := ctx.Plan(m, state, &PlanOpts{
+		_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 			Mode: plans.RefreshOnlyMode,
 			SetVariables: InputValues{
 				"boop": &InputValue{
@@ -3247,7 +3248,7 @@ resource "test_resource" "a" {
 				NewState: newVal,
 			}
 		}
-		_, diags := ctx.Plan(m, state, &PlanOpts{
+		_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 			Mode: plans.RefreshOnlyMode,
 			SetVariables: InputValues{
 				"boop": &InputValue{
@@ -3346,7 +3347,7 @@ resource "test_resource" "a" {
 				"results": cty.ListVal([]cty.Value{cty.StringVal("boop")}),
 			}),
 		}
-		plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 			Mode: plans.NormalMode,
 			SetVariables: InputValues{
 				"boop": &InputValue{
@@ -3390,7 +3391,7 @@ resource "test_resource" "a" {
 				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 			},
 		})
-		_, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		_, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 			Mode: plans.NormalMode,
 			SetVariables: InputValues{
 				"boop": &InputValue{
@@ -3416,7 +3417,7 @@ resource "test_resource" "a" {
 				addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 			},
 		})
-		plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 			Mode: plans.RefreshOnlyMode,
 			SetVariables: InputValues{
 				"boop": &InputValue{
@@ -3460,7 +3461,7 @@ resource "test_resource" "a" {
 				"results": cty.ListValEmpty(cty.String),
 			}),
 		}
-		_, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		_, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 			Mode: plans.NormalMode,
 			SetVariables: InputValues{
 				"boop": &InputValue{
@@ -3492,7 +3493,7 @@ resource "test_resource" "a" {
 				"results": cty.ListValEmpty(cty.String),
 			}),
 		}
-		plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 			Mode: plans.RefreshOnlyMode,
 			SetVariables: InputValues{
 				"boop": &InputValue{
@@ -3533,7 +3534,7 @@ resource "test_resource" "a" {
 				"results": cty.ListValEmpty(cty.String),
 			}),
 		}
-		_, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		_, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 			Mode: plans.RefreshOnlyMode,
 			SetVariables: InputValues{
 				"boop": &InputValue{
@@ -3585,7 +3586,7 @@ output "a" {
 	})
 
 	t.Run("condition pass", func(t *testing.T) {
-		plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 			Mode: plans.NormalMode,
 			SetVariables: InputValues{
 				"boop": &InputValue{
@@ -3619,7 +3620,7 @@ output "a" {
 	})
 
 	t.Run("condition fail", func(t *testing.T) {
-		_, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		_, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 			Mode: plans.NormalMode,
 			SetVariables: InputValues{
 				"boop": &InputValue{
@@ -3637,7 +3638,7 @@ output "a" {
 	})
 
 	t.Run("condition fail refresh-only", func(t *testing.T) {
-		plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 			Mode: plans.RefreshOnlyMode,
 			SetVariables: InputValues{
 				"boop": &InputValue{
@@ -3741,7 +3742,7 @@ func TestContext2Plan_preconditionErrors(t *testing.T) {
 			`, tc.condition)
 			m := testModuleInline(t, map[string]string{"main.tf": main})
 
-			plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+			plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 			if !diags.HasErrors() {
 				t.Fatal("succeeded; want errors")
 			}
@@ -3795,7 +3796,7 @@ output "a" {
 `,
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"boop": &InputValue{
@@ -3916,7 +3917,7 @@ resource "test_object" "b" {
 	for _, configuration := range configurations {
 		m := testModuleInline(t, configuration.inlineConfiguration)
 
-		plan, diags := ctx.Plan(m, state, &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 			Mode: plans.NormalMode,
 		})
 		if diags.HasErrors() {
@@ -4001,7 +4002,7 @@ data "test_object" "a" {
 		},
 	})
 
-	_, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 }
 
@@ -4051,7 +4052,7 @@ resource "test_object" "b" {
 		},
 	})
 
-	_, diags := ctx.Plan(m, state, &PlanOpts{
+	_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 	})
 	if !diags.HasErrors() {
@@ -4098,7 +4099,7 @@ output "out" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 
@@ -4175,7 +4176,7 @@ resource "test_object" "b" {
 		},
 	})
 
-	_, diags := ctx.Plan(m, state, &PlanOpts{
+	_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 	})
 	assertNoErrors(t, diags)
@@ -4240,7 +4241,7 @@ resource "test_object" "b" {
 
 	// plan+apply to create the initial state
 	opts := SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables))
-	plan, diags := ctx.Plan(m, states.NewState(), opts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), opts)
 	assertNoErrors(t, diags)
 	state, diags := ctx.Apply(plan, m)
 	assertNoErrors(t, diags)
@@ -4256,7 +4257,7 @@ resource "test_object" "b" {
 	addrB := mustResourceInstanceAddr(`test_object.b`)
 	opts.ForceReplace = []addrs.AbsResourceInstance{addrA, addrB}
 
-	_, diags = ctx.Plan(m, state, opts)
+	_, diags = ctx.Plan(context.Background(), m, state, opts)
 	assertNoErrors(t, diags)
 }
 
@@ -4356,7 +4357,7 @@ output "out" {
 		},
 	})
 
-	_, diags := ctx.Plan(m, state, &PlanOpts{
+	_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	assertNoErrors(t, diags)
@@ -4398,7 +4399,7 @@ output "out" {
 		},
 	})
 
-	_, diags := ctx.Plan(m, state, &PlanOpts{
+	_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	assertNoErrors(t, diags)
@@ -4426,7 +4427,7 @@ func TestContext2Plan_dataSourceReadPlanError(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if !diags.HasErrors() {
 		t.Fatalf("expected plan error")
 	}
@@ -4492,7 +4493,7 @@ resource "test_object" "a" {
 
 	// plan+apply to create the initial state
 	opts := SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables))
-	plan, diags := ctx.Plan(m, state, opts)
+	plan, diags := ctx.Plan(context.Background(), m, state, opts)
 	assertNoErrors(t, diags)
 
 	for _, c := range plan.Changes.Resources {
@@ -4578,7 +4579,7 @@ import {
 	for _, configuration := range configurations {
 		m := testModuleInline(t, configuration.inlineConfiguration)
 
-		plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		if diags.HasErrors() {
 			t.Fatalf("unexpected errors\n%s", diags.Err().Error())
 		}
@@ -4854,7 +4855,7 @@ import {
 				},
 			}
 
-			plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+			plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 			if diags.HasErrors() {
 				t.Fatalf("unexpected errors\n%s", diags.Err().Error())
 			}
@@ -5052,7 +5053,7 @@ import {
 				},
 			}
 
-			_, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+			_, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 
 			if !diags.HasErrors() {
 				t.Fatal("succeeded; want errors")
@@ -5202,7 +5203,7 @@ import {
 				},
 			}
 
-			plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+			plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 			if diags.HasErrors() {
 				t.Fatalf("unexpected errors\n%s", diags.Err().Error())
 			}
@@ -5539,7 +5540,7 @@ import {
 				},
 			}
 
-			_, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+			_, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 
 			if !diags.HasErrors() {
 				t.Fatal("succeeded; want errors")
@@ -5600,7 +5601,7 @@ import {
 		addrs.NoKey,
 	)
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
 	}
@@ -5666,7 +5667,7 @@ import {
 		},
 	}
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
 	}
@@ -5732,7 +5733,7 @@ import {
 		},
 	}
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		ForceReplace: []addrs.AbsResourceInstance{
 			addr,
@@ -5808,7 +5809,7 @@ import {
 		},
 	}
 
-	_, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		ForceReplace: []addrs.AbsResourceInstance{
 			addr,
@@ -5843,7 +5844,7 @@ func TestContext2Plan_importIdVariable(t *testing.T) {
 		},
 	}
 
-	_, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		SetVariables: InputValues{
 			"the_id": &InputValue{
 				// let var take its default value
@@ -5876,7 +5877,7 @@ func TestContext2Plan_importIdReference(t *testing.T) {
 		},
 	}
 
-	_, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		SetVariables: InputValues{
 			"the_id": &InputValue{
 				// let var take its default value
@@ -5909,7 +5910,7 @@ func TestContext2Plan_importIdFunc(t *testing.T) {
 		},
 	}
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -5972,7 +5973,7 @@ func TestContext2Plan_importIdDataSource(t *testing.T) {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -6010,7 +6011,7 @@ func TestContext2Plan_importIdModule(t *testing.T) {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -6025,7 +6026,7 @@ func TestContext2Plan_importIdInvalidNull(t *testing.T) {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		SetVariables: InputValues{
 			"the_id": &InputValue{
 				Value: cty.NullVal(cty.String),
@@ -6078,7 +6079,7 @@ func TestContext2Plan_importIdInvalidUnknown(t *testing.T) {
 		},
 	}
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if !diags.HasErrors() {
 		t.Fatal("succeeded; want errors")
 	}
@@ -6144,7 +6145,7 @@ resource "test_object" "a" {
 		},
 	}
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode:               plans.NormalMode,
 		GenerateConfigPath: "generated.tf", // Actual value here doesn't matter, as long as it is not empty.
 	})
@@ -6317,7 +6318,7 @@ resource "test_object" "a" {
 				},
 			})
 
-			_, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+			_, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 				Mode: plans.NormalMode,
 			})
 
@@ -6433,7 +6434,7 @@ import {
 				},
 			}
 
-			_, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+			_, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 
 			if !diags.HasErrors() {
 				t.Fatalf("expected error")
@@ -6489,7 +6490,7 @@ import {
 		},
 	}
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode:               plans.NormalMode,
 		GenerateConfigPath: "generated.tf", // Actual value here doesn't matter, as long as it is not empty.
 	})
@@ -6571,7 +6572,7 @@ import {
 		},
 	}
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode:               plans.NormalMode,
 		GenerateConfigPath: "generated.tf", // Actual value here doesn't matter, as long as it is not empty.
 	})
@@ -6833,7 +6834,7 @@ resource "test_object" "a" {
 				},
 			})
 
-			_, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+			_, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 				Mode:               plans.NormalMode,
 				GenerateConfigPath: "generated.tf",
 			})
@@ -6891,7 +6892,7 @@ import {
 		},
 	}
 
-	_, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode:               plans.NormalMode,
 		GenerateConfigPath: "generated.tf",
 	})
@@ -6941,7 +6942,7 @@ import {
 		},
 	}
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode:               plans.NormalMode,
 		GenerateConfigPath: "generated.tf", // Actual value here doesn't matter, as long as it is not empty.
 	})
@@ -6989,7 +6990,7 @@ locals {
 	})
 
 	state := states.NewState()
-	plan, diags := ctx.Plan(m, state, nil)
+	plan, diags := ctx.Plan(context.Background(), m, state, nil)
 	if diags.HasErrors() {
 		t.Errorf("expected no errors, but got %s", diags)
 	}
@@ -7056,7 +7057,7 @@ func TestContext2Plan_removedResourceBasic(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		ForceReplace: []addrs.AbsResourceInstance{
 			addr,
@@ -7137,7 +7138,7 @@ func TestContext2Plan_removedModuleBasic(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		ForceReplace: []addrs.AbsResourceInstance{
 			addr,
@@ -7213,7 +7214,7 @@ func TestContext2Plan_removedModuleForgetsAllInstances(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		ForceReplace: []addrs.AbsResourceInstance{
 			addrFirst, addrSecond,
@@ -7279,7 +7280,7 @@ func TestContext2Plan_removedResourceForgetsAllInstances(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		ForceReplace: []addrs.AbsResourceInstance{
 			addrFirst, addrSecond,
@@ -7343,7 +7344,7 @@ func TestContext2Plan_removedResourceInChildModuleFromParentModule(t *testing.T)
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		ForceReplace: []addrs.AbsResourceInstance{
 			addr,
@@ -7405,7 +7406,7 @@ func TestContext2Plan_removedResourceInChildModuleFromChildModule(t *testing.T) 
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		ForceReplace: []addrs.AbsResourceInstance{
 			addr,
@@ -7468,7 +7469,7 @@ func TestContext2Plan_removedResourceInGrandchildModuleFromRootModule(t *testing
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		ForceReplace: []addrs.AbsResourceInstance{
 			addr,
@@ -7531,7 +7532,7 @@ func TestContext2Plan_removedChildModuleForgetsResourceInGrandchildModule(t *tes
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		ForceReplace: []addrs.AbsResourceInstance{
 			addr,
@@ -7599,7 +7600,7 @@ func TestContext2Plan_movedAndRemovedResourceAtTheSameTime(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		ForceReplace: []addrs.AbsResourceInstance{
 			addrA,
@@ -7664,7 +7665,7 @@ func TestContext2Plan_removedResourceButResourceBlockStillExists(t *testing.T) {
 		},
 	})
 
-	_, diags := ctx.Plan(m, state, &PlanOpts{
+	_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		ForceReplace: []addrs.AbsResourceInstance{
 			addr,
@@ -7713,7 +7714,7 @@ func TestContext2Plan_removedResourceButResourceBlockStillExistsInChildModule(t 
 		},
 	})
 
-	_, diags := ctx.Plan(m, state, &PlanOpts{
+	_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		ForceReplace: []addrs.AbsResourceInstance{
 			addr,
@@ -7762,7 +7763,7 @@ func TestContext2Plan_removedModuleButModuleBlockStillExists(t *testing.T) {
 		},
 	})
 
-	_, diags := ctx.Plan(m, state, &PlanOpts{
+	_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		ForceReplace: []addrs.AbsResourceInstance{
 			addr,
@@ -7843,7 +7844,7 @@ func TestContext2Plan_importResourceWithSensitiveDataSource(t *testing.T) {
 		},
 	}
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
 	}
@@ -7922,7 +7923,7 @@ func TestContext2Plan_insufficient_block(t *testing.T) {
 				},
 			})
 
-			_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+			_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 			var expectedDiags tfdiags.Diagnostics
 
 			expectedDiags = expectedDiags.Append(

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -717,7 +717,7 @@ data "test_data_source" "a" {
 	// This is primarily a plan-time test, since the special handling of
 	// data resources is a plan-time concern, but we'll still try applying the
 	// plan here just to make sure it's valid.
-	newState, diags := ctx.Apply(plan, m)
+	newState, diags := ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	if rs := newState.ResourceInstance(dataAddr); rs != nil {
@@ -4243,7 +4243,7 @@ resource "test_object" "b" {
 	opts := SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables))
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), opts)
 	assertNoErrors(t, diags)
-	state, diags := ctx.Apply(plan, m)
+	state, diags := ctx.Apply(context.Background(), plan, m)
 	assertNoErrors(t, diags)
 
 	// Resource changes which have dependencies across providers which

--- a/internal/tofu/context_plan_test.go
+++ b/internal/tofu/context_plan_test.go
@@ -7,6 +7,7 @@ package tofu
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -42,7 +43,7 @@ func TestContext2Plan_basic(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -114,7 +115,7 @@ func TestContext2Plan_createBefore_deposed(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -205,7 +206,7 @@ func TestContext2Plan_createBefore_maintainRoot(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -240,7 +241,7 @@ func TestContext2Plan_emptyDiff(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -278,7 +279,7 @@ func TestContext2Plan_escapedVar(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -318,7 +319,7 @@ func TestContext2Plan_minimal(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -356,7 +357,7 @@ func TestContext2Plan_modules(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -414,7 +415,7 @@ func TestContext2Plan_moduleExpand(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -474,7 +475,7 @@ func TestContext2Plan_moduleCycle(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -528,7 +529,7 @@ func TestContext2Plan_moduleDeadlock(t *testing.T) {
 			},
 		})
 
-		plan, err := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+		plan, err := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -572,7 +573,7 @@ func TestContext2Plan_moduleInput(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -626,7 +627,7 @@ func TestContext2Plan_moduleInputComputed(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -677,7 +678,7 @@ func TestContext2Plan_moduleInputFromVar(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"foo": &InputValue{
@@ -746,7 +747,7 @@ func TestContext2Plan_moduleMultiVar(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -821,7 +822,7 @@ func TestContext2Plan_moduleOrphans(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -917,7 +918,7 @@ func TestContext2Plan_moduleOrphansWithProvisioner(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -1022,7 +1023,7 @@ func TestContext2Plan_moduleProviderInherit(t *testing.T) {
 		},
 	})
 
-	_, err := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, err := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -1086,7 +1087,7 @@ func TestContext2Plan_moduleProviderInheritDeep(t *testing.T) {
 		},
 	})
 
-	_, err := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, err := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -1141,7 +1142,7 @@ func TestContext2Plan_moduleProviderDefaultsVar(t *testing.T) {
 		},
 	})
 
-	_, err := ctx.Plan(m, states.NewState(), &PlanOpts{
+	_, err := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"foo": &InputValue{
@@ -1188,7 +1189,7 @@ func TestContext2Plan_moduleProviderVar(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -1230,7 +1231,7 @@ func TestContext2Plan_moduleVar(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -1283,7 +1284,7 @@ func TestContext2Plan_moduleVarWrongTypeBasic(t *testing.T) {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if !diags.HasErrors() {
 		t.Fatalf("succeeded; want errors")
 	}
@@ -1298,7 +1299,7 @@ func TestContext2Plan_moduleVarWrongTypeNested(t *testing.T) {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if !diags.HasErrors() {
 		t.Fatalf("succeeded; want errors")
 	}
@@ -1313,7 +1314,7 @@ func TestContext2Plan_moduleVarWithDefaultValue(t *testing.T) {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -1329,7 +1330,7 @@ func TestContext2Plan_moduleVarComputed(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -1391,7 +1392,7 @@ func TestContext2Plan_preventDestroy_bad(t *testing.T) {
 		},
 	})
 
-	plan, err := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, err := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 
 	expectedErr := "aws_instance.foo has lifecycle.prevent_destroy"
 	if !strings.Contains(fmt.Sprintf("%s", err), expectedErr) {
@@ -1431,7 +1432,7 @@ func TestContext2Plan_preventDestroy_good(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -1472,7 +1473,7 @@ func TestContext2Plan_preventDestroy_countBad(t *testing.T) {
 		},
 	})
 
-	plan, err := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, err := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 
 	expectedErr := "aws_instance.foo[1] has lifecycle.prevent_destroy"
 	if !strings.Contains(fmt.Sprintf("%s", err), expectedErr) {
@@ -1530,7 +1531,7 @@ func TestContext2Plan_preventDestroy_countGood(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -1574,7 +1575,7 @@ func TestContext2Plan_preventDestroy_countGoodNoChange(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -1606,7 +1607,7 @@ func TestContext2Plan_preventDestroy_destroyPlan(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 
@@ -1632,7 +1633,7 @@ func TestContext2Plan_provisionerCycle(t *testing.T) {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if !diags.HasErrors() {
 		t.Fatalf("succeeded; want errors")
 	}
@@ -1648,7 +1649,7 @@ func TestContext2Plan_computed(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -1720,7 +1721,7 @@ func TestContext2Plan_blockNestingGroup(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -1789,7 +1790,7 @@ func TestContext2Plan_computedDataResource(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -1860,7 +1861,7 @@ func TestContext2Plan_computedInFunction(t *testing.T) {
 	diags := ctx.Validate(m)
 	assertNoErrors(t, diags)
 
-	_, diags = ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags = ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	if !p.ReadDataSourceCalled {
@@ -1896,7 +1897,7 @@ func TestContext2Plan_computedDataCountResource(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -1924,7 +1925,7 @@ func TestContext2Plan_localValueCount(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -2004,7 +2005,7 @@ func TestContext2Plan_dataResourceBecomesComputed(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors during plan: %s", diags.Err())
 	}
@@ -2058,7 +2059,7 @@ func TestContext2Plan_computedList(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -2121,7 +2122,7 @@ func TestContext2Plan_computedMultiIndex(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -2175,7 +2176,7 @@ func TestContext2Plan_count(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -2248,7 +2249,7 @@ func TestContext2Plan_countComputed(t *testing.T) {
 		},
 	})
 
-	_, err := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, err := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if err == nil {
 		t.Fatal("should error")
 	}
@@ -2264,7 +2265,7 @@ func TestContext2Plan_countComputedModule(t *testing.T) {
 		},
 	})
 
-	_, err := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, err := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 
 	expectedErr := `The "count" value depends on resource attributes`
 	if !strings.Contains(fmt.Sprintf("%s", err), expectedErr) {
@@ -2283,7 +2284,7 @@ func TestContext2Plan_countModuleStatic(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -2336,7 +2337,7 @@ func TestContext2Plan_countModuleStaticGrandchild(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -2389,7 +2390,7 @@ func TestContext2Plan_countIndex(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -2439,7 +2440,7 @@ func TestContext2Plan_countVar(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"instance_count": &InputValue{
@@ -2524,7 +2525,7 @@ func TestContext2Plan_countZero(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -2564,7 +2565,7 @@ func TestContext2Plan_countOneIndex(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -2645,7 +2646,7 @@ func TestContext2Plan_countDecreaseToOne(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -2730,7 +2731,7 @@ func TestContext2Plan_countIncreaseFromNotSet(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -2808,7 +2809,7 @@ func TestContext2Plan_countIncreaseFromOne(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -2901,7 +2902,7 @@ func TestContext2Plan_countIncreaseFromOneCorrupted(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -3029,7 +3030,7 @@ func TestContext2Plan_countIncreaseWithSplatReference(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -3083,7 +3084,7 @@ func TestContext2Plan_forEach(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -3117,7 +3118,7 @@ func TestContext2Plan_forEachUnknownValue(t *testing.T) {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"foo": {
@@ -3179,7 +3180,7 @@ func TestContext2Plan_destroy(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	if diags.HasErrors() {
@@ -3243,7 +3244,7 @@ func TestContext2Plan_moduleDestroy(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	if diags.HasErrors() {
@@ -3307,7 +3308,7 @@ func TestContext2Plan_moduleDestroyCycle(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	if diags.HasErrors() {
@@ -3370,7 +3371,7 @@ func TestContext2Plan_moduleDestroyMultivar(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
 	if diags.HasErrors() {
@@ -3428,7 +3429,7 @@ func TestContext2Plan_pathVar(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("err: %s", diags.Err())
 	}
@@ -3484,7 +3485,7 @@ func TestContext2Plan_diffVar(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -3543,7 +3544,7 @@ func TestContext2Plan_hook(t *testing.T) {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -3568,7 +3569,7 @@ func TestContext2Plan_closeProvider(t *testing.T) {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -3600,7 +3601,7 @@ func TestContext2Plan_orphan(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -3655,7 +3656,7 @@ func TestContext2Plan_shadowUuid(t *testing.T) {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -3682,7 +3683,7 @@ func TestContext2Plan_state(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -3786,7 +3787,7 @@ func TestContext2Plan_requiresReplace(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -3854,7 +3855,7 @@ func TestContext2Plan_taint(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -3933,7 +3934,7 @@ func TestContext2Plan_taintIgnoreChanges(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -4017,7 +4018,7 @@ func TestContext2Plan_taintDestroyInterpolatedCountRace(t *testing.T) {
 			},
 		})
 
-		plan, diags := ctx.Plan(m, state.DeepCopy(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+		plan, diags := ctx.Plan(context.Background(), m, state.DeepCopy(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 		if diags.HasErrors() {
 			t.Fatalf("unexpected errors: %s", diags.Err())
 		}
@@ -4072,7 +4073,7 @@ func TestContext2Plan_targeted(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Targets: []addrs.Targetable{
 			addrs.RootModuleInstance.Resource(
@@ -4125,7 +4126,7 @@ func TestContext2Plan_excluded(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.Resource(addrs.ManagedResourceMode, "aws_instance", "foo"),
@@ -4175,7 +4176,7 @@ func TestContext2Plan_targetedCrossModule(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Targets: []addrs.Targetable{
 			addrs.RootModuleInstance.Child("B", addrs.NoKey),
@@ -4230,7 +4231,7 @@ func TestContext2Plan_excludedCrossModule(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.Child("A", addrs.NoKey),
@@ -4267,7 +4268,7 @@ func TestContext2Plan_targetedModuleWithProvider(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Targets: []addrs.Targetable{
 			addrs.RootModuleInstance.Child("child2", addrs.NoKey),
@@ -4317,7 +4318,7 @@ func TestContext2Plan_excludedModuleWithProvider(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.Child("child1", addrs.NoKey),
@@ -4376,7 +4377,7 @@ func TestContext2Plan_targetedOrphan(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 		Targets: []addrs.Targetable{
 			addrs.RootModuleInstance.Resource(
@@ -4443,7 +4444,7 @@ func TestContext2Plan_excludedOrphan(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.Resource(
@@ -4511,7 +4512,7 @@ func TestContext2Plan_targetedModuleOrphan(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 		Targets: []addrs.Targetable{
 			addrs.RootModuleInstance.Child("child", addrs.NoKey).Resource(
@@ -4575,7 +4576,7 @@ func TestContext2Plan_excludedModuleOrphan(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.Child("child", addrs.NoKey).Resource(
@@ -4618,7 +4619,7 @@ func TestContext2Plan_targetedModuleUntargetedVariable(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Targets: []addrs.Targetable{
 			addrs.RootModuleInstance.Resource(
 				addrs.ManagedResourceMode, "aws_instance", "blue",
@@ -4673,7 +4674,7 @@ func TestContext2Plan_excludedModuleUntargetedVariable(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Excludes: []addrs.Targetable{
 			// Exclude green instance, which should also exclude the dependent green module
 			addrs.RootModuleInstance.Resource(
@@ -4729,7 +4730,7 @@ func TestContext2Plan_outputContainsUntargetedResource(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Targets: []addrs.Targetable{
 			addrs.RootModuleInstance.Child("mod", addrs.NoKey).Resource(
 				addrs.ManagedResourceMode, "aws_instance", "a",
@@ -4780,7 +4781,7 @@ func TestContext2Plan_outputContainsExcludedResource(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.Child("mod", addrs.NoKey).Resource(
 				addrs.ManagedResourceMode, "aws_instance", "b",
@@ -4852,7 +4853,7 @@ func TestContext2Plan_targetedOverTen(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Targets: []addrs.Targetable{
 			addrs.RootModuleInstance.ResourceInstance(
 				addrs.ManagedResourceMode, "aws_instance", "foo", addrs.IntKey(1),
@@ -4907,7 +4908,7 @@ func TestContext2Plan_excludedOverTen(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.ResourceInstance(
 				addrs.ManagedResourceMode, "aws_instance", "foo", addrs.IntKey(1),
@@ -4957,7 +4958,7 @@ func TestContext2Plan_provider(t *testing.T) {
 		},
 	}
 
-	if _, err := ctx.Plan(m, states.NewState(), opts); err != nil {
+	if _, err := ctx.Plan(context.Background(), m, states.NewState(), opts); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -4975,7 +4976,7 @@ func TestContext2Plan_varListErr(t *testing.T) {
 		},
 	})
 
-	_, err := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, err := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 
 	if err == nil {
 		t.Fatal("should error")
@@ -5005,7 +5006,7 @@ func TestContext2Plan_ignoreChanges(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"foo": &InputValue{
@@ -5078,7 +5079,7 @@ func TestContext2Plan_ignoreChangesWildcard(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"foo": &InputValue{
@@ -5146,7 +5147,7 @@ func TestContext2Plan_ignoreChangesInMap(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, s, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, s, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -5202,7 +5203,7 @@ func TestContext2Plan_ignoreChangesSensitive(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"foo": &InputValue{
@@ -5272,7 +5273,7 @@ func TestContext2Plan_moduleMapLiteral(t *testing.T) {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -5314,7 +5315,7 @@ func TestContext2Plan_computedValueInMap(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -5369,7 +5370,7 @@ func TestContext2Plan_moduleVariableFromSplat(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -5451,7 +5452,7 @@ func TestContext2Plan_createBeforeDestroy_depends_datasource(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -5525,7 +5526,7 @@ func TestContext2Plan_listOrder(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -5594,7 +5595,7 @@ func TestContext2Plan_ignoreChangesWithFlatmaps(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -5719,7 +5720,7 @@ func TestContext2Plan_resourceNestedCount(t *testing.T) {
 		t.Fatalf("validate errors: %s", diags.Err())
 	}
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("plan errors: %s", diags.Err())
 	}
@@ -5768,7 +5769,7 @@ func TestContext2Plan_computedAttrRefTypeMismatch(t *testing.T) {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if !diags.HasErrors() {
 		t.Fatalf("Succeeded; want type mismatch error for 'ami' argument")
 	}
@@ -5803,7 +5804,7 @@ func TestContext2Plan_selfRef(t *testing.T) {
 		t.Fatalf("unexpected validation failure: %s", diags.Err())
 	}
 
-	_, diags = c.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags = c.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if !diags.HasErrors() {
 		t.Fatalf("plan succeeded; want error")
 	}
@@ -5839,7 +5840,7 @@ func TestContext2Plan_selfRefMulti(t *testing.T) {
 		t.Fatalf("unexpected validation failure: %s", diags.Err())
 	}
 
-	_, diags = c.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags = c.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if !diags.HasErrors() {
 		t.Fatalf("plan succeeded; want error")
 	}
@@ -5875,7 +5876,7 @@ func TestContext2Plan_selfRefMultiAll(t *testing.T) {
 		t.Fatalf("unexpected validation failure: %s", diags.Err())
 	}
 
-	_, diags = c.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags = c.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if !diags.HasErrors() {
 		t.Fatalf("plan succeeded; want error")
 	}
@@ -5915,7 +5916,7 @@ output "out" {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if !diags.HasErrors() {
 		// Should get this error:
 		// Unsupported attribute: This object does not have an attribute named "missing"
@@ -5961,7 +5962,7 @@ resource "aws_instance" "foo" {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if !diags.HasErrors() {
 		// Should get this error:
 		// Unsupported attribute: This object does not have an attribute named "missing"
@@ -6007,7 +6008,7 @@ resource "aws_instance" "foo" {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if !diags.HasErrors() {
 		// Should get this error:
 		// Unsupported attribute: This object does not have an attribute named "missing"
@@ -6030,7 +6031,7 @@ func TestContext2Plan_variableSensitivity(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -6090,7 +6091,7 @@ func TestContext2Plan_variableSensitivityModule(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		SetVariables: InputValues{
 			"sensitive_var": {Value: cty.NilVal},
@@ -6200,7 +6201,7 @@ func TestContext2Plan_requiredModuleOutput(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -6263,7 +6264,7 @@ func TestContext2Plan_requiredModuleObject(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -6348,7 +6349,7 @@ resource "aws_instance" "foo" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -6407,7 +6408,7 @@ output"out" {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -6449,7 +6450,7 @@ resource "aws_instance" "foo" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode:    plans.NormalMode,
 		Targets: targets,
 	})
@@ -6514,7 +6515,7 @@ resource "aws_instance" "foo" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode:     plans.NormalMode,
 		Excludes: excludes,
 	})
@@ -6573,7 +6574,7 @@ resource "aws_instance" "foo" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode:    plans.NormalMode,
 		Targets: targets,
 	})
@@ -6628,7 +6629,7 @@ resource "aws_instance" "foo" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode:     plans.NormalMode,
 		Excludes: excludes,
 	})
@@ -6692,7 +6693,7 @@ resource "aws_instance" "foo" {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -6748,7 +6749,7 @@ data "test_data_source" "foo" {}
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -6808,7 +6809,7 @@ resource "test_instance" "b" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	t.Run("test_instance.a[0]", func(t *testing.T) {
@@ -6855,7 +6856,7 @@ func TestContext2Plan_targetedModuleInstance(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Targets: []addrs.Targetable{
 			addrs.RootModuleInstance.Child("mod", addrs.IntKey(0)),
@@ -6903,7 +6904,7 @@ func TestContext2Plan_excludedModuleInstance(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 		Mode: plans.NormalMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.Resource(
@@ -6965,7 +6966,7 @@ data "test_data_source" "d" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -7028,7 +7029,7 @@ data "test_data_source" "e" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	rc := plan.Changes.ResourceInstance(addrs.Resource{
@@ -7108,7 +7109,7 @@ data "test_data_source" "d" {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if !diags.HasErrors() {
 		t.Fatalf("successful plan; want an error")
 	}
@@ -7147,7 +7148,7 @@ resource "test_instance" "a" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode:        plans.NormalMode,
 		SkipRefresh: true,
 	})
@@ -7209,7 +7210,7 @@ data "test_data_source" "b" {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
 	// The change to data source a should not prevent data source b from being
@@ -7249,7 +7250,7 @@ resource "test_instance" "a" {
 			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 		},
 	})
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -7319,7 +7320,7 @@ resource "test_instance" "a" {
 			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 		},
 	})
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -7383,7 +7384,7 @@ resource "test_instance" "a" {
 			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 		},
 	})
-	_, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -7442,7 +7443,7 @@ resource "test_instance" "a" {
 			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 		},
 	})
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -7499,7 +7500,7 @@ resource "test_instance" "a" {
 			addrs.NewProvider("registry.opentofu.org", "local", "test"): testProviderFuncFixed(p),
 		},
 	})
-	_, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -7548,7 +7549,7 @@ resource "test_resource" "foo" {
 			addrs.NoKey,
 		)
 	})
-	plan, diags := ctx.Plan(m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
+	plan, diags := ctx.Plan(context.Background(), m, state, SimplePlanOpts(plans.NormalMode, testInputValuesUnset(m.Module.Variables)))
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -7570,7 +7571,7 @@ func TestContext2Plan_variableCustomValidationsSensitive(t *testing.T) {
 		},
 	})
 
-	_, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if !diags.HasErrors() {
 		t.Fatal("succeeded; want errors")
 	}
@@ -7594,7 +7595,7 @@ output "planned" {
 		r := s.Module(addrs.RootModuleInstance)
 		r.SetOutputValue("planned", cty.NullVal(cty.DynamicPseudoType), false)
 	})
-	plan, diags := ctx.Plan(m, state, DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -7617,7 +7618,7 @@ output "planned" {
 	})
 
 	ctx := testContext2(t, &ContextOpts{})
-	plan, diags := ctx.Plan(m, states.NewState(), DefaultPlanOpts)
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}

--- a/internal/tofu/context_plan_test.go
+++ b/internal/tofu/context_plan_test.go
@@ -1858,7 +1858,7 @@ func TestContext2Plan_computedInFunction(t *testing.T) {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	assertNoErrors(t, diags)
 
 	_, diags = ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
@@ -5715,7 +5715,7 @@ func TestContext2Plan_resourceNestedCount(t *testing.T) {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatalf("validate errors: %s", diags.Err())
 	}
@@ -5799,7 +5799,7 @@ func TestContext2Plan_selfRef(t *testing.T) {
 		},
 	})
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected validation failure: %s", diags.Err())
 	}
@@ -5835,7 +5835,7 @@ func TestContext2Plan_selfRefMulti(t *testing.T) {
 		},
 	})
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected validation failure: %s", diags.Err())
 	}
@@ -5871,7 +5871,7 @@ func TestContext2Plan_selfRefMultiAll(t *testing.T) {
 		},
 	})
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected validation failure: %s", diags.Err())
 	}

--- a/internal/tofu/context_refresh.go
+++ b/internal/tofu/context_refresh.go
@@ -22,7 +22,7 @@ import (
 // automation relying on the "tofu refresh" subcommand. The modern way
 // to get this effect is to create and then apply a plan in the refresh-only
 // mode.
-func (c *Context) Refresh(config *configs.Config, prevRunState *states.State, opts *PlanOpts) (*states.State, tfdiags.Diagnostics) {
+func (c *Context) Refresh(ctx context.Context, config *configs.Config, prevRunState *states.State, opts *PlanOpts) (*states.State, tfdiags.Diagnostics) {
 	if opts == nil {
 		// This fallback is only here for tests, not for real code.
 		opts = &PlanOpts{
@@ -34,7 +34,7 @@ func (c *Context) Refresh(config *configs.Config, prevRunState *states.State, op
 	}
 
 	log.Printf("[DEBUG] Refresh is really just plan now, so creating a %s plan", opts.Mode)
-	p, diags := c.Plan(context.Background(), config, prevRunState, opts)
+	p, diags := c.Plan(ctx, config, prevRunState, opts)
 	if diags.HasErrors() {
 		return nil, diags
 	}

--- a/internal/tofu/context_refresh.go
+++ b/internal/tofu/context_refresh.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"log"
 
 	"github.com/opentofu/opentofu/internal/configs"
@@ -33,7 +34,7 @@ func (c *Context) Refresh(config *configs.Config, prevRunState *states.State, op
 	}
 
 	log.Printf("[DEBUG] Refresh is really just plan now, so creating a %s plan", opts.Mode)
-	p, diags := c.Plan(config, prevRunState, opts)
+	p, diags := c.Plan(context.Background(), config, prevRunState, opts)
 	if diags.HasErrors() {
 		return nil, diags
 	}

--- a/internal/tofu/context_refresh_test.go
+++ b/internal/tofu/context_refresh_test.go
@@ -1501,7 +1501,7 @@ func TestContext2Validate(t *testing.T) {
 		},
 	})
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if len(diags) != 0 {
 		t.Fatalf("unexpected error: %#v", diags.ErrWithWarnings())
 	}

--- a/internal/tofu/context_refresh_test.go
+++ b/internal/tofu/context_refresh_test.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"reflect"
 	"sort"
 	"strings"
@@ -208,7 +209,7 @@ func TestContext2Refresh_dataComputedModuleVar(t *testing.T) {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{Mode: plans.RefreshOnlyMode})
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{Mode: plans.RefreshOnlyMode})
 	if diags.HasErrors() {
 		t.Fatalf("refresh errors: %s", diags.Err())
 	}
@@ -1953,7 +1954,7 @@ resource "test_resource" "foo" {
 		},
 	})
 
-	plan, diags := ctx.Plan(m, state, &PlanOpts{Mode: plans.RefreshOnlyMode})
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{Mode: plans.RefreshOnlyMode})
 	if diags.HasErrors() {
 		t.Fatalf("refresh errors: %s", diags.Err())
 	}

--- a/internal/tofu/context_refresh_test.go
+++ b/internal/tofu/context_refresh_test.go
@@ -57,7 +57,7 @@ func TestContext2Refresh(t *testing.T) {
 		NewState: readState,
 	}
 
-	s, diags := ctx.Refresh(m, state, &PlanOpts{Mode: plans.NormalMode})
+	s, diags := ctx.Refresh(context.Background(), m, state, &PlanOpts{Mode: plans.NormalMode})
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -137,7 +137,7 @@ func TestContext2Refresh_dynamicAttr(t *testing.T) {
 	schema := p.GetProviderSchemaResponse.ResourceTypes["test_instance"].Block
 	ty := schema.ImpliedType()
 
-	s, diags := ctx.Refresh(m, startingState, &PlanOpts{Mode: plans.NormalMode})
+	s, diags := ctx.Refresh(context.Background(), m, startingState, &PlanOpts{Mode: plans.NormalMode})
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -281,7 +281,7 @@ func TestContext2Refresh_targeted(t *testing.T) {
 		}
 	}
 
-	_, diags := ctx.Refresh(m, state, &PlanOpts{
+	_, diags := ctx.Refresh(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		Targets: []addrs.Targetable{
 			addrs.RootModuleInstance.Resource(
@@ -368,7 +368,7 @@ func TestContext2Refresh_excluded(t *testing.T) {
 		}
 	}
 
-	_, diags := ctx.Refresh(m, state, &PlanOpts{
+	_, diags := ctx.Refresh(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.Resource(
@@ -452,7 +452,7 @@ func TestContext2Refresh_targetedCount(t *testing.T) {
 		}
 	}
 
-	_, diags := ctx.Refresh(m, state, &PlanOpts{
+	_, diags := ctx.Refresh(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		Targets: []addrs.Targetable{
 			addrs.RootModuleInstance.Resource(
@@ -545,7 +545,7 @@ func TestContext2Refresh_excludedCount(t *testing.T) {
 		}
 	}
 
-	_, diags := ctx.Refresh(m, state, &PlanOpts{
+	_, diags := ctx.Refresh(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.Resource(
@@ -633,7 +633,7 @@ func TestContext2Refresh_targetedCountIndex(t *testing.T) {
 		}
 	}
 
-	_, diags := ctx.Refresh(m, state, &PlanOpts{
+	_, diags := ctx.Refresh(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		Targets: []addrs.Targetable{
 			addrs.RootModuleInstance.ResourceInstance(
@@ -720,7 +720,7 @@ func TestContext2Refresh_excludedCountIndex(t *testing.T) {
 		}
 	}
 
-	_, diags := ctx.Refresh(m, state, &PlanOpts{
+	_, diags := ctx.Refresh(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		Excludes: []addrs.Targetable{
 			addrs.RootModuleInstance.ResourceInstance(
@@ -769,7 +769,7 @@ func TestContext2Refresh_moduleComputedVar(t *testing.T) {
 
 	// This was failing (see GH-2188) at some point, so this test just
 	// verifies that the failure goes away.
-	if _, diags := ctx.Refresh(m, states.NewState(), &PlanOpts{Mode: plans.NormalMode}); diags.HasErrors() {
+	if _, diags := ctx.Refresh(context.Background(), m, states.NewState(), &PlanOpts{Mode: plans.NormalMode}); diags.HasErrors() {
 		t.Fatalf("refresh errs: %s", diags.Err())
 	}
 }
@@ -792,7 +792,7 @@ func TestContext2Refresh_delete(t *testing.T) {
 		NewState: cty.NullVal(p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block.ImpliedType()),
 	}
 
-	s, diags := ctx.Refresh(m, state, &PlanOpts{Mode: plans.NormalMode})
+	s, diags := ctx.Refresh(context.Background(), m, state, &PlanOpts{Mode: plans.NormalMode})
 	if diags.HasErrors() {
 		t.Fatalf("refresh errors: %s", diags.Err())
 	}
@@ -818,7 +818,7 @@ func TestContext2Refresh_ignoreUncreated(t *testing.T) {
 		}),
 	}
 
-	_, diags := ctx.Refresh(m, states.NewState(), &PlanOpts{Mode: plans.NormalMode})
+	_, diags := ctx.Refresh(context.Background(), m, states.NewState(), &PlanOpts{Mode: plans.NormalMode})
 	if diags.HasErrors() {
 		t.Fatalf("refresh errors: %s", diags.Err())
 	}
@@ -843,7 +843,7 @@ func TestContext2Refresh_hook(t *testing.T) {
 		},
 	})
 
-	if _, diags := ctx.Refresh(m, state, &PlanOpts{Mode: plans.NormalMode}); diags.HasErrors() {
+	if _, diags := ctx.Refresh(context.Background(), m, state, &PlanOpts{Mode: plans.NormalMode}); diags.HasErrors() {
 		t.Fatalf("refresh errs: %s", diags.Err())
 	}
 	if !h.PreRefreshCalled {
@@ -888,7 +888,7 @@ func TestContext2Refresh_modules(t *testing.T) {
 		}
 	}
 
-	s, diags := ctx.Refresh(m, state, &PlanOpts{Mode: plans.NormalMode})
+	s, diags := ctx.Refresh(context.Background(), m, state, &PlanOpts{Mode: plans.NormalMode})
 	if diags.HasErrors() {
 		t.Fatalf("refresh errors: %s", diags.Err())
 	}
@@ -928,7 +928,7 @@ func TestContext2Refresh_moduleInputComputedOutput(t *testing.T) {
 		},
 	})
 
-	if _, diags := ctx.Refresh(m, states.NewState(), &PlanOpts{Mode: plans.NormalMode}); diags.HasErrors() {
+	if _, diags := ctx.Refresh(context.Background(), m, states.NewState(), &PlanOpts{Mode: plans.NormalMode}); diags.HasErrors() {
 		t.Fatalf("refresh errs: %s", diags.Err())
 	}
 }
@@ -942,7 +942,7 @@ func TestContext2Refresh_moduleVarModule(t *testing.T) {
 		},
 	})
 
-	if _, diags := ctx.Refresh(m, states.NewState(), &PlanOpts{Mode: plans.NormalMode}); diags.HasErrors() {
+	if _, diags := ctx.Refresh(context.Background(), m, states.NewState(), &PlanOpts{Mode: plans.NormalMode}); diags.HasErrors() {
 		t.Fatalf("refresh errs: %s", diags.Err())
 	}
 }
@@ -963,7 +963,7 @@ func TestContext2Refresh_noState(t *testing.T) {
 		}),
 	}
 
-	if _, diags := ctx.Refresh(m, states.NewState(), &PlanOpts{Mode: plans.NormalMode}); diags.HasErrors() {
+	if _, diags := ctx.Refresh(context.Background(), m, states.NewState(), &PlanOpts{Mode: plans.NormalMode}); diags.HasErrors() {
 		t.Fatalf("refresh errs: %s", diags.Err())
 	}
 }
@@ -1003,7 +1003,7 @@ func TestContext2Refresh_output(t *testing.T) {
 		},
 	})
 
-	s, diags := ctx.Refresh(m, state, &PlanOpts{Mode: plans.NormalMode})
+	s, diags := ctx.Refresh(context.Background(), m, state, &PlanOpts{Mode: plans.NormalMode})
 	if diags.HasErrors() {
 		t.Fatalf("refresh errors: %s", diags.Err())
 	}
@@ -1051,7 +1051,7 @@ func TestContext2Refresh_outputPartial(t *testing.T) {
 		},
 	})
 
-	s, diags := ctx.Refresh(m, state, &PlanOpts{Mode: plans.NormalMode})
+	s, diags := ctx.Refresh(context.Background(), m, state, &PlanOpts{Mode: plans.NormalMode})
 	if diags.HasErrors() {
 		t.Fatalf("refresh errors: %s", diags.Err())
 	}
@@ -1091,7 +1091,7 @@ func TestContext2Refresh_stateBasic(t *testing.T) {
 		NewState: readStateVal,
 	}
 
-	s, diags := ctx.Refresh(m, state, &PlanOpts{Mode: plans.NormalMode})
+	s, diags := ctx.Refresh(context.Background(), m, state, &PlanOpts{Mode: plans.NormalMode})
 	if diags.HasErrors() {
 		t.Fatalf("refresh errors: %s", diags.Err())
 	}
@@ -1147,7 +1147,7 @@ func TestContext2Refresh_dataCount(t *testing.T) {
 		},
 	})
 
-	s, diags := ctx.Refresh(m, states.NewState(), &PlanOpts{Mode: plans.NormalMode})
+	s, diags := ctx.Refresh(context.Background(), m, states.NewState(), &PlanOpts{Mode: plans.NormalMode})
 
 	if diags.HasErrors() {
 		t.Fatalf("refresh errors: %s", diags.Err())
@@ -1193,7 +1193,7 @@ func TestContext2Refresh_dataState(t *testing.T) {
 		}
 	}
 
-	s, diags := ctx.Refresh(m, state, &PlanOpts{Mode: plans.NormalMode})
+	s, diags := ctx.Refresh(context.Background(), m, state, &PlanOpts{Mode: plans.NormalMode})
 	if diags.HasErrors() {
 		t.Fatalf("refresh errors: %s", diags.Err())
 	}
@@ -1256,7 +1256,7 @@ func TestContext2Refresh_dataStateRefData(t *testing.T) {
 		}
 	}
 
-	s, diags := ctx.Refresh(m, state, &PlanOpts{Mode: plans.NormalMode})
+	s, diags := ctx.Refresh(context.Background(), m, state, &PlanOpts{Mode: plans.NormalMode})
 	if diags.HasErrors() {
 		t.Fatalf("refresh errors: %s", diags.Err())
 	}
@@ -1291,7 +1291,7 @@ func TestContext2Refresh_tainted(t *testing.T) {
 		}
 	}
 
-	s, diags := ctx.Refresh(m, state, &PlanOpts{Mode: plans.NormalMode})
+	s, diags := ctx.Refresh(context.Background(), m, state, &PlanOpts{Mode: plans.NormalMode})
 	if diags.HasErrors() {
 		t.Fatalf("refresh errors: %s", diags.Err())
 	}
@@ -1322,7 +1322,7 @@ func TestContext2Refresh_unknownProvider(t *testing.T) {
 	})
 	assertNoDiagnostics(t, diags)
 
-	_, diags = c.Refresh(m, states.NewState(), &PlanOpts{Mode: plans.NormalMode})
+	_, diags = c.Refresh(context.Background(), m, states.NewState(), &PlanOpts{Mode: plans.NormalMode})
 	if !diags.HasErrors() {
 		t.Fatal("successfully refreshed; want error")
 	}
@@ -1381,7 +1381,7 @@ func TestContext2Refresh_vars(t *testing.T) {
 		}
 	}
 
-	s, diags := ctx.Refresh(m, state, &PlanOpts{Mode: plans.NormalMode})
+	s, diags := ctx.Refresh(context.Background(), m, state, &PlanOpts{Mode: plans.NormalMode})
 	if diags.HasErrors() {
 		t.Fatalf("refresh errors: %s", diags.Err())
 	}
@@ -1461,7 +1461,7 @@ func TestContext2Refresh_orphanModule(t *testing.T) {
 	})
 
 	testCheckDeadlock(t, func() {
-		_, err := ctx.Refresh(m, state, &PlanOpts{Mode: plans.NormalMode})
+		_, err := ctx.Refresh(context.Background(), m, state, &PlanOpts{Mode: plans.NormalMode})
 		if err != nil {
 			t.Fatalf("err: %s", err.Err())
 		}
@@ -1526,7 +1526,7 @@ aws_instance.bar:
   ID = foo
   provider = provider["registry.opentofu.org/hashicorp/aws"].foo`)
 
-	s, diags := ctx.Refresh(m, state, &PlanOpts{Mode: plans.NormalMode})
+	s, diags := ctx.Refresh(context.Background(), m, state, &PlanOpts{Mode: plans.NormalMode})
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -1589,7 +1589,7 @@ func TestContext2Refresh_schemaUpgradeFlatmap(t *testing.T) {
 		},
 	})
 
-	state, diags := ctx.Refresh(m, s, &PlanOpts{Mode: plans.NormalMode})
+	state, diags := ctx.Refresh(context.Background(), m, s, &PlanOpts{Mode: plans.NormalMode})
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -1672,7 +1672,7 @@ func TestContext2Refresh_schemaUpgradeJSON(t *testing.T) {
 		},
 	})
 
-	state, diags := ctx.Refresh(m, s, &PlanOpts{Mode: plans.NormalMode})
+	state, diags := ctx.Refresh(context.Background(), m, s, &PlanOpts{Mode: plans.NormalMode})
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -1728,7 +1728,7 @@ data "aws_data_source" "foo" {
 		},
 	})
 
-	_, diags := ctx.Refresh(m, states.NewState(), &PlanOpts{Mode: plans.NormalMode})
+	_, diags := ctx.Refresh(context.Background(), m, states.NewState(), &PlanOpts{Mode: plans.NormalMode})
 	if diags.HasErrors() {
 		// Should get this error:
 		// Unsupported attribute: This object does not have an attribute named "missing"
@@ -1776,7 +1776,7 @@ func TestContext2Refresh_dataResourceDependsOn(t *testing.T) {
 		},
 	})
 
-	_, diags := ctx.Refresh(m, state, &PlanOpts{Mode: plans.NormalMode})
+	_, diags := ctx.Refresh(context.Background(), m, state, &PlanOpts{Mode: plans.NormalMode})
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
@@ -1821,7 +1821,7 @@ resource "aws_instance" "bar" {
 		},
 	})
 
-	state, diags := ctx.Refresh(m, state, &PlanOpts{Mode: plans.NormalMode})
+	state, diags := ctx.Refresh(context.Background(), m, state, &PlanOpts{Mode: plans.NormalMode})
 	if diags.HasErrors() {
 		t.Fatalf("plan errors: %s", diags.Err())
 	}
@@ -1868,7 +1868,7 @@ func TestContext2Refresh_dataSourceOrphan(t *testing.T) {
 		},
 	})
 
-	_, diags := ctx.Refresh(m, state, &PlanOpts{Mode: plans.NormalMode})
+	_, diags := ctx.Refresh(context.Background(), m, state, &PlanOpts{Mode: plans.NormalMode})
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}

--- a/internal/tofu/context_test.go
+++ b/internal/tofu/context_test.go
@@ -8,6 +8,7 @@ package tofu
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -211,7 +212,7 @@ resource "implicit_thing" "b" {
 	// be worth the complexity to check for them.
 
 	validateDiags := ctx.Validate(cfg)
-	_, planDiags := ctx.Plan(cfg, nil, DefaultPlanOpts)
+	_, planDiags := ctx.Plan(context.Background(), cfg, nil, DefaultPlanOpts)
 
 	tests := map[string]tfdiags.Diagnostics{
 		"validate": validateDiags,

--- a/internal/tofu/context_test.go
+++ b/internal/tofu/context_test.go
@@ -107,7 +107,7 @@ func TestNewContextRequiredVersion(t *testing.T) {
 				t.Fatalf("unexpected NewContext errors: %s", diags.Err())
 			}
 
-			diags = c.Validate(mod)
+			diags = c.Validate(context.Background(), mod)
 			if diags.HasErrors() != tc.Err {
 				t.Fatalf("err: %s", diags.Err())
 			}
@@ -166,7 +166,7 @@ terraform {}
 				t.Fatalf("unexpected NewContext errors: %s", diags.Err())
 			}
 
-			diags = c.Validate(mod)
+			diags = c.Validate(context.Background(), mod)
 			if diags.HasErrors() != tc.Err {
 				t.Fatalf("err: %s", diags.Err())
 			}
@@ -211,7 +211,7 @@ resource "implicit_thing" "b" {
 	// require doing some pretty weird things that aren't common enough to
 	// be worth the complexity to check for them.
 
-	validateDiags := ctx.Validate(cfg)
+	validateDiags := ctx.Validate(context.Background(), cfg)
 	_, planDiags := ctx.Plan(context.Background(), cfg, nil, DefaultPlanOpts)
 
 	tests := map[string]tfdiags.Diagnostics{

--- a/internal/tofu/context_validate.go
+++ b/internal/tofu/context_validate.go
@@ -76,7 +76,7 @@ func (c *Context) Validate(ctx context.Context, config *configs.Config) tfdiags.
 		return diags
 	}
 
-	walker, walkDiags := c.walk(graph, walkValidate, &graphWalkOpts{
+	walker, walkDiags := c.walk(ctx, graph, walkValidate, &graphWalkOpts{
 		Config:                  config,
 		ProviderFunctionTracker: providerFunctionTracker,
 	})

--- a/internal/tofu/context_validate.go
+++ b/internal/tofu/context_validate.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"log"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -26,7 +27,7 @@ import (
 // such as root module input variables. However, the Plan function includes
 // all of the same checks as Validate, in addition to the other work it does
 // to consider the previous run state and the planning options.
-func (c *Context) Validate(config *configs.Config) tfdiags.Diagnostics {
+func (c *Context) Validate(ctx context.Context, config *configs.Config) tfdiags.Diagnostics {
 	defer c.acquireRun("validate")()
 
 	var diags tfdiags.Diagnostics

--- a/internal/tofu/context_validate_test.go
+++ b/internal/tofu/context_validate_test.go
@@ -39,7 +39,7 @@ func TestContext2Validate_badCount(t *testing.T) {
 		},
 	})
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if !diags.HasErrors() {
 		t.Fatalf("succeeded; want error")
 	}
@@ -62,7 +62,7 @@ func TestContext2Validate_badResource_reference(t *testing.T) {
 		},
 	})
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if !diags.HasErrors() {
 		t.Fatalf("succeeded; want error")
 	}
@@ -88,7 +88,7 @@ func TestContext2Validate_badVar(t *testing.T) {
 		},
 	})
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if !diags.HasErrors() {
 		t.Fatalf("succeeded; want error")
 	}
@@ -165,7 +165,7 @@ func TestContext2Validate_computedVar(t *testing.T) {
 		return
 	}
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}
@@ -205,7 +205,7 @@ func TestContext2Validate_computedInFunction(t *testing.T) {
 		},
 	})
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}
@@ -243,7 +243,7 @@ func TestContext2Validate_countComputed(t *testing.T) {
 		},
 	})
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}
@@ -267,7 +267,7 @@ func TestContext2Validate_countNegative(t *testing.T) {
 		},
 	})
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if !diags.HasErrors() {
 		t.Fatalf("succeeded; want error")
 	}
@@ -293,7 +293,7 @@ func TestContext2Validate_countVariable(t *testing.T) {
 		},
 	})
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}
@@ -347,7 +347,7 @@ func TestContext2Validate_moduleBadOutput(t *testing.T) {
 		},
 	})
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if !diags.HasErrors() {
 		t.Fatalf("succeeded; want error")
 	}
@@ -373,7 +373,7 @@ func TestContext2Validate_moduleGood(t *testing.T) {
 		},
 	})
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}
@@ -402,7 +402,7 @@ func TestContext2Validate_moduleBadResource(t *testing.T) {
 		Diagnostics: tfdiags.Diagnostics{}.Append(fmt.Errorf("bad")),
 	}
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if !diags.HasErrors() {
 		t.Fatalf("succeeded; want error")
 	}
@@ -429,7 +429,7 @@ func TestContext2Validate_moduleDepsShouldNotCycle(t *testing.T) {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}
@@ -470,7 +470,7 @@ func TestContext2Validate_moduleProviderVar(t *testing.T) {
 		return
 	}
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}
@@ -511,7 +511,7 @@ func TestContext2Validate_moduleProviderInheritUnused(t *testing.T) {
 		return
 	}
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}
@@ -550,7 +550,7 @@ func TestContext2Validate_orphans(t *testing.T) {
 		}
 	}
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}
@@ -586,7 +586,7 @@ func TestContext2Validate_providerConfig_bad(t *testing.T) {
 		Diagnostics: tfdiags.Diagnostics{}.Append(fmt.Errorf("bad")),
 	}
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if len(diags) != 1 {
 		t.Fatalf("wrong number of diagnostics %d; want %d", len(diags), 1)
 	}
@@ -625,7 +625,7 @@ func TestContext2Validate_providerConfig_skippedEmpty(t *testing.T) {
 		Diagnostics: tfdiags.Diagnostics{}.Append(fmt.Errorf("should not be called")),
 	}
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}
@@ -657,7 +657,7 @@ func TestContext2Validate_providerConfig_good(t *testing.T) {
 		},
 	})
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}
@@ -692,7 +692,7 @@ func TestContext2Validate_requiredProviderConfig(t *testing.T) {
 		},
 	})
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}
@@ -728,7 +728,7 @@ func TestContext2Validate_provisionerConfig_bad(t *testing.T) {
 		Diagnostics: tfdiags.Diagnostics{}.Append(fmt.Errorf("bad")),
 	}
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if !diags.HasErrors() {
 		t.Fatalf("succeeded; want error")
 	}
@@ -760,7 +760,7 @@ func TestContext2Validate_badResourceConnection(t *testing.T) {
 		},
 	})
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	t.Log(diags.Err())
 	if !diags.HasErrors() {
 		t.Fatalf("succeeded; want error")
@@ -793,7 +793,7 @@ func TestContext2Validate_badProvisionerConnection(t *testing.T) {
 		},
 	})
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	t.Log(diags.Err())
 	if !diags.HasErrors() {
 		t.Fatalf("succeeded; want error")
@@ -842,7 +842,7 @@ func TestContext2Validate_provisionerConfig_good(t *testing.T) {
 		},
 	})
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}
@@ -908,7 +908,7 @@ func TestContext2Validate_resourceConfig_bad(t *testing.T) {
 		Diagnostics: tfdiags.Diagnostics{}.Append(fmt.Errorf("bad")),
 	}
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if !diags.HasErrors() {
 		t.Fatalf("succeeded; want error")
 	}
@@ -934,7 +934,7 @@ func TestContext2Validate_resourceConfig_good(t *testing.T) {
 		},
 	})
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}
@@ -972,7 +972,7 @@ func TestContext2Validate_tainted(t *testing.T) {
 		}
 	}
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}
@@ -1009,7 +1009,7 @@ func TestContext2Validate_targetedDestroy(t *testing.T) {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}
@@ -1041,7 +1041,7 @@ func TestContext2Validate_varRefUnknown(t *testing.T) {
 		return providers.ValidateResourceConfigResponse{}
 	}
 
-	c.Validate(m)
+	c.Validate(context.Background(), m)
 
 	// Input variables are always unknown during the validate walk, because
 	// we're checking for validity of all possible input values. Validity
@@ -1077,7 +1077,7 @@ func TestContext2Validate_interpolateVar(t *testing.T) {
 		UIInput: input,
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}
@@ -1109,7 +1109,7 @@ func TestContext2Validate_interpolateComputedModuleVarDef(t *testing.T) {
 		UIInput: input,
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}
@@ -1129,7 +1129,7 @@ func TestContext2Validate_interpolateMap(t *testing.T) {
 		UIInput: input,
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}
@@ -1179,7 +1179,7 @@ resource "aws_instance" "foo" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -1210,7 +1210,7 @@ output "out" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if !diags.HasErrors() {
 		t.Fatal("succeeded; want errors")
 	}
@@ -1246,7 +1246,7 @@ resource "aws_instance" "foo" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if !diags.HasErrors() {
 		t.Fatal("succeeded; want errors")
 	}
@@ -1281,7 +1281,7 @@ output "root" {
 
 	ctx := testContext2(t, &ContextOpts{})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -1304,7 +1304,7 @@ output "out" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if !diags.HasErrors() {
 		t.Fatal("succeeded; want errors")
 	}
@@ -1334,7 +1334,7 @@ output "out" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if !diags.HasErrors() {
 		t.Fatal("succeeded; want errors")
 	}
@@ -1364,7 +1364,7 @@ output "out" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if !diags.HasErrors() {
 		t.Fatal("succeeded; want errors")
 	}
@@ -1393,7 +1393,7 @@ resource "test_instance" "bar" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if !diags.HasErrors() {
 		t.Fatal("succeeded; want errors")
 	}
@@ -1425,7 +1425,7 @@ resource "test_instance" "bar" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if !diags.HasErrors() {
 		t.Fatal("succeeded; want errors")
 	}
@@ -1449,7 +1449,7 @@ func TestContext2Validate_variableCustomValidationsFail(t *testing.T) {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if !diags.HasErrors() {
 		t.Fatal("succeeded; want errors")
 	}
@@ -1483,7 +1483,7 @@ variable "test" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error\ngot: %s", diags.Err().Error())
 	}
@@ -1544,7 +1544,7 @@ resource "aws_instance" "foo" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -1571,7 +1571,7 @@ resource "aws_instance" "foo" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if !diags.HasErrors() {
 		t.Fatal("succeeded; want errors")
 	}
@@ -1601,7 +1601,7 @@ resource "aws_instance" "foo" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if !diags.HasErrors() {
 		t.Fatal("succeeded; want errors")
 	}
@@ -1682,7 +1682,7 @@ output "out" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -1709,7 +1709,7 @@ output "out" {
 `,
 	})
 
-	diags := testContext2(t, &ContextOpts{}).Validate(m)
+	diags := testContext2(t, &ContextOpts{}).Validate(context.Background(), m)
 	if !diags.HasErrors() {
 		t.Fatal("succeeded; want errors")
 	}
@@ -1747,7 +1747,7 @@ output "out" {
 `,
 	})
 
-	diags := testContext2(t, &ContextOpts{}).Validate(m)
+	diags := testContext2(t, &ContextOpts{}).Validate(context.Background(), m)
 	if !diags.HasErrors() {
 		t.Fatal("succeeded; want errors")
 	}
@@ -1795,7 +1795,7 @@ resource "test_instance" "a" {
 			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 		},
 	})
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -1845,7 +1845,7 @@ func TestContext2Validate_sensitiveProvisionerConfig(t *testing.T) {
 		return pr.ValidateProvisionerConfigResponse
 	}
 
-	diags := c.Validate(m)
+	diags := c.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}
@@ -1939,7 +1939,7 @@ resource "test_instance" "c" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -2006,7 +2006,7 @@ resource "test_object" "t" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -2063,7 +2063,7 @@ output "out" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -2096,7 +2096,7 @@ func TestContext2Validate_nonNullableVariableDefaultValidation(t *testing.T) {
 
 	ctx := testContext2(t, &ContextOpts{})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -2139,7 +2139,7 @@ resource "aws_instance" "test" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -2182,7 +2182,7 @@ resource "aws_instance" "test" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if !diags.HasErrors() {
 		t.Fatalf("succeeded; want error")
 	}
@@ -2228,7 +2228,7 @@ resource "aws_instance" "test" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if !diags.HasErrors() {
 		t.Fatalf("succeeded; want error")
 	}
@@ -2269,7 +2269,7 @@ resource "aws_instance" "test" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -2318,7 +2318,7 @@ resource "aws_instance" "test" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if !diags.HasErrors() {
 		t.Fatalf("succeeded; want error")
 	}
@@ -2359,7 +2359,7 @@ resource "aws_instance" "test" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if !diags.HasErrors() {
 		t.Fatalf("succeeded; want error")
 	}
@@ -2405,7 +2405,7 @@ resource "aws_instance" "test" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -2448,7 +2448,7 @@ resource "aws_instance" "test" {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
@@ -2482,7 +2482,7 @@ locals {
 		},
 	})
 
-	diags := ctx.Validate(m)
+	diags := ctx.Validate(context.Background(), m)
 	warn := diags.ErrWithWarnings().Error()
 	if !strings.Contains(warn, `The attribute "foo" is deprecated`) {
 		t.Fatalf("expected deprecated warning, got: %q\n", warn)

--- a/internal/tofu/context_validate_test.go
+++ b/internal/tofu/context_validate_test.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -108,7 +109,7 @@ func TestContext2Validate_varNoDefaultExplicitType(t *testing.T) {
 	// grown into a plan test rather than a validate test, but it lives on
 	// here in order to make it easier to navigate through that history in
 	// version control.
-	_, diags = c.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags = c.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if !diags.HasErrors() {
 		// Error should be: The input variable "maybe_a_map" has not been assigned a value.
 		t.Fatalf("succeeded; want error")
@@ -319,7 +320,7 @@ func TestContext2Validate_countVariableNoDefault(t *testing.T) {
 	})
 	assertNoDiagnostics(t, diags)
 
-	_, diags = c.Plan(m, nil, &PlanOpts{})
+	_, diags = c.Plan(context.Background(), m, nil, &PlanOpts{})
 	if !diags.HasErrors() {
 		// Error should be: The input variable "foo" has not been assigned a value.
 		t.Fatalf("succeeded; want error")
@@ -876,7 +877,7 @@ func TestContext2Validate_requiredVar(t *testing.T) {
 	// grown into a plan test rather than a validate test, but it lives on
 	// here in order to make it easier to navigate through that history in
 	// version control.
-	_, diags = c.Plan(m, states.NewState(), DefaultPlanOpts)
+	_, diags = c.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
 	if !diags.HasErrors() {
 		// Error should be: The input variable "foo" has not been assigned a value.
 		t.Fatalf("succeeded; want error")

--- a/internal/tofu/context_walk.go
+++ b/internal/tofu/context_walk.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"log"
 	"time"
 
@@ -48,7 +49,7 @@ type graphWalkOpts struct {
 	ProviderFunctionTracker ProviderFunctionMapping
 }
 
-func (c *Context) walk(graph *Graph, operation walkOperation, opts *graphWalkOpts) (*ContextGraphWalker, tfdiags.Diagnostics) {
+func (c *Context) walk(ctx context.Context, graph *Graph, operation walkOperation, opts *graphWalkOpts) (*ContextGraphWalker, tfdiags.Diagnostics) {
 	log.Printf("[DEBUG] Starting graph walk: %s", operation.String())
 
 	walker := c.graphWalker(operation, opts)
@@ -57,7 +58,7 @@ func (c *Context) walk(graph *Graph, operation walkOperation, opts *graphWalkOpt
 	watchStop, watchWait := c.watchStop(walker)
 
 	// Walk the real graph, this will block until it completes
-	diags := graph.Walk(walker)
+	diags := graph.Walk(ctx, walker)
 
 	// Close the channel so the watcher stops, and wait for it to return.
 	close(watchStop)

--- a/internal/tofu/node_module_variable_test.go
+++ b/internal/tofu/node_module_variable_test.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"testing"
@@ -220,7 +221,7 @@ func TestNodeModuleVariableConstraints(t *testing.T) {
 
 	t.Run("pass", func(t *testing.T) {
 		ctx := testContext2(t, ctxOpts)
-		plan, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 			Mode: plans.NormalMode,
 			SetVariables: InputValues{
 				"input": &InputValue{
@@ -253,7 +254,7 @@ func TestNodeModuleVariableConstraints(t *testing.T) {
 			}
 		}
 
-		plan, diags = ctx.Plan(m, state, &PlanOpts{
+		plan, diags = ctx.Plan(context.Background(), m, state, &PlanOpts{
 			Mode: plans.DestroyMode,
 			SetVariables: InputValues{
 				"input": &InputValue{
@@ -279,7 +280,7 @@ func TestNodeModuleVariableConstraints(t *testing.T) {
 
 	t.Run("fail", func(t *testing.T) {
 		ctx := testContext2(t, ctxOpts)
-		_, diags := ctx.Plan(m, states.NewState(), &PlanOpts{
+		_, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
 			Mode: plans.NormalMode,
 			SetVariables: InputValues{
 				"input": &InputValue{

--- a/internal/tofu/node_module_variable_test.go
+++ b/internal/tofu/node_module_variable_test.go
@@ -242,7 +242,7 @@ func TestNodeModuleVariableConstraints(t *testing.T) {
 			}
 		}
 
-		state, diags := ctx.Apply(plan, m)
+		state, diags := ctx.Apply(context.Background(), plan, m)
 		assertNoDiagnostics(t, diags)
 		for _, addr := range checkableObjects {
 			result := state.CheckResults.GetObjectResult(addr)
@@ -265,7 +265,7 @@ func TestNodeModuleVariableConstraints(t *testing.T) {
 		})
 		assertNoDiagnostics(t, diags)
 
-		state, diags = ctx.Apply(plan, m)
+		state, diags = ctx.Apply(context.Background(), plan, m)
 		assertNoDiagnostics(t, diags)
 		for _, addr := range checkableObjects {
 			result := state.CheckResults.GetObjectResult(addr)


### PR DESCRIPTION
Much of OpenTofu was written before the Go community adopted the idiom of passing a `ctx context.Context` argument as the first argument of any function which directly or indirectly performs expensive operations like network requests. 

Over the years we've gradually added those arguments to small, disconnected parts of the call graph, but there were gaps that prevented context values from propagating all the way from the root.

This series of commits plumbs `ctx context.Context` all the way from `package main` to `tofu.Graph.Walk`, which is only one step away from being able to use the context when we visit individual graph nodes. The next step here would be to change the interfaces `tofu.GraphNodeExecutable` and `tofu.GraphNodeDynamicExpandable` so that their methods each have a `context.Context` argument that `tofu.Graph.Walk` would then populate, and then we'll finally have a usable `context.Context` in the place where OpenTelemetry spans would be most useful: where we make requests to providers.

---

https://github.com/opentofu/opentofu/pull/2028 previously correctly identified that OpenTofu has a number of spots -- particularly in the local backend -- where it uses temporary internal `context.Context` objects as an implementation detail of orchestrating the graceful cancellation mechanism. Those uses don't follow the typical `context.Context` patterns because they are really just using the context type as a convenient way to use a channel-close as an event notification, without propagating those contexts between subsystems.

This set of changes intentionally leaves those existing unusual uses of `context.Context` in place, and adds _new_ `ctx context.Context` arguments to deal with the more conventional pattern of passing context down the call stack _between_ components. This follows the _spirit_ of #2028, but uses the idiomatic variable name `ctx` instead of `traceCtx`; all of the existing internal uses of `context.Context` were using other names anyway, so this is not ambiguous and should make our signatures familiar to Go developers bringing their experience from other codebases.

The name `ctx` _is_ ambiguous with our long-standing convention of using that variable name for values of type `tofu.EvalContext`. The last commit in this PR begins a transition to using `evalCtx` as the conventional name for a variable of that type, and so this PR implicitly proposes that we continue that renaming in the subsequent steps where we change the graph node interfaces, leading to the following signatures:

```hcl
type GraphNodeExecutable interface {
	Execute(ctx context.Context, evalCtx EvalContext, op walkOperation) tfdiags.Diagnostics
}

type GraphNodeDynamicExpandable interface {
	DynamicExpand(ctx context.Context, evalCtx EvalContext) (*Graph, error)
}
```

Again, the motivation here is to gradually make OpenTofu more Go-idiomatic, so that the codebase will become more accessible to folks who already have Go development experience from other codebases.

---

The commits that change the signature of exported methods on `tofu.Context` each involve a totally-mechanical set of test updates, which add noise to the diff but need not be reviewed in detail: in all cases the change is just to add `context.Background()` as the new first argument.

It may be easier to review this PR on a commit-by-commit basis rather than as one big diff; each commit leaves the codebase in a working state, with later commits just plumbing `context.Context` into increasingly-deeper parts of the system.

This PR is not intended to change the observable behavior of OpenTofu in any way. I carefully used `context.WithoutCancel` to neuter any cancellation effect of incoming contexts for existing codepaths that would not previously have inherited cancellation, while still allowing any values to propagate. That is reinforced by the fact that this PR includes no test updates aside from the mechanical additions of `context.Background()` to populate the new `ctx` parameters.

Once we have this plumbed enough that the context is able to propagate into the `providers.Interface` methods I intend to add tests that make sure we can pass a [`context.WithValue`](https://pkg.go.dev/context#WithValue) all the way from `command.Meta` to each provider method, so we can make sure we don't accidentally break the context chains under future maintenance. This PR does not yet plumb far enough to instrument in that way though, so there are not yet any new tests here.

This PR also intentionally does _not_ introduce any additional OpenTelemetry spans or logs. This _is_ intended to help us achieve that in future, but we'll want to carefully design how we arrange our telemetry output for end-user consumption since it will ultimately be effectively part of the OpenTofu UI, albeit indirectly. Therefore I'm focusing for now only on getting the contexts plumbed internally.


