### PR TITLE
Refactor the provider installer loop

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -927,7 +927,7 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 			// Either way, this is bad. Let's complain/warn.
 			incompleteProviders = append(incompleteProviders, provider.ForDisplay())
 		},
-		ProvidersFetched: func(authResults map[addrs.Provider]*getproviders.PackageAuthenticationResult) {
+		ProvidersAuthenticated: func(authResults map[addrs.Provider]*getproviders.PackageAuthenticationResult) {
 			thirdPartySigned := false
 			for _, authResult := range authResults {
 				if authResult.Signed() {

--- a/internal/providercache/installer.go
+++ b/internal/providercache/installer.go
@@ -436,7 +436,6 @@ func (i *Installer) ensureProviderVersionsInstall(
 	targetPlatform getproviders.Platform,
 	errs map[addrs.Provider]error,
 ) (map[addrs.Provider]*getproviders.PackageAuthenticationResult, error) {
-	evts := installerEventsForContext(ctx)
 	authResults := map[addrs.Provider]*getproviders.PackageAuthenticationResult{} // record auth results for all successfully fetched providers
 
 	for provider, version := range need {
@@ -447,236 +446,247 @@ func (i *Installer) ensureProviderVersionsInstall(
 			return nil, err
 		}
 
-		lock := locks.Provider(provider)
-		var preferredHashes []getproviders.Hash
-		if lock != nil && lock.Version() == version { // hash changes are expected if the version is also changing
-			preferredHashes = lock.PreferredHashes()
+		authResult, err := i.ensureProviderVersionInstall(ctx, locks, reqs, mode, provider, version, targetPlatform)
+		if authResult != nil {
+			authResults[provider] = authResult
 		}
-
-		// If our target directory already has the provider version that fulfills the lock file, carry on
-		if installed := i.targetDir.ProviderVersion(provider, version); installed != nil {
-			if len(preferredHashes) > 0 {
-				if matches, _ := installed.MatchesAnyHash(preferredHashes); matches {
-					if cb := evts.ProviderAlreadyInstalled; cb != nil {
-						cb(provider, version)
-					}
-					continue
-				}
-			}
-		}
-
-		if i.globalCacheDir != nil {
-			// If our global cache already has this version available then
-			// we'll just link it in.
-			installed, err := tryInstallPackageFromCacheDir(
-				ctx,
-				i.globalCacheDir,
-				i.targetDir,
-				provider, version,
-				reqs[provider],
-				lock, locks,
-				preferredHashes,
-				i.globalCacheDirMayBreakDependencyLockFile,
-			)
-			if err != nil {
-				errs[provider] = err
-				continue
-			}
-			if installed {
-				continue // nothing left to do for this provider, then
-			}
-		}
-
-		// Step 3b: Get the package metadata for the selected version from our
-		// provider source.
-		//
-		// This is the step where we might detect and report that the provider
-		// isn't available for the current platform.
-		if cb := evts.FetchPackageMeta; cb != nil {
-			cb(provider, version)
-		}
-		meta, err := i.source.PackageMeta(ctx, provider, version, targetPlatform)
 		if err != nil {
 			errs[provider] = err
-			if cb := evts.FetchPackageFailure; cb != nil {
-				cb(provider, version, err)
-			}
-			continue
 		}
+	}
+	return authResults, nil
+}
 
-		// Step 3c: Retrieve the package indicated by the metadata we received,
-		// either directly into our target directory or via the global cache
-		// directory.
-		if cb := evts.FetchPackageBegin; cb != nil {
-			cb(provider, version, meta.Location)
-		}
-		var installTo, linkTo *Dir
-		if i.globalCacheDir != nil {
-			installTo = i.globalCacheDir
-			linkTo = i.targetDir
-		} else {
-			installTo = i.targetDir
-			linkTo = nil // no linking needed
-		}
+func (i *Installer) ensureProviderVersionInstall(
+	ctx context.Context,
+	locks *depsfile.Locks,
+	reqs getproviders.Requirements,
+	mode InstallMode,
+	provider addrs.Provider,
+	version getproviders.Version,
+	targetPlatform getproviders.Platform,
+) (*getproviders.PackageAuthenticationResult, error) {
+	evts := installerEventsForContext(ctx)
 
-		allowedHashes := preferredHashes
-		if mode.forceInstallChecksums() {
-			allowedHashes = []getproviders.Hash{}
-		}
+	lock := locks.Provider(provider)
+	var preferredHashes []getproviders.Hash
+	if lock != nil && lock.Version() == version { // hash changes are expected if the version is also changing
+		preferredHashes = lock.PreferredHashes()
+	}
 
-		authResult, err := installTo.InstallPackage(ctx, meta, allowedHashes)
-		if err != nil {
-			// TODO: Consider retrying for certain kinds of error that seem
-			// likely to be transient. For now, we just treat all errors equally.
-			errs[provider] = err
-			if cb := evts.FetchPackageFailure; cb != nil {
-				cb(provider, version, err)
-			}
-			continue
-		}
-		new := installTo.ProviderVersion(provider, version)
-		if new == nil {
-			err := fmt.Errorf("after installing %s it is still not detected in %s; this is a bug in OpenTofu", provider, installTo.BasePath())
-			errs[provider] = err
-			if cb := evts.FetchPackageFailure; cb != nil {
-				cb(provider, version, err)
-			}
-			continue
-		}
-		if _, err := new.ExecutableFile(); err != nil {
-			err := fmt.Errorf("provider binary not found: %w", err)
-			errs[provider] = err
-			if cb := evts.FetchPackageFailure; cb != nil {
-				cb(provider, version, err)
-			}
-			continue
-		}
-		if linkTo != nil {
-			// We skip emitting the "LinkFromCache..." events here because
-			// it's simpler for the caller to treat them as mutually exclusive.
-			// We can just subsume the linking step under the "FetchPackage..."
-			// series here (and that's why we use FetchPackageFailure below).
-			// We also don't do a hash check here because we already did that
-			// as part of the installTo.InstallPackage call above.
-			err := linkTo.LinkFromOtherCache(new, nil)
-			if err != nil {
-				errs[provider] = err
-				if cb := evts.FetchPackageFailure; cb != nil {
-					cb(provider, version, err)
+	// If our target directory already has the provider version that fulfills the lock file, carry on
+	if installed := i.targetDir.ProviderVersion(provider, version); installed != nil {
+		if len(preferredHashes) > 0 {
+			if matches, _ := installed.MatchesAnyHash(preferredHashes); matches {
+				if cb := evts.ProviderAlreadyInstalled; cb != nil {
+					cb(provider, version)
 				}
-				continue
+				return nil, nil
 			}
-
-			// We should now also find the package in the linkTo dir, which
-			// gives us the final value of "new" where the path points in to
-			// the true target directory, rather than possibly the global
-			// cache directory.
-			new = linkTo.ProviderVersion(provider, version)
-			if new == nil {
-				err := fmt.Errorf("after installing %s it is still not detected in %s; this is a bug in OpenTofu", provider, linkTo.BasePath())
-				errs[provider] = err
-				if cb := evts.FetchPackageFailure; cb != nil {
-					cb(provider, version, err)
-				}
-				continue
-			}
-			if _, err := new.ExecutableFile(); err != nil {
-				err := fmt.Errorf("provider binary not found: %w", err)
-				errs[provider] = err
-				if cb := evts.FetchPackageFailure; cb != nil {
-					cb(provider, version, err)
-				}
-				continue
-			}
-		}
-		authResults[provider] = authResult
-
-		// The InstallPackage call above should've verified that
-		// the package matches one of the hashes previously recorded,
-		// if any. We'll now augment those hashes with a new set populated
-		// with the hashes returned by the upstream source and from the
-		// package we've just installed, which allows the lock file to
-		// gradually transition to newer hash schemes when they become
-		// available.
-		//
-		// This is assuming that if a package matches both a hash we saw before
-		// _and_ a new hash then the new hash is a valid substitute for
-		// the previous hash.
-		//
-		// The hashes slice gets deduplicated in the lock file
-		// implementation, so we don't worry about potentially
-		// creating duplicates here.
-		var priorHashes []getproviders.Hash
-		if lock != nil && lock.Version() == version {
-			// If the version we're installing is identical to the
-			// one we previously locked then we'll keep all of the
-			// hashes we saved previously and add to it. Otherwise
-			// we'll be starting fresh, because each version has its
-			// own set of packages and thus its own hashes.
-			priorHashes = append(priorHashes, preferredHashes...)
-		}
-		newHash, err := new.Hash()
-		if err != nil {
-			err := fmt.Errorf("after installing %s, failed to compute a checksum for it: %w", provider, err)
-			errs[provider] = err
-			if cb := evts.FetchPackageFailure; cb != nil {
-				cb(provider, version, err)
-			}
-			continue
-		}
-
-		// localHashes is the set of hashes that we were able to verify locally
-		// based on the data we downloaded.
-		localHashes := slices.Collect(authResult.HashesWithDisposition(func(hd *getproviders.HashDisposition) bool {
-			return hd.VerifiedLocally
-		}))
-		localHashes = append(localHashes, newHash) // the hash we calculated above was _also_ verified locally
-
-		// We have different rules for what subset of hashes we track in
-		// the dependency lock file depending on the provider. Refer to
-		// the documentation of the following function for more information.
-		signingRequired := getproviders.ShouldEnforceGPGValidationForProvider(provider)
-		signedHashes := slices.Collect(authResult.HashesWithDisposition(func(hd *getproviders.HashDisposition) bool {
-			if !signingRequired {
-				// When signing isn't required, we pretend that anything
-				// that was reported by the origin registry was "signed",
-				// just for the purposes of updating the lock file and
-				// reporting that lock file update to the UI layer through
-				// the evts object.
-				// Note that the "tofu init" UI relies on us pretending
-				// that these are "signed" to avoid generating its warning
-				// that the dependency lock file might be incomplete.
-				return hd.ReportedByRegistry
-			}
-			return hd.SignedByAnyGPGKeys()
-		}))
-
-		var newHashes []getproviders.Hash
-		newHashes = append(newHashes, newHash)
-		newHashes = append(newHashes, priorHashes...)
-		newHashes = append(newHashes, localHashes...)
-		newHashes = append(newHashes, signedHashes...)
-
-		locks.SetProvider(provider, version, reqs[provider], newHashes)
-		if cb := evts.ProvidersLockUpdated; cb != nil {
-			// priorHashes is already sorted, but we do need to sort
-			// the newly-generated localHashes and signedHashes.
-			sort.Slice(localHashes, func(i, j int) bool {
-				return localHashes[i].String() < localHashes[j].String()
-			})
-			sort.Slice(signedHashes, func(i, j int) bool {
-				return signedHashes[i].String() < signedHashes[j].String()
-			})
-
-			cb(provider, version, localHashes, signedHashes, priorHashes)
-		}
-
-		if cb := evts.FetchPackageSuccess; cb != nil {
-			cb(provider, version, new.PackageDir, authResult)
 		}
 	}
 
-	return authResults, nil
+	if i.globalCacheDir != nil {
+		// If our global cache already has this version available then
+		// we'll just link it in.
+		installed, err := tryInstallPackageFromCacheDir(
+			ctx,
+			i.globalCacheDir,
+			i.targetDir,
+			provider, version,
+			reqs[provider],
+			lock, locks,
+			preferredHashes,
+			i.globalCacheDirMayBreakDependencyLockFile,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if installed {
+			return nil, nil // nothing left to do for this provider, then
+		}
+	}
+
+	// Step 3b: Get the package metadata for the selected version from our
+	// provider source.
+	//
+	// This is the step where we might detect and report that the provider
+	// isn't available for the current platform.
+	if cb := evts.FetchPackageMeta; cb != nil {
+		cb(provider, version)
+	}
+	meta, err := i.source.PackageMeta(ctx, provider, version, targetPlatform)
+	if err != nil {
+		if cb := evts.FetchPackageFailure; cb != nil {
+			cb(provider, version, err)
+		}
+		return nil, err
+	}
+
+	// Step 3c: Retrieve the package indicated by the metadata we received,
+	// either directly into our target directory or via the global cache
+	// directory.
+	if cb := evts.FetchPackageBegin; cb != nil {
+		cb(provider, version, meta.Location)
+	}
+	var installTo, linkTo *Dir
+	if i.globalCacheDir != nil {
+		installTo = i.globalCacheDir
+		linkTo = i.targetDir
+	} else {
+		installTo = i.targetDir
+		linkTo = nil // no linking needed
+	}
+
+	allowedHashes := preferredHashes
+	if mode.forceInstallChecksums() {
+		allowedHashes = []getproviders.Hash{}
+	}
+
+	authResult, err := installTo.InstallPackage(ctx, meta, allowedHashes)
+	if err != nil {
+		// TODO: Consider retrying for certain kinds of error that seem
+		// likely to be transient. For now, we just treat all errors equally.
+		if cb := evts.FetchPackageFailure; cb != nil {
+			cb(provider, version, err)
+		}
+		return nil, err
+	}
+	new := installTo.ProviderVersion(provider, version)
+	if new == nil {
+		err := fmt.Errorf("after installing %s it is still not detected in %s; this is a bug in OpenTofu", provider, installTo.BasePath())
+		if cb := evts.FetchPackageFailure; cb != nil {
+			cb(provider, version, err)
+		}
+		return nil, err
+	}
+	if _, err := new.ExecutableFile(); err != nil {
+		err := fmt.Errorf("provider binary not found: %w", err)
+		if cb := evts.FetchPackageFailure; cb != nil {
+			cb(provider, version, err)
+		}
+		return nil, err
+	}
+	if linkTo != nil {
+		// We skip emitting the "LinkFromCache..." events here because
+		// it's simpler for the caller to treat them as mutually exclusive.
+		// We can just subsume the linking step under the "FetchPackage..."
+		// series here (and that's why we use FetchPackageFailure below).
+		// We also don't do a hash check here because we already did that
+		// as part of the installTo.InstallPackage call above.
+		err := linkTo.LinkFromOtherCache(new, nil)
+		if err != nil {
+			if cb := evts.FetchPackageFailure; cb != nil {
+				cb(provider, version, err)
+			}
+			return nil, err
+		}
+
+		// We should now also find the package in the linkTo dir, which
+		// gives us the final value of "new" where the path points in to
+		// the true target directory, rather than possibly the global
+		// cache directory.
+		new = linkTo.ProviderVersion(provider, version)
+		if new == nil {
+			err := fmt.Errorf("after installing %s it is still not detected in %s; this is a bug in OpenTofu", provider, linkTo.BasePath())
+			if cb := evts.FetchPackageFailure; cb != nil {
+				cb(provider, version, err)
+			}
+			return nil, err
+		}
+		if _, err := new.ExecutableFile(); err != nil {
+			err := fmt.Errorf("provider binary not found: %w", err)
+			if cb := evts.FetchPackageFailure; cb != nil {
+				cb(provider, version, err)
+			}
+			return nil, err
+		}
+	}
+
+	// The InstallPackage call above should've verified that
+	// the package matches one of the hashes previously recorded,
+	// if any. We'll now augment those hashes with a new set populated
+	// with the hashes returned by the upstream source and from the
+	// package we've just installed, which allows the lock file to
+	// gradually transition to newer hash schemes when they become
+	// available.
+	//
+	// This is assuming that if a package matches both a hash we saw before
+	// _and_ a new hash then the new hash is a valid substitute for
+	// the previous hash.
+	//
+	// The hashes slice gets deduplicated in the lock file
+	// implementation, so we don't worry about potentially
+	// creating duplicates here.
+	var priorHashes []getproviders.Hash
+	if lock != nil && lock.Version() == version {
+		// If the version we're installing is identical to the
+		// one we previously locked then we'll keep all of the
+		// hashes we saved previously and add to it. Otherwise
+		// we'll be starting fresh, because each version has its
+		// own set of packages and thus its own hashes.
+		priorHashes = append(priorHashes, preferredHashes...)
+	}
+	newHash, err := new.Hash()
+	if err != nil {
+		err := fmt.Errorf("after installing %s, failed to compute a checksum for it: %w", provider, err)
+		if cb := evts.FetchPackageFailure; cb != nil {
+			cb(provider, version, err)
+		}
+		return authResult, err
+	}
+
+	// localHashes is the set of hashes that we were able to verify locally
+	// based on the data we downloaded.
+	localHashes := slices.Collect(authResult.HashesWithDisposition(func(hd *getproviders.HashDisposition) bool {
+		return hd.VerifiedLocally
+	}))
+	localHashes = append(localHashes, newHash) // the hash we calculated above was _also_ verified locally
+
+	// We have different rules for what subset of hashes we track in
+	// the dependency lock file depending on the provider. Refer to
+	// the documentation of the following function for more information.
+	signingRequired := getproviders.ShouldEnforceGPGValidationForProvider(provider)
+	signedHashes := slices.Collect(authResult.HashesWithDisposition(func(hd *getproviders.HashDisposition) bool {
+		if !signingRequired {
+			// When signing isn't required, we pretend that anything
+			// that was reported by the origin registry was "signed",
+			// just for the purposes of updating the lock file and
+			// reporting that lock file update to the UI layer through
+			// the evts object.
+			// Note that the "tofu init" UI relies on us pretending
+			// that these are "signed" to avoid generating its warning
+			// that the dependency lock file might be incomplete.
+			return hd.ReportedByRegistry
+		}
+		return hd.SignedByAnyGPGKeys()
+	}))
+
+	var newHashes []getproviders.Hash
+	newHashes = append(newHashes, newHash)
+	newHashes = append(newHashes, priorHashes...)
+	newHashes = append(newHashes, localHashes...)
+	newHashes = append(newHashes, signedHashes...)
+
+	locks.SetProvider(provider, version, reqs[provider], newHashes)
+	if cb := evts.ProvidersLockUpdated; cb != nil {
+		// priorHashes is already sorted, but we do need to sort
+		// the newly-generated localHashes and signedHashes.
+		sort.Slice(localHashes, func(i, j int) bool {
+			return localHashes[i].String() < localHashes[j].String()
+		})
+		sort.Slice(signedHashes, func(i, j int) bool {
+			return signedHashes[i].String() < signedHashes[j].String()
+		})
+
+		cb(provider, version, localHashes, signedHashes, priorHashes)
+	}
+
+	if cb := evts.FetchPackageSuccess; cb != nil {
+		cb(provider, version, new.PackageDir, authResult)
+	}
+
+	return authResult, nil
 }
 
 // tryInstallPackageFromCacheDir attempts to satisfy a provider selection from

--- a/internal/providercache/installer.go
+++ b/internal/providercache/installer.go
@@ -235,7 +235,7 @@ func (i *Installer) EnsureProviderVersions(ctx context.Context, locks *depsfile.
 	}
 
 	// Emit final event for fetching if any were successfully fetched
-	if cb := evts.ProvidersFetched; cb != nil && len(authResults) > 0 {
+	if cb := evts.ProvidersAuthenticated; cb != nil && len(authResults) > 0 {
 		cb(authResults)
 	}
 

--- a/internal/providercache/installer_events.go
+++ b/internal/providercache/installer_events.go
@@ -130,9 +130,9 @@ type InstallerEvents struct {
 	// in the same manner enforced by the lock file within NewProviderLock.
 	ProvidersLockUpdated func(provider addrs.Provider, version getproviders.Version, localHashes []getproviders.Hash, signedHashes []getproviders.Hash, priorHashes []getproviders.Hash)
 
-	// The ProvidersFetched event is called after all fetch operations if at
+	// The ProvidersAuthenticated event is called after all fetch operations if at
 	// least one provider was fetched successfully.
-	ProvidersFetched func(authResults map[addrs.Provider]*getproviders.PackageAuthenticationResult)
+	ProvidersAuthenticated func(authResults map[addrs.Provider]*getproviders.PackageAuthenticationResult)
 }
 
 // OnContext produces a context with all of the same behaviors as the given

--- a/internal/providercache/installer_events_test.go
+++ b/internal/providercache/installer_events_test.go
@@ -181,9 +181,9 @@ func installerLogEventsForTests(into chan<- *testInstallerEventLogItem) *Install
 				}{version.String(), localHashes, signedHashes, priorHashes},
 			}
 		},
-		ProvidersFetched: func(authResults map[addrs.Provider]*getproviders.PackageAuthenticationResult) {
+		ProvidersAuthenticated: func(authResults map[addrs.Provider]*getproviders.PackageAuthenticationResult) {
 			into <- &testInstallerEventLogItem{
-				Event: "ProvidersFetched",
+				Event: "ProvidersAuthenticated",
 				Args:  authResults,
 			}
 		},

--- a/internal/providercache/installer_test.go
+++ b/internal/providercache/installer_test.go
@@ -187,12 +187,6 @@ func TestEnsureProviderVersions(t *testing.T) {
 								beepProvider: getproviders.MustParseVersionConstraints(">= 2.0.0"),
 							},
 						},
-						{
-							Event: "ProvidersFetched",
-							Args: map[addrs.Provider]*getproviders.PackageAuthenticationResult{
-								beepProvider: nil,
-							},
-						},
 					},
 					beepProvider: {
 						{
@@ -455,12 +449,6 @@ func TestEnsureProviderVersions(t *testing.T) {
 								beepProvider: getproviders.MustParseVersionConstraints(">= 2.0.0"),
 							},
 						},
-						{
-							Event: "ProvidersFetched",
-							Args: map[addrs.Provider]*getproviders.PackageAuthenticationResult{
-								beepProvider: nil,
-							},
-						},
 					},
 					beepProvider: {
 						{
@@ -597,12 +585,6 @@ func TestEnsureProviderVersions(t *testing.T) {
 							Event: "PendingProviders",
 							Args: map[addrs.Provider]getproviders.VersionConstraints{
 								beepProvider: getproviders.MustParseVersionConstraints(">= 2.0.0"),
-							},
-						},
-						{
-							Event: "ProvidersFetched",
-							Args: map[addrs.Provider]*getproviders.PackageAuthenticationResult{
-								beepProvider: nil,
 							},
 						},
 					},
@@ -924,12 +906,6 @@ func TestEnsureProviderVersions(t *testing.T) {
 							Event: "PendingProviders",
 							Args: map[addrs.Provider]getproviders.VersionConstraints{
 								beepProvider: getproviders.MustParseVersionConstraints(">= 2.0.0"),
-							},
-						},
-						{
-							Event: "ProvidersFetched",
-							Args: map[addrs.Provider]*getproviders.PackageAuthenticationResult{
-								beepProvider: nil,
 							},
 						},
 					},
@@ -1345,12 +1321,6 @@ func TestEnsureProviderVersions(t *testing.T) {
 								beepProvider: getproviders.MustParseVersionConstraints(">= 2.0.0"),
 							},
 						},
-						{
-							Event: "ProvidersFetched",
-							Args: map[addrs.Provider]*getproviders.PackageAuthenticationResult{
-								beepProvider: nil,
-							},
-						},
 					},
 					beepProvider: {
 						{
@@ -1588,12 +1558,6 @@ func TestEnsureProviderVersions(t *testing.T) {
 								beepProvider: getproviders.MustParseVersionConstraints(">= 2.0.0"),
 							},
 						},
-						{
-							Event: "ProvidersFetched",
-							Args: map[addrs.Provider]*getproviders.PackageAuthenticationResult{
-								beepProvider: nil,
-							},
-						},
 					},
 					beepProvider: {
 						{
@@ -1764,12 +1728,6 @@ func TestEnsureProviderVersions(t *testing.T) {
 							Event: "PendingProviders",
 							Args: map[addrs.Provider]getproviders.VersionConstraints{
 								beepProvider: getproviders.MustParseVersionConstraints(">= 1.0.0"),
-							},
-						},
-						{
-							Event: "ProvidersFetched",
-							Args: map[addrs.Provider]*getproviders.PackageAuthenticationResult{
-								beepProvider: nil,
 							},
 						},
 					},
@@ -2314,12 +2272,6 @@ func TestEnsureProviderVersions(t *testing.T) {
 							Event: "PendingProviders",
 							Args: map[addrs.Provider]getproviders.VersionConstraints{
 								beepProvider: getproviders.MustParseVersionConstraints(">= 1.0.0"),
-							},
-						},
-						{
-							Event: "ProvidersFetched",
-							Args: map[addrs.Provider]*getproviders.PackageAuthenticationResult{
-								beepProvider: nil,
 							},
 						},
 					},

--- a/internal/providercache/installer_test.go
+++ b/internal/providercache/installer_test.go
@@ -308,7 +308,7 @@ func TestEnsureProviderVersions(t *testing.T) {
 							},
 						},
 						{
-							Event: "ProvidersFetched",
+							Event: "ProvidersAuthenticated",
 							Args: map[addrs.Provider]*getproviders.PackageAuthenticationResult{
 								beepProvider: getproviders.NewPackageAuthenticationResult(getproviders.HashDispositions{
 									beepProviderZipHash: {


### PR DESCRIPTION
Both the OTEL and Provider Cache work both ran up against some intersting workarounds needed for this function.

This refactoring does slightly change the events emitted by the installer, but looking at the usages it should be safe.

Recommended to review with whitespace ignored.

See #1878 and #2665

## Target Release

1.10.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
