### PR TITLE
[Govulncheck] Fix the command that checks for duplicated reports

### DIFF
--- a/.github/scripts/govulncheck-submit-issues.sh
+++ b/.github/scripts/govulncheck-submit-issues.sh
@@ -46,7 +46,7 @@ do
   affected_versions="$(echo ${vuln} | jq -r '.value[]' | xargs)"
   ticket_title="${vuln_key} reported"
 
-  reported_issues="$(gh issue -R opentofu/opentofu list --search "\"${ticket_title}\"" --json number)"
+  reported_issues="$(gh issue -R opentofu/opentofu list --search "\"${ticket_title}\"" --state "all" --json number)"
   no_of_issues="$(echo ${reported_issues} | jq -r '. | length')"
   reported_issues="$(echo $reported_issues| jq -r '.[] | .number' | xargs)"
   [[ ${no_of_issues} -ge 1 ]] && echo "Vulnerabilties found but already reported for ${vuln_key} in: ${reported_issues}" && continue


### PR DESCRIPTION
In order to not report the same vulnerabilities multiple times, we want to check for closed issues too. There are some issues that are well known and will not be fixed since those are not directly affecting OpenTofu and their users.
Therefore, this PR is fixing the way we are checking for the already reported and solved issues.

There is no issue linked to this, this fix is only a response to the duplicated reports from yesterday:
* #2856
* #2857
* #2858
* #2859

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
