### PR TITLE
getproviders: `PackageAuthenticationResult.SigningSkipped` must return false when the package was signed

### DIFF
--- a/internal/getproviders/package_authentication.go
+++ b/internal/getproviders/package_authentication.go
@@ -127,6 +127,9 @@ func (t *PackageAuthenticationResult) HashesWithDisposition(cond func(*HashDispo
 // GPG key IDs that asserted the validity of at least one of the hashes
 // related to this package's provider version.
 func (t *PackageAuthenticationResult) GPGKeyIDsString() string {
+	if t == nil {
+		return ""
+	}
 	return t.hashes.AllGPGSigningKeysString()
 }
 
@@ -141,7 +144,7 @@ func (t *PackageAuthenticationResult) Signed() bool {
 // SigningSkipped returns whether the package was authenticated but the key
 // validation was skipped.
 func (t *PackageAuthenticationResult) SigningSkipped() bool {
-	if t == nil {
+	if t == nil || t.Signed() {
 		return false
 	}
 	return t.hashes.HasAnyReportedByRegistry()

--- a/internal/getproviders/package_authentication_test.go
+++ b/internal/getproviders/package_authentication_test.go
@@ -26,11 +26,16 @@ import (
 func TestPackageAuthenticationResult(t *testing.T) {
 	tests := map[string]struct {
 		result *PackageAuthenticationResult
-		want   string
+
+		want                string
+		wantGPGKeyIDsString string
+		wantSigned          bool
+		wantSigningSkipped  bool
 	}{
 		"nil": {
 			nil,
 			"unauthenticated",
+			"", false, false,
 		},
 		"SignedByGPGKeyIDs": {
 			&PackageAuthenticationResult{
@@ -41,6 +46,7 @@ func TestPackageAuthenticationResult(t *testing.T) {
 				},
 			},
 			"signed",
+			"abc123", true, false,
 		},
 		"VerifiedLocally": {
 			&PackageAuthenticationResult{
@@ -51,6 +57,7 @@ func TestPackageAuthenticationResult(t *testing.T) {
 				},
 			},
 			"verified checksum",
+			"", false, false,
 		},
 		"ReportedByRegistry": {
 			&PackageAuthenticationResult{
@@ -61,6 +68,7 @@ func TestPackageAuthenticationResult(t *testing.T) {
 				},
 			},
 			"signing skipped",
+			"", false, true,
 		},
 		"SignedByGPGKeyIDs+VerifiedLocally": {
 			&PackageAuthenticationResult{
@@ -72,6 +80,7 @@ func TestPackageAuthenticationResult(t *testing.T) {
 				},
 			},
 			"signed",
+			"abc123", true, false,
 		},
 		"SignedByGPGKeyIDs+ReportedByRegistry": {
 			&PackageAuthenticationResult{
@@ -83,6 +92,7 @@ func TestPackageAuthenticationResult(t *testing.T) {
 				},
 			},
 			"signed",
+			"abc123", true, false,
 		},
 		"ReportedByRegistry+VerifiedLocally": {
 			&PackageAuthenticationResult{
@@ -94,6 +104,7 @@ func TestPackageAuthenticationResult(t *testing.T) {
 				},
 			},
 			"signing skipped",
+			"", false, true,
 		},
 		"SignedByGPGKeyIDs+ReportedByRegistry+VerifiedLocally": {
 			&PackageAuthenticationResult{
@@ -106,12 +117,23 @@ func TestPackageAuthenticationResult(t *testing.T) {
 				},
 			},
 			"signed",
+			"abc123", true, false,
 		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			if got := test.result.String(); got != test.want {
 				t.Errorf("wrong value\ngot:  %q\nwant: %q", got, test.want)
+			}
+
+			if got, want := test.result.GPGKeyIDsString(), test.wantGPGKeyIDsString; got != want {
+				t.Errorf("wrong GPGKeyIDsString result\ngot:  %q\nwant: %q", got, want)
+			}
+			if got, want := test.result.Signed(), test.wantSigned; got != want {
+				t.Errorf("wrong Signed result\ngot:  %t\nwant: %t", got, want)
+			}
+			if got, want := test.result.SigningSkipped(), test.wantSigningSkipped; got != want {
+				t.Errorf("wrong SigningSkipped result\ngot:  %t\nwant: %t", got, want)
 			}
 		})
 	}


### PR DESCRIPTION
This `SigningSkipped` method is supposed to return true only in the narrow case where we have hashes that came from the provider's origin registry but we didn't have any signing keys to verify them against.

Previously it was returning true if any of the hashes came from the registry even if those hashes were also verified using a signing key, which violated the assumptions made by the `tofu init` UI and caused it to incorrectly report that the provider didn't have any signing keys even when it did.

This is a cosmetic fix only because the validation behavior was previously correct, and only this helper function for summarizing the validation result in the UI was incorrect.

These helper functions were not previously covered by any unit tests, so this change also includes new testing for all three of the helper functions, even though only `SigningSkipped` was incorrect.

This bug came from my work in https://github.com/opentofu/opentofu/pull/2656, which was not yet included in any release so there is no changelog entry required.
