### PR TITLE
getproviders: New provider installation method for OCI Registries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,8 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2
 	github.com/nishanths/exhaustive v0.7.11
 	github.com/openbao/openbao/api/v2 v2.1.0
+	github.com/opencontainers/go-digest v1.0.0
+	github.com/opencontainers/image-spec v1.1.0
 	github.com/opentofu/registry-address v0.0.0-20230920144404-f1e51167f633
 	github.com/packer-community/winrmcp v0.0.0-20180921211025-c76d91c1e7db
 	github.com/pkg/errors v0.9.1
@@ -228,8 +230,6 @@ require (
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d // indirect
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/samber/lo v1.37.0 // indirect

--- a/internal/getproviders/oci_registry_mirror_source.go
+++ b/internal/getproviders/oci_registry_mirror_source.go
@@ -1,0 +1,631 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package getproviders
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+
+	"github.com/apparentlymart/go-versions/versions"
+	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	orasErrors "oras.land/oras-go/v2/errdef"
+
+	"github.com/opentofu/opentofu/internal/addrs"
+)
+
+// ociIndexManifestArtifactType is the artifact type we expect for the top-level
+// index manifest for an OpenTofu provider version.
+//
+// If a selected tag refers to a manifest that either lacks an artifact type
+// or has a different artifact type then OpenTofu will reject it with an
+// error indicating that it seems to be something other than an OpenTofu provider.
+const ociIndexManifestArtifactType = "application/vnd.opentofu.provider"
+
+// ociPackageManifestArtifactType is the artifact type we expect for each of the
+// individual manifests listed in a provider version's top-level index manifest.
+//
+// OpenTofu will silently ignore any listed descriptors that either lack an artifact
+// type or use a different one, both so that future versions of OpenTofu can
+// be sensitive to additional artifact types if needed and so that those creating
+// an artifact can choose to blend in other non-OpenTofu-related artifacts if
+// they have some reason to do that.
+//
+// All descriptors with this artifact type MUST include a "platform" object
+// with "os" and "architecture" set to match the platform that the individual
+// package is built for. OpenTofu and OCI both use Go's codenames for operating
+// systems and CPU architectures, so these fields should exactly match the
+// names that would be used with this package's [Platform] type.
+//
+// OpenTofu does not currently make any use of the other properties defined for
+// a "platform" object, and so will silently ignore any descriptors that set
+// those properties. Future versions of OpenTofu might be able to use finer-grain
+// platform selection properties, in which case those versions should treat
+// a descriptor that uses those additional properties as higher precedence than
+// one that doesn't so that manifest authors can include both a specific descriptor
+// and a fallback descriptor with only os/architecture intended for use by
+// earlier OpenTofu versions.
+const ociPackageManifestArtifactType = "application/vnd.opentofu.provider-target"
+
+// ociImageManifestSizeLimit is the maximum size of artifact manifest (aka "image
+// manifest") we'll accept. This 4MiB value matches the recommended limit for
+// repositories to accept on push from the OCI Distribution v1.1 spec:
+//
+//	https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#pushing-manifests
+const ociImageManifestSizeLimitMiB = 4
+
+// OCIRegistryMirrorSource is a source that treats one or more repositories
+// in a registry implementing the OCI Distribution protocol as a kind of
+// provider mirror.
+//
+// This is conceptually similar to [HTTPMirrorSource], but whereas that one
+// acts as a client for the OpenTofu-specific "provider mirror protocol"
+// this one instead relies on a user-configured template to map provider
+// source addresses onto OCI repository addresses and then uses tags in
+// the selected registry to discover the available versions, and OCI
+// manifests to represent their metadata.
+//
+// This implementation is currently intended to be compatible with
+// OCI Distribution v1.1.0:
+//
+//	https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md
+type OCIRegistryMirrorSource struct {
+	// resolveOCIRepositoryAddr represents this source's rule for mapping
+	// OpenTofu-style provider source addresses into OCI Distribution
+	// repository addresses, which include both the domain name (and
+	// optional port number) of the registry where the repository is
+	// hosted and the name of the repository within that registry.
+	//
+	// This MUST behave as a pure function: a specific given provider
+	// address must always return the same results, because it will
+	// be called multiple times across the steps of selecting a provider
+	// version.
+	//
+	// Implementers are responsible for somehow dealing with the fact
+	// that OpenTofu-style provider source addresses support a
+	// considerably wider set of Unicode characters than OCI Distribution
+	// repository names do. That could mean either translating unsupported
+	// characters into a different representation, or as a last resort
+	// returning an error message explaining the problem in terms that make
+	// sense for however the end user would've defined the mapping rule.
+	//
+	// If this function returns with a nil error then registryDomain
+	// must be a valid domain name optionally followed by a colon
+	// and a decimal port number, and repositoryName must be a string
+	// conforming to the "<name>" pattern defined in the OCI Distribution
+	// specification. The source will return low-quality error messages
+	// if the results are unsuitable, and so implementers should prefer
+	// to return their own higher-quality error diagnostics if no valid
+	// mapping is possible.
+	//
+	// Any situation where the requested provider cannot be supported
+	// _at all_ MUST return an instance of [ErrProviderNotFound] so
+	// that a [MultiSource] can successfully blend the results from
+	// this and other sources.
+	resolveOCIRepositoryAddr func(ctx context.Context, addr addrs.Provider) (registryDomain, repositoryName string, err error)
+
+	// getOCIRepositoryStore is the dependency inversion adapter for
+	// obtaining a suitably-configured client for the given repository
+	// name on the given OCI Distribution registry domain.
+	//
+	// If successful, the returned client should be preconfigured with
+	// any credentials that are needed to access content from the
+	// given repository. Implementers can assume that the client will
+	// be used for only a short period after the call to this function,
+	// so e.g. it's valid to use time-limited credentials with a validity
+	// period on the order of 5 to 10 minutes if appropriate.
+	//
+	// Errors from this function should represent "operational-related"
+	// situations like a failure to execute a credentials helper or
+	// failure to issue a temporary access token, and will be presented
+	// in the UI as a diagnostic with terminology like "Failed to access
+	// OCI registry".
+	getOCIRepositoryStore func(ctx context.Context, registryDomain, repositoryName string) (OCIRepositoryStore, error)
+
+	// We keep an internal cache of the most-recently-instantiated
+	// repository store object because in the common case there will
+	// be call to AvailableVersions immediately followed by
+	// PackageMeta with the same provider address and this avoids
+	// us needing to repeat the translation and instantiation again.
+	storeCacheMutex          sync.Mutex
+	storeCacheProvider       addrs.Provider
+	storeCacheStore          OCIRepositoryStore
+	storeCacheRegistryDomain string
+	storeCacheRepositoryName string
+}
+
+var _ Source = (*OCIRegistryMirrorSource)(nil)
+
+// AvailableVersions implements Source.
+func (o *OCIRegistryMirrorSource) AvailableVersions(ctx context.Context, provider addrs.Provider) (VersionList, Warnings, error) {
+	store, _, _, err := o.getRepositoryStore(ctx, provider)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var ret VersionList
+	err = store.Tags(ctx, "", func(tagNames []string) error {
+		for _, tagName := range tagNames {
+			// We're only interested in the subset of tag names that we can parse
+			// as version numbers. However, the OCI tag name syntax does not allow
+			// the "+" symbol that can appear in the version number syntax, so we
+			// expect the underscore to stand in for that.
+			maybeVersionStr := strings.ReplaceAll(tagName, "_", "+")
+			version, err := versions.ParseVersion(maybeVersionStr)
+			if err != nil {
+				// Not a version tag, so ignored.
+				continue
+			}
+			ret = append(ret, version)
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(err, orasErrors.ErrNotFound) {
+			// We treat "not found" as special because this function might be
+			// called from [MultiSource.AvailableVersions] and that relies
+			// on us returning this specific error type to represent that this
+			// source can't handle the requested provider at all, so that it
+			// can blend the results of multiple sources and only return an
+			// error if _none_ of the eligible sources can handle the
+			// requested provider. We assume that if the given provider address
+			// translated to an OCI repository that doesn't exist then that
+			// means this source does not know anything about that provider,
+			// but other [MultiSource] candidates should still be offered it.
+			return nil, nil, ErrProviderNotFound{
+				Provider: provider,
+			}
+		}
+		return nil, nil, fmt.Errorf("listing tags from OCI repository: %w", err)
+	}
+	ret.Sort()
+	return ret, nil, nil
+}
+
+// PackageMeta implements Source.
+func (o *OCIRegistryMirrorSource) PackageMeta(ctx context.Context, provider addrs.Provider, version Version, target Platform) (PackageMeta, error) {
+	// Unfortunately we need to repeat our translation from provider address to
+	// OCI repository address here, but getRepositoryStore has a cache that
+	// allows us to reuse a previously-instantiated store if there are two
+	// consecutive calls for the same provider, as is commonly true when first
+	// calling AvailableVersions and then calling PackageMeta based on its result.
+	store, registryDomain, repositoryName, err := o.getRepositoryStore(ctx, provider)
+	if err != nil {
+		return PackageMeta{}, err
+	}
+
+	// The overall process here is:
+	// 1. Transform the version number into a tag name and resolve the descriptor
+	//    associated with that tag name.
+	// 2. Fetch the blob associated with that descriptor, which should be an
+	//    index manifest giving a descriptor for each platform supported by this
+	//    version of the provider.
+	// 3. Choose the descriptor that matches the requested platform.
+	// 4. Fetch the blob associated with that second descriptor, which should be
+	//    an image manifest that includes a layer descriptor for the blob containing
+	//    the actual zip package we need to fetch.
+	// 5. Return a PackageMeta whose location is that zip blob, using [PackageOCIBlobArchive].
+
+	// The errors from the following helper functions must not be wrapped by this
+	// function because some of them are of specific types that get special
+	// treatment by callers.
+	indexDesc, err := fetchOCIDescriptorForVersion(ctx, version, store) // step 1
+	if err != nil {
+		return PackageMeta{}, err
+	}
+	index, err := fetchOCIIndexManifest(ctx, indexDesc, store) // step 2
+	if err != nil {
+		return PackageMeta{}, err
+	}
+	imageDesc, err := selectOCIImageManifest(index.Manifests, provider, version, target) // step 3
+	if err != nil {
+		return PackageMeta{}, err
+	}
+	imageManifest, err := fetchOCIImageManifest(ctx, imageDesc, store) // step 4
+	if err != nil {
+		return PackageMeta{}, err
+	}
+	blobDesc, err := selectOCILayerBlob(imageManifest.Layers) // a little more of step 4
+	if err != nil {
+		return PackageMeta{}, err
+	}
+
+	// The remainder of this is "step 5" from the overview above, adapting the information
+	// we fetched to suit OpenTofu's provider installer API.
+
+	// We'll announce the OpenTofu-style package hash that we're expecting as part of
+	// the metadata. This isn't strictly necessary since OCI blobs are content-addressed
+	// anyway and so we'll authenticate it using the same digest that identifies it
+	// during the subsequent fetch, but this makes this source consistent with
+	// [HTTPMirrorSource] and allows generating an explicit "checksum verified"
+	// authentication result after install.
+	expectedHash, err := hashFromOCIDigest(blobDesc.Digest)
+	if err != nil {
+		return PackageMeta{}, err
+	}
+	authentication := NewPackageHashAuthentication(target, []Hash{expectedHash})
+
+	// If we got through all of the above then we seem to have found a suitable
+	// package to install, but our job is only to describe its metadata.
+	return PackageMeta{
+		Provider:       provider,
+		Version:        version,
+		TargetPlatform: target,
+		Location: PackageOCIBlobArchive{
+			repoStore:      store,
+			blobDescriptor: blobDesc,
+			registryDomain: registryDomain,
+			repositoryName: repositoryName,
+		},
+		Authentication: authentication,
+
+		// "Filename" isn't really a meaningful concept in an OCI registry, but
+		// that's okay because we don't care very much about it in OpenTofu
+		// either and so we can just populate something plausible here. This
+		// matches the way the package would be named in a traditional
+		// OpenTofu provider network mirror.
+		Filename: fmt.Sprintf("terraform-provider-%s_%s_%s_%s.zip", provider.Type, version, target.OS, target.Arch),
+
+		// TODO: Define an optional annotation that can announce which protocol
+		// versions are supported, so we can populate the ProtocolVersions
+		// field and can fail early if the provider clearly doesn't support
+		// any of the protocol versions that this OpenTofu version supports.
+		// Omitting this field is okay though, since some other mirror sources
+		// can't support it either: that just means that OpenTofu will discover
+		// the compatibility problem only after executing the plugin, rather
+		// than when installing it.
+	}, nil
+}
+
+// ForDisplay implements Source.
+func (o *OCIRegistryMirrorSource) ForDisplay(provider addrs.Provider) string {
+	// We don't really have a good concise way to differentiate between
+	// instances of this source because the mapping from provider source
+	// address to OCI repository address is arbitrarily-defined by the
+	// user, so we'll just settle for this right now since this is result
+	// only typically used in error messages anyway. If this turns out to
+	// be too vague in practice than hopefully whatever complaint caused
+	// us to realize that will give a clue as to what additional information
+	// is worth including here and where we might derive that information
+	// from.
+	return "OCI registry provider mirror"
+}
+
+func (o *OCIRegistryMirrorSource) getRepositoryStore(ctx context.Context, provider addrs.Provider) (store OCIRepositoryStore, registryDomain string, repositoryName string, err error) {
+	o.storeCacheMutex.Lock()
+	defer o.storeCacheMutex.Unlock()
+
+	// If our cache is for the requested provider then we can reuse the store
+	// we previously instantiated for this provider.
+	if o.storeCacheProvider == provider {
+		return o.storeCacheStore, o.storeCacheRegistryDomain, o.storeCacheRepositoryName, nil
+	}
+
+	// Otherwise we'll instantiate a new one and overwrite our cache with it.
+	registryDomain, repositoryName, err = o.resolveOCIRepositoryAddr(ctx, provider)
+	if err != nil {
+		if notFoundErr, ok := err.(ErrProviderNotFound); ok {
+			// [MultiSource] relies on this particular error type being returned
+			// directly, without any wrapping.
+			return nil, "", "", notFoundErr
+		}
+		return nil, "", "", fmt.Errorf("selecting OCI repository address: %w", err)
+	}
+	store, err = o.getOCIRepositoryStore(ctx, registryDomain, repositoryName)
+	if err != nil {
+		if errors.Is(err, orasErrors.ErrNotFound) {
+			return nil, "", "", ErrProviderNotFound{
+				Provider: provider,
+			}
+		}
+		return nil, "", "", fmt.Errorf("accessing OCI registry at %s: %w", registryDomain, err)
+	}
+	o.storeCacheProvider = provider
+	o.storeCacheStore = store
+	o.storeCacheRegistryDomain = registryDomain
+	o.storeCacheRepositoryName = repositoryName
+	return store, registryDomain, repositoryName, nil
+}
+
+// OCIRepositoryStore is the interface used by [OCIRegistryMirrorSource] to
+// interact with the content in a specific OCI repository.
+type OCIRepositoryStore interface {
+	// Tags lists the tag names available in the repository.
+	//
+	// The OCI Distribution protocol uses pagination for the tag list and so
+	// the given function will be called for each page until either it returns
+	// an error or there are no pages left to retrieve.
+	//
+	// "last" is a token used to begin at some point other than the start of
+	// the list, but callers in this package always set it to an empty string
+	// to represent intent to retrieve the entire list and so implementers are
+	// allowed to return an error if "last" is non-empty.
+	Tags(ctx context.Context, last string, fn func(tags []string) error) error
+
+	// Resolve finds the descriptor associated with the given tag name in the
+	// repository, if any.
+	//
+	// tagName MUST conform to the pattern defined for "<reference> as a tag"
+	// from the OCI distribution specification, or the result is unspecified.
+	Resolve(ctx context.Context, tagName string) (ociv1.Descriptor, error)
+
+	// Fetch retrieves the content of a specific blob from the repository, identified
+	// by the digest in the given descriptor.
+	//
+	// Implementations of this function tend not to check that the returned content
+	// actually matches the digest and size in the descriptor, so callers MUST
+	// verify that somehow themselves before making use of the resulting content.
+	//
+	// Callers MUST close the returned reader after using it, since it's typically
+	// connected to an active network socket or file handle.
+	Fetch(ctx context.Context, target ociv1.Descriptor) (io.ReadCloser, error)
+
+	// The design of the above intentionally matches a subset of the interfaces
+	// defined in the ORAS-Go library, but we have our own specific interface here
+	// both to clearly define the minimal interface we depend on and so that our
+	// use of ORAS-Go can be treated as an implementation detail rather than as
+	// an API contract should we need to switch to a different approach in future.
+	//
+	// If you need to expand this while we're still relying on ORAS-Go, aim to
+	// match the corresponding interface in that library if at all possible so
+	// that we can minimize the amount of adapter code we need to write.
+}
+
+func fetchOCIDescriptorForVersion(ctx context.Context, version versions.Version, store OCIRepositoryStore) (ociv1.Descriptor, error) {
+	// OCI tags don't support the "+" character used to mark the beginning of
+	// build metadata in semver-style version numbers, so we expect a tag name
+	// where those are replaced with "_".
+	tagName := strings.ReplaceAll(version.String(), "+", "_")
+	desc, err := store.Resolve(ctx, tagName)
+	if err != nil {
+		return ociv1.Descriptor{}, fmt.Errorf("resolving tag %q: %w", tagName, err)
+	}
+	if desc.ArtifactType != ociIndexManifestArtifactType {
+		switch desc.ArtifactType {
+		case "application/vnd.opentofu.provider-target":
+			// We'll get here for an incorrectly-constructed artifact layout where
+			// the tag refers directly to a specific platform's image manifest,
+			// rather than to the multi-platform index manifest.
+			return desc, fmt.Errorf("tag refers directly to image manifest, but OpenTofu providers require an index manifest for multi-platform support")
+		case "application/vnd.opentofu.modulepkg":
+			// If this happens to be using our artifact type for module packages then
+			// we'll return a specialized error, since confusion between providers
+			// and modules is common for those new to OpenTofu terminology.
+			return desc, fmt.Errorf("selected OCI artifact is an OpenTofu module package, not a provider package")
+		case "":
+			// Prior to there being an explicit way to represent artifact types earlier
+			// attempts to adapt OCI Distribution to non-container-image stuff used
+			// custom layer media types instead. This case also deals with container images
+			// themselves, which are essentially the "default" kind of artifact. We
+			// haven't yet fetched the full manifest so we can't actually distinguish
+			// these from the descriptor alone, and so this error message is generic.
+			return desc, fmt.Errorf("unsupported OCI artifact type; is this a container image, rather than an OpenTofu provider?")
+		default:
+			// For any other artifact type we'll just mention it in the error message
+			// and hope the reader can figure out what that artifact type represents.
+			return desc, fmt.Errorf("unsupported OCI artifact type %q", desc.ArtifactType)
+		}
+	}
+	if desc.MediaType != ociv1.MediaTypeImageIndex {
+		switch desc.MediaType {
+		case ociv1.MediaTypeImageManifest:
+			return desc, fmt.Errorf("selected an OCI image manifest directly, but providers must be selected through a multi-platform index manifest")
+		case ociv1.MediaTypeDescriptor:
+			return desc, fmt.Errorf("found OCI descriptor but expected multi-platform index manifest")
+		default:
+			return desc, fmt.Errorf("unsupported media type %q for OCI index manifest", desc.MediaType)
+		}
+	}
+	return desc, nil
+}
+
+func fetchOCIIndexManifest(ctx context.Context, desc ociv1.Descriptor, store OCIRepositoryStore) (*ociv1.Index, error) {
+	manifestSrc, err := fetchOCIManifestBlob(ctx, desc, store)
+	if err != nil {
+		return nil, err
+	}
+
+	var manifest ociv1.Index
+	err = json.Unmarshal(manifestSrc, &manifest)
+	if err != nil {
+		// As an aid to debugging, we'll check whether we seem to have retrieved
+		// an image manifest instead of an index manifest, since an unmarshal
+		// failure could prevent us from reaching the MediaType check below.
+		var manifest ociv1.Manifest
+		if err := json.Unmarshal(manifestSrc, &manifest); err == nil && manifest.MediaType == ociv1.MediaTypeImageManifest {
+			return nil, fmt.Errorf("found image manifest but need index manifest")
+		}
+		return nil, fmt.Errorf("invalid manifest content: %w", err)
+	}
+
+	// Now we'll make sure that what we decoded seems vaguely sensible before we
+	// return it. Callers are allowed to rely on these checks by verifying
+	// that their provided descriptor specifies the wanted media and artifact
+	// types before they call this function and then assuming that the result
+	// definitely matches what they asked for.
+	if manifest.MediaType != desc.MediaType {
+		return nil, fmt.Errorf("unexpected manifest media type %q", manifest.MediaType)
+	}
+	if manifest.ArtifactType != desc.ArtifactType {
+		return nil, fmt.Errorf("unexpected artifact type %q", manifest.ArtifactType)
+	}
+	// We intentionally leave everything else loose so that we'll have flexibility
+	// to extend this format in backward-compatible ways in future OpenTofu versions.
+	return &manifest, nil
+}
+
+func fetchOCIImageManifest(ctx context.Context, desc ociv1.Descriptor, store OCIRepositoryStore) (*ociv1.Manifest, error) {
+	manifestSrc, err := fetchOCIManifestBlob(ctx, desc, store)
+	if err != nil {
+		return nil, err
+	}
+
+	var manifest ociv1.Manifest
+	err = json.Unmarshal(manifestSrc, &manifest)
+	if err != nil {
+		// As an aid to debugging, we'll check whether we seem to have retrieved
+		// an index manifest instead of an image manifest, since an unmarshal
+		// failure could prevent us from reaching the MediaType check below.
+		var manifest ociv1.Index
+		if err := json.Unmarshal(manifestSrc, &manifest); err == nil && manifest.MediaType == ociv1.MediaTypeImageIndex {
+			return nil, fmt.Errorf("found index manifest but need image manifest")
+		}
+		return nil, fmt.Errorf("invalid manifest content: %w", err)
+	}
+
+	// Now we'll make sure that what we decoded seems vaguely sensible before we
+	// return it. Callers are allowed to rely on these checks by verifying
+	// that their provided descriptor specifies the wanted media and artifact
+	// types before they call this function and then assuming that the result
+	// definitely matches what they asked for.
+	if manifest.MediaType != desc.MediaType {
+		return nil, fmt.Errorf("unexpected manifest media type %q", manifest.MediaType)
+	}
+	if manifest.ArtifactType != desc.ArtifactType {
+		return nil, fmt.Errorf("unexpected artifact type %q", manifest.ArtifactType)
+	}
+	// We intentionally leave everything else loose so that we'll have flexibility
+	// to extend this format in backward-compatible ways in future OpenTofu versions.
+	return &manifest, nil
+}
+
+func selectOCIImageManifest(descs []ociv1.Descriptor, provider addrs.Provider, version versions.Version, target Platform) (ociv1.Descriptor, error) {
+	foundManifests := 0
+	foundWrongArtifactType := ""
+	foundWrongPlatform := 0
+	var selected ociv1.Descriptor
+	for _, desc := range descs {
+		if desc.ArtifactType != ociPackageManifestArtifactType {
+			if desc.ArtifactType != "" {
+				foundWrongArtifactType = desc.ArtifactType
+			}
+			continue // silently ignore anything that isn't claiming to be a provider package manifest
+		}
+		if desc.MediaType != ociv1.MediaTypeImageManifest {
+			// If this descriptor claims to be for a provider target manifest then
+			// it MUST be declared as being an image manifest.
+			return selected, fmt.Errorf("provider image manifest has unsupported media type %q", desc.MediaType)
+		}
+		if desc.Platform == nil {
+			return selected, fmt.Errorf("provider image manifest lacks the required platform constraints")
+		}
+		if desc.Platform.OSVersion != "" || desc.Platform.OS != target.OS || desc.Platform.Architecture != target.Arch {
+			// We ignore manifests that aren't for the platform we're trying to match.
+			// We also ignore manifests that specify a specific OS version because we
+			// don't currently have any means to handle that, but we want to give
+			// future OpenTofu versions the option of treating that as a more specific
+			// match while leaving an OSVersion-free entry as a compatibility fallback.
+			foundWrongPlatform++
+			continue
+		}
+		// We have found a plausible candidate!
+		foundManifests++
+		selected = desc
+	}
+	if foundManifests == 0 {
+		switch {
+		case foundWrongPlatform > 0:
+			// If all of the manifests were valid but none were eligible for this
+			// platform then we assume that this is a valid provider that just
+			// lacks support for the current platform, for which we have a special
+			// error type.
+			return selected, ErrPlatformNotSupported{
+				Provider: provider,
+				Version:  version,
+				Platform: target,
+			}
+		case foundWrongArtifactType != "":
+			// If we didn't find any manifests with the correct artifact type
+			// targeting _any_ platform but we found at least one with a
+			// different artifact type then we'll mention that here. We
+			// arbitrarily just take whichever incorrect artifact type we
+			// found most recently, since it's unlikely to get here so not
+			// worth the complexity of trying to collect multiple.
+			return selected, fmt.Errorf("provider image manifest has unsupported artifact type %q", foundWrongArtifactType)
+		default:
+			// This is a particularly annoying case: none of the declared
+			// manifests have any artifact type _at all_. The most likely
+			// cause of this is that the user has accidentally selected the
+			// index manifest for a multi-platform container image, and so
+			// we'll bias toward that explanation in the error message but
+			// present it as a question to communicate that we're not sure.
+			return selected, fmt.Errorf("provider image manifest has unsupported artifact type; is this a container image, rather than an OpenTofu provider?")
+		}
+	}
+	if foundManifests > 1 {
+		// There must be exactly one eligible manifest, to avoid ambiguity.
+		return selected, fmt.Errorf("ambiguous manifest has multiple descriptors for platform %s", target)
+	}
+	return selected, nil
+}
+
+func selectOCILayerBlob(descs []ociv1.Descriptor) (ociv1.Descriptor, error) {
+	foundBlobs := 0
+	foundWrongMediaTypeBlobs := 0
+	var selected ociv1.Descriptor
+	for _, desc := range descs {
+		if desc.ArtifactType != ociPackageArtifactType {
+			continue
+		}
+		if desc.MediaType != ociPackageMediaType {
+			// We silently ignore any "layer" that doesn't have both our expected
+			// artifact type and media type so that future versions of OpenTofu
+			// can potentially support additional archive formats, and so that
+			// artifact authors can include other non-OpenTofu-related layers
+			// in their manifests if needed... but we do still count them so that
+			// we can hint about it in an error message below.
+			foundWrongMediaTypeBlobs++
+			continue
+		}
+		foundBlobs++
+		selected = desc
+	}
+	if foundBlobs == 0 {
+		if foundWrongMediaTypeBlobs > 0 {
+			return selected, fmt.Errorf("image manifest contains no %q layers of type %q, but has other unsupported formats; this OCI artifact might be intended for a different version of OpenTofu", ociPackageArtifactType, ociPackageMediaType)
+		}
+		return selected, fmt.Errorf("image manifest contains no %q layers of type %q", ociPackageArtifactType, ociPackageMediaType)
+	}
+	if foundBlobs > 1 {
+		// There must be exactly one eligible blob, to avoid ambiguity.
+		return selected, fmt.Errorf("ambiguous manifest declares multiple eligible provider packages")
+	}
+	return selected, nil
+}
+
+func fetchOCIManifestBlob(ctx context.Context, desc ociv1.Descriptor, store OCIRepositoryStore) ([]byte, error) {
+	// We impose a size limit on the manifest just to avoid an abusive remote registry
+	// occupuing unbounded memory when we read the manifest content into memory below.
+	if (desc.Size / 1024 / 1024) > ociImageManifestSizeLimitMiB {
+		return nil, fmt.Errorf("manifest size exceeds OpenTofu's size limit of %d MiB", ociImageManifestSizeLimitMiB)
+	}
+
+	readCloser, err := store.Fetch(ctx, desc)
+	if err != nil {
+		return nil, err
+	}
+	defer readCloser.Close()
+	manifestReader := io.LimitReader(readCloser, desc.Size)
+
+	// We need to verify that the content matches the digest in the descriptor,
+	// and we also need to parse that data as JSON. We can only read from the
+	// reader once, so we have no choice but to buffer it all in memory.
+	manifestSrc, err := io.ReadAll(manifestReader)
+	if err != nil {
+		return nil, fmt.Errorf("reading manifest content: %w", err)
+	}
+
+	gotDigest := desc.Digest.Algorithm().FromBytes(manifestSrc)
+	if gotDigest != desc.Digest {
+		return nil, fmt.Errorf("manifest content does not match digest %s", desc.Digest)
+	}
+
+	return manifestSrc, nil
+}

--- a/internal/getproviders/oci_registry_mirror_source_test.go
+++ b/internal/getproviders/oci_registry_mirror_source_test.go
@@ -1,0 +1,509 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package getproviders
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	svchost "github.com/hashicorp/terraform-svchost"
+	ociDigest "github.com/opencontainers/go-digest"
+	ociSpecs "github.com/opencontainers/image-spec/specs-go"
+	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	orasContent "oras.land/oras-go/v2/content"
+	orasOCI "oras.land/oras-go/v2/content/oci"
+	orasErrors "oras.land/oras-go/v2/errdef"
+
+	"github.com/opentofu/opentofu/internal/addrs"
+)
+
+func TestOCIRegistryMirrorSource(t *testing.T) {
+	// For unit test purposes we use a local-filesystem-based repository
+	// rather than a remote registry repository. We use an on-disk
+	// fake rather than an in-memory fake for this one only because
+	// none of ORAS-Go's in-memory implementations implement the
+	// TagLister interface.
+	store, err := orasOCI.NewWithContext(t.Context(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// We'll create a few separate sets of blob+manifests so that we'll
+	// have multiple tags to choose from and can test that we selected
+	// the right one.
+	fakePlatforms := []Platform{
+		{OS: "amigaos", Arch: "m86k"},
+		{OS: "tos", Arch: "m86k"},
+	}
+	for patchVersion := range 3 {
+		version := Version{Major: 1, Minor: 0, Patch: uint64(patchVersion)}
+		if patchVersion == 2 {
+			// We'll include one version with build metadata so that we can
+			// test the transformation into a valid OCI Distribution tag.
+			version.Metadata = "foo.1"
+		}
+		manifestDescs := make([]ociv1.Descriptor, 0, len(fakePlatforms))
+		for _, platform := range fakePlatforms {
+			// We use different placeholder content for the fake executable in each
+			// version/platform combination so that once installation is complete
+			// we can check that we actually installed the correct one.
+			fakePackageBytes := makePlaceholderProviderPackageZip(t, fmt.Sprintf("placeholder executable for v%s on %s", version, platform))
+			packageDesc := pushOCIBlob(t, "archive/zip", "application/vnd.opentofu.providerpkg", fakePackageBytes, store)
+			manifestDesc := pushOCIImageManifest(t, &ociv1.Manifest{
+				Versioned:    ociSpecs.Versioned{SchemaVersion: 2},
+				MediaType:    ociv1.MediaTypeImageManifest,
+				ArtifactType: "application/vnd.opentofu.provider-target",
+				Config:       ociv1.DescriptorEmptyJSON,
+				Layers: []ociv1.Descriptor{
+					packageDesc,
+				},
+			}, store)
+			manifestDesc.Platform = &ociv1.Platform{
+				Architecture: platform.Arch,
+				OS:           platform.OS,
+			}
+			manifestDescs = append(manifestDescs, manifestDesc)
+		}
+		indexDesc := pushOCIIndexManifest(t, &ociv1.Index{
+			Versioned:    ociSpecs.Versioned{SchemaVersion: 2},
+			MediaType:    ociv1.MediaTypeImageIndex,
+			ArtifactType: "application/vnd.opentofu.provider",
+			Manifests:    manifestDescs,
+		}, store)
+		tagName := strings.ReplaceAll(version.String(), "+", "_") // tag names aren't allowed to contain "+", so we use "_" instead
+		createOCITag(t, tagName, indexDesc, store)
+	}
+	// One additional tag that intentionally doesn't conform to the version
+	// number pattern so that we can make sure it gets silently ignored when
+	// enumerating versions, rather than causing an error. The content of
+	// this one is irrelevant because OpenTofu can't interact with it.
+	pushOCIBlob(t, ociv1.DescriptorEmptyJSON.MediaType, ociv1.DescriptorEmptyJSON.ArtifactType, ociv1.DescriptorEmptyJSON.Data, store)
+	createOCITag(t, "latest", ociv1.DescriptorEmptyJSON, store)
+	// We also have a separate store that contains OCI content that
+	// intentionally doesn't match our provider-specific manifest layout,
+	// so that we can test our error handling for mistakes like accidentally
+	// selecting something that was intended to be a container image.
+	// This part is factored out into a separate function because it's
+	// not the main case of this test and is much less systematic than the
+	// above setup code.
+	wrongStore, wrongStoreLookups := makeFakeOCIRepositoryWithNonProviderContent(t)
+
+	// At this point our store should contain three tags: 1.0.0, 1.0.1, and 1.0.2.
+	// Each tag refers to manifests representing a provider that supports the platforms amigaos_m68k and tos_m68k.
+	// We'll set up our source to interact with the fake local repository we just set up.
+	source := &OCIRegistryMirrorSource{
+		resolveOCIRepositoryAddr: func(ctx context.Context, addr addrs.Provider) (registryDomain string, repositoryName string, err error) {
+			if addr.Hostname != svchost.Hostname("example.com") {
+				// We'll return [ErrProviderNotFound] here to satisfy the documented contract
+				// that the source will return that error type in particular when asked for
+				// a provider the mapping can't support, since [MultiSource] relies on that
+				// to be able to successfully blend results from multiple sources that each
+				// support a different subset of providers.
+				return "", "", ErrProviderNotFound{
+					Provider: addr,
+				}
+			}
+			return "example.com", fmt.Sprintf("%s_%s", addr.Namespace, addr.Type), nil
+		},
+		getOCIRepositoryStore: func(ctx context.Context, registryDomain, repositoryName string) (OCIRepositoryStore, error) {
+			if registryDomain != "example.com" {
+				// This result mimicks how ORAS-Go represents a missing repository.
+				return nil, orasErrors.ErrNotFound
+			}
+			switch repositoryName {
+			case "foo_bar":
+				// example.com/foo/bar is our repository containing valid provider
+				// artifacts.
+				return store, nil
+			case "not_provider":
+				// example.com/not/provider is our repository containing an assortment
+				// of not-actually-OpenTofu-provider artifacts.
+				return wrongStore, nil
+			default:
+				// All other addresses represent repositories that don't exist at all.
+				return nil, orasErrors.ErrNotFound
+			}
+		},
+	}
+
+	// The following subtests all interact in some way with the faked source we've just
+	// set up, although some of them use it more deeply than others.
+	t.Run("happy path", func(t *testing.T) {
+		fakeProvider := addrs.MustParseProviderSourceString("example.com/foo/bar")
+		wantVersions := VersionList{
+			MustParseVersion("1.0.0"),
+			MustParseVersion("1.0.1"),
+			MustParseVersion("1.0.2+foo.1"),
+			// NOTE: The tag called "latest" is silently ignored because it's not
+			// parsable as a version number.
+		}
+		gotVersions, warns, err := source.AvailableVersions(t.Context(), fakeProvider)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(warns) != 0 {
+			t.Errorf("unexpected warnings: %#v", warns)
+		}
+		if diff := cmp.Diff(wantVersions, gotVersions); diff != "" {
+			t.Error("wrong versions\n" + diff)
+		}
+
+		testVersion := wantVersions[1]
+		testPlatform := fakePlatforms[0]
+		meta, err := source.PackageMeta(t.Context(), fakeProvider, testVersion, testPlatform)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := meta.Provider, fakeProvider; got != want {
+			t.Errorf("wrong provider\ngot:  %s\nwant: %s", got, want)
+		}
+		if got, want := meta.Version, testVersion; got != want {
+			t.Errorf("wrong version\ngot:  %s\nwant: %s", got, want)
+		}
+		if got, want := meta.TargetPlatform, testPlatform; got != want {
+			t.Errorf("wrong platform\ngot:  %s\nwant: %s", got, want)
+		}
+		if got, want := meta.Filename, "terraform-provider-bar_1.0.1_amigaos_m86k.zip"; got != want {
+			// NOTE: This field doesn't actually really matter; OpenTofu doesn't
+			// do anything significant with it so we're just populating it with
+			// a plausible name to stay consistent with the other sources.
+			t.Errorf("wrong filename\ngot:  %s\nwant: %s", got, want)
+		}
+
+		// We're not going to exhaustively test the Location field here because
+		// this type has its own tests in [TestPackageOCIBlobArchive], but we
+		// will make some use of it here just because otherwise we'd end up
+		// reimplementing much of what [PackageOCIBlobArchive] does inline here.
+		loc, ok := meta.Location.(PackageOCIBlobArchive)
+		if !ok {
+			t.Fatalf("wrong type for meta.Location\ngot:  %T, want %T", meta.Location, loc)
+		}
+		pkgDir := t.TempDir()
+		authResult, err := loc.InstallProviderPackage(t.Context(), meta, pkgDir, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := authResult.result, verifiedChecksum; got != want {
+			t.Errorf("wrong authentication result\ngot:  %#v\nwant: %#v", got, want)
+		}
+		exeContent, err := os.ReadFile(filepath.Join(pkgDir, "terraform-provider-foo"))
+		if err != nil {
+			t.Fatalf("failed to read fake provider executable file: %s", err)
+		}
+		if got, want := string(exeContent), "placeholder executable for v1.0.1 on amigaos_m86k"; got != want {
+			t.Errorf("wrong content in fake executable file\ngot:  %q\nwant: %q", got, want)
+		}
+	})
+	t.Run("version number with build metadata", func(t *testing.T) {
+		// The "happy path" test verifies that we can list the tags and convert a tag name
+		// containing "_" into a semver version number with "+" for build metadata. This
+		// test case builds on that by making sure that when such a version is selected
+		// we'll translate it back to the expected tag name to fetch the manifests.
+		// This doesn't exercise the _full_ installation because most of it would be
+		// redundant with the "happy path" test, but we fetch the package meta here
+		// because that's the step that would need to resolve the tag.
+		testVersion := MustParseVersion("1.0.2+foo.1")
+		meta, err := source.PackageMeta(t.Context(), addrs.MustParseProviderSourceString("example.com/foo/bar"), testVersion, fakePlatforms[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := meta.Version, testVersion; got != want {
+			t.Errorf("wrong version\ngot:  %s\nwant: %s", got, want)
+		}
+	})
+	t.Run("provider that the source can't handle", func(t *testing.T) {
+		// The resolveOCIRepositoryAddr function is set up to return ErrProviderNotFound when
+		// asked for a provider that isn't on example.com, and so this test verifies that
+		// this error type propagates correctly through AvailableVersions as [MultiSource]
+		// expects so that it can disregard sources that don't know how to handle a
+		// particular provider.
+		unsupportedProvider := addrs.MustParseProviderSourceString("example.org/unsupported/domain")
+		_, _, err := source.AvailableVersions(t.Context(), unsupportedProvider)
+		gotErr, ok := err.(ErrProviderNotFound)
+		if !ok {
+			t.Fatalf("wrong error type\ngot:  %T (%s)\nwant: %T", err, err, gotErr)
+		}
+	})
+	t.Run("provider that the source could handle but doesn't exist", func(t *testing.T) {
+		// This is similar to the previous case but represents the dynamic form of the
+		// problem, where the translation from provider address to OCI repository address
+		// succeeded but then there is not actually an OCI repository at that address.
+		unsupportedProvider := addrs.MustParseProviderSourceString("example.com/nonexist/foo")
+		_, _, err := source.AvailableVersions(t.Context(), unsupportedProvider)
+		gotErr, ok := err.(ErrProviderNotFound)
+		if !ok {
+			t.Fatalf("wrong error type\ngot:  %T (%s)\nwant: %T", err, err, gotErr)
+		}
+	})
+	t.Run("request for unsupported platform", func(t *testing.T) {
+		fakeProvider := addrs.MustParseProviderSourceString("example.com/foo/bar")
+		_, err := source.PackageMeta(t.Context(), fakeProvider, MustParseVersion("1.0.0"), Platform{OS: "riscovite", Arch: "riscv64"})
+		gotErr, ok := err.(ErrPlatformNotSupported)
+		if !ok {
+			t.Fatalf("wrong error type\ngot:  %T (%s)\nwant: %T", err, err, gotErr)
+		}
+	})
+	t.Run("module package instead of provider", func(t *testing.T) {
+		fakeProvider := addrs.MustParseProviderSourceString("example.com/not/provider")
+		_, err := source.PackageMeta(t.Context(), fakeProvider, wrongStoreLookups.modulePackageVersion, fakePlatforms[0])
+		if err == nil {
+			t.Fatal("unexpected success; want error")
+		}
+		if got, want := err.Error(), `selected OCI artifact is an OpenTofu module package, not a provider package`; got != want {
+			t.Errorf("wrong error\ngot:  %s\nwant: %s", got, want)
+		}
+	})
+	t.Run("container image instead of provider", func(t *testing.T) {
+		fakeProvider := addrs.MustParseProviderSourceString("example.com/not/provider")
+		_, err := source.PackageMeta(t.Context(), fakeProvider, wrongStoreLookups.containerImageVersion, fakePlatforms[0])
+		if err == nil {
+			t.Fatal("unexpected success; want error")
+		}
+		if got, want := err.Error(), `unsupported OCI artifact type; is this a container image, rather than an OpenTofu provider?`; got != want {
+			t.Errorf("wrong error\ngot:  %s\nwant: %s", got, want)
+		}
+	})
+	t.Run("helm chart instead of provider", func(t *testing.T) {
+		fakeProvider := addrs.MustParseProviderSourceString("example.com/not/provider")
+		_, err := source.PackageMeta(t.Context(), fakeProvider, wrongStoreLookups.helmChartVersion, fakePlatforms[0])
+		if err == nil {
+			t.Fatal("unexpected success; want error")
+		}
+		// Note that the answer to the in the error message is "no" in this case:
+		// it's not an OpenTofu provider, but it's not a container image either.
+		// We can't differentiate these cases using only the information available
+		// in the manifest descriptor, so we assume that accidentally selecting
+		// a container image is more likely than accidentally selecting a Helm
+		// chart, but phrase it as a question to hopefully communicate that
+		// OpenTofu isn't actually sure what the artifact type is.
+		if got, want := err.Error(), `unsupported OCI artifact type; is this a container image, rather than an OpenTofu provider?`; got != want {
+			t.Errorf("wrong error\ngot:  %s\nwant: %s", got, want)
+		}
+	})
+	t.Run("tag directly refers to image manifest, not index manifest", func(t *testing.T) {
+		fakeProvider := addrs.MustParseProviderSourceString("example.com/not/provider")
+		_, err := source.PackageMeta(t.Context(), fakeProvider, wrongStoreLookups.missingIndexVersion, fakePlatforms[0])
+		if err == nil {
+			t.Fatal("unexpected success; want error")
+		}
+		if got, want := err.Error(), `tag refers directly to image manifest, but OpenTofu providers require an index manifest for multi-platform support`; got != want {
+			t.Errorf("wrong error\ngot:  %s\nwant: %s", got, want)
+		}
+	})
+	t.Run("valid manifests but unsupported archive format", func(t *testing.T) {
+		fakeProvider := addrs.MustParseProviderSourceString("example.com/not/provider")
+		_, err := source.PackageMeta(t.Context(), fakeProvider, wrongStoreLookups.wrongPackageMediaTypeVersion, Platform{OS: "acornmos", Arch: "6502"})
+		if err == nil {
+			t.Fatal("unexpected success; want error")
+		}
+		if got, want := err.Error(), `image manifest contains no "application/vnd.opentofu.providerpkg" layers of type "archive/zip", but has other unsupported formats; this OCI artifact might be intended for a different version of OpenTofu`; got != want {
+			t.Errorf("wrong error\ngot:  %s\nwant: %s", got, want)
+		}
+	})
+}
+
+func pushOCIImageManifest(t *testing.T, manifest *ociv1.Manifest, store orasContent.Pusher) ociv1.Descriptor {
+	t.Helper()
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pushOCIBlob(t, manifest.MediaType, manifest.ArtifactType, manifestBytes, store)
+}
+
+func pushOCIIndexManifest(t *testing.T, manifest *ociv1.Index, store orasContent.Pusher) ociv1.Descriptor {
+	t.Helper()
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pushOCIBlob(t, manifest.MediaType, manifest.ArtifactType, manifestBytes, store)
+}
+
+func pushOCIBlob(t *testing.T, mediaType, artifactType string, content []byte, store orasContent.Pusher) ociv1.Descriptor {
+	t.Helper()
+	desc := ociv1.Descriptor{
+		Digest:       ociDigest.FromBytes(content),
+		Size:         int64(len(content)),
+		MediaType:    mediaType,
+		ArtifactType: artifactType,
+	}
+	err := store.Push(t.Context(), desc, bytes.NewReader(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return desc
+}
+
+func createOCITag(t *testing.T, tagName string, desc ociv1.Descriptor, store orasContent.Tagger) {
+	t.Helper()
+	err := store.Tag(t.Context(), desc, tagName)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// fakeOCIRepositoryContent is returned by [makeFakeOCIRepositoryWithNonProviderContent]
+// to help the caller find each of the "fake" artifacts in the repository without having
+// to hard-code the arbitrary version numbers used for each one. We use version numbers
+// for these just because that's what [Source.PackageMeta] uses as its input, and so
+// non-version-shaped tags are not accessible through our provider source API at all.
+type fakeOCIRepositoryContent struct {
+	modulePackageVersion         Version
+	containerImageVersion        Version
+	helmChartVersion             Version
+	missingIndexVersion          Version
+	wrongPackageMediaTypeVersion Version
+}
+
+func makeFakeOCIRepositoryWithNonProviderContent(t *testing.T) (OCIRepositoryStore, *fakeOCIRepositoryContent) {
+	t.Helper()
+	store, err := orasOCI.NewWithContext(t.Context(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lookups := &fakeOCIRepositoryContent{
+		modulePackageVersion:         MustParseVersion("0.0.1"),
+		containerImageVersion:        MustParseVersion("0.0.2"),
+		helmChartVersion:             MustParseVersion("0.0.3"),
+		missingIndexVersion:          MustParseVersion("0.0.4"),
+		wrongPackageMediaTypeVersion: MustParseVersion("0.0.5"),
+	}
+
+	// This particular repository contains an assortment of odd manifests
+	// that don't match OpenTofu's provider package manifest layout, so that
+	// we can test that we generate plausible feedback when someone mistakenly
+	// tries to use such things as providers. Some of these are based on
+	// formats used by other OpenTofu features, some on other software that
+	// makes use of OCI repositories, and some that's just strange garbage
+	// that no software is likely to accept.
+	//
+	// Since the use of this is focused primarily on invalid metadata rather
+	// than invalid data, we'll just use a single small blob as a placeholder
+	// leaf object across all of the examples that need such a thing.
+	blobDesc := pushOCIBlob(t, "application/octet-stream", "", []byte(`!`), store)
+
+	// Many of the manifests also refer to the "well-known" empty JSON blob
+	// digest, so we'll put that in the store too. This is a conventional way
+	// to represent an empty JSON object so that each registry only needs to
+	// store it once.
+	pushOCIBlob(
+		t,
+		ociv1.DescriptorEmptyJSON.MediaType,
+		ociv1.DescriptorEmptyJSON.ArtifactType,
+		ociv1.DescriptorEmptyJSON.Data,
+		store,
+	)
+
+	// The following nested blocks are just to keep the temporary variables
+	// segregated for each case to avoid any risk of getting things mixed up
+	// under future maintenence.
+	{
+		// a manifest that follows our conventions for OpenTofu module packages, rather
+		// than for provider packages.
+		archiveDesc := blobDesc // shallow copy
+		archiveDesc.ArtifactType = "application/vnd.opentofu.modulepkg"
+		archiveDesc.MediaType = "archive/zip"
+		manifestDesc := pushOCIImageManifest(t, &ociv1.Manifest{
+			Versioned:    ociSpecs.Versioned{SchemaVersion: 2},
+			MediaType:    ociv1.MediaTypeImageManifest,
+			ArtifactType: archiveDesc.ArtifactType,
+			Config:       ociv1.DescriptorEmptyJSON,
+			Layers: []ociv1.Descriptor{
+				archiveDesc,
+			},
+		}, store)
+		createOCITag(t, lookups.modulePackageVersion.String(), manifestDesc, store)
+	}
+	{
+		// a manifest that resembles a container image
+		archiveDesc := blobDesc       // shallow copy
+		archiveDesc.ArtifactType = "" // container images are essentially the "default" artifact type
+		archiveDesc.MediaType = ociv1.MediaTypeImageLayerGzip
+		manifestDesc := pushOCIImageManifest(t, &ociv1.Manifest{
+			Versioned: ociSpecs.Versioned{SchemaVersion: 2},
+			MediaType: ociv1.MediaTypeImageManifest,
+			Config:    ociv1.DescriptorEmptyJSON,
+			Layers: []ociv1.Descriptor{
+				archiveDesc,
+			},
+		}, store)
+		createOCITag(t, lookups.containerImageVersion.String(), manifestDesc, store)
+	}
+	{
+		// a manifest that resembles a Helm chart
+		chartPkgDesc := blobDesc       // shallow copy
+		chartPkgDesc.ArtifactType = "" // Helm uses a custom media type rather instead of an artifact type
+		chartPkgDesc.MediaType = "application/vnd.cncf.helm.chart.content.v1.tar+gzip"
+		manifestDesc := pushOCIImageManifest(t, &ociv1.Manifest{
+			Versioned: ociSpecs.Versioned{SchemaVersion: 2},
+			MediaType: ociv1.MediaTypeImageManifest,
+			Config: ociv1.Descriptor{
+				MediaType: "application/vnd.cncf.helm.chart.content.v1.tar+gzip",
+				Digest:    chartPkgDesc.Digest,
+				Size:      chartPkgDesc.Size,
+			},
+			Layers: []ociv1.Descriptor{
+				chartPkgDesc,
+			},
+		}, store)
+		createOCITag(t, lookups.helmChartVersion.String(), manifestDesc, store)
+	}
+	{
+		// a manifest for a single provider package lacking the required index manifest
+		archiveDesc := blobDesc // shallow copy
+		archiveDesc.ArtifactType = ociPackageArtifactType
+		archiveDesc.MediaType = ociPackageMediaType
+		manifestDesc := pushOCIImageManifest(t, &ociv1.Manifest{
+			Versioned:    ociSpecs.Versioned{SchemaVersion: 2},
+			MediaType:    ociv1.MediaTypeImageManifest,
+			ArtifactType: ociPackageManifestArtifactType,
+			Config:       ociv1.DescriptorEmptyJSON,
+			Layers: []ociv1.Descriptor{
+				archiveDesc,
+			},
+		}, store)
+		createOCITag(t, lookups.missingIndexVersion.String(), manifestDesc, store)
+	}
+	{
+		// a manifest for a provider that is valid except for using an as-yet-unsupported
+		// archive format for the leaf provider package.
+		archiveDesc := blobDesc                                // shallow copy
+		archiveDesc.ArtifactType = ociPackageArtifactType      // correct artifact type
+		archiveDesc.MediaType = "application/x-lzh-compressed" // unsupported media type
+		manifestDesc := pushOCIImageManifest(t, &ociv1.Manifest{
+			Versioned:    ociSpecs.Versioned{SchemaVersion: 2},
+			MediaType:    ociv1.MediaTypeImageManifest,
+			ArtifactType: ociPackageManifestArtifactType,
+			Config:       ociv1.DescriptorEmptyJSON,
+			Layers: []ociv1.Descriptor{
+				archiveDesc,
+			},
+		}, store)
+		manifestDesc.Platform = &ociv1.Platform{
+			Architecture: "6502",
+			OS:           "acornmos",
+		}
+		indexDesc := pushOCIIndexManifest(t, &ociv1.Index{
+			Versioned:    ociSpecs.Versioned{SchemaVersion: 2},
+			MediaType:    ociv1.MediaTypeImageIndex,
+			ArtifactType: ociIndexManifestArtifactType,
+			Manifests: []ociv1.Descriptor{
+				manifestDesc,
+			},
+		}, store)
+		createOCITag(t, lookups.wrongPackageMediaTypeVersion.String(), indexDesc, store)
+	}
+
+	return store, lookups
+}

--- a/internal/getproviders/package_location_oci_blob_archive.go
+++ b/internal/getproviders/package_location_oci_blob_archive.go
@@ -1,0 +1,303 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package getproviders
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+
+	"github.com/hashicorp/go-getter"
+	ociDigest "github.com/opencontainers/go-digest"
+	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	orasContent "oras.land/oras-go/v2/content"
+)
+
+// ociPackageArtifactType is the specific artifact type we're expecting for the
+// blob representing a final distribution package that we'll fetch and extract, after
+// we've dug through all of the manifests.
+//
+// We silently ignore blobs that don't have this artifact type both so that future
+// OpenTofu versions can potentially introduce new blobs with different purposes and
+// so that a manifest can have other blobs listed in it for purposes that are
+// irrelevant to OpenTofu's interests, in case that becomes useful in the broader
+// OCI ecosystem.
+const ociPackageArtifactType = "application/vnd.opentofu.providerpkg"
+
+// ociPackageMediaType is the specific media type we're expecting for the blob
+// representing a final distribution package that we'll fetch and extract, after
+// we've dug through all of the manifests.
+//
+// We currently pay attention only to blobs which have both this media type AND
+// the artifact type in [ociPackageArtifactType], silently ignoring everything else,
+// so that future versions of OpenTofu can potentially support provider packages
+// using different archive formats.
+const ociPackageMediaType = "archive/zip"
+
+// PackageOCIBlobArchive represents a provider package archive stored as a blob in
+// an OCI Distribution repository.
+//
+// A [Source] returning this kind of location must first choose the appropriate
+// artifact from a provider's multi-platform index manifest, fetch that manifest,
+// and identify the single leaf blob whose content is the provider package
+// archive. This type does not interact with artifact manifests at all, expecting
+// that whatever constructed it has already interrogated all of the relevant
+// manifests.
+type PackageOCIBlobArchive struct {
+	// Unlike the other PackageLocation types, this one has its internals unexported
+	// so that we can make use of ORAS-Go types as an implementation detail without
+	// exposing that decision in this package's public API.
+
+	// repoStore is the ORAS storage that the artifact should be fetched from.
+	//
+	// In normal use this will typically be an instance of ORAS-Go's remote.Repository
+	// type representing a specific remote repository, but it's also valid to use
+	// a local filesystem or in-memory representation e.g. in unit tests.
+	repoStore orasContent.Fetcher
+
+	// registryDomain and repositoryName are UI-display-only values together describing
+	// which repository the repoStore object is configured to access, so that we can
+	// describe what we're downloading in a human-friendly way.
+	//
+	// registryDomain is empty if repoStore is not for a remote repository. In that case
+	// repositoryName might be a filesystem path if using a local OCI layout directory/archive,
+	// or also empty if it's an in-memory-only store as we use in some tests.
+	registryDomain, repositoryName string
+
+	// blobDescriptor is the in-memory representation of an OCI descriptor
+	// for the leaf blob to retrieve.
+	//
+	// We currently require that the digest in the descriptor use the "sha256"
+	// algorithm in particular, because that is directly analogous to
+	// our [HashSchemeZip] and thus we can cross-verify the archive against
+	// any signed checksums provided by the provider author from the provider's
+	// origin registry that were recorded into the dependency lock file after
+	// an earlier install from the origin registry.
+	//
+	// The MediaType and ArtifactType fields must represent valid selections for a
+	// provider package stored in an OCI Distribution repository. Currently that
+	// means that MediaType must be "archive/zip" and ArtifactType must be
+	// "application/vnd.opentofu.providerpkg"; future OpenTofu formats might support
+	// other file formats, which can be represented by choosing a new value of
+	// MediaType while retaining the same ArtifactType.
+	blobDescriptor ociv1.Descriptor
+}
+
+var _ PackageLocation = PackageOCIBlobArchive{}
+
+func (p PackageOCIBlobArchive) InstallProviderPackage(ctx context.Context, meta PackageMeta, targetDir string, allowedHashes []Hash) (*PackageAuthenticationResult, error) {
+	pkgDesc := p.blobDescriptor
+
+	// First we'll make sure that what we've been given makes sense to be the descriptor
+	// for a provider package blob. A failure here suggests a bug in the [Source] that
+	// generated this location object, since it should not select a blob that this
+	// location type cannot support.
+	err := checkOCIBlobDescriptor(pkgDesc, meta)
+	if err != nil {
+		return nil, err
+	}
+
+	// If we have a fixed set of allowed hashes then we'll check that our
+	// selected descriptor matches before we waste time fetching the package.
+	if len(allowedHashes) > 0 && !ociPackageDescriptorDigestMatchesAnyHash(pkgDesc.Digest, allowedHashes) {
+		return nil, fmt.Errorf(
+			// FIXME: We currently have slightly-different variations of this error
+			// message spread across the different [PackageLocation] implementations.
+			// It would be good to settle on a single good version of this text,
+			// centralize it into a constant or function somewhere, and then reuse
+			// it across all of the package location types. For now though, this
+			// matches some of the others so we can treat that refactoring as a
+			// separate task from implementing OCI-based installation as a new feature.
+			"the current package for %s %s doesn't match any of the checksums previously recorded in the dependency lock file; for more information: https://opentofu.org/docs/language/files/dependency-lock/#checksum-verification",
+			meta.Provider, meta.Version,
+		)
+	}
+
+	// If we reach this point then we have a descriptor for what will hopefully
+	// turn out to be a valid provider package blob, and so we'll download it
+	// into a temporary file from which we can verify it and then extract it
+	// into its final location.
+	localLoc, err := fetchOCIBlobToTemporaryFile(ctx, pkgDesc, p.repoStore)
+	if err != nil {
+		return nil, fmt.Errorf("fetching provider package blob %s: %w", pkgDesc.Digest.String(), err)
+	}
+	defer os.Remove(string(localLoc)) // Best effort to remove the temporary file before we return
+
+	// We'll now delegate the final installation step to the localLoc object,
+	// which knows how to extract the temporary archive into the target
+	// directory and verify/authenticate it.
+	// To do that we need a slightly-modified "meta" that refers to the
+	// local location instead of the remote one. (This redundancy is awkward,
+	// but is a historical artifact of how package installation used to be
+	// separated from the PackageLocation type. We're accepting that awkwardness
+	// for now to avoid a risky refactor, but hopefully we'll tidy this up
+	// someday.)
+	localMeta := PackageMeta{
+		Provider:         meta.Provider,
+		Version:          meta.Version,
+		ProtocolVersions: meta.ProtocolVersions,
+		TargetPlatform:   meta.TargetPlatform,
+		Filename:         meta.Filename,
+		Location:         localLoc,
+		Authentication:   meta.Authentication,
+	}
+	return localLoc.InstallProviderPackage(ctx, localMeta, targetDir, allowedHashes)
+}
+
+func (p PackageOCIBlobArchive) String() string {
+	switch {
+	case p.registryDomain != "" && p.repositoryName != "":
+		// This is the main case for real end-user use, where we should
+		// always be talking to a repository in a remote registry.
+		return fmt.Sprintf(
+			"%s/%s@%s",
+			p.registryDomain,
+			p.repositoryName,
+			p.blobDescriptor.Digest.String(),
+		)
+	case p.repositoryName != "":
+		// A local-filesystem-based repository is not currently something
+		// we support as an end-user-facing feature, so this situation is
+		// currently just for testing purposes.
+		return fmt.Sprintf(
+			"./%s@%s", // ./ prefix just to distinguish this from a remote registry address
+			filepath.Clean(p.repositoryName),
+			p.blobDescriptor.Digest.String(),
+		)
+	default:
+		// If we don't have either of the human-oriented location fields
+		// populated then we'll just use the digest, and hope that the
+		// reader knows what store we're using. This situation should
+		// arise only in unit tests.
+		return p.blobDescriptor.Digest.String()
+	}
+}
+
+// fetchOCIBlobToTemporaryFile uses the given ORAS fetcher to pull the content of the
+// blob described by "desc" into a temporary file on the local filesystem, and
+// then returns the path to that file as a [PackageLocalArchive] that can be used
+// to delegate the final verification and installation of that archive into a
+// target directory.
+//
+// It is the caller's responsibility to delete the temporary file once it's no longer
+// needed.
+func fetchOCIBlobToTemporaryFile(ctx context.Context, desc ociv1.Descriptor, store orasContent.Fetcher) (loc PackageLocalArchive, err error) {
+	// This is effectively an OCI Distribution equivalent of the similar technique
+	// used for PackageHTTPArchive.
+
+	// We'll eventually need to generate an OpenTofu-style hash for this package anyway,
+	// so we'll do that now to make sure we have a valid digest before we try to
+	// download anything.
+	wantHash, err := hashFromOCIDigest(desc.Digest)
+	if err != nil {
+		return PackageLocalArchive(""), fmt.Errorf("cannot verify package contents: %w", err)
+	}
+
+	readCloser, err := store.Fetch(ctx, desc)
+	if err != nil {
+		return PackageLocalArchive(""), err
+	}
+	defer readCloser.Close()
+	reader := io.LimitReader(readCloser, desc.Size)
+
+	f, err := os.CreateTemp("", "opentofu-provider")
+	if err != nil {
+		return PackageLocalArchive(""), fmt.Errorf("failed to open temporary file: %w", err)
+	}
+	loc = PackageLocalArchive(f.Name())
+	defer func() {
+		// If we're returning an error then the caller won't make use of the
+		// file we've created, so we'll make a best effort to proactively
+		// remove it. If we succeed then it's the caller's responsibility to
+		// remove the file once it's no longer needed.
+		if err != nil {
+			os.Remove(f.Name())
+		}
+	}()
+
+	// We'll borrow go-getter's "cancelable copy" implementation here so that
+	// the download can potentially be interrupted partway through.
+	n, err := getter.Copy(ctx, f, reader)
+	f.Close() // we're done using the filehandle now, even if the copy failed
+	if err == nil && n < desc.Size {
+		// This should be impossible because we used io.LimitReader, but we'll check
+		// anyway to be robust since go-getter returns this information regardless.
+		err = fmt.Errorf("incorrect response size: expected %d bytes, but got %d bytes", desc.Size, n)
+	}
+	if err != nil {
+		return loc, err
+	}
+
+	// Before we return we'll make sure that the file we've just created matches
+	// the digest we were given for it, since the ORAS fetcher doesn't do that
+	// automatically itself.
+	matchesHash, err := PackageMatchesHash(loc, wantHash)
+	if err != nil {
+		return loc, fmt.Errorf("cannot verify package contents: %w", err)
+	}
+	if !matchesHash {
+		return loc, fmt.Errorf("provider package does not match digest %s", desc.Digest)
+	}
+
+	// Everything seems okay, so we'll let the caller take ownership of the temporary file.
+	return loc, nil
+}
+
+func ociPackageDescriptorDigestMatchesAnyHash(found ociDigest.Digest, allowed []Hash) bool {
+	foundHash, err := hashFromOCIDigest(found)
+	if err != nil {
+		// An unsupported or invalid digest cannot possibly match
+		return false
+	}
+	return slices.Contains(allowed, foundHash)
+}
+
+func hashFromOCIDigest(digest ociDigest.Digest) (Hash, error) {
+	if err := digest.Validate(); err != nil {
+		return Hash(""), fmt.Errorf("invalid digest %q: %w", digest.String(), err)
+	}
+	if algo := digest.Algorithm(); algo != ociDigest.SHA256 {
+		// OpenTofu's "ziphash" format requires a SHA256 checksum in particular.
+		return Hash(""), fmt.Errorf("unsupported digest algorithm %q", algo.String())
+	}
+	// If we have a valid sha256 digest then we can use its payload
+	// directly as the payload for our "ziphash" checksum scheme,
+	// because both we and OCI use lowercase hex encoding for these.
+	return HashSchemeZip.New(digest.Encoded()), nil
+}
+
+func checkOCIBlobDescriptor(desc ociv1.Descriptor, meta PackageMeta) error {
+	if desc.ArtifactType != ociPackageArtifactType {
+		if desc.ArtifactType == "application/vnd.opentofu.modulepkg" {
+			// Seems like someone has tried to use a module package where a
+			// provider package was expected. Confusion beween modules and
+			// providers is common for those new to OpenTofu, so we'll
+			// use a more specific diagnosis for this.
+			return fmt.Errorf("selected OCI artifact is a module package rather than a provider package")
+		}
+		return fmt.Errorf("selected OCI artifact has unexpected type %q", desc.ArtifactType)
+	}
+	if desc.MediaType != ociPackageMediaType {
+		return fmt.Errorf("selected OCI artifact manifest has unexpected media type %q", desc.MediaType)
+	}
+	if desc.Platform != nil {
+		// A descriptor can optionally by annotated by a platform selection. We don't
+		// require this because the top-level index manifest for a provider artifact
+		// is enough of a signal of this information, but if someone has gone to the
+		// trouble of annotating their blob descriptor with a platform then we'll
+		// use that to generate a more useful error message than is likely to occur
+		// if we later try to run an executable intended for a different platform.
+		if desc.Platform.OS != meta.TargetPlatform.OS || desc.Platform.Architecture != meta.TargetPlatform.Arch {
+			// We'll use our own type here to produce an OpenTofu-conventional string representation
+			gotPlatform := Platform{OS: desc.Platform.OS, Arch: desc.Platform.Architecture}
+			return fmt.Errorf("selected OCI artifact is for %s, but was expected to be for %s", gotPlatform.String(), meta.TargetPlatform.String())
+		}
+	}
+	return nil
+}

--- a/internal/getproviders/package_location_oci_blob_archive_test.go
+++ b/internal/getproviders/package_location_oci_blob_archive_test.go
@@ -1,0 +1,365 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package getproviders
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"crypto/rand"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/apparentlymart/go-versions/versions"
+	"github.com/google/go-cmp/cmp"
+	ociDigest "github.com/opencontainers/go-digest"
+	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	orasContent "oras.land/oras-go/v2/content"
+	orasMemoryStore "oras.land/oras-go/v2/content/memory"
+
+	"github.com/opentofu/opentofu/internal/addrs"
+)
+
+func TestPackageOCIBlobArchive(t *testing.T) {
+	// To avoid any external dependencies we'll implement this test in terms
+	// of an in-memory-only OCI repository. In real use we instead use the
+	// ORAS-Go remote registry client, which implements the same interfaces.
+	//
+	// [PackageOCIBlobArchive] focuses only on the leaf archive artifact,
+	// so we don't need to include any manifests here as they would normally
+	// be dealt with by the [Source] implementation instead.
+	store := orasMemoryStore.New()
+
+	// Unfortunately we need to first construct our blob in a separate RAM
+	// buffer here because we need to calculate a checksum for it in order
+	// to "push" it into the store.
+	blobBytes := makePlaceholderProviderPackageZip(t)
+	blobDigest := ociDigest.SHA256.FromBytes(blobBytes)
+	desc := ociv1.Descriptor{
+		MediaType:    "archive/zip",
+		ArtifactType: "application/vnd.opentofu.providerpkg",
+		Digest:       blobDigest,
+		Size:         int64(len(blobBytes)),
+	}
+	err := store.Push(t.Context(), desc, bytes.NewReader(blobBytes))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("happy path", func(t *testing.T) {
+		// The in-memory OCI repository contains just the blob represented
+		// by desc, which would not be enough to query the package metadata
+		// through the [Source] API, but is sufficient for the limited scope
+		// of [PackageOCIBlobArchive], since that is interested only in the
+		// archive blob and assumes that some other component already
+		// used tags and manifests to select a suitable blob.
+		loc := PackageOCIBlobArchive{
+			repoStore:      store,
+			blobDescriptor: desc,
+		}
+		meta := PackageMeta{
+			Provider:       addrs.NewBuiltInProvider("foo"),
+			Version:        versions.MustParseVersion("1.0.0"),
+			TargetPlatform: CurrentPlatform,
+			Location:       loc,
+			Authentication: &mockAuthentication{
+				result: signed,
+			},
+		}
+		targetDir := t.TempDir()
+		authResult, err := loc.InstallProviderPackage(t.Context(), meta, targetDir, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		// Installation was successful, so we should now have the two files guaranteed
+		// by the documentation of [makePlaceholderProviderPackageZip].
+		if diff := diffDirForPlaceholderProviderPackageZip(t, targetDir); diff != "" {
+			t.Error("wrong directory contents after successful installation\n" + diff)
+		}
+		if !authResult.Signed() {
+			// This fake package isn't _actually_ signed, but the mockAuthentication
+			// object we passed in meta reports that it was and so that information
+			// should pass through to the installation result if the installation
+			// process is correctly implemented.
+			t.Errorf("auth result does not indicate that the package is signed")
+		}
+	})
+	t.Run("checksum mismatch", func(t *testing.T) {
+		loc := PackageOCIBlobArchive{
+			repoStore:      store,
+			blobDescriptor: desc,
+		}
+		meta := PackageMeta{
+			Provider:       addrs.NewBuiltInProvider("foo"),
+			Version:        versions.MustParseVersion("1.0.0"),
+			TargetPlatform: CurrentPlatform,
+			Location:       loc,
+		}
+		targetDir := t.TempDir()
+		_, err := loc.InstallProviderPackage(t.Context(), meta, targetDir, []Hash{
+			HashSchemeZip.New("not-valid-never-matches"),
+		})
+		const wantErrSubstr = `doesn't match any of the checksums`
+		if err == nil {
+			t.Fatalf("unexpected success\nwant error containing: %s", wantErrSubstr)
+		}
+		if gotErr := err.Error(); !strings.Contains(gotErr, wantErrSubstr) {
+			t.Fatalf("wrong error\ngot: %s\nwant substring: %s", gotErr, wantErrSubstr)
+		}
+		// The checksum failure should've been detected before actually
+		// extracting the package.
+		if diff := diffDirEmpty(t, targetDir); diff != "" {
+			t.Error("unexpected content in target directory\n" + diff)
+		}
+	})
+	t.Run("unsupported archive type", func(t *testing.T) {
+		wrongDesc := desc                                    // shallow copy
+		wrongDesc.MediaType = "application/x-lzh-compressed" // an unsupported archive type
+		loc := PackageOCIBlobArchive{
+			repoStore:      store,
+			blobDescriptor: wrongDesc,
+		}
+		meta := PackageMeta{
+			Provider:       addrs.NewBuiltInProvider("foo"),
+			Version:        versions.MustParseVersion("1.0.0"),
+			TargetPlatform: CurrentPlatform,
+			Location:       loc,
+		}
+		targetDir := t.TempDir()
+		_, err := loc.InstallProviderPackage(t.Context(), meta, targetDir, nil)
+		const wantErrSubstr = `selected OCI artifact manifest has unexpected media type "application/x-lzh-compressed"`
+		if err == nil {
+			t.Fatalf("unexpected success\nwant error containing: %s", wantErrSubstr)
+		}
+		if gotErr := err.Error(); !strings.Contains(gotErr, wantErrSubstr) {
+			t.Fatalf("wrong error\ngot: %s\nwant substring: %s", gotErr, wantErrSubstr)
+		}
+		// The unsupported format should've been detected before actually
+		// extracting the package. (The blob we provided was actually a
+		// zip archive despite the incorrect media type, so it could
+		// potentially still be extracted despite the media type problem.
+		if diff := diffDirEmpty(t, targetDir); diff != "" {
+			t.Error("unexpected content in target directory\n" + diff)
+		}
+	})
+	t.Run("unsupported artifact type", func(t *testing.T) {
+		wrongDesc := desc                                             // shallow copy
+		wrongDesc.ArtifactType = "application/vnd.opentofu.modulepkg" // a module package instead of a provider package
+		loc := PackageOCIBlobArchive{
+			repoStore:      store,
+			blobDescriptor: wrongDesc,
+		}
+		meta := PackageMeta{
+			Provider:       addrs.NewBuiltInProvider("foo"),
+			Version:        versions.MustParseVersion("1.0.0"),
+			TargetPlatform: CurrentPlatform,
+			Location:       loc,
+		}
+		targetDir := t.TempDir()
+		_, err := loc.InstallProviderPackage(t.Context(), meta, targetDir, nil)
+		const wantErrSubstr = `selected OCI artifact is a module package rather than a provider package`
+		if err == nil {
+			t.Fatalf("unexpected success\nwant error containing: %s", wantErrSubstr)
+		}
+		if gotErr := err.Error(); !strings.Contains(gotErr, wantErrSubstr) {
+			t.Fatalf("wrong error\ngot: %s\nwant substring: %s", gotErr, wantErrSubstr)
+		}
+		// The unsupported format should've been detected before actually
+		// extracting the package. (The blob we provided was actually a
+		// zip archive despite the incorrect media type, so it could
+		// potentially still be extracted despite the media type problem.
+		if diff := diffDirEmpty(t, targetDir); diff != "" {
+			t.Error("unexpected content in target directory\n" + diff)
+		}
+	})
+	t.Run("descriptor has incorrect size", func(t *testing.T) {
+		wrongDesc := desc  // shallow copy
+		wrongDesc.Size = 4 // not the actual size of the zip archive
+		loc := PackageOCIBlobArchive{
+			repoStore:      store,
+			blobDescriptor: wrongDesc,
+		}
+		meta := PackageMeta{
+			Provider:       addrs.NewBuiltInProvider("foo"),
+			Version:        versions.MustParseVersion("1.0.0"),
+			TargetPlatform: CurrentPlatform,
+			Location:       loc,
+		}
+		targetDir := t.TempDir()
+		_, err := loc.InstallProviderPackage(t.Context(), meta, targetDir, nil)
+		if err == nil {
+			// Unfortunately the shape of this error is not guaranteed since each
+			// implementation of orasContent.ReadOnlyStorage detects and reports
+			// this problem in a different way, so we can only test whether it failed.
+			t.Fatalf("unexpected success; want some sort of error about the descriptor being incorrect")
+		}
+	})
+	t.Run("descriptor has digest referring to missing blob", func(t *testing.T) {
+		wrongDesc := desc                                   // shallow copy
+		wrongDesc.Digest = ociv1.DescriptorEmptyJSON.Digest // not actually present in our store
+		loc := PackageOCIBlobArchive{
+			repoStore:      store,
+			blobDescriptor: wrongDesc,
+		}
+		meta := PackageMeta{
+			Provider:       addrs.NewBuiltInProvider("foo"),
+			Version:        versions.MustParseVersion("1.0.0"),
+			TargetPlatform: CurrentPlatform,
+			Location:       loc,
+		}
+		targetDir := t.TempDir()
+		_, err := loc.InstallProviderPackage(t.Context(), meta, targetDir, nil)
+		if err == nil {
+			// Unfortunately the shape of this error is not guaranteed since each
+			// implementation of orasContent.ReadOnlyStorage detects and reports
+			// this problem in a different way, so we can only test whether it failed.
+			t.Fatalf("unexpected success; want some sort of error about the descriptor being incorrect")
+		}
+	})
+	t.Run("misbehaving store returns wrong content", func(t *testing.T) {
+		// In this case we use the correct descriptor, but use a special store
+		// implementation that intentionally returns incorrect results.
+		// The installation process should detect the problem by verifying
+		// what it received against the digest in the checksum.
+		loc := PackageOCIBlobArchive{
+			// The "lying storage" will return a blob that is correctly-sized
+			// but has the wrong content, to make sure that we're actually
+			// checking the content against the digest.
+			repoStore:      LyingORASStorage{wantSize: desc.Size},
+			blobDescriptor: desc,
+		}
+		meta := PackageMeta{
+			Provider:       addrs.NewBuiltInProvider("foo"),
+			Version:        versions.MustParseVersion("1.0.0"),
+			TargetPlatform: CurrentPlatform,
+			Location:       loc,
+		}
+		targetDir := t.TempDir()
+		_, err := loc.InstallProviderPackage(t.Context(), meta, targetDir, nil)
+		const wantErrSubstr = `provider package does not match digest`
+		if err == nil {
+			t.Fatalf("unexpected success\nwant error containing: %s", wantErrSubstr)
+		}
+		if gotErr := err.Error(); !strings.Contains(gotErr, wantErrSubstr) {
+			t.Fatalf("wrong error\ngot: %s\nwant substring: %s", gotErr, wantErrSubstr)
+		}
+	})
+}
+
+// makePlaceholderProviderPackageZip returns a byte array with data that
+// would, if written to disk, represent a valid zip archive acting as
+// a placeholder for a provider plugin package.
+//
+// The zip archive includes files named "terraform-provider-foo" and
+// "README", with no guarantee made about their size or content. This is
+// intended as a general-purpose placeholder for when the content doesn't
+// actually matter since we're not going to actually execute the plugin.
+func makePlaceholderProviderPackageZip(t *testing.T) []byte {
+	t.Helper()
+
+	buf := bytes.NewBuffer(nil)
+	zipW := zip.NewWriter(buf)
+	exeW, err := zipW.Create("terraform-provider-foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = io.WriteString(exeW, "not a real executable; just a placeholder")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// additional file to make sure we get the entire package, and not just the executable
+	docW, err := zipW.Create("README")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = io.WriteString(docW, "not a real plugin; just a placeholder")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = zipW.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// diffDirForPlaceholderProviderPackageZip returns a string representation
+// of a diff between the entries in the given directory and the files
+// placed into an archive returned by [makePlaceholderProviderPackageZip].
+//
+// If the result is an empty string then there are no differences and so the
+// directory does appear to have been created from the content of such a
+// zip file.
+func diffDirForPlaceholderProviderPackageZip(t *testing.T, dir string) string {
+	t.Helper()
+
+	type DiffableEntry struct {
+		Filename string
+		IsDir    bool
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make([]DiffableEntry, len(entries))
+	for i, entry := range entries {
+		got[i] = DiffableEntry{
+			Filename: entry.Name(),
+			IsDir:    entry.IsDir(),
+		}
+	}
+	return cmp.Diff([]DiffableEntry{
+		{"README", false},
+		{"terraform-provider-foo", false},
+	}, got)
+}
+
+// diffDirForPlaceholderProviderPackageZip returns a string representation
+// of a diff between the entries in the given directory and an empty
+// directory.
+//
+// If the result is an empty string then there are no differences and so the
+// directory is empty.
+func diffDirEmpty(t *testing.T, dir string) string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make([]string, len(entries))
+	for i, entry := range entries {
+		got[i] = entry.Name()
+	}
+	return cmp.Diff([]string{}, got)
+}
+
+// LyingORASStorage is an implementation of [orasContent.ReadOnlyStorage]
+// which always returns fixed content regardless of what descriptor it is
+// given, which allows us to test that we're resilient against a remote
+// OCI registry returning incorrect content for a blob.
+type LyingORASStorage struct {
+	wantSize int64
+}
+
+var _ orasContent.ReadOnlyStorage = LyingORASStorage{}
+
+// Exists implements [orasContent.ReadOnlyStorage].
+func (s LyingORASStorage) Exists(ctx context.Context, target ociv1.Descriptor) (bool, error) {
+	// We pretend that everything exists
+	return true, nil
+}
+
+// Fetch implements [orasContent.ReadOnlyStorage].
+func (s LyingORASStorage) Fetch(ctx context.Context, target ociv1.Descriptor) (io.ReadCloser, error) {
+	// We return a blob consisting of s.wantSize bytes of garbage, which
+	// the caller should therefore check and find that it mismatches
+	// the digest in the descriptor, unless the caller happens to ask
+	// for a digest that matches the garbage, which is vanishingly unlikely.
+	return io.NopCloser(io.LimitReader(rand.Reader, s.wantSize)), nil
+}


### PR DESCRIPTION
This is part of https://github.com/opentofu/opentofu/issues/2540, and implements the [OCI Mirror Provider Installation Source](https://github.com/opentofu/opentofu/blob/b47237d410bfeaa86aca84a79bde973e3d8a724e/rfc/20241206-oci-registries/9-provider-implementation-details.md#oci-mirror-provider-installation-source).

An "OCI Mirror" is essentially just like the existing idea of "network mirror" but using OCI Distribution protocol and manifest conventions instead of [OpenTofu's own Provider Mirror Protocol](https://opentofu.org/docs/internals/provider-network-mirror-protocol/).

Therefore there are some direct analogies here:

* `getproviders.OCIRegistryMirrorSource` is analogous to `getproviders.HTTPMirrorSource`, dealing with the discovery of available versions and fetching the package metadata for the selected version.
* `getproviders.PackageOCIBlobArchive` is analogous to `getproviders.PackageHTTPURL`, dealing with the fetching and extraction of the final zip archive once the "source" has decided which to use.

However, there is definitely some tighter coupling here between `OCIRegistryMirrorSource` and `PackageOCIBlobArchive` than there is between `HTTPMirrorSource` and `PackageHTTPURL`, because in the existing network mirror case the system is designed to support the actual packages being hosted in an entirely different place to the metadata, and also to allow sharing the "fetch a `.zip` file over HTTP and extract it" functionality between the network mirror source and the source that implements direct installation from a provider registry.

For OCI, we require that the blob representing the `.zip` archive always belongs to the same OCI repository as the manifests came from, which means that we need to share the same repository object between both the "source" and the "location" object so that we can make sure to use the same registry domain, repository name, and credentials.[^1]

---

In order to break this work into some smaller chunks for easier review, I've stopped at a sorta-weird point here: we have an internal implementation for installing providers from OCI registries, but it's not yet actually accessible to end-users because there's no support in the CLI Configuration language for implementing it. What I've added is therefore effectively dead code from the perspective of a compiled `tofu` executable, but with unit tests confirming its behavior. I intend this to satisfy only the first item under "`oci_mirror` Provider Installation Method" in [the tracking issue](https://github.com/opentofu/opentofu/issues/2540).

So far I've primarily tested this so far using "fake" repositories with ORAS's in-memory and local filesystem repository implementations. I have also done some additional ad-hoc manual testing with ORAS-Go's real OCI registry client implementation just enough to feel confident that it works compatibly, but I'm going to wait until the next PR to test that _thoroughly_ against real OCI registry implementations, and so I do expect that some of the finer details in this PR will evolve slightly based on that testing, but the overall structure of this should not need to change significantly.

**(the non-user-facing-ness of this particular PR is also why there is no changelog entry here. The changelog entry will be included in the next PR)**

[^1]: The general structure of this, where the "source" populates the "location" object with both a place to fetch from _and_ a preconfigured client to use to fetch it, would probably also be roughly the structure required to satisfy something like https://github.com/hashicorp/terraform/issues/29349 with `RegistrySource` and `PackageHTTPURL` and a protocol change like https://github.com/hashicorp/terraform/issues/29349#issuecomment-2499387934, if there's ever an OpenTofu-flavored equivalent of that feature request.
