### PR TITLE
[OpenTelemetry] Add traces to `providers lock` command

### DIFF
--- a/internal/tracing/traceattrs/traceattrs.go
+++ b/internal/tracing/traceattrs/traceattrs.go
@@ -10,4 +10,6 @@ const (
 
 	ProviderAddress = "opentofu.provider.address"
 	ProviderVersion = "opentofu.provider.version"
+
+	TargetPlatform = "opentofu.target_platform"
 )


### PR DESCRIPTION
Helps give us some visibility for #2563 

Part of the OTEL Tracing implementation tracked here #2664

## Target Release

- ?

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
