### PR TITLE
lang/funcs: transpose panics with null elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ BUG FIXES:
 - Generating an OpenTofu configuration from an `import` block that is referencing a resource with nested attributes now works correctly, instead of giving an error that the nested computed attribute is required. ([#2372](https://github.com/opentofu/opentofu/issues/2372)) 
 - `base64gunzip` now doesn't expose sensitive values if it fails during the base64 decoding. ([#2503](https://github.com/opentofu/opentofu/pull/2503))
 - Fix loading only the necessary encryption key providers and methods for better `terraform_remote_state` support. ([2551](https://github.com/opentofu/opentofu/issues/2551))
+- Better error messages when using `null` in invalid positions in the argument to the `transpose` function. ([#2553](https://github.com/opentofu/opentofu/pull/2553))
 
 ## Previous Releases
 

--- a/internal/lang/funcs/collection_test.go
+++ b/internal/lang/funcs/collection_test.go
@@ -1822,6 +1822,23 @@ func TestTranspose(t *testing.T) {
 			}).WithMarks(cty.NewValueMarks("beep", "boop", "bloop")),
 			false,
 		},
+		{ // Null value must be rejected because map keys cannot be null
+			cty.MapVal(map[string]cty.Value{
+				"key1": cty.ListVal([]cty.Value{
+					cty.StringVal("a"),
+					cty.NullVal(cty.String),
+				}),
+			}),
+			cty.NilVal,
+			true,
+		},
+		{ // Null list must be rejected, too
+			cty.MapVal(map[string]cty.Value{
+				"key1": cty.NullVal(cty.List(cty.String)),
+			}),
+			cty.NilVal,
+			true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Previously the "transpose" function would panic if any of the given lists were null or if any of the strings inside the given lists were null.

Null values _are_ invalid in those positions because we can't project null values into the keys of the resulting map, but we should return explicit error messages in those cases rather than causing a Go panic.

Before this fix:

```
> transpose(null)
╷
│ Error: Invalid function argument
│ 
│   on <console-input> line 1:
│   (source code not available)
│ 
│ Invalid value for "values" parameter: argument must not be null.
╵


> transpose({"foo": null})
╷
│ Error: Error in function call
│ 
│   on <console-input> line 1:
│   (source code not available)
│ 
│ Call to function "transpose" failed: panic in function implementation: can't use ElementIterator on null value
│ goroutine 1 [running]:
│ runtime/debug.Stack()
│       /.../golang/1.24.0/go/src/runtime/debug/stack.go:26 +0x5e
│ github.com/zclconf/go-cty/cty/function.errorForPanic(...)
│       /.../golang/1.24.0/packages/pkg/mod/github.com/zclconf/go-cty@v1.16.1/cty/function/error.go:44
│ github.com/zclconf/go-cty/cty/function.Function.Call.func2()
│       /.../golang/1.24.0/packages/pkg/mod/github.com/zclconf/go-cty@v1.16.1/cty/function/function.go:349 +0x9b
│ panic({0x2f22b00?, 0x3c10980?})
│       /.../golang/1.24.0/go/src/runtime/panic.go:787 +0x132
│ github.com/zclconf/go-cty/cty.Value.ElementIterator({{{0x3c54038?, 0xc000618530?}}, {0x0?, 0x0?}})
│       /.../golang/1.24.0/packages/pkg/mod/github.com/zclconf/go-cty@v1.16.1/cty/value_ops.go:1219 +0xbe
│ github.com/opentofu/opentofu/internal/lang/funcs.init.func20({0xc0009142e0?, 0xc000618580?, 0x313bb40?}, {{0x3c53a98?, 0xc0005cd800?}})
│       /.../opentofu/internal/lang/funcs/collection.go:583 +0x245
│ github.com/zclconf/go-cty/cty/function.Function.Call({0x3c53a60?}, {0xc0009142e0, 0x1, 0x1})
│       /../golang/1.24.0/packages/pkg/mod/github.com/zclconf/go-cty@v1.16.1/cty/function/function.go:353 +0x691
│ github.com/hashicorp/hcl/v2/hclsyntax.(*FunctionCallExpr).Value(0xc000804000, 0xc0004d63a8)
│       /.../golang/1.24.0/packages/pkg/mod/github.com/opentofu/hcl/v2@v2.0.0-20240814143621-8048794c5c52/hclsyntax/expression.go:528 +0x1a9e
│ github.com/opentofu/opentofu/internal/lang.(*Scope).EvalExpr(0xc0009761b0, {0x3c542b8, 0xc000804000}, {{0x3c53f90?, 0x5783c80?}})
│       /.../opentofu/internal/lang/eval.go:183 +0x1a2
│ github.com/opentofu/opentofu/internal/repl.(*Session).handleEval(0xc000a878f8, {0xc000632160?, 0xc000a875c8?})
│       /.../opentofu/internal/repl/session.go:60 +0x14e
│ github.com/opentofu/opentofu/internal/repl.(*Session).Handle(0xc000a878f8, {0xc000632160, 0x18})
│       /.../opentofu/internal/repl/session.go:45 +0xbc
│ github.com/opentofu/opentofu/internal/command.(*ConsoleCommand).modeInteractive(0xc00094f200, 0xc000a878f8, {0x3c5af90, 0xc000963410})
│       /.../opentofu/internal/command/console_interactive.go:65 +0x330
│ github.com/opentofu/opentofu/internal/command.(*ConsoleCommand).Run(0xc00094f200, {0xc0000720d0?, 0x0?, 0x0?})
│       /.../opentofu/internal/command/console.go:180 +0x1405
│ github.com/mitchellh/cli.(*CLI).Run(0xc000922280)
│       /.../golang/1.24.0/packages/pkg/mod/github.com/mitchellh/cli@v1.1.5/cli.go:262 +0x4de
│ main.realMain()
│       /.../opentofu/cmd/tofu/main.go:347 +0x1fab
│ main.main()
│       /.../Devel/opentofu/cmd/tofu/main.go:66 +0x13
│ .
╵


> transpose({"foo": [null]})
╷
│ Error: Error in function call
│ 
│   on <console-input> line 1:
│   (source code not available)
│ 
│ Call to function "transpose" failed: panic in function implementation: value is null
│ goroutine 1 [running]:
│ runtime/debug.Stack()
│       /.../golang/1.24.0/go/src/runtime/debug/stack.go:26 +0x5e
│ github.com/zclconf/go-cty/cty/function.errorForPanic(...)
│       /.../golang/1.24.0/packages/pkg/mod/github.com/zclconf/go-cty@v1.16.1/cty/function/error.go:44
│ github.com/zclconf/go-cty/cty/function.Function.Call.func2()
│       /.../golang/1.24.0/packages/pkg/mod/github.com/zclconf/go-cty@v1.16.1/cty/function/function.go:349 +0x9b
│ panic({0x2f22b00?, 0x3c10950?})
│       /.../golang/1.24.0/go/src/runtime/panic.go:787 +0x132
│ github.com/zclconf/go-cty/cty.Value.AsString({{{0x3c538a0?, 0xc000012ca9?}}, {0x0?, 0x0?}})
│       /.../golang/1.24.0/packages/pkg/mod/github.com/zclconf/go-cty@v1.16.1/cty/value_ops.go:1413 +0x10b
│ github.com/opentofu/opentofu/internal/lang/funcs.init.func20({0xc000914720?, 0xc000618d30?, 0x313bb40?}, {{0x3c53a98?, 0xc0005cd800?}})
│       /.../opentofu/internal/lang/funcs/collection.go:589 +0x739
│ github.com/zclconf/go-cty/cty/function.Function.Call({0x3c53a60?}, {0xc000914720, 0x1, 0x1})
│       /.../golang/1.24.0/packages/pkg/mod/github.com/zclconf/go-cty@v1.16.1/cty/function/function.go:353 +0x691
│ github.com/hashicorp/hcl/v2/hclsyntax.(*FunctionCallExpr).Value(0xc000804690, 0xc0004d6a08)
│       /.../golang/1.24.0/packages/pkg/mod/github.com/opentofu/hcl/v2@v2.0.0-20240814143621-8048794c5c52/hclsyntax/expression.go:528 +0x1a9e
│ github.com/opentofu/opentofu/internal/lang.(*Scope).EvalExpr(0xc0009761b0, {0x3c542b8, 0xc000804690}, {{0x3c53f90?, 0x5783c80?}})
│       /.../opentofu/internal/lang/eval.go:183 +0x1a2
│ github.com/opentofu/opentofu/internal/repl.(*Session).handleEval(0xc000a878f8, {0xc0006327c0?, 0xc000a875c8?})
│       /.../opentofu/internal/repl/session.go:60 +0x14e
│ github.com/opentofu/opentofu/internal/repl.(*Session).Handle(0xc000a878f8, {0xc0006327c0, 0x1a})
│       /.../opentofu/internal/repl/session.go:45 +0xbc
│ github.com/opentofu/opentofu/internal/command.(*ConsoleCommand).modeInteractive(0xc00094f200, 0xc000a878f8, {0x3c5af90, 0xc000963410})
│       /.../opentofu/internal/command/console_interactive.go:65 +0x330
│ github.com/opentofu/opentofu/internal/command.(*ConsoleCommand).Run(0xc00094f200, {0xc0000720d0?, 0x0?, 0x0?})
│       /.../opentofu/internal/command/console.go:180 +0x1405
│ github.com/mitchellh/cli.(*CLI).Run(0xc000922280)
│       /.../golang/1.24.0/packages/pkg/mod/github.com/mitchellh/cli@v1.1.5/cli.go:262 +0x4de
│ main.realMain()
│       /.../opentofu/cmd/tofu/main.go:347 +0x1fab
│ main.main()
│       /.../opentofu/cmd/tofu/main.go:66 +0x13
│ .
╵
```

After this fix:

```
> transpose(null)
╷
│ Error: Invalid function argument
│ 
│   on <console-input> line 1:
│   (source code not available)
│ 
│ Invalid value for "values" parameter: argument must not be null.
╵


> transpose({"foo": null})
╷
│ Error: Invalid function argument
│ 
│   on <console-input> line 1:
│   (source code not available)
│ 
│ Invalid value for "values" parameter: cannot use null list for ["foo"].
╵


> transpose({"foo": [null]})
╷
│ Error: Invalid function argument
│ 
│   on <console-input> line 1:
│   (source code not available)
│ 
│ Invalid value for "values" parameter: cannot use null string for ["foo"][0].
╵
```

(I became aware of this bug indirectly through the discussion in https://github.com/zclconf/go-cty/pull/203, which was in turn informed by https://github.com/hashicorp/terraform/issues/36547.)

---

While this _is_ technically a user-visible change, it's really just replacing a poor error message with a better error message and so it doesn't seem worth mentioning in the changelog, but I could do that if others disagree. :man_shrugging: 
