### PR TITLE
website: Very early docs for the new OCI Registry functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ UPGRADE NOTES:
 
 NEW FEATURES:
 
+- Can now use OCI Registries as a new kind of provider mirror. ([#2540](https://github.com/opentofu/opentofu/issues/2540))
 - New builtin provider functions added ([#2306](https://github.com/opentofu/opentofu/pull/2306)) :
     - `provider::terraform::decode_tfvars` - Decode a TFVars file content into an object.
     - `provider::terraform::encode_tfvars` - Encode an object into a string with the same format as a TFVars file.

--- a/website/docs/cli/config/config-file.mdx
+++ b/website/docs/cli/config/config-file.mdx
@@ -63,6 +63,10 @@ The following settings can be set in the CLI configuration file:
   and retrieval of credentials for cloud backends.
   See [Credentials Helpers](#credentials-helpers) below for more information.
 
+* `oci_credentials` and `default_oci_credentials` - configures credentials for
+  interacting with an OCI Registry. Refer to
+  [OCI Registry Credentials](../oci_registries/credentials.mdx) for more information.
+
 * `plugin_cache_dir` — enables
   [plugin caching](#provider-plugin-cache)
   and specifies, as a string, the location of the plugin cache directory.
@@ -94,6 +98,10 @@ giving the API token to use for that host.
 The credentials hostname must match the hostname in your module
 sources and/or backend configuration.
 :::
+
+`credentials` blocks are used only for OpenTofu-specific protocols. You can
+configure credentials for OCI Registries using `oci_credentials` blocks,
+as described in [OCI Registry Credentials](../oci_registries/credentials.mdx).
 
 ### Environment Variable Credentials
 
@@ -247,6 +255,16 @@ The following are the supported installation method types:
   [the provider network mirror protocol](../../internals/provider-network-mirror-protocol.mdx),
   which is designed to be relatively easy to implement using typical static
   website hosting mechanisms.
+
+* `oci_mirror`: map provider source addresses into OCI repository addresses,
+  regardless of which registry host they belong to, and then retrieve them
+  using the OCI Distribution protocol.
+
+  This is similar to `network_mirror`, but uses the industry-standard OCI
+  registry protocol instead of the OpenTofu-specific provider network
+  mirror protocol to allow you to reuse a pre-existing OCI registry service.
+
+  For more information, refer to [Provider Mirrors in OCI Registries](../oci_registries/provider-mirror.mdx).
 
 :::warning
 Don't configure `network_mirror` URLs that you do not trust.

--- a/website/docs/cli/oci_registries/credentials.mdx
+++ b/website/docs/cli/oci_registries/credentials.mdx
@@ -1,0 +1,129 @@
+---
+description: >-
+  Central configuration of credentials for use when interacting with OCI Registries.
+---
+
+# OCI Registry Credentials
+
+All of the OpenTofu features which interact with OCI Registries use a centralized mechanism
+for obtaining credentials to use when making requests.
+
+## Default Implicit Behavior
+
+By default, OpenTofu searches the following locations for "Docker-style" configuration files
+containing credentials, likely to have been issued by other software that interacts with
+OCI registries:
+
+- `$XDG_RUNTIME_DIR/containers/auth.json` (Linux only)
+- `$HOME/.config/containers/auth.json` (Windows and macOS only)
+- `$XDG_CONFIG_HOME/containers/auth.json` (`XDG_CONFIG_HOME` defaults to `$HOME/.config`)
+- `$HOME/.docker/config.json`
+- `$HOME/.dockercfg`
+
+In these files, OpenTofu expects to find configuration following the format specified
+in [`containers-auth.json`](https://github.com/containers/image/blob/22415d4f7ea9cd9ffbfc46bcf919137dabf0c3bb/docs/containers-auth.json.5.md).
+
+Although you can hand-write these configuration files, the more common way to populate them
+is to run the "login" command of some other OCI-integrated software, such as `docker login`,
+`oras login`, `buildah login`, `skopeo login`, etc. All of those commands write the resulting
+credentials into one of the file paths listed above.
+
+OpenTofu selects the credentials associated with the pattern that most specifically matches
+the target repository address. For example, when making a request to a repository at
+`example.com/foo/bar`, OpenTofu prefers to use credentials configured for `example.com/foo`
+over credentials configured just for `example.com`.
+
+When there are multiple matching credentials of equal precedence, files earlier in the
+list above take priority over files later in the list.
+
+You can customize some aspects of this implicit credentials discovery behavior as part of
+[Default Credentials Configuration](#default-credentials-configuration).
+
+## Explicit Credentials Configuration
+
+OpenTofu also allows direct configuration of OCI Registry credentials as part of
+[the CLI configuration file](../config/config-file.mdx), using `oci_credentials` blocks:
+
+```hcl
+oci_credentials "example.com" {
+  username = "example"
+  password = "example"
+}
+```
+
+The label of each `oci_credentials` block must be an OCI registry domain name followed
+by an optional repository path prefix. For example, `example.com` matches all repositories
+on that registry, while `example.com/foo` only matches repositories whose name starts
+with a "foo" path segment.
+
+The content of an `oci_credentials` block has three forms depending on the kind of
+credentials and how they are specified:
+
+- **Inline username and password:** Use `username` and `password` arguments to directly
+  specify credentials to use for authentication schemes like HTTP "Basic" authentication.
+
+    When you specify a password directly you must protect your CLI Configuration file
+    to avoid your secret password becoming compromised.
+
+- **Docker-style credential helper:** Use the `docker_credentials_helper` argument
+  to specify the name of a program implementing the
+  [Docker Credential Helper](https://github.com/docker/docker-credential-helpers)
+  protocol, which OpenTofu then launches to obtain credentials only when they are needed.
+
+    For example, if you work on macOS and install the `osxkeychain` credential helper
+    then you can specify `docker_credentials_helper = "osxkeychain"` to make OpenTofu
+    obtain credentials from your macOS Keychain.
+
+    OpenTofu currently uses credential helpers only on a read-only basis, so any needed
+    credentials must first be written into the underlying credential store using
+    other software that has been configured to write credentials through the same
+    credential helper.
+
+- **Inline OAuth credentials:** Use `access_token` and `refresh_token` arguments
+  to directly specify OAuth-style credentials.
+
+    When you specify an access token and refresh token directly you must protect
+    your CLI Configuration file to avoid your tokens becoming compromised.
+
+When multiple `oci_credentials` blocks are present, OpenTofu selects the one whose
+block label most closely matches the target repository.
+
+By default, OpenTofu uses explicit `oci_credentials` blocks in conjunction with
+any automatically-discovered Docker-style configuration files, taking the most
+specific match across all of these sources. If the same repository address prefix
+is specified both in an explicit `oci_credentials` block and in a Docker-style
+configuration file then the explicit configuration takes priority.
+
+## Default Credentials Configuration
+
+The optional `oci_default_credentials` block type can appear at most once in the
+CLI configuration. When present, it customizes the
+[default implicit search behavior](#default-implicit-behavior), or disables it
+entirely.
+
+The following arguments may appear in an `oci_default_credentials` block:
+
+- `discover_ambient_credentials`: Set this to `false` to completely disable all
+  of the implicit search behavior, in which case only
+  [explicit credentials configuration](#explicit-credentials-configuration)
+  can be used.
+
+    Defaults to `true`, which allows the implicit search behavior.
+
+- `docker_style_config_files`: A list of strings specifying filenames to treat
+  as Docker-style configuration files, instead of the default search locations.
+
+    Set `docker_style_config_files = []` to prevent searching for any Docker-style
+    configuration files while still allowing discovery of other "ambient"
+    credentials. Docker-style configuration files are currently the only
+    available ambient credentials mechanism and so this is equivalent to
+    `discover_ambient_credentials = false`, but that might change in future
+    versions of OpenTofu.
+
+- `docker_credentials_helper`: Directly specifies the name of a global
+  Docker-style credentials helper to use for all OCI repositories that are not
+  matched by a more specific credentials configuration.
+
+    For example, specify `docker_credentials_helper = "osxkeychain"` to make
+    OpenTofu obtain credentials from your macOS Keychain. You must install the
+    selected credential helper first so that OpenTofu can execute it.

--- a/website/docs/cli/oci_registries/index.mdx
+++ b/website/docs/cli/oci_registries/index.mdx
@@ -1,0 +1,43 @@
+---
+description: >-
+  OpenTofu features that integrate with registries implementing the OCI Distribution protocol.
+---
+
+# OCI Registry Integrations
+
+Some of OpenTofu's features can be configured to interact with OCI Registries.
+
+:::note
+This section contains very early draft content for features that are still in development.
+
+We've included it to support prerelease testing, but the information here may be incomplete and
+anything documented in this section is subject to change before the final release.
+:::
+
+## OCI Registry Credentials
+
+By default, OpenTofu searches for OCI Registry credentials in the same locations as other
+tools in the OCI ecosystem, such as Docker CLI, Podman, Buildah, ORAS, etc. If you have
+already logged in to the registry you intend to use with the login facility from one of
+these programs then OpenTofu should discover and use the configured credentials
+automatically.
+
+If you need more control over the behavior, refer to [OCI Registry Credentials](credentials.mdx).
+
+## OpenTofu Modules in OCI Registries
+
+OpenTofu does not yet support distributing modules from OCI Registries, but we are intending
+to add support for this prior to the final v1.10.0 release. More information will appear here
+in a later prerelease.
+
+## OpenTofu Providers in OCI Registries
+
+OpenTofu supports OCI Registries as a secondary installation source for provider plugin
+packages. You can configure OpenTofu to retrieve some or all providers from an OCI
+Registry instead of from each provider's primary OpenTofu Provider Registry.
+
+For more information, refer to [Provider Mirrors in OCI Registries](provider-mirror.mdx).
+
+OpenTofu does not yet support using an OCI Registry as the _primary_ installation source
+for a provider, but we are hoping to allow that in a future version.
+

--- a/website/docs/cli/oci_registries/provider-mirror.mdx
+++ b/website/docs/cli/oci_registries/provider-mirror.mdx
@@ -1,0 +1,310 @@
+---
+description: >-
+  Use OCI registries as an alternative installation source for OpenTofu providers
+---
+
+# Provider Mirrors in OCI Registries
+
+A "provider mirror" is a secondary location hosting a copy of a provider to be used instead
+of accessing the provider's primary OpenTofu Provider Registry. Creating a local mirror of some
+or all of the providers you use can reduce data transfer costs and can help with running
+OpenTofu in "air-gapped" environments that cannot access any services over the public internet.
+
+Alternative provider installation methods are configured as part of
+[the OpenTofu CLI Configuration](../config/config-file.mdx). You can configure installation
+from OCI Registries using an `oci_mirror` block as part of your
+[Explicit Installation Method Configuration](../config/config-file.mdx#explicit-installation-method-configuration).
+
+```hcl
+provider_installation {
+  oci_mirror {
+    repository_template = "example.com/opentofu-providers/${namespace}/${type}"
+    include             = ["registry.opentofu.org/*/*"]
+  }
+}
+```
+
+The above example specifies that any provider that belongs to the primary OpenTofu Registry
+should instead be installed from a repository in an OCI registry, constructing the
+repository address dynamically using the components of the provider source address.
+
+For example, the provider source address `hashicorp/tls` is a shorthand for
+`registry.opentofu.org/hashicorp/tls`, and so it matches the installation method rule
+configured above, with `hashicorp` as the "namespace" and `tls` as the "type".
+Therefore this configuration calls for the provider to be installed from the
+repository named `opentofu-providers/hashicorp/tls` in the OCI registry running at
+`example.com`.
+
+## `oci_mirror` installation method arguments
+
+- `repository_template`: A HCL-style template string that evaluates to an OCI repository
+  address to use for a given provider.
+
+    The following symbols are available for interpolation in the template:
+
+    - `hostname`: The hostname of the primary registry that the provider belongs to,
+      such as `registry.opentofu.org`.
+    - `namespace`: The namespace that the provider belongs to within its origin registry,
+      such as `hashicorp` in the above example.
+    - `type`: The provider's "type" name, which is the final portion of the source address
+      that's unique within a particular namespace, such as `tls` in the above example.
+
+    The template **must** include an interpolation for any component of the provider source
+    address that is not constrained exactly by the `include` argument. For example,
+    setting `include = ["registry.opentofu.org/*/*"]` constrains to exactly one hostname
+    but leaves the namespace and type wildcarded, and so the template must include
+    an interpolation of each of `namespace` and `type`, but does not need to use `hostname`.
+
+- `include` and `exclude`: Lists of provider source address patterns that together specify
+  what subset of providers are to be handled by this installation method, as described
+  in [Explicit Installation Method Configuration](../config/config-file.mdx#explicit-installation-method-configuration).
+
+## Required OCI Repository Content
+
+The OCI repository selected by `repository_template` must contain content following a
+specific structure that allows OpenTofu to recognize the metadata for all of the
+available provider versions and their associated distribution packages.
+
+### Tag Names
+
+OpenTofu begins by listing all of the tags in the repository. A valid tag name must
+be a version number formatted using the syntax of
+[Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html), except that
+the tag name must use the underscore character (`_`) instead of the plus
+character (`+`) to delimit the optional "build metadata" portion.
+
+OpenTofu ignores all tags that cannot be parsed as version numbers, and then selects
+the greatest available version that matches all of the version constraints for this
+provider specified across all modules in the current OpenTofu configuration.
+
+### Manifest Structure
+
+OpenTofu providers use separate distribution packages for each supported operating
+system and CPU architecture, and so each tag in an OCI repository used as an
+OpenTofu provider mirror must refer to an [Image Index](https://github.com/opencontainers/image-spec/blob/v1.1.1/image-index.md)
+manifest that lists a separate manifest for each platform the provider has been
+compiled for.
+
+The index manifest **must** have its `artifactType` property set to
+`application/vnd.opentofu.provider` so that OpenTofu can recognize is as a
+representing a provider release.
+
+OpenTofu then searches the `manifests` array for a manifest descriptor
+whose `artifactType` is `application/vnd.opentofu.provider-target`
+and whose `platform` property matches the operating system and architecture
+that OpenTofu itself was compiled for.
+
+The selected descriptor is then used to retrieve an [Image Manifest](https://github.com/opencontainers/image-spec/blob/v1.1.1/manifest.md)
+representing the files and metadata needed to install the selected provider
+version for the current platform. This manifest must again have
+its `artifactType` set to `application/vnd.opentofu.provider-target`, to
+match the descriptor used to retrieve it.
+
+The image manifest's `layers` array must include exactly one descriptor
+whose `mediaType` is `archive/zip`, referring to a blob containing exactly
+the same `.zip` package that would be returned for the same version of
+the provider on the same platform if installed from the provider's origin
+registry.
+
+OpenTofu than finally retrieves the indicated blob and extracts the `.zip`
+archive into the provider cache directory so that it's available for use
+by subsequent workflow commands like [`tofu apply`](../commands/apply.mdx).
+
+## Assembling and Pushing Provider Manifests
+
+:::note
+This section currently describes a very manual process for constructing the
+required manifest structure as described in the previous section.
+
+We intend to replace this with a more automated approach in a later OpenTofu
+release, but hope that the following will suffice for now to allow early
+experimentation with OCI Registry provider mirrors in the OpenTofu v1.10 prereleases.
+:::
+
+### Install and Configure ORAS
+
+We recommend assembling and pushing the manifests and blobs for a provider
+using the CLI tool offered by [the ORAS project](https://oras.land/).
+At the time of writing, multi-platform index support is not yet finalized
+in ORAS and so unfortunately the index manifest must be constructed manually.
+
+If you are installing and using ORAS for the first time, and you intend to
+push to an OCI registry that requires authentication, you will need to first
+obtain credentials for that repository using [`oras login`](https://oras.land/docs/commands/oras_login).
+
+### Local OCI Image Layout
+
+The process of assembling OpenTofu provider manifests with ORAS requires
+multiple steps, and so we recommend pushing the various artifacts first
+to a local filesystem directory -- known as an
+[OCI Image Layout](https://github.com/opencontainers/image-spec/blob/v1.1.1/image-layout.md) --
+and then pushing the resulting objects all at once to your target repository,
+to avoid making the intermediate steps visible to other users of the
+remote repository.
+
+The command line examples in the following sections use the ORAS option
+`--oci-layout` to specify that the target of each operation is a local
+filesystem directory called `tmp-layout`, in the current working directory.
+You can change the name `tmp-layout` to whatever path you wish, as long
+as you use a consistent pathname across all of the commands.
+
+### Single-platform Image Manifests
+
+The top-level index manifest will eventually refer to the manifests for
+each of the platform-specific artifacts, and so the platform-specific
+artifacts must be pushed first in order to construct their manifests
+and determine the digests used to refer to them.
+
+First you must obtain the official `.zip` distribution packages for
+the provider you are intending to re-publish. For providers in the
+official OpenTofu Registry you can find a link to the provider's
+GitHub repository and retrieve the `.zip` artifacts from one of its
+releases.
+
+For example, to prepare to re-package the `hashicorp/tls` provider:
+
+1. Access [the `hashicorp/tls` provider's registry index page](https://search.opentofu.org/provider/hashicorp/tls/latest).
+2. Follow the "Repository" link in the navigation bar to [the provider's GitHub repository](https://github.com/opentofu/terraform-provider-tls).
+3. Find the "Releases" heading in the repository's own navigation bar and select the latest release, such which at the time of writing was [v4.0.6](https://github.com/opentofu/terraform-provider-tls/releases/tag/v4.0.6).
+4. Download the `.zip` assets for each platform you intend to include in your mirror into a new, empty directory on your local computer.
+
+After switching to that directory in your shell, you should be able to list all of the packages you downloaded:
+
+```shellsession
+$ ls -1
+terraform-provider-tls_4.0.6_darwin_amd64.zip
+terraform-provider-tls_4.0.6_linux_386.zip
+terraform-provider-tls_4.0.6_linux_amd64.zip
+terraform-provider-tls_4.0.6_linux_arm.zip
+terraform-provider-tls_4.0.6_linux_arm64.zip
+terraform-provider-tls_4.0.6_windows_386.zip
+terraform-provider-tls_4.0.6_windows_amd64.zip
+terraform-provider-tls_4.0.6_windows_arm.zip
+terraform-provider-tls_4.0.6_windows_arm64.zip
+```
+
+Use `oras push` for each package in turn to copy the `.zip` archive into your local OCI Image Layout and generate its manifest:
+
+```shellsession
+$ oras push \
+    --artifact-type application/vnd.opentofu.provider-target \
+    --artifact-platform linux/amd64 \
+    --oci-layout tmp-layout:linux_amd64 \
+    terraform-provider-tls_4.0.6_linux_amd64.zip:archive/zip
+
+✓ Uploaded  terraform-provider-tls_4.0.6_linux_amd64.zip
+  └─ sha256:5f12d51fa9e87b6d29275fa58d1cd8681c0177a1d3a71a4e6c78ad7b011fa065
+✓ Uploaded  application/vnd.oci.image.config.v1+json
+  └─ sha256:9d99a75171aea000c711b34c0e5e3f28d3d537dd99d110eafbfbc2bd8e52c2bf
+✓ Uploaded  application/vnd.oci.image.manifest.v1+json
+  └─ sha256:01d3ccf9747dd604ebaa314efbacf12e18a248f8bf1c783f5cbb220754954e67
+Pushed [oci-layout] tmp-layout:linux_amd64
+ArtifactType: application/vnd.opentofu.provider-target
+Digest: sha256:01d3ccf9747dd604ebaa314efbacf12e18a248f8bf1c783f5cbb220754954e67
+```
+
+The `Digest` returned at the end of the output is the identifier for the platform-specific manifest.
+The digest in the above example is a placeholder; your result will vary for each distinct
+provider package.
+
+Repeat the above command for each combination of operating system and CPU architecture
+that you want to include in your mirror distribution. Once you've pushed all of the
+packages you want to include, you can confirm all of the platform-specific tags you've
+created:
+
+```shellsession
+$ oras repo tags --oci-layout tmp-layout
+darwin_amd64
+linux_386
+linux_amd64
+linux_arm
+linux_arm64
+windows_386
+windows_amd64
+windows_arm
+windows_arm64
+```
+
+### Multi-platform Index Manifest
+
+The current stable release of ORAS cannot construct and push an index manifest
+directly, but the "OCI Image Layout" that you constructed in the previous step
+includes its own index manifest that can be adapted to make it suitable for
+pushing to a remote repository.
+
+First, copy the Image Layout's index file to another file so that you can edit
+it without damaging the Image Layout directory:
+
+```shellsession
+$ cp tmp-layout/index.json terraform-provider-tls_4.0.6.json
+```
+
+Open the new `terraform-provider-tls_4.0.6.json` file in your favorite text
+editor. The JSON document is likely to be "minified", so you may wish to ask
+your text editor to reformat it for readability before continuing.
+
+The file should include a JSON property `"mediaType" : "application/vnd.oci.image.index.v1+json"`
+representing that this is an OCI Index Manifest. After that property, add a new
+JSON property `"artifactType":"application/vnd.opentofu.provider"` to represent
+that this is an index for an OpenTofu provider artifact.
+
+You can then push this new index manifest into the OCI layout, along with all
+of the single-platform artifacts pushed in the previous section:
+
+```shellsession
+$ oras manifest push --oci-layout tmp-layout:4.0.6 terraform-provider-tls_4.0.6.json 
+Uploading da13ebaa32ba application/vnd.oci.image.index.v1+json
+Uploaded  da13ebaa32ba application/vnd.oci.image.index.v1+json
+Pushed: [oci-layout] tmp-layout:4.0.6
+Digest: sha256:da13ebaa32ba856d75da18e38daabc7a65ac8853230dfcc817f8ccbac15b639a
+```
+
+Notice that the provider version 4.0.6 appears twice in this command line. The
+first is the name of the tag to create in the OCI layout, while the second is
+part of the filename of the index manifest saved in the previous step.
+
+The OCI Image Layout now contains individual tags for the platform-specific
+arfacts and also a version number tag representing the index manifest:
+
+```shellsession
+$ oras repo tags --oci-layout tmp-layout
+4.0.6
+darwin_amd64
+linux_386
+linux_amd64
+linux_arm
+linux_arm64
+windows_386
+windows_amd64
+windows_arm
+windows_arm64
+```
+
+### Push the Artifacts to a Remote Repository
+
+The local image layout now contains all of the information required to push
+this provider release to a remote repository.
+
+```shellsession
+$ oras cp \
+   --from-oci-layout tmp-layout:4.0.6 \
+   example.com/opentofu-providers/hashicorp/tls:4.0.6
+
+✓ Copied  terraform-provider-tls_4.0.6_linux_amd64.zip
+  └─ sha256:5f12d51fa9e87b6d29275fa58d1cd8681c0177a1d3a71a4e6c78ad7b011fa065
+[...]
+✓ Copied  application/vnd.oci.image.config.v1+json
+  └─ sha256:9d99a75171aea000c711b34c0e5e3f28d3d537dd99d110eafbfbc2bd8e52c2bf
+✓ Copied  application/vnd.oci.image.manifest.v1+json
+  └─ sha256:01d3ccf9747dd604ebaa314efbacf12e18a248f8bf1c783f5cbb220754954e67
+✓ Copied  application/vnd.oci.image.index.v1+json
+  └─ sha256:da13ebaa32ba856d75da18e38daabc7a65ac8853230dfcc817f8ccbac15b639a
+Copied [oci-layout] tmp-layout:4.0.6 => [registry] example.com/opentofu-providers/hashicorp/tls:4.0.6
+Digest: sha256:da13ebaa32ba856d75da18e38daabc7a65ac8853230dfcc817f8ccbac15b639a
+```
+
+ORAS copies everything that the local 4.0.6 tag refers to into the remote registry,
+and then creates a remote tag 4.0.6 referring to the same content.
+
+This provider is now available for use using an `oci_mirror` installation
+block configured as in the example at the start of this page.


### PR DESCRIPTION
This is part of https://github.com/opentofu/opentofu/issues/2540.

This is a kinda-scrappy first pass at the OCI-registry-related docs intended to be sufficient just for the forthcoming alpha release.

I expect we'll revise this before final, but this is intended just to help folks who want to try out the early form of these features during our prereleases.

I decided to group together all of the OCI-Registry-related documentation content into a new section since I expect that anyone who is invested in using these features is likely to want to use all or most of them. This also minimizes the amount of new content added to the already-very-crowded "CLI Configuration" documentation page, with it just mentioning the new headline stuff and then linking to the new documentation section for all of the details.

---

I expect we'll now probably decide to cut the alpha before we reach the end of the second milestone in https://github.com/opentofu/opentofu/issues/2540, since we want to get some other things out in prerelease sooner rather than later, so I've added this feature's overall CHANGELOG entry as part of this PR too, to make sure _something_ ends up in there before we cut the alpha release. We might choose to rewrite this changelog entry this once we get closer to finished with the overall OCI registry work, but this should do for now.
