### PR TITLE
Use Equal instead of address strings

### DIFF
--- a/internal/plans/changes_sync.go
+++ b/internal/plans/changes_sync.go
@@ -126,9 +126,8 @@ func (cs *ChangesSync) RemoveResourceInstanceChange(addr addrs.AbsResourceInstan
 		dk = realDK
 	}
 
-	addrStr := addr.String()
 	for i, r := range cs.changes.Resources {
-		if r.Addr.String() != addrStr || r.DeposedKey != dk {
+		if !r.Addr.Equal(addr) || r.DeposedKey != dk {
 			continue
 		}
 		copy(cs.changes.Resources[i:], cs.changes.Resources[i+1:])
@@ -214,10 +213,8 @@ func (cs *ChangesSync) RemoveOutputChange(addr addrs.AbsOutputValue) {
 	cs.lock.Lock()
 	defer cs.lock.Unlock()
 
-	addrStr := addr.String()
-
 	for i, o := range cs.changes.Outputs {
-		if o.Addr.String() != addrStr {
+		if !o.Addr.Equal(addr) {
 			continue
 		}
 		copy(cs.changes.Outputs[i:], cs.changes.Outputs[i+1:])


### PR DESCRIPTION
Hello it's me again on my quest to make opentofu faster.

I have a workload where about 10% of the plan time is spent inside AbsResourceInstance.String() inside of RemoveResourceInstanceChange. I believe this is due to quadratic complexity at higher level, but this is an easier and more obvious fix that is hopefully uncontroversial until I can wrap my head around a more involved fix for that.

This also reduces the GC pressure by ~15% (in this case) because we aren't generating a bunch of strings that are used once.

Ideally this would show up in one of the test cases for https://github.com/opentofu/opentofu-performance-testing but I suspect none of them are representative of what I'm doing. If anyone more familiar with the codebase could help me come up with a test case for this that exercises the pathological behavior, I'd appreciate it.

If it helps, heres a snapshot of the flamegraph before (this is 64s):

<img width="1799" alt="image" src="https://github.com/user-attachments/assets/cfba2f07-6670-44da-9591-fe71e4de003b">


And after (this is 1.5s):

<img width="1800" alt="image" src="https://github.com/user-attachments/assets/9fb630a1-5f45-4ab0-b049-dcd876984eb0">


## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
