### PR TITLE
Remove providercache.Dir.metaCache

### DIFF
--- a/internal/providercache/dir.go
+++ b/internal/providercache/dir.go
@@ -11,7 +11,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"sort"
 	"time"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -160,28 +159,6 @@ func (d *Dir) Lock(ctx context.Context, provider addrs.Provider, version getprov
 	}, nil
 }
 
-// AllAvailablePackages returns a description of all of the packages already
-// present in the directory. The cache entries are grouped by the provider
-// they relate to and then sorted by version precedence, with highest
-// precedence first.
-//
-// This function will return an empty result both when the directory is empty
-// and when scanning the directory produces an error.
-//
-// The caller is forbidden from modifying the returned data structure in any
-// way, even though the Go type system permits it.
-//
-// Not performant / cached as it's only used in tests!
-func (d *Dir) AllAvailablePackages() map[addrs.Provider][]CachedProvider {
-	metaCache, err := d.fillMetaCache()
-	if err != nil {
-		log.Printf("[WARN] Failed to scan provider cache directory %s: %s", d.baseDir, err)
-		return nil
-	}
-
-	return metaCache
-}
-
 // ProviderVersion returns the cache entry for the requested provider version,
 // or nil if the requested provider version isn't present in the cache.
 func (d *Dir) ProviderVersion(provider addrs.Provider, version getproviders.Version) *CachedProvider {
@@ -195,85 +172,4 @@ func (d *Dir) ProviderVersion(provider addrs.Provider, version getproviders.Vers
 	}
 
 	return nil
-}
-
-// ProviderLatestVersion returns the cache entry for the latest
-// version of the requested provider already available in the cache, or nil if
-// there are no versions of that provider available.
-//
-// Not performant / cached as it's only used in tests!
-func (d *Dir) ProviderLatestVersion(provider addrs.Provider) *CachedProvider {
-	metaCache, err := d.fillMetaCache()
-	if err != nil {
-		return nil
-	}
-
-	entries := metaCache[provider]
-	if len(entries) == 0 {
-		return nil
-	}
-
-	return &entries[0]
-}
-
-// Not performant / cached as it's only used in tests!
-func (d *Dir) fillMetaCache() (map[addrs.Provider][]CachedProvider, error) {
-	log.Printf("[TRACE] providercache.fillMetaCache: scanning directory %s", d.baseDir)
-
-	allData, err := getproviders.SearchLocalDirectory(d.baseDir)
-	if err != nil {
-		log.Printf("[TRACE] providercache.fillMetaCache: error while scanning directory %s: %s", d.baseDir, err)
-		return nil, err
-	}
-
-	// The getproviders package just returns everything it found, but we're
-	// interested only in a subset of the results:
-	// - those that are for the current platform
-	// - those that are in the "unpacked" form, ready to execute
-	// ...so we'll filter in these ways while we're constructing our final
-	// map to save as the cache.
-	//
-	// We intentionally always make a non-nil map, even if it might ultimately
-	// be empty, because we use that to recognize that the cache is populated.
-	data := make(map[addrs.Provider][]CachedProvider)
-
-	for providerAddr, metas := range allData {
-		for _, meta := range metas {
-			if meta.TargetPlatform != d.targetPlatform {
-				log.Printf("[TRACE] providercache.fillMetaCache: ignoring %s because it is for %s, not %s", meta.Location, meta.TargetPlatform, d.targetPlatform)
-				continue
-			}
-			if _, ok := meta.Location.(getproviders.PackageLocalDir); !ok {
-				// PackageLocalDir indicates an unpacked provider package ready
-				// to execute.
-				log.Printf("[TRACE] providercache.fillMetaCache: ignoring %s because it is not an unpacked directory", meta.Location)
-				continue
-			}
-
-			packageDir := filepath.Clean(string(meta.Location.(getproviders.PackageLocalDir)))
-
-			log.Printf("[TRACE] providercache.fillMetaCache: including %s as a candidate package for %s %s", meta.Location, providerAddr, meta.Version)
-			data[providerAddr] = append(data[providerAddr], CachedProvider{
-				Provider:   providerAddr,
-				Version:    meta.Version,
-				PackageDir: filepath.ToSlash(packageDir),
-			})
-		}
-	}
-
-	// After we've built our lists per provider, we'll also sort them by
-	// version precedence so that the newest available version is always at
-	// index zero. If there are two versions that differ only in build metadata
-	// then it's undefined but deterministic which one we will select here,
-	// because we're preserving the order returned by SearchLocalDirectory
-	// in that case..
-	for _, entries := range data {
-		sort.SliceStable(entries, func(i, j int) bool {
-			// We're using GreaterThan rather than LessThan here because we
-			// want these in _decreasing_ order of precedence.
-			return entries[i].Version.GreaterThan(entries[j].Version)
-		})
-	}
-
-	return data, nil
 }

--- a/internal/providercache/dir_modify.go
+++ b/internal/providercache/dir_modify.go
@@ -29,10 +29,6 @@ func (d *Dir) InstallPackage(ctx context.Context, meta getproviders.PackageMeta,
 		d.baseDir, meta.Provider, meta.Version, d.targetPlatform,
 	)
 
-	// Invalidate our metaCache so that subsequent read calls will re-scan to
-	// incorporate any changes we make here.
-	d.metaCache = nil
-
 	log.Printf("[TRACE] providercache.Dir.InstallPackage: installing %s v%s from %s", meta.Provider, meta.Version, meta.Location)
 	return meta.Location.InstallProviderPackage(ctx, meta, newPath, allowedHashes)
 }
@@ -72,10 +68,6 @@ func (d *Dir) LinkFromOtherCache(entry *CachedProvider, allowedHashes []getprovi
 	)
 	currentPath := entry.PackageDir
 	log.Printf("[TRACE] providercache.Dir.LinkFromOtherCache: linking %s v%s from existing cache %s to %s", entry.Provider, entry.Version, currentPath, newPath)
-
-	// Invalidate our metaCache so that subsequent read calls will re-scan to
-	// incorporate any changes we make here.
-	d.metaCache = nil
 
 	// We re-use the process of installing from a local directory here, because
 	// the two operations are fundamentally the same: symlink if possible,

--- a/internal/providercache/dir_testing.go
+++ b/internal/providercache/dir_testing.go
@@ -1,0 +1,122 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package providercache
+
+import (
+	"log"
+	"path/filepath"
+	"sort"
+
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/getproviders"
+)
+
+// NOTE: The functions in this file are only used in testing and are not optimized!
+// The getproviders.SearchLocalDirectory call or allAvailablePackages could be
+// cached if these functions are needed by non-test features.
+
+// AllAvailablePackages returns a description of all of the packages already
+// present in the directory. The cache entries are grouped by the provider
+// they relate to and then sorted by version precedence, with highest
+// precedence first.
+//
+// This function will return an empty result both when the directory is empty
+// and when scanning the directory produces an error.
+//
+// The caller is forbidden from modifying the returned data structure in any
+// way, even though the Go type system permits it.
+//
+// Not performant / cached as it's only used in tests!
+func (d *Dir) AllAvailablePackages() map[addrs.Provider][]CachedProvider {
+	metaCache, err := d.allAvailablePackages()
+	if err != nil {
+		log.Printf("[WARN] Failed to scan provider cache directory %s: %s", d.baseDir, err)
+		return nil
+	}
+
+	return metaCache
+}
+
+// ProviderLatestVersion returns the cache entry for the latest
+// version of the requested provider already available in the cache, or nil if
+// there are no versions of that provider available.
+//
+// Not performant / cached as it's only used in tests!
+func (d *Dir) ProviderLatestVersion(provider addrs.Provider) *CachedProvider {
+	metaCache, err := d.allAvailablePackages()
+	if err != nil {
+		return nil
+	}
+
+	entries := metaCache[provider]
+	if len(entries) == 0 {
+		return nil
+	}
+
+	return &entries[0]
+}
+
+// Not performant / cached as it's only used in tests!
+func (d *Dir) allAvailablePackages() (map[addrs.Provider][]CachedProvider, error) {
+	log.Printf("[TRACE] providercache.fillMetaCache: scanning directory %s", d.baseDir)
+
+	allData, err := getproviders.SearchLocalDirectory(d.baseDir)
+	if err != nil {
+		log.Printf("[TRACE] providercache.fillMetaCache: error while scanning directory %s: %s", d.baseDir, err)
+		return nil, err
+	}
+
+	// The getproviders package just returns everything it found, but we're
+	// interested only in a subset of the results:
+	// - those that are for the current platform
+	// - those that are in the "unpacked" form, ready to execute
+	// ...so we'll filter in these ways while we're constructing our final
+	// map to save as the cache.
+	//
+	// We intentionally always make a non-nil map, even if it might ultimately
+	// be empty, because we use that to recognize that the cache is populated.
+	data := make(map[addrs.Provider][]CachedProvider)
+
+	for providerAddr, metas := range allData {
+		for _, meta := range metas {
+			if meta.TargetPlatform != d.targetPlatform {
+				log.Printf("[TRACE] providercache.fillMetaCache: ignoring %s because it is for %s, not %s", meta.Location, meta.TargetPlatform, d.targetPlatform)
+				continue
+			}
+			if _, ok := meta.Location.(getproviders.PackageLocalDir); !ok {
+				// PackageLocalDir indicates an unpacked provider package ready
+				// to execute.
+				log.Printf("[TRACE] providercache.fillMetaCache: ignoring %s because it is not an unpacked directory", meta.Location)
+				continue
+			}
+
+			packageDir := filepath.Clean(string(meta.Location.(getproviders.PackageLocalDir)))
+
+			log.Printf("[TRACE] providercache.fillMetaCache: including %s as a candidate package for %s %s", meta.Location, providerAddr, meta.Version)
+			data[providerAddr] = append(data[providerAddr], CachedProvider{
+				Provider:   providerAddr,
+				Version:    meta.Version,
+				PackageDir: filepath.ToSlash(packageDir),
+			})
+		}
+	}
+
+	// After we've built our lists per provider, we'll also sort them by
+	// version precedence so that the newest available version is always at
+	// index zero. If there are two versions that differ only in build metadata
+	// then it's undefined but deterministic which one we will select here,
+	// because we're preserving the order returned by SearchLocalDirectory
+	// in that case..
+	for _, entries := range data {
+		sort.SliceStable(entries, func(i, j int) bool {
+			// We're using GreaterThan rather than LessThan here because we
+			// want these in _decreasing_ order of precedence.
+			return entries[i].Version.GreaterThan(entries[j].Version)
+		})
+	}
+
+	return data, nil
+}


### PR DESCRIPTION
This is in preparation for parallelizing the package installation process.  Most of the "locate package(s)" functions on the Dir struct are only currently used by tests.  The only one that is used by non-test code is Dir.ProviderVersion, which is really just a path construction and `os.Stat()` call.

On the other hand, we had the metaCache structure on Dir which needed to be wiped in preparation for a a "rescan" every time we think the dir on disk was modified.  As it's only current utility was exercised during tests, it made sense to remove the cache and do the re-scan for those cases.

As these changes also reduce the number of times we scan the filesystem looking for providers, this could have a mild performance improvement for situations with a massive cache directory or slow networked filesystem.

## Target Release

1.10.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
