### PR TITLE
tofu: EvalContext.ProviderSchema takes context.Context

### DIFF
--- a/internal/tofu/eval_context.go
+++ b/internal/tofu/eval_context.go
@@ -6,7 +6,11 @@
 package tofu
 
 import (
+	"context"
+
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/checks"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
@@ -19,7 +23,6 @@ import (
 	"github.com/opentofu/opentofu/internal/refactoring"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // EvalContext is the interface that is given to eval nodes to execute.
@@ -60,7 +63,7 @@ type EvalContext interface {
 	//
 	// This method expects an _absolute_ provider configuration address, since
 	// resources in one module are able to use providers from other modules.
-	ProviderSchema(addrs.AbsProviderConfig) (providers.ProviderSchema, error)
+	ProviderSchema(context.Context, addrs.AbsProviderConfig) (providers.ProviderSchema, error)
 
 	// CloseProvider closes provider connections that aren't needed anymore.
 	//

--- a/internal/tofu/eval_context_builtin.go
+++ b/internal/tofu/eval_context_builtin.go
@@ -88,24 +88,24 @@ type BuiltinEvalContext struct {
 // BuiltinEvalContext implements EvalContext
 var _ EvalContext = (*BuiltinEvalContext)(nil)
 
-func (ctx *BuiltinEvalContext) WithPath(path addrs.ModuleInstance) EvalContext {
-	newCtx := *ctx
-	newCtx.pathSet = true
-	newCtx.PathValue = path
-	return &newCtx
+func (c *BuiltinEvalContext) WithPath(path addrs.ModuleInstance) EvalContext {
+	newEvalCtx := *c
+	newEvalCtx.pathSet = true
+	newEvalCtx.PathValue = path
+	return &newEvalCtx
 }
 
-func (ctx *BuiltinEvalContext) Stopped() <-chan struct{} {
+func (c *BuiltinEvalContext) Stopped() <-chan struct{} {
 	// This can happen during tests. During tests, we just block forever.
-	if ctx.StopContext == nil {
+	if c.StopContext == nil {
 		return nil
 	}
 
-	return ctx.StopContext.Done()
+	return c.StopContext.Done()
 }
 
-func (ctx *BuiltinEvalContext) Hook(fn func(Hook) (HookAction, error)) error {
-	for _, h := range ctx.Hooks {
+func (c *BuiltinEvalContext) Hook(fn func(Hook) (HookAction, error)) error {
+	for _, h := range c.Hooks {
 		action, err := fn(h)
 		if err != nil {
 			return err
@@ -124,34 +124,34 @@ func (ctx *BuiltinEvalContext) Hook(fn func(Hook) (HookAction, error)) error {
 	return nil
 }
 
-func (ctx *BuiltinEvalContext) Input() UIInput {
-	return ctx.InputValue
+func (c *BuiltinEvalContext) Input() UIInput {
+	return c.InputValue
 }
 
-func (ctx *BuiltinEvalContext) InitProvider(addr addrs.AbsProviderConfig, providerKey addrs.InstanceKey) (providers.Interface, error) {
-	ctx.ProviderLock.Lock()
-	defer ctx.ProviderLock.Unlock()
+func (c *BuiltinEvalContext) InitProvider(addr addrs.AbsProviderConfig, providerKey addrs.InstanceKey) (providers.Interface, error) {
+	c.ProviderLock.Lock()
+	defer c.ProviderLock.Unlock()
 
 	key := addr.String()
 
-	if ctx.ProviderCache[key] == nil {
-		ctx.ProviderCache[key] = make(map[addrs.InstanceKey]providers.Interface)
+	if c.ProviderCache[key] == nil {
+		c.ProviderCache[key] = make(map[addrs.InstanceKey]providers.Interface)
 	}
 
 	// If we have already initialized, it is an error
-	if _, ok := ctx.ProviderCache[key][providerKey]; ok {
+	if _, ok := c.ProviderCache[key][providerKey]; ok {
 		return nil, fmt.Errorf("%s is already initialized", addr)
 	}
 
-	p, err := ctx.Plugins.NewProviderInstance(addr.Provider)
+	p, err := c.Plugins.NewProviderInstance(addr.Provider)
 	if err != nil {
 		return nil, err
 	}
 
-	if ctx.Evaluator != nil && ctx.Evaluator.Config != nil && ctx.Evaluator.Config.Module != nil {
+	if c.Evaluator != nil && c.Evaluator.Config != nil && c.Evaluator.Config.Module != nil {
 		// If an aliased provider is mocked, we use providerForTest wrapper.
 		// We cannot wrap providers.Factory itself, because factories don't support aliases.
-		pc, ok := ctx.Evaluator.Config.Module.GetProviderConfig(addr.Provider.Type, addr.Alias)
+		pc, ok := c.Evaluator.Config.Module.GetProviderConfig(addr.Provider.Type, addr.Alias)
 		if ok && pc.IsMocked {
 			testP, err := newProviderForTestWithSchema(p, p.GetProviderSchema())
 			if err != nil {
@@ -165,16 +165,16 @@ func (ctx *BuiltinEvalContext) InitProvider(addr addrs.AbsProviderConfig, provid
 	}
 
 	log.Printf("[TRACE] BuiltinEvalContext: Initialized %q%s provider for %s", addr.String(), providerKey, addr)
-	ctx.ProviderCache[key][providerKey] = p
+	c.ProviderCache[key][providerKey] = p
 
 	return p, nil
 }
 
-func (ctx *BuiltinEvalContext) Provider(addr addrs.AbsProviderConfig, key addrs.InstanceKey) providers.Interface {
-	ctx.ProviderLock.Lock()
-	defer ctx.ProviderLock.Unlock()
+func (c *BuiltinEvalContext) Provider(addr addrs.AbsProviderConfig, key addrs.InstanceKey) providers.Interface {
+	c.ProviderLock.Lock()
+	defer c.ProviderLock.Unlock()
 
-	pm, ok := ctx.ProviderCache[addr.String()]
+	pm, ok := c.ProviderCache[addr.String()]
 	if !ok {
 		return nil
 	}
@@ -182,18 +182,18 @@ func (ctx *BuiltinEvalContext) Provider(addr addrs.AbsProviderConfig, key addrs.
 	return pm[key]
 }
 
-func (ctx *BuiltinEvalContext) ProviderSchema(addr addrs.AbsProviderConfig) (providers.ProviderSchema, error) {
-	return ctx.Plugins.ProviderSchema(addr.Provider)
+func (c *BuiltinEvalContext) ProviderSchema(addr addrs.AbsProviderConfig) (providers.ProviderSchema, error) {
+	return c.Plugins.ProviderSchema(addr.Provider)
 }
 
-func (ctx *BuiltinEvalContext) CloseProvider(addr addrs.AbsProviderConfig) error {
-	ctx.ProviderLock.Lock()
-	defer ctx.ProviderLock.Unlock()
+func (c *BuiltinEvalContext) CloseProvider(addr addrs.AbsProviderConfig) error {
+	c.ProviderLock.Lock()
+	defer c.ProviderLock.Unlock()
 
 	var diags tfdiags.Diagnostics
 
 	key := addr.String()
-	providerMap := ctx.ProviderCache[key]
+	providerMap := c.ProviderCache[key]
 	if providerMap != nil {
 		for _, provider := range providerMap {
 			err := provider.Close()
@@ -201,7 +201,7 @@ func (ctx *BuiltinEvalContext) CloseProvider(addr addrs.AbsProviderConfig) error
 				diags = diags.Append(err)
 			}
 		}
-		delete(ctx.ProviderCache, key)
+		delete(c.ProviderCache, key)
 	}
 	if diags.HasErrors() {
 		return diags.Err()
@@ -210,15 +210,15 @@ func (ctx *BuiltinEvalContext) CloseProvider(addr addrs.AbsProviderConfig) error
 	return nil
 }
 
-func (ctx *BuiltinEvalContext) ConfigureProvider(addr addrs.AbsProviderConfig, providerKey addrs.InstanceKey, cfg cty.Value) tfdiags.Diagnostics {
+func (c *BuiltinEvalContext) ConfigureProvider(addr addrs.AbsProviderConfig, providerKey addrs.InstanceKey, cfg cty.Value) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
-	if !ctx.Path().IsForModule(addr.Module) {
+	if !c.Path().IsForModule(addr.Module) {
 		// This indicates incorrect use of ConfigureProvider: it should be used
 		// only from the module that the provider configuration belongs to.
-		panic(fmt.Sprintf("%s configured by wrong module %s", addr, ctx.Path()))
+		panic(fmt.Sprintf("%s configured by wrong module %s", addr, c.Path()))
 	}
 
-	p := ctx.Provider(addr, providerKey)
+	p := c.Provider(addr, providerKey)
 	if p == nil {
 		diags = diags.Append(fmt.Errorf("%s not initialized", addr.InstanceString(providerKey)))
 		return diags
@@ -233,25 +233,25 @@ func (ctx *BuiltinEvalContext) ConfigureProvider(addr addrs.AbsProviderConfig, p
 	return resp.Diagnostics
 }
 
-func (ctx *BuiltinEvalContext) ProviderInput(pc addrs.AbsProviderConfig) map[string]cty.Value {
-	ctx.ProviderLock.Lock()
-	defer ctx.ProviderLock.Unlock()
+func (c *BuiltinEvalContext) ProviderInput(pc addrs.AbsProviderConfig) map[string]cty.Value {
+	c.ProviderLock.Lock()
+	defer c.ProviderLock.Unlock()
 
-	if !ctx.Path().IsForModule(pc.Module) {
+	if !c.Path().IsForModule(pc.Module) {
 		// This indicates incorrect use of InitProvider: it should be used
 		// only from the module that the provider configuration belongs to.
-		panic(fmt.Sprintf("%s initialized by wrong module %s", pc, ctx.Path()))
+		panic(fmt.Sprintf("%s initialized by wrong module %s", pc, c.Path()))
 	}
 
-	if !ctx.Path().IsRoot() {
+	if !c.Path().IsRoot() {
 		// Only root module provider configurations can have input.
 		return nil
 	}
 
-	return ctx.ProviderInputConfig[pc.String()]
+	return c.ProviderInputConfig[pc.String()]
 }
 
-func (ctx *BuiltinEvalContext) SetProviderInput(pc addrs.AbsProviderConfig, c map[string]cty.Value) {
+func (c *BuiltinEvalContext) SetProviderInput(pc addrs.AbsProviderConfig, vals map[string]cty.Value) {
 	absProvider := pc
 	if !pc.Module.IsRoot() {
 		// Only root module provider configurations can have input.
@@ -260,39 +260,39 @@ func (ctx *BuiltinEvalContext) SetProviderInput(pc addrs.AbsProviderConfig, c ma
 	}
 
 	// Save the configuration
-	ctx.ProviderLock.Lock()
-	ctx.ProviderInputConfig[absProvider.String()] = c
-	ctx.ProviderLock.Unlock()
+	c.ProviderLock.Lock()
+	c.ProviderInputConfig[absProvider.String()] = vals
+	c.ProviderLock.Unlock()
 }
 
-func (ctx *BuiltinEvalContext) Provisioner(n string) (provisioners.Interface, error) {
-	ctx.ProvisionerLock.Lock()
-	defer ctx.ProvisionerLock.Unlock()
+func (c *BuiltinEvalContext) Provisioner(n string) (provisioners.Interface, error) {
+	c.ProvisionerLock.Lock()
+	defer c.ProvisionerLock.Unlock()
 
-	p, ok := ctx.ProvisionerCache[n]
+	p, ok := c.ProvisionerCache[n]
 	if !ok {
 		var err error
-		p, err = ctx.Plugins.NewProvisionerInstance(n)
+		p, err = c.Plugins.NewProvisionerInstance(n)
 		if err != nil {
 			return nil, err
 		}
 
-		ctx.ProvisionerCache[n] = p
+		c.ProvisionerCache[n] = p
 	}
 
 	return p, nil
 }
 
-func (ctx *BuiltinEvalContext) ProvisionerSchema(n string) (*configschema.Block, error) {
-	return ctx.Plugins.ProvisionerSchema(n)
+func (c *BuiltinEvalContext) ProvisionerSchema(n string) (*configschema.Block, error) {
+	return c.Plugins.ProvisionerSchema(n)
 }
 
-func (ctx *BuiltinEvalContext) CloseProvisioners() error {
+func (c *BuiltinEvalContext) CloseProvisioners() error {
 	var diags tfdiags.Diagnostics
-	ctx.ProvisionerLock.Lock()
-	defer ctx.ProvisionerLock.Unlock()
+	c.ProvisionerLock.Lock()
+	defer c.ProvisionerLock.Unlock()
 
-	for name, prov := range ctx.ProvisionerCache {
+	for name, prov := range c.ProvisionerCache {
 		err := prov.Close()
 		if err != nil {
 			diags = diags.Append(fmt.Errorf("provisioner.Close %s: %w", name, err))
@@ -302,9 +302,9 @@ func (ctx *BuiltinEvalContext) CloseProvisioners() error {
 	return diags.Err()
 }
 
-func (ctx *BuiltinEvalContext) EvaluateBlock(body hcl.Body, schema *configschema.Block, self addrs.Referenceable, keyData InstanceKeyEvalData) (cty.Value, hcl.Body, tfdiags.Diagnostics) {
+func (c *BuiltinEvalContext) EvaluateBlock(body hcl.Body, schema *configschema.Block, self addrs.Referenceable, keyData InstanceKeyEvalData) (cty.Value, hcl.Body, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	scope := ctx.EvaluationScope(self, nil, keyData)
+	scope := c.EvaluationScope(self, nil, keyData)
 	body, evalDiags := scope.ExpandBlock(body, schema)
 	diags = diags.Append(evalDiags)
 	val, evalDiags := scope.EvalBlock(body, schema)
@@ -312,12 +312,12 @@ func (ctx *BuiltinEvalContext) EvaluateBlock(body hcl.Body, schema *configschema
 	return val, body, diags
 }
 
-func (ctx *BuiltinEvalContext) EvaluateExpr(expr hcl.Expression, wantType cty.Type, self addrs.Referenceable) (cty.Value, tfdiags.Diagnostics) {
-	scope := ctx.EvaluationScope(self, nil, EvalDataForNoInstanceKey)
+func (c *BuiltinEvalContext) EvaluateExpr(expr hcl.Expression, wantType cty.Type, self addrs.Referenceable) (cty.Value, tfdiags.Diagnostics) {
+	scope := c.EvaluationScope(self, nil, EvalDataForNoInstanceKey)
 	return scope.EvalExpr(expr, wantType)
 }
 
-func (ctx *BuiltinEvalContext) EvaluateReplaceTriggeredBy(expr hcl.Expression, repData instances.RepetitionData) (*addrs.Reference, bool, tfdiags.Diagnostics) {
+func (c *BuiltinEvalContext) EvaluateReplaceTriggeredBy(expr hcl.Expression, repData instances.RepetitionData) (*addrs.Reference, bool, tfdiags.Diagnostics) {
 
 	// get the reference to lookup changes in the plan
 	ref, diags := evalReplaceTriggeredByExpr(expr, repData)
@@ -333,12 +333,12 @@ func (ctx *BuiltinEvalContext) EvaluateReplaceTriggeredBy(expr hcl.Expression, r
 	switch sub := ref.Subject.(type) {
 	case addrs.Resource:
 		resourceAddr = sub
-		rc := sub.Absolute(ctx.Path())
-		changes = ctx.Changes().GetChangesForAbsResource(rc)
+		rc := sub.Absolute(c.Path())
+		changes = c.Changes().GetChangesForAbsResource(rc)
 	case addrs.ResourceInstance:
 		resourceAddr = sub.ContainingResource()
-		rc := sub.Absolute(ctx.Path())
-		change := ctx.Changes().GetResourceInstanceChange(rc, states.CurrentGen)
+		rc := sub.Absolute(c.Path())
+		change := c.Changes().GetResourceInstanceChange(rc, states.CurrentGen)
 		if change != nil {
 			// we'll generate an error below if there was no change
 			changes = append(changes, change)
@@ -346,13 +346,13 @@ func (ctx *BuiltinEvalContext) EvaluateReplaceTriggeredBy(expr hcl.Expression, r
 	}
 
 	// Do some validation to make sure we are expecting a change at all
-	cfg := ctx.Evaluator.Config.DescendentForInstance(ctx.Path())
+	cfg := c.Evaluator.Config.DescendentForInstance(c.Path())
 	resCfg := cfg.Module.ResourceByAddr(resourceAddr)
 	if resCfg == nil {
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  `Reference to undeclared resource`,
-			Detail:   fmt.Sprintf(`A resource %s has not been declared in %s`, ref.Subject, moduleDisplayAddr(ctx.Path())),
+			Detail:   fmt.Sprintf(`A resource %s has not been declared in %s`, ref.Subject, moduleDisplayAddr(c.Path())),
 			Subject:  expr.Range().Ptr(),
 		})
 		return nil, false, diags
@@ -360,7 +360,7 @@ func (ctx *BuiltinEvalContext) EvaluateReplaceTriggeredBy(expr hcl.Expression, r
 
 	if len(changes) == 0 {
 		// If the resource is valid there should always be at least one change.
-		diags = diags.Append(fmt.Errorf("no change found for %s in %s", ref.Subject, moduleDisplayAddr(ctx.Path())))
+		diags = diags.Append(fmt.Errorf("no change found for %s in %s", ref.Subject, moduleDisplayAddr(c.Path())))
 		return nil, false, diags
 	}
 
@@ -395,7 +395,7 @@ func (ctx *BuiltinEvalContext) EvaluateReplaceTriggeredBy(expr hcl.Expression, r
 	// Since we have a traversal after the resource reference, we will need to
 	// decode the changes, which means we need a schema.
 	providerAddr := change.ProviderAddr
-	schema, err := ctx.ProviderSchema(providerAddr)
+	schema, err := c.ProviderSchema(providerAddr)
 	if err != nil {
 		diags = diags.Append(err)
 		return nil, false, diags
@@ -431,15 +431,15 @@ func (ctx *BuiltinEvalContext) EvaluateReplaceTriggeredBy(expr hcl.Expression, r
 	return ref, replace, diags
 }
 
-func (ctx *BuiltinEvalContext) EvaluationScope(self addrs.Referenceable, source addrs.Referenceable, keyData InstanceKeyEvalData) *lang.Scope {
-	if !ctx.pathSet {
+func (c *BuiltinEvalContext) EvaluationScope(self addrs.Referenceable, source addrs.Referenceable, keyData InstanceKeyEvalData) *lang.Scope {
+	if !c.pathSet {
 		panic("context path not set")
 	}
 	data := &evaluationStateData{
-		Evaluator:       ctx.Evaluator,
-		ModulePath:      ctx.PathValue,
+		Evaluator:       c.Evaluator,
+		ModulePath:      c.PathValue,
 		InstanceKeyData: keyData,
-		Operation:       ctx.Evaluator.Operation,
+		Operation:       c.Evaluator.Operation,
 	}
 
 	// ctx.PathValue is the path of the module that contains whatever
@@ -449,14 +449,14 @@ func (ctx *BuiltinEvalContext) EvaluationScope(self addrs.Referenceable, source 
 	// package itself works. The nil check here is for robustness in
 	// incompletely-mocked testing situations; mc should never be nil in
 	// real situations.
-	mc := ctx.Evaluator.Config.DescendentForInstance(ctx.PathValue)
+	mc := c.Evaluator.Config.DescendentForInstance(c.PathValue)
 
 	if mc == nil || mc.Module.ProviderRequirements == nil {
-		return ctx.Evaluator.Scope(data, self, source, nil)
+		return c.Evaluator.Scope(data, self, source, nil)
 	}
 
-	scope := ctx.Evaluator.Scope(data, self, source, func(pf addrs.ProviderFunction, rng tfdiags.SourceRange) (*function.Function, tfdiags.Diagnostics) {
-		providedBy, ok := ctx.ProviderFunctionTracker.Lookup(ctx.PathValue.Module(), pf)
+	scope := c.Evaluator.Scope(data, self, source, func(pf addrs.ProviderFunction, rng tfdiags.SourceRange) (*function.Function, tfdiags.Diagnostics) {
+		providedBy, ok := c.ProviderFunctionTracker.Lookup(c.PathValue.Module(), pf)
 		if !ok {
 			// This should not be possible if references are tracked correctly
 			return nil, tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
@@ -468,20 +468,20 @@ func (ctx *BuiltinEvalContext) EvaluationScope(self addrs.Referenceable, source 
 		}
 
 		var providerKey addrs.InstanceKey
-		if providedBy.KeyExpression != nil && ctx.Evaluator.Operation != walkValidate {
-			moduleInstanceForKey := ctx.PathValue[:len(providedBy.KeyModule)]
+		if providedBy.KeyExpression != nil && c.Evaluator.Operation != walkValidate {
+			moduleInstanceForKey := c.PathValue[:len(providedBy.KeyModule)]
 			if !moduleInstanceForKey.IsForModule(providedBy.KeyModule) {
 				panic(fmt.Sprintf("Invalid module key expression location %s in function %s", providedBy.KeyModule, pf.String()))
 			}
 
 			var keyDiags tfdiags.Diagnostics
-			providerKey, keyDiags = resolveProviderModuleInstance(ctx, providedBy.KeyExpression, moduleInstanceForKey, ctx.PathValue.String()+" "+pf.String())
+			providerKey, keyDiags = resolveProviderModuleInstance(c, providedBy.KeyExpression, moduleInstanceForKey, c.PathValue.String()+" "+pf.String())
 			if keyDiags.HasErrors() {
 				return nil, keyDiags
 			}
 		}
 
-		provider := ctx.Provider(providedBy.Provider, providerKey)
+		provider := c.Provider(providedBy.Provider, providerKey)
 
 		if provider == nil {
 			// This should not be possible if references are tracked correctly
@@ -493,59 +493,59 @@ func (ctx *BuiltinEvalContext) EvaluationScope(self addrs.Referenceable, source 
 			})
 		}
 
-		return evalContextProviderFunction(provider, ctx.Evaluator.Operation, pf, rng)
+		return evalContextProviderFunction(provider, c.Evaluator.Operation, pf, rng)
 	})
 	scope.SetActiveExperiments(mc.Module.ActiveExperiments)
 
 	return scope
 }
 
-func (ctx *BuiltinEvalContext) Path() addrs.ModuleInstance {
-	if !ctx.pathSet {
+func (c *BuiltinEvalContext) Path() addrs.ModuleInstance {
+	if !c.pathSet {
 		panic("context path not set")
 	}
-	return ctx.PathValue
+	return c.PathValue
 }
 
-func (ctx *BuiltinEvalContext) SetRootModuleArgument(addr addrs.InputVariable, v cty.Value) {
-	ctx.VariableValuesLock.Lock()
-	defer ctx.VariableValuesLock.Unlock()
+func (c *BuiltinEvalContext) SetRootModuleArgument(addr addrs.InputVariable, v cty.Value) {
+	c.VariableValuesLock.Lock()
+	defer c.VariableValuesLock.Unlock()
 
 	log.Printf("[TRACE] BuiltinEvalContext: Storing final value for variable %s", addr.Absolute(addrs.RootModuleInstance))
 	key := addrs.RootModuleInstance.String()
-	args := ctx.VariableValues[key]
+	args := c.VariableValues[key]
 	if args == nil {
 		args = make(map[string]cty.Value)
-		ctx.VariableValues[key] = args
+		c.VariableValues[key] = args
 	}
 	args[addr.Name] = v
 }
 
-func (ctx *BuiltinEvalContext) SetModuleCallArgument(callAddr addrs.ModuleCallInstance, varAddr addrs.InputVariable, v cty.Value) {
-	ctx.VariableValuesLock.Lock()
-	defer ctx.VariableValuesLock.Unlock()
+func (c *BuiltinEvalContext) SetModuleCallArgument(callAddr addrs.ModuleCallInstance, varAddr addrs.InputVariable, v cty.Value) {
+	c.VariableValuesLock.Lock()
+	defer c.VariableValuesLock.Unlock()
 
-	if !ctx.pathSet {
+	if !c.pathSet {
 		panic("context path not set")
 	}
 
-	childPath := callAddr.ModuleInstance(ctx.PathValue)
+	childPath := callAddr.ModuleInstance(c.PathValue)
 	log.Printf("[TRACE] BuiltinEvalContext: Storing final value for variable %s", varAddr.Absolute(childPath))
 	key := childPath.String()
-	args := ctx.VariableValues[key]
+	args := c.VariableValues[key]
 	if args == nil {
 		args = make(map[string]cty.Value)
-		ctx.VariableValues[key] = args
+		c.VariableValues[key] = args
 	}
 	args[varAddr.Name] = v
 }
 
-func (ctx *BuiltinEvalContext) GetVariableValue(addr addrs.AbsInputVariableInstance) cty.Value {
-	ctx.VariableValuesLock.Lock()
-	defer ctx.VariableValuesLock.Unlock()
+func (c *BuiltinEvalContext) GetVariableValue(addr addrs.AbsInputVariableInstance) cty.Value {
+	c.VariableValuesLock.Lock()
+	defer c.VariableValuesLock.Unlock()
 
 	modKey := addr.Module.String()
-	modVars := ctx.VariableValues[modKey]
+	modVars := c.VariableValues[modKey]
 	val, ok := modVars[addr.Variable.Name]
 	if !ok {
 		return cty.DynamicVal
@@ -553,38 +553,38 @@ func (ctx *BuiltinEvalContext) GetVariableValue(addr addrs.AbsInputVariableInsta
 	return val
 }
 
-func (ctx *BuiltinEvalContext) Changes() *plans.ChangesSync {
-	return ctx.ChangesValue
+func (c *BuiltinEvalContext) Changes() *plans.ChangesSync {
+	return c.ChangesValue
 }
 
-func (ctx *BuiltinEvalContext) State() *states.SyncState {
-	return ctx.StateValue
+func (c *BuiltinEvalContext) State() *states.SyncState {
+	return c.StateValue
 }
 
-func (ctx *BuiltinEvalContext) Checks() *checks.State {
-	return ctx.ChecksValue
+func (c *BuiltinEvalContext) Checks() *checks.State {
+	return c.ChecksValue
 }
 
-func (ctx *BuiltinEvalContext) RefreshState() *states.SyncState {
-	return ctx.RefreshStateValue
+func (c *BuiltinEvalContext) RefreshState() *states.SyncState {
+	return c.RefreshStateValue
 }
 
-func (ctx *BuiltinEvalContext) PrevRunState() *states.SyncState {
-	return ctx.PrevRunStateValue
+func (c *BuiltinEvalContext) PrevRunState() *states.SyncState {
+	return c.PrevRunStateValue
 }
 
-func (ctx *BuiltinEvalContext) InstanceExpander() *instances.Expander {
-	return ctx.InstanceExpanderValue
+func (c *BuiltinEvalContext) InstanceExpander() *instances.Expander {
+	return c.InstanceExpanderValue
 }
 
-func (ctx *BuiltinEvalContext) MoveResults() refactoring.MoveResults {
-	return ctx.MoveResultsValue
+func (c *BuiltinEvalContext) MoveResults() refactoring.MoveResults {
+	return c.MoveResultsValue
 }
 
-func (ctx *BuiltinEvalContext) ImportResolver() *ImportResolver {
-	return ctx.ImportResolverValue
+func (c *BuiltinEvalContext) ImportResolver() *ImportResolver {
+	return c.ImportResolverValue
 }
 
-func (ctx *BuiltinEvalContext) GetEncryption() encryption.Encryption {
-	return ctx.Encryption
+func (c *BuiltinEvalContext) GetEncryption() encryption.Encryption {
+	return c.Encryption
 }

--- a/internal/tofu/eval_context_builtin.go
+++ b/internal/tofu/eval_context_builtin.go
@@ -182,7 +182,7 @@ func (c *BuiltinEvalContext) Provider(addr addrs.AbsProviderConfig, key addrs.In
 	return pm[key]
 }
 
-func (c *BuiltinEvalContext) ProviderSchema(addr addrs.AbsProviderConfig) (providers.ProviderSchema, error) {
+func (c *BuiltinEvalContext) ProviderSchema(_ context.Context, addr addrs.AbsProviderConfig) (providers.ProviderSchema, error) {
 	return c.Plugins.ProviderSchema(addr.Provider)
 }
 
@@ -395,7 +395,7 @@ func (c *BuiltinEvalContext) EvaluateReplaceTriggeredBy(expr hcl.Expression, rep
 	// Since we have a traversal after the resource reference, we will need to
 	// decode the changes, which means we need a schema.
 	providerAddr := change.ProviderAddr
-	schema, err := c.ProviderSchema(providerAddr)
+	schema, err := c.ProviderSchema(context.TODO(), providerAddr)
 	if err != nil {
 		diags = diags.Append(err)
 		return nil, false, diags

--- a/internal/tofu/eval_context_mock.go
+++ b/internal/tofu/eval_context_mock.go
@@ -6,8 +6,13 @@
 package tofu
 
 import (
+	"context"
+
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hcldec"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/checks"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
@@ -20,8 +25,6 @@ import (
 	"github.com/opentofu/opentofu/internal/refactoring"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
-	"github.com/zclconf/go-cty/cty/convert"
 )
 
 // MockEvalContext is a mock version of EvalContext that can be used
@@ -196,7 +199,7 @@ func (c *MockEvalContext) Provider(addr addrs.AbsProviderConfig, _ addrs.Instanc
 	return c.ProviderProvider
 }
 
-func (c *MockEvalContext) ProviderSchema(addr addrs.AbsProviderConfig) (providers.ProviderSchema, error) {
+func (c *MockEvalContext) ProviderSchema(_ context.Context, addr addrs.AbsProviderConfig) (providers.ProviderSchema, error) {
 	c.ProviderSchemaCalled = true
 	c.ProviderSchemaAddr = addr
 	return c.ProviderSchemaSchema, c.ProviderSchemaError

--- a/internal/tofu/eval_provider.go
+++ b/internal/tofu/eval_provider.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -140,7 +141,7 @@ func getProvider(ctx EvalContext, addr addrs.AbsProviderConfig, providerKey addr
 	}
 	// Not all callers require a schema, so we will leave checking for a nil
 	// schema to the callers.
-	schema, err := ctx.ProviderSchema(addr)
+	schema, err := ctx.ProviderSchema(context.TODO(), addr)
 	if err != nil {
 		return nil, providers.ProviderSchema{}, fmt.Errorf("failed to read schema for provider %s: %w", addr, err)
 	}


### PR DESCRIPTION
This is a continuation of https://github.com/opentofu/opentofu/pull/2754.

`tofu.EvalContext` is a _huge_ interface used as a "god object" all over the place. so I'm starting small on this one and focusing on updating just the one method that's involved in getting the schema for a provider, since getting trace spans in place for the schema lookup is our main remaining missing piece for tracing in the language runtime.

I've split this into two commits because the first one is just a big, totally-systematic rename of the receiver symbol on all of the `BuiltinEvalContext` methods from `ctx` to `c`, so that we can add `ctx context.Context` arguments without symbol conflicts.

The second one then changes the signature of `EvalContext.ProviderSchema` to include a `context.Context` argument and updates its callers to pass `context.TODO()` into it. Actually plumbing a useful context in here will wait for a subsequent PR because bridging these unfortunately requires altering all of the very many helper functions on `NodeAbstractResource`, `NodeAbstractResourceInstance` and everything that calls them, and that seems like far too much to review at once.
