### PR TITLE
[RFC] Deprecation of module variables and outputs

### DIFF
--- a/rfc/20241118-module-vars-and-outputs-deprecation.md
+++ b/rfc/20241118-module-vars-and-outputs-deprecation.md
@@ -140,7 +140,9 @@ enough from the UX point of view to potentially be extended for other purposes. 
 OpenTofu users. Deprecation marks could help reuse parts of the implementation (evaluation checks) to handle more `deprecation`
 flags in the future.
 
-Also, we want to keep compatibility with Terraform's deprecation mechanisms.
+At the time of writing, Terraform haven't yet released deprecation mechanism for module variables and outputs, so
+we are going to mark that feature as experimental in order to tweak UX in the future if needed. That way we are
+going to keep compatibility with the upstream project.
 
 ## Potential Alternatives
 

--- a/rfc/20241118-module-vars-and-outputs-deprecation.md
+++ b/rfc/20241118-module-vars-and-outputs-deprecation.md
@@ -81,8 +81,8 @@ deprecation warning as specified by module author:
 ```
 
 > [!NOTE]
-> Module users may rely on [output precondition check](https://opentofu.org/docs/language/values/outputs/#custom-condition-checks),
-> however it doesn't require implicit references, so this type of usage will not be counted when generating deprecation warnings. We
+> Module users may rely on [output precondition check](https://opentofu.org/docs/language/values/outputs/#custom-condition-checks).
+> However it doesn't require implicit references, so this type of usage will not be counted when generating deprecation warnings. We
 > might want to forbid deprecation of outputs with precondition checks so module authors would be required to migrate them beforehand.
 
 ### Technical Approach
@@ -90,13 +90,13 @@ deprecation warning as specified by module author:
 Technical approach should be different for input variables and outputs. For input variables, we can follow existing approach, where
 variables are being validated.
 
-As for module outputs, it is slightly harder to determine if it's is actually referenced in the user configuration, since
+As for module outputs, it is slightly harder to determine if it's is actually referenced in the user configuration, because
 `nodeExpandOutput` is included in the graph regardless of its actual usage. On graph walk, this node expands to one or more
-`NodeApplyableOutput` nodes, which also validates precondition checks on execution.
+`NodeApplyableOutput` nodes. `NodeApplyableOutput` also run validation of precondition checks on its execution.
 
 In the case we decide to forbid deprecating outputs with precondition checks, we can extend `nodeExpandOutput` with the
 deprecation check and then extend `ModuleExpansionTransformer` to not link `nodeExpandOutput` with `nodeCloseModule`. This
-way we are getting rid of unused output nodes from the graph. Deprecation check is just ignored if there is an output is unused.
+way we are getting rid of unused output nodes from the graph. Deprecation check is just ignored if the output is unused.
 
 Otherwise, we can extend existing `ReferenceTransformer` (or create a new one) to check if there are any connections to
 `nodeExpandOutput` from the outside of its module. We should keep in mind potential performance downgrades since for large

--- a/rfc/20241118-module-vars-and-outputs-deprecation.md
+++ b/rfc/20241118-module-vars-and-outputs-deprecation.md
@@ -37,13 +37,13 @@ should accept a required string value for a warning message:
 variable "this_is_my_variable" {
   type        = string
   description = "This is a variable for the old way of configuring things."
-  deprecated  = "This variable will be removed on 2024-12-31. Use that_is_my_variable instead."
+  deprecated  = "This variable will be removed on 2024-12-31. Use another_variable instead."
 }
 
 output "this_is_my_output" {
   value       = some_resource.some_name.some_field
   description = "This is an output for the old way of using things."
-  deprecated  = "This output will be removed on 2024-12-31. Use that_is_my_output instead."
+  deprecated  = "This output will be removed on 2024-12-31. Use another_output instead."
 }
 ```
 
@@ -58,7 +58,7 @@ specified by module author:
 │   on mod/main.tf line 9, in module call "mod":
 │    9:     this_is_my_variable = "something"
 │ 
-│ This variable will be removed on 2024-12-31. Use that_is_my_variable instead.
+│ This variable will be removed on 2024-12-31. Use another_variable instead.
 ```
 
 > [!NOTE]
@@ -80,7 +80,7 @@ deprecation warning as specified by module author:
 │ This value is derived from module.mod.this_is_my_output, which is
 │ deprecated with the following message:
 |
-| This output will be removed on 2024-12-31. Use that_is_my_output instead.
+| This output will be removed on 2024-12-31. Use another_output instead.
 ```
 
 #### Silencing deprecation warnings for dependencies
@@ -153,7 +153,7 @@ of functionality to be used across the OpenTofu. It would require a separate RFC
 evolve.
 
 ```hcl
-# @deprecated: This variable will be removed on 2024-12-31. Use that_is_my_variable instead.
+# @deprecated: This variable will be removed on 2024-12-31. Use another_variable instead.
 variable "this_is_my_variable" {
   type = string
   description = "This is a variable for the old way of configuring things."
@@ -175,7 +175,7 @@ variable "this_is_my_variable" {
 
 deprecation "this_is_my_variable" {
   type = "variable"
-  message = "This variable will be removed on 2024-12-31. Use that_is_my_variable instead."
+  message = "This variable will be removed on 2024-12-31. Use another_variable instead."
 }
 ```
 
@@ -191,7 +191,7 @@ variable "this_is_my_variable" {
   
   validation {
     condition     = var.this_is_my_variable != null
-    warning_message = "This variable will be removed on 2024-12-31. Use that_is_my_variable instead."
+    warning_message = "This variable will be removed on 2024-12-31. Use another_variable instead."
   }
 }
 ```
@@ -201,6 +201,6 @@ variable "this_is_my_variable" {
 ```hcl
 variable "this_is_my_variable" {
   type = string
-  description = "This is a variable for the old way of configuring things. @deprecated{ This variable will be removed on 2024-12-31. Use that_is_my_variable instead. }"
+  description = "This is a variable for the old way of configuring things. @deprecated{ This variable will be removed on 2024-12-31. Use another_variable instead. }"
 }
 ```

--- a/rfc/20241118-module-vars-and-outputs-deprecation.md
+++ b/rfc/20241118-module-vars-and-outputs-deprecation.md
@@ -86,13 +86,18 @@ deprecation warning as specified by module author:
 #### Silencing deprecation warnings for dependencies
 
 If the module is not controlled by the configuration author, it makes sense to optionally ignore deprecation warnings raised in such
-a module. This could be presented in two different ways: globally for all non-local module calls or on per-module
+a module. I will be refering to local and non-local modules, which contain module calls with deprecated variables or outputs. By local
+modules, I mean modules fetched from local filesystem and for non-local modules, it means they are fetched from remote systems. This
+separation helps with defining what module configuration users control. For example, module calls with deprecation warnings in local
+modules (even non-root ones) could be fixed by a configuration author, thus shouldn't be ignored.
+
+Silencing deprecation warnings could be presented in two different ways: globally for all non-local modules or on per-module
 basis. This setting shouldn't be a part of a module call block since there could be multiple calls for the same module and each such
 call should either produce or silence the warnings.
 
 In this RFC I suggest to allow users to control module deprecation warnings via a CLI flag: `module-deprecation-warnings`, which may
-have the following values: `all` (default) or `local` (raise deprecation warnings only from usage inside of the local modules). This
-could be extended later to include other options such as `none` to disable the deprecation warnings altogether.
+have the following values: `all` (default) or `local` (raise deprecation warnings only from module calls inside the local modules).
+This could be extended later to include other options such as `none` to disable the deprecation warnings altogether.
 
 ### Technical Approach
 

--- a/rfc/20241118-module-vars-and-outputs-deprecation.md
+++ b/rfc/20241118-module-vars-and-outputs-deprecation.md
@@ -1,0 +1,148 @@
+# Deprecation of module variables and outputs
+
+Issue: https://github.com/opentofu/opentofu/issues/1005
+
+OpenTofu configuration can be split into multiple [modules](https://opentofu.org/docs/language/modules/). Each module
+represents some part of the configuration, which can have its own [input variables](https://opentofu.org/docs/language/values/variables/)
+and [outputs](https://opentofu.org/docs/language/values/outputs/) to provide additional customization and integration
+into the configuration base.
+
+Oftentimes, users who [call modules](https://opentofu.org/docs/language/modules/syntax/#calling-a-child-module) are not the
+ones who implemented them, so it requires careful consideration from module authors on how the module should evolve. It also
+creates an additional challenge for module authors on how to properly introduce and communicate breaking changes, including
+deprecation of module input variables and outputs.
+
+Currently, module authors either keep backward compatiblity or put deprecation notices in the release notes. Both options are
+not ideal for the end-user. Therefore, it would be useful if OpenTofu could notify module users about the deprecation of input 
+variables or outputs as defined by module authors.
+
+> [!NOTE]
+> Module deprecation as a whole is a similar problem, however it is addressed on the OpenTofu Registry level.
+
+## Proposed Solution
+
+OpenTofu should allow module authors to mark input variables and outputs as deprecated with a warning message alongside.
+Module users have to see a respective warning message in cases, when deprecated input variable or output is used in their
+configuration.
+
+> [!NOTE]
+> The result of `tofu validate`, `tofu plan`, `tofu apply` and `tofu test` should include deprecation warnings.
+
+### User Documentation
+
+Module authors should be able to use a new field named `deprecated` in both `variable` and `output` blocks. This field 
+should accept a required string value for a warning message:
+
+```hcl
+variable "this_is_my_variable" {
+  type        = string
+  description = "This is a variable for the old way of configuring things."
+  deprecated  = "This variable will be removed on 2024-12-31. Use that_is_my_variable instead."
+}
+
+output "this_is_my_output" {
+  value       = some_resource.some_name.some_field
+  description = "This is an output for the old way of using things."
+  deprecated  = "This output will be removed on 2024-12-31. Use that_is_my_output instead."
+}
+```
+
+#### Deprecated module variable warning
+
+If module caller specify non-null value for a deprecated variable, OpenTofu shoould produce a deprecation warning as 
+specified by module author:
+
+```hcl
+│ Warning: The variable "this_is_my_variable" is marked as deprecated by module author.
+│ 
+│   on mod/main.tf line 9, in module call "mod":
+│    9:     this_is_my_variable = "something"
+│ 
+│ This variable will be removed on 2024-12-31. Use that_is_my_variable instead.
+```
+
+> [!NOTE]
+> It is possible for module user to specify a null value for a deprecated variable and receive no warnings. OpenTofu treats
+> variables with explicit null values the same way as if it was ommited completely. This is not an ideal, however an idiomatic
+> OpenTofu language approach. See `null` values note [in the docs](https://opentofu.org/docs/language/expressions/types/#types).
+
+#### Deprecated module output warning
+
+TBD
+
+### Technical Approach
+
+TBD
+
+### Open Questions
+
+* Do we want to support silencing of deprecation warnings?
+
+### Future Considerations
+
+It is hard to implement generic deprecation mechanism for the OpenTofu language. However, this solution should be generic 
+enough from the UX point of view to potentially be extended for other purposes. This way we keep consistent experience for
+OpenTofu users.
+
+Also, we want to keep compatibility with Terraform's deprecation mechanisms.
+
+## Potential Alternatives
+
+Here is the list of other potential options (mostly from the UX perspective), which were considered at the time of writing this RFC.
+
+#### HCL comment
+
+Right now, OpenTofu doesn't treat comments as something with a special meaning so this feature would introduce a whole new set
+of functionality to be used across the OpenTofu. It would require a separate RFC to define how this notion could potentially
+evolve.
+
+```hcl
+# @deprecated: This variable will be removed on 2024-12-31. Use that_is_my_variable instead.
+variable "this_is_my_variable" {
+  type = string
+  description = "This is a variable for the old way of configuring things."
+}
+```
+
+#### Separate `deprecation` block
+
+This approach is too verbose and doesn't align properly with OpenTofu language design. However, this way module authors can
+put their deprecation warnings in a separate `.tofu` file to keep compatibility with other tools.
+
+```hcl
+variable "this_is_my_variable" {
+  type = string
+  description = "This is a variable for the old way of configuring things."
+}
+
+deprecation "this_is_my_variable" {
+  type = "variable"
+  message = "This variable will be removed on 2024-12-31. Use that_is_my_variable instead."
+}
+```
+
+#### Custom variable validation
+
+This option could be reused for generic warning when potentially unwanted behaviour may take place. However, this option is
+not suitable for outputs deprecation.
+
+```hcl
+variable "this_is_my_variable" {
+  type = string
+  description = "This is a variable for the old way of configuring things."
+  
+  validation {
+    condition     = var.this_is_my_variable != null
+    warning_message = "This variable will be removed on 2024-12-31. Use that_is_my_variable instead."
+  }
+}
+```
+
+#### Extended variable description (rejected by TSC)
+
+```hcl
+variable "this_is_my_variable" {
+  type = string
+  description = "This is a variable for the old way of configuring things. @deprecated{ This variable will be removed on 2024-12-31. Use that_is_my_variable instead. }"
+}
+```


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Part of https://github.com/opentofu/opentofu/issues/1005.

In this PR I summarized the discussion around variables and outputs deprecation; provided answers to some of the questions that popped up; and described how to approach this feature technically.

[Rendered version.](https://github.com/opentofu/opentofu/blob/mod-depr-rfc/rfc/20241118-module-vars-and-outputs-deprecation.md)

## Target Release

Not applicable

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [X] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [X] I have not used an AI coding assistant to create this PR.
- [X] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [X] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
