### PR TITLE
addrs: Refactor parseRef to parse complexity linters

### DIFF
--- a/internal/addrs/map_test.go
+++ b/internal/addrs/map_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 )
 
+//nolint:cyclop // The complexity of this test naturally scales by the number of test conditions, and would be less readable/maintainable if broken into smaller parts.
 func TestMap(t *testing.T) {
 	variableName := InputVariable{Name: "name"}
 	localHello := LocalValue{Name: "hello"}


### PR DESCRIPTION
This is just another one for our complexity linting improvements in https://github.com/opentofu/opentofu/issues/2325.

As usual, the goal is to pass more of the complexity linting rules without changing the externally-observable behavior of OpenTofu at all.

---

Our complexity lint rules previously considered this function to have both too many statements and too many lines.

Factoring out more of the "single-attr ref" logic into the `parseSingleAttrRef` function eliminated one statement per case that was using it.

Factoring out the handling of module call references -- the most complex case this function handles -- into a separate `parseModuleCallRef` reduced it considerably more.

Removing the empty lines between the `case` statements was necessary after that just to get below the line count limit, which seems like a rather dubious situation for a lint rule to complain about but it doesn't seem to hurt readability, so fair enough.

The rework of `parseSingleAttrRef` made it slightly less convenient to use as part of `parseModuleCallRef`, but not onerously so and thus this prioritizes making the common case simpler at the expense of a small amount of extra work in the `parseModuleCallRef` function.

---

Although not strictly related to the rest of this, I also introduced a `nolint` directive for the `TestMap` test case since I don't see any reasonable way to improve its readability: its cyclomatic complexity is essentially just the number of `if` statements in the test, and so reducing it would require compromising the readability in some other way.

Including that here makes this whole package complexity-lint-free.
