### PR TITLE
Remove Target Release PR template field

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,10 +11,6 @@ change is something as trivial as a typo fix).
 <!-- If your PR resolves an issue, please add it here. -->
 Resolves # 
 
-## Target Release
-
-1.10.0
-
 ## Checklist
 
 <!-- Please check of ALL items in this list for all PRs: -->


### PR DESCRIPTION
This field has not been useful from the perspective of the maintainers of the project.  In the rare circumstance that it is needed, it can be added to a specific PR.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

