### PR TITLE
Fix S3 acceptance test panic, introduced in 1.7 encryption

### DIFF
--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -1284,7 +1284,7 @@ func TestBackendExtraPaths(t *testing.T) {
 	}
 
 	// Write the first state
-	stateMgr := &remote.State{Client: client}
+	stateMgr := remote.NewState(client, encryption.StateEncryptionDisabled())
 	if err := stateMgr.WriteState(s1); err != nil {
 		t.Fatal(err)
 	}
@@ -1296,7 +1296,7 @@ func TestBackendExtraPaths(t *testing.T) {
 	// Note a new state manager - otherwise, because these
 	// states are equal, the state will not Put to the remote
 	client.path = b.path("s2")
-	stateMgr2 := &remote.State{Client: client}
+	stateMgr2 := remote.NewState(client, encryption.StateEncryptionDisabled())
 	if err := stateMgr2.WriteState(s2); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
I had assumed that these tests were run on main, will need to double check that pipeline.

This is the last place we are constructing remote.State without the constructor (requires encryption)

## Target Release

1.10.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

