### PR TITLE
refactor a few more places for proper sensitive marks treatment

### DIFF
--- a/internal/tofu/marks_test.go
+++ b/internal/tofu/marks_test.go
@@ -204,3 +204,106 @@ func TestCombinePathValueMarks(t *testing.T) {
 		})
 	}
 }
+
+func TestSensitiveMarksEqual(t *testing.T) {
+	for i, tc := range []struct {
+		a, b  []cty.PathValueMarks
+		equal bool
+	}{
+		{
+			[]cty.PathValueMarks{
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "a"}}, Marks: cty.NewValueMarks(marks.Sensitive, "customMark")},
+			},
+			[]cty.PathValueMarks{
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "a"}}, Marks: cty.NewValueMarks(marks.Sensitive)},
+			},
+			true,
+		},
+		{
+			[]cty.PathValueMarks{
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "a"}}, Marks: cty.NewValueMarks(marks.Sensitive)},
+			},
+			[]cty.PathValueMarks{
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "A"}}, Marks: cty.NewValueMarks(marks.Sensitive)},
+			},
+			false,
+		},
+		{
+			[]cty.PathValueMarks{
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "a"}}, Marks: cty.NewValueMarks(marks.Sensitive)},
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "b"}}, Marks: cty.NewValueMarks(marks.Sensitive, "customMark")},
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "c"}}, Marks: cty.NewValueMarks(marks.Sensitive)},
+			},
+			[]cty.PathValueMarks{
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "b"}}, Marks: cty.NewValueMarks(marks.Sensitive, "customMark")},
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "c"}}, Marks: cty.NewValueMarks(marks.Sensitive, "customMark")},
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "a"}}, Marks: cty.NewValueMarks(marks.Sensitive)},
+			},
+			true,
+		},
+		{
+			[]cty.PathValueMarks{
+				cty.PathValueMarks{
+					Path:  cty.Path{cty.GetAttrStep{Name: "a"}, cty.GetAttrStep{Name: "b"}},
+					Marks: cty.NewValueMarks(marks.Sensitive),
+				},
+				cty.PathValueMarks{
+					Path:  cty.Path{cty.GetAttrStep{Name: "a"}, cty.GetAttrStep{Name: "c"}},
+					Marks: cty.NewValueMarks(marks.Sensitive, "customMark"),
+				},
+			},
+			[]cty.PathValueMarks{
+				cty.PathValueMarks{
+					Path:  cty.Path{cty.GetAttrStep{Name: "a"}, cty.GetAttrStep{Name: "c"}},
+					Marks: cty.NewValueMarks(marks.Sensitive),
+				},
+				cty.PathValueMarks{
+					Path:  cty.Path{cty.GetAttrStep{Name: "a"}, cty.GetAttrStep{Name: "b"}},
+					Marks: cty.NewValueMarks(marks.Sensitive, "customMark"),
+				},
+			},
+			true,
+		},
+		{
+			[]cty.PathValueMarks{
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "a"}}, Marks: cty.NewValueMarks(marks.Sensitive)},
+			},
+			[]cty.PathValueMarks{
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "b"}}, Marks: cty.NewValueMarks(marks.Sensitive)},
+			},
+			false,
+		},
+		{
+			nil,
+			nil,
+			true,
+		},
+		{
+			[]cty.PathValueMarks{
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "a"}}, Marks: cty.NewValueMarks(marks.Sensitive)},
+			},
+			nil,
+			false,
+		},
+		{
+			nil,
+			[]cty.PathValueMarks{
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "a"}}, Marks: cty.NewValueMarks(marks.Sensitive)},
+			},
+			false,
+		},
+		{
+			nil,
+			[]cty.PathValueMarks{
+				cty.PathValueMarks{Path: cty.Path{cty.GetAttrStep{Name: "a"}}, Marks: cty.NewValueMarks("customMark")},
+			},
+			true,
+		},
+	} {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			if sensitiveMarksEqual(tc.a, tc.b) != tc.equal {
+				t.Fatalf("marksEqual(\n%#v,\n%#v,\n) != %t\n", tc.a, tc.b, tc.equal)
+			}
+		})
+	}
+}

--- a/internal/tofu/node_output.go
+++ b/internal/tofu/node_output.go
@@ -616,13 +616,15 @@ func (n *NodeApplyableOutput) setValue(state *states.SyncState, changes *plans.C
 	// non-root outputs need to keep sensitive marks for evaluation, but are
 	// not serialized.
 	if n.Addr.Module.IsRoot() {
-		var valMarks cty.ValueMarks
+		var pvms []cty.PathValueMarks
 
-		val, valMarks = val.UnmarkDeep()
+		val, pvms = val.UnmarkDeepWithPaths()
 
-		delete(valMarks, marks.Sensitive)
+		for _, pvm := range pvms {
+			delete(pvm.Marks, marks.Sensitive)
+		}
 
-		val = cty.UnknownAsNull(val).WithMarks(valMarks)
+		val = cty.UnknownAsNull(val).MarkWithPaths(pvms)
 	}
 
 	state.SetOutputValue(n.Addr, val, n.Config.Sensitive)

--- a/internal/tofu/node_output_test.go
+++ b/internal/tofu/node_output_test.go
@@ -147,8 +147,15 @@ func TestNodeApplyableOutputExecute_alternativelyMarkedValue(t *testing.T) {
 
 	stateVal := ctx.StateState.OutputValue(modOutputAddr)
 
-	if !stateVal.Value.HasMark("alternative-mark") {
-		t.Fatalf("Non-sensitive mark has been erased")
+	_, pvms := stateVal.Value.UnmarkDeepWithPaths()
+	if len(pvms) != 1 {
+		t.Fatalf("Expected a single mark to be present, got: %v", pvms)
+	}
+
+	// We want to check if the mark is still under the same path.
+	if !pvms[0].Path.Equals(cty.IndexStringPath("a")) ||
+		!pvms[0].Marks.Equal(cty.NewValueMarks("alternative-mark")) {
+		t.Fatalf("Expected an alternativeMark with preserved path (a). Got: %v", pvms)
 	}
 }
 


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
This PR refactors a few more places where any mark is treated as sensitive. It introduces `sensitiveMarksEqual` to properly compare only sensitive marks in order to determine whether or not the sensitivity of the value has changed. Also, the PR makes root module outputs to preserve their pathes during sensitive marks removal.

Complimentary to https://github.com/opentofu/opentofu/pull/2503

Found those cases during the work on https://github.com/opentofu/opentofu/pull/2633

## Target Release

1.10.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [X] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [X] I have not used an AI coding assistant to create this PR.
- [X] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [X] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.
