### PR TITLE
Allow nodeExpandCheck to influence node pruning

### DIFF
--- a/internal/tofu/node_check.go
+++ b/internal/tofu/node_check.go
@@ -60,6 +60,7 @@ var (
 	_ GraphNodeModulePath        = (*nodeExpandCheck)(nil)
 	_ GraphNodeDynamicExpandable = (*nodeExpandCheck)(nil)
 	_ GraphNodeReferencer        = (*nodeExpandCheck)(nil)
+	_ graphNodeExpandsInstances  = (*nodeExpandCheck)(nil)
 )
 
 // nodeExpandCheck creates child nodes that actually execute the assertions for
@@ -80,6 +81,8 @@ type nodeExpandCheck struct {
 func (n *nodeExpandCheck) ModulePath() addrs.Module {
 	return n.addr.Module
 }
+
+func (n *nodeExpandCheck) expandsInstances() {}
 
 func (n *nodeExpandCheck) DynamicExpand(ctx EvalContext) (*Graph, error) {
 	exp := ctx.InstanceExpander()


### PR DESCRIPTION
I believe that nodeExpandCheck should have implemented graphNodeExpandsInstances when it was first created. Without it, there is no way for it to impact the pruning process.

Longer term, I need to better understand the distinction between graphNodeExpandsInstances and GraphNodeDynamicExpandable as they seem muddled throughout the codebase

<!-- If your PR resolves an issue, please add it here. -->
Resolves #2591

## Target Release

1.10.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
