### PR TITLE
website: OCI provider mirror build doesn't need --artifact-platform

### DIFF
--- a/website/docs/cli/oci_registries/provider-mirror.mdx
+++ b/website/docs/cli/oci_registries/provider-mirror.mdx
@@ -188,7 +188,6 @@ Use `oras push` for each package in turn to copy the `.zip` archive into your lo
 ```shellsession
 $ oras push \
     --artifact-type application/vnd.opentofu.provider-target \
-    --artifact-platform linux/amd64 \
     --oci-layout tmp-layout:linux_amd64 \
     terraform-provider-tls_4.0.6_linux_amd64.zip:archive/zip
 


### PR DESCRIPTION
This documentation was originally based on some instructions written for a future ORAS version that knows how to construct index manifests in the form OpenTofu needs, but then adapted to work with the current ORAS v1.2 before release.

However, I missed removing the --artifact-platform option from the "oras push" command. That argument is needed when constructing the index manifest using ORAS because it allows ORAS to recognize which platform each artifact was intended for, but in the current form of the instructions (where the index construction is manual) that option isn't needed.

Since that option isn't available yet in ORAS v1.2 anyway (it was added for ORAS v1.3, which is still in beta) we'll remove it for now and then re-add it once we update these docs for ORAS v1.4 where the index manifest can then be constructed automatically by ORAS.

---

If merged, this should be backported to the `v1.10` branch.

After merging this, https://github.com/opentofu/opentofu/pull/2963 should be updated so that it re-adds the line removed in this patch, because the new instructions in that PR _do_ depend on the effects of the `--artifact-platform` option.