### PR TITLE
Ephemeral resources in internal/tofu

### DIFF
--- a/internal/addrs/resource.go
+++ b/internal/addrs/resource.go
@@ -532,3 +532,19 @@ func ResourceModeLess(a, b ResourceMode) bool {
 	}
 	return false
 }
+
+// ResourceModeBlockName returns the name of the block that the given ResourceMode is mapped to.
+// At the time of writing this, the string values returned from this one are hardcoded all over the place so this is not
+// the source of truth for the name of those blocks.
+func ResourceModeBlockName(rm ResourceMode) string {
+	switch rm {
+	case ManagedResourceMode:
+		return "resource"
+	case DataResourceMode:
+		return "data"
+	case EphemeralResourceMode:
+		return "ephemeral"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/repl/session_test.go
+++ b/internal/repl/session_test.go
@@ -85,7 +85,7 @@ func TestSession_basicState(t *testing.T) {
 				{
 					Input:         "test_instance.bar.id",
 					Error:         true,
-					ErrorContains: `A managed resource "test_instance" "bar" has not been declared`,
+					ErrorContains: `There is no managed resource "test_instance" "bar" definition in the root module`,
 				},
 			},
 		})
@@ -196,7 +196,7 @@ func TestSession_stateless(t *testing.T) {
 				{
 					Input:         "test_instance.bar.id",
 					Error:         true,
-					ErrorContains: `resource "test_instance" "bar" has not been declared`,
+					ErrorContains: `resource "test_instance" "bar" definition`,
 				},
 			},
 		})

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -4169,7 +4169,7 @@ func TestContext2Plan_preconditionErrors(t *testing.T) {
 		{
 			"data.foo.bar",
 			"Reference to undeclared resource",
-			`A data resource "foo" "bar" has not been declared in the root module`,
+			`There is no data resource "foo" "bar" definition in the root module.`,
 		},
 		{
 			"test_resource.b.value",

--- a/internal/tofu/evaluate_valid.go
+++ b/internal/tofu/evaluate_valid.go
@@ -11,7 +11,6 @@ import (
 	"sort"
 
 	"github.com/hashicorp/hcl/v2"
-
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/didyoumean"
@@ -202,6 +201,8 @@ func (d *evaluationStateData) staticValidateResourceReference(modCfg *configs.Co
 		modeAdjective = "managed"
 	case addrs.DataResourceMode:
 		modeAdjective = "data"
+	case addrs.EphemeralResourceMode:
+		modeAdjective = "ephemeral"
 	default:
 		// should never happen
 		modeAdjective = "<invalid-mode>"
@@ -209,21 +210,14 @@ func (d *evaluationStateData) staticValidateResourceReference(modCfg *configs.Co
 
 	cfg := modCfg.Module.ResourceByAddr(addr)
 	if cfg == nil {
-		var suggestion string
-		// A common mistake is omitting the data. prefix when trying to refer
-		// to a data resource, so we'll add a special hint for that.
-		if addr.Mode == addrs.ManagedResourceMode {
-			candidateAddr := addr // not a pointer, so this is a copy
-			candidateAddr.Mode = addrs.DataResourceMode
-			if candidateCfg := modCfg.Module.ResourceByAddr(candidateAddr); candidateCfg != nil {
-				suggestion = fmt.Sprintf("\n\nDid you mean the data resource %s?", candidateAddr)
-			}
-		}
+		// A common mistake is omitting the "data." (or "ephemeral.") prefix when trying to refer
+		// to a data (or ephemeral) resource, so we'll add a special hint for that.
+		suggestion := candidateSuggestion(addr, modCfg)
 
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  `Reference to undeclared resource`,
-			Detail:   fmt.Sprintf(`A %s resource %q %q has not been declared in %s.%s`, modeAdjective, addr.Type, addr.Name, moduleConfigDisplayAddr(modCfg.Path), suggestion),
+			Detail:   fmt.Sprintf(`There is no %s resource %q %q definition in %s.%s`, modeAdjective, addr.Type, addr.Name, moduleConfigDisplayAddr(modCfg.Path), suggestion),
 			Subject:  rng.ToHCL().Ptr(),
 		})
 		return diags
@@ -260,7 +254,7 @@ func (d *evaluationStateData) staticValidateResourceReference(modCfg *configs.Co
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  `Invalid resource type`,
-			Detail:   fmt.Sprintf(`A %s resource type %q is not supported by provider %q.`, modeAdjective, addr.Type, providerFqn.String()),
+			Detail:   fmt.Sprintf(`The %s resource type %q is not supported by provider %q.`, modeAdjective, addr.Type, providerFqn.String()),
 			Subject:  rng.ToHCL().Ptr(),
 		})
 		return diags
@@ -288,6 +282,39 @@ func (d *evaluationStateData) staticValidateResourceReference(modCfg *configs.Co
 	diags = diags.Append(moreDiags)
 
 	return diags
+}
+
+// candidateSuggestion is trying to return a close candidate by simply trying to find a different type of resource
+// with the same type and name to suggest. We are trying to do so because a common mistake is omitting the "data." (or "ephemeral.")
+// prefix when trying to refer to a data (or ephemeral) resource, so we'll add a special hint for that.
+func candidateSuggestion(addr addrs.Resource, cfg *configs.Config) interface{} {
+	candidateAddr := addr // not a pointer, so this is a copy
+	tpl := "\n\nDid you mean the %s resource %s?"
+	filterOnOtherModes := func(targetModes []addrs.ResourceMode) *configs.Resource {
+		for _, candidateMode := range targetModes {
+			candidateAddr.Mode = candidateMode
+			if b := cfg.Module.ResourceByAddr(candidateAddr); b != nil {
+				return b
+			}
+		}
+		return nil
+	}
+	switch addr.Mode {
+	case addrs.ManagedResourceMode:
+		if candidateCfg := filterOnOtherModes([]addrs.ResourceMode{addrs.DataResourceMode, addrs.EphemeralResourceMode}); candidateCfg != nil {
+			return fmt.Sprintf(tpl, addrs.ResourceModeBlockName(candidateAddr.Mode), candidateAddr)
+		}
+	case addrs.DataResourceMode:
+		if candidateCfg := filterOnOtherModes([]addrs.ResourceMode{addrs.ManagedResourceMode, addrs.EphemeralResourceMode}); candidateCfg != nil {
+			return fmt.Sprintf(tpl, addrs.ResourceModeBlockName(candidateAddr.Mode), candidateAddr)
+		}
+	case addrs.EphemeralResourceMode:
+		if candidateCfg := filterOnOtherModes([]addrs.ResourceMode{addrs.ManagedResourceMode, addrs.DataResourceMode}); candidateCfg != nil {
+			return fmt.Sprintf(tpl, addrs.ResourceModeBlockName(candidateAddr.Mode), candidateAddr)
+		}
+	}
+
+	return ""
 }
 
 func (d *evaluationStateData) staticValidateModuleCallReference(modCfg *configs.Config, addr addrs.ModuleCall, remain hcl.Traversal, rng tfdiags.SourceRange) tfdiags.Diagnostics {

--- a/internal/tofu/evaluate_valid_test.go
+++ b/internal/tofu/evaluate_valid_test.go
@@ -38,11 +38,11 @@ func TestStaticValidateReferences(t *testing.T) {
 		},
 		{
 			Ref:     "aws_instance.nonexist",
-			WantErr: `Reference to undeclared resource: A managed resource "aws_instance" "nonexist" has not been declared in the root module.`,
+			WantErr: `Reference to undeclared resource: There is no managed resource "aws_instance" "nonexist" definition in the root module.`,
 		},
 		{
 			Ref: "beep.boop",
-			WantErr: `Reference to undeclared resource: A managed resource "beep" "boop" has not been declared in the root module.
+			WantErr: `Reference to undeclared resource: There is no managed resource "beep" "boop" definition in the root module.
 
 Did you mean the data resource data.beep.boop?`,
 		},
@@ -70,7 +70,7 @@ For example, to correlate with indices of a referring resource, use:
 		},
 		{
 			Ref:     "boop_whatever.nope",
-			WantErr: `Invalid resource type: A managed resource type "boop_whatever" is not supported by provider "registry.opentofu.org/foobar/beep".`,
+			WantErr: `Invalid resource type: The managed resource type "boop_whatever" is not supported by provider "registry.opentofu.org/foobar/beep".`,
 		},
 		{
 			Ref:     "data.boop_data.boop_nested",
@@ -80,6 +80,24 @@ For example, to correlate with indices of a referring resource, use:
 			Ref:     "data.boop_data.boop_nested",
 			WantErr: ``,
 			Src:     addrs.Check{Name: "foo"},
+		},
+		{
+			Ref: "foo.bar",
+			WantErr: `Reference to undeclared resource: There is no managed resource "foo" "bar" definition in the root module.
+
+Did you mean the ephemeral resource ephemeral.foo.bar?`,
+		},
+		{
+			Ref: "data.foo.bar",
+			WantErr: `Reference to undeclared resource: There is no data resource "foo" "bar" definition in the root module.
+
+Did you mean the ephemeral resource ephemeral.foo.bar?`,
+		},
+		{
+			Ref: "ephemeral.beep.boop",
+			WantErr: `Reference to undeclared resource: There is no ephemeral resource "beep" "boop" definition in the root module.
+
+Did you mean the data resource data.beep.boop?`,
 		},
 	}
 

--- a/internal/tofu/node_resource_abstract_instance.go
+++ b/internal/tofu/node_resource_abstract_instance.go
@@ -2055,6 +2055,10 @@ func (n *NodeAbstractResourceInstance) dependenciesHavePendingChanges(evalCtx Ev
 			// we'll also encounter it in this list of dependencies.
 			continue
 		}
+		// TODO ephemeral - since a data source cannot have write-only attributes, a data source that is referencing
+		// an ephemeral resource needs to show an error. We need to check where that evaluation needs to be done. Once
+		// it is done, this comment can be removed and best case scenario, we can add a check in here for the sake of safety,
+		// to ensure that an ephemeral cannot ever be referenced by a data source.
 
 		for _, change := range changes.GetChangesForConfigResource(d) {
 			changeModInst := change.Addr.Module

--- a/internal/tofu/node_resource_apply_instance.go
+++ b/internal/tofu/node_resource_apply_instance.go
@@ -174,6 +174,8 @@ func (n *NodeApplyableResourceInstance) Execute(ctx context.Context, evalCtx Eva
 		diags = diags.Append(
 			n.dataResourceExecute(ctx, evalCtx),
 		)
+	case addrs.EphemeralResourceMode:
+		// TODO ephemeral - here comes the integration with the actual implementation for ephemeral resources
 	default:
 		panic(fmt.Errorf("unsupported resource mode %s", n.Config.Mode))
 	}

--- a/internal/tofu/node_resource_destroy.go
+++ b/internal/tofu/node_resource_destroy.go
@@ -54,10 +54,20 @@ func (n *NodeDestroyResourceInstance) Name() string {
 }
 
 func (n *NodeDestroyResourceInstance) ProvidedBy() RequestedProvider {
-	if n.Addr.Resource.Resource.Mode == addrs.DataResourceMode {
+	switch n.Addr.Resource.Resource.Mode {
+	case addrs.DataResourceMode:
 		// indicate that this node does not require a configured provider
 		return RequestedProvider{}
+	case addrs.EphemeralResourceMode:
+		// Since ephemeral resources are not stored into the state or plan files,
+		// a change of type delete cannot be generated for it, meaning that this
+		// code path is not meant to be reached.
+		// Even though, let's ensure that ever the case, a destroy node for an
+		// ephemeral resource indicates correctly that for its removal there
+		// is no provider needed.
+		return RequestedProvider{}
 	}
+
 	return n.NodeAbstractResourceInstance.ProvidedBy()
 }
 
@@ -170,6 +180,10 @@ func (n *NodeDestroyResourceInstance) Execute(ctx context.Context, evalCtx EvalC
 		diags = diags.Append(
 			n.dataResourceExecute(ctx, evalCtx),
 		)
+	case addrs.EphemeralResourceMode:
+		diags = diags.Append(
+			n.ephemeralResourceExecute(ctx, evalCtx),
+		)
 	default:
 		panic(fmt.Errorf("unsupported resource mode %s", n.Config.Mode))
 	}
@@ -262,4 +276,17 @@ func (n *NodeDestroyResourceInstance) dataResourceExecute(_ context.Context, eva
 	log.Printf("[TRACE] NodeDestroyResourceInstance: removing state object for %s", n.Addr)
 	evalCtx.State().SetResourceInstanceCurrent(n.Addr, nil, n.ResolvedProvider.ProviderConfig, n.ResolvedProviderKey)
 	return diags.Append(updateStateHook(evalCtx))
+}
+
+// ephemeralResourceExecute for NodeDestroyResourceInstance is only here to return an error.
+// An ephemeral resource, by definition, cannot be destroyed. If the execution path is reaching this part, it means that
+// there is an issue somewhere else, most probably in the planning phase since the generation of NodeDestroyResourceInstance
+// is strictly related to the changes from the plan.
+func (n *NodeDestroyResourceInstance) ephemeralResourceExecute(_ context.Context, _ EvalContext) (diags tfdiags.Diagnostics) {
+	log.Printf("[TRACE] NodeDestroyResourceInstance: called for ephemeral resource %s", n.Addr)
+	return diags.Append(tfdiags.Sourceless(
+		tfdiags.Error,
+		"Destroy invoked for an ephemeral resource",
+		fmt.Sprintf("A destroy operation has been invoked for the ephemeral resource %q. This is an OpenTofu error. Please report this.", n.Addr),
+	))
 }

--- a/internal/tofu/node_resource_plan_instance.go
+++ b/internal/tofu/node_resource_plan_instance.go
@@ -119,6 +119,8 @@ func (n *NodePlannableResourceInstance) Execute(ctx context.Context, evalCtx Eva
 		diags = diags.Append(
 			n.dataResourceExecute(ctx, evalCtx),
 		)
+	case addrs.EphemeralResourceMode:
+		// TODO ephemeral - here comes the integration with the actual implementation for ephemeral resources
 	default:
 		panic(fmt.Errorf("unsupported resource mode %s", n.Config.Mode))
 	}

--- a/internal/tofu/node_resource_plan_orphan.go
+++ b/internal/tofu/node_resource_plan_orphan.go
@@ -103,8 +103,16 @@ func (n *NodePlannableResourceInstanceOrphan) Execute(ctx context.Context, evalC
 }
 
 func (n *NodePlannableResourceInstanceOrphan) ProvidedBy() RequestedProvider {
-	if n.Addr.Resource.Resource.Mode == addrs.DataResourceMode { // TODO andrei here should be also ephemeral resources
-		// indicate that this node does not require a configured provider
+	switch n.Addr.Resource.Resource.Mode {
+	case addrs.DataResourceMode:
+		return RequestedProvider{}
+	case addrs.EphemeralResourceMode:
+		// Since ephemeral resources are not stored into the state or plan files, such resources cannot be marked as orphan.
+		// In other words, this code path should never be reached since an orphan node for an ephemeral resource should not be
+		// possible to be created.
+		// Even though this is not possible, let's ensure that we are handling this accordingly, to not create unwanted behavior.
+		// If an ephemeral resource will ever have an orphan node that will be executed, an error will be raised
+		// from NodePlannableResourceInstanceOrphan#Execute().
 		return RequestedProvider{}
 	}
 	return n.NodeAbstractResourceInstance.ProvidedBy()

--- a/internal/tofu/node_resource_plan_orphan.go
+++ b/internal/tofu/node_resource_plan_orphan.go
@@ -91,6 +91,10 @@ func (n *NodePlannableResourceInstanceOrphan) Execute(ctx context.Context, evalC
 		diags = diags.Append(
 			n.dataResourceExecute(ctx, evalCtx),
 		)
+	case addrs.EphemeralResourceMode:
+		diags = diags.Append(
+			n.ephemeralResourceExecute(ctx, evalCtx),
+		)
 	default:
 		panic(fmt.Errorf("unsupported resource mode %s", n.Config.Mode))
 	}
@@ -99,7 +103,7 @@ func (n *NodePlannableResourceInstanceOrphan) Execute(ctx context.Context, evalC
 }
 
 func (n *NodePlannableResourceInstanceOrphan) ProvidedBy() RequestedProvider {
-	if n.Addr.Resource.Resource.Mode == addrs.DataResourceMode {
+	if n.Addr.Resource.Resource.Mode == addrs.DataResourceMode { // TODO andrei here should be also ephemeral resources
 		// indicate that this node does not require a configured provider
 		return RequestedProvider{}
 	}
@@ -352,4 +356,13 @@ func (n *NodePlannableResourceInstanceOrphan) deleteActionReason(evalCtx EvalCon
 	// as a fallback, which means the UI should just state it'll be deleted
 	// without any explicit reasoning.
 	return plans.ResourceInstanceChangeNoReason
+}
+
+func (n *NodePlannableResourceInstanceOrphan) ephemeralResourceExecute(_ context.Context, _ EvalContext) (diags tfdiags.Diagnostics) {
+	log.Printf("[TRACE] NodePlannableResourceInstanceOrphan: called for ephemeral resource %s", n.Addr)
+	return diags.Append(tfdiags.Sourceless(
+		tfdiags.Error,
+		"An ephemeral resource registered as orphan",
+		fmt.Sprintf("Ephemeral resource %q registered as orphan. This is an OpenTofu error. Please report this.", n.Addr),
+	))
 }

--- a/internal/tofu/node_resource_plan_orphan_test.go
+++ b/internal/tofu/node_resource_plan_orphan_test.go
@@ -402,3 +402,27 @@ func TestNodeResourcePlanOrphanExecute_deposed(t *testing.T) {
 		t.Fatalf("unexpected error: %s", diags.Err())
 	}
 }
+
+// TestNodeResourcePlanOrphanExecute_ephemeral is validating that NodePlannableResourceInstanceOrphan.Execute
+// returns the expected error when it's executed against an ephemeral resource.
+// Since ephemeral resources are not meant to be in the state, this case is not really possible in real life.
+func TestNodeResourcePlanOrphanExecute_ephemeral(t *testing.T) {
+	addr := addrs.Resource{
+		Mode: addrs.EphemeralResourceMode,
+		Type: "test_object",
+		Name: "foo",
+	}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance)
+
+	node := NodePlannableResourceInstanceOrphan{
+		NodeAbstractResourceInstance: &NodeAbstractResourceInstance{
+			NodeAbstractResource: NodeAbstractResource{},
+			Addr:                 addr,
+		},
+	}
+	diags := node.Execute(t.Context(), nil, walkPlan)
+	got := diags.Err().Error()
+	want := `An ephemeral resource registered as orphan: Ephemeral resource "ephemeral.test_object.foo" registered as orphan. This is an OpenTofu error. Please report this.`
+	if got != want {
+		t.Fatalf("unexpected error returned.\ngot: %s\nwant:%s", got, want)
+	}
+}

--- a/internal/tofu/node_resource_validate.go
+++ b/internal/tofu/node_resource_validate.go
@@ -370,19 +370,7 @@ func (n *NodeValidatableResource) validateResource(ctx context.Context, evalCtx 
 	case addrs.ManagedResourceMode:
 		schema, _ := providerSchema.SchemaForResourceType(n.Config.Mode, n.Config.Type)
 		if schema == nil {
-			var suggestion string
-			if dSchema, _ := providerSchema.SchemaForResourceType(addrs.DataResourceMode, n.Config.Type); dSchema != nil {
-				suggestion = fmt.Sprintf("\n\nDid you intend to use the data source %q? If so, declare this using a \"data\" block instead of a \"resource\" block.", n.Config.Type)
-			} else if len(providerSchema.ResourceTypes) > 0 {
-				suggestions := make([]string, 0, len(providerSchema.ResourceTypes))
-				for name := range providerSchema.ResourceTypes {
-					suggestions = append(suggestions, name)
-				}
-				if suggestion = didyoumean.NameSuggestion(n.Config.Type, suggestions); suggestion != "" {
-					suggestion = fmt.Sprintf(" Did you mean %q?", suggestion)
-				}
-			}
-
+			suggestion := n.noResourceSchemaSuggestion(providerSchema)
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Invalid resource type",
@@ -444,19 +432,7 @@ func (n *NodeValidatableResource) validateResource(ctx context.Context, evalCtx 
 	case addrs.DataResourceMode:
 		schema, _ := providerSchema.SchemaForResourceType(n.Config.Mode, n.Config.Type)
 		if schema == nil {
-			var suggestion string
-			if dSchema, _ := providerSchema.SchemaForResourceType(addrs.ManagedResourceMode, n.Config.Type); dSchema != nil {
-				suggestion = fmt.Sprintf("\n\nDid you intend to use the managed resource type %q? If so, declare this using a \"resource\" block instead of a \"data\" block.", n.Config.Type)
-			} else if len(providerSchema.DataSources) > 0 {
-				suggestions := make([]string, 0, len(providerSchema.DataSources))
-				for name := range providerSchema.DataSources {
-					suggestions = append(suggestions, name)
-				}
-				if suggestion = didyoumean.NameSuggestion(n.Config.Type, suggestions); suggestion != "" {
-					suggestion = fmt.Sprintf(" Did you mean %q?", suggestion)
-				}
-			}
-
+			suggestion := n.noResourceSchemaSuggestion(providerSchema)
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Invalid data source",
@@ -481,9 +457,84 @@ func (n *NodeValidatableResource) validateResource(ctx context.Context, evalCtx 
 
 		resp := provider.ValidateDataResourceConfig(ctx, req)
 		diags = diags.Append(resp.Diagnostics.InConfigBody(n.Config.Config, n.Addr.String()))
+	case addrs.EphemeralResourceMode:
+		schema, _ := providerSchema.SchemaForResourceType(n.Config.Mode, n.Config.Type)
+		if schema == nil {
+			suggestion := n.noResourceSchemaSuggestion(providerSchema)
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid ephemeral resource",
+				Detail:   fmt.Sprintf("The provider %s does not support ephemeral resource %q.%s", n.Provider().ForDisplay(), n.Config.Type, suggestion),
+				Subject:  &n.Config.TypeRange,
+			})
+			return diags
+		}
+
+		configVal, _, valDiags := evalCtx.EvaluateBlock(n.Config.Config, schema, nil, keyData)
+		diags = diags.Append(valDiags)
+		if valDiags.HasErrors() {
+			return diags
+		}
+
+		// Use unmarked value for validate request
+		unmarkedConfigVal, _ := configVal.UnmarkDeep()
+		req := providers.ValidateEphemeralConfigRequest{
+			TypeName: n.Config.Type,
+			Config:   unmarkedConfigVal,
+		}
+
+		resp := provider.ValidateEphemeralConfig(ctx, req)
+		diags = diags.Append(resp.Diagnostics.InConfigBody(n.Config.Config, n.Addr.String())) // TODO andrei test this with the branch for this particular feature
 	}
 
 	return diags
+}
+
+// noResourceSchemaSuggestion is trying to generate a suggestion to be appended into the diagnostic that is pointing to the fact
+// that the resource indicated by the user does not exist. This is doing its best to find a better alternative:
+//   - It is checking if in the provider's schema exists a resource with the same resource type but with a different mode.
+//   - If none found at the step above, it tries to determine if the name of the resource is incomplete and tries to recommend the
+//     closest resource type name to the one that is already configured.
+func (n *NodeValidatableResource) noResourceSchemaSuggestion(providerSchema providers.ProviderSchema) string {
+	var suggestion string
+	if candidateMode, candidateSchema := nodeValidationAlternateBlockModeSuggestion(providerSchema, n.Config.Mode, n.Config.Type); candidateSchema != nil {
+		suggestion = fmt.Sprintf("\n\nDid you intend to use a block of type %q %q? If so, declare this using a block of type %q instead of one of type %q.",
+			addrs.ResourceModeBlockName(candidateMode), n.Config.Type, addrs.ResourceModeBlockName(candidateMode), addrs.ResourceModeBlockName(n.Config.Mode))
+	} else if len(providerSchema.ResourceTypes) > 0 {
+		suggestions := make([]string, 0, len(providerSchema.ResourceTypes))
+		for name := range providerSchema.ResourceTypes {
+			suggestions = append(suggestions, name)
+		}
+		if suggestion = didyoumean.NameSuggestion(n.Config.Type, suggestions); suggestion != "" {
+			suggestion = fmt.Sprintf(" Did you mean %q?", suggestion)
+		}
+	}
+	return suggestion
+}
+
+// nodeValidationAlternateBlockModeSuggestion is trying to find an alternative addrs.ResourceMode for the given resourceType in the provider's schema.
+// This is needed to be able to provide a suggestion when the user is using a wrong block type for the type of the resource that it's intended
+// to be used.
+func nodeValidationAlternateBlockModeSuggestion(schema providers.ProviderSchema, mode addrs.ResourceMode, resourceType string) (addrs.ResourceMode, *configschema.Block) {
+	filterOnOtherModes := func(targetModes []addrs.ResourceMode) (addrs.ResourceMode, *configschema.Block) {
+		for _, candidateMode := range targetModes {
+			if b, _ := schema.SchemaForResourceType(candidateMode, resourceType); b != nil {
+				return candidateMode, b
+			}
+		}
+		return addrs.InvalidResourceMode, nil
+	}
+
+	switch mode {
+	case addrs.ManagedResourceMode:
+		return filterOnOtherModes([]addrs.ResourceMode{addrs.DataResourceMode, addrs.EphemeralResourceMode})
+	case addrs.DataResourceMode:
+		return filterOnOtherModes([]addrs.ResourceMode{addrs.ManagedResourceMode, addrs.EphemeralResourceMode})
+	case addrs.EphemeralResourceMode:
+		return filterOnOtherModes([]addrs.ResourceMode{addrs.ManagedResourceMode, addrs.DataResourceMode})
+	}
+
+	return addrs.InvalidResourceMode, nil
 }
 
 func (n *NodeValidatableResource) evaluateExpr(evalCtx EvalContext, expr hcl.Expression, wantTy cty.Type, self addrs.Referenceable, keyData instances.RepetitionData) (cty.Value, tfdiags.Diagnostics) {

--- a/internal/tofu/node_resource_validate_test.go
+++ b/internal/tofu/node_resource_validate_test.go
@@ -7,6 +7,7 @@ package tofu
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -636,5 +637,125 @@ func TestNodeValidatableResource_ValidateResource_invalidIgnoreChangesComputed(t
 
 The attribute computed_string is decided by the provider alone and therefore there can be no configured value to compare with. Including this attribute in ignore_changes has no effect. Remove the attribute from ignore_changes to quiet this warning.`; !strings.Contains(got, want) {
 		t.Fatalf("wrong error\ngot:  %s\nwant: Message containing %q", got, want)
+	}
+}
+
+// TestNodeValidatableResource_ValidateResource_suggestion validates that the suggestions generated for mismatched block types
+// are generated correctly. This was added when ephemeral resource were added and the suggestion code refactored to accommodate
+// all resource modes in one.
+func TestNodeValidatableResource_ValidateResource_suggestion(t *testing.T) {
+	ms := &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"test_string": {
+				Type:     cty.String,
+				Optional: true,
+			},
+			"computed_string": {
+				Type:     cty.String,
+				Computed: true,
+				Optional: false,
+			},
+		},
+	}
+
+	mp := &MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			Provider: providers.Schema{Block: ms},
+			ResourceTypes: map[string]providers.Schema{
+				"test_managed_resource": {Block: ms},
+			},
+			DataSources: map[string]providers.Schema{
+				"test_data_source": {Block: ms},
+			},
+			EphemeralResources: map[string]providers.Schema{
+				"test_ephemeral_resource": {Block: ms},
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		mode  addrs.ResourceMode
+		rtype string
+
+		wantSummary string
+		wantDetail  string
+	}{
+		"managed resource with resource type of a data source": {
+			mode:        addrs.ManagedResourceMode,
+			rtype:       "test_data_source",
+			wantSummary: "Invalid resource type",
+			wantDetail:  "The provider hashicorp/aws does not support resource type \"test_data_source\".\n\nDid you intend to use a block of type \"data\" \"test_data_source\"? If so, declare this using a block of type \"data\" instead of one of type \"resource\".",
+		},
+		"managed resource with resource type of an ephemeral resource": {
+			mode:        addrs.ManagedResourceMode,
+			rtype:       "test_ephemeral_resource",
+			wantSummary: "Invalid resource type",
+			wantDetail:  "The provider hashicorp/aws does not support resource type \"test_ephemeral_resource\".\n\nDid you intend to use a block of type \"ephemeral\" \"test_ephemeral_resource\"? If so, declare this using a block of type \"ephemeral\" instead of one of type \"resource\".",
+		},
+		"data source with resource type of a managed resource": {
+			mode:        addrs.DataResourceMode,
+			rtype:       "test_managed_resource",
+			wantSummary: "Invalid data source",
+			wantDetail:  "The provider hashicorp/aws does not support data source \"test_managed_resource\".\n\nDid you intend to use a block of type \"resource\" \"test_managed_resource\"? If so, declare this using a block of type \"resource\" instead of one of type \"data\".",
+		},
+		"data source with resource type of an ephemeral resource": {
+			mode:        addrs.DataResourceMode,
+			rtype:       "test_ephemeral_resource",
+			wantSummary: "Invalid data source",
+			wantDetail:  "The provider hashicorp/aws does not support data source \"test_ephemeral_resource\".\n\nDid you intend to use a block of type \"ephemeral\" \"test_ephemeral_resource\"? If so, declare this using a block of type \"ephemeral\" instead of one of type \"data\".",
+		},
+		"ephemeral resource with resource type of a managed resource": {
+			mode:        addrs.EphemeralResourceMode,
+			rtype:       "test_managed_resource",
+			wantSummary: "Invalid ephemeral resource",
+			wantDetail:  "The provider hashicorp/aws does not support ephemeral resource \"test_managed_resource\".\n\nDid you intend to use a block of type \"resource\" \"test_managed_resource\"? If so, declare this using a block of type \"resource\" instead of one of type \"ephemeral\".",
+		},
+		"ephemeral resource with resource type of a data source": {
+			mode:        addrs.EphemeralResourceMode,
+			rtype:       "test_data_source",
+			wantSummary: "Invalid ephemeral resource",
+			wantDetail:  "The provider hashicorp/aws does not support ephemeral resource \"test_data_source\".\n\nDid you intend to use a block of type \"data\" \"test_data_source\"? If so, declare this using a block of type \"data\" instead of one of type \"ephemeral\".",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			p := providers.Interface(mp)
+			rc := &configs.Resource{
+				Mode:   tt.mode,
+				Type:   tt.rtype,
+				Name:   "foo",
+				Config: configs.SynthBody("", map[string]cty.Value{}),
+			}
+			var prefix string
+			if tt.mode != addrs.ManagedResourceMode {
+				prefix = addrs.ResourceModeBlockName(tt.mode)
+			}
+			node := NodeValidatableResource{
+				NodeAbstractResource: &NodeAbstractResource{
+					Addr:             mustConfigResourceAddr(fmt.Sprintf("%s%s.bar", prefix, tt.rtype)),
+					Config:           rc,
+					ResolvedProvider: ResolvedProvider{ProviderConfig: mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`)},
+				},
+			}
+
+			ctx := &MockEvalContext{}
+			ctx.installSimpleEval()
+
+			ctx.ProviderSchemaSchema = mp.GetProviderSchema(t.Context())
+			ctx.ProviderProvider = p
+
+			diags := node.validateResource(t.Context(), ctx)
+			if got, want := len(diags), 1; got != want {
+				t.Fatalf("expected to have %d diagnostics but got %d", want, got)
+			}
+			d := diags[0]
+
+			if got, want := d.Description().Summary, tt.wantSummary; got != want {
+				t.Fatalf("unexpected diagnostic summary. \nwant:\n\t%s\ngot:\n\t%s", want, got)
+			}
+			if got, want := d.Description().Detail, tt.wantDetail; got != want {
+				t.Fatalf("unexpected diagnostic detail. \nwant:\n\t%s\ngot:\n\t%s", want, got)
+			}
+		})
 	}
 }

--- a/internal/tofu/resource_provider_mock_test.go
+++ b/internal/tofu/resource_provider_mock_test.go
@@ -92,6 +92,7 @@ func (p *MockProvider) ProviderSchema() *ProviderSchema {
 		ProviderMeta:               resp.ProviderMeta.Block,
 		ResourceTypes:              map[string]*configschema.Block{},
 		DataSources:                map[string]*configschema.Block{},
+		EphemeralTypes:             map[string]*configschema.Block{},
 		ResourceTypeSchemaVersions: map[string]uint64{},
 	}
 
@@ -102,6 +103,10 @@ func (p *MockProvider) ProviderSchema() *ProviderSchema {
 
 	for dataSource, s := range resp.DataSources {
 		schema.DataSources[dataSource] = s.Block
+	}
+
+	for ephemeral, s := range resp.EphemeralResources {
+		schema.EphemeralTypes[ephemeral] = s.Block
 	}
 
 	return schema
@@ -115,16 +120,18 @@ type ProviderSchema struct {
 	ResourceTypes              map[string]*configschema.Block
 	ResourceTypeSchemaVersions map[string]uint64
 	DataSources                map[string]*configschema.Block
+	EphemeralTypes             map[string]*configschema.Block
 }
 
 // getProviderSchemaResponseFromProviderSchema is a test helper to convert a
 // ProviderSchema to a GetProviderSchemaResponse for use when building a mock provider.
 func getProviderSchemaResponseFromProviderSchema(providerSchema *ProviderSchema) *providers.GetProviderSchemaResponse {
 	resp := &providers.GetProviderSchemaResponse{
-		Provider:      providers.Schema{Block: providerSchema.Provider},
-		ProviderMeta:  providers.Schema{Block: providerSchema.ProviderMeta},
-		ResourceTypes: map[string]providers.Schema{},
-		DataSources:   map[string]providers.Schema{},
+		Provider:           providers.Schema{Block: providerSchema.Provider},
+		ProviderMeta:       providers.Schema{Block: providerSchema.ProviderMeta},
+		ResourceTypes:      map[string]providers.Schema{},
+		DataSources:        map[string]providers.Schema{},
+		EphemeralResources: map[string]providers.Schema{},
 	}
 
 	for name, schema := range providerSchema.ResourceTypes {
@@ -136,6 +143,10 @@ func getProviderSchemaResponseFromProviderSchema(providerSchema *ProviderSchema)
 
 	for name, schema := range providerSchema.DataSources {
 		resp.DataSources[name] = providers.Schema{Block: schema}
+	}
+
+	for name, schema := range providerSchema.EphemeralTypes {
+		resp.EphemeralResources[name] = providers.Schema{Block: schema}
 	}
 
 	return resp

--- a/internal/tofu/testdata/input-provider/main.tf
+++ b/internal/tofu/testdata/input-provider/main.tf
@@ -1,1 +1,3 @@
 resource "aws_instance" "foo" {}
+data "cloudflare_account" "bar" {}
+ephemeral "azurerm_key_vault_secret" "baz" {}

--- a/internal/tofu/testdata/static-validate-refs/static-validate-refs.tf
+++ b/internal/tofu/testdata/static-validate-refs/static-validate-refs.tf
@@ -22,6 +22,9 @@ resource "boop_whatever" "nope" {
 data "beep" "boop" {
 }
 
+ephemeral "foo" "bar" {
+}
+
 check "foo" {
   data "boop_data" "boop_nested" {}
 

--- a/internal/tofu/transform_attach_config_resource.go
+++ b/internal/tofu/transform_attach_config_resource.go
@@ -58,6 +58,8 @@ func (t *AttachResourceConfigTransformer) Transform(_ context.Context, g *Graph)
 			m = config.Module.ManagedResources
 		case addrs.DataResourceMode:
 			m = config.Module.DataResources
+		case addrs.EphemeralResourceMode:
+			m = config.Module.EphemeralResources
 		default:
 			panic("unknown resource mode: " + addr.Resource.Mode.String())
 		}

--- a/internal/tofu/transform_config.go
+++ b/internal/tofu/transform_config.go
@@ -98,11 +98,14 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config, ge
 	module := config.Module
 	log.Printf("[TRACE] ConfigTransformer: Starting for path: %v", path)
 
-	allResources := make([]*configs.Resource, 0, len(module.ManagedResources)+len(module.DataResources))
+	allResources := make([]*configs.Resource, 0, len(module.ManagedResources)+len(module.DataResources)+len(module.EphemeralResources))
 	for _, r := range module.ManagedResources {
 		allResources = append(allResources, r)
 	}
 	for _, r := range module.DataResources {
+		allResources = append(allResources, r)
+	}
+	for _, r := range module.EphemeralResources {
 		allResources = append(allResources, r)
 	}
 

--- a/internal/tofu/transform_reference.go
+++ b/internal/tofu/transform_reference.go
@@ -201,7 +201,7 @@ func (t attachDataResourceDependsOnTransformer) Transform(_ context.Context, g *
 
 		// Only data need to attach depends_on, so they can determine if they
 		// are eligible to be read during plan.
-		if depender.ResourceAddr().Resource.Mode != addrs.DataResourceMode {
+		if depender.ResourceAddr().Resource.Mode != addrs.DataResourceMode { // TODO ephemeral - implement a similar transformer for ephemeral resources or reuse this one
 			continue
 		}
 
@@ -426,7 +426,7 @@ func (m ReferenceMap) dependsOn(g *Graph, depender graphNodeDependsOn) ([]dag.Ve
 func (m ReferenceMap) dataDependsOn(depender graphNodeDependsOn) []*addrs.Reference {
 	var refs []*addrs.Reference
 	if n, ok := depender.(GraphNodeConfigResource); ok &&
-		n.ResourceAddr().Resource.Mode == addrs.DataResourceMode {
+		n.ResourceAddr().Resource.Mode == addrs.DataResourceMode { // TODO ephemeral - implement a similar method for ephemeral
 		for _, r := range depender.References() {
 
 			var resAddr addrs.Resource


### PR DESCRIPTION
Part of #2834 

More details can be found in the commit messages.
Overview:
* Collect implicit providers from ephemeral resources too. This enables prompting the user for required attributes for the provider configuration that are implicitly imported by ephemeral resources (27810db5b7ad38999e63a316c406d0cb5ad9371a)
* Add ephemeral resources into the graph. More details into the commit (3048496f65a0e8e4d045e4512fb453f7f1bd22b8)
* Ensure that a NodeDestroyResourceInstance is never going to execute on ephemeral resources since these cannot be destroyed (c9ac05058392742a6b451b2e3e81ed96ec5b2c0e)
* Ensure that a NodePlanDestroyableResourceInstance is never going to execute on ephemeral resources since these cannot be planned for destroy operations (6650f11cfcea2a15879cafd0b0fad2103c97b5fd)
* Ensure that a NodePlannableResourcceInstanceOrphan is never going to execute on ephemeral resources since these cannot be marked as orphan. This is due to the fact that ephemeral resources are not meant to be stored in the state, which is the starting point of generating orphan nodes (190f7c21caede07edcfa6a7c3a60bb052b0c5bf6)
* Add a new TODO for later to ensure that data sources cannot reference ephemeral resources (385a16f3893473d1e325fdfc1d34edb0e8e16c54)
* Add TODOs for integration points in the plan and apply phases for ephemeral resources (c8588b8b7e246438776fa1010285575398291268)
* When NodeValidatableResource is executed against a resource type that is not present in the provider's schema, OpenTofu tries to generate a suggestion for the actual block type to be used. This commit introduces suggestions for ephemeral resources too (21d6ec8635ffae5bf75570edfc4fe57aec15da07)
* During evaluation of the expressions, OpenTofu creates suggestions of the possible candidates in case an expression is referring to other missing resource types. This commit introduced validation for ephemeral resources too (c338bf932c887e196e7fd06efb7210f2e6fce12f)
* Add TODOs for depends_on handling on ephemeral resources (eef75de7c005e432116a91dd84b45435c5b73860)
* Return the correct RequestedProvider from NodePlannableResourceInstanceOrphan for ephemeral (eb1262114e5c3bddd9d76d6c894a95b8a7728035)

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
