### PR TITLE
[BACKPORT v1.9] fix randomly failing destroyed_mod_outputs test (#2315)

### DIFF
--- a/internal/command/testdata/test/destroyed_mod_outputs/mod/main.tf
+++ b/internal/command/testdata/test/destroyed_mod_outputs/mod/main.tf
@@ -6,6 +6,6 @@ output "val" {
 }
 
 resource "test_resource" "resource" {
-  id = "598318e0"
+  id = "id-${var.val}"
   value = var.val
 }


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
This PR doesn't need to be released, it just fixes the flaky test for the branch. Cherry pick of be5b14625d2bcea594c22489e894b3ea4a6c8b6c

## Target Release

none

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
