### PR TITLE
ipaddr: Exempt from all lint rules

### DIFF
--- a/internal/ipaddr/ip.go
+++ b/internal/ipaddr/ip.go
@@ -10,6 +10,7 @@
 // This library accepts either size of byte slice but always
 // returns 16-byte addresses.
 
+//nolint:cyclop,funlen,gochecknoglobals,gocritic,nonamedreturns,mnd // This file is copied from the Go codebase and intended to remain close to the original in case we need to backport changes.
 package ipaddr
 
 import (

--- a/internal/ipaddr/ip_test.go
+++ b/internal/ipaddr/ip_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//nolint:gochecknoglobals,gocritic,govet // This file is copied from the Go codebase and intended to remain close to the original in case we need to backport changes.
 package ipaddr
 
 import (

--- a/internal/ipaddr/parse.go
+++ b/internal/ipaddr/parse.go
@@ -5,6 +5,7 @@
 // Simple file i/o and string manipulation, to avoid
 // depending on strconv and bufio and strings.
 
+//nolint:nonamedreturns,mnd // This file is copied from the Go codebase and intended to remain close to the original in case we need to backport changes.
 package ipaddr
 
 // Bigger than we need, not too big to worry about overflow


### PR DESCRIPTION
The code in `package ipaddr` is all snapshot from the Go codebase in older versions, inlined here to allow OpenTofu's cidr-calculation-related functions to preserve their original behavior despite upstream having changed the parsing rules in a breaking way (https://github.com/golang/go/issues/30999, and in particular https://github.com/golang/go/issues/30999#issuecomment-819696563).

This code is intentionally modified as little as possible from the upstream code it was derived from. In the rest of this codebase we are imposing on ourselves considerably stricter style conventions than the Go project follows but we need to disable various linters for `package ipaddr` package to allow this code to remain written in the Go idiomatic style, rather than in OpenTofu's stricter local style.

In particular, we've chosen to prohibit ourselves from using named return values or package-global variables, despite those both being typical in the Go standard library.

I started working on this as part of https://github.com/opentofu/opentofu/issues/2325, but most of the linters we're opting out of here are not actually complexity-related.
