### PR TITLE
website: OCI provider mirror shouldn't talk about prereleases anymore

### DIFF
--- a/website/docs/cli/oci_registries/provider-mirror.mdx
+++ b/website/docs/cli/oci_registries/provider-mirror.mdx
@@ -116,9 +116,9 @@ by subsequent workflow commands like [`tofu apply`](../commands/apply.mdx).
 This section currently describes a very manual process for constructing the
 required manifest structure as described in the previous section.
 
-We intend to replace this with a more automated approach in a later OpenTofu
-release, but hope that the following will suffice for now to allow early
-experimentation with OCI Registry provider mirrors in the OpenTofu v1.10 prereleases.
+The OpenTofu project is currently collaborating with the ORAS project to
+design and implement a more complete solution, which will be documented here
+once it's included in a generally-available ORAS release.
 :::
 
 ### Install and Configure ORAS


### PR DESCRIPTION
This text was from earlier on in the development period when we hadn't yet settled on a strategy, but now we are intending to work with the ORAS team so that ORAS can construct index manifests in the form that OpenTofu expects, so we'll talk about that instead of making a comment about prereleases that will become confusing once OpenTofu v1.10.0 final is released.

This is for https://github.com/opentofu/opentofu/issues/2540.