### PR TITLE
Ephemeral attributes in variables and outputs cfg

### DIFF
--- a/internal/configs/config_test.go
+++ b/internal/configs/config_test.go
@@ -232,6 +232,16 @@ func TestConfigProviderRequirements(t *testing.T) {
 	}
 }
 
+func TestRootModuleWithEphemeralOutput(t *testing.T) {
+	t.Chdir("testdata/ephemeral-outputs")
+	cfg, diags := testNestedModuleConfigFromDir(t, ".")
+	assertDiagnosticCount(t, diags, 1)
+	assertDiagnosticSummary(t, diags, "Invalid output configuration")
+	if len(cfg.Module.Outputs) != 1 {
+		t.Errorf("wrong number of outputs returned")
+	}
+}
+
 func TestConfigProviderRequirementsInclTests(t *testing.T) {
 	cfg, diags := testNestedModuleConfigFromDirWithTests(t, "testdata/provider-reqs-with-tests")
 	// TODO: Version Constraint Deprecation.

--- a/internal/configs/module.go
+++ b/internal/configs/module.go
@@ -409,6 +409,14 @@ func (m *Module) appendFile(file *File) hcl.Diagnostics {
 				Subject:  &o.DeclRange,
 			})
 		}
+		if o.Ephemeral && m.SourceDir == "." {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid output configuration",
+				Detail:   "Root modules are not allowed to have outputs defined as ephemeral",
+				Subject:  &o.DeclRange,
+			})
+		}
 		m.Outputs[o.Name] = o
 	}
 

--- a/internal/configs/module_merge.go
+++ b/internal/configs/module_merge.go
@@ -54,6 +54,10 @@ func (v *Variable) merge(ov *Variable) hcl.Diagnostics {
 	if ov.Deprecated != "" {
 		v.Deprecated = ov.Deprecated
 	}
+	if ov.EphemeralSet {
+		v.EphemeralSet = ov.EphemeralSet
+		v.Ephemeral = ov.Ephemeral
+	}
 	if ov.Default != cty.NilVal {
 		v.Default = ov.Default
 	}
@@ -155,6 +159,10 @@ func (o *Output) merge(oo *Output) hcl.Diagnostics {
 	}
 	if oo.Deprecated != "" {
 		o.Deprecated = oo.Deprecated
+	}
+	if oo.EphemeralSet {
+		o.EphemeralSet = oo.EphemeralSet
+		o.Ephemeral = oo.Ephemeral
 	}
 
 	// We don't allow depends_on to be overridden because that is likely to

--- a/internal/configs/module_merge_test.go
+++ b/internal/configs/module_merge_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -33,6 +34,8 @@ func TestModuleOverrideVariable(t *testing.T) {
 			Deprecated:     "b_override deprecated",
 			Nullable:       false,
 			NullableSet:    true,
+			Ephemeral:      false,
+			EphemeralSet:   true,
 			Type:           cty.String,
 			ConstraintType: cty.String,
 			ParsingMode:    VariableParseLiteral,
@@ -72,6 +75,125 @@ func TestModuleOverrideVariable(t *testing.T) {
 					Line:   7,
 					Column: 32,
 					Byte:   134,
+				},
+			},
+		},
+	}
+	assertResultDeepEqual(t, got, want)
+}
+
+func TestModuleOverrideOutput(t *testing.T) {
+	mod, diags := testModuleFromDir("testdata/valid-modules/override-output")
+	assertNoDiagnostics(t, diags)
+	if mod == nil {
+		t.Fatalf("module is nil")
+	}
+
+	got := mod.Outputs
+	want := map[string]*Output{
+		"fully_overridden": {
+			Name:           "fully_overridden",
+			Description:    "b_override description",
+			DescriptionSet: true,
+			Expr: &hclsyntax.TemplateExpr{
+				Parts: []hclsyntax.Expression{
+					&hclsyntax.LiteralValueExpr{
+						Val: cty.StringVal("b_override"),
+						SrcRange: hcl.Range{
+							Filename: "testdata/valid-modules/override-output/b_override.tf",
+							Start: hcl.Pos{
+								Line:   2,
+								Column: 12,
+								Byte:   39,
+							},
+							End: hcl.Pos{
+								Line:   2,
+								Column: 22,
+								Byte:   49,
+							},
+						},
+					},
+				},
+				SrcRange: hcl.Range{
+					Filename: "testdata/valid-modules/override-output/b_override.tf",
+					Start: hcl.Pos{
+						Line:   2,
+						Column: 11,
+						Byte:   38,
+					},
+					End: hcl.Pos{
+						Line:   2,
+						Column: 23,
+						Byte:   50,
+					},
+				},
+			},
+			Deprecated:   "b_override deprecated",
+			Ephemeral:    false,
+			EphemeralSet: true,
+			DeclRange: hcl.Range{
+				Filename: filepath.FromSlash("testdata/valid-modules/override-output/primary.tf"),
+				Start: hcl.Pos{
+					Line:   1,
+					Column: 1,
+					Byte:   0,
+				},
+				End: hcl.Pos{
+					Line:   1,
+					Column: 26,
+					Byte:   25,
+				},
+			},
+		},
+		"partially_overridden": {
+			Name:           "partially_overridden",
+			Description:    "base description",
+			DescriptionSet: true,
+			Expr: &hclsyntax.TemplateExpr{
+				Parts: []hclsyntax.Expression{
+					&hclsyntax.LiteralValueExpr{
+						Val: cty.StringVal("b_override partial"),
+						SrcRange: hcl.Range{
+							Filename: "testdata/valid-modules/override-output/b_override.tf",
+							Start: hcl.Pos{
+								Line:   9,
+								Column: 12,
+								Byte:   197,
+							},
+							End: hcl.Pos{
+								Line:   9,
+								Column: 30,
+								Byte:   215,
+							},
+						},
+					},
+				},
+				SrcRange: hcl.Range{
+					Filename: "testdata/valid-modules/override-output/b_override.tf",
+					Start: hcl.Pos{
+						Line:   9,
+						Column: 11,
+						Byte:   196,
+					},
+					End: hcl.Pos{
+						Line:   9,
+						Column: 31,
+						Byte:   216,
+					},
+				},
+			},
+			Deprecated: "b_override deprecated",
+			DeclRange: hcl.Range{
+				Filename: filepath.FromSlash("testdata/valid-modules/override-output/primary.tf"),
+				Start: hcl.Pos{
+					Line:   6,
+					Column: 1,
+					Byte:   83,
+				},
+				End: hcl.Pos{
+					Line:   6,
+					Column: 30,
+					Byte:   112,
 				},
 			},
 		},

--- a/internal/configs/named_values.go
+++ b/internal/configs/named_values.go
@@ -40,9 +40,11 @@ type Variable struct {
 	Validations []*CheckRule
 	Sensitive   bool
 	Deprecated  string
+	Ephemeral   bool
 
 	DescriptionSet bool
 	SensitiveSet   bool
+	EphemeralSet   bool
 
 	// Nullable indicates that null is a valid value for this variable. Setting
 	// Nullable to false means that the module can expect this variable to
@@ -136,6 +138,12 @@ func decodeVariableBlock(block *hcl.Block, override bool) (*Variable, hcl.Diagno
 				Subject:  &block.LabelRanges[0],
 			})
 		}
+	}
+
+	if attr, exists := content.Attributes["ephemeral"]; exists {
+		valDiags := gohcl.DecodeExpression(attr.Expr, nil, &v.Ephemeral)
+		diags = append(diags, valDiags...)
+		v.EphemeralSet = true
 	}
 
 	if attr, exists := content.Attributes["nullable"]; exists {
@@ -418,11 +426,13 @@ type Output struct {
 	DependsOn   []hcl.Traversal
 	Sensitive   bool
 	Deprecated  string
+	Ephemeral   bool
 
 	Preconditions []*CheckRule
 
 	DescriptionSet bool
 	SensitiveSet   bool
+	EphemeralSet   bool
 
 	DeclRange hcl.Range
 
@@ -488,6 +498,12 @@ func decodeOutputBlock(block *hcl.Block, override bool) (*Output, hcl.Diagnostic
 				Subject:  attr.Expr.Range().Ptr(),
 			})
 		}
+	}
+
+	if attr, exists := content.Attributes["ephemeral"]; exists {
+		valDiags := gohcl.DecodeExpression(attr.Expr, nil, &o.Ephemeral)
+		diags = append(diags, valDiags...)
+		o.EphemeralSet = true
 	}
 
 	if attr, exists := content.Attributes["depends_on"]; exists {
@@ -582,6 +598,9 @@ var variableBlockSchema = &hcl.BodySchema{
 			Name: "sensitive",
 		},
 		{
+			Name: "ephemeral",
+		},
+		{
 			Name: "deprecated",
 		},
 		{
@@ -609,6 +628,9 @@ var outputBlockSchema = &hcl.BodySchema{
 		},
 		{
 			Name: "sensitive",
+		},
+		{
+			Name: "ephemeral",
 		},
 		{
 			Name: "deprecated",

--- a/internal/configs/testdata/ephemeral-outputs/main.tf
+++ b/internal/configs/testdata/ephemeral-outputs/main.tf
@@ -1,0 +1,4 @@
+output "test" {
+  value = "explicit"
+  ephemeral = true // This needs to fail when loaded as root module
+}

--- a/internal/configs/testdata/valid-modules/override-output/a_override.tf
+++ b/internal/configs/testdata/valid-modules/override-output/a_override.tf
@@ -1,0 +1,10 @@
+output "fully_overridden" {
+  value = "a_override"
+  description = "a_override description"
+  deprecated = "a_override deprecated"
+  ephemeral = true
+}
+
+output "partially_overridden" {
+  value = "a_override partial"
+}

--- a/internal/configs/testdata/valid-modules/override-output/b_override.tf
+++ b/internal/configs/testdata/valid-modules/override-output/b_override.tf
@@ -1,0 +1,11 @@
+output "fully_overridden" {
+  value = "b_override"
+  description = "b_override description"
+  deprecated = "b_override deprecated"
+  ephemeral = false
+}
+
+output "partially_overridden" {
+  value = "b_override partial"
+  deprecated = "b_override deprecated"
+}

--- a/internal/configs/testdata/valid-modules/override-output/primary.tf
+++ b/internal/configs/testdata/valid-modules/override-output/primary.tf
@@ -1,0 +1,9 @@
+output "fully_overridden" {
+  value = "base"
+  description = "base description"
+}
+
+output "partially_overridden" {
+  value = "base"
+  description = "base description"
+}

--- a/internal/configs/testdata/valid-modules/override-variable/a_override.tf
+++ b/internal/configs/testdata/valid-modules/override-variable/a_override.tf
@@ -3,6 +3,7 @@ variable "fully_overridden" {
   description = "a_override description"
   deprecated = "a_override deprecated"
   type = string
+  ephemeral = true
 }
 
 variable "partially_overridden" {

--- a/internal/configs/testdata/valid-modules/override-variable/b_override.tf
+++ b/internal/configs/testdata/valid-modules/override-variable/b_override.tf
@@ -4,6 +4,7 @@ variable "fully_overridden" {
   description = "b_override description"
   deprecated = "b_override deprecated"
   type = string
+  ephemeral = false
 }
 
 variable "partially_overridden" {


### PR DESCRIPTION
Part of #2834 

This is just adding the `ephemeral` attribute in the `variable` and `output` blocks.
I didn't do the full integration since this is just to enable easier testing of the ephemeral resources.
This work is not considered to be final and another iteration over these changes should be done.
## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
