### PR TITLE
main: Docker credential helper support for OCI registry auth

### DIFF
--- a/cmd/tofu/oci_distribution_test.go
+++ b/cmd/tofu/oci_distribution_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestOCICredentialsLookupEnv_DockerCredHelper(t *testing.T) {
+	// This ociCredentialsLookupEnv is the concrete implementation of
+	// the abstraction that is created in package ociauthconfig, and
+	// so it depends directly on a real (non-substitutable)
+	// implementation of Docker credential helpers.
+	//
+	// Properly testing this would require a functioning credential
+	// helper executable, which is difficult to arrange for in a
+	// portable manner to allow this test to run across multiple
+	// platforms. It's just a thin wrapper around the ORAS-Go
+	// implementation anyway, and that has its own tests upstream
+	// so this test just settles for the compromise of making a
+	// call that we expect to fail and checking that it fails in
+	// the way we expect, to give confidence that we really did
+	// ask the ORAS-Go library to attempt to fetch credentials.
+
+	// To prevent this from accidentally executing some real
+	// credential helper that might be installed on the system
+	// where the tests are running, we'll temporarily override
+	// the PATH environment variable to include only an empty
+	// directory.
+	emptyDir := os.TempDir()
+	os.Setenv("PATH", emptyDir)
+
+	env := ociCredentialsLookupEnv{}
+	_, err := env.QueryDockerCredentialHelper(t.Context(), "fake-for-testing", "https://example.com")
+
+	if err == nil {
+		t.Fatal("unexpected success; want error")
+	}
+
+	// The exact details of the error message can vary between
+	// platforms, but it should always mention that it was
+	// trying to execute the specified credential helper
+	// executable.
+	wantErr := `docker-credential-fake-for-testing`
+	if gotErr := err.Error(); !strings.Contains(gotErr, wantErr) {
+		t.Errorf("wrong error\ngot: %s\nwant substring: %s", gotErr, wantErr)
+	}
+}


### PR DESCRIPTION
This is for https://github.com/opentofu/opentofu/issues/2540.

Our OCI credentials policy layer expects to be provided with an implementation of the Docker credential helper protocol as part of its "credentials lookup environment".

Since we're already using ORAS-Go for everything else we'll just wrap their implementation of this protocol here too, and then translate the result into our own type since we've been intentionally avoiding making ORAS-Go types part of any of our exported package APIs.

There is no additional CHANGELOG entry for this because it is already covered by the broader entries about supporting OCI registries for provider/module installation.

---

Because this is the concrete implementation of an interface we introduced so that unit tests elsewhere could fake it, it's pretty awkward to fully test this implementation without the overhead of having a test build its own credential helper executable dynamically to run on the platform where the test program is running.

ORAS-Go already has its own tests for this functionality, so as a pragmatic compromise here we just focus on testing that we're attempting to run the executable that the protocol expects us to execute, but detecting that through an error result rather than through a success result.
