### PR TITLE
plans/objchange: Reduce code complexity of the AssertObjectCompatible implementation details

### DIFF
--- a/internal/plans/objchange/compatible.go
+++ b/internal/plans/objchange/compatible.go
@@ -36,15 +36,15 @@ func assertObjectCompatible(schema *configschema.Block, planned, actual cty.Valu
 	var errs []error
 	var atRoot string
 	if len(path) == 0 {
-		atRoot = "Root object "
+		atRoot = "root object "
 	}
 
 	if planned.IsNull() && !actual.IsNull() {
-		errs = append(errs, path.NewErrorf(fmt.Sprintf("%swas absent, but now present", atRoot)))
+		errs = append(errs, path.NewErrorf("%swas absent, but now present", atRoot))
 		return errs
 	}
 	if actual.IsNull() && !planned.IsNull() {
-		errs = append(errs, path.NewErrorf(fmt.Sprintf("%swas present, but now absent", atRoot)))
+		errs = append(errs, path.NewErrorf("%swas present, but now absent", atRoot))
 		return errs
 	}
 	if planned.IsNull() {


### PR DESCRIPTION
This is another contribution to our complexity-lint-satisfaction project in https://github.com/opentofu/opentofu/issues/2325.

This change is focused on the unexported functions that are used to implement the exported `objchange.AssertObjectCompatible`. This logic necessarily dispatches differently depending on the schema of the objects being compared, and so there's lots of switch statements that previously had inline logic but are now changed into dispatch tables delegating to smaller functions.

The goal here is only to move code around without changing behavior, with one special exception: before I started working on this there were outstanding `go vet` warnings about how the early code in `assertObjectCompatible` was building errors about nullness inconsistencies, and so I fixed those in the first commit before beginning the complexity-related work. One of those changes is to make the error message for incorrect nullness of the root object to now start with a lowercase "r" rather than an uppercase one, since that better matches the Go convention for errors. Interestingly no tests seem to be covering that specific error message, but I consider this change low-risk enough to be okay to include here despite that. There _is_ test coverage for many of the more common cases that use the functions I've refactored.

This quiets all of the complexity lint failures in the `compatible.go` file in this package. Several other files in this package have their own complexity lint failures, but we'll save those for separate PRs because this one is already quite long.

