### PR TITLE
[PROTOTYPE] A more granular API for state storage

### DIFF
--- a/internal/states/statestore/data.go
+++ b/internal/states/statestore/data.go
@@ -1,0 +1,146 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package statestore
+
+import (
+	"errors"
+	"fmt"
+	"iter"
+	"unique"
+
+	"github.com/opentofu/opentofu/internal/collections"
+)
+
+// Key is an opaque token used to uniquely identify an object (or the potential
+// for an object) in a [Storage].
+//
+// Key strings are guaranteed to include only the following characters:
+// - Lowercase ASCII letters: a-z.
+// - ASCII digits: 0-9.
+// - The ASCII "hyphen-minus" character, "-".
+//
+// The zero value of this type is NOT a valid key, and a valid key must
+// always include at least one hyphen-minus character.
+//
+// This limited vocabulary is a compromise to work within the key naming
+// constraints of various different storage implementations, including
+// systems that use case-insensitive key matching.
+//
+// In situations where OpenTofu needs to represent identifiers that exceed this
+// alphabet, it will use the base32hex encoding as defined in [RFC 4648]
+// section 7 and implemented in Go as [encoding/base32.HexEncoding], with
+// padding disabled. However, that is only a guideline for internal
+// implementation and not the specification of an external integration point;
+// everything outside of OpenTofu Core must treat all keys as opaque, comparing
+// them only for string equality.
+type Key struct {
+	// We use unique.Unique here to intern the strings so that we can compare
+	// them by pointer rather than by content, e.g. when working with a set
+	// of keys represented as a map.
+	raw unique.Handle[string]
+}
+
+// MakeKey converts the given string into a [Key] without first checking whether
+// it uses the valid alphabet. Use this only for key strings constructed by
+// OpenTofu Core itself, which are guaranteed to be valid by construction.
+func MakeKey(raw string) Key {
+	if len(raw) == 0 { // this is a relatively-cheap check, at least
+		panic("can't build statestore.Key from empty string")
+	}
+	return Key{raw: unique.Make(raw)}
+}
+
+// ParseKey verifies whether the given string conforms to the expected alphabet
+// for [Key] values and returns the same string wrapped in one if so, or
+// otherwise returns an error.
+//
+// This is intended only for handling keys loaded from the underlying store
+// of a [Storage] implementation where someone might have introduced something
+// invalid into the data store. Keys constructed inside OpenTofu itself should
+// instead use a generation strategy that ensures that the alphabet will
+// definitely be followed and then use [MakeKey].
+func ParseKey(raw string) (Key, error) {
+	// NOTE: All of the error paths in this function intentionally avoid
+	// allocating anything on the heap so that callers can use this
+	// function to filter a large list of candidate key names without
+	// generating garbage for each one.
+	if len(raw) == 0 {
+		return Key{}, errKeyEmpty
+	}
+	foundHyphen := false
+	for _, c := range raw {
+		if !inKeyAlphabet(c) {
+			return Key{}, errKeyInvalidChar(c)
+		}
+		if c == '-' {
+			foundHyphen = true
+		}
+	}
+	if !foundHyphen {
+		// (this rule exists to ensure that a valid key name can never coincide
+		// with one of the filenames that is reserved on Windows for use as
+		// a legacy DOS-style device name, such as "nul", "con", etc, so that
+		// all keys can be assumed to be valid filenames on all of our
+		// supported platforms for the benefit of filesystem-based storage.)
+		return Key{}, errKeyNoHyphen
+	}
+	return MakeKey(raw), nil
+}
+
+func (k Key) Name() string {
+	return k.raw.Value()
+}
+
+func inKeyAlphabet(c rune) bool {
+	return (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')
+}
+
+var errKeyEmpty = errors.New("state storage key must have at least one character")
+var errKeyNoHyphen = errors.New("state storage key name must include at least one hyphen-minus character")
+
+type errKeyInvalidChar rune
+
+func (err errKeyInvalidChar) Error() string {
+	return fmt.Sprintf("state storage key contains invalid character %q", rune(err))
+}
+
+// Value is an opaque byte sequence that can be associated with a [Key].
+//
+// A valid Value always has a length of at least one. A zero-length (typically
+// nil) Value represents the absence of a value.
+//
+// The guarantee against zero-length blobs is a pragmatic concession to allow
+// the use of empty object placeholders as part of a representation of a lock
+// on a key that has not yet been created, when backed by a storage system that
+// can only acquire locks for objects that already exist.
+type Value []byte
+
+// NoValue is the zero value of [Value] representing the absense of a value.
+//
+// A non-nil [Value] of length zero also represents the absence of a value,
+// but implementers should avoid creating such a value to minimize risk of
+// surprise and bugs.
+var NoValue Value
+
+// KeySet is a set of [Key].
+type KeySet = collections.Set[Key]
+
+// NewKeySet constructs a new, empty [KeySet].
+func NewKeySet() KeySet {
+	return collections.NewSet[Key]()
+}
+
+// CollectKeySet collects results from [Storage.Keys] into a [KeySet].
+func CollectKeySet(items iter.Seq2[Key, error]) (KeySet, error) {
+	ret := collections.NewSet[Key]()
+	for key, err := range items {
+		if err != nil {
+			return nil, err
+		}
+		ret[key] = struct{}{}
+	}
+	return ret, nil
+}

--- a/internal/states/statestore/doc.go
+++ b/internal/states/statestore/doc.go
@@ -1,0 +1,56 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+// Package statestore defines our internal abstraction for mutable state
+// storage, along with vocabulary types and utilities needed by implementations
+// of this abstraction.
+//
+// State storage is conceptually a key/value store where keys are strings,
+// values are opaque blobs, and each key can be independently locked in either
+// a shared or an exclusive fashion. A fully-fledged state storage
+// implementation can:
+//
+//   - Enumerate all of the keys currently stored.
+//   - Read the blobs associated with a given set of keys.
+//   - Acquire shared or exclusive locks for a given set of keys.
+//   - Write or delete blobs for a given set of keys for which exclusive locks
+//     are already held.
+//   - Release previously-acquired locks on a given set of keys.
+//   - Force any existing lock on each of a set of keys to be released, as an
+//     administrative workaround for state storage left in an inconsistent
+//     state due to catastrophic failure.
+//
+// However, implementations are permitted to make certain compromises that
+// reduce opportunities for concurrency and failure-resilience but do not
+// sacrifice correctness when the system is behaving as designed:
+//
+//   - Remotely track only a single shared/exclusive lock (aka read/write lock)
+//     for the entire storage rather than on a per-key basis, and track the
+//     per-key locks only locally within the current process.
+//   - Remotely track only exclusive locks, tracking the shared vs. exclusive
+//     distinction only locally within the current process.
+//   - Track the entire state as a single blob, with the key/value granularity
+//     managed only locally within the current process and the whole blob
+//     flushed to persistent storage together. (This compromise requires that
+//     locks are also tracked at the same whole-state granularity or that the
+//     implementations are able to cooperate to resolve write conflicts, so that
+//     multiple processes to not race to update the same blob and erase
+//     each other's changes.)
+//
+// Callers of [Storage] treat the locking mechanism as advisory, but
+// implementations are allowed to use mandatory locks for additional assurance
+// if their underlying storage supports them.
+//
+// Refer to [Storage] for more details on the requirements for implementors.
+//
+// State storage implementations are not permitted to assume any special meaning
+// of the keys and values that their caller requests to store, whether
+// client-side or server-side. The object types and their storage
+// representations are subject to change in future OpenTofu releases and
+// are considered an implementation detail. External software that needs to
+// interact with stored OpenTofu state must do so via other documented
+// integration points, and must not access the underlying state storage
+// directly.
+package statestore

--- a/internal/states/statestore/storage.go
+++ b/internal/states/statestore/storage.go
@@ -1,0 +1,132 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package statestore
+
+import (
+	"context"
+	"iter"
+
+	"github.com/opentofu/opentofu/internal/collections"
+)
+
+// Storage is the interface implemented by a state storage implementation,
+// which OpenTofu Core uses to persiste and retrieve state information.
+//
+// To avoid data loss, implementers must ensure that they meet all of the
+// requirements described in the description of each method.
+//
+// The API is designed to allow callers to perform the same action against
+// many different keys at once, so that implementations can exploit efficiencies
+// from techniques such as batch requests when available in their underlying
+// storage APIs.
+type Storage interface {
+	// Keys enumerates all of the keys currently stored, in no particular order.
+	//
+	// If a sequence step returns an error then the caller must stop iterating
+	// and treat that as an error describing the entire traversal. For example,
+	// Storage implementations that need to request data one "page" at a time
+	// might succeed in fetching the first page but fail on a subsequent
+	// page.
+	//
+	// In storage implementations that use empty objects as the technique for
+	// representing a lock on an object that has not been created yet, the
+	// result of this function MUST NOT include the keys associated with those
+	// empty objects.
+	//
+	// Note that there is no overall lock constraining the addition or removal
+	// of keys and so the result from this method must be used carefully while
+	// taking into account that additional keys could be added concurrently
+	// with any downstream work. In particular, the presence of absence of any
+	// specific key must not be to make a decision leading to a change
+	// unless the caller is also holding a shared or exclusive lock on that key
+	// to ensure that it _stays_ absent or present.
+	Keys(context.Context) iter.Seq2[Key, error]
+
+	// Lock attempts to acquire a mixture of shared and exclusive locks for
+	// zero or more keys.
+	//
+	// If the returned error nil then all of the requested locks were all
+	// acquired and the caller MUST call Unlock for for all of the requested
+	// keys at some later point to release the locks. Callers are free to
+	// unlock each of the requested keys independently of the others as long
+	// as all are unlocked before the program terminates.
+	//
+	// Implementations are required to allow nested locks to be acquired by
+	// different calls to the same [Storage] object, such as by tracking an
+	// active lock count for each key and releasing the lock as observed by
+	// other clients only when the lock count returns to zero.
+	//
+	// If any of the requests conflict with already-active locks then the
+	// call must block until either all requested objects become available
+	// or until the given context is cancelled. If returning due to context
+	// cancellation then the returned error must be either [context.Canceled]
+	// or [context.DeadlineExceeded] as appropriate for the cancellation type.
+	//
+	// It is a bug in the caller to include the same key in both the "shared"
+	// and "exclusive" sets, or to otherwise request an exclusive lock when
+	// already holding a shared lock for the same key. Storage implementations
+	// may handle that either by deadlocking, by panicking, or by returning
+	// an error.
+	//
+	// FIXME: After some further design iteration, it doesn't actually seem
+	// necessary to support nested locks, so hopefully we can remove that
+	// requirement in a later draft.
+	Lock(ctx context.Context, shared collections.Set[Key], exclusive collections.Set[Key]) error
+
+	// Unlock releases locks previously acquired using [Storage.Lock].
+	//
+	// Both shared and exclusive locks can be released using this method, and
+	// can be mixed in a single call. There is no requirement that unlock
+	// requests be grouped in the same way as earlier successful lock
+	// requests.
+	//
+	// If this function returns an error then the lock state of all of the
+	// given keys is unspecified, and so the caller must behave as if all
+	// locks were released and should aim to cease further work as soon as
+	// possible.
+	Unlock(context.Context, collections.Set[Key]) error
+
+	// Read retrieves the values associated with a given set of keys,
+	// successfully returning [NoValue] for any that do not currently have
+	// an associated value.
+	//
+	// This may be called only while holding a shared or exclusive lock for
+	// all of the given keys, although implementers are not required to enforce
+	// that constraint -- reading without acquiring a lock is always a bug in
+	// the caller -- but is permitted to enforce it for implementation
+	// convenience.
+	//
+	// If the given set includes more keys than the underlying storage can
+	// return in a single request then the implementation must perform
+	// multiple requests, using the most efficient strategy available, and
+	// then aggregate the results to return.
+	Read(context.Context, collections.Set[Key]) (map[Key]Value, error)
+
+	// Write creates, updates, or deletes values associated with a set of
+	// keys as described in the given map. A map value of [NoValue] represents
+	// a request to completely delete the corresponding key.
+	//
+	// This may be called only while holding an exclusive lock for all of
+	// the given keys, although implementers are not required to enforce that
+	// constraint -- writing without acquiring a lock is always a bug in the
+	// caller -- but is permitted to enforce it for implementation convenience.
+	//
+	// If the given map includes more updates than the underlying storage
+	// can commit in a single request then the implementation must perform
+	// multiple requests. If this function returns an error then it's
+	// unspecified which of the given keys have been updated and which have
+	// not.
+	Write(context.Context, map[Key]Value) error
+
+	// Close is called once the Storage object is no longer needed.
+	//
+	// Implementations should ensure that any uncommitted changes are persisted
+	// to the underlying storage and release any active locks before returning.
+	//
+	// It's a bug in the caller if any other methods are called after beginning
+	// a call to Close.
+	Close(context.Context) error
+}

--- a/internal/states/statestore/storage_filesystem.go
+++ b/internal/states/statestore/storage_filesystem.go
@@ -1,0 +1,343 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package statestore
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"iter"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/opentofu/opentofu/internal/collections"
+)
+
+// FilesystemStorage is an implementation of [Storage] that uses files in
+// a directory accessible using the current operating system's filesystem
+// abstraction.
+//
+// Locking for this implementation relies on "flock" for Unix-style systems
+// and `LockFileEx` on Windows systems, and so this implementation is safe
+// to use only in filesystems where those mechanisms work reliably. For
+// example, this implementation is not safe to use on some network filesystems.
+type FilesystemStorage struct {
+	// root is the directory where we store our objects and
+	root *os.Root
+
+	// The remaining fields track our own locking state, so we can support
+	// nested locking and retain the file descriptors that our OS-level
+	// locks are associated with.
+	mu    sync.RWMutex
+	locks map[Key]*filesystemStorageLock // initialized on first lock request
+}
+
+var _ Storage = (*FilesystemStorage)(nil)
+
+// We create all files with the following suffix on their names so that we
+// can tolerate most situations where other software on a computer might
+// rudely add files into a directory, such as a file manager saving a
+// cache of metadata it's extracted from other files in the directory.
+const filesystemStorageFilenameSuffix = ".tofustate"
+
+// OpenFilesystemStorage creates a new [FilesystemStorage] object that
+// uses the given directory path for storage.
+//
+// Concurrent processes can safely work in the same directory as long as they
+// are all using this implementation. Any other changes to the directory
+// (including any content placed in that directory prior to its first use
+// with this function) causes unspecified behavior.
+func OpenFilesystemStorage(dir string) (*FilesystemStorage, error) {
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return nil, err
+	}
+	return &FilesystemStorage{root: root}, nil
+}
+
+// Close implements Storage.
+func (f *FilesystemStorage) Close(_ context.Context) error {
+	// TODO: Release all active locks.
+	return f.root.Close()
+}
+
+// Keys implements Storage.
+func (f *FilesystemStorage) Keys(ctx context.Context) iter.Seq2[Key, error] {
+	return func(yield func(Key, error) bool) {
+		// NOTE: The result from os.Root.FS is guaranteed by its documentation
+		// to implement fs.ReadDirFS.
+		entries, err := f.root.FS().(fs.ReadDirFS).ReadDir(".")
+		if err != nil {
+			yield(Key{}, err)
+			return
+		}
+		for _, entry := range entries {
+			if !entry.Type().IsRegular() {
+				continue // We only care about regular files
+			}
+			filename := entry.Name()
+			rawKey := strings.TrimSuffix(filename, filesystemStorageFilenameSuffix)
+			if len(rawKey) == len(filename) {
+				continue // filename did not end with the expected suffix
+			}
+			key, err := ParseKey(rawKey)
+			if err != nil {
+				continue // ignore anything that isn't a valid key
+			}
+			if err := ctx.Err(); err != nil { // respond to context cancellation in case we're on a slow filesystem
+				yield(key, err)
+				return
+			}
+			info, err := entry.Info()
+			if err != nil || info.Size() == 0 {
+				continue // ignore empty files and files that have vanished since we listed the directory
+			}
+			if !yield(key, nil) {
+				return
+			}
+		}
+	}
+}
+
+// Lock implements Storage.
+func (f *FilesystemStorage) Lock(ctx context.Context, shared collections.Set[Key], exclusive collections.Set[Key]) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.locks == nil {
+		f.locks = make(map[Key]*filesystemStorageLock)
+	}
+
+	// We aren't required to acquire the locks in any particular order as
+	// long as we have acquired them all by the time we return successfully,
+	// so we'll arbitrarily deal with the exclusive locks just because
+	// they are more likely to be contended.
+	err := f.acquireLocks(ctx, exclusive, true, f.lockFileExclusive)
+	if err != nil {
+		return err
+	}
+	return f.acquireLocks(ctx, shared, false, f.lockFileShared)
+}
+
+// acquireLocks must only be called by [FilesystemStorage.Lock], while holding
+// a lock on f.mu.
+func (f *FilesystemStorage) acquireLocks(ctx context.Context, want collections.Set[Key], exclusive bool, lockFunc func(target *os.File) error) error {
+	for key := range want {
+		lock, ok := f.locks[key]
+		if ok {
+			// This object already has a filesystem-level lock on this key,
+			// so we just need to update our internal tracking.
+			if exclusive != lock.exclusive {
+				// Caller is required to be consistent in whether it asks
+				// for a shared or an exclusive lock on each key.
+				return fmt.Errorf("shared/exclusive conflict for nested lock on %q", key.Name())
+			}
+			lock.lockCount++
+			continue
+		}
+
+		filename := f.filename(key)
+
+		// O_CREATE without O_EXCL means that we'll create the file if it
+		// doesn't already exist but just open it normally if it does.
+		// If we create the file then it will initially be empty, which
+		// is okey because [FilesystemStorage.Keys] ignores empty files.
+		file, err := f.root.OpenFile(filename, os.O_CREATE|os.O_RDONLY, os.ModePerm)
+		if err != nil {
+			return err
+		}
+		err = f.waitForFileLock(ctx, file, lockFunc)
+		if err != nil {
+			return err
+		}
+		f.locks[key] = &filesystemStorageLock{
+			exclusive: exclusive,
+			lockCount: 1,
+			file:      file,
+		}
+	}
+	return nil
+}
+
+func (f *FilesystemStorage) waitForFileLock(ctx context.Context, target *os.File, lockFunc func(target *os.File) error) error {
+	for {
+		err := lockFunc(target)
+		if err == nil || !isContendedFilesystemLockError(err) {
+			return err
+		}
+
+		// We'll wait a little before we poll again, unless the given context
+		// gets cancelled.
+		timer := time.NewTimer(time.Second)
+		select {
+		case <-timer.C:
+			continue
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// Read implements Storage.
+func (f *FilesystemStorage) Read(ctx context.Context, want collections.Set[Key]) (map[Key]Value, error) {
+	if len(want) == 0 {
+		return nil, nil
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	ret := make(map[Key]Value, len(want))
+	for key := range want {
+		lock := f.locks[key]
+		if lock == nil {
+			// We don't have an active lock for this file, so the caller is buggy.
+			return nil, fmt.Errorf("reading %q while not holding lock", key.Name())
+		}
+
+		value, err := readValueFromFile(lock.file)
+		if err != nil {
+			return nil, fmt.Errorf("reading %q: %w", key.Name(), err)
+		}
+		ret[key] = value
+	}
+	return ret, nil
+}
+
+// Unlock implements Storage.
+func (f *FilesystemStorage) Unlock(ctx context.Context, keys collections.Set[Key]) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	for key := range keys {
+		lock := f.locks[key]
+		if lock == nil {
+			return fmt.Errorf("unlocking %q while not holding lock", key.Name())
+		}
+
+		// Before we get too far here we'll try to make sure that any changes
+		// we've made are committed to disk, rather than just in cache.
+		err := lock.file.Sync()
+		if err != nil {
+			return fmt.Errorf("sync %q before unlock: %w", key.Name(), err)
+		}
+
+		lock.lockCount--
+		if lock.lockCount == 0 {
+			delete(f.locks, key)
+			err := f.unlockFile(lock.file)
+			if err != nil {
+				return fmt.Errorf("unlocking %q: %w", key.Name(), err)
+			}
+			err = lock.file.Close()
+			if err != nil {
+				// Weird to get here since we synced already above, but okay...
+				return fmt.Errorf("closing file for %q: %w", key.Name(), err)
+			}
+		}
+	}
+	return nil
+}
+
+// Write implements Storage.
+func (f *FilesystemStorage) Write(ctx context.Context, new map[Key]Value) error {
+	if len(new) == 0 {
+		return nil
+	}
+	// We use exclusive locking for writes to ensure that we can't have
+	// two goroutines in our process trying to write to the same file
+	// concurrently.
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	for key, value := range new {
+		lock := f.locks[key]
+		if lock == nil || !lock.exclusive {
+			// We don't have an active lock for this file, so the caller is buggy.
+			return fmt.Errorf("writing %q while not holding exclusive lock", key.Name())
+		}
+
+		err := writeValueToFile(value, lock.file)
+		if err != nil {
+			return fmt.Errorf("writing %q: %w", key.Name(), err)
+		}
+	}
+	return nil
+}
+
+func (f *FilesystemStorage) filename(key Key) string {
+	return key.Name() + filesystemStorageFilenameSuffix
+}
+
+type filesystemStorageLock struct {
+	exclusive bool
+	lockCount int
+	file      *os.File
+}
+
+// readValueFromFile is similar to [io.ReadAll] but is safe for multiple
+// concurrent calls on the same file because it does not use or change the
+// file position as tracked by the kernel.
+//
+// It is NOT safe to use this function concurrently with any changes to the
+// given file.
+func readValueFromFile(f *os.File) (Value, error) {
+	// To allow for multiple concurrent readers of the same file, we maintain
+	// our own local file cursor here instead of relying on the in-kernel
+	// position associated with the file descriptor.
+	pos := int64(0)
+	var buf bytes.Buffer
+	for {
+		buf.Grow(64) // arbitrary minimum buffer space to read into
+		into := buf.AvailableBuffer()
+		n, err := f.ReadAt(into, pos)
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+		buf.Write(into[:n])
+		pos += int64(n)
+		if err == io.EOF {
+			break
+		}
+	}
+	if buf.Len() == 0 {
+		return NoValue, nil
+	}
+	return Value(buf.Bytes()), nil
+}
+
+// writeValueToFile replaces the content of the given file with the
+// given value.
+//
+// It is not safe to call this function concurrently with the same file
+// or concurrently with any other changes to the given file.
+func writeValueToFile(value Value, f *os.File) error {
+	// Although we require exclusive access, for consistency with
+	// [readValueFromFile] we again avoid using the kernel's own file
+	// position since we know we always want to write at the very start.
+	pos := int64(0)
+	remain := []byte(value)
+	for len(remain) > 0 {
+		n, err := f.WriteAt(remain, pos)
+		if err != nil {
+			if pos > 0 {
+				// We've probably now corrupted the file, so we'll make
+				// a best effort to leave it empty rather than corrupt, but
+				// this won't necessarily succeed.
+				_ = f.Truncate(0)
+			}
+			return err
+		}
+		pos += int64(n)
+		remain = remain[n:]
+	}
+	// If we got here then we've written the new data, but if the old
+	// data was longer then we still have some straggling bytes after
+	// so we'll get rid of those now.
+	return f.Truncate(int64(len(value)))
+}

--- a/internal/states/statestore/storage_filesystem_unix.go
+++ b/internal/states/statestore/storage_filesystem_unix.go
@@ -1,0 +1,64 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !windows
+// +build !windows
+
+package statestore
+
+import (
+	"io"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func (f *FilesystemStorage) lockFileShared(target *os.File) error {
+	flock := &unix.Flock_t{
+		Type:   unix.F_RDLCK,
+		Whence: int16(io.SeekStart),
+		Start:  0,
+		Len:    0,
+	}
+	return unix.FcntlFlock(target.Fd(), unix.F_SETLK, flock)
+}
+
+func (f *FilesystemStorage) lockFileExclusive(target *os.File) error {
+	flock := &unix.Flock_t{
+		Type:   unix.F_WRLCK,
+		Whence: int16(io.SeekStart),
+		Start:  0,
+		Len:    0,
+	}
+	return unix.FcntlFlock(target.Fd(), unix.F_SETLK, flock)
+}
+
+func (f *FilesystemStorage) unlockFile(target *os.File) error {
+	flock := &unix.Flock_t{
+		Type:   unix.F_UNLCK,
+		Whence: int16(io.SeekStart),
+		Start:  0,
+		Len:    0,
+	}
+	return unix.FcntlFlock(target.Fd(), unix.F_SETLK, flock)
+}
+
+// isContendedFilesystemLockError returns true if the given error is one that
+// [FilesystemStorage.lockFileShared] or [FilesystemStorage.lockFileExclusive]
+// would return to indicate that the requested lock is contended.
+func isContendedFilesystemLockError(err error) bool {
+	errno, ok := err.(unix.Errno)
+	if !ok {
+		return false
+	}
+	switch errno {
+	case unix.EAGAIN, unix.EACCES, unix.EINTR:
+		// The exact error code used for "contended" varies between operating
+		// systems, so we'll allow all three above.
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/states/statestore/storage_filesystem_windows.go
+++ b/internal/states/statestore/storage_filesystem_windows.go
@@ -1,0 +1,83 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build windows
+// +build windows
+
+package statestore
+
+import (
+	"math"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func (f *FilesystemStorage) lockFileShared(target *os.File) error {
+	ol, err := newOverlapped()
+	if err != nil {
+		return err
+	}
+	defer windows.CloseHandle(ol.HEvent)
+
+	return windows.LockFileEx(
+		windows.Handle(target.Fd()),
+		windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,              // reserved
+		0,              // bytes low
+		math.MaxUint32, // bytes high
+		ol,
+	)
+}
+
+func (f *FilesystemStorage) lockFileExclusive(target *os.File) error {
+	ol, err := newOverlapped()
+	if err != nil {
+		return err
+	}
+	defer windows.CloseHandle(ol.HEvent)
+
+	return windows.LockFileEx(
+		windows.Handle(target.Fd()),
+		windows.LOCKFILE_FAIL_IMMEDIATELY|windows.LOCKFILE_EXCLUSIVE_LOCK,
+		0,              // reserved
+		0,              // bytes low
+		math.MaxUint32, // bytes high
+		ol,
+	)
+}
+
+func (f *FilesystemStorage) unlockFile(target *os.File) error {
+	ol, err := newOverlapped()
+	if err != nil {
+		return err
+	}
+	defer windows.CloseHandle(ol.HEvent)
+
+	return windows.UnlockFileEx(
+		windows.Handle(target.Fd()),
+		0,              // reserved
+		0,              // bytes low
+		math.MaxUint32, // bytes high
+		ol,
+	)
+}
+
+// isContendedFilesystemLockError returns true if the given error is one that
+// [FilesystemStorage.lockFileShared] or [FilesystemStorage.lockFileExclusive]
+// would return to indicate that the requested lock is contended.
+func isContendedFilesystemLockError(err error) bool {
+	return err == windows.ERROR_IO_PENDING
+}
+
+// newOverlapped creates a structure used to track asynchronous
+// I/O requests that have been issued.
+func newOverlapped() (*windows.Overlapped, error) {
+	handle, err := windows.CreateEvent(nil, 1, 0, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &windows.Overlapped{HEvent: handle}, nil
+}


### PR DESCRIPTION
This is an early API design sketch for part of https://github.com/opentofu/opentofu/issues/2662: a hypothetical new API for state storage as a key/value store with per-key locking rather than as a blob store with whole-blob locking.

This is not intended to be merged.
