### PR TITLE
Use modern helpers from Go's testing.T API

### DIFF
--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestReadPathOrContents_Path(t *testing.T) {
-	f, cleanup := testTempFile(t)
-	defer cleanup()
+	f := testTempFile(t)
 
 	if _, err := io.WriteString(f, "foobar"); err != nil {
 		t.Fatalf("err: %s", err)
@@ -39,8 +38,7 @@ func TestReadPathOrContents_TildePath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	f, cleanup := testTempFile(t, home)
-	defer cleanup()
+	f := testTempFile(t, home)
 
 	if _, err := io.WriteString(f, "foobar"); err != nil {
 		t.Fatalf("err: %s", err)
@@ -68,8 +66,7 @@ func TestRead_PathNoPermission(t *testing.T) {
 		t.Skip("This test is invalid when running as root, since root can read every file")
 	}
 
-	f, cleanup := testTempFile(t)
-	defer cleanup()
+	f := testTempFile(t)
 
 	if _, err := io.WriteString(f, "foobar"); err != nil {
 		t.Fatalf("err: %s", err)
@@ -116,8 +113,13 @@ func TestReadPathOrContents_TildeContents(t *testing.T) {
 	}
 }
 
-// Returns an open tempfile based at baseDir and a function to clean it up.
-func testTempFile(t *testing.T, baseDir ...string) (*os.File, func()) {
+// Returns an open tempfile based at baseDir.
+//
+// The temporary file is cleaned up automatically when the calling
+// test is complete.
+func testTempFile(t testing.TB, baseDir ...string) *os.File {
+	t.Helper()
+
 	base := ""
 	if len(baseDir) == 1 {
 		base = baseDir[0]
@@ -127,7 +129,8 @@ func testTempFile(t *testing.T, baseDir ...string) (*os.File, func()) {
 		t.Fatalf("err: %s", err)
 	}
 
-	return f, func() {
+	t.Cleanup(func() {
 		os.Remove(f.Name())
-	}
+	})
+	return f
 }

--- a/internal/backend/local/backend_apply_test.go
+++ b/internal/backend/local/backend_apply_test.go
@@ -42,8 +42,7 @@ func TestLocal_applyBasic(t *testing.T) {
 		"ami": cty.StringVal("bar"),
 	})}
 
-	op, configCleanup, done := testOperationApply(t, "./testdata/apply")
-	defer configCleanup()
+	op, done := testOperationApply(t, "./testdata/apply")
 
 	run, err := b.Operation(context.Background(), op)
 	if err != nil {
@@ -86,8 +85,7 @@ func TestLocal_applyCheck(t *testing.T) {
 		"ami": cty.StringVal("bar"),
 	})}
 
-	op, configCleanup, done := testOperationApply(t, "./testdata/apply-check")
-	defer configCleanup()
+	op, done := testOperationApply(t, "./testdata/apply-check")
 
 	run, err := b.Operation(context.Background(), op)
 	if err != nil {
@@ -128,8 +126,7 @@ func TestLocal_applyEmptyDir(t *testing.T) {
 	p := TestLocalProvider(t, b, "test", providers.ProviderSchema{})
 	p.ApplyResourceChangeResponse = &providers.ApplyResourceChangeResponse{NewState: cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("yes")})}
 
-	op, configCleanup, done := testOperationApply(t, "./testdata/empty")
-	defer configCleanup()
+	op, done := testOperationApply(t, "./testdata/empty")
 
 	run, err := b.Operation(context.Background(), op)
 	if err != nil {
@@ -162,8 +159,7 @@ func TestLocal_applyEmptyDirDestroy(t *testing.T) {
 	p := TestLocalProvider(t, b, "test", providers.ProviderSchema{})
 	p.ApplyResourceChangeResponse = &providers.ApplyResourceChangeResponse{}
 
-	op, configCleanup, done := testOperationApply(t, "./testdata/empty")
-	defer configCleanup()
+	op, done := testOperationApply(t, "./testdata/empty")
 	op.PlanMode = plans.DestroyMode
 
 	run, err := b.Operation(context.Background(), op)
@@ -229,8 +225,7 @@ func TestLocal_applyError(t *testing.T) {
 		}
 	}
 
-	op, configCleanup, done := testOperationApply(t, "./testdata/apply-error")
-	defer configCleanup()
+	op, done := testOperationApply(t, "./testdata/apply-error")
 
 	run, err := b.Operation(context.Background(), op)
 	if err != nil {
@@ -279,8 +274,7 @@ func TestLocal_applyBackendFail(t *testing.T) {
 	}
 	defer os.Chdir(wd)
 
-	op, configCleanup, done := testOperationApply(t, wd+"/testdata/apply")
-	defer configCleanup()
+	op, done := testOperationApply(t, wd+"/testdata/apply")
 
 	b.Backend = &backendWithFailingState{}
 
@@ -325,8 +319,7 @@ func TestLocal_applyRefreshFalse(t *testing.T) {
 	p := TestLocalProvider(t, b, "test", planFixtureSchema())
 	testStateFile(t, b.StatePath, testPlanState())
 
-	op, configCleanup, done := testOperationApply(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationApply(t, "./testdata/plan")
 
 	run, err := b.Operation(context.Background(), op)
 	if err != nil {
@@ -364,10 +357,10 @@ func (s failingState) WriteState(state *states.State) error {
 	return errors.New("fake failure")
 }
 
-func testOperationApply(t *testing.T, configDir string) (*backend.Operation, func(), func(*testing.T) *terminal.TestOutput) {
+func testOperationApply(t *testing.T, configDir string) (*backend.Operation, func(*testing.T) *terminal.TestOutput) {
 	t.Helper()
 
-	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
+	_, configLoader := initwd.MustLoadConfigForTests(t, configDir, "tests")
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewOperation(arguments.ViewHuman, false, views.NewView(streams))
@@ -385,7 +378,7 @@ func testOperationApply(t *testing.T, configDir string) (*backend.Operation, fun
 		StateLocker:     clistate.NewNoopLocker(),
 		View:            view,
 		DependencyLocks: depLocks,
-	}, configCleanup, done
+	}, done
 }
 
 // applyFixtureSchema returns a schema suitable for processing the
@@ -411,9 +404,8 @@ func TestApply_applyCanceledAutoApprove(t *testing.T) {
 
 	TestLocalProvider(t, b, "test", applyFixtureSchema())
 
-	op, configCleanup, done := testOperationApply(t, "./testdata/apply")
+	op, done := testOperationApply(t, "./testdata/apply")
 	op.AutoApprove = true
-	defer configCleanup()
 	defer func() {
 		output := done(t)
 		if !strings.Contains(output.Stderr(), "execution halted") {

--- a/internal/backend/local/backend_apply_test.go
+++ b/internal/backend/local/backend_apply_test.go
@@ -268,11 +268,7 @@ func TestLocal_applyBackendFail(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get current working directory")
 	}
-	err = os.Chdir(filepath.Dir(b.StatePath))
-	if err != nil {
-		t.Fatalf("failed to set temporary working directory")
-	}
-	defer os.Chdir(wd)
+	t.Chdir(filepath.Dir(b.StatePath))
 
 	op, done := testOperationApply(t, wd+"/testdata/apply")
 

--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -36,8 +36,7 @@ func TestLocalRun(t *testing.T) {
 	configDir := "./testdata/empty"
 	b := TestLocal(t)
 
-	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
-	defer configCleanup()
+	_, configLoader := initwd.MustLoadConfigForTests(t, configDir, "tests")
 
 	streams, _ := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -67,8 +66,7 @@ func TestLocalRun_error(t *testing.T) {
 	// should then cause LocalRun to return with the state unlocked.
 	b.Backend = backendWithStateStorageThatFailsRefresh{}
 
-	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
-	defer configCleanup()
+	_, configLoader := initwd.MustLoadConfigForTests(t, configDir, "tests")
 
 	streams, _ := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -94,8 +92,7 @@ func TestLocalRun_cloudPlan(t *testing.T) {
 	configDir := "./testdata/apply"
 	b := TestLocal(t)
 
-	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
-	defer configCleanup()
+	_, configLoader := initwd.MustLoadConfigForTests(t, configDir, "tests")
 
 	planPath := "./testdata/plan-bookmark/bookmark.json"
 
@@ -129,8 +126,7 @@ func TestLocalRun_stalePlan(t *testing.T) {
 	configDir := "./testdata/apply"
 	b := TestLocal(t)
 
-	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
-	defer configCleanup()
+	_, configLoader := initwd.MustLoadConfigForTests(t, configDir, "tests")
 
 	// Write an empty state file with serial 3
 	sf, err := os.Create(b.StatePath)

--- a/internal/backend/local/backend_plan_test.go
+++ b/internal/backend/local/backend_plan_test.go
@@ -35,8 +35,7 @@ func TestLocal_planBasic(t *testing.T) {
 	b := TestLocal(t)
 	p := TestLocalProvider(t, b, "test", planFixtureSchema())
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	op.PlanRefresh = true
 
 	run, err := b.Operation(context.Background(), op)
@@ -73,8 +72,7 @@ func TestLocal_planInAutomation(t *testing.T) {
 	//
 	// Ideally this test would be replaced by a call-logging mock view, but
 	// that's future work.
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	op.PlanRefresh = true
 
 	run, err := b.Operation(context.Background(), op)
@@ -95,8 +93,7 @@ func TestLocal_planNoConfig(t *testing.T) {
 	b := TestLocal(t)
 	TestLocalProvider(t, b, "test", providers.ProviderSchema{})
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/empty")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/empty")
 	op.PlanRefresh = true
 
 	run, err := b.Operation(context.Background(), op)
@@ -140,8 +137,7 @@ func TestLocal_plan_context_error(t *testing.T) {
 	}
 	b.ContextOpts.Parallelism = -1
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 
 	// we coerce a failure in Context() by omitting the provider schema
 	run, err := b.Operation(context.Background(), op)
@@ -196,8 +192,7 @@ func TestLocal_planOutputsChanged(t *testing.T) {
 	outDir := t.TempDir()
 	defer os.RemoveAll(outDir)
 	planPath := filepath.Join(outDir, "plan.tfplan")
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-outputs-changed")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan-outputs-changed")
 	op.PlanRefresh = true
 	op.PlanOutPath = planPath
 	cfg := cty.ObjectVal(map[string]cty.Value{
@@ -253,8 +248,7 @@ func TestLocal_planModuleOutputsChanged(t *testing.T) {
 	outDir := t.TempDir()
 	defer os.RemoveAll(outDir)
 	planPath := filepath.Join(outDir, "plan.tfplan")
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-module-outputs-changed")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan-module-outputs-changed")
 	op.PlanRefresh = true
 	op.PlanOutPath = planPath
 	cfg := cty.ObjectVal(map[string]cty.Value{
@@ -294,8 +288,7 @@ func TestLocal_planTainted(t *testing.T) {
 	testStateFile(t, b.StatePath, testPlanState_tainted())
 	outDir := t.TempDir()
 	planPath := filepath.Join(outDir, "plan.tfplan")
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	op.PlanRefresh = true
 	op.PlanOutPath = planPath
 	cfg := cty.ObjectVal(map[string]cty.Value{
@@ -374,8 +367,7 @@ func TestLocal_planDeposedOnly(t *testing.T) {
 	}))
 	outDir := t.TempDir()
 	planPath := filepath.Join(outDir, "plan.tfplan")
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	op.PlanRefresh = true
 	op.PlanOutPath = planPath
 	cfg := cty.ObjectVal(map[string]cty.Value{
@@ -465,8 +457,7 @@ func TestLocal_planTainted_createBeforeDestroy(t *testing.T) {
 	testStateFile(t, b.StatePath, testPlanState_tainted())
 	outDir := t.TempDir()
 	planPath := filepath.Join(outDir, "plan.tfplan")
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-cbd")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan-cbd")
 	op.PlanRefresh = true
 	op.PlanOutPath = planPath
 	cfg := cty.ObjectVal(map[string]cty.Value{
@@ -521,8 +512,7 @@ func TestLocal_planRefreshFalse(t *testing.T) {
 	p := TestLocalProvider(t, b, "test", planFixtureSchema())
 	testStateFile(t, b.StatePath, testPlanState())
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 
 	run, err := b.Operation(context.Background(), op)
 	if err != nil {
@@ -555,8 +545,7 @@ func TestLocal_planDestroy(t *testing.T) {
 	outDir := t.TempDir()
 	planPath := filepath.Join(outDir, "plan.tfplan")
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	op.PlanMode = plans.DestroyMode
 	op.PlanRefresh = true
 	op.PlanOutPath = planPath
@@ -607,8 +596,7 @@ func TestLocal_planDestroy_withDataSources(t *testing.T) {
 	outDir := t.TempDir()
 	planPath := filepath.Join(outDir, "plan.tfplan")
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/destroy-with-ds")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/destroy-with-ds")
 	op.PlanMode = plans.DestroyMode
 	op.PlanRefresh = true
 	op.PlanOutPath = planPath
@@ -681,8 +669,7 @@ func TestLocal_planOutPathNoChange(t *testing.T) {
 	outDir := t.TempDir()
 	planPath := filepath.Join(outDir, "plan.tfplan")
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	op.PlanOutPath = planPath
 	cfg := cty.ObjectVal(map[string]cty.Value{
 		"path": cty.StringVal(b.StatePath),
@@ -718,10 +705,10 @@ func TestLocal_planOutPathNoChange(t *testing.T) {
 	}
 }
 
-func testOperationPlan(t *testing.T, configDir string) (*backend.Operation, func(), func(*testing.T) *terminal.TestOutput) {
+func testOperationPlan(t *testing.T, configDir string) (*backend.Operation, func(*testing.T) *terminal.TestOutput) {
 	t.Helper()
 
-	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
+	_, configLoader := initwd.MustLoadConfigForTests(t, configDir, "tests")
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewOperation(arguments.ViewHuman, false, views.NewView(streams))
@@ -739,7 +726,7 @@ func testOperationPlan(t *testing.T, configDir string) (*backend.Operation, func
 		StateLocker:     clistate.NewNoopLocker(),
 		View:            view,
 		DependencyLocks: depLocks,
-	}, configCleanup, done
+	}, done
 }
 
 // testPlanState is just a common state that we use for testing plan.
@@ -902,8 +889,7 @@ func TestLocal_invalidOptions(t *testing.T) {
 	b := TestLocal(t)
 	TestLocalProvider(t, b, "test", planFixtureSchema())
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	op.PlanRefresh = true
 	op.PlanMode = plans.RefreshOnlyMode
 	op.ForceReplace = []addrs.AbsResourceInstance{mustResourceInstanceAddr("test_instance.foo")}

--- a/internal/backend/local/backend_refresh_test.go
+++ b/internal/backend/local/backend_refresh_test.go
@@ -38,8 +38,7 @@ func TestLocal_refresh(t *testing.T) {
 		"id": cty.StringVal("yes"),
 	})}
 
-	op, configCleanup, done := testOperationRefresh(t, "./testdata/refresh")
-	defer configCleanup()
+	op, done := testOperationRefresh(t, "./testdata/refresh")
 	defer done(t)
 
 	run, err := b.Operation(context.Background(), op)
@@ -106,8 +105,7 @@ func TestLocal_refreshInput(t *testing.T) {
 	b.OpInput = true
 	b.ContextOpts.UIInput = &tofu.MockUIInput{InputReturnString: "bar"}
 
-	op, configCleanup, done := testOperationRefresh(t, "./testdata/refresh-var-unset")
-	defer configCleanup()
+	op, done := testOperationRefresh(t, "./testdata/refresh-var-unset")
 	defer done(t)
 	op.UIIn = b.ContextOpts.UIInput
 
@@ -140,8 +138,7 @@ func TestLocal_refreshValidate(t *testing.T) {
 	// Enable validation
 	b.OpValidation = true
 
-	op, configCleanup, done := testOperationRefresh(t, "./testdata/refresh")
-	defer configCleanup()
+	op, done := testOperationRefresh(t, "./testdata/refresh")
 	defer done(t)
 
 	run, err := b.Operation(context.Background(), op)
@@ -190,8 +187,7 @@ func TestLocal_refreshValidateProviderConfigured(t *testing.T) {
 	// Enable validation
 	b.OpValidation = true
 
-	op, configCleanup, done := testOperationRefresh(t, "./testdata/refresh-provider-config")
-	defer configCleanup()
+	op, done := testOperationRefresh(t, "./testdata/refresh-provider-config")
 	defer done(t)
 
 	run, err := b.Operation(context.Background(), op)
@@ -216,8 +212,7 @@ test_instance.foo:
 func TestLocal_refresh_context_error(t *testing.T) {
 	b := TestLocal(t)
 	testStateFile(t, b.StatePath, testRefreshState())
-	op, configCleanup, done := testOperationRefresh(t, "./testdata/apply")
-	defer configCleanup()
+	op, done := testOperationRefresh(t, "./testdata/apply")
 	defer done(t)
 
 	// we coerce a failure in Context() by omitting the provider schema
@@ -244,8 +239,7 @@ func TestLocal_refreshEmptyState(t *testing.T) {
 		"id": cty.StringVal("yes"),
 	})}
 
-	op, configCleanup, done := testOperationRefresh(t, "./testdata/refresh")
-	defer configCleanup()
+	op, done := testOperationRefresh(t, "./testdata/refresh")
 
 	run, err := b.Operation(context.Background(), op)
 	if err != nil {
@@ -266,10 +260,10 @@ func TestLocal_refreshEmptyState(t *testing.T) {
 	assertBackendStateUnlocked(t, b)
 }
 
-func testOperationRefresh(t *testing.T, configDir string) (*backend.Operation, func(), func(*testing.T) *terminal.TestOutput) {
+func testOperationRefresh(t *testing.T, configDir string) (*backend.Operation, func(*testing.T) *terminal.TestOutput) {
 	t.Helper()
 
-	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
+	_, configLoader := initwd.MustLoadConfigForTests(t, configDir, "tests")
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewOperation(arguments.ViewHuman, false, views.NewView(streams))
@@ -286,7 +280,7 @@ func testOperationRefresh(t *testing.T, configDir string) (*backend.Operation, f
 		StateLocker:     clistate.NewNoopLocker(),
 		View:            view,
 		DependencyLocks: depLocks,
-	}, configCleanup, done
+	}, done
 }
 
 // testRefreshState is just a common state that we use for testing refresh.

--- a/internal/backend/local/backend_test.go
+++ b/internal/backend/local/backend_test.go
@@ -233,20 +233,8 @@ func TestLocal_multiStateBackend(t *testing.T) {
 
 // testTmpDir changes into a tmp dir and change back automatically when the test
 // and all its subtests complete.
-func testTmpDir(t *testing.T) {
+func testTmpDir(t testing.TB) {
+	t.Helper()
 	tmp := t.TempDir()
-
-	old, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.Chdir(tmp); err != nil {
-		t.Fatal(err)
-	}
-
-	t.Cleanup(func() {
-		// ignore errors and try to clean up
-		os.Chdir(old)
-	})
+	t.Chdir(tmp)
 }

--- a/internal/backend/remote/backend_context_test.go
+++ b/internal/backend/remote/backend_context_test.go
@@ -189,8 +189,7 @@ func TestRemoteContextWithVars(t *testing.T) {
 			b, bCleanup := testBackendDefault(t)
 			defer bCleanup()
 
-			_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
-			defer configCleanup()
+			_, configLoader := initwd.MustLoadConfigForTests(t, configDir, "tests")
 
 			workspaceID, err := b.getRemoteWorkspaceID(context.Background(), backend.DefaultStateName)
 			if err != nil {
@@ -412,8 +411,7 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 			b, bCleanup := testBackendDefault(t)
 			defer bCleanup()
 
-			_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
-			defer configCleanup()
+			_, configLoader := initwd.MustLoadConfigForTests(t, configDir, "tests")
 
 			workspaceID, err := b.getRemoteWorkspaceID(context.Background(), backend.DefaultStateName)
 			if err != nil {

--- a/internal/backend/remote/backend_plan_test.go
+++ b/internal/backend/remote/backend_plan_test.go
@@ -1011,17 +1011,9 @@ func TestRemote_planWithWorkingDirectoryFromCurrentPath(t *testing.T) {
 		t.Fatalf("error configuring working directory: %v", err)
 	}
 
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("error getting current working directory: %v", err)
-	}
-
 	// We need to change into the configuration directory to make sure
 	// the logic to upload the correct slug is working as expected.
-	if err := os.Chdir("./testdata/plan-with-working-directory/tofu"); err != nil {
-		t.Fatalf("error changing directory: %v", err)
-	}
-	defer os.Chdir(wd) // Make sure we change back again when were done.
+	t.Chdir("./testdata/plan-with-working-directory/tofu")
 
 	// For this test we need to give our current directory instead of the
 	// full path to the configuration as we already changed directories.

--- a/internal/backend/remote/backend_plan_test.go
+++ b/internal/backend/remote/backend_plan_test.go
@@ -33,16 +33,16 @@ import (
 	"github.com/opentofu/opentofu/internal/tofu"
 )
 
-func testOperationPlan(t *testing.T, configDir string) (*backend.Operation, func(), func(*testing.T) *terminal.TestOutput) {
+func testOperationPlan(t *testing.T, configDir string) (*backend.Operation, func(*testing.T) *terminal.TestOutput) {
 	t.Helper()
 
 	return testOperationPlanWithTimeout(t, configDir, 0)
 }
 
-func testOperationPlanWithTimeout(t *testing.T, configDir string, timeout time.Duration) (*backend.Operation, func(), func(*testing.T) *terminal.TestOutput) {
+func testOperationPlanWithTimeout(t *testing.T, configDir string, timeout time.Duration) (*backend.Operation, func(*testing.T) *terminal.TestOutput) {
 	t.Helper()
 
-	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
+	_, configLoader := initwd.MustLoadConfigForTests(t, configDir, "tests")
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -62,15 +62,14 @@ func testOperationPlanWithTimeout(t *testing.T, configDir string, timeout time.D
 		Type:            backend.OperationTypePlan,
 		View:            operationView,
 		DependencyLocks: depLocks,
-	}, configCleanup, done
+	}, done
 }
 
 func TestRemote_planBasic(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	defer done(t)
 
 	op.Workspace = backend.DefaultStateName
@@ -107,8 +106,7 @@ func TestRemote_planCanceled(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	defer done(t)
 
 	op.Workspace = backend.DefaultStateName
@@ -137,8 +135,7 @@ func TestRemote_planLongLine(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-long-line")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan-long-line")
 	defer done(t)
 
 	op.Workspace = backend.DefaultStateName
@@ -182,8 +179,7 @@ func TestRemote_planWithoutPermissions(t *testing.T) {
 	}
 	w.Permissions.CanQueueRun = false
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 
 	op.Workspace = "prod"
 
@@ -208,8 +204,7 @@ func TestRemote_planWithParallelism(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 
 	if b.ContextOpts == nil {
 		b.ContextOpts = &tofu.ContextOpts{}
@@ -238,8 +233,7 @@ func TestRemote_planWithPlan(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 
 	op.PlanFile = planfile.NewWrappedLocal(&planfile.Reader{})
 	op.Workspace = backend.DefaultStateName
@@ -268,8 +262,7 @@ func TestRemote_planWithPath(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 
 	op.PlanOutPath = "./testdata/plan"
 	op.Workspace = backend.DefaultStateName
@@ -298,8 +291,7 @@ func TestRemote_planWithoutRefresh(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	defer done(t)
 
 	op.PlanRefresh = false
@@ -335,8 +327,7 @@ func TestRemote_planWithoutRefreshIncompatibleAPIVersion(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 
 	b.client.SetFakeRemoteAPIVersion("2.3")
 
@@ -367,8 +358,7 @@ func TestRemote_planWithRefreshOnly(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	defer done(t)
 
 	op.PlanMode = plans.RefreshOnlyMode
@@ -404,8 +394,7 @@ func TestRemote_planWithRefreshOnlyIncompatibleAPIVersion(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 
 	b.client.SetFakeRemoteAPIVersion("2.3")
 
@@ -459,8 +448,7 @@ func TestRemote_planWithTarget(t *testing.T) {
 		}
 	}
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	defer done(t)
 
 	addr, _ := addrs.ParseAbsResourceStr("null_resource.foo")
@@ -505,8 +493,7 @@ func TestRemote_planWithTargetIncompatibleAPIVersion(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 
 	// Set the tfe client's RemoteAPIVersion to an empty string, to mimic
 	// API versions prior to 2.3.
@@ -542,8 +529,7 @@ func TestRemote_planWithExclude(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 
 	addr, _ := addrs.ParseAbsResourceStr("null_resource.foo")
 
@@ -574,8 +560,7 @@ func TestRemote_planWithReplace(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	defer done(t)
 
 	addr, _ := addrs.ParseAbsResourceInstanceStr("null_resource.foo")
@@ -613,8 +598,7 @@ func TestRemote_planWithReplaceIncompatibleAPIVersion(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 
 	b.client.SetFakeRemoteAPIVersion("2.3")
 
@@ -647,8 +631,7 @@ func TestRemote_planWithVariables(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-variables")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan-variables")
 
 	op.Variables = testVariables(tofu.ValueFromCLIArg, "foo", "bar")
 	op.Workspace = backend.DefaultStateName
@@ -674,8 +657,7 @@ func TestRemote_planNoConfig(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/empty")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/empty")
 
 	op.Workspace = backend.DefaultStateName
 
@@ -703,8 +685,7 @@ func TestRemote_planNoChanges(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-no-changes")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan-no-changes")
 	defer done(t)
 
 	op.Workspace = backend.DefaultStateName
@@ -739,8 +720,7 @@ func TestRemote_planForceLocal(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	defer done(t)
 
 	op.Workspace = backend.DefaultStateName
@@ -775,8 +755,7 @@ func TestRemote_planWithoutOperationsEntitlement(t *testing.T) {
 	b, bCleanup := testBackendNoOperations(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	defer done(t)
 
 	op.Workspace = backend.DefaultStateName
@@ -825,8 +804,7 @@ func TestRemote_planWorkspaceWithoutOperations(t *testing.T) {
 		t.Fatalf("error creating named workspace: %v", err)
 	}
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	defer done(t)
 
 	op.Workspace = "no-operations"
@@ -884,8 +862,7 @@ func TestRemote_planLockTimeout(t *testing.T) {
 		t.Fatalf("error creating pending run: %v", err)
 	}
 
-	op, configCleanup, done := testOperationPlanWithTimeout(t, "./testdata/plan", 50)
-	defer configCleanup()
+	op, done := testOperationPlanWithTimeout(t, "./testdata/plan", 50)
 	defer done(t)
 
 	input := testInput(t, map[string]string{
@@ -932,8 +909,7 @@ func TestRemote_planDestroy(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	defer done(t)
 
 	op.PlanMode = plans.DestroyMode
@@ -957,8 +933,7 @@ func TestRemote_planDestroyNoConfig(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/empty")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/empty")
 	defer done(t)
 
 	op.PlanMode = plans.DestroyMode
@@ -992,8 +967,7 @@ func TestRemote_planWithWorkingDirectory(t *testing.T) {
 		t.Fatalf("error configuring working directory: %v", err)
 	}
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-with-working-directory/tofu")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan-with-working-directory/tofu")
 	defer done(t)
 
 	op.Workspace = backend.DefaultStateName
@@ -1051,8 +1025,7 @@ func TestRemote_planWithWorkingDirectoryFromCurrentPath(t *testing.T) {
 
 	// For this test we need to give our current directory instead of the
 	// full path to the configuration as we already changed directories.
-	op, configCleanup, done := testOperationPlan(t, ".")
-	defer configCleanup()
+	op, done := testOperationPlan(t, ".")
 	defer done(t)
 
 	op.Workspace = backend.DefaultStateName
@@ -1083,8 +1056,7 @@ func TestRemote_planCostEstimation(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-cost-estimation")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan-cost-estimation")
 	defer done(t)
 
 	op.Workspace = backend.DefaultStateName
@@ -1118,8 +1090,7 @@ func TestRemote_planPolicyPass(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-policy-passed")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan-policy-passed")
 	defer done(t)
 
 	op.Workspace = backend.DefaultStateName
@@ -1153,8 +1124,7 @@ func TestRemote_planPolicyHardFail(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-policy-hard-failed")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan-policy-hard-failed")
 
 	op.Workspace = backend.DefaultStateName
 
@@ -1193,8 +1163,7 @@ func TestRemote_planPolicySoftFail(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-policy-soft-failed")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan-policy-soft-failed")
 
 	op.Workspace = backend.DefaultStateName
 
@@ -1233,8 +1202,7 @@ func TestRemote_planWithRemoteError(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-with-error")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan-with-error")
 	defer done(t)
 
 	op.Workspace = backend.DefaultStateName
@@ -1265,8 +1233,7 @@ func TestRemote_planOtherError(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	defer done(t)
 
 	op.Workspace = "network-error" // custom error response in backend_mock.go
@@ -1286,8 +1253,7 @@ func TestRemote_planWithGenConfigOut(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 
 	op.GenerateConfigOut = "generated.tf"
 	op.Workspace = backend.DefaultStateName

--- a/internal/checks/state_test.go
+++ b/internal/checks/state_test.go
@@ -19,8 +19,7 @@ import (
 
 func TestChecksHappyPath(t *testing.T) {
 	const fixtureDir = "testdata/happypath"
-	loader, close := configload.NewLoaderForTests(t)
-	defer close()
+	loader := configload.NewLoaderForTests(t)
 	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, nil, nil)
 	_, instDiags := inst.InstallModules(context.Background(), fixtureDir, "tests", true, false, initwd.ModuleInstallHooksImpl{}, configs.RootModuleCallForTesting())
 	if instDiags.HasErrors() {

--- a/internal/cloud/backend_context_test.go
+++ b/internal/cloud/backend_context_test.go
@@ -188,8 +188,7 @@ func TestRemoteContextWithVars(t *testing.T) {
 			b, bCleanup := testBackendWithName(t)
 			defer bCleanup()
 
-			_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
-			defer configCleanup()
+			_, configLoader := initwd.MustLoadConfigForTests(t, configDir, "tests")
 
 			workspaceID, err := b.getRemoteWorkspaceID(context.Background(), testBackendSingleWorkspaceName)
 			if err != nil {
@@ -411,8 +410,7 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 			b, bCleanup := testBackendWithName(t)
 			defer bCleanup()
 
-			_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
-			defer configCleanup()
+			_, configLoader := initwd.MustLoadConfigForTests(t, configDir, "tests")
 
 			workspaceID, err := b.getRemoteWorkspaceID(context.Background(), testBackendSingleWorkspaceName)
 			if err != nil {

--- a/internal/cloud/backend_plan_test.go
+++ b/internal/cloud/backend_plan_test.go
@@ -36,16 +36,16 @@ import (
 	"github.com/opentofu/opentofu/internal/tofu"
 )
 
-func testOperationPlan(t *testing.T, configDir string) (*backend.Operation, func(), func(*testing.T) *terminal.TestOutput) {
+func testOperationPlan(t *testing.T, configDir string) (*backend.Operation, func(*testing.T) *terminal.TestOutput) {
 	t.Helper()
 
 	return testOperationPlanWithTimeout(t, configDir, 0)
 }
 
-func testOperationPlanWithTimeout(t *testing.T, configDir string, timeout time.Duration) (*backend.Operation, func(), func(*testing.T) *terminal.TestOutput) {
+func testOperationPlanWithTimeout(t *testing.T, configDir string, timeout time.Duration) (*backend.Operation, func(*testing.T) *terminal.TestOutput) {
 	t.Helper()
 
-	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
+	_, configLoader := initwd.MustLoadConfigForTests(t, configDir, "tests")
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -65,15 +65,14 @@ func testOperationPlanWithTimeout(t *testing.T, configDir string, timeout time.D
 		Type:            backend.OperationTypePlan,
 		View:            operationView,
 		DependencyLocks: depLocks,
-	}, configCleanup, done
+	}, done
 }
 
 func TestCloud_planBasic(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	defer done(t)
 
 	op.Workspace = testBackendSingleWorkspaceName
@@ -117,8 +116,7 @@ func TestCloud_planJSONBasic(t *testing.T) {
 		Colorize: mockColorize(),
 	}
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-json-basic")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan-json-basic")
 	defer done(t)
 
 	op.Workspace = testBackendSingleWorkspaceName
@@ -156,8 +154,7 @@ func TestCloud_planCanceled(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	defer done(t)
 
 	op.Workspace = testBackendSingleWorkspaceName
@@ -186,8 +183,7 @@ func TestCloud_planLongLine(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-long-line")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan-long-line")
 	defer done(t)
 
 	op.Workspace = testBackendSingleWorkspaceName
@@ -225,8 +221,7 @@ func TestCloud_planJSONFull(t *testing.T) {
 		Colorize: mockColorize(),
 	}
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-json-full")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan-json-full")
 	defer done(t)
 
 	op.Workspace = testBackendSingleWorkspaceName
@@ -281,8 +276,7 @@ func TestCloud_planWithoutPermissions(t *testing.T) {
 	}
 	w.Permissions.CanQueueRun = false
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 
 	op.Workspace = "prod"
 
@@ -307,8 +301,7 @@ func TestCloud_planWithParallelism(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 
 	if b.ContextOpts == nil {
 		b.ContextOpts = &tofu.ContextOpts{}
@@ -337,8 +330,7 @@ func TestCloud_planWithPlan(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 
 	op.PlanFile = planfile.NewWrappedLocal(&planfile.Reader{})
 	op.Workspace = testBackendSingleWorkspaceName
@@ -367,8 +359,7 @@ func TestCloud_planWithPath(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	defer done(t)
 
 	tmpDir := t.TempDir()
@@ -426,8 +417,7 @@ func TestCloud_planWithoutRefresh(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	defer done(t)
 
 	op.PlanRefresh = false
@@ -463,8 +453,7 @@ func TestCloud_planWithRefreshOnly(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	defer done(t)
 
 	op.PlanMode = plans.RefreshOnlyMode
@@ -523,8 +512,7 @@ func TestCloud_planWithTarget(t *testing.T) {
 		}
 	}
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	defer done(t)
 
 	addr, _ := addrs.ParseAbsResourceStr("null_resource.foo")
@@ -570,8 +558,7 @@ func TestCloud_planWithExclude(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 
 	addr, _ := addrs.ParseAbsResourceStr("null_resource.foo")
 
@@ -602,8 +589,7 @@ func TestCloud_planWithReplace(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	defer done(t)
 
 	addr, _ := addrs.ParseAbsResourceInstanceStr("null_resource.foo")
@@ -641,8 +627,7 @@ func TestCloud_planWithRequiredVariables(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-variables")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan-variables")
 	defer done(t)
 
 	op.Variables = testVariables(tofu.ValueFromCLIArg, "foo") // "bar" variable defined in config is  missing
@@ -670,8 +655,7 @@ func TestCloud_planNoConfig(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/empty")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/empty")
 
 	op.Workspace = testBackendSingleWorkspaceName
 
@@ -699,8 +683,7 @@ func TestCloud_planNoChanges(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-no-changes")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan-no-changes")
 	defer done(t)
 
 	op.Workspace = testBackendSingleWorkspaceName
@@ -735,8 +718,7 @@ func TestCloud_planForceLocal(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	defer done(t)
 
 	op.Workspace = testBackendSingleWorkspaceName
@@ -771,8 +753,7 @@ func TestCloud_planWithoutOperationsEntitlement(t *testing.T) {
 	b, bCleanup := testBackendNoOperations(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	defer done(t)
 
 	op.Workspace = testBackendSingleWorkspaceName
@@ -821,8 +802,7 @@ func TestCloud_planWorkspaceWithoutOperations(t *testing.T) {
 		t.Fatalf("error creating named workspace: %v", err)
 	}
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	defer done(t)
 
 	op.Workspace = "no-operations"
@@ -880,8 +860,7 @@ func TestCloud_planLockTimeout(t *testing.T) {
 		t.Fatalf("error creating pending run: %v", err)
 	}
 
-	op, configCleanup, done := testOperationPlanWithTimeout(t, "./testdata/plan", 50)
-	defer configCleanup()
+	op, done := testOperationPlanWithTimeout(t, "./testdata/plan", 50)
 	defer done(t)
 
 	input := testInput(t, map[string]string{
@@ -928,8 +907,7 @@ func TestCloud_planDestroy(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	defer done(t)
 
 	op.PlanMode = plans.DestroyMode
@@ -953,8 +931,7 @@ func TestCloud_planDestroyNoConfig(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/empty")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/empty")
 	defer done(t)
 
 	op.PlanMode = plans.DestroyMode
@@ -988,8 +965,7 @@ func TestCloud_planWithWorkingDirectory(t *testing.T) {
 		t.Fatalf("error configuring working directory: %v", err)
 	}
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-with-working-directory/tofu")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan-with-working-directory/tofu")
 	defer done(t)
 
 	op.Workspace = testBackendSingleWorkspaceName
@@ -1033,22 +1009,13 @@ func TestCloud_planWithWorkingDirectoryFromCurrentPath(t *testing.T) {
 		t.Fatalf("error configuring working directory: %v", err)
 	}
 
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("error getting current working directory: %v", err)
-	}
-
 	// We need to change into the configuration directory to make sure
 	// the logic to upload the correct slug is working as expected.
-	if err := os.Chdir("./testdata/plan-with-working-directory/tofu"); err != nil {
-		t.Fatalf("error changing directory: %v", err)
-	}
-	defer os.Chdir(wd) // Make sure we change back again when were done.
+	t.Chdir("./testdata/plan-with-working-directory/tofu")
 
 	// For this test we need to give our current directory instead of the
 	// full path to the configuration as we already changed directories.
-	op, configCleanup, done := testOperationPlan(t, ".")
-	defer configCleanup()
+	op, done := testOperationPlan(t, ".")
 	defer done(t)
 
 	op.Workspace = testBackendSingleWorkspaceName
@@ -1079,8 +1046,7 @@ func TestCloud_planCostEstimation(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-cost-estimation")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan-cost-estimation")
 	defer done(t)
 
 	op.Workspace = testBackendSingleWorkspaceName
@@ -1114,8 +1080,7 @@ func TestCloud_planPolicyPass(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-policy-passed")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan-policy-passed")
 	defer done(t)
 
 	op.Workspace = testBackendSingleWorkspaceName
@@ -1149,8 +1114,7 @@ func TestCloud_planPolicyHardFail(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-policy-hard-failed")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan-policy-hard-failed")
 
 	op.Workspace = testBackendSingleWorkspaceName
 
@@ -1189,8 +1153,7 @@ func TestCloud_planPolicySoftFail(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-policy-soft-failed")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan-policy-soft-failed")
 
 	op.Workspace = testBackendSingleWorkspaceName
 
@@ -1229,8 +1192,7 @@ func TestCloud_planWithRemoteError(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-with-error")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan-with-error")
 	defer done(t)
 
 	op.Workspace = testBackendSingleWorkspaceName
@@ -1269,8 +1231,7 @@ func TestCloud_planJSONWithRemoteError(t *testing.T) {
 		Colorize: mockColorize(),
 	}
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-json-error")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan-json-error")
 	defer done(t)
 
 	op.Workspace = testBackendSingleWorkspaceName
@@ -1302,8 +1263,7 @@ func TestCloud_planOtherError(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	defer done(t)
 
 	op.Workspace = "network-error" // custom error response in backend_mock.go
@@ -1330,8 +1290,7 @@ func TestCloud_planImportConfigGeneration(t *testing.T) {
 		Colorize: mockColorize(),
 	}
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-import-config-gen")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan-import-config-gen")
 	defer done(t)
 
 	genPath := filepath.Join(op.ConfigDir, "generated.tf")
@@ -1381,8 +1340,7 @@ func TestCloud_planImportGenerateInvalidConfig(t *testing.T) {
 		Colorize: mockColorize(),
 	}
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-import-config-gen-validation-error")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan-import-config-gen-validation-error")
 	defer done(t)
 
 	genPath := filepath.Join(op.ConfigDir, "generated.tf")
@@ -1420,8 +1378,7 @@ func TestCloud_planInvalidGenConfigOutPath(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan-import-config-gen-exists")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan-import-config-gen-exists")
 
 	genPath := filepath.Join(op.ConfigDir, "generated.tf")
 	op.GenerateConfigOut = genPath

--- a/internal/cloud/backend_refresh_test.go
+++ b/internal/cloud/backend_refresh_test.go
@@ -23,16 +23,16 @@ import (
 	"github.com/opentofu/opentofu/internal/terminal"
 )
 
-func testOperationRefresh(t *testing.T, configDir string) (*backend.Operation, func(), func(*testing.T) *terminal.TestOutput) {
+func testOperationRefresh(t *testing.T, configDir string) (*backend.Operation, func(*testing.T) *terminal.TestOutput) {
 	t.Helper()
 
 	return testOperationRefreshWithTimeout(t, configDir, 0)
 }
 
-func testOperationRefreshWithTimeout(t *testing.T, configDir string, timeout time.Duration) (*backend.Operation, func(), func(*testing.T) *terminal.TestOutput) {
+func testOperationRefreshWithTimeout(t *testing.T, configDir string, timeout time.Duration) (*backend.Operation, func(*testing.T) *terminal.TestOutput) {
 	t.Helper()
 
-	_, configLoader, configCleanup := initwd.MustLoadConfigForTests(t, configDir, "tests")
+	_, configLoader := initwd.MustLoadConfigForTests(t, configDir, "tests")
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)
@@ -46,15 +46,14 @@ func testOperationRefreshWithTimeout(t *testing.T, configDir string, timeout tim
 		StateLocker:  clistate.NewLocker(timeout, stateLockerView),
 		Type:         backend.OperationTypeRefresh,
 		View:         operationView,
-	}, configCleanup, done
+	}, done
 }
 
 func TestCloud_refreshBasicActuallyRunsApplyRefresh(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	op, configCleanup, done := testOperationRefresh(t, "./testdata/refresh")
-	defer configCleanup()
+	op, done := testOperationRefresh(t, "./testdata/refresh")
 	defer done(t)
 
 	op.UIOut = b.CLI

--- a/internal/cloud/backend_taskStage_taskResults_test.go
+++ b/internal/cloud/backend_taskStage_taskResults_test.go
@@ -61,8 +61,7 @@ func newMockIntegrationContext(b *Cloud, t *testing.T) (*IntegrationContext, *te
 		t.Fatalf("error creating pending run: %v", err)
 	}
 
-	op, configCleanup, done := testOperationPlan(t, "./testdata/plan")
-	defer configCleanup()
+	op, done := testOperationPlan(t, "./testdata/plan")
 	defer done(t)
 
 	integrationContext := &IntegrationContext{

--- a/internal/command/apply_destroy_test.go
+++ b/internal/command/apply_destroy_test.go
@@ -27,7 +27,7 @@ func TestApply_destroy(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -132,7 +132,7 @@ func TestApply_destroyApproveNo(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Create some existing state
 	originalState := states.BuildState(func(s *states.SyncState) {
@@ -201,7 +201,7 @@ func TestApply_destroyApproveYes(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Create some existing state
 	originalState := states.BuildState(func(s *states.SyncState) {
@@ -273,7 +273,7 @@ func TestApply_destroyLockedState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -332,7 +332,7 @@ func TestApply_destroyPlan(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	planPath := testPlanFileNoop(t)
 
@@ -364,7 +364,7 @@ func TestApply_destroyPath(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := applyFixtureProvider()
 
@@ -472,7 +472,7 @@ func TestApply_targetedDestroy(t *testing.T) {
 			// Create a temporary working directory that is empty
 			td := filepath.Join(t.TempDir(), t.Name())
 			testCopyDir(t, testFixturePath("apply-destroy-targeted"), td)
-			defer testChdir(t, td)()
+			t.Chdir(td)
 
 			originalState := states.BuildState(func(s *states.SyncState) {
 				s.SetResourceInstanceCurrent(

--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -37,7 +37,7 @@ func TestApply(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	statePath := testTempFile(t)
 
@@ -74,7 +74,7 @@ func TestApply_conditionalSensitive(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-plan-conditional-sensitive"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := applyFixtureProvider()
 
@@ -104,7 +104,7 @@ func TestApply_path(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := applyFixtureProvider()
 
@@ -134,7 +134,7 @@ func TestApply_approveNo(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	statePath := testTempFile(t)
 
@@ -177,7 +177,7 @@ func TestApply_approveYes(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	statePath := testTempFile(t)
 
@@ -224,7 +224,7 @@ func TestApply_lockedState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	statePath := testTempFile(t)
 
@@ -263,7 +263,7 @@ func TestApply_lockedStateWait(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	statePath := testTempFile(t)
 
@@ -307,7 +307,7 @@ func TestApply_parallelism(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("parallelism"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	statePath := testTempFile(t)
 
@@ -401,7 +401,7 @@ func TestApply_configInvalid(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-config-invalid"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := testProvider()
 	view, done := testView(t)
@@ -427,19 +427,9 @@ func TestApply_defaultState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	statePath := filepath.Join(td, DefaultStateFilename)
-
-	// Change to the temporary directory
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if err := os.Chdir(filepath.Dir(statePath)); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.Chdir(cwd)
 
 	p := applyFixtureProvider()
 	view, done := testView(t)
@@ -478,7 +468,7 @@ func TestApply_error(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-error"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	statePath := testTempFile(t)
 
@@ -555,7 +545,7 @@ func TestApply_input(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-input"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Disable test mode so input would be asked
 	test = false
@@ -605,7 +595,7 @@ func TestApply_inputPartial(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-input-partial"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Disable test mode so input would be asked
 	test = false
@@ -651,7 +641,7 @@ func TestApply_noArgs(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	statePath := testTempFile(t)
 
@@ -805,7 +795,7 @@ func TestApply_plan_remoteState(t *testing.T) {
 	// Disable test mode so input would be asked
 	test = false
 	defer func() { test = true }()
-	tmp := testCwd(t)
+	tmp := testCwdTemp(t)
 	remoteStatePath := filepath.Join(tmp, DefaultDataDir, DefaultStateFilename)
 	if err := os.MkdirAll(filepath.Dir(remoteStatePath), 0755); err != nil {
 		t.Fatalf("err: %s", err)
@@ -882,7 +872,7 @@ func TestApply_plan_remoteState(t *testing.T) {
 }
 
 func TestApply_planWithVarFile(t *testing.T) {
-	varFileDir := testTempDir(t)
+	varFileDir := testTempDirRealpath(t)
 	varFilePath := filepath.Join(varFileDir, "terraform.tfvars")
 	if err := os.WriteFile(varFilePath, []byte(applyVarFile), 0644); err != nil {
 		t.Fatalf("err: %s", err)
@@ -890,15 +880,7 @@ func TestApply_planWithVarFile(t *testing.T) {
 
 	planPath := applyFixturePlanFile(t)
 	statePath := testTempFile(t)
-
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if err := os.Chdir(varFileDir); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.Chdir(cwd)
+	t.Chdir(varFileDir)
 
 	p := applyFixtureProvider()
 	view, done := testView(t)
@@ -957,10 +939,10 @@ func TestApply_planVars(t *testing.T) {
 // we should be able to apply a plan file with no other file dependencies
 func TestApply_planNoModuleFiles(t *testing.T) {
 	// temporary data directory which we can remove between commands
-	td := testTempDir(t)
+	td := testTempDirRealpath(t)
 	defer os.RemoveAll(td)
 
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := applyFixtureProvider()
 	planPath := applyFixturePlanFile(t)
@@ -983,7 +965,7 @@ func TestApply_refresh(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -1051,7 +1033,7 @@ func TestApply_refreshFalse(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -1101,7 +1083,7 @@ func TestApply_shutdown(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-shutdown"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	cancelled := make(chan struct{})
 	shutdownCh := make(chan struct{})
@@ -1189,7 +1171,7 @@ func TestApply_state(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -1284,7 +1266,7 @@ func TestApply_stateNoExist(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := applyFixtureProvider()
 	view, done := testView(t)
@@ -1309,7 +1291,7 @@ func TestApply_sensitiveOutput(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-sensitive-output"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := testProvider()
 	view, done := testView(t)
@@ -1346,7 +1328,7 @@ func TestApply_vars(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-vars"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	statePath := testTempFile(t)
 
@@ -1403,7 +1385,7 @@ func TestApply_varFile(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-vars"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	varFilePath := testTempFile(t)
 	if err := os.WriteFile(varFilePath, []byte(applyVarFile), 0644); err != nil {
@@ -1465,7 +1447,7 @@ func TestApply_varFileDefault(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-vars"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	varFilePath := filepath.Join(td, "terraform.tfvars")
 	if err := os.WriteFile(varFilePath, []byte(applyVarFile), 0644); err != nil {
@@ -1526,7 +1508,7 @@ func TestApply_varFileDefaultJSON(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-vars"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	varFilePath := filepath.Join(td, "terraform.tfvars.json")
 	if err := os.WriteFile(varFilePath, []byte(applyVarFileJSON), 0644); err != nil {
@@ -1587,7 +1569,7 @@ func TestApply_backup(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -1665,7 +1647,7 @@ func TestApply_disableBackup(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	originalState := testState()
 	statePath := testStateFile(t, originalState)
@@ -1743,7 +1725,7 @@ func TestApply_tfWorkspace(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-tf-workspace"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	statePath := testTempFile(t)
 
@@ -1780,7 +1762,7 @@ func TestApply_tofuWorkspace(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-tofu-workspace"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	statePath := testTempFile(t)
 
@@ -1816,7 +1798,7 @@ func TestApply_tfWorkspaceNonDefault(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-tf-workspace"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Create new env
 	{
@@ -1878,7 +1860,7 @@ func TestApply_tofuWorkspaceNonDefault(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-tofu-workspace"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Create new env
 	{
@@ -1939,7 +1921,7 @@ output = test
 func TestApply_targeted(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-targeted"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := testProvider()
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
@@ -1992,9 +1974,9 @@ func TestApply_targetFlagsDiags(t *testing.T) {
 
 	for target, wantDiag := range testCases {
 		t.Run(target, func(t *testing.T) {
-			td := testTempDir(t)
+			td := testTempDirRealpath(t)
 			defer os.RemoveAll(td)
-			defer testChdir(t, td)()
+			t.Chdir(td)
 
 			view, done := testView(t)
 			c := &ApplyCommand{
@@ -2028,7 +2010,7 @@ func TestApply_targetFlagsDiags(t *testing.T) {
 func TestApply_excluded(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-excluded"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := testProvider()
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
@@ -2080,9 +2062,9 @@ func TestApply_excludeFlagsDiags(t *testing.T) {
 
 	for exclude, wantDiag := range testCases {
 		t.Run(exclude, func(t *testing.T) {
-			td := testTempDir(t)
+			td := testTempDirRealpath(t)
 			defer os.RemoveAll(td)
-			defer testChdir(t, td)()
+			t.Chdir(td)
 
 			view, done := testView(t)
 			c := &ApplyCommand{
@@ -2115,7 +2097,7 @@ func TestApply_excludeFlagsDiags(t *testing.T) {
 func TestApply_replace(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-replace"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -2203,7 +2185,7 @@ func TestApply_pluginPath(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	statePath := testTempFile(t)
 
@@ -2243,7 +2225,7 @@ func TestApply_jsonGoldenReference(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	statePath := testTempFile(t)
 
@@ -2284,7 +2266,7 @@ func TestApply_warnings(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := testProvider()
 	p.GetProviderSchemaResponse = applyFixtureSchema()
@@ -2360,7 +2342,7 @@ func TestApply_warnings(t *testing.T) {
 func TestApply_showSensitiveArg(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-sensitive-output"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := testProvider()
 	view, done := testView(t)
@@ -2397,7 +2379,7 @@ func TestApply_showSensitiveArg(t *testing.T) {
 func TestApply_CreateBeforeDestroyWithRefreshFalse(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply_cbd_with_refresh_false"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -2474,7 +2456,7 @@ func TestApply_CreateBeforeDestroyWithRefreshFalse(t *testing.T) {
 func TestApply_concise(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := planFixtureProvider()
 	view, done := testView(t)

--- a/internal/command/autocomplete_test.go
+++ b/internal/command/autocomplete_test.go
@@ -18,7 +18,7 @@ func TestMetaCompletePredictWorkspaceName(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// make sure a vars file doesn't interfere
 	err := os.WriteFile(DefaultVarsFilename, nil, 0644)

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -124,7 +124,7 @@ func tempWorkingDir(t *testing.T) *workdir.Dir {
 func tempWorkingDirFixture(t *testing.T, fixtureName string) *workdir.Dir {
 	t.Helper()
 
-	dirPath := testTempDir(t)
+	dirPath := testTempDirRealpath(t)
 	t.Logf("temporary directory %s with fixture %q", dirPath, fixtureName)
 
 	fixturePath := testFixturePath(fixtureName)
@@ -541,62 +541,29 @@ func testProvider() *tofu.MockProvider {
 func testTempFile(t *testing.T) string {
 	t.Helper()
 
-	return filepath.Join(testTempDir(t), "state.tfstate")
+	return filepath.Join(testTempDirRealpath(t), "state.tfstate")
 }
 
-func testTempDir(t *testing.T) string {
+// testTempDirRealpath is like [testing.T.TempDir] but takes the
+// extra step of ensuring that the result is a path that does not
+// include any symlinks.
+func testTempDirRealpath(t *testing.T) string {
 	t.Helper()
 	d, err := filepath.EvalSymlinks(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	return d
 }
 
-// testChdir changes the directory and returns a function to defer to
-// revert the old cwd.
-func testChdir(t *testing.T, new string) func() {
-	t.Helper()
-
-	old, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	if err := os.Chdir(new); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	return func() {
-		// Re-run the function ignoring the defer result
-		testChdir(t, old)
-	}
-}
-
-// testCwd is used to change the current working directory into a temporary
+// testCwdTemp is used to change the current working directory into a temporary
 // directory. The cleanup is performed automatically after the test and all its
 // subtests complete.
-func testCwd(t *testing.T) string {
+func testCwdTemp(t testing.TB) string {
 	t.Helper()
 
 	tmp := t.TempDir()
-
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	if err := os.Chdir(tmp); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	t.Cleanup(func() {
-		if err := os.Chdir(cwd); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	})
-
+	t.Chdir(tmp)
 	return tmp
 }
 

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -153,10 +153,7 @@ func testModuleWithSnapshot(t *testing.T, name string) (*configs.Config, *config
 	t.Helper()
 
 	dir := filepath.Join(fixtureDir, name)
-	// FIXME: We're not dealing with the cleanup function here because
-	// this testModule function is used all over and so we don't want to
-	// change its interface at this late stage.
-	loader, _ := configload.NewLoaderForTests(t)
+	loader := configload.NewLoaderForTests(t)
 
 	// Test modules usually do not refer to remote sources, and for local
 	// sources only this ultimately just records all of the module paths

--- a/internal/command/console_interactive_test.go
+++ b/internal/command/console_interactive_test.go
@@ -19,7 +19,7 @@ import (
 func TestConsole_multiline_interactive(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("console-multiline-vars"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := testProvider()
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{

--- a/internal/command/console_test.go
+++ b/internal/command/console_test.go
@@ -27,7 +27,7 @@ import (
 // This file still contains some tests using the stdin-based input.
 
 func TestConsole_basic(t *testing.T) {
-	testCwd(t)
+	testCwdTemp(t)
 
 	p := testProvider()
 	ui := cli.NewMockUi()
@@ -60,7 +60,7 @@ func TestConsole_basic(t *testing.T) {
 func TestConsole_tfvars(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-vars"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Write a terraform.tfvars
 	varFilePath := filepath.Join(td, "terraform.tfvars")
@@ -118,7 +118,7 @@ func TestConsole_unsetRequiredVars(t *testing.T) {
 	// intentionally not setting here.
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-vars"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := testProvider()
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
@@ -162,7 +162,7 @@ func TestConsole_unsetRequiredVars(t *testing.T) {
 func TestConsole_variables(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("variables"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := testProvider()
 	ui := cli.NewMockUi()
@@ -204,7 +204,7 @@ func TestConsole_variables(t *testing.T) {
 func TestConsole_modules(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("modules"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := applyFixtureProvider()
 	ui := cli.NewMockUi()
@@ -246,7 +246,7 @@ func TestConsole_modules(t *testing.T) {
 func TestConsole_multiline_pipe(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("console-multiline-vars"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := testProvider()
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{

--- a/internal/command/fmt_test.go
+++ b/internal/command/fmt_test.go
@@ -170,7 +170,7 @@ func TestFmt_nonexist(t *testing.T) {
 }
 
 func TestFmt_syntaxError(t *testing.T) {
-	tempDir := testTempDir(t)
+	tempDir := testTempDirRealpath(t)
 
 	invalidSrc := `
 a = 1 +
@@ -201,7 +201,7 @@ a = 1 +
 }
 
 func TestFmt_snippetInError(t *testing.T) {
-	tempDir := testTempDir(t)
+	tempDir := testTempDirRealpath(t)
 
 	backendSrc := `terraform {backend "s3" {}}`
 
@@ -274,16 +274,7 @@ func TestFmt_manyArgs(t *testing.T) {
 
 func TestFmt_workingDirectory(t *testing.T) {
 	tempDir := fmtFixtureWriteDir(t)
-
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	err = os.Chdir(tempDir)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.Chdir(cwd)
+	t.Chdir(tempDir)
 
 	ui := new(cli.MockUi)
 	c := &FmtCommand{
@@ -491,7 +482,7 @@ var fmtFixture = struct {
 }
 
 func fmtFixtureWriteDir(t *testing.T) string {
-	dir := testTempDir(t)
+	dir := testTempDirRealpath(t)
 
 	err := os.WriteFile(filepath.Join(dir, fmtFixture.filename), fmtFixture.input, 0600)
 	if err != nil {

--- a/internal/command/get_test.go
+++ b/internal/command/get_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestGet(t *testing.T) {
 	wd := tempWorkingDirFixture(t, "get")
-	defer testChdir(t, wd.RootModuleDir())()
+	t.Chdir(wd.RootModuleDir())
 
 	ui := cli.NewMockUi()
 	c := &GetCommand{
@@ -42,7 +42,7 @@ func TestGet(t *testing.T) {
 
 func TestGet_multipleArgs(t *testing.T) {
 	wd := tempWorkingDir(t)
-	defer testChdir(t, wd.RootModuleDir())()
+	t.Chdir(wd.RootModuleDir())
 
 	ui := cli.NewMockUi()
 	c := &GetCommand{
@@ -64,7 +64,7 @@ func TestGet_multipleArgs(t *testing.T) {
 
 func TestGet_update(t *testing.T) {
 	wd := tempWorkingDirFixture(t, "get")
-	defer testChdir(t, wd.RootModuleDir())()
+	t.Chdir(wd.RootModuleDir())
 
 	ui := cli.NewMockUi()
 	c := &GetCommand{
@@ -180,7 +180,7 @@ func TestGetCommand_InvalidArgs(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			wd := tempWorkingDirFixture(t, "get")
-			defer testChdir(t, wd.RootModuleDir())()
+			t.Chdir(wd.RootModuleDir())
 
 			ui := cli.NewMockUi()
 			c := &GetCommand{

--- a/internal/command/graph_test.go
+++ b/internal/command/graph_test.go
@@ -21,7 +21,7 @@ import (
 func TestGraph(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("graph"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	ui := new(cli.MockUi)
 	c := &GraphCommand{
@@ -63,7 +63,7 @@ func TestGraph_multipleArgs(t *testing.T) {
 func TestGraph_noArgs(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("graph"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	ui := new(cli.MockUi)
 	c := &GraphCommand{
@@ -87,7 +87,7 @@ func TestGraph_noArgs(t *testing.T) {
 func TestGraph_noConfig(t *testing.T) {
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	ui := new(cli.MockUi)
 	c := &GraphCommand{
@@ -106,7 +106,7 @@ func TestGraph_noConfig(t *testing.T) {
 }
 
 func TestGraph_plan(t *testing.T) {
-	testCwd(t)
+	testCwdTemp(t)
 
 	plan := &plans.Plan{
 		Changes: plans.NewChanges(),

--- a/internal/command/import_test.go
+++ b/internal/command/import_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestImport(t *testing.T) {
-	defer testChdir(t, testFixturePath("import-provider-implicit"))()
+	t.Chdir(testFixturePath("import-provider-implicit"))
 
 	statePath := testTempFile(t)
 
@@ -78,7 +78,7 @@ func TestImport(t *testing.T) {
 }
 
 func TestImport_providerConfig(t *testing.T) {
-	defer testChdir(t, testFixturePath("import-provider"))()
+	t.Chdir(testFixturePath("import-provider"))
 
 	statePath := testTempFile(t)
 
@@ -167,7 +167,7 @@ func TestImport_providerConfig(t *testing.T) {
 func TestImport_remoteState(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("import-provider-remote-state"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	statePath := "imported.tfstate"
 
@@ -279,7 +279,7 @@ func TestImport_remoteState(t *testing.T) {
 func TestImport_initializationErrorShouldUnlock(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("import-provider-remote-state"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	statePath := "imported.tfstate"
 
@@ -346,7 +346,7 @@ func TestImport_initializationErrorShouldUnlock(t *testing.T) {
 }
 
 func TestImport_providerConfigWithVar(t *testing.T) {
-	defer testChdir(t, testFixturePath("import-provider-var"))()
+	t.Chdir(testFixturePath("import-provider-var"))
 
 	statePath := testTempFile(t)
 
@@ -426,7 +426,7 @@ func TestImport_providerConfigWithVar(t *testing.T) {
 }
 
 func TestImport_providerConfigWithDataSource(t *testing.T) {
-	defer testChdir(t, testFixturePath("import-provider-datasource"))()
+	t.Chdir(testFixturePath("import-provider-datasource"))
 
 	statePath := testTempFile(t)
 
@@ -491,7 +491,7 @@ func TestImport_providerConfigWithDataSource(t *testing.T) {
 }
 
 func TestImport_providerConfigWithVarDefault(t *testing.T) {
-	defer testChdir(t, testFixturePath("import-provider-var-default"))()
+	t.Chdir(testFixturePath("import-provider-var-default"))
 
 	statePath := testTempFile(t)
 
@@ -570,7 +570,7 @@ func TestImport_providerConfigWithVarDefault(t *testing.T) {
 }
 
 func TestImport_providerConfigWithVarFile(t *testing.T) {
-	defer testChdir(t, testFixturePath("import-provider-var-file"))()
+	t.Chdir(testFixturePath("import-provider-var-file"))
 
 	statePath := testTempFile(t)
 
@@ -650,7 +650,7 @@ func TestImport_providerConfigWithVarFile(t *testing.T) {
 }
 
 func TestImport_emptyConfig(t *testing.T) {
-	defer testChdir(t, testFixturePath("empty"))()
+	t.Chdir(testFixturePath("empty"))
 
 	statePath := testTempFile(t)
 
@@ -682,7 +682,7 @@ func TestImport_emptyConfig(t *testing.T) {
 }
 
 func TestImport_missingResourceConfig(t *testing.T) {
-	defer testChdir(t, testFixturePath("import-missing-resource-config"))()
+	t.Chdir(testFixturePath("import-missing-resource-config"))
 
 	statePath := testTempFile(t)
 
@@ -714,7 +714,7 @@ func TestImport_missingResourceConfig(t *testing.T) {
 }
 
 func TestImport_missingModuleConfig(t *testing.T) {
-	defer testChdir(t, testFixturePath("import-missing-resource-config"))()
+	t.Chdir(testFixturePath("import-missing-resource-config"))
 
 	statePath := testTempFile(t)
 
@@ -748,7 +748,7 @@ func TestImport_missingModuleConfig(t *testing.T) {
 func TestImportModuleVarFile(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("import-module-var-file"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	statePath := testTempFile(t)
 
@@ -822,7 +822,7 @@ func TestImportModuleVarFile(t *testing.T) {
 func TestImportModuleInputVariableEvaluation(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("import-module-input-variable"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	statePath := testTempFile(t)
 
@@ -882,7 +882,7 @@ func TestImportModuleInputVariableEvaluation(t *testing.T) {
 }
 
 func TestImport_dataResource(t *testing.T) {
-	defer testChdir(t, testFixturePath("import-missing-resource-config"))()
+	t.Chdir(testFixturePath("import-missing-resource-config"))
 
 	statePath := testTempFile(t)
 
@@ -914,7 +914,7 @@ func TestImport_dataResource(t *testing.T) {
 }
 
 func TestImport_invalidResourceAddr(t *testing.T) {
-	defer testChdir(t, testFixturePath("import-missing-resource-config"))()
+	t.Chdir(testFixturePath("import-missing-resource-config"))
 
 	statePath := testTempFile(t)
 
@@ -946,7 +946,7 @@ func TestImport_invalidResourceAddr(t *testing.T) {
 }
 
 func TestImport_targetIsModule(t *testing.T) {
-	defer testChdir(t, testFixturePath("import-missing-resource-config"))()
+	t.Chdir(testFixturePath("import-missing-resource-config"))
 
 	statePath := testTempFile(t)
 

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -40,7 +40,7 @@ func TestInit_empty(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	ui := new(cli.MockUi)
 	view, _ := testView(t)
@@ -62,7 +62,7 @@ func TestInit_multipleArgs(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	ui := new(cli.MockUi)
 	view, _ := testView(t)
@@ -87,7 +87,7 @@ func TestInit_fromModule_cwdDest(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	os.MkdirAll(td, os.ModePerm)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	ui := new(cli.MockUi)
 	view, _ := testView(t)
@@ -120,31 +120,14 @@ func TestInit_fromModule_cwdDest(t *testing.T) {
 // https://github.com/hashicorp/terraform/issues/518
 func TestInit_fromModule_dstInSrc(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	// Change to the temporary directory
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.Chdir(cwd)
-
+	t.Chdir(dir)
 	if err := os.Mkdir("foo", os.ModePerm); err != nil {
 		t.Fatal(err)
 	}
-
 	if _, err := os.Create("issue518.tf"); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-
-	if err := os.Chdir("foo"); err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	t.Chdir("foo")
 
 	ui := new(cli.MockUi)
 	view, _ := testView(t)
@@ -178,7 +161,7 @@ func TestInit_get(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-get"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	ui := new(cli.MockUi)
 	view, _ := testView(t)
@@ -206,7 +189,7 @@ func TestInit_getUpgradeModules(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-get"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	ui := new(cli.MockUi)
 	view, _ := testView(t)
@@ -237,7 +220,7 @@ func TestInit_backend(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	ui := new(cli.MockUi)
 	view, _ := testView(t)
@@ -263,7 +246,7 @@ func TestInit_backendUnset(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	{
 		log.Printf("[TRACE] TestInit_backendUnset: beginning first init")
@@ -329,7 +312,7 @@ func TestInit_backendConfigFile(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend-config-file"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	t.Run("good-config-file", func(t *testing.T) {
 		ui := new(cli.MockUi)
@@ -465,7 +448,7 @@ func TestInit_backendConfigFilePowershellConfusion(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend-config-file"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	ui := new(cli.MockUi)
 	view, _ := testView(t)
@@ -500,7 +483,7 @@ func TestInit_backendReconfigure(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	providerSource, close := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.2.3"},
@@ -547,7 +530,7 @@ func TestInit_backendConfigFileChange(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend-config-file-change"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	ui := new(cli.MockUi)
 	view, _ := testView(t)
@@ -575,7 +558,7 @@ func TestInit_backendMigrateWhileLocked(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend-migrate-while-locked"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	providerSource, close := newMockProviderSource(t, map[string][]string{
 		"hashicorp/test": {"1.2.3"},
@@ -628,7 +611,7 @@ func TestInit_backendConfigFileChangeWithExistingState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend-config-file-change-migrate-existing"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	ui := new(cli.MockUi)
 	c := &InitCommand{
@@ -662,7 +645,7 @@ func TestInit_backendConfigKV(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend-config-kv"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	ui := new(cli.MockUi)
 	view, _ := testView(t)
@@ -690,7 +673,7 @@ func TestInit_backendConfigKVReInit(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend-config-kv"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	ui := new(cli.MockUi)
 	view, _ := testView(t)
@@ -753,7 +736,7 @@ func TestInit_backendConfigKVReInitWithConfigDiff(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	ui := new(cli.MockUi)
 	view, _ := testView(t)
@@ -801,7 +784,7 @@ func TestInit_backendCli_no_config_block(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	ui := new(cli.MockUi)
 	view, _ := testView(t)
@@ -827,7 +810,7 @@ func TestInit_backendCli_no_config_block(t *testing.T) {
 func TestInit_backendReinitWithExtra(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend-empty"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	m := testMetaBackend(t, nil)
 	opts := &BackendOpts{
@@ -884,7 +867,7 @@ func TestInit_backendReinitWithExtra(t *testing.T) {
 func TestInit_backendReinitConfigToExtra(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	ui := new(cli.MockUi)
 	view, _ := testView(t)
@@ -950,12 +933,11 @@ func TestInit_backendCloudInvalidOptions(t *testing.T) {
 
 	// We use the same starting fixture for all of these tests, but some
 	// of them will customize it a bit as part of their work.
-	setupTempDir := func(t *testing.T) func() {
+	setupTempDir := func(t *testing.T) {
 		t.Helper()
 		td := t.TempDir()
 		testCopyDir(t, testFixturePath("init-cloud-simple"), td)
-		unChdir := testChdir(t, td)
-		return unChdir
+		t.Chdir(td)
 	}
 
 	// Some of the tests need a non-empty placeholder state file to work
@@ -984,7 +966,7 @@ func TestInit_backendCloudInvalidOptions(t *testing.T) {
 	fakeStateBytes := fakeStateBuf.Bytes()
 
 	t.Run("-backend-config", func(t *testing.T) {
-		defer setupTempDir(t)()
+		setupTempDir(t)
 
 		// We have -backend-config as a pragmatic way to dynamically set
 		// certain settings of backends that tend to vary depending on
@@ -1024,7 +1006,7 @@ Cloud configuration block in the root module.
 		}
 	})
 	t.Run("-reconfigure", func(t *testing.T) {
-		defer setupTempDir(t)()
+		setupTempDir(t)
 
 		// The -reconfigure option was originally imagined as a way to force
 		// skipping state migration when migrating between backends, but it
@@ -1063,7 +1045,7 @@ Cloud configuration settings.
 		}
 	})
 	t.Run("-reconfigure when migrating in", func(t *testing.T) {
-		defer setupTempDir(t)()
+		setupTempDir(t)
 
 		// We have a slightly different error message for the case where we
 		// seem to be trying to migrate to Terraform Cloud with existing
@@ -1099,7 +1081,7 @@ because activating cloud backend involves some additional steps.
 		}
 	})
 	t.Run("-migrate-state", func(t *testing.T) {
-		defer setupTempDir(t)()
+		setupTempDir(t)
 
 		// In Cloud mode, migrating in or out always proposes migrating state
 		// and changing configuration while staying in cloud mode never migrates
@@ -1133,7 +1115,7 @@ storage location is not configurable.
 		}
 	})
 	t.Run("-migrate-state when migrating in", func(t *testing.T) {
-		defer setupTempDir(t)()
+		setupTempDir(t)
 
 		// We have a slightly different error message for the case where we
 		// seem to be trying to migrate to Terraform Cloud with existing
@@ -1172,7 +1154,7 @@ prompts.
 		}
 	})
 	t.Run("-force-copy", func(t *testing.T) {
-		defer setupTempDir(t)()
+		setupTempDir(t)
 
 		// In Cloud mode, migrating in or out always proposes migrating state
 		// and changing configuration while staying in cloud mode never migrates
@@ -1206,7 +1188,7 @@ storage location is not configurable.
 		}
 	})
 	t.Run("-force-copy when migrating in", func(t *testing.T) {
-		defer setupTempDir(t)()
+		setupTempDir(t)
 
 		// We have a slightly different error message for the case where we
 		// seem to be trying to migrate to Terraform Cloud with existing
@@ -1251,7 +1233,7 @@ prompts.
 func TestInit_inputFalse(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	ui := new(cli.MockUi)
 	view, _ := testView(t)
@@ -1329,7 +1311,7 @@ func TestInit_getProvider(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-get-providers"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	overrides := metaOverridesForProvider(testProvider())
 	ui := new(cli.MockUi)
@@ -1434,7 +1416,7 @@ func TestInit_getProviderSource(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-get-provider-source"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	overrides := metaOverridesForProvider(testProvider())
 	ui := new(cli.MockUi)
@@ -1484,7 +1466,7 @@ func TestInit_getProviderLegacyFromState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-get-provider-legacy-from-state"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	overrides := metaOverridesForProvider(testProvider())
 	ui := new(cli.MockUi)
@@ -1525,7 +1507,7 @@ func TestInit_getProviderInvalidPackage(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-get-provider-invalid-package"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	overrides := metaOverridesForProvider(testProvider())
 	ui := new(cli.MockUi)
@@ -1587,7 +1569,7 @@ func TestInit_getProviderDetectedLegacy(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-get-provider-detected-legacy"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// We need to construct a multisource with a mock source and a registry
 	// source: the mock source will return ErrRegistryProviderNotKnown for an
@@ -1654,7 +1636,7 @@ func TestInit_getProviderDetectedDuplicate(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-get-provider-detected-duplicate"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// We need to construct a multisource with a mock source and a registry
 	// source: the mock source will return ErrRegistryProviderNotKnown for an
@@ -1719,7 +1701,7 @@ func TestInit_providerSource(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-required-providers"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	providerSource, close := newMockProviderSource(t, map[string][]string{
 		"test":      {"1.2.3", "1.2.4"},
@@ -1908,7 +1890,7 @@ func TestInit_cancelProviders(t *testing.T) {
 
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-required-providers"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Use a provider source implementation which is designed to hang indefinitely,
 	// to avoid a race between the closed shutdown channel and the provider source
@@ -1952,7 +1934,7 @@ func TestInit_getUpgradePlugins(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-get-providers"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	providerSource, close := newMockProviderSource(t, map[string][]string{
 		// looking for an exact version
@@ -2080,7 +2062,7 @@ func TestInit_getProviderMissing(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-get-providers"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	providerSource, close := newMockProviderSource(t, map[string][]string{
 		// looking for exact version 1.2.3
@@ -2119,7 +2101,7 @@ func TestInit_checkRequiredVersion(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-check-required-version"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	ui := cli.NewMockUi()
 	view, _ := testView(t)
@@ -2150,7 +2132,7 @@ func TestInit_checkRequiredVersionFirst(t *testing.T) {
 	t.Run("root_module", func(t *testing.T) {
 		td := t.TempDir()
 		testCopyDir(t, testFixturePath("init-check-required-version-first"), td)
-		defer testChdir(t, td)()
+		t.Chdir(td)
 
 		ui := cli.NewMockUi()
 		view, _ := testView(t)
@@ -2174,7 +2156,7 @@ func TestInit_checkRequiredVersionFirst(t *testing.T) {
 	t.Run("sub_module", func(t *testing.T) {
 		td := t.TempDir()
 		testCopyDir(t, testFixturePath("init-check-required-version-first-module"), td)
-		defer testChdir(t, td)()
+		t.Chdir(td)
 
 		ui := cli.NewMockUi()
 		view, _ := testView(t)
@@ -2203,7 +2185,7 @@ func TestInit_providerLockFile(t *testing.T) {
 	testCopyDir(t, testFixturePath("init-provider-lock-file"), td)
 	// The temporary directory does not have write permission (dr-xr-xr-x) after the copy
 	defer os.Chmod(td, os.ModePerm)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	providerSource, close := newMockProviderSource(t, map[string][]string{
 		"test": {"1.2.3"},
@@ -2391,7 +2373,7 @@ provider "registry.opentofu.org/hashicorp/test" {
 			// Create a temporary working directory that is empty
 			td := t.TempDir()
 			testCopyDir(t, testFixturePath(tc.fixture), td)
-			defer testChdir(t, td)()
+			t.Chdir(td)
 
 			providerSource, close := newMockProviderSource(t, tc.providers)
 			defer close()
@@ -2434,9 +2416,9 @@ provider "registry.opentofu.org/hashicorp/test" {
 }
 
 func TestInit_pluginDirReset(t *testing.T) {
-	td := testTempDir(t)
+	td := testTempDirRealpath(t)
 	defer os.RemoveAll(td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// An empty provider source
 	providerSource, close := newMockProviderSource(t, nil)
@@ -2506,7 +2488,7 @@ func TestInit_pluginDirReset(t *testing.T) {
 func TestInit_pluginDirProviders(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-get-providers"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// An empty provider source
 	providerSource, close := newMockProviderSource(t, nil)
@@ -2603,7 +2585,7 @@ func TestInit_pluginDirProviders(t *testing.T) {
 func TestInit_pluginDirProvidersDoesNotGet(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-get-providers"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Our provider source has a suitable package for "between" available,
 	// but we should ignore it because -plugin-dir is set and thus this
@@ -2680,7 +2662,7 @@ func TestInit_pluginDirProvidersDoesNotGet(t *testing.T) {
 func TestInit_pluginDirWithBuiltIn(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-internal"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// An empty provider source
 	providerSource, close := newMockProviderSource(t, nil)
@@ -2718,7 +2700,7 @@ func TestInit_invalidBuiltInProviders(t *testing.T) {
 	//   not exist at all.
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-internal-invalid"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// An empty provider source
 	providerSource, close := newMockProviderSource(t, nil)
@@ -2753,7 +2735,7 @@ func TestInit_invalidBuiltInProviders(t *testing.T) {
 func TestInit_invalidSyntaxNoBackend(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-syntax-invalid-no-backend"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	ui := cli.NewMockUi()
 	view, _ := testView(t)
@@ -2782,7 +2764,7 @@ func TestInit_invalidSyntaxNoBackend(t *testing.T) {
 func TestInit_invalidSyntaxWithBackend(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-syntax-invalid-with-backend"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	ui := cli.NewMockUi()
 	view, _ := testView(t)
@@ -2811,7 +2793,7 @@ func TestInit_invalidSyntaxWithBackend(t *testing.T) {
 func TestInit_invalidSyntaxInvalidBackend(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-syntax-invalid-backend-invalid"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	ui := cli.NewMockUi()
 	view, _ := testView(t)
@@ -2843,7 +2825,7 @@ func TestInit_invalidSyntaxInvalidBackend(t *testing.T) {
 func TestInit_invalidSyntaxBackendAttribute(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-syntax-invalid-backend-attribute-invalid"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	ui := cli.NewMockUi()
 	view, _ := testView(t)
@@ -2876,7 +2858,7 @@ func TestInit_tests(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-with-tests"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	provider := applyFixtureProvider() // We just want the types from this provider.
 
@@ -2906,7 +2888,7 @@ func TestInit_testsWithProvider(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-with-tests-with-provider"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	provider := applyFixtureProvider() // We just want the types from this provider.
 
@@ -2948,7 +2930,7 @@ func TestInit_testsWithModule(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-with-tests-with-module"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	provider := applyFixtureProvider() // We just want the types from this provider.
 
@@ -2985,7 +2967,7 @@ func TestInit_moduleSource(t *testing.T) {
 	t.Run("missing", func(t *testing.T) {
 		td := t.TempDir()
 		testCopyDir(t, testFixturePath("init-module-variable-source"), td)
-		defer testChdir(t, td)()
+		t.Chdir(td)
 
 		ui := cli.NewMockUi()
 		view, _ := testView(t)
@@ -3006,7 +2988,7 @@ func TestInit_moduleSource(t *testing.T) {
 	t.Run("missing-twice", func(t *testing.T) {
 		td := t.TempDir()
 		testCopyDir(t, testFixturePath("init-module-variable-source-multiple"), td)
-		defer testChdir(t, td)()
+		t.Chdir(td)
 
 		ui := cli.NewMockUi()
 		view, _ := testView(t)
@@ -3027,7 +3009,7 @@ func TestInit_moduleSource(t *testing.T) {
 	t.Run("no-input", func(t *testing.T) {
 		td := t.TempDir()
 		testCopyDir(t, testFixturePath("init-module-variable-source"), td)
-		defer testChdir(t, td)()
+		t.Chdir(td)
 
 		ui := cli.NewMockUi()
 		view, _ := testView(t)
@@ -3052,7 +3034,7 @@ func TestInit_moduleSource(t *testing.T) {
 	t.Run("provided", func(t *testing.T) {
 		td := t.TempDir()
 		testCopyDir(t, testFixturePath("init-module-variable-source"), td)
-		defer testChdir(t, td)()
+		t.Chdir(td)
 
 		ui := cli.NewMockUi()
 		view, _ := testView(t)
@@ -3079,7 +3061,7 @@ func TestInit_moduleVersion(t *testing.T) {
 	t.Run("provided", func(t *testing.T) {
 		td := t.TempDir()
 		testCopyDir(t, testFixturePath("init-module-variable-version"), td)
-		defer testChdir(t, td)()
+		t.Chdir(td)
 
 		ui := cli.NewMockUi()
 		view, _ := testView(t)
@@ -3100,7 +3082,7 @@ func TestInit_moduleVersion(t *testing.T) {
 func TestInit_invalidExtraLabel(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-syntax-invalid-extra-label"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	ui := cli.NewMockUi()
 	view, _ := testView(t)
@@ -3129,7 +3111,7 @@ func TestInit_skipEncryptionBackendFalse(t *testing.T) {
 		// Create a temporary working directory that is empty
 		td := t.TempDir()
 		testCopyDir(t, testFixturePath("init-encryption-available"), td)
-		defer testChdir(t, td)()
+		t.Chdir(td)
 
 		overrides := metaOverridesForProvider(testProvider())
 		ui := new(cli.MockUi)
@@ -3162,7 +3144,7 @@ func TestInit_skipEncryptionBackendFalse(t *testing.T) {
 		// Create a temporary working directory that is empty
 		td := t.TempDir()
 		testCopyDir(t, testFixturePath("init-encryption-available"), td)
-		defer testChdir(t, td)()
+		t.Chdir(td)
 
 		overrides := metaOverridesForProvider(testProvider())
 		ui := new(cli.MockUi)

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -40,7 +40,7 @@ func TestMetaBackend_emptyDir(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Get the backend
 	m := testMetaBackend(t, nil)
@@ -95,7 +95,7 @@ func TestMetaBackend_emptyWithDefaultState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Write the legacy state
 	statePath := DefaultStateFilename
@@ -159,7 +159,7 @@ func TestMetaBackend_emptyWithExplicitState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Create another directory to store our state
 	stateDir := t.TempDir()
@@ -230,7 +230,7 @@ func TestMetaBackend_configureInterpolation(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-new-interp"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Setup the meta
 	m := testMetaBackend(t, nil)
@@ -246,7 +246,7 @@ func TestMetaBackend_configureInterpolation(t *testing.T) {
 func TestMetaBackend_configureNew(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-new"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Setup the meta
 	m := testMetaBackend(t, nil)
@@ -310,7 +310,7 @@ func TestMetaBackend_configureNewWithState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-new-migrate"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Ask input
 	defer testInteractiveInput(t, []string{"yes"})()
@@ -387,7 +387,7 @@ func TestMetaBackend_configureNewWithoutCopy(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-new-migrate"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	if err := copy.CopyFile(DefaultStateFilename, "local-state.tfstate"); err != nil {
 		t.Fatal(err)
@@ -437,7 +437,7 @@ func TestMetaBackend_configureNewWithStateNoMigrate(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-new-migrate"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Ask input
 	defer testInteractiveInput(t, []string{"no"})()
@@ -481,7 +481,7 @@ func TestMetaBackend_configureNewWithStateExisting(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-new-migrate-existing"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Setup the meta
 	m := testMetaBackend(t, nil)
@@ -552,7 +552,7 @@ func TestMetaBackend_configureNewWithStateExistingNoMigrate(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-new-migrate-existing"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Ask input
 	defer testInteractiveInput(t, []string{"no"})()
@@ -620,7 +620,7 @@ func TestMetaBackend_configureNewWithStateExistingNoMigrate(t *testing.T) {
 
 // Saved backend state matching config
 func TestMetaBackend_configuredUnchanged(t *testing.T) {
-	defer testChdir(t, testFixturePath("backend-unchanged"))()
+	t.Chdir(testFixturePath("backend-unchanged"))
 
 	// Setup the meta
 	m := testMetaBackend(t, nil)
@@ -681,7 +681,7 @@ func TestMetaBackend_configuredUnchangedWithStaticEvalVars(t *testing.T) {
 	// have migration skipped, even if the rules for activating that fast path
 	// change in future.
 
-	defer testChdir(t, testFixturePath("backend-unchanged-vars"))()
+	t.Chdir(testFixturePath("backend-unchanged-vars"))
 
 	// We'll use a mock backend here because we need to control the schema to
 	// make sure that we always have a required field for the ConfigOverride
@@ -808,7 +808,7 @@ func TestMetaBackend_configuredChange(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-change"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Ask input
 	defer testInteractiveInput(t, []string{"no"})()
@@ -887,7 +887,7 @@ func TestMetaBackend_reconfigureChange(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-change-single-to-single"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Register the single-state backend
 	backendInit.Set("local-single", backendLocal.TestNewLocalSingle)
@@ -940,7 +940,7 @@ func TestMetaBackend_initSelectedWorkspaceDoesNotExist(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend-selected-workspace-doesnt-exist-multi"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Setup the meta
 	m := testMetaBackend(t, nil)
@@ -973,7 +973,7 @@ func TestMetaBackend_initSelectedWorkspaceDoesNotExistAutoSelect(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend-selected-workspace-doesnt-exist-single"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Setup the meta
 	m := testMetaBackend(t, nil)
@@ -1014,7 +1014,7 @@ func TestMetaBackend_initSelectedWorkspaceDoesNotExistInputFalse(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend-selected-workspace-doesnt-exist-multi"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Setup the meta
 	m := testMetaBackend(t, nil)
@@ -1034,7 +1034,7 @@ func TestMetaBackend_configuredChangeCopy(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-change"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Ask input
 	defer testInteractiveInput(t, []string{"yes", "yes"})()
@@ -1081,7 +1081,7 @@ func TestMetaBackend_configuredChangeCopy_singleState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-change-single-to-single"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Register the single-state backend
 	backendInit.Set("local-single", backendLocal.TestNewLocalSingle)
@@ -1135,7 +1135,7 @@ func TestMetaBackend_configuredChangeCopy_multiToSingleDefault(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-change-multi-default-to-single"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Register the single-state backend
 	backendInit.Set("local-single", backendLocal.TestNewLocalSingle)
@@ -1188,7 +1188,7 @@ func TestMetaBackend_configuredChangeCopy_multiToSingle(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-change-multi-to-single"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Register the single-state backend
 	backendInit.Set("local-single", backendLocal.TestNewLocalSingle)
@@ -1257,7 +1257,7 @@ func TestMetaBackend_configuredChangeCopy_multiToSingleCurrentEnv(t *testing.T) 
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-change-multi-to-single"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Register the single-state backend
 	backendInit.Set("local-single", backendLocal.TestNewLocalSingle)
@@ -1322,7 +1322,7 @@ func TestMetaBackend_configuredChangeCopy_multiToMulti(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-change-multi-to-multi"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Ask input
 	defer testInputMap(t, map[string]string{
@@ -1415,7 +1415,7 @@ func TestMetaBackend_configuredChangeCopy_multiToNoDefaultWithDefault(t *testing
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-change-multi-to-no-default-with-default"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Register the single-state backend
 	backendInit.Set("local-no-default", backendLocal.TestNewLocalNoDefault)
@@ -1490,7 +1490,7 @@ func TestMetaBackend_configuredChangeCopy_multiToNoDefaultWithoutDefault(t *test
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-change-multi-to-no-default-without-default"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Register the single-state backend
 	backendInit.Set("local-no-default", backendLocal.TestNewLocalNoDefault)
@@ -1562,7 +1562,7 @@ func TestMetaBackend_configuredUnset(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-unset"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Ask input
 	defer testInteractiveInput(t, []string{"no"})()
@@ -1624,7 +1624,7 @@ func TestMetaBackend_configuredUnsetCopy(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-unset"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Ask input
 	defer testInteractiveInput(t, []string{"yes", "yes"})()
@@ -1681,7 +1681,7 @@ func TestMetaBackend_planLocal(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-plan-local"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	backendConfigBlock := cty.ObjectVal(map[string]cty.Value{
 		"path":          cty.NullVal(cty.String),
@@ -1769,7 +1769,7 @@ func TestMetaBackend_planLocal(t *testing.T) {
 func TestMetaBackend_planLocalStatePath(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-plan-local"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	original := testState()
 	markStateForMatching(original, "hello")
@@ -1871,7 +1871,7 @@ func TestMetaBackend_planLocalMatch(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-plan-local-match"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	backendConfigBlock := cty.ObjectVal(map[string]cty.Value{
 		"path":          cty.NullVal(cty.String),
@@ -1958,7 +1958,7 @@ func TestMetaBackend_configureWithExtra(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend-empty"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	extras := map[string]cty.Value{"path": cty.StringVal("hello")}
 	m := testMetaBackend(t, nil)
@@ -2009,7 +2009,7 @@ func TestMetaBackend_localDoesNotDeleteLocal(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend-empty"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	//// create our local state
 	orig := states.NewState()
@@ -2036,7 +2036,7 @@ func TestMetaBackend_configToExtra(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// init the backend
 	m := testMetaBackend(t, nil)
@@ -2079,7 +2079,7 @@ func TestMetaBackend_configToExtra(t *testing.T) {
 // no config; return inmem backend stored in state
 func TestBackendFromState(t *testing.T) {
 	wd := tempWorkingDirFixture(t, "backend-from-state")
-	defer testChdir(t, wd.RootModuleDir())()
+	t.Chdir(wd.RootModuleDir())
 
 	// Setup the meta
 	m := testMetaBackend(t, nil)

--- a/internal/command/meta_test.go
+++ b/internal/command/meta_test.go
@@ -185,7 +185,7 @@ func TestMeta_initStatePaths(t *testing.T) {
 func TestMeta_Env(t *testing.T) {
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	m := new(Meta)
 
@@ -256,7 +256,7 @@ func TestMeta_Workspace_override(t *testing.T) {
 func TestMeta_Workspace_invalidSelected(t *testing.T) {
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// this is an invalid workspace name
 	workspace := "test workspace"
@@ -291,8 +291,7 @@ func TestMeta_process(t *testing.T) {
 
 	// Create a temporary directory for our cwd
 	d := t.TempDir()
-	os.MkdirAll(d, 0755)
-	defer testChdir(t, d)()
+	t.Chdir(d)
 
 	// At one point it was the responsibility of this process function to
 	// insert fake additional -var-file options into the command line
@@ -388,7 +387,7 @@ func TestCommand_checkRequiredVersion(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("command-check-required-version"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	ui := cli.NewMockUi()
 	meta := Meta{

--- a/internal/command/meta_vars_test.go
+++ b/internal/command/meta_vars_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestMeta_addVarsFromFile(t *testing.T) {
 	d := t.TempDir()
-	defer testChdir(t, d)()
+	t.Chdir(d)
 
 	hclData := `foo = "bar"`
 	jsonData := `{"foo": "bar"}`

--- a/internal/command/output_test.go
+++ b/internal/command/output_test.go
@@ -280,7 +280,7 @@ func TestOutput_stateDefault(t *testing.T) {
 
 	// Write the state file in a temporary directory with the
 	// default filename.
-	td := testTempDir(t)
+	td := testTempDirRealpath(t)
 	statePath := filepath.Join(td, DefaultStateFilename)
 
 	f, err := os.Create(statePath)
@@ -294,14 +294,7 @@ func TestOutput_stateDefault(t *testing.T) {
 	}
 
 	// Change to that directory
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if err := os.Chdir(filepath.Dir(statePath)); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.Chdir(cwd)
+	t.Chdir(filepath.Dir(statePath))
 
 	view, done := testView(t)
 	c := &OutputCommand{

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -35,7 +35,7 @@ import (
 func TestPlan(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := planFixtureProvider()
 	view, done := testView(t)
@@ -56,7 +56,7 @@ func TestPlan(t *testing.T) {
 func TestPlan_conditionalSensitive(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-plan-conditional-sensitive"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := planFixtureProvider()
 	view, done := testView(t)
@@ -82,7 +82,7 @@ func TestPlan_conditionalSensitive(t *testing.T) {
 func TestPlan_lockedState(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	unlock, err := testLockState(t, testDataDir, filepath.Join(td, DefaultStateFilename))
 	if err != nil {
@@ -112,7 +112,7 @@ func TestPlan_lockedState(t *testing.T) {
 }
 
 func TestPlan_plan(t *testing.T) {
-	testCwd(t)
+	testCwdTemp(t)
 
 	planPath := testPlanFileNoop(t)
 
@@ -136,7 +136,7 @@ func TestPlan_plan(t *testing.T) {
 func TestPlan_destroy(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -190,7 +190,7 @@ func TestPlan_destroy(t *testing.T) {
 func TestPlan_noState(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := planFixtureProvider()
 	view, done := testView(t)
@@ -224,7 +224,7 @@ func TestPlan_noState(t *testing.T) {
 func TestPlan_noTestVars(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-no-test-vars"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := planFixtureProvider()
 	view, done := testView(t)
@@ -257,7 +257,7 @@ func TestPlan_noTestVars(t *testing.T) {
 func TestPlan_generatedConfigPath(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-import-config-gen"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	genPath := filepath.Join(td, "generated.tf")
 
@@ -298,7 +298,7 @@ func TestPlan_generatedConfigPath(t *testing.T) {
 func TestPlan_outPath(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	outPath := filepath.Join(td, "test.plan")
 
@@ -330,7 +330,7 @@ func TestPlan_outPath(t *testing.T) {
 func TestPlan_outPathNoChange(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -385,7 +385,7 @@ func TestPlan_outPathNoChange(t *testing.T) {
 func TestPlan_outPathWithError(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-fail-condition"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	outPath := filepath.Join(td, "test.plan")
 
@@ -435,7 +435,7 @@ func TestPlan_outBackend(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-out-backend"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -536,7 +536,7 @@ func TestPlan_refreshFalse(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-existing-state"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := planFixtureProvider()
 	view, done := testView(t)
@@ -565,7 +565,7 @@ func TestPlan_refreshTrue(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-existing-state"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := planFixtureProvider()
 	view, done := testView(t)
@@ -600,7 +600,7 @@ func TestPlan_refreshFalseRefreshTrue(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-existing-state"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := planFixtureProvider()
 	view, done := testView(t)
@@ -630,7 +630,7 @@ func TestPlan_state(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	originalState := testState()
 	statePath := testStateFile(t, originalState)
@@ -672,7 +672,7 @@ func TestPlan_stateDefault(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Generate state and move it to the default path
 	originalState := testState()
@@ -717,7 +717,7 @@ func TestPlan_validate(t *testing.T) {
 
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-invalid"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := testProvider()
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
@@ -764,7 +764,7 @@ func TestPlan_vars(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-vars"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := planVarsFixtureProvider()
 	view, done := testView(t)
@@ -814,7 +814,7 @@ func TestPlan_varsInvalid(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-vars"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	for _, tc := range testCases {
 		t.Run(strings.Join(tc.args, " "), func(t *testing.T) {
@@ -845,7 +845,7 @@ func TestPlan_varsUnset(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-vars"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// The plan command will prompt for interactive input of var.foo.
 	// We'll answer "bar" to that prompt, which should then allow this
@@ -881,7 +881,7 @@ func TestPlan_providerArgumentUnset(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Disable test mode so input would be asked
 	test = false
@@ -960,7 +960,7 @@ func TestPlan_providerArgumentUnset(t *testing.T) {
 func TestPlan_resource_variable_inputs(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-vars-unset"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// The plan command will prompt for interactive input of var.src.
 	// We'll answer "mod" to that prompt, which should then allow this
@@ -995,7 +995,7 @@ func TestPlan_resource_variable_inputs(t *testing.T) {
 func TestPlan_providerConfigMerge(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-provider-input"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Disable test mode so input would be asked
 	test = false
@@ -1084,7 +1084,7 @@ func TestPlan_varFile(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-vars"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	varFilePath := testTempFile(t)
 	if err := os.WriteFile(varFilePath, []byte(planVarFile), 0644); err != nil {
@@ -1125,7 +1125,7 @@ func TestPlan_varFileDefault(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-vars"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	varFilePath := filepath.Join(td, "terraform.tfvars")
 	if err := os.WriteFile(varFilePath, []byte(planVarFile), 0644); err != nil {
@@ -1164,7 +1164,7 @@ func TestPlan_varFileWithDecls(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-vars"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	varFilePath := testTempFile(t)
 	if err := os.WriteFile(varFilePath, []byte(planVarFileWithDecl), 0644); err != nil {
@@ -1198,7 +1198,7 @@ func TestPlan_varFileWithDecls(t *testing.T) {
 func TestPlan_detailedExitcode(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	t.Run("return 1", func(t *testing.T) {
 		view, done := testView(t)
@@ -1236,7 +1236,7 @@ func TestPlan_detailedExitcode(t *testing.T) {
 func TestPlan_detailedExitcode_emptyDiff(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-emptydiff"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := testProvider()
 	view, done := testView(t)
@@ -1259,7 +1259,7 @@ func TestPlan_shutdown(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-shutdown"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	cancelled := make(chan struct{})
 	shutdownCh := make(chan struct{})
@@ -1328,7 +1328,7 @@ func TestPlan_shutdown(t *testing.T) {
 func TestPlan_init_required(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	view, done := testView(t)
 	c := &PlanCommand{
@@ -1354,7 +1354,7 @@ func TestPlan_init_required(t *testing.T) {
 func TestPlan_targeted(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-targeted"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := testProvider()
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
@@ -1406,9 +1406,9 @@ func TestPlan_targetFlagsDiags(t *testing.T) {
 
 	for target, wantDiag := range testCases {
 		t.Run(target, func(t *testing.T) {
-			td := testTempDir(t)
+			td := testTempDirRealpath(t)
 			defer os.RemoveAll(td)
-			defer testChdir(t, td)()
+			t.Chdir(td)
 
 			view, done := testView(t)
 			c := &PlanCommand{
@@ -1441,7 +1441,7 @@ func TestPlan_targetFlagsDiags(t *testing.T) {
 func TestPlan_excluded(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply-excluded"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := testProvider()
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
@@ -1492,9 +1492,9 @@ func TestPlan_excludeFlagsDiags(t *testing.T) {
 
 	for exclude, wantDiag := range testCases {
 		t.Run(exclude, func(t *testing.T) {
-			td := testTempDir(t)
+			td := testTempDirRealpath(t)
 			defer os.RemoveAll(td)
-			defer testChdir(t, td)()
+			t.Chdir(td)
 
 			view, done := testView(t)
 			c := &PlanCommand{
@@ -1526,7 +1526,7 @@ func TestPlan_excludeFlagsDiags(t *testing.T) {
 func TestPlan_replace(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-replace"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	originalState := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -1600,7 +1600,7 @@ func TestPlan_parallelism(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("parallelism"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	par := 4
 
@@ -1682,7 +1682,7 @@ func TestPlan_parallelism(t *testing.T) {
 func TestPlan_warnings(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	t.Run("full warnings", func(t *testing.T) {
 		p := planWarningsFixtureProvider()
@@ -1745,7 +1745,7 @@ func TestPlan_jsonGoldenReference(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := planFixtureProvider()
 	view, done := testView(t)
@@ -1816,7 +1816,7 @@ func planFixtureSchema() *providers.GetProviderSchemaResponse {
 func TestPlan_showSensitiveArg(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-sensitive-output"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := planFixtureProvider()
 	view, done := testView(t)
@@ -1844,7 +1844,7 @@ func TestPlan_showSensitiveArg(t *testing.T) {
 func TestPlan_withoutShowSensitiveArg(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan-sensitive-output"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := planFixtureProvider()
 	view, done := testView(t)
@@ -1870,7 +1870,7 @@ func TestPlan_withoutShowSensitiveArg(t *testing.T) {
 func TestPlan_concise(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("plan"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := planFixtureProvider()
 	view, done := testView(t)

--- a/internal/command/plugins_test.go
+++ b/internal/command/plugins_test.go
@@ -6,15 +6,13 @@
 package command
 
 import (
-	"os"
 	"reflect"
 	"testing"
 )
 
 func TestPluginPath(t *testing.T) {
-	td := testTempDir(t)
-	defer os.RemoveAll(td)
-	defer testChdir(t, td)()
+	td := testTempDirRealpath(t)
+	t.Chdir(td)
 
 	pluginPath := []string{"a", "b", "c"}
 

--- a/internal/command/providers_lock_test.go
+++ b/internal/command/providers_lock_test.go
@@ -25,8 +25,7 @@ func TestProvidersLock(t *testing.T) {
 		// in the most basic case, running providers lock in a directory with no configuration at all should succeed.
 		// create an empty working directory
 		td := t.TempDir()
-		os.MkdirAll(td, 0755)
-		defer testChdir(t, td)()
+		t.Chdir(td)
 
 		ui := new(cli.MockUi)
 		c := &ProvidersLockCommand{
@@ -77,7 +76,7 @@ provider "registry.opentofu.org/hashicorp/test" {
 func runProviderLockGenericTest(t *testing.T, testDirectory, expected string) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(testDirectory), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Our fixture dir has a generic os_arch dir, which we need to customize
 	// to the actual OS/arch where this test is running in order to get the

--- a/internal/command/providers_schema_test.go
+++ b/internal/command/providers_schema_test.go
@@ -51,7 +51,7 @@ func TestProvidersSchema_output(t *testing.T) {
 			td := t.TempDir()
 			inputDir := filepath.Join(fixtureDir, entry.Name())
 			testCopyDir(t, inputDir, td)
-			defer testChdir(t, td)()
+			t.Chdir(td)
 
 			providerSource, close := newMockProviderSource(t, map[string][]string{
 				"test": {"1.2.3"},

--- a/internal/command/providers_test.go
+++ b/internal/command/providers_test.go
@@ -6,7 +6,6 @@
 package command
 
 import (
-	"os"
 	"strings"
 	"testing"
 
@@ -14,14 +13,7 @@ import (
 )
 
 func TestProviders(t *testing.T) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if err := os.Chdir(testFixturePath("providers/basic")); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.Chdir(cwd)
+	t.Chdir(testFixturePath("providers/basic"))
 
 	ui := new(cli.MockUi)
 	c := &ProvidersCommand{
@@ -50,14 +42,7 @@ func TestProviders(t *testing.T) {
 }
 
 func TestProviders_noConfigs(t *testing.T) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if err := os.Chdir(testFixturePath("")); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.Chdir(cwd)
+	t.Chdir(testFixturePath(""))
 
 	ui := new(cli.MockUi)
 	c := &ProvidersCommand{
@@ -82,7 +67,7 @@ func TestProviders_noConfigs(t *testing.T) {
 func TestProviders_modules(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("providers/modules"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// first run init with mock provider sources to install the module
 	initUi := new(cli.MockUi)
@@ -133,14 +118,7 @@ func TestProviders_modules(t *testing.T) {
 }
 
 func TestProviders_state(t *testing.T) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if err := os.Chdir(testFixturePath("providers/state")); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.Chdir(cwd)
+	t.Chdir(testFixturePath("providers/state"))
 
 	ui := new(cli.MockUi)
 	c := &ProvidersCommand{
@@ -170,14 +148,7 @@ func TestProviders_state(t *testing.T) {
 }
 
 func TestProviders_tests(t *testing.T) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if err := os.Chdir(testFixturePath("providers/tests")); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.Chdir(cwd)
+	t.Chdir(testFixturePath("providers/tests"))
 
 	ui := new(cli.MockUi)
 	c := &ProvidersCommand{

--- a/internal/command/refresh_test.go
+++ b/internal/command/refresh_test.go
@@ -36,7 +36,7 @@ func TestRefresh(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("refresh"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	state := testState()
 	statePath := testStateFile(t, state)
@@ -93,7 +93,7 @@ func TestRefresh_empty(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("refresh-empty"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := testProvider()
 	view, done := testView(t)
@@ -127,7 +127,7 @@ func TestRefresh_lockedState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("refresh"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	state := testState()
 	statePath := testStateFile(t, state)
@@ -172,14 +172,7 @@ func TestRefresh_lockedState(t *testing.T) {
 }
 
 func TestRefresh_cwd(t *testing.T) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if err := os.Chdir(testFixturePath("refresh")); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.Chdir(cwd)
+	t.Chdir(testFixturePath("refresh"))
 
 	state := testState()
 	statePath := testStateFile(t, state)
@@ -236,7 +229,7 @@ func TestRefresh_defaultState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("refresh"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	originalState := testState()
 
@@ -254,14 +247,7 @@ func TestRefresh_defaultState(t *testing.T) {
 	}
 
 	// Change to that directory
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if err := os.Chdir(filepath.Dir(statePath)); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.Chdir(cwd)
+	t.Chdir(filepath.Dir(statePath))
 
 	p := testProvider()
 	view, done := testView(t)
@@ -318,7 +304,7 @@ func TestRefresh_outPath(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("refresh"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	state := testState()
 	statePath := testStateFile(t, state)
@@ -387,7 +373,7 @@ func TestRefresh_var(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("refresh-var"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	state := testState()
 	statePath := testStateFile(t, state)
@@ -424,7 +410,7 @@ func TestRefresh_varFile(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("refresh-var"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	state := testState()
 	statePath := testStateFile(t, state)
@@ -466,7 +452,7 @@ func TestRefresh_varFileDefault(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("refresh-var"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	state := testState()
 	statePath := testStateFile(t, state)
@@ -507,7 +493,7 @@ func TestRefresh_varsUnset(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("refresh-unset-var"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Disable test mode so input would be asked
 	test = false
@@ -555,7 +541,7 @@ func TestRefresh_backup(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("refresh"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	state := testState()
 	statePath := testStateFile(t, state)
@@ -640,7 +626,7 @@ func TestRefresh_disableBackup(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("refresh"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	state := testState()
 	statePath := testStateFile(t, state)
@@ -715,7 +701,7 @@ func TestRefresh_displaysOutputs(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("refresh-output"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	state := testState()
 	statePath := testStateFile(t, state)
@@ -762,7 +748,7 @@ func TestRefresh_displaysOutputs(t *testing.T) {
 func TestRefresh_targeted(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("refresh-targeted"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	state := testState()
 	statePath := testStateFile(t, state)
@@ -821,9 +807,9 @@ func TestRefresh_targetFlagsDiags(t *testing.T) {
 
 	for target, wantDiag := range testCases {
 		t.Run(target, func(t *testing.T) {
-			td := testTempDir(t)
+			td := testTempDirRealpath(t)
 			defer os.RemoveAll(td)
-			defer testChdir(t, td)()
+			t.Chdir(td)
 
 			view, done := testView(t)
 			c := &RefreshCommand{
@@ -856,7 +842,7 @@ func TestRefresh_targetFlagsDiags(t *testing.T) {
 func TestRefresh_excluded(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("refresh-targeted"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	state := testState()
 	statePath := testStateFile(t, state)
@@ -915,9 +901,9 @@ func TestRefresh_excludeFlagsDiags(t *testing.T) {
 
 	for exclude, wantDiag := range testCases {
 		t.Run(exclude, func(t *testing.T) {
-			td := testTempDir(t)
+			td := testTempDirRealpath(t)
 			defer os.RemoveAll(td)
-			defer testChdir(t, td)()
+			t.Chdir(td)
 
 			view, done := testView(t)
 			c := &RefreshCommand{
@@ -950,7 +936,7 @@ func TestRefresh_warnings(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("apply"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := testProvider()
 	p.GetProviderSchemaResponse = refreshFixtureSchema()

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -75,7 +75,7 @@ func TestShow_noArgsNoState(t *testing.T) {
 
 func TestShow_noArgsWithState(t *testing.T) {
 	// Get a temp cwd
-	testCwd(t)
+	testCwdTemp(t)
 	// Create the default state
 	testStateFileDefault(t, testState())
 
@@ -104,9 +104,7 @@ func TestShow_noArgsWithState(t *testing.T) {
 func TestShow_argsWithState(t *testing.T) {
 	// Create the default state
 	statePath := testStateFile(t, testState())
-	stateDir := filepath.Dir(statePath)
-	defer os.RemoveAll(stateDir)
-	defer testChdir(t, stateDir)()
+	t.Chdir(filepath.Dir(statePath))
 
 	view, done := testView(t)
 	c := &ShowCommand{
@@ -153,9 +151,7 @@ func TestShow_argsWithStateAliasedProvider(t *testing.T) {
 	})
 
 	statePath := testStateFile(t, testState)
-	stateDir := filepath.Dir(statePath)
-	defer os.RemoveAll(stateDir)
-	defer testChdir(t, stateDir)()
+	t.Chdir(filepath.Dir(statePath))
 
 	view, done := testView(t)
 	c := &ShowCommand{
@@ -544,7 +540,7 @@ func TestShow_json_output(t *testing.T) {
 			td := t.TempDir()
 			inputDir := filepath.Join(fixtureDir, entry.Name())
 			testCopyDir(t, inputDir, td)
-			defer testChdir(t, td)()
+			t.Chdir(td)
 
 			expectError := strings.Contains(entry.Name(), "error")
 
@@ -657,7 +653,7 @@ func TestShow_json_output_sensitive(t *testing.T) {
 	td := t.TempDir()
 	inputDir := "testdata/show-json-sensitive"
 	testCopyDir(t, inputDir, td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	providerSource, close := newMockProviderSource(t, map[string][]string{"test": {"1.2.3"}})
 	defer close()
@@ -750,7 +746,7 @@ func TestShow_json_output_conditions_refresh_only(t *testing.T) {
 	td := t.TempDir()
 	inputDir := "testdata/show-json/conditions"
 	testCopyDir(t, inputDir, td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	providerSource, close := newMockProviderSource(t, map[string][]string{"test": {"1.2.3"}})
 	defer close()
@@ -857,7 +853,7 @@ func TestShow_json_output_state(t *testing.T) {
 			td := t.TempDir()
 			inputDir := filepath.Join(fixtureDir, entry.Name())
 			testCopyDir(t, inputDir, td)
-			defer testChdir(t, td)()
+			t.Chdir(td)
 
 			providerSource, close := newMockProviderSource(t, map[string][]string{
 				"test": {"1.2.3"},
@@ -930,7 +926,7 @@ func TestShow_planWithNonDefaultStateLineage(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("show"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Write default state file with a testing lineage ("fake-for-testing")
 	testStateFileDefault(t, testState())
@@ -977,7 +973,7 @@ func TestShow_corruptStatefile(t *testing.T) {
 	td := t.TempDir()
 	inputDir := "testdata/show-corrupt-statefile"
 	testCopyDir(t, inputDir, td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	view, done := testView(t)
 	c := &ShowCommand{
@@ -1003,7 +999,7 @@ func TestShow_corruptStatefile(t *testing.T) {
 
 func TestShow_showSensitiveArg(t *testing.T) {
 	td := t.TempDir()
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	originalState := stateWithSensitiveValueForShow()
 
@@ -1035,7 +1031,7 @@ func TestShow_showSensitiveArg(t *testing.T) {
 
 func TestShow_withoutShowSensitiveArg(t *testing.T) {
 	td := t.TempDir()
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	originalState := stateWithSensitiveValueForShow()
 

--- a/internal/command/state_list_test.go
+++ b/internal/command/state_list_test.go
@@ -103,7 +103,7 @@ func TestStateList_backendDefaultState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("state-list-backend-default"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := testProvider()
 	ui := cli.NewMockUi()
@@ -131,7 +131,7 @@ func TestStateList_backendCustomState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("state-list-backend-custom"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := testProvider()
 	ui := cli.NewMockUi()
@@ -159,7 +159,7 @@ func TestStateList_backendOverrideState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("state-list-backend-custom"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := testProvider()
 	ui := cli.NewMockUi()
@@ -185,7 +185,7 @@ func TestStateList_backendOverrideState(t *testing.T) {
 }
 
 func TestStateList_noState(t *testing.T) {
-	testCwd(t)
+	testCwdTemp(t)
 
 	p := testProvider()
 	ui := cli.NewMockUi()
@@ -206,7 +206,7 @@ func TestStateList_modules(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("state-list-nested-modules"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := testProvider()
 	ui := cli.NewMockUi()

--- a/internal/command/state_mv_test.go
+++ b/internal/command/state_mv_test.go
@@ -180,7 +180,7 @@ func TestStateMv_backupAndBackupOutOptionsWithNonLocalBackend(t *testing.T) {
 	t.Run("backup option specified", func(t *testing.T) {
 		td := t.TempDir()
 		testCopyDir(t, testFixturePath("init-backend-http"), td)
-		defer testChdir(t, td)()
+		t.Chdir(td)
 
 		backupPath := filepath.Join(td, "backup")
 
@@ -228,7 +228,7 @@ on a local state file only. You must specify a local state file with the
 	t.Run("backup-out option specified", func(t *testing.T) {
 		td := t.TempDir()
 		testCopyDir(t, testFixturePath("init-backend-http"), td)
-		defer testChdir(t, td)()
+		t.Chdir(td)
 
 		backupOutPath := filepath.Join(td, "backup-out")
 
@@ -276,7 +276,7 @@ on a local state file only. You must specify a local state file with the
 	t.Run("backup and backup-out options specified", func(t *testing.T) {
 		td := t.TempDir()
 		testCopyDir(t, testFixturePath("init-backend-http"), td)
-		defer testChdir(t, td)()
+		t.Chdir(td)
 
 		backupPath := filepath.Join(td, "backup")
 		backupOutPath := filepath.Join(td, "backup-out")
@@ -326,7 +326,7 @@ on a local state file only. You must specify a local state file with the
 	t.Run("backup option specified with state option", func(t *testing.T) {
 		td := t.TempDir()
 		testCopyDir(t, testFixturePath("init-backend-http"), td)
-		defer testChdir(t, td)()
+		t.Chdir(td)
 
 		statePath := testStateFile(t, state)
 		backupPath := filepath.Join(td, "backup")
@@ -366,7 +366,7 @@ on a local state file only. You must specify a local state file with the
 	t.Run("backup-out option specified with state option", func(t *testing.T) {
 		td := t.TempDir()
 		testCopyDir(t, testFixturePath("init-backend-http"), td)
-		defer testChdir(t, td)()
+		t.Chdir(td)
 
 		statePath := testStateFile(t, state)
 		backupOutPath := filepath.Join(td, "backup-out")
@@ -865,7 +865,7 @@ match.
 func TestStateMv_explicitWithBackend(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("init-backend"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	backupPath := filepath.Join(td, "backup")
 
@@ -1157,7 +1157,7 @@ func TestStateMv_stateOutExisting(t *testing.T) {
 }
 
 func TestStateMv_noState(t *testing.T) {
-	testCwd(t)
+	testCwdTemp(t)
 
 	p := testProvider()
 	ui := new(cli.MockUi)
@@ -1493,7 +1493,7 @@ func TestStateMv_toNewModule(t *testing.T) {
 func TestStateMv_withinBackend(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-unchanged"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	state := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -1574,7 +1574,7 @@ func TestStateMv_withinBackend(t *testing.T) {
 func TestStateMv_fromBackendToLocal(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-unchanged"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	state := states.NewState()
 	state.Module(addrs.RootModuleInstance).SetResourceInstanceCurrent(
@@ -1744,7 +1744,7 @@ func TestStateMv_checkRequiredVersion(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("command-check-required-version"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	state := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(

--- a/internal/command/state_pull_test.go
+++ b/internal/command/state_pull_test.go
@@ -18,7 +18,7 @@ func TestStatePull(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("state-pull-backend"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	expected, err := os.ReadFile("local-state.tfstate")
 	if err != nil {
@@ -46,7 +46,7 @@ func TestStatePull(t *testing.T) {
 }
 
 func TestStatePull_noState(t *testing.T) {
-	testCwd(t)
+	testCwdTemp(t)
 
 	p := testProvider()
 	ui := cli.NewMockUi()
@@ -72,7 +72,7 @@ func TestStatePull_checkRequiredVersion(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("command-check-required-version"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := testProvider()
 	ui := cli.NewMockUi()

--- a/internal/command/state_push_test.go
+++ b/internal/command/state_push_test.go
@@ -21,7 +21,7 @@ func TestStatePush_empty(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("state-push-good"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	expected := testStateRead(t, "replace.tfstate")
 
@@ -51,7 +51,7 @@ func TestStatePush_lockedState(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("state-push-good"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := testProvider()
 	ui := new(cli.MockUi)
@@ -83,7 +83,7 @@ func TestStatePush_replaceMatch(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("state-push-replace-match"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	expected := testStateRead(t, "replace.tfstate")
 
@@ -113,7 +113,7 @@ func TestStatePush_replaceMatchStdin(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("state-push-replace-match"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	expected := testStateRead(t, "replace.tfstate")
 
@@ -150,7 +150,7 @@ func TestStatePush_lineageMismatch(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("state-push-bad-lineage"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	expected := testStateRead(t, "local-state.tfstate")
 
@@ -180,7 +180,7 @@ func TestStatePush_serialNewer(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("state-push-serial-newer"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	expected := testStateRead(t, "local-state.tfstate")
 
@@ -210,7 +210,7 @@ func TestStatePush_serialOlder(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("state-push-serial-older"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	expected := testStateRead(t, "replace.tfstate")
 
@@ -239,7 +239,7 @@ func TestStatePush_serialOlder(t *testing.T) {
 func TestStatePush_forceRemoteState(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("inmem-backend"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 	defer inmem.Reset()
 
 	s := states.NewState()
@@ -293,7 +293,7 @@ func TestStatePush_checkRequiredVersion(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("command-check-required-version"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := testProvider()
 	ui := cli.NewMockUi()

--- a/internal/command/state_replace_provider_test.go
+++ b/internal/command/state_replace_provider_test.go
@@ -306,7 +306,7 @@ func TestStateReplaceProvider_checkRequiredVersion(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("command-check-required-version"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	state := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(

--- a/internal/command/state_rm_test.go
+++ b/internal/command/state_rm_test.go
@@ -369,7 +369,7 @@ func TestStateRm_backupExplicit(t *testing.T) {
 }
 
 func TestStateRm_noState(t *testing.T) {
-	testCwd(t)
+	testCwdTemp(t)
 
 	p := testProvider()
 	ui := new(cli.MockUi)
@@ -393,7 +393,7 @@ func TestStateRm_noState(t *testing.T) {
 func TestStateRm_needsInit(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-change"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	p := testProvider()
 	ui := new(cli.MockUi)
@@ -421,7 +421,7 @@ func TestStateRm_needsInit(t *testing.T) {
 func TestStateRm_backendState(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-unchanged"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	state := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -504,7 +504,7 @@ func TestStateRm_checkRequiredVersion(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("command-check-required-version"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	state := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(

--- a/internal/command/state_show_test.go
+++ b/internal/command/state_show_test.go
@@ -160,7 +160,7 @@ func TestStateShow_multi(t *testing.T) {
 }
 
 func TestStateShow_noState(t *testing.T) {
-	testCwd(t)
+	testCwdTemp(t)
 
 	p := testProvider()
 	streams, done := terminal.StreamsForTesting(t)

--- a/internal/command/state_test.go
+++ b/internal/command/state_test.go
@@ -31,7 +31,7 @@ func testStateBackups(t *testing.T, dir string) []string {
 }
 
 func TestStateDefaultBackupExtension(t *testing.T) {
-	testCwd(t)
+	testCwdTemp(t)
 
 	s, err := (&StateMeta{}).State(encryption.Disabled())
 	if err != nil {

--- a/internal/command/taint_test.go
+++ b/internal/command/taint_test.go
@@ -109,7 +109,7 @@ func TestTaint_lockedState(t *testing.T) {
 
 func TestTaint_backup(t *testing.T) {
 	// Get a temp cwd
-	testCwd(t)
+	testCwdTemp(t)
 
 	// Write the temp state
 	state := states.BuildState(func(s *states.SyncState) {
@@ -154,7 +154,7 @@ func TestTaint_backup(t *testing.T) {
 
 func TestTaint_backupDisable(t *testing.T) {
 	// Get a temp cwd
-	testCwd(t)
+	testCwdTemp(t)
 
 	// Write the temp state
 	state := states.BuildState(func(s *states.SyncState) {
@@ -222,7 +222,7 @@ func TestTaint_badState(t *testing.T) {
 
 func TestTaint_defaultState(t *testing.T) {
 	// Get a temp cwd
-	testCwd(t)
+	testCwdTemp(t)
 
 	// Write the temp state
 	state := states.BuildState(func(s *states.SyncState) {
@@ -266,7 +266,7 @@ func TestTaint_defaultState(t *testing.T) {
 
 func TestTaint_defaultWorkspaceState(t *testing.T) {
 	// Get a temp cwd
-	testCwd(t)
+	testCwdTemp(t)
 
 	state := states.BuildState(func(s *states.SyncState) {
 		s.SetResourceInstanceCurrent(
@@ -401,7 +401,7 @@ because -allow-missing was set.
 
 func TestTaint_stateOut(t *testing.T) {
 	// Get a temp cwd
-	testCwd(t)
+	testCwdTemp(t)
 
 	// Write the temp state
 	state := states.BuildState(func(s *states.SyncState) {
@@ -506,7 +506,7 @@ func TestTaint_checkRequiredVersion(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("command-check-required-version"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Write the temp state
 	state := states.BuildState(func(s *states.SyncState) {

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -188,7 +188,7 @@ func TestTest(t *testing.T) {
 
 			td := t.TempDir()
 			testCopyDir(t, testFixturePath(path.Join("test", file)), td)
-			defer testChdir(t, td)()
+			t.Chdir(td)
 
 			provider := testing_command.NewProvider(nil)
 			view, done := testView(t)
@@ -277,7 +277,7 @@ func TestTest_Full_Output(t *testing.T) {
 
 			td := t.TempDir()
 			testCopyDir(t, testFixturePath(path.Join("test", file)), td)
-			defer testChdir(t, td)()
+			t.Chdir(td)
 
 			provider := testing_command.NewProvider(nil)
 			view, done := testView(t)
@@ -310,7 +310,7 @@ func TestTest_Full_Output(t *testing.T) {
 func TestTest_Interrupt(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "with_interrupt")), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	provider := testing_command.NewProvider(nil)
 	view, done := testView(t)
@@ -342,7 +342,7 @@ func TestTest_Interrupt(t *testing.T) {
 func TestTest_DoubleInterrupt(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "with_double_interrupt")), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	provider := testing_command.NewProvider(nil)
 	view, done := testView(t)
@@ -391,7 +391,7 @@ test:
 func TestTest_ProviderAlias(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "with_provider_alias")), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	provider := testing_command.NewProvider(nil)
 
@@ -446,7 +446,7 @@ func TestTest_ProviderAlias(t *testing.T) {
 func TestTest_ModuleDependencies(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "with_setup_module")), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Our two providers will share a common set of values to make things
 	// easier.
@@ -531,7 +531,7 @@ func TestTest_ModuleDependencies(t *testing.T) {
 func TestTest_CatchesErrorsBeforeDestroy(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "invalid_default_state")), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	provider := testing_command.NewProvider(nil)
 	view, done := testView(t)
@@ -586,7 +586,7 @@ variable.
 func TestTest_Verbose(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "plan_then_apply")), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	provider := testing_command.NewProvider(nil)
 	view, done := testView(t)
@@ -740,7 +740,7 @@ can remove the provider configuration again.
 
 			td := t.TempDir()
 			testCopyDir(t, testFixturePath(path.Join("test", file)), td)
-			defer testChdir(t, td)()
+			t.Chdir(td)
 
 			provider := testing_command.NewProvider(nil)
 
@@ -889,7 +889,7 @@ func TestTest_Modules(t *testing.T) {
 
 			td := t.TempDir()
 			testCopyDir(t, testFixturePath(path.Join("test", file)), td)
-			defer testChdir(t, td)()
+			t.Chdir(td)
 
 			provider := testing_command.NewProvider(nil)
 			providerSource, close := newMockProviderSource(t, map[string][]string{
@@ -965,7 +965,7 @@ func TestTest_Modules(t *testing.T) {
 func TestTest_StatePropagation(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "state_propagation")), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	provider := testing_command.NewProvider(nil)
 
@@ -1161,7 +1161,7 @@ Condition expression could not be evaluated at this time.
 		t.Run(file, func(t *testing.T) {
 			td := t.TempDir()
 			testCopyDir(t, testFixturePath(path.Join("test", file)), td)
-			defer testChdir(t, td)()
+			t.Chdir(td)
 
 			provider := testing_command.NewProvider(nil)
 			view, done := testView(t)
@@ -1262,7 +1262,7 @@ Success! 1 passed, 0 failed.
 
 			td := t.TempDir()
 			testCopyDir(t, testFixturePath(path.Join("test", file)), td)
-			defer testChdir(t, td)()
+			t.Chdir(td)
 
 			provider := testing_command.NewProvider(nil)
 			providerSource, providerClose := newMockProviderSource(t, map[string][]string{
@@ -1348,7 +1348,7 @@ func TestTest_InvalidLocalVariables(t *testing.T) {
 
 			td := t.TempDir()
 			testCopyDir(t, testFixturePath(path.Join("test", file)), td)
-			defer testChdir(t, td)()
+			t.Chdir(td)
 
 			provider := testing_command.NewProvider(nil)
 			providerSource, providerClose := newMockProviderSource(t, map[string][]string{
@@ -1433,7 +1433,7 @@ digits, underscores, and dashes.
 
 			td := t.TempDir()
 			testCopyDir(t, testFixturePath(path.Join("test", file)), td)
-			defer testChdir(t, td)()
+			t.Chdir(td)
 
 			provider := testing_command.NewProvider(nil)
 			providerSource, close := newMockProviderSource(t, map[string][]string{
@@ -1469,7 +1469,7 @@ digits, underscores, and dashes.
 func TestTest_MockProviderValidation(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("test/mock_provider_validation"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	provider := testing_command.NewProvider(nil)
 	providerSource, closePS := newMockProviderSource(t, map[string][]string{

--- a/internal/command/unlock_test.go
+++ b/internal/command/unlock_test.go
@@ -20,7 +20,7 @@ import (
 func TestUnlock(t *testing.T) {
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// Write the legacy state
 	statePath := DefaultStateFilename
@@ -72,7 +72,7 @@ func TestUnlock_inmemBackend(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("backend-inmem-locked"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 	defer inmem.Reset()
 
 	// init backend

--- a/internal/command/untaint_test.go
+++ b/internal/command/untaint_test.go
@@ -113,7 +113,7 @@ func TestUntaint_lockedState(t *testing.T) {
 
 func TestUntaint_backup(t *testing.T) {
 	// Get a temp cwd
-	testCwd(t)
+	testCwdTemp(t)
 
 	// Write the temp state
 	state := states.BuildState(func(s *states.SyncState) {
@@ -169,7 +169,7 @@ test_instance.foo:
 
 func TestUntaint_backupDisable(t *testing.T) {
 	// Get a temp cwd
-	testCwd(t)
+	testCwdTemp(t)
 
 	// Write the temp state
 	state := states.BuildState(func(s *states.SyncState) {
@@ -241,7 +241,7 @@ func TestUntaint_badState(t *testing.T) {
 
 func TestUntaint_defaultState(t *testing.T) {
 	// Get a temp cwd
-	testCwd(t)
+	testCwdTemp(t)
 
 	// Write the temp state
 	state := states.BuildState(func(s *states.SyncState) {
@@ -289,7 +289,7 @@ test_instance.foo:
 
 func TestUntaint_defaultWorkspaceState(t *testing.T) {
 	// Get a temp cwd
-	testCwd(t)
+	testCwdTemp(t)
 
 	// Write the temp state
 	state := states.BuildState(func(s *states.SyncState) {
@@ -429,7 +429,7 @@ because -allow-missing was set.
 
 func TestUntaint_stateOut(t *testing.T) {
 	// Get a temp cwd
-	testCwd(t)
+	testCwdTemp(t)
 
 	// Write the temp state
 	state := states.BuildState(func(s *states.SyncState) {

--- a/internal/command/validate_test.go
+++ b/internal/command/validate_test.go
@@ -75,7 +75,7 @@ func TestValidateCommandWithTfvarsFile(t *testing.T) {
 	// requires scanning the current working directory by validate command.
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("validate-valid/with-tfvars-file"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	view, done := testView(t)
 	c := &ValidateCommand{
@@ -258,7 +258,7 @@ func TestValidateWithInvalidTestModule(t *testing.T) {
 
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath(path.Join("test", "invalid-module")), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	streams, done := terminal.StreamsForTesting(t)
 	view := views.NewView(streams)

--- a/internal/command/version_test.go
+++ b/internal/command/version_test.go
@@ -23,7 +23,7 @@ func TestVersionCommand_implements(t *testing.T) {
 
 func TestVersion(t *testing.T) {
 	td := t.TempDir()
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// We'll create a fixed dependency lock file in our working directory
 	// so we can verify that the version command shows the information
@@ -93,7 +93,7 @@ func TestVersion_flags(t *testing.T) {
 
 func TestVersion_json(t *testing.T) {
 	td := t.TempDir()
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	ui := cli.NewMockUi()
 	meta := Meta{

--- a/internal/command/views/show_test.go
+++ b/internal/command/views/show_test.go
@@ -171,8 +171,7 @@ func TestShowJSON(t *testing.T) {
 		},
 	}
 
-	config, _, configCleanup := initwd.MustLoadConfigForTests(t, "./testdata/show", "tests")
-	defer configCleanup()
+	config, _ := initwd.MustLoadConfigForTests(t, "./testdata/show", "tests")
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/command/views/test_test.go
+++ b/internal/command/views/test_test.go
@@ -3521,22 +3521,8 @@ func runTestSaveErroredStateFile(t *testing.T, tc map[string]struct {
 			// Modify the state file path to use the temporary directory
 			tempStateFilePath := filepath.Clean(filepath.Join(tempDir, "errored_test.tfstate"))
 
-			// Get the current working directory
-			originalDir, err := os.Getwd()
-			if err != nil {
-				t.Fatalf("Error getting current working directory: %v", err)
-			}
-
 			// Change the working directory to the temporary directory
-			if err := os.Chdir(tempDir); err != nil {
-				t.Fatalf("Error changing working directory: %v", err)
-			}
-			defer func() {
-				// Change the working directory back to the original directory after the test
-				if err := os.Chdir(originalDir); err != nil {
-					t.Fatalf("Error changing working directory back: %v", err)
-				}
-			}()
+			t.Chdir(tempDir)
 
 			streams, done := terminal.StreamsForTesting(t)
 

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -27,7 +27,7 @@ func TestWorkspace_createAndChange(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	newCmd := &WorkspaceNewCommand{}
 
@@ -70,7 +70,7 @@ func TestWorkspace_createAndList(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// make sure a vars file doesn't interfere
 	err := os.WriteFile(
@@ -118,7 +118,7 @@ func TestWorkspace_createAndShow(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// make sure a vars file doesn't interfere
 	err := os.WriteFile(
@@ -186,7 +186,7 @@ func TestWorkspace_createInvalid(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	envs := []string{"test_a*", "test_b/foo", "../../../test_c", "好_d"}
 
@@ -223,7 +223,7 @@ func TestWorkspace_createInvalid(t *testing.T) {
 func TestWorkspace_createWithState(t *testing.T) {
 	td := t.TempDir()
 	testCopyDir(t, testFixturePath("inmem-backend"), td)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 	defer inmem.Reset()
 
 	// init the backend
@@ -294,7 +294,7 @@ func TestWorkspace_createWithState(t *testing.T) {
 func TestWorkspace_delete(t *testing.T) {
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// create the workspace directories
 	if err := os.MkdirAll(filepath.Join(local.DefaultWorkspaceDir, "test"), 0755); err != nil {
@@ -347,7 +347,7 @@ func TestWorkspace_delete(t *testing.T) {
 func TestWorkspace_deleteInvalid(t *testing.T) {
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// choose an invalid workspace name
 	workspace := "test workspace"
@@ -379,7 +379,7 @@ func TestWorkspace_deleteInvalid(t *testing.T) {
 func TestWorkspace_deleteWithState(t *testing.T) {
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	// create the workspace directories
 	if err := os.MkdirAll(filepath.Join(local.DefaultWorkspaceDir, "test"), 0755); err != nil {
@@ -446,7 +446,7 @@ func TestWorkspace_selectWithOrCreate(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := t.TempDir()
 	os.MkdirAll(td, 0755)
-	defer testChdir(t, td)()
+	t.Chdir(td)
 
 	selectCmd := &WorkspaceSelectCommand{}
 

--- a/internal/communicator/ssh/ssh_test.go
+++ b/internal/communicator/ssh/ssh_test.go
@@ -22,14 +22,7 @@ import (
 func TestFindKeyData(t *testing.T) {
 	// set up a test directory
 	td := t.TempDir()
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Chdir(td); err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(cwd)
+	t.Chdir(td)
 
 	id := "provisioner_id"
 

--- a/internal/configs/configload/loader_snapshot_test.go
+++ b/internal/configs/configload/loader_snapshot_test.go
@@ -6,7 +6,6 @@
 package configload
 
 import (
-	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -88,10 +87,7 @@ module "child_b" {
 
 func TestLoadConfigWithSnapshot_invalidSource(t *testing.T) {
 	fixtureDir := filepath.Clean("testdata/already-installed-now-invalid")
-
-	old, _ := os.Getwd()
-	os.Chdir(fixtureDir)
-	defer os.Chdir(old)
+	t.Chdir(fixtureDir)
 
 	loader, err := NewLoader(&Config{
 		ModulesDir: ".terraform/modules",

--- a/internal/configs/configload/testing.go
+++ b/internal/configs/configload/testing.go
@@ -6,7 +6,6 @@
 package configload
 
 import (
-	"os"
 	"testing"
 )
 
@@ -14,34 +13,22 @@ import (
 // convenient for unit tests.
 //
 // The loader's modules directory is a separate temporary directory created
-// for each call. Along with the created loader, this function returns a
-// cleanup function that should be called before the test completes in order
-// to remove that temporary directory.
+// for each call. The temporary directory is deleted automatically at the
+// conclusion of the test.
 //
 // In the case of any errors, t.Fatal (or similar) will be called to halt
 // execution of the test, so the calling test does not need to handle errors
 // itself.
-func NewLoaderForTests(t testing.TB) (*Loader, func()) {
+func NewLoaderForTests(t testing.TB) *Loader {
 	t.Helper()
 
-	modulesDir, err := os.MkdirTemp("", "tf-configs")
-	if err != nil {
-		t.Fatalf("failed to create temporary modules dir: %s", err)
-		return nil, func() {}
-	}
-
-	cleanup := func() {
-		os.RemoveAll(modulesDir)
-	}
-
+	modulesDir := t.TempDir()
 	loader, err := NewLoader(&Config{
 		ModulesDir: modulesDir,
 	})
 	if err != nil {
-		cleanup()
 		t.Fatalf("failed to create config loader: %s", err)
-		return nil, func() {}
+		return nil
 	}
-
-	return loader, cleanup
+	return loader
 }

--- a/internal/initwd/from_module_test.go
+++ b/internal/initwd/from_module_test.go
@@ -45,8 +45,7 @@ func TestDirFromModule_registry(t *testing.T) {
 	hooks := &testInstallHooks{}
 
 	reg := registry.NewClient(nil, nil)
-	loader, cleanup := configload.NewLoaderForTests(t)
-	defer cleanup()
+	loader := configload.NewLoaderForTests(t)
 	diags := DirFromModule(context.Background(), loader, dir, modsDir, "hashicorp/module-installer-acctest/aws//examples/main", reg, nil, hooks)
 	assertNoDiagnostics(t, diags)
 
@@ -163,8 +162,7 @@ func TestDirFromModule_submodules(t *testing.T) {
 	}
 	modInstallDir := filepath.Join(dir, ".terraform/modules")
 
-	loader, cleanup := configload.NewLoaderForTests(t)
-	defer cleanup()
+	loader := configload.NewLoaderForTests(t)
 	diags := DirFromModule(
 		context.Background(),
 		loader,
@@ -250,8 +248,7 @@ func TestDirFromModule_submodulesWithProvider(t *testing.T) {
 	}
 	modInstallDir := filepath.Join(dir, ".terraform/modules")
 
-	loader, cleanup := configload.NewLoaderForTests(t)
-	defer cleanup()
+	loader := configload.NewLoaderForTests(t)
 	diags := DirFromModule(
 		context.Background(),
 		loader,
@@ -320,8 +317,7 @@ func TestDirFromModule_rel_submodules(t *testing.T) {
 
 	modInstallDir := ".terraform/modules"
 	sourceDir := "../local-modules"
-	loader, cleanup := configload.NewLoaderForTests(t)
-	defer cleanup()
+	loader := configload.NewLoaderForTests(t)
 	diags := DirFromModule(
 		context.Background(),
 		loader, ".",

--- a/internal/initwd/from_module_test.go
+++ b/internal/initwd/from_module_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -29,8 +28,7 @@ func TestDirFromModule_registry(t *testing.T) {
 	}
 
 	fixtureDir := filepath.Clean("testdata/empty")
-	tmpDir, done := tempChdir(t, fixtureDir)
-	defer done()
+	tmpDir := tempChdir(t, fixtureDir)
 
 	// the module installer runs filepath.EvalSymlinks() on the destination
 	// directory before copying files, and the resultant directory is what is
@@ -152,8 +150,7 @@ func TestDirFromModule_submodules(t *testing.T) {
 		t.Error(err)
 	}
 
-	tmpDir, done := tempChdir(t, fixtureDir)
-	defer done()
+	tmpDir := tempChdir(t, fixtureDir)
 
 	hooks := &testInstallHooks{}
 	dir, err := filepath.EvalSymlinks(tmpDir)
@@ -238,9 +235,7 @@ func TestDirFromModule_submodulesWithProvider(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tmpDir, done := tempChdir(t, fixtureDir)
-	defer done()
-
+	tmpDir := tempChdir(t, fixtureDir)
 	hooks := &testInstallHooks{}
 	dir, err := filepath.EvalSymlinks(tmpDir)
 	if err != nil {
@@ -296,22 +291,7 @@ func TestDirFromModule_rel_submodules(t *testing.T) {
 	if err := os.Mkdir(targetDir, os.ModePerm); err != nil {
 		t.Fatal(err)
 	}
-	oldDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = os.Chdir(targetDir)
-	if err != nil {
-		t.Fatalf("failed to switch to temp dir %s: %s", tmpDir, err)
-	}
-	t.Cleanup(func() {
-		os.Chdir(oldDir)
-		// Trigger garbage collection to ensure that all open file handles are closed.
-		// This prevents TempDir RemoveAll cleanup errors on Windows.
-		if runtime.GOOS == "windows" {
-			runtime.GC()
-		}
-	})
+	t.Chdir(targetDir)
 
 	hooks := &testInstallHooks{}
 
@@ -349,7 +329,7 @@ func TestDirFromModule_rel_submodules(t *testing.T) {
 		return
 	}
 
-	loader, err = configload.NewLoader(&configload.Config{
+	loader, err := configload.NewLoader(&configload.Config{
 		ModulesDir: modInstallDir,
 	})
 	if err != nil {

--- a/internal/initwd/module_install_test.go
+++ b/internal/initwd/module_install_test.go
@@ -45,8 +45,7 @@ func TestModuleInstaller(t *testing.T) {
 	hooks := &testInstallHooks{}
 
 	modulesDir := filepath.Join(dir, ".terraform/modules")
-	loader, close := configload.NewLoaderForTests(t)
-	defer close()
+	loader := configload.NewLoaderForTests(t)
 	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 	assertNoDiagnostics(t, diags)
@@ -109,8 +108,7 @@ func TestModuleInstaller_error(t *testing.T) {
 
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 
-	loader, close := configload.NewLoaderForTests(t)
-	defer close()
+	loader := configload.NewLoaderForTests(t)
 	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 
@@ -130,8 +128,7 @@ func TestModuleInstaller_emptyModuleName(t *testing.T) {
 
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 
-	loader, close := configload.NewLoaderForTests(t)
-	defer close()
+	loader := configload.NewLoaderForTests(t)
 	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 
@@ -151,8 +148,7 @@ func TestModuleInstaller_invalidModuleName(t *testing.T) {
 
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 
-	loader, close := configload.NewLoaderForTests(t)
-	defer close()
+	loader := configload.NewLoaderForTests(t)
 	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil), nil)
 	_, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks, configs.RootModuleCallForTesting())
 	if !diags.HasErrors() {
@@ -188,8 +184,7 @@ func TestModuleInstaller_packageEscapeError(t *testing.T) {
 
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 
-	loader, close := configload.NewLoaderForTests(t)
-	defer close()
+	loader := configload.NewLoaderForTests(t)
 	// This test needs a real getmodules.PackageFetcher because it makes use of
 	// the esoteric legacy support for treating an absolute filesystem path
 	// as if it were a "remote package". This should not use any of the
@@ -230,8 +225,7 @@ func TestModuleInstaller_explicitPackageBoundary(t *testing.T) {
 
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 
-	loader, close := configload.NewLoaderForTests(t)
-	defer close()
+	loader := configload.NewLoaderForTests(t)
 	// This test needs a real getmodules.PackageFetcher because it makes use of
 	// the esoteric legacy support for treating an absolute filesystem path
 	// as if it were a "remote package". This should not use any of the
@@ -320,8 +314,7 @@ func TestModuleInstaller_Prerelease(t *testing.T) {
 
 			modulesDir := filepath.Join(dir, ".terraform/modules")
 
-			loader, closeLoader := configload.NewLoaderForTests(t)
-			defer closeLoader()
+			loader := configload.NewLoaderForTests(t)
 			inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil), nil)
 			cfg, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 
@@ -352,8 +345,7 @@ func TestModuleInstaller_invalid_version_constraint_error(t *testing.T) {
 
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 
-	loader, close := configload.NewLoaderForTests(t)
-	defer close()
+	loader := configload.NewLoaderForTests(t)
 	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 
@@ -378,8 +370,7 @@ func TestModuleInstaller_invalidVersionConstraintGetter(t *testing.T) {
 
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 
-	loader, close := configload.NewLoaderForTests(t)
-	defer close()
+	loader := configload.NewLoaderForTests(t)
 	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 
@@ -404,8 +395,7 @@ func TestModuleInstaller_invalidVersionConstraintLocal(t *testing.T) {
 
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 
-	loader, close := configload.NewLoaderForTests(t)
-	defer close()
+	loader := configload.NewLoaderForTests(t)
 	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 
@@ -430,8 +420,7 @@ func TestModuleInstaller_symlink(t *testing.T) {
 
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 
-	loader, close := configload.NewLoaderForTests(t)
-	defer close()
+	loader := configload.NewLoaderForTests(t)
 	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 	assertNoDiagnostics(t, diags)
@@ -506,8 +495,7 @@ func TestLoaderInstallModules_registry(t *testing.T) {
 	hooks := &testInstallHooks{}
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 
-	loader, close := configload.NewLoaderForTests(t)
-	defer close()
+	loader := configload.NewLoaderForTests(t)
 	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil), nil)
 	_, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks, configs.RootModuleCallForTesting())
 	assertNoDiagnostics(t, diags)
@@ -669,8 +657,7 @@ func TestLoaderInstallModules_goGetter(t *testing.T) {
 	hooks := &testInstallHooks{}
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 
-	loader, close := configload.NewLoaderForTests(t)
-	defer close()
+	loader := configload.NewLoaderForTests(t)
 	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil), nil)
 	_, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks, configs.RootModuleCallForTesting())
 	assertNoDiagnostics(t, diags)
@@ -787,8 +774,7 @@ func TestModuleInstaller_fromTests(t *testing.T) {
 	hooks := &testInstallHooks{}
 
 	modulesDir := filepath.Join(dir, ".terraform/modules")
-	loader, close := configload.NewLoaderForTests(t)
-	defer close()
+	loader := configload.NewLoaderForTests(t)
 	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 	assertNoDiagnostics(t, diags)
@@ -844,8 +830,7 @@ func TestLoadInstallModules_registryFromTest(t *testing.T) {
 	hooks := &testInstallHooks{}
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 
-	loader, close := configload.NewLoaderForTests(t)
-	defer close()
+	loader := configload.NewLoaderForTests(t)
 	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(nil, nil), nil)
 	_, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks, configs.RootModuleCallForTesting())
 	assertNoDiagnostics(t, diags)

--- a/internal/initwd/module_install_test.go
+++ b/internal/initwd/module_install_test.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	"flag"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -39,8 +38,7 @@ func TestMain(m *testing.M) {
 
 func TestModuleInstaller(t *testing.T) {
 	fixtureDir := filepath.Clean("testdata/local-modules")
-	dir, done := tempChdir(t, fixtureDir)
-	defer done()
+	dir := tempChdir(t, fixtureDir)
 
 	hooks := &testInstallHooks{}
 
@@ -101,8 +99,7 @@ func TestModuleInstaller(t *testing.T) {
 
 func TestModuleInstaller_error(t *testing.T) {
 	fixtureDir := filepath.Clean("testdata/local-module-error")
-	dir, done := tempChdir(t, fixtureDir)
-	defer done()
+	dir := tempChdir(t, fixtureDir)
 
 	hooks := &testInstallHooks{}
 
@@ -121,8 +118,7 @@ func TestModuleInstaller_error(t *testing.T) {
 
 func TestModuleInstaller_emptyModuleName(t *testing.T) {
 	fixtureDir := filepath.Clean("testdata/empty-module-name")
-	dir, done := tempChdir(t, fixtureDir)
-	defer done()
+	dir := tempChdir(t, fixtureDir)
 
 	hooks := &testInstallHooks{}
 
@@ -141,8 +137,7 @@ func TestModuleInstaller_emptyModuleName(t *testing.T) {
 
 func TestModuleInstaller_invalidModuleName(t *testing.T) {
 	fixtureDir := filepath.Clean("testdata/invalid-module-name")
-	dir, done := tempChdir(t, fixtureDir)
-	defer done()
+	dir := tempChdir(t, fixtureDir)
 
 	hooks := &testInstallHooks{}
 
@@ -160,8 +155,7 @@ func TestModuleInstaller_invalidModuleName(t *testing.T) {
 
 func TestModuleInstaller_packageEscapeError(t *testing.T) {
 	fixtureDir := filepath.Clean("testdata/load-module-package-escape")
-	dir, done := tempChdir(t, fixtureDir)
-	defer done()
+	dir := tempChdir(t, fixtureDir)
 
 	// For this particular test we need an absolute path in the root module
 	// that must actually resolve to our temporary directory in "dir", so
@@ -201,8 +195,7 @@ func TestModuleInstaller_packageEscapeError(t *testing.T) {
 
 func TestModuleInstaller_explicitPackageBoundary(t *testing.T) {
 	fixtureDir := filepath.Clean("testdata/load-module-package-prefix")
-	dir, done := tempChdir(t, fixtureDir)
-	defer done()
+	dir := tempChdir(t, fixtureDir)
 
 	// For this particular test we need an absolute path in the root module
 	// that must actually resolve to our temporary directory in "dir", so
@@ -307,8 +300,7 @@ func TestModuleInstaller_Prerelease(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			fixtureDir := filepath.Clean(tc.modulePath)
-			dir, done := tempChdir(t, fixtureDir)
-			defer done()
+			dir := tempChdir(t, fixtureDir)
 
 			hooks := &testInstallHooks{}
 
@@ -338,8 +330,7 @@ func TestModuleInstaller_Prerelease(t *testing.T) {
 
 func TestModuleInstaller_invalid_version_constraint_error(t *testing.T) {
 	fixtureDir := filepath.Clean("testdata/invalid-version-constraint")
-	dir, done := tempChdir(t, fixtureDir)
-	defer done()
+	dir := tempChdir(t, fixtureDir)
 
 	hooks := &testInstallHooks{}
 
@@ -363,8 +354,7 @@ func TestModuleInstaller_invalid_version_constraint_error(t *testing.T) {
 
 func TestModuleInstaller_invalidVersionConstraintGetter(t *testing.T) {
 	fixtureDir := filepath.Clean("testdata/invalid-version-constraint")
-	dir, done := tempChdir(t, fixtureDir)
-	defer done()
+	dir := tempChdir(t, fixtureDir)
 
 	hooks := &testInstallHooks{}
 
@@ -388,8 +378,7 @@ func TestModuleInstaller_invalidVersionConstraintGetter(t *testing.T) {
 
 func TestModuleInstaller_invalidVersionConstraintLocal(t *testing.T) {
 	fixtureDir := filepath.Clean("testdata/invalid-version-constraint-local")
-	dir, done := tempChdir(t, fixtureDir)
-	defer done()
+	dir := tempChdir(t, fixtureDir)
 
 	hooks := &testInstallHooks{}
 
@@ -413,8 +402,7 @@ func TestModuleInstaller_invalidVersionConstraintLocal(t *testing.T) {
 
 func TestModuleInstaller_symlink(t *testing.T) {
 	fixtureDir := filepath.Clean("testdata/local-module-symlink")
-	dir, done := tempChdir(t, fixtureDir)
-	defer done()
+	dir := tempChdir(t, fixtureDir)
 
 	hooks := &testInstallHooks{}
 
@@ -480,7 +468,7 @@ func TestLoaderInstallModules_registry(t *testing.T) {
 	}
 
 	fixtureDir := filepath.Clean("testdata/registry-modules")
-	tmpDir, done := tempChdir(t, fixtureDir)
+	tmpDir := tempChdir(t, fixtureDir)
 	// the module installer runs filepath.EvalSymlinks() on the destination
 	// directory before copying files, and the resultant directory is what is
 	// returned by the install hooks. Without this, tests could fail on machines
@@ -489,8 +477,6 @@ func TestLoaderInstallModules_registry(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-
-	defer done()
 
 	hooks := &testInstallHooks{}
 	modulesDir := filepath.Join(dir, ".terraform/modules")
@@ -643,7 +629,7 @@ func TestLoaderInstallModules_goGetter(t *testing.T) {
 	}
 
 	fixtureDir := filepath.Clean("testdata/go-getter-modules")
-	tmpDir, done := tempChdir(t, fixtureDir)
+	tmpDir := tempChdir(t, fixtureDir)
 	// the module installer runs filepath.EvalSymlinks() on the destination
 	// directory before copying files, and the resultant directory is what is
 	// returned by the install hooks. Without this, tests could fail on machines
@@ -652,7 +638,6 @@ func TestLoaderInstallModules_goGetter(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	defer done()
 
 	hooks := &testInstallHooks{}
 	modulesDir := filepath.Join(dir, ".terraform/modules")
@@ -768,8 +753,7 @@ func TestLoaderInstallModules_goGetter(t *testing.T) {
 
 func TestModuleInstaller_fromTests(t *testing.T) {
 	fixtureDir := filepath.Clean("testdata/local-module-from-test")
-	dir, done := tempChdir(t, fixtureDir)
-	defer done()
+	dir := tempChdir(t, fixtureDir)
 
 	hooks := &testInstallHooks{}
 
@@ -815,7 +799,7 @@ func TestLoadInstallModules_registryFromTest(t *testing.T) {
 	}
 
 	fixtureDir := filepath.Clean("testdata/registry-module-from-test")
-	tmpDir, done := tempChdir(t, fixtureDir)
+	tmpDir := tempChdir(t, fixtureDir)
 	// the module installer runs filepath.EvalSymlinks() on the destination
 	// directory before copying files, and the resultant directory is what is
 	// returned by the install hooks. Without this, tests could fail on machines
@@ -824,8 +808,6 @@ func TestLoadInstallModules_registryFromTest(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-
-	defer done()
 
 	hooks := &testInstallHooks{}
 	modulesDir := filepath.Join(dir, ".terraform/modules")
@@ -949,52 +931,28 @@ func (h *testInstallHooks) Install(moduleAddr string, version *version.Version, 
 
 // tempChdir copies the contents of the given directory to a temporary
 // directory and changes the test process's current working directory to
-// point to that directory. Also returned is a function that should be
-// called at the end of the test (e.g. via "defer") to restore the previous
-// working directory.
+// point to that directory. The temporary directory is deleted and the
+// working directory restored after the calling test is complete.
 //
 // Tests using this helper cannot safely be run in parallel with other tests.
-func tempChdir(t *testing.T, sourceDir string) (string, func()) {
+func tempChdir(t testing.TB, sourceDir string) string {
 	t.Helper()
 
-	tmpDir, err := os.MkdirTemp("", "terraform-configload")
-	if err != nil {
-		t.Fatalf("failed to create temporary directory: %s", err)
-		return "", nil
-	}
-
+	tmpDir := t.TempDir()
 	if err := copy.CopyDir(tmpDir, sourceDir); err != nil {
 		t.Fatalf("failed to copy fixture to temporary directory: %s", err)
-		return "", nil
+		return ""
 	}
-
-	oldDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("failed to determine current working directory: %s", err)
-		return "", nil
-	}
-
-	err = os.Chdir(tmpDir)
-	if err != nil {
-		t.Fatalf("failed to switch to temp dir %s: %s", tmpDir, err)
-		return "", nil
-	}
+	t.Chdir(tmpDir)
 
 	// Most of the tests need this, so we'll make it just in case.
-	os.MkdirAll(filepath.Join(tmpDir, ".terraform/modules"), os.ModePerm)
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".terraform/modules"), os.ModePerm); err != nil {
+		t.Fatalf("failed to make module cache directory: %s", err)
+		return ""
+	}
 
 	t.Logf("tempChdir switched to %s after copying from %s", tmpDir, sourceDir)
-
-	return tmpDir, func() {
-		err := os.Chdir(oldDir)
-		if err != nil {
-			panic(fmt.Errorf("failed to restore previous working directory %s: %w", oldDir, err))
-		}
-
-		if os.Getenv("TF_CONFIGLOAD_TEST_KEEP_TMP") == "" {
-			os.RemoveAll(tmpDir)
-		}
-	}
+	return tmpDir
 }
 
 func assertNoDiagnostics(t *testing.T, diags tfdiags.Diagnostics) bool {

--- a/internal/lang/globalref/analyzer_test.go
+++ b/internal/lang/globalref/analyzer_test.go
@@ -24,9 +24,7 @@ import (
 func testAnalyzer(t *testing.T, fixtureName string) *Analyzer {
 	configDir := filepath.Join("testdata", fixtureName)
 
-	loader, cleanup := configload.NewLoaderForTests(t)
-	defer cleanup()
-
+	loader := configload.NewLoaderForTests(t)
 	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil), nil)
 	_, instDiags := inst.InstallModules(context.Background(), configDir, "tests", true, false, initwd.ModuleInstallHooksImpl{}, configs.RootModuleCallForTesting())
 	if instDiags.HasErrors() {

--- a/internal/refactoring/move_validate_test.go
+++ b/internal/refactoring/move_validate_test.go
@@ -538,9 +538,7 @@ A chain of move statements must end with an address that doesn't appear in any o
 func loadRefactoringFixture(t *testing.T, dir string) (*configs.Config, instances.Set) {
 	t.Helper()
 
-	loader, cleanup := configload.NewLoaderForTests(t)
-	defer cleanup()
-
+	loader := configload.NewLoaderForTests(t)
 	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(nil, nil), nil)
 	_, instDiags := inst.InstallModules(context.Background(), dir, "tests", true, false, initwd.ModuleInstallHooksImpl{}, configs.RootModuleCallForTesting())
 	if instDiags.HasErrors() {

--- a/internal/repl/session_test.go
+++ b/internal/repl/session_test.go
@@ -279,8 +279,7 @@ func testSession(t *testing.T, test testSessionTest) {
 		},
 	}
 
-	config, _, cleanup, configDiags := initwd.LoadConfigForTests(t, "testdata/config-fixture", "tests")
-	defer cleanup()
+	config, _, configDiags := initwd.LoadConfigForTests(t, "testdata/config-fixture", "tests")
 	if configDiags.HasErrors() {
 		t.Fatalf("unexpected problems loading config: %s", configDiags.Err())
 	}

--- a/internal/tofu/opentf_test.go
+++ b/internal/tofu/opentf_test.go
@@ -57,10 +57,7 @@ func testModuleWithSnapshot(t testing.TB, name string) (*configs.Config, *config
 	t.Helper()
 
 	dir := filepath.Join(fixtureDir, name)
-	// FIXME: We're not dealing with the cleanup function here because
-	// this testModule function is used all over and so we don't want to
-	// change its interface at this late stage.
-	loader, _ := configload.NewLoaderForTests(t)
+	loader := configload.NewLoaderForTests(t)
 
 	// We need to be able to exercise experimental features in our integration tests.
 	loader.AllowLanguageExperiments(true)
@@ -116,8 +113,7 @@ func testModuleInline(t testing.TB, sources map[string]string) *configs.Config {
 		}
 	}
 
-	loader, cleanup := configload.NewLoaderForTests(t)
-	defer cleanup()
+	loader := configload.NewLoaderForTests(t)
 
 	// We need to be able to exercise experimental features in our integration tests.
 	loader.AllowLanguageExperiments(true)

--- a/internal/tofumigrate/tofumigrate_test.go
+++ b/internal/tofumigrate/tofumigrate_test.go
@@ -18,9 +18,7 @@ import (
 )
 
 func TestMigrateStateProviderAddresses(t *testing.T) {
-	loader, close := configload.NewLoaderForTests(t)
-	defer close()
-
+	loader := configload.NewLoaderForTests(t)
 	mustParseInstAddr := func(s string) addrs.AbsResourceInstance {
 		addr, err := addrs.ParseAbsResourceInstanceStr(s)
 		if err != nil {


### PR DESCRIPTION
Much of this codebase is nearly as old as the Go programming language itself, and so it contains various local workarounds for then-missing features of the Go standard library, particularly in test code.

Recent versions of Go have introduced some useful additions to the test harness:

- [`t.Cleanup`](https://pkg.go.dev/testing#T.Cleanup) runs an arbitrary function after the current test is complete.
- [`t.TempDir`](https://pkg.go.dev/testing#T.TempDir) creates a temporary directory in the filesystem and arranges to clean it up automatically after the current test is complete.
- [`t.Chdir`](https://pkg.go.dev/testing#T.Chdir) changes the test program's current working directory and arranges to change it back again after the current test is complete.

Over in https://github.com/opentofu/opentofu/pull/2620#issuecomment-2789363667 @bittelc noticed that a few of our tests were leaving behind little turds in the temporary directory each time they ran, without cleaning them up. That was caused by some compromises made in [probably the worst commit in this codebase's history](https://github.com/opentofu/opentofu/commit/c937c06a03386caee280c36ee10eebeb0dc7813b), where I intentionally left the signature of two commonly-used test helpers unchanged to avoid making that commit _even worse_ but as a consequence caused a number of tests to leave their temporary directories behind on each run.

The new test harness functionality provides a way to fix that problem _without_ changing the API of those old test helpers, but to make use of that we need to change the API of the newer test helpers at the next-lowest level of abstraction :roll_eyes: so that they no longer return a cleanup function that callers are expected to call using a defer statement.

I really don't like making this sort of systematic cross-cutting change because it tends to make it harder to backport changes across it in future, but it was difficult to avoid that for the _first_ commit in this series and so I figure that if we can't avoid making cross-cutting cleanup changes then the next best thing is to make as many as possible all at once so that at least there's only _one_ point in the history where there's a bunch of stuff that's awkward to backport through, so I reviewed various other similar patterns elsewhere in the codebase and tried to clean up as many as I could find.

The result then is a huge, ugly diff that consists mostly of systematic changes from old practices to more modern practices. This only touches the test code, so the risk is relatively low, and I split it into [several separate commits](https://github.com/opentofu/opentofu/pull/2692/commits) in the hope that this helps reviewers notice the patterns in the updates at each step and thus feel better about not reviewing every single line in detail, because this is definitely not the sort of change that is well-suited to human review. :confounded: 


