### PR TITLE
Fix: Change warning to error when incorrect type is used for mocking a resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ ENHANCEMENTS:
 * Improved performance for large graphs when debug logs are not enabled. ([#1810](https://github.com/opentofu/opentofu/pull/1810))
 * Improved performance for large graphs with many submodules. ([#1809](https://github.com/opentofu/opentofu/pull/1809))
 * Extended trace logging for HTTP backend, including request and response bodies. ([#2120](https://github.com/opentofu/opentofu/pull/2120))
+* `tofu test` now throws errors instead of warnings for invalid override and mock fields. ([#2220](https://github.com/opentofu/opentofu/pull/2220))
 
 BUG FIXES:
 * `templatefile` no longer crashes if the given filename is derived from a sensitive value. ([#1801](https://github.com/opentofu/opentofu/issues/1801))

--- a/internal/configs/hcl2shim/mock_value_composer.go
+++ b/internal/configs/hcl2shim/mock_value_composer.go
@@ -90,7 +90,7 @@ func (mvc MockValueComposer) composeMockValueForAttributes(schema *configschema.
 				diags = diags.Append(tfdiags.WholeContainingBody(
 					tfdiags.Error,
 					fmt.Sprintf("Invalid mock/override field `%v`", k),
-					fmt.Sprintf(k, "The field is ignored since overriding configuration values is not allowed."),
+					"The field is ignored since overriding configuration values is not allowed.",
 				))
 				continue
 			}
@@ -101,6 +101,7 @@ func (mvc MockValueComposer) composeMockValueForAttributes(schema *configschema.
 		// Non-computed attributes can't be generated
 		// so we set them from configuration only.
 		if !attr.Computed {
+			mockAttrs[k] = cty.NullVal(attr.Type)
 			if _, ok := defaults[k]; ok {
 				diags = diags.Append(tfdiags.WholeContainingBody(
 					tfdiags.Error,

--- a/internal/configs/hcl2shim/mock_value_composer.go
+++ b/internal/configs/hcl2shim/mock_value_composer.go
@@ -87,14 +87,14 @@ func (mvc MockValueComposer) composeMockValueForAttributes(schema *configschema.
 		// If the value present in configuration - just use it.
 		if cv, ok := configMap[k]; ok && !cv.IsNull() {
 			if _, ok := defaults[k]; ok {
-				mockAttrs[k] = cv
+				diags = diags.Append(tfdiags.WholeContainingBody(
+					tfdiags.Error,
+					fmt.Sprintf("Invalid mock/override field `%v`", k),
+					fmt.Sprintf(k, "The field is ignored since overriding configuration values is not allowed."),
+				))
 				continue
 			}
-			diags = diags.Append(tfdiags.WholeContainingBody(
-				tfdiags.Error,
-				fmt.Sprintf("Invalid mock/override field `%v`", k),
-				fmt.Sprintf(k, "The field is ignored since overriding configuration values is not allowed."),
-			))
+			mockAttrs[k] = cv
 			continue
 		}
 

--- a/internal/configs/hcl2shim/mock_value_composer.go
+++ b/internal/configs/hcl2shim/mock_value_composer.go
@@ -115,7 +115,7 @@ func (mvc MockValueComposer) composeMockValueForAttributes(schema *configschema.
 			converted, err := convert.Convert(ov, attr.Type)
 			if err != nil {
 				diags = diags.Append(tfdiags.WholeContainingBody(
-					tfdiags.Warning,
+					tfdiags.Error,
 					fmt.Sprintf("Ignored mock/override field `%v`", k),
 					fmt.Sprintf("Values provided for override / mock must match resource fields types: %v.", tfdiags.FormatError(err)),
 				))

--- a/internal/configs/hcl2shim/mock_value_composer.go
+++ b/internal/configs/hcl2shim/mock_value_composer.go
@@ -86,7 +86,10 @@ func (mvc MockValueComposer) composeMockValueForAttributes(schema *configschema.
 
 		// If the value present in configuration - just use it.
 		if cv, ok := configMap[k]; ok && !cv.IsNull() {
-			mockAttrs[k] = cv
+			if _, ok := defaults[k]; ok {
+				mockAttrs[k] = cv
+				continue
+			}
 			diags = diags.Append(tfdiags.WholeContainingBody(
 				tfdiags.Error,
 				fmt.Sprintf("Invalid mock/override field `%v`", k),

--- a/internal/configs/hcl2shim/mock_value_composer_test.go
+++ b/internal/configs/hcl2shim/mock_value_composer_test.go
@@ -14,12 +14,11 @@ func TestComposeMockValueBySchema(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		schema      *configschema.Block
-		config      cty.Value
-		defaults    map[string]cty.Value
-		wantVal     cty.Value
-		wantWarning bool
-		wantError   bool
+		schema    *configschema.Block
+		config    cty.Value
+		defaults  map[string]cty.Value
+		wantVal   cty.Value
+		wantError bool
 	}{
 		"diff-props-in-root-attributes": {
 			schema: &configschema.Block{
@@ -511,6 +510,24 @@ func TestComposeMockValueBySchema(t *testing.T) {
 				}),
 			}),
 		},
+		"config-override": {
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"config-field": {
+						Type:     cty.String,
+						Optional: true,
+						Computed: true,
+					},
+				},
+			},
+			config: cty.ObjectVal(map[string]cty.Value{
+				"config-field": cty.StringVal("iAmFromConfig"),
+			}),
+			defaults: map[string]cty.Value{
+				"config-field": cty.StringVal("str"),
+			},
+			wantError: true,
+		},
 	}
 
 	for name, test := range tests {
@@ -526,12 +543,6 @@ func TestComposeMockValueBySchema(t *testing.T) {
 
 			case !test.wantError && gotDiags.HasErrors():
 				t.Fatalf("Got unexpected error diags: %v", gotDiags.ErrWithWarnings())
-
-			case test.wantWarning && len(gotDiags) == 0:
-				t.Fatalf("Expected warning in diags, but none returned")
-
-			case !test.wantWarning && len(gotDiags) != 0:
-				t.Fatalf("Got unexpected diags: %v", gotDiags.ErrWithWarnings())
 
 			case !test.wantVal.RawEquals(gotVal):
 				t.Fatalf("Got unexpected value: %v", gotVal.GoString())

--- a/internal/configs/hcl2shim/mock_value_composer_test.go
+++ b/internal/configs/hcl2shim/mock_value_composer_test.go
@@ -473,10 +473,8 @@ func TestComposeMockValueBySchema(t *testing.T) {
 				}),
 			}),
 			defaults: map[string]cty.Value{
-				"useConfigValue":   cty.StringVal("iAmFromDefaults"),
 				"useDefaultsValue": cty.StringVal("iAmFromDefaults"),
 				"nested": cty.ObjectVal(map[string]cty.Value{
-					"useConfigValue":   cty.StringVal("iAmFromDefaults"),
 					"useDefaultsValue": cty.StringVal("iAmFromDefaults"),
 				}),
 			},
@@ -492,7 +490,6 @@ func TestComposeMockValueBySchema(t *testing.T) {
 					}),
 				}),
 			}),
-			wantWarning: true, // ignored value in defaults
 		},
 		"type-conversion": {
 			schema: &configschema.Block{


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves https://github.com/opentofu/opentofu/issues/1839 and continues work started in https://github.com/opentofu/opentofu/pull/1903 by @pooriaghaedi 

## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
