### PR TITLE
Change Go arch from amd64 to arm64 on macos-latest

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -46,7 +46,7 @@ jobs:
           - { runson: ubuntu-latest, goos: linux, goarch: "amd64" }
           - { runson: ubuntu-latest, goos: linux, goarch: "386" }
           - { runson: ubuntu-latest, goos: linux, goarch: "arm" }
-          - { runson: macos-latest, goos: darwin, goarch: "amd64" }
+          - { runson: macos-latest, goos: darwin, goarch: "arm64" }
           # - { runson: windows-latest, goos: windows, goarch: "amd64" }
           # https://github.com/opentofu/opentofu/issues/1201 if fixed
           #  ^ un-comment the  windows-latest line


### PR DESCRIPTION
As discovered by @yottta and tracked on https://github.com/opentofu/opentofu/pull/2678#issuecomment-2811913812, it seems there's a mismatch of the Go architecture being used on `GOARCH` and on the Mac OS X Runner:

<img width="393" alt="Screenshot 2025-04-18 at 08 13 21" src="https://github.com/user-attachments/assets/8ce725bc-e515-452d-ad82-49449e0c501f" />


Relates to #2678

## Target Release

1.10.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
