### PR TITLE
Adding pagination to azure backend workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ BUG FIXES:
 - Better error messages when using `null` in invalid positions in the argument to the `transpose` function. ([#2553](https://github.com/opentofu/opentofu/pull/2553))
 - Provider GPG Expiration warnings no longer show when only one of the keys have expired. Only once all are expired or invalid. ([#2475](https://github.com/opentofu/opentofu/issues/2475))
 - The "oss" backend, for state storage in Alibaba Cloud OSS, now fully supports all of the typical environment variables for HTTP/HTTPS proxy configuration. Previously it supported configuring a proxy using variables like `HTTPS_PROXY`, but did not support per-origin opt-out using the `NO_PROXY` environment variable. ([#2675](https://github.com/opentofu/opentofu/pull/2675))
+- `AzureRM` backend now supports pagination when retrieving workspaces. `timeout_seconds` backend configuration is also used in these operations. ([#2720](https://github.com/opentofu/opentofu/pull/2720))
 
 INTERNAL CHANGES:
 - `skip_s3_checksum=true` now blocks the [aws-sdk new default S3 integrity checks](https://github.com/aws/aws-sdk-go-v2/discussions/2960) ([#2596](https://github.com/opentofu/opentofu/pull/2596))

--- a/internal/backend/remote-state/azure/backend_test.go
+++ b/internal/backend/remote-state/azure/backend_test.go
@@ -102,6 +102,9 @@ func TestBackendConfig_Timeout(t *testing.T) {
 		})
 	}
 }
+
+// TestAccBackendAccessKeyBasic tests if resources are created using basic access key.
+// The call to backend.TestBackendStates tests workspace creation, list and deletion.
 func TestAccBackendAccessKeyBasic(t *testing.T) {
 	testAccAzureBackend(t)
 	rs := acctest.RandString(4)
@@ -109,10 +112,10 @@ func TestAccBackendAccessKeyBasic(t *testing.T) {
 	armClient := buildTestClient(t, res)
 
 	ctx := context.TODO()
-	err := armClient.buildTestResources(ctx, &res)
-	defer armClient.destroyTestResources(ctx, res)
+	err := armClient.buildTestResources(t, ctx, &res)
+	defer armClient.destroyTestResources(t, ctx, res)
 	if err != nil {
-		armClient.destroyTestResources(ctx, res)
+		armClient.destroyTestResources(t, ctx, res)
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
 
@@ -135,8 +138,8 @@ func TestAccBackendSASTokenBasic(t *testing.T) {
 	armClient := buildTestClient(t, res)
 
 	ctx := context.TODO()
-	err := armClient.buildTestResources(ctx, &res)
-	defer armClient.destroyTestResources(ctx, res)
+	err := armClient.buildTestResources(t, ctx, &res)
+	defer armClient.destroyTestResources(t, ctx, res)
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
@@ -165,8 +168,8 @@ func TestAccBackendOIDCBasic(t *testing.T) {
 	armClient := buildTestClient(t, res)
 
 	ctx := context.TODO()
-	err := armClient.buildTestResources(ctx, &res)
-	defer armClient.destroyTestResources(ctx, res)
+	err := armClient.buildTestResources(t, ctx, &res)
+	defer armClient.destroyTestResources(t, ctx, res)
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
@@ -193,8 +196,8 @@ func TestAccBackendManagedServiceIdentityBasic(t *testing.T) {
 	armClient := buildTestClient(t, res)
 
 	ctx := context.TODO()
-	err := armClient.buildTestResources(ctx, &res)
-	defer armClient.destroyTestResources(ctx, res)
+	err := armClient.buildTestResources(t, ctx, &res)
+	defer armClient.destroyTestResources(t, ctx, res)
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
@@ -228,8 +231,8 @@ func TestAccBackendServicePrincipalClientCertificateBasic(t *testing.T) {
 	armClient := buildTestClient(t, res)
 
 	ctx := context.TODO()
-	err := armClient.buildTestResources(ctx, &res)
-	defer armClient.destroyTestResources(ctx, res)
+	err := armClient.buildTestResources(t, ctx, &res)
+	defer armClient.destroyTestResources(t, ctx, res)
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
@@ -258,8 +261,8 @@ func TestAccBackendServicePrincipalClientSecretBasic(t *testing.T) {
 	armClient := buildTestClient(t, res)
 
 	ctx := context.TODO()
-	err := armClient.buildTestResources(ctx, &res)
-	defer armClient.destroyTestResources(ctx, res)
+	err := armClient.buildTestResources(t, ctx, &res)
+	defer armClient.destroyTestResources(t, ctx, res)
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
@@ -294,8 +297,8 @@ func TestAccBackendServicePrincipalClientSecretCustomEndpoint(t *testing.T) {
 	armClient := buildTestClient(t, res)
 
 	ctx := context.TODO()
-	err := armClient.buildTestResources(ctx, &res)
-	defer armClient.destroyTestResources(ctx, res)
+	err := armClient.buildTestResources(t, ctx, &res)
+	defer armClient.destroyTestResources(t, ctx, res)
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
@@ -323,8 +326,8 @@ func TestAccBackendAccessKeyLocked(t *testing.T) {
 	armClient := buildTestClient(t, res)
 
 	ctx := context.TODO()
-	err := armClient.buildTestResources(ctx, &res)
-	defer armClient.destroyTestResources(ctx, res)
+	err := armClient.buildTestResources(t, ctx, &res)
+	defer armClient.destroyTestResources(t, ctx, res)
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
@@ -361,8 +364,8 @@ func TestAccBackendServicePrincipalLocked(t *testing.T) {
 	armClient := buildTestClient(t, res)
 
 	ctx := context.TODO()
-	err := armClient.buildTestResources(ctx, &res)
-	defer armClient.destroyTestResources(ctx, res)
+	err := armClient.buildTestResources(t, ctx, &res)
+	defer armClient.destroyTestResources(t, ctx, res)
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}

--- a/internal/backend/remote-state/azure/backend_test.go
+++ b/internal/backend/remote-state/azure/backend_test.go
@@ -114,9 +114,12 @@ func TestAccBackendAccessKeyBasic(t *testing.T) {
 
 	ctx := context.TODO()
 	err := armClient.buildTestResources(t, ctx, &res)
-	defer armClient.destroyTestResources(t, ctx, res)
+	t.Cleanup(func() {
+		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+			t.Fatalf("error when destroying resources: %q", err)
+		}
+	})
 	if err != nil {
-		armClient.destroyTestResources(t, ctx, res)
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
 
@@ -140,7 +143,11 @@ func TestAccBackendSASTokenBasic(t *testing.T) {
 
 	ctx := context.TODO()
 	err := armClient.buildTestResources(t, ctx, &res)
-	defer armClient.destroyTestResources(t, ctx, res)
+	t.Cleanup(func() {
+		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+			t.Fatalf("error when destroying resources: %q", err)
+		}
+	})
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
@@ -170,7 +177,11 @@ func TestAccBackendOIDCBasic(t *testing.T) {
 
 	ctx := context.TODO()
 	err := armClient.buildTestResources(t, ctx, &res)
-	defer armClient.destroyTestResources(t, ctx, res)
+	t.Cleanup(func() {
+		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+			t.Fatalf("error when destroying resources: %q", err)
+		}
+	})
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
@@ -198,7 +209,11 @@ func TestAccBackendManagedServiceIdentityBasic(t *testing.T) {
 
 	ctx := context.TODO()
 	err := armClient.buildTestResources(t, ctx, &res)
-	defer armClient.destroyTestResources(t, ctx, res)
+	t.Cleanup(func() {
+		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+			t.Fatalf("error when destroying resources: %q", err)
+		}
+	})
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
@@ -233,7 +248,11 @@ func TestAccBackendServicePrincipalClientCertificateBasic(t *testing.T) {
 
 	ctx := context.TODO()
 	err := armClient.buildTestResources(t, ctx, &res)
-	defer armClient.destroyTestResources(t, ctx, res)
+	t.Cleanup(func() {
+		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+			t.Fatalf("error when destroying resources: %q", err)
+		}
+	})
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
@@ -263,7 +282,11 @@ func TestAccBackendServicePrincipalClientSecretBasic(t *testing.T) {
 
 	ctx := context.TODO()
 	err := armClient.buildTestResources(t, ctx, &res)
-	defer armClient.destroyTestResources(t, ctx, res)
+	t.Cleanup(func() {
+		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+			t.Fatalf("error when destroying resources: %q", err)
+		}
+	})
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
@@ -299,7 +322,11 @@ func TestAccBackendServicePrincipalClientSecretCustomEndpoint(t *testing.T) {
 
 	ctx := context.TODO()
 	err := armClient.buildTestResources(t, ctx, &res)
-	defer armClient.destroyTestResources(t, ctx, res)
+	t.Cleanup(func() {
+		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+			t.Fatalf("error when destroying resources: %q", err)
+		}
+	})
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
@@ -328,7 +355,11 @@ func TestAccBackendAccessKeyLocked(t *testing.T) {
 
 	ctx := context.TODO()
 	err := armClient.buildTestResources(t, ctx, &res)
-	defer armClient.destroyTestResources(t, ctx, res)
+	t.Cleanup(func() {
+		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+			t.Fatalf("error when destroying resources: %q", err)
+		}
+	})
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
@@ -366,7 +397,11 @@ func TestAccBackendServicePrincipalLocked(t *testing.T) {
 
 	ctx := context.TODO()
 	err := armClient.buildTestResources(t, ctx, &res)
-	defer armClient.destroyTestResources(t, ctx, res)
+	t.Cleanup(func() {
+		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+			t.Fatalf("error when destroying resources: %q", err)
+		}
+	})
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
@@ -435,7 +470,7 @@ func TestBackendPagination(t *testing.T) {
 	client := &mockClient{}
 	result, err := getPaginatedResults(ctx, client, "env", "acc-name", "storage-name")
 	if err != nil {
-		t.Fatalf("error getting paginated results %s", err)
+		t.Fatalf("error getting paginated results %q", err)
 	}
 
 	// default is always on the list + 10k generated blobs from the mocked ListBlobs

--- a/internal/backend/remote-state/azure/client_test.go
+++ b/internal/backend/remote-state/azure/client_test.go
@@ -29,8 +29,8 @@ func TestRemoteClientAccessKeyBasic(t *testing.T) {
 	armClient := buildTestClient(t, res)
 
 	ctx := context.TODO()
-	err := armClient.buildTestResources(ctx, &res)
-	defer armClient.destroyTestResources(ctx, res)
+	err := armClient.buildTestResources(t, ctx, &res)
+	defer armClient.destroyTestResources(t, ctx, res)
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
@@ -59,8 +59,8 @@ func TestRemoteClientManagedServiceIdentityBasic(t *testing.T) {
 	armClient := buildTestClient(t, res)
 
 	ctx := context.TODO()
-	err := armClient.buildTestResources(ctx, &res)
-	defer armClient.destroyTestResources(ctx, res)
+	err := armClient.buildTestResources(t, ctx, &res)
+	defer armClient.destroyTestResources(t, ctx, res)
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
@@ -92,8 +92,8 @@ func TestRemoteClientSasTokenBasic(t *testing.T) {
 	armClient := buildTestClient(t, res)
 
 	ctx := context.TODO()
-	err := armClient.buildTestResources(ctx, &res)
-	defer armClient.destroyTestResources(ctx, res)
+	err := armClient.buildTestResources(t, ctx, &res)
+	defer armClient.destroyTestResources(t, ctx, res)
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
@@ -127,8 +127,8 @@ func TestRemoteClientServicePrincipalBasic(t *testing.T) {
 	armClient := buildTestClient(t, res)
 
 	ctx := context.TODO()
-	err := armClient.buildTestResources(ctx, &res)
-	defer armClient.destroyTestResources(ctx, res)
+	err := armClient.buildTestResources(t, ctx, &res)
+	defer armClient.destroyTestResources(t, ctx, res)
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
@@ -161,8 +161,8 @@ func TestRemoteClientAccessKeyLocks(t *testing.T) {
 	armClient := buildTestClient(t, res)
 
 	ctx := context.TODO()
-	err := armClient.buildTestResources(ctx, &res)
-	defer armClient.destroyTestResources(ctx, res)
+	err := armClient.buildTestResources(t, ctx, &res)
+	defer armClient.destroyTestResources(t, ctx, res)
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
@@ -205,8 +205,8 @@ func TestRemoteClientServicePrincipalLocks(t *testing.T) {
 	armClient := buildTestClient(t, res)
 
 	ctx := context.TODO()
-	err := armClient.buildTestResources(ctx, &res)
-	defer armClient.destroyTestResources(ctx, res)
+	err := armClient.buildTestResources(t, ctx, &res)
+	defer armClient.destroyTestResources(t, ctx, res)
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
@@ -257,8 +257,8 @@ func TestPutMaintainsMetaData(t *testing.T) {
 	armClient := buildTestClient(t, res)
 
 	ctx := context.TODO()
-	err := armClient.buildTestResources(ctx, &res)
-	defer armClient.destroyTestResources(ctx, res)
+	err := armClient.buildTestResources(t, ctx, &res)
+	defer armClient.destroyTestResources(t, ctx, res)
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}

--- a/internal/backend/remote-state/azure/client_test.go
+++ b/internal/backend/remote-state/azure/client_test.go
@@ -30,7 +30,11 @@ func TestRemoteClientAccessKeyBasic(t *testing.T) {
 
 	ctx := context.TODO()
 	err := armClient.buildTestResources(t, ctx, &res)
-	defer armClient.destroyTestResources(t, ctx, res)
+	t.Cleanup(func() {
+		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+			t.Fatalf("error when destroying resources: %q", err)
+		}
+	})
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
@@ -60,7 +64,11 @@ func TestRemoteClientManagedServiceIdentityBasic(t *testing.T) {
 
 	ctx := context.TODO()
 	err := armClient.buildTestResources(t, ctx, &res)
-	defer armClient.destroyTestResources(t, ctx, res)
+	t.Cleanup(func() {
+		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+			t.Fatalf("error when destroying resources: %q", err)
+		}
+	})
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
@@ -93,7 +101,11 @@ func TestRemoteClientSasTokenBasic(t *testing.T) {
 
 	ctx := context.TODO()
 	err := armClient.buildTestResources(t, ctx, &res)
-	defer armClient.destroyTestResources(t, ctx, res)
+	t.Cleanup(func() {
+		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+			t.Fatalf("error when destroying resources: %q", err)
+		}
+	})
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
@@ -128,7 +140,11 @@ func TestRemoteClientServicePrincipalBasic(t *testing.T) {
 
 	ctx := context.TODO()
 	err := armClient.buildTestResources(t, ctx, &res)
-	defer armClient.destroyTestResources(t, ctx, res)
+	t.Cleanup(func() {
+		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+			t.Fatalf("error when destroying resources: %q", err)
+		}
+	})
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
@@ -162,7 +178,11 @@ func TestRemoteClientAccessKeyLocks(t *testing.T) {
 
 	ctx := context.TODO()
 	err := armClient.buildTestResources(t, ctx, &res)
-	defer armClient.destroyTestResources(t, ctx, res)
+	t.Cleanup(func() {
+		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+			t.Fatalf("error when destroying resources: %q", err)
+		}
+	})
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
@@ -206,7 +226,11 @@ func TestRemoteClientServicePrincipalLocks(t *testing.T) {
 
 	ctx := context.TODO()
 	err := armClient.buildTestResources(t, ctx, &res)
-	defer armClient.destroyTestResources(t, ctx, res)
+	t.Cleanup(func() {
+		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+			t.Fatalf("error when destroying resources: %q", err)
+		}
+	})
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}
@@ -258,7 +282,11 @@ func TestPutMaintainsMetaData(t *testing.T) {
 
 	ctx := context.TODO()
 	err := armClient.buildTestResources(t, ctx, &res)
-	defer armClient.destroyTestResources(t, ctx, res)
+	t.Cleanup(func() {
+		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+			t.Fatalf("error when destroying resources: %q", err)
+		}
+	})
 	if err != nil {
 		t.Fatalf("Error creating Test Resources: %q", err)
 	}


### PR DESCRIPTION
<!-- If your PR resolves an issue, please add it here. -->
Resolves #2700 

Adding pagination to the fetching of Azure backend workspaces.

It solves the problem when the workspace is not returned on the first page of results. The user should be mindful if you have a **Blob container** full of files, it's going to take an extra time to find the blob since it's extra requests will be done to find the workspaces.

I was able to reproduce the issue linked above by creating blobs with the following command:

```
# for i in $(seq 1 10000); do az storage blob upload -c tfstate --name prod.terraform.tfstateenv:env$i --file a.txt --account-name opentofutest; done
```

The example tofu configuration was:

```
terraform {
  backend "azurerm" {
    resource_group_name  = "test"
    storage_account_name = "opentofutest"
    container_name       = "tfstate"
    key                  = "prod.terraform.tfstate"
  }
}
```

Acceptance Tests:

```
(base) ➜  opentofu git:(2700-az-list) ✗ go test -v ./... -run TestAccBackendServicePrincipalClientSecretBasic
ok  	github.com/opentofu/opentofu/internal/backend/remote	3.523s [no tests to run]
=== RUN   TestAccBackendServicePrincipalClientSecretBasic
    backend_test.go:264: Creating Resource Group "acctestRG-backend-25042814355490-pym9"
    backend_test.go:264: Creating Storage Account "acctestsapym9" in Resource Group "acctestRG-backend-25042814355490-pym9"
    backend_test.go:264: fetching access key for storage account
    backend_test.go:264: Creating Container "acctestcont" in Storage Account "acctestsapym9" (Resource Group "acctestRG-backend-25042814355490-pym9")
    backend_test.go:270: TestBackendConfig on *azure.Backend with hcl2shim.synthBody{Filename:"<TestWrapConfig>", Values:map[string]cty.Value{"client_id":cty.StringVal("459b0713-7ad4-4e74-9b9f-9e8818cf58ae"), "client_secret":cty.StringVal("KSx8Q~uWXZIqzDpRkC_BAl_wHrzvoIuWvZ30mbm3"), "container_name":cty.StringVal("acctestcont"), "endpoint":cty.StringVal(""), "environment":cty.StringVal("public"), "key":cty.StringVal("testState"), "resource_group_name":cty.StringVal("acctestRG-backend-25042814355490-pym9"), "storage_account_name":cty.StringVal("acctestsapym9"), "subscription_id":cty.StringVal("1498f77d-8f21-4ce7-93a4-39905d398283"), "tenant_id":cty.StringVal("0e004ebd-4497-4781-a2e8-50f89b860e37")}}
    backend_test.go:284: [DEBUG] Deleting Resource Group "acctestRG-backend-25042814355490-pym9"..
    backend_test.go:284: [DEBUG] Waiting for deletion of Resource Group "acctestRG-backend-25042814355490-pym9"..
--- PASS: TestAccBackendServicePrincipalClientSecretBasic (123.23s)
```


## Target Release

1.10.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
