### PR TITLE
Enhance `removed` block with `lifecycle` and `provisioner` functionalities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ ENHANCEMENTS:
 * Upgrade aws-sdk version to include `mx-central-1` region. ([#2596](https://github.com/opentofu/opentofu/pull/2596))
 * When installing a provider from a source that offers a `.zip` archive of a provider package but that cannot also offer a signed set of official checksums for the provider, OpenTofu will now include its locally-verified zip archive checksum (`zh:` scheme) in the dependency lock file in addition to the package contents checksum (`h1:` checksum) previously recorded. This makes it more likely that a future reinstall of the same package from a different source will be verified successfully. ([#2656](https://github.com/opentofu/opentofu/pull/2656))
 * The `tofu show` command now supports a new explicit and extensible usage style, with `-state` and `-plan=PLANFILE` options. The old style with zero or one positional arguments is still supported for backward-compatibility. ([#2699](https://github.com/opentofu/opentofu/pull/2699))
+* `removed` now supports `lifecycle` and `provisioner` configuration. ([#2556](https://github.com/opentofu/opentofu/issues/2556))
 
 BUG FIXES:
 

--- a/internal/configs/removed.go
+++ b/internal/configs/removed.go
@@ -6,13 +6,19 @@
 package configs
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/opentofu/opentofu/internal/addrs"
 )
 
 // Removed represents a removed block in the configuration.
 type Removed struct {
 	From *addrs.RemoveEndpoint
+
+	Destroy    bool
+	DestroySet bool
 
 	DeclRange hcl.Range
 }
@@ -21,6 +27,7 @@ func decodeRemovedBlock(block *hcl.Block) (*Removed, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 	removed := &Removed{
 		DeclRange: block.DefRange,
+		Destroy:   false, // NOTE: false for backwards compatibility. This is not the same behavior that the other system is having.
 	}
 
 	content, moreDiags := block.Body.Content(removedBlockSchema)
@@ -36,6 +43,32 @@ func decodeRemovedBlock(block *hcl.Block) (*Removed, hcl.Diagnostics) {
 		}
 	}
 
+	var seenLifecycle *hcl.Block
+	for _, block := range content.Blocks {
+		switch block.Type {
+		case "lifecycle":
+			if seenLifecycle != nil {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Duplicate lifecycle block",
+					Detail:   fmt.Sprintf("The removed block already has a lifecycle block at %s.", seenLifecycle.DefRange),
+					Subject:  &block.DefRange,
+				})
+				continue
+			}
+			seenLifecycle = block
+
+			lcContent, lcDiags := block.Body.Content(removedLifecycleBlockSchema)
+			diags = append(diags, lcDiags...)
+
+			if attr, exists := lcContent.Attributes["destroy"]; exists {
+				valDiags := gohcl.DecodeExpression(attr.Expr, nil, &removed.Destroy)
+				diags = append(diags, valDiags...)
+				removed.DestroySet = true
+			}
+		}
+	}
+
 	return removed, diags
 }
 
@@ -44,6 +77,17 @@ var removedBlockSchema = &hcl.BodySchema{
 		{
 			Name:     "from",
 			Required: true,
+		},
+	},
+	Blocks: []hcl.BlockHeaderSchema{
+		{Type: "lifecycle"},
+	},
+}
+
+var removedLifecycleBlockSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{
+			Name: "destroy",
 		},
 	},
 }

--- a/internal/configs/removed.go
+++ b/internal/configs/removed.go
@@ -95,6 +95,15 @@ func decodeRemovedBlock(removedBlock *hcl.Block) (*Removed, hcl.Diagnostics) {
 		}
 	}
 
+	if !diags.HasErrors() && !removed.DestroySet {
+		// This warning is necessary because of a difference in the default behavior of the removed block compared with other .tf files runners.
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Summary:  "Missing lifecycle from the removed block",
+			Detail:   "It is recommended for each 'removed' block configured to have also the 'lifecycle' block defined. By not specifying if the resource should be destroyed or not, could lead to unwanted behavior.",
+			Subject:  &removedBlock.DefRange,
+		})
+	}
 	return removed, diags
 }
 

--- a/internal/configs/testdata/valid-files/refactoring.tf
+++ b/internal/configs/testdata/valid-files/refactoring.tf
@@ -10,4 +10,7 @@ moved {
 
 removed {
   from = aws_instance.removed
+  lifecycle {
+    destroy = false
+  }
 }

--- a/internal/configs/testdata/valid-modules/removed-blocks/removed-blocks-1.tf
+++ b/internal/configs/testdata/valid-modules/removed-blocks/removed-blocks-1.tf
@@ -1,19 +1,34 @@
 removed {
   from = test.foo
+  lifecycle {
+    destroy = false
+  }
 }
 
 removed {
   from = test.foo
+  lifecycle {
+    destroy = true
+  }
 }
 
 removed {
   from = module.a
+  lifecycle {
+    destroy = false
+  }
 }
 
 removed {
   from = module.a
+  lifecycle {
+    destroy = true
+  }
 }
 
 removed {
   from = test.foo
+  lifecycle {
+    destroy = false
+  }
 }

--- a/internal/configs/testdata/valid-modules/removed-blocks/removed-blocks-2.tf
+++ b/internal/configs/testdata/valid-modules/removed-blocks/removed-blocks-2.tf
@@ -2,4 +2,7 @@
 # appending of multiple files works properly.
 removed {
   from = test.boop
+  lifecycle {
+    destroy = false
+  }
 }

--- a/internal/refactoring/remove_statement.go
+++ b/internal/refactoring/remove_statement.go
@@ -58,9 +58,6 @@ func FindResourceRemovedBlockProvisioners(rootCfg *configs.Config, resAddr addrs
 }
 
 func findRemoveStatements(cfg *configs.Config, into []*RemoveStatement) []*RemoveStatement {
-	if cfg == nil {
-		return nil
-	}
 	modAddr := cfg.Path
 
 	for _, rc := range cfg.Module.Removed {

--- a/internal/refactoring/remove_statement.go
+++ b/internal/refactoring/remove_statement.go
@@ -18,6 +18,10 @@ type RemoveStatement struct {
 	From      addrs.ConfigRemovable
 	Destroy   bool
 	DeclRange tfdiags.SourceRange
+	// Provisioners here are used only to be able to return these to the transformer that is injecting these
+	// in the nodes that are supporting this kind of operation. To get a better understanding of the usage of this field,
+	// check ResourceRemovedProvisioners
+	Provisioners []*configs.Provisioner
 }
 
 // FindRemoveStatements recurses through the modules of the given configuration
@@ -30,7 +34,33 @@ func FindRemoveStatements(rootCfg *configs.Config) ([]*RemoveStatement, tfdiags.
 	return rm, diags
 }
 
+// FindResourceRemovedStatement returns the RemoveStatement if found for the given resAddr.
+// This function is searching in the Config for any "removed" block targeting the given resource.
+// This method shouldn't be concerned if resAddr is pointing to a "module" or a "data" block because all of
+// these will be validated way before this function is going to be called.
+func FindResourceRemovedStatement(rootCfg *configs.Config, resAddr addrs.ConfigResource) *RemoveStatement {
+	rm := findRemoveStatements(rootCfg, nil)
+	// no need to call validateRemoveStatements again since these should have been validated in the plan phase
+	for _, rs := range rm {
+		if rs.From.TargetContains(resAddr) {
+			return rs
+		}
+	}
+	return nil
+}
+
+// FindResourceRemovedBlockProvisioners is returning the provisioners of the RemoveStatement found by calling FindResourceRemovedStatement
+func FindResourceRemovedBlockProvisioners(rootCfg *configs.Config, resAddr addrs.ConfigResource) []*configs.Provisioner {
+	if rs := FindResourceRemovedStatement(rootCfg, resAddr); rs != nil {
+		return rs.Provisioners
+	}
+	return nil
+}
+
 func findRemoveStatements(cfg *configs.Config, into []*RemoveStatement) []*RemoveStatement {
+	if cfg == nil {
+		return nil
+	}
 	modAddr := cfg.Path
 
 	for _, rc := range cfg.Module.Removed {
@@ -48,7 +78,7 @@ func findRemoveStatements(cfg *configs.Config, into []*RemoveStatement) []*Remov
 				Module:   absModule,
 			}
 
-			removedEndpoint = &RemoveStatement{From: absConfigResource, Destroy: rc.Destroy, DeclRange: tfdiags.SourceRangeFromHCL(rc.DeclRange)}
+			removedEndpoint = &RemoveStatement{From: absConfigResource, Destroy: rc.Destroy, DeclRange: tfdiags.SourceRangeFromHCL(rc.DeclRange), Provisioners: rc.Provisioners}
 
 		case addrs.Module:
 			// Get the absolute address of the module by appending the module config address
@@ -56,7 +86,7 @@ func findRemoveStatements(cfg *configs.Config, into []*RemoveStatement) []*Remov
 			var absModule = make(addrs.Module, 0, len(modAddr)+len(FromAddress))
 			absModule = append(absModule, modAddr...)
 			absModule = append(absModule, FromAddress...)
-			removedEndpoint = &RemoveStatement{From: absModule, Destroy: rc.Destroy, DeclRange: tfdiags.SourceRangeFromHCL(rc.DeclRange)}
+			removedEndpoint = &RemoveStatement{From: absModule, Destroy: rc.Destroy, DeclRange: tfdiags.SourceRangeFromHCL(rc.DeclRange), Provisioners: rc.Provisioners}
 
 		default:
 			panic(fmt.Sprintf("unhandled address type %T", FromAddress))

--- a/internal/refactoring/remove_statement_test.go
+++ b/internal/refactoring/remove_statement_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/opentofu/opentofu/internal/tfdiags"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 )
@@ -17,47 +18,96 @@ func TestGetEndpointsToRemove(t *testing.T) {
 	tests := []struct {
 		name        string
 		fixtureName string
-		want        []addrs.ConfigRemovable
+		want        []*RemoveStatement
 		wantError   string
 	}{
 		{
 			name:        "Valid cases",
 			fixtureName: "testdata/remove-statement/valid-remove-statements",
-			want: []addrs.ConfigRemovable{
-				interface{}(mustConfigResourceAddr("foo.basic_resource")).(addrs.ConfigRemovable),
-				interface{}(addrs.Module{"basic_module"}).(addrs.ConfigRemovable),
-				interface{}(mustConfigResourceAddr("module.child.foo.removed_resource_from_root_module")).(addrs.ConfigRemovable),
-				interface{}(mustConfigResourceAddr("module.child.foo.removed_resource_from_child_module")).(addrs.ConfigRemovable),
-				interface{}(addrs.Module{"child", "removed_module_from_child_module"}).(addrs.ConfigRemovable),
-				interface{}(mustConfigResourceAddr("module.child.module.grandchild.foo.removed_resource_from_grandchild_module")).(addrs.ConfigRemovable),
-				interface{}(addrs.Module{"child", "grandchild", "removed_module_from_grandchild_module"}).(addrs.ConfigRemovable),
+			want: []*RemoveStatement{
+				{
+					From: mustConfigResourceAddr("foo.basic_resource"),
+					DeclRange: tfdiags.SourceRange{
+						Filename: "testdata/remove-statement/valid-remove-statements/main.tf",
+						Start:    tfdiags.SourcePos{Line: 1, Column: 1},
+						End:      tfdiags.SourcePos{Line: 1, Column: 8, Byte: 7},
+					},
+				},
+				{
+					From: addrs.Module{"basic_module"},
+					DeclRange: tfdiags.SourceRange{
+						Filename: "testdata/remove-statement/valid-remove-statements/main.tf",
+						Start:    tfdiags.SourcePos{Line: 5, Column: 1, Byte: 41},
+						End:      tfdiags.SourcePos{Line: 5, Column: 8, Byte: 48},
+					},
+				},
+				{
+					From: mustConfigResourceAddr("module.child.foo.removed_resource_from_root_module"),
+					DeclRange: tfdiags.SourceRange{
+						Filename: "testdata/remove-statement/valid-remove-statements/main.tf",
+						Start:    tfdiags.SourcePos{Line: 9, Column: 1, Byte: 83},
+						End:      tfdiags.SourcePos{Line: 9, Column: 8, Byte: 90},
+					},
+				},
+				{
+					From: mustConfigResourceAddr("module.child.foo.removed_resource_from_child_module"),
+					DeclRange: tfdiags.SourceRange{
+						Filename: "testdata/remove-statement/valid-remove-statements/child/main.tf",
+						Start:    tfdiags.SourcePos{Line: 1, Column: 1},
+						End:      tfdiags.SourcePos{Line: 1, Column: 8, Byte: 7},
+					},
+				},
+				{
+					From: addrs.Module{"child", "removed_module_from_child_module"},
+					DeclRange: tfdiags.SourceRange{
+						Filename: "testdata/remove-statement/valid-remove-statements/child/main.tf",
+						Start:    tfdiags.SourcePos{Line: 9, Column: 1, Byte: 112},
+						End:      tfdiags.SourcePos{Line: 9, Column: 8, Byte: 119},
+					},
+				},
+				{
+					From: mustConfigResourceAddr("module.child.module.grandchild.foo.removed_resource_from_grandchild_module"),
+					DeclRange: tfdiags.SourceRange{
+						Filename: "testdata/remove-statement/valid-remove-statements/child/grandchild/main.tf",
+						Start:    tfdiags.SourcePos{Line: 1, Column: 1},
+						End:      tfdiags.SourcePos{Line: 1, Column: 8, Byte: 7},
+					},
+				},
+				{
+					From: addrs.Module{"child", "grandchild", "removed_module_from_grandchild_module"},
+					DeclRange: tfdiags.SourceRange{
+						Filename: "testdata/remove-statement/valid-remove-statements/child/grandchild/main.tf",
+						Start:    tfdiags.SourcePos{Line: 5, Column: 1, Byte: 66},
+						End:      tfdiags.SourcePos{Line: 5, Column: 8, Byte: 73},
+					},
+				},
 			},
 			wantError: ``,
 		},
 		{
 			name:        "Error - resource block still exist",
 			fixtureName: "testdata/remove-statement/not-valid-resource-block-still-exist",
-			want: []addrs.ConfigRemovable{
-				interface{}(mustConfigResourceAddr("foo.basic_resource")).(addrs.ConfigRemovable),
+			want: []*RemoveStatement{
+				{From: mustConfigResourceAddr("foo.basic_resource")},
 			},
 			wantError: `Removed resource block still exists: This statement declares a removal of the resource foo.basic_resource, but this resource block still exists in the configuration. Please remove the resource block.`,
 		},
 		{
 			name:        "Error - module block still exist",
 			fixtureName: "testdata/remove-statement/not-valid-module-block-still-exist",
-			want:        []addrs.ConfigRemovable{},
+			want:        []*RemoveStatement{},
 			wantError:   `Removed module block still exists: This statement declares a removal of the module module.child, but this module block still exists in the configuration. Please remove the module block.`,
 		},
 		{
 			name:        "Error - nested resource block still exist",
 			fixtureName: "testdata/remove-statement/not-valid-nested-resource-block-still-exist",
-			want:        []addrs.ConfigRemovable{},
+			want:        []*RemoveStatement{},
 			wantError:   `Removed resource block still exists: This statement declares a removal of the resource module.child.foo.basic_resource, but this resource block still exists in the configuration. Please remove the resource block.`,
 		}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rootCfg, _ := loadRefactoringFixture(t, tt.fixtureName)
-			got, diags := GetEndpointsToRemove(rootCfg)
+			got, diags := FindRemoveStatements(rootCfg)
 
 			if tt.wantError != "" {
 				if !diags.HasErrors() {

--- a/internal/tofu/context_plan.go
+++ b/internal/tofu/context_plan.go
@@ -98,9 +98,9 @@ type PlanOpts struct {
 	// will be added to the plan graph.
 	ImportTargets []*ImportTarget
 
-	// EndpointsToRemove are the list of resources and modules to forget from
+	// RemoveStatements are the list of resources and modules to forget from
 	// the state.
-	EndpointsToRemove []addrs.ConfigRemovable
+	RemoveStatements []*refactoring.RemoveStatement
 
 	// GenerateConfig tells OpenTofu where to write any generated configuration
 	// for any ImportTargets that do not have configuration already.
@@ -331,7 +331,7 @@ func (c *Context) plan(ctx context.Context, config *configs.Config, prevRunState
 	}
 
 	var endpointsToRemoveDiags tfdiags.Diagnostics
-	opts.EndpointsToRemove, endpointsToRemoveDiags = refactoring.GetEndpointsToRemove(config)
+	opts.RemoveStatements, endpointsToRemoveDiags = refactoring.FindRemoveStatements(config)
 	diags = diags.Append(endpointsToRemoveDiags)
 
 	if diags.HasErrors() {
@@ -856,7 +856,7 @@ func (c *Context) planGraph(config *configs.Config, prevRunState *states.State, 
 			ExternalReferences:      opts.ExternalReferences,
 			ImportTargets:           opts.ImportTargets,
 			GenerateConfigPath:      opts.GenerateConfigPath,
-			EndpointsToRemove:       opts.EndpointsToRemove,
+			RemoveStatements:        opts.RemoveStatements,
 			ProviderFunctionTracker: providerFunctionTracker,
 		}).Build(addrs.RootModuleInstance)
 		return graph, walkPlan, diags

--- a/internal/tofu/graph_builder_plan.go
+++ b/internal/tofu/graph_builder_plan.go
@@ -11,6 +11,7 @@ import (
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/dag"
+	"github.com/opentofu/opentofu/internal/refactoring"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
@@ -86,9 +87,9 @@ type PlanGraphBuilder struct {
 	// ImportTargets are the list of resources to import.
 	ImportTargets []*ImportTarget
 
-	// EndpointsToRemove are the list of resources and modules to forget from
+	// RemoveStatements are the list of resources and modules to forget from
 	// the state.
-	EndpointsToRemove []addrs.ConfigRemovable
+	RemoveStatements []*refactoring.RemoveStatement
 
 	// GenerateConfig tells OpenTofu where to write and generated config for
 	// any import targets that do not already have configuration.
@@ -283,7 +284,7 @@ func (b *PlanGraphBuilder) initPlan() {
 			NodeAbstractResourceInstance: a,
 			skipRefresh:                  b.skipRefresh,
 			skipPlanChanges:              b.skipPlanChanges,
-			EndpointsToRemove:            b.EndpointsToRemove,
+			RemoveStatements:             b.RemoveStatements,
 		}
 	}
 
@@ -292,9 +293,9 @@ func (b *PlanGraphBuilder) initPlan() {
 			NodeAbstractResourceInstance: a,
 			DeposedKey:                   key,
 
-			skipRefresh:       b.skipRefresh,
-			skipPlanChanges:   b.skipPlanChanges,
-			EndpointsToRemove: b.EndpointsToRemove,
+			skipRefresh:      b.skipRefresh,
+			skipPlanChanges:  b.skipPlanChanges,
+			RemoveStatements: b.RemoveStatements,
 		}
 	}
 }

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -90,6 +90,11 @@ type NodeAbstractResource struct {
 	// generateConfigPath tells this node which file to write generated config
 	// into. If empty, then config should not be generated.
 	generateConfigPath string
+
+	// removedBlockProvisioners holds any possibly existing configs.Provisioner configs that could be defined by using
+	// removed.provisioner configuration. If the field "Config.Managed.Provisioners" is having no provisioners, then
+	// these provisioners should be used instead.
+	removedBlockProvisioners []*configs.Provisioner
 }
 
 var (

--- a/internal/tofu/node_resource_deposed_test.go
+++ b/internal/tofu/node_resource_deposed_test.go
@@ -9,12 +9,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/plans"
 	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/refactoring"
 	"github.com/opentofu/opentofu/internal/states"
+	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -24,6 +26,7 @@ func TestNodePlanDeposedResourceInstanceObject_Execute(t *testing.T) {
 		nodeAddress           string
 		nodeEndpointsToRemove []*refactoring.RemoveStatement
 		wantAction            plans.Action
+		wantDiags             tfdiags.Diagnostics
 	}{
 		{
 			description:           "no remove blocks",
@@ -60,6 +63,11 @@ func TestNodePlanDeposedResourceInstanceObject_Execute(t *testing.T) {
 				},
 			},
 			wantAction: plans.Forget,
+			wantDiags: tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagWarning,
+				Summary:  "Resource going to be removed from the state",
+				Detail:   fmt.Sprintf("After this plan gets applied, the resource %s will not be managed anymore by OpenTofu.\n\nIn case you want to manage the resource again, you will have to import it.", "test_instance.foo"),
+			}),
 		},
 		{
 			description: "remove block is targeting current node and required to get it destroyed",
@@ -81,6 +89,11 @@ func TestNodePlanDeposedResourceInstanceObject_Execute(t *testing.T) {
 				},
 			},
 			wantAction: plans.Forget,
+			wantDiags: tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagWarning,
+				Summary:  "Resource going to be removed from the state",
+				Detail:   fmt.Sprintf("After this plan gets applied, the resource %s will not be managed anymore by OpenTofu.\n\nIn case you want to manage the resource again, you will have to import it.", "test_instance.foo[1]"),
+			}),
 		},
 		{
 			description: "remove block is targeting a resource to be destroyed and the current node is an instance of that",
@@ -102,6 +115,11 @@ func TestNodePlanDeposedResourceInstanceObject_Execute(t *testing.T) {
 				},
 			},
 			wantAction: plans.Forget,
+			wantDiags: tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagWarning,
+				Summary:  "Resource going to be removed from the state",
+				Detail:   fmt.Sprintf("After this plan gets applied, the resource %s will not be managed anymore by OpenTofu.\n\nIn case you want to manage the resource again, you will have to import it.", "module.boop.test_instance.foo"),
+			}),
 		},
 		{
 			description: "remove block is targeting a resource from a module to be destroyed which is the current node",
@@ -134,6 +152,11 @@ func TestNodePlanDeposedResourceInstanceObject_Execute(t *testing.T) {
 				},
 			},
 			wantAction: plans.Forget,
+			wantDiags: tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagWarning,
+				Summary:  "Resource going to be removed from the state",
+				Detail:   fmt.Sprintf("After this plan gets applied, the resource %s will not be managed anymore by OpenTofu.\n\nIn case you want to manage the resource again, you will have to import it.", "module.boop[1].test_instance.foo[1]"),
+			}),
 		},
 		{
 			description: "remove block is targeting a module and the current node is a resource of that module",
@@ -144,6 +167,11 @@ func TestNodePlanDeposedResourceInstanceObject_Execute(t *testing.T) {
 				},
 			},
 			wantAction: plans.Forget,
+			wantDiags: tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagWarning,
+				Summary:  "Resource going to be removed from the state",
+				Detail:   fmt.Sprintf("After this plan gets applied, the resource %s will not be managed anymore by OpenTofu.\n\nIn case you want to manage the resource again, you will have to import it.", "module.boop.test_instance.foo"),
+			}),
 		},
 		{
 			description: "remove block is targeting a module and the current node is a resource of one of the module instances",
@@ -154,6 +182,11 @@ func TestNodePlanDeposedResourceInstanceObject_Execute(t *testing.T) {
 				},
 			},
 			wantAction: plans.Forget,
+			wantDiags: tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagWarning,
+				Summary:  "Resource going to be removed from the state",
+				Detail:   fmt.Sprintf("After this plan gets applied, the resource %s will not be managed anymore by OpenTofu.\n\nIn case you want to manage the resource again, you will have to import it.", "module.boop[1].test_instance.foo"),
+			}),
 		},
 	}
 
@@ -175,10 +208,8 @@ func TestNodePlanDeposedResourceInstanceObject_Execute(t *testing.T) {
 				RemoveStatements: test.nodeEndpointsToRemove,
 			}
 
-			err := node.Execute(ctx, walkPlan)
-			if err != nil {
-				t.Fatalf("unexpected error: %s", err)
-			}
+			gotDiags := node.Execute(ctx, walkPlan)
+			assertDiags(t, gotDiags, test.wantDiags)
 
 			if !p.UpgradeResourceStateCalled {
 				t.Errorf("UpgradeResourceState wasn't called; should've been called to upgrade the previous run's object")
@@ -369,4 +400,35 @@ func initMockEvalContext(resourceAddrs string, deposedKey states.DeposedKey) (*M
 		ProviderSchemaSchema: schema,
 		ChangesChanges:       plans.NewChanges().SyncWrapper(),
 	}, p
+}
+
+func assertDiags(t *testing.T, got, want tfdiags.Diagnostics) {
+	if len(got) != len(want) {
+		t.Errorf("invalid number of diags wanted %d but got %d.\nwant:\n\t%s\ngot:\n\t%s", len(want), len(got), want, got)
+		return
+	}
+	for _, gd := range got {
+		var found bool
+		for _, wd := range want {
+			if !gd.Description().Equal(wd.Description()) {
+				continue
+			}
+			if !gd.Source().Equal(wd.Source()) {
+				continue
+			}
+			if gd.Severity() != wd.Severity() {
+				continue
+			}
+			if gd.ExtraInfo() != wd.ExtraInfo() {
+				continue
+			}
+			if gd.FromExpr() != wd.FromExpr() {
+				continue
+			}
+			found = true
+		}
+		if !found {
+			t.Errorf("got a diagnostic that is not expected.\nwanted:\n\t%s\ngot:\n\t%s", want, gd)
+		}
+	}
 }

--- a/internal/tofu/node_resource_plan_orphan.go
+++ b/internal/tofu/node_resource_plan_orphan.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/plans"
 	"github.com/opentofu/opentofu/internal/refactoring"
@@ -162,6 +163,11 @@ func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(ctx EvalCon
 		if shouldDestroy {
 			change, planDiags = n.planDestroy(ctx, oldState, "")
 		} else {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagWarning,
+				Summary:  "Resource going to be removed from the state",
+				Detail:   fmt.Sprintf("After this plan gets applied, the resource %s will not be managed anymore by OpenTofu.\n\nIn case you want to manage the resource again, you will have to import it.", n.Addr),
+			})
 			change = n.planForget(ctx, oldState, "")
 		}
 	} else {

--- a/internal/tofu/node_resource_plan_orphan_test.go
+++ b/internal/tofu/node_resource_plan_orphan_test.go
@@ -6,9 +6,11 @@
 package tofu
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/opentofu/opentofu/internal/configs/configschema"
+	"github.com/opentofu/opentofu/internal/refactoring"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/instances"
@@ -22,150 +24,205 @@ func TestNodeResourcePlanOrphan_Execute(t *testing.T) {
 	tests := []struct {
 		description           string
 		nodeAddress           string
-		nodeEndpointsToRemove []addrs.ConfigRemovable
+		nodeEndpointsToRemove []*refactoring.RemoveStatement
 		wantAction            plans.Action
 	}{
 		{
+			description:           "no remove block",
 			nodeAddress:           "test_instance.foo",
-			nodeEndpointsToRemove: make([]addrs.ConfigRemovable, 0),
+			nodeEndpointsToRemove: make([]*refactoring.RemoveStatement, 0),
 			wantAction:            plans.Delete,
 		},
 		{
+			description: "remove block is targeting another resource name of same type",
 			nodeAddress: "test_instance.foo",
-			nodeEndpointsToRemove: []addrs.ConfigRemovable{
-				interface{}(mustConfigResourceAddr("test_instance.bar")).(addrs.ConfigRemovable),
+			nodeEndpointsToRemove: []*refactoring.RemoveStatement{
+				{From: mustConfigResourceAddr("test_instance.bar")},
 			},
 			wantAction: plans.Delete,
 		},
 		{
+			description: "remove block is targeting a module but current node is from root module",
 			nodeAddress: "test_instance.foo",
-			nodeEndpointsToRemove: []addrs.ConfigRemovable{
-				interface{}(addrs.Module{"boop"}).(addrs.ConfigRemovable),
+			nodeEndpointsToRemove: []*refactoring.RemoveStatement{
+				{From: addrs.Module{"boop"}},
 			},
 			wantAction: plans.Delete,
 		},
 		{
+			description: "remove block is targeting current node",
 			nodeAddress: "test_instance.foo",
-			nodeEndpointsToRemove: []addrs.ConfigRemovable{
-				interface{}(mustConfigResourceAddr("test_instance.foo")).(addrs.ConfigRemovable),
+			nodeEndpointsToRemove: []*refactoring.RemoveStatement{
+				{From: mustConfigResourceAddr("test_instance.foo")},
 			},
 			wantAction: plans.Forget,
 		},
 		{
+			description: "remove block is targeting current node and required to get it destroyed",
+			nodeAddress: "test_instance.foo",
+			nodeEndpointsToRemove: []*refactoring.RemoveStatement{
+				{
+					From:    mustConfigResourceAddr("test_instance.foo"),
+					Destroy: true,
+				},
+			},
+			wantAction: plans.Delete,
+		},
+		{
+			description: "remove block is targeting a resource and the current node is an instance of that",
 			nodeAddress: "test_instance.foo[1]",
-			nodeEndpointsToRemove: []addrs.ConfigRemovable{
-				interface{}(mustConfigResourceAddr("test_instance.foo")).(addrs.ConfigRemovable),
+			nodeEndpointsToRemove: []*refactoring.RemoveStatement{
+				{From: mustConfigResourceAddr("test_instance.foo")},
 			},
 			wantAction: plans.Forget,
 		},
 		{
+			description: "remove block is targeting a resource to be destroyed and the current node is an instance of that",
+			nodeAddress: "test_instance.foo[1]",
+			nodeEndpointsToRemove: []*refactoring.RemoveStatement{
+				{
+					From:    mustConfigResourceAddr("test_instance.foo"),
+					Destroy: true,
+				},
+			},
+			wantAction: plans.Delete,
+		},
+		{
+			description: "remove block is targeting a resource from a module which is the current node",
 			nodeAddress: "module.boop.test_instance.foo",
-			nodeEndpointsToRemove: []addrs.ConfigRemovable{
-				interface{}(mustConfigResourceAddr("module.boop.test_instance.foo")).(addrs.ConfigRemovable),
+			nodeEndpointsToRemove: []*refactoring.RemoveStatement{
+				{From: mustConfigResourceAddr("module.boop.test_instance.foo")},
 			},
 			wantAction: plans.Forget,
 		},
 		{
+			description: "remove block is targeting a resource from a module to be destroyed which is the current node",
+			nodeAddress: "module.boop.test_instance.foo",
+			nodeEndpointsToRemove: []*refactoring.RemoveStatement{
+				{
+					From:    mustConfigResourceAddr("module.boop.test_instance.foo"),
+					Destroy: true,
+				},
+			},
+			wantAction: plans.Delete,
+		},
+		{
+			description: "remove block is targeting a resource from a module to be destroyed which is the current node",
+			nodeAddress: "module.boop.test_instance.foo",
+			nodeEndpointsToRemove: []*refactoring.RemoveStatement{
+				{
+					From:    mustConfigResourceAddr("module.boop.test_instance.foo"),
+					Destroy: true,
+				},
+			},
+			wantAction: plans.Delete,
+		},
+		{
+			description: "remove block is targeting a resource from a module of which the current node is an instance of",
 			nodeAddress: "module.boop[1].test_instance.foo[1]",
-			nodeEndpointsToRemove: []addrs.ConfigRemovable{
-				interface{}(mustConfigResourceAddr("module.boop.test_instance.foo")).(addrs.ConfigRemovable),
+			nodeEndpointsToRemove: []*refactoring.RemoveStatement{
+				{From: mustConfigResourceAddr("module.boop.test_instance.foo")},
 			},
 			wantAction: plans.Forget,
 		},
 		{
+			description: "remove block is targeting a module and the current node is a resource of that module",
 			nodeAddress: "module.boop.test_instance.foo",
-			nodeEndpointsToRemove: []addrs.ConfigRemovable{
-				interface{}(addrs.Module{"boop"}).(addrs.ConfigRemovable),
+			nodeEndpointsToRemove: []*refactoring.RemoveStatement{
+				{From: addrs.Module{"boop"}},
 			},
 			wantAction: plans.Forget,
 		},
 		{
+			description: "remove block is targeting a module and the current node is a resource of one of the module instances",
 			nodeAddress: "module.boop[1].test_instance.foo",
-			nodeEndpointsToRemove: []addrs.ConfigRemovable{
-				interface{}(addrs.Module{"boop"}).(addrs.ConfigRemovable),
+			nodeEndpointsToRemove: []*refactoring.RemoveStatement{
+				{From: addrs.Module{"boop"}},
 			},
 			wantAction: plans.Forget,
 		},
 	}
 
 	for _, test := range tests {
-		state := states.NewState()
-		absResource := mustResourceInstanceAddr(test.nodeAddress)
+		t.Run(fmt.Sprintf("%s %s", test.wantAction, test.description), func(t *testing.T) {
+			state := states.NewState()
+			absResource := mustResourceInstanceAddr(test.nodeAddress)
 
-		if !absResource.Module.IsRoot() {
-			state.EnsureModule(addrs.RootModuleInstance.Child(absResource.Module[0].Name, absResource.Module[0].InstanceKey))
-		}
+			if !absResource.Module.IsRoot() {
+				state.EnsureModule(addrs.RootModuleInstance.Child(absResource.Module[0].Name, absResource.Module[0].InstanceKey))
+			}
 
-		state.Module(absResource.Module).SetResourceInstanceCurrent(
-			absResource.Resource,
-			&states.ResourceInstanceObjectSrc{
-				AttrsFlat: map[string]string{
-					"test_string": "foo",
+			state.Module(absResource.Module).SetResourceInstanceCurrent(
+				absResource.Resource,
+				&states.ResourceInstanceObjectSrc{
+					AttrsFlat: map[string]string{
+						"test_string": "foo",
+					},
+					Status: states.ObjectReady,
 				},
-				Status: states.ObjectReady,
-			},
-			addrs.AbsProviderConfig{
-				Provider: addrs.NewDefaultProvider("test"),
-				Module:   addrs.RootModule,
-			},
-			addrs.NoKey,
-		)
+				addrs.AbsProviderConfig{
+					Provider: addrs.NewDefaultProvider("test"),
+					Module:   addrs.RootModule,
+				},
+				addrs.NoKey,
+			)
 
-		schema := providers.ProviderSchema{
-			ResourceTypes: map[string]providers.Schema{
-				"test_instance": {
-					Block: &configschema.Block{
-						Attributes: map[string]*configschema.Attribute{
-							"id": {
-								Type:     cty.String,
-								Computed: true,
+			schema := providers.ProviderSchema{
+				ResourceTypes: map[string]providers.Schema{
+					"test_instance": {
+						Block: &configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"id": {
+									Type:     cty.String,
+									Computed: true,
+								},
 							},
 						},
 					},
 				},
-			},
-		}
+			}
 
-		p := simpleMockProvider()
-		p.ConfigureProvider(providers.ConfigureProviderRequest{})
-		p.GetProviderSchemaResponse = &schema
+			p := simpleMockProvider()
+			p.ConfigureProvider(providers.ConfigureProviderRequest{})
+			p.GetProviderSchemaResponse = &schema
 
-		ctx := &MockEvalContext{
-			StateState:               state.SyncWrapper(),
-			RefreshStateState:        state.DeepCopy().SyncWrapper(),
-			PrevRunStateState:        state.DeepCopy().SyncWrapper(),
-			InstanceExpanderExpander: instances.NewExpander(),
-			ProviderProvider:         p,
-			ProviderSchemaSchema:     schema,
-			ChangesChanges:           plans.NewChanges().SyncWrapper(),
-		}
+			ctx := &MockEvalContext{
+				StateState:               state.SyncWrapper(),
+				RefreshStateState:        state.DeepCopy().SyncWrapper(),
+				PrevRunStateState:        state.DeepCopy().SyncWrapper(),
+				InstanceExpanderExpander: instances.NewExpander(),
+				ProviderProvider:         p,
+				ProviderSchemaSchema:     schema,
+				ChangesChanges:           plans.NewChanges().SyncWrapper(),
+			}
 
-		node := NodePlannableResourceInstanceOrphan{
-			NodeAbstractResourceInstance: &NodeAbstractResourceInstance{
-				NodeAbstractResource: NodeAbstractResource{
-					ResolvedProvider: ResolvedProvider{ProviderConfig: addrs.AbsProviderConfig{
-						Provider: addrs.NewDefaultProvider("test"),
-						Module:   addrs.RootModule,
-					}},
+			node := NodePlannableResourceInstanceOrphan{
+				NodeAbstractResourceInstance: &NodeAbstractResourceInstance{
+					NodeAbstractResource: NodeAbstractResource{
+						ResolvedProvider: ResolvedProvider{ProviderConfig: addrs.AbsProviderConfig{
+							Provider: addrs.NewDefaultProvider("test"),
+							Module:   addrs.RootModule,
+						}},
+					},
+					Addr: absResource,
 				},
-				Addr: absResource,
-			},
-			EndpointsToRemove: test.nodeEndpointsToRemove,
-		}
+				RemoveStatements: test.nodeEndpointsToRemove,
+			}
 
-		err := node.Execute(ctx, walkPlan)
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
+			err := node.Execute(ctx, walkPlan)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
 
-		change := ctx.Changes().GetResourceInstanceChange(absResource, states.NotDeposed)
-		if got, want := change.ChangeSrc.Action, test.wantAction; got != want {
-			t.Fatalf("wrong planned action\ngot:  %s\nwant: %s", got, want)
-		}
+			change := ctx.Changes().GetResourceInstanceChange(absResource, states.NotDeposed)
+			if got, want := change.ChangeSrc.Action, test.wantAction; got != want {
+				t.Fatalf("wrong planned action\ngot:  %s\nwant: %s", got, want)
+			}
 
-		if !state.Empty() {
-			t.Fatalf("expected empty state, got %s", state.String())
-		}
+			if !state.Empty() {
+				t.Fatalf("expected empty state, got %s", state.String())
+			}
+		})
 	}
 }
 

--- a/internal/tofu/testdata/transform-diff-creates-destroy-node/child/main.tf
+++ b/internal/tofu/testdata/transform-diff-creates-destroy-node/child/main.tf
@@ -1,0 +1,12 @@
+removed {
+	from = tfcoremock_simple_resource.example
+
+	lifecycle {
+		destroy = true
+	}
+
+	provisioner "local-exec" {
+		when = destroy
+		command = "echo 'execute against ${self.id}'"
+	}
+}

--- a/internal/tofu/testdata/transform-diff-creates-destroy-node/main.tf
+++ b/internal/tofu/testdata/transform-diff-creates-destroy-node/main.tf
@@ -1,0 +1,3 @@
+module "child" {
+	source = "./child"
+}

--- a/internal/tofu/transform_destroy_edge_test.go
+++ b/internal/tofu/transform_destroy_edge_test.go
@@ -407,6 +407,7 @@ func TestPruneUnusedNodesTransformer_rootModuleOutputValues(t *testing.T) {
 				Concrete: concreteResourceInstance,
 				State:    state,
 				Changes:  changes,
+				Config:   config,
 			},
 			&ReferenceTransformer{},
 			&AttachDependenciesTransformer{},

--- a/internal/tofu/transform_diff.go
+++ b/internal/tofu/transform_diff.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/dag"
 	"github.com/opentofu/opentofu/internal/plans"
+	"github.com/opentofu/opentofu/internal/refactoring"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
@@ -215,6 +216,9 @@ func (t *DiffTransformer) Transform(g *Graph) error {
 			var node GraphNodeResourceInstance
 			abstract := NewNodeAbstractResourceInstance(addr)
 			if dk == states.NotDeposed {
+				// If any removed block is targeting the resource in this node, ensure that any provisioners defined in that block are going to be
+				// executed before actual resource destruction.
+				abstract.removedBlockProvisioners = refactoring.FindResourceRemovedBlockProvisioners(t.Config, abstract.Addr.ConfigResource())
 				node = &NodeDestroyResourceInstance{
 					NodeAbstractResourceInstance: abstract,
 					DeposedKey:                   dk,

--- a/website/docs/language/modules/syntax.mdx
+++ b/website/docs/language/modules/syntax.mdx
@@ -189,3 +189,25 @@ The above selects a `resource "aws_instance" "example"` declared inside a
 Because replacing is a very disruptive action, OpenTofu only allows selecting
 individual resource instances. There is no syntax to force replacing _all_
 resource instances belonging to a particular module.
+
+## Removing a module
+The same as any `resource`, a `module` can be removed as well by using the `removed` refactoring block.
+When you remove the configuration of a module, OpenTofu will destroy all the resources that the removed module was managing.
+
+There are cases when the module is wanted to be removed from the configuration (and from the state) but the resources managed by it should stay untouched.
+To achieve this, follow these steps:
+1. Delete the module from your configuration.
+2. Add a removed block instead, specifying the module address you want to "forget" in the `from` attribute.
+3. Specify the `lifecycle.destroy = false`
+
+```hcl
+removed {
+  from = module.some_module
+  lifecycle {
+    destroy = false
+  }
+}
+```
+:::note
+In contrast with `resource` blocks removal, `removed` blocks pointing to modules, do not allow usage of `provisioners`.
+:::

--- a/website/docs/language/resources/syntax.mdx
+++ b/website/docs/language/resources/syntax.mdx
@@ -128,30 +128,59 @@ while allowing it to persist in the remote system.
 To achieve this, follow these steps:
 1. Delete the resource from your configuration.
 2. Add a removed block instead, specifying the resource address you want to "forget" in the `from` attribute.
+3. Specify the `lifecycle.destroy = false`
 
 For example:
 ```hcl
 removed {
   from = aws_instance.web
+  lifecycle {
+    destroy = false
+  }
 }
 ```
 
 :::note
-
 The address in the `from` attribute cannot include instance keys (for example, "aws_instance.web[0]").
+:::
+:::note
+The `lifecycle.destroy` can be also `true`, case in which OpenTofu will behave just like the resource was deleted from the configuration.
+Though, we allow this since such a `removed` block can be used as historical hint about the previously existing resource.
+:::
 
+:::warning
+The `lifecycle` block is not required, but it's highly recommended to be added. OpenTofu will also generate a warning if it finds any
+`removed` block without a `lifecycle` block defined inside. This is just to ensure that the user adding the `removed` block
+is indicating clearly what the block is meant to do.
 :::
 
 Upon executing `tofu plan`, OpenTofu will indicate that the resource is slated for removal from the state but will not
 be destroyed.
 
-The `removed` block can be used to remove specific resources or modules containing multiple resources. For example:
+The `removed` blocks do also support inner `provisioner` blocks. This is useful when the `resource` that is targeted to be removed
+was having `provisioner` blocks that the user wants to have executed before destroying the actual resource.
 ```hcl
 removed {
-  from = module.some_module
+  from = aws_s3_bucket.example
+  lifecycle {
+    destroy = true
+  }
+  provisioner "local-exec" {
+    when = destroy
+    command = "echo 'destroying bucket ${self.bucket}'"
+  }
 }
 ```
+The `command` field do support references only the `self` object, which represents the information that OpenTofu is still having
+in the state about the targeted `resource`.
 
+The `provisioner` block will be executed only when the `removed` block is configured in a specific way:
+- `lifecycle.destroy = true`
+- `provisioner.when = destroy`
+
+In any other cases, the execution will be skipped.
+
+For more information about provisioners, you can refer to this [page](./provisioners/syntax.mdx).
 ## Meta-Arguments
 
 The OpenTofu language defines several meta-arguments, which can be used with

--- a/website/docs/language/resources/syntax.mdx
+++ b/website/docs/language/resources/syntax.mdx
@@ -171,7 +171,7 @@ removed {
   }
 }
 ```
-The `command` field do support references only the `self` object, which represents the information that OpenTofu is still having
+The `command` field do support references only the `self` object, `each.key` and `count.index`, which represents the information that OpenTofu is still having
 in the state about the targeted `resource`.
 
 The `provisioner` block will be executed only when the `removed` block is configured in a specific way:


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves #2556

_Recommended to be reviewed per commit since there are a lot of changes. Reworked the commit history and split the changes per commit and added information in each of those for easing the review a little_

This PR adds two new functionalities on the `removed` block:
* Now supports a `lifecycle` block that can have one attribute: `destroy` that can have two values `true`/`false`.
* Now supports `provisioner` blocks for the author of the `removed` block to be able to move the `provisioner` blocks from the actual removed `resource`. This is needed because `removed` and the targeted `resource` block cannot be in the same time in the configuration. Therefore, the user needs to have an option to still execute the provisioners before destroying the `resource`.
* Some additional warnings/errors that were missed in the initial implementation

## `lifecycle` block
This block is introduced in order to control the way a `resource` is removed.
* If `lifecycle.destroy=true`, the `resource` will be planned for deletion, following exactly the same path as by just removing the `resource` from the configuration.
* If `lifecycle.destroy=false`, the `resource` will be planned for being forgotten, which will leave the actual `resource` untouched but will remove it from the state.

⚠️ Due to having a default behavior different than other HCL tools (where OpenTofu is by default forgetting the `resource`, but the other tool is `destroy`ing it) this PR is also adding a warning when a `removed` block is used without having `lifecycle` block configured inside.

## `provisioner` block(s)
Multiple `provisioner` blocks can be configured now in the `removed` block.
Because the initial implementation of the `removed` block is baked for the `plan` phase, in contrast with the `provisioner` block which is an `apply` phase action, the implementation for this is in the `DiffTransformer`:
* When the transformer creates a `NodeDestroyResourceInstance`, we are searching for the `removed` block that could is targeting the underlying resource and attach the provisioners defined in there to the `NodeAbstractResource` to be later executed before the destroy operation.

> [!WARNING]
> * A `provisioner` defined in a `removed` block cannot have other `when` values than `destroy`.
> * A `provisioner` block will be executed **only** when the `removed.lifecycle.destroy=true` and `removed.provisioner.when=destroy`.

## Additional checks added
* Error: A `provisioner` block cannot be used in a `removed` block that is targeting a module.
  * By allowing that, provisioners defined in the `removed` block will be executed against **each and every resource inside the module**.
* Warning: When `removed.lifecycle.destroy=false` is planned, a warning will be shown about the `resource` being removed from the state.


## Target Release

1.10.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.

Related to #1032 
