### PR TITLE
Update .devcontainer.json go's version to 1.22

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "Go",
-	"image": "mcr.microsoft.com/devcontainers/go:1-1.21-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/go:1-1.22-bullseye",
 	"customizations": {
 		"vscode": {
 			"extensions": [


### PR DESCRIPTION
Updates devcontainer.json file to use Go 1.22. Go mod is asking for 1.22 but the file is using 1.21, leading to the following errors while trying to run go commands there:

```
vscode ➜ .../opentofu/internal/lang/funcs (update-dev-containers) $ go test ./...
go: ../../../go.mod requires go >= 1.22 (running go 1.21.13; GOTOOLCHAIN=local)
```

## Target Release

1.10.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

