### PR TITLE
fix: type defaults for variables in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ BUG FIXES:
 * Skip imports blocks logic on `tofu destroy` ([#2214](https://github.com/opentofu/opentofu/pull/2214))
 * Updated github.com/golang-jwt/jwt/v4 from 4.4.2 to 4.5.1 to make security scanners happy (no vulnerability, see [#2179](https://github.com/opentofu/opentofu/pull/2179))
 * `tofu test` is now setting `null`s for dynamic type when generating mock values. ([#2245](https://github.com/opentofu/opentofu/pull/2245))
+* Variables declared in test files are now taking into account type default values. ([#2244](https://github.com/opentofu/opentofu/pull/2244))
 
 INTERNAL CHANGES:
 

--- a/internal/command/test.go
+++ b/internal/command/test.go
@@ -1148,6 +1148,13 @@ func parseAndApplyDefaultValues(unparsedVariables map[string]backend.UnparsedVar
 	for name, variable := range unparsedVariables {
 		value, valueDiags := variable.ParseVariableValue(configs.VariableParseLiteral)
 		diags = diags.Append(valueDiags)
+
+		// Even so the variable is declared, some of the fields could
+		// be empty and filled in via type default values.
+		if confVariable, ok := configVariables[name]; ok && confVariable.TypeDefaults != nil {
+			value.Value = confVariable.TypeDefaults.Apply(value.Value)
+		}
+
 		inputs[name] = value
 	}
 

--- a/internal/command/testdata/test/default_variables/main.tf
+++ b/internal/command/testdata/test/default_variables/main.tf
@@ -3,3 +3,10 @@ variable "input" {
   type    = string
   default = "Hello, world!"
 }
+
+variable "another_input" {
+  type = object({
+    optional_string = optional(string, "type_default")
+    optional_number = optional(number, 42)
+  })
+}

--- a/internal/command/testdata/test/default_variables/main.tftest.hcl
+++ b/internal/command/testdata/test/default_variables/main.tftest.hcl
@@ -4,4 +4,20 @@ run "applies_defaults" {
     condition     = var.input == "Hello, world!"
     error_message = "should have applied default value"
   }
+
+  variables {
+    another_input = {
+      optional_string = "Hello, world!"
+    }
+  }
+
+  assert {
+    condition     = var.another_input.optional_string == "Hello, world!"
+    error_message = "should have used custom value from test file"
+  }
+
+  assert {
+    condition     = var.another_input.optional_number == 42
+    error_message = "should have used default type value"
+  }
 }


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves #2018

## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
