### PR TITLE
Replace custom mocks with httptest in registry client tests to improve maintainability

### DIFF
--- a/internal/registry/client_test.go
+++ b/internal/registry/client_test.go
@@ -392,7 +392,7 @@ func TestModuleLocation_readRegistryResponse(t *testing.T) {
 			wantStatusCode: http.StatusOK,
 			handlerFunc: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				json.NewEncoder(w).Encode(response.ModuleLocationRegistryResp{Location: "file:///registry/exists"})
+				_ = json.NewEncoder(w).Encode(response.ModuleLocationRegistryResp{Location: "file:///registry/exists"})
 			},
 		},
 		"shall find the module location in the registry response header": {
@@ -415,7 +415,7 @@ func TestModuleLocation_readRegistryResponse(t *testing.T) {
 			handlerFunc: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("X-Terraform-Get", "file:///registry/exists-header")
 				w.WriteHeader(http.StatusOK)
-				json.NewEncoder(w).Encode(response.ModuleLocationRegistryResp{Location: "file:///registry/exists"})
+				_ = json.NewEncoder(w).Encode(response.ModuleLocationRegistryResp{Location: "file:///registry/exists"})
 			},
 		},
 		"shall fail to find the module": {
@@ -435,7 +435,7 @@ func TestModuleLocation_readRegistryResponse(t *testing.T) {
 			handlerFunc: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Length", "1000") // Set incorrect content length
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte("{")) // Only write a partial response
+				_, _ = w.Write([]byte("{")) // Only write a partial response
 				// The connection will close after handler returns, but client will expect more data
 			},
 		},
@@ -445,7 +445,7 @@ func TestModuleLocation_readRegistryResponse(t *testing.T) {
 			wantStatusCode: http.StatusOK,
 			handlerFunc: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte("{"))
+				_, _ = w.Write([]byte("{"))
 			},
 		},
 		"shall fail because of unexpected protocol change - 422 http status": {
@@ -454,7 +454,7 @@ func TestModuleLocation_readRegistryResponse(t *testing.T) {
 			wantStatusCode: http.StatusUnprocessableEntity,
 			handlerFunc: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusUnprocessableEntity)
-				w.Write([]byte("bar"))
+				_, _ = w.Write([]byte("bar"))
 			},
 		},
 		"shall fail because location is not found in the response": {
@@ -464,7 +464,7 @@ func TestModuleLocation_readRegistryResponse(t *testing.T) {
 			handlerFunc: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				// note that the response emulates a contract change
-				w.Write([]byte(`{"foo":"git::https://github.com/foo/terraform-baz-bar?ref=v0.2.0"}`))
+				_, _ = w.Write([]byte(`{"foo":"git::https://github.com/foo/terraform-baz-bar?ref=v0.2.0"}`))
 			},
 		},
 	}

--- a/internal/registry/client_test.go
+++ b/internal/registry/client_test.go
@@ -7,19 +7,21 @@ package registry
 
 import (
 	"context"
-	"errors"
-	"io"
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-svchost/disco"
+
 	"github.com/opentofu/opentofu/internal/httpclient"
 	"github.com/opentofu/opentofu/internal/registry/regsrc"
+	"github.com/opentofu/opentofu/internal/registry/response"
 	"github.com/opentofu/opentofu/internal/registry/test"
 	tfversion "github.com/opentofu/opentofu/version"
 )
@@ -377,7 +379,7 @@ func TestLookupModuleNetworkError(t *testing.T) {
 func TestModuleLocation_readRegistryResponse(t *testing.T) {
 	cases := map[string]struct {
 		src                  string
-		httpClient           *http.Client
+		handlerFunc          func(w http.ResponseWriter, r *http.Request)
 		registryFlags        []uint8
 		want                 string
 		wantErrorStr         string
@@ -388,8 +390,9 @@ func TestModuleLocation_readRegistryResponse(t *testing.T) {
 			src:            "exists-in-registry/identifier/provider",
 			want:           "file:///registry/exists",
 			wantStatusCode: http.StatusOK,
-			httpClient: &http.Client{
-				Transport: &mockRoundTripper{},
+			handlerFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(response.ModuleLocationRegistryResp{Location: "file:///registry/exists"})
 			},
 		},
 		"shall find the module location in the registry response header": {
@@ -398,8 +401,9 @@ func TestModuleLocation_readRegistryResponse(t *testing.T) {
 			want:                 "file:///registry/exists",
 			wantToReadFromHeader: true,
 			wantStatusCode:       http.StatusNoContent,
-			httpClient: &http.Client{
-				Transport: &mockRoundTripper{},
+			handlerFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("X-Terraform-Get", "file:///registry/exists")
+				w.WriteHeader(http.StatusNoContent)
 			},
 		},
 		"shall read location from the registry response body even if the header with location address is also set": {
@@ -408,8 +412,10 @@ func TestModuleLocation_readRegistryResponse(t *testing.T) {
 			wantStatusCode:       http.StatusOK,
 			wantToReadFromHeader: false,
 			registryFlags:        []uint8{test.WithModuleLocationInBody, test.WithModuleLocationInHeader},
-			httpClient: &http.Client{
-				Transport: &mockRoundTripper{},
+			handlerFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("X-Terraform-Get", "file:///registry/exists-header")
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(response.ModuleLocationRegistryResp{Location: "file:///registry/exists"})
 			},
 		},
 		"shall fail to find the module": {
@@ -418,63 +424,47 @@ func TestModuleLocation_readRegistryResponse(t *testing.T) {
 			// see: /internal/registry/test/mock_registry.go:testMods
 			wantErrorStr:   `module "not-exist/identifier/provider" version "0.2.0" not found`,
 			wantStatusCode: http.StatusNotFound,
-			httpClient: &http.Client{
-				Transport: &mockRoundTripper{},
+			handlerFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
 			},
 		},
 		"shall fail because of reading response body error": {
 			src:            "foo/bar/baz",
-			wantErrorStr:   "error reading response body from registry: foo",
+			wantErrorStr:   "error reading response body from registry",
 			wantStatusCode: http.StatusOK,
-			httpClient: &http.Client{
-				Transport: &mockRoundTripper{
-					forwardResponse: &http.Response{
-						StatusCode: http.StatusOK,
-						Body:       mockErrorReadCloser{err: errors.New("foo")},
-					},
-				},
+			handlerFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Length", "1000") // Set incorrect content length
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("{")) // Only write a partial response
+				// The connection will close after handler returns, but client will expect more data
 			},
 		},
 		"shall fail to deserialize JSON response": {
 			src:            "foo/bar/baz",
 			wantErrorStr:   `module "foo/bar/baz" version "0.2.0" failed to deserialize response body {: unexpected end of JSON input`,
 			wantStatusCode: http.StatusOK,
-			httpClient: &http.Client{
-				Transport: &mockRoundTripper{
-					forwardResponse: &http.Response{
-						StatusCode: http.StatusOK,
-						Body:       io.NopCloser(strings.NewReader("{")),
-					},
-				},
+			handlerFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("{"))
 			},
 		},
 		"shall fail because of unexpected protocol change - 422 http status": {
 			src:            "foo/bar/baz",
-			wantErrorStr:   `error getting download location for "foo/bar/baz": foo resp:bar`,
+			wantErrorStr:   `error getting download location for "foo/bar/baz": 422 Unprocessable Entity resp:bar`,
 			wantStatusCode: http.StatusUnprocessableEntity,
-			httpClient: &http.Client{
-				Transport: &mockRoundTripper{
-					forwardResponse: &http.Response{
-						StatusCode: http.StatusUnprocessableEntity,
-						Status:     "foo",
-						Body:       io.NopCloser(strings.NewReader("bar")),
-					},
-				},
+			handlerFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				w.Write([]byte("bar"))
 			},
 		},
 		"shall fail because location is not found in the response": {
 			src:            "foo/bar/baz",
-			wantErrorStr:   `failed to get download URL for "foo/bar/baz": OK resp:{"foo":"git::https://github.com/foo/terraform-baz-bar?ref=v0.2.0"}`,
+			wantErrorStr:   `failed to get download URL for "foo/bar/baz": 200 OK resp:{"foo":"git::https://github.com/foo/terraform-baz-bar?ref=v0.2.0"}`,
 			wantStatusCode: http.StatusOK,
-			httpClient: &http.Client{
-				Transport: &mockRoundTripper{
-					forwardResponse: &http.Response{
-						StatusCode: http.StatusOK,
-						Status:     "OK",
-						// note that the response emulates a contract change
-						Body: io.NopCloser(strings.NewReader(`{"foo":"git::https://github.com/foo/terraform-baz-bar?ref=v0.2.0"}`)),
-					},
-				},
+			handlerFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				// note that the response emulates a contract change
+				w.Write([]byte(`{"foo":"git::https://github.com/foo/terraform-baz-bar?ref=v0.2.0"}`))
 			},
 		},
 	}
@@ -482,10 +472,18 @@ func TestModuleLocation_readRegistryResponse(t *testing.T) {
 	t.Parallel()
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			server := test.Registry(tc.registryFlags...)
-			defer server.Close()
+			mockServer := httptest.NewServer(http.HandlerFunc(tc.handlerFunc))
+			defer mockServer.Close()
 
-			client := NewClient(test.Disco(server), tc.httpClient)
+			registryServer := test.Registry(tc.registryFlags...)
+			defer registryServer.Close()
+
+			transport := &testTransport{
+				mockURL: mockServer.URL,
+			}
+			client := NewClient(test.Disco(registryServer), &http.Client{
+				Transport: transport,
+			})
 
 			mod, err := regsrc.ParseModuleSource(tc.src)
 			if err != nil {
@@ -493,62 +491,66 @@ func TestModuleLocation_readRegistryResponse(t *testing.T) {
 			}
 
 			got, err := client.ModuleLocation(context.Background(), mod, "0.2.0")
+
+			// Validate the results
 			if err != nil && tc.wantErrorStr == "" {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if err != nil && err.Error() != tc.wantErrorStr {
+			if err != nil && !strings.Contains(err.Error(), tc.wantErrorStr) {
 				t.Fatalf("unexpected error content: want=%s, got=%v", tc.wantErrorStr, err)
 			}
 			if got != tc.want {
 				t.Fatalf("unexpected location: want=%s, got=%v", tc.want, got)
 			}
 
-			gotStatusCode := tc.httpClient.Transport.(*mockRoundTripper).reverseResponse.StatusCode
-			if tc.wantStatusCode != gotStatusCode {
-				t.Fatalf("unexpected response status code: want=%d, got=%d", tc.wantStatusCode, gotStatusCode)
-			}
+			// Verify status code if we have a successful response
+			if transport.lastResponse != nil {
+				gotStatusCode := transport.lastResponse.StatusCode
+				if tc.wantStatusCode != gotStatusCode {
+					t.Fatalf("unexpected response status code: want=%d, got=%d", tc.wantStatusCode, gotStatusCode)
+				}
 
-			if tc.wantToReadFromHeader {
-				resp := tc.httpClient.Transport.(*mockRoundTripper).reverseResponse
-				if !reflect.DeepEqual(resp.Body, http.NoBody) {
-					t.Fatalf("expected no body")
+				// Check if we expected to read from header
+				if tc.wantToReadFromHeader && err == nil {
+					headerVal := transport.lastResponse.Header.Get("X-Terraform-Get")
+					if headerVal == "" {
+						t.Fatalf("expected to read location from header but X-Terraform-Get header was not set")
+					}
 				}
 			}
 		})
 	}
 }
 
-type mockRoundTripper struct {
-	// response to return without calling the server
-	// SET TO USE AS A REVERSE PROXY
-	forwardResponse *http.Response
-	// the response from the server will be written here
-	// DO NOT SET
-	reverseResponse *http.Response
-	err             error
+// testTransport is a custom http.RoundTripper that redirects requests to the mock server
+// and captures the response for inspection
+type testTransport struct {
+	mockURL string
+	// Store the last response received from the mock server
+	lastResponse *http.Response
 }
 
-func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	if m.err != nil {
-		return nil, m.err
+func (t *testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Create a new request to the mock server with the same path, method, body, etc.
+	mockReq := &http.Request{
+		Method: req.Method,
+		URL: &url.URL{
+			Scheme: "http",
+			Host:   strings.TrimPrefix(t.mockURL, "http://"),
+			Path:   req.URL.Path,
+		},
+		Header:     req.Header,
+		Body:       req.Body,
+		Host:       req.Host,
+		Proto:      req.Proto,
+		ProtoMajor: req.ProtoMajor,
+		ProtoMinor: req.ProtoMinor,
 	}
-	if m.forwardResponse != nil {
-		m.reverseResponse = m.forwardResponse
-		return m.forwardResponse, nil
+
+	// Send the request to the mock server
+	resp, err := http.DefaultTransport.RoundTrip(mockReq)
+	if err == nil {
+		t.lastResponse = resp
 	}
-	resp, err := http.DefaultTransport.RoundTrip(req)
-	m.reverseResponse = resp
 	return resp, err
-}
-
-type mockErrorReadCloser struct {
-	err error
-}
-
-func (m mockErrorReadCloser) Read(_ []byte) (n int, err error) {
-	return 0, m.err
-}
-
-func (m mockErrorReadCloser) Close() error {
-	return m.err
 }


### PR DESCRIPTION
The hard cast to mockRoundTripper caused issues as tests relied on client having full control of the transport, which is not always the case

<!-- If your PR resolves an issue, please add it here. -->
Helps #2711

## Target Release

1.10.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.
