### PR TITLE
Force state change if encryption used fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ ENHANCEMENTS:
 * Extended trace logging for HTTP backend, including request and response bodies. ([#2120](https://github.com/opentofu/opentofu/pull/2120))
 * `tofu test` now throws errors instead of warnings for invalid override and mock fields. ([#2220](https://github.com/opentofu/opentofu/pull/2220))
 * `tofu test` now supports `override_resource` and `override_data` blocks in the scope of a single `mock_provider`. ([#2168](https://github.com/opentofu/opentofu/pull/2168))
+* Changes to encryption configuration now auto-apply the migration ([#2232](https://github.com/opentofu/opentofu/pull/2232))
 
 BUG FIXES:
 * `templatefile` no longer crashes if the given filename is derived from a sensitive value. ([#1801](https://github.com/opentofu/opentofu/issues/1801))

--- a/internal/encryption/dual_custody_test.go
+++ b/internal/encryption/dual_custody_test.go
@@ -71,7 +71,7 @@ func TestDualCustody(t *testing.T) {
 	if string(encryptedState) == string(testData) {
 		t.Fatalf("The state has not been encrypted.")
 	}
-	decryptedState, err := sfe.DecryptState(encryptedState)
+	decryptedState, _, err := sfe.DecryptState(encryptedState)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/internal/encryption/example_test.go
+++ b/internal/encryption/example_test.go
@@ -80,9 +80,13 @@ func Example() {
 	}
 
 	// Decrypt
-	decryptedState, err := sfe.DecryptState(encrypted)
+	decryptedState, status, err := sfe.DecryptState(encrypted)
 	if err != nil {
 		panic(err)
+	}
+
+	if status != encryption.StatusSatisfied {
+		panic(status)
 	}
 
 	fmt.Printf("%s\n", decryptedState)

--- a/internal/encryption/keyprovider_meta_change_test.go
+++ b/internal/encryption/keyprovider_meta_change_test.go
@@ -82,7 +82,7 @@ func TestChangingKeyProviderAddr(t *testing.T) {
 	if string(encryptedState) == string(testData) {
 		t.Fatalf("The state has not been encrypted.")
 	}
-	decryptedState, err := sfe2.DecryptState(encryptedState)
+	decryptedState, _, err := sfe2.DecryptState(encryptedState)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/internal/encryption/plan.go
+++ b/internal/encryption/plan.go
@@ -60,13 +60,14 @@ func (p planEncryption) EncryptPlan(data []byte) ([]byte, error) {
 }
 
 func (p planEncryption) DecryptPlan(data []byte) ([]byte, error) {
-	return p.base.decrypt(data, func(data []byte) error {
+	data, _, err := p.base.decrypt(data, func(data []byte) error {
 		// Check magic bytes
 		if len(data) < 2 || string(data[:2]) != "PK" {
 			return fmt.Errorf("Invalid plan file %v", string(data[:2]))
 		}
 		return nil
 	})
+	return data, err
 }
 
 func PlanEncryptionDisabled() PlanEncryption {

--- a/internal/encryption/state.go
+++ b/internal/encryption/state.go
@@ -32,7 +32,7 @@ type StateEncryption interface {
 	// function. Do not attempt to determine if the state file is encrypted as this function will take care of any
 	// and all encryption-related matters. After the function returns, use the returned byte array as a normal state
 	// file.
-	DecryptState([]byte) ([]byte, error)
+	DecryptState([]byte) ([]byte, EncryptionStatus, error)
 
 	// EncryptState encrypts a state file and returns the encrypted form.
 	//
@@ -87,8 +87,8 @@ func (s *stateEncryption) EncryptState(plainState []byte) ([]byte, error) {
 	})
 }
 
-func (s *stateEncryption) DecryptState(encryptedState []byte) ([]byte, error) {
-	decryptedState, err := s.base.decrypt(encryptedState, func(data []byte) error {
+func (s *stateEncryption) DecryptState(encryptedState []byte) ([]byte, EncryptionStatus, error) {
+	decryptedState, status, err := s.base.decrypt(encryptedState, func(data []byte) error {
 		tmp := struct {
 			FormatVersion string `json:"terraform_version"`
 		}{}
@@ -105,32 +105,32 @@ func (s *stateEncryption) DecryptState(encryptedState []byte) ([]byte, error) {
 	})
 
 	if err != nil {
-		return nil, err
+		return nil, status, err
 	}
 
 	// Make sure that the state passthrough fields match
 	var encrypted statedata
 	err = json.Unmarshal(encryptedState, &encrypted)
 	if err != nil {
-		return nil, err
+		return nil, status, err
 	}
 	var state statedata
 	err = json.Unmarshal(decryptedState, &state)
 	if err != nil {
-		return nil, err
+		return nil, status, err
 	}
 
 	// TODO make encrypted.Serial non-optional.  This is only for supporting alpha1 states!
 	if encrypted.Serial != nil && state.Serial != nil && *state.Serial != *encrypted.Serial {
-		return nil, fmt.Errorf("invalid state metadata, serial field mismatch %v vs %v", *encrypted.Serial, *state.Serial)
+		return nil, status, fmt.Errorf("invalid state metadata, serial field mismatch %v vs %v", *encrypted.Serial, *state.Serial)
 	}
 
 	// TODO make encrypted.Lineage non-optional.  This is only for supporting alpha1 states!
 	if encrypted.Lineage != "" && state.Lineage != encrypted.Lineage {
-		return nil, fmt.Errorf("invalid state metadata, linage field mismatch %v vs %v", encrypted.Lineage, state.Lineage)
+		return nil, status, fmt.Errorf("invalid state metadata, linage field mismatch %v vs %v", encrypted.Lineage, state.Lineage)
 	}
 
-	return decryptedState, nil
+	return decryptedState, status, nil
 }
 
 func StateEncryptionDisabled() StateEncryption {
@@ -142,6 +142,6 @@ type stateDisabled struct{}
 func (s *stateDisabled) EncryptState(plainState []byte) ([]byte, error) {
 	return plainState, nil
 }
-func (s *stateDisabled) DecryptState(encryptedState []byte) ([]byte, error) {
-	return encryptedState, nil
+func (s *stateDisabled) DecryptState(encryptedState []byte) ([]byte, EncryptionStatus, error) {
+	return encryptedState, StatusSatisfied, nil
 }

--- a/internal/plans/planfile/planfile_test.go
+++ b/internal/plans/planfile/planfile_test.go
@@ -47,12 +47,14 @@ func TestRoundtrip(t *testing.T) {
 		Serial:           2,
 		Lineage:          "abc123",
 		State:            states.NewState(),
+		EncryptionStatus: encryption.StatusSatisfied,
 	}
 	prevStateFileIn := &statefile.File{
 		TerraformVersion: tfversion.SemVer,
 		Serial:           1,
 		Lineage:          "abc123",
 		State:            states.NewState(),
+		EncryptionStatus: encryption.StatusSatisfied,
 	}
 
 	// Minimal plan too, since the serialization of the tfplan portion of the

--- a/internal/states/statefile/file.go
+++ b/internal/states/statefile/file.go
@@ -8,6 +8,7 @@ package statefile
 import (
 	version "github.com/hashicorp/go-version"
 
+	"github.com/opentofu/opentofu/internal/encryption"
 	"github.com/opentofu/opentofu/internal/states"
 	tfversion "github.com/opentofu/opentofu/version"
 )
@@ -34,6 +35,8 @@ type File struct {
 
 	// State is the actual state represented by this file.
 	State *states.State
+
+	EncryptionStatus encryption.EncryptionStatus
 }
 
 func New(state *states.State, lineage string, serial uint64) *File {
@@ -49,6 +52,7 @@ func New(state *states.State, lineage string, serial uint64) *File {
 		State:            state,
 		Lineage:          lineage,
 		Serial:           serial,
+		EncryptionStatus: encryption.StatusUnknown,
 	}
 }
 
@@ -63,5 +67,6 @@ func (f *File) DeepCopy() *File {
 		Serial:           f.Serial,
 		Lineage:          f.Lineage,
 		State:            f.State.DeepCopy(),
+		EncryptionStatus: f.EncryptionStatus,
 	}
 }

--- a/internal/states/statefile/read.go
+++ b/internal/states/statefile/read.go
@@ -76,7 +76,7 @@ func Read(r io.Reader, enc encryption.StateEncryption) (*File, error) {
 		return nil, ErrNoState
 	}
 
-	decrypted, err := enc.DecryptState(src)
+	decrypted, status, err := enc.DecryptState(src)
 	if err != nil {
 		return nil, err
 	}
@@ -85,6 +85,7 @@ func Read(r io.Reader, enc encryption.StateEncryption) (*File, error) {
 	if err != nil {
 		return nil, err
 	}
+	state.EncryptionStatus = status
 
 	if state == nil {
 		// Should never happen

--- a/internal/states/statefile/read.go
+++ b/internal/states/statefile/read.go
@@ -85,12 +85,13 @@ func Read(r io.Reader, enc encryption.StateEncryption) (*File, error) {
 	if err != nil {
 		return nil, err
 	}
-	state.EncryptionStatus = status
 
 	if state == nil {
 		// Should never happen
 		panic("readState returned nil state with no errors")
 	}
+
+	state.EncryptionStatus = status
 
 	return state, diags.Err()
 }

--- a/internal/states/statefile/roundtrip_test.go
+++ b/internal/states/statefile/roundtrip_test.go
@@ -97,6 +97,10 @@ func TestRoundtripEncryption(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
+	// Check status
+	if originalState.EncryptionStatus != encryption.StatusMigration {
+		t.Fatal("wrong status")
+	}
 
 	// Write encrypted
 	var encrypted bytes.Buffer
@@ -117,6 +121,13 @@ func TestRoundtripEncryption(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
+	// Check status
+	if newState.EncryptionStatus != encryption.StatusSatisfied {
+		t.Fatal("wrong status")
+	}
+
+	// Overwrite status for deep comparison
+	originalState.EncryptionStatus = newState.EncryptionStatus
 
 	// Compare before/after encryption workflow
 	problems := deep.Equal(newState, originalState)


### PR DESCRIPTION
Currently when using a remote state storage configuration, if the encryption method is changed a null_resource, output or similar state change is required to apply the encryption change.  This has caused significant confusion for end users migrating to opentofu's state encryption solution, most recently https://gitlab.com/gitlab-org/gitlab/-/issues/450816#note_2215987832.

This change tracks the if a fallback was used to decrypt the state and forces a persist in the remote state storage client.  The local backend already writes the state regardless of if a migration is needed or not and does not require a change.

* Should this be backported? Yes
* ~Does any documentation need to be updated?~

<!-- If your PR resolves an issue, please add it here. -->
Resolves #1606 

## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
