### PR TITLE
Alternate approach to linking and locking the global cache

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -656,8 +656,12 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 				"\n[reset][bold]Initializing provider plugins...",
 			))
 		},
-		ProviderAlreadyInstalled: func(provider addrs.Provider, selectedVersion getproviders.Version) {
-			c.Ui.Info(fmt.Sprintf("- Using previously-installed %s v%s", provider.ForDisplay(), selectedVersion))
+		ProviderAlreadyInstalled: func(provider addrs.Provider, selectedVersion getproviders.Version, inProviderCache bool) {
+			if inProviderCache {
+				c.Ui.Info(fmt.Sprintf("- Detected previously-installed %s v%s in the shared cache directory", provider.ForDisplay(), selectedVersion))
+			} else {
+				c.Ui.Info(fmt.Sprintf("- Using previously-installed %s v%s", provider.ForDisplay(), selectedVersion))
+			}
 		},
 		BuiltInProviderAvailable: func(provider addrs.Provider) {
 			c.Ui.Info(fmt.Sprintf("- %s is built in to OpenTofu", provider.ForDisplay()))
@@ -683,8 +687,12 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 		LinkFromCacheBegin: func(provider addrs.Provider, version getproviders.Version, cacheRoot string) {
 			c.Ui.Info(fmt.Sprintf("- Using %s v%s from the shared cache directory", provider.ForDisplay(), version))
 		},
-		FetchPackageBegin: func(provider addrs.Provider, version getproviders.Version, location getproviders.PackageLocation) {
-			c.Ui.Info(fmt.Sprintf("- Installing %s v%s...", provider.ForDisplay(), version))
+		FetchPackageBegin: func(provider addrs.Provider, version getproviders.Version, location getproviders.PackageLocation, inProviderCache bool) {
+			if inProviderCache {
+				c.Ui.Info(fmt.Sprintf("- Installing %s v%s to the shared cache directory...", provider.ForDisplay(), version))
+			} else {
+				c.Ui.Info(fmt.Sprintf("- Installing %s v%s...", provider.ForDisplay(), version))
+			}
 		},
 		QueryPackagesFailure: func(provider addrs.Provider, err error) {
 			switch errorTy := err.(type) {

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -3283,7 +3283,7 @@ func installFakeProviderPackagesElsewhere(t *testing.T, cacheDir *providercache.
 			if err != nil {
 				t.Fatalf("failed to prepare fake package for %s %s: %s", name, versionStr, err)
 			}
-			_, err = cacheDir.InstallPackage(context.Background(), meta, nil)
+			_, err = cacheDir.InstallPackage(context.Background(), meta, nil, false)
 			if err != nil {
 				t.Fatalf("failed to install fake package for %s %s: %s", name, versionStr, err)
 			}

--- a/internal/command/providers_lock.go
+++ b/internal/command/providers_lock.go
@@ -227,7 +227,7 @@ func (c *ProvidersLockCommand) Run(args []string) int {
 		evts := &providercache.InstallerEvents{
 			// Our output from this command is minimal just to show that
 			// we're making progress, rather than just silently hanging.
-			FetchPackageBegin: func(provider addrs.Provider, version getproviders.Version, loc getproviders.PackageLocation) {
+			FetchPackageBegin: func(provider addrs.Provider, version getproviders.Version, loc getproviders.PackageLocation, inCacheDirectory bool) {
 				c.Ui.Output(fmt.Sprintf("- Fetching %s %s for %s...", provider.ForDisplay(), version, platform))
 				if prevVersion, exists := selectedVersions[provider]; exists && version != prevVersion {
 					// This indicates a weird situation where we ended up

--- a/internal/providercache/dir_modify.go
+++ b/internal/providercache/dir_modify.go
@@ -9,7 +9,12 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
+	"time"
 
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/flock"
 	"github.com/opentofu/opentofu/internal/getproviders"
 )
 
@@ -31,7 +36,7 @@ func (d *Dir) InstallPackage(ctx context.Context, meta getproviders.PackageMeta,
 
 	log.Printf("[TRACE] providercache.Dir.InstallPackage: installing %s v%s from %s", meta.Provider, meta.Version, meta.Location)
 
-	unlock, err := d.Lock(ctx, meta.Provider, meta.Version)
+	unlock, err := d.lock(ctx, meta.Provider, meta.Version)
 	if err != nil {
 		return nil, err
 	}
@@ -108,4 +113,93 @@ func (d *Dir) LinkFromOtherCache(ctx context.Context, entry *CachedProvider, all
 	// of the source directory above.
 	_, err := meta.Location.InstallProviderPackage(ctx, meta, newPath, nil)
 	return err
+}
+
+func (d *Dir) lock(ctx context.Context, provider addrs.Provider, version getproviders.Version) (func() error, error) {
+	providerPath := getproviders.UnpackedDirectoryPathForPackage(d.baseDir, provider, version, d.targetPlatform)
+
+	// If the lockfile is put within the target directory, it can mess with hashing
+	// Instead we add a suffix to the last part of the path (targetplatform) and lock that file instead.
+	dirPath := filepath.Dir(providerPath)
+	lockFileName := filepath.Base(providerPath) + ".lock"
+	lockFile := filepath.Join(dirPath, lockFileName)
+
+	log.Printf("[TRACE] Attempting to acquire global provider lock %s", lockFile)
+
+	// Ensure the provider directory exists
+	//nolint: mnd // directory permissions
+	if err := os.MkdirAll(dirPath, 0755); err != nil {
+		return nil, err
+	}
+
+	var f *os.File
+
+	// Try to create the lock file, wait up to 1 second for transient errors to clear.
+	for timeout := time.After(time.Second); ; {
+		var err error
+
+		// Try to get a handle to the file (or create if it does not exist)
+		// They will all end up with the same file handle on any correctly implemented filesystem.
+		// This is one of the many reasons we recommend users look at the flock support of their
+		// networked filesystems when using the global provider cache.
+		// Windows: even though out flock creates an exclusive lock, we are still able to open a handle to this file and wait below for the actual lock to be provided.
+		// Sometimes the creates can conflict and will need to be tried multiple times (incredibly uncommon).
+		f, err = os.OpenFile(lockFile, os.O_RDWR|os.O_CREATE, 0644)
+		if err == nil {
+			// We don't defer f.Close() here as we explicitly want to handle it below
+			break
+		}
+
+		select {
+		case <-timeout:
+			return nil, err
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+			// Chill for a bit before trying again
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+
+	// Wait for the file lock for up to 60s.  Might make sense to have the timeout be configurable for different network conditions / package sizes.
+	for timeout := time.After(time.Second * 60); ; {
+		// We have a valid file handle, let's try to lock it (nonblocking)
+		err := flock.Lock(f)
+		if err == nil {
+			// Lock succeeded
+			break
+		}
+
+		select {
+		case <-timeout:
+			if f != nil {
+				f.Close()
+			}
+			return nil, fmt.Errorf("unable to acquire file lock on %q: %w", lockFile, err)
+		case <-ctx.Done():
+			if f != nil {
+				f.Close()
+			}
+			return nil, ctx.Err()
+		default:
+			// Chill for a bit before trying again
+			time.Sleep(100 * time.Millisecond)
+		}
+
+	}
+
+	log.Printf("[TRACE] Acquired global provider lock %s", lockFile)
+
+	return func() error {
+		log.Printf("[TRACE] Releasing global provider lock %s", lockFile)
+
+		unlockErr := flock.Unlock(f)
+
+		// Prefer close error over unlock error
+		err := f.Close()
+		if err != nil {
+			return err
+		}
+		return unlockErr
+	}, nil
 }

--- a/internal/providercache/dir_modify.go
+++ b/internal/providercache/dir_modify.go
@@ -21,7 +21,7 @@ import (
 // in the set must match the package that "entry" refers to. If none of the
 // hashes match then the returned error message assumes that the hashes came
 // from a lock file.
-func (d *Dir) InstallPackage(ctx context.Context, meta getproviders.PackageMeta, allowedHashes []getproviders.Hash) (*getproviders.PackageAuthenticationResult, error) {
+func (d *Dir) InstallPackage(ctx context.Context, meta getproviders.PackageMeta, allowedHashes []getproviders.Hash, canIgnoreHashes bool) (*getproviders.PackageAuthenticationResult, error) {
 	if meta.TargetPlatform != d.targetPlatform {
 		return nil, fmt.Errorf("can't install %s package into cache directory expecting %s", meta.TargetPlatform, d.targetPlatform)
 	}
@@ -30,6 +30,24 @@ func (d *Dir) InstallPackage(ctx context.Context, meta getproviders.PackageMeta,
 	)
 
 	log.Printf("[TRACE] providercache.Dir.InstallPackage: installing %s v%s from %s", meta.Provider, meta.Version, meta.Location)
+
+	unlock, err := d.Lock(ctx, meta.Provider, meta.Version)
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+
+	// Check to see if it is already installed
+	if entry := d.ProviderVersion(meta.Provider, meta.Version); entry != nil {
+		if matches, err := entry.MatchesAnyHash(allowedHashes); err == nil && matches {
+			// No auth result needed, package is valid
+			return getproviders.NewPackageHashAuthentication(meta.TargetPlatform, allowedHashes).AuthenticatePackage(entry.PackageLocation())
+		}
+		if canIgnoreHashes {
+			return nil, nil
+		}
+	}
+
 	return meta.Location.InstallProviderPackage(ctx, meta, newPath, allowedHashes)
 }
 

--- a/internal/providercache/dir_modify.go
+++ b/internal/providercache/dir_modify.go
@@ -47,12 +47,6 @@ func (d *Dir) installPackageWithLock(ctx context.Context, meta getproviders.Pack
 
 	log.Printf("[TRACE] providercache.Dir.InstallPackage: installing %s v%s from %s", meta.Provider, meta.Version, meta.Location)
 
-	unlock, err := d.lock(ctx, meta.Provider, meta.Version)
-	if err != nil {
-		return nil, err
-	}
-	defer unlock()
-
 	// Check to see if it is already installed
 	if entry := d.ProviderVersion(meta.Provider, meta.Version); entry != nil {
 		if allowSkippingInstallWithoutHashes && len(allowedHashes) == 0 {

--- a/internal/providercache/dir_modify.go
+++ b/internal/providercache/dir_modify.go
@@ -45,7 +45,10 @@ func (d *Dir) InstallPackage(ctx context.Context, meta getproviders.PackageMeta,
 	// Check to see if it is already installed
 	if entry := d.ProviderVersion(meta.Provider, meta.Version); entry != nil {
 		if allowSkippingInstallWithoutHashes && len(allowedHashes) == 0 {
-			return nil, nil
+			// Ensure that the provider exists
+			if _, err := entry.ExecutableFile(); err == nil {
+				return nil, nil
+			}
 		}
 
 		if matches, err := entry.MatchesAnyHash(allowedHashes); err == nil && matches {

--- a/internal/providercache/dir_modify_test.go
+++ b/internal/providercache/dir_modify_test.go
@@ -43,7 +43,7 @@ func TestInstallPackage(t *testing.T) {
 		Location: getproviders.PackageLocalArchive("testdata/provider-null_2.1.0_linux_amd64.zip"),
 	}
 
-	result, err := tmpDir.InstallPackage(t.Context(), meta, nil)
+	result, err := tmpDir.InstallPackage(t.Context(), meta, nil, false)
 	if err != nil {
 		t.Fatalf("InstallPackage failed: %s", err)
 	}

--- a/internal/providercache/installer.go
+++ b/internal/providercache/installer.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	"github.com/apparentlymart/go-versions/versions"
-	"github.com/apparentlymart/go-versions/versions/constraints"
 	otelAttr "go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
@@ -488,19 +487,6 @@ func (i *Installer) ensureProviderVersionInstall(
 	targetPlatform getproviders.Platform,
 ) (*getproviders.PackageAuthenticationResult, error) {
 	evts := installerEventsForContext(ctx)
-
-	// The unlock function may be used if the globalCacheDir is set.  It is unlocked in the *next* iteration of the loop or after the loop exits
-	// We create a file lock per-provider to prevent modification from different processes using the shared global cache
-	// We lock per-provider to prevent deadlocks and release as soon as possible (instead of defer at the function scope)
-	// This is not ideal, but the best option for not generating a large code diff
-	var unlock func()
-	defer func() {
-		if unlock != nil {
-			// Free remaining lock on return
-			unlock()
-		}
-	}()
-
 	lock := locks.Provider(provider)
 	var preferredHashes []getproviders.Hash
 	if lock != nil && lock.Version() == version { // hash changes are expected if the version is also changing
@@ -516,42 +502,6 @@ func (i *Installer) ensureProviderVersionInstall(
 				}
 				return nil, nil
 			}
-		}
-	}
-
-	if i.globalCacheDir != nil {
-		// Try to lock the provider's directory.
-		unlockProvider, err := i.globalCacheDir.Lock(ctx, provider, version)
-		if err != nil {
-			if cb := evts.LinkFromCacheFailure; cb != nil {
-				cb(provider, version, err)
-			}
-			return nil, err
-		}
-		unlock = func() {
-			err = unlockProvider()
-			if err != nil {
-				log.Printf("[ERROR] Unable to clear provider lock: %s", err.Error())
-			}
-		}
-
-		// If our global cache already has this version available then
-		// we'll just link it in.
-		installed, err := tryInstallPackageFromCacheDir(
-			ctx,
-			i.globalCacheDir,
-			i.targetDir,
-			provider, version,
-			reqs[provider],
-			lock, locks,
-			preferredHashes,
-			i.globalCacheDirMayBreakDependencyLockFile,
-		)
-		if err != nil {
-			return nil, err
-		}
-		if installed {
-			return nil, nil // nothing left to do for this provider, then
 		}
 	}
 
@@ -591,7 +541,8 @@ func (i *Installer) ensureProviderVersionInstall(
 		allowedHashes = []getproviders.Hash{}
 	}
 
-	authResult, err := installTo.InstallPackage(ctx, meta, allowedHashes)
+	canIgnoreHashes := i.globalCacheDirMayBreakDependencyLockFile && i.globalCacheDir != nil
+	authResult, err := installTo.InstallPackage(ctx, meta, allowedHashes, canIgnoreHashes)
 	if err != nil {
 		// TODO: Consider retrying for certain kinds of error that seem
 		// likely to be transient. For now, we just treat all errors equally.
@@ -599,12 +550,6 @@ func (i *Installer) ensureProviderVersionInstall(
 			cb(provider, version, err)
 		}
 		return nil, err
-	}
-
-	if unlock != nil {
-		// Early unlock as the write to the globalCacheDir has completed
-		unlock()
-		unlock = nil
 	}
 
 	new := installTo.ProviderVersion(provider, version)
@@ -623,15 +568,15 @@ func (i *Installer) ensureProviderVersionInstall(
 		return nil, err
 	}
 	if linkTo != nil {
-		// We skip emitting the "LinkFromCache..." events here because
-		// it's simpler for the caller to treat them as mutually exclusive.
-		// We can just subsume the linking step under the "FetchPackage..."
-		// series here (and that's why we use FetchPackageFailure below).
-		// We also don't do a hash check here because we already did that
+		if cb := evts.LinkFromCacheBegin; cb != nil {
+			cb(provider, version, installTo.BasePath())
+		}
+
+		// We don't do a hash check here because we already did that
 		// as part of the installTo.InstallPackage call above.
 		err := linkTo.LinkFromOtherCache(ctx, new, nil)
 		if err != nil {
-			if cb := evts.FetchPackageFailure; cb != nil {
+			if cb := evts.LinkFromCacheFailure; cb != nil {
 				cb(provider, version, err)
 			}
 			return nil, err
@@ -644,17 +589,21 @@ func (i *Installer) ensureProviderVersionInstall(
 		new = linkTo.ProviderVersion(provider, version)
 		if new == nil {
 			err := fmt.Errorf("after installing %s it is still not detected in %s; this is a bug in OpenTofu", provider, linkTo.BasePath())
-			if cb := evts.FetchPackageFailure; cb != nil {
+			if cb := evts.LinkFromCacheFailure; cb != nil {
 				cb(provider, version, err)
 			}
 			return nil, err
 		}
 		if _, err := new.ExecutableFile(); err != nil {
 			err := fmt.Errorf("provider binary not found: %w", err)
-			if cb := evts.FetchPackageFailure; cb != nil {
+			if cb := evts.LinkFromCacheFailure; cb != nil {
 				cb(provider, version, err)
 			}
 			return nil, err
+		}
+
+		if cb := evts.LinkFromCacheSuccess; cb != nil {
+			cb(provider, version, new.PackageDir)
 		}
 	}
 
@@ -733,7 +682,12 @@ func (i *Installer) ensureProviderVersionInstall(
 		sort.Slice(signedHashes, func(i, j int) bool {
 			return signedHashes[i].String() < signedHashes[j].String()
 		})
-
+		// these slices might also contain duplicates if the
+		// same hash was found in two different ways, so we'll
+		// adjust for that. This relies on the sorting above
+		// and modifies the underlying arrays in-place.
+		localHashes = slices.Compact(localHashes)
+		signedHashes = slices.Compact(signedHashes)
 		cb(provider, version, localHashes, signedHashes, priorHashes)
 	}
 
@@ -742,210 +696,6 @@ func (i *Installer) ensureProviderVersionInstall(
 	}
 
 	return authResult, nil
-}
-
-// tryInstallPackageFromCacheDir attempts to satisfy a provider selection from
-// the upstream cache sourceDir.
-//
-// If successful it returns (true, nil) and updates "locks" to contain the
-// checksum of the package that was installed.
-//
-// If sourceDir does not have a suitable package for the selected provider
-// version then it returns (false, nil), after which the caller can attempt
-// to install a suitable provider package from some other location.
-//
-// If sourceDir has a package that appears to be for the selected provider
-// version but there are any problems with that package that prevent it from
-// being installed then it returns a non-nil error describing the problem.
-func tryInstallPackageFromCacheDir(
-	ctx context.Context,
-	sourceDir *Dir,
-	destDir *Dir,
-	provider addrs.Provider,
-	version versions.Version,
-	versionConstraints constraints.IntersectionSpec,
-	lock *depsfile.ProviderLock,
-	locks *depsfile.Locks,
-	preferredHashes []getproviders.Hash,
-	mayBreakDependencyLockFile bool,
-
-	// FIXME: The above set of arguments came from exhaustively including
-	// everything that a previously-inline version of this chunk of code
-	// referred to, to minimize the risk of factoring it out. In future
-	// we should try to separate these concerns a little better so that
-	// this doesn't need so many arguments. For example, it might be better
-	// for the caller to be responsible for updating "locks" when
-	// installation is successful, but that would likely require changing
-	// the order of emitted events so that the locks-update event
-	// comes after the successful-linking event.
-) (installed bool, err error) {
-	evts := installerEventsForContext(ctx)
-
-	cached := sourceDir.ProviderVersion(provider, version)
-	if cached == nil {
-		// If we don't have a cache entry then we can't install from cache.
-		return false, nil
-	}
-
-	// An existing cache entry is only an acceptable choice
-	// if there is already a lock file entry for this provider
-	// and the cache entry matches its checksums.
-	//
-	// If there was no lock file entry at all then we need to
-	// install the package for real so that we can lock as complete
-	// as possible a set of checksums for all of this provider's
-	// packages.
-	//
-	// If there was a lock file entry but the cache doesn't match
-	// it then we assume that the lock file checksums were only
-	// partially populated (e.g. from a local mirror where we can
-	// only see one package to checksum it) and so we'll fetch
-	// from upstream to see if the origin can give us a package
-	// that _does_ match. This might still not work out, but if
-	// it does then it allows us to avoid returning a checksum
-	// mismatch error.
-	acceptablePackage := false
-	if len(preferredHashes) != 0 {
-		acceptablePackage, err = cached.MatchesAnyHash(preferredHashes)
-		if err != nil {
-			// If we can't calculate the checksum for the cached
-			// package then we'll just treat it as a checksum failure.
-			acceptablePackage = false
-		}
-	}
-
-	if !acceptablePackage && mayBreakDependencyLockFile {
-		// The "may break dependency lock file" setting effectively
-		// means that we'll accept any matching package that's
-		// already in the cache, regardless of whether it matches
-		// what's in the dependency lock file.
-		//
-		// That means two less-ideal situations might occur:
-		// - If this provider is not currently tracked in the lock
-		//   file at all then after installation the lock file will
-		//   only accept the package that was already present in
-		//   the cache as a valid checksum. That means the generated
-		//   lock file won't be portable to other operating systems
-		//   or CPU architectures.
-		// - If the provider _is_ currently tracked in the lock file
-		//   but the checksums there don't match what was in the
-		//   cache then the LinkFromOtherCache call below will
-		//   fail with a checksum error, and the user will need to
-		//   either manually remove the entry from the lock file
-		//   or remove the mismatching item from the cache,
-		//   depending on which of these they prefer to use as the
-		//   source of truth for the expected contents of the
-		//   package.
-		//
-		// If the lock file already includes this provider and the
-		// cache entry matches one of the locked checksums then
-		// there's no problem, but in that case we wouldn't enter
-		// this branch because acceptablePackage would already be
-		// true from the check above.
-		log.Printf(
-			"[WARN] plugin_cache_may_break_dependency_lock_file: Using global cache dir package for %s v%s even though it doesn't match this configuration's dependency lock file",
-			provider.String(), version.String(),
-		)
-		acceptablePackage = true
-	}
-
-	if !acceptablePackage {
-		// TODO: Should we emit an event through the events object
-		// for "there was an entry in the cache but we ignored it
-		// because the checksum didn't match"? We can't use
-		// LinkFromCacheFailure in that case because this isn't a
-		// failure. For now we'll just be quiet about it.
-		return false, nil
-	}
-
-	if cb := evts.LinkFromCacheBegin; cb != nil {
-		cb(provider, version, sourceDir.baseDir)
-	}
-	if _, err = cached.ExecutableFile(); err != nil {
-		err = fmt.Errorf("provider binary not found: %w", err)
-		if cb := evts.LinkFromCacheFailure; cb != nil {
-			cb(provider, version, err)
-		}
-		return false, err
-	}
-
-	err = destDir.LinkFromOtherCache(ctx, cached, preferredHashes)
-	if err != nil {
-		if cb := evts.LinkFromCacheFailure; cb != nil {
-			cb(provider, version, err)
-		}
-		return false, err
-	}
-	// We'll fetch what we just linked to make sure it actually
-	// did show up there.
-	newCached := destDir.ProviderVersion(provider, version)
-	if newCached == nil {
-		err = fmt.Errorf("after linking %s from provider cache at %s it is still not detected in the target directory; this is a bug in OpenTofu", provider, sourceDir.baseDir)
-		if cb := evts.LinkFromCacheFailure; cb != nil {
-			cb(provider, version, err)
-		}
-		return false, err
-	}
-
-	// The LinkFromOtherCache call above should've verified that
-	// the package matches one of the hashes previously recorded,
-	// if any. We'll now augment those hashes with one freshly
-	// calculated from the package we just linked, which allows
-	// the lock file to gradually transition to recording newer hash
-	// schemes when they become available.
-	var priorHashes []getproviders.Hash
-	if lock != nil && lock.Version() == version {
-		// If the version we're installing is identical to the
-		// one we previously locked then we'll keep all of the
-		// hashes we saved previously and add to it. Otherwise
-		// we'll be starting fresh, because each version has its
-		// own set of packages and thus its own hashes.
-		priorHashes = append(priorHashes, preferredHashes...)
-
-		// NOTE: The behavior here is unfortunate when a particular
-		// provider version was already cached on the first time
-		// the current configuration requested it, because that
-		// means we don't currently get the opportunity to fetch
-		// and verify the checksums for the new package from
-		// upstream. That's currently unavoidable because upstream
-		// checksums are in the "ziphash" format and so we can't
-		// verify them against our cache directory's unpacked
-		// packages: we'd need to go fetch the package from the
-		// origin and compare against it, which would defeat the
-		// purpose of the global cache.
-		//
-		// If we fetch from upstream on the first encounter with
-		// a particular provider then we'll end up in the other
-		// codepath below where we're able to also include the
-		// checksums from the origin registry.
-	}
-	newHash, err := cached.Hash()
-	if err != nil {
-		err = fmt.Errorf("after linking %s from provider cache at %s, failed to compute a checksum for it: %w", provider, sourceDir.baseDir, err)
-		if cb := evts.LinkFromCacheFailure; cb != nil {
-			cb(provider, version, err)
-		}
-		return false, err
-	}
-	// The hashes slice gets deduplicated in the lock file
-	// implementation, so we don't worry about potentially
-	// creating a duplicate here.
-	var newHashes []getproviders.Hash
-	newHashes = append(newHashes, priorHashes...)
-	newHashes = append(newHashes, newHash)
-	locks.SetProvider(provider, version, versionConstraints, newHashes)
-	if cb := evts.ProvidersLockUpdated; cb != nil {
-		// We want to ensure that newHash and priorHashes are
-		// sorted. newHash is a single value, so it's definitely
-		// sorted. priorHashes are pulled from the lock file, so
-		// are also already sorted.
-		cb(provider, version, []getproviders.Hash{newHash}, nil, priorHashes)
-	}
-
-	if cb := evts.LinkFromCacheSuccess; cb != nil {
-		cb(provider, version, newCached.PackageDir)
-	}
-	return true, nil
 }
 
 // checkUnspecifiedVersion Check the presence of version 0.0.0 and return an error with a tip

--- a/internal/providercache/installer_events.go
+++ b/internal/providercache/installer_events.go
@@ -80,7 +80,7 @@ type InstallerEvents struct {
 	// a selected provider package from the system-wide shared cache into the
 	// current configuration's local cache.
 	//
-	// This sequence occurs within the FetchPackage... sequence if the
+	// This sequence occurs after the FetchPackage... sequence if the
 	// QueryPackages... sequence selects a version that is already in the
 	// system-wide cache, and thus we will skip fetching it from the
 	// originating provider source and take it from the shared cache instead.
@@ -102,7 +102,7 @@ type InstallerEvents struct {
 	// identifier to correlate between successive events.
 	//
 	// For each provider there will be a FetchPackage... sequence which may
-	// or may not contain a LinkFromCache... sequence, depending on whether
+	// or may not be followed by a LinkFromCache... sequence, depending on whether
 	// the "fetch" is coming from a real source or from an upstream cache.
 	//
 	// The Query, Begin, Success, and Failure events will each occur only once

--- a/internal/providercache/installer_events.go
+++ b/internal/providercache/installer_events.go
@@ -80,7 +80,7 @@ type InstallerEvents struct {
 	// a selected provider package from the system-wide shared cache into the
 	// current configuration's local cache.
 	//
-	// This sequence occurs instead of the FetchPackage... sequence if the
+	// This sequence occurs within the FetchPackage... sequence if the
 	// QueryPackages... sequence selects a version that is already in the
 	// system-wide cache, and thus we will skip fetching it from the
 	// originating provider source and take it from the shared cache instead.
@@ -101,8 +101,9 @@ type InstallerEvents struct {
 	// provider, so a caller can use the provider argument as a unique
 	// identifier to correlate between successive events.
 	//
-	// A particular provider will either notify the LinkFromCache... events
-	// or the FetchPackage... events, never both in the same install operation.
+	// For each provider there will be a FetchPackage... sequence which may
+	// or may not contain a LinkFromCache... sequence, depending on whether
+	// the "fetch" is coming from a real source or from an upstream cache.
 	//
 	// The Query, Begin, Success, and Failure events will each occur only once
 	// per distinct provider.

--- a/internal/providercache/installer_events.go
+++ b/internal/providercache/installer_events.go
@@ -43,7 +43,7 @@ type InstallerEvents struct {
 	// This event can also appear after the QueryPackages... series if
 	// querying determines that a version already available is the newest
 	// available version.
-	ProviderAlreadyInstalled func(provider addrs.Provider, selectedVersion getproviders.Version)
+	ProviderAlreadyInstalled func(provider addrs.Provider, selectedVersion getproviders.Version, inProviderCache bool)
 
 	// The BuiltInProvider... family of events describe the outcome for any
 	// requested providers that are built in to OpenTofu. Only one of these
@@ -108,7 +108,7 @@ type InstallerEvents struct {
 	// The Query, Begin, Success, and Failure events will each occur only once
 	// per distinct provider.
 	FetchPackageMeta    func(provider addrs.Provider, version getproviders.Version) // fetching metadata prior to real download
-	FetchPackageBegin   func(provider addrs.Provider, version getproviders.Version, location getproviders.PackageLocation)
+	FetchPackageBegin   func(provider addrs.Provider, version getproviders.Version, location getproviders.PackageLocation, inProviderCache bool)
 	FetchPackageSuccess func(provider addrs.Provider, version getproviders.Version, localDir string, authResult *getproviders.PackageAuthenticationResult)
 	FetchPackageFailure func(provider addrs.Provider, version getproviders.Version, err error)
 

--- a/internal/providercache/installer_events_test.go
+++ b/internal/providercache/installer_events_test.go
@@ -50,11 +50,14 @@ func installerLogEventsForTests(into chan<- *testInstallerEventLogItem) *Install
 				Args:  reqs,
 			}
 		},
-		ProviderAlreadyInstalled: func(provider addrs.Provider, selectedVersion getproviders.Version) {
+		ProviderAlreadyInstalled: func(provider addrs.Provider, selectedVersion getproviders.Version, inCache bool) {
 			into <- &testInstallerEventLogItem{
 				Event:    "ProviderAlreadyInstalled",
 				Provider: provider,
-				Args:     selectedVersion,
+				Args: struct {
+					Version getproviders.Version
+					InCache bool
+				}{Version: selectedVersion, InCache: inCache},
 			}
 		},
 		BuiltInProviderAvailable: func(provider addrs.Provider) {
@@ -138,14 +141,15 @@ func installerLogEventsForTests(into chan<- *testInstallerEventLogItem) *Install
 				Args:     version.String(),
 			}
 		},
-		FetchPackageBegin: func(provider addrs.Provider, version getproviders.Version, location getproviders.PackageLocation) {
+		FetchPackageBegin: func(provider addrs.Provider, version getproviders.Version, location getproviders.PackageLocation, inCache bool) {
 			into <- &testInstallerEventLogItem{
 				Event:    "FetchPackageBegin",
 				Provider: provider,
 				Args: struct {
 					Version  string
 					Location getproviders.PackageLocation
-				}{version.String(), location},
+					InCache  bool
+				}{version.String(), location, inCache},
 			}
 		},
 		FetchPackageSuccess: func(provider addrs.Provider, version getproviders.Version, localDir string, authResult *getproviders.PackageAuthenticationResult) {

--- a/internal/providercache/installer_test.go
+++ b/internal/providercache/installer_test.go
@@ -478,6 +478,28 @@ func TestEnsureProviderVersions(t *testing.T) {
 							}{"2.1.0", beepProviderDir},
 						},
 						{
+							Event:    "LinkFromCacheBegin",
+							Provider: beepProvider,
+							Args: struct {
+								Version   string
+								CacheRoot string
+							}{
+								"2.1.0",
+								inst.globalCacheDir.BasePath(),
+							},
+						},
+						{
+							Event:    "LinkFromCacheSuccess",
+							Provider: beepProvider,
+							Args: struct {
+								Version  string
+								LocalDir string
+							}{
+								"2.1.0",
+								filepath.Join(dir.BasePath(), "example.com/foo/beep/2.1.0/bleep_bloop"),
+							},
+						},
+						{
 							Event:    "ProvidersLockUpdated",
 							Provider: beepProvider,
 							Args: struct {
@@ -539,6 +561,7 @@ func TestEnsureProviderVersions(t *testing.T) {
 						Location:       beepProviderDir,
 					},
 					nil,
+					false,
 				)
 				if err != nil {
 					t.Fatalf("failed to populate global cache: %s", err)
@@ -623,6 +646,28 @@ func TestEnsureProviderVersions(t *testing.T) {
 							},
 						},
 						{
+							Event:    "LinkFromCacheBegin",
+							Provider: beepProvider,
+							Args: struct {
+								Version   string
+								CacheRoot string
+							}{
+								"2.1.0",
+								inst.globalCacheDir.BasePath(),
+							},
+						},
+						{
+							Event:    "LinkFromCacheSuccess",
+							Provider: beepProvider,
+							Args: struct {
+								Version  string
+								LocalDir string
+							}{
+								"2.1.0",
+								filepath.Join(dir.BasePath(), "example.com/foo/beep/2.1.0/bleep_bloop"),
+							},
+						},
+						{
 							Event:    "ProvidersLockUpdated",
 							Provider: beepProvider,
 							Args: struct {
@@ -695,6 +740,7 @@ func TestEnsureProviderVersions(t *testing.T) {
 						Location:       beepProviderDir,
 					},
 					nil,
+					false,
 				)
 				if err != nil {
 					t.Fatalf("failed to populate global cache: %s", err)
@@ -743,6 +789,17 @@ func TestEnsureProviderVersions(t *testing.T) {
 								beepProvider: getproviders.MustParseVersionConstraints(">= 2.0.0"),
 							},
 						},
+						{
+							Event: "ProvidersAuthenticated",
+							Args: map[addrs.Provider]*getproviders.PackageAuthenticationResult{
+								beepProvider: getproviders.NewPackageAuthenticationResult(getproviders.HashDispositions{
+									beepProviderHash: {
+										// This is from the installer verifying the pre-existing global cache entry.
+										VerifiedLocally: true,
+									},
+								}),
+							},
+						},
 					},
 					beepProvider: {
 						{
@@ -759,6 +816,22 @@ func TestEnsureProviderVersions(t *testing.T) {
 							Args:     "2.1.0",
 						},
 						{
+							Event:    "FetchPackageMeta",
+							Provider: beepProvider,
+							Args:     "2.1.0",
+						},
+						{
+							Event:    "FetchPackageBegin",
+							Provider: beepProvider,
+							Args: struct {
+								Version  string
+								Location getproviders.PackageLocation
+							}{
+								"2.1.0",
+								beepProviderDir,
+							},
+						},
+						{
 							Event:    "LinkFromCacheBegin",
 							Provider: beepProvider,
 							Args: struct {
@@ -767,6 +840,17 @@ func TestEnsureProviderVersions(t *testing.T) {
 							}{
 								"2.1.0",
 								inst.globalCacheDir.BasePath(),
+							},
+						},
+						{
+							Event:    "LinkFromCacheSuccess",
+							Provider: beepProvider,
+							Args: struct {
+								Version  string
+								LocalDir string
+							}{
+								"2.1.0",
+								filepath.Join(dir.BasePath(), "/example.com/foo/beep/2.1.0/bleep_bloop"),
 							},
 						},
 						{
@@ -785,14 +869,16 @@ func TestEnsureProviderVersions(t *testing.T) {
 							},
 						},
 						{
-							Event:    "LinkFromCacheSuccess",
+							Event:    "FetchPackageSuccess",
 							Provider: beepProvider,
 							Args: struct {
-								Version  string
-								LocalDir string
+								Version    string
+								LocalDir   string
+								AuthResult string
 							}{
 								"2.1.0",
-								filepath.Join(dir.BasePath(), "/example.com/foo/beep/2.1.0/bleep_bloop"),
+								filepath.Join(dir.BasePath(), "example.com/foo/beep/2.1.0/bleep_bloop"),
+								"verified checksum",
 							},
 						},
 					},
@@ -860,6 +946,7 @@ func TestEnsureProviderVersions(t *testing.T) {
 						Location:       beepProviderOtherPlatformDir,
 					},
 					nil,
+					false,
 				)
 				if err != nil {
 					t.Fatalf("failed to populate global cache: %s", err)
@@ -940,6 +1027,28 @@ func TestEnsureProviderVersions(t *testing.T) {
 							},
 						},
 						{
+							Event:    "LinkFromCacheBegin",
+							Provider: beepProvider,
+							Args: struct {
+								Version   string
+								CacheRoot string
+							}{
+								"2.1.0",
+								inst.globalCacheDir.BasePath(),
+							},
+						},
+						{
+							Event:    "LinkFromCacheSuccess",
+							Provider: beepProvider,
+							Args: struct {
+								Version  string
+								LocalDir string
+							}{
+								"2.1.0",
+								filepath.Join(dir.BasePath(), "example.com/foo/beep/2.1.0/bleep_bloop"),
+							},
+						},
+						{
 							Event:    "ProvidersLockUpdated",
 							Provider: beepProvider,
 							Args: struct {
@@ -1004,6 +1113,7 @@ func TestEnsureProviderVersions(t *testing.T) {
 						Location:       beepProviderDir,
 					},
 					nil,
+					false,
 				)
 				if err != nil {
 					t.Fatalf("failed to populate global cache: %s", err)
@@ -1151,6 +1261,7 @@ func TestEnsureProviderVersions(t *testing.T) {
 						Location:       beepProviderDir,
 					},
 					nil,
+					false,
 				)
 				if err != nil {
 					t.Fatalf("failed to populate global cache: %s", err)
@@ -1412,6 +1523,7 @@ func TestEnsureProviderVersions(t *testing.T) {
 						Location:       beepProviderDir,
 					},
 					nil,
+					false,
 				)
 				if err != nil {
 					t.Fatalf("installation to the test dir failed: %s", err)

--- a/internal/providercache/installer_test.go
+++ b/internal/providercache/installer_test.go
@@ -1179,6 +1179,19 @@ func TestEnsureProviderVersions(t *testing.T) {
 							Args:     "2.1.0",
 						},
 						{
+							Event:    "FetchPackageMeta",
+							Provider: beepProvider,
+							Args:     "2.1.0",
+						},
+						{
+							Event:    "FetchPackageBegin",
+							Provider: beepProvider,
+							Args: struct {
+								Version  string
+								Location getproviders.PackageLocation
+							}{"2.1.0", beepProviderDir},
+						},
+						{
 							Event:    "LinkFromCacheBegin",
 							Provider: beepProvider,
 							Args: struct {
@@ -1187,6 +1200,17 @@ func TestEnsureProviderVersions(t *testing.T) {
 							}{
 								"2.1.0",
 								inst.globalCacheDir.BasePath(),
+							},
+						},
+						{
+							Event:    "LinkFromCacheSuccess",
+							Provider: beepProvider,
+							Args: struct {
+								Version  string
+								LocalDir string
+							}{
+								"2.1.0",
+								filepath.Join(dir.BasePath(), "/example.com/foo/beep/2.1.0/bleep_bloop"),
 							},
 						},
 						{
@@ -1205,14 +1229,16 @@ func TestEnsureProviderVersions(t *testing.T) {
 							},
 						},
 						{
-							Event:    "LinkFromCacheSuccess",
+							Event:    "FetchPackageSuccess",
 							Provider: beepProvider,
 							Args: struct {
-								Version  string
-								LocalDir string
+								Version    string
+								LocalDir   string
+								AuthResult string
 							}{
 								"2.1.0",
-								filepath.Join(dir.BasePath(), "/example.com/foo/beep/2.1.0/bleep_bloop"),
+								filepath.Join(dir.BasePath(), "example.com/foo/beep/2.1.0/bleep_bloop"),
+								"unauthenticated",
 							},
 						},
 					},
@@ -1329,18 +1355,20 @@ func TestEnsureProviderVersions(t *testing.T) {
 							Args:     "2.1.0",
 						},
 						{
-							Event:    "LinkFromCacheBegin",
+							Event:    "FetchPackageMeta",
 							Provider: beepProvider,
-							Args: struct {
-								Version   string
-								CacheRoot string
-							}{
-								"2.1.0",
-								inst.globalCacheDir.BasePath(),
-							},
+							Args:     "2.1.0",
 						},
 						{
-							Event:    "LinkFromCacheFailure",
+							Event:    "FetchPackageBegin",
+							Provider: beepProvider,
+							Args: struct {
+								Version  string
+								Location getproviders.PackageLocation
+							}{"2.1.0", beepProviderDir},
+						},
+						{
+							Event:    "FetchPackageFailure",
 							Provider: beepProvider,
 							Args: struct {
 								Version string
@@ -1348,8 +1376,8 @@ func TestEnsureProviderVersions(t *testing.T) {
 							}{
 								"2.1.0",
 								fmt.Sprintf(
-									"the provider cache at %s has a copy of example.com/foo/beep 2.1.0 that doesn't match any of the checksums recorded in the dependency lock file",
-									dir.BasePath(),
+									"the local package for %s 2.1.0 doesn't match any of the checksums previously recorded in the dependency lock file (this might be because the available checksums are for packages targeting different platforms); for more information: https://opentofu.org/docs/language/files/dependency-lock/#checksum-verification",
+									beepProvider,
 								),
 							},
 						},


### PR DESCRIPTION
This unifies a lot of the duplicate logic between the global cache install path and the normal install path. 

It is the result of a few conversations between @apparentlymart and myself.  The original approach had a much wider lock and was a bit harder to wrap your head around.  With this refactoring, it's much more simply scoped.

## Target Release

1.10.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
