### PR TITLE
[BACKPORT v1.9] Skip reading encryption keys on `tofu init ` with `-backend=false` flag set (#2293)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ BUG FIXES:
 * Variables declared in test files are now taking into account type default values. ([#2244](https://github.com/opentofu/opentofu/pull/2244))
 * `tofu test` now removes outputs of destroyed modules between different test runs. ([#2274](https://github.com/opentofu/opentofu/pull/2274))
 * Changes in `create_before_destroy` for resources which require replacement are now properly handled when refresh is disabled. ([#2248](https://github.com/opentofu/opentofu/pull/2248))
+* `tofu init` command does not attempt to read encryption keys when `-backend=false` flag is set. (https://github.com/opentofu/opentofu/pull/2293)
 
 INTERNAL CHANGES:
 

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -204,12 +204,19 @@ func (c *InitCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Load the encryption configuration
-	enc, encDiags := c.EncryptionFromModule(rootModEarly)
-	diags = diags.Append(encDiags)
-	if encDiags.HasErrors() {
-		c.showDiagnostics(diags)
-		return 1
+	var enc encryption.Encryption
+	// If backend flag is explicitly set to false i.e -backend=false, we disable state and plan encryption
+	if backendFlagSet && !flagBackend {
+		enc = encryption.Disabled()
+	} else {
+		// Load the encryption configuration
+		var encDiags tfdiags.Diagnostics
+		enc, encDiags = c.EncryptionFromModule(rootModEarly)
+		diags = diags.Append(encDiags)
+		if encDiags.HasErrors() {
+			c.showDiagnostics(diags)
+			return 1
+		}
 	}
 
 	var back backend.Backend

--- a/internal/command/testdata/init-encryption-available/main.tf
+++ b/internal/command/testdata/init-encryption-available/main.tf
@@ -1,0 +1,33 @@
+variable "encryption_kms_key_id" {
+  type = string
+  default = "1234abcd-12ab-34cd-56ef-1234567890ab"
+}
+
+terraform {
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.8"
+    }
+  }
+
+  encryption {
+    key_provider "aws_kms" "key" {
+      kms_key_id = var.encryption_kms_key_id
+      region     = "eu-central-1"
+      key_spec   = "AES_256"
+    }
+    method "aes_gcm" "encrypt-aes" {
+      keys = key_provider.aws_kms.key
+    }
+    state {
+      enforced = true
+      method   = method.aes_gcm.encrypt-aes
+    }
+    plan {
+      enforced = true
+      method   = method.aes_gcm.encrypt-aes
+    }
+  }
+}


### PR DESCRIPTION


<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Cherry pick of 211ec55a30a7696a17661f5aaea0f8a5f623ee89 to include the fix for the upcoming 1.9 stable release.

## Target Release

1.9.0
