### PR TITLE
builtin/providers/tf: pass real context.Context to backend methods

### DIFF
--- a/internal/builtin/providers/tf/data_source_state.go
+++ b/internal/builtin/providers/tf/data_source_state.go
@@ -106,7 +106,7 @@ func dataSourceRemoteStateValidate(cfg cty.Value) tfdiags.Diagnostics {
 	return diags
 }
 
-func dataSourceRemoteStateRead(d cty.Value, enc encryption.StateEncryption, path addrs.AbsResourceInstance) (cty.Value, tfdiags.Diagnostics) {
+func dataSourceRemoteStateRead(ctx context.Context, d cty.Value, enc encryption.StateEncryption, path addrs.AbsResourceInstance) (cty.Value, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	b, cfg, moreDiags := getBackend(d, enc)
@@ -115,9 +115,7 @@ func dataSourceRemoteStateRead(d cty.Value, enc encryption.StateEncryption, path
 		return cty.NilVal, diags
 	}
 
-	// TODO: Plumb a real context in here, once [providers.Interface] has
-	// been updated to allow one to pass through its API.
-	configureDiags := b.Configure(context.TODO(), cfg)
+	configureDiags := b.Configure(ctx, cfg)
 	if configureDiags.HasErrors() {
 		diags = diags.Append(configureDiags.Err())
 		return cty.NilVal, diags
@@ -137,7 +135,7 @@ func dataSourceRemoteStateRead(d cty.Value, enc encryption.StateEncryption, path
 		workspaceName = workspaceVal.AsString()
 	}
 
-	state, err := b.StateMgr(context.TODO(), workspaceName)
+	state, err := b.StateMgr(ctx, workspaceName)
 	if err != nil {
 		diags = diags.Append(tfdiags.AttributeValue(
 			tfdiags.Error,

--- a/internal/builtin/providers/tf/data_source_state_test.go
+++ b/internal/builtin/providers/tf/data_source_state_test.go
@@ -328,7 +328,7 @@ func TestState_basic(t *testing.T) {
 			var got cty.Value
 			if !diags.HasErrors() && config.IsWhollyKnown() {
 				var moreDiags tfdiags.Diagnostics
-				got, moreDiags = dataSourceRemoteStateRead(config, encryption.StateEncryptionDisabled(), addrs.AbsResourceInstance{
+				got, moreDiags = dataSourceRemoteStateRead(t.Context(), config, encryption.StateEncryptionDisabled(), addrs.AbsResourceInstance{
 					Resource: addrs.ResourceInstance{
 						Resource: addrs.Resource{
 							Mode: addrs.DataResourceMode,

--- a/internal/builtin/providers/tf/provider.go
+++ b/internal/builtin/providers/tf/provider.go
@@ -91,7 +91,7 @@ func (p *Provider) ReadDataSource(_ context.Context, req providers.ReadDataSourc
 	panic("Should not be called directly, special case for terraform_remote_state")
 }
 
-func (p *Provider) ReadDataSourceEncrypted(_ context.Context, req providers.ReadDataSourceRequest, path addrs.AbsResourceInstance, enc encryption.Encryption) providers.ReadDataSourceResponse {
+func (p *Provider) ReadDataSourceEncrypted(ctx context.Context, req providers.ReadDataSourceRequest, path addrs.AbsResourceInstance, enc encryption.Encryption) providers.ReadDataSourceResponse {
 	// call function
 	var res providers.ReadDataSourceResponse
 
@@ -113,7 +113,7 @@ func (p *Provider) ReadDataSourceEncrypted(_ context.Context, req providers.Read
 
 	log.Printf("[DEBUG] accessing remote state at %s", key)
 
-	newState, diags := dataSourceRemoteStateRead(req.Config, enc.RemoteState(key), path)
+	newState, diags := dataSourceRemoteStateRead(ctx, req.Config, enc.RemoteState(key), path)
 
 	if diags.HasErrors() {
 		diags = diags.Append(fmt.Errorf("%s: Unable to read remote state", path.String()))


### PR DESCRIPTION
An earlier commit made providers.Interface methods now have `context.Context` available, so we can pass that through to the `Backend` methods that expect it.

A future commit will presumably also change the `statemgr.Full` interface in a similar way, at which point we can plumb the same interface into those calls here too, but `statemgr.Full` has lots of callers so we'll deal with that as a separate focused commit.

(This is for https://github.com/opentofu/opentofu/issues/2664.)
