### PR TITLE
backend: Add context.Context parameters to the methods that can make external requests

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -119,7 +119,7 @@ type Backend interface {
 
 	// States returns a list of the names of all of the workspaces that exist
 	// in this backend.
-	Workspaces() ([]string, error)
+	Workspaces(context.Context) ([]string, error)
 }
 
 // HostAlias describes a list of aliases that should be used when initializing an

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -98,7 +98,7 @@ type Backend interface {
 	//
 	// If error diagnostics are returned, the internal state of the instance
 	// is undefined and no other methods may be called.
-	Configure(cty.Value) tfdiags.Diagnostics
+	Configure(context.Context, cty.Value) tfdiags.Diagnostics
 
 	// StateMgr returns the state manager for the given workspace name.
 	//

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -108,7 +108,7 @@ type Backend interface {
 	// If the named workspace doesn't exist, or if it has no state, it will
 	// be created either immediately on this call or the first time
 	// PersistState is called, depending on the state manager implementation.
-	StateMgr(workspace string) (statemgr.Full, error)
+	StateMgr(ctx context.Context, workspace string) (statemgr.Full, error)
 
 	// DeleteWorkspace removes the workspace with the given name if it exists.
 	//

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -115,7 +115,7 @@ type Backend interface {
 	// DeleteWorkspace cannot prevent deleting a state that is in use. It is
 	// the responsibility of the caller to hold a Lock for the state manager
 	// belonging to this workspace before calling this method.
-	DeleteWorkspace(name string, force bool) error
+	DeleteWorkspace(ctx context.Context, name string, force bool) error
 
 	// States returns a list of the names of all of the workspaces that exist
 	// in this backend.

--- a/internal/backend/init/testing.go
+++ b/internal/backend/init/testing.go
@@ -157,7 +157,7 @@ func (m *MockBackend) Configure(ctx context.Context, configObj cty.Value) tfdiag
 }
 
 // DeleteWorkspace implements Backend.
-func (m *MockBackend) DeleteWorkspace(name string, force bool) error {
+func (m *MockBackend) DeleteWorkspace(_ context.Context, name string, force bool) error {
 	m.DeleteWorkspaceCalled = true
 	m.DeleteWorkspaceName = name
 	m.DeleteWorkspaceForce = force

--- a/internal/backend/init/testing.go
+++ b/internal/backend/init/testing.go
@@ -194,7 +194,7 @@ func (m *MockBackend) StateMgr(workspace string) (statemgr.Full, error) {
 }
 
 // Workspaces implements Backend.
-func (m *MockBackend) Workspaces() ([]string, error) {
+func (m *MockBackend) Workspaces(context.Context) ([]string, error) {
 	m.WorkspacesCalled = true
 
 	if m.WorkspacesFn == nil {

--- a/internal/backend/init/testing.go
+++ b/internal/backend/init/testing.go
@@ -182,7 +182,7 @@ func (m *MockBackend) PrepareConfig(configObj cty.Value) (cty.Value, tfdiags.Dia
 }
 
 // StateMgr implements Backend.
-func (m *MockBackend) StateMgr(workspace string) (statemgr.Full, error) {
+func (m *MockBackend) StateMgr(_ context.Context, workspace string) (statemgr.Full, error) {
 	m.StateMgrCalled = true
 	m.StateMgrWorkspace = workspace
 

--- a/internal/backend/init/testing.go
+++ b/internal/backend/init/testing.go
@@ -6,6 +6,7 @@
 package init
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -144,7 +145,7 @@ func (m *MockBackend) ConfigSchema() *configschema.Block {
 }
 
 // Configure implements Backend.
-func (m *MockBackend) Configure(configObj cty.Value) tfdiags.Diagnostics {
+func (m *MockBackend) Configure(ctx context.Context, configObj cty.Value) tfdiags.Diagnostics {
 	m.ConfigureCalled = true
 	m.ConfigureConfigObj = configObj
 

--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -246,10 +246,10 @@ func (b *Local) DeleteWorkspace(name string, force bool) error {
 	return os.RemoveAll(filepath.Join(b.stateWorkspaceDir(), name))
 }
 
-func (b *Local) StateMgr(name string) (statemgr.Full, error) {
+func (b *Local) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {
 	// If we have a backend handling state, delegate to that.
 	if b.Backend != nil {
-		return b.Backend.StateMgr(name)
+		return b.Backend.StateMgr(ctx, name)
 	}
 
 	if s, ok := b.states[name]; ok {

--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -164,9 +164,9 @@ func (b *Local) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) {
 	return obj, diags
 }
 
-func (b *Local) Configure(obj cty.Value) tfdiags.Diagnostics {
+func (b *Local) Configure(ctx context.Context, obj cty.Value) tfdiags.Diagnostics {
 	if b.Backend != nil {
-		return b.Backend.Configure(obj)
+		return b.Backend.Configure(ctx, obj)
 	}
 
 	var diags tfdiags.Diagnostics

--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -194,10 +194,10 @@ func (b *Local) ServiceDiscoveryAliases() ([]backend.HostAlias, error) {
 	return []backend.HostAlias{}, nil
 }
 
-func (b *Local) Workspaces() ([]string, error) {
+func (b *Local) Workspaces(ctx context.Context) ([]string, error) {
 	// If we have a backend handling state, defer to that.
 	if b.Backend != nil {
-		return b.Backend.Workspaces()
+		return b.Backend.Workspaces(ctx)
 	}
 
 	// the listing always start with "default"
@@ -447,7 +447,7 @@ func (b *Local) StatePaths(name string) (stateIn, stateOut, backupOut string) {
 // in the same files as the "new" state snapshots.
 func (b *Local) PathsConflictWith(other *Local) bool {
 	otherPaths := map[string]struct{}{}
-	otherWorkspaces, err := other.Workspaces()
+	otherWorkspaces, err := other.Workspaces(context.TODO())
 	if err != nil {
 		// If we can't enumerate the workspaces then we'll conservatively
 		// assume that paths _do_ overlap, since we can't be certain.
@@ -458,7 +458,7 @@ func (b *Local) PathsConflictWith(other *Local) bool {
 		otherPaths[p] = struct{}{}
 	}
 
-	ourWorkspaces, err := other.Workspaces()
+	ourWorkspaces, err := other.Workspaces(context.TODO())
 	if err != nil {
 		// If we can't enumerate the workspaces then we'll conservatively
 		// assume that paths _do_ overlap, since we can't be certain.

--- a/internal/backend/local/backend.go
+++ b/internal/backend/local/backend.go
@@ -228,10 +228,10 @@ func (b *Local) Workspaces(ctx context.Context) ([]string, error) {
 // DeleteWorkspace removes a workspace.
 //
 // The "default" workspace cannot be removed.
-func (b *Local) DeleteWorkspace(name string, force bool) error {
+func (b *Local) DeleteWorkspace(ctx context.Context, name string, force bool) error {
 	// If we have a backend handling state, defer to that.
 	if b.Backend != nil {
-		return b.Backend.DeleteWorkspace(name, force)
+		return b.Backend.DeleteWorkspace(ctx, name, force)
 	}
 
 	if name == "" {

--- a/internal/backend/local/backend_apply_test.go
+++ b/internal/backend/local/backend_apply_test.go
@@ -339,7 +339,7 @@ type backendWithFailingState struct {
 	Local
 }
 
-func (b *backendWithFailingState) StateMgr(name string) (statemgr.Full, error) {
+func (b *backendWithFailingState) StateMgr(_ context.Context, name string) (statemgr.Full, error) {
 	return &failingState{
 		statemgr.NewFilesystem("failing-state.tfstate", encryption.StateEncryptionDisabled()),
 	}, nil

--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -49,7 +49,7 @@ func (b *Local) localRun(ctx context.Context, op *backend.Operation) (*backend.L
 
 	// Get the latest state.
 	log.Printf("[TRACE] backend/local: requesting state manager for workspace %q", op.Workspace)
-	s, err := b.StateMgr(op.Workspace)
+	s, err := b.StateMgr(ctx, op.Workspace)
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("error loading state: %w", err))
 		return nil, nil, nil, diags

--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -224,7 +224,7 @@ func (b backendWithStateStorageThatFailsRefresh) PrepareConfig(in cty.Value) (ct
 	return in, nil
 }
 
-func (b backendWithStateStorageThatFailsRefresh) Configure(cty.Value) tfdiags.Diagnostics {
+func (b backendWithStateStorageThatFailsRefresh) Configure(context.Context, cty.Value) tfdiags.Diagnostics {
 	return nil
 }
 

--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -138,7 +138,7 @@ func TestLocalRun_stalePlan(t *testing.T) {
 	}
 
 	// Refresh the state
-	sm, err := b.StateMgr("")
+	sm, err := b.StateMgr(t.Context(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -212,7 +212,7 @@ type backendWithStateStorageThatFailsRefresh struct {
 
 var _ backend.Backend = backendWithStateStorageThatFailsRefresh{}
 
-func (b backendWithStateStorageThatFailsRefresh) StateMgr(workspace string) (statemgr.Full, error) {
+func (b backendWithStateStorageThatFailsRefresh) StateMgr(_ context.Context, workspace string) (statemgr.Full, error) {
 	return &stateStorageThatFailsRefresh{}, nil
 }
 

--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -232,7 +232,7 @@ func (b backendWithStateStorageThatFailsRefresh) DeleteWorkspace(name string, fo
 	return fmt.Errorf("unimplemented")
 }
 
-func (b backendWithStateStorageThatFailsRefresh) Workspaces() ([]string, error) {
+func (b backendWithStateStorageThatFailsRefresh) Workspaces(context.Context) ([]string, error) {
 	return []string{"default"}, nil
 }
 

--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -228,7 +228,7 @@ func (b backendWithStateStorageThatFailsRefresh) Configure(context.Context, cty.
 	return nil
 }
 
-func (b backendWithStateStorageThatFailsRefresh) DeleteWorkspace(name string, force bool) error {
+func (b backendWithStateStorageThatFailsRefresh) DeleteWorkspace(_ context.Context, name string, force bool) error {
 	return fmt.Errorf("unimplemented")
 }
 

--- a/internal/backend/local/backend_test.go
+++ b/internal/backend/local/backend_test.go
@@ -140,7 +140,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatalf("expected %q, got %q", expectedStates, states)
 	}
 
-	if err := b.DeleteWorkspace(expectedA, true); err != nil {
+	if err := b.DeleteWorkspace(t.Context(), expectedA, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -154,7 +154,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatalf("expected %q, got %q", expectedStates, states)
 	}
 
-	if err := b.DeleteWorkspace(expectedB, true); err != nil {
+	if err := b.DeleteWorkspace(t.Context(), expectedB, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -168,7 +168,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatalf("expected %q, got %q", expectedStates, states)
 	}
 
-	if err := b.DeleteWorkspace(dflt, true); err == nil {
+	if err := b.DeleteWorkspace(t.Context(), dflt, true); err == nil {
 		t.Fatal("expected error deleting default state")
 	}
 }
@@ -203,7 +203,7 @@ func (b *testDelegateBackend) Workspaces(context.Context) ([]string, error) {
 	return []string{"default"}, nil
 }
 
-func (b *testDelegateBackend) DeleteWorkspace(name string, force bool) error {
+func (b *testDelegateBackend) DeleteWorkspace(_ context.Context, name string, force bool) error {
 	if b.deleteErr {
 		return errTestDelegateDeleteState
 	}
@@ -227,7 +227,7 @@ func TestLocal_multiStateBackend(t *testing.T) {
 		t.Fatal("expected errTestDelegateStates, got:", err)
 	}
 
-	if err := b.DeleteWorkspace("test", true); err != errTestDelegateDeleteState {
+	if err := b.DeleteWorkspace(t.Context(), "test", true); err != errTestDelegateDeleteState {
 		t.Fatal("expected errTestDelegateDeleteState, got:", err)
 	}
 }

--- a/internal/backend/local/backend_test.go
+++ b/internal/backend/local/backend_test.go
@@ -111,7 +111,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 	}
 
 	expectedA := "test_A"
-	if _, err := b.StateMgr(expectedA); err != nil {
+	if _, err := b.StateMgr(t.Context(), expectedA); err != nil {
 		t.Fatal(err)
 	}
 
@@ -126,7 +126,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 	}
 
 	expectedB := "test_B"
-	if _, err := b.StateMgr(expectedB); err != nil {
+	if _, err := b.StateMgr(t.Context(), expectedB); err != nil {
 		t.Fatal(err)
 	}
 
@@ -188,7 +188,7 @@ var errTestDelegateState = errors.New("state called")
 var errTestDelegateStates = errors.New("states called")
 var errTestDelegateDeleteState = errors.New("delete called")
 
-func (b *testDelegateBackend) StateMgr(name string) (statemgr.Full, error) {
+func (b *testDelegateBackend) StateMgr(_ context.Context, name string) (statemgr.Full, error) {
 	if b.stateErr {
 		return nil, errTestDelegateState
 	}
@@ -219,7 +219,7 @@ func TestLocal_multiStateBackend(t *testing.T) {
 		deleteErr: true,
 	}, nil)
 
-	if _, err := b.StateMgr("test"); err != errTestDelegateState {
+	if _, err := b.StateMgr(t.Context(), "test"); err != errTestDelegateState {
 		t.Fatal("expected errTestDelegateState, got:", err)
 	}
 

--- a/internal/backend/local/backend_test.go
+++ b/internal/backend/local/backend_test.go
@@ -6,6 +6,7 @@
 package local
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -100,7 +101,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 	expectedStates := []string{dflt}
 
 	b := New(encryption.StateEncryptionDisabled())
-	states, err := b.Workspaces()
+	states, err := b.Workspaces(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +115,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	states, err = b.Workspaces()
+	states, err = b.Workspaces(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -129,7 +130,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	states, err = b.Workspaces()
+	states, err = b.Workspaces(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -143,7 +144,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	states, err = b.Workspaces()
+	states, err = b.Workspaces(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +158,7 @@ func TestLocal_addAndRemoveStates(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	states, err = b.Workspaces()
+	states, err = b.Workspaces(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -195,7 +196,7 @@ func (b *testDelegateBackend) StateMgr(name string) (statemgr.Full, error) {
 	return s, nil
 }
 
-func (b *testDelegateBackend) Workspaces() ([]string, error) {
+func (b *testDelegateBackend) Workspaces(context.Context) ([]string, error) {
 	if b.statesErr {
 		return nil, errTestDelegateStates
 	}
@@ -222,7 +223,7 @@ func TestLocal_multiStateBackend(t *testing.T) {
 		t.Fatal("expected errTestDelegateState, got:", err)
 	}
 
-	if _, err := b.Workspaces(); err != errTestDelegateStates {
+	if _, err := b.Workspaces(t.Context()); err != errTestDelegateStates {
 		t.Fatal("expected errTestDelegateStates, got:", err)
 	}
 

--- a/internal/backend/local/testing.go
+++ b/internal/backend/local/testing.go
@@ -129,12 +129,12 @@ func (b *TestLocalSingleState) DeleteWorkspace(string, bool) error {
 	return backend.ErrWorkspacesNotSupported
 }
 
-func (b *TestLocalSingleState) StateMgr(name string) (statemgr.Full, error) {
+func (b *TestLocalSingleState) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {
 	if name != backend.DefaultStateName {
 		return nil, backend.ErrWorkspacesNotSupported
 	}
 
-	return b.Local.StateMgr(name)
+	return b.Local.StateMgr(ctx, name)
 }
 
 // TestLocalNoDefaultState is a backend implementation that wraps
@@ -174,11 +174,11 @@ func (b *TestLocalNoDefaultState) DeleteWorkspace(name string, force bool) error
 	return b.Local.DeleteWorkspace(name, force)
 }
 
-func (b *TestLocalNoDefaultState) StateMgr(name string) (statemgr.Full, error) {
+func (b *TestLocalNoDefaultState) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {
 	if name == backend.DefaultStateName {
 		return nil, backend.ErrDefaultWorkspaceNotSupported
 	}
-	return b.Local.StateMgr(name)
+	return b.Local.StateMgr(ctx, name)
 }
 
 func testStateFile(t *testing.T, path string, s *states.State) {
@@ -210,7 +210,7 @@ func mustResourceInstanceAddr(s string) addrs.AbsResourceInstance {
 // True is returned if a lock was obtained.
 func assertBackendStateUnlocked(t *testing.T, b *Local) bool {
 	t.Helper()
-	stateMgr, _ := b.StateMgr(backend.DefaultStateName)
+	stateMgr, _ := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Errorf("state is already locked: %s", err.Error())
 		// lock was obtained
@@ -225,7 +225,7 @@ func assertBackendStateUnlocked(t *testing.T, b *Local) bool {
 // True is returned if a lock was not obtained.
 func assertBackendStateLocked(t *testing.T, b *Local) bool {
 	t.Helper()
-	stateMgr, _ := b.StateMgr(backend.DefaultStateName)
+	stateMgr, _ := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		// lock was not obtained
 		return true

--- a/internal/backend/local/testing.go
+++ b/internal/backend/local/testing.go
@@ -6,6 +6,7 @@
 package local
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -120,7 +121,7 @@ func TestNewLocalSingle(enc encryption.StateEncryption) backend.Backend {
 	return &TestLocalSingleState{Local: New(encryption.StateEncryptionDisabled())}
 }
 
-func (b *TestLocalSingleState) Workspaces() ([]string, error) {
+func (b *TestLocalSingleState) Workspaces(context.Context) ([]string, error) {
 	return nil, backend.ErrWorkspacesNotSupported
 }
 
@@ -150,8 +151,8 @@ func TestNewLocalNoDefault(enc encryption.StateEncryption) backend.Backend {
 	return &TestLocalNoDefaultState{Local: New(encryption.StateEncryptionDisabled())}
 }
 
-func (b *TestLocalNoDefaultState) Workspaces() ([]string, error) {
-	workspaces, err := b.Local.Workspaces()
+func (b *TestLocalNoDefaultState) Workspaces(ctx context.Context) ([]string, error) {
+	workspaces, err := b.Local.Workspaces(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/local/testing.go
+++ b/internal/backend/local/testing.go
@@ -125,7 +125,7 @@ func (b *TestLocalSingleState) Workspaces(context.Context) ([]string, error) {
 	return nil, backend.ErrWorkspacesNotSupported
 }
 
-func (b *TestLocalSingleState) DeleteWorkspace(string, bool) error {
+func (b *TestLocalSingleState) DeleteWorkspace(context.Context, string, bool) error {
 	return backend.ErrWorkspacesNotSupported
 }
 
@@ -167,11 +167,11 @@ func (b *TestLocalNoDefaultState) Workspaces(ctx context.Context) ([]string, err
 	return filtered, nil
 }
 
-func (b *TestLocalNoDefaultState) DeleteWorkspace(name string, force bool) error {
+func (b *TestLocalNoDefaultState) DeleteWorkspace(ctx context.Context, name string, force bool) error {
 	if name == backend.DefaultStateName {
 		return backend.ErrDefaultWorkspaceNotSupported
 	}
-	return b.Local.DeleteWorkspace(name, force)
+	return b.Local.DeleteWorkspace(ctx, name, force)
 }
 
 func (b *TestLocalNoDefaultState) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {

--- a/internal/backend/remote-state/azure/backend_state.go
+++ b/internal/backend/remote-state/azure/backend_state.go
@@ -71,7 +71,7 @@ func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	return nil
 }
 
-func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
+func (b *Backend) StateMgr(_ context.Context, name string) (statemgr.Full, error) {
 	ctx, cancel := b.getContextWithTimeout()
 	defer cancel()
 

--- a/internal/backend/remote-state/azure/backend_state.go
+++ b/internal/backend/remote-state/azure/backend_state.go
@@ -50,7 +50,7 @@ func (b *Backend) Workspaces(_ context.Context) ([]string, error) {
 	return result, nil
 }
 
-func (b *Backend) DeleteWorkspace(name string, _ bool) error {
+func (b *Backend) DeleteWorkspace(_ context.Context, name string, _ bool) error {
 	if name == backend.DefaultStateName || name == "" {
 		return fmt.Errorf("can't delete default state")
 	}

--- a/internal/backend/remote-state/azure/backend_state.go
+++ b/internal/backend/remote-state/azure/backend_state.go
@@ -32,7 +32,7 @@ func (b *Backend) getContextWithTimeout() (context.Context, context.CancelFunc) 
 	return context.WithTimeout(context.Background(), time.Duration(b.armClient.timeoutSeconds)*time.Second)
 }
 
-func (b *Backend) Workspaces() ([]string, error) {
+func (b *Backend) Workspaces(_ context.Context) ([]string, error) {
 	ctx, cancel := b.getContextWithTimeout()
 	defer cancel()
 

--- a/internal/backend/remote-state/azure/backend_state.go
+++ b/internal/backend/remote-state/azure/backend_state.go
@@ -28,12 +28,12 @@ const (
 )
 
 // getContextWithTimeout returns a context with timeout based on the timeoutSeconds
-func (b *Backend) getContextWithTimeout() (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), time.Duration(b.armClient.timeoutSeconds)*time.Second)
+func (b *Backend) getContextWithTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, time.Duration(b.armClient.timeoutSeconds)*time.Second)
 }
 
-func (b *Backend) Workspaces(_ context.Context) ([]string, error) {
-	ctx, cancel := b.getContextWithTimeout()
+func (b *Backend) Workspaces(ctx context.Context) ([]string, error) {
+	ctx, cancel := b.getContextWithTimeout(ctx)
 	defer cancel()
 
 	client, err := b.armClient.getContainersClient(ctx)
@@ -50,12 +50,12 @@ func (b *Backend) Workspaces(_ context.Context) ([]string, error) {
 	return result, nil
 }
 
-func (b *Backend) DeleteWorkspace(_ context.Context, name string, _ bool) error {
+func (b *Backend) DeleteWorkspace(ctx context.Context, name string, _ bool) error {
 	if name == backend.DefaultStateName || name == "" {
 		return fmt.Errorf("can't delete default state")
 	}
 
-	ctx, cancel := b.getContextWithTimeout()
+	ctx, cancel := b.getContextWithTimeout(ctx)
 	defer cancel()
 	client, err := b.armClient.getBlobClient(ctx)
 	if err != nil {
@@ -71,8 +71,8 @@ func (b *Backend) DeleteWorkspace(_ context.Context, name string, _ bool) error 
 	return nil
 }
 
-func (b *Backend) StateMgr(_ context.Context, name string) (statemgr.Full, error) {
-	ctx, cancel := b.getContextWithTimeout()
+func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {
+	ctx, cancel := b.getContextWithTimeout(ctx)
 	defer cancel()
 
 	blobClient, err := b.armClient.getBlobClient(ctx)

--- a/internal/backend/remote-state/azure/client_test.go
+++ b/internal/backend/remote-state/azure/client_test.go
@@ -46,7 +46,7 @@ func TestRemoteClientAccessKeyBasic(t *testing.T) {
 		"endpoint":             os.Getenv("ARM_ENDPOINT"),
 	})).(*Backend)
 
-	state, err := b.StateMgr(backend.DefaultStateName)
+	state, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +82,7 @@ func TestRemoteClientManagedServiceIdentityBasic(t *testing.T) {
 		"endpoint":             os.Getenv("ARM_ENDPOINT"),
 	})).(*Backend)
 
-	state, err := b.StateMgr(backend.DefaultStateName)
+	state, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +120,7 @@ func TestRemoteClientSasTokenBasic(t *testing.T) {
 		"endpoint":             os.Getenv("ARM_ENDPOINT"),
 	})).(*Backend)
 
-	state, err := b.StateMgr(backend.DefaultStateName)
+	state, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +157,7 @@ func TestRemoteClientServicePrincipalBasic(t *testing.T) {
 		"endpoint":             os.Getenv("ARM_ENDPOINT"),
 	})).(*Backend)
 
-	state, err := b.StateMgr(backend.DefaultStateName)
+	state, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -199,12 +199,12 @@ func TestRemoteClientAccessKeyLocks(t *testing.T) {
 		"endpoint":             os.Getenv("ARM_ENDPOINT"),
 	})).(*Backend)
 
-	s1, err := b1.StateMgr(backend.DefaultStateName)
+	s1, err := b1.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	s2, err := b2.StateMgr(backend.DefaultStateName)
+	s2, err := b2.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -254,12 +254,12 @@ func TestRemoteClientServicePrincipalLocks(t *testing.T) {
 		"endpoint":             os.Getenv("ARM_ENDPOINT"),
 	})).(*Backend)
 
-	s1, err := b1.StateMgr(backend.DefaultStateName)
+	s1, err := b1.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	s2, err := b2.StateMgr(backend.DefaultStateName)
+	s2, err := b2.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/remote-state/consul/backend_state.go
+++ b/internal/backend/remote-state/consul/backend_state.go
@@ -6,6 +6,7 @@
 package consul
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -19,7 +20,7 @@ const (
 	keyEnvPrefix = "-env:"
 )
 
-func (b *Backend) Workspaces() ([]string, error) {
+func (b *Backend) Workspaces(context.Context) ([]string, error) {
 	// List our raw path
 	prefix := b.configData.Get("path").(string) + keyEnvPrefix
 	keys, _, err := b.client.KV().Keys(prefix, "/", nil)

--- a/internal/backend/remote-state/consul/backend_state.go
+++ b/internal/backend/remote-state/consul/backend_state.go
@@ -69,7 +69,7 @@ func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	return err
 }
 
-func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
+func (b *Backend) StateMgr(_ context.Context, name string) (statemgr.Full, error) {
 	// Determine the path of the data
 	path := b.path(name)
 

--- a/internal/backend/remote-state/consul/backend_state.go
+++ b/internal/backend/remote-state/consul/backend_state.go
@@ -55,7 +55,7 @@ func (b *Backend) Workspaces(context.Context) ([]string, error) {
 	return result, nil
 }
 
-func (b *Backend) DeleteWorkspace(name string, _ bool) error {
+func (b *Backend) DeleteWorkspace(_ context.Context, name string, _ bool) error {
 	if name == backend.DefaultStateName || name == "" {
 		return fmt.Errorf("can't delete default state")
 	}

--- a/internal/backend/remote-state/consul/client_test.go
+++ b/internal/backend/remote-state/consul/client_test.go
@@ -47,7 +47,7 @@ func TestRemoteClient(t *testing.T) {
 			}))
 
 			// Grab the client
-			state, err := b.StateMgr(backend.DefaultStateName)
+			state, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 			if err != nil {
 				t.Fatalf("err: %s", err)
 			}
@@ -72,7 +72,7 @@ func TestRemoteClient_gzipUpgrade(t *testing.T) {
 	}))
 
 	// Grab the client
-	state, err := b.StateMgr(backend.DefaultStateName)
+	state, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -88,7 +88,7 @@ func TestRemoteClient_gzipUpgrade(t *testing.T) {
 	}))
 
 	// Grab the client
-	state, err = b.StateMgr(backend.DefaultStateName)
+	state, err = b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -111,7 +111,7 @@ func TestConsul_largeState(t *testing.T) {
 		"path":    path,
 	}))
 
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,7 +198,7 @@ func TestConsul_largeState(t *testing.T) {
 		"gzip":    true,
 	}))
 
-	s, err = b.StateMgr(backend.DefaultStateName)
+	s, err = b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -257,7 +257,7 @@ func TestConsul_stateLock(t *testing.T) {
 			sA, err := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]interface{}{
 				"address": srv.HTTPAddr,
 				"path":    path,
-			})).StateMgr(backend.DefaultStateName)
+			})).StateMgr(t.Context(), backend.DefaultStateName)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -265,7 +265,7 @@ func TestConsul_stateLock(t *testing.T) {
 			sB, err := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]interface{}{
 				"address": srv.HTTPAddr,
 				"path":    path,
-			})).StateMgr(backend.DefaultStateName)
+			})).StateMgr(t.Context(), backend.DefaultStateName)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -304,7 +304,7 @@ func TestConsul_destroyLock(t *testing.T) {
 			}))
 
 			// Grab the client
-			s, err := b.StateMgr(backend.DefaultStateName)
+			s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 			if err != nil {
 				t.Fatalf("err: %s", err)
 			}
@@ -327,7 +327,7 @@ func TestConsul_destroyLock(t *testing.T) {
 
 			// The release the lock from a second client to test the
 			// `tofu force-unlock <lock_id>` functionality
-			s, err = b.StateMgr(backend.DefaultStateName)
+			s, err = b.StateMgr(t.Context(), backend.DefaultStateName)
 			if err != nil {
 				t.Fatalf("err: %s", err)
 			}
@@ -368,7 +368,7 @@ func TestConsul_lostLock(t *testing.T) {
 	sA, err := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]interface{}{
 		"address": srv.HTTPAddr,
 		"path":    path,
-	})).StateMgr(backend.DefaultStateName)
+	})).StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -376,7 +376,7 @@ func TestConsul_lostLock(t *testing.T) {
 	sB, err := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]interface{}{
 		"address": srv.HTTPAddr,
 		"path":    path + "-not-used",
-	})).StateMgr(backend.DefaultStateName)
+	})).StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -428,7 +428,7 @@ func TestConsul_lostLockConnection(t *testing.T) {
 		"path":    path,
 	}))
 
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/remote-state/cos/backend_state.go
+++ b/internal/backend/remote-state/cos/backend_state.go
@@ -6,6 +6,7 @@
 package cos
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"path"
@@ -25,7 +26,7 @@ const (
 )
 
 // Workspaces returns a list of names for the workspaces
-func (b *Backend) Workspaces() ([]string, error) {
+func (b *Backend) Workspaces(context.Context) ([]string, error) {
 	c, err := b.client("tencentcloud")
 	if err != nil {
 		return nil, err
@@ -87,7 +88,7 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	}
 	stateMgr := remote.NewState(c, b.encryption)
 
-	ws, err := b.Workspaces()
+	ws, err := b.Workspaces(context.TODO())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/remote-state/cos/backend_state.go
+++ b/internal/backend/remote-state/cos/backend_state.go
@@ -63,7 +63,7 @@ func (b *Backend) Workspaces(context.Context) ([]string, error) {
 }
 
 // DeleteWorkspace deletes the named workspaces. The "default" state cannot be deleted.
-func (b *Backend) DeleteWorkspace(name string, _ bool) error {
+func (b *Backend) DeleteWorkspace(_ context.Context, name string, _ bool) error {
 	log.Printf("[DEBUG] delete workspace, workspace: %v", name)
 
 	if name == backend.DefaultStateName || name == "" {

--- a/internal/backend/remote-state/cos/backend_state.go
+++ b/internal/backend/remote-state/cos/backend_state.go
@@ -79,7 +79,7 @@ func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 }
 
 // StateMgr manage the state, if the named state not exists, a new file will created
-func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
+func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {
 	log.Printf("[DEBUG] state manager, current workspace: %v", name)
 
 	c, err := b.client(name)
@@ -88,7 +88,7 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	}
 	stateMgr := remote.NewState(c, b.encryption)
 
-	ws, err := b.Workspaces(context.TODO())
+	ws, err := b.Workspaces(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/remote-state/cos/backend_test.go
+++ b/internal/backend/remote-state/cos/backend_test.go
@@ -66,7 +66,7 @@ func TestRemoteClient(t *testing.T) {
 	be := setupBackend(t, bucket, defaultPrefix, defaultKey, false)
 	defer teardownBackend(t, be)
 
-	ss, err := be.StateMgr(backend.DefaultStateName)
+	ss, err := be.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -88,7 +88,7 @@ func TestRemoteClientWithPrefix(t *testing.T) {
 	be := setupBackend(t, bucket, prefix, defaultKey, false)
 	defer teardownBackend(t, be)
 
-	ss, err := be.StateMgr(backend.DefaultStateName)
+	ss, err := be.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -109,7 +109,7 @@ func TestRemoteClientWithEncryption(t *testing.T) {
 	be := setupBackend(t, bucket, defaultPrefix, defaultKey, true)
 	defer teardownBackend(t, be)
 
-	ss, err := be.StateMgr(backend.DefaultStateName)
+	ss, err := be.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -131,7 +131,7 @@ func TestRemoteLocks(t *testing.T) {
 	defer teardownBackend(t, be)
 
 	remoteClient := func() (remote.Client, error) {
-		ss, err := be.StateMgr(backend.DefaultStateName)
+		ss, err := be.StateMgr(t.Context(), backend.DefaultStateName)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/backend/remote-state/gcs/backend_state.go
+++ b/internal/backend/remote-state/gcs/backend_state.go
@@ -93,7 +93,7 @@ func (b *Backend) client(name string) (*remoteClient, error) {
 
 // StateMgr reads and returns the named state from GCS. If the named state does
 // not yet exist, a new state file is created.
-func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
+func (b *Backend) StateMgr(_ context.Context, name string) (statemgr.Full, error) {
 	c, err := b.client(name)
 	if err != nil {
 		return nil, err

--- a/internal/backend/remote-state/gcs/backend_state.go
+++ b/internal/backend/remote-state/gcs/backend_state.go
@@ -61,7 +61,7 @@ func (b *Backend) Workspaces(context.Context) ([]string, error) {
 }
 
 // DeleteWorkspace deletes the named workspaces. The "default" state cannot be deleted.
-func (b *Backend) DeleteWorkspace(name string, _ bool) error {
+func (b *Backend) DeleteWorkspace(_ context.Context, name string, _ bool) error {
 	if name == backend.DefaultStateName {
 		return fmt.Errorf("cowardly refusing to delete the %q state", name)
 	}

--- a/internal/backend/remote-state/gcs/backend_state.go
+++ b/internal/backend/remote-state/gcs/backend_state.go
@@ -6,6 +6,7 @@
 package gcs
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"sort"
@@ -27,7 +28,7 @@ const (
 
 // Workspaces returns a list of names for the workspaces found on GCS. The default
 // state is always returned as the first element in the slice.
-func (b *Backend) Workspaces() ([]string, error) {
+func (b *Backend) Workspaces(context.Context) ([]string, error) {
 	states := []string{backend.DefaultStateName}
 
 	bucket := b.storageClient.Bucket(b.bucketName)

--- a/internal/backend/remote-state/gcs/backend_test.go
+++ b/internal/backend/remote-state/gcs/backend_test.go
@@ -82,7 +82,7 @@ func TestRemoteClient(t *testing.T) {
 	be := setupBackend(t, bucket, noPrefix, noEncryptionKey, noKmsKeyName)
 	defer teardownBackend(t, be, noPrefix)
 
-	ss, err := be.StateMgr(backend.DefaultStateName)
+	ss, err := be.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("be.StateMgr(%q) = %v", backend.DefaultStateName, err)
 	}
@@ -101,7 +101,7 @@ func TestRemoteClientWithEncryption(t *testing.T) {
 	be := setupBackend(t, bucket, noPrefix, encryptionKey, noKmsKeyName)
 	defer teardownBackend(t, be, noPrefix)
 
-	ss, err := be.StateMgr(backend.DefaultStateName)
+	ss, err := be.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("be.StateMgr(%q) = %v", backend.DefaultStateName, err)
 	}
@@ -122,7 +122,7 @@ func TestRemoteLocks(t *testing.T) {
 	defer teardownBackend(t, be, noPrefix)
 
 	remoteClient := func() (remote.Client, error) {
-		ss, err := be.StateMgr(backend.DefaultStateName)
+		ss, err := be.StateMgr(t.Context(), backend.DefaultStateName)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/backend/remote-state/http/backend.go
+++ b/internal/backend/remote-state/http/backend.go
@@ -315,6 +315,6 @@ func (b *Backend) Workspaces(context.Context) ([]string, error) {
 	return nil, backend.ErrWorkspacesNotSupported
 }
 
-func (b *Backend) DeleteWorkspace(string, bool) error {
+func (b *Backend) DeleteWorkspace(context.Context, string, bool) error {
 	return backend.ErrWorkspacesNotSupported
 }

--- a/internal/backend/remote-state/http/backend.go
+++ b/internal/backend/remote-state/http/backend.go
@@ -303,7 +303,7 @@ func (b *Backend) configure(ctx context.Context) error {
 	return nil
 }
 
-func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
+func (b *Backend) StateMgr(_ context.Context, name string) (statemgr.Full, error) {
 	if name != backend.DefaultStateName {
 		return nil, backend.ErrWorkspacesNotSupported
 	}

--- a/internal/backend/remote-state/http/backend.go
+++ b/internal/backend/remote-state/http/backend.go
@@ -311,7 +311,7 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	return remote.NewState(b.client, b.encryption), nil
 }
 
-func (b *Backend) Workspaces() ([]string, error) {
+func (b *Backend) Workspaces(context.Context) ([]string, error) {
 	return nil, backend.ErrWorkspacesNotSupported
 }
 

--- a/internal/backend/remote-state/http/server_test.go
+++ b/internal/backend/remote-state/http/server_test.go
@@ -283,7 +283,7 @@ func TestMTLSServer_NoCertFails(t *testing.T) {
 	}
 
 	// Now get a state manager and check that it fails to refresh the state
-	sm, err := b.StateMgr(backend.DefaultStateName)
+	sm, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error fetching StateMgr with %s: %v", backend.DefaultStateName, err)
 	}
@@ -354,7 +354,7 @@ func TestMTLSServer_WithCertPasses(t *testing.T) {
 	}
 
 	// Now get a state manager, fetch the state, and ensure that the "foo" output is not set
-	sm, err := b.StateMgr(backend.DefaultStateName)
+	sm, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error fetching StateMgr with %s: %v", backend.DefaultStateName, err)
 	}

--- a/internal/backend/remote-state/inmem/backend.go
+++ b/internal/backend/remote-state/inmem/backend.go
@@ -92,7 +92,7 @@ func (b *Backend) configure(ctx context.Context) error {
 	return nil
 }
 
-func (b *Backend) Workspaces() ([]string, error) {
+func (b *Backend) Workspaces(context.Context) ([]string, error) {
 	states.Lock()
 	defer states.Unlock()
 

--- a/internal/backend/remote-state/inmem/backend.go
+++ b/internal/backend/remote-state/inmem/backend.go
@@ -118,7 +118,7 @@ func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	return nil
 }
 
-func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
+func (b *Backend) StateMgr(_ context.Context, name string) (statemgr.Full, error) {
 	states.Lock()
 	defer states.Unlock()
 

--- a/internal/backend/remote-state/inmem/backend.go
+++ b/internal/backend/remote-state/inmem/backend.go
@@ -106,7 +106,7 @@ func (b *Backend) Workspaces(context.Context) ([]string, error) {
 	return workspaces, nil
 }
 
-func (b *Backend) DeleteWorkspace(name string, _ bool) error {
+func (b *Backend) DeleteWorkspace(_ context.Context, name string, _ bool) error {
 	states.Lock()
 	defer states.Unlock()
 

--- a/internal/backend/remote-state/inmem/backend_test.go
+++ b/internal/backend/remote-state/inmem/backend_test.go
@@ -39,7 +39,7 @@ func TestBackendConfig(t *testing.T) {
 
 	b := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(config)).(*Backend)
 
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,7 +76,7 @@ func TestRemoteState(t *testing.T) {
 	workspace := "workspace"
 
 	// create a new workspace in this backend
-	s, err := b.StateMgr(workspace)
+	s, err := b.StateMgr(t.Context(), workspace)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/remote-state/inmem/client_test.go
+++ b/internal/backend/remote-state/inmem/client_test.go
@@ -23,7 +23,7 @@ func TestRemoteClient(t *testing.T) {
 	defer Reset()
 	b := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), hcl.EmptyBody())
 
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,7 +33,7 @@ func TestRemoteClient(t *testing.T) {
 
 func TestInmemLocks(t *testing.T) {
 	defer Reset()
-	s, err := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), hcl.EmptyBody()).StateMgr(backend.DefaultStateName)
+	s, err := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), hcl.EmptyBody()).StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/remote-state/kubernetes/backend_state.go
+++ b/internal/backend/remote-state/kubernetes/backend_state.go
@@ -20,14 +20,14 @@ import (
 
 // Workspaces returns a list of names for the workspaces found in k8s. The default
 // workspace is always returned as the first element in the slice.
-func (b *Backend) Workspaces() ([]string, error) {
+func (b *Backend) Workspaces(ctx context.Context) ([]string, error) {
 	secretClient, err := b.getKubernetesSecretClient()
 	if err != nil {
 		return nil, err
 	}
 
 	secrets, err := secretClient.List(
-		context.Background(),
+		ctx,
 		metav1.ListOptions{
 			LabelSelector: tfstateKey + "=true",
 		},

--- a/internal/backend/remote-state/kubernetes/backend_state.go
+++ b/internal/backend/remote-state/kubernetes/backend_state.go
@@ -65,7 +65,7 @@ func (b *Backend) Workspaces(ctx context.Context) ([]string, error) {
 	return states, nil
 }
 
-func (b *Backend) DeleteWorkspace(name string, _ bool) error {
+func (b *Backend) DeleteWorkspace(_ context.Context, name string, _ bool) error {
 	if name == backend.DefaultStateName || name == "" {
 		return fmt.Errorf("can't delete default state")
 	}

--- a/internal/backend/remote-state/kubernetes/backend_state.go
+++ b/internal/backend/remote-state/kubernetes/backend_state.go
@@ -78,7 +78,7 @@ func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	return client.Delete()
 }
 
-func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
+func (b *Backend) StateMgr(_ context.Context, name string) (statemgr.Full, error) {
 	c, err := b.remoteClient(name)
 	if err != nil {
 		return nil, err

--- a/internal/backend/remote-state/kubernetes/backend_test.go
+++ b/internal/backend/remote-state/kubernetes/backend_test.go
@@ -92,7 +92,7 @@ func TestBackendLocksSoak(t *testing.T) {
 			"secret_suffix": secretSuffix,
 		}))
 
-		s, err := b.StateMgr(backend.DefaultStateName)
+		s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 		if err != nil {
 			t.Fatalf("Error creating state manager: %v", err)
 		}

--- a/internal/backend/remote-state/kubernetes/client_test.go
+++ b/internal/backend/remote-state/kubernetes/client_test.go
@@ -27,7 +27,7 @@ func TestRemoteClient(t *testing.T) {
 		"secret_suffix": secretSuffix,
 	}))
 
-	state, err := b.StateMgr(backend.DefaultStateName)
+	state, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,12 +47,12 @@ func TestRemoteClientLocks(t *testing.T) {
 		"secret_suffix": secretSuffix,
 	}))
 
-	s1, err := b1.StateMgr(backend.DefaultStateName)
+	s1, err := b1.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	s2, err := b2.StateMgr(backend.DefaultStateName)
+	s2, err := b2.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func TestForceUnlock(t *testing.T) {
 	}))
 
 	// first test with default
-	s1, err := b1.StateMgr(backend.DefaultStateName)
+	s1, err := b1.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +88,7 @@ func TestForceUnlock(t *testing.T) {
 	}
 
 	// s1 is now locked, get the same state through s2 and unlock it
-	s2, err := b2.StateMgr(backend.DefaultStateName)
+	s2, err := b2.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal("failed to get default state to force unlock:", err)
 	}
@@ -99,7 +99,7 @@ func TestForceUnlock(t *testing.T) {
 
 	// now try the same thing with a named state
 	// first test with default
-	s1, err = b1.StateMgr("test")
+	s1, err = b1.StateMgr(t.Context(), "test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func TestForceUnlock(t *testing.T) {
 	}
 
 	// s1 is now locked, get the same state through s2 and unlock it
-	s2, err = b2.StateMgr("test")
+	s2, err = b2.StateMgr(t.Context(), "test")
 	if err != nil {
 		t.Fatal("failed to get named state to force unlock:", err)
 	}

--- a/internal/backend/remote-state/oss/backend_state.go
+++ b/internal/backend/remote-state/oss/backend_state.go
@@ -6,6 +6,7 @@
 package oss
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -54,7 +55,7 @@ func (b *Backend) remoteClient(name string) (*RemoteClient, error) {
 	return client, nil
 }
 
-func (b *Backend) Workspaces() ([]string, error) {
+func (b *Backend) Workspaces(context.Context) ([]string, error) {
 	bucket, err := b.ossClient.Bucket(b.bucketName)
 	if err != nil {
 		return []string{""}, fmt.Errorf("error getting bucket: %w", err)
@@ -121,7 +122,7 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	stateMgr := remote.NewState(client, b.encryption)
 
 	// Check to see if this state already exists.
-	existing, err := b.Workspaces()
+	existing, err := b.Workspaces(context.TODO())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/remote-state/oss/backend_state.go
+++ b/internal/backend/remote-state/oss/backend_state.go
@@ -102,7 +102,7 @@ func (b *Backend) Workspaces(context.Context) ([]string, error) {
 	return result, nil
 }
 
-func (b *Backend) DeleteWorkspace(name string, _ bool) error {
+func (b *Backend) DeleteWorkspace(_ context.Context, name string, _ bool) error {
 	if name == backend.DefaultStateName || name == "" {
 		return fmt.Errorf("can't delete default state")
 	}

--- a/internal/backend/remote-state/oss/backend_state.go
+++ b/internal/backend/remote-state/oss/backend_state.go
@@ -114,7 +114,7 @@ func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	return client.Delete()
 }
 
-func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
+func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {
 	client, err := b.remoteClient(name)
 	if err != nil {
 		return nil, err
@@ -122,7 +122,7 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	stateMgr := remote.NewState(client, b.encryption)
 
 	// Check to see if this state already exists.
-	existing, err := b.Workspaces(context.TODO())
+	existing, err := b.Workspaces(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/remote-state/oss/backend_test.go
+++ b/internal/backend/remote-state/oss/backend_test.go
@@ -88,7 +88,7 @@ func TestBackendConfigWorkSpace(t *testing.T) {
 	b := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(config)).(*Backend)
 	createOSSBucket(t, b.ossClient, bucketName)
 	defer deleteOSSBucket(t, b.ossClient, bucketName)
-	if _, err := b.Workspaces(); err != nil {
+	if _, err := b.Workspaces(t.Context()); err != nil {
 		t.Fatal(err.Error())
 	}
 	if !strings.HasPrefix(b.ossClient.Config.Endpoint, "https://oss-cn-beijing") {

--- a/internal/backend/remote-state/oss/client_test.go
+++ b/internal/backend/remote-state/oss/client_test.go
@@ -43,7 +43,7 @@ func TestRemoteClient(t *testing.T) {
 	createOSSBucket(t, b.ossClient, bucketName)
 	defer deleteOSSBucket(t, b.ossClient, bucketName)
 
-	state, err := b.StateMgr(backend.DefaultStateName)
+	state, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,12 +78,12 @@ func TestRemoteClientLocks(t *testing.T) {
 	createTablestoreTable(t, b1.otsClient, tableName)
 	defer deleteTablestoreTable(t, b1.otsClient, tableName)
 
-	s1, err := b1.StateMgr(backend.DefaultStateName)
+	s1, err := b1.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	s2, err := b2.StateMgr(backend.DefaultStateName)
+	s2, err := b2.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +119,7 @@ func TestRemoteClientLocks_multipleStates(t *testing.T) {
 	createTablestoreTable(t, b1.otsClient, tableName)
 	defer deleteTablestoreTable(t, b1.otsClient, tableName)
 
-	s1, err := b1.StateMgr("s1")
+	s1, err := b1.StateMgr(t.Context(), "s1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,7 +128,7 @@ func TestRemoteClientLocks_multipleStates(t *testing.T) {
 	}
 
 	// s1 is now locked, s2 should not be locked as it's a different state file
-	s2, err := b2.StateMgr("s2")
+	s2, err := b2.StateMgr(t.Context(), "s2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,7 +166,7 @@ func TestRemoteForceUnlock(t *testing.T) {
 	defer deleteTablestoreTable(t, b1.otsClient, tableName)
 
 	// first test with default
-	s1, err := b1.StateMgr(backend.DefaultStateName)
+	s1, err := b1.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -181,7 +181,7 @@ func TestRemoteForceUnlock(t *testing.T) {
 	}
 
 	// s1 is now locked, get the same state through s2 and unlock it
-	s2, err := b2.StateMgr(backend.DefaultStateName)
+	s2, err := b2.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal("failed to get default state to force unlock:", err)
 	}
@@ -192,7 +192,7 @@ func TestRemoteForceUnlock(t *testing.T) {
 
 	// now try the same thing with a named state
 	// first test with default
-	s1, err = b1.StateMgr("test")
+	s1, err = b1.StateMgr(t.Context(), "test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -207,7 +207,7 @@ func TestRemoteForceUnlock(t *testing.T) {
 	}
 
 	// s1 is now locked, get the same state through s2 and unlock it
-	s2, err = b2.StateMgr("test")
+	s2, err = b2.StateMgr(t.Context(), "test")
 	if err != nil {
 		t.Fatal("failed to get named state to force unlock:", err)
 	}
@@ -236,7 +236,7 @@ func TestRemoteClient_clientMD5(t *testing.T) {
 	createTablestoreTable(t, b.otsClient, tableName)
 	defer deleteTablestoreTable(t, b.otsClient, tableName)
 
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -286,7 +286,7 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 	createTablestoreTable(t, b1.otsClient, tableName)
 	defer deleteTablestoreTable(t, b1.otsClient, tableName)
 
-	s1, err := b1.StateMgr(backend.DefaultStateName)
+	s1, err := b1.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -311,7 +311,7 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 		"bucket": bucketName,
 		"prefix": path,
 	})).(*Backend)
-	s2, err := b2.StateMgr(backend.DefaultStateName)
+	s2, err := b2.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/remote-state/pg/backend_state.go
+++ b/internal/backend/remote-state/pg/backend_state.go
@@ -57,7 +57,7 @@ func (b *Backend) DeleteWorkspace(name string, _ bool) error {
 	return nil
 }
 
-func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
+func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {
 	// Build the state client
 	var stateMgr statemgr.Full = remote.NewState(
 		&RemoteClient{
@@ -73,7 +73,7 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	// Check to see if this state already exists.
 	// If the state doesn't exist, we have to assume this
 	// is a normal create operation, and take the lock at that point.
-	existing, err := b.Workspaces(context.TODO())
+	existing, err := b.Workspaces(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/remote-state/pg/backend_state.go
+++ b/internal/backend/remote-state/pg/backend_state.go
@@ -43,7 +43,7 @@ func (b *Backend) Workspaces(context.Context) ([]string, error) {
 	return result, nil
 }
 
-func (b *Backend) DeleteWorkspace(name string, _ bool) error {
+func (b *Backend) DeleteWorkspace(_ context.Context, name string, _ bool) error {
 	if name == backend.DefaultStateName || name == "" {
 		return fmt.Errorf("can't delete default state")
 	}

--- a/internal/backend/remote-state/pg/backend_state.go
+++ b/internal/backend/remote-state/pg/backend_state.go
@@ -6,7 +6,9 @@
 package pg
 
 import (
+	"context"
 	"fmt"
+
 	"github.com/lib/pq"
 
 	"github.com/opentofu/opentofu/internal/backend"
@@ -15,7 +17,7 @@ import (
 	"github.com/opentofu/opentofu/internal/states/statemgr"
 )
 
-func (b *Backend) Workspaces() ([]string, error) {
+func (b *Backend) Workspaces(context.Context) ([]string, error) {
 	query := fmt.Sprintf(`SELECT name FROM %s.%s WHERE name != 'default' ORDER BY name`, pq.QuoteIdentifier(b.schemaName), pq.QuoteIdentifier(b.tableName))
 	rows, err := b.db.Query(query)
 	if err != nil {
@@ -71,7 +73,7 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	// Check to see if this state already exists.
 	// If the state doesn't exist, we have to assume this
 	// is a normal create operation, and take the lock at that point.
-	existing, err := b.Workspaces()
+	existing, err := b.Workspaces(context.TODO())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/remote-state/pg/backend_test.go
+++ b/internal/backend/remote-state/pg/backend_test.go
@@ -292,12 +292,12 @@ func TestBackendConfig(t *testing.T) {
 				}
 			}
 
-			_, err = b.StateMgr(backend.DefaultStateName)
+			_, err = b.StateMgr(t.Context(), backend.DefaultStateName)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			s, err := b.StateMgr(backend.DefaultStateName)
+			s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -484,12 +484,12 @@ func TestBackendConfigSkipOptions(t *testing.T) {
 				}
 			}
 
-			_, err = b.StateMgr(backend.DefaultStateName)
+			_, err = b.StateMgr(t.Context(), backend.DefaultStateName)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			s, err := b.StateMgr(backend.DefaultStateName)
+			s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -602,7 +602,7 @@ func TestBackendConcurrentLock(t *testing.T) {
 		if b == nil {
 			t.Fatal("Backend could not be configured")
 		}
-		stateMgr, err := b.StateMgr(backend.DefaultStateName)
+		stateMgr, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 		if err != nil {
 			t.Fatalf("Failed to get the state manager: %v", err)
 		}

--- a/internal/backend/remote-state/pg/backend_test.go
+++ b/internal/backend/remote-state/pg/backend_test.go
@@ -216,7 +216,7 @@ func TestBackendConfig(t *testing.T) {
 
 			obj = newObj
 
-			confDiags := b.Configure(obj)
+			confDiags := b.Configure(t.Context(), obj)
 			if tc.ExpectConnectionError != "" {
 				err := confDiags.InConfigBody(config, "").ErrWithWarnings()
 				if err == nil {

--- a/internal/backend/remote-state/pg/client_test.go
+++ b/internal/backend/remote-state/pg/client_test.go
@@ -49,7 +49,7 @@ func TestRemoteClient(t *testing.T) {
 		t.Fatal("Backend could not be configured")
 	}
 
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,13 +77,13 @@ func TestRemoteLocks(t *testing.T) {
 	})
 
 	b1 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), config).(*Backend)
-	s1, err := b1.StateMgr(backend.DefaultStateName)
+	s1, err := b1.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	b2 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), config).(*Backend)
-	s2, err := b2.StateMgr(backend.DefaultStateName)
+	s2, err := b2.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -647,7 +647,7 @@ func (b *Backend) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) 
 // The given configuration is assumed to have already been validated
 // against the schema returned by ConfigSchema and passed validation
 // via PrepareConfig.
-func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
+func (b *Backend) Configure(ctx context.Context, obj cty.Value) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 	if obj.IsNull() {
 		return diags
@@ -718,7 +718,6 @@ func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
 		}
 	}
 
-	ctx := context.TODO()
 	ctx, baselog := attachLoggerToContext(ctx)
 
 	cfg := &awsbase.Config{

--- a/internal/backend/remote-state/s3/backend_complete_test.go
+++ b/internal/backend/remote-state/s3/backend_complete_test.go
@@ -2181,7 +2181,7 @@ func configureBackend(t *testing.T, config map[string]any) (*Backend, tfdiags.Di
 		return b, diags
 	}
 
-	confDiags := b.Configure(configSchema)
+	confDiags := b.Configure(t.Context(), configSchema)
 	diags = diags.Append(confDiags)
 
 	return b, diags

--- a/internal/backend/remote-state/s3/backend_state.go
+++ b/internal/backend/remote-state/s3/backend_state.go
@@ -113,7 +113,7 @@ func (b *Backend) keyEnv(key string) string {
 	return parts[0]
 }
 
-func (b *Backend) DeleteWorkspace(name string, _ bool) error {
+func (b *Backend) DeleteWorkspace(_ context.Context, name string, _ bool) error {
 	if name == backend.DefaultStateName || name == "" {
 		return fmt.Errorf("can't delete default state")
 	}

--- a/internal/backend/remote-state/s3/backend_state.go
+++ b/internal/backend/remote-state/s3/backend_state.go
@@ -24,7 +24,7 @@ import (
 	"github.com/opentofu/opentofu/internal/states/statemgr"
 )
 
-func (b *Backend) Workspaces() ([]string, error) {
+func (b *Backend) Workspaces(ctx context.Context) ([]string, error) {
 	const maxKeys = 1000
 
 	prefix := ""
@@ -38,8 +38,6 @@ func (b *Backend) Workspaces() ([]string, error) {
 		Prefix:  aws.String(prefix),
 		MaxKeys: aws.Int32(maxKeys),
 	}
-
-	ctx := context.TODO()
 
 	ctx, _ = attachLoggerToContext(ctx)
 
@@ -166,7 +164,7 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	// If we need to force-unlock, but for some reason the state no longer
 	// exists, the user will have to use aws tools to manually fix the
 	// situation.
-	existing, err := b.Workspaces()
+	existing, err := b.Workspaces(context.TODO())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/remote-state/s3/backend_state.go
+++ b/internal/backend/remote-state/s3/backend_state.go
@@ -149,7 +149,7 @@ func (b *Backend) remoteClient(name string) (*RemoteClient, error) {
 	return client, nil
 }
 
-func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
+func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {
 	client, err := b.remoteClient(name)
 	if err != nil {
 		return nil, err
@@ -164,7 +164,7 @@ func (b *Backend) StateMgr(name string) (statemgr.Full, error) {
 	// If we need to force-unlock, but for some reason the state no longer
 	// exists, the user will have to use aws tools to manually fix the
 	// situation.
-	existing, err := b.Workspaces(context.TODO())
+	existing, err := b.Workspaces(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -1335,7 +1335,7 @@ func TestBackendExtraPaths(t *testing.T) {
 	}
 
 	// delete the real workspace
-	if err := b.DeleteWorkspace("s2", true); err != nil {
+	if err := b.DeleteWorkspace(t.Context(), "s2", true); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -1586,7 +1586,7 @@ func testGetWorkspaceForKey(b *Backend, key string, expected string) error {
 }
 
 func checkStateList(b backend.Backend, expected []string) error {
-	states, err := b.Workspaces()
+	states, err := b.Workspaces(context.TODO())
 	if err != nil {
 		return err
 	}

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -1344,7 +1344,7 @@ func TestBackendExtraPaths(t *testing.T) {
 	}
 
 	// fetch that state again, which should produce a new lineage
-	s2Mgr, err := b.StateMgr("s2")
+	s2Mgr, err := b.StateMgr(t.Context(), "s2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1368,7 +1368,7 @@ func TestBackendExtraPaths(t *testing.T) {
 	}
 
 	// make sure s2 is OK
-	s2Mgr, err = b.StateMgr("s2")
+	s2Mgr, err = b.StateMgr(t.Context(), "s2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1401,7 +1401,7 @@ func TestBackendPrefixInWorkspace(t *testing.T) {
 	defer deleteS3Bucket(t.Context(), t, b.s3Client, bucketName)
 
 	// get a state that contains the prefix as a substring
-	sMgr, err := b.StateMgr("env-1")
+	sMgr, err := b.StateMgr(t.Context(), "env-1")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -143,7 +143,7 @@ func TestBackendConfig_InvalidRegion(t *testing.T) {
 				t.Fatal(diags.ErrWithWarnings())
 			}
 
-			confDiags := b.Configure(configSchema)
+			confDiags := b.Configure(t.Context(), configSchema)
 			diags = diags.Append(confDiags)
 
 			if diff := cmp.Diff(diags, tc.expectedDiags, cmp.Comparer(diagnosticComparer)); diff != "" {
@@ -364,7 +364,7 @@ func TestBackendConfig_STSEndpoint(t *testing.T) {
 				t.Fatal(diags.ErrWithWarnings())
 			}
 
-			confDiags := b.Configure(configSchema)
+			confDiags := b.Configure(t.Context(), configSchema)
 			diags = diags.Append(confDiags)
 
 			if diff := cmp.Diff(diags, tc.expectedDiags, cmp.Comparer(diagnosticSummaryComparer)); diff != "" {
@@ -595,7 +595,7 @@ func TestBackendConfig_AssumeRole(t *testing.T) {
 			testCase.Config["sts_endpoint"] = endpoint
 
 			b := New(encryption.StateEncryptionDisabled())
-			diags := b.Configure(populateSchema(t, b.ConfigSchema(), hcl2shim.HCL2ValueFromConfigValue(testCase.Config)))
+			diags := b.Configure(t.Context(), populateSchema(t, b.ConfigSchema(), hcl2shim.HCL2ValueFromConfigValue(testCase.Config)))
 
 			if diags.HasErrors() {
 				for _, diag := range diags {
@@ -1046,7 +1046,7 @@ func TestBackendConfig_proxy(t *testing.T) {
 
 			b := New(encryption.StateEncryptionDisabled())
 
-			got := b.Configure(populateSchema(t, b.ConfigSchema(), tc.config))
+			got := b.Configure(t.Context(), populateSchema(t, b.ConfigSchema(), tc.config))
 			if got.HasErrors() != (tc.wantErrSubstr != "") {
 				t.Fatalf("unexpected error: %v", got.Err())
 			}
@@ -1156,7 +1156,7 @@ func TestBackendSSECustomerKeyConfig(t *testing.T) {
 			}
 
 			b := New(encryption.StateEncryptionDisabled()).(*Backend)
-			diags := b.Configure(populateSchema(t, b.ConfigSchema(), hcl2shim.HCL2ValueFromConfigValue(config)))
+			diags := b.Configure(t.Context(), populateSchema(t, b.ConfigSchema(), hcl2shim.HCL2ValueFromConfigValue(config)))
 
 			if testCase.expectedErr != "" {
 				if diags.Err() != nil {
@@ -1219,7 +1219,7 @@ func TestBackendSSECustomerKeyEnvVar(t *testing.T) {
 			t.Setenv("AWS_SSE_CUSTOMER_KEY", testCase.customerKey)
 
 			b := New(encryption.StateEncryptionDisabled()).(*Backend)
-			diags := b.Configure(populateSchema(t, b.ConfigSchema(), hcl2shim.HCL2ValueFromConfigValue(config)))
+			diags := b.Configure(t.Context(), populateSchema(t, b.ConfigSchema(), hcl2shim.HCL2ValueFromConfigValue(config)))
 
 			if testCase.expectedErr != "" {
 				if diags.Err() != nil {

--- a/internal/backend/remote-state/s3/client_test.go
+++ b/internal/backend/remote-state/s3/client_test.go
@@ -46,7 +46,7 @@ func TestRemoteClient(t *testing.T) {
 	createS3Bucket(t.Context(), t, b.s3Client, bucketName, b.awsConfig.Region)
 	defer deleteS3Bucket(t.Context(), t, b.s3Client, bucketName)
 
-	state, err := b.StateMgr(backend.DefaultStateName)
+	state, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,12 +78,12 @@ func TestRemoteClientLocks(t *testing.T) {
 	createDynamoDBTable(t.Context(), t, b1.dynClient, bucketName)
 	defer deleteDynamoDBTable(t.Context(), t, b1.dynClient, bucketName)
 
-	s1, err := b1.StateMgr(backend.DefaultStateName)
+	s1, err := b1.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	s2, err := b2.StateMgr(backend.DefaultStateName)
+	s2, err := b2.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,12 +113,12 @@ func TestRemoteS3ClientLocks(t *testing.T) {
 	createS3Bucket(t.Context(), t, b1.s3Client, bucketName, b1.awsConfig.Region)
 	defer deleteS3Bucket(t.Context(), t, b1.s3Client, bucketName)
 
-	s1, err := b1.StateMgr(backend.DefaultStateName)
+	s1, err := b1.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	s2, err := b2.StateMgr(backend.DefaultStateName)
+	s2, err := b2.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -152,12 +152,12 @@ func TestRemoteS3AndDynamoDBClientLocks(t *testing.T) {
 	createDynamoDBTable(t.Context(), t, b1.dynClient, bucketName)
 	defer deleteDynamoDBTable(t.Context(), t, b1.dynClient, bucketName)
 
-	s1, err := b1.StateMgr(backend.DefaultStateName)
+	s1, err := b1.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	s2, err := b2.StateMgr(backend.DefaultStateName)
+	s2, err := b2.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -189,7 +189,7 @@ func TestRemoteS3AndDynamoDBClientLocksWithNoDBInstance(t *testing.T) {
 	createS3Bucket(t.Context(), t, b1.s3Client, bucketName, b1.awsConfig.Region)
 	defer deleteS3Bucket(t.Context(), t, b1.s3Client, bucketName)
 
-	s1, err := b1.StateMgr(backend.DefaultStateName)
+	s1, err := b1.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -234,7 +234,7 @@ func TestForceUnlock(t *testing.T) {
 	defer deleteDynamoDBTable(t.Context(), t, b1.dynClient, bucketName)
 
 	// first test with default
-	s1, err := b1.StateMgr(backend.DefaultStateName)
+	s1, err := b1.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -249,7 +249,7 @@ func TestForceUnlock(t *testing.T) {
 	}
 
 	// s1 is now locked, get the same state through s2 and unlock it
-	s2, err := b2.StateMgr(backend.DefaultStateName)
+	s2, err := b2.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal("failed to get default state to force unlock:", err)
 	}
@@ -260,7 +260,7 @@ func TestForceUnlock(t *testing.T) {
 
 	// now try the same thing with a named state
 	// first test with default
-	s1, err = b1.StateMgr("test")
+	s1, err = b1.StateMgr(t.Context(), "test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -275,7 +275,7 @@ func TestForceUnlock(t *testing.T) {
 	}
 
 	// s1 is now locked, get the same state through s2 and unlock it
-	s2, err = b2.StateMgr("test")
+	s2, err = b2.StateMgr(t.Context(), "test")
 	if err != nil {
 		t.Fatal("failed to get named state to force unlock:", err)
 	}
@@ -286,7 +286,7 @@ func TestForceUnlock(t *testing.T) {
 
 	// No State lock information found for the new workspace. The client should throw the appropriate error message.
 	secondWorkspace := "new-workspace"
-	s2, err = b2.StateMgr(secondWorkspace)
+	s2, err = b2.StateMgr(t.Context(), secondWorkspace)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -324,7 +324,7 @@ func TestForceUnlockS3Only(t *testing.T) {
 	defer deleteS3Bucket(t.Context(), t, b1.s3Client, bucketName)
 
 	// first test with default
-	s1, err := b1.StateMgr(backend.DefaultStateName)
+	s1, err := b1.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -339,7 +339,7 @@ func TestForceUnlockS3Only(t *testing.T) {
 	}
 
 	// s1 is now locked, get the same state through s2 and unlock it
-	s2, err := b2.StateMgr(backend.DefaultStateName)
+	s2, err := b2.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal("failed to get default state to force unlock:", err)
 	}
@@ -350,7 +350,7 @@ func TestForceUnlockS3Only(t *testing.T) {
 
 	// now try the same thing with a named state
 	// first test with default
-	s1, err = b1.StateMgr("test")
+	s1, err = b1.StateMgr(t.Context(), "test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -365,7 +365,7 @@ func TestForceUnlockS3Only(t *testing.T) {
 	}
 
 	// s1 is now locked, get the same state through s2 and unlock it
-	s2, err = b2.StateMgr("test")
+	s2, err = b2.StateMgr(t.Context(), "test")
 	if err != nil {
 		t.Fatal("failed to get named state to force unlock:", err)
 	}
@@ -376,7 +376,7 @@ func TestForceUnlockS3Only(t *testing.T) {
 
 	// No State lock information found for the new workspace. The client should throw the appropriate error message.
 	secondWorkspace := "new-workspace"
-	s2, err = b2.StateMgr(secondWorkspace)
+	s2, err = b2.StateMgr(t.Context(), secondWorkspace)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -418,7 +418,7 @@ func TestForceUnlockS3AndDynamo(t *testing.T) {
 	defer deleteDynamoDBTable(t.Context(), t, b1.dynClient, bucketName)
 
 	// first test with default
-	s1, err := b1.StateMgr(backend.DefaultStateName)
+	s1, err := b1.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -433,7 +433,7 @@ func TestForceUnlockS3AndDynamo(t *testing.T) {
 	}
 
 	// s1 is now locked, get the same state through s2 and unlock it
-	s2, err := b2.StateMgr(backend.DefaultStateName)
+	s2, err := b2.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal("failed to get default state to force unlock:", err)
 	}
@@ -444,7 +444,7 @@ func TestForceUnlockS3AndDynamo(t *testing.T) {
 
 	// now try the same thing with a named state
 	// first test with default
-	s1, err = b1.StateMgr("test")
+	s1, err = b1.StateMgr(t.Context(), "test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -459,7 +459,7 @@ func TestForceUnlockS3AndDynamo(t *testing.T) {
 	}
 
 	// s1 is now locked, get the same state through s2 and unlock it
-	s2, err = b2.StateMgr("test")
+	s2, err = b2.StateMgr(t.Context(), "test")
 	if err != nil {
 		t.Fatal("failed to get named state to force unlock:", err)
 	}
@@ -470,7 +470,7 @@ func TestForceUnlockS3AndDynamo(t *testing.T) {
 
 	// No State lock information found for the new workspace. The client should throw the appropriate error message.
 	secondWorkspace := "new-workspace"
-	s2, err = b2.StateMgr(secondWorkspace)
+	s2, err = b2.StateMgr(t.Context(), secondWorkspace)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -509,7 +509,7 @@ func TestForceUnlockS3WithAndDynamoWithout(t *testing.T) {
 	defer deleteDynamoDBTable(t.Context(), t, b1.dynClient, bucketName)
 
 	// first create both locks: s3 and dynamo
-	s1, err := b1.StateMgr(backend.DefaultStateName)
+	s1, err := b1.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -568,7 +568,7 @@ func TestRemoteClient_clientMD5(t *testing.T) {
 	createDynamoDBTable(t.Context(), t, b.dynClient, bucketName)
 	defer deleteDynamoDBTable(t.Context(), t, b.dynClient, bucketName)
 
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -616,7 +616,7 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 	createDynamoDBTable(t.Context(), t, b1.dynClient, bucketName)
 	defer deleteDynamoDBTable(t.Context(), t, b1.dynClient, bucketName)
 
-	s1, err := b1.StateMgr(backend.DefaultStateName)
+	s1, err := b1.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -641,7 +641,7 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 		"bucket": bucketName,
 		"key":    keyName,
 	})).(*Backend)
-	s2, err := b2.StateMgr(backend.DefaultStateName)
+	s2, err := b2.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -649,7 +649,7 @@ func (b *Remote) DeleteWorkspace(name string, _ bool) error {
 }
 
 // StateMgr implements backend.Enhanced.
-func (b *Remote) StateMgr(name string) (statemgr.Full, error) {
+func (b *Remote) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {
 	if b.workspace == "" && name == backend.DefaultStateName {
 		return nil, backend.ErrDefaultWorkspaceNotSupported
 	}
@@ -665,7 +665,7 @@ func (b *Remote) StateMgr(name string) (statemgr.Full, error) {
 		name = b.prefix + name
 	}
 
-	workspace, err := b.client.Workspaces.Read(context.Background(), b.organization, name)
+	workspace, err := b.client.Workspaces.Read(ctx, b.organization, name)
 	if err != nil && err != tfe.ErrResourceNotFound {
 		return nil, fmt.Errorf("Failed to retrieve workspace %s: %w", name, err)
 	}
@@ -681,7 +681,7 @@ func (b *Remote) StateMgr(name string) (statemgr.Full, error) {
 			options.TerraformVersion = tfe.String(tfversion.String())
 		}
 
-		workspace, err = b.client.Workspaces.Create(context.Background(), b.organization, options)
+		workspace, err = b.client.Workspaces.Create(ctx, b.organization, options)
 		if err != nil {
 			return nil, fmt.Errorf("Error creating workspace %s: %w", name, err)
 		}

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -557,7 +557,7 @@ func (b *Remote) retryLogHook(attemptNum int, resp *http.Response) {
 }
 
 // Workspaces implements backend.Enhanced.
-func (b *Remote) Workspaces() ([]string, error) {
+func (b *Remote) Workspaces(context.Context) ([]string, error) {
 	if b.prefix == "" {
 		return nil, backend.ErrWorkspacesNotSupported
 	}

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -620,7 +620,7 @@ func (b *Remote) WorkspaceNamePattern() string {
 }
 
 // DeleteWorkspace implements backend.Enhanced.
-func (b *Remote) DeleteWorkspace(name string, _ bool) error {
+func (b *Remote) DeleteWorkspace(_ context.Context, name string, _ bool) error {
 	if b.workspace == "" && name == backend.DefaultStateName {
 		return backend.ErrDefaultWorkspaceNotSupported
 	}

--- a/internal/backend/remote/backend.go
+++ b/internal/backend/remote/backend.go
@@ -228,7 +228,7 @@ func (b *Remote) ServiceDiscoveryAliases() ([]backend.HostAlias, error) {
 }
 
 // Configure implements backend.Enhanced.
-func (b *Remote) Configure(obj cty.Value) tfdiags.Diagnostics {
+func (b *Remote) Configure(ctx context.Context, obj cty.Value) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 	if obj.IsNull() {
 		return diags

--- a/internal/backend/remote/backend_apply_test.go
+++ b/internal/backend/remote/backend_apply_test.go
@@ -110,7 +110,7 @@ func TestRemote_applyBasic(t *testing.T) {
 		t.Fatalf("expected apply summery in output: %s", output)
 	}
 
-	stateMgr, _ := b.StateMgr(backend.DefaultStateName)
+	stateMgr, _ := b.StateMgr(t.Context(), backend.DefaultStateName)
 	// An error suggests that the state was not unlocked after apply
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after apply: %s", err.Error())
@@ -139,7 +139,7 @@ func TestRemote_applyCanceled(t *testing.T) {
 		t.Fatal("expected apply operation to fail")
 	}
 
-	stateMgr, _ := b.StateMgr(backend.DefaultStateName)
+	stateMgr, _ := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after cancelling apply: %s", err.Error())
 	}
@@ -486,7 +486,7 @@ func TestRemote_applyWithExclude(t *testing.T) {
 		t.Fatalf("expected -exclude option is not supported error, got: %v", errOutput)
 	}
 
-	stateMgr, _ := b.StateMgr(backend.DefaultStateName)
+	stateMgr, _ := b.StateMgr(t.Context(), backend.DefaultStateName)
 	// An error suggests that the state was not unlocked after apply
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after failed apply: %s", err.Error())
@@ -652,7 +652,7 @@ func TestRemote_applyNoConfig(t *testing.T) {
 		t.Fatalf("expected configuration files error, got: %v", errOutput)
 	}
 
-	stateMgr, _ := b.StateMgr(backend.DefaultStateName)
+	stateMgr, _ := b.StateMgr(t.Context(), backend.DefaultStateName)
 	// An error suggests that the state was not unlocked after apply
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after failed apply: %s", err.Error())

--- a/internal/backend/remote/backend_context.go
+++ b/internal/backend/remote/backend_context.go
@@ -44,7 +44,7 @@ func (b *Remote) LocalRun(ctx context.Context, op *backend.Operation) (*backend.
 
 	// Get the latest state.
 	log.Printf("[TRACE] backend/remote: requesting state manager for workspace %q", remoteWorkspaceName)
-	stateMgr, err := b.StateMgr(op.Workspace)
+	stateMgr, err := b.StateMgr(ctx, op.Workspace)
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("error loading state: %w", err))
 		return nil, nil, diags

--- a/internal/backend/remote/backend_context_test.go
+++ b/internal/backend/remote/backend_context_test.go
@@ -227,7 +227,7 @@ func TestRemoteContextWithVars(t *testing.T) {
 				}
 				// When Context() returns an error, it should unlock the state,
 				// so re-locking it is expected to succeed.
-				stateMgr, _ := b.StateMgr(backend.DefaultStateName)
+				stateMgr, _ := b.StateMgr(t.Context(), backend.DefaultStateName)
 				if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 					t.Fatalf("unexpected error locking state: %s", err.Error())
 				}
@@ -236,7 +236,7 @@ func TestRemoteContextWithVars(t *testing.T) {
 					t.Fatalf("unexpected error\ngot:  %s\nwant: <no error>", diags.Err().Error())
 				}
 				// When Context() succeeds, this should fail w/ "workspace already locked"
-				stateMgr, _ := b.StateMgr(backend.DefaultStateName)
+				stateMgr, _ := b.StateMgr(t.Context(), backend.DefaultStateName)
 				if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err == nil {
 					t.Fatal("unexpected success locking state after Context")
 				}
@@ -444,7 +444,7 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 				t.Fatalf("unexpected error\ngot:  %s\nwant: <no error>", diags.Err().Error())
 			}
 			// When Context() succeeds, this should fail w/ "workspace already locked"
-			stateMgr, _ := b.StateMgr(backend.DefaultStateName)
+			stateMgr, _ := b.StateMgr(t.Context(), backend.DefaultStateName)
 			if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err == nil {
 				t.Fatal("unexpected success locking state after Context")
 			}

--- a/internal/backend/remote/backend_plan_test.go
+++ b/internal/backend/remote/backend_plan_test.go
@@ -95,7 +95,7 @@ func TestRemote_planBasic(t *testing.T) {
 		t.Fatalf("expected plan summary in output: %s", output)
 	}
 
-	stateMgr, _ := b.StateMgr(backend.DefaultStateName)
+	stateMgr, _ := b.StateMgr(t.Context(), backend.DefaultStateName)
 	// An error suggests that the state was not unlocked after the operation finished
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after successful plan: %s", err.Error())
@@ -124,7 +124,7 @@ func TestRemote_planCanceled(t *testing.T) {
 		t.Fatal("expected plan operation to fail")
 	}
 
-	stateMgr, _ := b.StateMgr(backend.DefaultStateName)
+	stateMgr, _ := b.StateMgr(t.Context(), backend.DefaultStateName)
 	// An error suggests that the state was not unlocked after the operation finished
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after cancelled plan: %s", err.Error())

--- a/internal/backend/remote/backend_state_test.go
+++ b/internal/backend/remote/backend_state_test.go
@@ -30,12 +30,12 @@ func TestRemoteClient_stateLock(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	s1, err := b.StateMgr(backend.DefaultStateName)
+	s1, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	s2, err := b.StateMgr(backend.DefaultStateName)
+	s2, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/internal/backend/remote/backend_test.go
+++ b/internal/backend/remote/backend_test.go
@@ -273,11 +273,11 @@ func TestRemote_addAndRemoveWorkspacesDefault(t *testing.T) {
 		t.Fatalf("expected error %v, got %v", backend.ErrWorkspacesNotSupported, err)
 	}
 
-	if _, err := b.StateMgr(backend.DefaultStateName); err != nil {
+	if _, err := b.StateMgr(t.Context(), backend.DefaultStateName); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if _, err := b.StateMgr("prod"); err != backend.ErrWorkspacesNotSupported {
+	if _, err := b.StateMgr(t.Context(), "prod"); err != backend.ErrWorkspacesNotSupported {
 		t.Fatalf("expected error %v, got %v", backend.ErrWorkspacesNotSupported, err)
 	}
 
@@ -304,12 +304,12 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 		t.Fatalf("expected states %#+v, got %#+v", expectedWorkspaces, states)
 	}
 
-	if _, err := b.StateMgr(backend.DefaultStateName); err != backend.ErrDefaultWorkspaceNotSupported {
+	if _, err := b.StateMgr(t.Context(), backend.DefaultStateName); err != backend.ErrDefaultWorkspaceNotSupported {
 		t.Fatalf("expected error %v, got %v", backend.ErrDefaultWorkspaceNotSupported, err)
 	}
 
 	expectedA := "test_A"
-	if _, err := b.StateMgr(expectedA); err != nil {
+	if _, err := b.StateMgr(t.Context(), expectedA); err != nil {
 		t.Fatal(err)
 	}
 
@@ -324,7 +324,7 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 	}
 
 	expectedB := "test_B"
-	if _, err := b.StateMgr(expectedB); err != nil {
+	if _, err := b.StateMgr(t.Context(), expectedB); err != nil {
 		t.Fatal(err)
 	}
 
@@ -511,7 +511,7 @@ func TestRemote_StateMgr_versionCheck(t *testing.T) {
 	}
 
 	// This should succeed
-	if _, err := b.StateMgr(backend.DefaultStateName); err != nil {
+	if _, err := b.StateMgr(t.Context(), backend.DefaultStateName); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
@@ -529,7 +529,7 @@ func TestRemote_StateMgr_versionCheck(t *testing.T) {
 
 	// This should fail
 	want := `Remote workspace OpenTofu version "0.13.5" does not match local OpenTofu version "0.14.0"`
-	if _, err := b.StateMgr(backend.DefaultStateName); err.Error() != want {
+	if _, err := b.StateMgr(t.Context(), backend.DefaultStateName); err.Error() != want {
 		t.Fatalf("wrong error\n got: %v\nwant: %v", err.Error(), want)
 	}
 }
@@ -558,7 +558,7 @@ func TestRemote_Unlock_ignoreVersion(t *testing.T) {
 	tfversion.Version = v111.String()
 	tfversion.SemVer = v111
 
-	state, err := b.StateMgr(backend.DefaultStateName)
+	state, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("error: %v", err)
 	}
@@ -608,7 +608,7 @@ func TestRemote_StateMgr_versionCheckLatest(t *testing.T) {
 	}
 
 	// This should succeed despite not being a string match
-	if _, err := b.StateMgr(backend.DefaultStateName); err != nil {
+	if _, err := b.StateMgr(t.Context(), backend.DefaultStateName); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 }

--- a/internal/backend/remote/backend_test.go
+++ b/internal/backend/remote/backend_test.go
@@ -164,7 +164,7 @@ func TestRemote_config(t *testing.T) {
 		}
 
 		// Configure
-		confDiags := b.Configure(tc.config)
+		confDiags := b.Configure(t.Context(), tc.config)
 		if (confDiags.Err() != nil || tc.confErr != "") &&
 			(confDiags.Err() == nil || !strings.Contains(confDiags.Err().Error(), tc.confErr)) {
 			t.Fatalf("%s: unexpected configure result: %v", name, confDiags.Err())
@@ -242,7 +242,7 @@ func TestRemote_versionConstraints(t *testing.T) {
 		}
 
 		// Configure
-		confDiags := b.Configure(tc.config)
+		confDiags := b.Configure(t.Context(), tc.config)
 		if (confDiags.Err() != nil || tc.result != "") &&
 			(confDiags.Err() == nil || !strings.Contains(confDiags.Err().Error(), tc.result)) {
 			t.Fatalf("%s: unexpected configure result: %v", name, confDiags.Err())
@@ -786,7 +786,7 @@ func TestRemote_ServiceDiscoveryAliases(t *testing.T) {
 	s := testServer(t)
 	b := New(testDisco(s), encryption.StateEncryptionDisabled())
 
-	diag := b.Configure(cty.ObjectVal(map[string]cty.Value{
+	diag := b.Configure(t.Context(), cty.ObjectVal(map[string]cty.Value{
 		"hostname":     cty.StringVal(mockedBackendHost),
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),

--- a/internal/backend/remote/backend_test.go
+++ b/internal/backend/remote/backend_test.go
@@ -269,7 +269,7 @@ func TestRemote_addAndRemoveWorkspacesDefault(t *testing.T) {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	if _, err := b.Workspaces(); err != backend.ErrWorkspacesNotSupported {
+	if _, err := b.Workspaces(t.Context()); err != backend.ErrWorkspacesNotSupported {
 		t.Fatalf("expected error %v, got %v", backend.ErrWorkspacesNotSupported, err)
 	}
 
@@ -294,7 +294,7 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 	b, bCleanup := testBackendNoDefault(t)
 	defer bCleanup()
 
-	states, err := b.Workspaces()
+	states, err := b.Workspaces(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -313,7 +313,7 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	states, err = b.Workspaces()
+	states, err = b.Workspaces(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -328,7 +328,7 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	states, err = b.Workspaces()
+	states, err = b.Workspaces(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -346,7 +346,7 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	states, err = b.Workspaces()
+	states, err = b.Workspaces(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -360,7 +360,7 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	states, err = b.Workspaces()
+	states, err = b.Workspaces(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/remote/backend_test.go
+++ b/internal/backend/remote/backend_test.go
@@ -281,11 +281,11 @@ func TestRemote_addAndRemoveWorkspacesDefault(t *testing.T) {
 		t.Fatalf("expected error %v, got %v", backend.ErrWorkspacesNotSupported, err)
 	}
 
-	if err := b.DeleteWorkspace(backend.DefaultStateName, true); err != nil {
+	if err := b.DeleteWorkspace(t.Context(), backend.DefaultStateName, true); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if err := b.DeleteWorkspace("prod", true); err != backend.ErrWorkspacesNotSupported {
+	if err := b.DeleteWorkspace(t.Context(), "prod", true); err != backend.ErrWorkspacesNotSupported {
 		t.Fatalf("expected error %v, got %v", backend.ErrWorkspacesNotSupported, err)
 	}
 }
@@ -338,11 +338,11 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 		t.Fatalf("expected %#+v, got %#+v", expectedWorkspaces, states)
 	}
 
-	if err := b.DeleteWorkspace(backend.DefaultStateName, true); err != backend.ErrDefaultWorkspaceNotSupported {
+	if err := b.DeleteWorkspace(t.Context(), backend.DefaultStateName, true); err != backend.ErrDefaultWorkspaceNotSupported {
 		t.Fatalf("expected error %v, got %v", backend.ErrDefaultWorkspaceNotSupported, err)
 	}
 
-	if err := b.DeleteWorkspace(expectedA, true); err != nil {
+	if err := b.DeleteWorkspace(t.Context(), expectedA, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -356,7 +356,7 @@ func TestRemote_addAndRemoveWorkspacesNoDefault(t *testing.T) {
 		t.Fatalf("expected %#+v got %#+v", expectedWorkspaces, states)
 	}
 
-	if err := b.DeleteWorkspace(expectedB, true); err != nil {
+	if err := b.DeleteWorkspace(t.Context(), expectedB, true); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/backend/remote/testing.go
+++ b/internal/backend/remote/testing.go
@@ -114,7 +114,7 @@ func testRemoteClient(t *testing.T) remote.Client {
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
-	raw, err := b.StateMgr(backend.DefaultStateName)
+	raw, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("error: %v", err)
 	}

--- a/internal/backend/remote/testing.go
+++ b/internal/backend/remote/testing.go
@@ -133,7 +133,7 @@ func testBackend(t *testing.T, obj cty.Value) (*Remote, func()) {
 	}
 	obj = newObj
 
-	confDiags := b.Configure(obj)
+	confDiags := b.Configure(t.Context(), obj)
 	if len(confDiags) != 0 {
 		t.Fatal(confDiags.ErrWithWarnings())
 	}

--- a/internal/backend/testing.go
+++ b/internal/backend/testing.go
@@ -282,12 +282,12 @@ func TestBackendStates(t *testing.T, b Backend) {
 	}
 
 	// Delete some workspaces
-	if err := b.DeleteWorkspace("foo", true); err != nil {
+	if err := b.DeleteWorkspace(t.Context(), "foo", true); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
 	// Verify the default state can't be deleted
-	if err := b.DeleteWorkspace(DefaultStateName, true); err == nil {
+	if err := b.DeleteWorkspace(t.Context(), DefaultStateName, true); err == nil {
 		t.Fatal("expected error")
 	}
 
@@ -305,7 +305,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 		t.Fatalf("should be empty: %s", v)
 	}
 	// and delete it again
-	if err := b.DeleteWorkspace("foo", true); err != nil {
+	if err := b.DeleteWorkspace(t.Context(), "foo", true); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/internal/backend/testing.go
+++ b/internal/backend/testing.go
@@ -138,7 +138,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 	t.Helper()
 
 	noDefault := false
-	if _, err := b.StateMgr(DefaultStateName); err != nil {
+	if _, err := b.StateMgr(t.Context(), DefaultStateName); err != nil {
 		if err == ErrDefaultWorkspaceNotSupported {
 			noDefault = true
 		} else {
@@ -161,7 +161,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 	}
 
 	// Create a couple states
-	foo, err := b.StateMgr("foo")
+	foo, err := b.StateMgr(t.Context(), "foo")
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}
@@ -172,7 +172,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 		t.Fatalf("should be empty: %s", v)
 	}
 
-	bar, err := b.StateMgr("bar")
+	bar, err := b.StateMgr(t.Context(), "bar")
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}
@@ -237,7 +237,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 		}
 
 		// fetch foo again from the backend
-		foo, err = b.StateMgr("foo")
+		foo, err = b.StateMgr(t.Context(), "foo")
 		if err != nil {
 			t.Fatal("error re-fetching state:", err)
 		}
@@ -250,7 +250,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 		}
 
 		// fetch the bar again from the backend
-		bar, err = b.StateMgr("bar")
+		bar, err = b.StateMgr(t.Context(), "bar")
 		if err != nil {
 			t.Fatal("error re-fetching state:", err)
 		}
@@ -294,7 +294,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 	// Create and delete the foo workspace again.
 	// Make sure that there are no leftover artifacts from a deleted state
 	// preventing re-creation.
-	foo, err = b.StateMgr("foo")
+	foo, err = b.StateMgr(t.Context(), "foo")
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}
@@ -367,7 +367,7 @@ func testLocksInWorkspace(t *testing.T, b1, b2 Backend, testForceUnlock bool, wo
 	t.Helper()
 
 	// Get the default state for each
-	b1StateMgr, err := b1.StateMgr(DefaultStateName)
+	b1StateMgr, err := b1.StateMgr(t.Context(), DefaultStateName)
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}
@@ -383,7 +383,7 @@ func testLocksInWorkspace(t *testing.T, b1, b2 Backend, testForceUnlock bool, wo
 
 	t.Logf("TestBackend: testing state locking for %T", b1)
 
-	b2StateMgr, err := b2.StateMgr(DefaultStateName)
+	b2StateMgr, err := b2.StateMgr(t.Context(), DefaultStateName)
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}
@@ -411,7 +411,7 @@ func testLocksInWorkspace(t *testing.T, b1, b2 Backend, testForceUnlock bool, wo
 	// Make sure we can still get the statemgr.Full from another instance even
 	// when locked.  This should only happen when a state is loaded via the
 	// backend, and as a remote state.
-	_, err = b2.StateMgr(DefaultStateName)
+	_, err = b2.StateMgr(t.Context(), DefaultStateName)
 	if err != nil {
 		t.Errorf("failed to read locked state from another backend instance: %s", err)
 	}

--- a/internal/backend/testing.go
+++ b/internal/backend/testing.go
@@ -146,7 +146,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 		}
 	}
 
-	workspaces, err := b.Workspaces()
+	workspaces, err := b.Workspaces(t.Context())
 	if err != nil {
 		if err == ErrWorkspacesNotSupported {
 			t.Logf("TestBackend: workspaces not supported in %T, skipping", b)
@@ -266,7 +266,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 	// Verify we can now list them
 	{
 		// we determined that named stated are supported earlier
-		workspaces, err := b.Workspaces()
+		workspaces, err := b.Workspaces(t.Context())
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -311,7 +311,7 @@ func TestBackendStates(t *testing.T, b Backend) {
 
 	// Verify deletion
 	{
-		workspaces, err := b.Workspaces()
+		workspaces, err := b.Workspaces(t.Context())
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}

--- a/internal/backend/testing.go
+++ b/internal/backend/testing.go
@@ -69,7 +69,7 @@ func TestBackendConfigWarningsAndErrors(t *testing.T, b Backend, c hcl.Body) (Ba
 
 	obj = newObj
 
-	confDiags := b.Configure(obj)
+	confDiags := b.Configure(t.Context(), obj)
 	if len(confDiags) != 0 {
 		confDiags = confDiags.InConfigBody(c, "")
 		warnings, errors := separateWarningsAndErrors(confDiags)
@@ -110,7 +110,7 @@ func TestBackendConfig(t *testing.T, b Backend, c hcl.Body) Backend {
 
 	obj = newObj
 
-	confDiags := b.Configure(obj)
+	confDiags := b.Configure(t.Context(), obj)
 	if len(confDiags) != 0 {
 		confDiags = confDiags.InConfigBody(c, "")
 		t.Fatal(confDiags.ErrWithWarnings())

--- a/internal/builtin/providers/tf/data_source_state.go
+++ b/internal/builtin/providers/tf/data_source_state.go
@@ -6,6 +6,7 @@
 package tf
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -114,7 +115,9 @@ func dataSourceRemoteStateRead(d cty.Value, enc encryption.StateEncryption, path
 		return cty.NilVal, diags
 	}
 
-	configureDiags := b.Configure(cfg)
+	// TODO: Plumb a real context in here, once [providers.Interface] has
+	// been updated to allow one to pass through its API.
+	configureDiags := b.Configure(context.TODO(), cfg)
 	if configureDiags.HasErrors() {
 		diags = diags.Append(configureDiags.Err())
 		return cty.NilVal, diags

--- a/internal/builtin/providers/tf/data_source_state.go
+++ b/internal/builtin/providers/tf/data_source_state.go
@@ -137,7 +137,7 @@ func dataSourceRemoteStateRead(d cty.Value, enc encryption.StateEncryption, path
 		workspaceName = workspaceVal.AsString()
 	}
 
-	state, err := b.StateMgr(workspaceName)
+	state, err := b.StateMgr(context.TODO(), workspaceName)
 	if err != nil {
 		diags = diags.Append(tfdiags.AttributeValue(
 			tfdiags.Error,

--- a/internal/builtin/providers/tf/data_source_state_test.go
+++ b/internal/builtin/providers/tf/data_source_state_test.go
@@ -404,7 +404,7 @@ func (b backendFailsConfigure) Configure(ctx context.Context, config cty.Value) 
 	return diags
 }
 
-func (b backendFailsConfigure) StateMgr(workspace string) (statemgr.Full, error) {
+func (b backendFailsConfigure) StateMgr(_ context.Context, workspace string) (statemgr.Full, error) {
 	return nil, fmt.Errorf("StateMgr not implemented")
 }
 

--- a/internal/builtin/providers/tf/data_source_state_test.go
+++ b/internal/builtin/providers/tf/data_source_state_test.go
@@ -6,6 +6,7 @@
 package tf
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"testing"
@@ -396,7 +397,7 @@ func (b backendFailsConfigure) PrepareConfig(given cty.Value) (cty.Value, tfdiag
 	return given, nil
 }
 
-func (b backendFailsConfigure) Configure(config cty.Value) tfdiags.Diagnostics {
+func (b backendFailsConfigure) Configure(ctx context.Context, config cty.Value) tfdiags.Diagnostics {
 	log.Printf("[TRACE] backendFailsConfigure.Configure(%#v)", config)
 	var diags tfdiags.Diagnostics
 	diags = diags.Append(fmt.Errorf("Configure should never be called"))

--- a/internal/builtin/providers/tf/data_source_state_test.go
+++ b/internal/builtin/providers/tf/data_source_state_test.go
@@ -412,6 +412,6 @@ func (b backendFailsConfigure) DeleteWorkspace(name string, _ bool) error {
 	return fmt.Errorf("DeleteWorkspace not implemented")
 }
 
-func (b backendFailsConfigure) Workspaces() ([]string, error) {
+func (b backendFailsConfigure) Workspaces(context.Context) ([]string, error) {
 	return nil, fmt.Errorf("Workspaces not implemented")
 }

--- a/internal/builtin/providers/tf/data_source_state_test.go
+++ b/internal/builtin/providers/tf/data_source_state_test.go
@@ -408,7 +408,7 @@ func (b backendFailsConfigure) StateMgr(_ context.Context, workspace string) (st
 	return nil, fmt.Errorf("StateMgr not implemented")
 }
 
-func (b backendFailsConfigure) DeleteWorkspace(name string, _ bool) error {
+func (b backendFailsConfigure) DeleteWorkspace(_ context.Context, name string, _ bool) error {
 	return fmt.Errorf("DeleteWorkspace not implemented")
 }
 

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -259,7 +259,7 @@ func (b *Cloud) ServiceDiscoveryAliases() ([]backend.HostAlias, error) {
 }
 
 // Configure implements backend.Enhanced.
-func (b *Cloud) Configure(obj cty.Value) tfdiags.Diagnostics {
+func (b *Cloud) Configure(ctx context.Context, obj cty.Value) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 	if obj.IsNull() {
 		return diags

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -619,7 +619,7 @@ func (b *Cloud) Workspaces(ctx context.Context) ([]string, error) {
 }
 
 // DeleteWorkspace implements backend.Enhanced.
-func (b *Cloud) DeleteWorkspace(name string, force bool) error {
+func (b *Cloud) DeleteWorkspace(ctx context.Context, name string, force bool) error {
 	if name == backend.DefaultStateName {
 		return backend.ErrDefaultWorkspaceNotSupported
 	}
@@ -628,7 +628,7 @@ func (b *Cloud) DeleteWorkspace(name string, force bool) error {
 		return backend.ErrWorkspacesNotSupported
 	}
 
-	workspace, err := b.client.Workspaces.Read(context.Background(), b.organization, name)
+	workspace, err := b.client.Workspaces.Read(ctx, b.organization, name)
 	if err == tfe.ErrResourceNotFound {
 		return nil // If the workspace does not exist, succeed
 	}

--- a/internal/cloud/backend.go
+++ b/internal/cloud/backend.go
@@ -558,7 +558,7 @@ func (b *Cloud) retryLogHook(attemptNum int, resp *http.Response) {
 
 // Workspaces implements backend.Enhanced, returning a filtered list of workspace names according to
 // the workspace mapping strategy configured.
-func (b *Cloud) Workspaces() ([]string, error) {
+func (b *Cloud) Workspaces(ctx context.Context) ([]string, error) {
 	// Create a slice to contain all the names.
 	var names []string
 
@@ -581,7 +581,7 @@ func (b *Cloud) Workspaces() ([]string, error) {
 		listOpts := &tfe.ProjectListOptions{
 			Name: b.WorkspaceMapping.Project,
 		}
-		projects, err := b.client.Projects.List(context.Background(), b.organization, listOpts)
+		projects, err := b.client.Projects.List(ctx, b.organization, listOpts)
 		if err != nil && err != tfe.ErrResourceNotFound {
 			return nil, fmt.Errorf("failed to retrieve project %s: %w", listOpts.Name, err)
 		}
@@ -594,7 +594,7 @@ func (b *Cloud) Workspaces() ([]string, error) {
 	}
 
 	for {
-		wl, err := b.client.Workspaces.List(context.Background(), b.organization, options)
+		wl, err := b.client.Workspaces.List(ctx, b.organization, options)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cloud/backend_apply_test.go
+++ b/internal/cloud/backend_apply_test.go
@@ -114,7 +114,7 @@ func TestCloud_applyBasic(t *testing.T) {
 		t.Fatalf("expected apply summery in output: %s", output)
 	}
 
-	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
+	stateMgr, _ := b.StateMgr(t.Context(), testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after apply
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after apply: %s", err.Error())
@@ -172,7 +172,7 @@ func TestCloud_applyJSONBasic(t *testing.T) {
 		t.Fatalf("expected apply summary in output: %s", gotOut)
 	}
 
-	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
+	stateMgr, _ := b.StateMgr(t.Context(), testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after apply
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after apply: %s", err.Error())
@@ -259,7 +259,7 @@ func TestCloud_applyJSONWithOutputs(t *testing.T) {
 	if !strings.Contains(gotOut, expectedComplexOutput) {
 		t.Fatalf("expected output: %s, got: %s", expectedComplexOutput, gotOut)
 	}
-	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
+	stateMgr, _ := b.StateMgr(t.Context(), testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after apply
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after apply: %s", err.Error())
@@ -288,7 +288,7 @@ func TestCloud_applyCanceled(t *testing.T) {
 		t.Fatal("expected apply operation to fail")
 	}
 
-	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
+	stateMgr, _ := b.StateMgr(t.Context(), testBackendSingleWorkspaceName)
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after cancelling apply: %s", err.Error())
 	}
@@ -494,7 +494,7 @@ func TestCloud_applyWithCloudPlan(t *testing.T) {
 		t.Fatalf("expected apply summary in output: %s", gotOut)
 	}
 
-	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
+	stateMgr, _ := b.StateMgr(t.Context(), testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after apply
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after apply: %s", err.Error())
@@ -642,7 +642,7 @@ func TestCloud_applyWithExclude(t *testing.T) {
 		t.Fatalf("expected -exclude option is not supported error, got: %v", errOutput)
 	}
 
-	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
+	stateMgr, _ := b.StateMgr(t.Context(), testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after apply
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after failed apply: %s", err.Error())
@@ -742,7 +742,7 @@ func TestCloud_applyNoConfig(t *testing.T) {
 		t.Fatalf("expected configuration files error, got: %v", errOutput)
 	}
 
-	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
+	stateMgr, _ := b.StateMgr(t.Context(), testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after apply
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after failed apply: %s", err.Error())
@@ -1403,7 +1403,7 @@ func TestCloud_applyJSONWithProvisioner(t *testing.T) {
 		t.Fatalf("expected provisioner local-exec output in logs: %s", gotOut)
 	}
 
-	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
+	stateMgr, _ := b.StateMgr(t.Context(), testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after apply
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after apply: %s", err.Error())

--- a/internal/cloud/backend_context.go
+++ b/internal/cloud/backend_context.go
@@ -44,7 +44,7 @@ func (b *Cloud) LocalRun(ctx context.Context, op *backend.Operation) (*backend.L
 
 	// Get the latest state.
 	log.Printf("[TRACE] cloud: requesting state manager for workspace %q", remoteWorkspaceName)
-	stateMgr, err := b.StateMgr(op.Workspace)
+	stateMgr, err := b.StateMgr(ctx, op.Workspace)
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("error loading state: %w", err))
 		return nil, nil, diags

--- a/internal/cloud/backend_context_test.go
+++ b/internal/cloud/backend_context_test.go
@@ -226,7 +226,7 @@ func TestRemoteContextWithVars(t *testing.T) {
 				}
 				// When Context() returns an error, it should unlock the state,
 				// so re-locking it is expected to succeed.
-				stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
+				stateMgr, _ := b.StateMgr(t.Context(), testBackendSingleWorkspaceName)
 				if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 					t.Fatalf("unexpected error locking state: %s", err.Error())
 				}
@@ -235,7 +235,7 @@ func TestRemoteContextWithVars(t *testing.T) {
 					t.Fatalf("unexpected error\ngot:  %s\nwant: <no error>", diags.Err().Error())
 				}
 				// When Context() succeeds, this should fail w/ "workspace already locked"
-				stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
+				stateMgr, _ := b.StateMgr(t.Context(), testBackendSingleWorkspaceName)
 				if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err == nil {
 					t.Fatal("unexpected success locking state after Context")
 				}
@@ -443,7 +443,7 @@ func TestRemoteVariablesDoNotOverride(t *testing.T) {
 				t.Fatalf("unexpected error\ngot:  %s\nwant: <no error>", diags.Err().Error())
 			}
 			// When Context() succeeds, this should fail w/ "workspace already locked"
-			stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
+			stateMgr, _ := b.StateMgr(t.Context(), testBackendSingleWorkspaceName)
 			if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err == nil {
 				t.Fatal("unexpected success locking state after Context")
 			}

--- a/internal/cloud/backend_plan_test.go
+++ b/internal/cloud/backend_plan_test.go
@@ -98,7 +98,7 @@ func TestCloud_planBasic(t *testing.T) {
 		t.Fatalf("expected plan summary in output: %s", output)
 	}
 
-	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
+	stateMgr, _ := b.StateMgr(t.Context(), testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after the operation finished
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after successful plan: %s", err.Error())
@@ -143,7 +143,7 @@ func TestCloud_planJSONBasic(t *testing.T) {
 		t.Fatalf("expected plan summary in output: %s", gotOut)
 	}
 
-	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
+	stateMgr, _ := b.StateMgr(t.Context(), testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after the operation finished
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after successful plan: %s", err.Error())
@@ -172,7 +172,7 @@ func TestCloud_planCanceled(t *testing.T) {
 		t.Fatal("expected plan operation to fail")
 	}
 
-	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
+	stateMgr, _ := b.StateMgr(t.Context(), testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after the operation finished
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after cancelled plan: %s", err.Error())
@@ -252,7 +252,7 @@ func TestCloud_planJSONFull(t *testing.T) {
 		t.Fatalf("expected plan summary in output: %s", gotOut)
 	}
 
-	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
+	stateMgr, _ := b.StateMgr(t.Context(), testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after the operation finished
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after successful plan: %s", err.Error())
@@ -1320,7 +1320,7 @@ func TestCloud_planImportConfigGeneration(t *testing.T) {
 		t.Fatalf("expected plan summary in output: %s", gotOut)
 	}
 
-	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
+	stateMgr, _ := b.StateMgr(t.Context(), testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after the operation finished
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after successful plan: %s", err.Error())

--- a/internal/cloud/backend_refresh_test.go
+++ b/internal/cloud/backend_refresh_test.go
@@ -76,7 +76,7 @@ func TestCloud_refreshBasicActuallyRunsApplyRefresh(t *testing.T) {
 		t.Fatalf("expected TFC header in output: %s", output)
 	}
 
-	stateMgr, _ := b.StateMgr(testBackendSingleWorkspaceName)
+	stateMgr, _ := b.StateMgr(t.Context(), testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after apply
 	if _, err := stateMgr.Lock(statemgr.NewLockInfo()); err != nil {
 		t.Fatalf("unexpected error locking state after apply: %s", err.Error())

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -32,7 +32,7 @@ func TestCloud_backendWithName(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	workspaces, err := b.Workspaces()
+	workspaces, err := b.Workspaces(t.Context())
 	if err != nil {
 		t.Fatalf("error: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestCloud_backendWithTags(t *testing.T) {
 		}
 	}
 
-	workspaces, err := b.Workspaces()
+	workspaces, err := b.Workspaces(t.Context())
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}
@@ -1248,7 +1248,7 @@ func TestCloudBackend_DeleteWorkspace_SafeAndForce(t *testing.T) {
 	}
 
 	// sanity check that the mock now contains two workspaces
-	wl, err := b.Workspaces()
+	wl, err := b.Workspaces(t.Context())
 	if err != nil {
 		t.Fatalf("error fetching workspace names: %v", err)
 	}

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -41,7 +41,7 @@ func TestCloud_backendWithName(t *testing.T) {
 		t.Fatalf("should only have a single configured workspace matching the configured 'name' strategy, but got: %#v", workspaces)
 	}
 
-	if _, err := b.StateMgr("foo"); err != backend.ErrWorkspacesNotSupported {
+	if _, err := b.StateMgr(t.Context(), "foo"); err != backend.ErrWorkspacesNotSupported {
 		t.Fatalf("expected fetching a state which is NOT the single configured workspace to have an ErrWorkspacesNotSupported error, but got: %v", err)
 	}
 
@@ -95,7 +95,7 @@ func TestCloud_backendWithTags(t *testing.T) {
 
 	// Test pagination works
 	for i := 0; i < 25; i++ {
-		_, err := b.StateMgr(fmt.Sprintf("foo-%d", i+1))
+		_, err := b.StateMgr(t.Context(), fmt.Sprintf("foo-%d", i+1))
 		if err != nil {
 			t.Fatalf("error: %s", err)
 		}
@@ -597,7 +597,7 @@ func TestCloud_setUnavailableTerraformVersion(t *testing.T) {
 		t.Fatalf("the workspace we were about to try and create (%s/%s) already exists in the mocks somehow, so this test isn't trustworthy anymore", b.organization, workspaceName)
 	}
 
-	_, err = b.StateMgr(workspaceName)
+	_, err = b.StateMgr(t.Context(), workspaceName)
 	if err != nil {
 		t.Fatalf("expected no error from StateMgr, despite not being able to set remote TF version: %#v", err)
 	}
@@ -943,7 +943,7 @@ func TestCloud_addAndRemoveWorkspacesDefault(t *testing.T) {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	if _, err := b.StateMgr(testBackendSingleWorkspaceName); err != nil {
+	if _, err := b.StateMgr(t.Context(), testBackendSingleWorkspaceName); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
@@ -990,7 +990,7 @@ func TestCloud_StateMgr_versionCheck(t *testing.T) {
 	}
 
 	// This should succeed
-	if _, err := b.StateMgr(testBackendSingleWorkspaceName); err != nil {
+	if _, err := b.StateMgr(t.Context(), testBackendSingleWorkspaceName); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
@@ -1008,7 +1008,7 @@ func TestCloud_StateMgr_versionCheck(t *testing.T) {
 
 	// This should fail
 	want := `Remote workspace TF version "0.13.5" does not match local OpenTofu version "0.14.0"`
-	if _, err := b.StateMgr(testBackendSingleWorkspaceName); err.Error() != want {
+	if _, err := b.StateMgr(t.Context(), testBackendSingleWorkspaceName); err.Error() != want {
 		t.Fatalf("wrong error\n got: %v\nwant: %v", err.Error(), want)
 	}
 }
@@ -1047,7 +1047,7 @@ func TestCloud_StateMgr_versionCheckLatest(t *testing.T) {
 	}
 
 	// This should succeed despite not being a string match
-	if _, err := b.StateMgr(testBackendSingleWorkspaceName); err != nil {
+	if _, err := b.StateMgr(t.Context(), testBackendSingleWorkspaceName); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 }
@@ -1237,12 +1237,12 @@ func TestCloudBackend_DeleteWorkspace_SafeAndForce(t *testing.T) {
 	safeDeleteWorkspaceName := "safe-delete-workspace"
 	forceDeleteWorkspaceName := "force-delete-workspace"
 
-	_, err := b.StateMgr(safeDeleteWorkspaceName)
+	_, err := b.StateMgr(t.Context(), safeDeleteWorkspaceName)
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}
 
-	_, err = b.StateMgr(forceDeleteWorkspaceName)
+	_, err = b.StateMgr(t.Context(), forceDeleteWorkspaceName)
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -45,11 +45,11 @@ func TestCloud_backendWithName(t *testing.T) {
 		t.Fatalf("expected fetching a state which is NOT the single configured workspace to have an ErrWorkspacesNotSupported error, but got: %v", err)
 	}
 
-	if err := b.DeleteWorkspace(testBackendSingleWorkspaceName, true); err != backend.ErrWorkspacesNotSupported {
+	if err := b.DeleteWorkspace(t.Context(), testBackendSingleWorkspaceName, true); err != backend.ErrWorkspacesNotSupported {
 		t.Fatalf("expected deleting the single configured workspace name to result in an error, but got: %v", err)
 	}
 
-	if err := b.DeleteWorkspace("foo", true); err != backend.ErrWorkspacesNotSupported {
+	if err := b.DeleteWorkspace(t.Context(), "foo", true); err != backend.ErrWorkspacesNotSupported {
 		t.Fatalf("expected deleting a workspace which is NOT the configured workspace name to result in an error, but got: %v", err)
 	}
 }
@@ -947,7 +947,7 @@ func TestCloud_addAndRemoveWorkspacesDefault(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if err := b.DeleteWorkspace(testBackendSingleWorkspaceName, true); err != backend.ErrWorkspacesNotSupported {
+	if err := b.DeleteWorkspace(t.Context(), testBackendSingleWorkspaceName, true); err != backend.ErrWorkspacesNotSupported {
 		t.Fatalf("expected error %v, got %v", backend.ErrWorkspacesNotSupported, err)
 	}
 }
@@ -1267,7 +1267,7 @@ func TestCloudBackend_DeleteWorkspace_SafeAndForce(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error locking workspace: %v", err)
 	}
-	err = b.DeleteWorkspace(safeDeleteWorkspaceName, false)
+	err = b.DeleteWorkspace(t.Context(), safeDeleteWorkspaceName, false)
 	if err == nil {
 		t.Fatalf("workspace should have failed to safe delete")
 	}
@@ -1277,7 +1277,7 @@ func TestCloudBackend_DeleteWorkspace_SafeAndForce(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error unlocking workspace: %v", err)
 	}
-	err = b.DeleteWorkspace(safeDeleteWorkspaceName, false)
+	err = b.DeleteWorkspace(t.Context(), safeDeleteWorkspaceName, false)
 	if err != nil {
 		t.Fatalf("error safe deleting workspace: %v", err)
 	}
@@ -1291,7 +1291,7 @@ func TestCloudBackend_DeleteWorkspace_SafeAndForce(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error locking workspace: %v", err)
 	}
-	err = b.DeleteWorkspace(forceDeleteWorkspaceName, true)
+	err = b.DeleteWorkspace(t.Context(), forceDeleteWorkspaceName, true)
 	if err != nil {
 		t.Fatalf("error force deleting workspace: %v", err)
 	}
@@ -1301,7 +1301,7 @@ func TestCloudBackend_DeleteWorkspace_DoesNotExist(t *testing.T) {
 	b, bCleanup := testBackendWithTags(t)
 	defer bCleanup()
 
-	err := b.DeleteWorkspace("non-existent-workspace", false)
+	err := b.DeleteWorkspace(t.Context(), "non-existent-workspace", false)
 	if err != nil {
 		t.Fatalf("expected deleting a workspace which does not exist to succeed")
 	}

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -76,7 +76,7 @@ func TestCloud_backendWithoutHost(t *testing.T) {
 	}
 	obj = newObj
 
-	confDiags := b.Configure(obj)
+	confDiags := b.Configure(t.Context(), obj)
 
 	if !confDiags.HasErrors() {
 		t.Fatalf("testBackend: backend.Configure() should have failed")
@@ -479,7 +479,7 @@ func TestCloud_config(t *testing.T) {
 			}
 
 			// Configure
-			confDiags := b.Configure(tc.config)
+			confDiags := b.Configure(t.Context(), tc.config)
 			if (confDiags.Err() != nil || tc.confErr != "") &&
 				(confDiags.Err() == nil || !strings.Contains(confDiags.Err().Error(), tc.confErr)) {
 				t.Fatalf("unexpected configure result: %v", confDiags.Err())
@@ -514,7 +514,7 @@ func TestCloud_configVerifyMinimumTFEVersion(t *testing.T) {
 
 	b := New(testDisco(s), encryption.StateEncryptionDisabled())
 
-	confDiags := b.Configure(config)
+	confDiags := b.Configure(t.Context(), config)
 	if confDiags.Err() == nil {
 		t.Fatalf("expected configure to error")
 	}
@@ -552,7 +552,7 @@ func TestCloud_configVerifyMinimumTFEVersionInAutomation(t *testing.T) {
 	b := New(testDisco(s), encryption.StateEncryptionDisabled())
 	b.runningInAutomation = true
 
-	confDiags := b.Configure(config)
+	confDiags := b.Configure(t.Context(), config)
 	if confDiags.Err() == nil {
 		t.Fatalf("expected configure to error")
 	}
@@ -1311,7 +1311,7 @@ func TestCloud_ServiceDiscoveryAliases(t *testing.T) {
 	s := testServer(t)
 	b := New(testDisco(s), encryption.StateEncryptionDisabled())
 
-	diag := b.Configure(cty.ObjectVal(map[string]cty.Value{
+	diag := b.Configure(t.Context(), cty.ObjectVal(map[string]cty.Value{
 		"hostname":     cty.StringVal(tfeHost),
 		"organization": cty.StringVal("hashicorp"),
 		"token":        cty.NullVal(cty.String),

--- a/internal/cloud/state_test.go
+++ b/internal/cloud/state_test.go
@@ -147,11 +147,11 @@ func TestCloudLocks(t *testing.T) {
 	back, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	a, err := back.StateMgr(testBackendSingleWorkspaceName)
+	a, err := back.StateMgr(t.Context(), testBackendSingleWorkspaceName)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	b, err := back.StateMgr(testBackendSingleWorkspaceName)
+	b, err := back.StateMgr(t.Context(), testBackendSingleWorkspaceName)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/internal/cloud/testing.go
+++ b/internal/cloud/testing.go
@@ -252,7 +252,7 @@ func testBackend(t *testing.T, obj cty.Value, handlers map[string]func(http.Resp
 	}
 	obj = newObj
 
-	confDiags := b.Configure(obj)
+	confDiags := b.Configure(t.Context(), obj)
 	if len(confDiags) != 0 {
 		t.Fatalf("testBackend: backend.Configure() failed: %s", confDiags.ErrWithWarnings())
 	}

--- a/internal/cloud/testing.go
+++ b/internal/cloud/testing.go
@@ -165,7 +165,7 @@ func testCloudState(t *testing.T) *State {
 	b, bCleanup := testBackendWithName(t)
 	defer bCleanup()
 
-	raw, err := b.StateMgr(testBackendSingleWorkspaceName)
+	raw, err := b.StateMgr(t.Context(), testBackendSingleWorkspaceName)
 	if err != nil {
 		t.Fatalf("error: %v", err)
 	}

--- a/internal/command/autocomplete.go
+++ b/internal/command/autocomplete.go
@@ -70,7 +70,7 @@ func (m *Meta) completePredictWorkspaceName(ctx context.Context) complete.Predic
 			return nil
 		}
 
-		names, _ := b.Workspaces()
+		names, _ := b.Workspaces(ctx)
 		return names
 	})
 }

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -256,7 +256,7 @@ func (c *InitCommand) Run(args []string) int {
 			c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
 			return 1
 		}
-		sMgr, err := back.StateMgr(workspace)
+		sMgr, err := back.StateMgr(ctx, workspace)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Error loading state: %s", err))
 			return 1

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -328,7 +328,7 @@ func (m *Meta) BackendForLocalPlan(ctx context.Context, settings plans.Backend, 
 		return nil, diags
 	}
 
-	configureDiags := b.Configure(newVal)
+	configureDiags := b.Configure(ctx, newVal)
 	diags = diags.Append(configureDiags)
 	if configureDiags.HasErrors() {
 		return nil, diags
@@ -838,7 +838,7 @@ func (m *Meta) backendFromState(ctx context.Context, enc encryption.StateEncrypt
 		return nil, diags
 	}
 
-	configDiags := b.Configure(newVal)
+	configDiags := b.Configure(ctx, newVal)
 	diags = diags.Append(configDiags)
 	if configDiags.HasErrors() {
 		return nil, diags
@@ -1296,7 +1296,7 @@ func (m *Meta) savedBackend(sMgr *clistate.LocalState, enc encryption.StateEncry
 		return nil, diags
 	}
 
-	configDiags := b.Configure(newVal)
+	configDiags := b.Configure(context.TODO(), newVal)
 	diags = diags.Append(configDiags)
 	if configDiags.HasErrors() {
 		return nil, diags
@@ -1441,7 +1441,7 @@ func (m *Meta) backendInitFromConfig(c *configs.Backend, enc encryption.StateEnc
 		return nil, cty.NilVal, diags
 	}
 
-	configureDiags := b.Configure(newVal)
+	configureDiags := b.Configure(context.TODO(), newVal)
 	diags = diags.Append(configureDiags.InConfigBody(c.Config, ""))
 
 	// If the result of loading the backend is an enhanced backend,

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -980,7 +980,7 @@ func (m *Meta) backend_C_r_s(ctx context.Context, c *configs.Backend, cHash int,
 
 	var localStates []statemgr.Full
 	for _, workspace := range workspaces {
-		localState, err := localB.StateMgr(workspace)
+		localState, err := localB.StateMgr(ctx, workspace)
 		if err != nil {
 			diags = diags.Append(fmt.Errorf(errBackendLocalRead, err))
 			return nil, diags

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -217,7 +217,7 @@ func (m *Meta) Backend(ctx context.Context, opts *BackendOpts, enc encryption.St
 // if the currently selected workspace is valid. If not, it will ask
 // the user to select a workspace from the list.
 func (m *Meta) selectWorkspace(ctx context.Context, b backend.Backend) error {
-	workspaces, err := b.Workspaces()
+	workspaces, err := b.Workspaces(ctx)
 	if err == backend.ErrWorkspacesNotSupported {
 		return nil
 	}
@@ -972,7 +972,7 @@ func (m *Meta) backend_C_r_s(ctx context.Context, c *configs.Backend, cHash int,
 		return nil, diags
 	}
 
-	workspaces, err := localB.Workspaces()
+	workspaces, err := localB.Workspaces(ctx)
 	if err != nil {
 		diags = diags.Append(fmt.Errorf(errBackendLocalRead, err))
 		return nil, diags

--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -189,7 +189,7 @@ func (m *Meta) backendMigrateState_S_S(ctx context.Context, opts *backendMigrate
 	}
 
 	// Read all the states
-	sourceWorkspaces, err := opts.Source.Workspaces()
+	sourceWorkspaces, err := opts.Source.Workspaces(ctx)
 	if err != nil {
 		return fmt.Errorf(strings.TrimSpace(
 			errMigrateLoadStates), opts.SourceType, err)
@@ -538,7 +538,7 @@ func (m *Meta) backendMigrateNonEmptyConfirm(
 func retrieveWorkspaces(back backend.Backend, sourceType string) ([]string, bool, error) {
 	var singleState bool
 	var err error
-	workspaces, err := back.Workspaces()
+	workspaces, err := back.Workspaces(context.TODO())
 	if err == backend.ErrWorkspacesNotSupported {
 		singleState = true
 		err = nil
@@ -757,7 +757,7 @@ func (m *Meta) backendMigrateState_S_TFC(ctx context.Context, opts *backendMigra
 
 	// After migrating multiple workspaces, we need to reselect the current workspace as it may
 	// have been renamed. Query the backend first to be sure it now exists.
-	workspaces, err := opts.Destination.Workspaces()
+	workspaces, err := opts.Destination.Workspaces(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -263,7 +263,7 @@ func (m *Meta) backendMigrateState_S_s(ctx context.Context, opts *backendMigrate
 func (m *Meta) backendMigrateState_s_s(ctx context.Context, opts *backendMigrateOpts) error {
 	log.Printf("[INFO] backendMigrateState: single-to-single migrating %q workspace to %q workspace", opts.sourceWorkspace, opts.destinationWorkspace)
 
-	sourceState, err := opts.Source.StateMgr(opts.sourceWorkspace)
+	sourceState, err := opts.Source.StateMgr(ctx, opts.sourceWorkspace)
 	if err != nil {
 		return fmt.Errorf(strings.TrimSpace(
 			errMigrateSingleLoadDefault), opts.SourceType, err)
@@ -279,7 +279,7 @@ func (m *Meta) backendMigrateState_s_s(ctx context.Context, opts *backendMigrate
 		return nil
 	}
 
-	destinationState, err := opts.Destination.StateMgr(opts.destinationWorkspace)
+	destinationState, err := opts.Destination.StateMgr(ctx, opts.destinationWorkspace)
 	if err == backend.ErrDefaultWorkspaceNotSupported {
 		// If the backend doesn't support using the default state, we ask the user
 		// for a new name and migrate the default state to the given named state.
@@ -293,7 +293,7 @@ func (m *Meta) backendMigrateState_s_s(ctx context.Context, opts *backendMigrate
 			// Update the name of the destination state.
 			opts.destinationWorkspace = name
 
-			destinationState, err := opts.Destination.StateMgr(opts.destinationWorkspace)
+			destinationState, err := opts.Destination.StateMgr(ctx, opts.destinationWorkspace)
 			if err != nil {
 				return nil, err
 			}
@@ -596,7 +596,7 @@ func (m *Meta) backendMigrateTFC(ctx context.Context, opts *backendMigrateOpts) 
 
 		// If the current workspace is has no state we do not need to ask
 		// if they want to migrate the state.
-		sourceState, err := opts.Source.StateMgr(currentWorkspace)
+		sourceState, err := opts.Source.StateMgr(ctx, currentWorkspace)
 		if err != nil {
 			return err
 		}
@@ -682,7 +682,7 @@ func (m *Meta) backendMigrateState_S_TFC(ctx context.Context, opts *backendMigra
 		if sourceWorkspaces[i] == backend.DefaultStateName {
 			// For the default workspace we want to look to see if there is any state
 			// before we ask for a workspace name to migrate the default workspace into.
-			sourceState, err := opts.Source.StateMgr(backend.DefaultStateName)
+			sourceState, err := opts.Source.StateMgr(ctx, backend.DefaultStateName)
 			if err != nil {
 				return fmt.Errorf(strings.TrimSpace(
 					errMigrateSingleLoadDefault), opts.SourceType, err)

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -50,7 +50,7 @@ func TestMetaBackend_emptyDir(t *testing.T) {
 	}
 
 	// Write some state
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -119,7 +119,7 @@ func TestMetaBackend_emptyWithDefaultState(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -190,7 +190,7 @@ func TestMetaBackend_emptyWithExplicitState(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -258,7 +258,7 @@ func TestMetaBackend_configureNew(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -329,7 +329,7 @@ func TestMetaBackend_configureNewWithState(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -452,7 +452,7 @@ func TestMetaBackend_configureNewWithStateNoMigrate(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -495,7 +495,7 @@ func TestMetaBackend_configureNewWithStateExisting(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -567,7 +567,7 @@ func TestMetaBackend_configureNewWithStateExistingNoMigrate(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -632,7 +632,7 @@ func TestMetaBackend_configuredUnchanged(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -778,7 +778,7 @@ func TestMetaBackend_configuredUnchangedWithStaticEvalVars(t *testing.T) {
 	// also follows the usual invariants for a failed backend init.
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -824,7 +824,7 @@ func TestMetaBackend_configuredChange(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -910,7 +910,7 @@ func TestMetaBackend_reconfigureChange(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1050,7 +1050,7 @@ func TestMetaBackend_configuredChangeCopy(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1103,7 +1103,7 @@ func TestMetaBackend_configuredChangeCopy_singleState(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1157,7 +1157,7 @@ func TestMetaBackend_configuredChangeCopy_multiToSingleDefault(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1211,7 +1211,7 @@ func TestMetaBackend_configuredChangeCopy_multiToSingle(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1285,7 +1285,7 @@ func TestMetaBackend_configuredChangeCopy_multiToSingleCurrentEnv(t *testing.T) 
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1353,7 +1353,7 @@ func TestMetaBackend_configuredChangeCopy_multiToMulti(t *testing.T) {
 
 	{
 		// Check the default state
-		s, err := b.StateMgr(backend.DefaultStateName)
+		s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -1371,7 +1371,7 @@ func TestMetaBackend_configuredChangeCopy_multiToMulti(t *testing.T) {
 
 	{
 		// Check the other state
-		s, err := b.StateMgr("env2")
+		s, err := b.StateMgr(t.Context(), "env2")
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -1451,7 +1451,7 @@ func TestMetaBackend_configuredChangeCopy_multiToNoDefaultWithDefault(t *testing
 
 	{
 		// Check the renamed default state
-		s, err := b.StateMgr("env1")
+		s, err := b.StateMgr(t.Context(), "env1")
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -1525,7 +1525,7 @@ func TestMetaBackend_configuredChangeCopy_multiToNoDefaultWithoutDefault(t *test
 
 	{
 		// Check the named state
-		s, err := b.StateMgr("env2")
+		s, err := b.StateMgr(t.Context(), "env2")
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -1578,7 +1578,7 @@ func TestMetaBackend_configuredUnset(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1640,7 +1640,7 @@ func TestMetaBackend_configuredUnsetCopy(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1708,7 +1708,7 @@ func TestMetaBackend_planLocal(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1809,7 +1809,7 @@ func TestMetaBackend_planLocalStatePath(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1898,7 +1898,7 @@ func TestMetaBackend_planLocalMatch(t *testing.T) {
 	}
 
 	// Check the state
-	s, err := b.StateMgr(backend.DefaultStateName)
+	s, err := b.StateMgr(t.Context(), backend.DefaultStateName)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -1340,7 +1340,7 @@ func TestMetaBackend_configuredChangeCopy_multiToMulti(t *testing.T) {
 	}
 
 	// Check resulting states
-	workspaces, err := b.Workspaces()
+	workspaces, err := b.Workspaces(t.Context())
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1438,7 +1438,7 @@ func TestMetaBackend_configuredChangeCopy_multiToNoDefaultWithDefault(t *testing
 	}
 
 	// Check resulting states
-	workspaces, err := b.Workspaces()
+	workspaces, err := b.Workspaces(t.Context())
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -1512,7 +1512,7 @@ func TestMetaBackend_configuredChangeCopy_multiToNoDefaultWithoutDefault(t *test
 	}
 
 	// Check resulting states
-	workspaces, err := b.Workspaces()
+	workspaces, err := b.Workspaces(t.Context())
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/internal/command/output.go
+++ b/internal/command/output.go
@@ -97,7 +97,7 @@ func (c *OutputCommand) Outputs(ctx context.Context, statePath string, enc encry
 	}
 
 	// Get the state
-	stateStore, err := b.StateMgr(env)
+	stateStore, err := b.StateMgr(ctx, env)
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("Failed to load state: %w", err))
 		return nil, diags

--- a/internal/command/providers.go
+++ b/internal/command/providers.go
@@ -112,7 +112,7 @@ func (c *ProvidersCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
 		return 1
 	}
-	s, err := b.StateMgr(env)
+	s, err := b.StateMgr(ctx, env)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
 		return 1

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -472,7 +472,7 @@ func getStateFromPath(path string, enc encryption.Encryption) (*statefile.File, 
 // getStateFromBackend returns the State for the current workspace, if available.
 func getStateFromBackend(b backend.Backend, workspace string) (*statefile.File, error) {
 	// Get the state store for the given workspace
-	stateStore, err := b.StateMgr(workspace)
+	stateStore, err := b.StateMgr(context.TODO(), workspace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load state manager: %w", err)
 	}

--- a/internal/command/state_list.go
+++ b/internal/command/state_list.go
@@ -65,7 +65,7 @@ func (c *StateListCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
 		return 1
 	}
-	stateMgr, err := b.StateMgr(env)
+	stateMgr, err := b.StateMgr(ctx, env)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf(errStateLoadingState, err))
 		return 1

--- a/internal/command/state_meta.go
+++ b/internal/command/state_meta.go
@@ -57,7 +57,7 @@ func (c *StateMeta) State(ctx context.Context, enc encryption.Encryption) (state
 		}
 
 		// Get the state
-		s, err := b.StateMgr(workspace)
+		s, err := b.StateMgr(ctx, workspace)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/command/state_pull.go
+++ b/internal/command/state_pull.go
@@ -60,7 +60,7 @@ func (c *StatePullCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
 		return 1
 	}
-	stateMgr, err := b.StateMgr(env)
+	stateMgr, err := b.StateMgr(ctx, env)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf(errStateLoadingState, err))
 		return 1

--- a/internal/command/state_push.go
+++ b/internal/command/state_push.go
@@ -109,7 +109,7 @@ func (c *StatePushCommand) Run(args []string) int {
 	}
 
 	// Get the state manager for the currently-selected workspace
-	stateMgr, err := b.StateMgr(workspace)
+	stateMgr, err := b.StateMgr(ctx, workspace)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load destination state: %s", err))
 		return 1

--- a/internal/command/state_push_test.go
+++ b/internal/command/state_push_test.go
@@ -266,7 +266,7 @@ func TestStatePush_forceRemoteState(t *testing.T) {
 
 	// put a dummy state in place, so we have something to force
 	b := backend.TestBackendConfig(t, inmem.New(encryption.StateEncryptionDisabled()), nil)
-	sMgr, err := b.StateMgr("test")
+	sMgr, err := b.StateMgr(t.Context(), "test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/command/state_show.go
+++ b/internal/command/state_show.go
@@ -133,7 +133,7 @@ func (c *StateShowCommand) Run(args []string) int {
 		c.Streams.Eprintf("Error selecting workspace: %s\n", err)
 		return 1
 	}
-	stateMgr, err := b.StateMgr(env)
+	stateMgr, err := b.StateMgr(ctx, env)
 	if err != nil {
 		c.Streams.Eprintln(fmt.Sprintf(errStateLoadingState, err))
 		return 1

--- a/internal/command/taint.go
+++ b/internal/command/taint.go
@@ -99,7 +99,7 @@ func (c *TaintCommand) Run(args []string) int {
 	}
 
 	// Get the state
-	stateMgr, err := b.StateMgr(workspace)
+	stateMgr, err := b.StateMgr(ctx, workspace)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
 		return 1

--- a/internal/command/unlock.go
+++ b/internal/command/unlock.go
@@ -88,7 +88,7 @@ func (c *UnlockCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Error selecting workspace: %s", err))
 		return 1
 	}
-	stateMgr, err := b.StateMgr(env)
+	stateMgr, err := b.StateMgr(ctx, env)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
 		return 1

--- a/internal/command/untaint.go
+++ b/internal/command/untaint.go
@@ -90,7 +90,7 @@ func (c *UntaintCommand) Run(args []string) int {
 	}
 
 	// Get the state
-	stateMgr, err := b.StateMgr(workspace)
+	stateMgr, err := b.StateMgr(ctx, workspace)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
 		return 1

--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -280,7 +280,7 @@ func TestWorkspace_createWithState(t *testing.T) {
 	}
 
 	b := backend.TestBackendConfig(t, inmem.New(encryption.StateEncryptionDisabled()), nil)
-	sMgr, err := b.StateMgr(workspace)
+	sMgr, err := b.StateMgr(t.Context(), workspace)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/command/workspace_delete.go
+++ b/internal/command/workspace_delete.go
@@ -86,7 +86,7 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 	// This command will not write state
 	c.ignoreRemoteVersionConflict(b)
 
-	workspaces, err := b.Workspaces()
+	workspaces, err := b.Workspaces(ctx)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1

--- a/internal/command/workspace_delete.go
+++ b/internal/command/workspace_delete.go
@@ -181,7 +181,7 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 	// be delegated from the Backend to the State itself.
 	stateLocker.Unlock()
 
-	err = b.DeleteWorkspace(workspace, force)
+	err = b.DeleteWorkspace(ctx, workspace, force)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1

--- a/internal/command/workspace_delete.go
+++ b/internal/command/workspace_delete.go
@@ -117,7 +117,7 @@ func (c *WorkspaceDeleteCommand) Run(args []string) int {
 	}
 
 	// we need the actual state to see if it's empty
-	stateMgr, err := b.StateMgr(workspace)
+	stateMgr, err := b.StateMgr(ctx, workspace)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1

--- a/internal/command/workspace_list.go
+++ b/internal/command/workspace_list.go
@@ -69,7 +69,7 @@ func (c *WorkspaceListCommand) Run(args []string) int {
 	// This command will not write state
 	c.ignoreRemoteVersionConflict(b)
 
-	states, err := b.Workspaces()
+	states, err := b.Workspaces(ctx)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1

--- a/internal/command/workspace_new.go
+++ b/internal/command/workspace_new.go
@@ -102,7 +102,7 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 	// This command will not write state
 	c.ignoreRemoteVersionConflict(b)
 
-	workspaces, err := b.Workspaces()
+	workspaces, err := b.Workspaces(ctx)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to get configured named states: %s", err))
 		return 1

--- a/internal/command/workspace_new.go
+++ b/internal/command/workspace_new.go
@@ -114,7 +114,7 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 		}
 	}
 
-	_, err = b.StateMgr(workspace)
+	_, err = b.StateMgr(ctx, workspace)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1
@@ -135,7 +135,7 @@ func (c *WorkspaceNewCommand) Run(args []string) int {
 	}
 
 	// load the new Backend state
-	stateMgr, err := b.StateMgr(workspace)
+	stateMgr, err := b.StateMgr(ctx, workspace)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1

--- a/internal/command/workspace_select.go
+++ b/internal/command/workspace_select.go
@@ -89,7 +89,7 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 		return 1
 	}
 
-	states, err := b.Workspaces()
+	states, err := b.Workspaces(ctx)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1

--- a/internal/command/workspace_select.go
+++ b/internal/command/workspace_select.go
@@ -112,7 +112,7 @@ func (c *WorkspaceSelectCommand) Run(args []string) int {
 
 	if !found {
 		if orCreate {
-			_, err = b.StateMgr(name)
+			_, err = b.StateMgr(ctx, name)
 			if err != nil {
 				c.Ui.Error(err.Error())
 				return 1

--- a/internal/legacy/helper/schema/backend.go
+++ b/internal/legacy/helper/schema/backend.go
@@ -146,7 +146,7 @@ func (b *Backend) PrepareConfig(configVal cty.Value) (cty.Value, tfdiags.Diagnos
 	return configVal, diags
 }
 
-func (b *Backend) Configure(obj cty.Value) tfdiags.Diagnostics {
+func (b *Backend) Configure(ctx context.Context, obj cty.Value) tfdiags.Diagnostics {
 	if b == nil {
 		return nil
 	}

--- a/internal/legacy/helper/schema/backend_test.go
+++ b/internal/legacy/helper/schema/backend_test.go
@@ -189,7 +189,7 @@ func TestBackendConfigure(t *testing.T) {
 
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.Name), func(t *testing.T) {
-			diags := tc.B.Configure(cty.ObjectVal(tc.Config))
+			diags := tc.B.Configure(t.Context(), cty.ObjectVal(tc.Config))
 			if diags.HasErrors() != tc.Err {
 				t.Errorf("wrong number of diagnostics")
 			}


### PR DESCRIPTION
(This is for https://github.com/opentofu/opentofu/issues/2664.)

I've updated the four main methods of `backend.Backend` that are expected to make requests to external services so that their signature now includes a `context.Context` argument, updated all of the implementations of this interface, and updated all of the callers to pass in a reasonable `context.Context` value.

As usual, this is mostly just mechanical updates without anything interesting going on, because this sort of change is hard to review thoroughly and so it's unwise to mix any interesting changes in with it.

There are a few spots where there isn't yet any context plumbed in and so I used `context.TODO()` placeholders in those cases so that we should be able to find them again relatively easily later and make a plan for how to plumb a context value to them, but there are enough callers that can already pass a suitable context by this point that I think this is worth doing as a step towards making the state storage implementations trace what they are doing. (We will need to update the interfaces in `package statemgr` too before we can actually do that, though; that's for another PR!)
