### PR TITLE
Allow end-users to set OTEL_SERVICE_NAME

### DIFF
--- a/internal/tracing/init.go
+++ b/internal/tracing/init.go
@@ -51,6 +51,12 @@ const traceParentEnvVar = "TRACEPARENT"
 // trace state to use.
 const traceStateEnvVar = "TRACESTATE"
 
+// ServiceNameEnvVar is the standard OpenTelemetry environment variable for specifying the service name
+const ServiceNameEnvVar = "OTEL_SERVICE_NAME"
+
+// DefaultServiceName is the default service name to use if not specified in the environment
+const DefaultServiceName = "OpenTofu CLI"
+
 // isTracingEnabled is true if OpenTelemetry is enabled.
 var isTracingEnabled bool
 
@@ -91,6 +97,13 @@ func OpenTelemetryInit(ctx context.Context) (context.Context, error) {
 
 	log.Printf("[TRACE] OpenTelemetry: enabled")
 
+	// Get service name from environment variable or use default
+	serviceName := DefaultServiceName
+	if envServiceName := os.Getenv(ServiceNameEnvVar); envServiceName != "" {
+		log.Printf("[TRACE] OpenTelemetry: using service name from %s: %s", ServiceNameEnvVar, envServiceName)
+		serviceName = envServiceName
+	}
+
 	otelResource, err := resource.New(context.Background(),
 		// Use built-in detectors to simplify the collation of the racing information
 		resource.WithOS(),
@@ -101,7 +114,7 @@ func OpenTelemetryInit(ctx context.Context) (context.Context, error) {
 
 		// Add custom service attributes
 		resource.WithAttributes(
-			semconv.ServiceName("OpenTofu CLI"),
+			semconv.ServiceName(serviceName),
 			semconv.ServiceVersion(version.Version),
 
 			// We add in the telemetry SDK information so that we don't end up with


### PR DESCRIPTION
There are situations where the service name may want to be overwritten by the end-user. This commit allows the user to set the service name via the environment variable OTEL_SERVICE_NAME. This is useful for testing and debugging purposes, but also to help identify in what context tofu is running. For example in github actions you may want to set the service name to "github-actions-tofu" to help identify the run.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.