### PR TITLE
pin node version for docusaurus build

### DIFF
--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -8,7 +8,7 @@ FROM alpine AS parent
 RUN apk add git
 RUN git clone --recurse-submodules https://github.com/opentofu/opentofu.org /work
 
-FROM node
+FROM node:22
 COPY --from=parent /work /work
 WORKDIR /work
 RUN npm i


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
The website build started to fail with a weird error (`Unexpected end of JSON input`), see [this run](https://github.com/opentofu/opentofu/actions/runs/11903561357/job/33170767394?pr=2170) as an example. We don't pin node version in website Dockerfile build so it seems to be broken due to node v23 upgrade. Some of the tools don't work well with node v23 yet (including Docusaurus) so this PR sets node version to v22.

Related Docusaurus issue: https://github.com/facebook/docusaurus/issues/10684

## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [ ] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [ ] I have not used an AI coding assistant to create this PR.
- [ ] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [ ] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [X] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
