### PR TITLE
Fix lint issues in internal/getproviders

### DIFF
--- a/internal/getproviders/mock_source.go
+++ b/internal/getproviders/mock_source.go
@@ -185,9 +185,13 @@ func FakeInstallablePackageMeta(provider addrs.Provider, version Version, protoc
 
 	// Compute the SHA256 checksum of the generated file, to allow package
 	// authentication code to be exercised.
-	f.Seek(0, io.SeekStart)
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return PackageMeta{}, close, err
+	}
 	h := sha256.New()
-	io.Copy(h, f)
+	if _, err := io.Copy(h, f); err != nil {
+		return PackageMeta{}, close, err
+	}
 	checksum := [32]byte{}
 	h.Sum(checksum[:0])
 

--- a/internal/getproviders/multi_source.go
+++ b/internal/getproviders/multi_source.go
@@ -185,7 +185,7 @@ func ParseMultiSourceMatchingPatterns(strs []string) (MultiSourceMatchingPattern
 			Type:      pType,
 		}
 
-		if ret[i].Hostname == svchost.Hostname(Wildcard) && !(ret[i].Namespace == Wildcard && ret[i].Type == Wildcard) {
+		if ret[i].Hostname == svchost.Hostname(Wildcard) && (ret[i].Namespace != Wildcard || ret[i].Type != Wildcard) {
 			return nil, fmt.Errorf("invalid provider matching pattern %q: hostname can be a wildcard only if both namespace and provider type are also wildcards", str)
 		}
 		if ret[i].Namespace == Wildcard && ret[i].Type != Wildcard {

--- a/internal/getproviders/package_authentication_test.go
+++ b/internal/getproviders/package_authentication_test.go
@@ -698,8 +698,6 @@ func TestSignatureAuthentication_failure(t *testing.T) {
 	}
 }
 
-const testAuthorKeyID = `37A6AB3BCF2C170A`
-
 // testAuthorKeyArmor is test key ID 5BFEEC4317E746008621970637A6AB3BCF2C170A.
 const testAuthorKeyArmor = `-----BEGIN PGP PUBLIC KEY BLOCK-----
 


### PR DESCRIPTION
Part of #2769

## Target Release

1.10.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.