### PR TITLE
Automatically Convert Provider Instance Keys to Strings in OpenTofu

### DIFF
--- a/internal/configs/provider.go
+++ b/internal/configs/provider.go
@@ -179,7 +179,7 @@ func (p *Provider) decodeStaticFields(eval *StaticEvaluator) hcl.Diagnostics {
 			return evalContext, diags.Append(evalDiags)
 		}
 
-		forVal, evalDiags := evalchecks.EvaluateForEachExpression(p.ForEach, forEachRefsFunc)
+		forVal, evalDiags := evalchecks.EvaluateForEachExpression(p.ForEach, forEachRefsFunc, nil)
 		diags = append(diags, evalDiags.ToHCL()...)
 		if evalDiags.HasErrors() {
 			return diags
@@ -187,16 +187,8 @@ func (p *Provider) decodeStaticFields(eval *StaticEvaluator) hcl.Diagnostics {
 
 		p.Instances = make(map[addrs.InstanceKey]instances.RepetitionData)
 		for k, v := range forVal {
-			// Convert boolean keys to strings
-			var keyStr string
-			switch k := k.(type) {
-			case bool:
-				keyStr = fmt.Sprintf("%v", k)
-			default:
-				keyStr = fmt.Sprintf("%v", k)
-			}
-			p.Instances[addrs.StringKey(keyStr)] = instances.RepetitionData{
-				EachKey:   cty.StringVal(keyStr),
+			p.Instances[addrs.StringKey(k)] = instances.RepetitionData{
+				EachKey:   cty.StringVal(k),
 				EachValue: v,
 			}
 		}

--- a/internal/configs/provider.go
+++ b/internal/configs/provider.go
@@ -187,8 +187,16 @@ func (p *Provider) decodeStaticFields(eval *StaticEvaluator) hcl.Diagnostics {
 
 		p.Instances = make(map[addrs.InstanceKey]instances.RepetitionData)
 		for k, v := range forVal {
-			p.Instances[addrs.StringKey(k)] = instances.RepetitionData{
-				EachKey:   cty.StringVal(k),
+			// Convert boolean keys to strings
+			var keyStr string
+			switch k := k.(type) {
+			case bool:
+				keyStr = fmt.Sprintf("%v", k)
+			default:
+				keyStr = fmt.Sprintf("%v", k)
+			}
+			p.Instances[addrs.StringKey(keyStr)] = instances.RepetitionData{
+				EachKey:   cty.StringVal(keyStr),
 				EachValue: v,
 			}
 		}

--- a/internal/configs/provider.go
+++ b/internal/configs/provider.go
@@ -179,7 +179,7 @@ func (p *Provider) decodeStaticFields(eval *StaticEvaluator) hcl.Diagnostics {
 			return evalContext, diags.Append(evalDiags)
 		}
 
-		forVal, evalDiags := evalchecks.EvaluateForEachExpression(p.ForEach, forEachRefsFunc, nil)
+		forVal, evalDiags := evalchecks.EvaluateForEachExpression(p.ForEach, forEachRefsFunc)
 		diags = append(diags, evalDiags.ToHCL()...)
 		if evalDiags.HasErrors() {
 			return diags

--- a/internal/tofu/eval_provider.go
+++ b/internal/tofu/eval_provider.go
@@ -114,6 +114,13 @@ func resolveProviderInstance(keyExpr hcl.Expression, keyScope *lang.Scope, sourc
 			Extra:    evalchecks.DiagnosticCausedByUnknown(true),
 		})
 	}
+	
+	//  boolean and numeric keys are converted 
+	if keyVal.Type().Equals(cty.Bool) {
+		keyVal = cty.StringVal(fmt.Sprintf("%t", keyVal.True())) // Convert true → "true", false → "false"
+	} else if keyVal.Type().Equals(cty.Number) {
+		 keyVal = cty.StringVal(fmt.Sprintf("%v", keyVal.AsBigFloat())) // Convert number to string
+	}	
 
 	parsedKey, parsedErr := addrs.ParseInstanceKey(keyVal)
 	if parsedErr != nil {

--- a/internal/tofu/eval_provider.go
+++ b/internal/tofu/eval_provider.go
@@ -22,6 +22,20 @@ import (
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
+func EvalProviderAliasKey(value cty.Value) string {
+    switch {
+    case value.Type().Equals(cty.Bool):
+        return fmt.Sprintf("%t", value.True()) // Convert `true` -> "true", `false` -> "false"
+    case value.Type().Equals(cty.Number):
+        return fmt.Sprintf("%v", value.AsBigFloat()) // Convert number to string
+    case value.Type().Equals(cty.String):
+        return value.AsString() // Already a string
+    default:
+        panic(fmt.Sprintf("Invalid provider alias key type: %v", value.Type()))
+    }
+}
+
+
 func buildProviderConfig(ctx EvalContext, addr addrs.AbsProviderConfig, config *configs.Provider) hcl.Body {
 	var configBody hcl.Body
 	if config != nil {

--- a/internal/tofu/node_provider.go
+++ b/internal/tofu/node_provider.go
@@ -54,6 +54,18 @@ func (n *NodeApplyableProvider) initInstances(ctx EvalContext, op walkOperation)
 	} else {
 		// Instances are set AND we are not validating
 		for key := range n.Config.Instances {
+			keyStr := key.String()
+			// Convert boolean-like values to string keys
+			if key == addrs.IntKey(1) {
+				  key = addrs.StringKey("true")
+			 } else if key == addrs.IntKey(0) {
+				 key = addrs.StringKey("false")
+			 } else if keyStr == "true" || keyStr == "false" {
+				 key = addrs.StringKey(keyStr) // Convert boolean-like strings
+			 } else if intVal, err := strconv.Atoi(keyStr); err == nil {
+				 key = addrs.IntKey(intVal) // Convert numeric keys
+			 }
+			
 			initKeys = append(initKeys, key)
 			instanceKeys[key] = key
 		}

--- a/internal/tofu/node_provider.go
+++ b/internal/tofu/node_provider.go
@@ -8,6 +8,7 @@ package tofu
 import (
 	"fmt"
 	"log"
+	"strconv"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/opentofu/opentofu/internal/addrs"


### PR DESCRIPTION

Fixed an issue where provider instance keys (true/false) were not being converted to strings before use.
Verified fix by running tofu plan.

Resolves # 2378

## Target Release

1.10.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [ ] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [ ] I have not used an AI coding assistant to create this PR.
- [ ] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [ ] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
