### PR TITLE
jsonformat: Tolerate incorrect paths in plan relevant_attributes

### DIFF
--- a/internal/command/testdata/plan-invalid-reference-try/plan-invalid-reference-try.tf
+++ b/internal/command/testdata/plan-invalid-reference-try/plan-invalid-reference-try.tf
@@ -1,0 +1,20 @@
+resource "test" "a" {
+  values = {
+    phase = "updated"
+  }
+}
+
+resource "test" "b" {
+  values = {
+    a_phase = try(
+      # This is intentionally an invalid reference that is nonetheless
+      # visible to static reference analysis, and so can be detected
+      # by the "relevant attributes" heuristic in the language runtime.
+      test.a.values[0].phase,
+
+      # This is a valid version of the above, thereby allowing this
+      # overall expression to succeed evaluation.
+      test.a.values.phase,
+    )
+  }
+}


### PR DESCRIPTION
The code for matching relevant_attributes against resource_drift entries (a part of the heuristic for deciding whether to show "changes outside of OpenTofu" in the human-oriented plan UI) was previously assuming that paths in resource_drift would always be valid for the associated resource instance object values because in most cases the language runtime will detect invalid references and so fail to generate a plan at all.

However, when the reference is to something within a dynamically-typed argument (such as the manifest in kubernetes_manifest) and when it appears only as an argument to either the "try" or "can" functions (so the dynamic error is intentionally suppressed) the language runtime can't catch it and so the incorrect reference will leak out into relevant_attributes, thereby violating assumptions made by the path matcher.

Instead then, we'll continue the existing precedent that this "relevant attributes" mechanism is a best-effort heuristic that prefers to succeed with an incomplete result rather than to fail, extending that to the traversals in the plan renderer which will now treat incorrectly-typed steps as not matching rather than causing OpenTofu to crash completely.

Since a reference to something that doesn't exist cannot succeed it also cannot possibly _actually_ contribute directly to the final result of the expression it appeared in, so in practice it should be okay to disregard these invalid references for the purposes of deciding which changes outside of OpenTofu seem likely to have caused the actions that OpenTofu is proposing to make during the apply phase.

---

This problem was originally reported as a provider bug in https://github.com/hashicorp/terraform-provider-helm/issues/1657. Although it was a change to the provider that caused existing valid references to become incorrect after upgrading, it's OpenTofu CLI's responsibility to describe that situation correctly without crashing, and so that's what this change aims to achieve.

Since this is arguably a pretty rare situation that arises only when a few different components interact together in a specific way, I'm ambivalent about whether this justifies a v1.10 backport. I've left this without a changelog entry for now so we can discuss that risk/reward tradeoff, but if we ultimately decide _not_ to backport it then I'll add another commit here to introduce the changelog entry on the main branch rather than on the v1.10 branch.

