### PR TITLE
getproviders: Don't require artifactType on OCI layers for providers

### DIFF
--- a/internal/getproviders/oci_registry_mirror_source.go
+++ b/internal/getproviders/oci_registry_mirror_source.go
@@ -583,9 +583,6 @@ func selectOCILayerBlob(descs []ociv1.Descriptor) (ociv1.Descriptor, error) {
 	foundWrongMediaTypeBlobs := 0
 	var selected ociv1.Descriptor
 	for _, desc := range descs {
-		if desc.ArtifactType != ociPackageArtifactType {
-			continue
-		}
 		if desc.MediaType != ociPackageMediaType {
 			// We silently ignore any "layer" that doesn't have both our expected
 			// artifact type and media type so that future versions of OpenTofu
@@ -601,9 +598,9 @@ func selectOCILayerBlob(descs []ociv1.Descriptor) (ociv1.Descriptor, error) {
 	}
 	if foundBlobs == 0 {
 		if foundWrongMediaTypeBlobs > 0 {
-			return selected, fmt.Errorf("image manifest contains no %q layers of type %q, but has other unsupported formats; this OCI artifact might be intended for a different version of OpenTofu", ociPackageArtifactType, ociPackageMediaType)
+			return selected, fmt.Errorf("image manifest contains no layers of type %q, but has other unsupported formats; this OCI artifact might be intended for a different version of OpenTofu", ociPackageMediaType)
 		}
-		return selected, fmt.Errorf("image manifest contains no %q layers of type %q", ociPackageArtifactType, ociPackageMediaType)
+		return selected, fmt.Errorf("image manifest contains no layers of type %q", ociPackageMediaType)
 	}
 	if foundBlobs > 1 {
 		// There must be exactly one eligible blob, to avoid ambiguity.

--- a/internal/getproviders/oci_registry_mirror_source_test.go
+++ b/internal/getproviders/oci_registry_mirror_source_test.go
@@ -57,7 +57,7 @@ func TestOCIRegistryMirrorSource(t *testing.T) {
 			// version/platform combination so that once installation is complete
 			// we can check that we actually installed the correct one.
 			fakePackageBytes := makePlaceholderProviderPackageZip(t, fmt.Sprintf("placeholder executable for v%s on %s", version, platform))
-			packageDesc := pushOCIBlob(t, "archive/zip", "application/vnd.opentofu.providerpkg", fakePackageBytes, store)
+			packageDesc := pushOCIBlob(t, "archive/zip", "", fakePackageBytes, store)
 			manifestDesc := pushOCIImageManifest(t, &ociv1.Manifest{
 				Versioned:    ociSpecs.Versioned{SchemaVersion: 2},
 				MediaType:    ociv1.MediaTypeImageManifest,
@@ -312,7 +312,7 @@ func TestOCIRegistryMirrorSource(t *testing.T) {
 		if err == nil {
 			t.Fatal("unexpected success; want error")
 		}
-		if got, want := err.Error(), `image manifest contains no "application/vnd.opentofu.providerpkg" layers of type "archive/zip", but has other unsupported formats; this OCI artifact might be intended for a different version of OpenTofu`; got != want {
+		if got, want := err.Error(), `image manifest contains no layers of type "archive/zip", but has other unsupported formats; this OCI artifact might be intended for a different version of OpenTofu`; got != want {
 			t.Errorf("wrong error\ngot:  %s\nwant: %s", got, want)
 		}
 	})
@@ -469,7 +469,6 @@ func makeFakeOCIRepositoryWithNonProviderContent(t *testing.T) (OCIRepositorySto
 	{
 		// a manifest for a single provider package lacking the required index manifest
 		archiveDesc := blobDesc // shallow copy
-		archiveDesc.ArtifactType = ociPackageArtifactType
 		archiveDesc.MediaType = ociPackageMediaType
 		manifestDesc := pushOCIImageManifest(t, &ociv1.Manifest{
 			Versioned:    ociSpecs.Versioned{SchemaVersion: 2},
@@ -486,7 +485,6 @@ func makeFakeOCIRepositoryWithNonProviderContent(t *testing.T) (OCIRepositorySto
 		// a manifest for a provider that is valid except for using an as-yet-unsupported
 		// archive format for the leaf provider package.
 		archiveDesc := blobDesc                                // shallow copy
-		archiveDesc.ArtifactType = ociPackageArtifactType      // correct artifact type
 		archiveDesc.MediaType = "application/x-lzh-compressed" // unsupported media type
 		manifestDesc := pushOCIImageManifest(t, &ociv1.Manifest{
 			Versioned:    ociSpecs.Versioned{SchemaVersion: 2},

--- a/internal/getproviders/package_location_oci_blob_archive.go
+++ b/internal/getproviders/package_location_oci_blob_archive.go
@@ -19,17 +19,6 @@ import (
 	orasContent "oras.land/oras-go/v2/content"
 )
 
-// ociPackageArtifactType is the specific artifact type we're expecting for the
-// blob representing a final distribution package that we'll fetch and extract, after
-// we've dug through all of the manifests.
-//
-// We silently ignore blobs that don't have this artifact type both so that future
-// OpenTofu versions can potentially introduce new blobs with different purposes and
-// so that a manifest can have other blobs listed in it for purposes that are
-// irrelevant to OpenTofu's interests, in case that becomes useful in the broader
-// OCI ecosystem.
-const ociPackageArtifactType = "application/vnd.opentofu.providerpkg"
-
 // ociPackageMediaType is the specific media type we're expecting for the blob
 // representing a final distribution package that we'll fetch and extract, after
 // we've dug through all of the manifests.
@@ -273,16 +262,6 @@ func hashFromOCIDigest(digest ociDigest.Digest) (Hash, error) {
 }
 
 func checkOCIBlobDescriptor(desc ociv1.Descriptor, meta PackageMeta) error {
-	if desc.ArtifactType != ociPackageArtifactType {
-		if desc.ArtifactType == "application/vnd.opentofu.modulepkg" {
-			// Seems like someone has tried to use a module package where a
-			// provider package was expected. Confusion beween modules and
-			// providers is common for those new to OpenTofu, so we'll
-			// use a more specific diagnosis for this.
-			return fmt.Errorf("selected OCI artifact is a module package rather than a provider package")
-		}
-		return fmt.Errorf("selected OCI artifact has unexpected type %q", desc.ArtifactType)
-	}
 	if desc.MediaType != ociPackageMediaType {
 		return fmt.Errorf("selected OCI artifact manifest has unexpected media type %q", desc.MediaType)
 	}

--- a/internal/getproviders/package_location_oci_blob_archive_test.go
+++ b/internal/getproviders/package_location_oci_blob_archive_test.go
@@ -38,7 +38,7 @@ func TestPackageOCIBlobArchive(t *testing.T) {
 	// buffer here because we need to calculate a checksum for it in order
 	// to "push" it into the store.
 	blobBytes := makePlaceholderProviderPackageZip(t, "not a real executable; just a placeholder")
-	desc := pushOCIBlob(t, "archive/zip", "application/vnd.opentofu.providerpkg", blobBytes, store)
+	desc := pushOCIBlob(t, "archive/zip", "", blobBytes, store)
 
 	t.Run("happy path", func(t *testing.T) {
 		// The in-memory OCI repository contains just the blob represented
@@ -123,36 +123,6 @@ func TestPackageOCIBlobArchive(t *testing.T) {
 		targetDir := t.TempDir()
 		_, err := loc.InstallProviderPackage(t.Context(), meta, targetDir, nil)
 		const wantErrSubstr = `selected OCI artifact manifest has unexpected media type "application/x-lzh-compressed"`
-		if err == nil {
-			t.Fatalf("unexpected success\nwant error containing: %s", wantErrSubstr)
-		}
-		if gotErr := err.Error(); !strings.Contains(gotErr, wantErrSubstr) {
-			t.Fatalf("wrong error\ngot: %s\nwant substring: %s", gotErr, wantErrSubstr)
-		}
-		// The unsupported format should've been detected before actually
-		// extracting the package. (The blob we provided was actually a
-		// zip archive despite the incorrect media type, so it could
-		// potentially still be extracted despite the media type problem.
-		if diff := diffDirEmpty(t, targetDir); diff != "" {
-			t.Error("unexpected content in target directory\n" + diff)
-		}
-	})
-	t.Run("unsupported artifact type", func(t *testing.T) {
-		wrongDesc := desc                                             // shallow copy
-		wrongDesc.ArtifactType = "application/vnd.opentofu.modulepkg" // a module package instead of a provider package
-		loc := PackageOCIBlobArchive{
-			repoStore:      store,
-			blobDescriptor: wrongDesc,
-		}
-		meta := PackageMeta{
-			Provider:       addrs.NewBuiltInProvider("foo"),
-			Version:        versions.MustParseVersion("1.0.0"),
-			TargetPlatform: CurrentPlatform,
-			Location:       loc,
-		}
-		targetDir := t.TempDir()
-		_, err := loc.InstallProviderPackage(t.Context(), meta, targetDir, nil)
-		const wantErrSubstr = `selected OCI artifact is a module package rather than a provider package`
 		if err == nil {
 			t.Fatalf("unexpected success\nwant error containing: %s", wantErrSubstr)
 		}

--- a/website/docs/cli/oci_registries/provider-mirror.mdx
+++ b/website/docs/cli/oci_registries/provider-mirror.mdx
@@ -248,6 +248,28 @@ representing that this is an OCI Index Manifest. After that property, add a new
 JSON property `"artifactType":"application/vnd.opentofu.provider"` to represent
 that this is an index for an OpenTofu provider artifact.
 
+The file also includes a `"manifests"` property that describes each of the
+platform-specific manifests previously created. Each of these descriptor
+objects must contain a `"platform"` property specifying the platform that
+the manifest is for. For example:
+
+```json
+{
+  "artifactType": "application/vnd.opentofu.provider-target",
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "digest": "sha256:01d3ccf9747dd604ebaa314efbacf12e18a248f8bf1c783f5cbb220754954e67",
+  "size": 606,
+  "platform": {
+    "os": "linux",
+    "architecture": "amd64"
+  }
+}
+```
+
+Make sure that each of the manifest descriptors includes a `"platform"` property
+specifying the correct operating system and CPU architecture for the associated
+manifest.
+
 You can then push this new index manifest into the OCI layout, along with all
 of the single-platform artifacts pushed in the previous section:
 


### PR DESCRIPTION
(This is part of https://github.com/opentofu/opentofu/issues/2540.)

The initial design of this attempted to maximize our flexibility to make backward-compatible changes to the manifest structure for providers in future OpenTofu releases, by expecting the `layers` entry describing the provider package to include a specific `artifactType` and ignoring any layers with different `artifactType` values.

However, general-purpose tools for constructing image manifests don't tend to allow setting the `artifactType` in a layer descriptor, so we'll drop that requirement as a measure of pragmatism.

This implies that the only possible extension we could make for _layers in particular_ in a future release is to support an additional archive format that would presumably then be used in much the same way as our current `archive/zip` usage: by extracting the archive into the target directory. This ability to introduce new archive formats is the most likely future evolution we identified while designing this, with all other evolutions being more speculative/theoretical.

This does still retain various other extension points for future additions, including but not limited to:
- Introducing an alternative `artifactType` for the image manifest _itself_, rather than for the layers within it, and then having the later version of OpenTofu prefer to choose a manifest with the newer `artifactType` while still supporting the old one as a fallback.
- Using the `config` property of the manifest to introduce arbitrary additional metadata that future versions might need, and using the config descriptor's own mediaType to recognize when those new additions are present.
- Using OpenTofu-specific "annotations" in either the index or image manifests to represent additional metadata.

Therefore this seems like a reasonable compromise to make it easier to assemble OCI manifests for OpenTofu provider packages using general-purpose tools like ORAS CLI, rather than requiring OpenTofu-specific tools.

This change does not invalidate any previously-valid manifests we might've used for testing already. It just loosens the requirements so that _more_ manifests are now considered valid. (Specifically: any image manifest with the appropriate `artifactType` and exactly one layer that has `mediaType` set to `archive/zip` is now valid.)

(Note also that while this PR removes a test for a situation that would previously have generated a tailored error message about selecting an OpenTofu module artifact instead of a provider artifact during final package installation, in practice that error message was only accessible for very-improperly-constructed manifests anyway, since there's an equivalent check against the top-level manifest -- rather than the for the `.zip` archive blob itself -- which would still catch and report the same problem before we even try to retrieve the `.zip` file.)

---

I also included a small addition to the previously-drafted documentation in this PR. The `getproviders` behavior that this PR removed was previously blocking me from fully verifying the last step of these instructions and so I missed this while I was drafting the docs.

The current last section of the docs where we discuss manually constructing an index manifest is intended to be _very temporary_, since the ORAS project is apparently planning to include a new command for this in their forthcoming v1.3.0 release and so we intend to replace this pretty-onerous final step with just one more ORAS CLI command once that functionality is settled.

I've now verified that following the modified version of the instructions produces an artifact that OpenTofu will accept, when installed using the `getproviders` changes from this PR.
