### PR TITLE
Split variable evaluation / validation scope

### DIFF
--- a/internal/tofu/graph_builder_plan_test.go
+++ b/internal/tofu/graph_builder_plan_test.go
@@ -250,7 +250,7 @@ func TestPlanGraphBuilder_forEach(t *testing.T) {
 const testPlanGraphBuilderStr = `
 aws_instance.web (expand)
   aws_security_group.firewall (expand)
-  var.foo
+  var.foo (expand, reference)
 aws_load_balancer.weblb (expand)
   aws_instance.web (expand)
 aws_security_group.firewall (expand)
@@ -273,6 +273,8 @@ root
   provider["registry.opentofu.org/hashicorp/aws"] (close)
   provider["registry.opentofu.org/hashicorp/openstack"] (close)
 var.foo
+var.foo (expand, reference)
+  var.foo
 `
 const testPlanGraphBuilderForEachStr = `
 aws_instance.bar (expand)

--- a/internal/tofu/node_root_variable_test.go
+++ b/internal/tofu/node_root_variable_test.go
@@ -128,6 +128,11 @@ func TestNodeRootVariableExecute(t *testing.T) {
 			},
 		}
 
+		ref := &nodeVariableReference{
+			Addr:   n.Addr,
+			Config: n.Config,
+		}
+
 		ctx.ChecksState = checks.NewState(&configs.Config{
 			Module: &configs.Module{
 				Variables: map[string]*configs.Variable{
@@ -139,6 +144,20 @@ func TestNodeRootVariableExecute(t *testing.T) {
 		diags := n.Execute(ctx, walkApply)
 		if diags.HasErrors() {
 			t.Fatalf("unexpected error: %s", diags.Err())
+		}
+
+		g, err := ref.DynamicExpand(ctx)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		for _, v := range g.Vertices() {
+			if ev, ok := v.(GraphNodeExecutable); ok {
+				diags = ev.Execute(ctx, walkApply)
+				if diags.HasErrors() {
+					t.Fatalf("unexpected error: %s", diags.Err())
+				}
+			}
 		}
 
 		if !ctx.SetRootModuleArgumentCalled {

--- a/internal/tofu/node_variable_reference.go
+++ b/internal/tofu/node_variable_reference.go
@@ -1,0 +1,154 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tofu
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/configs"
+	"github.com/opentofu/opentofu/internal/dag"
+	"github.com/opentofu/opentofu/internal/lang"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+)
+
+// nodeVariableReference is the placeholder for an variable reference that has not yet had
+// its module path expanded.  It is a dependency on the evaluation (in a different scope) of
+// the nodes which provide the actual variable value to the evaluation context.  This split
+// allows the evaluation and validation of the variable in the two different scopes required.
+type nodeVariableReference struct {
+	Addr   addrs.InputVariable
+	Module addrs.Module
+	Config *configs.Variable
+	Expr   hcl.Expression // Used for diagnostics only
+}
+
+var (
+	_ GraphNodeDynamicExpandable = (*nodeVariableReference)(nil)
+	_ GraphNodeReferenceable     = (*nodeVariableReference)(nil)
+	_ GraphNodeReferencer        = (*nodeVariableReference)(nil)
+	_ graphNodeExpandsInstances  = (*nodeVariableReference)(nil)
+)
+
+// graphNodeExpandsInstances
+func (n *nodeVariableReference) expandsInstances() {}
+
+// GraphNodeDynamicExpandable
+func (n *nodeVariableReference) DynamicExpand(ctx EvalContext) (*Graph, error) {
+	var g Graph
+
+	// If this variable has preconditions, we need to report these checks now.
+	//
+	// We should only do this during planning as the apply phase starts with
+	// all the same checkable objects that were registered during the plan.
+	var checkableAddrs addrs.Set[addrs.Checkable]
+	if checkState := ctx.Checks(); checkState.ConfigHasChecks(n.Addr.InModule(n.Module)) {
+		checkableAddrs = addrs.MakeSet[addrs.Checkable]()
+	}
+
+	expander := ctx.InstanceExpander()
+	for _, module := range expander.ExpandModule(n.Module) {
+		addr := n.Addr.Absolute(module)
+		if checkableAddrs != nil {
+			checkableAddrs.Add(addr)
+		}
+
+		o := &nodeVariableReferenceInstance{
+			Addr:   addr,
+			Config: n.Config,
+			Expr:   n.Expr,
+		}
+		g.Add(o)
+	}
+	addRootNodeToGraph(&g)
+
+	if checkableAddrs != nil {
+		ctx.Checks().ReportCheckableObjects(n.Addr.InModule(n.Module), checkableAddrs)
+	}
+
+	return &g, nil
+}
+
+func (n *nodeVariableReference) Name() string {
+	addrStr := n.Addr.String()
+	if len(n.Module) != 0 {
+		addrStr = n.Module.String() + "." + addrStr
+	}
+	return fmt.Sprintf("%s (expand, reference)", addrStr)
+}
+
+// GraphNodeModulePath
+func (n *nodeVariableReference) ModulePath() addrs.Module {
+	return n.Module
+}
+
+// GraphNodeReferencer
+func (n *nodeVariableReference) References() []*addrs.Reference {
+	var refs []*addrs.Reference
+	if n.Config != nil {
+		for _, validation := range n.Config.Validations {
+			condFuncs, _ := lang.ProviderFunctionsInExpr(addrs.ParseRef, validation.Condition)
+			refs = append(refs, condFuncs...)
+			errFuncs, _ := lang.ProviderFunctionsInExpr(addrs.ParseRef, validation.ErrorMessage)
+			refs = append(refs, errFuncs...)
+		}
+	}
+	return refs
+}
+
+// GraphNodeReferenceable
+func (n *nodeVariableReference) ReferenceableAddrs() []addrs.Referenceable {
+	return []addrs.Referenceable{n.Addr}
+}
+
+// nodeVariableReferenceInstance represents a module variable reference during
+// the apply step.
+type nodeVariableReferenceInstance struct {
+	Addr   addrs.AbsInputVariableInstance
+	Config *configs.Variable // Config is the var in the config
+	Expr   hcl.Expression    // Used for diagnostics only
+}
+
+// Ensure that we are implementing all of the interfaces we think we are
+// implementing.
+var (
+	_ GraphNodeModuleInstance = (*nodeVariableReferenceInstance)(nil)
+	_ GraphNodeExecutable     = (*nodeVariableReferenceInstance)(nil)
+	_ dag.GraphNodeDotter     = (*nodeVariableReferenceInstance)(nil)
+)
+
+func (n *nodeVariableReferenceInstance) Name() string {
+	return n.Addr.String() + " (reference)"
+}
+
+// GraphNodeModuleInstance
+func (n *nodeVariableReferenceInstance) Path() addrs.ModuleInstance {
+	return n.Addr.Module
+}
+
+// GraphNodeModulePath
+func (n *nodeVariableReferenceInstance) ModulePath() addrs.Module {
+	return n.Addr.Module.Module()
+}
+
+// GraphNodeExecutable
+func (n *nodeVariableReferenceInstance) Execute(ctx EvalContext, _ walkOperation) tfdiags.Diagnostics {
+	log.Printf("[TRACE] nodeVariableReferenceInstance: evaluating %s", n.Addr)
+	return evalVariableValidations(n.Addr, n.Config, n.Expr, ctx)
+}
+
+// dag.GraphNodeDotter impl.
+func (n *nodeVariableReferenceInstance) DotNode(name string, _ *dag.DotOpts) *dag.DotNode {
+	return &dag.DotNode{
+		Name: name,
+		Attrs: map[string]string{
+			"label": n.Name(),
+			"shape": "note",
+		},
+	}
+}

--- a/internal/tofu/transform_module_variable.go
+++ b/internal/tofu/transform_module_variable.go
@@ -11,6 +11,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/dag"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 
 	"github.com/hashicorp/hcl/v2"
@@ -102,9 +103,10 @@ func (t *ModuleVariableTransformer) transformSingle(g *Graph, parent, c *configs
 			expr = attr.Expr
 		}
 
-		// Add a plannable node, as the variable may expand
+		// Add a plannable input, as the variable may expand
 		// during module expansion
-		node := &nodeExpandModuleVariable{
+		// It is evaluated in the "parent" module
+		input := &nodeExpandModuleVariable{
 			Addr: addrs.InputVariable{
 				Name: v.Name,
 			},
@@ -112,7 +114,21 @@ func (t *ModuleVariableTransformer) transformSingle(g *Graph, parent, c *configs
 			Config: v,
 			Expr:   expr,
 		}
-		g.Add(node)
+		g.Add(input)
+
+		// It is evaluated in the "child" module
+		ref := &nodeVariableReference{
+			Addr: addrs.InputVariable{
+				Name: v.Name,
+			},
+			Module: c.Path,
+			Config: v,
+			Expr:   expr,
+		}
+		g.Add(ref)
+
+		// Input must be available before reference is valid
+		g.Connect(dag.BasicEdge(ref, input))
 	}
 
 	return nil

--- a/internal/tofu/transform_module_variable_test.go
+++ b/internal/tofu/transform_module_variable_test.go
@@ -63,10 +63,16 @@ func TestModuleVariableTransformer_nested(t *testing.T) {
 }
 
 const testTransformModuleVarBasicStr = `
-module.child.var.value (expand)
+module.child.var.value (expand, input)
+module.child.var.value (expand, reference)
+  module.child.var.value (expand, input)
 `
 
 const testTransformModuleVarNestedStr = `
-module.child.module.child.var.value (expand)
-module.child.var.value (expand)
+module.child.module.child.var.value (expand, input)
+module.child.module.child.var.value (expand, reference)
+  module.child.module.child.var.value (expand, input)
+module.child.var.value (expand, input)
+module.child.var.value (expand, reference)
+  module.child.var.value (expand, input)
 `

--- a/internal/tofu/transform_variable.go
+++ b/internal/tofu/transform_variable.go
@@ -8,6 +8,7 @@ package tofu
 import (
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
+	"github.com/opentofu/opentofu/internal/dag"
 )
 
 // RootVariableTransformer is a GraphTransformer that adds all the root
@@ -42,6 +43,17 @@ func (t *RootVariableTransformer) Transform(g *Graph) error {
 			RawValue: t.RawValues[v.Name],
 		}
 		g.Add(node)
+
+		ref := &nodeVariableReference{
+			Addr: addrs.InputVariable{
+				Name: v.Name,
+			},
+			Config: v,
+		}
+		g.Add(ref)
+
+		// Input must be available before reference is valid
+		g.Connect(dag.BasicEdge(ref, node))
 	}
 
 	return nil


### PR DESCRIPTION
Currently, GraphNodeReferenceOutside is used to make sure that variables are evaluated in the correct scope.  However, with the addition of function providers and "bugfixes" introduced in provider iteration, variables now require two completely distinct scopes.

One scope is used for variable evaluation from module call inputs, the other for the validation scope.  These two scopes are now represented by the original struct in charge of the variable, and an new one which only contains the validation logic.

Only the new "validation scope" node provides the reference and will be depended on, other nodes may use the value post-validation.

Additionally ProviderFunctionTransformer now understands GraphNodeReferenceOutside, which fixes a few related bugs.  Idealy, we could get rid of that interface, but due to how expansion is handled, it's quite tricky.

This also implements a lot of the required machinery for #1336.

<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves #2175

## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
