### PR TITLE
Better error message when provider config is not found for iteration

### DIFF
--- a/internal/configs/config_test.go
+++ b/internal/configs/config_test.go
@@ -299,6 +299,39 @@ func TestConfigProviderRequirementsDuplicate(t *testing.T) {
 	assertDiagnosticSummary(t, diags, "Duplicate required provider")
 }
 
+func TestConfigProviderForEach(t *testing.T) {
+	_, diags := testNestedModuleConfigFromDir(t, "testdata/provider_for_each")
+	assertDiagnosticCount(t, diags, 4)
+
+	want := hcl.Diagnostics{
+		{
+			Summary: "Provider configuration for_each matches module",
+			Detail:  "This provider configuration uses the same for_each expression as a module, which means that subsequent removal of elements from this collection would cause a planning error.",
+		}, {
+			Summary: "Provider configuration for_each matches resource",
+			Detail:  "This provider configuration uses the same for_each expression as a resource, which means that subsequent removal of elements from this collection would cause a planning error.",
+		}, {
+			Summary: "Invalid module provider configuration",
+			Detail:  `An instance key can only be used with a provider configured with for_each. No provider configuration was detected for "dumme.key"`,
+		}, {
+			Summary: "Invalid resource provider configuration",
+			Detail:  `An instance key can only be used with a provider configured with for_each. No provider configuration was detected for "dumme.key"`,
+		},
+	}
+
+	for _, wd := range want {
+		found := false
+		for _, gd := range diags {
+			if gd.Summary == wd.Summary && strings.HasPrefix(gd.Detail, wd.Detail) {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("Expected Diagnostic %s", wd)
+		}
+	}
+}
+
 func TestConfigProviderRequirementsShallow(t *testing.T) {
 	cfg, diags := testNestedModuleConfigFromDir(t, "testdata/provider-reqs")
 	// TODO: Version Constraint Deprecation.

--- a/internal/configs/provider_validation.go
+++ b/internal/configs/provider_validation.go
@@ -489,8 +489,10 @@ func validateProviderConfigs(parentCall *ModuleCall, cfg *Config, noProviderConf
 				})
 			}
 
-			instanceExpr := instanced[providerName(passed.InParent.Name, passed.InParent.Alias)]
-			diags = diags.Extend(passed.InParent.InstanceValidation("module", instanceExpr != nil))
+			pn := providerName(passed.InParent.Name, passed.InParent.Alias)
+			_, hasConfig := configured[pn]
+			instanceExpr := instanced[pn]
+			diags = diags.Extend(passed.InParent.InstanceValidation("module", instanceExpr != nil, hasConfig))
 			// We could theoretically check here if there are resources (ignoring data blocks) within this submodule graph.
 			// The foot-gun only exists in that scenario, but the complexity of differentiating at the moment is not worth it
 			if passed.InParent.KeyExpression != nil {
@@ -506,8 +508,10 @@ func validateProviderConfigs(parentCall *ModuleCall, cfg *Config, noProviderConf
 				continue
 			}
 
-			instanceExpr := instanced[providerName(r.ProviderConfigRef.Name, r.ProviderConfigRef.Alias)]
-			diags = diags.Extend(r.ProviderConfigRef.InstanceValidation("resource", instanceExpr != nil))
+			pn := providerName(r.ProviderConfigRef.Name, r.ProviderConfigRef.Alias)
+			_, hasConfig := configured[pn]
+			instanceExpr := instanced[pn]
+			diags = diags.Extend(r.ProviderConfigRef.InstanceValidation("resource", instanceExpr != nil, hasConfig))
 			if r.ProviderConfigRef.KeyExpression != nil && r.Mode == addrs.ManagedResourceMode {
 				addr := fmt.Sprintf("%s.%s", r.Type, r.Name)
 				if !cfg.Path.IsRoot() {

--- a/internal/configs/resource.go
+++ b/internal/configs/resource.go
@@ -801,7 +801,7 @@ func (r *ProviderConfigRef) String() string {
 	return r.Name
 }
 
-func (r *ProviderConfigRef) InstanceValidation(blockType string, isInstanced bool) hcl.Diagnostics {
+func (r *ProviderConfigRef) InstanceValidation(blockType string, isInstanced bool, hasConfig bool) hcl.Diagnostics {
 	var diags hcl.Diagnostics
 
 	summary := fmt.Sprintf("Invalid %s provider configuration", blockType)
@@ -816,12 +816,22 @@ func (r *ProviderConfigRef) InstanceValidation(blockType string, isInstanced boo
 			})
 		}
 		if !isInstanced {
-			diags = append(diags, &hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  summary,
-				Detail:   "An instance key can be specified only for a provider configuration that uses for_each.",
-				Subject:  r.KeyExpression.Range().Ptr(),
-			})
+			if !hasConfig {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  summary,
+					Detail:   fmt.Sprintf("An instance key can only be used with a provider configured with for_each. No provider configuration was detected for %q", r.String()),
+					Subject:  r.KeyExpression.Range().Ptr(),
+				})
+			} else {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  summary,
+					Detail:   "An instance key can be specified only for a provider configuration that uses for_each.",
+					Subject:  r.KeyExpression.Range().Ptr(),
+				})
+
+			}
 		}
 	} else if isInstanced {
 		diags = append(diags, &hcl.Diagnostic{

--- a/internal/configs/testdata/provider_for_each/main.tf
+++ b/internal/configs/testdata/provider_for_each/main.tf
@@ -1,0 +1,45 @@
+terraform {
+  required_providers {
+    dummy = {
+      source = "my/dummy"
+    }
+  }
+}
+
+locals {
+        fe = {}
+} 
+
+provider "dummy" {
+  alias = "key"
+  for_each = local.fe
+}
+
+resource "dummy_warning" "test" {
+  for_each = local.fe
+  provider = dummy.key[each.key]
+}
+
+
+module "mod_warning" {
+  source = "./mod"
+  for_each = local.fe
+  providers = {
+        dummy = dummy.key[each.key]
+  }
+}
+
+resource "dummy_error" "test" {
+  for_each = local.fe
+  provider = dumme.key[each.key]
+}
+
+
+module "mod_error" {
+  source = "./mod"
+  for_each = local.fe
+  providers = {
+        dummy = dumme.key[each.key]
+  }
+}
+

--- a/internal/configs/testdata/provider_for_each/mod/main.tf
+++ b/internal/configs/testdata/provider_for_each/mod/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    dummy = {
+      source = "my/dummy"
+    }
+  }
+}


### PR DESCRIPTION
Given the inspections available during config validation, I think this is the best compromise I could come up with for now.

<!-- If your PR resolves an issue, please add it here. -->
Resolves #2805 

## Target Release

1.10.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

