### PR TITLE
Documentation for the new `-target-file` and `-exclude-file` planning options

### DIFF
--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -204,115 +204,128 @@ func (c *PlanCommand) Help() string {
 	helpText := `
 Usage: tofu [global options] plan [options]
 
-  Generates a speculative execution plan, showing what actions OpenTofu
-  would take to apply the current configuration. This command will not
-  actually perform the planned actions.
+  Generates a speculative execution plan, showing what actions OpenTofu would
+  take to apply the current configuration. This command will not actually
+  perform the planned actions.
 
-  You can optionally save the plan to a file, which you can then pass to
-  the "apply" command to perform exactly the actions described in the plan.
+  You can optionally save the plan to a file, which you can then pass to the
+  "apply" command to perform exactly the actions described in the plan.
 
 Plan Customization Options:
 
-  The following options customize how OpenTofu will produce its plan. You
-  can also use these options when you run "tofu apply" without passing
-  it a saved plan, in order to plan and apply in a single command.
+  The following options customize how OpenTofu will produce its plan. You can
+  also use these options when you run "tofu apply" without passing it a saved
+  plan, in order to plan and apply in a single command.
 
-  -destroy            Select the "destroy" planning mode, which creates a plan
-                      to destroy all objects currently managed by this
-                      OpenTofu configuration instead of the usual behavior.
+  -destroy                Select the "destroy" planning mode, which creates a
+                          plan to destroy all objects currently managed by this
+                          OpenTofu configuration instead of the usual behavior.
 
-  -refresh-only       Select the "refresh only" planning mode, which checks
-                      whether remote objects still match the outcome of the
-                      most recent OpenTofu apply but does not propose any
-                      actions to undo any changes made outside of OpenTofu.
+  -refresh-only           Select the "refresh only" planning mode, which checks
+                          whether remote objects still match the outcome of the
+                          most recent OpenTofu apply but does not propose any
+                          actions to undo any changes made outside of OpenTofu.
 
-  -refresh=false      Skip checking for external changes to remote objects
-                      while creating the plan. This can potentially make
-                      planning faster, but at the expense of possibly planning
-                      against a stale record of the remote system state.
+  -refresh=false          Skip checking for external changes to remote objects
+                          while creating the plan. This can potentially make
+                          planning faster, but at the expense of possibly
+                          planning against a stale record of the remote system
+                          state.
 
-  -replace=resource   Force replacement of a particular resource instance using
-                      its resource address. If the plan would've normally
-                      produced an update or no-op action for this instance,
-                      OpenTofu will plan to replace it instead. You can use
-                      this option multiple times to replace more than one object.
+  -replace=resource       Force replacement of a particular resource instance
+                          using its resource address. If the plan would've
+                          otherwise produced an update or no-op action for this
+                          instance, OpenTofu will plan to replace it instead.
+                          You can use this option multiple times to replace
+                          more than one object.
 
-  -target=resource    Limit the planning operation to only the given module,
-                      resource, or resource instance and all of its
-                      dependencies. You can use this option multiple times to
-                      include more than one object. This is for exceptional
-                      use only. Cannot be used alongside the -exclude flag
+  -target=resource        Limit the planning operation to only the given
+                          module, resource, or resource instance and all of its
+                          dependencies. You can use this option multiple times
+                          to include more than one object. This is for
+                          exceptional use only. Cannot be used alongside the
+                          -exclude option.
 
-  -exclude=resource   Limit the planning operation to not operate on the given
-                      module, resource, or resource instance and all of the
-                      resources and modules that depend on it. You can use this
-                      option multiple times to exclude more than one object.
-                      This is for exceptional use only. Cannot be used alongside
-                      the -target flag
+  -target-file=filename   Similar to -target, but specifies zero or more
+                          resource addresses from a file.
 
-  -var 'foo=bar'      Set a value for one of the input variables in the root
-                      module of the configuration. Use this option more than
-                      once to set more than one variable.
+  -exclude=resource       Limit the planning operation to not operate on the
+                          given module, resource, or resource instance and all
+                          of the resources and modules that depend on it. You
+                          can use this option multiple times to exclude more
+                          than one object. This is for exceptional use only.
+                          Cannot be used together with the -target option.
 
-  -var-file=filename  Load variable values from the given file, in addition
-                      to the default files terraform.tfvars and *.auto.tfvars.
-                      Use this option more than once to include more than one
-                      variables file.
+  -exclude-file=filename  Similar to -exclude, but specifies zero or more
+                          resource addresses from a file.
+
+  -var 'foo=bar'          Set a value for one of the input variables in the
+                          root module of the configuration. Use this option
+                          more than once to set more than one variable.
+
+  -var-file=filename      Load variable values from the given file, in addition
+                          to the default files terraform.tfvars and
+                          *.auto.tfvars. Use this option more than once to
+                          include more than one variables file.
 
 Other Options:
 
-  -compact-warnings          If OpenTofu produces any warnings that are not
-                             accompanied by errors, shows them in a more compact
-                             form that includes only the summary messages.
+  -compact-warnings            If OpenTofu produces any warnings that are not
+                               accompanied by errors, shows them in a more
+                               compact form that includes only the summary
+                               messages.
 
-  -consolidate-warnings      If OpenTofu produces any warnings, no consolidation
-                             will be performed. All locations, for all warnings
-                             will be listed. Enabled by default.
+  -consolidate-warnings=false  If OpenTofu produces any warnings, do not
+                               attempt to consolidate similar messages. All
+                               locations for all warnings will be listed.
 
-  -consolidate-errors        If OpenTofu produces any errors, no consolidation
-                             will be performed. All locations, for all errors
-                             will be listed. Disabled by default
+  -consolidate-errors          If OpenTofu produces any errors, attempt to
+                               consolidate similar messages into a single item.
 
-  -detailed-exitcode         Return detailed exit codes when the command exits.
-                             This will change the meaning of exit codes to:
-                             0 - Succeeded, diff is empty (no changes)
-                             1 - Errored
-                             2 - Succeeded, there is a diff
+  -detailed-exitcode           Return detailed exit codes when the command
+                               exits. The detailed exit codes are:
+                                 0 - Succeeded but no changes proposed
+                                 1 - Planning failed with an error
+                                 2 - Succeeded and changes are proposed
 
-  -generate-config-out=path  (Experimental) If import blocks are present in
-                             configuration, instructs OpenTofu to generate HCL
-                             for any imported resources not already present. The
-                             configuration is written to a new file at PATH,
-                             which must not already exist. OpenTofu may still
-                             attempt to write configuration if the plan errors.
+  -generate-config-out=path    (Experimental) If import blocks are present in
+                               configuration, instructs OpenTofu to generate
+                               HCL for any imported resources not already
+                               present. The configuration is written to a new
+                               file at PATH, which must not already exist.
+                               OpenTofu may still attempt to write
+                               configuration if planning fails with an error.
 
-  -input=true                Ask for input for variables if not directly set.
+  -input=false                 Disable prompting for required input variables
+                               that are not set some other way.
 
-  -lock=false                Don't hold a state lock during the operation. This
-                             is dangerous if others might concurrently run
-                             commands against the same workspace.
+  -lock=false                  Don't hold a state lock during the operation.
+                               This is dangerous if others might concurrently
+                               run commands against the same workspace.
 
-  -lock-timeout=0s           Duration to retry a state lock.
+  -lock-timeout=duration       Duration to retry a state lock, such as "5s"
+                               to represent five seconds.
 
-  -no-color                  If specified, output won't contain any color.
+  -no-color                    Disable virtual terminal escape sequences.
 
-  -concise                   Disables progress-related messages in the output.
+  -concise                     Disable progress-related messages.
 
-  -out=path                  Write a plan file to the given path. This can be
-                             used as input to the "apply" command.
+  -out=path                    Write a plan file to the given path. This can be
+                               used as input to the "apply" command.
 
-  -parallelism=n             Limit the number of concurrent operations. Defaults
-                             to 10.
+  -parallelism=n               Limit the number of concurrent operations.
+                               Defaults to 10.
 
-  -state=statefile           A legacy option used for the local backend only.
-                             See the local backend's documentation for more
-                             information.
+  -state=statefile             A legacy option used for the local backend only.
+                               Refer to the local backend's documentation for
+                               more information.
 
-  -show-sensitive            If specified, sensitive values will be displayed.
+  -show-sensitive              If specified, sensitive values will not be
+                               redacted in te UI output.
 
-  -json                      Produce output in a machine-readable JSON format, 
-                             suitable for use in text editor integrations and 
-                             other automated systems. Always disables color.
+  -json                        Produce output in a machine-readable JSON
+                               format, suitable for use in text editor
+                               integrations and other automated systems.
 `
 	return strings.TrimSpace(helpText)
 }

--- a/website/docs/cli/commands/plan.mdx
+++ b/website/docs/cli/commands/plan.mdx
@@ -115,6 +115,17 @@ In addition to alternate [planning modes](#planning-modes), there are several op
 - `-replace=ADDRESS` - Instructs OpenTofu to plan to replace the
   resource instance with the given address. This is helpful when one or more remote objects have become degraded, and you can use replacement objects with the same configuration to align with immutable infrastructure patterns. OpenTofu will use a "replace" action if the specified resource would normally cause an "update" action or no action at all. Include this option multiple times to replace several objects at once. You cannot use `-replace` with the `-destroy` option.
 
+- `-exclude=ADDRESS` - Instructs OpenTofu to focus its planning efforts only
+  on resource instances which do not match the given excluded address, and that
+  do not depend on any such resources or modules that were excluded.
+
+  :::note
+  Use `-exclude=ADDRESS` in exceptional circumstances only, such as recovering from mistakes or working around OpenTofu limitations. Refer to [Resource Targeting](#resource-targeting) for more details.
+  :::
+
+- `-exclude-file=FILENAME` - Similar to `-exclude` but with multiple addresses
+  specified in a separate file rather than directly on the command line.
+
 - `-target=ADDRESS` - Instructs OpenTofu to focus its planning efforts only
   on resource instances which match the given address and on any objects that
   those instances depend on.
@@ -123,13 +134,8 @@ In addition to alternate [planning modes](#planning-modes), there are several op
   Use `-target=ADDRESS` in exceptional circumstances only, such as recovering from mistakes or working around OpenTofu limitations. Refer to [Resource Targeting](#resource-targeting) for more details.
   :::
 
-- `-exclude=ADDRESS` - Instructs OpenTofu to focus its planning efforts only
-  on resource instances which do not match the given excluded address, and that
-  do not depend on any such resources or modules that were excluded.
-
-  :::note
-  Use `-exclude=ADDRESS` in exceptional circumstances only, such as recovering from mistakes or working around OpenTofu limitations. Refer to [Resource Targeting](#resource-targeting) for more details.
-  :::
+- `-target-file=FILENAME` - Similar to `-target` but with multiple addresses
+  specified in a separate file rather than directly on the command line.
 
 - `-var 'NAME=VALUE'` - Sets a value for a single
   [input variable](../../language/values/variables.mdx) declared in the
@@ -225,25 +231,44 @@ input variables, see
 
 ### Resource Targeting
 
-You can use the `-target` or the `-exclude` option to trigger resource targeting,
-focusing OpenTofu's attention on only a subset of resources.
-Using the `-target` option will focus OpenTofu's attention only on resources and
-module that are directly targeted, or are dependencies of the target.
-Using the `-exclude` option will focus OpenTofu's attention only on resources and
-modules that are not directly excluded, and are not dependent on an excluded resource
-or module.
+You can use the `-target`, `-target-file`, `-exclude`, and `-exclude-file` options
+to activate resource targeting, which focuses OpenTofu's attention on only a
+subset of the resource instances that are declared in the configuration or tracked
+in the current state.
 
-You can use multiple `-target` flags in order to target multiple resources and modules,
-and you can use multiple `-exclude` flags in order to exclude multiple resource and
-modules. You cannot use both `-target` and `-exclude` flags together.
+Using `-target` or `-target-file` focuses OpenTofu's attention only on resource
+instances that match the given target addresses and resource instances that
+are dependencies of those.
 
-You can use [resource address syntax](../../cli/state/resource-addressing.mdx)
-to specify the constraint. OpenTofu interprets the resource address as follows:
+Using `-exclude` or `-exclude-file` instead focuses OpenTofu's attention on
+resource instances _other than_ those that match and anything that depends
+on those.
+
+Positive targeting using `-target` and `-target-file` is mutually exclusive with
+negative targeting using `-exclude` and `-exclude-file`. You cannot use both
+the target options and the exclude options together in a single command.
+
+Specify the resource instances to target using [resource address syntax](../../cli/state/resource-addressing.mdx).
+For `-target` and `-exclude`, refer to
+[Resource Addresses on the Command Line](../../cli/state/resource-addressing.mdx#resource-addresses-on-the-command-line).
+For `-target-file` and `-exclude-file`, refer to
+[Resource Addresses in Targeting Files](../../cli/state/resource-addressing.mdx#resource-addresses-in-targeting-files).
+
+OpenTofu matches resource instances with the given resource addresses as
+follows:
 
 * If the given address identifies one specific resource instance, OpenTofu
-  will select that instance alone. For resources with either `count` or
-  `for_each` set, a resource instance address must include the instance index
-  part, like `aws_instance.example[0]`.
+  will select that instance alone.
+
+  For resources with either `count` or `for_each` set, a resource instance
+  address must include the instance index part, like `aws_instance.example[0]`.
+
+  Your shell may assign special meaning to some punctuation characters used
+  in a resource instance address, such as quotes and brackets, so it's
+  important to properly quote or escape resource instance addresses written
+  directly on the command line in `-target` or `-exclude` options as
+  described in
+  [Resource Addresses on the Command Line](../../cli/state/resource-addressing.mdx#resource-addresses-on-the-command-line).
 
 * If the given address identifies a resource as a whole, OpenTofu will select
   all of the instances of that resource. For resources with either `count`
@@ -258,15 +283,15 @@ to specify the constraint. OpenTofu interprets the resource address as follows:
 
 This targeting capability is provided for exceptional circumstances, such
 as recovering from mistakes or working around OpenTofu limitations. It
-is _not recommended_ to use `-target` or `-exclude` for routine operations, since
-this can lead to undetected configuration drift and confusion about how the true
-state of resources relates to configuration.
+is _not recommended_ to use these options for routine operations, because
+that can lead to undetected configuration drift and confusion about how the
+true state of resources relates to configuration.
 
-Instead of using `-target` or `-exclude` as a means to operate on isolated portions
-of very large configurations, prefer instead to break large configurations into
+Instead of using resource targeting to operate on isolated portions
+of very large configurations, prefer to break large configurations into
 several smaller configurations that can each be independently applied.
-[Data sources](../../language/data-sources/index.mdx) can be used to access
-information about resources created in other configurations, allowing
+You can use [data sources](../../language/data-sources/index.mdx) to access
+information about resources declared in other configurations, allowing
 a complex system architecture to be broken down into more manageable parts
 that can be updated independently.
 

--- a/website/docs/cli/state/resource-addressing.mdx
+++ b/website/docs/cli/state/resource-addressing.mdx
@@ -127,3 +127,97 @@ aws_instance.web["example"]
 ```
 
 Refers to only the "example" instance in the config, and resolves to "value4".
+
+## Resource Addresses on the Command Line
+
+When using resource addresses directly in command line arguments such as
+the `-target`, `-exclude`, and `-replace` planning options, the punctuation
+characters in the resource address syntax might conflict with special
+interpretation of those characters by the shell you are using to run
+OpenTofu.
+
+To avoid this, you must ensure that those characters are properly quoted
+or escaped so that your shell will pass them literally to OpenTofu.
+The syntax for doing so varies depending on your shell or command
+interpreter:
+
+- For Unix-style shells such as `bash`, write the resource address in
+  single quotes (`'`):
+
+    ```bash
+    tofu apply -target='aws_instance.example["foo"]'
+    ```
+
+    If you need to specify an instance key string that includes a
+    single quote character, use two separate single-quoted sequences
+    with an escaped single quote between them. For example,
+    the following includes the instance key `"example'foo"`:
+
+    ```bash
+    tofu apply -target='aws_instance.example["example'\''foo"]'
+    ```
+
+- For PowerShell 7.3 or later, write the resource address in single
+  quotes (`'`):
+
+    ```powershell
+    tofu apply -target='aws_instance.example["foo"]'
+    ```
+
+    Older versions of PowerShell have different requirements. For more
+    information, refer to
+    [Passing arguments that contain quote characters](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_parsing?view=powershell-7.5#passing-arguments-that-contain-quote-characters).
+
+    If you need to specify an instance key string that includes a
+    single quote character, use two consecutive single quotes to
+    represent a single literal quote. For example, the following
+    includes the instance key `"example'foo"`:
+
+    ```powershell
+    tofu apply -target='aws_instance.example["example''foo"]'
+    ```
+
+- For Windows Command Prompt (`cmd.exe`), write the resource address in
+  double quotes (`"`) and escape any quotes from the resource address
+  using a backslash (`\`):
+
+    ```batchfile
+    tofu apply -target="aws_instance.example[\"foo\"]"
+    ```
+
+## Resource Addresses in Targeting Files
+
+The `-target-file` and `-exclude-file`
+[planning options](../commands/plan.mdx#planning-options) read resource
+addresses from a separate file that can contain zero or more resource
+addresses.
+
+OpenTofu interprets a targeting file on a line-by-line basis. The
+content of each line must be one of the following:
+
+- A resource address using the syntax described above, in which case
+  OpenTofu adds the address to the set of target addresses.
+- A comment starting with the `#` character, in which case OpenTofu
+  ignores the line completely.
+- A blank line consisting only of zero or more space characters, in
+  which case OpenTofu also ignores the line completely.
+
+For example, the following is a valid targeting file specifying a
+number of resource addresses that might need to be created first
+when applying a certain configuration for the first time:
+
+```hcl
+# These modules must be targeted during initial creation.
+module.network
+module.cluster
+
+# The following resources must also be included on initial
+# creation.
+aws_iam_role.all["base"]
+aws_iam_role_policy.all["base"]
+```
+
+The targeting file above would match all instances of all resources
+whose addresses begin with `module.network` or `module.cluster`, and
+also the specific resource instances `aws_iam_role.all["base"]` and
+`aws_iam_role_policy.all["base"]`.


### PR DESCRIPTION
This adds documentation for the features introduced by https://github.com/opentofu/opentofu/pull/2620.

---

While updating the `tofu plan -help` output I noticed that in other recent work a variety of inconsistencies had accumulated, and so fixed them since I needed to re-wrap most of the options to accommodate the new column sizes anyway:

- The line-wrapping length was somewhat erratic. It's now restored to being a maximum of 80 columns per line.
- Options that take string arguments were all presented as `-name=placeholder`, except for `-lock-timeout` which was previously given as `-lock-timeout=0s`. Setting this to `0s` is pointless because that's the default anyway, so now includes a more realistic example.
- Boolean options that default to being on were not all consistently shown with `=false` to indicate that such a suffix is required for them to have any effect. Along with this, the descriptions associated with some were confusing about whether the effect of the option is to enable or disable the effect. They now all consistently use `=false` and the effect of specifying that is described in imperative voice.

    (We'd previously been trying for new examples of this to be named with `-no-` prefixes and have inverted meaning so that the disabled state is more concise, but I notice some new examples of the old `-positive-thing=false` have appeared recently, which is unfortunate but they are now constrained by compatibility promises.)

In the much longer term I hope we can one day move away from these hand-formatted messages in favor of something generated dynamically in a systematic way from data, but that would be far too far beyond the intended scope of this PR. :grinning:


