### PR TITLE
Adds docs for tests - `run` references in test files

### DIFF
--- a/website/docs/cli/commands/test/examples/run_in_variables/main.tftest.hcl
+++ b/website/docs/cli/commands/test/examples/run_in_variables/main.tftest.hcl
@@ -1,0 +1,11 @@
+run "setup" {
+  module {
+    source = "./setup"
+  }
+}
+
+run "test" {
+  variables {
+    file_name_from_setup = run.setup.file_name
+  }
+}

--- a/website/docs/cli/commands/test/examples/run_in_variables/mod/main.tf
+++ b/website/docs/cli/commands/test/examples/run_in_variables/mod/main.tf
@@ -1,0 +1,3 @@
+output "filename" {
+  value = "some_file.txt"
+}

--- a/website/docs/cli/commands/test/index.mdx
+++ b/website/docs/cli/commands/test/index.mdx
@@ -23,6 +23,8 @@ import ProviderAliasMain from '!!raw-loader!./examples/provider_alias/main.tf'
 import ProviderAliasTest from '!!raw-loader!./examples/provider_alias/main.tftest.hcl'
 import VariablesMain from '!!raw-loader!./examples/variables/main.tf'
 import VariablesTest from '!!raw-loader!./examples/variables/main.tftest.hcl'
+import RunInVariablesMain from '!!raw-loader!./examples/run_in_variables/mod/main.tf'
+import RunInVariablesTest from '!!raw-loader!./examples/run_in_variables/main.tftest.hcl'
 import ExpectFailureVariablesMain from '!!raw-loader!./examples/expect_failures_variables/main.tf'
 import ExpectFailureVariablesTest from '!!raw-loader!./examples/expect_failures_variables/main.tftest.hcl'
 import ExpectFailureResourcesMain from '!!raw-loader!./examples/expect_failures_resources/main.tf'
@@ -298,6 +300,19 @@ For example:
     <TabItem value="main" label="main.tf"><CodeBlock language={"hcl"}>{VariablesMain}</CodeBlock></TabItem>
 </Tabs>
 
+#### The `run` block outputs for variables
+
+It is also possible to use the earlier-executed `run` block module outputs to set another `run` block `variables` values.
+
+This can be useful when you need to pass values between different test cases.
+
+<Tabs>
+    <TabItem value="test" label="main.tftest.hcl" default>
+        <CodeBlock language={"hcl"}>{RunInVariablesTest}</CodeBlock>
+    </TabItem>
+    <TabItem value="main" label="mod/main.tf"><CodeBlock language={"hcl"}>{RunInVariablesMain}</CodeBlock></TabItem>
+</Tabs>
+
 ### The `run.expect_failures` list
 
 In some cases you may want to test deliberate failures of your code, for example to ensure your validation is working.
@@ -412,6 +427,29 @@ of the file.
         <CodeBlock language={"hcl"}>{ProviderAliasMain}</CodeBlock>
     </TabItem>
 </Tabs>
+
+#### References to `run` module outputs and variables in `provider` blocks
+
+You can reference `var` (variables) and the `run` block module outputs in `provider` blocks to set provider configuration values.
+
+```hcl
+variables {
+  region = "us-west-2"
+}
+
+provider "aws" {
+  region = var.region
+  access_key = run.setup.access_key
+  secret_key = run.setup.secret_key
+}
+
+run "setup" {
+  # `mod` module has outputs access_key and secret_key
+  module {
+    source = "./mod"
+  }
+}
+```
 
 ### The `mock_provider` blocks
 


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

## Adds docs for tests - `run` references in test files

This PR adds docs on the website for tests regarding features introduced in the following 2 PRs:
- Run block variable references #1129
-  Support for run block outputs in the test provider block #2543 

## Target Release

1.10.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
