### PR TITLE
gitignore: add coverage.out and coverage.html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ vendor/
 .vscode/launch.json
 
 # Coverage
+coverage.html
+coverage.out
 coverage.txt
 
 # GoReleaser build directory


### PR DESCRIPTION
While playing around with the codebase I noticed that coverage.html and coverage.out are not yet in the git ignore, so I decided to add them.

## Checklist

- [X] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [X] I have not used an AI coding assistant to create this PR.
- [X] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [X] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.