### PR TITLE
keep original workaround when there is no state for tofu show

### DIFF
--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -24,7 +24,6 @@ import (
 	"github.com/opentofu/opentofu/internal/encryption"
 	"github.com/opentofu/opentofu/internal/plans"
 	"github.com/opentofu/opentofu/internal/plans/planfile"
-	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/states/statefile"
 	"github.com/opentofu/opentofu/internal/states/statemgr"
 	"github.com/opentofu/opentofu/internal/tfdiags"
@@ -397,11 +396,10 @@ func (c *ShowCommand) getDataFromCloudPlan(plan *cloudplan.SavedPlanBookmark, re
 // the state file being nil, since that's more convenient for the
 // "tofu show" methods that may or may not have a state file to use.
 func (c *ShowCommand) maybeGetSchemas(stateFile *statefile.File, config *configs.Config) (*tofu.Schemas, tfdiags.Diagnostics) {
-	var state *states.State
-	if stateFile != nil {
-		state = stateFile.State
+	if stateFile == nil {
+		return nil, nil
 	}
-	return c.MaybeGetSchemas(state, config)
+	return c.MaybeGetSchemas(stateFile.State, config)
 }
 
 // getDataFromPlanfileReader returns a plan, statefile, and config, extracted from a local plan file.


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
This PR fixes failing test on main. The use case is to call `tofu show -json` with the following config (without the init call):

```hcl
terraform {
  required_providers {
    null = {
      version = "3.1.0"
    }
  }
}

resource null_resource "foo" {
}
```

## Target Release

1.10.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [X] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [X] I have not used an AI coding assistant to create this PR.
- [X] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [X] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [X] I have run golangci-lint on my change and receive no errors relevant to my code.
- [X] I have run existing tests to ensure my code doesn't break anything.
- [X] I have added tests for all relevant use cases of my code, and those tests are passing.
- [X] I have only exported functions, variables and structs that should be used from other packages.
- [X] I have added meaningful comments to all exported functions, variables, and structs.
