### PR TITLE
statefile: old snapshot format version upgrades are exempt from linters

### DIFF
--- a/internal/states/statefile/version1_upgrade.go
+++ b/internal/states/statefile/version1_upgrade.go
@@ -3,6 +3,7 @@
 // Copyright (c) 2023 HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
+//nolint:govet,mnd,nilnil // The functions in this file are effectively frozen to support an older state format version, so they will never be updated to pass lint rules.
 package statefile
 
 import (

--- a/internal/states/statefile/version2_upgrade.go
+++ b/internal/states/statefile/version2_upgrade.go
@@ -3,6 +3,7 @@
 // Copyright (c) 2023 HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
+//nolint:cyclop,errcheck,funlen,gocritic,gocognit,gocyclo,predeclared,revive,unparam // The functions in this file are effectively frozen to support an older state format version, so they will never be updated to pass lint rules.
 package statefile
 
 import (

--- a/internal/states/statefile/version3_upgrade.go
+++ b/internal/states/statefile/version3_upgrade.go
@@ -3,6 +3,7 @@
 // Copyright (c) 2023 HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
+//nolint:cyclop,exhaustive,funlen,goconst,gocognit,gosec,govet,gocyclo,mnd,nestif,predeclared,revive // The functions in this file are effectively frozen to support an older state format version, so they will never be updated to pass lint rules.
 package statefile
 
 import (
@@ -22,7 +23,6 @@ import (
 )
 
 func upgradeStateV3ToV4(old *stateV3) (*stateV4, error) {
-
 	if old.Serial < 0 {
 		// The new format is using uint64 here, which should be fine for any
 		// real state (we only used positive integers in practice) but we'll
@@ -272,8 +272,7 @@ func upgradeStateV3ToV4(old *stateV3) (*stateV4, error) {
 	return new, nil
 }
 
-func upgradeInstanceObjectV3ToV4(rsOld *resourceStateV2, isOld *instanceStateV2, instKey addrs.InstanceKey, deposedKey states.DeposedKey) (*instanceObjectStateV4, error) {
-
+func upgradeInstanceObjectV3ToV4(_ *resourceStateV2, isOld *instanceStateV2, instKey addrs.InstanceKey, deposedKey states.DeposedKey) (*instanceObjectStateV4, error) {
 	// Schema versions were, in prior formats, a private concern of the provider
 	// SDK, and not a first-class concept in the state format. Here we're
 	// sniffing for the pre-0.12 SDK's way of representing schema versions


### PR DESCRIPTION
The functions in these files are for handling older state snapshot formats that current OpenTofu versions never generate, and so it's highly unlikely that we'll ever make substantial changes to these functions.

Therefore it's unjustified to risk reworking it to pass linting rules, and so we'll add nolint comments instead. Our priority is to make as few changes as possible to these functions, to minimize the risk of regressing a upgrade paths that are exercised very infrequently.

(For context, state version 4 has been current ever since Terraform v0.12.0, and so the earlier versions are long obsolete.)

I worked on this today primarily to remove some functions from consideration on https://github.com/opentofu/opentofu/issues/2325, but this also opts out of the non-complexity-related linters that raise warnings for these files because I think we should aim to leave this legacy code largely unmodified and should not expect to be performing regular ongoing in this area.
