### PR TITLE
Remove m*n locking from resource evaluation and O(m * n * (m+n)) iteration

### DIFF
--- a/internal/tofu/evaluate.go
+++ b/internal/tofu/evaluate.go
@@ -748,7 +748,7 @@ func (d *evaluationStateData) GetResource(addr addrs.Resource, rng tfdiags.Sourc
 	}
 
 	// Fetch all instance data in a single call.  We previously used GetResourceInstanceChange in
-	// each loop iteration which caused n^2 locking contention.  This is expecially problematic for
+	// each loop iteration which caused n^2 locking contention.  This is especially problematic for
 	// resources with large count/for_each.
 	instChanges := d.Evaluator.Changes.GetChangesForConfigResource(addr.InModule(moduleConfig.Path))
 	instMap := map[string]*plans.ResourceInstanceChangeSrc{}

--- a/internal/tofu/evaluate.go
+++ b/internal/tofu/evaluate.go
@@ -747,6 +747,17 @@ func (d *evaluationStateData) GetResource(addr addrs.Resource, rng tfdiags.Sourc
 		}
 	}
 
+	// Fetch all instance data in a single call.  We previously used GetResourceInstanceChange in
+	// each loop iteration which caused n^2 locking contention.  This is expecially problematic for
+	// resources with large count/for_each.
+	instChanges := d.Evaluator.Changes.GetChangesForConfigResource(addr.InModule(moduleConfig.Path))
+	instMap := map[string]*plans.ResourceInstanceChangeSrc{}
+	for _, rc := range instChanges {
+		if rc.DeposedKey == states.NotDeposed {
+			instMap[rc.Addr.String()] = rc
+		}
+	}
+
 	// Decode all instances in the current state
 	instances := map[addrs.InstanceKey]cty.Value{}
 	pendingDestroy := d.Operation == walkDestroy
@@ -759,7 +770,7 @@ func (d *evaluationStateData) GetResource(addr addrs.Resource, rng tfdiags.Sourc
 
 		instAddr := addr.Instance(key).Absolute(d.ModulePath)
 
-		change := d.Evaluator.Changes.GetResourceInstanceChange(instAddr, states.CurrentGen)
+		change := instMap[instAddr.String()]
 		if change != nil {
 			// Don't take any resources that are yet to be deleted into account.
 			// If the referenced resource is CreateBeforeDestroy, then orphaned


### PR DESCRIPTION
When given a resource m that depends on resource n, if for_each or count were used in any significant way a massive lock contention was encountered.

In pseudocode:
```
for mi in m {
  for ni in n {
    lock()
    for c in {m, n} {
      ...
    }
    unlock()
  }
}

// Iterations: m * n * (m+n)
// Locking: m * n
```

To:
```
for mi in m {
  lock()
  for c in {m, n} {
    ...
  }
  unlock()

  for ni in n {
    ...
  }
  for ni in n {
    ...
  }
}

// Iterations: m * (m+n+n+n)
// Locking: m
```

Concretely, the following goes from ~40minutes down to under 5 minutes on my system:
```hcl
locals {
        entities = merge([for i in range(25) : {for k, v in {for i in range(100) : "s${i}" => i } : "${i}${k}"=> v}]...)

}

resource "tfcoremock_simple_resource" "entities" {
        for_each = local.entities
        string = each.key
        number = each.value
}

resource "tfcoremock_simple_resource" "entities_cert" {
        for_each = local.entities
        string = tfcoremock_simple_resource.entities[each.key].string
        number = tfcoremock_simple_resource.entities[each.key].number
}
```

Benchmark results:
```
goos: linux
goarch: amd64
pkg: github.com/opentofu/opentofu/internal/tofu
cpu: AMD Custom APU 0932

Before:
BenchmarkManyResourceInstances-8               1        217849181056 ns/op
PASS
ok      github.com/opentofu/opentofu/internal/tofu      227.441s

After:
BenchmarkManyResourceInstances-8               4        20823364224 ns/op
PASS
ok      github.com/opentofu/opentofu/internal/tofu      209.007s
```
Based on the ns/op, it's 10x faster.

Similar results were seen in the performance testing repo: https://github.com/opentofu/opentofu-performance-testing/pull/4


<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->


## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

