### PR TITLE
getproviders: context.Context for source constructor functions

### DIFF
--- a/cmd/tofu/main.go
+++ b/cmd/tofu/main.go
@@ -173,7 +173,7 @@ func realMain() int {
 
 	modulePkgFetcher := remoteModulePackageFetcher(ctx, config.OCICredentialsPolicy)
 
-	providerSrc, diags := providerSource(config.ProviderInstallation, services, config.OCICredentialsPolicy)
+	providerSrc, diags := providerSource(ctx, config.ProviderInstallation, services, config.OCICredentialsPolicy)
 	if len(diags) > 0 {
 		Ui.Error("There are some problems with the provider_installation configuration:")
 		for _, diag := range diags {

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -1005,7 +1005,7 @@ func testServices(t *testing.T) (services *disco.Disco, cleanup func()) {
 // of your test in order to shut down the test server.
 func testRegistrySource(t *testing.T) (source *getproviders.RegistrySource, cleanup func()) {
 	services, close := testServices(t)
-	source = getproviders.NewRegistrySource(services, nil)
+	source = getproviders.NewRegistrySource(t.Context(), services, nil)
 	return source, close
 }
 

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -631,7 +631,7 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 		// the usual sources and forces OpenTofu to consult only the given
 		// directories. Anything not available in one of those directories
 		// is not available for installation.
-		source := c.providerCustomLocalDirectorySource(pluginDirs)
+		source := c.providerCustomLocalDirectorySource(ctx, pluginDirs)
 		inst = c.providerInstallerCustomSource(source)
 
 		// The default (or configured) search paths are logged earlier, in provider_source.go

--- a/internal/command/meta_providers.go
+++ b/internal/command/meta_providers.go
@@ -7,6 +7,7 @@ package command
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -93,11 +94,11 @@ func (m *Meta) providerInstallerCustomSource(source getproviders.Source) *provid
 //
 // If the given list of directories is empty then the resulting source will
 // have no providers available for installation at all.
-func (m *Meta) providerCustomLocalDirectorySource(dirs []string) getproviders.Source {
+func (m *Meta) providerCustomLocalDirectorySource(ctx context.Context, dirs []string) getproviders.Source {
 	var ret getproviders.MultiSource
 	for _, dir := range dirs {
 		ret = append(ret, getproviders.MultiSourceSelector{
-			Source: getproviders.NewFilesystemMirrorSource(dir),
+			Source: getproviders.NewFilesystemMirrorSource(ctx, dir),
 		})
 	}
 	return ret

--- a/internal/command/providers_lock.go
+++ b/internal/command/providers_lock.go
@@ -121,7 +121,7 @@ func (c *ProvidersLockCommand) Run(args []string) int {
 	var source getproviders.Source
 	switch {
 	case fsMirrorDir != "":
-		source = getproviders.NewFilesystemMirrorSource(fsMirrorDir)
+		source = getproviders.NewFilesystemMirrorSource(ctx, fsMirrorDir)
 	case netMirrorURL != "":
 		u, err := url.Parse(netMirrorURL)
 		if err != nil || u.Scheme != "https" {
@@ -139,12 +139,12 @@ func (c *ProvidersLockCommand) Run(args []string) int {
 		// this client is not suitable for the HTTP mirror source, so we
 		// don't use this client directly.
 		httpTimeout := c.registryHTTPClient(ctx).HTTPClient.Timeout
-		source = getproviders.NewHTTPMirrorSource(u, c.Services.CredentialsSource(), httpTimeout)
+		source = getproviders.NewHTTPMirrorSource(ctx, u, c.Services.CredentialsSource(), httpTimeout)
 	default:
 		// With no special options we consult upstream registries directly,
 		// because that gives us the most information to produce as complete
 		// and portable as possible a lock entry.
-		source = getproviders.NewRegistrySource(c.Services, c.registryHTTPClient(ctx))
+		source = getproviders.NewRegistrySource(ctx, c.Services, c.registryHTTPClient(ctx))
 	}
 
 	config, confDiags := c.loadConfig(ctx, ".")

--- a/internal/command/providers_mirror.go
+++ b/internal/command/providers_mirror.go
@@ -112,7 +112,7 @@ func (c *ProvidersMirrorCommand) Run(args []string) int {
 	// directory without needing to first disable that local mirror
 	// in the CLI configuration.
 	source := getproviders.NewMemoizeSource(
-		getproviders.NewRegistrySource(c.Services, c.registryHTTPClient(ctx)),
+		getproviders.NewRegistrySource(ctx, c.Services, c.registryHTTPClient(ctx)),
 	)
 
 	// Providers from registries always use HTTP, so we don't need the full

--- a/internal/getproviders/filesystem_mirror_source.go
+++ b/internal/getproviders/filesystem_mirror_source.go
@@ -28,7 +28,7 @@ var _ Source = (*FilesystemMirrorSource)(nil)
 
 // NewFilesystemMirrorSource constructs and returns a new filesystem-based
 // mirror source with the given base directory.
-func NewFilesystemMirrorSource(baseDir string) *FilesystemMirrorSource {
+func NewFilesystemMirrorSource(_ context.Context, baseDir string) *FilesystemMirrorSource {
 	return &FilesystemMirrorSource{
 		baseDir: baseDir,
 	}

--- a/internal/getproviders/filesystem_mirror_source_test.go
+++ b/internal/getproviders/filesystem_mirror_source_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestFilesystemMirrorSourceAllAvailablePackages(t *testing.T) {
-	source := NewFilesystemMirrorSource("testdata/filesystem-mirror")
+	source := NewFilesystemMirrorSource(t.Context(), "testdata/filesystem-mirror")
 	got, err := source.AllAvailablePackages()
 	if err != nil {
 		t.Fatal(err)
@@ -102,7 +102,7 @@ func TestFilesystemMirrorSourceAllAvailablePackages(t *testing.T) {
 // In this test the directory layout is invalid (missing the hostname
 // subdirectory). The provider installer should ignore the invalid directory.
 func TestFilesystemMirrorSourceAllAvailablePackages_invalid(t *testing.T) {
-	source := NewFilesystemMirrorSource("testdata/filesystem-mirror-invalid")
+	source := NewFilesystemMirrorSource(t.Context(), "testdata/filesystem-mirror-invalid")
 	_, err := source.AllAvailablePackages()
 	if err != nil {
 		t.Fatal(err)
@@ -110,7 +110,7 @@ func TestFilesystemMirrorSourceAllAvailablePackages_invalid(t *testing.T) {
 }
 
 func TestFilesystemMirrorSourceAvailableVersions(t *testing.T) {
-	source := NewFilesystemMirrorSource("testdata/filesystem-mirror")
+	source := NewFilesystemMirrorSource(t.Context(), "testdata/filesystem-mirror")
 	got, _, err := source.AvailableVersions(context.Background(), nullProvider)
 	if err != nil {
 		t.Fatal(err)
@@ -132,7 +132,7 @@ func TestFilesystemMirrorSourceAvailableVersions_Unspecified(t *testing.T) {
 		Namespace: "testnamespace",
 		Type:      "unspecified",
 	}
-	source := NewFilesystemMirrorSource("testdata/filesystem-mirror-unspecified")
+	source := NewFilesystemMirrorSource(t.Context(), "testdata/filesystem-mirror-unspecified")
 	got, warn, err := source.AvailableVersions(context.Background(), unspecifiedProvider)
 	if err != nil {
 		t.Fatal(err)
@@ -152,7 +152,7 @@ func TestFilesystemMirrorSourceAvailableVersions_Unspecified(t *testing.T) {
 }
 func TestFilesystemMirrorSourcePackageMeta(t *testing.T) {
 	t.Run("available platform", func(t *testing.T) {
-		source := NewFilesystemMirrorSource("testdata/filesystem-mirror")
+		source := NewFilesystemMirrorSource(t.Context(), "testdata/filesystem-mirror")
 		got, err := source.PackageMeta(
 			context.Background(),
 			nullProvider,
@@ -176,7 +176,7 @@ func TestFilesystemMirrorSourcePackageMeta(t *testing.T) {
 		}
 	})
 	t.Run("unavailable platform", func(t *testing.T) {
-		source := NewFilesystemMirrorSource("testdata/filesystem-mirror")
+		source := NewFilesystemMirrorSource(t.Context(), "testdata/filesystem-mirror")
 		// We'll request a version that does exist in the fixture directory,
 		// but for a platform that isn't supported.
 		_, err := source.PackageMeta(

--- a/internal/getproviders/http_mirror_source.go
+++ b/internal/getproviders/http_mirror_source.go
@@ -46,8 +46,8 @@ var _ Source = (*HTTPMirrorSource)(nil)
 // (When the URL comes from user input, such as in the CLI config, it's the
 // UI/config layer's responsibility to validate this and return a suitable
 // error message for the end-user audience.)
-func NewHTTPMirrorSource(baseURL *url.URL, creds svcauth.CredentialsSource, requestTimeout time.Duration) *HTTPMirrorSource {
-	httpClient := httpclient.NewForRegistryRequests(context.TODO(), 0, requestTimeout)
+func NewHTTPMirrorSource(ctx context.Context, baseURL *url.URL, creds svcauth.CredentialsSource, requestTimeout time.Duration) *HTTPMirrorSource {
+	httpClient := httpclient.NewForRegistryRequests(ctx, 0, requestTimeout)
 	httpClient.HTTPClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		// If we get redirected more than five times we'll assume we're
 		// in a redirect loop and bail out, rather than hanging forever.

--- a/internal/getproviders/oci_registry_mirror_source.go
+++ b/internal/getproviders/oci_registry_mirror_source.go
@@ -149,6 +149,7 @@ type OCIRegistryMirrorSource struct {
 var _ Source = (*OCIRegistryMirrorSource)(nil)
 
 func NewOCIRegistryMirrorSource(
+	_ context.Context,
 	resolveRepositoryAddr func(addr addrs.Provider) (registryDomain, repositoryName string, err error),
 	getRepositoryStore func(ctx context.Context, registryDomain, repositoryName string) (OCIRepositoryStore, error),
 ) *OCIRegistryMirrorSource {

--- a/internal/getproviders/registry_client_test.go
+++ b/internal/getproviders/registry_client_test.go
@@ -75,7 +75,7 @@ func testRegistryServices(t *testing.T) (services *disco.Disco, baseURL string, 
 // of your test in order to shut down the test server.
 func testRegistrySource(t *testing.T) (source *RegistrySource, baseURL string, cleanup func()) {
 	services, baseURL, close := testRegistryServices(t)
-	source = NewRegistrySource(services, nil)
+	source = NewRegistrySource(t.Context(), services, nil)
 	return source, baseURL, close
 }
 

--- a/internal/getproviders/registry_source.go
+++ b/internal/getproviders/registry_source.go
@@ -29,12 +29,12 @@ var _ Source = (*RegistrySource)(nil)
 
 // NewRegistrySource creates and returns a new source that will install
 // providers from their originating provider registries.
-func NewRegistrySource(services *disco.Disco, httpClient *retryablehttp.Client) *RegistrySource {
+func NewRegistrySource(ctx context.Context, services *disco.Disco, httpClient *retryablehttp.Client) *RegistrySource {
 	if httpClient == nil {
 		// As an aid to our tests that don't really care that much about
 		// the HTTP client configuration, we'll provide some reasonable
 		// defaults if no custom client is provided.
-		httpClient = httpclient.NewForRegistryRequests(context.Background(), 1, 10*time.Second)
+		httpClient = httpclient.NewForRegistryRequests(ctx, 1, 10*time.Second)
 	}
 
 	return &RegistrySource{

--- a/internal/providercache/installer_test.go
+++ b/internal/providercache/installer_test.go
@@ -2518,7 +2518,7 @@ func TestEnsureProviderVersions(t *testing.T) {
 
 func TestEnsureProviderVersions_local_source(t *testing.T) {
 	// create filesystem source using the test provider cache dir
-	source := getproviders.NewFilesystemMirrorSource("testdata/cachedir")
+	source := getproviders.NewFilesystemMirrorSource(t.Context(), "testdata/cachedir")
 
 	// create a temporary workdir
 	tmpDirPath := t.TempDir()
@@ -2740,7 +2740,7 @@ func testServices(t *testing.T) (services *disco.Disco, baseURL string, cleanup 
 // of your test in order to shut down the test server.
 func testRegistrySource(t *testing.T) (source *getproviders.RegistrySource, baseURL string, cleanup func()) {
 	services, baseURL, close := testServices(t)
-	source = getproviders.NewRegistrySource(services, nil)
+	source = getproviders.NewRegistrySource(t.Context(), services, nil)
 	return source, baseURL, close
 }
 


### PR DESCRIPTION
This is related to https://github.com/opentofu/opentofu/issues/2664.

This completes some of the missing connections for contexts in the provider source codepaths by introducing context.Context parameters and wiring them through so we can eliminate a few more `context.TODO()` placeholders.

For consistency's sake this adds context.Context to all four of the `getproviders.Source` implementations that directly interact with stuff outside of OpenTofu (network services or filesystem), even though not all of them currently make use of it, just because interactions with outside stuff tends to encourage the use of cross-cutting concerns like logging and tracing and so this ensures we have contexts propagated in there for such future uses.
