### PR TITLE
Adding support for write only attributes parsing from the provider schema

### DIFF
--- a/internal/configs/configschema/schema.go
+++ b/internal/configs/configschema/schema.go
@@ -80,6 +80,8 @@ type Attribute struct {
 	Sensitive bool
 
 	Deprecated bool
+
+	WriteOnly bool
 }
 
 // Object represents the embedding of a structural object inside an Attribute.

--- a/internal/legacy/helper/schema/schema.go
+++ b/internal/legacy/helper/schema/schema.go
@@ -252,6 +252,8 @@ type Schema struct {
 	// secret fields. Future versions of OpenTofu may encrypt these
 	// values.
 	Sensitive bool
+
+	WriteOnly bool
 }
 
 // SchemaConfigMode is used to influence how a schema item is mapped into a

--- a/internal/plans/objchange/plan_valid.go
+++ b/internal/plans/objchange/plan_valid.go
@@ -313,6 +313,9 @@ func assertPlannedValueValid(attrS *configschema.Attribute, priorV, configV, pla
 		return assertPlannedObjectValid(attrS.NestedType, priorV, configV, plannedV, path)
 	}
 
+	if !configV.IsNull() && plannedV.IsNull() && attrS.WriteOnly {
+		return errs // TODO andrei check other places that might need a validation like this
+	}
 	// If none of the above conditions match, the provider has made an invalid
 	// change to this attribute.
 	if priorV.IsNull() {

--- a/internal/plugin/convert/schema.go
+++ b/internal/plugin/convert/schema.go
@@ -120,6 +120,7 @@ func ProtoToConfigSchema(b *proto.Schema_Block) *configschema.Block {
 			Computed:        a.Computed,
 			Sensitive:       a.Sensitive,
 			Deprecated:      a.Deprecated,
+			WriteOnly:       a.WriteOnly,
 		}
 
 		if err := json.Unmarshal(a.Type, &attr.Type); err != nil {

--- a/internal/plugin/convert/schema.go
+++ b/internal/plugin/convert/schema.go
@@ -36,6 +36,7 @@ func ConfigSchemaToProto(b *configschema.Block) *proto.Schema_Block {
 			Required:        a.Required,
 			Sensitive:       a.Sensitive,
 			Deprecated:      a.Deprecated,
+			WriteOnly:       a.WriteOnly,
 		}
 
 		ty, err := json.Marshal(a.Type)

--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -238,6 +238,9 @@ func (p *GRPCProvider) ValidateResourceConfig(r providers.ValidateResourceConfig
 	protoReq := &proto.ValidateResourceTypeConfig_Request{
 		TypeName: r.TypeName,
 		Config:   &proto.DynamicValue{Msgpack: mp},
+		ClientCapabilities: &proto.ClientCapabilities{
+			WriteOnlyAttributesAllowed: true,
+		},
 	}
 
 	protoResp, err := p.client.ValidateResourceTypeConfig(p.ctx, protoReq)
@@ -354,6 +357,9 @@ func (p *GRPCProvider) ConfigureProvider(r providers.ConfigureProviderRequest) (
 		TerraformVersion: r.TerraformVersion,
 		Config: &proto.DynamicValue{
 			Msgpack: mp,
+		},
+		ClientCapabilities: &proto.ClientCapabilities{
+			WriteOnlyAttributesAllowed: true,
 		},
 	}
 

--- a/internal/plugin6/convert/schema.go
+++ b/internal/plugin6/convert/schema.go
@@ -37,6 +37,7 @@ func ConfigSchemaToProto(b *configschema.Block) *proto.Schema_Block {
 			Required:        a.Required,
 			Sensitive:       a.Sensitive,
 			Deprecated:      a.Deprecated,
+			WriteOnly:       a.WriteOnly,
 		}
 
 		if a.Type != cty.NilType {
@@ -125,6 +126,7 @@ func ProtoToConfigSchema(b *proto.Schema_Block) *configschema.Block {
 			Computed:        a.Computed,
 			Sensitive:       a.Sensitive,
 			Deprecated:      a.Deprecated,
+			WriteOnly:       a.WriteOnly,
 		}
 
 		if a.Type != nil {
@@ -215,6 +217,7 @@ func protoObjectToConfigSchema(b *proto.Schema_Object) *configschema.Object {
 			Computed:        a.Computed,
 			Sensitive:       a.Sensitive,
 			Deprecated:      a.Deprecated,
+			WriteOnly:       a.WriteOnly,
 		}
 
 		if a.Type != nil {

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -231,6 +231,9 @@ func (p *GRPCProvider) ValidateResourceConfig(r providers.ValidateResourceConfig
 	protoReq := &proto6.ValidateResourceConfig_Request{
 		TypeName: r.TypeName,
 		Config:   &proto6.DynamicValue{Msgpack: mp},
+		ClientCapabilities: &proto6.ClientCapabilities{
+			WriteOnlyAttributesAllowed: true,
+		},
 	}
 
 	protoResp, err := p.client.ValidateResourceConfig(p.ctx, protoReq)
@@ -343,6 +346,9 @@ func (p *GRPCProvider) ConfigureProvider(r providers.ConfigureProviderRequest) (
 		TerraformVersion: r.TerraformVersion,
 		Config: &proto6.DynamicValue{
 			Msgpack: mp,
+		},
+		ClientCapabilities: &proto6.ClientCapabilities{
+			WriteOnlyAttributesAllowed: true,
 		},
 	}
 


### PR DESCRIPTION
This is adding basic parsing of the writeOnly attributes from the schema from the provider.
From my initial tests this is already working well. We need to test this and ensure that the changes are covering all the edge-cases.

_This is draft for the moment since it was generated from playing around with this and not dug deep enough. Whoever wants to, can continue the work on this._

Part of #2834 

<!-- Please check of ALL items in this list for all PRs: -->

- [ ] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [ ] I have not used an AI coding assistant to create this PR.
- [ ] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [ ] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
