### PR TITLE
Fix iteration issue in transform_destroy

### DIFF
--- a/internal/tofu/transform_destroy_edge.go
+++ b/internal/tofu/transform_destroy_edge.go
@@ -379,6 +379,10 @@ func (t *pruneUnusedNodesTransformer) Transform(_ context.Context, g *Graph) err
 				last := len(nodes) - 1
 				nodes[i], nodes[last] = nodes[last], nodes[i]
 				nodes = nodes[:last]
+
+				// Now that we have shifted the next element into the i'th position, we need to re-inspect
+				// the value at index i
+				i -= 1
 			}()
 		}
 	}


### PR DESCRIPTION
This would have potentially caused more iterations of the loop, which is already approaching n*2 time.

Given that the loop would already run until all possible nodes would be pruned, this change just adjusts it to prune more items in the same iteration instead of breaking it into more iterations.

## Target Release

1.10.0

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.