### PR TITLE
 Add context propagation to Command Meta entrypoint methods

### DIFF
--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -114,7 +115,7 @@ func (c *ApplyCommand) Run(rawArgs []string) int {
 
 	// Prepare the backend, passing the plan file if present, and the
 	// backend-specific arguments
-	be, beDiags := c.PrepareBackend(planFile, args.State, args.ViewType, enc.State())
+	be, beDiags := c.PrepareBackend(ctx, planFile, args.State, args.ViewType, enc.State())
 	diags = diags.Append(beDiags)
 	if diags.HasErrors() {
 		view.Diagnostics(diags)
@@ -207,7 +208,7 @@ func (c *ApplyCommand) LoadPlanFile(path string, enc encryption.Encryption) (*pl
 	return planFile, diags
 }
 
-func (c *ApplyCommand) PrepareBackend(planFile *planfile.WrappedPlanFile, args *arguments.State, viewType arguments.ViewType, enc encryption.StateEncryption) (backend.Enhanced, tfdiags.Diagnostics) {
+func (c *ApplyCommand) PrepareBackend(ctx context.Context, planFile *planfile.WrappedPlanFile, args *arguments.State, viewType arguments.ViewType, enc encryption.StateEncryption) (backend.Enhanced, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	// FIXME: we need to apply the state arguments to the meta object here
@@ -247,7 +248,7 @@ func (c *ApplyCommand) PrepareBackend(planFile *planfile.WrappedPlanFile, args *
 			return nil, diags
 		}
 
-		be, beDiags = c.Backend(&BackendOpts{
+		be, beDiags = c.Backend(ctx, &BackendOpts{
 			Config:   backendConfig,
 			ViewType: viewType,
 		}, enc)

--- a/internal/command/autocomplete.go
+++ b/internal/command/autocomplete.go
@@ -6,6 +6,8 @@
 package command
 
 import (
+	"context"
+
 	"github.com/posener/complete"
 )
 
@@ -33,7 +35,7 @@ func (s completePredictSequence) Predict(a complete.Args) []string {
 	return s[idx].Predict(a)
 }
 
-func (m *Meta) completePredictWorkspaceName() complete.Predictor {
+func (m *Meta) completePredictWorkspaceName(ctx context.Context) complete.Predictor {
 	return complete.PredictFunc(func(a complete.Args) []string {
 		// There are lot of things that can fail in here, so if we encounter
 		// any error then we'll just return nothing and not support autocomplete
@@ -61,7 +63,7 @@ func (m *Meta) completePredictWorkspaceName() complete.Predictor {
 			return nil
 		}
 
-		b, diags := m.Backend(&BackendOpts{
+		b, diags := m.Backend(ctx, &BackendOpts{
 			Config: backendConfig,
 		}, enc.State())
 		if diags.HasErrors() {

--- a/internal/command/autocomplete.go
+++ b/internal/command/autocomplete.go
@@ -52,13 +52,13 @@ func (m *Meta) completePredictWorkspaceName(ctx context.Context) complete.Predic
 			return nil
 		}
 
-		backendConfig, diags := m.loadBackendConfig(configPath)
+		backendConfig, diags := m.loadBackendConfig(ctx, configPath)
 		if diags.HasErrors() {
 			return nil
 		}
 
 		// Load the encryption configuration
-		enc, encDiags := m.Encryption()
+		enc, encDiags := m.Encryption(ctx)
 		if encDiags.HasErrors() {
 			return nil
 		}

--- a/internal/command/autocomplete_test.go
+++ b/internal/command/autocomplete_test.go
@@ -29,7 +29,7 @@ func TestMetaCompletePredictWorkspaceName(t *testing.T) {
 	ui := new(cli.MockUi)
 	meta := &Meta{Ui: ui}
 
-	predictor := meta.completePredictWorkspaceName()
+	predictor := meta.completePredictWorkspaceName(t.Context())
 
 	got := predictor.Predict(complete.Args{
 		Last: "",

--- a/internal/command/console.go
+++ b/internal/command/console.go
@@ -70,7 +70,7 @@ func (c *ConsoleCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(&BackendOpts{
+	b, backendDiags := c.Backend(ctx, &BackendOpts{
 		Config: backendConfig,
 	}, enc.State())
 	diags = diags.Append(backendDiags)

--- a/internal/command/console.go
+++ b/internal/command/console.go
@@ -55,14 +55,14 @@ func (c *ConsoleCommand) Run(args []string) int {
 	var diags tfdiags.Diagnostics
 
 	// Load the encryption configuration
-	enc, encDiags := c.EncryptionFromPath(configPath)
+	enc, encDiags := c.EncryptionFromPath(ctx,configPath)
 	diags = diags.Append(encDiags)
 	if encDiags.HasErrors() {
 		c.showDiagnostics(diags)
 		return 1
 	}
 
-	backendConfig, backendDiags := c.loadBackendConfig(configPath)
+	backendConfig, backendDiags := c.loadBackendConfig(ctx, configPath)
 	diags = diags.Append(backendDiags)
 	if diags.HasErrors() {
 		c.showDiagnostics(diags)
@@ -91,7 +91,7 @@ func (c *ConsoleCommand) Run(args []string) int {
 	c.ignoreRemoteVersionConflict(b)
 
 	// Build the operation
-	opReq := c.Operation(b, arguments.ViewHuman, enc)
+	opReq := c.Operation(ctx, b, arguments.ViewHuman, enc)
 	opReq.ConfigDir = configPath
 	opReq.ConfigLoader, err = c.initConfigLoader()
 	opReq.AllowUnsetVariables = true // we'll just evaluate them as unknown
@@ -105,7 +105,7 @@ func (c *ConsoleCommand) Run(args []string) int {
 		// Setup required variables/call for operation (usually done in Meta.RunOperation)
 		var moreDiags, callDiags tfdiags.Diagnostics
 		opReq.Variables, moreDiags = c.collectVariableValues()
-		opReq.RootCall, callDiags = c.rootModuleCall(opReq.ConfigDir)
+		opReq.RootCall, callDiags = c.rootModuleCall(ctx, opReq.ConfigDir)
 		diags = diags.Append(moreDiags).Append(callDiags)
 		if moreDiags.HasErrors() {
 			c.showDiagnostics(diags)

--- a/internal/command/graph.go
+++ b/internal/command/graph.go
@@ -62,7 +62,7 @@ func (c *GraphCommand) Run(args []string) int {
 	}
 
 	// Load the encryption configuration
-	enc, encDiags := c.EncryptionFromPath(configPath)
+	enc, encDiags := c.EncryptionFromPath(ctx, configPath)
 	diags = diags.Append(encDiags)
 	if encDiags.HasErrors() {
 		c.showDiagnostics(diags)
@@ -103,14 +103,14 @@ func (c *GraphCommand) Run(args []string) int {
 			return 1
 		}
 		var backendDiags tfdiags.Diagnostics
-		b, backendDiags = c.BackendForLocalPlan(plan.Backend, enc.State())
+		b, backendDiags = c.BackendForLocalPlan(ctx, plan.Backend, enc.State())
 		diags = diags.Append(backendDiags)
 		if backendDiags.HasErrors() {
 			c.showDiagnostics(diags)
 			return 1
 		}
 	} else {
-		backendConfig, backendDiags := c.loadBackendConfig(configPath)
+		backendConfig, backendDiags := c.loadBackendConfig(ctx, configPath)
 		diags = diags.Append(backendDiags)
 		if diags.HasErrors() {
 			c.showDiagnostics(diags)
@@ -139,7 +139,7 @@ func (c *GraphCommand) Run(args []string) int {
 	c.ignoreRemoteVersionConflict(b)
 
 	// Build the operation
-	opReq := c.Operation(b, arguments.ViewHuman, enc)
+	opReq := c.Operation(ctx, b, arguments.ViewHuman, enc)
 	opReq.ConfigDir = configPath
 	opReq.ConfigLoader, err = c.initConfigLoader()
 	opReq.PlanFile = planFile
@@ -147,7 +147,7 @@ func (c *GraphCommand) Run(args []string) int {
 
 	// Inject information required for static evaluation
 	var callDiags tfdiags.Diagnostics
-	opReq.RootCall, callDiags = c.rootModuleCall(opReq.ConfigDir)
+	opReq.RootCall, callDiags = c.rootModuleCall(ctx, opReq.ConfigDir)
 	diags = diags.Append(callDiags)
 	if callDiags.HasErrors() {
 		c.showDiagnostics(diags)

--- a/internal/command/graph.go
+++ b/internal/command/graph.go
@@ -117,7 +117,7 @@ func (c *GraphCommand) Run(args []string) int {
 			return 1
 		}
 
-		b, backendDiags = c.Backend(&BackendOpts{
+		b, backendDiags = c.Backend(ctx, &BackendOpts{
 			Config: backendConfig,
 		}, enc.State())
 		diags = diags.Append(backendDiags)

--- a/internal/command/import.go
+++ b/internal/command/import.go
@@ -106,7 +106,7 @@ func (c *ImportCommand) Run(args []string) int {
 
 	// Load the full config, so we can verify that the target resource is
 	// already configured.
-	config, configDiags := c.loadConfig(configPath)
+	config, configDiags := c.loadConfig(ctx, configPath)
 	diags = diags.Append(configDiags)
 	if configDiags.HasErrors() {
 		c.showDiagnostics(diags)
@@ -114,7 +114,7 @@ func (c *ImportCommand) Run(args []string) int {
 	}
 
 	// Load the encryption configuration
-	enc, encDiags := c.EncryptionFromPath(configPath)
+	enc, encDiags := c.EncryptionFromPath(ctx, configPath)
 	diags = diags.Append(encDiags)
 	if encDiags.HasErrors() {
 		c.showDiagnostics(diags)
@@ -197,7 +197,7 @@ func (c *ImportCommand) Run(args []string) int {
 	}
 
 	// Build the operation
-	opReq := c.Operation(b, arguments.ViewHuman, enc)
+	opReq := c.Operation(ctx, b, arguments.ViewHuman, enc)
 	opReq.ConfigDir = configPath
 	opReq.ConfigLoader, err = c.initConfigLoader()
 	if err != nil {
@@ -210,7 +210,7 @@ func (c *ImportCommand) Run(args []string) int {
 		// Setup required variables/call for operation (usually done in Meta.RunOperation)
 		var moreDiags, callDiags tfdiags.Diagnostics
 		opReq.Variables, moreDiags = c.collectVariableValues()
-		opReq.RootCall, callDiags = c.rootModuleCall(opReq.ConfigDir)
+		opReq.RootCall, callDiags = c.rootModuleCall(ctx, opReq.ConfigDir)
 		diags = diags.Append(moreDiags).Append(callDiags)
 		if moreDiags.HasErrors() {
 			c.showDiagnostics(diags)
@@ -271,7 +271,7 @@ func (c *ImportCommand) Run(args []string) int {
 	var schemas *tofu.Schemas
 	if isCloudMode(b) {
 		var schemaDiags tfdiags.Diagnostics
-		schemas, schemaDiags = c.MaybeGetSchemas(newState, nil)
+		schemas, schemaDiags = c.MaybeGetSchemas(ctx, newState, nil)
 		diags = diags.Append(schemaDiags)
 	}
 

--- a/internal/command/import.go
+++ b/internal/command/import.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/backend"
 	"github.com/opentofu/opentofu/internal/command/arguments"
@@ -175,7 +176,7 @@ func (c *ImportCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(&BackendOpts{
+	b, backendDiags := c.Backend(ctx, &BackendOpts{
 		Config: config.Module.Backend,
 	}, enc.State())
 	diags = diags.Append(backendDiags)

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -195,7 +195,7 @@ func (c *InitCommand) Run(args []string) int {
 	}
 
 	// Load just the root module to begin backend and module initialization
-	rootModEarly, earlyConfDiags := c.loadSingleModuleWithTests(path, testsDirectory)
+	rootModEarly, earlyConfDiags := c.loadSingleModuleWithTests(ctx, path, testsDirectory)
 
 	// There may be parsing errors in config loading but these will be shown later _after_
 	// checking for core version requirement errors. Not meeting the version requirement should
@@ -251,7 +251,7 @@ func (c *InitCommand) Run(args []string) int {
 	// of provider dependencies.
 	if back != nil {
 		c.ignoreRemoteVersionConflict(back)
-		workspace, err := c.Workspace()
+		workspace, err := c.Workspace(ctx)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
 			return 1
@@ -284,7 +284,7 @@ func (c *InitCommand) Run(args []string) int {
 
 	// With all of the modules (hopefully) installed, we can now try to load the
 	// whole configuration tree.
-	config, confDiags := c.loadConfigWithTests(path, testsDirectory)
+	config, confDiags := c.loadConfigWithTests(ctx, path, testsDirectory)
 	// configDiags will be handled after the version constraint check, since an
 	// incorrect version of tofu may be producing errors for configuration
 	// constructs added in later versions.

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -469,7 +469,7 @@ func (c *InitCommand) initCloud(ctx context.Context, root *configs.Module, extra
 		Init:   true,
 	}
 
-	back, backDiags := c.Backend(opts, enc.State())
+	back, backDiags := c.Backend(ctx, opts, enc.State())
 	diags = diags.Append(backDiags)
 	return back, true, diags
 }
@@ -552,7 +552,7 @@ the backend configuration is present and valid.
 		Init:           true,
 	}
 
-	back, backDiags := c.Backend(opts, enc.State())
+	back, backDiags := c.Backend(ctx, opts, enc.State())
 	diags = diags.Append(backDiags)
 	return back, true, diags
 }

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -820,7 +820,7 @@ func TestInit_backendReinitWithExtra(t *testing.T) {
 		Init: true,
 	}
 
-	_, cHash, err := m.backendConfig(opts)
+	_, cHash, err := m.backendConfig(t.Context(), opts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -91,7 +91,7 @@ type BackendWithRemoteTerraformVersion interface {
 // A side-effect of this method is the population of m.backendState, recording
 // the final resolved backend configuration after dealing with overrides from
 // the "tofu init" command line, etc.
-func (m *Meta) Backend(opts *BackendOpts, enc encryption.StateEncryption) (backend.Enhanced, tfdiags.Diagnostics) {
+func (m *Meta) Backend(ctx context.Context, opts *BackendOpts, enc encryption.StateEncryption) (backend.Enhanced, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	// If no opts are set, then initialize
@@ -104,7 +104,7 @@ func (m *Meta) Backend(opts *BackendOpts, enc encryption.StateEncryption) (backe
 	var b backend.Backend
 	if !opts.ForceLocal {
 		var backendDiags tfdiags.Diagnostics
-		b, backendDiags = m.backendFromConfig(opts, enc)
+		b, backendDiags = m.backendFromConfig(ctx, opts, enc)
 		diags = diags.Append(backendDiags)
 
 		if diags.HasErrors() {
@@ -532,7 +532,7 @@ func (m *Meta) backendConfig(opts *BackendOpts) (*configs.Backend, int, tfdiags.
 //
 // This function may query the user for input unless input is disabled, in
 // which case this function will error.
-func (m *Meta) backendFromConfig(opts *BackendOpts, enc encryption.StateEncryption) (backend.Backend, tfdiags.Diagnostics) {
+func (m *Meta) backendFromConfig(ctx context.Context, opts *BackendOpts, enc encryption.StateEncryption) (backend.Backend, tfdiags.Diagnostics) {
 	// Get the local backend configuration.
 	c, cHash, diags := m.backendConfig(opts)
 	if diags.HasErrors() {
@@ -631,7 +631,7 @@ func (m *Meta) backendFromConfig(opts *BackendOpts, enc encryption.StateEncrypti
 			return nil, diags
 		}
 
-		return m.backend_c_r_S(c, cHash, sMgr, true, opts, enc)
+		return m.backend_c_r_S(ctx, c, cHash, sMgr, true, opts, enc)
 
 	// Configuring a backend for the first time or -reconfigure flag was used
 	case c != nil && s.Backend.Empty():
@@ -654,7 +654,7 @@ func (m *Meta) backendFromConfig(opts *BackendOpts, enc encryption.StateEncrypti
 			}
 			return nil, diags
 		}
-		return m.backend_C_r_s(c, cHash, sMgr, opts, enc)
+		return m.backend_C_r_s(ctx, c, cHash, sMgr, opts, enc)
 	// Potentially changing a backend configuration
 	case c != nil && !s.Backend.Empty():
 		// We are not going to migrate if...
@@ -877,6 +877,7 @@ func (m *Meta) backendFromState(ctx context.Context, enc encryption.StateEncrypt
 
 // Unconfiguring a backend (moving from backend => local).
 func (m *Meta) backend_c_r_S(
+	ctx context.Context,
 	c *configs.Backend, cHash int, sMgr *clistate.LocalState, output bool, opts *BackendOpts, enc encryption.StateEncryption) (backend.Backend, tfdiags.Diagnostics) {
 
 	var diags tfdiags.Diagnostics
@@ -906,7 +907,7 @@ func (m *Meta) backend_c_r_S(
 	}
 
 	// Grab a purely local backend to get the local state if it exists
-	localB, moreDiags := m.Backend(&BackendOpts{ForceLocal: true, Init: true}, enc)
+	localB, moreDiags := m.Backend(ctx, &BackendOpts{ForceLocal: true, Init: true}, enc)
 	diags = diags.Append(moreDiags)
 	if moreDiags.HasErrors() {
 		return nil, diags
@@ -954,7 +955,7 @@ func (m *Meta) backend_c_r_S(
 }
 
 // Configuring a backend for the first time.
-func (m *Meta) backend_C_r_s(c *configs.Backend, cHash int, sMgr *clistate.LocalState, opts *BackendOpts, enc encryption.StateEncryption) (backend.Backend, tfdiags.Diagnostics) {
+func (m *Meta) backend_C_r_s(ctx context.Context, c *configs.Backend, cHash int, sMgr *clistate.LocalState, opts *BackendOpts, enc encryption.StateEncryption) (backend.Backend, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	vt := arguments.ViewJSON
@@ -965,7 +966,7 @@ func (m *Meta) backend_C_r_s(c *configs.Backend, cHash int, sMgr *clistate.Local
 	}
 
 	// Grab a purely local backend to get the local state if it exists
-	localB, localBDiags := m.Backend(&BackendOpts{ForceLocal: true, Init: true}, enc)
+	localB, localBDiags := m.Backend(ctx, &BackendOpts{ForceLocal: true, Init: true}, enc)
 	if localBDiags.HasErrors() {
 		diags = diags.Append(localBDiags)
 		return nil, diags

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -44,7 +44,7 @@ func TestMetaBackend_emptyDir(t *testing.T) {
 
 	// Get the backend
 	m := testMetaBackend(t, nil)
-	b, diags := m.Backend(&BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
+	b, diags := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -113,7 +113,7 @@ func TestMetaBackend_emptyWithDefaultState(t *testing.T) {
 
 	// Get the backend
 	m := testMetaBackend(t, nil)
-	b, diags := m.Backend(&BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
+	b, diags := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -184,7 +184,7 @@ func TestMetaBackend_emptyWithExplicitState(t *testing.T) {
 	m.statePath = statePath
 
 	// Get the backend
-	b, diags := m.Backend(&BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
+	b, diags := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -236,7 +236,7 @@ func TestMetaBackend_configureInterpolation(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	_, err := m.Backend(&BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
+	_, err := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
 	if err != nil {
 		t.Fatal("should not error")
 	}
@@ -252,7 +252,7 @@ func TestMetaBackend_configureNew(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, diags := m.Backend(&BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
+	b, diags := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -323,7 +323,7 @@ func TestMetaBackend_configureNewWithState(t *testing.T) {
 	m.migrateState = false
 
 	// Get the backend
-	b, diags := m.Backend(&BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
+	b, diags := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -398,7 +398,7 @@ func TestMetaBackend_configureNewWithoutCopy(t *testing.T) {
 	m.input = false
 
 	// init the backend
-	_, diags := m.Backend(&BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
+	_, diags := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -446,7 +446,7 @@ func TestMetaBackend_configureNewWithStateNoMigrate(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, diags := m.Backend(&BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
+	b, diags := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -489,7 +489,7 @@ func TestMetaBackend_configureNewWithStateExisting(t *testing.T) {
 	m.forceInitCopy = true
 
 	// Get the backend
-	b, diags := m.Backend(&BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
+	b, diags := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -561,7 +561,7 @@ func TestMetaBackend_configureNewWithStateExistingNoMigrate(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, diags := m.Backend(&BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
+	b, diags := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -626,7 +626,7 @@ func TestMetaBackend_configuredUnchanged(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, diags := m.Backend(&BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
+	b, diags := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -740,6 +740,7 @@ func TestMetaBackend_configuredUnchangedWithStaticEvalVars(t *testing.T) {
 
 	// Get the backend
 	b, diags := m.Backend(
+		t.Context(),
 		&BackendOpts{
 			Init: true,
 
@@ -817,7 +818,7 @@ func TestMetaBackend_configuredChange(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, diags := m.Backend(&BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
+	b, diags := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -903,7 +904,7 @@ func TestMetaBackend_reconfigureChange(t *testing.T) {
 	m.reconfigure = true
 
 	// Get the backend
-	b, diags := m.Backend(&BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
+	b, diags := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -950,7 +951,7 @@ func TestMetaBackend_initSelectedWorkspaceDoesNotExist(t *testing.T) {
 	})()
 
 	// Get the backend
-	_, diags := m.Backend(&BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
+	_, diags := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -992,7 +993,7 @@ func TestMetaBackend_initSelectedWorkspaceDoesNotExistAutoSelect(t *testing.T) {
 	}
 
 	// Get the backend
-	_, diags := m.Backend(&BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
+	_, diags := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -1021,7 +1022,7 @@ func TestMetaBackend_initSelectedWorkspaceDoesNotExistInputFalse(t *testing.T) {
 	m.input = false
 
 	// Get the backend
-	_, diags := m.Backend(&BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
+	_, diags := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
 
 	// Should fail immediately
 	if got, want := diags.ErrWithWarnings().Error(), `Currently selected workspace "bar" does not exist`; !strings.Contains(got, want) {
@@ -1043,7 +1044,7 @@ func TestMetaBackend_configuredChangeCopy(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, diags := m.Backend(&BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
+	b, diags := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -1096,7 +1097,7 @@ func TestMetaBackend_configuredChangeCopy_singleState(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, diags := m.Backend(&BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
+	b, diags := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -1150,7 +1151,7 @@ func TestMetaBackend_configuredChangeCopy_multiToSingleDefault(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, diags := m.Backend(&BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
+	b, diags := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -1204,7 +1205,7 @@ func TestMetaBackend_configuredChangeCopy_multiToSingle(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, diags := m.Backend(&BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
+	b, diags := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -1278,7 +1279,7 @@ func TestMetaBackend_configuredChangeCopy_multiToSingleCurrentEnv(t *testing.T) 
 	}
 
 	// Get the backend
-	b, diags := m.Backend(&BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
+	b, diags := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -1333,7 +1334,7 @@ func TestMetaBackend_configuredChangeCopy_multiToMulti(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, diags := m.Backend(&BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
+	b, diags := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -1431,7 +1432,7 @@ func TestMetaBackend_configuredChangeCopy_multiToNoDefaultWithDefault(t *testing
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, diags := m.Backend(&BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
+	b, diags := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -1505,7 +1506,7 @@ func TestMetaBackend_configuredChangeCopy_multiToNoDefaultWithoutDefault(t *test
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, diags := m.Backend(&BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
+	b, diags := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -1571,7 +1572,7 @@ func TestMetaBackend_configuredUnset(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, diags := m.Backend(&BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
+	b, diags := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -1633,7 +1634,7 @@ func TestMetaBackend_configuredUnsetCopy(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, diags := m.Backend(&BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
+	b, diags := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -1973,7 +1974,7 @@ func TestMetaBackend_configureWithExtra(t *testing.T) {
 	}
 
 	// init the backend
-	_, diags := m.Backend(&BackendOpts{
+	_, diags := m.Backend(t.Context(), &BackendOpts{
 		ConfigOverride: configs.SynthBody("synth", extras),
 		Init:           true,
 	}, encryption.StateEncryptionDisabled())
@@ -1989,7 +1990,7 @@ func TestMetaBackend_configureWithExtra(t *testing.T) {
 
 	// init the backend again with the same options
 	m = testMetaBackend(t, nil)
-	_, err = m.Backend(&BackendOpts{
+	_, err = m.Backend(t.Context(), &BackendOpts{
 		ConfigOverride: configs.SynthBody("synth", extras),
 		Init:           true,
 	}, encryption.StateEncryptionDisabled())
@@ -2019,7 +2020,7 @@ func TestMetaBackend_localDoesNotDeleteLocal(t *testing.T) {
 	m := testMetaBackend(t, nil)
 	m.forceInitCopy = true
 	// init the backend
-	_, diags := m.Backend(&BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
+	_, diags := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -2040,7 +2041,7 @@ func TestMetaBackend_configToExtra(t *testing.T) {
 
 	// init the backend
 	m := testMetaBackend(t, nil)
-	_, err := m.Backend(&BackendOpts{
+	_, err := m.Backend(t.Context(), &BackendOpts{
 		Init: true,
 	}, encryption.StateEncryptionDisabled())
 	if err != nil {
@@ -2061,7 +2062,7 @@ func TestMetaBackend_configToExtra(t *testing.T) {
 	extras := map[string]cty.Value{"path": cty.StringVal("hello")}
 	m = testMetaBackend(t, nil)
 	m.forceInitCopy = true
-	_, diags := m.Backend(&BackendOpts{
+	_, diags := m.Backend(t.Context(), &BackendOpts{
 		ConfigOverride: configs.SynthBody("synth", extras),
 		Init:           true,
 	}, encryption.StateEncryptionDisabled())

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -957,7 +957,7 @@ func TestMetaBackend_initSelectedWorkspaceDoesNotExist(t *testing.T) {
 	}
 
 	expected := "foo"
-	actual, err := m.Workspace()
+	actual, err := m.Workspace(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -983,7 +983,7 @@ func TestMetaBackend_initSelectedWorkspaceDoesNotExistAutoSelect(t *testing.T) {
 	m.input = false
 
 	// Assert test precondition: The current selected workspace is "bar"
-	previousName, err := m.Workspace()
+	previousName, err := m.Workspace(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -999,7 +999,7 @@ func TestMetaBackend_initSelectedWorkspaceDoesNotExistAutoSelect(t *testing.T) {
 	}
 
 	expected := "default"
-	actual, err := m.Workspace()
+	actual, err := m.Workspace(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1243,7 +1243,7 @@ func TestMetaBackend_configuredChangeCopy_multiToSingle(t *testing.T) {
 	}
 
 	// Verify we are now in the default env, or we may not be able to access the new backend
-	env, err := m.Workspace()
+	env, err := m.Workspace(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1702,7 +1702,7 @@ func TestMetaBackend_planLocal(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, diags := m.BackendForLocalPlan(backendConfig, encryption.StateEncryptionDisabled())
+	b, diags := m.BackendForLocalPlan(t.Context(), backendConfig, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -1803,7 +1803,7 @@ func TestMetaBackend_planLocalStatePath(t *testing.T) {
 	m.stateOutPath = statePath
 
 	// Get the backend
-	b, diags := m.BackendForLocalPlan(plannedBackend, encryption.StateEncryptionDisabled())
+	b, diags := m.BackendForLocalPlan(t.Context(), plannedBackend, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -1892,7 +1892,7 @@ func TestMetaBackend_planLocalMatch(t *testing.T) {
 	m := testMetaBackend(t, nil)
 
 	// Get the backend
-	b, diags := m.BackendForLocalPlan(backendConfig, encryption.StateEncryptionDisabled())
+	b, diags := m.BackendForLocalPlan(t.Context(), backendConfig, encryption.StateEncryptionDisabled())
 	if diags.HasErrors() {
 		t.Fatal(diags.Err())
 	}
@@ -1968,7 +1968,7 @@ func TestMetaBackend_configureWithExtra(t *testing.T) {
 		Init:           true,
 	}
 
-	_, cHash, err := m.backendConfig(opts)
+	_, cHash, err := m.backendConfig(t.Context(), opts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/command/meta_encryption.go
+++ b/internal/command/meta_encryption.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -17,19 +18,19 @@ import (
 
 const encryptionConfigEnvName = "TF_ENCRYPTION"
 
-func (m *Meta) Encryption() (encryption.Encryption, tfdiags.Diagnostics) {
+func (m *Meta) Encryption(ctx context.Context) (encryption.Encryption, tfdiags.Diagnostics) {
 	path, err := os.Getwd()
 	if err != nil {
 		return nil, tfdiags.Diagnostics{}.Append(fmt.Errorf("Error getting pwd: %w", err))
 	}
 
-	return m.EncryptionFromPath(path)
+	return m.EncryptionFromPath(ctx, path)
 }
 
-func (m *Meta) EncryptionFromPath(path string) (encryption.Encryption, tfdiags.Diagnostics) {
+func (m *Meta) EncryptionFromPath(ctx context.Context, path string) (encryption.Encryption, tfdiags.Diagnostics) {
 	// This is not ideal, but given how fragmented the command package is, loading the root module here is our best option
 	// See other meta commands like version check which do that same.
-	module, diags := m.loadSingleModule(path, configs.SelectiveLoadEncryption)
+	module, diags := m.loadSingleModule(ctx, path, configs.SelectiveLoadEncryption)
 	if diags.HasErrors() {
 		return nil, diags
 	}

--- a/internal/command/meta_test.go
+++ b/internal/command/meta_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/mitchellh/cli"
+
 	"github.com/opentofu/opentofu/internal/backend"
 	"github.com/opentofu/opentofu/internal/backend/local"
 	"github.com/opentofu/opentofu/internal/tofu"
@@ -189,7 +190,7 @@ func TestMeta_Env(t *testing.T) {
 
 	m := new(Meta)
 
-	env, err := m.Workspace()
+	env, err := m.Workspace(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,7 +204,7 @@ func TestMeta_Env(t *testing.T) {
 		t.Fatal("error setting env:", err)
 	}
 
-	env, _ = m.Workspace()
+	env, _ = m.Workspace(t.Context())
 	if env != testEnv {
 		t.Fatalf("expected env %q, got env %q", testEnv, env)
 	}
@@ -212,7 +213,7 @@ func TestMeta_Env(t *testing.T) {
 		t.Fatal("error setting env:", err)
 	}
 
-	env, _ = m.Workspace()
+	env, _ = m.Workspace(t.Context())
 	if env != backend.DefaultStateName {
 		t.Fatalf("expected env %q, got env %q", backend.DefaultStateName, env)
 	}
@@ -242,7 +243,7 @@ func TestMeta_Workspace_override(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			t.Setenv(WorkspaceNameEnvVar, name)
-			workspace, err := m.Workspace()
+			workspace, err := m.Workspace(t.Context())
 			if workspace != tc.workspace {
 				t.Errorf("Unexpected workspace\n got: %s\nwant: %s\n", workspace, tc.workspace)
 			}
@@ -276,7 +277,7 @@ func TestMeta_Workspace_invalidSelected(t *testing.T) {
 
 	m := new(Meta)
 
-	ws, err := m.Workspace()
+	ws, err := m.Workspace(t.Context())
 	if ws != workspace {
 		t.Errorf("Unexpected workspace\n got: %s\nwant: %s\n", ws, workspace)
 	}
@@ -394,7 +395,7 @@ func TestCommand_checkRequiredVersion(t *testing.T) {
 		Ui: ui,
 	}
 
-	diags := meta.checkRequiredVersion()
+	diags := meta.checkRequiredVersion(t.Context())
 	if diags == nil {
 		t.Fatalf("diagnostics should contain unmet version constraint, but is nil")
 	}

--- a/internal/command/output.go
+++ b/internal/command/output.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -23,6 +24,7 @@ type OutputCommand struct {
 }
 
 func (c *OutputCommand) Run(rawArgs []string) int {
+	ctx := c.CommandContext()
 	// Parse and apply global view arguments
 	common, rawArgs := arguments.ParseView(rawArgs)
 	c.View.Configure(common)
@@ -51,7 +53,7 @@ func (c *OutputCommand) Run(rawArgs []string) int {
 	}
 
 	// Fetch data from state
-	outputs, diags := c.Outputs(args.StatePath, enc)
+	outputs, diags := c.Outputs(ctx, args.StatePath, enc)
 	if diags.HasErrors() {
 		view.Diagnostics(diags)
 		return 1
@@ -70,7 +72,7 @@ func (c *OutputCommand) Run(rawArgs []string) int {
 	return 0
 }
 
-func (c *OutputCommand) Outputs(statePath string, enc encryption.Encryption) (map[string]*states.OutputValue, tfdiags.Diagnostics) {
+func (c *OutputCommand) Outputs(ctx context.Context, statePath string, enc encryption.Encryption) (map[string]*states.OutputValue, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	// Allow state path override
@@ -79,7 +81,7 @@ func (c *OutputCommand) Outputs(statePath string, enc encryption.Encryption) (ma
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(nil, enc.State())
+	b, backendDiags := c.Backend(ctx, nil, enc.State())
 	diags = diags.Append(backendDiags)
 	if diags.HasErrors() {
 		return nil, diags

--- a/internal/command/output.go
+++ b/internal/command/output.go
@@ -45,7 +45,7 @@ func (c *OutputCommand) Run(rawArgs []string) int {
 	c.GatherVariables(args.Vars)
 
 	// Load the encryption configuration
-	enc, encDiags := c.Encryption()
+	enc, encDiags := c.Encryption(ctx)
 	diags = diags.Append(encDiags)
 	if encDiags.HasErrors() {
 		c.View.Diagnostics(diags)
@@ -90,7 +90,7 @@ func (c *OutputCommand) Outputs(ctx context.Context, statePath string, enc encry
 	// This is a read-only command
 	c.ignoreRemoteVersionConflict(b)
 
-	env, err := c.Workspace()
+	env, err := c.Workspace(ctx)
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("Error selecting workspace: %w", err))
 		return nil, diags

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -85,7 +86,7 @@ func (c *PlanCommand) Run(rawArgs []string) int {
 	}
 
 	// Prepare the backend with the backend-specific arguments
-	be, beDiags := c.PrepareBackend(args.State, args.ViewType, enc)
+	be, beDiags := c.PrepareBackend(ctx, args.State, args.ViewType, enc)
 	diags = diags.Append(beDiags)
 	if diags.HasErrors() {
 		view.Diagnostics(diags)
@@ -123,7 +124,7 @@ func (c *PlanCommand) Run(rawArgs []string) int {
 	return op.Result.ExitStatus()
 }
 
-func (c *PlanCommand) PrepareBackend(args *arguments.State, viewType arguments.ViewType, enc encryption.Encryption) (backend.Enhanced, tfdiags.Diagnostics) {
+func (c *PlanCommand) PrepareBackend(ctx context.Context, args *arguments.State, viewType arguments.ViewType, enc encryption.Encryption) (backend.Enhanced, tfdiags.Diagnostics) {
 	// FIXME: we need to apply the state arguments to the meta object here
 	// because they are later used when initializing the backend. Carving a
 	// path to pass these arguments to the functions that need them is
@@ -136,7 +137,7 @@ func (c *PlanCommand) PrepareBackend(args *arguments.State, viewType arguments.V
 	}
 
 	// Load the backend
-	be, beDiags := c.Backend(&BackendOpts{
+	be, beDiags := c.Backend(ctx, &BackendOpts{
 		Config:   backendConfig,
 		ViewType: viewType,
 	}, enc.State())

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -78,7 +78,7 @@ func (c *PlanCommand) Run(rawArgs []string) int {
 	c.GatherVariables(args.Vars)
 
 	// Load the encryption configuration
-	enc, encDiags := c.Encryption()
+	enc, encDiags := c.Encryption(ctx)
 	diags = diags.Append(encDiags)
 	if encDiags.HasErrors() {
 		view.Diagnostics(diags)
@@ -94,7 +94,7 @@ func (c *PlanCommand) Run(rawArgs []string) int {
 	}
 
 	// Build the operation request
-	opReq, opDiags := c.OperationRequest(be, view, args.ViewType, args.Operation, args.OutPath, args.GenerateConfigPath, enc)
+	opReq, opDiags := c.OperationRequest(ctx, be, view, args.ViewType, args.Operation, args.OutPath, args.GenerateConfigPath, enc)
 	diags = diags.Append(opDiags)
 	if diags.HasErrors() {
 		view.Diagnostics(diags)
@@ -131,7 +131,7 @@ func (c *PlanCommand) PrepareBackend(ctx context.Context, args *arguments.State,
 	// difficult but would make their use easier to understand.
 	c.Meta.applyStateArguments(args)
 
-	backendConfig, diags := c.loadBackendConfig(".")
+	backendConfig, diags := c.loadBackendConfig(ctx, ".")
 	if diags.HasErrors() {
 		return nil, diags
 	}
@@ -150,6 +150,7 @@ func (c *PlanCommand) PrepareBackend(ctx context.Context, args *arguments.State,
 }
 
 func (c *PlanCommand) OperationRequest(
+	ctx context.Context,
 	be backend.Enhanced,
 	view views.Plan,
 	viewType arguments.ViewType,
@@ -161,7 +162,7 @@ func (c *PlanCommand) OperationRequest(
 	var diags tfdiags.Diagnostics
 
 	// Build the operation
-	opReq := c.Operation(be, viewType, enc)
+	opReq := c.Operation(ctx, be, viewType, enc)
 	opReq.ConfigDir = "."
 	opReq.PlanMode = args.PlanMode
 	opReq.Hooks = view.Hooks()

--- a/internal/command/providers.go
+++ b/internal/command/providers.go
@@ -34,6 +34,8 @@ func (c *ProvidersCommand) Synopsis() string {
 func (c *ProvidersCommand) Run(args []string) int {
 	var testsDirectory string
 
+	ctx := c.CommandContext()
+
 	args = c.Meta.process(args)
 	cmdFlags := c.Meta.defaultFlagSet("providers")
 	c.Meta.varFlagSet(cmdFlags)
@@ -92,7 +94,7 @@ func (c *ProvidersCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(&BackendOpts{
+	b, backendDiags := c.Backend(ctx, &BackendOpts{
 		Config: config.Module.Backend,
 	}, enc.State())
 	diags = diags.Append(backendDiags)

--- a/internal/command/providers.go
+++ b/internal/command/providers.go
@@ -78,7 +78,7 @@ func (c *ProvidersCommand) Run(args []string) int {
 		return 1
 	}
 
-	config, configDiags := c.loadConfigWithTests(configPath, testsDirectory)
+	config, configDiags := c.loadConfigWithTests(ctx, configPath, testsDirectory)
 	diags = diags.Append(configDiags)
 	if configDiags.HasErrors() {
 		c.showDiagnostics(diags)
@@ -86,7 +86,7 @@ func (c *ProvidersCommand) Run(args []string) int {
 	}
 
 	// Load the encryption configuration
-	enc, encDiags := c.EncryptionFromPath(configPath)
+	enc, encDiags := c.EncryptionFromPath(ctx, configPath)
 	diags = diags.Append(encDiags)
 	if encDiags.HasErrors() {
 		c.showDiagnostics(diags)
@@ -107,7 +107,7 @@ func (c *ProvidersCommand) Run(args []string) int {
 	c.ignoreRemoteVersionConflict(b)
 
 	// Get the state
-	env, err := c.Workspace()
+	env, err := c.Workspace(ctx)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
 		return 1

--- a/internal/command/providers_lock.go
+++ b/internal/command/providers_lock.go
@@ -142,7 +142,7 @@ func (c *ProvidersLockCommand) Run(args []string) int {
 		source = getproviders.NewRegistrySource(c.Services)
 	}
 
-	config, confDiags := c.loadConfig(".")
+	config, confDiags := c.loadConfig(ctx, ".")
 	diags = diags.Append(confDiags)
 	reqs, _, hclDiags := config.ProviderRequirements()
 	diags = diags.Append(hclDiags)

--- a/internal/command/providers_mirror.go
+++ b/internal/command/providers_mirror.go
@@ -81,7 +81,7 @@ func (c *ProvidersMirrorCommand) Run(args []string) int {
 	ctx, done := c.InterruptibleContext(c.CommandContext())
 	defer done()
 
-	config, confDiags := c.loadConfig(".")
+	config, confDiags := c.loadConfig(ctx, ".")
 	diags = diags.Append(confDiags)
 	reqs, _, moreDiags := config.ProviderRequirements()
 	diags = diags.Append(moreDiags)

--- a/internal/command/providers_schema.go
+++ b/internal/command/providers_schema.go
@@ -68,7 +68,7 @@ func (c *ProvidersSchemaCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(nil, enc.State())
+	b, backendDiags := c.Backend(ctx, nil, enc.State())
 	diags = diags.Append(backendDiags)
 	if backendDiags.HasErrors() {
 		c.showDiagnostics(diags)

--- a/internal/command/providers_schema.go
+++ b/internal/command/providers_schema.go
@@ -60,7 +60,7 @@ func (c *ProvidersSchemaCommand) Run(args []string) int {
 
 	var diags tfdiags.Diagnostics
 
-	enc, encDiags := c.Encryption()
+	enc, encDiags := c.Encryption(ctx)
 	diags = diags.Append(encDiags)
 	if encDiags.HasErrors() {
 		c.showDiagnostics(diags)
@@ -94,11 +94,11 @@ func (c *ProvidersSchemaCommand) Run(args []string) int {
 	}
 
 	// Build the operation
-	opReq := c.Operation(b, arguments.ViewJSON, enc)
+	opReq := c.Operation(ctx, b, arguments.ViewJSON, enc)
 	opReq.ConfigDir = cwd
 	opReq.ConfigLoader, err = c.initConfigLoader()
 	var callDiags tfdiags.Diagnostics
-	opReq.RootCall, callDiags = c.rootModuleCall(opReq.ConfigDir)
+	opReq.RootCall, callDiags = c.rootModuleCall(ctx, opReq.ConfigDir)
 	diags = diags.Append(callDiags)
 	if callDiags.HasErrors() {
 		c.showDiagnostics(diags)

--- a/internal/command/refresh.go
+++ b/internal/command/refresh.go
@@ -75,7 +75,7 @@ func (c *RefreshCommand) Run(rawArgs []string) int {
 	c.GatherVariables(args.Vars)
 
 	// Load the encryption configuration
-	enc, encDiags := c.Encryption()
+	enc, encDiags := c.Encryption(ctx)
 	diags = diags.Append(encDiags)
 	if encDiags.HasErrors() {
 		c.showDiagnostics(diags)
@@ -91,7 +91,7 @@ func (c *RefreshCommand) Run(rawArgs []string) int {
 	}
 
 	// Build the operation request
-	opReq, opDiags := c.OperationRequest(be, view, args.ViewType, args.Operation, enc)
+	opReq, opDiags := c.OperationRequest(ctx, be, view, args.ViewType, args.Operation, enc)
 	diags = diags.Append(opDiags)
 	if diags.HasErrors() {
 		view.Diagnostics(diags)
@@ -125,7 +125,7 @@ func (c *RefreshCommand) PrepareBackend(ctx context.Context, args *arguments.Sta
 	// difficult but would make their use easier to understand.
 	c.Meta.applyStateArguments(args)
 
-	backendConfig, diags := c.loadBackendConfig(".")
+	backendConfig, diags := c.loadBackendConfig(ctx, ".")
 	if diags.HasErrors() {
 		return nil, diags
 	}
@@ -143,12 +143,12 @@ func (c *RefreshCommand) PrepareBackend(ctx context.Context, args *arguments.Sta
 	return be, diags
 }
 
-func (c *RefreshCommand) OperationRequest(be backend.Enhanced, view views.Refresh, viewType arguments.ViewType, args *arguments.Operation, enc encryption.Encryption,
+func (c *RefreshCommand) OperationRequest(ctx context.Context, be backend.Enhanced, view views.Refresh, viewType arguments.ViewType, args *arguments.Operation, enc encryption.Encryption,
 ) (*backend.Operation, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	// Build the operation
-	opReq := c.Operation(be, viewType, enc)
+	opReq := c.Operation(ctx, be, viewType, enc)
 	opReq.ConfigDir = "."
 	opReq.Hooks = view.Hooks()
 	opReq.Targets = args.Targets

--- a/internal/command/refresh.go
+++ b/internal/command/refresh.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -82,7 +83,7 @@ func (c *RefreshCommand) Run(rawArgs []string) int {
 	}
 
 	// Prepare the backend with the backend-specific arguments
-	be, beDiags := c.PrepareBackend(args.State, args.ViewType, enc)
+	be, beDiags := c.PrepareBackend(ctx, args.State, args.ViewType, enc)
 	diags = diags.Append(beDiags)
 	if diags.HasErrors() {
 		view.Diagnostics(diags)
@@ -117,7 +118,7 @@ func (c *RefreshCommand) Run(rawArgs []string) int {
 	return op.Result.ExitStatus()
 }
 
-func (c *RefreshCommand) PrepareBackend(args *arguments.State, viewType arguments.ViewType, enc encryption.Encryption) (backend.Enhanced, tfdiags.Diagnostics) {
+func (c *RefreshCommand) PrepareBackend(ctx context.Context, args *arguments.State, viewType arguments.ViewType, enc encryption.Encryption) (backend.Enhanced, tfdiags.Diagnostics) {
 	// FIXME: we need to apply the state arguments to the meta object here
 	// because they are later used when initializing the backend. Carving a
 	// path to pass these arguments to the functions that need them is
@@ -130,7 +131,7 @@ func (c *RefreshCommand) PrepareBackend(args *arguments.State, viewType argument
 	}
 
 	// Load the backend
-	be, beDiags := c.Backend(&BackendOpts{
+	be, beDiags := c.Backend(ctx, &BackendOpts{
 		Config:   backendConfig,
 		ViewType: viewType,
 	}, enc.State())

--- a/internal/command/state_list.go
+++ b/internal/command/state_list.go
@@ -24,6 +24,8 @@ type StateListCommand struct {
 }
 
 func (c *StateListCommand) Run(args []string) int {
+	ctx := c.CommandContext()
+
 	args = c.Meta.process(args)
 	var statePath string
 	cmdFlags := c.Meta.defaultFlagSet("state list")
@@ -48,7 +50,7 @@ func (c *StateListCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(nil, enc.State())
+	b, backendDiags := c.Backend(ctx, nil, enc.State())
 	if backendDiags.HasErrors() {
 		c.showDiagnostics(backendDiags)
 		return 1

--- a/internal/command/state_list.go
+++ b/internal/command/state_list.go
@@ -43,7 +43,7 @@ func (c *StateListCommand) Run(args []string) int {
 	}
 
 	// Load the encryption configuration
-	enc, encDiags := c.Encryption()
+	enc, encDiags := c.Encryption(ctx)
 	if encDiags.HasErrors() {
 		c.showDiagnostics(encDiags)
 		return 1
@@ -60,7 +60,7 @@ func (c *StateListCommand) Run(args []string) int {
 	c.ignoreRemoteVersionConflict(b)
 
 	// Get the state
-	env, err := c.Workspace()
+	env, err := c.Workspace(ctx)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
 		return 1

--- a/internal/command/state_meta.go
+++ b/internal/command/state_meta.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"time"
@@ -28,7 +29,7 @@ type StateMeta struct {
 // the backend, but changes the way that backups are done. This configures
 // backups to be timestamped rather than just the original state path plus a
 // backup path.
-func (c *StateMeta) State(enc encryption.Encryption) (statemgr.Full, error) {
+func (c *StateMeta) State(ctx context.Context, enc encryption.Encryption) (statemgr.Full, error) {
 	var realState statemgr.Full
 	backupPath := c.backupPath
 	stateOutPath := c.statePath
@@ -38,7 +39,7 @@ func (c *StateMeta) State(enc encryption.Encryption) (statemgr.Full, error) {
 		realState = statemgr.NewFilesystem(c.statePath, encryption.StateEncryptionDisabled()) // User specified state file should not be encrypted
 	} else {
 		// Load the backend
-		b, backendDiags := c.Backend(nil, enc.State())
+		b, backendDiags := c.Backend(ctx, nil, enc.State())
 		if backendDiags.HasErrors() {
 			return nil, backendDiags.Err()
 		}
@@ -62,7 +63,7 @@ func (c *StateMeta) State(enc encryption.Encryption) (statemgr.Full, error) {
 		}
 
 		// Get a local backend
-		localRaw, backendDiags := c.Backend(&BackendOpts{ForceLocal: true}, enc.State())
+		localRaw, backendDiags := c.Backend(ctx, &BackendOpts{ForceLocal: true}, enc.State())
 		if backendDiags.HasErrors() {
 			// This should never fail
 			panic(backendDiags.Err())

--- a/internal/command/state_meta.go
+++ b/internal/command/state_meta.go
@@ -44,7 +44,7 @@ func (c *StateMeta) State(ctx context.Context, enc encryption.Encryption) (state
 			return nil, backendDiags.Err()
 		}
 
-		workspace, err := c.Workspace()
+		workspace, err := c.Workspace(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/command/state_mv.go
+++ b/internal/command/state_mv.go
@@ -27,6 +27,7 @@ type StateMvCommand struct {
 }
 
 func (c *StateMvCommand) Run(args []string) int {
+	ctx := c.CommandContext()
 	args = c.Meta.process(args)
 	// We create two metas to track the two states
 	var backupPathOut, statePathOut string
@@ -77,7 +78,7 @@ func (c *StateMvCommand) Run(args []string) int {
 	}
 
 	if len(setLegacyLocalBackendOptions) > 0 {
-		currentBackend, diags := c.backendFromConfig(&BackendOpts{}, enc.State())
+		currentBackend, diags := c.backendFromConfig(ctx, &BackendOpts{}, enc.State())
 		if diags.HasErrors() {
 			c.showDiagnostics(diags)
 			return 1
@@ -100,7 +101,7 @@ func (c *StateMvCommand) Run(args []string) int {
 	}
 
 	// Read the from state
-	stateFromMgr, err := c.State(enc)
+	stateFromMgr, err := c.State(ctx, enc)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf(errStateLoadingState, err))
 		return 1
@@ -138,7 +139,7 @@ func (c *StateMvCommand) Run(args []string) int {
 		c.statePath = statePathOut
 		c.backupPath = backupPathOut
 
-		stateToMgr, err = c.State(enc)
+		stateToMgr, err = c.State(ctx, enc)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf(errStateLoadingState, err))
 			return 1
@@ -399,7 +400,7 @@ func (c *StateMvCommand) Run(args []string) int {
 		return 0 // This is as far as we go in dry-run mode
 	}
 
-	b, backendDiags := c.Backend(nil, enc.State())
+	b, backendDiags := c.Backend(ctx, nil, enc.State())
 	diags = diags.Append(backendDiags)
 	if backendDiags.HasErrors() {
 		c.showDiagnostics(diags)

--- a/internal/command/state_mv.go
+++ b/internal/command/state_mv.go
@@ -51,7 +51,7 @@ func (c *StateMvCommand) Run(args []string) int {
 		return cli.RunResultHelp
 	}
 
-	if diags := c.Meta.checkRequiredVersion(); diags != nil {
+	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {
 		c.showDiagnostics(diags)
 		return 1
 	}
@@ -71,7 +71,7 @@ func (c *StateMvCommand) Run(args []string) int {
 	}
 
 	// Load the encryption configuration
-	enc, encDiags := c.Encryption()
+	enc, encDiags := c.Encryption(ctx)
 	if encDiags.HasErrors() {
 		c.showDiagnostics(encDiags)
 		return 1
@@ -411,7 +411,7 @@ func (c *StateMvCommand) Run(args []string) int {
 	var schemas *tofu.Schemas
 	if isCloudMode(b) {
 		var schemaDiags tfdiags.Diagnostics
-		schemas, schemaDiags = c.MaybeGetSchemas(stateTo, nil)
+		schemas, schemaDiags = c.MaybeGetSchemas(ctx, stateTo, nil)
 		diags = diags.Append(schemaDiags)
 	}
 

--- a/internal/command/state_pull.go
+++ b/internal/command/state_pull.go
@@ -22,6 +22,8 @@ type StatePullCommand struct {
 }
 
 func (c *StatePullCommand) Run(args []string) int {
+	ctx := c.CommandContext()
+
 	args = c.Meta.process(args)
 	cmdFlags := c.Meta.defaultFlagSet("state pull")
 	c.Meta.varFlagSet(cmdFlags)
@@ -43,7 +45,7 @@ func (c *StatePullCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(nil, enc.State())
+	b, backendDiags := c.Backend(ctx, nil, enc.State())
 	if backendDiags.HasErrors() {
 		c.showDiagnostics(backendDiags)
 		return 1

--- a/internal/command/state_pull.go
+++ b/internal/command/state_pull.go
@@ -32,13 +32,13 @@ func (c *StatePullCommand) Run(args []string) int {
 		return 1
 	}
 
-	if diags := c.Meta.checkRequiredVersion(); diags != nil {
+	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {
 		c.showDiagnostics(diags)
 		return 1
 	}
 
 	// Load the encryption configuration
-	enc, encDiags := c.Encryption()
+	enc, encDiags := c.Encryption(ctx)
 	if encDiags.HasErrors() {
 		c.showDiagnostics(encDiags)
 		return 1
@@ -55,7 +55,7 @@ func (c *StatePullCommand) Run(args []string) int {
 	c.ignoreRemoteVersionConflict(b)
 
 	// Get the state manager for the current workspace
-	env, err := c.Workspace()
+	env, err := c.Workspace(ctx)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
 		return 1

--- a/internal/command/state_push.go
+++ b/internal/command/state_push.go
@@ -30,6 +30,7 @@ type StatePushCommand struct {
 }
 
 func (c *StatePushCommand) Run(args []string) int {
+	ctx := c.CommandContext()
 	args = c.Meta.process(args)
 	var flagForce bool
 	cmdFlags := c.Meta.ignoreRemoteVersionFlagSet("state push")
@@ -87,7 +88,7 @@ func (c *StatePushCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(nil, enc.State())
+	b, backendDiags := c.Backend(ctx, nil, enc.State())
 	if backendDiags.HasErrors() {
 		c.showDiagnostics(backendDiags)
 		return 1

--- a/internal/command/state_push.go
+++ b/internal/command/state_push.go
@@ -48,13 +48,13 @@ func (c *StatePushCommand) Run(args []string) int {
 		return cli.RunResultHelp
 	}
 
-	if diags := c.Meta.checkRequiredVersion(); diags != nil {
+	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {
 		c.showDiagnostics(diags)
 		return 1
 	}
 
 	// Load the encryption configuration
-	enc, encDiags := c.Encryption()
+	enc, encDiags := c.Encryption(ctx)
 	if encDiags.HasErrors() {
 		c.showDiagnostics(encDiags)
 		return 1
@@ -95,7 +95,7 @@ func (c *StatePushCommand) Run(args []string) int {
 	}
 
 	// Determine the workspace name
-	workspace, err := c.Workspace()
+	workspace, err := c.Workspace(ctx)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
 		return 1
@@ -148,7 +148,7 @@ func (c *StatePushCommand) Run(args []string) int {
 	var schemas *tofu.Schemas
 	var diags tfdiags.Diagnostics
 	if isCloudMode(b) {
-		schemas, diags = c.MaybeGetSchemas(srcStateFile.State, nil)
+		schemas, diags = c.MaybeGetSchemas(ctx, srcStateFile.State, nil)
 	}
 
 	if err := stateMgr.WriteState(srcStateFile.State); err != nil {

--- a/internal/command/state_replace_provider.go
+++ b/internal/command/state_replace_provider.go
@@ -30,6 +30,8 @@ type StateReplaceProviderCommand struct {
 }
 
 func (c *StateReplaceProviderCommand) Run(args []string) int {
+	ctx := c.CommandContext()
+
 	args = c.Meta.process(args)
 
 	var autoApprove bool
@@ -87,7 +89,7 @@ func (c *StateReplaceProviderCommand) Run(args []string) int {
 	}
 
 	// Initialize the state manager as configured
-	stateMgr, err := c.State(enc)
+	stateMgr, err := c.State(ctx, enc)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf(errStateLoadingState, err))
 		return 1
@@ -175,7 +177,7 @@ func (c *StateReplaceProviderCommand) Run(args []string) int {
 		resource.ProviderConfig.Provider = to
 	}
 
-	b, backendDiags := c.Backend(nil, enc.State())
+	b, backendDiags := c.Backend(ctx, nil, enc.State())
 	diags = diags.Append(backendDiags)
 	if backendDiags.HasErrors() {
 		c.showDiagnostics(diags)

--- a/internal/command/state_replace_provider.go
+++ b/internal/command/state_replace_provider.go
@@ -51,7 +51,7 @@ func (c *StateReplaceProviderCommand) Run(args []string) int {
 		return cli.RunResultHelp
 	}
 
-	if diags := c.Meta.checkRequiredVersion(); diags != nil {
+	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {
 		c.showDiagnostics(diags)
 		return 1
 	}
@@ -81,7 +81,7 @@ func (c *StateReplaceProviderCommand) Run(args []string) int {
 	}
 
 	// Load the encryption configuration
-	enc, encDiags := c.Encryption()
+	enc, encDiags := c.Encryption(ctx)
 	diags = diags.Append(encDiags)
 	if encDiags.HasErrors() {
 		c.showDiagnostics(diags)
@@ -188,7 +188,7 @@ func (c *StateReplaceProviderCommand) Run(args []string) int {
 	var schemas *tofu.Schemas
 	if isCloudMode(b) {
 		var schemaDiags tfdiags.Diagnostics
-		schemas, schemaDiags = c.MaybeGetSchemas(state, nil)
+		schemas, schemaDiags = c.MaybeGetSchemas(ctx, state, nil)
 		diags = diags.Append(schemaDiags)
 	}
 

--- a/internal/command/state_rm.go
+++ b/internal/command/state_rm.go
@@ -25,6 +25,7 @@ type StateRmCommand struct {
 }
 
 func (c *StateRmCommand) Run(args []string) int {
+	ctx := c.CommandContext()
 	args = c.Meta.process(args)
 	var dryRun bool
 	cmdFlags := c.Meta.ignoreRemoteVersionFlagSet("state rm")
@@ -57,7 +58,7 @@ func (c *StateRmCommand) Run(args []string) int {
 	}
 
 	// Get the state
-	stateMgr, err := c.State(enc)
+	stateMgr, err := c.State(ctx, enc)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf(errStateLoadingState, err))
 		return 1
@@ -124,7 +125,7 @@ func (c *StateRmCommand) Run(args []string) int {
 		return 0 // This is as far as we go in dry-run mode
 	}
 
-	b, backendDiags := c.Backend(nil, enc.State())
+	b, backendDiags := c.Backend(ctx, nil, enc.State())
 	diags = diags.Append(backendDiags)
 	if backendDiags.HasErrors() {
 		c.showDiagnostics(diags)

--- a/internal/command/state_rm.go
+++ b/internal/command/state_rm.go
@@ -45,13 +45,13 @@ func (c *StateRmCommand) Run(args []string) int {
 		return cli.RunResultHelp
 	}
 
-	if diags := c.Meta.checkRequiredVersion(); diags != nil {
+	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {
 		c.showDiagnostics(diags)
 		return 1
 	}
 
 	// Load the encryption configuration
-	enc, encDiags := c.Encryption()
+	enc, encDiags := c.Encryption(ctx)
 	if encDiags.HasErrors() {
 		c.showDiagnostics(encDiags)
 		return 1
@@ -136,7 +136,7 @@ func (c *StateRmCommand) Run(args []string) int {
 	var schemas *tofu.Schemas
 	if isCloudMode(b) {
 		var schemaDiags tfdiags.Diagnostics
-		schemas, schemaDiags = c.MaybeGetSchemas(state, nil)
+		schemas, schemaDiags = c.MaybeGetSchemas(ctx, state, nil)
 		diags = diags.Append(schemaDiags)
 	}
 

--- a/internal/command/state_show.go
+++ b/internal/command/state_show.go
@@ -66,7 +66,7 @@ func (c *StateShowCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(nil, enc.State())
+	b, backendDiags := c.Backend(ctx, nil, enc.State())
 	if backendDiags.HasErrors() {
 		c.showDiagnostics(backendDiags)
 		return 1

--- a/internal/command/state_show.go
+++ b/internal/command/state_show.go
@@ -59,7 +59,7 @@ func (c *StateShowCommand) Run(args []string) int {
 	}
 
 	// Load the encryption configuration
-	enc, encDiags := c.Encryption()
+	enc, encDiags := c.Encryption(ctx)
 	if encDiags.HasErrors() {
 		c.showDiagnostics(encDiags)
 		return 1
@@ -97,11 +97,11 @@ func (c *StateShowCommand) Run(args []string) int {
 	}
 
 	// Build the operation (required to get the schemas)
-	opReq := c.Operation(b, arguments.ViewHuman, enc)
+	opReq := c.Operation(ctx, b, arguments.ViewHuman, enc)
 	opReq.AllowUnsetVariables = true
 	opReq.ConfigDir = cwd
 	var callDiags tfdiags.Diagnostics
-	opReq.RootCall, callDiags = c.rootModuleCall(opReq.ConfigDir)
+	opReq.RootCall, callDiags = c.rootModuleCall(ctx, opReq.ConfigDir)
 	if callDiags.HasErrors() {
 		c.showDiagnostics(callDiags)
 		return 1
@@ -128,7 +128,7 @@ func (c *StateShowCommand) Run(args []string) int {
 	}
 
 	// Get the state
-	env, err := c.Workspace()
+	env, err := c.Workspace(ctx)
 	if err != nil {
 		c.Streams.Eprintf("Error selecting workspace: %s\n", err)
 		return 1

--- a/internal/command/state_test.go
+++ b/internal/command/state_test.go
@@ -33,7 +33,7 @@ func testStateBackups(t *testing.T, dir string) []string {
 func TestStateDefaultBackupExtension(t *testing.T) {
 	testCwdTemp(t)
 
-	s, err := (&StateMeta{}).State(encryption.Disabled())
+	s, err := (&StateMeta{}).State(t.Context(), encryption.Disabled())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/command/taint.go
+++ b/internal/command/taint.go
@@ -25,6 +25,7 @@ type TaintCommand struct {
 }
 
 func (c *TaintCommand) Run(args []string) int {
+	ctx := c.CommandContext()
 	args = c.Meta.process(args)
 	var allowMissing bool
 	cmdFlags := c.Meta.ignoreRemoteVersionFlagSet("taint")
@@ -75,7 +76,7 @@ func (c *TaintCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(nil, enc.State())
+	b, backendDiags := c.Backend(ctx, nil, enc.State())
 	diags = diags.Append(backendDiags)
 	if backendDiags.HasErrors() {
 		c.showDiagnostics(diags)

--- a/internal/command/taint.go
+++ b/internal/command/taint.go
@@ -63,13 +63,13 @@ func (c *TaintCommand) Run(args []string) int {
 		return 1
 	}
 
-	if diags := c.Meta.checkRequiredVersion(); diags != nil {
+	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {
 		c.showDiagnostics(diags)
 		return 1
 	}
 
 	// Load the encryption configuration
-	enc, encDiags := c.Encryption()
+	enc, encDiags := c.Encryption(ctx)
 	if encDiags.HasErrors() {
 		c.showDiagnostics(encDiags)
 		return 1
@@ -84,7 +84,7 @@ func (c *TaintCommand) Run(args []string) int {
 	}
 
 	// Determine the workspace name
-	workspace, err := c.Workspace()
+	workspace, err := c.Workspace(ctx)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
 		return 1
@@ -143,7 +143,7 @@ func (c *TaintCommand) Run(args []string) int {
 	var schemas *tofu.Schemas
 	if isCloudMode(b) {
 		var schemaDiags tfdiags.Diagnostics
-		schemas, schemaDiags = c.MaybeGetSchemas(state, nil)
+		schemas, schemaDiags = c.MaybeGetSchemas(ctx, state, nil)
 		diags = diags.Append(schemaDiags)
 	}
 

--- a/internal/command/test.go
+++ b/internal/command/test.go
@@ -151,7 +151,7 @@ func (c *TestCommand) Run(rawArgs []string) int {
 		return 1
 	}
 
-	config, configDiags := c.loadConfigWithTests(".", args.TestDirectory)
+	config, configDiags := c.loadConfigWithTests(ctx, ".", args.TestDirectory)
 	diags = diags.Append(configDiags)
 	if configDiags.HasErrors() {
 		view.Diagnostics(nil, nil, diags)
@@ -242,7 +242,7 @@ func (c *TestCommand) Run(rawArgs []string) int {
 		return 1
 	}
 
-	opts, err := c.contextOpts()
+	opts, err := c.contextOpts(ctx)
 	if err != nil {
 		diags = diags.Append(err)
 		view.Diagnostics(nil, nil, diags)

--- a/internal/command/unlock.go
+++ b/internal/command/unlock.go
@@ -55,7 +55,7 @@ func (c *UnlockCommand) Run(args []string) int {
 	}
 
 	// Load the encryption configuration
-	enc, encDiags := c.EncryptionFromPath(configPath)
+	enc, encDiags := c.EncryptionFromPath(ctx, configPath)
 	if encDiags.HasErrors() {
 		c.showDiagnostics(encDiags)
 		return 1
@@ -63,7 +63,7 @@ func (c *UnlockCommand) Run(args []string) int {
 
 	var diags tfdiags.Diagnostics
 
-	backendConfig, backendDiags := c.loadBackendConfig(configPath)
+	backendConfig, backendDiags := c.loadBackendConfig(ctx, configPath)
 	diags = diags.Append(backendDiags)
 	if diags.HasErrors() {
 		c.showDiagnostics(diags)
@@ -83,7 +83,7 @@ func (c *UnlockCommand) Run(args []string) int {
 	// unlocking is read only when looking at state data
 	c.ignoreRemoteVersionConflict(b)
 
-	env, err := c.Workspace()
+	env, err := c.Workspace(ctx)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
 		return 1

--- a/internal/command/unlock.go
+++ b/internal/command/unlock.go
@@ -25,6 +25,7 @@ type UnlockCommand struct {
 }
 
 func (c *UnlockCommand) Run(args []string) int {
+	ctx := c.CommandContext()
 	args = c.Meta.process(args)
 	var force bool
 	cmdFlags := c.Meta.defaultFlagSet("force-unlock")
@@ -70,7 +71,7 @@ func (c *UnlockCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(&BackendOpts{
+	b, backendDiags := c.Backend(ctx, &BackendOpts{
 		Config: backendConfig,
 	}, enc.State())
 	diags = diags.Append(backendDiags)

--- a/internal/command/untaint.go
+++ b/internal/command/untaint.go
@@ -59,7 +59,7 @@ func (c *UntaintCommand) Run(args []string) int {
 	}
 
 	// Load the encryption configuration
-	enc, encDiags := c.Encryption()
+	enc, encDiags := c.Encryption(ctx)
 	diags = diags.Append(encDiags)
 	if encDiags.HasErrors() {
 		c.showDiagnostics(diags)
@@ -75,7 +75,7 @@ func (c *UntaintCommand) Run(args []string) int {
 	}
 
 	// Determine the workspace name
-	workspace, err := c.Workspace()
+	workspace, err := c.Workspace(ctx)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
 		return 1
@@ -183,7 +183,7 @@ func (c *UntaintCommand) Run(args []string) int {
 	var schemas *tofu.Schemas
 	if isCloudMode(b) {
 		var schemaDiags tfdiags.Diagnostics
-		schemas, schemaDiags = c.MaybeGetSchemas(state, nil)
+		schemas, schemaDiags = c.MaybeGetSchemas(ctx, state, nil)
 		diags = diags.Append(schemaDiags)
 	}
 

--- a/internal/command/untaint.go
+++ b/internal/command/untaint.go
@@ -25,6 +25,7 @@ type UntaintCommand struct {
 }
 
 func (c *UntaintCommand) Run(args []string) int {
+	ctx := c.CommandContext()
 	args = c.Meta.process(args)
 	var allowMissing bool
 	cmdFlags := c.Meta.ignoreRemoteVersionFlagSet("untaint")
@@ -66,7 +67,7 @@ func (c *UntaintCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(nil, enc.State())
+	b, backendDiags := c.Backend(ctx, nil, enc.State())
 	diags = diags.Append(backendDiags)
 	if backendDiags.HasErrors() {
 		c.showDiagnostics(diags)

--- a/internal/command/validate.go
+++ b/internal/command/validate.go
@@ -96,9 +96,9 @@ func (c *ValidateCommand) validate(ctx context.Context, dir, testDir string, noT
 	var cfg *configs.Config
 
 	if noTests {
-		cfg, diags = c.loadConfig(dir)
+		cfg, diags = c.loadConfig(ctx, dir)
 	} else {
-		cfg, diags = c.loadConfigWithTests(dir, testDir)
+		cfg, diags = c.loadConfigWithTests(ctx, dir, testDir)
 	}
 	if diags.HasErrors() {
 		return diags
@@ -107,7 +107,7 @@ func (c *ValidateCommand) validate(ctx context.Context, dir, testDir string, noT
 	validate := func(cfg *configs.Config) tfdiags.Diagnostics {
 		var diags tfdiags.Diagnostics
 
-		opts, err := c.contextOpts()
+		opts, err := c.contextOpts(ctx)
 		if err != nil {
 			diags = diags.Append(err)
 			return diags

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/mitchellh/cli"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/backend"
 	"github.com/opentofu/opentofu/internal/backend/local"
@@ -31,7 +32,7 @@ func TestWorkspace_createAndChange(t *testing.T) {
 
 	newCmd := &WorkspaceNewCommand{}
 
-	current, _ := newCmd.Workspace()
+	current, _ := newCmd.Workspace(t.Context())
 	if current != backend.DefaultStateName {
 		t.Fatal("current workspace should be 'default'")
 	}
@@ -44,7 +45,7 @@ func TestWorkspace_createAndChange(t *testing.T) {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
 	}
 
-	current, _ = newCmd.Workspace()
+	current, _ = newCmd.Workspace(t.Context())
 	if current != "test" {
 		t.Fatalf("current workspace should be 'test', got %q", current)
 	}
@@ -57,7 +58,7 @@ func TestWorkspace_createAndChange(t *testing.T) {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
 	}
 
-	current, _ = newCmd.Workspace()
+	current, _ = newCmd.Workspace(t.Context())
 	if current != backend.DefaultStateName {
 		t.Fatal("current workspace should be 'default'")
 	}
@@ -315,7 +316,7 @@ func TestWorkspace_delete(t *testing.T) {
 		Meta: Meta{Ui: ui, View: view},
 	}
 
-	current, _ := delCmd.Workspace()
+	current, _ := delCmd.Workspace(t.Context())
 	if current != "test" {
 		t.Fatal("wrong workspace:", current)
 	}
@@ -338,7 +339,7 @@ func TestWorkspace_delete(t *testing.T) {
 		t.Fatalf("error deleting workspace: %s", ui.ErrorWriter)
 	}
 
-	current, _ = delCmd.Workspace()
+	current, _ = delCmd.Workspace(t.Context())
 	if current != backend.DefaultStateName {
 		t.Fatalf("wrong workspace: %q", current)
 	}
@@ -450,7 +451,7 @@ func TestWorkspace_selectWithOrCreate(t *testing.T) {
 
 	selectCmd := &WorkspaceSelectCommand{}
 
-	current, _ := selectCmd.Workspace()
+	current, _ := selectCmd.Workspace(t.Context())
 	if current != backend.DefaultStateName {
 		t.Fatal("current workspace should be 'default'")
 	}
@@ -463,7 +464,7 @@ func TestWorkspace_selectWithOrCreate(t *testing.T) {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
 	}
 
-	current, _ = selectCmd.Workspace()
+	current, _ = selectCmd.Workspace(t.Context())
 	if current != "test" {
 		t.Fatalf("current workspace should be 'test', got %q", current)
 	}

--- a/internal/command/workspace_delete.go
+++ b/internal/command/workspace_delete.go
@@ -26,6 +26,7 @@ type WorkspaceDeleteCommand struct {
 }
 
 func (c *WorkspaceDeleteCommand) Run(args []string) int {
+	ctx := c.CommandContext()
 	args = c.Meta.process(args)
 	envCommandShowWarning(c.Ui, c.LegacyName)
 
@@ -73,7 +74,7 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(&BackendOpts{
+	b, backendDiags := c.Backend(ctx, &BackendOpts{
 		Config: backendConfig,
 	}, enc.State())
 	diags = diags.Append(backendDiags)
@@ -205,7 +206,7 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 
 func (c *WorkspaceDeleteCommand) AutocompleteArgs() complete.Predictor {
 	return completePredictSequence{
-		c.completePredictWorkspaceName(),
+		c.completePredictWorkspaceName(c.CommandContext()),
 		complete.PredictDirs(""),
 	}
 }

--- a/internal/command/workspace_delete.go
+++ b/internal/command/workspace_delete.go
@@ -58,7 +58,7 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 
 	var diags tfdiags.Diagnostics
 
-	backendConfig, backendDiags := c.loadBackendConfig(configPath)
+	backendConfig, backendDiags := c.loadBackendConfig(ctx, configPath)
 	diags = diags.Append(backendDiags)
 	if diags.HasErrors() {
 		c.showDiagnostics(diags)
@@ -66,7 +66,7 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 	}
 
 	// Load the encryption configuration
-	enc, encDiags := c.EncryptionFromPath(configPath)
+	enc, encDiags := c.EncryptionFromPath(ctx, configPath)
 	diags = diags.Append(encDiags)
 	if encDiags.HasErrors() {
 		c.showDiagnostics(diags)
@@ -106,7 +106,7 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 		return 1
 	}
 
-	currentWorkspace, err := c.Workspace()
+	currentWorkspace, err := c.Workspace(ctx)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
 		return 1

--- a/internal/command/workspace_list.go
+++ b/internal/command/workspace_list.go
@@ -41,7 +41,7 @@ func (c *WorkspaceListCommand) Run(args []string) int {
 	}
 
 	// Load the encryption configuration
-	enc, encDiags := c.EncryptionFromPath(configPath)
+	enc, encDiags := c.EncryptionFromPath(ctx, configPath)
 	if encDiags.HasErrors() {
 		c.showDiagnostics(encDiags)
 		return 1
@@ -49,7 +49,7 @@ func (c *WorkspaceListCommand) Run(args []string) int {
 
 	var diags tfdiags.Diagnostics
 
-	backendConfig, backendDiags := c.loadBackendConfig(configPath)
+	backendConfig, backendDiags := c.loadBackendConfig(ctx, configPath)
 	diags = diags.Append(backendDiags)
 	if diags.HasErrors() {
 		c.showDiagnostics(diags)
@@ -75,7 +75,7 @@ func (c *WorkspaceListCommand) Run(args []string) int {
 		return 1
 	}
 
-	env, isOverridden := c.WorkspaceOverridden()
+	env, isOverridden := c.WorkspaceOverridden(ctx)
 
 	var out bytes.Buffer
 	for _, s := range states {

--- a/internal/command/workspace_list.go
+++ b/internal/command/workspace_list.go
@@ -21,6 +21,7 @@ type WorkspaceListCommand struct {
 }
 
 func (c *WorkspaceListCommand) Run(args []string) int {
+	ctx := c.CommandContext()
 	args = c.Meta.process(args)
 	envCommandShowWarning(c.Ui, c.LegacyName)
 
@@ -56,7 +57,7 @@ func (c *WorkspaceListCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(&BackendOpts{
+	b, backendDiags := c.Backend(ctx, &BackendOpts{
 		Config: backendConfig,
 	}, enc.State())
 	diags = diags.Append(backendDiags)

--- a/internal/command/workspace_new.go
+++ b/internal/command/workspace_new.go
@@ -28,6 +28,7 @@ type WorkspaceNewCommand struct {
 }
 
 func (c *WorkspaceNewCommand) Run(args []string) int {
+	ctx := c.CommandContext()
 	args = c.Meta.process(args)
 	envCommandShowWarning(c.Ui, c.LegacyName)
 
@@ -89,7 +90,7 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(&BackendOpts{
+	b, backendDiags := c.Backend(ctx, &BackendOpts{
 		Config: backendConfig,
 	}, enc.State())
 	diags = diags.Append(backendDiags)

--- a/internal/command/workspace_new.go
+++ b/internal/command/workspace_new.go
@@ -61,7 +61,7 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 
 	// You can't ask to create a workspace when you're overriding the
 	// workspace name to be something different.
-	if current, isOverridden := c.WorkspaceOverridden(); current != workspace && isOverridden {
+	if current, isOverridden := c.WorkspaceOverridden(ctx); current != workspace && isOverridden {
 		c.Ui.Error(envIsOverriddenNewError)
 		return 1
 	}
@@ -74,7 +74,7 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 
 	var diags tfdiags.Diagnostics
 
-	backendConfig, backendDiags := c.loadBackendConfig(configPath)
+	backendConfig, backendDiags := c.loadBackendConfig(ctx, configPath)
 	diags = diags.Append(backendDiags)
 	if diags.HasErrors() {
 		c.showDiagnostics(diags)
@@ -82,7 +82,7 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 	}
 
 	// Load the encryption configuration
-	enc, encDiags := c.EncryptionFromPath(configPath)
+	enc, encDiags := c.EncryptionFromPath(ctx, configPath)
 	diags = diags.Append(encDiags)
 	if encDiags.HasErrors() {
 		c.showDiagnostics(diags)

--- a/internal/command/workspace_select.go
+++ b/internal/command/workspace_select.go
@@ -49,21 +49,21 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 
 	var diags tfdiags.Diagnostics
 
-	backendConfig, backendDiags := c.loadBackendConfig(configPath)
+	backendConfig, backendDiags := c.loadBackendConfig(ctx, configPath)
 	diags = diags.Append(backendDiags)
 	if diags.HasErrors() {
 		c.showDiagnostics(diags)
 		return 1
 	}
 
-	current, isOverridden := c.WorkspaceOverridden()
+	current, isOverridden := c.WorkspaceOverridden(ctx)
 	if isOverridden {
 		c.Ui.Error(envIsOverriddenSelectError)
 		return 1
 	}
 
 	// Load the encryption configuration
-	enc, encDiags := c.EncryptionFromPath(configPath)
+	enc, encDiags := c.EncryptionFromPath(ctx, configPath)
 	diags = diags.Append(encDiags)
 	if encDiags.HasErrors() {
 		c.showDiagnostics(diags)

--- a/internal/command/workspace_select.go
+++ b/internal/command/workspace_select.go
@@ -21,6 +21,7 @@ type WorkspaceSelectCommand struct {
 }
 
 func (c *WorkspaceSelectCommand) Run(args []string) int {
+	ctx := c.CommandContext()
 	args = c.Meta.process(args)
 	envCommandShowWarning(c.Ui, c.LegacyName)
 
@@ -70,7 +71,7 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, backendDiags := c.Backend(&BackendOpts{
+	b, backendDiags := c.Backend(ctx, &BackendOpts{
 		Config: backendConfig,
 	}, enc.State())
 	diags = diags.Append(backendDiags)
@@ -145,7 +146,7 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 
 func (c *WorkspaceSelectCommand) AutocompleteArgs() complete.Predictor {
 	return completePredictSequence{
-		c.completePredictWorkspaceName(),
+		c.completePredictWorkspaceName(c.CommandContext()),
 		complete.PredictDirs(""),
 	}
 }

--- a/internal/command/workspace_show.go
+++ b/internal/command/workspace_show.go
@@ -17,6 +17,7 @@ type WorkspaceShowCommand struct {
 }
 
 func (c *WorkspaceShowCommand) Run(args []string) int {
+	ctx := c.CommandContext()
 	args = c.Meta.process(args)
 	cmdFlags := c.Meta.extendedFlagSet("workspace show")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
@@ -25,7 +26,7 @@ func (c *WorkspaceShowCommand) Run(args []string) int {
 		return 1
 	}
 
-	workspace, err := c.Workspace()
+	workspace, err := c.Workspace(ctx)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
 		return 1


### PR DESCRIPTION
This PR adds context propagation to key entrypoint methods in the Meta struct, which forms the foundation of OpenTofu's command infrastructure. 

The changes include:
    
- Added context parameter to Backend() and related backend initialization
  methods (BackendForLocalPlan, backendFromConfig, backendFromState)
- Added context to Operation() method which prepares backend operations
- Added context parameter to Workspace() and WorkspaceOverridden() methods
- Added context to loadConfig and related configuration loading methods
- Added context to MaybeGetSchemas for provider schema resolution
- Added context in other methods that were using these methods


<!-- If your PR resolves an issue, please add it here. -->
Part of #2664 

## Target Release

1.10.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
