### PR TITLE
Add TOFU_CPU_PROFILE for enabling go pprof

### DIFF
--- a/website/docs/cli/config/environment-variables.mdx
+++ b/website/docs/cli/config/environment-variables.mdx
@@ -202,3 +202,12 @@ If the key (or similar) has non-alphanumeric characters in it, beware that your 
 
 Make sure your secret doesn't get changed by your shell without you realizing. This is also shell dependent, but common ways of avoiding this are using single quotes or escaping special characters with a backslash.
 :::
+
+## TOFU_CPU_PROFILE
+
+Set `TOFU_CPU_PROFILE` to instruct OpenTofu to write a [Go pprof file](https://pkg.go.dev/runtime/pprof). These profiles can be used to help developers identify hot-spots in OpenTofu's codebase that slow down execution.  It pairs well with the more granular and well structured OpenTelemetry tracing (available in OpenTofu 1.10.0). For more information on profiling in Go, see https://go.dev/blog/pprof.
+
+```shell
+TOFU_CPU_PROFILE=./tofu.pprof tofu plan
+go tool pprof -http ./tofu.pprof
+```


### PR DESCRIPTION
In a recent TSC meeting, [we discussed](https://github.com/opentofu/opentofu/blob/main/TSC/2025-05-27_NOTES.md#24-performance---its-a-feature) adding a pprof option to compliment the new OpenTelemetry feature.

OpenTelemetry provides a well structured and curated view into OpenTofu's execution.  PProf is a much more detailed and raw window into the Golang execution and is primarily useful for developers.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [ ] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
