### PR TITLE
Fix: When a RequiredProvider is having syntax errors, return an empty one to allow further validations to generate their diags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ BUG FIXES:
 - The `format` and `formatlist` functions can now accept `null` as one of the arguments without causing problems during the apply phase. Previously these functions would incorrectly return an unknown value when given `null` and so could cause a failure during the apply phase where no unknown values are allowed. ([#2371](https://github.com/opentofu/opentofu/pull/2371))
 - Provider used in import is correctly identified. ([#2336](https://github.com/opentofu/opentofu/pull/2336))
 - `plantimestamp()` now returns unknown value during validation ([#2397](https://github.com/opentofu/opentofu/issues/2397))
+- Syntax error in the `required_providers` block does not panic anymore, but yields "syntax error" ([2344](https://github.com/opentofu/opentofu/issues/2344))
 
 ## Previous Releases
 

--- a/internal/configs/module_test.go
+++ b/internal/configs/module_test.go
@@ -226,7 +226,7 @@ func TestModule_required_providers_multiple_one_with_syntax_error(t *testing.T) 
 		`Duplicate required providers configuration`,
 	}
 	if wantLen, gotLen := len(want), len(diags.Errs()); wantLen != gotLen {
-		t.Fatalf("got less errors than expected. Expected %d but got %d", wantLen, gotLen)
+		t.Fatalf("expected %d errors but got %d", wantLen, gotLen)
 	}
 	for i, e := range diags.Errs() {
 		if got := e.Error(); !strings.Contains(got, want[i]) {

--- a/internal/configs/module_test.go
+++ b/internal/configs/module_test.go
@@ -210,6 +210,31 @@ func TestModule_required_provider_overrides(t *testing.T) {
 	}
 }
 
+// When having multiple required providers defined, and one with syntax error,
+// ensure that the diagnostics are returned correctly for each and every validation.
+// In case a required_provider is containing syntax errors, we are returning an empty one just to allow the
+// later validations to add their results.
+func TestModule_required_providers_multiple_one_with_syntax_error(t *testing.T) {
+	_, diags := testModuleFromDir("testdata/invalid-modules/multiple-required-providers-with-syntax-error")
+	if !diags.HasErrors() {
+		t.Fatal("module should have error diags, but does not")
+	}
+
+	want := []string{
+		`Missing attribute value; Expected an attribute value`,
+		`Unexpected "resource" block; Blocks are not allowed here`,
+		`Duplicate required providers configuration`,
+	}
+	if wantLen, gotLen := len(want), len(diags.Errs()); wantLen != gotLen {
+		t.Fatalf("got less errors than expected. Expected %d but got %d", wantLen, gotLen)
+	}
+	for i, e := range diags.Errs() {
+		if got := e.Error(); !strings.Contains(got, want[i]) {
+			t.Errorf("expected error to contain %q\nerror was: \n\t%q\n", want[i], got)
+		}
+	}
+}
+
 // Resources without explicit provider configuration are assigned a provider
 // implied based on the resource type. For example, this resource:
 //

--- a/internal/configs/provider_requirements.go
+++ b/internal/configs/provider_requirements.go
@@ -33,14 +33,16 @@ type RequiredProviders struct {
 }
 
 func decodeRequiredProvidersBlock(block *hcl.Block) (*RequiredProviders, hcl.Diagnostics) {
-	attrs, diags := block.Body.JustAttributes()
-	if diags.HasErrors() {
-		return nil, diags
-	}
-
 	ret := &RequiredProviders{
 		RequiredProviders: make(map[string]*RequiredProvider),
 		DeclRange:         block.DefRange,
+	}
+
+	attrs, diags := block.Body.JustAttributes()
+	if diags.HasErrors() {
+		// Returns an empty RequiredProvider to allow further validations to work properly,
+		// allowing to return correctly all the diagnostics.
+		return ret, diags
 	}
 
 	for name, attr := range attrs {

--- a/internal/configs/provider_requirements.go
+++ b/internal/configs/provider_requirements.go
@@ -41,7 +41,7 @@ func decodeRequiredProvidersBlock(block *hcl.Block) (*RequiredProviders, hcl.Dia
 	attrs, diags := block.Body.JustAttributes()
 	if diags.HasErrors() {
 		// Returns an empty RequiredProvider to allow further validations to work properly,
-		// allowing to return correctly all the diagnostics.
+		// allowing to return all the diagnostics correctly.
 		return ret, diags
 	}
 

--- a/internal/configs/testdata/invalid-modules/multiple-required-providers-with-syntax-error/main.tf
+++ b/internal/configs/testdata/invalid-modules/multiple-required-providers-with-syntax-error/main.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    tfcoremock = {
+      source  = "tfcoremock"
+      version = "0.3.0"
+    }
+  }
+}
+
+resource "tfcoremock_simple_resource" "foo" {}

--- a/internal/configs/testdata/invalid-modules/multiple-required-providers-with-syntax-error/other.tf
+++ b/internal/configs/testdata/invalid-modules/multiple-required-providers-with-syntax-error/other.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    tfcoremock = {
+      source  = "tfcoremock"
+      version = "0.3.0"
+    {
+  }
+}
+
+resource "tfcoremock_simple_resource" "bar" {}


### PR DESCRIPTION
Resolves #2344

Instead of just adding a nil check, just return an empty RequiredProvider to ensure that down the line we are not getting a panic.
Checking the usage `decodeRequiredProvidersBlock` function, the changes made should have no other side-effects.

## Target Release

1.10.0

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
