### PR TITLE
Caching of computed resource values from state+changes

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,61 @@
+package cache
+
+import (
+	"sync"
+
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type Eval struct {
+	resourcesLock sync.Mutex
+	resources     map[string]*cacheEntry
+}
+
+func NewEval() *Eval {
+	return &Eval{
+		resources: map[string]*cacheEntry{},
+	}
+}
+
+type cacheEntry struct {
+	sync.Mutex
+
+	populated bool
+	value     cty.Value
+	diags     tfdiags.Diagnostics
+}
+
+func (e *Eval) Resource(addr addrs.AbsResource, populate func() (cty.Value, tfdiags.Diagnostics)) (cty.Value, tfdiags.Diagnostics) {
+	key := addr.String()
+
+	e.resourcesLock.Lock()
+	entry, ok := e.resources[key]
+	if !ok {
+		entry = &cacheEntry{populated: false}
+		e.resources[key] = entry
+	}
+	e.resourcesLock.Unlock()
+
+	entry.Lock()
+	defer entry.Unlock()
+	if !entry.populated {
+		entry.value, entry.diags = populate()
+		entry.populated = true
+	}
+
+	return entry.value, entry.diags
+}
+
+func (e *Eval) EvictResource(addr addrs.AbsResource) {
+	key := addr.String()
+
+	e.resourcesLock.Lock()
+	defer e.resourcesLock.Unlock()
+
+	entry, ok := e.resources[key]
+	if ok {
+		entry.populated = false
+	}
+}

--- a/internal/tofu/graph_walk_context.go
+++ b/internal/tofu/graph_walk_context.go
@@ -13,6 +13,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/cache"
 	"github.com/opentofu/opentofu/internal/checks"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/encryption"
@@ -32,11 +33,12 @@ type ContextGraphWalker struct {
 
 	// Configurable values
 	Context                 *Context
-	State                   *states.SyncState       // Used for safe concurrent access to state
-	RefreshState            *states.SyncState       // Used for safe concurrent access to state
-	PrevRunState            *states.SyncState       // Used for safe concurrent access to state
-	Changes                 *plans.ChangesSync      // Used for safe concurrent writes to changes
-	Checks                  *checks.State           // Used for safe concurrent writes of checkable objects and their check results
+	State                   *states.SyncState  // Used for safe concurrent access to state
+	RefreshState            *states.SyncState  // Used for safe concurrent access to state
+	PrevRunState            *states.SyncState  // Used for safe concurrent access to state
+	Changes                 *plans.ChangesSync // Used for safe concurrent writes to changes
+	Checks                  *checks.State      // Used for safe concurrent writes of checkable objects and their check results
+	EvalCache               *cache.Eval
 	InstanceExpander        *instances.Expander     // Tracks our gradual expansion of module and resource instances
 	ImportResolver          *ImportResolver         // Tracks import targets as they are being resolved
 	MoveResults             refactoring.MoveResults // Read-only record of earlier processing of move statements
@@ -95,6 +97,7 @@ func (w *ContextGraphWalker) EvalContext() EvalContext {
 		Operation:          w.Operation,
 		State:              w.State,
 		Changes:            w.Changes,
+		EvalCache:          w.EvalCache,
 		Plugins:            w.Context.plugins,
 		VariableValues:     w.variableValues,
 		VariableValuesLock: &w.variableValuesLock,

--- a/internal/tofu/test_context.go
+++ b/internal/tofu/test_context.go
@@ -16,6 +16,7 @@ import (
 	"github.com/zclconf/go-cty/cty/function"
 
 	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/cache"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/lang"
 	"github.com/opentofu/opentofu/internal/lang/marks"
@@ -78,14 +79,17 @@ func (ctx *TestContext) evaluate(state *states.SyncState, changes *plans.Changes
 		state = synchronizeStates(ctx.State, ctx.Plan.PlannedState)
 	}
 
+	evalCache := cache.NewEval()
+
 	data := &evaluationStateData{
 		Evaluator: &Evaluator{
 			Operation: operation,
 			Meta:      ctx.meta,
 			Config:    ctx.Config,
 			Plugins:   ctx.plugins,
-			State:     state,
-			Changes:   changes,
+			State:     state.WithCache(evalCache),
+			EvalCache: evalCache,
+			Changes:   changes.WithCache(evalCache),
 			VariableValues: func() map[string]map[string]cty.Value {
 				variables := map[string]map[string]cty.Value{
 					addrs.RootModule.String(): make(map[string]cty.Value),


### PR DESCRIPTION
This adds a cache for resource values that is evicted by changes to state or plan sync objects.  In theory the eviction is not needed, but there are hints from tests that the current architecture requires it.

Before:
```
goos: linux
goarch: amd64
pkg: github.com/opentofu/opentofu/internal/tofu
cpu: AMD Ryzen 7 2700X Eight-Core Processor         
BenchmarkManyResourceInstances-16              3        13771574147 ns/op
PASS
ok      github.com/opentofu/opentofu/internal/tofu      91.263s
```
After:
```
goos: linux
goarch: amd64
pkg: github.com/opentofu/opentofu/internal/tofu
cpu: AMD Ryzen 7 2700X Eight-Core Processor         
BenchmarkManyResourceInstances-16              5        6983208774 ns/op
PASS
ok      github.com/opentofu/opentofu/internal/tofu      78.373s
```

This is not as dramatic as the first PR, but still has a substantial impact in many workloads.

TODO:
* Experiment with a more granular instance cache suggested by @apparentlymart

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
