### PR TITLE
Add support for the ephemeral resources pre and postcondition evaluation

### DIFF
--- a/internal/checks/state_init.go
+++ b/internal/checks/state_init.go
@@ -35,6 +35,10 @@ func collectInitialStatuses(into addrs.Map[addrs.ConfigCheckable, *configCheckab
 		addr := rc.Addr().InModule(moduleAddr)
 		collectInitialStatusForResource(into, addr, rc)
 	}
+	for _, rc := range cfg.Module.EphemeralResources {
+		addr := rc.Addr().InModule(moduleAddr)
+		collectInitialStatusForResource(into, addr, rc)
+	}
 
 	for _, oc := range cfg.Module.Outputs {
 		addr := oc.Addr().InModule(moduleAddr)

--- a/internal/checks/testdata/happypath/child/checks-happypath-child.tf
+++ b/internal/checks/testdata/happypath/child/checks-happypath-child.tf
@@ -1,3 +1,11 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.81.0"
+    }
+  }
+}
 resource "null_resource" "b" {
   lifecycle {
     precondition {
@@ -18,6 +26,27 @@ resource "null_resource" "c" {
   }
 }
 
+data "aws_s3_object" "foo" {
+  lifecycle {
+    precondition {
+      condition     = self.id == ""
+      error_message = "Impossible data."
+    }
+  }
+  bucket = "test-bucket"
+  key    = "test-key"
+}
+
+ephemeral "aws_secretsmanager_secret_version" "bar" {
+  lifecycle {
+    precondition {
+      condition     = self.id == ""
+      error_message = "Impossible ephemeral."
+    }
+  }
+  secret_id = "secret-manager-id"
+}
+
 output "b" {
   value = null_resource.b.id
 
@@ -26,4 +55,3 @@ output "b" {
     error_message = "B has no id."
   }
 }
-


### PR DESCRIPTION
Part of #2834

This is adding support for precondition and postcondition evaluation for ephemeral resources.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [ ] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [ ] I have not used an AI coding assistant to create this PR.
- [ ] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [ ] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
