### PR TITLE
fix: provider not initialized in some cases (mostly, deposed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@ ENHANCEMENTS:
 
 BUG FIXES:
 * `tofu init` command does not attempt to read encryption keys when `-backend=false` flag is set. ([#2293](https://github.com/opentofu/opentofu/pull/2293))
-* Provider iteration no longer fails on plan / apply, when dealing with deposed and forgotten resources. Also, some error messages for provider configuration changes are more understandable. ([#2334](https://github.com/opentofu/opentofu/pull/2334))
-
 * Changes in `create_before_destroy` for resources which require replacement are now properly handled when refresh is disabled. ([#2248](https://github.com/opentofu/opentofu/pull/2248))
 
 ## Previous Releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,7 @@ ENHANCEMENTS:
 * OpenTofu will now recommend using `-exclude` instead of `-target`, when possible, in the error messages about unknown values in `count` and `for_each` arguments, thereby providing a more definitive workaround. ([#2154](https://github.com/opentofu/opentofu/pull/2154))
 
 BUG FIXES:
-* `tofu init` command does not attempt to read encryption keys when `-backend=false` flag is set. ([#2293](https://github.com/opentofu/opentofu/pull/2293))
-* Changes in `create_before_destroy` for resources which require replacement are now properly handled when refresh is disabled. ([#2248](https://github.com/opentofu/opentofu/pull/2248))
+
 
 ## Previous Releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ ENHANCEMENTS:
 * OpenTofu will now recommend using `-exclude` instead of `-target`, when possible, in the error messages about unknown values in `count` and `for_each` arguments, thereby providing a more definitive workaround. ([#2154](https://github.com/opentofu/opentofu/pull/2154))
 
 BUG FIXES:
-* `tofu init` command does not attempt to read encryption keys when `-backend=false` flag is set. (https://github.com/opentofu/opentofu/pull/2293)
+* `tofu init` command does not attempt to read encryption keys when `-backend=false` flag is set. ([#2293](https://github.com/opentofu/opentofu/pull/2293))
+* Provider iteration no longer fails on plan / apply, when dealing with deposed and forgotten resources. Also, some error messages for provider configuration changes are more understandable. ([#2334](https://github.com/opentofu/opentofu/pull/2334))
 
 * Changes in `create_before_destroy` for resources which require replacement are now properly handled when refresh is disabled. ([#2248](https://github.com/opentofu/opentofu/pull/2248))
 

--- a/internal/tofu/context_apply2_test.go
+++ b/internal/tofu/context_apply2_test.go
@@ -621,6 +621,61 @@ resource "test_object" "x" {
 
 }
 
+// This test is a copy and paste from TestContext2Apply_destroyWithDeposed
+// with modifications to test the same scenario with dynamic providers.
+func TestContext2Apply_destroyWithDeposedWithDynamicProvider(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+provider "test" {
+  alias = "for_eached"
+  for_each = {a: {}}
+}
+
+resource "test_object" "x" {
+  test_string = "ok"
+  lifecycle {
+    create_before_destroy = true
+  }
+  provider = test.for_eached["a"]
+}`,
+	})
+
+	p := simpleMockProvider()
+
+	deposedKey := states.NewDeposedKey()
+
+	state := states.NewState()
+	root := state.EnsureModule(addrs.RootModuleInstance)
+	root.SetResourceInstanceDeposed(
+		mustResourceInstanceAddr("test_object.x").Resource,
+		deposedKey,
+		&states.ResourceInstanceObjectSrc{
+			Status:    states.ObjectTainted,
+			AttrsJSON: []byte(`{"test_string":"deposed"}`),
+		},
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"].for_eached`),
+		addrs.StringKey("a"),
+	)
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
+		Mode: plans.DestroyMode,
+	})
+	if diags.HasErrors() {
+		t.Fatalf("plan: %s", diags.Err())
+	}
+
+	_, diags = ctx.Apply(context.Background(), plan, m)
+	if diags.HasErrors() {
+		t.Fatalf("apply: %s", diags.Err())
+	}
+}
+
 func TestContext2Apply_nullableVariables(t *testing.T) {
 	m := testModule(t, "apply-nullable-variables")
 	state := states.NewState()
@@ -2376,6 +2431,67 @@ func TestContext2Apply_forgetOrphanAndDeposed(t *testing.T) {
 
 	if hook.PostApplyCalled {
 		t.Fatalf("PostApply hook should not be called as part of forget")
+	}
+}
+
+// This test is a copy and paste from TestContext2Apply_forgetOrphanAndDeposed
+// with modifications to test the same scenario with dynamic providers.
+func TestContext2Apply_forgetOrphanAndDeposedWithDynamicProvider(t *testing.T) {
+	desposedKey := states.DeposedKey("deposed")
+	addr := "aws_instance.baz"
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+			provider aws {
+				alias = "for_eached"
+				for_each = {a: {}}
+			}
+
+			removed {
+				from = aws_instance.baz
+			}
+		`,
+	})
+	p := testProvider("aws")
+	state := states.NewState()
+	root := state.EnsureModule(addrs.RootModuleInstance)
+	root.SetResourceInstanceCurrent(
+		mustResourceInstanceAddr(addr).Resource,
+		&states.ResourceInstanceObjectSrc{
+			Status:    states.ObjectReady,
+			AttrsJSON: []byte(`{"id":"bar"}`),
+		},
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"].for_eached`),
+		addrs.StringKey("a"),
+	)
+	root.SetResourceInstanceDeposed(
+		mustResourceInstanceAddr(addr).Resource,
+		desposedKey,
+		&states.ResourceInstanceObjectSrc{
+			Status:       states.ObjectTainted,
+			AttrsJSON:    []byte(`{"id":"bar"}`),
+			Dependencies: []addrs.ConfigResource{},
+		},
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"].for_eached`),
+		addrs.StringKey("a"),
+	)
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
+		},
+	})
+
+	p.PlanResourceChangeFn = testDiffFn
+
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
+	assertNoErrors(t, diags)
+
+	s, diags := ctx.Apply(context.Background(), plan, m)
+	if diags.HasErrors() {
+		t.Fatalf("diags: %s", diags.Err())
+	}
+
+	if !s.Empty() {
+		t.Fatalf("State should be empty")
 	}
 }
 

--- a/internal/tofu/context_apply2_test.go
+++ b/internal/tofu/context_apply2_test.go
@@ -622,7 +622,7 @@ resource "test_object" "x" {
 }
 
 // This test is a copy and paste from TestContext2Apply_destroyWithDeposed
-// with modifications to test the same scenario with dynamic providers.
+// with modifications to test the same scenario with a dynamic provider instance.
 func TestContext2Apply_destroyWithDeposedWithDynamicProvider(t *testing.T) {
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
@@ -2435,7 +2435,7 @@ func TestContext2Apply_forgetOrphanAndDeposed(t *testing.T) {
 }
 
 // This test is a copy and paste from TestContext2Apply_forgetOrphanAndDeposed
-// with modifications to test the same scenario with dynamic providers.
+// with modifications to test the same scenario with  a dynamic provider instance.
 func TestContext2Apply_forgetOrphanAndDeposedWithDynamicProvider(t *testing.T) {
 	desposedKey := states.DeposedKey("deposed")
 	addr := "aws_instance.baz"

--- a/internal/tofu/node_data_destroy.go
+++ b/internal/tofu/node_data_destroy.go
@@ -23,7 +23,6 @@ var (
 
 // GraphNodeExecutable
 func (n *NodeDestroyableDataResourceInstance) Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
-	// TODO/Oleksandr: test it
 	log.Printf("[TRACE] NodeDestroyableDataResourceInstance: removing state object for %s", n.Addr)
 	ctx.State().SetResourceInstanceCurrent(n.Addr, nil, n.ResolvedProvider.ProviderConfig, nil)
 	return nil

--- a/internal/tofu/node_data_destroy.go
+++ b/internal/tofu/node_data_destroy.go
@@ -23,6 +23,7 @@ var (
 
 // GraphNodeExecutable
 func (n *NodeDestroyableDataResourceInstance) Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
+	// TODO/Oleksandr: test it
 	log.Printf("[TRACE] NodeDestroyableDataResourceInstance: removing state object for %s", n.Addr)
 	ctx.State().SetResourceInstanceCurrent(n.Addr, nil, n.ResolvedProvider.ProviderConfig, nil)
 	return nil

--- a/internal/tofu/node_resource_apply_instance.go
+++ b/internal/tofu/node_resource_apply_instance.go
@@ -141,7 +141,7 @@ func (n *NodeApplyableResourceInstance) Execute(ctx EvalContext, op walkOperatio
 		return diags
 	}
 
-	diags = n.resolveProvider(ctx, true)
+	diags = n.resolveProvider(ctx, true, states.NotDeposed)
 	if diags.HasErrors() {
 		return diags
 	}

--- a/internal/tofu/node_resource_deposed.go
+++ b/internal/tofu/node_resource_deposed.go
@@ -87,7 +87,7 @@ func (n *NodePlanDeposedResourceInstanceObject) References() []*addrs.Reference 
 func (n *NodePlanDeposedResourceInstanceObject) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	log.Printf("[TRACE] NodePlanDeposedResourceInstanceObject: planning %s deposed object %s", n.Addr, n.DeposedKey)
 
-	diags = n.resolveProvider(ctx, false)
+	diags = n.resolveProvider(ctx, false, n.DeposedKey)
 	if diags.HasErrors() {
 		return diags
 	}
@@ -257,7 +257,7 @@ func (n *NodeDestroyDeposedResourceInstanceObject) ModifyCreateBeforeDestroy(v b
 func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	var change *plans.ResourceInstanceChange
 
-	diags = n.resolveProvider(ctx, false)
+	diags = n.resolveProvider(ctx, false, n.DeposedKey)
 	if diags.HasErrors() {
 		return diags
 	}
@@ -409,7 +409,7 @@ func (n *NodeForgetDeposedResourceInstanceObject) References() []*addrs.Referenc
 
 // GraphNodeExecutable impl.
 func (n *NodeForgetDeposedResourceInstanceObject) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
-	diags = n.resolveProvider(ctx, false)
+	diags = n.resolveProvider(ctx, false, n.DeposedKey)
 	if diags.HasErrors() {
 		return diags
 	}

--- a/internal/tofu/node_resource_deposed.go
+++ b/internal/tofu/node_resource_deposed.go
@@ -87,6 +87,11 @@ func (n *NodePlanDeposedResourceInstanceObject) References() []*addrs.Reference 
 func (n *NodePlanDeposedResourceInstanceObject) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	log.Printf("[TRACE] NodePlanDeposedResourceInstanceObject: planning %s deposed object %s", n.Addr, n.DeposedKey)
 
+	diags = n.resolveProvider(ctx, false)
+	if diags.HasErrors() {
+		return diags
+	}
+
 	// Read the state for the deposed resource instance
 	state, err := n.readResourceInstanceStateDeposed(ctx, n.Addr, n.DeposedKey)
 	diags = diags.Append(err)
@@ -252,6 +257,11 @@ func (n *NodeDestroyDeposedResourceInstanceObject) ModifyCreateBeforeDestroy(v b
 func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	var change *plans.ResourceInstanceChange
 
+	diags = n.resolveProvider(ctx, false)
+	if diags.HasErrors() {
+		return diags
+	}
+
 	// Read the state for the deposed resource instance
 	state, err := n.readResourceInstanceStateDeposed(ctx, n.Addr, n.DeposedKey)
 	if err != nil {
@@ -399,6 +409,11 @@ func (n *NodeForgetDeposedResourceInstanceObject) References() []*addrs.Referenc
 
 // GraphNodeExecutable impl.
 func (n *NodeForgetDeposedResourceInstanceObject) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+	diags = n.resolveProvider(ctx, false)
+	if diags.HasErrors() {
+		return diags
+	}
+
 	// Read the state for the deposed resource instance
 	state, err := n.readResourceInstanceStateDeposed(ctx, n.Addr, n.DeposedKey)
 	if err != nil {

--- a/internal/tofu/node_resource_destroy.go
+++ b/internal/tofu/node_resource_destroy.go
@@ -143,7 +143,7 @@ func (n *NodeDestroyResourceInstance) Execute(ctx EvalContext, op walkOperation)
 	// Eval info is different depending on what kind of resource this is
 	switch addr.Resource.Resource.Mode {
 	case addrs.ManagedResourceMode:
-		diags = n.resolveProvider(ctx, false)
+		diags = n.resolveProvider(ctx, false, states.NotDeposed)
 		if diags.HasErrors() {
 			return diags
 		}

--- a/internal/tofu/node_resource_forget.go
+++ b/internal/tofu/node_resource_forget.go
@@ -53,7 +53,7 @@ func (n *NodeForgetResourceInstance) Execute(ctx EvalContext, op walkOperation) 
 		log.Printf("[WARN] NodeForgetResourceInstance for %s with no state", addr)
 	}
 
-	diags = n.resolveProvider(ctx, false)
+	diags = n.resolveProvider(ctx, false, states.NotDeposed)
 	if diags.HasErrors() {
 		return diags
 	}

--- a/internal/tofu/node_resource_forget.go
+++ b/internal/tofu/node_resource_forget.go
@@ -53,6 +53,11 @@ func (n *NodeForgetResourceInstance) Execute(ctx EvalContext, op walkOperation) 
 		log.Printf("[WARN] NodeForgetResourceInstance for %s with no state", addr)
 	}
 
+	diags = n.resolveProvider(ctx, false)
+	if diags.HasErrors() {
+		return diags
+	}
+
 	var state *states.ResourceInstanceObject
 
 	state, readDiags := n.readResourceInstanceState(ctx, addr)

--- a/internal/tofu/node_resource_import.go
+++ b/internal/tofu/node_resource_import.go
@@ -92,7 +92,7 @@ func (n *graphNodeImportState) Execute(ctx EvalContext, op walkOperation) (diags
 			ResolvedProvider: n.ResolvedProvider,
 		},
 	}
-	diags = diags.Append(asAbsNode.resolveProvider(ctx, true))
+	diags = diags.Append(asAbsNode.resolveProvider(ctx, true, states.NotDeposed))
 	if diags.HasErrors() {
 		return diags
 	}

--- a/internal/tofu/node_resource_plan_destroy.go
+++ b/internal/tofu/node_resource_plan_destroy.go
@@ -47,7 +47,7 @@ func (n *NodePlanDestroyableResourceInstance) DestroyAddr() *addrs.AbsResourceIn
 func (n *NodePlanDestroyableResourceInstance) Execute(ctx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	addr := n.ResourceInstanceAddr()
 
-	diags = diags.Append(n.resolveProvider(ctx, false))
+	diags = diags.Append(n.resolveProvider(ctx, false, states.NotDeposed))
 	if diags.HasErrors() {
 		return diags
 	}

--- a/internal/tofu/node_resource_plan_instance.go
+++ b/internal/tofu/node_resource_plan_instance.go
@@ -86,7 +86,7 @@ var (
 func (n *NodePlannableResourceInstance) Execute(ctx EvalContext, op walkOperation) tfdiags.Diagnostics {
 	addr := n.ResourceInstanceAddr()
 
-	diags := n.resolveProvider(ctx, true)
+	diags := n.resolveProvider(ctx, true, states.NotDeposed)
 	if diags.HasErrors() {
 		return diags
 	}

--- a/internal/tofu/node_resource_plan_orphan.go
+++ b/internal/tofu/node_resource_plan_orphan.go
@@ -57,7 +57,7 @@ func (n *NodePlannableResourceInstanceOrphan) Execute(ctx EvalContext, op walkOp
 	// Eval info is different depending on what kind of resource this is
 	switch addr.Resource.Resource.Mode {
 	case addrs.ManagedResourceMode:
-		diags := n.resolveProvider(ctx, true)
+		diags := n.resolveProvider(ctx, true, states.NotDeposed)
 		if diags.HasErrors() {
 			return diags
 		}

--- a/internal/tofu/node_resource_plan_orphan.go
+++ b/internal/tofu/node_resource_plan_orphan.go
@@ -63,6 +63,7 @@ func (n *NodePlannableResourceInstanceOrphan) Execute(ctx EvalContext, op walkOp
 		}
 		return n.managedResourceExecute(ctx)
 	case addrs.DataResourceMode:
+		// TODO/Oleksandr: should we resolve provider for data resources as well here?
 		return n.dataResourceExecute(ctx)
 	default:
 		panic(fmt.Errorf("unsupported resource mode %s", n.Config.Mode))

--- a/internal/tofu/node_resource_plan_orphan.go
+++ b/internal/tofu/node_resource_plan_orphan.go
@@ -63,7 +63,6 @@ func (n *NodePlannableResourceInstanceOrphan) Execute(ctx EvalContext, op walkOp
 		}
 		return n.managedResourceExecute(ctx)
 	case addrs.DataResourceMode:
-		// TODO/Oleksandr: should we resolve provider for data resources as well here?
 		return n.dataResourceExecute(ctx)
 	default:
 		panic(fmt.Errorf("unsupported resource mode %s", n.Config.Mode))


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves #2334

This PR resolves the issue described in #2334 and a few more cases, where a provider is not resolved before its usage. Also, we improve error messages for cases, when provider configuration is changed (its instances, or the presence of for_each).

Must be backported to v1.9

## Target Release

1.9.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
