### PR TITLE
TofuPipes experiment

### DIFF
--- a/internal/command/arguments/extended.go
+++ b/internal/command/arguments/extended.go
@@ -228,8 +228,10 @@ func (o *Operation) Parse() tfdiags.Diagnostics {
 // desirable for the arguments package to handle the gathering of variables
 // directly, returning a map of variable values.
 type Vars struct {
-	vars     *flagNameValueSlice
-	varFiles *flagNameValueSlice
+	vars        *flagNameValueSlice
+	varFiles    *flagNameValueSlice
+	varCommands *flagNameValueSlice
+	varUpstream *flagNameValueSlice
 }
 
 func (v *Vars) All() []FlagNameValue {
@@ -279,10 +281,17 @@ func extendedFlagSet(name string, state *State, operation *Operation, vars *Vars
 	if vars != nil {
 		varsFlags := newFlagNameValueSlice("-var")
 		varFilesFlags := varsFlags.Alias("-var-file")
+		varCommandsFlags := varsFlags.Alias("-var-command")
+		varUpstreamFlags := varsFlags.Alias("-var-upstream")
+
 		vars.vars = &varsFlags
 		vars.varFiles = &varFilesFlags
+		vars.varCommands = &varCommandsFlags
+		vars.varUpstream = &varUpstreamFlags
 		f.Var(vars.vars, "var", "var")
 		f.Var(vars.varFiles, "var-file", "var-file")
+		f.Var(vars.varCommands, "var-command", "var-command")
+		f.Var(vars.varUpstream, "var-upstream", "var-upstream")
 	}
 
 	return f

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -611,8 +611,12 @@ func (m *Meta) varFlagSet(f *flag.FlagSet) {
 	}
 	varValues := m.variableArgs.Alias("-var")
 	varFiles := m.variableArgs.Alias("-var-file")
+	varCommands := m.variableArgs.Alias("-var-command")
+	varUpstream := m.variableArgs.Alias("var-upstream")
 	f.Var(varValues, "var", "variables")
 	f.Var(varFiles, "var-file", "variable file")
+	f.Var(varCommands, "var-command", "run this external command to obtain variable values")
+	f.Var(varUpstream, "var-upstream", "obtain values from this OpenTofu project's outputs")
 }
 
 // extendedFlagSet adds custom flags that are mostly used by commands

--- a/internal/tofu/variables.go
+++ b/internal/tofu/variables.go
@@ -107,6 +107,14 @@ const (
 	// ValueFromCaller indicates that the value was explicitly overridden by
 	// a caller to Context.SetVariable after the context was constructed.
 	ValueFromCaller ValueSourceType = 'S'
+
+	// ValueFromExternalCommand indicates that the value was obtained by executing
+	// an external command.
+	ValueFromExternalCommand ValueSourceType = 'X'
+
+	// ValueFromUpstreamProject indicates that the value was obtained by querying
+	// the state of an upstream project.
+	ValueFromUpstreamProject ValueSourceType = 'U'
 )
 
 func (v *InputValue) GoString() string {


### PR DESCRIPTION
This is an experiment related to #2221 and #931. It simplifies wiring together multiple OpenTofu projects by allowing a project to consume the outputs of another projects like this:

```
tofu apply -var-upstream=/path/to/upstream/project
```

Internally, this works by executing `tofu -chdir /path/to/upstream/project output -json` and applying the received output the same way as `-var-file` would. The main limitation of this approach is that the upstream project must declare the exact same output names as the downstream project declares variables and any marks, such as sensitive, will not translate through the project boundary.

As a side-effect, it also adds `-var-command`, which serves as the implementation for `-var-upstream`.

## Alternatives

- The source code makes mention of a potential `-var-file=<(./scripts/vars.sh)` possibility, but this doesn't actually work.
- One could create Unix pipes and read from them, or write the contents (including sensitive values) to a file, but that's clunky and suboptimal.
- We could implement this as full-blown block in OpenTofu.

## Target Release

N/A, this is an experiment.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [X] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [X] I have not used an AI coding assistant to create this PR.
- [X] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [X] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.
