### PR TITLE
fix: select CLI configuration files in the correct order on Windows

### DIFF
--- a/internal/command/cliconfig/config_windows.go
+++ b/internal/command/cliconfig/config_windows.go
@@ -27,10 +27,10 @@ func configFile() (string, error) {
 		return "", err
 	}
 
-	newConfigFile := filepath.Join(dir, "terraform.rc")
-	oldConfigFile := filepath.Join(dir, "tofu.rc")
+	newConfigFile := filepath.Join(dir, "tofu.rc")
+	legacyConfigFile := filepath.Join(dir, "terraform.rc")
 
-	return getNewOrLegacyPath(newConfigFile, oldConfigFile)
+	return getNewOrLegacyPath(newConfigFile, legacyConfigFile)
 }
 
 func configDir() (string, error) {


### PR DESCRIPTION
## Background

My org runs Terraform & OpenTofu depending on the project and mirrors the respective registries for both. For local development and CI pipelines, we have separate `.tofurc` and `.terraformrc` files setup pointed to the different `network_mirror` for each as per the instructions in the [CLI Configuration File Documentation](https://opentofu.org/docs/cli/config/config-file/).

This works as expected on Linux runners and on MacOS workstations. However, OpenTofu does not follow it's documentation on how precedence works between `tofu.rc` and `terraform.rc` files on Windows machines.

The documentation states:
> On Windows, the file must be named `tofu.rc` and placed in the relevant user's `%APPDATA%` directory. The physical location of this directory depends on your Windows version and system configuration; use `$env:APPDATA` in PowerShell to find its location on your system. The `terraform.rc` is supported for backward-compatibility purposes. **If both `terraform.rc` and `tofu.rc` files exists, the later would take precedence.**

However on all versions of OpenTofu I've tested, below shows `1.9.1`, the `terraform.rc` file seems to take precedence on Windows over `tofu.rc`:
```bash
$ export TF_LOG=TRACE

$ tofu version
2025-06-06T15:12:11.746-0700 [INFO]  OpenTofu version: 1.9.1
...
2025-06-06T15:12:11.750-0700 [DEBUG] Attempting to open CLI config file: C:\Users\jellayy\AppData\Roaming\terraform.rc
2025-06-06T15:12:11.750-0700 [INFO]  Loading CLI configuration from C:\Users\jellayy\AppData\Roaming\terraform.rc
...
```

## Changes

The issue seems to just come from `"terraform.rc"` and `"tofu.rc"` being unintentionally swapped when `newConfigFile` and `oldConfigFile` are declared in `config_windows`.

I swapped these declarations around in `config_windows` and renamed `oldConfigFile` to `legacyConfigFile` to match the working logic in `config_unix.go`

## Result

On Windows, OpenTofu properly takes the `tofu.rc` file as precedent over `terraform.rc`:
```bash
$ export TF_LOG=TRACE

$ ./tofu-dev version
...
2025-06-06T15:12:21.535-0700 [DEBUG] Attempting to open CLI config file: C:\Users\jellayy\AppData\Roaming\tofu.rc
2025-06-06T15:12:21.535-0700 [INFO]  Loading CLI configuration from C:\Users\jellayy\AppData\Roaming\tofu.rc
...
```

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [X] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [X] I have not used an AI coding assistant to create this PR.
- [X] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [X] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [X] I have run golangci-lint on my change and receive no errors relevant to my code.
- [X] I have run existing tests to ensure my code doesn't break anything.
- [X] I have added tests for all relevant use cases of my code, and those tests are passing.
- [X] I have only exported functions, variables and structs that should be used from other packages.
- [X] I have added meaningful comments to all exported functions, variables, and structs.