### PR TITLE
docs(state): mark input passphrase as sensitive

### DIFF
--- a/website/docs/language/state/examples/encryption/fallback_from_unencrypted.tf
+++ b/website/docs/language/state/examples/encryption/fallback_from_unencrypted.tf
@@ -1,6 +1,7 @@
 variable "passphrase" {
   # Change passphrase to be at least 16 characters long:
-  default = "changeme!"
+  default   = "changeme!"
+  sensitive = true
 }
 
 terraform {

--- a/website/docs/language/state/examples/encryption/sample.tf
+++ b/website/docs/language/state/examples/encryption/sample.tf
@@ -1,6 +1,7 @@
 variable "passphrase" {
   # Change passphrase to be at least 16 characters long:
-  default = "changeme!"
+  default   = "changeme!"
+  sensitive = true
 }
 
 terraform {


### PR DESCRIPTION
On the `State and Plan Encryption` page, some code examples comprise an input variable for the encryption passphrase. This PR marks this input variable as sensitive.

Despite being only code examples, I believe it is important to educate about good practices, especially when it comes to security. I myself got surprised to see my passphrase displayed on screen when experimenting with the code examples.

<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

## Target Release

1.10.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
