### PR TITLE
PROTOTYPE: Recommend -exclude=... when a provider can't plan for a resource instance due to unknown values

### DIFF
--- a/internal/plugin/convert/deferral.go
+++ b/internal/plugin/convert/deferral.go
@@ -1,0 +1,19 @@
+package convert
+
+import (
+	"github.com/opentofu/opentofu/internal/providers"
+	"github.com/opentofu/opentofu/internal/tfplugin5"
+)
+
+func DeferralReasonFromProto(reason tfplugin5.Deferred_Reason) providers.DeferralReason {
+	switch reason {
+	case tfplugin5.Deferred_RESOURCE_CONFIG_UNKNOWN:
+		return providers.DeferredBecauseResourceConfigUnknown
+	case tfplugin5.Deferred_PROVIDER_CONFIG_UNKNOWN:
+		return providers.DeferredBecauseProviderConfigUnknown
+	case tfplugin5.Deferred_ABSENT_PREREQ:
+		return providers.DeferredBecausePrereqAbsent
+	default:
+		return providers.DeferredReasonUnknown
+	}
+}

--- a/internal/plugin6/convert/deferral.go
+++ b/internal/plugin6/convert/deferral.go
@@ -1,0 +1,19 @@
+package convert
+
+import (
+	"github.com/opentofu/opentofu/internal/providers"
+	"github.com/opentofu/opentofu/internal/tfplugin6"
+)
+
+func DeferralReasonFromProto(reason tfplugin6.Deferred_Reason) providers.DeferralReason {
+	switch reason {
+	case tfplugin6.Deferred_RESOURCE_CONFIG_UNKNOWN:
+		return providers.DeferredBecauseResourceConfigUnknown
+	case tfplugin6.Deferred_PROVIDER_CONFIG_UNKNOWN:
+		return providers.DeferredBecauseProviderConfigUnknown
+	case tfplugin6.Deferred_ABSENT_PREREQ:
+		return providers.DeferredBecausePrereqAbsent
+	default:
+		return providers.DeferredReasonUnknown
+	}
+}

--- a/internal/providers/deferral.go
+++ b/internal/providers/deferral.go
@@ -1,0 +1,121 @@
+package providers
+
+import (
+	"github.com/opentofu/opentofu/internal/tfdiags"
+)
+
+// DeferralReason is an enumeration of the different reasons a provider might
+// return when reporting why it is unable to perform a requested action with
+// the currently-available context.
+type DeferralReason int
+
+const (
+	// DeferredReasonUnknown is the zero value of DeferralReason, used when
+	// a provider returns an unsupported deferral reason.
+	DeferredReasonUnknown DeferralReason = 0
+
+	// DeferredBecauseResourceConfigUnknown indicates that the request cannot
+	// be completed because of unknown values in the resource configuration.
+	DeferredBecauseResourceConfigUnknown DeferralReason = 1
+
+	// DeferredBecauseProviderConfigUnknown indicates that the request cannot
+	// be completed because of unknown values in the provider configuration.
+	DeferredBecauseProviderConfigUnknown DeferralReason = 2
+
+	// DeferredBecausePrereqAbsent indicates that the request cannot be
+	// completed because a hard dependency has not been satisfied.
+	DeferredBecausePrereqAbsent DeferralReason = 3
+)
+
+// NewDeferralDiagnostic returns a contextual error diagnostic reporting that
+// an operation cannot be completed for the given deferral reason.
+//
+// The returned diagnostic will cause [IsDeferralDiagnostic] to return true,
+// so that callers can optionally annotate the diagnostic with suggestions
+// for how to skip the affected request so that other unaffected requests can
+// still be completed.
+func NewDeferralDiagnostic(reason DeferralReason) tfdiags.Diagnostic {
+	var summary, detail string
+	switch reason {
+	case DeferredBecauseResourceConfigUnknown:
+		summary = "Resource configuration is incomplete"
+		detail = "The provider was unable to act on this resource configuration because it makes use of values from other resources that will not be known until after apply."
+	case DeferredBecauseProviderConfigUnknown:
+		summary = "Provider configuration is incomplete"
+		detail = "The provider was unable to work with this resource because the associated provider configuration makes use of values from other resources that will not be known until after apply."
+	default:
+		// This is the most general (and therefore least helpful) message, which
+		// we'll return if the provider produces a reason that we don't know about
+		// yet, such as one added in a later protocol version. This fallback
+		// is very much a last resort.
+		// (Note that this also currently handles DeferredBecausePrereqAbsent,
+		// because there are not yet any known examples of providers using that
+		// reason and so we don't yet know what it will turn out to mean in
+		// practice. If it becomes used in more providers in future then we can
+		// hopefully devise a better message that describes what those providers
+		// use it to mean.)
+		summary = "Operation cannot be completed yet"
+		detail = "The provider reported that it is not able to perform the requested operation until more information is available."
+	}
+
+	// We start with a "whole-body" contextual diagnostic, so that the caller
+	// can elaborate this with any configuration body whose presence caused
+	// the request to be made and thus add useful source location information
+	// that we cannot determine at the provider layer.
+	contextual := tfdiags.WholeContainingBody(tfdiags.Error, summary, detail)
+
+	// We then further wrap that contextual diagnostic in an override so that
+	// we can annotate it with the "extra info" that IsDeferralDiagnostic
+	// will use to recognize diagnostics returned from this function.
+	return tfdiags.Override(contextual, tfdiags.Error, func() tfdiags.DiagnosticExtraWrapper {
+		return &deferralDiagnosticExtraImpl{reason: reason}
+	})
+}
+
+// IsDeferralDiagnostic returns true if the given diagnostic was constructed
+// with NewDeferralDiagnostic, meaning that it describes a situation where a
+// provider reported that it is not yet able to complete an operation with the
+// currently-available context.
+func IsDeferralDiagnostic(diag tfdiags.Diagnostic) bool {
+	// NOTE: We're intentionally not actually exposing the deferral reason
+	// in the first incarnation of this functionality because the associated
+	// plugin protocol feature is not yet well-deployed and so we're trying
+	// to keep our use of it as confined to the provider-related packages
+	// as possible in case ongoing protocol evolution causes us to need to
+	// revise this in a later version. However, once the underlying protocol
+	// has settled it would be reasonable to actually expose the reason
+	// so that callers can substitute more contextually-relevant versions of
+	// the error diagnostics when appropriate, or indeed choose to handle
+	// this situation in a way that doesn't return an error to the user at all.
+	extra := tfdiags.ExtraInfo[deferralDiagnosticExtra](diag)
+	return extra != nil
+}
+
+type deferralDiagnosticExtra interface {
+	deferralReason() DeferralReason
+}
+
+// deferralDiagnosticExtraImpl is an indirection used to combine
+// deferralDiagnosticExtra with tfdiags.DiagnosticExtraWrapper because the
+// design of tfdiags.Override unfortunately exposes its implementation
+// detail of possibly needing to preserve an existing "extra info"
+// as part of its public API.
+//
+// (Maybe we can improve tfdiags.Override to encapsulate this better in
+// future, so that the type representing the union of two "extra info"
+// values can be an unexported struct within package tfdiags, but
+// this API is already being used elsewhere and so is risky to change.)
+type deferralDiagnosticExtraImpl struct {
+	reason  DeferralReason
+	wrapped any
+}
+
+// WrapDiagnosticExtra implements deferralDiagnosticExtra.
+func (d *deferralDiagnosticExtraImpl) deferralReason() DeferralReason {
+	return d.reason
+}
+
+// WrapDiagnosticExtra implements tfdiags.DiagnosticExtraWrapper.
+func (d *deferralDiagnosticExtraImpl) WrapDiagnosticExtra(inner any) {
+	d.wrapped = inner
+}

--- a/internal/tfdiags/override.go
+++ b/internal/tfdiags/override.go
@@ -5,6 +5,10 @@
 
 package tfdiags
 
+import (
+	"github.com/hashicorp/hcl/v2"
+)
+
 // overriddenDiagnostic implements the Diagnostic interface by wrapping another
 // Diagnostic while overriding the severity of the original Diagnostic.
 type overriddenDiagnostic struct {
@@ -14,6 +18,7 @@ type overriddenDiagnostic struct {
 }
 
 var _ Diagnostic = overriddenDiagnostic{}
+var _ contextualFromConfigBody = overriddenDiagnostic{}
 
 // OverrideAll accepts a set of Diagnostics and wraps them with a new severity
 // and, optionally, a new ExtraInfo.
@@ -74,4 +79,25 @@ func (o overriddenDiagnostic) FromExpr() *FromExpr {
 
 func (o overriddenDiagnostic) ExtraInfo() interface{} {
 	return o.extra
+}
+
+// ElaborateFromConfigBody implements contextualFromConfigBody.
+//
+// If the original diagnostic also implements contextualFromConfigBody then this
+// delegates to its own ElaborateFromConfigBody implementation and then re-wraps
+// the result with the same overrides.
+//
+// Otherwise, the reciever is returned unchanged.
+func (o overriddenDiagnostic) ElaborateFromConfigBody(body hcl.Body, addr string) Diagnostic {
+	innerContextual, ok := o.original.(contextualFromConfigBody)
+	if !ok {
+		return o // inner diagnostic is not contextual, so nothing to do
+	}
+
+	newOriginal := innerContextual.ElaborateFromConfigBody(body, addr)
+	return overriddenDiagnostic{
+		original: newOriginal,
+		severity: o.severity,
+		extra:    o.extra,
+	}
 }

--- a/internal/tofu/node_resource_abstract_instance.go
+++ b/internal/tofu/node_resource_abstract_instance.go
@@ -2776,3 +2776,60 @@ func (n *NodeAbstractResourceInstance) getProvider(ctx EvalContext) (providers.I
 
 	return provider, schema, nil
 }
+
+func maybeImproveResourceInstanceDiagnostics(diags tfdiags.Diagnostics, excludeAddr addrs.Targetable) tfdiags.Diagnostics {
+	// We defer allocating a new diagnostics array until we know we need to
+	// change something, because most of the time we'll just be returning
+	// the given diagnostics verbatim.
+	var ret tfdiags.Diagnostics
+	for i, diag := range diags {
+		if excludeAddr != nil && providers.IsDeferralDiagnostic(diag) {
+			// We've found a diagnostic we want to change, so we'll allocate
+			// a new diagnostics array if we didn't already.
+			if ret == nil {
+				ret = make(tfdiags.Diagnostics, len(diags))
+				copy(ret, diags)
+			}
+			// FIXME: The following is a hack to slightly modify the diagnostic
+			// with an extra paragraph of detail content. If we decide we want
+			// to actually ship this special hint then we should find a less
+			// clunky way to do this, probably with a new feature in tfdiags.
+			desc := diag.Description()
+			src := diag.Source()
+			extraDetail := fmt.Sprintf(
+				// FIXME: This should use a technique similar to evalchecks.commandLineArgumentsSuggestion
+				// to generate appropriate quoting/escaping of the address for the current platform.
+				"\n\nTo work around this, use the planning option -exclude=%q to first apply without this object, and then apply normally to converge.",
+				excludeAddr.String(),
+			)
+			newDiag := &hcl.Diagnostic{
+				Severity: diag.Severity().ToHCL(),
+				Summary:  desc.Summary,
+				Detail:   desc.Detail + extraDetail,
+			}
+			if src.Subject != nil {
+				newDiag.Subject = src.Subject.ToHCL().Ptr()
+			}
+			if src.Context != nil {
+				newDiag.Context = src.Context.ToHCL().Ptr()
+			}
+			// The following is a little awkward because of how tfdiags is
+			// designed: we need to "append" a new diagnostic over the
+			// one we're trying to replace so that tfdiags has an opportunity
+			// to transform it, so we'll make a zero-length slice whose
+			// capacity covers the one element we're trying to replace.
+			appendTo := ret[i : i : i+1]
+			appendTo = appendTo.Append(newDiag)
+			// appendTo.Append isn't _actually_ required to use the
+			// capacity we gave it (that's an implementation detail)
+			// so just to make sure we'll copy from what was returned
+			// into the final slot. This is likely to be a no-op in most
+			// cases.
+			ret[i] = appendTo[0]
+		}
+	}
+	if ret == nil { // We didn't change anything
+		return diags
+	}
+	return ret
+}

--- a/internal/tofu/node_resource_plan_instance.go
+++ b/internal/tofu/node_resource_plan_instance.go
@@ -259,7 +259,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 	// The import process handles its own refresh
 	if !n.skipRefresh && !importing {
 		s, refreshDiags := n.refresh(ctx, states.NotDeposed, instanceRefreshState)
-		diags = diags.Append(refreshDiags)
+		diags = diags.Append(maybeImproveResourceInstanceDiagnostics(refreshDiags, addr))
 		if diags.HasErrors() {
 			return diags
 		}
@@ -303,7 +303,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx EvalContext) 
 		change, instancePlanState, repeatData, planDiags := n.plan(
 			ctx, nil, instanceRefreshState, n.ForceCreateBeforeDestroy, n.forceReplace,
 		)
-		diags = diags.Append(planDiags)
+		diags = diags.Append(maybeImproveResourceInstanceDiagnostics(planDiags, addr))
 		if diags.HasErrors() {
 			// If we are importing and generating a configuration, we need to
 			// ensure the change is written out so the configuration can be


### PR DESCRIPTION
This is a prototype of the idea from https://github.com/opentofu/opentofu/issues/2464#issuecomment-2669365525.

It seems that a small number of providers are now able to return a special signal when they find that they are unable to perform an operation due to unknown values in the provider or resource configuration.

This is a prototype of using that new signal to recommend a workaround in that situation, giving a more actionable error message than would've been returned by the provider otherwise.

It's unclear at this point whether these protocol features are actually subject to the upstream compatibility promises and so this is intentionally implemented in a way where most of the logic is centralized in the provider-related packages rather than sprawled all over `package tofu`. However, hopefully a future incarnation of this would do this differently so that we can incorporate more context into the messages, or even find some way to handle these exclusions automatically without the user needing to do anything unusual.

If we _did_ decide to do this I would only consider it a short-term improvement and not as a solution for either https://github.com/opentofu/opentofu/issues/2464 or https://github.com/opentofu/opentofu/issues/1685, but I think it's still much better than the confusing dead-end error messages that providers tend to generate in these situations otherwise.

---

The easiest way to try this out is to use the `hashicorp/helm` provider, since [that provider just treats any unknown value in the provider config as sufficient to generate this new signal](https://github.com/hashicorp/terraform-provider-helm/blob/afc64eda2181bf835ac648177e7464416c9b9fef/helm/provider.go#L160-L164).

```hcl
terraform {
  required_providers {
    helm = {
      source  = "hashicorp/helm"
      version = "2.17.0"
    }
    null = {
      source  = "hashicorp/null"
      version = "3.2.3"
    }
  }
}

resource "null_resource" "foo" {
}

provider "helm" {
  kubernetes {
    host = null_resource.foo.id
  }
}

resource "helm_release" "example" {
  name       = "example"
  chart      = "./charts/example"
}
```

This (very contrived) simple configuration produces the following output from `tofu plan`:

```shellsession
$ tofu plan

OpenTofu used the selected providers to generate the following execution plan.
Resource actions are indicated with the following symbols:
  + create

OpenTofu planned the following actions, but then encountered a problem:

  # null_resource.foo will be created
  + resource "null_resource" "foo" {
      + id = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
╷
│ Error: Provider configuration is incomplete
│ 
│   on kubernetes-unknown.tf line 23, in resource "helm_release" "example":
│   23: resource "helm_release" "example" {
│ 
│ The provider was unable to work with this resource because the associated
│ provider configuration makes use of values from other resources that will not
│ be known until after apply.
│ 
│ To work around this, use the planning option -exclude="helm_release.example"
│ to first apply without this object, and then apply normally to converge.
╵
```

Notice that the error message directly suggests using `-exclude` as a workaround for this problem. Following that advice does indeed cause the plan to succeed:

```shellsession
$ tofu plan -exclude="helm_release.example"

OpenTofu used the selected providers to generate the following execution plan.
Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # null_resource.foo will be created
  + resource "null_resource" "foo" {
      + id = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
╷
│ Warning: Resource targeting is in effect
│ 
│ You are creating a plan with either the -target option or the -exclude
│ option, which means that the result of this plan may not represent all of the
│ changes requested by the current configuration.
│ 
│ The -target and -exclude options are not for routine use, and are provided
│ only for exceptional situations such as recovering from errors or mistakes,
│ or when OpenTofu specifically suggests to use it as part of an error message.
╵

───────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so OpenTofu can't
guarantee to take exactly these actions if you run "tofu apply" now.
```

Of course this contrived configuration doesn't actually produce a valid configuration for the `hashicorp/helm` provider and so it's not possible to proceed with _actually_ applying this partial plan and then applying normally again to converge, but this would work in a more realistic situation involving this provider.

The `hashicorp/kubernetes` provider is also able to generate signals like this in various cases, but that one is harder to trigger because it tries to handle it more granularly to return the signal only when it's strictly necessary; many resource types in that provider _can_ actually work with an incomplete provider configuration.
