### PR TITLE
Add example on supporting both OpenTofu and Terraform versions to version-constraints.mdx

### DIFF
--- a/website/docs/language/expressions/version-constraints.mdx
+++ b/website/docs/language/expressions/version-constraints.mdx
@@ -99,4 +99,4 @@ versions do not match inexact operators such as `>=`, `~>`, etc.
 - When configuration needs to be supported by both OpenTofu and Terraform, for example in modules
   which need to be consumed by both engines, use a `providers.tofu` file to specify
   the OpenTofu version constraint, overriding the constraint defined in `providers.tf`.
-  [Read more about extension precedence](../../language/files/#extension-precedence).
+  [Read more about extension precedence](../../files/#extension-precedence).

--- a/website/docs/language/expressions/version-constraints.mdx
+++ b/website/docs/language/expressions/version-constraints.mdx
@@ -96,6 +96,6 @@ versions do not match inexact operators such as `>=`, `~>`, etc.
 
 ### Supporting both OpenTofu and Terraform Versions
 
-- When code needs to support both OpenTofu and Terraform, for example in modules
+- When configuration needs to be supported by both OpenTofu and Terraform, for example in modules
   which need to be consumed by both engines, use a `providers.tofu` file to specify
   the OpenTofu version constraint, overriding the constraint defined in `providers.tf`.

--- a/website/docs/language/expressions/version-constraints.mdx
+++ b/website/docs/language/expressions/version-constraints.mdx
@@ -93,3 +93,9 @@ versions do not match inexact operators such as `>=`, `~>`, etc.
 
 - Root modules should use a `~>` constraint to set both a lower and upper bound
   on versions for each provider they depend on.
+
+### Supporting both OpenTofu and Terraform Versions
+
+- When code needs to support both OpenTofu and Terraform, for example in modules
+  which need to be consumed by both engines, use a `providers.tofu` file to specify
+  the OpenTofu version constraint, overriding the constraint defined in `providers.tf`.

--- a/website/docs/language/expressions/version-constraints.mdx
+++ b/website/docs/language/expressions/version-constraints.mdx
@@ -99,3 +99,4 @@ versions do not match inexact operators such as `>=`, `~>`, etc.
 - When configuration needs to be supported by both OpenTofu and Terraform, for example in modules
   which need to be consumed by both engines, use a `providers.tofu` file to specify
   the OpenTofu version constraint, overriding the constraint defined in `providers.tf`.
+  [Read more about extension precedence](../../language/files/#extension-precedence).


### PR DESCRIPTION
Followup from #2301.

### Website/documentation checklist

- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
