### PR TITLE
Consume TRACEPARENT and TRACESTATE to construct the OTel trace context

### DIFF
--- a/cmd/tofu/main.go
+++ b/cmd/tofu/main.go
@@ -70,7 +70,7 @@ func main() {
 func realMain() int {
 	defer logging.PanicHandler()
 
-	err := tracing.OpenTelemetryInit()
+	ctx, err := tracing.OpenTelemetryInit(context.Background())
 	if err != nil {
 		// openTelemetryInit can only fail if OpenTofu was run with an
 		// explicit environment variable to enable telemetry collection,
@@ -81,7 +81,6 @@ func realMain() int {
 		return 1
 	}
 	defer tracing.ForceFlush(5 * time.Second)
-	ctx := context.Background()
 
 	// At minimum, we emit a span covering the entire command execution.
 	ctx, span := tracing.Tracer().Start(ctx, "tofu")

--- a/internal/tracing/init.go
+++ b/internal/tracing/init.go
@@ -83,7 +83,7 @@ func OpenTelemetryInit(ctx context.Context) (context.Context, error) {
 	// that exporting should always be enabled and so will expect to find
 	// an OTLP server on localhost if no environment variables are set at all.
 	if os.Getenv(OTELExporterEnvVar) != "otlp" {
-		log.Printf(fmt.Sprintf("[TRACE] OpenTelemetry: %s not set, OTel tracing is not enabled", OTELExporterEnvVar))
+		log.Printf("[TRACE] OpenTelemetry: %s not set, OTel tracing is not enabled", OTELExporterEnvVar)
 		return ctx, nil // By default, we just discard all telemetry calls
 	}
 

--- a/internal/tracing/init.go
+++ b/internal/tracing/init.go
@@ -174,6 +174,8 @@ type envMapCarrier struct {
 	values map[string]string
 }
 
+var _ propagation.TextMapCarrier = (*envMapCarrier)(nil)
+
 func (c *envMapCarrier) Get(key string) string {
 	return c.values[key]
 }

--- a/internal/tracing/init.go
+++ b/internal/tracing/init.go
@@ -39,6 +39,18 @@ better based on experience with this experiment.
 // then we'll enable an experimental OTLP trace exporter.
 const OTELExporterEnvVar = "OTEL_TRACES_EXPORTER"
 
+// OTELTraceParentEnvVar is the env var that should be used to instruct opentofu which
+// trace parent to use.
+// If this environment variable is set when running OpenTofu CLI
+// then we'll extract the traceparent from the environment and add it to the context.
+// This ensures that all opentofu traces are linked to the trace that invoked
+// this command.
+const OTELTraceParentEnvVar = "TRACEPARENT"
+
+// OTELTraceStateEnvVar is the env var that should be used to instruct opentofu which
+// trace state to use.
+const OTELTraceStateEnvVar = "TRACESTATE"
+
 // isTracingEnabled is true if OpenTelemetry is enabled.
 var isTracingEnabled bool
 
@@ -60,14 +72,19 @@ var isTracingEnabled bool
 // means another relatively-heavy external dependency. OTLP happens to use
 // protocol buffers and gRPC, which OpenTofu would depend on for other reasons
 // anyway.
-func OpenTelemetryInit() error {
+//
+// Returns the context with trace context extracted from environment variables
+// if TRACEPARENT is set.
+func OpenTelemetryInit(ctx context.Context) (context.Context, error) {
 	isTracingEnabled = false
+
 	// We'll check the environment variable ourselves first, because the
 	// "autoexport" helper we're about to use is built under the assumption
 	// that exporting should always be enabled and so will expect to find
 	// an OTLP server on localhost if no environment variables are set at all.
 	if os.Getenv(OTELExporterEnvVar) != "otlp" {
-		return nil // By default, we just discard all telemetry calls
+		log.Printf(fmt.Sprintf("[TRACE] OpenTelemetry: %s not set, OTel tracing is not enabled", OTELExporterEnvVar))
+		return ctx, nil // By default, we just discard all telemetry calls
 	}
 
 	isTracingEnabled = true
@@ -95,12 +112,33 @@ func OpenTelemetryInit() error {
 		),
 	)
 	if err != nil {
-		return fmt.Errorf("failed to create resource: %w", err)
+		return ctx, fmt.Errorf("failed to create resource: %w", err)
 	}
 
-	exporter, err := autoexport.NewSpanExporter(context.Background())
+	// Check if the trace parent/state environment variable is set and extract it into our context
+	if traceparent := os.Getenv(OTELTraceParentEnvVar); traceparent != "" {
+		log.Printf("[TRACE] OpenTelemetry: found trace parent in environment: %s", traceparent)
+		// Create a carrier that contains the traceparent from environment variables
+		// The key is lowercase because the TraceContext propagator expects lowercase keys
+		envCarrier := &envMapCarrier{
+			values: map[string]string{
+				"traceparent": traceparent,
+			},
+		}
+
+		if tracestate := os.Getenv(OTELTraceStateEnvVar); tracestate != "" {
+			log.Printf("[TRACE] OpenTelemetry: found trace state in environment: %s", traceparent)
+			envCarrier.values["tracestate"] = tracestate
+		}
+
+		// Extract the trace context into the context
+		tc := propagation.TraceContext{}
+		ctx = tc.Extract(ctx, envCarrier)
+	}
+
+	exporter, err := autoexport.NewSpanExporter(ctx)
 	if err != nil {
-		return err
+		return ctx, err
 	}
 
 	// Set the global tracer provider, this allows us to use this global TracerProvider
@@ -114,6 +152,7 @@ func OpenTelemetryInit() error {
 	)
 	otel.SetTracerProvider(provider)
 
+	// Create a composite propagator that includes both TraceContext and Baggage
 	prop := propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{})
 	otel.SetTextMapPropagator(prop)
 
@@ -124,5 +163,29 @@ func OpenTelemetryInit() error {
 		panic(fmt.Sprintf("OpenTelemetry error: %v", err))
 	}))
 
-	return nil
+	return ctx, nil
+}
+
+// envMapCarrier is a simple implementation of the TextMapCarrier interface
+// that uses a map to store the key-value pairs.
+// This is used to carry the extracted traceparent and tracestate
+// from the environment variables into the context.
+type envMapCarrier struct {
+	values map[string]string
+}
+
+func (c *envMapCarrier) Get(key string) string {
+	return c.values[key]
+}
+
+func (c *envMapCarrier) Set(key, value string) {
+	c.values[key] = value
+}
+
+func (c *envMapCarrier) Keys() []string {
+	keys := make([]string, 0, len(c.values))
+	for k := range c.values {
+		keys = append(keys, k)
+	}
+	return keys
 }

--- a/internal/tracing/utils.go
+++ b/internal/tracing/utils.go
@@ -81,14 +81,14 @@ func ForceFlush(timeout time.Duration) {
 
 	provider, ok := otel.GetTracerProvider().(*sdktrace.TracerProvider)
 	if !ok {
-		log.Printf("[DEBUG] OpenTelemetry: tracer provider is not an SDK provider, can't force flush")
+		log.Printf("[TRACE] OpenTelemetry: tracer provider is not an SDK provider, can't force flush")
 		return
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	log.Printf("[DEBUG] OpenTelemetry: flushing spans")
+	log.Printf("[TRACE] OpenTelemetry: flushing spans")
 	if err := provider.ForceFlush(ctx); err != nil {
 		log.Printf("[WARN] OpenTelemetry: error flushing spans: %v", err)
 	}


### PR DESCRIPTION
Updated OpenTelemetry initialization to accept and propagate the trace context, enabling trace linkage via `TRACEPARENT` and `TRACESTATE` environment variables.

Part of #2664 

## Target Release

1.10.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [ ] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [ ] I have not used an AI coding assistant to create this PR.
- [ ] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [ ] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.