### PR TITLE
e2etest: TestProviderGlobalCache generate valid CLI config on Windows

### DIFF
--- a/internal/command/e2etest/provider_plugin_test.go
+++ b/internal/command/e2etest/provider_plugin_test.go
@@ -110,7 +110,9 @@ func TestProviderGlobalCache(t *testing.T) {
 	}
 
 	rcLoc := filepath.Join(tmpDir, ".tofurc")
-	rcData := fmt.Sprintf(`plugin_cache_dir = "%s"`, tmpDir)
+	// We use forward slashes consistently, even on Windows, because backslashes
+	// require escaping for valid HCL syntax.
+	rcData := fmt.Sprintf(`plugin_cache_dir = "%s"`, filepath.ToSlash(tmpDir))
 	err = os.WriteFile(rcLoc, []byte(rcData), 0600)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This test uses a temporary file as an overridden CLI configuration to force using a specific plugin cache directory, but temporary file paths contain backslashes on Windows and the CLI configuration syntax is HCL so would require backslashes to be escaped.

Since Windows will accept forward-slash paths as a supported variation, and we typically recommend that folks write paths that way in HCL for portability anyway, this uses filepath.ToSlash to force consistent use of slashes on all platforms. It would also have been reasonable to use a %q format verb to use Go's string quoting syntax, but that's not the way we typically recommend folks hand-write their CLI configurations and so this way is just-so-slightly more "realistic".

(This test has been failing in the e2etest runs on `main` since d0ee5a36a58.)
