### PR TITLE
registry+getproviders: Registry client policy centralized in `package main`

### DIFF
--- a/cmd/tofu/commands.go
+++ b/cmd/tofu/commands.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 
 	"github.com/hashicorp/go-plugin"
+	"github.com/hashicorp/go-retryablehttp"
 	svchost "github.com/hashicorp/terraform-svchost"
 	"github.com/hashicorp/terraform-svchost/auth"
 	"github.com/hashicorp/terraform-svchost/disco"
@@ -109,6 +110,12 @@ func initCommands(
 		ShutdownCh:    makeShutdownCh(),
 		CallerContext: ctx,
 
+		MakeRegistryHTTPClient: func() *retryablehttp.Client {
+			// This ctx is used only to choose global configuration settings
+			// for the client, and is not retained as part of the result for
+			// making individual HTTP requests.
+			return newRegistryHTTPClient(ctx)
+		},
 		ModulePackageFetcher: modulePkgFetcher,
 		ProviderSource:       providerSrc,
 		ProviderDevOverrides: providerDevOverrides,

--- a/cmd/tofu/registries_disco.go
+++ b/cmd/tofu/registries_disco.go
@@ -1,0 +1,89 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/hashicorp/terraform-svchost/auth"
+	"github.com/hashicorp/terraform-svchost/disco"
+	"github.com/opentofu/opentofu/internal/httpclient"
+	"github.com/opentofu/opentofu/internal/logging"
+	"github.com/opentofu/opentofu/version"
+)
+
+const (
+	// registryDiscoveryRetryEnvName is the name of the environment variable that
+	// can be configured to customize number of retries for module and provider
+	// discovery requests with the remote registry.
+	registryDiscoveryRetryEnvName      = "TF_REGISTRY_DISCOVERY_RETRY"
+	registryDiscoveryDefaultRetryCount = 1
+
+	// registryClientTimeoutEnvName is the name of the environment variable that
+	// can be configured to customize the timeout duration (seconds) for module
+	// and provider discovery with a remote registry. For historical reasons
+	// this also applies to all service discovery requests regardless of whether
+	// they are registry-related.
+	registryClientTimeoutEnvName        = "TF_REGISTRY_CLIENT_TIMEOUT"
+	registryClientDefaultRequestTimeout = 10 * time.Second
+)
+
+// newServiceDiscovery returns a newly-created [disco.Disco] object that is
+// configured appropriately for use elsewhere in OpenTofu.
+//
+// The credSrc argument represents the policy for how the service discovery
+// object should obtain authentication credentials for service discovery
+// requests. Passing a nil credSrc is acceptable and means that all discovery
+// requests are to be made anonymously.
+func newServiceDiscovery(ctx context.Context, credSrc auth.CredentialsSource) *disco.Disco {
+	services := disco.NewWithCredentialsSource(credSrc)
+	services.SetUserAgent(httpclient.OpenTofuUserAgent(version.String()))
+
+	// For historical reasons, the registry request retry policy also applies
+	// to all service discovery requests, which we implement by using transport
+	// from a HTTP client that is configured for registry client use.
+	client := newRegistryHTTPClient(ctx)
+	services.Transport = client.HTTPClient.Transport
+
+	return services
+}
+
+// newRegistryHTTPClient returns a new HTTP client configured to respect the
+// automatic retry behavior expected for registry requests and service discovery
+// requests.
+func newRegistryHTTPClient(ctx context.Context) *retryablehttp.Client {
+	// The retry count is configurable by environment variable.
+	retryCount := registryDiscoveryDefaultRetryCount
+	if v := os.Getenv(registryDiscoveryRetryEnvName); v != "" {
+		override, err := strconv.Atoi(v)
+		if err == nil && override > 0 {
+			retryCount = override
+		}
+	}
+
+	// The timeout is also configurable by environment variable.
+	timeout := registryClientDefaultRequestTimeout
+	if v := os.Getenv(registryClientTimeoutEnvName); v != "" {
+		override, err := strconv.Atoi(v)
+		if err == nil && timeout > 0 {
+			timeout = time.Duration(override) * time.Second
+		}
+	}
+
+	client := httpclient.NewForRegistryRequests(ctx, retryCount, timeout)
+
+	// Per historical tradition our registry client also generates log messages
+	// describing the requests that it makes.
+	logOutput := logging.LogOutput()
+	client.Logger = log.New(logOutput, "", log.Flags())
+
+	return client
+}

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -985,7 +985,7 @@ func testServices(t *testing.T) (services *disco.Disco, cleanup func()) {
 // of your test in order to shut down the test server.
 func testRegistrySource(t *testing.T) (source *getproviders.RegistrySource, cleanup func()) {
 	services, close := testServices(t)
-	source = getproviders.NewRegistrySource(services)
+	source = getproviders.NewRegistrySource(services, nil)
 	return source, close
 }
 

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-plugin"
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/terraform-svchost/disco"
 	"github.com/mitchellh/cli"
 	"github.com/mitchellh/colorstring"
@@ -138,6 +139,15 @@ type Meta struct {
 	// in the source address) are supported, which is only reasonable for
 	// unit testing.
 	ModulePackageFetcher *getmodules.PackageFetcher
+
+	// MakeRegistryHTTPClient is a function called each time a command needs
+	// an HTTP client that will be used to make requests to a module or
+	// provider registry.
+	//
+	// This is used by package main to deal with some operator-configurable
+	// settings for retries and timeouts. If this isn't set then a new client
+	// with reasonable defaults for tests will be used instead.
+	MakeRegistryHTTPClient func() *retryablehttp.Client
 
 	// BrowserLauncher is used by commands that need to open a URL in a
 	// web browser.

--- a/internal/command/providers_mirror.go
+++ b/internal/command/providers_mirror.go
@@ -112,7 +112,7 @@ func (c *ProvidersMirrorCommand) Run(args []string) int {
 	// directory without needing to first disable that local mirror
 	// in the CLI configuration.
 	source := getproviders.NewMemoizeSource(
-		getproviders.NewRegistrySource(c.Services),
+		getproviders.NewRegistrySource(c.Services, c.registryHTTPClient(ctx)),
 	)
 
 	// Providers from registries always use HTTP, so we don't need the full

--- a/internal/getproviders/registry_source.go
+++ b/internal/getproviders/registry_source.go
@@ -8,26 +8,38 @@ package getproviders
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/hashicorp/go-retryablehttp"
 	svchost "github.com/hashicorp/terraform-svchost"
 	disco "github.com/hashicorp/terraform-svchost/disco"
 
 	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/httpclient"
 )
 
 // RegistrySource is a Source that knows how to find and install providers from
 // their originating provider registries.
 type RegistrySource struct {
-	services *disco.Disco
+	services   *disco.Disco
+	httpClient *retryablehttp.Client
 }
 
 var _ Source = (*RegistrySource)(nil)
 
 // NewRegistrySource creates and returns a new source that will install
 // providers from their originating provider registries.
-func NewRegistrySource(services *disco.Disco) *RegistrySource {
+func NewRegistrySource(services *disco.Disco, httpClient *retryablehttp.Client) *RegistrySource {
+	if httpClient == nil {
+		// As an aid to our tests that don't really care that much about
+		// the HTTP client configuration, we'll provide some reasonable
+		// defaults if no custom client is provided.
+		httpClient = httpclient.NewForRegistryRequests(context.Background(), 1, 10*time.Second)
+	}
+
 	return &RegistrySource{
-		services: services,
+		services:   services,
+		httpClient: httpClient,
 	}
 }
 
@@ -147,7 +159,7 @@ func (s *RegistrySource) registryClient(ctx context.Context, hostname svchost.Ho
 		return nil, fmt.Errorf("failed to retrieve credentials for %s: %w", hostname, err)
 	}
 
-	return newRegistryClient(ctx, url, creds), nil
+	return newRegistryClient(ctx, url, creds, s.httpClient), nil
 }
 
 func (s *RegistrySource) ForDisplay(provider addrs.Provider) string {

--- a/internal/getproviders/registry_source_test.go
+++ b/internal/getproviders/registry_source_test.go
@@ -60,7 +60,7 @@ func TestSourceAvailableVersions(t *testing.T) {
 		{
 			"fails.example.com/foo/bar",
 			nil,
-			`could not query provider registry for fails.example.com/foo/bar: the request failed after 2 attempts, please try again later: Get "` + baseURL + `/fails-immediately/foo/bar/versions": EOF`,
+			`could not query provider registry for fails.example.com/foo/bar: request failed after 2 attempts: Get "` + baseURL + `/fails-immediately/foo/bar/versions": EOF`,
 		},
 	}
 
@@ -188,7 +188,7 @@ func TestSourcePackageMeta(t *testing.T) {
 			"1.2.0",
 			"linux", "amd64",
 			PackageMeta{},
-			`could not query provider registry for fails.example.com/awesomesauce/happycloud: the request failed after 2 attempts, please try again later: Get "http://placeholder-origin/fails-immediately/awesomesauce/happycloud/1.2.0/download/linux/amd64": EOF`,
+			`could not query provider registry for fails.example.com/awesomesauce/happycloud: request failed after 2 attempts: Get "http://placeholder-origin/fails-immediately/awesomesauce/happycloud/1.2.0/download/linux/amd64": EOF`,
 		},
 	}
 

--- a/internal/httpclient/registry_client.go
+++ b/internal/httpclient/registry_client.go
@@ -1,0 +1,85 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package httpclient
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+// NewForRegistryRequests is a variant of [New] that deals with some additional
+// policy concerns related to "registry requests".
+//
+// Exactly what constitutes a "registry request" is actually more about
+// historical technical debt than intentional design, since these concerns
+// were originally supposed to be handled internally within the module and
+// provider registry clients but the implementation of that unfortunately caused
+// the effects to "leak out" into other parts of the system, which we now
+// preserve for backward compatibility here.
+//
+// Therefore "registry requests" includes the following:
+//   - All requests from the client of our network service discovery protocol,
+//     even though not all discoverable services are actually "registries".
+//   - Requests to module registries during module installation.
+//   - Requests to provider registries during provider installation.
+//
+// The retryCount argument specifies how many times requests from the resulting
+// client should be automatically retried when certain transient errors occur.
+//
+// The timeout argument specifies a deadline for the completion of each
+// request made using the client.
+func NewForRegistryRequests(ctx context.Context, retryCount int, timeout time.Duration) *retryablehttp.Client {
+	// We'll start with the result of New, so that what we return still
+	// honors our general policy for HTTP client behavior.
+	baseClient := New(ctx)
+	baseClient.Timeout = timeout
+
+	// Registry requests historically offered automatic retry on certain
+	// transient errors implemented using the retryablehttp library, so
+	// we'll now deal with that here.
+	retryableClient := retryablehttp.NewClient()
+	retryableClient.HTTPClient = baseClient
+	retryableClient.RetryMax = retryCount
+	retryableClient.RequestLogHook = registryRequestLogHook
+	retryableClient.ErrorHandler = registryMaxRetryErrorHandler
+
+	return retryableClient
+}
+
+func registryRequestLogHook(logger retryablehttp.Logger, req *http.Request, i int) {
+	if i > 0 {
+		logger.Printf("[INFO] Failed request to %s; retrying", req.URL.String())
+	}
+}
+
+func registryMaxRetryErrorHandler(resp *http.Response, err error, numTries int) (*http.Response, error) {
+	// Close the body per library instructions
+	if resp != nil {
+		resp.Body.Close()
+	}
+
+	// Additional error detail: if we have a response, use the status code;
+	// if we have an error, use that; otherwise nothing. We will never have
+	// both response and error.
+	var errMsg string
+	if resp != nil {
+		errMsg = fmt.Sprintf(": %s returned from %s", resp.Status, resp.Request.URL)
+	} else if err != nil {
+		errMsg = fmt.Sprintf(": %s", err)
+	}
+
+	// This function is always called with numTries=RetryMax+1. If we made any
+	// retry attempts, include that in the error message.
+	if numTries > 1 {
+		return resp, fmt.Errorf("request failed after %d attempts%s",
+			numTries, errMsg)
+	}
+	return resp, fmt.Errorf("request failed%s", errMsg)
+}

--- a/internal/providercache/installer_test.go
+++ b/internal/providercache/installer_test.go
@@ -2740,7 +2740,7 @@ func testServices(t *testing.T) (services *disco.Disco, baseURL string, cleanup 
 // of your test in order to shut down the test server.
 func testRegistrySource(t *testing.T) (source *getproviders.RegistrySource, baseURL string, cleanup func()) {
 	services, baseURL, close := testServices(t)
-	source = getproviders.NewRegistrySource(services)
+	source = getproviders.NewRegistrySource(services, nil)
 	return source, baseURL, close
 }
 

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -13,9 +13,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
-	"os"
 	"path"
-	"strconv"
 	"strings"
 	"time"
 
@@ -26,7 +24,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/opentofu/opentofu/internal/httpclient"
-	"github.com/opentofu/opentofu/internal/logging"
 	"github.com/opentofu/opentofu/internal/registry/regsrc"
 	"github.com/opentofu/opentofu/internal/registry/response"
 	"github.com/opentofu/opentofu/internal/tracing"
@@ -39,34 +36,11 @@ const (
 	xTerraformVersion  = "X-Terraform-Version"
 	modulesServiceID   = "modules.v1"
 	providersServiceID = "providers.v1"
-
-	// registryDiscoveryRetryEnvName is the name of the environment variable that
-	// can be configured to customize number of retries for module and provider
-	// discovery requests with the remote registry.
-	registryDiscoveryRetryEnvName = "TF_REGISTRY_DISCOVERY_RETRY"
-	defaultRetry                  = 1
-
-	// registryClientTimeoutEnvName is the name of the environment variable that
-	// can be configured to customize the timeout duration (seconds) for module
-	// and provider discovery with the remote registry.
-	registryClientTimeoutEnvName = "TF_REGISTRY_CLIENT_TIMEOUT"
-
-	// defaultRequestTimeout is the default timeout duration for requests to the
-	// remote registry.
-	defaultRequestTimeout = 10 * time.Second
 )
 
 var (
 	tfVersion = version.String()
-
-	discoveryRetry int
-	requestTimeout time.Duration
 )
-
-func init() {
-	configureDiscoveryRetry()
-	configureRequestTimeout()
-}
 
 // Client provides methods to query OpenTofu Registries.
 type Client struct {
@@ -79,30 +53,19 @@ type Client struct {
 }
 
 // NewClient returns a new initialized registry client.
-func NewClient(ctx context.Context, services *disco.Disco, client *http.Client) *Client {
+func NewClient(ctx context.Context, services *disco.Disco, client *retryablehttp.Client) *Client {
 	if services == nil {
 		services = disco.New()
 	}
 
 	if client == nil {
-		client = httpclient.New(ctx)
-		client.Timeout = requestTimeout
+		// The following is a fallback client configuration intended primarily
+		// for our test cases that directly call this function.
+		client = httpclient.NewForRegistryRequests(ctx, 1, 10*time.Second)
 	}
-	retryableClient := retryablehttp.NewClient()
-	retryableClient.HTTPClient = client
-	retryableClient.RetryMax = discoveryRetry
-	retryableClient.RequestLogHook = requestLogHook
-	retryableClient.ErrorHandler = maxRetryErrorHandler
-
-	logOutput := logging.LogOutput()
-	retryableClient.Logger = log.New(logOutput, "", log.Flags())
-
-	services.Transport = retryableClient.HTTPClient.Transport
-
-	services.SetUserAgent(httpclient.OpenTofuUserAgent(version.String()))
 
 	return &Client{
-		client:   retryableClient,
+		client:   client,
 		services: services,
 	}
 }
@@ -309,61 +272,4 @@ func (c *Client) ModuleLocation(ctx context.Context, module *regsrc.Module, vers
 	}
 
 	return location, nil
-}
-
-// configureDiscoveryRetry configures the number of retries the registry client
-// will attempt for requests with retryable errors, like 502 status codes
-func configureDiscoveryRetry() {
-	discoveryRetry = defaultRetry
-
-	if v := os.Getenv(registryDiscoveryRetryEnvName); v != "" {
-		retry, err := strconv.Atoi(v)
-		if err == nil && retry > 0 {
-			discoveryRetry = retry
-		}
-	}
-}
-
-func requestLogHook(logger retryablehttp.Logger, req *http.Request, i int) {
-	if i > 0 {
-		logger.Printf("[INFO] Previous request to the remote registry failed, attempting retry.")
-	}
-}
-
-func maxRetryErrorHandler(resp *http.Response, err error, numTries int) (*http.Response, error) {
-	// Close the body per library instructions
-	if resp != nil {
-		resp.Body.Close()
-	}
-
-	// Additional error detail: if we have a response, use the status code;
-	// if we have an error, use that; otherwise nothing. We will never have
-	// both response and error.
-	var errMsg string
-	if resp != nil {
-		errMsg = fmt.Sprintf(": %s returned from %s", resp.Status, resp.Request.URL)
-	} else if err != nil {
-		errMsg = fmt.Sprintf(": %s", err)
-	}
-
-	// This function is always called with numTries=RetryMax+1. If we made any
-	// retry attempts, include that in the error message.
-	if numTries > 1 {
-		return resp, fmt.Errorf("the request failed after %d attempts, please try again later%s",
-			numTries, errMsg)
-	}
-	return resp, fmt.Errorf("the request failed, please try again later%s", errMsg)
-}
-
-// configureRequestTimeout configures the registry client request timeout from
-// environment variables
-func configureRequestTimeout() {
-	requestTimeout = defaultRequestTimeout
-
-	if v := os.Getenv(registryClientTimeoutEnvName); v != "" {
-		timeout, err := strconv.Atoi(v)
-		if err == nil && timeout > 0 {
-			requestTimeout = time.Duration(timeout) * time.Second
-		}
-	}
 }


### PR DESCRIPTION
The primary reason for this change is that `registry.NewClient` was originally imposing its own decision about service discovery request policy on every other user of the shared disco.Disco object by modifying it directly, as I discovered while investigating https://github.com/opentofu/opentofu/pull/2772#issuecomment-2867153130.

We have been moving towards using a dependency inversion style where package main is responsible for deciding how everything should be configured based on global CLI arguments, environment variables, and the CLI configuration, and so this commit moves to using that model for the HTTP clients used by the module and provider registry client code.

In particular, this makes explicit what was previously hidden away: that all service discovery requests are made using the same HTTP client retry/timeout policy as for requests to module registries, even if the service being discovered is not a registry. This doesn't seem to have been the intention of the code as previously written, but was still its ultimate effect: there is only one `disco.Disco` object shared across all discovery callers and so changing its configuration in any way changes it for everyone.

This initial rework is certainly not perfect: these components were not originally designed to be wired together in this way and there are lots of existing test cases relying on the old shape of things, and so this is a compromise to get the behavior we want (using consistent HTTP client settings across all callers) without disrupting too much existing code.

This is tangentially related to https://github.com/opentofu/opentofu/issues/2664, but is not directly in its critical path.

---

I should also note that _this doesn't actually fix the problem that prompted me to dig into this in the first place_!

My motivation here was only to address the maintenance hazard of having the registry client instantiation secretly modify the global service discovery behavior.

The `disco.Disco` object is still shared across everything that needs to do service discovery and so we're still making a single central decision about whether those requests should generate trace spans. In a separate commit I'm intending to make sure that every downstream use of the `disco.Disco` object has a useful `context.Context` plumbed to it, and then the trace spans generated by these requests will appear in the appropriate place in the trace and so will be useful rather than a nuisance.
