### PR TITLE
docs: clarifying -filter and -test-directory behavior in tofu test

### DIFF
--- a/internal/command/test.go
+++ b/internal/command/test.go
@@ -9,12 +9,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/opentofu/opentofu/internal/lang"
 	"log"
 	"path"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/opentofu/opentofu/internal/lang"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
@@ -75,7 +76,9 @@ Options:
 
   -filter=testfile      If specified, OpenTofu will only execute the test files
                         specified by this flag. You can use this option multiple
-                        times to execute more than one test file.
+                        times to execute more than one test file. The path should
+                        be relative to the current working directory, even if
+                        -test-directory is set.
 
   -json                 If specified, machine readable output will be printed in
                         JSON format

--- a/internal/command/test.go
+++ b/internal/command/test.go
@@ -228,6 +228,14 @@ func (c *TestCommand) Run(rawArgs []string) int {
 
 	log.Printf("[DEBUG] TestCommand: found %d files with %d run blocks", fileCount, runCount)
 
+	if len(args.Filter) > 0 && len(suite.Files) == 0 {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Warning,
+			"No tests were found",
+			"-filter is being used but no tests were found. Make sure you're using a relative path to the current working directory.",
+		))
+	}
+
 	diags = diags.Append(fileDiags)
 	if fileDiags.HasErrors() {
 		view.Diagnostics(nil, nil, diags)

--- a/website/docs/cli/commands/test/index.mdx
+++ b/website/docs/cli/commands/test/index.mdx
@@ -92,6 +92,14 @@ only load `main.tofutest.json` and ignore `main.tftest.json`.
   working directory.
 * `-filter=testfile` Specify an individual test file to run. Use this option multiple times to specify more than one
   file. The path should be relative to the current working directory.
+:::warning
+
+If `-filter` is used alongside `-test-directory=path`, any filters for test files in the \<test-directory\> must be prepended by the \<test-directory\>, as in:
+
+```
+tofu test -test-directory=extra-tests -filter=extra-tests/a.tftest.hcl
+```
+:::
 * `-var 'foo=bar'` Set an input variable of the root module. Specify this option multiple times to add more
   than one variable.
 * `-var-file=filename` Set multiple variables from the specified file. In addition to this file, OpenTofu automatically


### PR DESCRIPTION
Adds more information between the interaction with -test-directory and -filter:

1. A warning to tofu test docs;
2. An extra explanation on tofu test -filter CLI docs;

<img width="768" alt="Screenshot 2025-04-25 at 09 19 43" src="https://github.com/user-attachments/assets/9d458c82-392d-4499-bd15-88dd0fcddbc2" />


<!-- If your PR resolves an issue, please add it here. -->
Resolves #182

## Target Release

1.10.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
