### PR TITLE
Fix quadratic marshalPlannedValues

### DIFF
--- a/internal/command/jsonplan/values_test.go
+++ b/internal/command/jsonplan/values_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/plans"
 	"github.com/opentofu/opentofu/internal/providers"
+	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tofu"
 )
 
@@ -295,7 +296,7 @@ func TestMarshalPlanResources(t *testing.T) {
 
 			ris := testResourceAddrs()
 
-			got, err := marshalPlanResources(testChange, ris, testSchemas())
+			got, err := marshalPlanResources(testChanges(testChange), ris, testSchemas())
 			if test.Err {
 				if err == nil {
 					t.Fatal("succeeded; want error")
@@ -364,6 +365,16 @@ func testSchemas() *tofu.Schemas {
 			},
 		},
 	}
+}
+
+func testChanges(changes *plans.Changes) map[string]*plans.ResourceInstanceChangeSrc {
+	ret := make(map[string]*plans.ResourceInstanceChangeSrc)
+	for _, resource := range changes.Resources {
+		if resource.Action != plans.Delete && resource.DeposedKey == states.NotDeposed {
+			ret[resource.Addr.String()] = resource
+		}
+	}
+	return ret
 }
 
 func testResourceAddrs() []addrs.AbsResourceInstance {

--- a/internal/command/jsonplan/values_test.go
+++ b/internal/command/jsonplan/values_test.go
@@ -370,7 +370,7 @@ func testSchemas() *tofu.Schemas {
 func testChanges(changes *plans.Changes) map[string]*plans.ResourceInstanceChangeSrc {
 	ret := make(map[string]*plans.ResourceInstanceChangeSrc)
 	for _, resource := range changes.Resources {
-		if resource.Action != plans.Delete && resource.DeposedKey == states.NotDeposed {
+		if resource.DeposedKey == states.NotDeposed {
 			ret[resource.Addr.String()] = resource
 		}
 	}


### PR DESCRIPTION
As mentioned in https://github.com/opentofu/opentofu/issues/2252, Changes.ResourceInstance() has linear complexity in the number of resources being changed. Ideally, we will eventually address the root problem here, but given that the Resources slice is exposed, it's hard to make that change without breaking all the callers.

In this change, I aim to fix only the "tofu show" path, which already is reaching into Changes.Resources to construct its own module mappings. I just take this one step further by adding an additional map to make lookups constant time. Since we're visiting every change in order to marshal them, we were calling ResourceInstance for every change, which then iterated over every change again, hence the quadratic performance.

This cuts my "tofu show" time in half. What remains is just loading the plan files, some thorny go-cty stuff I don't want to touch, and finally the actual JSON marshalling. I don't think we can do much better without a significant undertaking (due to the go-cty stuff) beyond parallelizing some of this, which seems doable but I'll save for a later date.

[Before](https://profiler.firefox.com/public/vf0adrt0wn0vj1mbjzmz04bbhsh4bfak47qj6pr/flame-graph/?globalTrackOrder=0w9&hiddenGlobalTracks=1w9&hiddenLocalTracksByPid=24597-07d~24614-0wa~24615-0wc~24616-0we~24617-0we~24618-0w7~24619-0w6~24620-0w6~24624-0w7~24633-0w7&symbolServer=http%3A%2F%2F127.0.0.1%3A3000%2F05kfyd3pvqinq21ka2bfykzn3hh544z2mrsjkxk&thread=02w79wdfwh&v=10)

![image](https://github.com/user-attachments/assets/e993c5be-8a9f-49e1-8cbe-ac7aa148046d)

[After](https://profiler.firefox.com/public/gs8rjc0yhyb2e7epqjxn68j22afz4rbh7p52ewg/flame-graph/?globalTrackOrder=0w9&hiddenGlobalTracks=1w9&hiddenLocalTracksByPid=41251-0cd~41265-0wb~41266-0wc~41267-0wf~41268-0wd~41279-0w7~41288-0w9~41292-0w8~41295-0w7~41297-0w7&symbolServer=http%3A%2F%2F127.0.0.1%3A3000%2F02r6cpz6p74rwc85z4skk0jpg1y0da47hv55jgc&thread=02wcfwh&v=10)

![image](https://github.com/user-attachments/assets/f4d56c25-9433-401f-af53-14230bdaec1e)

<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves # 

## Target Release

1.10.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
