### PR TITLE
command: Improve reliability of module install cancel tests

### DIFF
--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
@@ -1830,17 +1831,41 @@ func TestInit_providerSource(t *testing.T) {
 }
 
 func TestInit_cancelModules(t *testing.T) {
-	// This test runs `tofu init` as if SIGINT (or similar on other
-	// platforms) were sent to it, testing that it is interruptible.
+	// This test runs `tofu init` against a server that stalls indefinitely
+	// instead of responding, and then requests shutdown in the same way
+	// as package main would in response to SIGINT (or similar on other
+	// platforms). This ensures that slow requests can be interrupted.
 
-	td := t.TempDir()
-	testCopyDir(t, testFixturePath("init-registry-module"), td)
-	defer testChdir(t, td)()
+	wd := tempWorkingDirFixture(t, "init-module-early-eval")
+	t.Chdir(wd.RootModuleDir())
 
-	// Our shutdown channel is pre-closed so init will exit as soon as it
-	// starts a cancelable portion of the process.
+	// One failure mode of this test is for the cancellation to fail and
+	// so the command runs indefinitely, and so we'll impose a timeout
+	// to allow us to eventually catch that and diagnose it as a test
+	// failure message.
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	// This server intentionally stalls any incoming request by leaving
+	// the connection open but not responding. "reqs" will become
+	// readable each time a request arrives.
+	server, reqs := testHangServer(t)
+
+	// We'll close this channel once we've been notified that the server
+	// received our request, which should then cause cancellation.
 	shutdownCh := make(chan struct{})
-	close(shutdownCh)
+	go func() {
+		select {
+		case <-reqs:
+			// Request received, so time to interrupt.
+			t.Log("server received request, but won't respond")
+			close(shutdownCh)
+		case <-ctx.Done():
+			// Exit early if we reach our timeout.
+			t.Log("timeout before server received request")
+		}
+		server.CloseClientConnections() // force any active client request to fail
+	}()
 
 	ui := cli.NewMockUi()
 	view, _ := testView(t)
@@ -1858,17 +1883,20 @@ func TestInit_cancelModules(t *testing.T) {
 		// that can then fail with a cancellation error.
 		ModulePackageFetcher: getmodules.NewPackageFetcher(nil),
 	}
-
 	c := &InitCommand{
 		Meta: m,
 	}
 
-	args := []string{}
-
-	if code := c.Run(args); code == 0 {
+	fakeModuleSourceAddr := server.URL + "/example.zip"
+	t.Logf("attempting to install module package from %s", fakeModuleSourceAddr)
+	args := []string{"-var=module_source=" + fakeModuleSourceAddr}
+	code := c.Run(args)
+	if err := ctx.Err(); err != nil {
+		t.Errorf("context error: %s", err) // probably reporting a timeout
+	}
+	if code == 0 {
 		t.Fatalf("succeeded; wanted error\n%s", ui.OutputWriter.String())
 	}
-
 	if got, want := ui.ErrorWriter.String(), `Module installation was canceled by an interrupt signal`; !strings.Contains(got, want) {
 		t.Fatalf("wrong error message\nshould contain: %s\ngot:\n%s", want, got)
 	}

--- a/internal/command/testdata/init-module-early-eval/init-module-early-eval.tf
+++ b/internal/command/testdata/init-module-early-eval/init-module-early-eval.tf
@@ -1,0 +1,9 @@
+// The calling test must set this variable for any command that
+// will load this configuration.
+variable "module_source" {
+  type = string
+}
+
+module "test" {
+  source = var.module_source
+}

--- a/internal/command/testdata/init-registry-module/main.tf
+++ b/internal/command/testdata/init-registry-module/main.tf
@@ -1,4 +1,0 @@
-module "foo" {
-  source = "registry.does.not.exist/example_corp/foo/bar"
-  version = "0.1.0"
-}


### PR DESCRIPTION
We previously had two tests of how the module installer responds to cancellation (e.g. `SIGINT`) which were flakey because they tried to rely on the cancellation being detected at some arbitrary point before the module installer attempted to make a request, which isn't guaranteed in practice because our interrupt mechanism only aims to cause OpenTofu to exit "soon", with no guarantee about how much ongoing progress it will make before it does.

To make these tests more robust, we'll now instead tell the module installer to install from a real HTTP server that is intentionally designed to stall the client by accepting its request but then just leaving the connection open without responding.

This means that we can now test the more realistic situation of the cancel signal being triggered after a slow request is already in progress, and be sure that we're definitely sending the cancel signal at a moment that matches that intention.

This is similar to a strategy we previously took to improve the reliability of the tests for cancellation of the _provider_ installer, in `TestInit_cancelProviders`. However, our provider installer version of this used an intentionally-stalling implementation of `getproviders.Source` instead of running a real server because the provider installer is designed to support configurable installation methods, while the module installer is not: its policy about what module source types are accepted is hard-coded in `package getproviders`, at least for now.

This change only affects our test suite, so there is no CHANGELOG entry.

This closes https://github.com/opentofu/opentofu/issues/2677.
