### PR TITLE
fix: unused config's create_before_destroy on resource change with no refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
+* Changes in `create_before_destroy` for resources which require replacement are now properly handled when refresh is disabled. ([#2248](https://github.com/opentofu/opentofu/pull/2248))
+
 ## Previous Releases
 
 For information on prior major and minor releases, see their changelogs:

--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -2394,6 +2394,83 @@ func TestApply_showSensitiveArg(t *testing.T) {
 	}
 }
 
+func TestApply_CreateBeforeDestroyWithRefreshFalse(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("apply_cbd_with_refresh_false"), td)
+	defer testChdir(t, td)()
+
+	originalState := states.BuildState(func(s *states.SyncState) {
+		s.SetResourceInstanceCurrent(
+			addrs.Resource{
+				Mode: addrs.ManagedResourceMode,
+				Type: "test_instance",
+				Name: "a",
+			}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+			&states.ResourceInstanceObjectSrc{
+				AttrsJSON: []byte(`{"id":"foo"}`),
+				Status:    states.ObjectReady,
+				// Create before destroy is set in the state and
+				// omitted in the configuration.
+				CreateBeforeDestroy: true,
+			},
+			addrs.AbsProviderConfig{
+				Provider: addrs.NewDefaultProvider("test"),
+				Module:   addrs.RootModule,
+			},
+			addrs.NoKey,
+		)
+	})
+	statePath := testStateFile(t, originalState)
+
+	p := testProvider()
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
+			"test_instance": {
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id": {Type: cty.String, Computed: true},
+					},
+				},
+			},
+		},
+	}
+	// Resource must be replaced.
+	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+		return providers.PlanResourceChangeResponse{
+			PlannedState:    req.ProposedNewState,
+			RequiresReplace: []cty.Path{{cty.GetAttrStep{Name: "id"}}},
+		}
+	}
+
+	view, done := testView(t)
+	c := &ApplyCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(p),
+			View:             view,
+		},
+	}
+
+	args := []string{
+		"-state", statePath,
+		"-auto-approve",
+		// We are disabling refresh to see if cbd will be updated.
+		"-refresh=false",
+	}
+
+	code := c.Run(args)
+	output := done(t)
+	if code != 0 {
+		t.Fatalf("Failed to run: \n%s", output.Stderr())
+	}
+
+	// If cbd is not updated, resource becomes detached and
+	// apply results in 1 added, 0 changed, 0 destroyed.
+	stdout := output.Stdout()
+	if !strings.Contains(stdout, "Apply complete! Resources: 1 added, 0 changed, 1 destroyed.") {
+		t.Fatalf("bad: output should contain 'notsensitive' output\n%s", stdout)
+	}
+}
+
 // applyFixtureSchema returns a schema suitable for processing the
 // configuration in testdata/apply . This schema should be
 // assigned to a mock provider named "test".

--- a/internal/command/testdata/apply_cbd_with_refresh_false/main.tf
+++ b/internal/command/testdata/apply_cbd_with_refresh_false/main.tf
@@ -1,0 +1,3 @@
+resource "test_instance" "a" {
+  id = "bar"
+}

--- a/internal/tofu/context_apply.go
+++ b/internal/tofu/context_apply.go
@@ -57,7 +57,7 @@ func (c *Context) Apply(ctx context.Context, plan *plans.Plan, config *configs.C
 
 	providerFunctionTracker := make(ProviderFunctionMapping)
 
-	graph, operation, diags := c.applyGraph(plan, config, true, providerFunctionTracker)
+	graph, operation, diags := c.applyGraph(plan, config, providerFunctionTracker)
 	if diags.HasErrors() {
 		return nil, diags
 	}
@@ -123,8 +123,8 @@ Note that the -target and -exclude options are not suitable for routine use, and
 	return newState, diags
 }
 
-//nolint:revive,unparam // TODO remove validate bool as it's not used
-func (c *Context) applyGraph(plan *plans.Plan, config *configs.Config, validate bool, providerFunctionTracker ProviderFunctionMapping) (*Graph, walkOperation, tfdiags.Diagnostics) {
+//nolint:revive
+func (c *Context) applyGraph(plan *plans.Plan, config *configs.Config, providerFunctionTracker ProviderFunctionMapping) (*Graph, walkOperation, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	variables := InputValues{}
@@ -211,7 +211,7 @@ func (c *Context) ApplyGraphForUI(plan *plans.Plan, config *configs.Config) (*Gr
 
 	var diags tfdiags.Diagnostics
 
-	graph, _, moreDiags := c.applyGraph(plan, config, false, make(ProviderFunctionMapping))
+	graph, _, moreDiags := c.applyGraph(plan, config, make(ProviderFunctionMapping))
 	diags = diags.Append(moreDiags)
 	return graph, diags
 }

--- a/internal/tofu/context_apply.go
+++ b/internal/tofu/context_apply.go
@@ -123,7 +123,6 @@ Note that the -target and -exclude options are not suitable for routine use, and
 	return newState, diags
 }
 
-//nolint:revive
 func (c *Context) applyGraph(plan *plans.Plan, config *configs.Config, providerFunctionTracker ProviderFunctionMapping) (*Graph, walkOperation, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 

--- a/internal/tofu/context_plan.go
+++ b/internal/tofu/context_plan.go
@@ -291,7 +291,7 @@ func (c *Context) checkApplyGraph(plan *plans.Plan, config *configs.Config) tfdi
 		return nil
 	}
 	log.Println("[DEBUG] building apply graph to check for errors")
-	_, _, diags := c.applyGraph(plan, config, true, make(ProviderFunctionMapping))
+	_, _, diags := c.applyGraph(plan, config, make(ProviderFunctionMapping))
 	return diags
 }
 

--- a/internal/tofu/graph_builder_apply.go
+++ b/internal/tofu/graph_builder_apply.go
@@ -187,10 +187,7 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 			Changes:   b.Changes,
 			Operation: b.Operation,
 		},
-		&CBDEdgeTransformer{
-			Config: b.Config,
-			State:  b.State,
-		},
+		&CBDEdgeTransformer{},
 
 		// We need to remove configuration nodes that are not used at all, as
 		// they may not be able to evaluate, especially during destroy.

--- a/internal/tofu/node_resource_destroy.go
+++ b/internal/tofu/node_resource_destroy.go
@@ -65,16 +65,18 @@ func (n *NodeDestroyResourceInstance) DestroyAddr() *addrs.AbsResourceInstance {
 
 // GraphNodeDestroyerCBD
 func (n *NodeDestroyResourceInstance) CreateBeforeDestroy() bool {
-	if n.Config != nil && n.Config.Managed != nil {
-		return n.Config.Managed.CreateBeforeDestroy
-	}
-
-	// We only care about create_before_destroy value
-	// from state when there is no configuration present.
+	// State takes precedence during destroy.
+	// If the resource was removed, there is no config to check.
+	// If CBD was forced from descendent, it should be saved in the state
+	// already.
 	if s := n.instanceState; s != nil {
 		if s.Current != nil {
 			return s.Current.CreateBeforeDestroy
 		}
+	}
+
+	if n.Config != nil && n.Config.Managed != nil {
+		return n.Config.Managed.CreateBeforeDestroy
 	}
 
 	return false

--- a/internal/tofu/node_resource_destroy.go
+++ b/internal/tofu/node_resource_destroy.go
@@ -65,18 +65,16 @@ func (n *NodeDestroyResourceInstance) DestroyAddr() *addrs.AbsResourceInstance {
 
 // GraphNodeDestroyerCBD
 func (n *NodeDestroyResourceInstance) CreateBeforeDestroy() bool {
-	// State takes precedence during destroy.
-	// If the resource was removed, there is no config to check.
-	// If CBD was forced from descendent, it should be saved in the state
-	// already.
+	if n.Config != nil && n.Config.Managed != nil {
+		return n.Config.Managed.CreateBeforeDestroy
+	}
+
+	// We only care about create_before_destroy value
+	// from state when there is no configuration present.
 	if s := n.instanceState; s != nil {
 		if s.Current != nil {
 			return s.Current.CreateBeforeDestroy
 		}
-	}
-
-	if n.Config != nil && n.Config.Managed != nil {
-		return n.Config.Managed.CreateBeforeDestroy
 	}
 
 	return false

--- a/internal/tofu/transform_destroy_cbd.go
+++ b/internal/tofu/transform_destroy_cbd.go
@@ -9,9 +9,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/dag"
-	"github.com/opentofu/opentofu/internal/states"
 )
 
 // GraphNodeDestroyerCBD must be implemented by nodes that might be
@@ -115,12 +113,7 @@ func (t *ForcedCBDTransformer) hasCBDDescendent(g *Graph, v dag.Vertex) bool {
 // will get here by recording the CBD-ness of each change in the plan during
 // the plan walk and then forcing the nodes into the appropriate setting during
 // DiffTransformer when building the apply graph.
-type CBDEdgeTransformer struct {
-	// Module and State are only needed to look up dependencies in
-	// any way possible. Either can be nil if not available.
-	Config *configs.Config
-	State  *states.State
-}
+type CBDEdgeTransformer struct{}
 
 func (t *CBDEdgeTransformer) Transform(g *Graph) error {
 	// Go through and reverse any destroy edges


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
In this PR I add an additional refresh state write on planning even when `refresh=false` is used, since this is the place where we synchronize configuration `create_before_destroy` value with the state itself. As discussed in the issue, we only write to the refreshed state for this specific use case (`refresh=false` + configuration value present + state value differs).

Note: I didn't alter the logic of `create_before_destroy` itself, however I suspect there could be a problem for cases when OpenTofu needs to use state's value (inherited) when replacing a resource even if the configuration doesn't force cbd anymore. Not sure if that's a practical problem though.

Also, I removed a few unused params, which I encountered during debugging. This is irrelevant to the PR, however those are pretty small changes.

Resolves #1806

## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
