### PR TITLE
[v1.10 BACKPORT] jsonformat: Tolerate incorrect paths in plan relevant_attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.10.3 (Unreleased)
 
+BUG FIXES:
+
+- OpenTofu will no longer crash in a rare case where a dynamically-invalid expression has its error suppressed by `try` or `can` and then that expression becomes relevant for deciding whether to report a "change outside of OpenTofu" in the human-oriented plan diff. ([#2988](https://github.com/opentofu/opentofu/pull/2988))
 
 ## 1.10.2
 
@@ -11,6 +14,7 @@ BUG FIXES:
 ## 1.10.1
 
 BUG FIXES:
+
 - Fix `TF_APPEND_USER_AGENT` handling in the S3 remote state backend. ([#2955](https://github.com/opentofu/opentofu/pull/2955))
 
 ## 1.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
+## 1.10.3 (Unreleased)
+
+
 ## 1.10.2
+
+BUG FIXES:
 
 - S3 backend now correctly sends the `x-amz-server-side-encryption` header for the lockfile. ([#2870](https://github.com/opentofu/opentofu/issues/2970))
 - A provider source address explicitly using the hostname `registry.terraform.io` will no longer cause errors related to a corresponding provider on `registry.opentofu.org` when executing workflow commands like plan and apply. ([#2979](https://github.com/opentofu/opentofu/issues/2979))

--- a/internal/command/testdata/plan-invalid-reference-try/plan-invalid-reference-try.tf
+++ b/internal/command/testdata/plan-invalid-reference-try/plan-invalid-reference-try.tf
@@ -1,0 +1,20 @@
+resource "test" "a" {
+  values = {
+    phase = "updated"
+  }
+}
+
+resource "test" "b" {
+  values = {
+    a_phase = try(
+      # This is intentionally an invalid reference that is nonetheless
+      # visible to static reference analysis, and so can be detected
+      # by the "relevant attributes" heuristic in the language runtime.
+      test.a.values[0].phase,
+
+      # This is a valid version of the above, thereby allowing this
+      # overall expression to succeed evaluation.
+      test.a.values.phase,
+    )
+  }
+}


### PR DESCRIPTION
This is a direct backport of https://github.com/opentofu/opentofu/pull/2988 to the `v1.10` branch, along with its changelog entry since we expect this change will be released for the first time in v1.10.3.
