### PR TITLE
docs: add dev version step for local docs

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -12,6 +12,8 @@ docker compose up --build
 
 The development server will be available on http://localhost:3000/docs/main/ .
 
+Under `Docs` in the navigation bar, select `Development` version to see local changes.
+
 ## Suggesting Changes
 
 You can [submit an issue](https://github.com/opentofu/opentofu/issues/new/choose) with documentation requests or submit a pull request with suggested changes.


### PR DESCRIPTION
Related to #2885

I spent a couple hours trying to link a custom local version via. code because I didn't understand how the local development versioning was set up for docusaurus.
Added the extra step to the doc for the next person

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Website/documentation checklist

- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
