### PR TITLE
tofu: Variable validation diagnostics must mark sensitive values

### DIFF
--- a/internal/tofu/eval_variable.go
+++ b/internal/tofu/eval_variable.go
@@ -235,6 +235,13 @@ func evalVariableValidations(addr addrs.AbsInputVariableInstance, config *config
 		})
 		return diags
 	}
+	if config.Sensitive {
+		// Normally this marking is handled automatically during construction
+		// of the HCL eval context the evaluation scope, but this codepath
+		// augments that scope with the not-yet-finalized input variable
+		// value, so we need to apply this mark separately.
+		val = val.Mark(marks.Sensitive)
+	}
 	for ix, validation := range config.Validations {
 		condFuncs, condDiags := lang.ProviderFunctionsInExpr(addrs.ParseRef, validation.Condition)
 		diags = diags.Append(condDiags)


### PR DESCRIPTION
The existing test for input variable validation with sensitive values was building on a false premise that sensitive-flagged variables always emerge from `EvalContext.GetVariableValue` as marked. In practice that's true only for input variables passed from a parent model where the value was already marked on entry, because the marking caused directly by the `sensitive = true` argument is handled later once the value has been finalized and is being reported from the main expression scope.

Since the variable validation codepath writes a not-yet-finalized value for the variable into its own HCL expression scope directly, it needs to apply the sensitive mark itself when the variable was configured as sensitive, which therefore means that the value provided to the "condition" expression is properly marked and any diagnostics generated from it will capture that marked value.

Along with fixing the existing test to have a mock `GetVariableValue` that more realistically models `BuiltinEvalContext`'s behavior, this introduces a new test specifically about the marking of the values in the diagnostic errors to help avoid potentially regressing that specific detail, since diagnostics there can potentially originate from various different parts
of the system.

This is for #2219, but will not resolve it until a similar fix is applied to the `main` branch.

## Target Release

1.8.7

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

