### PR TITLE
various: Remove context.TODO() usage from all tests

### DIFF
--- a/internal/backend/remote-state/azure/backend_test.go
+++ b/internal/backend/remote-state/azure/backend_test.go
@@ -112,10 +112,9 @@ func TestAccBackendAccessKeyBasic(t *testing.T) {
 	res := testResourceNames(rs, "testState")
 	armClient := buildTestClient(t, res)
 
-	ctx := context.TODO()
-	err := armClient.buildTestResources(t, ctx, &res)
+	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -141,10 +140,9 @@ func TestAccBackendSASTokenBasic(t *testing.T) {
 	res := testResourceNames(rs, "testState")
 	armClient := buildTestClient(t, res)
 
-	ctx := context.TODO()
-	err := armClient.buildTestResources(t, ctx, &res)
+	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -175,10 +173,9 @@ func TestAccBackendOIDCBasic(t *testing.T) {
 	res := testResourceNames(rs, "testState")
 	armClient := buildTestClient(t, res)
 
-	ctx := context.TODO()
-	err := armClient.buildTestResources(t, ctx, &res)
+	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -207,10 +204,9 @@ func TestAccBackendManagedServiceIdentityBasic(t *testing.T) {
 	res := testResourceNames(rs, "testState")
 	armClient := buildTestClient(t, res)
 
-	ctx := context.TODO()
-	err := armClient.buildTestResources(t, ctx, &res)
+	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -246,10 +242,9 @@ func TestAccBackendServicePrincipalClientCertificateBasic(t *testing.T) {
 	res := testResourceNames(rs, "testState")
 	armClient := buildTestClient(t, res)
 
-	ctx := context.TODO()
-	err := armClient.buildTestResources(t, ctx, &res)
+	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -280,10 +275,9 @@ func TestAccBackendServicePrincipalClientSecretBasic(t *testing.T) {
 	res := testResourceNames(rs, "testState")
 	armClient := buildTestClient(t, res)
 
-	ctx := context.TODO()
-	err := armClient.buildTestResources(t, ctx, &res)
+	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -320,10 +314,9 @@ func TestAccBackendServicePrincipalClientSecretCustomEndpoint(t *testing.T) {
 	res := testResourceNames(rs, "testState")
 	armClient := buildTestClient(t, res)
 
-	ctx := context.TODO()
-	err := armClient.buildTestResources(t, ctx, &res)
+	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -353,10 +346,9 @@ func TestAccBackendAccessKeyLocked(t *testing.T) {
 	res := testResourceNames(rs, "testState")
 	armClient := buildTestClient(t, res)
 
-	ctx := context.TODO()
-	err := armClient.buildTestResources(t, ctx, &res)
+	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -395,10 +387,9 @@ func TestAccBackendServicePrincipalLocked(t *testing.T) {
 	res := testResourceNames(rs, "testState")
 	armClient := buildTestClient(t, res)
 
-	ctx := context.TODO()
-	err := armClient.buildTestResources(t, ctx, &res)
+	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})

--- a/internal/backend/remote-state/azure/client_test.go
+++ b/internal/backend/remote-state/azure/client_test.go
@@ -6,7 +6,6 @@
 package azure
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -28,10 +27,9 @@ func TestRemoteClientAccessKeyBasic(t *testing.T) {
 	res := testResourceNames(rs, "testState")
 	armClient := buildTestClient(t, res)
 
-	ctx := context.TODO()
-	err := armClient.buildTestResources(t, ctx, &res)
+	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -62,10 +60,9 @@ func TestRemoteClientManagedServiceIdentityBasic(t *testing.T) {
 	res := testResourceNames(rs, "testState")
 	armClient := buildTestClient(t, res)
 
-	ctx := context.TODO()
-	err := armClient.buildTestResources(t, ctx, &res)
+	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -99,10 +96,9 @@ func TestRemoteClientSasTokenBasic(t *testing.T) {
 	res := testResourceNames(rs, "testState")
 	armClient := buildTestClient(t, res)
 
-	ctx := context.TODO()
-	err := armClient.buildTestResources(t, ctx, &res)
+	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -138,10 +134,9 @@ func TestRemoteClientServicePrincipalBasic(t *testing.T) {
 	res := testResourceNames(rs, "testState")
 	armClient := buildTestClient(t, res)
 
-	ctx := context.TODO()
-	err := armClient.buildTestResources(t, ctx, &res)
+	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -176,10 +171,9 @@ func TestRemoteClientAccessKeyLocks(t *testing.T) {
 	res := testResourceNames(rs, "testState")
 	armClient := buildTestClient(t, res)
 
-	ctx := context.TODO()
-	err := armClient.buildTestResources(t, ctx, &res)
+	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -224,10 +218,9 @@ func TestRemoteClientServicePrincipalLocks(t *testing.T) {
 	res := testResourceNames(rs, "testState")
 	armClient := buildTestClient(t, res)
 
-	ctx := context.TODO()
-	err := armClient.buildTestResources(t, ctx, &res)
+	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -280,10 +273,9 @@ func TestPutMaintainsMetaData(t *testing.T) {
 	res := testResourceNames(rs, "testState")
 	armClient := buildTestClient(t, res)
 
-	ctx := context.TODO()
-	err := armClient.buildTestResources(t, ctx, &res)
+	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, ctx, res); err != nil {
+		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -294,17 +286,17 @@ func TestPutMaintainsMetaData(t *testing.T) {
 	headerName := "acceptancetest"
 	expectedValue := "f3b56bad-33ad-4b93-a600-7a66e9cbd1eb"
 
-	client, err := armClient.getBlobClient(ctx)
+	client, err := armClient.getBlobClient(t.Context())
 	if err != nil {
 		t.Fatalf("Error building Blob Client: %+v", err)
 	}
 
-	_, err = client.PutBlockBlob(ctx, res.storageAccountName, res.storageContainerName, res.storageKeyName, blobs.PutBlockBlobInput{})
+	_, err = client.PutBlockBlob(t.Context(), res.storageAccountName, res.storageContainerName, res.storageKeyName, blobs.PutBlockBlobInput{})
 	if err != nil {
 		t.Fatalf("Error Creating Block Blob: %+v", err)
 	}
 
-	blobReference, err := client.GetProperties(ctx, res.storageAccountName, res.storageContainerName, res.storageKeyName, blobs.GetPropertiesInput{})
+	blobReference, err := client.GetProperties(t.Context(), res.storageAccountName, res.storageContainerName, res.storageKeyName, blobs.GetPropertiesInput{})
 	if err != nil {
 		t.Fatalf("Error loading MetaData: %+v", err)
 	}
@@ -313,7 +305,7 @@ func TestPutMaintainsMetaData(t *testing.T) {
 	opts := blobs.SetMetaDataInput{
 		MetaData: blobReference.MetaData,
 	}
-	_, err = client.SetMetaData(ctx, res.storageAccountName, res.storageContainerName, res.storageKeyName, opts)
+	_, err = client.SetMetaData(t.Context(), res.storageAccountName, res.storageContainerName, res.storageKeyName, opts)
 	if err != nil {
 		t.Fatalf("Error setting MetaData: %+v", err)
 	}
@@ -334,7 +326,7 @@ func TestPutMaintainsMetaData(t *testing.T) {
 	}
 
 	// Verify it still exists
-	blobReference, err = client.GetProperties(ctx, res.storageAccountName, res.storageContainerName, res.storageKeyName, blobs.GetPropertiesInput{})
+	blobReference, err = client.GetProperties(t.Context(), res.storageAccountName, res.storageContainerName, res.storageKeyName, blobs.GetPropertiesInput{})
 	if err != nil {
 		t.Fatalf("Error loading MetaData: %+v", err)
 	}

--- a/internal/backend/remote-state/azure/helpers_test.go
+++ b/internal/backend/remote-state/azure/helpers_test.go
@@ -87,7 +87,7 @@ func buildTestClient(t *testing.T, res resourceNames) *ArmClient {
 	// Endpoint is optional (only for Stack)
 	endpoint := os.Getenv("ARM_ENDPOINT")
 
-	armClient, err := buildArmClient(context.TODO(), BackendConfig{
+	armClient, err := buildArmClient(t.Context(), BackendConfig{
 		SubscriptionID:                subscriptionID,
 		TenantID:                      tenantID,
 		ClientID:                      clientID,

--- a/internal/backend/remote-state/s3/backend_complete_test.go
+++ b/internal/backend/remote-state/s3/backend_complete_test.go
@@ -6,7 +6,6 @@
 package s3
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -742,7 +741,7 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 				return
 			}
 
-			credentials, err := b.awsConfig.Credentials.Retrieve(context.TODO())
+			credentials, err := b.awsConfig.Credentials.Retrieve(t.Context())
 			if err != nil {
 				t.Fatalf("Error when requesting credentials: %s", err)
 			}
@@ -1100,8 +1099,6 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 		t.Run(name, func(t *testing.T) {
 			servicemocks.InitSessionTestEnv(t)
 
-			ctx := context.TODO()
-
 			// Populate required fields
 			tc.config["region"] = "us-east-1"
 			tc.config["bucket"] = "bucket"
@@ -1181,7 +1178,7 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 				return
 			}
 
-			credentials, err := b.awsConfig.Credentials.Retrieve(ctx)
+			credentials, err := b.awsConfig.Credentials.Retrieve(t.Context())
 			if err != nil {
 				t.Fatalf("Error when requesting credentials: %s", err)
 			}
@@ -1502,8 +1499,6 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 		t.Run(name, func(t *testing.T) {
 			servicemocks.InitSessionTestEnv(t)
 
-			ctx := context.TODO()
-
 			// Populate required fields
 			tc.config["region"] = "us-east-1"
 			tc.config["bucket"] = "bucket"
@@ -1585,7 +1580,7 @@ aws_secret_access_key = DefaultSharedCredentialsSecretKey
 				return
 			}
 
-			credentials, err := b.awsConfig.Credentials.Retrieve(ctx)
+			credentials, err := b.awsConfig.Credentials.Retrieve(t.Context())
 			if err != nil {
 				t.Fatalf("Error when requesting credentials: %s", err)
 			}
@@ -1775,8 +1770,6 @@ web_identity_token_file = no-such-file
 		t.Run(name, func(t *testing.T) {
 			servicemocks.InitSessionTestEnv(t)
 
-			ctx := context.TODO()
-
 			// Populate required fields
 			tc.config["region"] = "us-east-1"
 			tc.config["bucket"] = "bucket"
@@ -1863,7 +1856,7 @@ web_identity_token_file = no-such-file
 				return
 			}
 
-			credentials, err := b.awsConfig.Credentials.Retrieve(ctx)
+			credentials, err := b.awsConfig.Credentials.Retrieve(t.Context())
 			if err != nil {
 				t.Fatalf("Error when requesting credentials: %s", err)
 			}

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -86,7 +86,7 @@ func TestBackendConfig_original(t *testing.T) {
 		t.Fatalf("Incorrect keyName was populated")
 	}
 
-	credentials, err := b.awsConfig.Credentials.Retrieve(context.TODO())
+	credentials, err := b.awsConfig.Credentials.Retrieve(t.Context())
 	if err != nil {
 		t.Fatalf("Error when requesting credentials")
 	}
@@ -1085,9 +1085,8 @@ func TestBackend(t *testing.T) {
 		"region":  "us-west-1",
 	})).(*Backend)
 
-	ctx := context.TODO()
-	createS3Bucket(ctx, t, b.s3Client, bucketName, b.awsConfig.Region)
-	defer deleteS3Bucket(ctx, t, b.s3Client, bucketName)
+	createS3Bucket(t.Context(), t, b.s3Client, bucketName, b.awsConfig.Region)
+	defer deleteS3Bucket(t.Context(), t, b.s3Client, bucketName)
 
 	backend.TestBackendStates(t, b)
 }
@@ -1114,11 +1113,10 @@ func TestBackendLocked(t *testing.T) {
 		"region":         "us-west-1",
 	})).(*Backend)
 
-	ctx := context.TODO()
-	createS3Bucket(ctx, t, b1.s3Client, bucketName, b1.awsConfig.Region)
-	defer deleteS3Bucket(ctx, t, b1.s3Client, bucketName)
-	createDynamoDBTable(ctx, t, b1.dynClient, bucketName)
-	defer deleteDynamoDBTable(ctx, t, b1.dynClient, bucketName)
+	createS3Bucket(t.Context(), t, b1.s3Client, bucketName, b1.awsConfig.Region)
+	defer deleteS3Bucket(t.Context(), t, b1.s3Client, bucketName)
+	createDynamoDBTable(t.Context(), t, b1.dynClient, bucketName)
+	defer deleteDynamoDBTable(t.Context(), t, b1.dynClient, bucketName)
 
 	backend.TestBackendStateLocks(t, b1, b2)
 	backend.TestBackendStateForceUnlock(t, b1, b2)
@@ -1177,9 +1175,8 @@ func TestBackendSSECustomerKeyConfig(t *testing.T) {
 					t.Fatal("unexpected value for customer encryption key")
 				}
 
-				ctx := context.TODO()
-				createS3Bucket(ctx, t, b.s3Client, bucketName, b.awsConfig.Region)
-				defer deleteS3Bucket(ctx, t, b.s3Client, bucketName)
+				createS3Bucket(t.Context(), t, b.s3Client, bucketName, b.awsConfig.Region)
+				defer deleteS3Bucket(t.Context(), t, b.s3Client, bucketName)
 
 				backend.TestBackendStates(t, b)
 			}
@@ -1241,9 +1238,8 @@ func TestBackendSSECustomerKeyEnvVar(t *testing.T) {
 					t.Fatal("unexpected value for customer encryption key")
 				}
 
-				ctx := context.TODO()
-				createS3Bucket(ctx, t, b.s3Client, bucketName, b.awsConfig.Region)
-				defer deleteS3Bucket(ctx, t, b.s3Client, bucketName)
+				createS3Bucket(t.Context(), t, b.s3Client, bucketName, b.awsConfig.Region)
+				defer deleteS3Bucket(t.Context(), t, b.s3Client, bucketName)
 
 				backend.TestBackendStates(t, b)
 			}
@@ -1263,9 +1259,8 @@ func TestBackendExtraPaths(t *testing.T) {
 		"encrypt": true,
 	})).(*Backend)
 
-	ctx := context.TODO()
-	createS3Bucket(ctx, t, b.s3Client, bucketName, b.awsConfig.Region)
-	defer deleteS3Bucket(ctx, t, b.s3Client, bucketName)
+	createS3Bucket(t.Context(), t, b.s3Client, bucketName, b.awsConfig.Region)
+	defer deleteS3Bucket(t.Context(), t, b.s3Client, bucketName)
 
 	// put multiple states in old env paths.
 	s1 := states.NewState()
@@ -1402,9 +1397,8 @@ func TestBackendPrefixInWorkspace(t *testing.T) {
 		"workspace_key_prefix": "env",
 	})).(*Backend)
 
-	ctx := context.TODO()
-	createS3Bucket(ctx, t, b.s3Client, bucketName, b.awsConfig.Region)
-	defer deleteS3Bucket(ctx, t, b.s3Client, bucketName)
+	createS3Bucket(t.Context(), t, b.s3Client, bucketName, b.awsConfig.Region)
+	defer deleteS3Bucket(t.Context(), t, b.s3Client, bucketName)
 
 	// get a state that contains the prefix as a substring
 	sMgr, err := b.StateMgr("env-1")
@@ -1432,9 +1426,8 @@ func TestKeyEnv(t *testing.T) {
 		"workspace_key_prefix": "",
 	})).(*Backend)
 
-	ctx := context.TODO()
-	createS3Bucket(ctx, t, b0.s3Client, bucket0Name, b0.awsConfig.Region)
-	defer deleteS3Bucket(ctx, t, b0.s3Client, bucket0Name)
+	createS3Bucket(t.Context(), t, b0.s3Client, bucket0Name, b0.awsConfig.Region)
+	defer deleteS3Bucket(t.Context(), t, b0.s3Client, bucket0Name)
 
 	bucket1Name := fmt.Sprintf("%s-%x-1", testBucketPrefix, time.Now().Unix())
 	b1 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]interface{}{
@@ -1444,8 +1437,8 @@ func TestKeyEnv(t *testing.T) {
 		"workspace_key_prefix": "project/env:",
 	})).(*Backend)
 
-	createS3Bucket(ctx, t, b1.s3Client, bucket1Name, b1.awsConfig.Region)
-	defer deleteS3Bucket(ctx, t, b1.s3Client, bucket1Name)
+	createS3Bucket(t.Context(), t, b1.s3Client, bucket1Name, b1.awsConfig.Region)
+	defer deleteS3Bucket(t.Context(), t, b1.s3Client, bucket1Name)
 
 	bucket2Name := fmt.Sprintf("%s-%x-2", testBucketPrefix, time.Now().Unix())
 	b2 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]interface{}{
@@ -1454,8 +1447,8 @@ func TestKeyEnv(t *testing.T) {
 		"encrypt": true,
 	})).(*Backend)
 
-	createS3Bucket(ctx, t, b2.s3Client, bucket2Name, b2.awsConfig.Region)
-	defer deleteS3Bucket(ctx, t, b2.s3Client, bucket2Name)
+	createS3Bucket(t.Context(), t, b2.s3Client, bucket2Name, b2.awsConfig.Region)
+	defer deleteS3Bucket(t.Context(), t, b2.s3Client, bucket2Name)
 
 	if err := testGetWorkspaceForKey(b0, "some/paths/tfstate", ""); err != nil {
 		t.Fatal(err)

--- a/internal/backend/remote-state/s3/client_test.go
+++ b/internal/backend/remote-state/s3/client_test.go
@@ -43,9 +43,8 @@ func TestRemoteClient(t *testing.T) {
 		"encrypt": true,
 	})).(*Backend)
 
-	ctx := context.TODO()
-	createS3Bucket(ctx, t, b.s3Client, bucketName, b.awsConfig.Region)
-	defer deleteS3Bucket(ctx, t, b.s3Client, bucketName)
+	createS3Bucket(t.Context(), t, b.s3Client, bucketName, b.awsConfig.Region)
+	defer deleteS3Bucket(t.Context(), t, b.s3Client, bucketName)
 
 	state, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
@@ -74,11 +73,10 @@ func TestRemoteClientLocks(t *testing.T) {
 		"dynamodb_table": bucketName,
 	})).(*Backend)
 
-	ctx := context.TODO()
-	createS3Bucket(ctx, t, b1.s3Client, bucketName, b1.awsConfig.Region)
-	defer deleteS3Bucket(ctx, t, b1.s3Client, bucketName)
-	createDynamoDBTable(ctx, t, b1.dynClient, bucketName)
-	defer deleteDynamoDBTable(ctx, t, b1.dynClient, bucketName)
+	createS3Bucket(t.Context(), t, b1.s3Client, bucketName, b1.awsConfig.Region)
+	defer deleteS3Bucket(t.Context(), t, b1.s3Client, bucketName)
+	createDynamoDBTable(t.Context(), t, b1.dynClient, bucketName)
+	defer deleteDynamoDBTable(t.Context(), t, b1.dynClient, bucketName)
 
 	s1, err := b1.StateMgr(backend.DefaultStateName)
 	if err != nil {
@@ -112,9 +110,8 @@ func TestRemoteS3ClientLocks(t *testing.T) {
 		"use_lockfile": true,
 	})).(*Backend)
 
-	ctx := context.TODO()
-	createS3Bucket(ctx, t, b1.s3Client, bucketName, b1.awsConfig.Region)
-	defer deleteS3Bucket(ctx, t, b1.s3Client, bucketName)
+	createS3Bucket(t.Context(), t, b1.s3Client, bucketName, b1.awsConfig.Region)
+	defer deleteS3Bucket(t.Context(), t, b1.s3Client, bucketName)
 
 	s1, err := b1.StateMgr(backend.DefaultStateName)
 	if err != nil {
@@ -150,11 +147,10 @@ func TestRemoteS3AndDynamoDBClientLocks(t *testing.T) {
 		"use_lockfile":   true,
 	})).(*Backend)
 
-	ctx := context.TODO()
-	createS3Bucket(ctx, t, b1.s3Client, bucketName, b1.awsConfig.Region)
-	defer deleteS3Bucket(ctx, t, b1.s3Client, bucketName)
-	createDynamoDBTable(ctx, t, b1.dynClient, bucketName)
-	defer deleteDynamoDBTable(ctx, t, b1.dynClient, bucketName)
+	createS3Bucket(t.Context(), t, b1.s3Client, bucketName, b1.awsConfig.Region)
+	defer deleteS3Bucket(t.Context(), t, b1.s3Client, bucketName)
+	createDynamoDBTable(t.Context(), t, b1.dynClient, bucketName)
+	defer deleteDynamoDBTable(t.Context(), t, b1.dynClient, bucketName)
 
 	s1, err := b1.StateMgr(backend.DefaultStateName)
 	if err != nil {
@@ -190,9 +186,8 @@ func TestRemoteS3AndDynamoDBClientLocksWithNoDBInstance(t *testing.T) {
 		"use_lockfile":   true,
 	})).(*Backend)
 
-	ctx := context.TODO()
-	createS3Bucket(ctx, t, b1.s3Client, bucketName, b1.awsConfig.Region)
-	defer deleteS3Bucket(ctx, t, b1.s3Client, bucketName)
+	createS3Bucket(t.Context(), t, b1.s3Client, bucketName, b1.awsConfig.Region)
+	defer deleteS3Bucket(t.Context(), t, b1.s3Client, bucketName)
 
 	s1, err := b1.StateMgr(backend.DefaultStateName)
 	if err != nil {
@@ -208,7 +203,7 @@ func TestRemoteS3AndDynamoDBClientLocksWithNoDBInstance(t *testing.T) {
 	}
 
 	expected := 0
-	if actual := numberOfObjectsInBucket(t, ctx, b1.s3Client, bucketName); actual != expected {
+	if actual := numberOfObjectsInBucket(t, t.Context(), b1.s3Client, bucketName); actual != expected {
 		t.Fatalf("expected to have %d objects but got %d", expected, actual)
 	}
 }
@@ -233,11 +228,10 @@ func TestForceUnlock(t *testing.T) {
 		"dynamodb_table": bucketName,
 	})).(*Backend)
 
-	ctx := context.TODO()
-	createS3Bucket(ctx, t, b1.s3Client, bucketName, b1.awsConfig.Region)
-	defer deleteS3Bucket(ctx, t, b1.s3Client, bucketName)
-	createDynamoDBTable(ctx, t, b1.dynClient, bucketName)
-	defer deleteDynamoDBTable(ctx, t, b1.dynClient, bucketName)
+	createS3Bucket(t.Context(), t, b1.s3Client, bucketName, b1.awsConfig.Region)
+	defer deleteS3Bucket(t.Context(), t, b1.s3Client, bucketName)
+	createDynamoDBTable(t.Context(), t, b1.dynClient, bucketName)
+	defer deleteDynamoDBTable(t.Context(), t, b1.dynClient, bucketName)
 
 	// first test with default
 	s1, err := b1.StateMgr(backend.DefaultStateName)
@@ -326,9 +320,8 @@ func TestForceUnlockS3Only(t *testing.T) {
 		"use_lockfile": true,
 	})).(*Backend)
 
-	ctx := context.TODO()
-	createS3Bucket(ctx, t, b1.s3Client, bucketName, b1.awsConfig.Region)
-	defer deleteS3Bucket(ctx, t, b1.s3Client, bucketName)
+	createS3Bucket(t.Context(), t, b1.s3Client, bucketName, b1.awsConfig.Region)
+	defer deleteS3Bucket(t.Context(), t, b1.s3Client, bucketName)
 
 	// first test with default
 	s1, err := b1.StateMgr(backend.DefaultStateName)
@@ -419,11 +412,10 @@ func TestForceUnlockS3AndDynamo(t *testing.T) {
 		"dynamodb_table": bucketName,
 	})).(*Backend)
 
-	ctx := context.TODO()
-	createS3Bucket(ctx, t, b1.s3Client, bucketName, b1.awsConfig.Region)
-	defer deleteS3Bucket(ctx, t, b1.s3Client, bucketName)
-	createDynamoDBTable(ctx, t, b1.dynClient, bucketName)
-	defer deleteDynamoDBTable(ctx, t, b1.dynClient, bucketName)
+	createS3Bucket(t.Context(), t, b1.s3Client, bucketName, b1.awsConfig.Region)
+	defer deleteS3Bucket(t.Context(), t, b1.s3Client, bucketName)
+	createDynamoDBTable(t.Context(), t, b1.dynClient, bucketName)
+	defer deleteDynamoDBTable(t.Context(), t, b1.dynClient, bucketName)
 
 	// first test with default
 	s1, err := b1.StateMgr(backend.DefaultStateName)
@@ -511,11 +503,10 @@ func TestForceUnlockS3WithAndDynamoWithout(t *testing.T) {
 		"dynamodb_table": bucketName,
 	})).(*Backend)
 
-	ctx := context.TODO()
-	createS3Bucket(ctx, t, b1.s3Client, bucketName, b1.awsConfig.Region)
-	defer deleteS3Bucket(ctx, t, b1.s3Client, bucketName)
-	createDynamoDBTable(ctx, t, b1.dynClient, bucketName)
-	defer deleteDynamoDBTable(ctx, t, b1.dynClient, bucketName)
+	createS3Bucket(t.Context(), t, b1.s3Client, bucketName, b1.awsConfig.Region)
+	defer deleteS3Bucket(t.Context(), t, b1.s3Client, bucketName)
+	createDynamoDBTable(t.Context(), t, b1.dynClient, bucketName)
+	defer deleteDynamoDBTable(t.Context(), t, b1.dynClient, bucketName)
 
 	// first create both locks: s3 and dynamo
 	s1, err := b1.StateMgr(backend.DefaultStateName)
@@ -534,7 +525,7 @@ func TestForceUnlockS3WithAndDynamoWithout(t *testing.T) {
 
 	// Remove the dynamo lock to simulate that the lock in s3 was acquired, dynamo failed but s3 release failed in the end.
 	// Therefore, the user is left in the situation with s3 lock existing and dynamo missing.
-	deleteDynamoEntry(ctx, t, b1.dynClient, bucketName, info.Path)
+	deleteDynamoEntry(t.Context(), t, b1.dynClient, bucketName, info.Path)
 	err = s1.Unlock(lockID)
 	if err == nil {
 		t.Fatal("expected to get an error but got nil")
@@ -572,11 +563,10 @@ func TestRemoteClient_clientMD5(t *testing.T) {
 		"dynamodb_table": bucketName,
 	})).(*Backend)
 
-	ctx := context.TODO()
-	createS3Bucket(ctx, t, b.s3Client, bucketName, b.awsConfig.Region)
-	defer deleteS3Bucket(ctx, t, b.s3Client, bucketName)
-	createDynamoDBTable(ctx, t, b.dynClient, bucketName)
-	defer deleteDynamoDBTable(ctx, t, b.dynClient, bucketName)
+	createS3Bucket(t.Context(), t, b.s3Client, bucketName, b.awsConfig.Region)
+	defer deleteS3Bucket(t.Context(), t, b.s3Client, bucketName)
+	createDynamoDBTable(t.Context(), t, b.dynClient, bucketName)
+	defer deleteDynamoDBTable(t.Context(), t, b.dynClient, bucketName)
 
 	s, err := b.StateMgr(backend.DefaultStateName)
 	if err != nil {
@@ -586,11 +576,11 @@ func TestRemoteClient_clientMD5(t *testing.T) {
 
 	sum := md5.Sum([]byte("test"))
 
-	if err := client.putMD5(ctx, sum[:]); err != nil {
+	if err := client.putMD5(t.Context(), sum[:]); err != nil {
 		t.Fatal(err)
 	}
 
-	getSum, err := client.getMD5(ctx)
+	getSum, err := client.getMD5(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -599,11 +589,11 @@ func TestRemoteClient_clientMD5(t *testing.T) {
 		t.Fatalf("getMD5 returned the wrong checksum: expected %x, got %x", sum[:], getSum)
 	}
 
-	if err := client.deleteMD5(ctx); err != nil {
+	if err := client.deleteMD5(t.Context()); err != nil {
 		t.Fatal(err)
 	}
 
-	if getSum, err := client.getMD5(ctx); err == nil {
+	if getSum, err := client.getMD5(t.Context()); err == nil {
 		t.Fatalf("expected getMD5 error, got none. checksum: %x", getSum)
 	}
 }
@@ -621,11 +611,10 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 		"dynamodb_table": bucketName,
 	})).(*Backend)
 
-	ctx := context.TODO()
-	createS3Bucket(ctx, t, b1.s3Client, bucketName, b1.awsConfig.Region)
-	defer deleteS3Bucket(ctx, t, b1.s3Client, bucketName)
-	createDynamoDBTable(ctx, t, b1.dynClient, bucketName)
-	defer deleteDynamoDBTable(ctx, t, b1.dynClient, bucketName)
+	createS3Bucket(t.Context(), t, b1.s3Client, bucketName, b1.awsConfig.Region)
+	defer deleteS3Bucket(t.Context(), t, b1.s3Client, bucketName)
+	createDynamoDBTable(t.Context(), t, b1.dynClient, bucketName)
+	defer deleteDynamoDBTable(t.Context(), t, b1.dynClient, bucketName)
 
 	s1, err := b1.StateMgr(backend.DefaultStateName)
 	if err != nil {

--- a/internal/backend/remote/backend_context_test.go
+++ b/internal/backend/remote/backend_context_test.go
@@ -6,7 +6,6 @@
 package remote
 
 import (
-	"context"
 	"reflect"
 	"testing"
 
@@ -191,7 +190,7 @@ func TestRemoteContextWithVars(t *testing.T) {
 
 			_, configLoader := initwd.MustLoadConfigForTests(t, configDir, "tests")
 
-			workspaceID, err := b.getRemoteWorkspaceID(context.Background(), backend.DefaultStateName)
+			workspaceID, err := b.getRemoteWorkspaceID(t.Context(), backend.DefaultStateName)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -211,12 +210,12 @@ func TestRemoteContextWithVars(t *testing.T) {
 				key := "key"
 				v.Key = &key
 			}
-			_, err = b.client.Variables.Create(context.TODO(), workspaceID, *v)
+			_, err = b.client.Variables.Create(t.Context(), workspaceID, *v)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			_, _, diags := b.LocalRun(context.Background(), op)
+			_, _, diags := b.LocalRun(t.Context(), op)
 
 			if test.WantError != "" {
 				if !diags.HasErrors() {
@@ -416,7 +415,7 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 
 			_, configLoader := initwd.MustLoadConfigForTests(t, configDir, "tests")
 
-			workspaceID, err := b.getRemoteWorkspaceID(context.Background(), backend.DefaultStateName)
+			workspaceID, err := b.getRemoteWorkspaceID(t.Context(), backend.DefaultStateName)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -433,13 +432,13 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 			}
 
 			for _, v := range test.remoteVariables {
-				_, err = b.client.Variables.Create(context.TODO(), workspaceID, *v)
+				_, err = b.client.Variables.Create(t.Context(), workspaceID, *v)
 				if err != nil {
 					t.Fatal(err)
 				}
 			}
 
-			lr, _, diags := b.LocalRun(context.Background(), op)
+			lr, _, diags := b.LocalRun(t.Context(), op)
 
 			if diags.HasErrors() {
 				t.Fatalf("unexpected error\ngot:  %s\nwant: <no error>", diags.Err().Error())

--- a/internal/backend/remote/backend_context_test.go
+++ b/internal/backend/remote/backend_context_test.go
@@ -211,7 +211,10 @@ func TestRemoteContextWithVars(t *testing.T) {
 				key := "key"
 				v.Key = &key
 			}
-			b.client.Variables.Create(context.TODO(), workspaceID, *v)
+			_, err = b.client.Variables.Create(context.TODO(), workspaceID, *v)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			_, _, diags := b.LocalRun(context.Background(), op)
 
@@ -430,7 +433,10 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 			}
 
 			for _, v := range test.remoteVariables {
-				b.client.Variables.Create(context.TODO(), workspaceID, *v)
+				_, err = b.client.Variables.Create(context.TODO(), workspaceID, *v)
+				if err != nil {
+					t.Fatal(err)
+				}
 			}
 
 			lr, _, diags := b.LocalRun(context.Background(), op)

--- a/internal/cloud/backend_context_test.go
+++ b/internal/cloud/backend_context_test.go
@@ -6,7 +6,6 @@
 package cloud
 
 import (
-	"context"
 	"reflect"
 	"testing"
 
@@ -190,7 +189,7 @@ func TestRemoteContextWithVars(t *testing.T) {
 
 			_, configLoader := initwd.MustLoadConfigForTests(t, configDir, "tests")
 
-			workspaceID, err := b.getRemoteWorkspaceID(context.Background(), testBackendSingleWorkspaceName)
+			workspaceID, err := b.getRemoteWorkspaceID(t.Context(), testBackendSingleWorkspaceName)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -210,12 +209,12 @@ func TestRemoteContextWithVars(t *testing.T) {
 				key := "key"
 				v.Key = &key
 			}
-			_, err = b.client.Variables.Create(context.TODO(), workspaceID, *v)
+			_, err = b.client.Variables.Create(t.Context(), workspaceID, *v)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			_, _, diags := b.LocalRun(context.Background(), op)
+			_, _, diags := b.LocalRun(t.Context(), op)
 
 			if test.WantError != "" {
 				if !diags.HasErrors() {
@@ -415,7 +414,7 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 
 			_, configLoader := initwd.MustLoadConfigForTests(t, configDir, "tests")
 
-			workspaceID, err := b.getRemoteWorkspaceID(context.Background(), testBackendSingleWorkspaceName)
+			workspaceID, err := b.getRemoteWorkspaceID(t.Context(), testBackendSingleWorkspaceName)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -432,13 +431,13 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 			}
 
 			for _, v := range test.remoteVariables {
-				_, err = b.client.Variables.Create(context.TODO(), workspaceID, *v)
+				_, err = b.client.Variables.Create(t.Context(), workspaceID, *v)
 				if err != nil {
 					t.Fatal(err)
 				}
 			}
 
-			lr, _, diags := b.LocalRun(context.Background(), op)
+			lr, _, diags := b.LocalRun(t.Context(), op)
 
 			if diags.HasErrors() {
 				t.Fatalf("unexpected error\ngot:  %s\nwant: <no error>", diags.Err().Error())

--- a/internal/cloud/backend_context_test.go
+++ b/internal/cloud/backend_context_test.go
@@ -210,7 +210,10 @@ func TestRemoteContextWithVars(t *testing.T) {
 				key := "key"
 				v.Key = &key
 			}
-			b.client.Variables.Create(context.TODO(), workspaceID, *v)
+			_, err = b.client.Variables.Create(context.TODO(), workspaceID, *v)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			_, _, diags := b.LocalRun(context.Background(), op)
 
@@ -429,7 +432,10 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 			}
 
 			for _, v := range test.remoteVariables {
-				b.client.Variables.Create(context.TODO(), workspaceID, *v)
+				_, err = b.client.Variables.Create(context.TODO(), workspaceID, *v)
+				if err != nil {
+					t.Fatal(err)
+				}
 			}
 
 			lr, _, diags := b.LocalRun(context.Background(), op)

--- a/internal/cloud/backend_run_warning_test.go
+++ b/internal/cloud/backend_run_warning_test.go
@@ -6,7 +6,6 @@
 package cloud
 
 import (
-	"context"
 	"strings"
 	"testing"
 	"time"
@@ -93,9 +92,7 @@ func TestRunEventWarningsAll(t *testing.T) {
 	client, _ := tfe.NewClient(config)
 	fullRunID, _ := MockAllRunEvents(t, client)
 
-	ctx := context.TODO()
-
-	err := b.renderRunWarnings(ctx, client, fullRunID)
+	err := b.renderRunWarnings(t.Context(), client, fullRunID)
 	if err != nil {
 		t.Fatalf("Expected to not error but received %s", err)
 	}
@@ -125,9 +122,7 @@ func TestRunEventWarningsEmpty(t *testing.T) {
 	client, _ := tfe.NewClient(config)
 	_, emptyRunID := MockAllRunEvents(t, client)
 
-	ctx := context.TODO()
-
-	err := b.renderRunWarnings(ctx, client, emptyRunID)
+	err := b.renderRunWarnings(t.Context(), client, emptyRunID)
 	if err != nil {
 		t.Fatalf("Expected to not error but received %s", err)
 	}
@@ -148,9 +143,7 @@ func TestRunEventWarningsWithError(t *testing.T) {
 	client, _ := tfe.NewClient(config)
 	MockAllRunEvents(t, client)
 
-	ctx := context.TODO()
-
-	err := b.renderRunWarnings(ctx, client, "bad run id")
+	err := b.renderRunWarnings(t.Context(), client, "bad run id")
 
 	if err == nil {
 		t.Error("Expected to error but did not")

--- a/internal/cloud/backend_taskStages_test.go
+++ b/internal/cloud/backend_taskStages_test.go
@@ -6,7 +6,6 @@
 package cloud
 
 import (
-	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -119,8 +118,7 @@ func TestTaskStagesWithAllStages(t *testing.T) {
 	client, _ := tfe.NewClient(config)
 	runID := MockAllTaskStages(t, client)
 
-	ctx := context.TODO()
-	taskStages, err := b.runTaskStages(ctx, client, runID)
+	taskStages, err := b.runTaskStages(t.Context(), client, runID)
 
 	if err != nil {
 		t.Fatalf("Expected to not error but received %s", err)
@@ -151,8 +149,7 @@ func TestTaskStagesWithOneStage(t *testing.T) {
 	client, _ := tfe.NewClient(config)
 	runID := MockPrePlanTaskStage(t, client)
 
-	ctx := context.TODO()
-	taskStages, err := b.runTaskStages(ctx, client, runID)
+	taskStages, err := b.runTaskStages(t.Context(), client, runID)
 
 	if err != nil {
 		t.Fatalf("Expected to not error but received %s", err)
@@ -182,8 +179,7 @@ func TestTaskStagesWithOldTFC(t *testing.T) {
 	client, _ := tfe.NewClient(config)
 	runID := MockTaskStageUnsupported(t, client)
 
-	ctx := context.TODO()
-	taskStages, err := b.runTaskStages(ctx, client, runID)
+	taskStages, err := b.runTaskStages(t.Context(), client, runID)
 
 	if err != nil {
 		t.Fatalf("Expected to not error but received %s", err)
@@ -204,8 +200,7 @@ func TestTaskStagesWithErrors(t *testing.T) {
 	client, _ := tfe.NewClient(config)
 	MockTaskStageUnsupported(t, client)
 
-	ctx := context.TODO()
-	_, err := b.runTaskStages(ctx, client, "this run ID will not exist is invalid anyway")
+	_, err := b.runTaskStages(t.Context(), client, "this run ID will not exist is invalid anyway")
 
 	if err == nil {
 		t.Error("Expected to error but did not")

--- a/internal/providercache/dir_modify_test.go
+++ b/internal/providercache/dir_modify_test.go
@@ -6,7 +6,6 @@
 package providercache
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 
@@ -44,7 +43,7 @@ func TestInstallPackage(t *testing.T) {
 		Location: getproviders.PackageLocalArchive("testdata/provider-null_2.1.0_linux_amd64.zip"),
 	}
 
-	result, err := tmpDir.InstallPackage(context.TODO(), meta, nil)
+	result, err := tmpDir.InstallPackage(t.Context(), meta, nil)
 	if err != nil {
 		t.Fatalf("InstallPackage failed: %s", err)
 	}

--- a/internal/providercache/installer_test.go
+++ b/internal/providercache/installer_test.go
@@ -2457,8 +2457,6 @@ func TestEnsureProviderVersions_local_source(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.TODO()
-
 			provider := addrs.MustParseProviderSourceString(test.provider)
 			versionConstraint := getproviders.MustParseVersionConstraints(test.version)
 			version := getproviders.MustParseVersion(test.version)
@@ -2466,7 +2464,7 @@ func TestEnsureProviderVersions_local_source(t *testing.T) {
 				provider: versionConstraint,
 			}
 
-			newLocks, err := installer.EnsureProviderVersions(ctx, depsfile.NewLocks(), reqs, InstallNewProvidersOnly)
+			newLocks, err := installer.EnsureProviderVersions(t.Context(), depsfile.NewLocks(), reqs, InstallNewProvidersOnly)
 			gotProviderlocks := newLocks.AllProviders()
 			wantProviderLocks := map[addrs.Provider]*depsfile.ProviderLock{
 				provider: depsfile.NewProviderLock(
@@ -2553,8 +2551,7 @@ func TestEnsureProviderVersions_protocol_errors(t *testing.T) {
 			reqs := getproviders.Requirements{
 				test.provider: test.inputVersion,
 			}
-			ctx := context.TODO()
-			_, err := installer.EnsureProviderVersions(ctx, depsfile.NewLocks(), reqs, InstallNewProvidersOnly)
+			_, err := installer.EnsureProviderVersions(t.Context(), depsfile.NewLocks(), reqs, InstallNewProvidersOnly)
 
 			switch err := err.(type) {
 			case nil:


### PR DESCRIPTION
When [`context.Context`](https://pkg.go.dev/context#Context) was new, APIs using it arrived sporadically and so the Go team introduced [`context.TODO()`](https://pkg.go.dev/context#TODO) as an explicit way to say "I need a context here but I don't yet have a useful one to provide".

It took quite a while for there to be an established pattern for contexts in tests, but now there is finally [`testing.T.Context`](https://pkg.go.dev/testing#T.Context) which returns a context that gets cancelled once the test is complete, and so that's a good parent context to use for all contexts belonging to a test case.

This commit therefore mechanically replaces every use of `context.TODO` in our test cases throughout the codebase with a call to `t.Context` instead. There were a small number of tests that were using a mixture of `context.TODO` and [`context.Background`](https://pkg.go.dev/context#Background) as placeholders and so those are also updated to use `t.Context` consistently. There are probably still some remaining uses of `context.Background` in our tests, but we'll save those for another day.

As of this commit there are still various uses of context.TODO left in _non-test_ code, but we need to take more care in how we update those so those are intentionally excluded here.

This commit only changes test code, so it should not affect any behavior included in Tofu CLI releases, and there will be no changelog entry for this commit.