### PR TITLE
lang: Data methods now take context.Context

### DIFF
--- a/internal/configs/static_scope.go
+++ b/internal/configs/static_scope.go
@@ -75,7 +75,7 @@ func (s staticScopeData) enhanceDiagnostics(ident StaticIdentifier, diags tfdiag
 }
 
 // Early check to only allow references we expect in a static context
-func (s staticScopeData) StaticValidateReferences(refs []*addrs.Reference, _ addrs.Referenceable, _ addrs.Referenceable) tfdiags.Diagnostics {
+func (s staticScopeData) StaticValidateReferences(_ context.Context, refs []*addrs.Reference, _ addrs.Referenceable, _ addrs.Referenceable) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 	top := s.stack[len(s.stack)-1]
 	for _, ref := range refs {
@@ -114,19 +114,19 @@ func (s staticScopeData) StaticValidateReferences(refs []*addrs.Reference, _ add
 	return diags
 }
 
-func (s staticScopeData) GetCountAttr(addrs.CountAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+func (s staticScopeData) GetCountAttr(context.Context, addrs.CountAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	panic("Not Available in Static Context")
 }
 
-func (s staticScopeData) GetForEachAttr(addrs.ForEachAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+func (s staticScopeData) GetForEachAttr(context.Context, addrs.ForEachAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	panic("Not Available in Static Context")
 }
 
-func (s staticScopeData) GetResource(addrs.Resource, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+func (s staticScopeData) GetResource(context.Context, addrs.Resource, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	panic("Not Available in Static Context")
 }
 
-func (s staticScopeData) GetLocalValue(ident addrs.LocalValue, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+func (s staticScopeData) GetLocalValue(ctx context.Context, ident addrs.LocalValue, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	local, ok := s.eval.cfg.Locals[ident.Name]
@@ -151,15 +151,15 @@ func (s staticScopeData) GetLocalValue(ident addrs.LocalValue, rng tfdiags.Sourc
 		return cty.DynamicVal, diags
 	}
 
-	val, valDiags := scope.EvalExpr(context.TODO(), local.Expr, cty.DynamicPseudoType)
+	val, valDiags := scope.EvalExpr(ctx, local.Expr, cty.DynamicPseudoType)
 	return val, s.enhanceDiagnostics(id, diags.Append(valDiags))
 }
 
-func (s staticScopeData) GetModule(addrs.ModuleCall, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+func (s staticScopeData) GetModule(context.Context, addrs.ModuleCall, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	panic("Not Available in Static Context")
 }
 
-func (s staticScopeData) GetPathAttr(addr addrs.PathAttr, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+func (s staticScopeData) GetPathAttr(_ context.Context, addr addrs.PathAttr, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	// TODO this is copied and trimmed down from tofu/evaluate.go GetPathAttr.  Ideally this should be refactored to a common location.
 	var diags tfdiags.Diagnostics
 	switch addr.Name {
@@ -208,7 +208,7 @@ func (s staticScopeData) GetPathAttr(addr addrs.PathAttr, rng tfdiags.SourceRang
 	}
 }
 
-func (s staticScopeData) GetTerraformAttr(addr addrs.TerraformAttr, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+func (s staticScopeData) GetTerraformAttr(_ context.Context, addr addrs.TerraformAttr, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	// TODO this is copied and trimmed down from tofu/evaluate.go GetTerraformAttr.  Ideally this should be refactored to a common location.
 	var diags tfdiags.Diagnostics
 	switch addr.Name {
@@ -239,7 +239,7 @@ func (s staticScopeData) GetTerraformAttr(addr addrs.TerraformAttr, rng tfdiags.
 	}
 }
 
-func (s staticScopeData) GetInputVariable(ident addrs.InputVariable, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+func (s staticScopeData) GetInputVariable(_ context.Context, ident addrs.InputVariable, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	variable, ok := s.eval.cfg.Variables[ident.Name]
@@ -376,10 +376,10 @@ func (s staticScopeData) GetInputVariable(ident addrs.InputVariable, rng tfdiags
 	return val, s.enhanceDiagnostics(id, diags)
 }
 
-func (s staticScopeData) GetOutput(addrs.OutputValue, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+func (s staticScopeData) GetOutput(context.Context, addrs.OutputValue, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	panic("Not Available in Static Context")
 }
 
-func (s staticScopeData) GetCheckBlock(addrs.Check, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+func (s staticScopeData) GetCheckBlock(context.Context, addrs.Check, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	panic("Not Available in Static Context")
 }

--- a/internal/configs/static_scope_test.go
+++ b/internal/configs/static_scope_test.go
@@ -199,7 +199,7 @@ func TestStaticScope_GetInputVariable(t *testing.T) {
 		for name, test := range tests {
 			t.Run(name, func(t *testing.T) {
 				addr := addrs.InputVariable{Name: name}
-				gotFinalVal, moreDiags := scope.Data.GetInputVariable(addr, tfdiags.SourceRange{Filename: "test.tf"})
+				gotFinalVal, moreDiags := scope.Data.GetInputVariable(t.Context(), addr, tfdiags.SourceRange{Filename: "test.tf"})
 				assertNoDiagnostics(t, moreDiags.ToHCL())
 
 				if !test.wantFinalVal.RawEquals(gotFinalVal) {
@@ -233,7 +233,7 @@ func TestStaticScope_GetInputVariable(t *testing.T) {
 		scope := newStaticScope(eval, test_ident)
 
 		addr := addrs.InputVariable{Name: "bad_default"}
-		_, moreDiags := scope.Data.GetInputVariable(addr, tfdiags.SourceRange{Filename: "test.tf"})
+		_, moreDiags := scope.Data.GetInputVariable(t.Context(), addr, tfdiags.SourceRange{Filename: "test.tf"})
 		if !moreDiags.HasErrors() {
 			t.Fatal("unexpected success; want a type conversion error")
 		}
@@ -271,7 +271,7 @@ func TestStaticScope_GetInputVariable(t *testing.T) {
 		scope := newStaticScope(eval, test_ident)
 
 		addr := addrs.InputVariable{Name: "not_nullable"}
-		_, moreDiags := scope.Data.GetInputVariable(addr, tfdiags.SourceRange{Filename: "test.tf"})
+		_, moreDiags := scope.Data.GetInputVariable(t.Context(), addr, tfdiags.SourceRange{Filename: "test.tf"})
 		if !moreDiags.HasErrors() {
 			t.Fatal("unexpected success; want an error about the variable being required")
 		}
@@ -313,7 +313,7 @@ func TestStaticScope_GetLocalValue(t *testing.T) {
 		scope := newStaticScope(eval, test_ident)
 
 		addr := addrs.LocalValue{Name: "foo"}
-		got, moreDiags := scope.Data.GetLocalValue(addr, tfdiags.SourceRange{Filename: "test.tf"})
+		got, moreDiags := scope.Data.GetLocalValue(t.Context(), addr, tfdiags.SourceRange{Filename: "test.tf"})
 		want := cty.StringVal("bar")
 		assertNoDiagnostics(t, moreDiags.ToHCL())
 		if !got.RawEquals(want) {
@@ -344,7 +344,7 @@ func TestStaticScope_GetLocalValue(t *testing.T) {
 		scope := newStaticScope(eval, test_ident)
 
 		addr := addrs.LocalValue{Name: "nonexist"}
-		_, moreDiags := scope.Data.GetLocalValue(addr, tfdiags.SourceRange{Filename: "test.tf"})
+		_, moreDiags := scope.Data.GetLocalValue(t.Context(), addr, tfdiags.SourceRange{Filename: "test.tf"})
 		if !moreDiags.HasErrors() {
 			t.Fatal("unexpected success; want error")
 		}

--- a/internal/lang/data.go
+++ b/internal/lang/data.go
@@ -6,6 +6,8 @@
 package lang
 
 import (
+	"context"
+
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -26,16 +28,16 @@ import (
 // cases where it's not possible to even determine a suitable result type,
 // cty.DynamicVal is returned along with errors describing the problem.
 type Data interface {
-	StaticValidateReferences(refs []*addrs.Reference, self addrs.Referenceable, source addrs.Referenceable) tfdiags.Diagnostics
+	StaticValidateReferences(ctx context.Context, refs []*addrs.Reference, self addrs.Referenceable, source addrs.Referenceable) tfdiags.Diagnostics
 
-	GetCountAttr(addrs.CountAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
-	GetForEachAttr(addrs.ForEachAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
-	GetResource(addrs.Resource, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
-	GetLocalValue(addrs.LocalValue, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
-	GetModule(addrs.ModuleCall, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
-	GetPathAttr(addrs.PathAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
-	GetTerraformAttr(addrs.TerraformAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
-	GetInputVariable(addrs.InputVariable, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
-	GetOutput(addrs.OutputValue, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
-	GetCheckBlock(addrs.Check, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
+	GetCountAttr(context.Context, addrs.CountAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
+	GetForEachAttr(context.Context, addrs.ForEachAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
+	GetResource(context.Context, addrs.Resource, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
+	GetLocalValue(context.Context, addrs.LocalValue, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
+	GetModule(context.Context, addrs.ModuleCall, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
+	GetPathAttr(context.Context, addrs.PathAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
+	GetTerraformAttr(context.Context, addrs.TerraformAttr, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
+	GetInputVariable(context.Context, addrs.InputVariable, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
+	GetOutput(context.Context, addrs.OutputValue, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
+	GetCheckBlock(context.Context, addrs.Check, tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics)
 }

--- a/internal/lang/data_test.go
+++ b/internal/lang/data_test.go
@@ -6,6 +6,8 @@
 package lang
 
 import (
+	"context"
+
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -27,52 +29,52 @@ type dataForTests struct {
 
 var _ Data = &dataForTests{}
 
-func (d *dataForTests) StaticValidateReferences(refs []*addrs.Reference, self addrs.Referenceable, source addrs.Referenceable) tfdiags.Diagnostics {
+func (d *dataForTests) StaticValidateReferences(_ context.Context, refs []*addrs.Reference, self addrs.Referenceable, source addrs.Referenceable) tfdiags.Diagnostics {
 	return nil // does nothing in this stub implementation
 }
 
-func (d *dataForTests) GetCountAttr(addr addrs.CountAttr, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+func (d *dataForTests) GetCountAttr(_ context.Context, addr addrs.CountAttr, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	return d.CountAttrs[addr.Name], nil
 }
 
-func (d *dataForTests) GetForEachAttr(addr addrs.ForEachAttr, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+func (d *dataForTests) GetForEachAttr(_ context.Context, addr addrs.ForEachAttr, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	return d.ForEachAttrs[addr.Name], nil
 }
 
-func (d *dataForTests) GetResource(addr addrs.Resource, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+func (d *dataForTests) GetResource(_ context.Context, addr addrs.Resource, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	return d.Resources[addr.String()], nil
 }
 
-func (d *dataForTests) GetInputVariable(addr addrs.InputVariable, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+func (d *dataForTests) GetInputVariable(_ context.Context, addr addrs.InputVariable, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	return d.InputVariables[addr.Name], nil
 }
 
-func (d *dataForTests) GetLocalValue(addr addrs.LocalValue, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+func (d *dataForTests) GetLocalValue(_ context.Context, addr addrs.LocalValue, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	return d.LocalValues[addr.Name], nil
 }
 
-func (d *dataForTests) GetModule(addr addrs.ModuleCall, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+func (d *dataForTests) GetModule(_ context.Context, addr addrs.ModuleCall, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	return d.Modules[addr.String()], nil
 }
 
-func (d *dataForTests) GetModuleInstanceOutput(addr addrs.ModuleCallInstanceOutput, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+func (d *dataForTests) GetModuleInstanceOutput(_ context.Context, addr addrs.ModuleCallInstanceOutput, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	// This will panic if the module object does not have the requested attribute
 	obj := d.Modules[addr.Call.String()]
 	return obj.GetAttr(addr.Name), nil
 }
 
-func (d *dataForTests) GetPathAttr(addr addrs.PathAttr, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+func (d *dataForTests) GetPathAttr(_ context.Context, addr addrs.PathAttr, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	return d.PathAttrs[addr.Name], nil
 }
 
-func (d *dataForTests) GetTerraformAttr(addr addrs.TerraformAttr, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+func (d *dataForTests) GetTerraformAttr(_ context.Context, addr addrs.TerraformAttr, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	return d.TerraformAttrs[addr.Name], nil
 }
 
-func (d *dataForTests) GetOutput(addr addrs.OutputValue, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+func (d *dataForTests) GetOutput(_ context.Context, addr addrs.OutputValue, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	return d.OutputValues[addr.Name], nil
 }
 
-func (d *dataForTests) GetCheckBlock(addr addrs.Check, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
+func (d *dataForTests) GetCheckBlock(_ context.Context, addr addrs.Check, rng tfdiags.SourceRange) (cty.Value, tfdiags.Diagnostics) {
 	return d.CheckBlocks[addr.Name], nil
 }

--- a/internal/lang/eval_test.go
+++ b/internal/lang/eval_test.go
@@ -929,7 +929,7 @@ func TestScopeEvalSelfBlock(t *testing.T) {
 				ParseRef: addrs.ParseRef,
 			}
 
-			gotVal, ctxDiags := scope.EvalSelfBlock(body, test.Self, schema, test.KeyData)
+			gotVal, ctxDiags := scope.EvalSelfBlock(t.Context(), body, test.Self, schema, test.KeyData)
 			if ctxDiags.HasErrors() {
 				t.Fatal(ctxDiags.Err())
 			}

--- a/internal/tofu/context_functions.go
+++ b/internal/tofu/context_functions.go
@@ -25,7 +25,7 @@ func evalContextProviderFunction(ctx context.Context, provider providers.Interfa
 	var diags tfdiags.Diagnostics
 
 	// First try to look up the function from provider schema
-	schema := provider.GetProviderSchema(context.TODO())
+	schema := provider.GetProviderSchema(ctx)
 	if schema.Diagnostics.HasErrors() {
 		return nil, schema.Diagnostics
 	}

--- a/internal/tofu/context_import.go
+++ b/internal/tofu/context_import.go
@@ -127,7 +127,7 @@ func (ri *ImportResolver) ExpandAndResolveImport(importTarget *ImportTarget, ctx
 		const tupleAllowed = true
 
 		// The import target has a for_each attribute, so we need to expand it
-		forEachVal, evalDiags := evaluateForEachExpressionValue(importTarget.Config.ForEach, rootCtx, unknownsNotAllowed, tupleAllowed, nil)
+		forEachVal, evalDiags := evaluateForEachExpressionValue(context.TODO(), importTarget.Config.ForEach, rootCtx, unknownsNotAllowed, tupleAllowed, nil)
 		diags = diags.Append(evalDiags)
 		if diags.HasErrors() {
 			return diags

--- a/internal/tofu/eval_conditions.go
+++ b/internal/tofu/eval_conditions.go
@@ -33,10 +33,10 @@ import (
 //
 // If any of the rules do not pass, the returned diagnostics will contain
 // errors. Otherwise, it will either be empty or contain only warnings.
-func evalCheckRules(typ addrs.CheckRuleType, rules []*configs.CheckRule, ctx EvalContext, self addrs.Checkable, keyData instances.RepetitionData, diagSeverity tfdiags.Severity) tfdiags.Diagnostics {
+func evalCheckRules(ctx context.Context, typ addrs.CheckRuleType, rules []*configs.CheckRule, evalCtx EvalContext, self addrs.Checkable, keyData instances.RepetitionData, diagSeverity tfdiags.Severity) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
-	checkState := ctx.Checks()
+	checkState := evalCtx.Checks()
 	if !checkState.ConfigHasChecks(self.ConfigCheckable()) {
 		// We have nothing to do if this object doesn't have any checks,
 		// but the "rules" slice should agree that we don't.
@@ -54,7 +54,7 @@ func evalCheckRules(typ addrs.CheckRuleType, rules []*configs.CheckRule, ctx Eva
 	severity := diagSeverity.ToHCL()
 
 	for i, rule := range rules {
-		result, ruleDiags := evalCheckRule(addrs.NewCheckRule(self, typ, i), rule, ctx, keyData, severity)
+		result, ruleDiags := evalCheckRule(ctx, addrs.NewCheckRule(self, typ, i), rule, evalCtx, keyData, severity)
 		diags = diags.Append(ruleDiags)
 
 		log.Printf("[TRACE] evalCheckRules: %s status is now %s", self, result.Status)
@@ -73,7 +73,7 @@ type checkResult struct {
 	FailureMessage string
 }
 
-func validateCheckRule(addr addrs.CheckRule, rule *configs.CheckRule, ctx EvalContext, keyData instances.RepetitionData) (string, *hcl.EvalContext, tfdiags.Diagnostics) {
+func validateCheckRule(ctx context.Context, addr addrs.CheckRule, rule *configs.CheckRule, evalCtx EvalContext, keyData instances.RepetitionData) (string, *hcl.EvalContext, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	refs, moreDiags := lang.ReferencesInExpr(addrs.ParseRef, rule.Condition)
@@ -102,9 +102,9 @@ func validateCheckRule(addr addrs.CheckRule, rule *configs.CheckRule, ctx EvalCo
 			panic(fmt.Sprintf("Invalid source reference type %t", addr.Container))
 		}
 	}
-	scope := ctx.EvaluationScope(selfReference, sourceReference, keyData)
+	scope := evalCtx.EvaluationScope(selfReference, sourceReference, keyData)
 
-	hclCtx, moreDiags := scope.EvalContext(context.TODO(), refs)
+	hclCtx, moreDiags := scope.EvalContext(ctx, refs)
 	diags = diags.Append(moreDiags)
 
 	errorMessage, moreDiags := evalCheckErrorMessage(rule.ErrorMessage, hclCtx)
@@ -113,11 +113,11 @@ func validateCheckRule(addr addrs.CheckRule, rule *configs.CheckRule, ctx EvalCo
 	return errorMessage, hclCtx, diags
 }
 
-func evalCheckRule(addr addrs.CheckRule, rule *configs.CheckRule, ctx EvalContext, keyData instances.RepetitionData, severity hcl.DiagnosticSeverity) (checkResult, tfdiags.Diagnostics) {
+func evalCheckRule(ctx context.Context, addr addrs.CheckRule, rule *configs.CheckRule, evalCtx EvalContext, keyData instances.RepetitionData, severity hcl.DiagnosticSeverity) (checkResult, tfdiags.Diagnostics) {
 	// NOTE: Intentionally not passing the caller's selected severity in here,
 	// because this reports errors in the configuration itself, not the failure
 	// of an otherwise-valid condition.
-	errorMessage, hclCtx, diags := validateCheckRule(addr, rule, ctx, keyData)
+	errorMessage, hclCtx, diags := validateCheckRule(ctx, addr, rule, evalCtx, keyData)
 
 	const errInvalidCondition = "Invalid condition result"
 

--- a/internal/tofu/eval_context_builtin.go
+++ b/internal/tofu/eval_context_builtin.go
@@ -477,7 +477,7 @@ func (c *BuiltinEvalContext) EvaluationScope(self addrs.Referenceable, source ad
 			}
 
 			var keyDiags tfdiags.Diagnostics
-			providerKey, keyDiags = resolveProviderModuleInstance(c, providedBy.KeyExpression, moduleInstanceForKey, c.PathValue.String()+" "+pf.String())
+			providerKey, keyDiags = resolveProviderModuleInstance(ctx, c, providedBy.KeyExpression, moduleInstanceForKey, c.PathValue.String()+" "+pf.String())
 			if keyDiags.HasErrors() {
 				return nil, keyDiags
 			}

--- a/internal/tofu/eval_count_test.go
+++ b/internal/tofu/eval_count_test.go
@@ -34,7 +34,7 @@ func TestEvaluateCountExpression(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := &MockEvalContext{}
 			ctx.installSimpleEval()
-			countVal, diags := evaluateCountExpression(test.Expr, ctx, nil)
+			countVal, diags := evaluateCountExpression(t.Context(), test.Expr, ctx, nil)
 
 			if len(diags) != 0 {
 				t.Errorf("unexpected diagnostics %s", spew.Sdump(diags))

--- a/internal/tofu/eval_expansion.go
+++ b/internal/tofu/eval_expansion.go
@@ -16,7 +16,7 @@ import (
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
-func evalContextScope(evalCtx EvalContext) evalchecks.ContextFunc {
+func evalContextScope(ctx context.Context, evalCtx EvalContext) evalchecks.ContextFunc {
 	scope := evalCtx.EvaluationScope(nil, nil, EvalDataForNoInstanceKey)
 	return func(refs []*addrs.Reference) (*hcl.EvalContext, tfdiags.Diagnostics) {
 		if scope == nil {
@@ -24,28 +24,28 @@ func evalContextScope(evalCtx EvalContext) evalchecks.ContextFunc {
 			// in unit tests due to incompletely-implemented mocks. :(
 			return &hcl.EvalContext{}, nil
 		}
-		return scope.EvalContext(context.TODO(), refs)
+		return scope.EvalContext(ctx, refs)
 	}
 }
 
-func evalContextEvaluate(evalCtx EvalContext) evalchecks.EvaluateFunc {
+func evalContextEvaluate(ctx context.Context, evalCtx EvalContext) evalchecks.EvaluateFunc {
 	return func(expr hcl.Expression) (cty.Value, tfdiags.Diagnostics) {
 		return evalCtx.EvaluateExpr(expr, cty.Number, nil)
 	}
 }
 
-func evaluateForEachExpression(expr hcl.Expression, evalCtx EvalContext, excludeableAddr addrs.Targetable) (map[string]cty.Value, tfdiags.Diagnostics) {
-	return evalchecks.EvaluateForEachExpression(expr, evalContextScope(evalCtx), excludeableAddr)
+func evaluateForEachExpression(ctx context.Context, expr hcl.Expression, evalCtx EvalContext, excludeableAddr addrs.Targetable) (map[string]cty.Value, tfdiags.Diagnostics) {
+	return evalchecks.EvaluateForEachExpression(expr, evalContextScope(ctx, evalCtx), excludeableAddr)
 }
 
-func evaluateForEachExpressionValue(expr hcl.Expression, evalCtx EvalContext, allowUnknown bool, allowTuple bool, excludeableAddr addrs.Targetable) (cty.Value, tfdiags.Diagnostics) {
-	return evalchecks.EvaluateForEachExpressionValue(expr, evalContextScope(evalCtx), allowUnknown, allowTuple, excludeableAddr)
+func evaluateForEachExpressionValue(ctx context.Context, expr hcl.Expression, evalCtx EvalContext, allowUnknown bool, allowTuple bool, excludeableAddr addrs.Targetable) (cty.Value, tfdiags.Diagnostics) {
+	return evalchecks.EvaluateForEachExpressionValue(expr, evalContextScope(ctx, evalCtx), allowUnknown, allowTuple, excludeableAddr)
 }
 
-func evaluateCountExpression(expr hcl.Expression, evalCtx EvalContext, excludeableAddr addrs.Targetable) (int, tfdiags.Diagnostics) {
-	return evalchecks.EvaluateCountExpression(expr, evalContextEvaluate(evalCtx), excludeableAddr)
+func evaluateCountExpression(ctx context.Context, expr hcl.Expression, evalCtx EvalContext, excludeableAddr addrs.Targetable) (int, tfdiags.Diagnostics) {
+	return evalchecks.EvaluateCountExpression(expr, evalContextEvaluate(ctx, evalCtx), excludeableAddr)
 }
 
-func evaluateCountExpressionValue(expr hcl.Expression, evalCtx EvalContext) (cty.Value, tfdiags.Diagnostics) {
-	return evalchecks.EvaluateCountExpressionValue(expr, evalContextEvaluate(evalCtx))
+func evaluateCountExpressionValue(ctx context.Context, expr hcl.Expression, evalCtx EvalContext) (cty.Value, tfdiags.Diagnostics) {
+	return evalchecks.EvaluateCountExpressionValue(expr, evalContextEvaluate(ctx, evalCtx))
 }

--- a/internal/tofu/eval_provider_test.go
+++ b/internal/tofu/eval_provider_test.go
@@ -96,7 +96,7 @@ func TestResolveProviderInstance_TypeConversion(t *testing.T) {
 				BaseDir: ".",
 			}
 			// call of the function to test
-			actualKey, diags := resolveProviderInstance(expr, scope, "test-source")
+			actualKey, diags := resolveProviderInstance(t.Context(), expr, scope, "test-source")
 
 			if diags.HasErrors() {
 				t.Fatalf("Unexpected error: %s", diags.Err())

--- a/internal/tofu/eval_variable_test.go
+++ b/internal/tofu/eval_variable_test.go
@@ -1172,11 +1172,11 @@ func TestEvalVariableValidations_jsonErrorMessageEdgeCase(t *testing.T) {
 
 			// Build a mock context to allow the function under test to
 			// retrieve the variable value and evaluate the expressions
-			ctx := &MockEvalContext{}
+			evalCtx := &MockEvalContext{}
 
 			// We need a minimal scope to allow basic functions to be passed to
 			// the HCL scope
-			ctx.EvaluationScopeScope = &lang.Scope{
+			evalCtx.EvaluationScopeScope = &lang.Scope{
 				Data: &evaluationStateData{Evaluator: &Evaluator{
 					Config:             cfg,
 					VariableValuesLock: &sync.Mutex{},
@@ -1185,21 +1185,21 @@ func TestEvalVariableValidations_jsonErrorMessageEdgeCase(t *testing.T) {
 					}},
 				}},
 			}
-			ctx.GetVariableValueFunc = func(addr addrs.AbsInputVariableInstance) cty.Value {
+			evalCtx.GetVariableValueFunc = func(addr addrs.AbsInputVariableInstance) cty.Value {
 				if got, want := addr.String(), varAddr.String(); got != want {
 					t.Errorf("incorrect argument to GetVariableValue: got %s, want %s", got, want)
 				}
 				return test.given
 			}
-			ctx.ChecksState = checks.NewState(cfg)
-			ctx.ChecksState.ReportCheckableObjects(varAddr.ConfigCheckable(), addrs.MakeSet[addrs.Checkable](varAddr))
+			evalCtx.ChecksState = checks.NewState(cfg)
+			evalCtx.ChecksState.ReportCheckableObjects(varAddr.ConfigCheckable(), addrs.MakeSet[addrs.Checkable](varAddr))
 
 			gotDiags := evalVariableValidations(
-				varAddr, varCfg, nil, ctx,
+				t.Context(), varAddr, varCfg, nil, evalCtx,
 			)
 
-			if ctx.ChecksState.ObjectCheckStatus(varAddr) != test.status {
-				t.Errorf("expected check result %s but instead %s", test.status, ctx.ChecksState.ObjectCheckStatus(varAddr))
+			if evalCtx.ChecksState.ObjectCheckStatus(varAddr) != test.status {
+				t.Errorf("expected check result %s but instead %s", test.status, evalCtx.ChecksState.ObjectCheckStatus(varAddr))
 			}
 
 			if len(test.wantErr) == 0 && len(test.wantWarn) == 0 {
@@ -1333,11 +1333,11 @@ variable "bar" {
 
 			// Build a mock context to allow the function under test to
 			// retrieve the variable value and evaluate the expressions
-			ctx := &MockEvalContext{}
+			evalCtx := &MockEvalContext{}
 
 			// We need a minimal scope to allow basic functions to be passed to
 			// the HCL scope
-			ctx.EvaluationScopeScope = &lang.Scope{
+			evalCtx.EvaluationScopeScope = &lang.Scope{
 				Data: &evaluationStateData{Evaluator: &Evaluator{
 					Config:             cfg,
 					VariableValuesLock: &sync.Mutex{},
@@ -1346,7 +1346,7 @@ variable "bar" {
 					}},
 				}},
 			}
-			ctx.GetVariableValueFunc = func(addr addrs.AbsInputVariableInstance) cty.Value {
+			evalCtx.GetVariableValueFunc = func(addr addrs.AbsInputVariableInstance) cty.Value {
 				if got, want := addr.String(), varAddr.String(); got != want {
 					t.Errorf("incorrect argument to GetVariableValue: got %s, want %s", got, want)
 				}
@@ -1356,15 +1356,15 @@ variable "bar" {
 				// configured sensitivity.
 				return test.given
 			}
-			ctx.ChecksState = checks.NewState(cfg)
-			ctx.ChecksState.ReportCheckableObjects(varAddr.ConfigCheckable(), addrs.MakeSet[addrs.Checkable](varAddr))
+			evalCtx.ChecksState = checks.NewState(cfg)
+			evalCtx.ChecksState.ReportCheckableObjects(varAddr.ConfigCheckable(), addrs.MakeSet[addrs.Checkable](varAddr))
 
 			gotDiags := evalVariableValidations(
-				varAddr, varCfg, nil, ctx,
+				t.Context(), varAddr, varCfg, nil, evalCtx,
 			)
 
-			if ctx.ChecksState.ObjectCheckStatus(varAddr) != test.status {
-				t.Errorf("expected check result %s but instead %s", test.status, ctx.ChecksState.ObjectCheckStatus(varAddr))
+			if evalCtx.ChecksState.ObjectCheckStatus(varAddr) != test.status {
+				t.Errorf("expected check result %s but instead %s", test.status, evalCtx.ChecksState.ObjectCheckStatus(varAddr))
 			}
 
 			if len(test.wantErr) == 0 {
@@ -1437,7 +1437,7 @@ func TestEvalVariableValidations_sensitiveValueDiagnostics(t *testing.T) {
 	ctx.ChecksState.ReportCheckableObjects(varAddr.ConfigCheckable(), addrs.MakeSet[addrs.Checkable](varAddr))
 
 	gotDiags := evalVariableValidations(
-		varAddr, cfg.Module.Variables["foo"], nil, ctx,
+		t.Context(), varAddr, cfg.Module.Variables["foo"], nil, ctx,
 	)
 	if !gotDiags.HasErrors() {
 		t.Fatalf("unexpected success; want validation error")

--- a/internal/tofu/evaluate_test.go
+++ b/internal/tofu/evaluate_test.go
@@ -35,7 +35,7 @@ func TestEvaluatorGetTerraformAttr(t *testing.T) {
 
 	t.Run("terraform.workspace", func(t *testing.T) {
 		want := cty.StringVal("foo")
-		got, diags := scope.Data.GetTerraformAttr(addrs.NewTerraformAttr("terraform", "workspace"), tfdiags.SourceRange{})
+		got, diags := scope.Data.GetTerraformAttr(t.Context(), addrs.NewTerraformAttr("terraform", "workspace"), tfdiags.SourceRange{})
 		if len(diags) != 0 {
 			t.Errorf("unexpected diagnostics %s", spew.Sdump(diags))
 		}
@@ -46,7 +46,7 @@ func TestEvaluatorGetTerraformAttr(t *testing.T) {
 
 	t.Run("tofu.workspace", func(t *testing.T) {
 		want := cty.StringVal("foo")
-		got, diags := scope.Data.GetTerraformAttr(addrs.NewTerraformAttr("tofu", "workspace"), tfdiags.SourceRange{})
+		got, diags := scope.Data.GetTerraformAttr(t.Context(), addrs.NewTerraformAttr("tofu", "workspace"), tfdiags.SourceRange{})
 		if len(diags) != 0 {
 			t.Errorf("unexpected diagnostics %s", spew.Sdump(diags))
 		}
@@ -74,7 +74,7 @@ func TestEvaluatorGetPathAttr(t *testing.T) {
 
 	t.Run("module", func(t *testing.T) {
 		want := cty.StringVal("bar/baz")
-		got, diags := scope.Data.GetPathAttr(addrs.PathAttr{
+		got, diags := scope.Data.GetPathAttr(t.Context(), addrs.PathAttr{
 			Name: "module",
 		}, tfdiags.SourceRange{})
 		if len(diags) != 0 {
@@ -87,7 +87,7 @@ func TestEvaluatorGetPathAttr(t *testing.T) {
 
 	t.Run("root", func(t *testing.T) {
 		want := cty.StringVal("bar/baz")
-		got, diags := scope.Data.GetPathAttr(addrs.PathAttr{
+		got, diags := scope.Data.GetPathAttr(t.Context(), addrs.PathAttr{
 			Name: "root",
 		}, tfdiags.SourceRange{})
 		if len(diags) != 0 {
@@ -139,7 +139,7 @@ func TestEvaluatorGetOutputValue(t *testing.T) {
 	scope := evaluator.Scope(data, nil, nil, nil)
 
 	want := cty.StringVal("first").Mark(marks.Sensitive)
-	got, diags := scope.Data.GetOutput(addrs.OutputValue{
+	got, diags := scope.Data.GetOutput(t.Context(), addrs.OutputValue{
 		Name: "some_output",
 	}, tfdiags.SourceRange{})
 
@@ -151,7 +151,7 @@ func TestEvaluatorGetOutputValue(t *testing.T) {
 	}
 
 	want = cty.StringVal("second")
-	got, diags = scope.Data.GetOutput(addrs.OutputValue{
+	got, diags = scope.Data.GetOutput(t.Context(), addrs.OutputValue{
 		Name: "some_other_output",
 	}, tfdiags.SourceRange{})
 
@@ -206,7 +206,7 @@ func TestEvaluatorGetInputVariable(t *testing.T) {
 	scope := evaluator.Scope(data, nil, nil, nil)
 
 	want := cty.StringVal("bar").Mark(marks.Sensitive)
-	got, diags := scope.Data.GetInputVariable(addrs.InputVariable{
+	got, diags := scope.Data.GetInputVariable(t.Context(), addrs.InputVariable{
 		Name: "some_var",
 	}, tfdiags.SourceRange{})
 
@@ -218,7 +218,7 @@ func TestEvaluatorGetInputVariable(t *testing.T) {
 	}
 
 	want = cty.StringVal("boop").Mark(marks.Sensitive)
-	got, diags = scope.Data.GetInputVariable(addrs.InputVariable{
+	got, diags = scope.Data.GetInputVariable(t.Context(), addrs.InputVariable{
 		Name: "some_other_var",
 	}, tfdiags.SourceRange{})
 
@@ -391,7 +391,7 @@ func TestEvaluatorGetResource(t *testing.T) {
 		Type: "test_resource",
 		Name: "foo",
 	}
-	got, diags := scope.Data.GetResource(addr, tfdiags.SourceRange{})
+	got, diags := scope.Data.GetResource(t.Context(), addr, tfdiags.SourceRange{})
 
 	if len(diags) != 0 {
 		t.Errorf("unexpected diagnostics %s", spew.Sdump(diags))
@@ -532,7 +532,7 @@ func TestEvaluatorGetResource_changes(t *testing.T) {
 		}).Mark(marks.Sensitive),
 	})
 
-	got, diags := scope.Data.GetResource(addr, tfdiags.SourceRange{})
+	got, diags := scope.Data.GetResource(t.Context(), addr, tfdiags.SourceRange{})
 
 	if len(diags) != 0 {
 		t.Errorf("unexpected diagnostics %s", spew.Sdump(diags))
@@ -559,7 +559,7 @@ func TestEvaluatorGetModule(t *testing.T) {
 	}
 	scope := evaluator.Scope(data, nil, nil, nil)
 	want := cty.ObjectVal(map[string]cty.Value{"out": cty.StringVal("bar").Mark(marks.Sensitive)})
-	got, diags := scope.Data.GetModule(addrs.ModuleCall{
+	got, diags := scope.Data.GetModule(t.Context(), addrs.ModuleCall{
 		Name: "mod",
 	}, tfdiags.SourceRange{})
 
@@ -587,7 +587,7 @@ func TestEvaluatorGetModule(t *testing.T) {
 	}
 	scope = evaluator.Scope(data, nil, nil, nil)
 	want = cty.ObjectVal(map[string]cty.Value{"out": cty.StringVal("baz").Mark(marks.Sensitive)})
-	got, diags = scope.Data.GetModule(addrs.ModuleCall{
+	got, diags = scope.Data.GetModule(t.Context(), addrs.ModuleCall{
 		Name: "mod",
 	}, tfdiags.SourceRange{})
 
@@ -605,7 +605,7 @@ func TestEvaluatorGetModule(t *testing.T) {
 	}
 	scope = evaluator.Scope(data, nil, nil, nil)
 	want = cty.ObjectVal(map[string]cty.Value{"out": cty.StringVal("baz").Mark(marks.Sensitive)})
-	got, diags = scope.Data.GetModule(addrs.ModuleCall{
+	got, diags = scope.Data.GetModule(t.Context(), addrs.ModuleCall{
 		Name: "mod",
 	}, tfdiags.SourceRange{})
 

--- a/internal/tofu/evaluate_valid_test.go
+++ b/internal/tofu/evaluate_valid_test.go
@@ -133,7 +133,7 @@ For example, to correlate with indices of a referring resource, use:
 				Evaluator: evaluator,
 			}
 
-			diags = data.StaticValidateReferences(refs, nil, test.Src)
+			diags = data.StaticValidateReferences(t.Context(), refs, nil, test.Src)
 			if diags.HasErrors() {
 				if test.WantErr == "" {
 					t.Fatalf("Unexpected diagnostics: %s", diags.Err())

--- a/internal/tofu/node_check.go
+++ b/internal/tofu/node_check.go
@@ -151,7 +151,7 @@ func (n *nodeCheckAssert) Path() addrs.ModuleInstance {
 	return n.addr.Module
 }
 
-func (n *nodeCheckAssert) Execute(_ context.Context, evalCtx EvalContext, _ walkOperation) tfdiags.Diagnostics {
+func (n *nodeCheckAssert) Execute(ctx context.Context, evalCtx EvalContext, _ walkOperation) tfdiags.Diagnostics {
 
 	// We only want to actually execute the checks during specific
 	// operations, such as plan and applies.
@@ -164,6 +164,7 @@ func (n *nodeCheckAssert) Execute(_ context.Context, evalCtx EvalContext, _ walk
 		}
 
 		return evalCheckRules(
+			ctx,
 			addrs.CheckAssertion,
 			n.config.Asserts,
 			evalCtx,
@@ -177,7 +178,7 @@ func (n *nodeCheckAssert) Execute(_ context.Context, evalCtx EvalContext, _ walk
 	// diagnostics if references do not exist etc.
 	var diags tfdiags.Diagnostics
 	for ix, assert := range n.config.Asserts {
-		_, _, moreDiags := validateCheckRule(addrs.NewCheckRule(n.addr, addrs.CheckAssertion, ix), assert, evalCtx, EvalDataForNoInstanceKey)
+		_, _, moreDiags := validateCheckRule(ctx, addrs.NewCheckRule(n.addr, addrs.CheckAssertion, ix), assert, evalCtx, EvalDataForNoInstanceKey)
 		diags = diags.Append(moreDiags)
 	}
 	return diags

--- a/internal/tofu/node_module_variable.go
+++ b/internal/tofu/node_module_variable.go
@@ -151,10 +151,10 @@ func (n *nodeModuleVariable) ModulePath() addrs.Module {
 }
 
 // GraphNodeExecutable
-func (n *nodeModuleVariable) Execute(_ context.Context, evalCtx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *nodeModuleVariable) Execute(ctx context.Context, evalCtx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	log.Printf("[TRACE] nodeModuleVariable: evaluating %s", n.Addr)
 
-	val, err := n.evalModuleVariable(evalCtx, op == walkValidate)
+	val, err := n.evalModuleVariable(ctx, evalCtx, op == walkValidate)
 	diags = diags.Append(err)
 	if diags.HasErrors() {
 		return diags
@@ -190,7 +190,7 @@ func (n *nodeModuleVariable) DotNode(name string, opts *dag.DotOpts) *dag.DotNod
 // validateOnly indicates that this evaluation is only for config
 // validation, and we will not have any expansion module instance
 // repetition data.
-func (n *nodeModuleVariable) evalModuleVariable(evalCtx EvalContext, validateOnly bool) (cty.Value, error) {
+func (n *nodeModuleVariable) evalModuleVariable(ctx context.Context, evalCtx EvalContext, validateOnly bool) (cty.Value, error) {
 	var diags tfdiags.Diagnostics
 	var givenVal cty.Value
 	var errSourceRange tfdiags.SourceRange
@@ -214,7 +214,7 @@ func (n *nodeModuleVariable) evalModuleVariable(evalCtx EvalContext, validateOnl
 		}
 
 		scope := evalCtx.EvaluationScope(nil, nil, moduleInstanceRepetitionData)
-		val, moreDiags := scope.EvalExpr(context.TODO(), expr, cty.DynamicPseudoType)
+		val, moreDiags := scope.EvalExpr(ctx, expr, cty.DynamicPseudoType)
 		diags = diags.Append(moreDiags)
 		if moreDiags.HasErrors() {
 			return cty.DynamicVal, diags.ErrWithWarnings()

--- a/internal/tofu/node_output.go
+++ b/internal/tofu/node_output.go
@@ -303,7 +303,7 @@ func (n *NodeApplyableOutput) References() []*addrs.Reference {
 }
 
 // GraphNodeExecutable
-func (n *NodeApplyableOutput) Execute(_ context.Context, evalCtx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *NodeApplyableOutput) Execute(ctx context.Context, evalCtx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	state := evalCtx.State()
 	if state == nil {
 		return
@@ -331,6 +331,7 @@ func (n *NodeApplyableOutput) Execute(_ context.Context, evalCtx EvalContext, op
 			checkRuleSeverity = tfdiags.Warning
 		}
 		checkDiags := evalCheckRules(
+			ctx,
 			addrs.OutputPrecondition,
 			n.Config.Preconditions,
 			evalCtx, n.Addr, EvalDataForNoInstanceKey,
@@ -368,7 +369,7 @@ func (n *NodeApplyableOutput) Execute(_ context.Context, evalCtx EvalContext, op
 		// We'll handle errors below, after we have loaded the module.
 		// Outputs don't have a separate mode for validation, so validate
 		// depends_on expressions here too
-		diags = diags.Append(validateDependsOn(evalCtx, n.Config.DependsOn))
+		diags = diags.Append(validateDependsOn(ctx, evalCtx, n.Config.DependsOn))
 
 		// For root module outputs in particular, an output value must be
 		// statically declared as sensitive in order to dynamically return

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -506,7 +506,7 @@ func (n *NodeAbstractResource) writeResourceState(evalCtx EvalContext, addr addr
 
 	switch {
 	case n.Config != nil && n.Config.Count != nil:
-		count, countDiags := evaluateCountExpression(n.Config.Count, evalCtx, addr)
+		count, countDiags := evaluateCountExpression(context.TODO(), n.Config.Count, evalCtx, addr)
 		diags = diags.Append(countDiags)
 		if countDiags.HasErrors() {
 			return diags
@@ -516,7 +516,7 @@ func (n *NodeAbstractResource) writeResourceState(evalCtx EvalContext, addr addr
 		expander.SetResourceCount(addr.Module, n.Addr.Resource, count)
 
 	case n.Config != nil && n.Config.ForEach != nil:
-		forEach, forEachDiags := evaluateForEachExpression(n.Config.ForEach, evalCtx, addr)
+		forEach, forEachDiags := evaluateForEachExpression(context.TODO(), n.Config.ForEach, evalCtx, addr)
 		diags = diags.Append(forEachDiags)
 		if forEachDiags.HasErrors() {
 			return diags

--- a/internal/tofu/node_resource_apply_instance.go
+++ b/internal/tofu/node_resource_apply_instance.go
@@ -231,6 +231,7 @@ func (n *NodeApplyableResourceInstance) dataResourceExecute(ctx context.Context,
 	// the result of the operation, and to fail on future operations
 	// until the user makes the condition succeed.
 	checkDiags := evalCheckRules(
+		ctx,
 		addrs.ResourcePostcondition,
 		n.Config.Postconditions,
 		evalCtx, n.ResourceInstanceAddr(),
@@ -334,7 +335,7 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx context.Conte
 	// If there is no change, there was nothing to apply, and we don't need to
 	// re-write the state, but we do need to re-evaluate postconditions.
 	if diffApply.Action == plans.NoOp {
-		return diags.Append(n.managedResourcePostconditions(evalCtx, repeatData))
+		return diags.Append(n.managedResourcePostconditions(ctx, evalCtx, repeatData))
 	}
 
 	state, applyDiags := n.apply(ctx, evalCtx, state, diffApply, n.Config, repeatData, n.CreateBeforeDestroy())
@@ -412,12 +413,13 @@ func (n *NodeApplyableResourceInstance) managedResourceExecute(ctx context.Conte
 	// _after_ writing the state because we want to check against
 	// the result of the operation, and to fail on future operations
 	// until the user makes the condition succeed.
-	return diags.Append(n.managedResourcePostconditions(evalCtx, repeatData))
+	return diags.Append(n.managedResourcePostconditions(ctx, evalCtx, repeatData))
 }
 
-func (n *NodeApplyableResourceInstance) managedResourcePostconditions(evalCtx EvalContext, repeatData instances.RepetitionData) (diags tfdiags.Diagnostics) {
+func (n *NodeApplyableResourceInstance) managedResourcePostconditions(ctx context.Context, evalCtx EvalContext, repeatData instances.RepetitionData) (diags tfdiags.Diagnostics) {
 
 	checkDiags := evalCheckRules(
+		ctx,
 		addrs.ResourcePostcondition,
 		n.Config.Postconditions,
 		evalCtx, n.ResourceInstanceAddr(), repeatData,

--- a/internal/tofu/node_resource_deposed_test.go
+++ b/internal/tofu/node_resource_deposed_test.go
@@ -196,7 +196,7 @@ func TestNodePlanDeposedResourceInstanceObject_Execute(t *testing.T) {
 			deposedKey := states.NewDeposedKey()
 			absResource := mustResourceInstanceAddr(test.nodeAddress)
 
-			evalCtx, p := initMockEvalContext(test.nodeAddress, deposedKey)
+			evalCtx, p := initMockEvalContext(t.Context(), test.nodeAddress, deposedKey)
 
 			node := NodePlanDeposedResourceInstanceObject{
 				NodeAbstractResourceInstance: &NodeAbstractResourceInstance{
@@ -231,7 +231,7 @@ func TestNodeDestroyDeposedResourceInstanceObject_Execute(t *testing.T) {
 	deposedKey := states.NewDeposedKey()
 	state := states.NewState()
 	absResourceAddr := "test_instance.foo"
-	evalCtx, _ := initMockEvalContext(absResourceAddr, deposedKey)
+	evalCtx, _ := initMockEvalContext(t.Context(), absResourceAddr, deposedKey)
 
 	absResource := mustResourceInstanceAddr(absResourceAddr)
 	node := NodeDestroyDeposedResourceInstanceObject{
@@ -327,7 +327,7 @@ func TestNodeForgetDeposedResourceInstanceObject_Execute(t *testing.T) {
 	deposedKey := states.NewDeposedKey()
 	state := states.NewState()
 	absResourceAddr := "test_instance.foo"
-	evalCtx, _ := initMockEvalContext(absResourceAddr, deposedKey)
+	evalCtx, _ := initMockEvalContext(t.Context(), absResourceAddr, deposedKey)
 
 	absResource := mustResourceInstanceAddr(absResourceAddr)
 	node := NodeForgetDeposedResourceInstanceObject{
@@ -350,7 +350,7 @@ func TestNodeForgetDeposedResourceInstanceObject_Execute(t *testing.T) {
 	}
 }
 
-func initMockEvalContext(resourceAddrs string, deposedKey states.DeposedKey) (*MockEvalContext, *MockProvider) {
+func initMockEvalContext(ctx context.Context, resourceAddrs string, deposedKey states.DeposedKey) (*MockEvalContext, *MockProvider) {
 	state := states.NewState()
 	absResource := mustResourceInstanceAddr(resourceAddrs)
 
@@ -385,7 +385,7 @@ func initMockEvalContext(resourceAddrs string, deposedKey states.DeposedKey) (*M
 	}
 
 	p := testProvider("test")
-	p.ConfigureProvider(context.TODO(), providers.ConfigureProviderRequest{})
+	p.ConfigureProvider(ctx, providers.ConfigureProviderRequest{})
 	p.GetProviderSchemaResponse = &schema
 
 	p.UpgradeResourceStateResponse = &providers.UpgradeResourceStateResponse{

--- a/internal/tofu/node_resource_plan.go
+++ b/internal/tofu/node_resource_plan.go
@@ -435,6 +435,6 @@ func (n *nodeExpandPlannableResource) resourceInstanceSubgraph(ctx context.Conte
 		Steps: steps,
 		Name:  "nodeExpandPlannableResource",
 	}
-	graph, graphDiags := b.Build(context.TODO(), addr.Module)
+	graph, graphDiags := b.Build(ctx, addr.Module)
 	return graph, diags.Append(graphDiags).ErrWithWarnings()
 }

--- a/internal/tofu/node_resource_plan_instance.go
+++ b/internal/tofu/node_resource_plan_instance.go
@@ -172,6 +172,7 @@ func (n *NodePlannableResourceInstance) dataResourceExecute(ctx context.Context,
 	// the result of the operation, and to fail on future operations
 	// until the user makes the condition succeed.
 	checkDiags := evalCheckRules(
+		ctx,
 		addrs.ResourcePostcondition,
 		n.Config.Postconditions,
 		evalCtx, addr, repeatData,
@@ -412,6 +413,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx context.Conte
 		// (Note that some preconditions will end up being skipped during
 		// planning, because their conditions depend on values not yet known.)
 		checkDiags := evalCheckRules(
+			ctx,
 			addrs.ResourcePostcondition,
 			n.Config.Postconditions,
 			evalCtx, n.ResourceInstanceAddr(), repeatData,
@@ -426,10 +428,11 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx context.Conte
 		// values, which could result in a post-condition check relying on that
 		// value being inaccurate. Unless we decide to store the value of the
 		// for-each expression in state, this is unavoidable.
-		forEach, _ := evaluateForEachExpression(n.Config.ForEach, evalCtx, n.ResourceAddr())
+		forEach, _ := evaluateForEachExpression(ctx, n.Config.ForEach, evalCtx, n.ResourceAddr())
 		repeatData := EvalDataForInstanceKey(n.ResourceInstanceAddr().Resource.Key, forEach)
 
 		checkDiags := evalCheckRules(
+			ctx,
 			addrs.ResourcePrecondition,
 			n.Config.Preconditions,
 			evalCtx, addr, repeatData,
@@ -453,6 +456,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx context.Conte
 		// even if pre-conditions generated diagnostics, because we have no
 		// planned changes to block.
 		checkDiags = evalCheckRules(
+			ctx,
 			addrs.ResourcePostcondition,
 			n.Config.Postconditions,
 			evalCtx, addr, repeatData,

--- a/internal/tofu/node_variable_reference.go
+++ b/internal/tofu/node_variable_reference.go
@@ -154,9 +154,9 @@ func (n *nodeVariableReferenceInstance) ModulePath() addrs.Module {
 }
 
 // GraphNodeExecutable
-func (n *nodeVariableReferenceInstance) Execute(_ context.Context, evalCtx EvalContext, op walkOperation) tfdiags.Diagnostics {
+func (n *nodeVariableReferenceInstance) Execute(ctx context.Context, evalCtx EvalContext, op walkOperation) tfdiags.Diagnostics {
 	log.Printf("[TRACE] nodeVariableReferenceInstance: evaluating %s", n.Addr)
-	diags := evalVariableValidations(n.Addr, n.Config, n.Expr, evalCtx)
+	diags := evalVariableValidations(ctx, n.Addr, n.Config, n.Expr, evalCtx)
 
 	if op == walkValidate {
 		var filtered tfdiags.Diagnostics


### PR DESCRIPTION
This caused a bunch of mechanical changes to callers, of course. Expression evaluation is a very cross-cutting concern, so updating everything all at once would be a lot and so this stops at a mostly-arbitrary point wiring a bunch of callers to pass in contexts without changing anything that has lots of callers.

We'll continue pulling on this thread in later commits.

As usual, this is intended to not change the externally-observable behavior at all, and so there is no changelog entry.

(This is related to https://github.com/opentofu/opentofu/issues/2664.)