### PR TITLE
legacy packages: Exempt from complexity linters

### DIFF
--- a/internal/legacy/helper/schema/field_reader.go
+++ b/internal/legacy/helper/schema/field_reader.go
@@ -3,6 +3,7 @@
 // Copyright (c) 2023 HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
+//nolint:cyclop,funlen,gocognit // This legacy code is frozen from an older version of the codebase and will not be updated to pass any linters.
 package schema
 
 import (

--- a/internal/legacy/helper/schema/field_reader_config.go
+++ b/internal/legacy/helper/schema/field_reader_config.go
@@ -3,6 +3,7 @@
 // Copyright (c) 2023 HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
+//nolint:cyclop,funlen,nestif // This legacy code is frozen from an older version of the codebase and will not be updated to pass any linters.
 package schema
 
 import (

--- a/internal/legacy/helper/schema/resource.go
+++ b/internal/legacy/helper/schema/resource.go
@@ -3,6 +3,7 @@
 // Copyright (c) 2023 HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
+//nolint:cyclop,gocyclo,gocognit,nestif // This legacy code is frozen from an older version of the codebase and will not be updated to pass any linters.
 package schema
 
 import (

--- a/internal/legacy/helper/schema/resource_data.go
+++ b/internal/legacy/helper/schema/resource_data.go
@@ -3,6 +3,7 @@
 // Copyright (c) 2023 HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
+//nolint:cyclop // This legacy code is frozen from an older version of the codebase and will not be updated to pass any linters.
 package schema
 
 import (

--- a/internal/legacy/helper/schema/resource_timeout.go
+++ b/internal/legacy/helper/schema/resource_timeout.go
@@ -3,6 +3,7 @@
 // Copyright (c) 2023 HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
+//nolint:cyclop,funlen,nestif // This legacy code is frozen from an older version of the codebase and will not be updated to pass any linters.
 package schema
 
 import (

--- a/internal/legacy/helper/schema/schema.go
+++ b/internal/legacy/helper/schema/schema.go
@@ -14,6 +14,8 @@
 // everything else is meant to just work.
 //
 // A good starting point is to view the Provider structure.
+//
+//nolint:cyclop,funlen,gocognit,gocyclo,nestif // This legacy code is frozen from an older version of the codebase and will not be updated to pass any linters.
 package schema
 
 import (

--- a/internal/legacy/helper/schema/serialize.go
+++ b/internal/legacy/helper/schema/serialize.go
@@ -3,6 +3,7 @@
 // Copyright (c) 2023 HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
+//nolint:funlen // This legacy code is frozen from an older version of the codebase and will not be updated to pass any linters.
 package schema
 
 import (

--- a/internal/legacy/helper/schema/shims_test.go
+++ b/internal/legacy/helper/schema/shims_test.go
@@ -3,6 +3,7 @@
 // Copyright (c) 2023 HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
+//nolint:cyclop,gocognit // This legacy code is frozen from an older version of the codebase and will not be updated to pass any linters.
 package schema
 
 import (

--- a/internal/legacy/tofu/diff.go
+++ b/internal/legacy/tofu/diff.go
@@ -3,6 +3,7 @@
 // Copyright (c) 2023 HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
+//nolint:cyclop,funlen,gocognit,gocyclo,nestif // This legacy code is frozen from an older version of the codebase and will not be updated to pass any linters.
 package tofu
 
 import (

--- a/internal/legacy/tofu/provider_mock.go
+++ b/internal/legacy/tofu/provider_mock.go
@@ -3,6 +3,7 @@
 // Copyright (c) 2023 HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
+//nolint:nestif // This legacy code is frozen from an older version of the codebase and will not be updated to pass any linters.
 package tofu
 
 import (

--- a/internal/legacy/tofu/provisioner_mock.go
+++ b/internal/legacy/tofu/provisioner_mock.go
@@ -3,6 +3,7 @@
 // Copyright (c) 2023 HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
+//nolint:nestif // This legacy code is frozen from an older version of the codebase and will not be updated to pass any linters.
 package tofu
 
 import (

--- a/internal/legacy/tofu/state.go
+++ b/internal/legacy/tofu/state.go
@@ -3,6 +3,7 @@
 // Copyright (c) 2023 HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
+//nolint:cyclop,funlen // This legacy code is frozen from an older version of the codebase and will not be updated to pass any linters.
 package tofu
 
 import (

--- a/internal/legacy/tofu/state_filter.go
+++ b/internal/legacy/tofu/state_filter.go
@@ -3,6 +3,7 @@
 // Copyright (c) 2023 HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
+//nolint:gocognit,nestif // This legacy code is frozen from an older version of the codebase and will not be updated to pass any linters.
 package tofu
 
 import (

--- a/internal/legacy/tofu/upgrade_state_v2_test.go
+++ b/internal/legacy/tofu/upgrade_state_v2_test.go
@@ -3,6 +3,7 @@
 // Copyright (c) 2023 HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
+//nolint:cyclop,gocyclo // This legacy code is frozen from an older version of the codebase and will not be updated to pass any linters.
 package tofu
 
 import (


### PR DESCRIPTION
These packages are frozen copies of old code from much older versions of the product that are preserved to keep the state storage backends working until we decide on a way to get them out of this codebase entirely.

Therefore the only potential future change to this code is to delete it once it's no longer needed. It would not be worth the risk or time investment to rework these to meet our strict complexity linting rules.

This is for https://github.com/opentofu/opentofu/issues/2325, just to get these legacy packages off our radar so we can focus on improving packages that we might actually do maintenance on in future.
