### PR TITLE
command: Only shim dependency lock file for installation actions

### DIFF
--- a/internal/command/e2etest/testdata/predecessor-dependency-lock-file-abs/.terraform.lock.hcl
+++ b/internal/command/e2etest/testdata/predecessor-dependency-lock-file-abs/.terraform.lock.hcl
@@ -1,0 +1,13 @@
+
+# This intentionally refers to the registry of OpenTofu's predecessor, but
+# the associated configuration refers to the shorthand "hashicorp/null"
+# and so will be understood by OpenTofu as depending instead on
+# "registry.opentofu.org/hashicorp/null", thereby activating our special
+# fixup behavior and selecting the same version of OpenTofu's re-release
+# of this provider.
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.0"
+  hashes = [
+    "h1:DvLRiv4Pbjq3Rh0yNWtq+9dwVXqHF+bQspfhckLyFWU=",
+  ]
+}

--- a/internal/command/e2etest/testdata/predecessor-dependency-lock-file-abs/predecessor-dependency-lock-file.tf
+++ b/internal/command/e2etest/testdata/predecessor-dependency-lock-file-abs/predecessor-dependency-lock-file.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    null = {
+      # This intentionally refers to our predecessor project's registry directly
+      # because we use this to test the situation where that hostname is
+      # specified explicitly.
+      #
+      # This registry's terms of service does not allow use from OpenTofu, so
+      # it's only acceptable to use a configuration like this with OpenTofu
+      # when using custom installation methods to remap this hostname to a
+      # separate mirror source. DO NOT USE THIS TEST FIXTURE IN ANY TEST THAT
+      # USES THE "direct" INSTALLATION METHOD FOR THIS HOSTNAME!
+      source = "registry.terraform.io/hashicorp/null"
+    }
+  }
+}

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -614,7 +614,7 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 		}
 	}
 
-	previousLocks, moreDiags := c.lockedDependencies()
+	previousLocks, moreDiags := c.lockedDependenciesWithPredecessorRegistryShimmed()
 	diags = diags.Append(moreDiags)
 
 	if diags.HasErrors() {

--- a/internal/command/providers_lock.go
+++ b/internal/command/providers_lock.go
@@ -193,7 +193,7 @@ func (c *ProvidersLockCommand) Run(args []string) int {
 	// We'll start our work with whatever locks we already have, so that
 	// we'll honor any existing version selections and just add additional
 	// hashes for them.
-	oldLocks, moreDiags := c.lockedDependencies()
+	oldLocks, moreDiags := c.lockedDependenciesWithPredecessorRegistryShimmed()
 	diags = diags.Append(moreDiags)
 
 	// If we have any error diagnostics already then we won't proceed further.

--- a/internal/command/providers_mirror.go
+++ b/internal/command/providers_mirror.go
@@ -87,7 +87,7 @@ func (c *ProvidersMirrorCommand) Run(args []string) int {
 	diags = diags.Append(moreDiags)
 
 	// Read lock file
-	lockedDeps, lockedDepsDiags := c.Meta.lockedDependencies()
+	lockedDeps, lockedDepsDiags := c.Meta.lockedDependenciesWithPredecessorRegistryShimmed()
 	diags = diags.Append(lockedDepsDiags)
 
 	// If we have any error diagnostics already then we won't proceed further.


### PR DESCRIPTION
Recently (in https://github.com/opentofu/opentofu/pull/2791) we added a call to `Locks.UpgradeFromPredecessorProject` to try to preserve dependency selections made for providers under `registry.terraform.io/hashicorp/*` when switching to OpenTofu for the first time.

However, this behavior did not properly cater for the situation where the configuration intentionally specifies `registry.terraform.io` explicitly in a provider source address: that would then cause OpenTofu to incorrectly try to make a factory function for the shimmed provider version when working in `command.Meta.providerFactories`, which would then fail because no such provider appears in the cache directory.

Instead then, we'll limit the shimming only to installation-related actions while only using the dependency locks exactly as written when preparing to actually _run_ the provider plugins.

This is bothersome to test because our tests are not allowed to directly access `registry.terraform.io`; the test case here mimicks one situation in which it could be allowable for an OpenTofu user to explicitly use the `registry.terraform.io` hostname: if they've used the CLI configuration to arrange for that hostname to be handled only via a mirror rather than by direct access to the origin registry.[^1]

[^1]: The terms of service for `registry.terraform.io` currently prohibit using it for anything other than Terraform, so we ensure that this test cannot make requests to any real services at that hostname. As far as we know it is not allowable to use OpenTofu CLI to access services at that hostname, but this is not legal advice.

Note that telling OpenTofu to use `registry.terraform.io` is not officially supported and may cause other problems beyond what was addressed by this PR, since OpenTofu tends to assume that this hostname would appear only during the process of migrating from Terraform and might make unexpected decisions based on that assumption. Despite us making this fix to allow some forward progress in the meantime, those who are explicitly specifying `registry.terraform.io` in their configuration should make plans to stop doing that and to set things up some other way instead.

This fixes https://github.com/opentofu/opentofu/issues/2977 . This will be backported to the `v1.10` branch if merged, and then the changelog entry will be recorded on that branch rather than on `main`.

