### PR TITLE
main: Log the effective set of OCI credential search locations

### DIFF
--- a/cmd/tofu/oci_distribution.go
+++ b/cmd/tofu/oci_distribution.go
@@ -84,6 +84,17 @@ func getOCIRepositoryStore(ctx context.Context, registryDomain, repositoryName s
 	)
 	defer span.End()
 
+	// Since there are lots of different ways to provide OCI credentials to
+	// OpenTofu, and several are implicit based on files and/or environment
+	// variables we found on the system, we'll generate some debug logs
+	// listing the locations where we're searching so we'll have some good
+	// context for a bug report about OpenTofu selecting different credentials
+	// than the operator expected. There should not typically be more than a
+	// few of these on a reasonably-configured system.
+	for _, cfg := range credsPolicy.AllConfigs() {
+		log.Printf("[DEBUG] OCI registry client will consider credentials from %s", cfg.CredentialsConfigLocationForUI())
+	}
+
 	client, err := getOCIRepositoryORASClient(ctx, registryDomain, repositoryName, credsPolicy)
 	if err != nil {
 		tracing.SetSpanError(span, err)


### PR DESCRIPTION
Previously we generated some logs during the discovery process indicating which locations OpenTofu was probing for ambient credentials, but we didn't explicitly report the overall result of the discovery process.

These new log lines will now report the final effective set of credential configuration locations just before we try to use them in either the provider installation or module installation codepaths. The strings returned by `CredentialsConfigLocationForUI` are intended for just this sort of feedback: the exact format varies for each kind of location, but it's always a concise string identifying a location that OpenTofu will consider when attempting to decide credentials.

Logging this here does unfortunately mean that the log output will be repeated for each separate OCI registry request. There not being a great single location to generate these logs was the main reason we didn't include something like this in the first implementation, but the set of config locations is small on any reasonable system and we've already had a few folks struggle to understand why OpenTofu is making a certain decision about credential sources so this is a pragmatic small step to give us some extra diagnostic information in bug reports without affecting the normal UI output for now.

---

For example, when OpenTofu discovers an "ambient" Docker CLI configuration file this would produce a log line like the following:

```
[DEBUG] OCI registry client will consider credentials from /home/username/.docker/config.json
```

Other possible sources this could log are explicit `oci_credentials` blocks in CLI configuration files, or the `oci_default_credentials` block in CLI configuration files when present (if it specifies a global credentials helper). Unlike the existing logs produced during discovery, this only lists credential config locations that actually exist (as opposed to everything OpenTofu _attempted_ to read).

---

This was mainly motivated by https://github.com/opentofu/opentofu/issues/2962, since over there we have an unanswered question about where OpenTofu is finding a configuration selecting the `wincred` credential helper. This does not actually close that issue, but once this change has been included in a release we can hopefully use it to gather more information for that issue.

I don't intend to add a changelog entry for this since this is primarily here so that its results will be shared automatically by anyone following our bug reporting process, rather than it being a direct end-user feature. Of course, some users might still find this additional information useful in their own debugging.

If merged, this should be backported to the `v1.10` branch for inclusion in a patch release.
