### PR TITLE
tofu: Plumb a reasonable amount of OpenTelemetry tracing into OpenTofu Core

### DIFF
--- a/internal/plans/mode.go
+++ b/internal/plans/mode.go
@@ -34,3 +34,19 @@ const (
 	// "tofu plan".
 	RefreshOnlyMode Mode = 'R'
 )
+
+// UIName returns a name suitable for describing the mode in the UI.
+func (m Mode) UIName() string {
+	switch m {
+	case NormalMode:
+		return "normal"
+	case DestroyMode:
+		return "destroy"
+	case RefreshOnlyMode:
+		return "refresh-only"
+	default:
+		// Should not get here because the cases above should cover every
+		// valid value of this type.
+		return "unknown"
+	}
+}

--- a/internal/tofu/context_eval.go
+++ b/internal/tofu/context_eval.go
@@ -14,6 +14,7 @@ import (
 	"github.com/opentofu/opentofu/internal/lang"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
+	"github.com/opentofu/opentofu/internal/tracing"
 )
 
 type EvalOpts struct {
@@ -45,6 +46,11 @@ func (c *Context) Eval(ctx context.Context, config *configs.Config, state *state
 
 	var diags tfdiags.Diagnostics
 	defer c.acquireRun("eval")()
+
+	ctx, span := tracing.Tracer().Start(
+		ctx, "Evaluation phase",
+	)
+	defer span.End()
 
 	// Start with a copy of state so that we don't affect the instance that
 	// the caller is holding.

--- a/internal/tofu/context_input.go
+++ b/internal/tofu/context_input.go
@@ -17,6 +17,7 @@ import (
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/tfdiags"
+	"github.com/opentofu/opentofu/internal/tracing"
 )
 
 // Input asks for input to fill unset required arguments in provider
@@ -49,6 +50,11 @@ func (c *Context) Input(ctx context.Context, config *configs.Config, mode InputM
 
 	var diags tfdiags.Diagnostics
 	defer c.acquireRun("input")()
+
+	ctx, span := tracing.Tracer().Start(
+		ctx, "Gather input",
+	)
+	defer span.End()
 
 	schemas, moreDiags := c.Schemas(config, nil)
 	diags = diags.Append(moreDiags)

--- a/internal/tofu/context_validate.go
+++ b/internal/tofu/context_validate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
+	"github.com/opentofu/opentofu/internal/tracing"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -31,6 +32,11 @@ func (c *Context) Validate(ctx context.Context, config *configs.Config) tfdiags.
 	defer c.acquireRun("validate")()
 
 	var diags tfdiags.Diagnostics
+
+	ctx, span := tracing.Tracer().Start(
+		ctx, "Validation phase",
+	)
+	defer span.End()
 
 	moreDiags := c.checkConfigDependencies(config)
 	diags = diags.Append(moreDiags)

--- a/internal/tofu/node_provider.go
+++ b/internal/tofu/node_provider.go
@@ -11,12 +11,41 @@ import (
 	"log"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+	otelAttr "go.opentelemetry.io/otel/attribute"
+	otelTrace "go.opentelemetry.io/otel/trace"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
+	"github.com/opentofu/opentofu/internal/tracing"
 )
+
+// traceAttrProviderAddress is a standardized trace span attribute name that we
+// use for recording the address of the main provider that a span is associated
+// with.
+//
+// The value of this should be populated by calling the String method on
+// a value of type [addrs.Provider].
+const traceAttrProviderAddr = "opentofu.provider.source"
+
+// traceAttrProviderConfigAddress is a standardized trace span attribute
+// name that we use for recording the address of the main provider configuration
+// block that a span is associated with.
+//
+// The value of this should be populated by calling the String method on
+// a value of type [addrs.AbsProviderConfig].
+const traceAttrProviderConfigAddr = "opentofu.provider_config.address"
+
+// traceAttrProviderInstanceAddr is a standardized trace span attribute
+// name that we use for recording the address of the main provider instance
+// that a span is associated with.
+//
+// The value of this should be populated by calling traceProviderInstanceAddr
+// with the [addrs.AbsProviderConfig] and [addrs.InstanceKey] value that
+// together uniquely identify the provider instance.
+const traceAttrProviderInstanceAddr = "opentofu.provider_instance.address"
 
 // NodeApplyableProvider represents a provider during an apply.
 type NodeApplyableProvider struct {
@@ -28,16 +57,16 @@ var (
 )
 
 // GraphNodeExecutable
-func (n *NodeApplyableProvider) Execute(_ context.Context, evalCtx EvalContext, op walkOperation) tfdiags.Diagnostics {
-	instances, diags := n.initInstances(evalCtx, op)
+func (n *NodeApplyableProvider) Execute(ctx context.Context, evalCtx EvalContext, op walkOperation) tfdiags.Diagnostics {
+	instances, diags := n.initInstances(ctx, evalCtx, op)
 
 	for key, provider := range instances {
-		diags = diags.Append(n.executeInstance(evalCtx, op, key, provider))
+		diags = diags.Append(n.executeInstance(ctx, evalCtx, op, key, provider))
 	}
 
 	return diags
 }
-func (n *NodeApplyableProvider) initInstances(ctx EvalContext, op walkOperation) (map[addrs.InstanceKey]providers.Interface, tfdiags.Diagnostics) {
+func (n *NodeApplyableProvider) initInstances(_ context.Context, evalCtx EvalContext, op walkOperation) (map[addrs.InstanceKey]providers.Interface, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	var initKeys []addrs.InstanceKey
@@ -61,7 +90,7 @@ func (n *NodeApplyableProvider) initInstances(ctx EvalContext, op walkOperation)
 	}
 
 	for _, key := range initKeys {
-		_, err := ctx.InitProvider(n.Addr, key)
+		_, err := evalCtx.InitProvider(n.Addr, key)
 		diags = diags.Append(err)
 	}
 	if diags.HasErrors() {
@@ -70,7 +99,7 @@ func (n *NodeApplyableProvider) initInstances(ctx EvalContext, op walkOperation)
 
 	instances := make(map[addrs.InstanceKey]providers.Interface)
 	for configKey, initKey := range instanceKeys {
-		provider, _, err := getProvider(ctx, n.Addr, initKey)
+		provider, _, err := getProvider(evalCtx, n.Addr, initKey)
 		diags = diags.Append(err)
 		instances[configKey] = provider
 	}
@@ -80,23 +109,33 @@ func (n *NodeApplyableProvider) initInstances(ctx EvalContext, op walkOperation)
 
 	return instances, diags
 }
-func (n *NodeApplyableProvider) executeInstance(ctx EvalContext, op walkOperation, providerKey addrs.InstanceKey, provider providers.Interface) tfdiags.Diagnostics {
+func (n *NodeApplyableProvider) executeInstance(ctx context.Context, evalCtx EvalContext, op walkOperation, providerKey addrs.InstanceKey, provider providers.Interface) tfdiags.Diagnostics {
 	switch op {
 	case walkValidate:
 		log.Printf("[TRACE] NodeApplyableProvider: validating configuration for %s", n.Addr)
-		return n.ValidateProvider(ctx, providerKey, provider)
+		return n.ValidateProvider(ctx, evalCtx, providerKey, provider)
 	case walkPlan, walkPlanDestroy, walkApply, walkDestroy:
 		log.Printf("[TRACE] NodeApplyableProvider: configuring %s", n.Addr)
-		return n.ConfigureProvider(ctx, providerKey, provider, false)
+		return n.ConfigureProvider(ctx, evalCtx, providerKey, provider, false)
 	case walkImport:
 		log.Printf("[TRACE] NodeApplyableProvider: configuring %s (requiring that configuration is wholly known)", n.Addr)
-		return n.ConfigureProvider(ctx, providerKey, provider, true)
+		return n.ConfigureProvider(ctx, evalCtx, providerKey, provider, true)
 	}
 	return nil
 }
 
-func (n *NodeApplyableProvider) ValidateProvider(ctx EvalContext, providerKey addrs.InstanceKey, provider providers.Interface) tfdiags.Diagnostics {
-	configBody := buildProviderConfig(ctx, n.Addr, n.ProviderConfig())
+func (n *NodeApplyableProvider) ValidateProvider(ctx context.Context, evalCtx EvalContext, providerKey addrs.InstanceKey, provider providers.Interface) tfdiags.Diagnostics {
+	_, span := tracing.Tracer().Start(
+		ctx, "Validate provider configuration",
+		otelTrace.WithAttributes(
+			otelAttr.String(traceAttrProviderAddr, n.Addr.Provider.String()),
+			otelAttr.String(traceAttrProviderConfigAddr, n.Addr.String()),
+			otelAttr.String(traceAttrProviderInstanceAddr, traceProviderInstanceAddr(n.Addr, providerKey)),
+		),
+	)
+	defer span.End()
+
+	configBody := buildProviderConfig(evalCtx, n.Addr, n.ProviderConfig())
 
 	// if a provider config is empty (only an alias), return early and don't continue
 	// validation. validate doesn't need to fully configure the provider itself, so
@@ -109,6 +148,7 @@ func (n *NodeApplyableProvider) ValidateProvider(ctx EvalContext, providerKey ad
 	schemaResp := provider.GetProviderSchema()
 	diags := schemaResp.Diagnostics.InConfigBody(configBody, n.Addr.InstanceString(providerKey))
 	if diags.HasErrors() {
+		tracing.SetSpanError(span, diags)
 		return diags
 	}
 
@@ -125,8 +165,9 @@ func (n *NodeApplyableProvider) ValidateProvider(ctx EvalContext, providerKey ad
 		data = n.Config.Instances[providerKey]
 	}
 
-	configVal, _, evalDiags := ctx.EvaluateBlock(configBody, configSchema, nil, data)
+	configVal, _, evalDiags := evalCtx.EvaluateBlock(configBody, configSchema, nil, data)
 	if evalDiags.HasErrors() {
+		tracing.SetSpanError(span, diags)
 		return diags.Append(evalDiags)
 	}
 	diags = diags.Append(evalDiags)
@@ -142,20 +183,32 @@ func (n *NodeApplyableProvider) ValidateProvider(ctx EvalContext, providerKey ad
 	validateResp := provider.ValidateProviderConfig(req)
 	diags = diags.Append(validateResp.Diagnostics.InConfigBody(configBody, n.Addr.InstanceString(providerKey)))
 
+	tracing.SetSpanError(span, diags)
 	return diags
 }
 
 // ConfigureProvider configures a provider that is already initialized and retrieved.
 // If verifyConfigIsKnown is true, ConfigureProvider will return an error if the
 // provider configVal is not wholly known and is meant only for use during import.
-func (n *NodeApplyableProvider) ConfigureProvider(ctx EvalContext, providerKey addrs.InstanceKey, provider providers.Interface, verifyConfigIsKnown bool) tfdiags.Diagnostics {
+func (n *NodeApplyableProvider) ConfigureProvider(ctx context.Context, evalCtx EvalContext, providerKey addrs.InstanceKey, provider providers.Interface, verifyConfigIsKnown bool) tfdiags.Diagnostics {
+	_, span := tracing.Tracer().Start(
+		ctx, "Configure provider",
+		otelTrace.WithAttributes(
+			otelAttr.String(traceAttrProviderAddr, n.Addr.Provider.String()),
+			otelAttr.String(traceAttrProviderConfigAddr, n.Addr.String()),
+			otelAttr.String(traceAttrProviderInstanceAddr, traceProviderInstanceAddr(n.Addr, providerKey)),
+		),
+	)
+	defer span.End()
+
 	config := n.ProviderConfig()
 
-	configBody := buildProviderConfig(ctx, n.Addr, config)
+	configBody := buildProviderConfig(evalCtx, n.Addr, config)
 
 	resp := provider.GetProviderSchema()
 	diags := resp.Diagnostics.InConfigBody(configBody, n.Addr.InstanceString(providerKey))
 	if diags.HasErrors() {
+		tracing.SetSpanError(span, diags)
 		return diags
 	}
 
@@ -165,9 +218,10 @@ func (n *NodeApplyableProvider) ConfigureProvider(ctx EvalContext, providerKey a
 		data = n.Config.Instances[providerKey]
 	}
 
-	configVal, configBody, evalDiags := ctx.EvaluateBlock(configBody, configSchema, nil, data)
+	configVal, configBody, evalDiags := evalCtx.EvaluateBlock(configBody, configSchema, nil, data)
 	diags = diags.Append(evalDiags)
 	if evalDiags.HasErrors() {
+		tracing.SetSpanError(span, diags)
 		return diags
 	}
 
@@ -178,6 +232,7 @@ func (n *NodeApplyableProvider) ConfigureProvider(ctx EvalContext, providerKey a
 			Detail:   fmt.Sprintf("The configuration for %s depends on values that cannot be determined until apply.", n.Addr),
 			Subject:  &config.DeclRange,
 		})
+		tracing.SetSpanError(span, diags)
 		return diags
 	}
 
@@ -207,6 +262,7 @@ func (n *NodeApplyableProvider) ConfigureProvider(ctx EvalContext, providerKey a
 	}
 
 	if diags.HasErrors() {
+		tracing.SetSpanError(span, diags)
 		return diags
 	}
 
@@ -217,7 +273,7 @@ func (n *NodeApplyableProvider) ConfigureProvider(ctx EvalContext, providerKey a
 		log.Printf("[WARN] ValidateProviderConfig from %q changed the config value, but that value is unused", n.Addr)
 	}
 
-	configDiags := ctx.ConfigureProvider(n.Addr, providerKey, unmarkedConfigVal)
+	configDiags := evalCtx.ConfigureProvider(n.Addr, providerKey, unmarkedConfigVal)
 	diags = diags.Append(configDiags.InConfigBody(configBody, n.Addr.InstanceString(providerKey)))
 	if diags.HasErrors() && config == nil {
 		// If there isn't an explicit "provider" block in the configuration,
@@ -229,8 +285,25 @@ func (n *NodeApplyableProvider) ConfigureProvider(ctx EvalContext, providerKey a
 			fmt.Sprintf(providerConfigErr, n.Addr.Provider),
 		))
 	}
+	tracing.SetSpanError(span, diags)
 	return diags
 }
 
 const providerConfigErr = `Provider %q requires explicit configuration. Add a provider block to the root module and configure the provider's required arguments as described in the provider documentation.
 `
+
+// traceProviderInstanceAddr generates a value to be used for tracing attributes
+// that refer to a specific instance of a provider configuration.
+//
+// This is here to compensate for the fact that we don't currently have an
+// address type for provider instance addresses in package addrs, and instead
+// just pass around loose config address and instance key values as separate
+// arguments. If we do eventually have a suitable address type then this
+// function should be removed and all uses of it replaced by calling the
+// String method on that address type.
+func traceProviderInstanceAddr(configAddr addrs.AbsProviderConfig, instKey addrs.InstanceKey) string {
+	if instKey == addrs.NoKey {
+		return configAddr.String()
+	}
+	return configAddr.String() + instKey.String()
+}

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -20,6 +20,21 @@ import (
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
+// traceNameValidateResource is a standardized trace span name we use for the
+// overall execution of all graph nodes that somehow represent the planning
+// phase for a resource instance.
+const traceNameValidateResource = "Validate resource configuration"
+
+// traceAttrConfigResourceAddr is a standardized trace span attribute name that we
+// use for recording the address of the main resource that a particular span is
+// concerned with.
+//
+// The value of this should be populated by calling the String method on
+// a value of type [addrs.ConfigResource]. DO NOT use this with results from
+// [addrs.AbsResourceInstance]; use [traceAttrResourceInstanceAddr] instead
+// for that address type.
+const traceAttrConfigResourceAddr = "opentofu.resource.address"
+
 // ConcreteResourceNodeFunc is a callback type used to convert an
 // abstract resource to a concrete one of some type.
 type ConcreteResourceNodeFunc func(*NodeAbstractResource) dag.Vertex

--- a/internal/tofu/node_resource_abstract_instance.go
+++ b/internal/tofu/node_resource_abstract_instance.go
@@ -28,6 +28,36 @@ import (
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
+// traceNamePlanResourceInstance is a standardize trace span name we use for the
+// overall execution of all graph nodes that somehow represent the planning
+// phase for a resource instance.
+const traceNamePlanResourceInstance = "Plan resource instance changes"
+
+// traceNameApplyResourceInstance is a standardize trace span name we use for
+// the overall execution of all graph nodes that somehow represent the apply
+// phase for a resource instance.
+const traceNameApplyResourceInstance = "Apply resource instance changes"
+
+// traceAttrResourceInstanceAddr is a standardized trace span attribute
+// name that we use for recording the address of the main resource instance that
+// a particular span is concerned with.
+//
+// The value of this should be populated by calling the String method on
+// a value of type [addrs.AbsResourceInstance].
+const traceAttrResourceInstanceAddr = "opentofu.resource_instance.address"
+
+// traceAttrPlanRefresh is a standardized trace span attribute name that we use
+// for a boolean attribute describing whether the refresh step is enabled
+// for the main resource instance associated with the span during the planning
+// phase.
+const traceAttrPlanRefresh = "opentofu.plan.refresh"
+
+// traceAttrPlanPlanChanges is a standardized trace span attribute name that we
+// use for a boolean attribute describing whether the plan step is enabled
+// for the main resource instance associated with the span during the planning
+// phase. (This is false in refresh-only mode.)
+const traceAttrPlanPlanChanges = "opentofu.plan.plan_changes"
+
 // NodeAbstractResourceInstance represents a resource instance with no
 // associated operations. It embeds NodeAbstractResource but additionally
 // contains an instance key, used to identify one of potentially many

--- a/internal/tracing/data.go
+++ b/internal/tracing/data.go
@@ -1,0 +1,44 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tracing
+
+import (
+	"fmt"
+	"iter"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+// This file contains utilities that are not directly related to tracing but
+// that are useful for transforming data to include in trace attributes, etc.
+//
+// These functions all take a span object as their first argument so that
+// they can skip performing expensive work when the span is not actually
+// recording. The documentation of each function describes how its behavior
+// differs when the span is not recording.
+
+// StringSlice takes a sequence of any type that implements [fmt.Stringer]
+// and returns a slice containing the results of calling the String method
+// on each item in that sequence.
+//
+// If the given span is not recording then this immediately returns nil
+// without consuming the iterator at all.
+//
+// Use [slices.Values] to use the elements of an existing slice. For example:
+//
+//	span.SetAttributes(
+//	    otelAttr.StringSlice("example", tracing.StringSlice(span, slices.Values(opts.Targets))),
+//	)
+func StringSlice[E fmt.Stringer](span trace.Span, items iter.Seq[E]) []string {
+	if !span.IsRecording() {
+		return nil // shortcut for when tracing is not enabled
+	}
+	var ret []string
+	for item := range items {
+		ret = append(ret, item.String())
+	}
+	return ret
+}


### PR DESCRIPTION
(This is for https://github.com/opentofu/opentofu/issues/2664.)

This introduces two new levels of trace span hierarchy that belong to the core language runtime:

1. Phases: these top-level spans distinguish between the validation phase, the input phase, the planning phase, and the apply phase, mainly just as context to help group together the items at the next level.

    These all intentionally include the word "phase" because I know from previous experience that newcomers often get confused between the OpenTofu CLI commands and the core runtime phases they cause. For example, `tofu apply`'s work includes all three phases, even though the command name only mentions "apply".
3. High-level operations: these roughly correspond to the operations that OpenTofu already reports in its UI, such as planning changes for a particular resource instance.

Since our current focus is on providing a similar level of detail as provided in our UI today, I think this represents a suitable level of detail for giving a broad overview of what's going on, without getting into implementation details. For nesting level 2 I intentionally restricted this only to the following categories:

- Operations that we already report in the UI anyway, such as applying changes for a particular resource instance.
- Operations that can involve making at least one gRPC request, since I expect that future work will add one more level of detail directly reporting those individual requests.
- Operations whose execution time materially depends on something outside of OpenTofu, such as interactive input prompts where the elapsed time is dominated by how long the operator took to enter an answer, and this is therefore worth segregating from time when OpenTofu is actively working on something.

In particular, this intentionally does not report relatively mundane details such as "evaluating local value" because the time spent doing those things ought to be minuscule in comparison to those which contact external systems, and so that information is likely to be more noise than useful signal for now.

In practice the bulk of the trace output involves planning and applying changes to resource instances, which is to be expected since that's what OpenTofu spends most of its time doing and is the most important part of OpenTofu's work.

---

There are two specific additions I'd like to make to this in future commits, but have left them out today because they require some more invasive `context.Context` plumbing work:

- Ensure that the `context.Context` plumbing reaches all the way to our gRPC requests to provider plugins so that those physical requests get traced directly, similar to how we're already tracing the individual HTTP requests made by our installer steps during `tofu init`.

    Although these are arguably implementation details, they can nonetheless have a material impact on overall execution time and correspond to a handoff to something outside of OpenTofu whose performance we cannot directly control.
- Generate a single trace span around the work of collecting schema information for providers.

    The need to fetch schemas is itself an implementation detail that we ideally wouldn't expose, but it's misleading _not_ to expose it because it takes a material amount of time and involves making several provider gRPC requests which currently just get associated with whichever caller is unfortunate to ask for the schemas first. (We fetch them once on first request and then cache them for future use.)

I think with this PR plus those two additional things we should be in good shape for a first useful form of core tracing, which we can then release and see what feedback we get before considering adding additional detail in later releases.
