### PR TITLE
command/views/json: Diagnostic context for single-symbol traversals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ ENHANCEMENTS:
 * Remove restriction on test module sources now allowing all source types for modules during tests ([#2651]https://github.com/opentofu/opentofu/pull/2651)
 * `moved` now supports moving between different types ([#2370](https://github.com/opentofu/opentofu/pull/2370))
 * `moved` block can now be used to migrate from the `null_resource` to the `terraform_data` resource. ([#2481](https://github.com/opentofu/opentofu/pull/2481))
+* OpenTofu now includes more information about value types when describing type conversion-related errors, and some other errors relating to local iteration symbols. ([#2815](https://github.com/opentofu/opentofu/pull/2815), [#2816](https://github.com/opentofu/opentofu/pull/2816))
 * Warn on implicit references of providers without a `required_providers` entry. ([#2084](https://github.com/opentofu/opentofu/issues/2084))
 * The test `run` outputs can now be used in the test `provider` blocks defined in test files. ([#2543](https://github.com/opentofu/opentofu/pull/2543))
 * Provider instance keys now automatically converted to string ([#2378](https://github.com/opentofu/opentofu/issues/2378))

--- a/internal/command/views/json/testdata/diagnostic/error-with-source-code-subject-and-expression-with-local-symbol.json
+++ b/internal/command/views/json/testdata/diagnostic/error-with-source-code-subject-and-expression-with-local-symbol.json
@@ -1,0 +1,31 @@
+{
+  "severity": "error",
+  "summary": "Wrong noises",
+  "detail": "Biological sounds are not allowed",
+  "range": {
+    "filename": "test.tf",
+    "start": {
+      "line": 2,
+      "column": 9,
+      "byte": 42
+    },
+    "end": {
+      "line": 2,
+      "column": 26,
+      "byte": 59
+    }
+  },
+  "snippet": {
+    "context": "resource \"test_resource\" \"test\"",
+    "code": "  foo = var.boop[\"hello!\"]",
+    "start_line": 2,
+    "highlight_start_offset": 8,
+    "highlight_end_offset": 25,
+    "values": [
+      {
+        "traversal": "i",
+        "statement": "is 5"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This code was designed to keep trying gradually-shorter traversals until it finds something that can be evaluated, because we're probably reporting that the given expression wasn't actually valid and so it's possible that one of the references we're trying to describe was the cause of the problem in the first place.

However, there was an off-by-one error in the termination condition that prevented this from working for the top-level symbols that are typically introduced by language constructs that generate child scopes, such as a `for` expression's iteration symbols. We'll now try to find a value for even a single-step traversal, which means that we can report such things as which iteration of a for expression we were on when an error occurred.

Due to how the tests for this function are structured the test input is a synthetically-constructed approximation of what a `for` expression might generate, so to help with understand of the real case this is trying to match here's a real example that reproduces the problem:

```hcl
output "example" {
  value = [
    for x in [1, {}] : "Hello, ${x}!"
  ]
}
```

With this fix, the diagnostic renders like this:

```
╷
│ Error: Invalid template interpolation value
│ 
│   on diags-missing-exprvals.tf line 8, in output "example":
│    8:     for x in [1, {}] : "Hello, ${x}!"
│     ├────────────────
│     │ x is object with no attributes
│ 
│ Cannot include the given value in a string template: string required.
╵
```

Without this fix, the "x is object with no attributes" context is missing from the output, because `x` is a traversal of length 1.

I learned of this problem from https://github.com/hashicorp/hcl/issues/746, which is actually intending to report a different thing in my cty library that I am intending to also address in a future release of that library, but this solution further improves the situation by describing the _inputs_ that caused the problem, and will benefit any possible `for` result expression, whereas the cty improvement will only improve the error handling for type conversion errors in particular.

**Update:** I also made the change in `cty`, with an upgrade PR in https://github.com/opentofu/opentofu/pull/2816. The changelog entry for this PR intentionally covers both at once, because from an end-user perspective these are two different components of the same general improvement, separated to different PRs only because they are quite far apart in the implementation details.
