### PR TITLE
Dependency inversion style for module package installer

### DIFF
--- a/cmd/tofu/commands.go
+++ b/cmd/tofu/commands.go
@@ -21,6 +21,7 @@ import (
 	"github.com/opentofu/opentofu/internal/command/cliconfig"
 	"github.com/opentofu/opentofu/internal/command/views"
 	"github.com/opentofu/opentofu/internal/command/webbrowser"
+	"github.com/opentofu/opentofu/internal/getmodules"
 	"github.com/opentofu/opentofu/internal/getproviders"
 	pluginDiscovery "github.com/opentofu/opentofu/internal/plugin/discovery"
 	"github.com/opentofu/opentofu/internal/terminal"
@@ -60,6 +61,7 @@ func initCommands(
 	streams *terminal.Streams,
 	config *cliconfig.Config,
 	services *disco.Disco,
+	modulePkgFetcher *getmodules.PackageFetcher,
 	providerSrc getproviders.Source,
 	providerDevOverrides map[addrs.Provider]getproviders.PackageLocalDir,
 	unmanagedProviders map[addrs.Provider]*plugin.ReattachConfig,
@@ -107,6 +109,7 @@ func initCommands(
 		ShutdownCh:    makeShutdownCh(),
 		CallerContext: ctx,
 
+		ModulePackageFetcher: modulePkgFetcher,
 		ProviderSource:       providerSrc,
 		ProviderDevOverrides: providerDevOverrides,
 		UnmanagedProviders:   unmanagedProviders,

--- a/cmd/tofu/main.go
+++ b/cmd/tofu/main.go
@@ -185,6 +185,8 @@ func realMain() int {
 	}
 	services.SetUserAgent(httpclient.OpenTofuUserAgent(version.String()))
 
+	modulePkgFetcher := remoteModulePackageFetcher()
+
 	providerSrc, diags := providerSource(config.ProviderInstallation, services, config.OCICredentialsPolicy)
 	if len(diags) > 0 {
 		Ui.Error("There are some problems with the provider_installation configuration:")
@@ -248,7 +250,7 @@ func realMain() int {
 		// in case they need to refer back to it for any special reason, though
 		// they should primarily be working with the override working directory
 		// that we've now switched to above.
-		initCommands(ctx, originalWd, streams, config, services, providerSrc, providerDevOverrides, unmanagedProviders)
+		initCommands(ctx, originalWd, streams, config, services, modulePkgFetcher, providerSrc, providerDevOverrides, unmanagedProviders)
 	}
 
 	// Attempt to ensure the config directory exists.

--- a/cmd/tofu/main.go
+++ b/cmd/tofu/main.go
@@ -185,7 +185,7 @@ func realMain() int {
 	}
 	services.SetUserAgent(httpclient.OpenTofuUserAgent(version.String()))
 
-	modulePkgFetcher := remoteModulePackageFetcher()
+	modulePkgFetcher := remoteModulePackageFetcher(config.OCICredentialsPolicy)
 
 	providerSrc, diags := providerSource(config.ProviderInstallation, services, config.OCICredentialsPolicy)
 	if len(diags) > 0 {

--- a/cmd/tofu/module_source.go
+++ b/cmd/tofu/module_source.go
@@ -6,11 +6,35 @@
 package main
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/opentofu/opentofu/internal/getmodules"
 )
 
-func remoteModulePackageFetcher() *getmodules.PackageFetcher {
+func remoteModulePackageFetcher(getOCICredsPolicy ociCredsPolicyBuilder) *getmodules.PackageFetcher {
 	// TODO: Pass in a real getmodules.PackageFetcherEnvironment here,
 	// which knows how to make use of the OCI authentication policy.
-	return getmodules.NewPackageFetcher(nil)
+	return getmodules.NewPackageFetcher(&modulePackageFetcherEnvironment{
+		getOCICredsPolicy: getOCICredsPolicy,
+	})
+}
+
+type modulePackageFetcherEnvironment struct {
+	getOCICredsPolicy ociCredsPolicyBuilder
+}
+
+// OCIRepositoryStore implements getmodules.PackageFetcherEnvironment.
+func (m *modulePackageFetcherEnvironment) OCIRepositoryStore(ctx context.Context, registryDomainName string, repositoryPath string) (getmodules.OCIRepositoryStore, error) {
+	// We intentionally delay the finalization of the credentials policy until
+	// just before we need it because most OpenTofu commands don't install
+	// module packages at all, and even those that do only need to do this if
+	// using the "oci" source type, so we can avoid doing this work at all
+	// most of the time.
+	credsPolicy, err := m.getOCICredsPolicy(ctx)
+	if err != nil {
+		// This deals with only a small number of errors that we can't catch during CLI config validation
+		return nil, fmt.Errorf("invalid credentials configuration for OCI registries: %w", err)
+	}
+	return getOCIRepositoryStore(ctx, registryDomainName, repositoryPath, credsPolicy)
 }

--- a/cmd/tofu/module_source.go
+++ b/cmd/tofu/module_source.go
@@ -1,0 +1,16 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"github.com/opentofu/opentofu/internal/getmodules"
+)
+
+func remoteModulePackageFetcher() *getmodules.PackageFetcher {
+	// TODO: Pass in a real getmodules.PackageFetcherEnvironment here,
+	// which knows how to make use of the OCI authentication policy.
+	return getmodules.NewPackageFetcher(nil)
+}

--- a/cmd/tofu/oci_distribution.go
+++ b/cmd/tofu/oci_distribution.go
@@ -1,0 +1,119 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+// This file deals with our cross-cutting concerns relating to the OCI Distribution
+// protocol, shared across both the provider and module installers, and potentially
+// other OCI Registry concerns in future.
+
+import (
+	"context"
+	"fmt"
+
+	orasRemote "oras.land/oras-go/v2/registry/remote"
+	orasAuth "oras.land/oras-go/v2/registry/remote/auth"
+
+	"github.com/opentofu/opentofu/internal/command/cliconfig/ociauthconfig"
+	"github.com/opentofu/opentofu/internal/getmodules"
+	"github.com/opentofu/opentofu/internal/getproviders"
+	"github.com/opentofu/opentofu/internal/httpclient"
+)
+
+// ociCredsPolicyBuilder is the type of a callback function that the [providerSource]
+// and [remoteModulePackageFetcher] functions will use if any of the configured
+// provider installation methods or the module installer need to interact with
+// OCI Distribution registries.
+//
+// We represent this indirectly as a callback function so that we can skip doing
+// this work in the common case where we won't need to interact with OCI registries
+// at all.
+type ociCredsPolicyBuilder func(context.Context) (ociauthconfig.CredentialsConfigs, error)
+
+// getOCIRepositoryStore instantiates a [getproviders.OCIRepositoryStore] implementation to use
+// when accessing the given repository on the given registry, using the given OCI credentials
+// policy to decide which credentials to use.
+func getOCIRepositoryStore(ctx context.Context, registryDomain, repositoryName string, credsPolicy ociauthconfig.CredentialsConfigs) (ociRepositoryStore, error) {
+	// We currently use the ORAS-Go library to satisfy both the [getproviders.OCIRepositoryStore]
+	// and [getmodules.OCIRepositoryStore] interfaces, which is easy because those interfaces
+	// were designed to match a subset of the ORAS-Go API since we had no particular need to
+	// diverge from it. However, we consider ORAS-Go to be an implementation detail here and so
+	// we should avoid any ORAS-Go types becoming part of the direct public API between packages.
+
+	// ORAS-Go has a bit of an impedence mismatch with us in that it thinks of credentials
+	// as being a per-registry thing rather than a per-repository thing, so we deal with
+	// the credSource resolution ourselves here and then just return whatever we found to
+	// ORAS when it asks through its callback. In practice we only interact with one
+	// repository per client so this is just a little inconvenient and not a practical problem.
+	credSource, err := credsPolicy.CredentialsSourceForRepository(ctx, registryDomain, repositoryName)
+	if ociauthconfig.IsCredentialsNotFoundError(err) {
+		credSource = nil // we'll just try without any credentials, then
+	} else if err != nil {
+		return nil, fmt.Errorf("finding credentials for %q: %w", registryDomain, err)
+	}
+	client := &orasAuth.Client{
+		Client: httpclient.New(), // the underlying HTTP client to use, preconfigured with OpenTofu's User-Agent string
+		Credential: func(ctx context.Context, hostport string) (orasAuth.Credential, error) {
+			if hostport != registryDomain {
+				// We should not send the credentials we selected to any registry
+				// other than the one they were configured for.
+				return orasAuth.EmptyCredential, nil
+			}
+			if credSource == nil {
+				return orasAuth.EmptyCredential, nil
+			}
+			creds, err := credSource.Credentials(ctx, ociCredentialsLookupEnv{})
+			if ociauthconfig.IsCredentialsNotFoundError(err) {
+				return orasAuth.EmptyCredential, nil
+			}
+			if err != nil {
+				return orasAuth.Credential{}, err
+			}
+			return creds.ToORASCredential(), nil
+		},
+		Cache: orasAuth.NewCache(),
+	}
+	reg, err := orasRemote.NewRegistry(registryDomain)
+	if err != nil {
+		return nil, err // This is only for registryDomain validation errors, and we should've caught those much earlier than here
+	}
+	reg.Client = client
+	err = reg.Ping(ctx) // tests whether the given domain refers to a valid OCI repository and will accept the credentials
+	if err != nil {
+		return nil, fmt.Errorf("failed to contact OCI registry at %q: %w", registryDomain, err)
+	}
+	repo, err := reg.Repository(ctx, repositoryName)
+	if err != nil {
+		return nil, err // This is only for repositoryName validation errors, and we should've caught those much earlier than here
+	}
+	// NOTE: At this point we don't yet know if the named repository actually exists
+	// in the registry. The caller will find that out when they try to interact
+	// with the methods of the returned object.
+	return repo, nil
+}
+
+// ociRepositoryStore represents the combined needs of both
+// [getproviders.OCIRepositoryStore] and [getmodules.OCIRepositoryStore],
+// both of which are intentionally defined to be subsets of the API
+// used by ORAS-Go so that we can use the implementations from that
+// library without directly exposing any ORAS-Go symbols in the
+// public API of any of our packages, since we want to reserve the
+// ability to switch to other implementations in future if needed.
+type ociRepositoryStore interface {
+	getproviders.OCIRepositoryStore
+	getmodules.OCIRepositoryStore
+}
+
+// ociCredentialsLookupEnv is our implementation of ociauthconfig.CredentialsLookupEnvironment
+// used when resolving the selected credentials for a particular OCI repository.
+type ociCredentialsLookupEnv struct{}
+
+var _ ociauthconfig.CredentialsLookupEnvironment = ociCredentialsLookupEnv{}
+
+// QueryDockerCredentialHelper implements ociauthconfig.CredentialsLookupEnvironment.
+func (o ociCredentialsLookupEnv) QueryDockerCredentialHelper(ctx context.Context, helperName string, serverURL string) (ociauthconfig.DockerCredentialHelperGetResult, error) {
+	// TODO: Implement this
+	return ociauthconfig.DockerCredentialHelperGetResult{}, fmt.Errorf("support for Docker-style credential helpers is not yet available")
+}

--- a/internal/checks/state_test.go
+++ b/internal/checks/state_test.go
@@ -21,7 +21,7 @@ func TestChecksHappyPath(t *testing.T) {
 	const fixtureDir = "testdata/happypath"
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, nil)
+	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, nil, nil)
 	_, instDiags := inst.InstallModules(context.Background(), fixtureDir, "tests", true, false, initwd.ModuleInstallHooksImpl{}, configs.RootModuleCallForTesting())
 	if instDiags.HasErrors() {
 		t.Fatal(instDiags.Err())

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -161,7 +161,7 @@ func testModuleWithSnapshot(t *testing.T, name string) (*configs.Config, *config
 	// Test modules usually do not refer to remote sources, and for local
 	// sources only this ultimately just records all of the module paths
 	// in a JSON file so that we can load them below.
-	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil))
+	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil), nil)
 	_, instDiags := inst.InstallModules(context.Background(), dir, "tests", true, false, initwd.ModuleInstallHooksImpl{}, configs.RootModuleCallForTesting())
 	if instDiags.HasErrors() {
 		t.Fatal(instDiags.Err())

--- a/internal/command/get_test.go
+++ b/internal/command/get_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/mitchellh/cli"
+
+	"github.com/opentofu/opentofu/internal/getmodules"
 )
 
 func TestGet(t *testing.T) {
@@ -103,6 +105,14 @@ func TestGet_cancel(t *testing.T) {
 			Ui:               ui,
 			WorkingDir:       wd,
 			ShutdownCh:       shutdownCh,
+
+			// This test needs a real module package fetcher instance because
+			// its configuration includes a reference to a module from a registry
+			// that doesn't really exist. The shutdown signal prevents us from
+			// actually making a request to this, but we still need to provide
+			// the fetcher so that it will _attempt_ to make a network request
+			// that can then fail with a cancellation error.
+			ModulePackageFetcher: getmodules.NewPackageFetcher(nil),
 		},
 	}
 

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -34,6 +34,7 @@ import (
 	"github.com/opentofu/opentofu/internal/command/workdir"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/configs/configload"
+	"github.com/opentofu/opentofu/internal/getmodules"
 	"github.com/opentofu/opentofu/internal/getproviders"
 	legacy "github.com/opentofu/opentofu/internal/legacy/tofu"
 	"github.com/opentofu/opentofu/internal/providers"
@@ -128,6 +129,15 @@ type Meta struct {
 	// and determines where a distribution package for a particular
 	// provider version can be obtained.
 	ProviderSource getproviders.Source
+
+	// ModulePackageFetcher is the client to use when fetching module packages
+	// from remote locations. This object effectively represents the policy
+	// for how to fetch remote module packages, which is decided by the caller.
+	//
+	// Leaving this nil means that only local modules (using relative paths
+	// in the source address) are supported, which is only reasonable for
+	// unit testing.
+	ModulePackageFetcher *getmodules.PackageFetcher
 
 	// BrowserLauncher is used by commands that need to open a URL in a
 	// web browser.

--- a/internal/command/meta_config.go
+++ b/internal/command/meta_config.go
@@ -24,7 +24,6 @@ import (
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/configs/configload"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
-	"github.com/opentofu/opentofu/internal/getmodules"
 	"github.com/opentofu/opentofu/internal/initwd"
 	"github.com/opentofu/opentofu/internal/registry"
 	"github.com/opentofu/opentofu/internal/tfdiags"
@@ -292,7 +291,7 @@ func (m *Meta) installModules(ctx context.Context, rootDir, testsDir string, upg
 		return true, diags
 	}
 
-	inst := initwd.NewModuleInstaller(m.modulesDir(), loader, m.registryClient(), getmodules.NewPackageFetcher())
+	inst := initwd.NewModuleInstaller(m.modulesDir(), loader, m.registryClient(), m.ModulePackageFetcher)
 
 	call, vDiags := m.rootModuleCall(rootDir)
 	diags = diags.Append(vDiags)
@@ -334,7 +333,7 @@ func (m *Meta) initDirFromModule(ctx context.Context, targetDir string, addr str
 	}
 
 	targetDir = m.normalizePath(targetDir)
-	moreDiags := initwd.DirFromModule(ctx, loader, targetDir, m.modulesDir(), addr, m.registryClient(), hooks)
+	moreDiags := initwd.DirFromModule(ctx, loader, targetDir, m.modulesDir(), addr, m.registryClient(), m.ModulePackageFetcher, hooks)
 	diags = diags.Append(moreDiags)
 	if ctx.Err() == context.Canceled {
 		m.showDiagnostics(diags)

--- a/internal/command/meta_config.go
+++ b/internal/command/meta_config.go
@@ -24,6 +24,7 @@ import (
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/configs/configload"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
+	"github.com/opentofu/opentofu/internal/getmodules"
 	"github.com/opentofu/opentofu/internal/initwd"
 	"github.com/opentofu/opentofu/internal/registry"
 	"github.com/opentofu/opentofu/internal/tfdiags"
@@ -291,7 +292,7 @@ func (m *Meta) installModules(ctx context.Context, rootDir, testsDir string, upg
 		return true, diags
 	}
 
-	inst := initwd.NewModuleInstaller(m.modulesDir(), loader, m.registryClient())
+	inst := initwd.NewModuleInstaller(m.modulesDir(), loader, m.registryClient(), getmodules.NewPackageFetcher())
 
 	call, vDiags := m.rootModuleCall(rootDir)
 	diags = diags.Append(vDiags)

--- a/internal/getmodules/installer.go
+++ b/internal/getmodules/installer.go
@@ -7,6 +7,7 @@ package getmodules
 
 import (
 	"context"
+	"fmt"
 )
 
 // PackageFetcher is a low-level utility for fetching remote module packages
@@ -26,7 +27,16 @@ type PackageFetcher struct {
 	getter reusingGetter
 }
 
-func NewPackageFetcher() *PackageFetcher {
+// NewPackageFetcher constructs a new [PackageFetcher] that interacts with
+// the rest of the system and with the execution environment using the
+// given [PackageFetcherEnvironment] implementation.
+//
+// It's valid to set "env" to nil, but that will make certain module
+// package source types unavailable for use and so that concession is
+// intended only for use in unit tests.
+func NewPackageFetcher(env PackageFetcherEnvironment) *PackageFetcher {
+	env = preparePackageFetcherEnvironment(env)
+	_ = env // TODO: Actually use this, once we have an OCI Distribution getter
 	return &PackageFetcher{
 		getter: reusingGetter{},
 	}
@@ -46,4 +56,41 @@ func NewPackageFetcher() *PackageFetcher {
 // getmodules.SplitPackageSubdir and getmodules.ExpandSubdirGlobs functions.
 func (f *PackageFetcher) FetchPackage(ctx context.Context, instDir string, packageAddr string) error {
 	return f.getter.getWithGoGetter(ctx, instDir, packageAddr)
+}
+
+// PackageFetcherEnvironment is an interface used with [NewPackageFetcher]
+// to allow the caller to define how the package fetcher should interact
+// with the rest of OpenTofu and with OpenTofu's execution environment.
+//
+// This interface may grow to include new methods if we learn of new
+// requirements, so implementations of this interface should all be
+// inside this codebase. If we decide to factor out module installation
+// to a separate library for broader use in future then we should consider
+// carefully whether a single interface aggregating all of the fetcher's
+// concerns is still the best design for that different context.
+type PackageFetcherEnvironment interface {
+	OCIRepositoryStore(ctx context.Context, registryDomainName, repositoryPath string) (OCIRepositoryStore, error)
+}
+
+// preparePackageFetcherEnvironment takes a [PackageFetcherEnvironment]
+// value provided directly by a caller to [NewPackageFetcher] and
+// optionally wraps or replaces it as needed to better suit the
+// implementation details of this package.
+//
+// Currently its only special behavior is that it replaces a nil
+// PackageFetcherEnvironment with a default implementation that stubs
+// out all of the methods, so that the other code in this package can
+// then assume that the environment is always valid to call.
+func preparePackageFetcherEnvironment(given PackageFetcherEnvironment) PackageFetcherEnvironment {
+	if given == nil {
+		return noopPackageFetcherEnvironment{}
+	}
+	return given
+}
+
+type noopPackageFetcherEnvironment struct{}
+
+// OCIRepositoryStore implements PackageFetcherEnvironment.
+func (n noopPackageFetcherEnvironment) OCIRepositoryStore(ctx context.Context, registryDomainName string, repositoryPath string) (OCIRepositoryStore, error) {
+	return nil, fmt.Errorf("module installation from OCI repositories is not available in this context")
 }

--- a/internal/getmodules/oci_getter.go
+++ b/internal/getmodules/oci_getter.go
@@ -1,0 +1,49 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package getmodules
+
+import (
+	"context"
+	"io"
+
+	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// OCIRepositoryStore is the interface that [PackageFetcher] uses to
+// interact with a single OCI Distribution repository when installing
+// a remote module using the "oci" scheme.
+//
+// Implementations of this interface are returned by
+// [PackageFetcherEnvironment.OCIRepositoryStore].
+type OCIRepositoryStore interface {
+	// Resolve finds the descriptor associated with the given tag name in the
+	// repository, if any.
+	//
+	// tagName MUST conform to the pattern defined for "<reference> as a tag"
+	// from the OCI distribution specification, or the result is unspecified.
+	Resolve(ctx context.Context, tagName string) (ociv1.Descriptor, error)
+
+	// Fetch retrieves the content of a specific blob from the repository, identified
+	// by the digest in the given descriptor.
+	//
+	// Implementations of this function tend not to check that the returned content
+	// actually matches the digest and size in the descriptor, so callers MUST
+	// verify that somehow themselves before making use of the resulting content.
+	//
+	// Callers MUST close the returned reader after using it, since it's typically
+	// connected to an active network socket or file handle.
+	Fetch(ctx context.Context, target ociv1.Descriptor) (io.ReadCloser, error)
+
+	// The design of the above intentionally matches a subset of the interfaces
+	// defined in the ORAS-Go library, but we have our own specific interface here
+	// both to clearly define the minimal interface we depend on and so that our
+	// use of ORAS-Go can be treated as an implementation detail rather than as
+	// an API contract should we need to switch to a different approach in future.
+	//
+	// If you need to expand this while we're still relying on ORAS-Go, aim to
+	// match the corresponding interface in that library if at all possible so
+	// that we can minimize the amount of adapter code we need to write.
+}

--- a/internal/initwd/from_module.go
+++ b/internal/initwd/from_module.go
@@ -96,7 +96,7 @@ func DirFromModule(ctx context.Context, loader *configload.Loader, rootDir, modu
 	}
 
 	instDir := filepath.Join(rootDir, ".terraform/init-from-module")
-	inst := NewModuleInstaller(instDir, loader, reg)
+	inst := NewModuleInstaller(instDir, loader, reg, getmodules.NewPackageFetcher())
 	log.Printf("[DEBUG] installing modules in %s to initialize working directory from %q", instDir, sourceAddrStr)
 	os.RemoveAll(instDir) // if this fails then we'll fail on MkdirAll below too
 	err := os.MkdirAll(instDir, os.ModePerm)

--- a/internal/initwd/from_module.go
+++ b/internal/initwd/from_module.go
@@ -50,7 +50,7 @@ const initFromModuleRootKeyPrefix = initFromModuleRootCallName + "."
 // references using ../ from that module to be unresolvable. Error diagnostics
 // are produced in that case, to prompt the user to rewrite the source strings
 // to be absolute references to the original remote module.
-func DirFromModule(ctx context.Context, loader *configload.Loader, rootDir, modulesDir, sourceAddrStr string, reg *registry.Client, hooks ModuleInstallHooks) tfdiags.Diagnostics {
+func DirFromModule(ctx context.Context, loader *configload.Loader, rootDir, modulesDir, sourceAddrStr string, reg *registry.Client, remoteFetcher *getmodules.PackageFetcher, hooks ModuleInstallHooks) tfdiags.Diagnostics {
 
 	var diags tfdiags.Diagnostics
 
@@ -96,7 +96,7 @@ func DirFromModule(ctx context.Context, loader *configload.Loader, rootDir, modu
 	}
 
 	instDir := filepath.Join(rootDir, ".terraform/init-from-module")
-	inst := NewModuleInstaller(instDir, loader, reg, getmodules.NewPackageFetcher())
+	inst := NewModuleInstaller(instDir, loader, reg, remoteFetcher)
 	log.Printf("[DEBUG] installing modules in %s to initialize working directory from %q", instDir, sourceAddrStr)
 	os.RemoveAll(instDir) // if this fails then we'll fail on MkdirAll below too
 	err := os.MkdirAll(instDir, os.ModePerm)
@@ -168,9 +168,8 @@ func DirFromModule(ctx context.Context, loader *configload.Loader, rootDir, modu
 		Key: "",
 		Dir: rootDir,
 	}
-	fetcher := getmodules.NewPackageFetcher()
 
-	walker := inst.moduleInstallWalker(ctx, instManifest, true, wrapHooks, fetcher)
+	walker := inst.moduleInstallWalker(ctx, instManifest, true, wrapHooks, remoteFetcher)
 	_, cDiags := inst.installDescendentModules(fakeRootModule, instManifest, walker, true)
 	if cDiags.HasErrors() {
 		return diags.Append(cDiags)

--- a/internal/initwd/module_install_test.go
+++ b/internal/initwd/module_install_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/configs/configload"
 	"github.com/opentofu/opentofu/internal/copy"
+	"github.com/opentofu/opentofu/internal/getmodules"
 	"github.com/opentofu/opentofu/internal/registry"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 
@@ -46,7 +47,7 @@ func TestModuleInstaller(t *testing.T) {
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, nil)
+	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 	assertNoDiagnostics(t, diags)
 
@@ -110,7 +111,7 @@ func TestModuleInstaller_error(t *testing.T) {
 
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, nil)
+	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 
 	if !diags.HasErrors() {
@@ -131,7 +132,7 @@ func TestModuleInstaller_emptyModuleName(t *testing.T) {
 
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, nil)
+	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 
 	if !diags.HasErrors() {
@@ -152,7 +153,7 @@ func TestModuleInstaller_invalidModuleName(t *testing.T) {
 
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil))
+	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil), nil)
 	_, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks, configs.RootModuleCallForTesting())
 	if !diags.HasErrors() {
 		t.Fatal("expected error")
@@ -189,7 +190,11 @@ func TestModuleInstaller_packageEscapeError(t *testing.T) {
 
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, nil)
+	// This test needs a real getmodules.PackageFetcher because it makes use of
+	// the esoteric legacy support for treating an absolute filesystem path
+	// as if it were a "remote package". This should not use any of the
+	// truly-"remote" module sources, even though it technically has access to.
+	inst := NewModuleInstaller(modulesDir, loader, nil, getmodules.NewPackageFetcher())
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 
 	if !diags.HasErrors() {
@@ -227,7 +232,11 @@ func TestModuleInstaller_explicitPackageBoundary(t *testing.T) {
 
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, nil)
+	// This test needs a real getmodules.PackageFetcher because it makes use of
+	// the esoteric legacy support for treating an absolute filesystem path
+	// as if it were a "remote package". This should not use any of the
+	// truly-"remote" module sources, even though it technically has access to.
+	inst := NewModuleInstaller(modulesDir, loader, nil, getmodules.NewPackageFetcher())
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 
 	if diags.HasErrors() {
@@ -313,7 +322,7 @@ func TestModuleInstaller_Prerelease(t *testing.T) {
 
 			loader, closeLoader := configload.NewLoaderForTests(t)
 			defer closeLoader()
-			inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil))
+			inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil), nil)
 			cfg, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 
 			if tc.shouldError {
@@ -345,7 +354,7 @@ func TestModuleInstaller_invalid_version_constraint_error(t *testing.T) {
 
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, nil)
+	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 
 	if !diags.HasErrors() {
@@ -371,7 +380,7 @@ func TestModuleInstaller_invalidVersionConstraintGetter(t *testing.T) {
 
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, nil)
+	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 
 	if !diags.HasErrors() {
@@ -397,7 +406,7 @@ func TestModuleInstaller_invalidVersionConstraintLocal(t *testing.T) {
 
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, nil)
+	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 
 	if !diags.HasErrors() {
@@ -423,7 +432,7 @@ func TestModuleInstaller_symlink(t *testing.T) {
 
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, nil)
+	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 	assertNoDiagnostics(t, diags)
 
@@ -499,7 +508,7 @@ func TestLoaderInstallModules_registry(t *testing.T) {
 
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil))
+	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil), nil)
 	_, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks, configs.RootModuleCallForTesting())
 	assertNoDiagnostics(t, diags)
 
@@ -662,7 +671,7 @@ func TestLoaderInstallModules_goGetter(t *testing.T) {
 
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil))
+	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil), nil)
 	_, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks, configs.RootModuleCallForTesting())
 	assertNoDiagnostics(t, diags)
 
@@ -780,7 +789,7 @@ func TestModuleInstaller_fromTests(t *testing.T) {
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, nil)
+	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 	assertNoDiagnostics(t, diags)
 
@@ -837,7 +846,7 @@ func TestLoadInstallModules_registryFromTest(t *testing.T) {
 
 	loader, close := configload.NewLoaderForTests(t)
 	defer close()
-	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil))
+	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil), nil)
 	_, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks, configs.RootModuleCallForTesting())
 	assertNoDiagnostics(t, diags)
 

--- a/internal/initwd/module_install_test.go
+++ b/internal/initwd/module_install_test.go
@@ -194,7 +194,7 @@ func TestModuleInstaller_packageEscapeError(t *testing.T) {
 	// the esoteric legacy support for treating an absolute filesystem path
 	// as if it were a "remote package". This should not use any of the
 	// truly-"remote" module sources, even though it technically has access to.
-	inst := NewModuleInstaller(modulesDir, loader, nil, getmodules.NewPackageFetcher())
+	inst := NewModuleInstaller(modulesDir, loader, nil, getmodules.NewPackageFetcher(nil))
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 
 	if !diags.HasErrors() {
@@ -236,7 +236,7 @@ func TestModuleInstaller_explicitPackageBoundary(t *testing.T) {
 	// the esoteric legacy support for treating an absolute filesystem path
 	// as if it were a "remote package". This should not use any of the
 	// truly-"remote" module sources, even though it technically has access to.
-	inst := NewModuleInstaller(modulesDir, loader, nil, getmodules.NewPackageFetcher())
+	inst := NewModuleInstaller(modulesDir, loader, nil, getmodules.NewPackageFetcher(nil))
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 
 	if diags.HasErrors() {
@@ -1022,7 +1022,8 @@ func assertDiagnosticCount(t *testing.T, diags tfdiags.Diagnostics, want int) bo
 	if len(diags) != want {
 		t.Errorf("wrong number of diagnostics %d; want %d", len(diags), want)
 		for _, diag := range diags {
-			t.Logf("- %#v", diag)
+			desc := diag.Description()
+			t.Logf("- %s: %s", desc.Summary, desc.Detail)
 		}
 		return true
 	}
@@ -1040,7 +1041,8 @@ func assertDiagnosticSummary(t *testing.T, diags tfdiags.Diagnostics, want strin
 
 	t.Errorf("missing diagnostic summary %q", want)
 	for _, diag := range diags {
-		t.Logf("- %#v", diag)
+		desc := diag.Description()
+		t.Logf("- %s: %s", desc.Summary, desc.Detail)
 	}
 	return true
 }

--- a/internal/initwd/testing.go
+++ b/internal/initwd/testing.go
@@ -39,7 +39,7 @@ func LoadConfigForTests(t *testing.T, rootDir string, testsDir string) (*configs
 	var diags tfdiags.Diagnostics
 
 	loader, cleanup := configload.NewLoaderForTests(t)
-	inst := NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil))
+	inst := NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil), nil)
 
 	call := configs.RootModuleCallForTesting()
 	_, moreDiags := inst.InstallModules(context.Background(), rootDir, testsDir, true, false, ModuleInstallHooksImpl{}, call)

--- a/internal/lang/globalref/analyzer_test.go
+++ b/internal/lang/globalref/analyzer_test.go
@@ -27,7 +27,7 @@ func testAnalyzer(t *testing.T, fixtureName string) *Analyzer {
 	loader, cleanup := configload.NewLoaderForTests(t)
 	defer cleanup()
 
-	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil))
+	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil), nil)
 	_, instDiags := inst.InstallModules(context.Background(), configDir, "tests", true, false, initwd.ModuleInstallHooksImpl{}, configs.RootModuleCallForTesting())
 	if instDiags.HasErrors() {
 		t.Fatalf("unexpected module installation errors: %s", instDiags.Err().Error())

--- a/internal/refactoring/move_validate_test.go
+++ b/internal/refactoring/move_validate_test.go
@@ -541,7 +541,7 @@ func loadRefactoringFixture(t *testing.T, dir string) (*configs.Config, instance
 	loader, cleanup := configload.NewLoaderForTests(t)
 	defer cleanup()
 
-	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil))
+	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil), nil)
 	_, instDiags := inst.InstallModules(context.Background(), dir, "tests", true, false, initwd.ModuleInstallHooksImpl{}, configs.RootModuleCallForTesting())
 	if instDiags.HasErrors() {
 		t.Fatal(instDiags.Err())

--- a/internal/tofu/opentf_test.go
+++ b/internal/tofu/opentf_test.go
@@ -68,7 +68,7 @@ func testModuleWithSnapshot(t testing.TB, name string) (*configs.Config, *config
 	// Test modules usually do not refer to remote sources, and for local
 	// sources only this ultimately just records all of the module paths
 	// in a JSON file so that we can load them below.
-	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil))
+	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil), nil)
 	_, instDiags := inst.InstallModules(context.Background(), dir, "tests", true, false, initwd.ModuleInstallHooksImpl{}, configs.RootModuleCallForTesting())
 	if instDiags.HasErrors() {
 		t.Fatal(instDiags.Err())
@@ -125,7 +125,7 @@ func testModuleInline(t testing.TB, sources map[string]string) *configs.Config {
 	// Test modules usually do not refer to remote sources, and for local
 	// sources only this ultimately just records all of the module paths
 	// in a JSON file so that we can load them below.
-	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil))
+	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil), nil)
 	_, instDiags := inst.InstallModules(context.Background(), cfgPath, "tests", true, false, initwd.ModuleInstallHooksImpl{}, configs.RootModuleCallForTesting())
 	if instDiags.HasErrors() {
 		t.Fatal(instDiags.Err())


### PR DESCRIPTION
This is for https://github.com/opentofu/opentofu/issues/2540, and aims to complete the work described in [OCI Client for the Module Package Installer](https://github.com/opentofu/opentofu/blob/b47237d410bfeaa86aca84a79bde973e3d8a724e/rfc/20241206-oci-registries/8-auth-implementation-details.md#oci-client-for-the-module-package-installer).

I suggest reviewing this [on a commit-by-commit basis](https://github.com/opentofu/opentofu/pull/2661/commits), since the message in each commit will hopefully give some context on what each step of the refactoring was aiming to achieve.

The overall idea here is to continue the previous work in making the module installer follow a similar dependency inversion style as the provider installer, where `package main` is responsible for configuration the "policy" for module installation based on information learned from the CLI Configuration.

The scope of this PR ends once the module installer is able to access the OCI Registry authentication policy information. A _subsequent_ PR will then make use of that to implement the new OCI module source address type as described in [OCI Distribution "Getter" for go-getter](https://github.com/opentofu/opentofu/blob/b47237d410bfeaa86aca84a79bde973e3d8a724e/rfc/20241206-oci-registries/10-module-implementation-details.md#oci-distribution-getter-for-go-getter).

This PR is limited only to internal refactoring and so will not change the externally-visible behavior of OpenTofu in any significant way. Therefore there will be no CHANGELOG entry in this PR.
