### PR TITLE
tofu: Plumb context.Context through the resource-handling functions

### DIFF
--- a/internal/tofu/eval_provider.go
+++ b/internal/tofu/eval_provider.go
@@ -130,18 +130,18 @@ func resolveProviderInstance(keyExpr hcl.Expression, keyScope *lang.Scope, sourc
 }
 
 // getProvider returns the providers.Interface and schema for a given provider.
-func getProvider(ctx EvalContext, addr addrs.AbsProviderConfig, providerKey addrs.InstanceKey) (providers.Interface, providers.ProviderSchema, error) {
+func getProvider(ctx context.Context, evalCtx EvalContext, addr addrs.AbsProviderConfig, providerKey addrs.InstanceKey) (providers.Interface, providers.ProviderSchema, error) {
 	if addr.Provider.Type == "" {
 		// Should never happen
 		panic("GetProvider used with uninitialized provider configuration address")
 	}
-	provider := ctx.Provider(addr, providerKey)
+	provider := evalCtx.Provider(addr, providerKey)
 	if provider == nil {
 		return nil, providers.ProviderSchema{}, fmt.Errorf("provider %s not initialized", addr.InstanceString(providerKey))
 	}
 	// Not all callers require a schema, so we will leave checking for a nil
 	// schema to the callers.
-	schema, err := ctx.ProviderSchema(context.TODO(), addr)
+	schema, err := evalCtx.ProviderSchema(ctx, addr)
 	if err != nil {
 		return nil, providers.ProviderSchema{}, fmt.Errorf("failed to read schema for provider %s: %w", addr, err)
 	}

--- a/internal/tofu/node_provider.go
+++ b/internal/tofu/node_provider.go
@@ -66,7 +66,7 @@ func (n *NodeApplyableProvider) Execute(ctx context.Context, evalCtx EvalContext
 
 	return diags
 }
-func (n *NodeApplyableProvider) initInstances(_ context.Context, evalCtx EvalContext, op walkOperation) (map[addrs.InstanceKey]providers.Interface, tfdiags.Diagnostics) {
+func (n *NodeApplyableProvider) initInstances(ctx context.Context, evalCtx EvalContext, op walkOperation) (map[addrs.InstanceKey]providers.Interface, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	var initKeys []addrs.InstanceKey
@@ -99,7 +99,7 @@ func (n *NodeApplyableProvider) initInstances(_ context.Context, evalCtx EvalCon
 
 	instances := make(map[addrs.InstanceKey]providers.Interface)
 	for configKey, initKey := range instanceKeys {
-		provider, _, err := getProvider(evalCtx, n.Addr, initKey)
+		provider, _, err := getProvider(ctx, evalCtx, n.Addr, initKey)
 		diags = diags.Append(err)
 		instances[configKey] = provider
 	}

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -540,9 +541,9 @@ func isResourceMovedToDifferentType(newAddr, oldAddr addrs.AbsResourceInstance) 
 
 // readResourceInstanceState reads the current object for a specific instance in
 // the state.
-func (n *NodeAbstractResourceInstance) readResourceInstanceState(evalCtx EvalContext, addr addrs.AbsResourceInstance) (*states.ResourceInstanceObject, tfdiags.Diagnostics) {
+func (n *NodeAbstractResourceInstance) readResourceInstanceState(ctx context.Context, evalCtx EvalContext, addr addrs.AbsResourceInstance) (*states.ResourceInstanceObject, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	provider, providerSchema, err := getProvider(evalCtx, n.ResolvedProvider.ProviderConfig, n.ResolvedProviderKey)
+	provider, providerSchema, err := getProvider(ctx, evalCtx, n.ResolvedProvider.ProviderConfig, n.ResolvedProviderKey)
 	if err != nil {
 		return nil, diags.Append(err)
 	}
@@ -595,9 +596,9 @@ func (n *NodeAbstractResourceInstance) readResourceInstanceState(evalCtx EvalCon
 
 // readResourceInstanceStateDeposed reads the deposed object for a specific
 // instance in the state.
-func (n *NodeAbstractResourceInstance) readResourceInstanceStateDeposed(evalCtx EvalContext, addr addrs.AbsResourceInstance, key states.DeposedKey) (*states.ResourceInstanceObject, tfdiags.Diagnostics) {
+func (n *NodeAbstractResourceInstance) readResourceInstanceStateDeposed(ctx context.Context, evalCtx EvalContext, addr addrs.AbsResourceInstance, key states.DeposedKey) (*states.ResourceInstanceObject, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	provider, providerSchema, err := getProvider(evalCtx, n.ResolvedProvider.ProviderConfig, n.ResolvedProviderKey)
+	provider, providerSchema, err := getProvider(ctx, evalCtx, n.ResolvedProvider.ProviderConfig, n.ResolvedProviderKey)
 	if err != nil {
 		diags = diags.Append(err)
 		return nil, diags

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -494,18 +494,18 @@ func (n *NodeAbstractResource) DotNode(name string, opts *dag.DotOpts) *dag.DotN
 // eval is the only change we get to set the resource "each mode" to list
 // in that case, allowing expression evaluation to see it as a zero-element list
 // rather than as not set at all.
-func (n *NodeAbstractResource) writeResourceState(ctx EvalContext, addr addrs.AbsResource) (diags tfdiags.Diagnostics) {
-	state := ctx.State()
+func (n *NodeAbstractResource) writeResourceState(evalCtx EvalContext, addr addrs.AbsResource) (diags tfdiags.Diagnostics) {
+	state := evalCtx.State()
 
 	// We'll record our expansion decision in the shared "expander" object
 	// so that later operations (i.e. DynamicExpand and expression evaluation)
 	// can refer to it. Since this node represents the abstract module, we need
 	// to expand the module here to create all resources.
-	expander := ctx.InstanceExpander()
+	expander := evalCtx.InstanceExpander()
 
 	switch {
 	case n.Config != nil && n.Config.Count != nil:
-		count, countDiags := evaluateCountExpression(n.Config.Count, ctx, addr)
+		count, countDiags := evaluateCountExpression(n.Config.Count, evalCtx, addr)
 		diags = diags.Append(countDiags)
 		if countDiags.HasErrors() {
 			return diags
@@ -515,7 +515,7 @@ func (n *NodeAbstractResource) writeResourceState(ctx EvalContext, addr addrs.Ab
 		expander.SetResourceCount(addr.Module, n.Addr.Resource, count)
 
 	case n.Config != nil && n.Config.ForEach != nil:
-		forEach, forEachDiags := evaluateForEachExpression(n.Config.ForEach, ctx, addr)
+		forEach, forEachDiags := evaluateForEachExpression(n.Config.ForEach, evalCtx, addr)
 		diags = diags.Append(forEachDiags)
 		if forEachDiags.HasErrors() {
 			return diags

--- a/internal/tofu/node_resource_abstract_instance_test.go
+++ b/internal/tofu/node_resource_abstract_instance_test.go
@@ -149,9 +149,9 @@ func TestNodeAbstractResourceInstanceProvider(t *testing.T) {
 
 func TestNodeAbstractResourceInstance_WriteResourceInstanceState(t *testing.T) {
 	state := states.NewState()
-	ctx := new(MockEvalContext)
-	ctx.StateState = state.SyncWrapper()
-	ctx.PathPath = addrs.RootModuleInstance
+	evalCtx := new(MockEvalContext)
+	evalCtx.StateState = state.SyncWrapper()
+	evalCtx.PathPath = addrs.RootModuleInstance
 
 	mockProvider := mockProviderWithResourceTypeSchema("aws_instance", &configschema.Block{
 		Attributes: map[string]*configschema.Attribute{
@@ -176,10 +176,10 @@ func TestNodeAbstractResourceInstance_WriteResourceInstanceState(t *testing.T) {
 			ResolvedProvider: ResolvedProvider{ProviderConfig: mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`)},
 		},
 	}
-	ctx.ProviderProvider = mockProvider
-	ctx.ProviderSchemaSchema = mockProvider.GetProviderSchema()
+	evalCtx.ProviderProvider = mockProvider
+	evalCtx.ProviderSchemaSchema = mockProvider.GetProviderSchema()
 
-	err := node.writeResourceInstanceState(ctx, obj, workingState)
+	err := node.writeResourceInstanceState(t.Context(), evalCtx, obj, workingState)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err.Error())
 	}

--- a/internal/tofu/node_resource_abstract_test.go
+++ b/internal/tofu/node_resource_abstract_test.go
@@ -7,9 +7,10 @@ package tofu
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/opentofu/opentofu/internal/refactoring"
 	"github.com/opentofu/opentofu/internal/tfdiags"
-	"testing"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
@@ -330,14 +331,14 @@ func TestNodeAbstractResource_ReadResourceInstanceState(t *testing.T) {
 	})
 	for _, test := range tests {
 		t.Run("ReadState "+test.Name, func(t *testing.T) {
-			ctx := new(MockEvalContext)
-			ctx.StateState = test.State.SyncWrapper()
-			ctx.PathPath = addrs.RootModuleInstance
-			ctx.ProviderSchemaSchema = test.Provider.GetProviderSchema()
-			ctx.MoveResultsResults = test.MoveResults
-			ctx.ProviderProvider = providers.Interface(test.Provider)
+			evalCtx := new(MockEvalContext)
+			evalCtx.StateState = test.State.SyncWrapper()
+			evalCtx.PathPath = addrs.RootModuleInstance
+			evalCtx.ProviderSchemaSchema = test.Provider.GetProviderSchema()
+			evalCtx.MoveResultsResults = test.MoveResults
+			evalCtx.ProviderProvider = providers.Interface(test.Provider)
 
-			got, readDiags := test.Node.readResourceInstanceState(ctx, test.Node.Addr)
+			got, readDiags := test.Node.readResourceInstanceState(t.Context(), evalCtx, test.Node.Addr)
 			if test.WantErrorStr != "" {
 				if !readDiags.HasErrors() {
 					t.Fatalf("[%s] Expected error, got none", test.Name)
@@ -377,15 +378,15 @@ func TestNodeAbstractResource_ReadResourceInstanceState(t *testing.T) {
 	})
 	for _, test := range deposedTests {
 		t.Run("ReadStateDeposed "+test.Name, func(t *testing.T) {
-			ctx := new(MockEvalContext)
-			ctx.StateState = test.State.SyncWrapper()
-			ctx.PathPath = addrs.RootModuleInstance
-			ctx.ProviderSchemaSchema = test.Provider.GetProviderSchema()
-			ctx.MoveResultsResults = test.MoveResults
-			ctx.ProviderProvider = providers.Interface(test.Provider)
+			evalCtx := new(MockEvalContext)
+			evalCtx.StateState = test.State.SyncWrapper()
+			evalCtx.PathPath = addrs.RootModuleInstance
+			evalCtx.ProviderSchemaSchema = test.Provider.GetProviderSchema()
+			evalCtx.MoveResultsResults = test.MoveResults
+			evalCtx.ProviderProvider = providers.Interface(test.Provider)
 
 			key := states.DeposedKey("00000001") // shim from legacy state assigns 0th deposed index this key
-			got, readDiags := test.Node.readResourceInstanceStateDeposed(ctx, test.Node.Addr, key)
+			got, readDiags := test.Node.readResourceInstanceStateDeposed(t.Context(), evalCtx, test.Node.Addr, key)
 			if test.WantErrorStr != "" {
 				if !readDiags.HasErrors() {
 					t.Fatalf("[%s] Expected error, got none", test.Name)

--- a/internal/tofu/node_resource_apply_instance.go
+++ b/internal/tofu/node_resource_apply_instance.go
@@ -415,12 +415,12 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx context.Conte
 	return diags.Append(n.managedResourcePostconditions(evalCtx, repeatData))
 }
 
-func (n *NodeApplyableResourceInstance) managedResourcePostconditions(ctx EvalContext, repeatData instances.RepetitionData) (diags tfdiags.Diagnostics) {
+func (n *NodeApplyableResourceInstance) managedResourcePostconditions(evalCtx EvalContext, repeatData instances.RepetitionData) (diags tfdiags.Diagnostics) {
 
 	checkDiags := evalCheckRules(
 		addrs.ResourcePostcondition,
 		n.Config.Postconditions,
-		ctx, n.ResourceInstanceAddr(), repeatData,
+		evalCtx, n.ResourceInstanceAddr(), repeatData,
 		tfdiags.Error,
 	)
 	return diags.Append(checkDiags)
@@ -432,7 +432,7 @@ func (n *NodeApplyableResourceInstance) managedResourcePostconditions(ctx EvalCo
 // Errors here are most often indicative of a bug in the provider, so our error
 // messages will report with that in mind. It's also possible that there's a bug
 // in OpenTofu's Core's own "proposed new value" code in EvalDiff.
-func (n *NodeApplyableResourceInstance) checkPlannedChange(ctx EvalContext, plannedChange, actualChange *plans.ResourceInstanceChange, providerSchema providers.ProviderSchema) tfdiags.Diagnostics {
+func (n *NodeApplyableResourceInstance) checkPlannedChange(evalCtx EvalContext, plannedChange, actualChange *plans.ResourceInstanceChange, providerSchema providers.ProviderSchema) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 	addr := n.ResourceInstanceAddr().Resource
 
@@ -443,7 +443,7 @@ func (n *NodeApplyableResourceInstance) checkPlannedChange(ctx EvalContext, plan
 		return diags
 	}
 
-	absAddr := addr.Absolute(ctx.Path())
+	absAddr := addr.Absolute(evalCtx.Path())
 
 	log.Printf("[TRACE] checkPlannedChange: Verifying that actual change (action %s) matches planned change (action %s)", actualChange.Action, plannedChange.Action)
 

--- a/internal/tofu/node_resource_apply_instance.go
+++ b/internal/tofu/node_resource_apply_instance.go
@@ -181,8 +181,8 @@ func (n *NodeApplyableResourceInstance) Execute(ctx context.Context, evalCtx Eva
 	return diags
 }
 
-func (n *NodeApplyableResourceInstance) dataResourceExecute(_ context.Context, evalCtx EvalContext) (diags tfdiags.Diagnostics) {
-	_, providerSchema, err := getProvider(evalCtx, n.ResolvedProvider.ProviderConfig, n.ResolvedProviderKey)
+func (n *NodeApplyableResourceInstance) dataResourceExecute(ctx context.Context, evalCtx EvalContext) (diags tfdiags.Diagnostics) {
+	_, providerSchema, err := getProvider(ctx, evalCtx, n.ResolvedProvider.ProviderConfig, n.ResolvedProviderKey)
 	diags = diags.Append(err)
 	if diags.HasErrors() {
 		return diags
@@ -204,7 +204,7 @@ func (n *NodeApplyableResourceInstance) dataResourceExecute(_ context.Context, e
 	// In this particular call to applyDataSource we include our planned
 	// change, which signals that we expect this read to complete fully
 	// with no unknown values; it'll produce an error if not.
-	state, repeatData, applyDiags := n.applyDataSource(evalCtx, change)
+	state, repeatData, applyDiags := n.applyDataSource(ctx, evalCtx, change)
 	diags = diags.Append(applyDiags)
 	if diags.HasErrors() {
 		return diags
@@ -216,13 +216,13 @@ func (n *NodeApplyableResourceInstance) dataResourceExecute(_ context.Context, e
 		// actually reading the data (e.g. because it was already read during
 		// the plan phase) and so we're only running through here to get the
 		// extra details like precondition/postcondition checks.
-		diags = diags.Append(n.writeResourceInstanceState(evalCtx, state, workingState))
+		diags = diags.Append(n.writeResourceInstanceState(ctx, evalCtx, state, workingState))
 		if diags.HasErrors() {
 			return diags
 		}
 	}
 
-	diags = diags.Append(n.writeChange(evalCtx, nil, ""))
+	diags = diags.Append(n.writeChange(ctx, evalCtx, nil, ""))
 
 	diags = diags.Append(updateStateHook(evalCtx))
 
@@ -250,7 +250,7 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx context.Conte
 	var deposedKey states.DeposedKey
 
 	addr := n.ResourceInstanceAddr().Resource
-	_, providerSchema, err := getProvider(evalCtx, n.ResolvedProvider.ProviderConfig, n.ResolvedProviderKey)
+	_, providerSchema, err := getProvider(ctx, evalCtx, n.ResolvedProvider.ProviderConfig, n.ResolvedProviderKey)
 	diags = diags.Append(err)
 	if diags.HasErrors() {
 		return diags
@@ -291,7 +291,7 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx context.Conte
 		log.Printf("[TRACE] managedResourceExecute: prior object for %s now deposed with key %s", n.Addr, deposedKey)
 	}
 
-	state, readDiags := n.readResourceInstanceState(evalCtx, n.ResourceInstanceAddr())
+	state, readDiags := n.readResourceInstanceState(ctx, evalCtx, n.ResourceInstanceAddr())
 	diags = diags.Append(readDiags)
 	if diags.HasErrors() {
 		return diags
@@ -306,7 +306,7 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx context.Conte
 
 	// Make a new diff, in case we've learned new values in the state
 	// during apply which we can now incorporate.
-	diffApply, _, repeatData, planDiags := n.plan(evalCtx, diff, state, false, n.forceReplace)
+	diffApply, _, repeatData, planDiags := n.plan(ctx, evalCtx, diff, state, false, n.forceReplace)
 	diags = diags.Append(planDiags)
 	if diags.HasErrors() {
 		return diags
@@ -337,12 +337,12 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx context.Conte
 		return diags.Append(n.managedResourcePostconditions(evalCtx, repeatData))
 	}
 
-	state, applyDiags := n.apply(evalCtx, state, diffApply, n.Config, repeatData, n.CreateBeforeDestroy())
+	state, applyDiags := n.apply(ctx, evalCtx, state, diffApply, n.Config, repeatData, n.CreateBeforeDestroy())
 	diags = diags.Append(applyDiags)
 
 	// We clear the change out here so that future nodes don't see a change
 	// that is already complete.
-	err = n.writeChange(evalCtx, nil, "")
+	err = n.writeChange(ctx, evalCtx, nil, "")
 	if err != nil {
 		return diags.Append(err)
 	}
@@ -353,20 +353,20 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx context.Conte
 		// dependencies are always updated to match the configuration during apply
 		state.Dependencies = n.Dependencies
 	}
-	err = n.writeResourceInstanceState(evalCtx, state, workingState)
+	err = n.writeResourceInstanceState(ctx, evalCtx, state, workingState)
 	if err != nil {
 		return diags.Append(err)
 	}
 
 	// Run Provisioners
 	createNew := (diffApply.Action == plans.Create || diffApply.Action.IsReplace())
-	applyProvisionersDiags := n.evalApplyProvisioners(evalCtx, state, createNew, configs.ProvisionerWhenCreate)
+	applyProvisionersDiags := n.evalApplyProvisioners(ctx, evalCtx, state, createNew, configs.ProvisionerWhenCreate)
 	// the provisioner errors count as port of the apply error, so we can bundle the diags
 	diags = diags.Append(applyProvisionersDiags)
 
 	state = maybeTainted(addr.Absolute(evalCtx.Path()), state, diffApply, diags.Err())
 
-	err = n.writeResourceInstanceState(evalCtx, state, workingState)
+	err = n.writeResourceInstanceState(ctx, evalCtx, state, workingState)
 	if err != nil {
 		return diags.Append(err)
 	}

--- a/internal/tofu/node_resource_deposed.go
+++ b/internal/tofu/node_resource_deposed.go
@@ -112,7 +112,7 @@ func (n *NodePlanDeposedResourceInstanceObject) Execute(ctx context.Context, eva
 	)
 
 	// Read the state for the deposed resource instance
-	state, err := n.readResourceInstanceStateDeposed(evalCtx, n.Addr, n.DeposedKey)
+	state, err := n.readResourceInstanceStateDeposed(ctx, evalCtx, n.Addr, n.DeposedKey)
 	diags = diags.Append(err)
 	if diags.HasErrors() {
 		return diags
@@ -120,13 +120,13 @@ func (n *NodePlanDeposedResourceInstanceObject) Execute(ctx context.Context, eva
 
 	// Note any upgrades that readResourceInstanceState might've done in the
 	// prevRunState, so that it'll conform to current schema.
-	diags = diags.Append(n.writeResourceInstanceStateDeposed(evalCtx, n.DeposedKey, state, prevRunState))
+	diags = diags.Append(n.writeResourceInstanceStateDeposed(ctx, evalCtx, n.DeposedKey, state, prevRunState))
 	if diags.HasErrors() {
 		return diags
 	}
 	// Also the refreshState, because that should still reflect schema upgrades
 	// even if not refreshing.
-	diags = diags.Append(n.writeResourceInstanceStateDeposed(evalCtx, n.DeposedKey, state, refreshState))
+	diags = diags.Append(n.writeResourceInstanceStateDeposed(ctx, evalCtx, n.DeposedKey, state, refreshState))
 	if diags.HasErrors() {
 		return diags
 	}
@@ -144,13 +144,13 @@ func (n *NodePlanDeposedResourceInstanceObject) Execute(ctx context.Context, eva
 		// resource during Delete correctly. If this is a simple refresh,
 		// OpenTofu is expected to remove the missing resource from the state
 		// entirely
-		refreshedState, refreshDiags := n.refresh(evalCtx, n.DeposedKey, state)
+		refreshedState, refreshDiags := n.refresh(ctx, evalCtx, n.DeposedKey, state)
 		diags = diags.Append(refreshDiags)
 		if diags.HasErrors() {
 			return diags
 		}
 
-		diags = diags.Append(n.writeResourceInstanceStateDeposed(evalCtx, n.DeposedKey, refreshedState, refreshState))
+		diags = diags.Append(n.writeResourceInstanceStateDeposed(ctx, evalCtx, n.DeposedKey, refreshedState, refreshState))
 		if diags.HasErrors() {
 			return diags
 		}
@@ -176,17 +176,17 @@ func (n *NodePlanDeposedResourceInstanceObject) Execute(ctx context.Context, eva
 
 		if shouldForget {
 			if shouldDestroy {
-				change, planDiags = n.planDestroy(evalCtx, state, n.DeposedKey)
+				change, planDiags = n.planDestroy(ctx, evalCtx, state, n.DeposedKey)
 			} else {
 				diags = diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagWarning,
 					Summary:  "Resource going to be removed from the state",
 					Detail:   fmt.Sprintf("After this plan gets applied, the resource %s will not be managed anymore by OpenTofu.\n\nIn case you want to manage the resource again, you will have to import it.", n.Addr),
 				})
-				change = n.planForget(evalCtx, state, n.DeposedKey)
+				change = n.planForget(ctx, evalCtx, state, n.DeposedKey)
 			}
 		} else {
-			change, planDiags = n.planDestroy(evalCtx, state, n.DeposedKey)
+			change, planDiags = n.planDestroy(ctx, evalCtx, state, n.DeposedKey)
 		}
 
 		diags = diags.Append(planDiags)
@@ -202,16 +202,16 @@ func (n *NodePlanDeposedResourceInstanceObject) Execute(ctx context.Context, eva
 		// now just need to get the deposed object destroyed, because there
 		// should be a new object already serving as its replacement.
 
-		diags = diags.Append(n.writeChange(evalCtx, change, n.DeposedKey))
+		diags = diags.Append(n.writeChange(ctx, evalCtx, change, n.DeposedKey))
 		if diags.HasErrors() {
 			return diags
 		}
 
-		diags = diags.Append(n.writeResourceInstanceStateDeposed(evalCtx, n.DeposedKey, nil, workingState))
+		diags = diags.Append(n.writeResourceInstanceStateDeposed(ctx, evalCtx, n.DeposedKey, nil, workingState))
 	} else {
 		// The working state should at least be updated with the result
 		// of upgrading and refreshing from above.
-		diags = diags.Append(n.writeResourceInstanceStateDeposed(evalCtx, n.DeposedKey, state, workingState))
+		diags = diags.Append(n.writeResourceInstanceStateDeposed(ctx, evalCtx, n.DeposedKey, state, workingState))
 	}
 
 	return diags
@@ -284,7 +284,7 @@ func (n *NodeDestroyDeposedResourceInstanceObject) ModifyCreateBeforeDestroy(v b
 }
 
 // GraphNodeExecutable impl.
-func (n *NodeDestroyDeposedResourceInstanceObject) Execute(_ context.Context, evalCtx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *NodeDestroyDeposedResourceInstanceObject) Execute(ctx context.Context, evalCtx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	var change *plans.ResourceInstanceChange
 
 	diags = n.resolveProvider(evalCtx, false, n.DeposedKey)
@@ -293,7 +293,7 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(_ context.Context, ev
 	}
 
 	// Read the state for the deposed resource instance
-	state, err := n.readResourceInstanceStateDeposed(evalCtx, n.Addr, n.DeposedKey)
+	state, err := n.readResourceInstanceStateDeposed(ctx, evalCtx, n.Addr, n.DeposedKey)
 	if err != nil {
 		return diags.Append(err)
 	}
@@ -303,7 +303,7 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(_ context.Context, ev
 		return diags
 	}
 
-	change, destroyPlanDiags := n.planDestroy(evalCtx, state, n.DeposedKey)
+	change, destroyPlanDiags := n.planDestroy(ctx, evalCtx, state, n.DeposedKey)
 	diags = diags.Append(destroyPlanDiags)
 	if diags.HasErrors() {
 		return diags
@@ -316,14 +316,14 @@ func (n *NodeDestroyDeposedResourceInstanceObject) Execute(_ context.Context, ev
 	}
 
 	// we pass a nil configuration to apply because we are destroying
-	state, applyDiags := n.apply(evalCtx, state, change, nil, instances.RepetitionData{}, false)
+	state, applyDiags := n.apply(ctx, evalCtx, state, change, nil, instances.RepetitionData{}, false)
 	diags = diags.Append(applyDiags)
 	// don't return immediately on errors, we need to handle the state
 
 	// Always write the resource back to the state deposed. If it
 	// was successfully destroyed it will be pruned. If it was not, it will
 	// be caught on the next run.
-	writeDiags := n.writeResourceInstanceState(evalCtx, state)
+	writeDiags := n.writeResourceInstanceState(ctx, evalCtx, state)
 	diags.Append(writeDiags)
 	if diags.HasErrors() {
 		return diags
@@ -356,7 +356,7 @@ func (n *graphNodeDeposer) SetPreallocatedDeposedKey(key states.DeposedKey) {
 	n.PreallocatedDeposedKey = key
 }
 
-func (n *NodeDestroyDeposedResourceInstanceObject) writeResourceInstanceState(evalCtx EvalContext, obj *states.ResourceInstanceObject) error {
+func (n *NodeDestroyDeposedResourceInstanceObject) writeResourceInstanceState(ctx context.Context, evalCtx EvalContext, obj *states.ResourceInstanceObject) error {
 	absAddr := n.Addr
 	key := n.DeposedKey
 	state := evalCtx.State()
@@ -373,7 +373,7 @@ func (n *NodeDestroyDeposedResourceInstanceObject) writeResourceInstanceState(ev
 		return nil
 	}
 
-	_, providerSchema, err := getProvider(evalCtx, n.ResolvedProvider.ProviderConfig, n.ResolvedProviderKey)
+	_, providerSchema, err := getProvider(ctx, evalCtx, n.ResolvedProvider.ProviderConfig, n.ResolvedProviderKey)
 	if err != nil {
 		return err
 	}
@@ -438,14 +438,14 @@ func (n *NodeForgetDeposedResourceInstanceObject) References() []*addrs.Referenc
 }
 
 // GraphNodeExecutable impl.
-func (n *NodeForgetDeposedResourceInstanceObject) Execute(_ context.Context, evalCtx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *NodeForgetDeposedResourceInstanceObject) Execute(ctx context.Context, evalCtx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	diags = n.resolveProvider(evalCtx, false, n.DeposedKey)
 	if diags.HasErrors() {
 		return diags
 	}
 
 	// Read the state for the deposed resource instance
-	state, err := n.readResourceInstanceStateDeposed(evalCtx, n.Addr, n.DeposedKey)
+	state, err := n.readResourceInstanceStateDeposed(ctx, evalCtx, n.Addr, n.DeposedKey)
 	if err != nil {
 		return diags.Append(err)
 	}

--- a/internal/tofu/node_resource_deposed.go
+++ b/internal/tofu/node_resource_deposed.go
@@ -356,10 +356,10 @@ func (n *graphNodeDeposer) SetPreallocatedDeposedKey(key states.DeposedKey) {
 	n.PreallocatedDeposedKey = key
 }
 
-func (n *NodeDestroyDeposedResourceInstanceObject) writeResourceInstanceState(ctx EvalContext, obj *states.ResourceInstanceObject) error {
+func (n *NodeDestroyDeposedResourceInstanceObject) writeResourceInstanceState(evalCtx EvalContext, obj *states.ResourceInstanceObject) error {
 	absAddr := n.Addr
 	key := n.DeposedKey
-	state := ctx.State()
+	state := evalCtx.State()
 
 	if key == states.NotDeposed {
 		// should never happen
@@ -373,7 +373,7 @@ func (n *NodeDestroyDeposedResourceInstanceObject) writeResourceInstanceState(ct
 		return nil
 	}
 
-	_, providerSchema, err := getProvider(ctx, n.ResolvedProvider.ProviderConfig, n.ResolvedProviderKey)
+	_, providerSchema, err := getProvider(evalCtx, n.ResolvedProvider.ProviderConfig, n.ResolvedProviderKey)
 	if err != nil {
 		return err
 	}

--- a/internal/tofu/node_resource_deposed_test.go
+++ b/internal/tofu/node_resource_deposed_test.go
@@ -255,9 +255,9 @@ func TestNodeDestroyDeposedResourceInstanceObject_Execute(t *testing.T) {
 
 func TestNodeDestroyDeposedResourceInstanceObject_WriteResourceInstanceState(t *testing.T) {
 	state := states.NewState()
-	ctx := new(MockEvalContext)
-	ctx.StateState = state.SyncWrapper()
-	ctx.PathPath = addrs.RootModuleInstance
+	evalCtx := new(MockEvalContext)
+	evalCtx.StateState = state.SyncWrapper()
+	evalCtx.PathPath = addrs.RootModuleInstance
 	mockProvider := mockProviderWithResourceTypeSchema("aws_instance", &configschema.Block{
 		Attributes: map[string]*configschema.Attribute{
 			"id": {
@@ -266,8 +266,8 @@ func TestNodeDestroyDeposedResourceInstanceObject_WriteResourceInstanceState(t *
 			},
 		},
 	})
-	ctx.ProviderProvider = mockProvider
-	ctx.ProviderSchemaSchema = mockProvider.GetProviderSchema()
+	evalCtx.ProviderProvider = mockProvider
+	evalCtx.ProviderSchemaSchema = mockProvider.GetProviderSchema()
 
 	obj := &states.ResourceInstanceObject{
 		Value: cty.ObjectVal(map[string]cty.Value{
@@ -284,7 +284,7 @@ func TestNodeDestroyDeposedResourceInstanceObject_WriteResourceInstanceState(t *
 		},
 		DeposedKey: states.NewDeposedKey(),
 	}
-	err := node.writeResourceInstanceState(ctx, obj)
+	err := node.writeResourceInstanceState(t.Context(), evalCtx, obj)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err.Error())
 	}

--- a/internal/tofu/node_resource_forget.go
+++ b/internal/tofu/node_resource_forget.go
@@ -45,7 +45,7 @@ func (n *NodeForgetResourceInstance) Name() string {
 }
 
 // GraphNodeExecutable
-func (n *NodeForgetResourceInstance) Execute(_ context.Context, evalCtx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *NodeForgetResourceInstance) Execute(ctx context.Context, evalCtx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	addr := n.ResourceInstanceAddr()
 
 	// Get our state
@@ -61,7 +61,7 @@ func (n *NodeForgetResourceInstance) Execute(_ context.Context, evalCtx EvalCont
 
 	var state *states.ResourceInstanceObject
 
-	state, readDiags := n.readResourceInstanceState(evalCtx, addr)
+	state, readDiags := n.readResourceInstanceState(ctx, evalCtx, addr)
 	diags = diags.Append(readDiags)
 	if diags.HasErrors() {
 		return diags

--- a/internal/tofu/node_resource_import.go
+++ b/internal/tofu/node_resource_import.go
@@ -145,10 +145,10 @@ func (n *graphNodeImportState) Execute(_ context.Context, evalCtx EvalContext, o
 // and state inserts we need to do for our import state. Since they're new
 // resources they don't depend on anything else and refreshes are isolated
 // so this is nearly a perfect use case for dynamic expand.
-func (n *graphNodeImportState) DynamicExpand(ctx EvalContext) (*Graph, error) {
+func (n *graphNodeImportState) DynamicExpand(evalCtx EvalContext) (*Graph, error) {
 	var diags tfdiags.Diagnostics
 
-	g := &Graph{Path: ctx.Path()}
+	g := &Graph{Path: evalCtx.Path()}
 
 	// nameCounter is used to de-dup names in the state.
 	nameCounter := make(map[string]int)
@@ -177,7 +177,7 @@ func (n *graphNodeImportState) DynamicExpand(ctx EvalContext) (*Graph, error) {
 	}
 
 	// Verify that all the addresses are clear
-	state := ctx.State()
+	state := evalCtx.State()
 	for _, addr := range addrs {
 		existing := state.ResourceInstance(addr)
 		if existing != nil {

--- a/internal/tofu/node_resource_import.go
+++ b/internal/tofu/node_resource_import.go
@@ -76,7 +76,7 @@ func (n *graphNodeImportState) ModulePath() addrs.Module {
 }
 
 // GraphNodeExecutable impl.
-func (n *graphNodeImportState) Execute(_ context.Context, evalCtx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *graphNodeImportState) Execute(ctx context.Context, evalCtx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	// Reset our states
 	n.states = nil
 
@@ -100,7 +100,7 @@ func (n *graphNodeImportState) Execute(_ context.Context, evalCtx EvalContext, o
 	n.ResolvedProviderKey = asAbsNode.ResolvedProviderKey
 	log.Printf("[TRACE] graphNodeImportState: importing using %s", n.ResolvedProvider.ProviderConfig.InstanceString(n.ResolvedProviderKey))
 
-	provider, _, err := getProvider(evalCtx, n.ResolvedProvider.ProviderConfig, n.ResolvedProviderKey)
+	provider, _, err := getProvider(ctx, evalCtx, n.ResolvedProvider.ProviderConfig, n.ResolvedProviderKey)
 	diags = diags.Append(err)
 	if diags.HasErrors() {
 		return diags
@@ -244,7 +244,7 @@ func (n *graphNodeImportStateSub) Path() addrs.ModuleInstance {
 }
 
 // GraphNodeExecutable impl.
-func (n *graphNodeImportStateSub) Execute(_ context.Context, evalCtx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *graphNodeImportStateSub) Execute(ctx context.Context, evalCtx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	// If the Ephemeral type isn't set, then it is an error
 	if n.State.TypeName == "" {
 		diags = diags.Append(fmt.Errorf("import of %s didn't set type", n.TargetAddr.String()))
@@ -261,7 +261,7 @@ func (n *graphNodeImportStateSub) Execute(_ context.Context, evalCtx EvalContext
 		},
 		ResolvedProviderKey: n.ResolvedProviderKey,
 	}
-	state, refreshDiags := riNode.refresh(evalCtx, states.NotDeposed, state)
+	state, refreshDiags := riNode.refresh(ctx, evalCtx, states.NotDeposed, state)
 	diags = diags.Append(refreshDiags)
 	if diags.HasErrors() {
 		return diags
@@ -297,6 +297,6 @@ func (n *graphNodeImportStateSub) Execute(_ context.Context, evalCtx EvalContext
 		state.Value = state.Value.MarkWithPaths(combined)
 	}
 
-	diags = diags.Append(riNode.writeResourceInstanceState(evalCtx, state, workingState))
+	diags = diags.Append(riNode.writeResourceInstanceState(ctx, evalCtx, state, workingState))
 	return diags
 }

--- a/internal/tofu/node_resource_plan.go
+++ b/internal/tofu/node_resource_plan.go
@@ -178,7 +178,7 @@ func (n *nodeExpandPlannableResource) DynamicExpand(evalCtx EvalContext) (*Graph
 	instAddrs := addrs.MakeSet[addrs.Checkable]()
 	for _, module := range moduleInstances {
 		resAddr := n.Addr.Resource.Absolute(module)
-		err := n.expandResourceInstances(evalCtx, resAddr, &g, instAddrs)
+		err := n.expandResourceInstances(context.TODO(), evalCtx, resAddr, &g, instAddrs)
 		diags = diags.Append(err)
 	}
 	if diags.HasErrors() {
@@ -211,7 +211,7 @@ func (n *nodeExpandPlannableResource) DynamicExpand(evalCtx EvalContext) (*Graph
 // within, the caller must register the final superset instAddrs with the
 // checks subsystem so that it knows the fully expanded set of checkable
 // object instances for this resource instance.
-func (n *nodeExpandPlannableResource) expandResourceInstances(globalCtx EvalContext, resAddr addrs.AbsResource, g *Graph, instAddrs addrs.Set[addrs.Checkable]) error {
+func (n *nodeExpandPlannableResource) expandResourceInstances(ctx context.Context, globalCtx EvalContext, resAddr addrs.AbsResource, g *Graph, instAddrs addrs.Set[addrs.Checkable]) error {
 	var diags tfdiags.Diagnostics
 
 	// The rest of our work here needs to know which module instance it's
@@ -306,7 +306,7 @@ func (n *nodeExpandPlannableResource) expandResourceInstances(globalCtx EvalCont
 	// construct a subgraph just for this individual modules's instances and
 	// then we'll steal all of its nodes and edges to incorporate into our
 	// main graph which contains all of the resource instances together.
-	instG, err := n.resourceInstanceSubgraph(moduleCtx, resAddr, instanceAddrs)
+	instG, err := n.resourceInstanceSubgraph(ctx, moduleCtx, resAddr, instanceAddrs)
 	if err != nil {
 		diags = diags.Append(err)
 		return diags.ErrWithWarnings()
@@ -316,7 +316,7 @@ func (n *nodeExpandPlannableResource) expandResourceInstances(globalCtx EvalCont
 	return diags.ErrWithWarnings()
 }
 
-func (n *nodeExpandPlannableResource) resourceInstanceSubgraph(evalCtx EvalContext, addr addrs.AbsResource, instanceAddrs []addrs.AbsResourceInstance) (*Graph, error) {
+func (n *nodeExpandPlannableResource) resourceInstanceSubgraph(ctx context.Context, evalCtx EvalContext, addr addrs.AbsResource, instanceAddrs []addrs.AbsResourceInstance) (*Graph, error) {
 	var diags tfdiags.Diagnostics
 
 	var commandLineImportTargets []CommandLineImportTarget

--- a/internal/tofu/node_resource_plan_destroy.go
+++ b/internal/tofu/node_resource_plan_destroy.go
@@ -86,7 +86,7 @@ func (n *NodePlanDestroyableResourceInstance) Execute(ctx context.Context, evalC
 	return diags
 }
 
-func (n *NodePlanDestroyableResourceInstance) managedResourceExecute(_ context.Context, evalCtx EvalContext, _ walkOperation) (diags tfdiags.Diagnostics) {
+func (n *NodePlanDestroyableResourceInstance) managedResourceExecute(ctx context.Context, evalCtx EvalContext, _ walkOperation) (diags tfdiags.Diagnostics) {
 	addr := n.ResourceInstanceAddr()
 
 	// Declare a bunch of variables that are used for state during
@@ -95,7 +95,7 @@ func (n *NodePlanDestroyableResourceInstance) managedResourceExecute(_ context.C
 	var change *plans.ResourceInstanceChange
 	var state *states.ResourceInstanceObject
 
-	state, err := n.readResourceInstanceState(evalCtx, addr)
+	state, err := n.readResourceInstanceState(ctx, evalCtx, addr)
 	diags = diags.Append(err)
 	if diags.HasErrors() {
 		return diags
@@ -111,23 +111,23 @@ func (n *NodePlanDestroyableResourceInstance) managedResourceExecute(_ context.C
 	// conditionals must agree (be exactly opposite) in order to get the
 	// correct behavior in both cases.
 	if n.skipRefresh {
-		diags = diags.Append(n.writeResourceInstanceState(evalCtx, state, prevRunState))
+		diags = diags.Append(n.writeResourceInstanceState(ctx, evalCtx, state, prevRunState))
 		if diags.HasErrors() {
 			return diags
 		}
-		diags = diags.Append(n.writeResourceInstanceState(evalCtx, state, refreshState))
+		diags = diags.Append(n.writeResourceInstanceState(ctx, evalCtx, state, refreshState))
 		if diags.HasErrors() {
 			return diags
 		}
 	}
 
-	change, destroyPlanDiags := n.planDestroy(evalCtx, state, "")
+	change, destroyPlanDiags := n.planDestroy(ctx, evalCtx, state, "")
 	diags = diags.Append(destroyPlanDiags)
 	if diags.HasErrors() {
 		return diags
 	}
 
-	diags = diags.Append(n.writeChange(evalCtx, change, ""))
+	diags = diags.Append(n.writeChange(ctx, evalCtx, change, ""))
 	if diags.HasErrors() {
 		return diags
 	}
@@ -136,7 +136,7 @@ func (n *NodePlanDestroyableResourceInstance) managedResourceExecute(_ context.C
 	return diags
 }
 
-func (n *NodePlanDestroyableResourceInstance) dataResourceExecute(_ context.Context, evalCtx EvalContext, _ walkOperation) (diags tfdiags.Diagnostics) {
+func (n *NodePlanDestroyableResourceInstance) dataResourceExecute(ctx context.Context, evalCtx EvalContext, _ walkOperation) (diags tfdiags.Diagnostics) {
 
 	// We may not be able to read a prior data source from the state if the
 	// schema was upgraded and we are destroying before ever refreshing that
@@ -152,5 +152,5 @@ func (n *NodePlanDestroyableResourceInstance) dataResourceExecute(_ context.Cont
 		},
 		ProviderAddr: n.ResolvedProvider.ProviderConfig,
 	}
-	return diags.Append(n.writeChange(evalCtx, change, ""))
+	return diags.Append(n.writeChange(ctx, evalCtx, change, ""))
 }

--- a/internal/tofu/node_resource_plan_orphan.go
+++ b/internal/tofu/node_resource_plan_orphan.go
@@ -120,10 +120,10 @@ func (n *NodePlannableResourceInstanceOrphan) dataResourceExecute(_ context.Cont
 	return nil
 }
 
-func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(_ context.Context, evalCtx EvalContext) (diags tfdiags.Diagnostics) {
+func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(ctx context.Context, evalCtx EvalContext) (diags tfdiags.Diagnostics) {
 	addr := n.ResourceInstanceAddr()
 
-	oldState, readDiags := n.readResourceInstanceState(evalCtx, addr)
+	oldState, readDiags := n.readResourceInstanceState(ctx, evalCtx, addr)
 	diags = diags.Append(readDiags)
 	if diags.HasErrors() {
 		return diags
@@ -131,13 +131,13 @@ func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(_ context.C
 
 	// Note any upgrades that readResourceInstanceState might've done in the
 	// prevRunState, so that it'll conform to current schema.
-	diags = diags.Append(n.writeResourceInstanceState(evalCtx, oldState, prevRunState))
+	diags = diags.Append(n.writeResourceInstanceState(ctx, evalCtx, oldState, prevRunState))
 	if diags.HasErrors() {
 		return diags
 	}
 	// Also the refreshState, because that should still reflect schema upgrades
 	// even if not refreshing.
-	diags = diags.Append(n.writeResourceInstanceState(evalCtx, oldState, refreshState))
+	diags = diags.Append(n.writeResourceInstanceState(ctx, evalCtx, oldState, refreshState))
 	if diags.HasErrors() {
 		return diags
 	}
@@ -149,13 +149,13 @@ func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(_ context.C
 		// plan before apply, and may not handle a missing resource during
 		// Delete correctly.  If this is a simple refresh, OpenTofu is
 		// expected to remove the missing resource from the state entirely
-		refreshedState, refreshDiags := n.refresh(evalCtx, states.NotDeposed, oldState)
+		refreshedState, refreshDiags := n.refresh(ctx, evalCtx, states.NotDeposed, oldState)
 		diags = diags.Append(refreshDiags)
 		if diags.HasErrors() {
 			return diags
 		}
 
-		diags = diags.Append(n.writeResourceInstanceState(evalCtx, refreshedState, refreshState))
+		diags = diags.Append(n.writeResourceInstanceState(ctx, evalCtx, refreshedState, refreshState))
 		if diags.HasErrors() {
 			return diags
 		}
@@ -170,7 +170,7 @@ func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(_ context.C
 	// to plan because there is no longer any state and it doesn't exist in the
 	// config.
 	if n.skipPlanChanges || oldState == nil || oldState.Value.IsNull() {
-		return diags.Append(n.writeResourceInstanceState(evalCtx, oldState, workingState))
+		return diags.Append(n.writeResourceInstanceState(ctx, evalCtx, oldState, workingState))
 	}
 
 	var change *plans.ResourceInstanceChange
@@ -188,17 +188,17 @@ func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(_ context.C
 
 	if shouldForget {
 		if shouldDestroy {
-			change, planDiags = n.planDestroy(evalCtx, oldState, "")
+			change, planDiags = n.planDestroy(ctx, evalCtx, oldState, "")
 		} else {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagWarning,
 				Summary:  "Resource going to be removed from the state",
 				Detail:   fmt.Sprintf("After this plan gets applied, the resource %s will not be managed anymore by OpenTofu.\n\nIn case you want to manage the resource again, you will have to import it.", n.Addr),
 			})
-			change = n.planForget(evalCtx, oldState, "")
+			change = n.planForget(ctx, evalCtx, oldState, "")
 		}
 	} else {
-		change, planDiags = n.planDestroy(evalCtx, oldState, "")
+		change, planDiags = n.planDestroy(ctx, evalCtx, oldState, "")
 	}
 
 	diags = diags.Append(planDiags)
@@ -211,7 +211,7 @@ func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(_ context.C
 	// sometimes not have a reason.)
 	change.ActionReason = n.deleteActionReason(evalCtx)
 
-	diags = diags.Append(n.writeChange(evalCtx, change, ""))
+	diags = diags.Append(n.writeChange(ctx, evalCtx, change, ""))
 	if diags.HasErrors() {
 		return diags
 	}
@@ -221,7 +221,7 @@ func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(_ context.C
 		return diags
 	}
 
-	return diags.Append(n.writeResourceInstanceState(evalCtx, nil, workingState))
+	return diags.Append(n.writeResourceInstanceState(ctx, evalCtx, nil, workingState))
 }
 
 func (n *NodePlannableResourceInstanceOrphan) deleteActionReason(evalCtx EvalContext) plans.ResourceInstanceChangeActionReason {

--- a/internal/tofu/node_resource_plan_orphan.go
+++ b/internal/tofu/node_resource_plan_orphan.go
@@ -224,10 +224,10 @@ func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(_ context.C
 	return diags.Append(n.writeResourceInstanceState(evalCtx, nil, workingState))
 }
 
-func (n *NodePlannableResourceInstanceOrphan) deleteActionReason(ctx EvalContext) plans.ResourceInstanceChangeActionReason {
+func (n *NodePlannableResourceInstanceOrphan) deleteActionReason(evalCtx EvalContext) plans.ResourceInstanceChangeActionReason {
 	cfg := n.Config
 	if cfg == nil {
-		if !n.Addr.Equal(n.prevRunAddr(ctx)) {
+		if !n.Addr.Equal(n.prevRunAddr(evalCtx)) {
 			// This means the resource was moved - see also
 			// ResourceInstanceChange.Moved() which calculates
 			// this the same way.
@@ -241,7 +241,7 @@ func (n *NodePlannableResourceInstanceOrphan) deleteActionReason(ctx EvalContext
 	// longer declared then we will have a config (because config isn't
 	// instance-specific) but the expander will know that our resource
 	// address's module path refers to an undeclared module instance.
-	if expander := ctx.InstanceExpander(); expander != nil { // (sometimes nil in MockEvalContext in tests)
+	if expander := evalCtx.InstanceExpander(); expander != nil { // (sometimes nil in MockEvalContext in tests)
 		validModuleAddr := expander.GetDeepestExistingModuleInstance(n.Addr.Module)
 		if len(validModuleAddr) != len(n.Addr.Module) {
 			// If we get here then at least one step in the resource's module
@@ -268,7 +268,7 @@ func (n *NodePlannableResourceInstanceOrphan) deleteActionReason(ctx EvalContext
 			return plans.ResourceInstanceDeleteBecauseWrongRepetition
 		}
 
-		expander := ctx.InstanceExpander()
+		expander := evalCtx.InstanceExpander()
 		if expander == nil {
 			break // only for tests that produce an incomplete MockEvalContext
 		}
@@ -290,7 +290,7 @@ func (n *NodePlannableResourceInstanceOrphan) deleteActionReason(ctx EvalContext
 			return plans.ResourceInstanceDeleteBecauseWrongRepetition
 		}
 
-		expander := ctx.InstanceExpander()
+		expander := evalCtx.InstanceExpander()
 		if expander == nil {
 			break // only for tests that produce an incomplete MockEvalContext
 		}
@@ -311,7 +311,7 @@ func (n *NodePlannableResourceInstanceOrphan) deleteActionReason(ctx EvalContext
 	// If we get here then the instance key type matches the configured
 	// repetition mode, and so we need to consider whether the key itself
 	// is within the range of the repetition construct.
-	if expander := ctx.InstanceExpander(); expander != nil { // (sometimes nil in MockEvalContext in tests)
+	if expander := evalCtx.InstanceExpander(); expander != nil { // (sometimes nil in MockEvalContext in tests)
 		// First we'll check whether our containing module instance still
 		// exists, so we can talk about that differently in the reason.
 		declared := false

--- a/internal/tofu/node_resource_validate.go
+++ b/internal/tofu/node_resource_validate.go
@@ -63,7 +63,7 @@ func (n *NodeValidatableResource) Execute(ctx context.Context, evalCtx EvalConte
 		return diags
 	}
 
-	diags = diags.Append(n.validateResource(evalCtx))
+	diags = diags.Append(n.validateResource(ctx, evalCtx))
 
 	diags = diags.Append(n.validateCheckRules(evalCtx, n.Config))
 
@@ -86,7 +86,7 @@ func (n *NodeValidatableResource) Execute(ctx context.Context, evalCtx EvalConte
 			}
 
 			// Validate Provisioner Config
-			diags = diags.Append(n.validateProvisioner(evalCtx, &provisioner))
+			diags = diags.Append(n.validateProvisioner(ctx, evalCtx, &provisioner))
 			if diags.HasErrors() {
 				return diags
 			}
@@ -98,7 +98,7 @@ func (n *NodeValidatableResource) Execute(ctx context.Context, evalCtx EvalConte
 // validateProvisioner validates the configuration of a provisioner belonging to
 // a resource. The provisioner config is expected to contain the merged
 // connection configurations.
-func (n *NodeValidatableResource) validateProvisioner(evalCtx EvalContext, p *configs.Provisioner) tfdiags.Diagnostics {
+func (n *NodeValidatableResource) validateProvisioner(_ context.Context, evalCtx EvalContext, p *configs.Provisioner) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
 	provisioner, err := evalCtx.Provisioner(p.Type)
@@ -291,10 +291,10 @@ var connectionBlockSupersetSchema = &configschema.Block{
 	},
 }
 
-func (n *NodeValidatableResource) validateResource(evalCtx EvalContext) tfdiags.Diagnostics {
+func (n *NodeValidatableResource) validateResource(ctx context.Context, evalCtx EvalContext) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
-	provider, providerSchema, err := getProvider(evalCtx, n.ResolvedProvider.ProviderConfig, addrs.NoKey) // Provider Instance Keys are ignored during validate
+	provider, providerSchema, err := getProvider(ctx, evalCtx, n.ResolvedProvider.ProviderConfig, addrs.NoKey) // Provider Instance Keys are ignored during validate
 	diags = diags.Append(err)
 	if diags.HasErrors() {
 		return diags

--- a/internal/tofu/node_resource_validate_test.go
+++ b/internal/tofu/node_resource_validate_test.go
@@ -56,7 +56,7 @@ func TestNodeValidatableResource_ValidateProvisioner_valid(t *testing.T) {
 		},
 	}
 
-	diags := node.validateProvisioner(ctx, pc)
+	diags := node.validateProvisioner(t.Context(), ctx, pc)
 	if diags.HasErrors() {
 		t.Fatalf("node.Eval failed: %s", diags.Err())
 	}
@@ -101,7 +101,7 @@ func TestNodeValidatableResource_ValidateProvisioner__warning(t *testing.T) {
 		}
 	}
 
-	diags := node.validateProvisioner(ctx, pc)
+	diags := node.validateProvisioner(t.Context(), ctx, pc)
 	if len(diags) != 1 {
 		t.Fatalf("wrong number of diagnostics in %s; want one warning", diags.ErrWithWarnings())
 	}
@@ -146,7 +146,7 @@ func TestNodeValidatableResource_ValidateProvisioner__connectionInvalid(t *testi
 		},
 	}
 
-	diags := node.validateProvisioner(ctx, pc)
+	diags := node.validateProvisioner(t.Context(), ctx, pc)
 	if !diags.HasErrors() {
 		t.Fatalf("node.Eval succeeded; want error")
 	}
@@ -198,7 +198,7 @@ func TestNodeValidatableResource_ValidateResource_managedResource(t *testing.T) 
 	ctx.ProviderSchemaSchema = mp.GetProviderSchema()
 	ctx.ProviderProvider = p
 
-	err := node.validateResource(ctx)
+	err := node.validateResource(t.Context(), ctx)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -261,7 +261,7 @@ func TestNodeValidatableResource_ValidateResource_managedResourceCount(t *testin
 				},
 			}
 
-			diags := node.validateResource(ctx)
+			diags := node.validateResource(t.Context(), ctx)
 			if diags.HasErrors() {
 				t.Fatalf("err: %s", diags.Err())
 			}
@@ -312,7 +312,7 @@ func TestNodeValidatableResource_ValidateResource_dataSource(t *testing.T) {
 	ctx.ProviderSchemaSchema = mp.GetProviderSchema()
 	ctx.ProviderProvider = p
 
-	diags := node.validateResource(ctx)
+	diags := node.validateResource(t.Context(), ctx)
 	if diags.HasErrors() {
 		t.Fatalf("err: %s", diags.Err())
 	}
@@ -348,7 +348,7 @@ func TestNodeValidatableResource_ValidateResource_valid(t *testing.T) {
 	ctx.ProviderSchemaSchema = mp.GetProviderSchema()
 	ctx.ProviderProvider = p
 
-	diags := node.validateResource(ctx)
+	diags := node.validateResource(t.Context(), ctx)
 	if diags.HasErrors() {
 		t.Fatalf("err: %s", diags.Err())
 	}
@@ -385,7 +385,7 @@ func TestNodeValidatableResource_ValidateResource_warningsAndErrorsPassedThrough
 	ctx.ProviderSchemaSchema = mp.GetProviderSchema()
 	ctx.ProviderProvider = p
 
-	diags := node.validateResource(ctx)
+	diags := node.validateResource(t.Context(), ctx)
 	if !diags.HasErrors() {
 		t.Fatal("unexpected success; want error")
 	}
@@ -448,7 +448,7 @@ func TestNodeValidatableResource_ValidateResource_invalidDependsOn(t *testing.T)
 	ctx.ProviderSchemaSchema = mp.GetProviderSchema()
 	ctx.ProviderProvider = p
 
-	diags := node.validateResource(ctx)
+	diags := node.validateResource(t.Context(), ctx)
 	if diags.HasErrors() {
 		t.Fatalf("error for supposedly-valid config: %s", diags.ErrWithWarnings())
 	}
@@ -469,7 +469,7 @@ func TestNodeValidatableResource_ValidateResource_invalidDependsOn(t *testing.T)
 		},
 	})
 
-	diags = node.validateResource(ctx)
+	diags = node.validateResource(t.Context(), ctx)
 	if !diags.HasErrors() {
 		t.Fatal("no error for invalid depends_on")
 	}
@@ -485,7 +485,7 @@ func TestNodeValidatableResource_ValidateResource_invalidDependsOn(t *testing.T)
 		},
 	})
 
-	diags = node.validateResource(ctx)
+	diags = node.validateResource(t.Context(), ctx)
 	if !diags.HasErrors() {
 		t.Fatal("no error for invalid depends_on")
 	}
@@ -532,7 +532,7 @@ func TestNodeValidatableResource_ValidateResource_invalidIgnoreChangesNonexisten
 	ctx.ProviderSchemaSchema = mp.GetProviderSchema()
 	ctx.ProviderProvider = p
 
-	diags := node.validateResource(ctx)
+	diags := node.validateResource(t.Context(), ctx)
 	if diags.HasErrors() {
 		t.Fatalf("error for supposedly-valid config: %s", diags.ErrWithWarnings())
 	}
@@ -545,7 +545,7 @@ func TestNodeValidatableResource_ValidateResource_invalidIgnoreChangesNonexisten
 		},
 	})
 
-	diags = node.validateResource(ctx)
+	diags = node.validateResource(t.Context(), ctx)
 	if !diags.HasErrors() {
 		t.Fatal("no error for invalid ignore_changes")
 	}
@@ -615,7 +615,7 @@ func TestNodeValidatableResource_ValidateResource_invalidIgnoreChangesComputed(t
 	ctx.ProviderSchemaSchema = mp.GetProviderSchema()
 	ctx.ProviderProvider = p
 
-	diags := node.validateResource(ctx)
+	diags := node.validateResource(t.Context(), ctx)
 	if diags.HasErrors() {
 		t.Fatalf("error for supposedly-valid config: %s", diags.ErrWithWarnings())
 	}
@@ -628,7 +628,7 @@ func TestNodeValidatableResource_ValidateResource_invalidIgnoreChangesComputed(t
 		},
 	})
 
-	diags = node.validateResource(ctx)
+	diags = node.validateResource(t.Context(), ctx)
 	if diags.HasErrors() {
 		t.Fatalf("got unexpected error: %s", diags.ErrWithWarnings())
 	}

--- a/internal/tofu/transform_attach_schema.go
+++ b/internal/tofu/transform_attach_schema.go
@@ -53,7 +53,7 @@ type AttachSchemaTransformer struct {
 	Config  *configs.Config
 }
 
-func (t *AttachSchemaTransformer) Transform(_ context.Context, g *Graph) error {
+func (t *AttachSchemaTransformer) Transform(ctx context.Context, g *Graph) error {
 	if t.Plugins == nil {
 		// Should never happen with a reasonable caller, but we'll return a
 		// proper error here anyway so that we'll fail gracefully.
@@ -69,7 +69,7 @@ func (t *AttachSchemaTransformer) Transform(_ context.Context, g *Graph) error {
 			providerFqn := tv.Provider()
 
 			// TODO: Plumb a useful context.Context through to here.
-			schema, version, err := t.Plugins.ResourceTypeSchema(context.TODO(), providerFqn, mode, typeName)
+			schema, version, err := t.Plugins.ResourceTypeSchema(ctx, providerFqn, mode, typeName)
 			if err != nil {
 				return fmt.Errorf("failed to read schema for %s in %s: %w", addr, providerFqn, err)
 			}
@@ -84,7 +84,7 @@ func (t *AttachSchemaTransformer) Transform(_ context.Context, g *Graph) error {
 		if tv, ok := v.(GraphNodeAttachProviderConfigSchema); ok {
 			providerAddr := tv.ProviderAddr()
 			// TODO: Plumb a useful context.Context through to here.
-			schema, err := t.Plugins.ProviderConfigSchema(context.TODO(), providerAddr.Provider)
+			schema, err := t.Plugins.ProviderConfigSchema(ctx, providerAddr.Provider)
 			if err != nil {
 				return fmt.Errorf("failed to read provider configuration schema for %s: %w", providerAddr.Provider, err)
 			}


### PR DESCRIPTION
The graph node types related to resources and resource instances use a bunch of helper functions in different combinations, rather than calling directly into the provider API.

This changeset plumbs `context.Context` through to the functions that _do_ call methods directly on the provider object, leaving us just one more step away from plumbing the context through to the actual gRPC calls.

The next step (in a future PR) will be to update the `providers.Interface` methods to take `context.Context` arguments and then have the gRPC-based implementations of that interface pass the context through to the gRPC client stub calls, and then we should be pretty close to being able to turn on OTel tracing instrumentation for our gRPC client requests.