### PR TITLE
Fix potential loss of local state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ BUG FIXES:
 - Provider GPG Expiration warnings no longer show when only one of the keys have expired. Only once all are expired or invalid. ([#2475](https://github.com/opentofu/opentofu/issues/2475))
 - The "oss" backend, for state storage in Alibaba Cloud OSS, now fully supports all of the typical environment variables for HTTP/HTTPS proxy configuration. Previously it supported configuring a proxy using variables like `HTTPS_PROXY`, but did not support per-origin opt-out using the `NO_PROXY` environment variable. ([#2675](https://github.com/opentofu/opentofu/pull/2675))
 - `AzureRM` backend now supports pagination when retrieving workspaces. `timeout_seconds` backend configuration is also used in these operations. ([#2720](https://github.com/opentofu/opentofu/pull/2720))
+- Fix potential loss of local statefile if file creation failed. ([#2798](https://github.com/opentofu/opentofu/pull/2798))
 
 INTERNAL CHANGES:
 - `skip_s3_checksum=true` now blocks the [aws-sdk new default S3 integrity checks](https://github.com/aws/aws-sdk-go-v2/discussions/2960) ([#2596](https://github.com/opentofu/opentofu/pull/2596))

--- a/internal/command/clistate/local_state.go
+++ b/internal/command/clistate/local_state.go
@@ -73,7 +73,7 @@ func (s *LocalState) WriteState(state *tofu.State) error {
 
 	if s.stateFileOut == nil {
 		if err := s.createStateFiles(); err != nil {
-			return nil
+			return err
 		}
 	}
 	defer s.stateFileOut.Sync()


### PR DESCRIPTION
In 6162cde6ffde8436ff82aa42b50f7fe7d44fb9e1, a bug was introduced where creating a new local statefile would ignore file creation errors.

## Target Release

1.10.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
