### PR TITLE
tfdiags: Override cooperates with contextual diagnostics

### DIFF
--- a/internal/tfdiags/override.go
+++ b/internal/tfdiags/override.go
@@ -5,6 +5,10 @@
 
 package tfdiags
 
+import (
+	"github.com/hashicorp/hcl/v2"
+)
+
 // overriddenDiagnostic implements the Diagnostic interface by wrapping another
 // Diagnostic while overriding the severity of the original Diagnostic.
 type overriddenDiagnostic struct {
@@ -14,6 +18,7 @@ type overriddenDiagnostic struct {
 }
 
 var _ Diagnostic = overriddenDiagnostic{}
+var _ contextualFromConfigBody = overriddenDiagnostic{}
 
 // OverrideAll accepts a set of Diagnostics and wraps them with a new severity
 // and, optionally, a new ExtraInfo.
@@ -74,4 +79,25 @@ func (o overriddenDiagnostic) FromExpr() *FromExpr {
 
 func (o overriddenDiagnostic) ExtraInfo() interface{} {
 	return o.extra
+}
+
+// ElaborateFromConfigBody implements contextualFromConfigBody.
+//
+// If the original diagnostic also implements contextualFromConfigBody then this
+// delegates to its own ElaborateFromConfigBody implementation and then re-wraps
+// the result with the same overrides.
+//
+// Otherwise, the reciever is returned unchanged.
+func (o overriddenDiagnostic) ElaborateFromConfigBody(body hcl.Body, addr string) Diagnostic {
+	innerContextual, ok := o.original.(contextualFromConfigBody)
+	if !ok {
+		return o // inner diagnostic is not contextual, so nothing to do
+	}
+
+	newOriginal := innerContextual.ElaborateFromConfigBody(body, addr)
+	return overriddenDiagnostic{
+		original: newOriginal,
+		severity: o.severity,
+		extra:    o.extra,
+	}
 }


### PR DESCRIPTION
This PR just cherry-picked https://github.com/opentofu/opentofu/commit/4a9f10a726ef6a925393528336db51ecf77e75f0 in order to make those changes available to #2705.

-------
This package has two different mechanisms that can cause an existing diagnostic to be replaced with a modified version:
- "Override" effectively wraps an arbitrary other diagnostic with a new severity and optional new "extra info".
- Contextual diagnostics allow a diagnostic to be created in one place with some incomplete information, and then "elaborated" in another place where more information is available.

Those two mechanisms did not previously interact well together: passing a contextual diagnostic to Override would prevent its elaboration process from taking effect.

Now the overriddenDiagnostic type -- implementation detail of "Override" -- implements the same unexported interface that the contextual diagnostics do, and delegates the elaboration request to the diagnostic that it's wrapping so that the elaboration can take effect while still preserving the effect of the overrides.

This combination is okay because in practice "override" only affects Severity and ExtraInfo, while contextual diagnostics today only affect the source location information and the "address" components of the diagnostic, so the two can work independently of one another.

<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves # 

## Target Release

1.10.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
