### PR TITLE
[v1.10 BACKPORT] website: OCI provider mirror shouldn't talk about prereleases anymore

### DIFF
--- a/website/docs/cli/oci_registries/provider-mirror.mdx
+++ b/website/docs/cli/oci_registries/provider-mirror.mdx
@@ -116,9 +116,9 @@ by subsequent workflow commands like [`tofu apply`](../commands/apply.mdx).
 This section currently describes a very manual process for constructing the
 required manifest structure as described in the previous section.
 
-We intend to replace this with a more automated approach in a later OpenTofu
-release, but hope that the following will suffice for now to allow early
-experimentation with OCI Registry provider mirrors in the OpenTofu v1.10 prereleases.
+The OpenTofu project is currently collaborating with the ORAS project to
+design and implement a more complete solution, which will be documented here
+once it's included in a generally-available ORAS release.
 :::
 
 ### Install and Configure ORAS


### PR DESCRIPTION
This is a (belated) backport of https://github.com/opentofu/opentofu/pull/2873 to the `v1.10` release branch, since that PR got merged after we'd already created the release branch and so didn't make it into the release tree yet. (The old content is currently live on the website.)
