### PR TITLE
Add option "-json" in help text of apply command and plan command.

### DIFF
--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -392,6 +392,10 @@ Options:
 
   -show-sensitive        If specified, sensitive values will be displayed.
 
+  -json                  Produce output in a machine-readable JSON format,
+                         suitable for use in text editor integrations and 
+                         other automated systems. Always disables color.
+
   If you don't provide a saved plan file then this command will also accept
   all of the plan-customization options accepted by the tofu plan command.
   For more information on those options, run:

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -310,6 +310,10 @@ Other Options:
                              information.
 
   -show-sensitive            If specified, sensitive values will be displayed.
+
+  -json                      Produce output in a machine-readable JSON format, 
+                             suitable for use in text editor integrations and 
+                             other automated systems. Always disables color.
 `
 	return strings.TrimSpace(helpText)
 }

--- a/internal/command/refresh.go
+++ b/internal/command/refresh.go
@@ -236,6 +236,10 @@ Options:
                          a file. If "terraform.tfvars" or any ".auto.tfvars"
                          files are present, they will be automatically loaded.
 
+  -json                  Produce output in a machine-readable JSON format,
+                         suitable for use in text editor integrations and 
+                         other automated systems. Always disables color.
+
   -state, state-out, and -backup are legacy options supported for the local
   backend only. For more information, see the local backend's documentation.
 `


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

In OpenTofu v1.8, a new option "-json" was added to the "init" command, and this option is included in the help text. However, this option "-json" is not included in the help text of "apply", "plan" or "refresh", but is included on the OpenTofu website. I believe that they should be consistent, so I raised this PR to add the option in the help text of commands "apply", "plan" and "refresh".

## Target Release

1.10.0

1.9.x

1.8.x

1.7.x

1.6.x

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] (Not applicable) I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] (Not applicable) I have only exported functions, variables and structs that should be used from other packages.
- [x] (Not applicable) I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [x] (Not applicable) I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
