### PR TITLE
Rename the CLI arg for deprecation outputs/variables

### DIFF
--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -400,8 +400,8 @@ Options:
                          suitable for use in text editor integrations and
                          other automated systems. Always disables color.
 
-  -deprecation-warns=lvl Specify what type of warnings are shown. Accepted
-                         values for lvl: all, local, none. Default: all.
+  -deprecation=module:m  Specify what type of warnings are shown. Accepted
+                         values for "m": all, local, none. Default: all.
                          When "all" is selected, OpenTofu will show the
                          deprecation warnings for all modules. When "local"
                          is selected, the warns will be shown only for the

--- a/internal/command/arguments/apply.go
+++ b/internal/command/arguments/apply.go
@@ -54,7 +54,7 @@ func ParseApply(args []string) (*Apply, tfdiags.Diagnostics) {
 	cmdFlags.BoolVar(&apply.AutoApprove, "auto-approve", false, "auto-approve")
 	cmdFlags.BoolVar(&apply.InputEnabled, "input", true, "input")
 	cmdFlags.BoolVar(&apply.ShowSensitive, "show-sensitive", false, "displays sensitive values")
-	cmdFlags.StringVar(&apply.ModuleDeprecationWarnings, "deprecation-warns", "", "control the level of deprecation warnings")
+	cmdFlags.StringVar(&apply.ModuleDeprecationWarnings, "deprecation", "", "control the level of deprecation warnings")
 
 	var json bool
 	cmdFlags.BoolVar(&json, "json", false, "json")

--- a/internal/command/arguments/plan.go
+++ b/internal/command/arguments/plan.go
@@ -59,7 +59,7 @@ func ParsePlan(args []string) (*Plan, tfdiags.Diagnostics) {
 	cmdFlags.StringVar(&plan.OutPath, "out", "", "out")
 	cmdFlags.StringVar(&plan.GenerateConfigPath, "generate-config-out", "", "generate-config-out")
 	cmdFlags.BoolVar(&plan.ShowSensitive, "show-sensitive", false, "displays sensitive values")
-	cmdFlags.StringVar(&plan.ModuleDeprecationWarnLevel, "deprecation-warns", "", "control the level of deprecation warnings")
+	cmdFlags.StringVar(&plan.ModuleDeprecationWarnLevel, "deprecation", "", "control the level of deprecation warnings")
 
 	var json bool
 	cmdFlags.BoolVar(&json, "json", false, "json")

--- a/internal/command/arguments/view.go
+++ b/internal/command/arguments/view.go
@@ -47,7 +47,7 @@ func ParseView(args []string) (*View, []string) {
 	// argument we support, "i" will not be incremented.
 	i := 0
 	for _, v := range args {
-		if prefix := "-deprecation-warns"; strings.HasPrefix(v, prefix) {
+		if prefix := "-deprecation=module:"; strings.HasPrefix(v, prefix) {
 			common.ModuleDeprecationWarnLvl = tofu.ParseDeprecatedWarningLevel(strings.ReplaceAll(v, prefix, ""))
 			continue // continue to ensure that the counter is not incremented
 		}

--- a/internal/command/arguments/view_test.go
+++ b/internal/command/arguments/view_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/opentofu/opentofu/internal/tofu"
 )
 
 func TestParseView(t *testing.T) {
@@ -76,6 +77,26 @@ func TestParseView(t *testing.T) {
 			[]string{"-consolidate-warnings=false"},
 			&View{NoColor: false, CompactWarnings: false, ConsolidateWarnings: false, Concise: false},
 			[]string{},
+		},
+		"show all deprecation warnings": {
+			[]string{"-deprecation=module:all"},
+			&View{ModuleDeprecationWarnLvl: tofu.DeprecationWarningLevelAll, ConsolidateWarnings: true},
+			[]string{},
+		},
+		"show only local deprecation warnings": {
+			[]string{"-deprecation=module:local"},
+			&View{ModuleDeprecationWarnLvl: tofu.DeprecationWarningLevelLocal, ConsolidateWarnings: true},
+			[]string{},
+		},
+		"show no deprecation warnings": {
+			[]string{"-deprecation=module:none"},
+			&View{ModuleDeprecationWarnLvl: tofu.DeprecationWarningLevelNone, ConsolidateWarnings: true},
+			[]string{},
+		},
+		"deprecation used with other yet non-existing namespaces is returning those in the unparsed args": {
+			[]string{"-deprecation=othernamespace:arg", "-deprecation=module:none", "-deprecation=backend:arg"},
+			&View{ModuleDeprecationWarnLvl: tofu.DeprecationWarningLevelNone, ConsolidateWarnings: true},
+			[]string{"-deprecation=othernamespace:arg", "-deprecation=backend:arg"},
 		},
 	}
 	for name, tc := range testCases {

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -329,8 +329,8 @@ Other Options:
                                format, suitable for use in text editor
                                integrations and other automated systems.
 
-  -deprecation-warns=lvl       Specify what type of warnings are shown.
-                               Accepted values for lvl: all, local, none. 
+  -deprecation=module:m        Specify what type of warnings are shown.
+                               Accepted values for "m": all, local, none. 
                                Default: all. When "all" is selected, OpenTofu
                                will show the deprecation warnings for all
                                modules. When "local" is selected, the warns

--- a/rfc/20241118-module-vars-and-outputs-deprecation.md
+++ b/rfc/20241118-module-vars-and-outputs-deprecation.md
@@ -95,8 +95,12 @@ Silencing deprecation warnings could be presented in two different ways: globall
 basis. This setting shouldn't be a part of a module call block since there could be multiple calls for the same module and each such
 call should either produce or silence the warnings.
 
-In this RFC I suggest to allow users to control module deprecation warnings via a CLI flag: `deprecation-warns`, which may
-have the following values: `all` (default) or `local` (raise deprecation warnings only from module calls inside the local modules).
+In this RFC I suggest to allow users to control module deprecation warnings via a CLI flag: `deprecation`, which may
+have the following values: 
+* `module:all` (default) - shows all the deprecation warnings from local and remote module calls.
+* `module:local` - raise deprecation warnings only from module calls inside the local modules.
+* `module:none` - is silencing all the warnings regarding deprecated outputs/variables.
+
 This could be extended later to include other options such as `none` to disable the deprecation warnings altogether.
 
 ### Technical Approach
@@ -123,7 +127,7 @@ presence.
 
 We would need to extend module output nodes to also mark values as deprecated if the user specified so. Then, the mark should
 be checked where `tofu.EvalContext` is used to evaluate expressions and blocks (i.e. `EvalContext.EvaluateBlock` and
-`EvalContext.EvaluateExpr`). The deprecation mark check must take into account the value of `deprecation-warns` flag
+`EvalContext.EvaluateExpr`). The deprecation mark check must take into account the value of `deprecation` flag
 and also it shouldn't fire if the value is used inside the module, which marked this value as deprecated.
 
 This approach would also allow us to reuse the implementation, if we want to mark more values as deprecated from different

--- a/website/docs/cli/commands/apply.mdx
+++ b/website/docs/cli/commands/apply.mdx
@@ -97,11 +97,11 @@ The following options change how the apply command executes and reports on the a
 - `-show-sensitive` - If specified, sensitive values will not be
   redacted in te UI output.
 
-- `-deprecation-warns` - Specify what type of warnings are shown.
-  Accepted values: all, local, none. Default: all. When "all" is selected,
-  OpenTofu will show the deprecation warnings for all modules. When "local" is selected,
+- `-deprecation` - Specify what type of warnings are shown.
+  Accepted values: "module:all", "module:local", "module:none". Default: module:all. When "module:all" is selected,
+  OpenTofu will show the deprecation warnings for all modules. When "module:local" is selected,
   the warnings will be shown only for the modules that are imported with a relative
-  path. When "none" is selected, all the deprecation warnings will be dropped.
+  path. When "module:none" is selected, all the deprecation warnings will be dropped.
 
 - All [planning modes](plan.mdx#planning-modes) and
 [planning options](plan.mdx#planning-options) for

--- a/website/docs/cli/commands/plan.mdx
+++ b/website/docs/cli/commands/plan.mdx
@@ -385,11 +385,11 @@ The available options are:
 * `-json` - Produce output in a machine-readable JSON format, suitable for
   use in text editor integrations and other automated systems.
 
-* `-deprecation-warns` - Specify what type of warnings are shown.
-  Accepted values: all, local, none. Default: all. When "all" is selected,
-  OpenTofu will show the deprecation warnings for all modules. When "local" is selected,
+* `-deprecation` - Specify what type of warnings are shown.
+  Accepted values: "module:all", "module:local", "module:none". Default: "module:all". When "module:all" is selected,
+  OpenTofu will show the deprecation warnings for all modules. When "module:local" is selected,
   the warnings will be shown only for the modules that are imported with a relative
-  path. When "none" is selected, all the deprecation warnings will be dropped.
+  path. When "module:none" is selected, all the deprecation warnings will be dropped.
 
 For configurations using
 [the `local` backend](../../language/settings/backends/local.mdx) only,

--- a/website/docs/language/values/outputs.mdx
+++ b/website/docs/language/values/outputs.mdx
@@ -243,5 +243,5 @@ their configuration:
 │ 
 │ 'examle' output must no longer be used due to a typo, use 'example' instead
 ```
-Deprecation warnings can be filtered or disabled by using the `-deprecation-warns` CLI argument. For more details, check its description
+Deprecation warnings can be filtered or disabled by using the `-deprecation` CLI argument. For more details, check its description
 in the command options for [plan](../../cli/commands/plan.mdx#other-options) and [apply](../../cli/commands/apply.mdx#apply-options).

--- a/website/docs/language/values/variables.mdx
+++ b/website/docs/language/values/variables.mdx
@@ -329,7 +329,7 @@ their configuration:
 │ 'examle' variable must no longer be used due to a typo, use 'example' instead
 ```
 
-Deprecation warnings can be filtered or disabled by using the `-deprecation-warns` CLI argument. For more details, check its description
+Deprecation warnings can be filtered or disabled by using the `-deprecation` CLI argument. For more details, check its description
 in the command options for [plan](../../cli/commands/plan.mdx#other-options) and [apply](../../cli/commands/apply.mdx#apply-options).
 ## Using Input Variable Values
 


### PR DESCRIPTION
Based on the agreement from the [community slack](https://opentofucommunity.slack.com/archives/C05RKE7PS72/p1746629411144469), we are renaming the cli argument that controls the deprecation warnings to accommodate more possible future functions regarding "deprecation".

Part of #2555

## Target Release

1.10.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
