### PR TITLE
Warn user about provider version 0.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ ENHANCEMENTS:
 * Changes to encryption configuration now auto-apply the migration ([#2232](https://github.com/opentofu/opentofu/pull/2232))
 * References to vars, data, etc. are now usable in variable validation ([#2216](https://github.com/opentofu/opentofu/pull/2216))
 * `AzureRM` backend now support `timeout_seconds` with default timeout of 300 seconds ([#2263](https://github.com/opentofu/opentofu/pull/2263))
+* Added warning about provider version `0.0.0` ([#2281](https://github.com/opentofu/opentofu/pull/2281))
 
 BUG FIXES:
 * `templatefile` no longer crashes if the given filename is derived from a sensitive value. ([#1801](https://github.com/opentofu/opentofu/issues/1801))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ ENHANCEMENTS:
 * Changes to encryption configuration now auto-apply the migration ([#2232](https://github.com/opentofu/opentofu/pull/2232))
 * References to vars, data, etc. are now usable in variable validation ([#2216](https://github.com/opentofu/opentofu/pull/2216))
 * `AzureRM` backend now support `timeout_seconds` with default timeout of 300 seconds ([#2263](https://github.com/opentofu/opentofu/pull/2263))
-* Added warning about provider version `0.0.0` ([#2281](https://github.com/opentofu/opentofu/pull/2281))
+* Adds warning about provider version `0.0.0` ([#2281](https://github.com/opentofu/opentofu/pull/2281))
 
 BUG FIXES:
 * `templatefile` no longer crashes if the given filename is derived from a sensitive value. ([#1801](https://github.com/opentofu/opentofu/issues/1801))

--- a/internal/getproviders/filesystem_mirror_source.go
+++ b/internal/getproviders/filesystem_mirror_source.go
@@ -7,7 +7,9 @@ package getproviders
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/apparentlymart/go-versions/versions"
 	"github.com/opentofu/opentofu/internal/addrs"
 )
 
@@ -54,7 +56,15 @@ func (s *FilesystemMirrorSource) AvailableVersions(ctx context.Context, provider
 		ret = append(ret, v)
 	}
 	ret.Sort()
-	return ret, nil, nil
+	// check if we get unspecified available version (0.0.0) and log a warning about it
+	var warnings Warnings
+	if len(ret) > 0 && ret[0] == versions.Unspecified {
+		warning := fmt.Sprintf("Provider %s has an unspecified (0.0.0) version available in the filesystem mirror, source at %s. It will not be used. \n"+
+			"If the version 0.0.0 is intended to represent a non-published provider, consider using dev_overrides - https://opentofu.org/docs/cli/config/config-file/#development-overrides-for-provider-developers",
+			provider, s.baseDir)
+		warnings = append(warnings, warning)
+	}
+	return ret, warnings, nil
 }
 
 // PackageMeta checks to see if the source's base directory contains a

--- a/internal/getproviders/filesystem_mirror_source.go
+++ b/internal/getproviders/filesystem_mirror_source.go
@@ -56,7 +56,8 @@ func (s *FilesystemMirrorSource) AvailableVersions(ctx context.Context, provider
 		ret = append(ret, v)
 	}
 	ret.Sort()
-	// check if we get unspecified available version (0.0.0) and log a warning about it
+	// Check the existence of provider version 0.0.0 in the filesystem and warn the user about it
+	// If it exists, it will be the first element in the sorted list
 	var warnings Warnings
 	if len(ret) > 0 && ret[0] == versions.Unspecified {
 		warning := fmt.Sprintf("Provider %s has an unspecified (0.0.0) version available in the filesystem mirror, source at %s. It will not be used. \n"+

--- a/internal/getproviders/filesystem_mirror_source_test.go
+++ b/internal/getproviders/filesystem_mirror_source_test.go
@@ -127,6 +127,11 @@ func TestFilesystemMirrorSourceAvailableVersions(t *testing.T) {
 }
 
 func TestFilesystemMirrorSourceAvailableVersions_Unspecified(t *testing.T) {
+	unspecifiedProvider := addrs.Provider{
+		Hostname:  svchost.Hostname("registry.opentofu.org"),
+		Namespace: "testnamespace",
+		Type:      "unspecified",
+	}
 	source := NewFilesystemMirrorSource("testdata/filesystem-mirror-unspecified")
 	got, warn, err := source.AvailableVersions(context.Background(), unspecifiedProvider)
 	if err != nil {
@@ -204,11 +209,6 @@ func TestFilesystemMirrorSourcePackageMeta(t *testing.T) {
 	})
 }
 
-var unspecifiedProvider = addrs.Provider{
-	Hostname:  svchost.Hostname("registry.opentofu.org"),
-	Namespace: "testnamespace",
-	Type:      "unspecified",
-}
 var nullProvider = addrs.Provider{
 	Hostname:  svchost.Hostname("registry.opentofu.org"),
 	Namespace: "hashicorp",

--- a/internal/getproviders/filesystem_mirror_source_test.go
+++ b/internal/getproviders/filesystem_mirror_source_test.go
@@ -7,6 +7,7 @@ package getproviders
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/apparentlymart/go-versions/versions"
@@ -125,6 +126,25 @@ func TestFilesystemMirrorSourceAvailableVersions(t *testing.T) {
 	}
 }
 
+func TestFilesystemMirrorSourceAvailableVersions_Unspecified(t *testing.T) {
+	source := NewFilesystemMirrorSource("testdata/filesystem-mirror-unspecified")
+	got, warn, err := source.AvailableVersions(context.Background(), unspecifiedProvider)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Check that we got the unspecified version
+	if len(got) != 1 || got[0] != versions.Unspecified {
+		t.Fatalf("expected unspecified version, got %v", got)
+	}
+	// We should have unspecified (0.0.0) version warning
+	if len(warn) != 1 {
+		t.Fatalf("expected 1 warning, got %v", warn)
+	}
+	warningBit := "unspecified (0.0.0) version available in the filesystem mirror"
+	if !strings.Contains(warn[0], warningBit) {
+		t.Fatalf("expected warning to contain %q, got %q", warningBit, warn[0])
+	}
+}
 func TestFilesystemMirrorSourcePackageMeta(t *testing.T) {
 	t.Run("available platform", func(t *testing.T) {
 		source := NewFilesystemMirrorSource("testdata/filesystem-mirror")
@@ -184,6 +204,11 @@ func TestFilesystemMirrorSourcePackageMeta(t *testing.T) {
 	})
 }
 
+var unspecifiedProvider = addrs.Provider{
+	Hostname:  svchost.Hostname("registry.opentofu.org"),
+	Namespace: "testnamespace",
+	Type:      "unspecified",
+}
 var nullProvider = addrs.Provider{
 	Hostname:  svchost.Hostname("registry.opentofu.org"),
 	Namespace: "hashicorp",

--- a/internal/getproviders/testdata/filesystem-mirror-unspecified/registry.opentofu.org/testnamespace/unspecified/0.0.0/linux_amd64/unspecified-provider
+++ b/internal/getproviders/testdata/filesystem-mirror-unspecified/registry.opentofu.org/testnamespace/unspecified/0.0.0/linux_amd64/unspecified-provider
@@ -1,0 +1,1 @@
+# This is just a placeholder file for discovery testing, not a real provider plugin.

--- a/internal/providercache/installer.go
+++ b/internal/providercache/installer.go
@@ -294,7 +294,7 @@ NeedProvider:
 		if cb := evts.QueryPackagesBegin; cb != nil {
 			cb(provider, reqs[provider], locked[provider])
 		}
-		//Version 0.0.0 not supported, warn about it if it is present and if it is the only acceptable version return an error
+		// Version 0.0.0 not supported, warn about it if it is present and if it is the only acceptable version return an error
 		warnings, err := checkUnspecifiedVersion(acceptableVersions)
 		if err != nil {
 			errs[provider] = err

--- a/internal/providercache/installer.go
+++ b/internal/providercache/installer.go
@@ -294,7 +294,7 @@ NeedProvider:
 		if cb := evts.QueryPackagesBegin; cb != nil {
 			cb(provider, reqs[provider], locked[provider])
 		}
-		// Version 0.0.0 not supported, warn about it if it is present and if it is the only acceptable version return an error
+		// Version 0.0.0 not supported
 		if err := checkUnspecifiedVersion(acceptableVersions); err != nil {
 			errs[provider] = err
 			if cb := evts.QueryPackagesFailure; cb != nil {
@@ -744,20 +744,9 @@ NeedProvider:
 	return locks, nil
 }
 
+// checkUnspecifiedVersion Check the presence of version 0.0.0 and return an error with a tip
 func checkUnspecifiedVersion(acceptableVersions versions.Set) error {
-	// If the version set is infinite, no need to warn
-	if !acceptableVersions.IsFinite() {
-		return nil
-	}
-	l := acceptableVersions.List()
-	hasUnspecified := false
-	for _, v := range l {
-		if v == versions.Unspecified {
-			hasUnspecified = true
-			break
-		}
-	}
-	if !hasUnspecified {
+	if !acceptableVersions.Exactly(versions.Unspecified) {
 		return nil
 	}
 	tip := "If the version 0.0.0 is intended to represent a non-published provider, consider using dev_overrides - https://opentofu.org/docs/cli/config/config-file/#development-overrides-for-provider-developers"

--- a/internal/providercache/installer_test.go
+++ b/internal/providercache/installer_test.go
@@ -2315,6 +2315,12 @@ func TestEnsureProviderVersions_local_source(t *testing.T) {
 			wantHash: getproviders.NilHash, // installation fails for a provider with no executable
 			err:      "provider binary not found: could not find executable file starting with terraform-provider-executable",
 		},
+		"unspecified-version": {
+			provider: "null",
+			version:  "0.0.0",
+			wantHash: getproviders.NilHash,
+			err:      "0.0.0 is not a valid provider version. \nIf the version 0.0.0 is intended to represent a non-published provider, consider using dev_overrides - https://opentofu.org/docs/cli/config/config-file/#development-overrides-for-provider-developers",
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
Warn user about provider version 0.0.0
---

Version 0.0.0 is defined as the unspecified version by the versioning library we are using ([go-versions](https://github.com/apparentlymart/go-versions/blob/main/versions/version.go)).
It is used in a few places, and as Martin (@apparentlymart) suggested in the issue, in the short term, we should warn the user about such use cases and direct them toward the [dev-overrides](https://opentofu.org/docs/cli/config/config-file/#development-overrides-for-provider-developers) docs.

I've made two main changes here:
- Issue a warning for the user, when we detect provider version 0.0.0 in the file system.
- Return an error when the user tries to use a provider with the exact version 0.0.0

In both cases, I've attached the dev_overrides docs URL.


P.S. Thanks for the well-detailed issue and the bash script for replication, it helped a lot!

---
Resolves #2225 

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
