### PR TITLE
backend/local and providercache: Clean up some leftover `context.TODO`

### DIFF
--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -194,7 +194,7 @@ func (b *Local) localRunDirect(ctx context.Context, op *backend.Operation, run *
 		// values through interactive prompts.
 		// TODO: Need to route the operation context through into here, so that
 		// the interactive prompts can be sensitive to its timeouts/etc.
-		rawVariables = b.interactiveCollectVariables(context.TODO(), op.Variables, config.Module.Variables, op.UIIn)
+		rawVariables = b.interactiveCollectVariables(ctx, op.Variables, config.Module.Variables, op.UIIn)
 	}
 
 	variables, varDiags := backend.ParseVariableValues(rawVariables, config.Module.Variables)

--- a/internal/providercache/dir_modify.go
+++ b/internal/providercache/dir_modify.go
@@ -48,7 +48,7 @@ func (d *Dir) InstallPackage(ctx context.Context, meta getproviders.PackageMeta,
 // in the set must match the package that "entry" refers to. If none of the
 // hashes match then the returned error message assumes that the hashes came
 // from a lock file.
-func (d *Dir) LinkFromOtherCache(entry *CachedProvider, allowedHashes []getproviders.Hash) error {
+func (d *Dir) LinkFromOtherCache(ctx context.Context, entry *CachedProvider, allowedHashes []getproviders.Hash) error {
 	if len(allowedHashes) > 0 {
 		if matches, err := entry.MatchesAnyHash(allowedHashes); err != nil {
 			return fmt.Errorf(
@@ -88,6 +88,6 @@ func (d *Dir) LinkFromOtherCache(entry *CachedProvider, allowedHashes []getprovi
 	}
 	// No further hash check here because we already checked the hash
 	// of the source directory above.
-	_, err := meta.Location.InstallProviderPackage(context.TODO(), meta, newPath, nil)
+	_, err := meta.Location.InstallProviderPackage(ctx, meta, newPath, nil)
 	return err
 }

--- a/internal/providercache/dir_modify_test.go
+++ b/internal/providercache/dir_modify_test.go
@@ -122,7 +122,7 @@ func TestLinkFromOtherCache(t *testing.T) {
 		t.Fatalf("null provider has no latest version in source directory")
 	}
 
-	err = tmpDir.LinkFromOtherCache(cacheEntry, nil)
+	err = tmpDir.LinkFromOtherCache(t.Context(), cacheEntry, nil)
 	if err != nil {
 		t.Fatalf("LinkFromOtherCache failed: %s", err)
 	}

--- a/internal/providercache/installer.go
+++ b/internal/providercache/installer.go
@@ -629,7 +629,7 @@ func (i *Installer) ensureProviderVersionInstall(
 		// series here (and that's why we use FetchPackageFailure below).
 		// We also don't do a hash check here because we already did that
 		// as part of the installTo.InstallPackage call above.
-		err := linkTo.LinkFromOtherCache(new, nil)
+		err := linkTo.LinkFromOtherCache(ctx, new, nil)
 		if err != nil {
 			if cb := evts.FetchPackageFailure; cb != nil {
 				cb(provider, version, err)
@@ -869,7 +869,7 @@ func tryInstallPackageFromCacheDir(
 		return false, err
 	}
 
-	err = destDir.LinkFromOtherCache(cached, preferredHashes)
+	err = destDir.LinkFromOtherCache(ctx, cached, preferredHashes)
 	if err != nil {
 		if cb := evts.LinkFromCacheFailure; cb != nil {
 			cb(provider, version, err)


### PR DESCRIPTION
This is a similar idea as https://github.com/opentofu/opentofu/pull/2755 (with similar background info) but now deals with the parts of the non-test code that were using `context.TODO` in places where there was already a real `context.Context` somewhere close by that we can now use.

This shouldn't change the externally-observable behavior of OpenTofu, so there won't be a changelog entry for this one.

---

This commit leaves quite a few other uses of `context.TODO` in place because they are inside implementations of interfaces whose methods aren't yet updated to pass `context.Context`, and so we'll need some more invasive commits to update those interfaces and all of their implementations and callers before we'll be able to finally eradicate `context.TODO` and propagate our trace spans everywhere they might need to be.
