### PR TITLE
Parallelize provider installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ ENHANCEMENTS:
 - `prevent_destroy` arguments in the `lifecycle` block for managed resources can now use references to other symbols in the same module, such as to a module's input variables. ([#3474](https://github.com/opentofu/opentofu/issues/3474), [#3507](https://github.com/opentofu/opentofu/issues/3507))
 - OpenTofu now uses the `BROWSER` environment variable when launching a web browser on Unix platforms, as long as it's set to a single command that can accept a URL to open as its first and only argument. ([#3456](https://github.com/opentofu/opentofu/issues/3456))
 - Improve performance around provider checking and schema management. ([#2730](https://github.com/opentofu/opentofu/pull/2730))
+- `tofu init` now fetches providers and their metadata in parallel. Depending on provider size and network properties, this can reduce provider installation and checking time. ([#2729](https://github.com/opentofu/opentofu/pull/2729))
 
 BUG FIXES:
 

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -961,7 +961,7 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 		},
 	}
 	// Ensure that events emitted on multiple routines do not trigger race conditions
-	evts = evts.Serialized()
+	evts = evts.Sync()
 	ctx = evts.OnContext(ctx)
 
 	mode := providercache.InstallNewProvidersOnly

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -960,6 +960,8 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 			}
 		},
 	}
+	// Ensure that events emitted on multiple routines do not trigger race conditions
+	evts = evts.Serialized()
 	ctx = evts.OnContext(ctx)
 
 	mode := providercache.InstallNewProvidersOnly

--- a/internal/command/providers_lock.go
+++ b/internal/command/providers_lock.go
@@ -269,7 +269,7 @@ func (c *ProvidersLockCommand) Run(args []string) int {
 			},
 		}
 		// Ensure that events emitted on multiple routines do not trigger race conditions
-		evts = evts.Serialized()
+		evts = evts.Sync()
 		ctx := evts.OnContext(ctx)
 
 		dir := providercache.NewDirWithPlatform(tempDir, platform)

--- a/internal/command/providers_lock.go
+++ b/internal/command/providers_lock.go
@@ -268,6 +268,8 @@ func (c *ProvidersLockCommand) Run(args []string) int {
 				c.Ui.Output(fmt.Sprintf("- Retrieved %s %s for %s (%s%s)", provider.ForDisplay(), version, platform, auth, keyID))
 			},
 		}
+		// Ensure that events emitted on multiple routines do not trigger race conditions
+		evts = evts.Serialized()
 		ctx := evts.OnContext(ctx)
 
 		dir := providercache.NewDirWithPlatform(tempDir, platform)

--- a/internal/getproviders/filesystem_mirror_source.go
+++ b/internal/getproviders/filesystem_mirror_source.go
@@ -8,6 +8,7 @@ package getproviders
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/apparentlymart/go-versions/versions"
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -22,6 +23,8 @@ type FilesystemMirrorSource struct {
 	// packages on the first call that needs package availability information,
 	// to avoid re-scanning the filesystem on subsequent operations.
 	allPackages map[addrs.Provider]PackageMetaList
+
+	lock sync.Mutex
 }
 
 var _ Source = (*FilesystemMirrorSource)(nil)
@@ -117,6 +120,9 @@ func (s *FilesystemMirrorSource) AllAvailablePackages() (map[addrs.Provider]Pack
 }
 
 func (s *FilesystemMirrorSource) scanAllVersions() error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
 	if s.allPackages != nil {
 		// we're distinguishing nil-ness from emptiness here so we can
 		// recognize when we've scanned the directory without errors, even

--- a/internal/providercache/installer.go
+++ b/internal/providercache/installer.go
@@ -444,7 +444,7 @@ func (i *Installer) ensureProviderVersionsNeed(
 	}
 
 	need := map[addrs.Provider]getproviders.Version{}
-	for _ = range mightNeed {
+	for range mightNeed {
 		r := <-results
 		if r.err != nil {
 			errs[r.provider] = r.err
@@ -510,7 +510,7 @@ func (i *Installer) ensureProviderVersionsInstall(
 		}(provider, version)
 	}
 
-	for _ = range need {
+	for range need {
 		i := <-results
 
 		if i.authResult != nil {

--- a/internal/providercache/installer.go
+++ b/internal/providercache/installer.go
@@ -496,7 +496,7 @@ func (i *Installer) ensureProviderVersionsInstall(
 			)
 			defer span.End()
 
-			authResult, newHashes, err := i.ensureProviderVersionInstalled(traceCtx, locks.Provider(provider), reqs[provider], mode, provider, version, targetPlatform)
+			authResult, newHashes, err := i.ensureProviderVersionInstalled(traceCtx, locks.Provider(provider), mode, provider, version, targetPlatform)
 			if err != nil {
 				tracing.SetSpanError(span, err)
 			}
@@ -530,7 +530,6 @@ func (i *Installer) ensureProviderVersionsInstall(
 func (i *Installer) ensureProviderVersionInstalled(
 	ctx context.Context,
 	lock *depsfile.ProviderLock,
-	constraint getproviders.VersionConstraints,
 	mode InstallMode,
 	provider addrs.Provider,
 	version getproviders.Version,
@@ -565,7 +564,7 @@ func (i *Installer) ensureProviderVersionInstalled(
 		linkTo = nil // no linking needed
 	}
 
-	result, newHashes, err := i.ensureProviderVersionInDirectory(ctx, lock, constraint, mode, provider, version, targetPlatform, installTo)
+	result, newHashes, err := i.ensureProviderVersionInDirectory(ctx, lock, mode, provider, version, targetPlatform, installTo)
 
 	if err != nil {
 		return result, newHashes, err
@@ -618,7 +617,6 @@ func (i *Installer) ensureProviderVersionInstalled(
 func (i *Installer) ensureProviderVersionInDirectory(
 	ctx context.Context,
 	lock *depsfile.ProviderLock,
-	constraint getproviders.VersionConstraints,
 	mode InstallMode,
 	provider addrs.Provider,
 	version getproviders.Version,

--- a/internal/providercache/installer_events.go
+++ b/internal/providercache/installer_events.go
@@ -152,10 +152,10 @@ func (e *InstallerEvents) OnContext(ctx context.Context) context.Context {
 	return context.WithValue(ctx, ctxInstallerEvents, e)
 }
 
-// As these events may be emitted by multiple go-routines. This wraps the
-// events in a single lock to allow consumers of the InstallerEvents concept
-// to not have to worry about race conditions
-func (e *InstallerEvents) Serialized() *InstallerEvents {
+// Sync wraps the events in a single lock to allow consumers of the
+// InstallerEvents concept to not have to worry about race conditions
+// as these events may be emitted by multiple go-routines
+func (e *InstallerEvents) Sync() *InstallerEvents {
 	lock := sync.Mutex{}
 
 	return &InstallerEvents{

--- a/internal/providercache/installer_events.go
+++ b/internal/providercache/installer_events.go
@@ -7,6 +7,7 @@ package providercache
 
 import (
 	"context"
+	"sync"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/getproviders"
@@ -149,6 +150,142 @@ type InstallerEvents struct {
 // installer to send event notifications via the callbacks inside.
 func (e *InstallerEvents) OnContext(ctx context.Context) context.Context {
 	return context.WithValue(ctx, ctxInstallerEvents, e)
+}
+
+// As these events may be emitted by multiple go-routines. This wraps the
+// events in a single lock to allow consumers of the InstallerEvents concept
+// to not have to worry about race conditions
+func (e *InstallerEvents) Serialized() *InstallerEvents {
+	lock := sync.Mutex{}
+
+	return &InstallerEvents{
+		PendingProviders: func(reqs map[addrs.Provider]getproviders.VersionConstraints) {
+			lock.Lock()
+			defer lock.Unlock()
+			if e.PendingProviders != nil {
+				e.PendingProviders(reqs)
+			}
+		},
+		ProviderAlreadyInstalled: func(provider addrs.Provider, selectedVersion getproviders.Version, inProviderCache bool) {
+			lock.Lock()
+			defer lock.Unlock()
+			if e.ProviderAlreadyInstalled != nil {
+				e.ProviderAlreadyInstalled(provider, selectedVersion, inProviderCache)
+			}
+		},
+		BuiltInProviderAvailable: func(provider addrs.Provider) {
+			lock.Lock()
+			defer lock.Unlock()
+			if e.BuiltInProviderAvailable != nil {
+				e.BuiltInProviderAvailable(provider)
+			}
+		},
+		BuiltInProviderFailure: func(provider addrs.Provider, err error) {
+			lock.Lock()
+			defer lock.Unlock()
+			if e.BuiltInProviderFailure != nil {
+				e.BuiltInProviderFailure(provider, err)
+			}
+		},
+		QueryPackagesBegin: func(provider addrs.Provider, versionConstraints getproviders.VersionConstraints, locked bool) {
+			lock.Lock()
+			defer lock.Unlock()
+			if e.QueryPackagesBegin != nil {
+				e.QueryPackagesBegin(provider, versionConstraints, locked)
+			}
+		},
+		QueryPackagesSuccess: func(provider addrs.Provider, selectedVersion getproviders.Version) {
+			lock.Lock()
+			defer lock.Unlock()
+			if e.QueryPackagesSuccess != nil {
+				e.QueryPackagesSuccess(provider, selectedVersion)
+			}
+		},
+		QueryPackagesFailure: func(provider addrs.Provider, err error) {
+			lock.Lock()
+			defer lock.Unlock()
+			if e.QueryPackagesFailure != nil {
+				e.QueryPackagesFailure(provider, err)
+			}
+		},
+		QueryPackagesWarning: func(provider addrs.Provider, warn []string) {
+			lock.Lock()
+			defer lock.Unlock()
+			if e.QueryPackagesWarning != nil {
+				e.QueryPackagesWarning(provider, warn)
+			}
+		},
+		LinkFromCacheBegin: func(provider addrs.Provider, version getproviders.Version, cacheRoot string) {
+			lock.Lock()
+			defer lock.Unlock()
+			if e.LinkFromCacheBegin != nil {
+				e.LinkFromCacheBegin(provider, version, cacheRoot)
+			}
+		},
+		LinkFromCacheSuccess: func(provider addrs.Provider, version getproviders.Version, localDir string) {
+			lock.Lock()
+			defer lock.Unlock()
+			if e.LinkFromCacheSuccess != nil {
+				e.LinkFromCacheSuccess(provider, version, localDir)
+			}
+		},
+		LinkFromCacheFailure: func(provider addrs.Provider, version getproviders.Version, err error) {
+			lock.Lock()
+			defer lock.Unlock()
+			if e.LinkFromCacheFailure != nil {
+				e.LinkFromCacheFailure(provider, version, err)
+			}
+		},
+		FetchPackageMeta: func(provider addrs.Provider, version getproviders.Version) {
+			lock.Lock()
+			defer lock.Unlock()
+			if e.FetchPackageMeta != nil {
+				e.FetchPackageMeta(provider, version)
+			}
+		},
+		FetchPackageBegin: func(provider addrs.Provider, version getproviders.Version, location getproviders.PackageLocation, inProviderCache bool) {
+			lock.Lock()
+			defer lock.Unlock()
+			if e.FetchPackageBegin != nil {
+				e.FetchPackageBegin(provider, version, location, inProviderCache)
+			}
+		},
+		FetchPackageSuccess: func(provider addrs.Provider, version getproviders.Version, localDir string, authResult *getproviders.PackageAuthenticationResult) {
+			lock.Lock()
+			defer lock.Unlock()
+			if e.FetchPackageSuccess != nil {
+				e.FetchPackageSuccess(provider, version, localDir, authResult)
+			}
+		},
+		FetchPackageFailure: func(provider addrs.Provider, version getproviders.Version, err error) {
+			lock.Lock()
+			defer lock.Unlock()
+			if e.FetchPackageFailure != nil {
+				e.FetchPackageFailure(provider, version, err)
+			}
+		},
+		CacheDirLockContended: func(cacheDir string) {
+			lock.Lock()
+			defer lock.Unlock()
+			if e.CacheDirLockContended != nil {
+				e.CacheDirLockContended(cacheDir)
+			}
+		},
+		ProvidersLockUpdated: func(provider addrs.Provider, version getproviders.Version, localHashes []getproviders.Hash, signedHashes []getproviders.Hash, priorHashes []getproviders.Hash) {
+			lock.Lock()
+			defer lock.Unlock()
+			if e.ProvidersLockUpdated != nil {
+				e.ProvidersLockUpdated(provider, version, localHashes, signedHashes, priorHashes)
+			}
+		},
+		ProvidersAuthenticated: func(authResults map[addrs.Provider]*getproviders.PackageAuthenticationResult) {
+			lock.Lock()
+			defer lock.Unlock()
+			if e.ProvidersAuthenticated != nil {
+				e.ProvidersAuthenticated(authResults)
+			}
+		},
+	}
 }
 
 // installerEventsForContext looks on the given context for a registered


### PR DESCRIPTION
Now that https://github.com/opentofu/opentofu/pull/2726 is merged, we can safely parallelize the provider installation process.

This PR makes two direct changes:
* Fetch each provider version metadata in it's  own go routine
* Fetch each provider version binary in it's own go routine

And one secondary change: Modify the memoize source to be more granular.  This was necessary to allow the metadata fetching to happen in parallel.  Discovering this was helped with @Yantrio's recent OTel tracing PRs :+1: 

Considerations:
* Go channels paired with result structs were used in this PR.  It could easily be adapted to sync.WaitGroup and locking instead.
* This will now send of lots of requests to the provider source (meta and download), which we may want to consider a rate limit for.  I haven't hit this (yet) in testing, but it is worth considering.
* Each commit message is well formatted so this PR should be squashed

Anecdata:
* Cold cache `tofu init` with 5 large providers: 13s -> 7s (depending on network throughput)
* Warm cache `tofu init` with 5 large providers: 2.2s -> 1.3s

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
