### PR TITLE
add simulated state serialization between tofu test runs

### DIFF
--- a/internal/command/test.go
+++ b/internal/command/test.go
@@ -470,13 +470,15 @@ func (runner *TestFileRunner) ExecuteTestFile(ctx context.Context, file *modulet
 
 		state, updatedState := runner.ExecuteTestRun(ctx, run, file, runner.States[key].State, config)
 		if updatedState {
+			var err error
+
 			// We need to simulate state serialization between multiple runs
 			// due to its side effects. One of such side effects is removal
 			// of destroyed non-root module outputs. This is not handled
 			// during graph walk since those values are not stored in the
 			// state file. This is more of a weird workaround instead of a
 			// proper fix, unfortunately.
-			state, err := simulateStateSerialization(state)
+			state, err = simulateStateSerialization(state)
 			if err != nil {
 				run.Diagnostics = run.Diagnostics.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,

--- a/internal/command/test.go
+++ b/internal/command/test.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log"
@@ -28,6 +29,7 @@ import (
 	"github.com/opentofu/opentofu/internal/moduletest"
 	"github.com/opentofu/opentofu/internal/plans"
 	"github.com/opentofu/opentofu/internal/states"
+	"github.com/opentofu/opentofu/internal/states/statefile"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/opentofu/opentofu/internal/tofu"
 )
@@ -468,6 +470,24 @@ func (runner *TestFileRunner) ExecuteTestFile(ctx context.Context, file *modulet
 
 		state, updatedState := runner.ExecuteTestRun(ctx, run, file, runner.States[key].State, config)
 		if updatedState {
+			// We need to simulate state serialization between multiple runs
+			// due to its side effects. One of such side effects is removal
+			// of destroyed non-root module outputs. This is not handled
+			// during graph walk since those values are not stored in the
+			// state file. This is more of a weird workaround instead of a
+			// proper fix, unfortunately.
+			state, err := simulateStateSerialization(state)
+			if err != nil {
+				run.Diagnostics = run.Diagnostics.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Failure during state serialization",
+					Detail:   err.Error(),
+				})
+
+				// We cannot reuse state later so that's a hard stop.
+				return
+			}
+
 			// Only update the most recent run and state if the state was
 			// actually updated by this change. We want to use the run that
 			// most recently updated the tracked state as the cleanup
@@ -1301,4 +1321,25 @@ func checkProblematicPlanErrors(expectedFailures addrs.Map[addrs.Referenceable, 
 		}
 	}
 	return planDiags
+}
+
+// simulateStateSerialization takes a state, serializes it, deserializes it
+// and then returns. This is useful for state writing side effects without
+// actually writing a state file.
+func simulateStateSerialization(state *states.State) (*states.State, error) {
+	buff := &bytes.Buffer{}
+
+	f := statefile.New(state, "", 0)
+
+	err := statefile.Write(f, buff, encryption.StateEncryptionDisabled())
+	if err != nil {
+		return nil, fmt.Errorf("writing state to buffer: %w", err)
+	}
+
+	f, err = statefile.Read(buff, encryption.StateEncryptionDisabled())
+	if err != nil {
+		return nil, fmt.Errorf("reading state from buffer: %w", err)
+	}
+
+	return f.State, nil
 }

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -820,6 +820,10 @@ func TestTest_Modules(t *testing.T) {
 			expected: "main.tftest.hcl... pass\n  run \"setup\"... pass\n  run \"test\"... pass\n\nSuccess! 2 passed, 0 failed.\n",
 			code:     0,
 		},
+		"destroyed_mod_outputs": {
+			expected: "main.tftest.hcl... pass\n  run \"first_apply\"... pass\n  run \"second_apply\"... pass\n\nSuccess! 2 passed, 0 failed.\n",
+			code:     0,
+		},
 	}
 
 	for name, tc := range tcs {

--- a/internal/command/testdata/test/destroyed_mod_outputs/main.tf
+++ b/internal/command/testdata/test/destroyed_mod_outputs/main.tf
@@ -1,0 +1,9 @@
+variable "numbers" {
+    type = set(string)
+}
+
+module "mod" {
+    source = "./mod"
+    for_each = var.numbers
+    val = each.key
+}

--- a/internal/command/testdata/test/destroyed_mod_outputs/main.tftest.hcl
+++ b/internal/command/testdata/test/destroyed_mod_outputs/main.tftest.hcl
@@ -1,0 +1,21 @@
+run "first_apply" {
+  variables {
+    numbers = [ "a", "b" ]
+  }
+
+  assert {
+    condition     = length(module.mod) == 2
+    error_message = "Amount of module outputs is wrong"
+  }
+}
+
+run "second_apply" {
+  variables {
+    numbers = [ "c", "d" ]
+  }
+
+  assert {
+    condition     = length(module.mod) == 2
+    error_message = "Amount of module outputs is wrong (persisted outputs?)"
+  }
+}

--- a/internal/command/testdata/test/destroyed_mod_outputs/mod/main.tf
+++ b/internal/command/testdata/test/destroyed_mod_outputs/mod/main.tf
@@ -1,0 +1,11 @@
+variable "val" {
+}
+
+output "val" {
+    value = "${var.val}_${test_resource.resource.id}"
+}
+
+resource "test_resource" "resource" {
+  id = "598318e0"
+  value = var.val
+}


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves #2260.

This PR adds a simulation of state file write between multiple tofu test runs.

The fix needs to be backported

## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
