### PR TITLE
tofu: Some initial context.Context plumbing for the schema lookup codepaths

### DIFF
--- a/internal/backend/local/backend_apply.go
+++ b/internal/backend/local/backend_apply.go
@@ -102,7 +102,7 @@ func (b *Local) opApply(
 	// operation.
 	runningOp.State = lr.InputState
 
-	schemas, moreDiags := lr.Core.Schemas(lr.Config, lr.InputState)
+	schemas, moreDiags := lr.Core.Schemas(ctx, lr.Config, lr.InputState)
 	diags = diags.Append(moreDiags)
 	if moreDiags.HasErrors() {
 		op.ReportResult(runningOp, diags)

--- a/internal/backend/local/backend_plan.go
+++ b/internal/backend/local/backend_plan.go
@@ -196,7 +196,7 @@ func (b *Local) opPlan(
 
 	// Render the plan, if we produced one.
 	// (This might potentially be a partial plan with Errored set to true)
-	schemas, moreDiags := lr.Core.Schemas(lr.Config, lr.InputState)
+	schemas, moreDiags := lr.Core.Schemas(ctx, lr.Config, lr.InputState)
 	diags = diags.Append(moreDiags)
 	if moreDiags.HasErrors() {
 		op.ReportResult(runningOp, diags)

--- a/internal/backend/local/backend_refresh.go
+++ b/internal/backend/local/backend_refresh.go
@@ -88,7 +88,7 @@ func (b *Local) opRefresh(
 	}
 
 	// get schemas before writing state
-	schemas, moreDiags := lr.Core.Schemas(lr.Config, lr.InputState)
+	schemas, moreDiags := lr.Core.Schemas(ctx, lr.Config, lr.InputState)
 	diags = diags.Append(moreDiags)
 	if moreDiags.HasErrors() {
 		op.ReportResult(runningOp, diags)

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -945,7 +945,7 @@ func (c *Meta) MaybeGetSchemas(ctx context.Context, state *states.State, config 
 			return nil, diags
 		}
 		var schemaDiags tfdiags.Diagnostics
-		schemas, schemaDiags := tfCtx.Schemas(config, state)
+		schemas, schemaDiags := tfCtx.Schemas(ctx, config, state)
 		diags = diags.Append(schemaDiags)
 		if schemaDiags.HasErrors() {
 			return nil, diags

--- a/internal/command/providers_schema.go
+++ b/internal/command/providers_schema.go
@@ -120,7 +120,7 @@ func (c *ProvidersSchemaCommand) Run(args []string) int {
 		return 1
 	}
 
-	schemas, moreDiags := lr.Core.Schemas(lr.Config, lr.InputState)
+	schemas, moreDiags := lr.Core.Schemas(ctx, lr.Config, lr.InputState)
 	diags = diags.Append(moreDiags)
 	if moreDiags.HasErrors() {
 		c.showDiagnostics(diags)

--- a/internal/command/state_show.go
+++ b/internal/command/state_show.go
@@ -121,7 +121,7 @@ func (c *StateShowCommand) Run(args []string) int {
 	}
 
 	// Get the schemas from the context
-	schemas, diags := lr.Core.Schemas(lr.Config, lr.InputState)
+	schemas, diags := lr.Core.Schemas(ctx, lr.Config, lr.InputState)
 	if diags.HasErrors() {
 		c.View.Diagnostics(diags)
 		return 1

--- a/internal/command/test.go
+++ b/internal/command/test.go
@@ -591,7 +591,7 @@ func (runner *TestFileRunner) ExecuteTestRun(ctx context.Context, run *moduletes
 		}
 
 		if runner.Suite.Verbose {
-			schemas, diags := planCtx.Schemas(config, plan.PlannedState)
+			schemas, diags := planCtx.Schemas(ctx, config, plan.PlannedState)
 
 			// If we're going to fail to render the plan, let's not fail the overall
 			// test. It can still have succeeded. So we'll add the diagnostics, but
@@ -668,7 +668,7 @@ func (runner *TestFileRunner) ExecuteTestRun(ctx context.Context, run *moduletes
 	}
 
 	if runner.Suite.Verbose {
-		schemas, diags := planCtx.Schemas(config, plan.PlannedState)
+		schemas, diags := planCtx.Schemas(ctx, config, plan.PlannedState)
 
 		// If we're going to fail to render the plan, let's not fail the overall
 		// test. It can still have succeeded. So we'll add the diagnostics, but

--- a/internal/tofu/context.go
+++ b/internal/tofu/context.go
@@ -153,7 +153,7 @@ func NewContext(opts *ContextOpts) (*Context, tfdiags.Diagnostics) {
 	}, diags
 }
 
-func (c *Context) Schemas(config *configs.Config, state *states.State) (*Schemas, tfdiags.Diagnostics) {
+func (c *Context) Schemas(ctx context.Context, config *configs.Config, state *states.State) (*Schemas, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	ret, err := loadSchemas(config, state, c.plugins)

--- a/internal/tofu/context.go
+++ b/internal/tofu/context.go
@@ -156,7 +156,7 @@ func NewContext(opts *ContextOpts) (*Context, tfdiags.Diagnostics) {
 func (c *Context) Schemas(ctx context.Context, config *configs.Config, state *states.State) (*Schemas, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	ret, err := loadSchemas(config, state, c.plugins)
+	ret, err := loadSchemas(ctx, config, state, c.plugins)
 	if err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,

--- a/internal/tofu/context_input.go
+++ b/internal/tofu/context_input.go
@@ -56,7 +56,7 @@ func (c *Context) Input(ctx context.Context, config *configs.Config, mode InputM
 	)
 	defer span.End()
 
-	schemas, moreDiags := c.Schemas(config, nil)
+	schemas, moreDiags := c.Schemas(ctx, config, nil)
 	diags = diags.Append(moreDiags)
 	if moreDiags.HasErrors() {
 		return diags

--- a/internal/tofu/context_plugins.go
+++ b/internal/tofu/context_plugins.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -66,7 +67,7 @@ func (cp *contextPlugins) NewProvisionerInstance(typ string) (provisioners.Inter
 // ProviderSchema memoizes results by unique provider address, so it's fine
 // to repeatedly call this method with the same address if various different
 // parts of OpenTofu all need the same schema information.
-func (cp *contextPlugins) ProviderSchema(addr addrs.Provider) (providers.ProviderSchema, error) {
+func (cp *contextPlugins) ProviderSchema(ctx context.Context, addr addrs.Provider) (providers.ProviderSchema, error) {
 	// Check the global schema cache first.
 	// This cache is only written by the provider client, and transparently
 	// used by GetProviderSchema, but we check it here because at this point we
@@ -128,8 +129,8 @@ func (cp *contextPlugins) ProviderSchema(addr addrs.Provider) (providers.Provide
 // reads the full schema of the given provider and then extracts just the
 // provider's configuration schema, which defines what's expected in a
 // "provider" block in the configuration when configuring this provider.
-func (cp *contextPlugins) ProviderConfigSchema(providerAddr addrs.Provider) (*configschema.Block, error) {
-	providerSchema, err := cp.ProviderSchema(providerAddr)
+func (cp *contextPlugins) ProviderConfigSchema(ctx context.Context, providerAddr addrs.Provider) (*configschema.Block, error) {
+	providerSchema, err := cp.ProviderSchema(ctx, providerAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -148,8 +149,8 @@ func (cp *contextPlugins) ProviderConfigSchema(providerAddr addrs.Provider) (*co
 // Managed resource types have versioned schemas, so the second return value
 // is the current schema version number for the requested resource. The version
 // is irrelevant for other resource modes.
-func (cp *contextPlugins) ResourceTypeSchema(providerAddr addrs.Provider, resourceMode addrs.ResourceMode, resourceType string) (*configschema.Block, uint64, error) {
-	providerSchema, err := cp.ProviderSchema(providerAddr)
+func (cp *contextPlugins) ResourceTypeSchema(ctx context.Context, providerAddr addrs.Provider, resourceMode addrs.ResourceMode, resourceType string) (*configschema.Block, uint64, error) {
+	providerSchema, err := cp.ProviderSchema(ctx, providerAddr)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/tofu/eval_context_builtin.go
+++ b/internal/tofu/eval_context_builtin.go
@@ -183,7 +183,8 @@ func (ctx *BuiltinEvalContext) Provider(addr addrs.AbsProviderConfig, key addrs.
 }
 
 func (ctx *BuiltinEvalContext) ProviderSchema(addr addrs.AbsProviderConfig) (providers.ProviderSchema, error) {
-	return ctx.Plugins.ProviderSchema(addr.Provider)
+	// TODO: Update the EvalContext interface to expect context.Context on most/all methods.
+	return ctx.Plugins.ProviderSchema(context.TODO(), addr.Provider)
 }
 
 func (ctx *BuiltinEvalContext) CloseProvider(addr addrs.AbsProviderConfig) error {

--- a/internal/tofu/evaluate.go
+++ b/internal/tofu/evaluate.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -914,7 +915,8 @@ func (d *evaluationStateData) GetResource(addr addrs.Resource, rng tfdiags.Sourc
 }
 
 func (d *evaluationStateData) getResourceSchema(addr addrs.Resource, providerAddr addrs.Provider) *configschema.Block {
-	schema, _, err := d.Evaluator.Plugins.ResourceTypeSchema(providerAddr, addr.Mode, addr.Type)
+	// TODO: Plumb a useful context.Context through to here.
+	schema, _, err := d.Evaluator.Plugins.ResourceTypeSchema(context.TODO(), providerAddr, addr.Mode, addr.Type)
 	if err != nil {
 		// We have plenty of other codepaths that will detect and report
 		// schema lookup errors before we'd reach this point, so we'll just

--- a/internal/tofu/evaluate_valid.go
+++ b/internal/tofu/evaluate_valid.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"sort"
 
@@ -237,8 +238,9 @@ func (d *evaluationStateData) staticValidateResourceReference(modCfg *configs.Co
 		})
 	}
 
+	// TODO: Plugin a suitable context.Context through to here.
 	providerFqn := modCfg.Module.ProviderForLocalConfig(cfg.ProviderConfigAddr())
-	schema, _, err := d.Evaluator.Plugins.ResourceTypeSchema(providerFqn, addr.Mode, addr.Type)
+	schema, _, err := d.Evaluator.Plugins.ResourceTypeSchema(context.TODO(), providerFqn, addr.Mode, addr.Type)
 	if err != nil {
 		// Prior validation should've taken care of a schema lookup error,
 		// so we should never get here but we'll handle it here anyway for

--- a/internal/tofu/schemas.go
+++ b/internal/tofu/schemas.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -72,22 +73,27 @@ func (ss *Schemas) ProvisionerConfig(name string) *configschema.Block {
 // either misbehavior on the part of one of the providers or of the provider
 // protocol itself. When returned with errors, the returned schemas object is
 // still valid but may be incomplete.
-func loadSchemas(config *configs.Config, state *states.State, plugins *contextPlugins) (*Schemas, error) {
+func loadSchemas(ctx context.Context, config *configs.Config, state *states.State, plugins *contextPlugins) (*Schemas, error) {
 	schemas := &Schemas{
 		Providers:    map[addrs.Provider]providers.ProviderSchema{},
 		Provisioners: map[string]*configschema.Block{},
 	}
 	var diags tfdiags.Diagnostics
 
-	newDiags := loadProviderSchemas(schemas.Providers, config, state, plugins)
+	// TODO: Start an OpenTelemetry trace span covering the entire time spent
+	// loading schemas. (Our use of schemas is an implementation concern
+	// rather than something end-users typically worry about, so we should
+	// avoid exposing excessive amounts of detail under this codepath.)
+
+	newDiags := loadProviderSchemas(ctx, schemas.Providers, config, state, plugins)
 	diags = diags.Append(newDiags)
-	newDiags = loadProvisionerSchemas(schemas.Provisioners, config, plugins)
+	newDiags = loadProvisionerSchemas(ctx, schemas.Provisioners, config, plugins)
 	diags = diags.Append(newDiags)
 
 	return schemas, diags.Err()
 }
 
-func loadProviderSchemas(schemas map[addrs.Provider]providers.ProviderSchema, config *configs.Config, state *states.State, plugins *contextPlugins) tfdiags.Diagnostics {
+func loadProviderSchemas(ctx context.Context, schemas map[addrs.Provider]providers.ProviderSchema, config *configs.Config, state *states.State, plugins *contextPlugins) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
 	ensure := func(fqn addrs.Provider) {
@@ -98,7 +104,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]providers.ProviderSchema, co
 		}
 
 		log.Printf("[TRACE] LoadSchemas: retrieving schema for provider type %q", name)
-		schema, err := plugins.ProviderSchema(fqn)
+		schema, err := plugins.ProviderSchema(ctx, fqn)
 		if err != nil {
 			// We'll put a stub in the map so we won't re-attempt this on
 			// future calls, which would then repeat the same error message
@@ -133,7 +139,7 @@ func loadProviderSchemas(schemas map[addrs.Provider]providers.ProviderSchema, co
 	return diags
 }
 
-func loadProvisionerSchemas(schemas map[string]*configschema.Block, config *configs.Config, plugins *contextPlugins) tfdiags.Diagnostics {
+func loadProvisionerSchemas(ctx context.Context, schemas map[string]*configschema.Block, config *configs.Config, plugins *contextPlugins) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
 	ensure := func(name string) {
@@ -170,7 +176,7 @@ func loadProvisionerSchemas(schemas map[string]*configschema.Block, config *conf
 
 		// Must also visit our child modules, recursively.
 		for _, cc := range config.Children {
-			childDiags := loadProvisionerSchemas(schemas, cc, plugins)
+			childDiags := loadProvisionerSchemas(ctx, schemas, cc, plugins)
 			diags = diags.Append(childDiags)
 		}
 	}

--- a/internal/tofu/transform_attach_schema.go
+++ b/internal/tofu/transform_attach_schema.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -67,7 +68,8 @@ func (t *AttachSchemaTransformer) Transform(g *Graph) error {
 			typeName := addr.Resource.Type
 			providerFqn := tv.Provider()
 
-			schema, version, err := t.Plugins.ResourceTypeSchema(providerFqn, mode, typeName)
+			// TODO: Plumb a useful context.Context through to here.
+			schema, version, err := t.Plugins.ResourceTypeSchema(context.TODO(), providerFqn, mode, typeName)
 			if err != nil {
 				return fmt.Errorf("failed to read schema for %s in %s: %w", addr, providerFqn, err)
 			}
@@ -81,7 +83,8 @@ func (t *AttachSchemaTransformer) Transform(g *Graph) error {
 
 		if tv, ok := v.(GraphNodeAttachProviderConfigSchema); ok {
 			providerAddr := tv.ProviderAddr()
-			schema, err := t.Plugins.ProviderConfigSchema(providerAddr.Provider)
+			// TODO: Plumb a useful context.Context through to here.
+			schema, err := t.Plugins.ProviderConfigSchema(context.TODO(), providerAddr.Provider)
 			if err != nil {
 				return fmt.Errorf("failed to read provider configuration schema for %s: %w", providerAddr.Provider, err)
 			}


### PR DESCRIPTION
(This is for https://github.com/opentofu/opentofu/issues/2664.)

In https://github.com/opentofu/opentofu/pull/2749 I skipped adding a span for the time spent populating the schema cache because the functions involved in that were not yet updated to take `context.Context` arguments.

This PR makes a good start on addressing that by adding `context.Context` arguments as deeply as we can go without modifying any interface definitions (which would require a _lot_ of mechanical updates), with the intention of continuing this work after we've dealt with the broader (and more disruptive) concerns of adding context parameters to the methods of `tofu.EvalContext`, `tofu.GraphTransformer`, and `providers.Interface`.

In a few spots this PR uses [`context.TODO()`](https://pkg.go.dev/context#TODO) as a temporary placeholder where a context is required but not yet easily plumbable. Being a temporary placeholder is the documented purpose of that function, and so later we'll be able to use "Find References" functionality in `gopls` to find these and update them to use a more useful `ctx` value instead.
