### PR TITLE
backend/s3: Use APNInfo instead of UserAgent

### DIFF
--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -745,9 +745,11 @@ func (b *Backend) Configure(ctx context.Context, obj cty.Value) tfdiags.Diagnost
 		Insecure:             boolAttr(obj, "insecure"),
 		UseDualStackEndpoint: boolAttr(obj, "use_dualstack_endpoint"),
 		UseFIPSEndpoint:      boolAttr(obj, "use_fips_endpoint"),
-		UserAgent: awsbase.UserAgentProducts{
-			{Name: "APN", Version: "1.0"},
-			{Name: httpclient.DefaultApplicationName, Version: version.String()},
+		APNInfo: &awsbase.APNInfo{
+			PartnerName: "OpenTofu-S3-Backend",
+			Products: []awsbase.UserAgentProduct{
+				{Name: httpclient.DefaultApplicationName, Version: version.String()},
+			},
 		},
 		CustomCABundle:                 stringAttrDefaultEnvVar(obj, "custom_ca_bundle", "AWS_CA_BUNDLE"),
 		EC2MetadataServiceEndpoint:     stringAttrDefaultEnvVar(obj, "ec2_metadata_service_endpoint", "AWS_EC2_METADATA_SERVICE_ENDPOINT"),


### PR DESCRIPTION
For reasons that upstream did not describe due to an NDA, the upstream library [hashicorp/aws-sdk-go-base](https://github.com/hashicorp/aws-sdk-go-base) now prefers to receive `User-Agent` additions through this `APNInfo` field instead of the older `UserAgent` field. Using `UserAgent` causes problems when combined with the `TF_APPEND_USER_AGENT` environment variable, since the library tries to use the same middleware to handle both but the AWS SDK only allows each middleware to be registered once.

The `APNInfo` handling causes a similar effect but using a separate middleware name. The "APN/1.0" part is now hard-coded upstream, and the `PartnerName` given here is also included as a new "OpenTofu-S3-Backend/1.0" part, where the version number "1.0" is also hard-coded upstream. The "Products" are then included, causing us to generate the "OpenTofu" entry with the correct current OpenTofu version.

Therefore the final string has a suffix like the following:

```
    APN/1.0 OpenTofu-S3-Backend/1.0 OpenTofu/1.10.1
```

(and then the `TF_APPEND_USER_AGENT` can extend that separately, via logic elsewhere in the upstream library. OpenTofu is not involved in the handling of that because the library calls `os.Getenv` directly.)

It seems that "APN" here refers to [AWS Partner Network](https://docs.aws.amazon.com/partner-central/latest/getting-started/becoming.html), and so I expect AWS would prefer us to use a registered "partner name" here, but I don't believe we currently have one. Perhaps we can obtain one to use in a later release, but continuing to use `UserAgent` makes the `TF_APPEND_USER_AGENT` environment variable unusable and I think using an unregistered partner name is our only recourse to resolve this regression quickly with the upstream library as currently implemented.

---

Unfortunately this is messy to test because the upstream library rudely pulls `TF_APPEND_USER_AGENT` directly out of the environment without OpenTofu's involvement, and the final user-agent string doesn't seem to be exposed anywhere we can conveniently access it.

I expect we could probably find a way to test it using a custom round-tripper to intercept an outgoing request, but I chose to be pragmatic here and just test this manually (reviewing the user-agent string included in the library's verbose logs) so that we can clear this regression sooner.

(I note also that this upstream library is expressly documented as not intended for use outside of the callers maintained by the same vendor that maintains this library, and so we should probably plan to migrate away from it in a future release to something else that is better suited to our needs.)

---

This resolves https://github.com/opentofu/opentofu/issues/2954. There's some additional context about this change in my  comments on that issue, including some links to upstream code and PRs related to this change.

This should be backported to the `v1.10` branch once merged, for inclusion in a patch release. The changelog entry for this will be included in the backport PR, because it'll appear in a v1.10 patch release long before v1.11 is released.

