### PR TITLE
website: Finalize some of the OCI Registry-related docs for the v1.1.0 release

### DIFF
--- a/website/docs/cli/oci_registries/credentials.mdx
+++ b/website/docs/cli/oci_registries/credentials.mdx
@@ -127,3 +127,18 @@ The following arguments may appear in an `oci_default_credentials` block:
     For example, specify `docker_credentials_helper = "osxkeychain"` to make
     OpenTofu obtain credentials from your macOS Keychain. You must install the
     selected credential helper first so that OpenTofu can execute it.
+
+    :::note
+    **OpenTofu does not use any credential helper unless explicitly configured to do so.**
+
+    Docker CLI and some other more-closely-related software default to searching
+    certain hard-coded credential helper names depending on your platform when
+    no credential helper is configured and no static credentials are available.
+
+    To avoid executing third-party software without explicit consent, OpenTofu
+    instead requires that you directly configure any credential helper you
+    intend to use, either by using this OpenTofu-specific setting or by
+    using
+    [the `"credsStore"` property](https://docs.docker.com/reference/cli/docker/#credential-store-options)
+    in your Docker CLI configuration file.
+    :::

--- a/website/docs/cli/oci_registries/index.mdx
+++ b/website/docs/cli/oci_registries/index.mdx
@@ -7,12 +7,12 @@ description: >-
 
 Some of OpenTofu's features can be configured to interact with OCI Registries.
 
-:::note
-This section contains very early draft content for features that are still in development.
-
-We've included it to support prerelease testing, but the information here may be incomplete and
-anything documented in this section is subject to change before the final release.
-:::
+These integrations are designed to support registries that implement
+[OCI Distribution v1.1.0](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md).
+Registries that implement earlier versions may work, depending on how strictly
+they validate submitted manifests, but we cannot officially support them because
+v1.1.0 is the first protocol version that includes explicit support for
+non-container-image artifacts.
 
 ## OCI Registry Credentials
 
@@ -46,4 +46,3 @@ For more information, refer to [Provider Mirrors in OCI Registries](provider-mir
 
 OpenTofu does not yet support using an OCI Registry as the _primary_ installation source
 for a provider, but we are hoping to allow that in a future version.
-


### PR DESCRIPTION
(This is for https://github.com/opentofu/opentofu/issues/2540.)

Firstly this removes the callout box we'd previously included for the alpha releases warning that these features are incomplete and subject to change, because based on our current information we believe we are now feature complete and are expecting to carry the current design through the v1.1.0 betas and into the final release.

This also includes two additions:

1. A note that OpenTofu doesn't automatically detect and use certain hard-coded credential helpers based on the current platform, unlike Docker CLI.

    This difference came up in passing while we were discussing https://github.com/opentofu/opentofu/issues/2725, although it turned out to not actually be significant to that issue because the credential helper was explicitly selected in that case anyway.

    Nonetheless, this _is_ a minor difference compared to Docker CLI (but also consistent with some other non-Docker OCI-integrated software) so we'll include a note about it in the docs, in the hope that it might satisfy searches from folks who are trying to understand why their implicitly-selected credential helper isn't working for OpenTofu.

2. The "this is a draft" callout box is replaced with a short statement making it explicit that OpenTofu is designed for registries supporting v1.1.0 or later of the OCI Distribution protocol.

    v1.1.0 is the version that introduced explicit support for non-container-image artifacts, and so our artifact layouts may not be accepted by older implementations. In practice some implementations _will_ accept them because they accept and ignore extra manifest properties they don't understand, but that's not technically required in the older versions of the spec. (v1.1.0 is already quite well deployed, so this isn't a huge problem in practice but might be helpful for folks who have an on-premises private registry based on older software.)

---

One remaining documentation concern is that we don't yet have the finalized instructions for how to construct provider package artifacts for use with the `oci_mirror` feature, since we're still waiting for a definitive resolution on https://github.com/oras-project/oras/pull/1696 and https://github.com/oras-project/oras/pull/1700.

I'll deal with that in a subsequent PR once we have a little more clarity about what the situation is likely to be at the time we ship v1.10.0 final, but for the sake of this PR I've left the very manual long instructions intact.
