### PR TITLE
Make table name and index name a config value for PG backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ NEW FEATURES:
     - `provider::terraform::encode_tfvars` - Encode an object into a string with the same format as a TFVars file.
     - `provider::terraform::encode_expr` - Encode an arbitrary expression into a string with valid OpenTofu syntax.
 - Added support for S3 native locking ([#599](https://github.com/opentofu/opentofu/issues/599))
+- Backend `pg` now allows the `table_name` and `index_name` to be specified. This enables a single database schema to support multiple backends via multiple tables. ([#2465](https://github.com/opentofu/opentofu/pull/2465))
 
 ENHANCEMENTS:
 
@@ -45,7 +46,7 @@ BUG FIXES:
 - Changing Go version to 1.22.11 in order to fix [CVE-2024-45336](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-45336) and [CVE-2024-45341](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-45341) ([#2438](https://github.com/opentofu/opentofu/pull/2438))
 - Fix the error message when default value of a complex variable is containing a wrong type ([2394](https://github.com/opentofu/opentofu/issues/2394))
 - Fix the way OpenTofu downloads a module that is sourced from a GitHub branch containing slashes in the name. ([2396](https://github.com/opentofu/opentofu/issues/2396))
-- `pg` backend doesn't fail on workspace creation for paralel runs, when the database is shared across multiple projects. ([#2411](https://github.com/opentofu/opentofu/pull/2411))
+- `pg` backend doesn't fail on workspace creation for parallel runs, when the database is shared across multiple projects. ([#2411](https://github.com/opentofu/opentofu/pull/2411))
 - Generating an OpenTofu configuration from an `import` block that is referencing a resource with nested attributes now works correctly, instead of giving an error that the nested computed attribute is required. ([#2372](https://github.com/opentofu/opentofu/issues/2372)) 
 - `base64gunzip` now doesn't expose sensitive values if it fails during the base64 decoding. ([#2503](https://github.com/opentofu/opentofu/pull/2503))
 - Fix loading only the necessary encryption key providers and methods for better `terraform_remote_state` support. ([2551](https://github.com/opentofu/opentofu/issues/2551))

--- a/internal/backend/remote-state/pg/backend.go
+++ b/internal/backend/remote-state/pg/backend.go
@@ -9,18 +9,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"github.com/lib/pq"
 	"os"
 	"strconv"
 
-	"github.com/lib/pq"
 	"github.com/opentofu/opentofu/internal/backend"
 	"github.com/opentofu/opentofu/internal/encryption"
 	"github.com/opentofu/opentofu/internal/legacy/helper/schema"
-)
-
-const (
-	statesTableName = "states"
-	statesIndexName = "states_by_name"
 )
 
 func defaultBoolFunc(k string, dv bool) schema.SchemaDefaultFunc {
@@ -58,11 +53,25 @@ func New(enc encryption.StateEncryption) backend.Backend {
 				DefaultFunc: defaultBoolFunc("PG_SKIP_SCHEMA_CREATION", false),
 			},
 
+			"table_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Name of the automatically managed Postgres table to store state",
+				DefaultFunc: schema.EnvDefaultFunc("PG_TABLE_NAME", "states"),
+			},
+
 			"skip_table_creation": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "If set to `true`, OpenTofu won't try to create the Postgres table",
 				DefaultFunc: defaultBoolFunc("PG_SKIP_TABLE_CREATION", false),
+			},
+
+			"index_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Name of the automatically managed Postgres index used for stored state",
+				DefaultFunc: schema.EnvDefaultFunc("PG_INDEX_NAME", "states_by_name"),
 			},
 
 			"skip_index_creation": {
@@ -88,6 +97,8 @@ type Backend struct {
 	configData *schema.ResourceData
 	connStr    string
 	schemaName string
+	tableName  string
+	indexName  string
 }
 
 func (b *Backend) configure(ctx context.Context) error {
@@ -96,7 +107,12 @@ func (b *Backend) configure(ctx context.Context) error {
 	data := b.configData
 
 	b.connStr = data.Get("conn_str").(string)
-	b.schemaName = pq.QuoteIdentifier(data.Get("schema_name").(string))
+	b.schemaName = data.Get("schema_name").(string)
+	b.tableName = data.Get("table_name").(string)
+	b.indexName = data.Get("index_name").(string)
+	skipSchemaCreation := data.Get("skip_schema_creation").(bool)
+	skipTableCreation := data.Get("skip_table_creation").(bool)
+	skipIndexCreation := data.Get("skip_index_creation").(bool)
 
 	db, err := sql.Open("postgres", b.connStr)
 	if err != nil {
@@ -106,11 +122,11 @@ func (b *Backend) configure(ctx context.Context) error {
 	// Prepare database schema, tables, & indexes.
 	var query string
 
-	if !data.Get("skip_schema_creation").(bool) {
+	if !skipSchemaCreation {
 		// list all schemas to see if it exists
 		var count int
 		query = `select count(1) from information_schema.schemata where schema_name = $1`
-		if err := db.QueryRow(query, data.Get("schema_name").(string)).Scan(&count); err != nil {
+		if err = db.QueryRow(query, b.schemaName).Scan(&count); err != nil {
 			return err
 		}
 
@@ -119,31 +135,33 @@ func (b *Backend) configure(ctx context.Context) error {
 		// a user hasn't been granted the `CREATE SCHEMA` privilege
 		if count < 1 {
 			// tries to create the schema
-			query = `CREATE SCHEMA IF NOT EXISTS %s`
-			if _, err := db.Exec(fmt.Sprintf(query, b.schemaName)); err != nil {
+			query = fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %s`, pq.QuoteIdentifier(b.schemaName))
+			if _, err = db.Exec(query); err != nil {
 				return err
 			}
 		}
 	}
 
-	if !data.Get("skip_table_creation").(bool) {
-		if _, err := db.Exec("CREATE SEQUENCE IF NOT EXISTS public.global_states_id_seq AS bigint"); err != nil {
+	if !skipTableCreation {
+		query = "CREATE SEQUENCE IF NOT EXISTS public.global_states_id_seq AS bigint"
+		if _, err = db.Exec(query); err != nil {
 			return err
 		}
 
-		query = `CREATE TABLE IF NOT EXISTS %s.%s (
+		query = fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.%s (
 			id bigint NOT NULL DEFAULT nextval('public.global_states_id_seq') PRIMARY KEY,
 			name text UNIQUE,
 			data text
-			)`
-		if _, err := db.Exec(fmt.Sprintf(query, b.schemaName, statesTableName)); err != nil {
+			)`, pq.QuoteIdentifier(b.schemaName), pq.QuoteIdentifier(b.tableName))
+
+		if _, err = db.Exec(query); err != nil {
 			return err
 		}
 	}
 
-	if !data.Get("skip_index_creation").(bool) {
-		query = `CREATE UNIQUE INDEX IF NOT EXISTS %s ON %s.%s (name)`
-		if _, err := db.Exec(fmt.Sprintf(query, statesIndexName, b.schemaName, statesTableName)); err != nil {
+	if !skipIndexCreation {
+		query = fmt.Sprintf(`CREATE UNIQUE INDEX IF NOT EXISTS %s ON %s.%s (name)`, pq.QuoteIdentifier(b.indexName), pq.QuoteIdentifier(b.schemaName), pq.QuoteIdentifier(b.tableName))
+		if _, err = db.Exec(query); err != nil {
 			return err
 		}
 	}

--- a/website/docs/language/settings/backends/pg.mdx
+++ b/website/docs/language/settings/backends/pg.mdx
@@ -97,12 +97,16 @@ The following configuration options or environment variables are supported:
 - `conn_str` - Postgres connection string; a `postgres://` URL. The `PG_CONN_STR` and [standard `libpq`](https://www.postgresql.org/docs/current/libpq-envars.html) environment variables can also be used to indicate how to connect to the PostgreSQL database.
 - `schema_name` - Name of the automatically-managed Postgres schema, default to `terraform_remote_state`. Can also be set using the `PG_SCHEMA_NAME` environment variable.
 - `skip_schema_creation` - If set to `true`, the Postgres schema must already exist. Can also be set using the `PG_SKIP_SCHEMA_CREATION` environment variable. OpenTofu won't try to create the schema, this is useful when it has already been created by a database administrator.
+- `table_name` - Name of the automatically-managed Postgres table, default to `states`. Can also be set using the `PG_TABLE_NAME` environment variable.
 - `skip_table_creation` - If set to `true`, the Postgres table must already exist. Can also be set using the `PG_SKIP_TABLE_CREATION` environment variable. OpenTofu won't try to create the table, this is useful when it has already been created by a database administrator.
+- `index_name` - Name of the automatically-managed Postgres index, default to `states_by_name`. Can also be set using the `PG_INDEX_NAME` environment variable.
 - `skip_index_creation` - If set to `true`, the Postgres index must already exist. Can also be set using the `PG_SKIP_INDEX_CREATION` environment variable. OpenTofu won't try to create the index, this is useful when it has already been created by a database administrator.
+
+Please, keep in mind, that if `table_name` or `schema_name` is changed, you would need to manually migrate the existing state data.
 
 ## Technical Design
 
-This backend creates one table **states** in the automatically-managed Postgres schema configured by the `schema_name` variable.
+This backend creates a table with a name defined by `table_name` in the automatically-managed Postgres schema configured by the `schema_name` variable.
 
 The table is keyed by the [workspace](../../../language/state/workspaces.mdx) name. If workspaces are not in use, the name `default` is used.
 
@@ -110,7 +114,7 @@ Locking is supported using [Postgres advisory locks](https://www.postgresql.org/
 
 Advisory locks are used for multiple scenarios: state updates and state creation. When the state is updated, advisory lock is acquired with state ID. Otherwise, on state (and workspace) creation, it is acquired with the hash of schema name. This way, multiple backend configurations doesn't affect each other, when the database is shared.
 
-The **states** table contains:
+The table used for state contains:
 
 - a serial integer `id`, used as the key for advisory locks
 - the workspace `name` key as _text_ with a unique index


### PR DESCRIPTION
Make it possible to specify the table name and index name when using PG backend. 

This makes it easier to use PG backend provider for scenarios such as using Terragrunt with convention based state storage per a `terragrunt.hcl` file by providing an additional layer of grouping.

Having many tables vs many schemas could be preferred by some users and the tools they use too.