### PR TITLE
tofu: EvalContext expression evaluation takes context.Context

### DIFF
--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -753,7 +753,7 @@ func testBackendState(t *testing.T, s *states.State, c int) (*legacy.State, *htt
 	}
 	b := backendInit.Backend("http")(encryption.StateEncryptionDisabled())
 	configSchema := b.ConfigSchema()
-	hash, _ := backendConfig.Hash(configSchema)
+	hash, _ := backendConfig.Hash(t.Context(), configSchema)
 
 	state := legacy.NewState()
 	state.Backend = &legacy.BackendState{

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -216,7 +216,7 @@ func (c *InitCommand) Run(args []string) int {
 	} else {
 		// Load the encryption configuration
 		var encDiags tfdiags.Diagnostics
-		enc, encDiags = c.EncryptionFromModule(rootModEarly)
+		enc, encDiags = c.EncryptionFromModule(ctx, rootModEarly)
 		diags = diags.Append(encDiags)
 		if encDiags.HasErrors() {
 			c.showDiagnostics(diags)

--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -60,11 +60,11 @@ func (m *Meta) backendMigrateState(ctx context.Context, opts *backendMigrateOpts
 	_, sourceTFC = opts.Source.(*cloud.Cloud)
 	_, destinationTFC = opts.Destination.(*cloud.Cloud)
 
-	sourceWorkspaces, sourceSingleState, err := retrieveWorkspaces(opts.Source, opts.SourceType)
+	sourceWorkspaces, sourceSingleState, err := retrieveWorkspaces(ctx, opts.Source, opts.SourceType)
 	if err != nil {
 		return err
 	}
-	destinationWorkspaces, destinationSingleState, err := retrieveWorkspaces(opts.Destination, opts.SourceType)
+	destinationWorkspaces, destinationSingleState, err := retrieveWorkspaces(ctx, opts.Destination, opts.SourceType)
 	if err != nil {
 		return err
 	}
@@ -537,10 +537,10 @@ func (m *Meta) backendMigrateNonEmptyConfirm(
 	return m.confirm(inputOpts)
 }
 
-func retrieveWorkspaces(back backend.Backend, sourceType string) ([]string, bool, error) {
+func retrieveWorkspaces(ctx context.Context, back backend.Backend, sourceType string) ([]string, bool, error) {
 	var singleState bool
 	var err error
-	workspaces, err := back.Workspaces(context.TODO())
+	workspaces, err := back.Workspaces(ctx)
 	if err == backend.ErrWorkspacesNotSupported {
 		singleState = true
 		err = nil
@@ -557,13 +557,13 @@ func (m *Meta) backendMigrateTFC(ctx context.Context, opts *backendMigrateOpts) 
 	_, sourceTFC := opts.Source.(*cloud.Cloud)
 	cloudBackendDestination, destinationTFC := opts.Destination.(*cloud.Cloud)
 
-	sourceWorkspaces, sourceSingleState, err := retrieveWorkspaces(opts.Source, opts.SourceType)
+	sourceWorkspaces, sourceSingleState, err := retrieveWorkspaces(ctx, opts.Source, opts.SourceType)
 	if err != nil {
 		return err
 	}
 	// to be used below, not yet implemented
 	// destinationWorkspaces, destinationSingleState
-	_, _, err = retrieveWorkspaces(opts.Destination, opts.SourceType)
+	_, _, err = retrieveWorkspaces(ctx, opts.Destination, opts.SourceType)
 	if err != nil {
 		return err
 	}

--- a/internal/command/meta_encryption.go
+++ b/internal/command/meta_encryption.go
@@ -34,12 +34,12 @@ func (m *Meta) EncryptionFromPath(ctx context.Context, path string) (encryption.
 	if diags.HasErrors() {
 		return nil, diags
 	}
-	enc, encDiags := m.EncryptionFromModule(module)
+	enc, encDiags := m.EncryptionFromModule(ctx, module)
 	diags = diags.Append(encDiags)
 	return enc, diags
 }
 
-func (m *Meta) EncryptionFromModule(module *configs.Module) (encryption.Encryption, tfdiags.Diagnostics) {
+func (m *Meta) EncryptionFromModule(ctx context.Context, module *configs.Module) (encryption.Encryption, tfdiags.Diagnostics) {
 	cfg := module.Encryption
 	var diags tfdiags.Diagnostics
 
@@ -53,7 +53,7 @@ func (m *Meta) EncryptionFromModule(module *configs.Module) (encryption.Encrypti
 		cfg = cfg.Merge(envCfg)
 	}
 
-	enc, encDiags := encryption.New(encryption.DefaultRegistry, cfg, module.StaticEvaluator)
+	enc, encDiags := encryption.New(ctx, encryption.DefaultRegistry, cfg, module.StaticEvaluator)
 	diags = diags.Append(encDiags)
 
 	return enc, diags

--- a/internal/configs/module.go
+++ b/internal/configs/module.go
@@ -6,6 +6,7 @@
 package configs
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
@@ -246,12 +247,12 @@ func NewModule(primaryFiles, overrideFiles []*File, call StaticModuleCall, sourc
 
 	// Process all module calls now that we have the static context
 	for _, mc := range mod.ModuleCalls {
-		mDiags := mc.decodeStaticFields(mod.StaticEvaluator)
+		mDiags := mc.decodeStaticFields(context.TODO(), mod.StaticEvaluator)
 		diags = append(diags, mDiags...)
 	}
 
 	for _, pc := range mod.ProviderConfigs {
-		pDiags := pc.decodeStaticFields(mod.StaticEvaluator)
+		pDiags := pc.decodeStaticFields(context.TODO(), mod.StaticEvaluator)
 		diags = append(diags, pDiags...)
 	}
 

--- a/internal/configs/module_call_test.go
+++ b/internal/configs/module_call_test.go
@@ -131,7 +131,7 @@ func TestLoadModuleCall(t *testing.T) {
 		// This is a structural issue which existed before static evaluation, but has been made worse by it
 		// See https://github.com/opentofu/opentofu/issues/1467 for more details
 		eval := NewStaticEvaluator(nil, RootModuleCallForTesting())
-		diags := m.decodeStaticFields(eval)
+		diags := m.decodeStaticFields(t.Context(), eval)
 		if diags.HasErrors() {
 			t.Fatal(diags.Error())
 		}
@@ -301,7 +301,7 @@ func TestModuleCallWithVersion(t *testing.T) {
 	for _, m := range gotModules {
 		// Create a static evaluator with the module context
 		eval := NewStaticEvaluator(mod, RootModuleCallForTesting())
-		diags := m.decodeStaticFields(eval)
+		diags := m.decodeStaticFields(t.Context(), eval)
 		if diags.HasErrors() {
 			t.Fatal(diags.Error())
 		}

--- a/internal/configs/parser_config_test.go
+++ b/internal/configs/parser_config_test.go
@@ -301,7 +301,7 @@ func TestParserLoadConfigFileError(t *testing.T) {
 			// See https://github.com/opentofu/opentofu/issues/1467 for more details
 			eval := NewStaticEvaluator(nil, RootModuleCallForTesting())
 			for _, mc := range file.ModuleCalls {
-				mDiags := mc.decodeStaticFields(eval)
+				mDiags := mc.decodeStaticFields(t.Context(), eval)
 				diags = append(diags, mDiags...)
 			}
 

--- a/internal/configs/provider.go
+++ b/internal/configs/provider.go
@@ -166,13 +166,13 @@ func decodeProviderBlock(block *hcl.Block) (*Provider, hcl.Diagnostics) {
 	return provider, diags
 }
 
-func (p *Provider) decodeStaticFields(eval *StaticEvaluator) hcl.Diagnostics {
+func (p *Provider) decodeStaticFields(ctx context.Context, eval *StaticEvaluator) hcl.Diagnostics {
 	var diags hcl.Diagnostics
 
 	if p.ForEach != nil {
 		forEachRefsFunc := func(refs []*addrs.Reference) (*hcl.EvalContext, tfdiags.Diagnostics) {
 			var diags tfdiags.Diagnostics
-			evalContext, evalDiags := eval.EvalContext(context.TODO(), StaticIdentifier{
+			evalContext, evalDiags := eval.EvalContext(ctx, StaticIdentifier{
 				Module:    eval.call.addr,
 				Subject:   fmt.Sprintf("provider.%s.%s.for_each", p.Name, p.Alias),
 				DeclRange: p.ForEach.Range(),

--- a/internal/configs/static_evaluator_test.go
+++ b/internal/configs/static_evaluator_test.go
@@ -405,13 +405,13 @@ terraform {
 
 			mod, _ := NewModule([]*File{file}, nil, RootModuleCallForTesting(), "dir", SelectiveLoadAll)
 
-			_, diags := mod.Backend.Hash(schema)
+			_, diags := mod.Backend.Hash(t.Context(), schema)
 			if diags.HasErrors() {
 				assertExactDiagnostics(t, diags, tc.diags)
 				return
 			}
 
-			_, diags = mod.Backend.Decode(schema)
+			_, diags = mod.Backend.Decode(t.Context(), schema)
 
 			assertExactDiagnostics(t, diags, tc.diags)
 		})

--- a/internal/encryption/base.go
+++ b/internal/encryption/base.go
@@ -6,6 +6,7 @@
 package encryption
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -39,7 +40,7 @@ type keyProviderMetadata struct {
 	output keyProviderMetamap
 }
 
-func newBaseEncryption(enc *encryption, target *config.TargetConfig, enforced bool, name string, staticEval *configs.StaticEvaluator) (*baseEncryption, hcl.Diagnostics) {
+func newBaseEncryption(ctx context.Context, enc *encryption, target *config.TargetConfig, enforced bool, name string, staticEval *configs.StaticEvaluator) (*baseEncryption, hcl.Diagnostics) {
 	// Lookup method configs for the target, ordered by fallback precedence
 	methods, diags := methodConfigsFromTarget(enc.cfg, target, name, enforced)
 	if diags.HasErrors() {
@@ -82,7 +83,7 @@ func newBaseEncryption(enc *encryption, target *config.TargetConfig, enforced bo
 
 	// methodConfigsFromTarget guarantees that there will be at least one encryption method.  They are not optional in the common target
 	// block, which is required to get to this code.
-	encMethod, encDiags := setupMethod(enc.cfg, methods[0], encMeta, enc.reg, staticEval)
+	encMethod, encDiags := setupMethod(ctx, enc.cfg, methods[0], encMeta, enc.reg, staticEval)
 	diags = diags.Extend(encDiags)
 	if diags.HasErrors() {
 		return nil, diags
@@ -152,7 +153,7 @@ const (
 )
 
 // TODO Find a way to make these errors actionable / clear
-func (base *baseEncryption) decrypt(data []byte, validator func([]byte) error) ([]byte, EncryptionStatus, error) {
+func (base *baseEncryption) decrypt(ctx context.Context, data []byte, validator func([]byte) error) ([]byte, EncryptionStatus, error) {
 	inputData := basedata{}
 	err := json.Unmarshal(data, &inputData)
 
@@ -207,7 +208,7 @@ func (base *baseEncryption) decrypt(data []byte, validator func([]byte) error) (
 		}
 
 		// TODO Discuss if we should potentially cache this based on a json-encoded version of inputData.Meta and reduce overhead dramatically
-		decMethod, diags := setupMethod(base.enc.cfg, method, keyProviderMetadata{
+		decMethod, diags := setupMethod(ctx, base.enc.cfg, method, keyProviderMetadata{
 			input:  inputData.Meta,
 			output: outputData.Meta,
 		}, base.enc.reg, base.staticEval)

--- a/internal/encryption/dual_custody_test.go
+++ b/internal/encryption/dual_custody_test.go
@@ -57,7 +57,7 @@ func TestDualCustody(t *testing.T) {
 
 	staticEval := configs.NewStaticEvaluator(nil, configs.RootModuleCallForTesting())
 
-	enc, diags := New(reg, parsedSourceConfig, staticEval)
+	enc, diags := New(t.Context(), reg, parsedSourceConfig, staticEval)
 	if diags.HasErrors() {
 		t.Fatalf("%v", diags.Error())
 	}

--- a/internal/encryption/enctest/setup.go
+++ b/internal/encryption/enctest/setup.go
@@ -8,6 +8,8 @@ package enctest
 // This package is used for supplying a fully configured encryption instance for use in unit and integration tests
 
 import (
+	"testing"
+
 	"github.com/hashicorp/hcl/v2"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/encryption"
@@ -20,7 +22,7 @@ import (
 
 // TODO docstrings once this stabilizes
 
-func EncryptionDirect(configData string) encryption.Encryption {
+func EncryptionDirect(t testing.TB, configData string) encryption.Encryption {
 	reg := lockingencryptionregistry.New()
 	if err := reg.RegisterKeyProvider(static.New()); err != nil {
 		panic(err)
@@ -38,14 +40,14 @@ func EncryptionDirect(configData string) encryption.Encryption {
 
 	staticEval := configs.NewStaticEvaluator(nil, configs.RootModuleCallForTesting())
 
-	enc, diags := encryption.New(reg, cfg, staticEval)
+	enc, diags := encryption.New(t.Context(), reg, cfg, staticEval)
 	handleDiags(diags)
 
 	return enc
 }
 
-func EncryptionRequired() encryption.Encryption {
-	return EncryptionDirect(`
+func EncryptionRequired(t testing.TB) encryption.Encryption {
+	return EncryptionDirect(t, `
 		key_provider "static" "basic" {
 			key = "6f6f706830656f67686f6834616872756f3751756165686565796f6f72653169"
 		}
@@ -66,8 +68,8 @@ func EncryptionRequired() encryption.Encryption {
 	`)
 }
 
-func EncryptionWithFallback() encryption.Encryption {
-	return EncryptionDirect(`
+func EncryptionWithFallback(t testing.TB) encryption.Encryption {
+	return EncryptionDirect(t, `
 		key_provider "static" "basic" {
 			key = "6f6f706830656f67686f6834616872756f3751756165686565796f6f72653169"
 		}

--- a/internal/encryption/example_test.go
+++ b/internal/encryption/example_test.go
@@ -6,6 +6,7 @@
 package encryption_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
@@ -62,7 +63,7 @@ func Example() {
 	staticEval := configs.NewStaticEvaluator(nil, configs.RootModuleCallForTesting())
 
 	// Construct the encryption object
-	enc, diags := encryption.New(reg, cfg, staticEval)
+	enc, diags := encryption.New(context.Background(), reg, cfg, staticEval)
 	handleDiags(diags)
 
 	sfe := enc.State()

--- a/internal/encryption/keyprovider/external/chain_test.go
+++ b/internal/encryption/keyprovider/external/chain_test.go
@@ -64,7 +64,7 @@ state {
 
 	staticEval := configs.NewStaticEvaluator(nil, configs.RootModuleCallForTesting())
 
-	enc, diags := encryption.New(reg, cfg, staticEval)
+	enc, diags := encryption.New(t.Context(), reg, cfg, staticEval)
 	if diags.HasErrors() {
 		t.Fatalf("%v", diags)
 	}

--- a/internal/encryption/keyprovider/static/example_test.go
+++ b/internal/encryption/keyprovider/static/example_test.go
@@ -6,6 +6,7 @@
 package static_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -47,7 +48,7 @@ func Example() {
 
 	staticEvaluator := configs.NewStaticEvaluator(nil, configs.RootModuleCallForTesting())
 
-	enc, diags := encryption.New(registry, cfg, staticEvaluator)
+	enc, diags := encryption.New(context.Background(), registry, cfg, staticEvaluator)
 	if diags.HasErrors() {
 		panic(diags)
 	}

--- a/internal/encryption/keyprovider_meta_change_test.go
+++ b/internal/encryption/keyprovider_meta_change_test.go
@@ -62,11 +62,11 @@ func TestChangingKeyProviderAddr(t *testing.T) {
 
 	staticEval := configs.NewStaticEvaluator(nil, configs.RootModuleCallForTesting())
 
-	enc1, diags := New(reg, parsedSourceConfig, staticEval)
+	enc1, diags := New(t.Context(), reg, parsedSourceConfig, staticEval)
 	if diags.HasErrors() {
 		t.Fatalf("%v", diags.Error())
 	}
-	enc2, diags := New(reg, parsedDestinationConfig, staticEval)
+	enc2, diags := New(t.Context(), reg, parsedDestinationConfig, staticEval)
 	if diags.HasErrors() {
 		t.Fatalf("%v", diags.Error())
 	}
@@ -133,7 +133,7 @@ func TestDuplicateKeyProvider(t *testing.T) {
 
 	staticEval := configs.NewStaticEvaluator(nil, configs.RootModuleCallForTesting())
 
-	_, diags = New(reg, parsedSourceConfig, staticEval)
+	_, diags = New(t.Context(), reg, parsedSourceConfig, staticEval)
 	if diags.HasErrors() {
 		if !strings.Contains(diags.Error(), "Duplicate metadata key") {
 			t.Fatalf("No error due to duplicate metadata key: %v", diags)

--- a/internal/encryption/methods.go
+++ b/internal/encryption/methods.go
@@ -20,7 +20,7 @@ import (
 )
 
 // setupMethod sets up a single method for encryption. It returns a list of diagnostics if the method is invalid.
-func setupMethod(enc *config.EncryptionConfig, cfg config.MethodConfig, meta keyProviderMetadata, reg registry.Registry, staticEval *configs.StaticEvaluator) (method.Method, hcl.Diagnostics) {
+func setupMethod(ctx context.Context, enc *config.EncryptionConfig, cfg config.MethodConfig, meta keyProviderMetadata, reg registry.Registry, staticEval *configs.StaticEvaluator) (method.Method, hcl.Diagnostics) {
 	// Lookup the definition of the encryption method from the registry
 	encryptionMethod, err := reg.GetMethodDescriptor(method.ID(cfg.Type))
 	if err != nil {
@@ -56,13 +56,13 @@ func setupMethod(enc *config.EncryptionConfig, cfg config.MethodConfig, meta key
 		return nil, diags
 	}
 
-	hclCtx, kpDiags := setupKeyProviders(enc, kpConfigs, meta, reg, staticEval)
+	hclCtx, kpDiags := setupKeyProviders(ctx, enc, kpConfigs, meta, reg, staticEval)
 	diags = diags.Extend(kpDiags)
 	if diags.HasErrors() {
 		return nil, diags
 	}
 
-	hclCtx, evalDiags := staticEval.EvalContextWithParent(context.TODO(), hclCtx, configs.StaticIdentifier{
+	hclCtx, evalDiags := staticEval.EvalContextWithParent(ctx, hclCtx, configs.StaticIdentifier{
 		Module:    addrs.RootModule,
 		Subject:   fmt.Sprintf("encryption.method.%s.%s", cfg.Type, cfg.Name),
 		DeclRange: enc.DeclRange,

--- a/internal/encryption/plan.go
+++ b/internal/encryption/plan.go
@@ -6,6 +6,7 @@
 package encryption
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
@@ -50,8 +51,8 @@ type planEncryption struct {
 	base *baseEncryption
 }
 
-func newPlanEncryption(enc *encryption, target *config.TargetConfig, enforced bool, name string, staticEval *configs.StaticEvaluator) (PlanEncryption, hcl.Diagnostics) {
-	base, diags := newBaseEncryption(enc, target, enforced, name, staticEval)
+func newPlanEncryption(ctx context.Context, enc *encryption, target *config.TargetConfig, enforced bool, name string, staticEval *configs.StaticEvaluator) (PlanEncryption, hcl.Diagnostics) {
+	base, diags := newBaseEncryption(ctx, enc, target, enforced, name, staticEval)
 	return &planEncryption{base}, diags
 }
 
@@ -60,7 +61,7 @@ func (p planEncryption) EncryptPlan(data []byte) ([]byte, error) {
 }
 
 func (p planEncryption) DecryptPlan(data []byte) ([]byte, error) {
-	data, _, err := p.base.decrypt(data, func(data []byte) error {
+	data, _, err := p.base.decrypt(context.TODO(), data, func(data []byte) error {
 		// Check magic bytes
 		if len(data) < 2 || string(data[:2]) != "PK" {
 			return fmt.Errorf("Invalid plan file %v", string(data[:2]))

--- a/internal/encryption/state.go
+++ b/internal/encryption/state.go
@@ -6,6 +6,7 @@
 package encryption
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -58,8 +59,8 @@ type stateEncryption struct {
 	base *baseEncryption
 }
 
-func newStateEncryption(enc *encryption, target *config.TargetConfig, enforced bool, name string, staticEval *configs.StaticEvaluator) (StateEncryption, hcl.Diagnostics) {
-	base, diags := newBaseEncryption(enc, target, enforced, name, staticEval)
+func newStateEncryption(ctx context.Context, enc *encryption, target *config.TargetConfig, enforced bool, name string, staticEval *configs.StaticEvaluator) (StateEncryption, hcl.Diagnostics) {
+	base, diags := newBaseEncryption(ctx, enc, target, enforced, name, staticEval)
 	return &stateEncryption{base}, diags
 }
 
@@ -88,7 +89,7 @@ func (s *stateEncryption) EncryptState(plainState []byte) ([]byte, error) {
 }
 
 func (s *stateEncryption) DecryptState(encryptedState []byte) ([]byte, EncryptionStatus, error) {
-	decryptedState, status, err := s.base.decrypt(encryptedState, func(data []byte) error {
+	decryptedState, status, err := s.base.decrypt(context.TODO(), encryptedState, func(data []byte) error {
 		tmp := struct {
 			FormatVersion string `json:"terraform_version"`
 		}{}

--- a/internal/encryption/targets_test.go
+++ b/internal/encryption/targets_test.go
@@ -364,7 +364,7 @@ func (testCase btmTestCase) newTestRun(reg registry.Registry, staticEval *config
 		var methods []method.Method
 		methodConfigs, diags := methodConfigsFromTarget(cfg, target, "test", cfg.State.Enforced)
 		for _, methodConfig := range methodConfigs {
-			m, mDiags := setupMethod(cfg, methodConfig, meta, reg, staticEval)
+			m, mDiags := setupMethod(t.Context(), cfg, methodConfig, meta, reg, staticEval)
 			diags = diags.Extend(mDiags)
 			if !mDiags.HasErrors() {
 				methods = append(methods, m)

--- a/internal/states/statefile/read_test.go
+++ b/internal/states/statefile/read_test.go
@@ -39,7 +39,7 @@ func TestReadErrNoState_nilFile(t *testing.T) {
 func TestReadEmptyWithEncryption(t *testing.T) {
 	payload := bytes.NewBufferString("")
 
-	_, err := Read(payload, enctest.EncryptionRequired().State())
+	_, err := Read(payload, enctest.EncryptionRequired(t).State())
 	if !errors.Is(err, ErrNoState) {
 		t.Fatalf("expected ErrNoState, got %T", err)
 	}
@@ -47,7 +47,7 @@ func TestReadEmptyWithEncryption(t *testing.T) {
 func TestReadEmptyJsonWithEncryption(t *testing.T) {
 	payload := bytes.NewBufferString("{}")
 
-	_, err := Read(payload, enctest.EncryptionRequired().State())
+	_, err := Read(payload, enctest.EncryptionRequired(t).State())
 
 	if err == nil || err.Error() != "unable to determine data structure during decryption: Given payload is not a state file" {
 		t.Fatalf("expected encryption error, got %v", err)

--- a/internal/states/statefile/roundtrip_test.go
+++ b/internal/states/statefile/roundtrip_test.go
@@ -84,7 +84,7 @@ func TestRoundtrip(t *testing.T) {
 func TestRoundtripEncryption(t *testing.T) {
 	const path = "testdata/roundtrip/v4-modules.out.tfstate"
 
-	enc := enctest.EncryptionWithFallback().State()
+	enc := enctest.EncryptionWithFallback(t).State()
 
 	unencryptedInput, err := os.Open(path)
 	if err != nil {

--- a/internal/tofu/context_import.go
+++ b/internal/tofu/context_import.go
@@ -114,20 +114,20 @@ func NewImportResolver() *ImportResolver {
 // them. The resolved import target would be an EvaluatedConfigImportTarget.
 // This function mutates the EvalContext's ImportResolver, adding the resolved import target.
 // The function errors if we failed to evaluate the ID or the address.
-func (ri *ImportResolver) ExpandAndResolveImport(importTarget *ImportTarget, ctx EvalContext) tfdiags.Diagnostics {
+func (ri *ImportResolver) ExpandAndResolveImport(ctx context.Context, importTarget *ImportTarget, evalCtx EvalContext) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
 	// The import block expressions are declared within the root module.
 	// We need to explicitly use the context with the path of the root module, so that all references will be
 	// relative to the root module
-	rootCtx := ctx.WithPath(addrs.RootModuleInstance)
+	rootCtx := evalCtx.WithPath(addrs.RootModuleInstance)
 
 	if importTarget.Config.ForEach != nil {
 		const unknownsNotAllowed = false
 		const tupleAllowed = true
 
 		// The import target has a for_each attribute, so we need to expand it
-		forEachVal, evalDiags := evaluateForEachExpressionValue(context.TODO(), importTarget.Config.ForEach, rootCtx, unknownsNotAllowed, tupleAllowed, nil)
+		forEachVal, evalDiags := evaluateForEachExpressionValue(ctx, importTarget.Config.ForEach, rootCtx, unknownsNotAllowed, tupleAllowed, nil)
 		diags = diags.Append(evalDiags)
 		if diags.HasErrors() {
 			return diags

--- a/internal/tofu/eval_context.go
+++ b/internal/tofu/eval_context.go
@@ -117,7 +117,7 @@ type EvalContext interface {
 	// "dynamic" blocks replaced with zero or more static blocks. This can be
 	// used to extract correct source location information about attributes of
 	// the returned object value.
-	EvaluateBlock(body hcl.Body, schema *configschema.Block, self addrs.Referenceable, keyData InstanceKeyEvalData) (cty.Value, hcl.Body, tfdiags.Diagnostics)
+	EvaluateBlock(ctx context.Context, body hcl.Body, schema *configschema.Block, self addrs.Referenceable, keyData InstanceKeyEvalData) (cty.Value, hcl.Body, tfdiags.Diagnostics)
 
 	// EvaluateExpr takes the given HCL expression and evaluates it to produce
 	// a value.
@@ -125,12 +125,12 @@ type EvalContext interface {
 	// The "self" argument is optional. If given, it is the referenceable
 	// address that the name "self" should behave as an alias for when
 	// evaluating. Set this to nil if the "self" object should not be available.
-	EvaluateExpr(expr hcl.Expression, wantType cty.Type, self addrs.Referenceable) (cty.Value, tfdiags.Diagnostics)
+	EvaluateExpr(ctx context.Context, expr hcl.Expression, wantType cty.Type, self addrs.Referenceable) (cty.Value, tfdiags.Diagnostics)
 
 	// EvaluateReplaceTriggeredBy takes the raw reference expression from the
 	// config, and returns the evaluated *addrs.Reference along with a boolean
 	// indicating if that reference forces replacement.
-	EvaluateReplaceTriggeredBy(expr hcl.Expression, repData instances.RepetitionData) (*addrs.Reference, bool, tfdiags.Diagnostics)
+	EvaluateReplaceTriggeredBy(ctx context.Context, expr hcl.Expression, repData instances.RepetitionData) (*addrs.Reference, bool, tfdiags.Diagnostics)
 
 	// EvaluationScope returns a scope that can be used to evaluate reference
 	// addresses in this context.

--- a/internal/tofu/eval_context_builtin.go
+++ b/internal/tofu/eval_context_builtin.go
@@ -304,22 +304,22 @@ func (c *BuiltinEvalContext) CloseProvisioners() error {
 	return diags.Err()
 }
 
-func (c *BuiltinEvalContext) EvaluateBlock(body hcl.Body, schema *configschema.Block, self addrs.Referenceable, keyData InstanceKeyEvalData) (cty.Value, hcl.Body, tfdiags.Diagnostics) {
+func (c *BuiltinEvalContext) EvaluateBlock(ctx context.Context, body hcl.Body, schema *configschema.Block, self addrs.Referenceable, keyData InstanceKeyEvalData) (cty.Value, hcl.Body, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	scope := c.EvaluationScope(self, nil, keyData)
-	body, evalDiags := scope.ExpandBlock(context.TODO(), body, schema)
+	body, evalDiags := scope.ExpandBlock(ctx, body, schema)
 	diags = diags.Append(evalDiags)
-	val, evalDiags := scope.EvalBlock(context.TODO(), body, schema)
+	val, evalDiags := scope.EvalBlock(ctx, body, schema)
 	diags = diags.Append(evalDiags)
 	return val, body, diags
 }
 
-func (c *BuiltinEvalContext) EvaluateExpr(expr hcl.Expression, wantType cty.Type, self addrs.Referenceable) (cty.Value, tfdiags.Diagnostics) {
+func (c *BuiltinEvalContext) EvaluateExpr(ctx context.Context, expr hcl.Expression, wantType cty.Type, self addrs.Referenceable) (cty.Value, tfdiags.Diagnostics) {
 	scope := c.EvaluationScope(self, nil, EvalDataForNoInstanceKey)
-	return scope.EvalExpr(context.TODO(), expr, wantType)
+	return scope.EvalExpr(ctx, expr, wantType)
 }
 
-func (c *BuiltinEvalContext) EvaluateReplaceTriggeredBy(expr hcl.Expression, repData instances.RepetitionData) (*addrs.Reference, bool, tfdiags.Diagnostics) {
+func (c *BuiltinEvalContext) EvaluateReplaceTriggeredBy(ctx context.Context, expr hcl.Expression, repData instances.RepetitionData) (*addrs.Reference, bool, tfdiags.Diagnostics) {
 
 	// get the reference to lookup changes in the plan
 	ref, diags := evalReplaceTriggeredByExpr(expr, repData)
@@ -397,7 +397,7 @@ func (c *BuiltinEvalContext) EvaluateReplaceTriggeredBy(expr hcl.Expression, rep
 	// Since we have a traversal after the resource reference, we will need to
 	// decode the changes, which means we need a schema.
 	providerAddr := change.ProviderAddr
-	schema, err := c.ProviderSchema(context.TODO(), providerAddr)
+	schema, err := c.ProviderSchema(ctx, providerAddr)
 	if err != nil {
 		diags = diags.Append(err)
 		return nil, false, diags

--- a/internal/tofu/eval_context_mock.go
+++ b/internal/tofu/eval_context_mock.go
@@ -250,7 +250,7 @@ func (c *MockEvalContext) CloseProvisioners() error {
 	return nil
 }
 
-func (c *MockEvalContext) EvaluateBlock(body hcl.Body, schema *configschema.Block, self addrs.Referenceable, keyData InstanceKeyEvalData) (cty.Value, hcl.Body, tfdiags.Diagnostics) {
+func (c *MockEvalContext) EvaluateBlock(_ context.Context, body hcl.Body, schema *configschema.Block, self addrs.Referenceable, keyData InstanceKeyEvalData) (cty.Value, hcl.Body, tfdiags.Diagnostics) {
 	c.EvaluateBlockCalled = true
 	c.EvaluateBlockBody = body
 	c.EvaluateBlockSchema = schema
@@ -262,7 +262,7 @@ func (c *MockEvalContext) EvaluateBlock(body hcl.Body, schema *configschema.Bloc
 	return c.EvaluateBlockResult, c.EvaluateBlockExpandedBody, c.EvaluateBlockDiags
 }
 
-func (c *MockEvalContext) EvaluateExpr(expr hcl.Expression, wantType cty.Type, self addrs.Referenceable) (cty.Value, tfdiags.Diagnostics) {
+func (c *MockEvalContext) EvaluateExpr(_ context.Context, expr hcl.Expression, wantType cty.Type, self addrs.Referenceable) (cty.Value, tfdiags.Diagnostics) {
 	c.EvaluateExprCalled = true
 	c.EvaluateExprExpr = expr
 	c.EvaluateExprWantType = wantType
@@ -273,7 +273,7 @@ func (c *MockEvalContext) EvaluateExpr(expr hcl.Expression, wantType cty.Type, s
 	return c.EvaluateExprResult, c.EvaluateExprDiags
 }
 
-func (c *MockEvalContext) EvaluateReplaceTriggeredBy(hcl.Expression, instances.RepetitionData) (*addrs.Reference, bool, tfdiags.Diagnostics) {
+func (c *MockEvalContext) EvaluateReplaceTriggeredBy(context.Context, hcl.Expression, instances.RepetitionData) (*addrs.Reference, bool, tfdiags.Diagnostics) {
 	return nil, false, nil
 }
 

--- a/internal/tofu/eval_expansion.go
+++ b/internal/tofu/eval_expansion.go
@@ -30,7 +30,7 @@ func evalContextScope(ctx context.Context, evalCtx EvalContext) evalchecks.Conte
 
 func evalContextEvaluate(ctx context.Context, evalCtx EvalContext) evalchecks.EvaluateFunc {
 	return func(expr hcl.Expression) (cty.Value, tfdiags.Diagnostics) {
-		return evalCtx.EvaluateExpr(expr, cty.Number, nil)
+		return evalCtx.EvaluateExpr(ctx, expr, cty.Number, nil)
 	}
 }
 

--- a/internal/tofu/node_local.go
+++ b/internal/tofu/node_local.go
@@ -136,7 +136,7 @@ func (n *NodeLocal) References() []*addrs.Reference {
 // NodeLocal.Execute is an Execute implementation that evaluates the
 // expression for a local value and writes it into a transient part of
 // the state.
-func (n *NodeLocal) Execute(_ context.Context, evalCtx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
+func (n *NodeLocal) Execute(ctx context.Context, evalCtx EvalContext, op walkOperation) (diags tfdiags.Diagnostics) {
 	expr := n.Config.Expr
 	addr := n.Addr.LocalValue
 
@@ -158,7 +158,7 @@ func (n *NodeLocal) Execute(_ context.Context, evalCtx EvalContext, op walkOpera
 		return diags
 	}
 
-	val, moreDiags := evalCtx.EvaluateExpr(expr, cty.DynamicPseudoType, nil)
+	val, moreDiags := evalCtx.EvaluateExpr(ctx, expr, cty.DynamicPseudoType, nil)
 	diags = diags.Append(moreDiags)
 	if moreDiags.HasErrors() {
 		return diags

--- a/internal/tofu/node_output.go
+++ b/internal/tofu/node_output.go
@@ -352,7 +352,7 @@ func (n *NodeApplyableOutput) Execute(ctx context.Context, evalCtx EvalContext, 
 			// This has to run before we have a state lock, since evaluation also
 			// reads the state
 			var evalDiags tfdiags.Diagnostics
-			val, evalDiags = evalCtx.EvaluateExpr(n.Config.Expr, cty.DynamicPseudoType, nil)
+			val, evalDiags = evalCtx.EvaluateExpr(ctx, n.Config.Expr, cty.DynamicPseudoType, nil)
 			diags = diags.Append(evalDiags)
 
 		// If the module is being overridden and we have a value to use,

--- a/internal/tofu/node_provider.go
+++ b/internal/tofu/node_provider.go
@@ -165,7 +165,7 @@ func (n *NodeApplyableProvider) ValidateProvider(ctx context.Context, evalCtx Ev
 		data = n.Config.Instances[providerKey]
 	}
 
-	configVal, _, evalDiags := evalCtx.EvaluateBlock(configBody, configSchema, nil, data)
+	configVal, _, evalDiags := evalCtx.EvaluateBlock(ctx, configBody, configSchema, nil, data)
 	if evalDiags.HasErrors() {
 		tracing.SetSpanError(span, diags)
 		return diags.Append(evalDiags)
@@ -218,7 +218,7 @@ func (n *NodeApplyableProvider) ConfigureProvider(ctx context.Context, evalCtx E
 		data = n.Config.Instances[providerKey]
 	}
 
-	configVal, configBody, evalDiags := evalCtx.EvaluateBlock(configBody, configSchema, nil, data)
+	configVal, configBody, evalDiags := evalCtx.EvaluateBlock(ctx, configBody, configSchema, nil, data)
 	diags = diags.Append(evalDiags)
 	if evalDiags.HasErrors() {
 		tracing.SetSpanError(span, diags)

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -495,7 +495,7 @@ func (n *NodeAbstractResource) DotNode(name string, opts *dag.DotOpts) *dag.DotN
 // eval is the only change we get to set the resource "each mode" to list
 // in that case, allowing expression evaluation to see it as a zero-element list
 // rather than as not set at all.
-func (n *NodeAbstractResource) writeResourceState(evalCtx EvalContext, addr addrs.AbsResource) (diags tfdiags.Diagnostics) {
+func (n *NodeAbstractResource) writeResourceState(ctx context.Context, evalCtx EvalContext, addr addrs.AbsResource) (diags tfdiags.Diagnostics) {
 	state := evalCtx.State()
 
 	// We'll record our expansion decision in the shared "expander" object
@@ -506,7 +506,7 @@ func (n *NodeAbstractResource) writeResourceState(evalCtx EvalContext, addr addr
 
 	switch {
 	case n.Config != nil && n.Config.Count != nil:
-		count, countDiags := evaluateCountExpression(context.TODO(), n.Config.Count, evalCtx, addr)
+		count, countDiags := evaluateCountExpression(ctx, n.Config.Count, evalCtx, addr)
 		diags = diags.Append(countDiags)
 		if countDiags.HasErrors() {
 			return diags
@@ -516,7 +516,7 @@ func (n *NodeAbstractResource) writeResourceState(evalCtx EvalContext, addr addr
 		expander.SetResourceCount(addr.Module, n.Addr.Resource, count)
 
 	case n.Config != nil && n.Config.ForEach != nil:
-		forEach, forEachDiags := evaluateForEachExpression(context.TODO(), n.Config.ForEach, evalCtx, addr)
+		forEach, forEachDiags := evaluateForEachExpression(ctx, n.Config.ForEach, evalCtx, addr)
 		diags = diags.Append(forEachDiags)
 		if forEachDiags.HasErrors() {
 			return diags

--- a/internal/tofu/node_resource_abstract_instance.go
+++ b/internal/tofu/node_resource_abstract_instance.go
@@ -950,7 +950,7 @@ func (n *NodeAbstractResourceInstance) plan(
 		return plannedChange, currentState.DeepCopy(), keyData, diags
 	}
 
-	origConfigVal, _, configDiags := evalCtx.EvaluateBlock(config.Config, schema, nil, keyData)
+	origConfigVal, _, configDiags := evalCtx.EvaluateBlock(ctx, config.Config, schema, nil, keyData)
 	diags = diags.Append(configDiags)
 	if configDiags.HasErrors() {
 		return nil, nil, keyData, diags
@@ -1788,7 +1788,7 @@ func (n *NodeAbstractResourceInstance) providerMetas(ctx context.Context, evalCt
 				})
 			} else {
 				var configDiags tfdiags.Diagnostics
-				metaConfigVal, _, configDiags = evalCtx.EvaluateBlock(m.Config, providerSchema.ProviderMeta.Block, nil, EvalDataForNoInstanceKey)
+				metaConfigVal, _, configDiags = evalCtx.EvaluateBlock(ctx, m.Config, providerSchema.ProviderMeta.Block, nil, EvalDataForNoInstanceKey)
 				diags = diags.Append(configDiags)
 			}
 		}
@@ -1842,7 +1842,7 @@ func (n *NodeAbstractResourceInstance) planDataSource(ctx context.Context, evalC
 	}
 
 	var configDiags tfdiags.Diagnostics
-	configVal, _, configDiags = evalCtx.EvaluateBlock(config.Config, schema, nil, keyData)
+	configVal, _, configDiags = evalCtx.EvaluateBlock(ctx, config.Config, schema, nil, keyData)
 	diags = diags.Append(configDiags)
 	if configDiags.HasErrors() {
 		return nil, nil, keyData, diags
@@ -2131,7 +2131,7 @@ func (n *NodeAbstractResourceInstance) applyDataSource(ctx context.Context, eval
 		return nil, keyData, diags
 	}
 
-	configVal, _, configDiags := evalCtx.EvaluateBlock(config.Config, schema, nil, keyData)
+	configVal, _, configDiags := evalCtx.EvaluateBlock(ctx, config.Config, schema, nil, keyData)
 	diags = diags.Append(configDiags)
 	if configDiags.HasErrors() {
 		return nil, keyData, diags
@@ -2428,7 +2428,7 @@ func (n *NodeAbstractResourceInstance) evalProvisionerConfig(ctx context.Context
 
 	keyData := EvalDataForInstanceKey(n.ResourceInstanceAddr().Resource.Key, forEach)
 
-	config, _, configDiags := evalCtx.EvaluateBlock(body, schema, n.ResourceInstanceAddr().Resource, keyData)
+	config, _, configDiags := evalCtx.EvaluateBlock(ctx, body, schema, n.ResourceInstanceAddr().Resource, keyData)
 	diags = diags.Append(configDiags)
 
 	return config, diags
@@ -2493,7 +2493,7 @@ func (n *NodeAbstractResourceInstance) apply(
 	configVal := cty.NullVal(cty.DynamicPseudoType)
 	if applyConfig != nil {
 		var configDiags tfdiags.Diagnostics
-		configVal, _, configDiags = evalCtx.EvaluateBlock(applyConfig.Config, schema, nil, keyData)
+		configVal, _, configDiags = evalCtx.EvaluateBlock(ctx, applyConfig.Config, schema, nil, keyData)
 		diags = diags.Append(configDiags)
 		if configDiags.HasErrors() {
 			return nil, diags

--- a/internal/tofu/node_resource_apply.go
+++ b/internal/tofu/node_resource_apply.go
@@ -51,13 +51,13 @@ func (n *nodeExpandApplyableResource) Name() string {
 	return n.NodeAbstractResource.Name() + " (expand)"
 }
 
-func (n *nodeExpandApplyableResource) Execute(_ context.Context, evalCtx EvalContext, op walkOperation) tfdiags.Diagnostics {
+func (n *nodeExpandApplyableResource) Execute(ctx context.Context, evalCtx EvalContext, op walkOperation) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 	expander := evalCtx.InstanceExpander()
 	moduleInstances := expander.ExpandModule(n.Addr.Module)
 	for _, module := range moduleInstances {
 		evalCtx = evalCtx.WithPath(module)
-		diags = diags.Append(n.writeResourceState(evalCtx, n.Addr.Resource.Absolute(module)))
+		diags = diags.Append(n.writeResourceState(ctx, evalCtx, n.Addr.Resource.Absolute(module)))
 	}
 
 	return diags

--- a/internal/tofu/node_resource_import.go
+++ b/internal/tofu/node_resource_import.go
@@ -289,7 +289,7 @@ func (n *graphNodeImportStateSub) Execute(ctx context.Context, evalCtx EvalConte
 	// Insert marks from configuration
 	if n.Config != nil {
 		// Since the import command allow import resource with incomplete configuration, we ignore diagnostics here
-		valueWithConfigurationSchemaMarks, _, _ := evalCtx.EvaluateBlock(n.Config.Config, n.Schema, nil, EvalDataForNoInstanceKey)
+		valueWithConfigurationSchemaMarks, _, _ := evalCtx.EvaluateBlock(ctx, n.Config.Config, n.Schema, nil, EvalDataForNoInstanceKey)
 
 		_, stateValueMarks := state.Value.UnmarkDeepWithPaths()
 		_, valueWithConfigurationSchemaMarksPaths := valueWithConfigurationSchemaMarks.UnmarkDeepWithPaths()

--- a/internal/tofu/node_resource_plan.go
+++ b/internal/tofu/node_resource_plan.go
@@ -163,7 +163,7 @@ func (n *nodeExpandPlannableResource) DynamicExpand(evalCtx EvalContext) (*Graph
 		// plan. In the destroy plan mode, import blocks are not relevant, that's why we skip resolving imports
 		skipImports := importTarget.IsFromImportBlock() && !n.preDestroyRefresh
 		if skipImports {
-			err := importResolver.ExpandAndResolveImport(importTarget, evalCtx)
+			err := importResolver.ExpandAndResolveImport(context.TODO(), importTarget, evalCtx)
 			diags = diags.Append(err)
 		}
 	}
@@ -221,7 +221,7 @@ func (n *nodeExpandPlannableResource) expandResourceInstances(ctx context.Contex
 	// writeResourceState is responsible for informing the expander of what
 	// repetition mode this resource has, which allows expander.ExpandResource
 	// to work below.
-	moreDiags := n.writeResourceState(moduleCtx, resAddr)
+	moreDiags := n.writeResourceState(ctx, moduleCtx, resAddr)
 	diags = diags.Append(moreDiags)
 	if moreDiags.HasErrors() {
 		return diags.ErrWithWarnings()

--- a/internal/tofu/node_resource_plan_instance.go
+++ b/internal/tofu/node_resource_plan_instance.go
@@ -320,7 +320,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx context.Conte
 			repData.EachValue = cty.DynamicVal
 		}
 
-		diags = diags.Append(n.replaceTriggered(evalCtx, repData))
+		diags = diags.Append(n.replaceTriggered(ctx, evalCtx, repData))
 		if diags.HasErrors() {
 			return diags
 		}
@@ -471,14 +471,14 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx context.Conte
 // replaceTriggered checks if this instance needs to be replace due to a change
 // in a replace_triggered_by reference. If replacement is required, the
 // instance address is added to forceReplace
-func (n *NodePlannableResourceInstance) replaceTriggered(evalCtx EvalContext, repData instances.RepetitionData) tfdiags.Diagnostics {
+func (n *NodePlannableResourceInstance) replaceTriggered(ctx context.Context, evalCtx EvalContext, repData instances.RepetitionData) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 	if n.Config == nil {
 		return diags
 	}
 
 	for _, expr := range n.Config.TriggersReplacement {
-		ref, replace, evalDiags := evalCtx.EvaluateReplaceTriggeredBy(expr, repData)
+		ref, replace, evalDiags := evalCtx.EvaluateReplaceTriggeredBy(ctx, expr, repData)
 		diags = diags.Append(evalDiags)
 		if diags.HasErrors() {
 			continue
@@ -622,7 +622,7 @@ func (n *NodePlannableResourceInstance) importState(ctx context.Context, evalCtx
 			}
 		}
 
-		valueWithConfigurationSchemaMarks, _, configDiags := evalCtx.EvaluateBlock(n.Config.Config, n.Schema, nil, keyData)
+		valueWithConfigurationSchemaMarks, _, configDiags := evalCtx.EvaluateBlock(ctx, n.Config.Config, n.Schema, nil, keyData)
 		diags = diags.Append(configDiags)
 		if configDiags.HasErrors() {
 			return instanceRefreshState, diags


### PR DESCRIPTION
Because expression evaluation can potentially call provider-defined functions, we need to be able to propagate tracing context all the way to those calls to properly capture the resulting gRPC requests in traces.

As with similar previous work, this does not actually add any new tracing instrumentation immediately but is part of an ongoing effort to get the contexts plumbed in so we can eventually turn that on.

This includes updates to a somewhat-arbitrary subset of the codepaths leading to this interface, and some of the other
expression-evaluation-related codepaths that were relatively easy to update at the same time. There are some new context.TODO() calls in places where plumbing a proper context would be disruptive to too many callers; we'll deal with those in later commits.

There are no user-facing changes here; this is just supporting work for future additions in https://github.com/opentofu/opentofu/issues/2664.