### PR TITLE
PROTOTYPE: `enabled` meta argument for `module`/`resource`/`data` blocks

### DIFF
--- a/internal/configs/checks.go
+++ b/internal/configs/checks.go
@@ -222,7 +222,9 @@ func decodeCheckBlock(block *hcl.Block, override bool) (*Check, hcl.Diagnostics)
 				continue
 			}
 
-			data, moreDiags := decodeDataBlock(block, override, true)
+			nestedDataBlock := true
+			enabledMetaArgAllowed := false
+			data, moreDiags := decodeDataBlock(block, override, nestedDataBlock, enabledMetaArgAllowed)
 			diags = append(diags, moreDiags...)
 			if !moreDiags.HasErrors() {
 				// Connect this data block back up to this check block.

--- a/internal/configs/module_call_test.go
+++ b/internal/configs/module_call_test.go
@@ -27,7 +27,7 @@ func TestLoadModuleCall(t *testing.T) {
 
 	file, diags := parser.LoadConfigFile("module-calls.tf")
 	assertExactDiagnostics(t, diags, []string{
-		`module-calls.tf:20,3-11: Invalid combination of "count" and "for_each"; The "count" and "for_each" meta-arguments are mutually-exclusive, only one should be used to be explicit about the number of resources to be created.`,
+		`module-calls.tf:20,3-11: Invalid combination of "count" and "for_each"; The "count" and "for_each" meta-arguments are mutually-exclusive. Only one may be used to be explicit about the number of resources to be created.`,
 	})
 
 	gotModules := file.ModuleCalls

--- a/internal/configs/parser_config.go
+++ b/internal/configs/parser_config.go
@@ -8,6 +8,7 @@ package configs
 import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/opentofu/opentofu/internal/encryption/config"
+	"github.com/opentofu/opentofu/internal/experiments"
 )
 
 // LoadConfigFile reads the file at the given path and parses it as a config
@@ -163,21 +164,21 @@ func (p *Parser) loadConfigFile(path string, override bool) (*File, hcl.Diagnost
 			}
 
 		case "module":
-			cfg, cfgDiags := decodeModuleBlock(block, override)
+			cfg, cfgDiags := decodeModuleBlock(block, override, file.ActiveExperiments.Has(experiments.EnabledMetaArgument))
 			diags = append(diags, cfgDiags...)
 			if cfg != nil {
 				file.ModuleCalls = append(file.ModuleCalls, cfg)
 			}
 
 		case "resource":
-			cfg, cfgDiags := decodeResourceBlock(block, override)
+			cfg, cfgDiags := decodeResourceBlock(block, override, file.ActiveExperiments.Has(experiments.EnabledMetaArgument))
 			diags = append(diags, cfgDiags...)
 			if cfg != nil {
 				file.ManagedResources = append(file.ManagedResources, cfg)
 			}
 
 		case "data":
-			cfg, cfgDiags := decodeDataBlock(block, override, false)
+			cfg, cfgDiags := decodeDataBlock(block, override, false, file.ActiveExperiments.Has(experiments.EnabledMetaArgument))
 			diags = append(diags, cfgDiags...)
 			if cfg != nil {
 				file.DataResources = append(file.DataResources, cfg)

--- a/internal/experiments/experiment.go
+++ b/internal/experiments/experiment.go
@@ -18,6 +18,7 @@ type Experiment string
 // Each experiment is represented by a string that must be a valid HCL
 // identifier so that it can be specified in configuration.
 const (
+	EnabledMetaArgument            = Experiment("enabled_meta_arg")
 	VariableValidation             = Experiment("variable_validation")
 	ModuleVariableOptionalAttrs    = Experiment("module_variable_optional_attrs")
 	SuppressProviderSensitiveAttrs = Experiment("provider_sensitive_attrs")
@@ -28,6 +29,7 @@ const (
 func init() {
 	// Each experiment constant defined above must be registered here as either
 	// a current or a concluded experiment.
+	registerCurrentExperiment(EnabledMetaArgument)
 	registerConcludedExperiment(VariableValidation, "Custom variable validation can now be used by default, without enabling an experiment.")
 	registerConcludedExperiment(SuppressProviderSensitiveAttrs, "Provider-defined sensitive attributes are now redacted by default, without enabling an experiment.")
 	registerConcludedExperiment(ConfigDrivenMove, "Declarations of moved resource instances using \"moved\" blocks can now be used by default, without enabling an experiment.")

--- a/internal/instances/expander.go
+++ b/internal/instances/expander.go
@@ -58,6 +58,12 @@ func (e *Expander) SetModuleSingle(parentAddr addrs.ModuleInstance, callAddr add
 	e.setModuleExpansion(parentAddr, callAddr, expansionSingleVal)
 }
 
+// SetModuleEnabled records that the given module call inside the given parent
+// module uses the "enabled" repetition argument, with the given value.
+func (e *Expander) SetModuleEnabled(parentAddr addrs.ModuleInstance, callAddr addrs.ModuleCall, enabled bool) {
+	e.setModuleExpansion(parentAddr, callAddr, expansionEnabled(enabled))
+}
+
 // SetModuleCount records that the given module call inside the given parent
 // module instance uses the "count" repetition argument, with the given value.
 func (e *Expander) SetModuleCount(parentAddr addrs.ModuleInstance, callAddr addrs.ModuleCall, count int) {
@@ -79,6 +85,12 @@ func (e *Expander) SetModuleForEach(parentAddr addrs.ModuleInstance, callAddr ad
 // does not use any repetition arguments and is therefore a singleton.
 func (e *Expander) SetResourceSingle(moduleAddr addrs.ModuleInstance, resourceAddr addrs.Resource) {
 	e.setResourceExpansion(moduleAddr, resourceAddr, expansionSingleVal)
+}
+
+// SetResourceEnabled records that the given resource inside the given module
+// uses the "enabled" repetition argument, with the given value.
+func (e *Expander) SetResourceEnabled(moduleAddr addrs.ModuleInstance, resourceAddr addrs.Resource, enabled bool) {
+	e.setResourceExpansion(moduleAddr, resourceAddr, expansionEnabled(enabled))
 }
 
 // SetResourceCount records that the given resource inside the given module

--- a/internal/instances/expander_test.go
+++ b/internal/instances/expander_test.go
@@ -22,6 +22,7 @@ func TestExpander(t *testing.T) {
 	count2ModuleAddr := addrs.ModuleCall{Name: "count2"}
 	count0ModuleAddr := addrs.ModuleCall{Name: "count0"}
 	forEachModuleAddr := addrs.ModuleCall{Name: "for_each"}
+	enabledModuleAddr := addrs.ModuleCall{Name: "enabled"}
 	singleResourceAddr := addrs.Resource{
 		Mode: addrs.ManagedResourceMode,
 		Type: "test",
@@ -41,6 +42,11 @@ func TestExpander(t *testing.T) {
 		Mode: addrs.ManagedResourceMode,
 		Type: "test",
 		Name: "for_each",
+	}
+	enabledResourceAddr := addrs.Resource{
+		Mode: addrs.ManagedResourceMode,
+		Type: "test",
+		Name: "enabled",
 	}
 	eachMap := map[string]cty.Value{
 		"a": cty.NumberIntVal(1),
@@ -88,6 +94,7 @@ func TestExpander(t *testing.T) {
 		ex.SetResourceCount(addrs.RootModuleInstance, count2ResourceAddr, 2)
 		ex.SetResourceCount(addrs.RootModuleInstance, count0ResourceAddr, 0)
 		ex.SetResourceForEach(addrs.RootModuleInstance, forEachResourceAddr, eachMap)
+		ex.SetResourceEnabled(addrs.RootModuleInstance, enabledResourceAddr, true)
 
 		ex.SetModuleSingle(addrs.RootModuleInstance, singleModuleAddr)
 		{
@@ -95,6 +102,12 @@ func TestExpander(t *testing.T) {
 			moduleInstanceAddr := addrs.RootModuleInstance.Child("single", addrs.NoKey)
 			ex.SetResourceSingle(moduleInstanceAddr, singleResourceAddr)
 			ex.SetResourceCount(moduleInstanceAddr, count2ResourceAddr, 2)
+		}
+
+		ex.SetModuleEnabled(addrs.RootModuleInstance, enabledModuleAddr, true)
+		{
+			moduleInstanceAddr := addrs.RootModuleInstance.Child("enabled", addrs.NoKey)
+			ex.SetResourceSingle(moduleInstanceAddr, singleResourceAddr)
 		}
 
 		ex.SetModuleCount(addrs.RootModuleInstance, count2ModuleAddr, 2)
@@ -146,6 +159,18 @@ func TestExpander(t *testing.T) {
 			t.Errorf("wrong result\n%s", diff)
 		}
 	})
+	t.Run("resource enabled", func(t *testing.T) {
+		got := ex.ExpandModuleResource(
+			addrs.RootModule,
+			enabledResourceAddr,
+		)
+		want := []addrs.AbsResourceInstance{
+			mustAbsResourceInstanceAddr(`test.enabled`),
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
 	t.Run("resource count2", func(t *testing.T) {
 		got := ex.ExpandModuleResource(
 			addrs.RootModule,
@@ -186,6 +211,15 @@ func TestExpander(t *testing.T) {
 		got := ex.ExpandModule(addrs.RootModule.Child("single"))
 		want := []addrs.ModuleInstance{
 			mustModuleInstanceAddr(`module.single`),
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+	t.Run("module enabled", func(t *testing.T) {
+		got := ex.ExpandModule(addrs.RootModule.Child("enabled"))
+		want := []addrs.ModuleInstance{
+			mustModuleInstanceAddr(`module.enabled`),
 		}
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("wrong result\n%s", diff)

--- a/internal/instances/expansion_mode.go
+++ b/internal/instances/expansion_mode.go
@@ -42,6 +42,24 @@ func (e expansionSingle) repetitionData(key addrs.InstanceKey) RepetitionData {
 	return RepetitionData{}
 }
 
+// expansionEnabled is the expansion corresponding to the "enabled" argument,
+// producing either no instances or one instance with no instance key.
+type expansionEnabled bool
+
+func (e expansionEnabled) instanceKeys() []addrs.InstanceKey {
+	if !bool(e) {
+		return nil
+	}
+	return singleKeys
+}
+
+func (e expansionEnabled) repetitionData(key addrs.InstanceKey) RepetitionData {
+	if key != addrs.NoKey {
+		panic("cannot use instance key with non-repeating object")
+	}
+	return RepetitionData{}
+}
+
 // expansionCount is the expansion corresponding to the "count" argument.
 type expansionCount int
 

--- a/internal/lang/evalchecks/eval_enabled.go
+++ b/internal/lang/evalchecks/eval_enabled.go
@@ -1,0 +1,94 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+package evalchecks
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/lang"
+	"github.com/opentofu/opentofu/internal/lang/marks"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+)
+
+// EvaluateEnabledExpression evaluates an expression assigned to an "enabled"
+// meta-argument and returns either its boolean result or errors describing
+// why such a result cannot be evaluated.
+func EvaluateEnabledExpression(expr hcl.Expression, hclCtxFunc ContextFunc) (bool, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	if expr == nil {
+		return false, diags
+	}
+
+	refs, refsDiags := lang.ReferencesInExpr(addrs.ParseRef, expr)
+	diags = diags.Append(refsDiags)
+	var hclCtx *hcl.EvalContext
+	hclCtx, refsDiags = hclCtxFunc(refs)
+	diags = diags.Append(refsDiags)
+	if diags.HasErrors() { // Can't continue if we don't even have a valid scope
+		return false, diags
+	}
+
+	rawEnabledVal, enabledDiags := expr.Value(hclCtx)
+	diags = diags.Append(enabledDiags)
+
+	if rawEnabledVal.HasMark(marks.Sensitive) {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity:    hcl.DiagError,
+			Summary:     "Invalid enabled argument",
+			Detail:      "Sensitive values, or values derived from sensitive values, cannot be used in \"enabled\" arguments. If used, the sensitive value would be exposed by whether an instance is present.",
+			Subject:     expr.Range().Ptr(),
+			Expression:  expr,
+			EvalContext: hclCtx,
+			Extra:       DiagnosticCausedBySensitive(true),
+		})
+	}
+
+	enabledVal, err := convert.Convert(rawEnabledVal, cty.Bool)
+	if err != nil {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity:    hcl.DiagError,
+			Summary:     "Invalid enabled argument",
+			Detail:      fmt.Sprintf(`The given "enabled" argument value is unsuitable: %s.`, err),
+			Subject:     expr.Range().Ptr(),
+			Expression:  expr,
+			EvalContext: hclCtx,
+		})
+	}
+
+	if enabledVal.IsNull() {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity:    hcl.DiagError,
+			Summary:     "Invalid enabled argument",
+			Detail:      `The given "enabled" argument value is unsuitable: the given value is null.`,
+			Subject:     expr.Range().Ptr(),
+			Expression:  expr,
+			EvalContext: hclCtx,
+		})
+	}
+	if !enabledVal.IsKnown() {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity:    hcl.DiagError,
+			Summary:     "Invalid enabled argument",
+			Detail:      `The given "enabled" argument value is derived from a value that won't be known until the apply phase, so OpenTofu cannot determine whether an instance of this object is declared or not.`,
+			Subject:     expr.Range().Ptr(),
+			Expression:  expr,
+			EvalContext: hclCtx,
+			Extra:       DiagnosticCausedByUnknown(true),
+		})
+	}
+
+	if diags.HasErrors() {
+		return false, diags
+	}
+
+	// If we get here then we've eliminated all of the reasons why the
+	// following could potentially panic.
+	return enabledVal.True(), diags
+}

--- a/internal/tofu/eval_iteration.go
+++ b/internal/tofu/eval_iteration.go
@@ -32,6 +32,10 @@ func evalContextEvaluate(ctx EvalContext) evalchecks.EvaluateFunc {
 	}
 }
 
+func evaluateEnabledExpression(expr hcl.Expression, evalCtx EvalContext) (bool, tfdiags.Diagnostics) {
+	return evalchecks.EvaluateEnabledExpression(expr, evalContextScope(evalCtx))
+}
+
 func evaluateForEachExpression(expr hcl.Expression, ctx EvalContext) (map[string]cty.Value, tfdiags.Diagnostics) {
 	return evalchecks.EvaluateForEachExpression(expr, evalContextScope(ctx))
 }

--- a/internal/tofu/node_module_expand.go
+++ b/internal/tofu/node_module_expand.go
@@ -138,6 +138,14 @@ func (n *nodeExpandModule) Execute(ctx EvalContext, op walkOperation) (diags tfd
 			}
 			expander.SetModuleForEach(module, call, forEach)
 
+		case n.ModuleCall.Enabled != nil:
+			enabled, enDiags := evaluateEnabledExpression(n.ModuleCall.Enabled, ctx)
+			diags = diags.Append(enDiags)
+			if diags.HasErrors() {
+				return diags
+			}
+			expander.SetModuleEnabled(module, call, enabled)
+
 		default:
 			expander.SetModuleSingle(module, call)
 		}

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -506,6 +506,16 @@ func (n *NodeAbstractResource) writeResourceState(ctx EvalContext, addr addrs.Ab
 		state.SetResourceProvider(addr, n.ResolvedProvider.ProviderConfig)
 		expander.SetResourceForEach(addr.Module, n.Addr.Resource, forEach)
 
+	case n.Config != nil && n.Config.Enabled != nil:
+		enabled, enabledDiags := evaluateEnabledExpression(n.Config.Enabled, ctx)
+		diags = diags.Append(enabledDiags)
+		if enabledDiags.HasErrors() {
+			return diags
+		}
+
+		state.SetResourceProvider(addr, n.ResolvedProvider.ProviderConfig)
+		expander.SetResourceEnabled(addr.Module, n.Addr.Resource, enabled)
+
 	default:
 		state.SetResourceProvider(addr, n.ResolvedProvider.ProviderConfig)
 		expander.SetResourceSingle(addr.Module, n.Addr.Resource)

--- a/internal/tofu/node_resource_abstract_instance.go
+++ b/internal/tofu/node_resource_abstract_instance.go
@@ -1741,8 +1741,8 @@ func (n *NodeAbstractResourceInstance) planDataSource(ctx EvalContext, checkRule
 	objTy := schema.ImpliedType()
 	priorVal := cty.NullVal(objTy)
 
-	forEach, _ := evaluateForEachExpression(config.ForEach, ctx)
-	keyData = EvalDataForInstanceKey(n.ResourceInstanceAddr().Resource.Key, forEach)
+	expander := ctx.InstanceExpander()
+	keyData = expander.GetResourceInstanceRepetitionData(n.Addr)
 
 	checkDiags := evalCheckRules(
 		addrs.ResourcePrecondition,
@@ -2020,8 +2020,8 @@ func (n *NodeAbstractResourceInstance) applyDataSource(ctx EvalContext, planned 
 		return nil, keyData, diags
 	}
 
-	forEach, _ := evaluateForEachExpression(config.ForEach, ctx)
-	keyData = EvalDataForInstanceKey(n.Addr.Resource.Key, forEach)
+	expander := ctx.InstanceExpander()
+	keyData = expander.GetResourceInstanceRepetitionData(n.Addr)
 
 	checkDiags := evalCheckRules(
 		addrs.ResourcePrecondition,
@@ -2324,10 +2324,8 @@ func (n *NodeAbstractResourceInstance) applyProvisioners(ctx EvalContext, state 
 func (n *NodeAbstractResourceInstance) evalProvisionerConfig(ctx EvalContext, body hcl.Body, self cty.Value, schema *configschema.Block) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	forEach, forEachDiags := evaluateForEachExpression(n.Config.ForEach, ctx)
-	diags = diags.Append(forEachDiags)
-
-	keyData := EvalDataForInstanceKey(n.ResourceInstanceAddr().Resource.Key, forEach)
+	expander := ctx.InstanceExpander()
+	keyData := expander.GetResourceInstanceRepetitionData(n.Addr)
 
 	config, _, configDiags := ctx.EvaluateBlock(body, schema, n.ResourceInstanceAddr().Resource, keyData)
 	diags = diags.Append(configDiags)

--- a/internal/tofu/testdata/apply-enabled-resource/apply-enabled-resource.tf
+++ b/internal/tofu/testdata/apply-enabled-resource/apply-enabled-resource.tf
@@ -1,0 +1,23 @@
+
+terraform {
+  # The "enabled" argument currently requires opting in to this experiment.
+  experiments = [enabled_meta_arg]
+}
+
+variable "on" {
+  type = bool
+}
+
+resource "test" "test" {
+  enabled = var.on
+
+  name = "boop"
+}
+
+output "result" {
+  // This is in a 1-tuple just because OpenTofu treats a fully-null
+  // root module output value as if it wasn't declared at all,
+  // but we want to make sure we're actually testing the result
+  // of this resource directly.
+  value = [one(test.test[*].name)]
+}


### PR DESCRIPTION
This is just a basic prototype of supporting a configuration like the following:

```hcl
terraform {
  # The "enabled" argument currently requires opting in to this experiment,
  # because adding a new meta-argument is a breaking change and we've
  # not yet decided how to handle that.
  experiments = [enabled_meta_arg]
}

variable "on" {
  type = bool
}

resource "example" "thing" {
  enabled = var.on

  name = "boop"
}

output "result" {
  value = one(example.thing[*].name)
}
```

This new `enabled` argument causes `example.thing` to have two possible results: either a resource object as normal if `true`, or null if `false`. Making any use of this result still requires using either `one` with a splat or a conditional check for null, because `example.thing.name` alone would fail if `example.thing` were null. (There is no proactive check that such expressions have been written correctly; more on that in https://github.com/opentofu/opentofu/issues/1306#issuecomment-2398120132.)

This is for https://github.com/opentofu/opentofu/issues/1306. I wrote this today just to try to see if there was any hidden tech debt making this harder than it seemed like it would be. Thankfully it seems that earlier investments in tidying up how `count` and `for_each` were implemented (using an `instances.Expander` object to centralize that concern) have paid off and made this considerably easier than it would've been some years ago.

The question of how we can introduce a new meta-argument without breaking backward compatibility still remains to be answered.

(Unfortunately this is the type of change that the idea in https://github.com/opentofu/opentofu/pull/2262 can't directly cover -- it's a new meta-argument, rather than a new top-level symbol.)

