### PR TITLE
[v1.10 BACKPORT] command: Only shim dependency lock file for installation actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 ## 1.10.2 (Unreleased)
 
-## 1.10.1 (Unreleased)
+- S3 backend now correctly sends the `x-amz-server-side-encryption` header for the lockfile. ([#2870](https://github.com/opentofu/opentofu/issues/2970))
+- A provider source address explicitly using the hostname `registry.terraform.io` will no longer cause errors related to a corresponding provider on `registry.opentofu.org` when executing workflow commands like plan and apply. ([#2979](https://github.com/opentofu/opentofu/issues/2979))
+
+## 1.10.1
 
 BUG FIXES:
-* Fix `TF_APPEND_USER_AGENT` handling in the S3 remote state backend. ((#2955)[https://github.com/opentofu/opentofu/pull/2955])
+- Fix `TF_APPEND_USER_AGENT` handling in the S3 remote state backend. ([#2955](https://github.com/opentofu/opentofu/pull/2955))
 
 ## 1.10.0
 
@@ -77,7 +80,6 @@ BUG FIXES:
 - `tofu init` now detects and reports errors when creating the file used to track backend initialization, instead of silently failing to save that information. ([#2798](https://github.com/opentofu/opentofu/pull/2798))
 - An invalid provider name in a `provider_meta` block no longer causes OpenTofu to crash. ([#2347](https://github.com/opentofu/opentofu/pull/2347))
 - OpenTofu no longer indirectly uses software that was affected by [CVE-2024-45336](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-45336) and [CVE-2024-45341](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-45341). These advisories did not significantly affect OpenTofu, and so this upgrade is purely to reduce false positives in naive security scanners. ([#2438](https://github.com/opentofu/opentofu/pull/2438))
-- S3 backend now correctly sends the `x-amz-server-side-encryption` header for the lockfile ([#2870](https://github.com/opentofu/opentofu/issues/2970))
 
 ## Previous Releases
 

--- a/internal/command/e2etest/testdata/predecessor-dependency-lock-file-abs/.terraform.lock.hcl
+++ b/internal/command/e2etest/testdata/predecessor-dependency-lock-file-abs/.terraform.lock.hcl
@@ -1,0 +1,13 @@
+
+# This intentionally refers to the registry of OpenTofu's predecessor, but
+# the associated configuration refers to the shorthand "hashicorp/null"
+# and so will be understood by OpenTofu as depending instead on
+# "registry.opentofu.org/hashicorp/null", thereby activating our special
+# fixup behavior and selecting the same version of OpenTofu's re-release
+# of this provider.
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.0"
+  hashes = [
+    "h1:DvLRiv4Pbjq3Rh0yNWtq+9dwVXqHF+bQspfhckLyFWU=",
+  ]
+}

--- a/internal/command/e2etest/testdata/predecessor-dependency-lock-file-abs/predecessor-dependency-lock-file.tf
+++ b/internal/command/e2etest/testdata/predecessor-dependency-lock-file-abs/predecessor-dependency-lock-file.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    null = {
+      # This intentionally refers to our predecessor project's registry directly
+      # because we use this to test the situation where that hostname is
+      # specified explicitly.
+      #
+      # This registry's terms of service does not allow use from OpenTofu, so
+      # it's only acceptable to use a configuration like this with OpenTofu
+      # when using custom installation methods to remap this hostname to a
+      # separate mirror source. DO NOT USE THIS TEST FIXTURE IN ANY TEST THAT
+      # USES THE "direct" INSTALLATION METHOD FOR THIS HOSTNAME!
+      source = "registry.terraform.io/hashicorp/null"
+    }
+  }
+}

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -614,7 +614,7 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 		}
 	}
 
-	previousLocks, moreDiags := c.lockedDependencies()
+	previousLocks, moreDiags := c.lockedDependenciesWithPredecessorRegistryShimmed()
 	diags = diags.Append(moreDiags)
 
 	if diags.HasErrors() {

--- a/internal/command/providers_lock.go
+++ b/internal/command/providers_lock.go
@@ -193,7 +193,7 @@ func (c *ProvidersLockCommand) Run(args []string) int {
 	// We'll start our work with whatever locks we already have, so that
 	// we'll honor any existing version selections and just add additional
 	// hashes for them.
-	oldLocks, moreDiags := c.lockedDependencies()
+	oldLocks, moreDiags := c.lockedDependenciesWithPredecessorRegistryShimmed()
 	diags = diags.Append(moreDiags)
 
 	// If we have any error diagnostics already then we won't proceed further.

--- a/internal/command/providers_mirror.go
+++ b/internal/command/providers_mirror.go
@@ -87,7 +87,7 @@ func (c *ProvidersMirrorCommand) Run(args []string) int {
 	diags = diags.Append(moreDiags)
 
 	// Read lock file
-	lockedDeps, lockedDepsDiags := c.Meta.lockedDependencies()
+	lockedDeps, lockedDepsDiags := c.Meta.lockedDependenciesWithPredecessorRegistryShimmed()
 	diags = diags.Append(lockedDepsDiags)
 
 	// If we have any error diagnostics already then we won't proceed further.


### PR DESCRIPTION
This is a backport of https://github.com/opentofu/opentofu/pull/2979 to the v1.10 branch.
