### PR TITLE
Skip reading encryption keys on `tofu init ` with `-backend=false` flag set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ NEW FEATURES:
 ENHANCEMENTS:
 
 BUG FIXES:
+* `tofu init` command does not attempt to read encryption keys when `-backend=false` flag is set. (https://github.com/opentofu/opentofu/pull/2293)
 
 ## Previous Releases
 

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -204,12 +204,19 @@ func (c *InitCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Load the encryption configuration
-	enc, encDiags := c.EncryptionFromModule(rootModEarly)
-	diags = diags.Append(encDiags)
-	if encDiags.HasErrors() {
-		c.showDiagnostics(diags)
-		return 1
+	var enc encryption.Encryption
+	// If backend flag is explicitly set to false i.e -backend=false, we disable state and plan encryption
+	if backendFlagSet && !flagBackend {
+		enc = encryption.Disabled()
+	} else {
+		// Load the encryption configuration
+		var encDiags tfdiags.Diagnostics
+		enc, encDiags = c.EncryptionFromModule(rootModEarly)
+		diags = diags.Append(encDiags)
+		if encDiags.HasErrors() {
+			c.showDiagnostics(diags)
+			return 1
+		}
 	}
 
 	var back backend.Backend

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -3096,7 +3096,7 @@ func TestInit_skipEncryptionBackendFalse(t *testing.T) {
 			"-backend=false", // should disable reading encryption key run init successfully
 		}
 		if code := c.Run(args); code != 0 {
-			t.Fatalf("init should run successfully with -backend=false: \n%s", ui.ErrorWriter.String())
+			t.Fatalf("init should run successfully with -backend=false: \ngot error : %s\n", ui.ErrorWriter.String())
 		}
 	})
 
@@ -3129,8 +3129,8 @@ func TestInit_skipEncryptionBackendFalse(t *testing.T) {
 		// Check error is generated from trying to read encryption key or fail test
 		if code := c.Run(args); code == 0 {
 			t.Fatalf("init should not run successfully\n")
-		} else if !strings.Contains(ui.ErrorWriter.String(), "Error: Unable to fetch encryption key data") {
-			t.Fatalf("generated error should contain the string \"Error: Unable to fetch encryption key data\"\n")
+		} else if !strings.Contains(ui.ErrorWriter.String(), "key_provider.aws_kms.key failed with error:") {
+			t.Fatalf("generated error should contain the string \"Error: Unable to fetch encryption key data\"\ninstead got : %s\n", ui.ErrorWriter.String())
 		}
 	})
 }

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -3066,7 +3066,6 @@ func TestInit_invalidExtraLabel(t *testing.T) {
 }
 
 func TestInit_skipEncryptionBackendFalse(t *testing.T) {
-
 	t.Run("init success with encryption present and -backend=false", func(t *testing.T) {
 		// Create a temporary working directory that is empty
 		td := t.TempDir()

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -3076,11 +3076,11 @@ func TestInit_skipEncryptionBackendFalse(t *testing.T) {
 		overrides := metaOverridesForProvider(testProvider())
 		ui := new(cli.MockUi)
 		view, _ := testView(t)
-		providerSource, close := newMockProviderSource(t, map[string][]string{
+		providerSource, closeCallback := newMockProviderSource(t, map[string][]string{
 			// mock aws provider
 			"hashicorp/aws": {"5.0", "5.8"},
 		})
-		defer close()
+		defer closeCallback()
 		m := Meta{
 			testingOverrides: overrides,
 			Ui:               ui,
@@ -3109,11 +3109,11 @@ func TestInit_skipEncryptionBackendFalse(t *testing.T) {
 		overrides := metaOverridesForProvider(testProvider())
 		ui := new(cli.MockUi)
 		view, _ := testView(t)
-		providerSource, close := newMockProviderSource(t, map[string][]string{
+		providerSource, closeCallback := newMockProviderSource(t, map[string][]string{
 			// mock aws provider
 			"hashicorp/aws": {"5.0", "5.8"},
 		})
-		defer close()
+		defer closeCallback()
 		m := Meta{
 			testingOverrides: overrides,
 			Ui:               ui,
@@ -3129,10 +3129,8 @@ func TestInit_skipEncryptionBackendFalse(t *testing.T) {
 		// Check error is generated from trying to read encryption key or fail test
 		if code := c.Run(args); code == 0 {
 			t.Fatalf("init should not run successfully\n")
-		} else {
-			if !strings.Contains(ui.ErrorWriter.String(), "Error: Unable to fetch encryption key data") {
-				t.Fatalf("generated error should contain the string \"Error: Unable to fetch encryption key data\"\n")
-			}
+		} else if !strings.Contains(ui.ErrorWriter.String(), "Error: Unable to fetch encryption key data") {
+			t.Fatalf("generated error should contain the string \"Error: Unable to fetch encryption key data\"\n")
 		}
 	})
 }

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -3065,6 +3065,78 @@ func TestInit_invalidExtraLabel(t *testing.T) {
 	}
 }
 
+func TestInit_skipEncryptionBackendFalse(t *testing.T) {
+
+	t.Run("init success with encryption present and -backend=false", func(t *testing.T) {
+		// Create a temporary working directory that is empty
+		td := t.TempDir()
+		testCopyDir(t, testFixturePath("init-encryption-available"), td)
+		defer testChdir(t, td)()
+
+		overrides := metaOverridesForProvider(testProvider())
+		ui := new(cli.MockUi)
+		view, _ := testView(t)
+		providerSource, close := newMockProviderSource(t, map[string][]string{
+			// mock aws provider
+			"hashicorp/aws": {"5.0", "5.8"},
+		})
+		defer close()
+		m := Meta{
+			testingOverrides: overrides,
+			Ui:               ui,
+			View:             view,
+			ProviderSource:   providerSource,
+		}
+
+		c := &InitCommand{
+			Meta: m,
+		}
+
+		args := []string{
+			"-backend=false", // should disable reading encryption key run init successfully
+		}
+		if code := c.Run(args); code != 0 {
+			t.Fatalf("init should run successfully with -backend=false: \n%s", ui.ErrorWriter.String())
+		}
+	})
+
+	t.Run("init fails with encryption present -backend=false not set", func(t *testing.T) {
+		// Create a temporary working directory that is empty
+		td := t.TempDir()
+		testCopyDir(t, testFixturePath("init-encryption-available"), td)
+		defer testChdir(t, td)()
+
+		overrides := metaOverridesForProvider(testProvider())
+		ui := new(cli.MockUi)
+		view, _ := testView(t)
+		providerSource, close := newMockProviderSource(t, map[string][]string{
+			// mock aws provider
+			"hashicorp/aws": {"5.0", "5.8"},
+		})
+		defer close()
+		m := Meta{
+			testingOverrides: overrides,
+			Ui:               ui,
+			View:             view,
+			ProviderSource:   providerSource,
+		}
+
+		c := &InitCommand{
+			Meta: m,
+		}
+
+		var args []string
+		// Check error is generated from trying to read encryption key or fail test
+		if code := c.Run(args); code == 0 {
+			t.Fatalf("init should not run successfully\n")
+		} else {
+			if !strings.Contains(ui.ErrorWriter.String(), "Error: Unable to fetch encryption key data") {
+				t.Fatalf("generated error should contain the string \"Error: Unable to fetch encryption key data\"\n")
+			}
+		}
+	})
+}
+
 // newMockProviderSource is a helper to succinctly construct a mock provider
 // source that contains a set of packages matching the given provider versions
 // that are available for installation (from temporary local files).

--- a/internal/command/testdata/init-encryption-available/main.tf
+++ b/internal/command/testdata/init-encryption-available/main.tf
@@ -1,0 +1,33 @@
+variable "encryption_kms_key_id" {
+  type = string
+  default = "1234abcd-12ab-34cd-56ef-1234567890ab"
+}
+
+terraform {
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.8"
+    }
+  }
+
+  encryption {
+    key_provider "aws_kms" "key" {
+      kms_key_id = var.encryption_kms_key_id
+      region     = "eu-central-1"
+      key_spec   = "AES_256"
+    }
+    method "aes_gcm" "encrypt-aes" {
+      keys = key_provider.aws_kms.key
+    }
+    state {
+      enforced = true
+      method   = method.aes_gcm.encrypt-aes
+    }
+    plan {
+      enforced = true
+      method   = method.aes_gcm.encrypt-aes
+    }
+  }
+}


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->
With this change, `tofu init -backend=false` runs successfully without attempting to read encryption keys as suggested by @bt909  

<!-- If your PR resolves an issue, please add it here. -->
Resolves #2217

## Target Release

1.10.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
