### PR TITLE
Prototype: Support top-level configuration blocks

### DIFF
--- a/internal/configs/testdata/error-files/required-providers-toplevel.tf
+++ b/internal/configs/testdata/error-files/required-providers-toplevel.tf
@@ -1,9 +1,0 @@
-# A top-level required_providers block is not valid, but we have a specialized
-# error for it to hint the user to move it into a terraform block.
-required_providers { # ERROR: Invalid required_providers block
-}
-
-# This one is valid, and what the user should rewrite the above to be like.
-terraform {
-  required_providers {}
-}

--- a/internal/configs/top_level_blocks_test.go
+++ b/internal/configs/top_level_blocks_test.go
@@ -1,0 +1,171 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package configs
+
+import (
+	"testing"
+)
+
+// TestTopLevelBlocksOnly verifies that the parser correctly identifies
+// top-level blocks in a configuration file. It checks that the
+// expected number of each type of block is present and that they
+// are correctly parsed into the file structure.
+func TestTopLevelBlocksOnly(t *testing.T) {
+	topLevelOnlyConfig := `
+backend "local" {
+  path = "test.tfstate"
+}
+
+required_providers {
+  test = {
+    source  = "hashicorp/test"
+    version = "1.0.0"
+  }
+}
+
+cloud {
+  organization = "test-org"
+  workspaces {
+    name = "test-workspace"
+  }
+}
+
+provider_meta "test" {
+  foo = "bar"
+}
+
+encryption {
+  key_provider "pgp" "test-key" {
+    key_id = "keyid"
+  }
+}
+`
+	parser := testParser(map[string]string{
+		"top-level-only.tf": topLevelOnlyConfig,
+	})
+
+	file, diags := parser.LoadConfigFile("top-level-only.tf")
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags)
+	}
+
+	if file == nil {
+		t.Fatal("Expected file to be non-nil")
+	}
+
+	if len(file.Backends) != 1 {
+		t.Errorf("Expected 1 backend block, got %d", len(file.Backends))
+	}
+	if len(file.RequiredProviders) != 1 {
+		t.Errorf("Expected 1 required_providers block, got %d", len(file.RequiredProviders))
+	}
+	if len(file.CloudConfigs) != 1 {
+		t.Errorf("Expected 1 cloud block, got %d", len(file.CloudConfigs))
+	}
+	if len(file.ProviderMetas) != 1 {
+		t.Errorf("Expected 1 provider_meta block, got %d", len(file.ProviderMetas))
+	}
+	if len(file.Encryptions) != 1 {
+		t.Errorf("Expected 1 encryption block, got %d", len(file.Encryptions))
+	}
+}
+
+// TestTopLevelBlocksConflict_ShouldError verifies that the parser correctly
+// identifies that there is a conflict between a top-level "backend"
+// block and a "terraform" block in the same configuration file.
+func TestTopLevelBlocksConflict_ShouldError(t *testing.T) {
+	conflictingContent := `
+terraform {
+  required_version = ">= 1.6.0"
+  backend "remote" {}
+}
+
+backend "local" {}
+`
+	parser := testParser(map[string]string{
+		"conflict.tf": conflictingContent,
+	})
+
+	_, diags := parser.LoadConfigFile("conflict.tf")
+	if !diags.HasErrors() {
+		t.Fatal("expected error diagnostics for conflicting blocks")
+	}
+
+	assertExactDiagnostics(t, diags, []string{"conflict.tf:7,1-16: Top-level \"backend\" block not allowed alongside terraform block; A \"backend\" block cannot be used at the top level whilst a terraform block exists in the file. Move this \"backend\" block inside the terraform block or remove the existing terraform block."})
+}
+
+// TestTerraformBlocksOnly verifies that the parser correctly
+// identifies and parses the terraform block correctly when it has no other
+// conflicting top-level blocks.
+func TestTerraformBlocksOnly(t *testing.T) {
+	terraformOnlyConfig := `
+terraform {
+  required_version = ">= 1.6.0"
+  
+  backend "remote" {
+    organization = "test-org"
+    workspaces {
+      name = "test-workspace-internal"
+    }
+  }
+  
+  required_providers {
+    test-internal = {
+      source  = "hashicorp/test-internal"
+      version = "1.0.0"
+    }
+  }
+
+  provider_meta "test" {
+    foo = "bar"
+  }
+
+  encryption {
+    key_provider "pgp" "test-key" {
+      key_id = "keyid"
+    }
+  }
+}
+`
+	parser := testParser(map[string]string{
+		"terraform-block-only.tf": terraformOnlyConfig,
+	})
+
+	file, diags := parser.LoadConfigFile("terraform-block-only.tf")
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags)
+	}
+
+	if len(file.Backends) != 1 {
+		t.Errorf("Expected 1 backend block, got %d", len(file.Backends))
+	}
+	if len(file.RequiredProviders) != 1 {
+		t.Errorf("Expected 1 required_providers block, got %d", len(file.RequiredProviders))
+	}
+	if len(file.ProviderMetas) != 1 {
+		t.Errorf("Expected 1 provider_meta block, got %d", len(file.ProviderMetas))
+	}
+	if len(file.Encryptions) != 1 {
+		t.Errorf("Expected 1 encryption block, got %d", len(file.Encryptions))
+	}
+
+	module, modDiags := NewModule([]*File{file}, nil, RootModuleCallForTesting(), "", SelectiveLoadAll)
+	if modDiags.HasErrors() {
+		t.Fatalf("unexpected module errors: %s", modDiags)
+	}
+
+	if module.ProviderRequirements == nil {
+		t.Fatal("Expected provider requirements to be set")
+	}
+
+	providers := module.ProviderRequirements.RequiredProviders
+	if len(providers) != 1 {
+		t.Errorf("Expected 1 provider in requirements, got %d", len(providers))
+	}
+	if _, exists := providers["test-internal"]; !exists {
+		t.Error("Expected test-internal provider to be present")
+	}
+}


### PR DESCRIPTION
This experimental prototype allows for a more streamlined OpenTofu configuration experience by supporting key terraform configuration blocks at the top level of .tf files, removing the need for explicit terraform {} blocks in many common scenarios.

What this adds:
- Support for these blocks both at top-level and inside terraform blocks:
  - required_providers
  - backend
  - cloud
  - provider_meta
  - encryption

To prevent configuration ambiguities, it is possible to either use the new top-level blocks or the traditional terraform {} blocks, but not both. This is enforced when parsing the configuration files. If both are detected, an error is raised with a clear message indicating the conflict. This is to ensure that we maintain backward compatibility with traditional terraform block configurations while offering a more intuitive experience for simple configurations.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [ ] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [ ] I have not used an AI coding assistant to create this PR.
- [ ] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [ ] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
