### PR TITLE
Catch invalid name in provider_meta before it causes a crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
+- Fixed an issue where an invalid provider name in the `provider_meta` block would crash OpenTofu rather than report an error ([#2347](https://github.com/opentofu/opentofu/pull/2347))
 
 ## Previous Releases
 

--- a/internal/configs/provider_meta.go
+++ b/internal/configs/provider_meta.go
@@ -30,7 +30,8 @@ func decodeProviderMetaBlock(block *hcl.Block) (*ProviderMeta, hcl.Diagnostics) 
 		diags = append(diags, d...)
 	}
 
-	// verify that the local name is already localized or produce an error.
+	// If the name is invalid, we return an error early, lest the invalid value
+	// is used by the caller and causes a panic further down the line.
 	if diags = append(diags, checkProviderNameNormalized(block.Labels[0], block.DefRange)...); diags.HasErrors() {
 		return nil, diags
 	}

--- a/internal/configs/provider_meta.go
+++ b/internal/configs/provider_meta.go
@@ -31,7 +31,9 @@ func decodeProviderMetaBlock(block *hcl.Block) (*ProviderMeta, hcl.Diagnostics) 
 	}
 
 	// verify that the local name is already localized or produce an error.
-	diags = append(diags, checkProviderNameNormalized(block.Labels[0], block.DefRange)...)
+	if diags = append(diags, checkProviderNameNormalized(block.Labels[0], block.DefRange)...); diags.HasErrors() {
+		return nil, diags
+	}
 
 	return &ProviderMeta{
 		Provider:      block.Labels[0],

--- a/internal/configs/testdata/invalid-modules/provider-meta-invalid-interpolation/main.tf
+++ b/internal/configs/testdata/invalid-modules/provider-meta-invalid-interpolation/main.tf
@@ -7,4 +7,3 @@ terraform {
 variable "name" {
   type = string
 }
-

--- a/internal/configs/testdata/invalid-modules/provider-meta-invalid-name/main.tf
+++ b/internal/configs/testdata/invalid-modules/provider-meta-invalid-name/main.tf
@@ -1,0 +1,5 @@
+terraform {
+  provider_meta "chunky_bacon" {
+    hello = "world"
+  }
+}


### PR DESCRIPTION
The name of the provider in the `provider_meta` block is enforced by `addrs.MustParseProviderPart`. The caller chain of the affected function assumes that if the returned `ProviderMeta` is not `nil`, it is valid. Hence the panic later.

The fix is to return `nil` if *any* of the diagnostics in this function fail with an error.

Resolves #2345 

## Target Release

1.10.0

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
