### PR TITLE
hcl2shim: MockValueComposer handles structural-typed attributes

### DIFF
--- a/internal/configs/hcl2shim/mock_value_composer.go
+++ b/internal/configs/hcl2shim/mock_value_composer.go
@@ -101,7 +101,7 @@ func (mvc MockValueComposer) composeMockValueForAttributes(schema *configschema.
 		// Non-computed attributes can't be generated
 		// so we set them from configuration only.
 		if !attr.Computed {
-			mockAttrs[k] = cty.NullVal(attr.Type)
+			mockAttrs[k] = cty.NullVal(attr.ImpliedType())
 			if _, ok := defaults[k]; ok {
 				diags = diags.Append(tfdiags.WholeContainingBody(
 					tfdiags.Error,
@@ -115,7 +115,7 @@ func (mvc MockValueComposer) composeMockValueForAttributes(schema *configschema.
 		// If the attribute is computed and not configured,
 		// we use provided value from defaults.
 		if ov, ok := defaults[k]; ok {
-			converted, err := convert.Convert(ov, attr.Type)
+			converted, err := convert.Convert(ov, attr.ImpliedType())
 			if err != nil {
 				diags = diags.Append(tfdiags.WholeContainingBody(
 					tfdiags.Error,

--- a/internal/configs/hcl2shim/mock_value_composer.go
+++ b/internal/configs/hcl2shim/mock_value_composer.go
@@ -101,6 +101,16 @@ func (mvc MockValueComposer) composeMockValueForAttributes(schema *configschema.
 		// Non-computed attributes can't be generated
 		// so we set them from configuration only.
 		if !attr.Computed {
+			if attr.NestedType != nil && attr.NestedType.Nesting == configschema.NestingGroup {
+				// This should not be possible to hit.  Neither tofu or the provider framework will allow
+				// NestingGroup in here.  However, this could change at some point and we want to be prepared for it.
+				diags = diags.Append(tfdiags.WholeContainingBody(
+					tfdiags.Error,
+					fmt.Sprintf("Unsupported field `%v` in attribute mocking", k),
+					"Overriding non-computed fields is not allowed, so this field cannot be processed.",
+				))
+				continue
+			}
 			mockAttrs[k] = cty.NullVal(attr.ImpliedType())
 			if _, ok := defaults[k]; ok {
 				diags = diags.Append(tfdiags.WholeContainingBody(

--- a/internal/configs/hcl2shim/mock_value_composer_test.go
+++ b/internal/configs/hcl2shim/mock_value_composer_test.go
@@ -3,8 +3,10 @@ package hcl2shim
 import (
 	"testing"
 
-	"github.com/opentofu/opentofu/internal/configs/configschema"
+	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/opentofu/opentofu/internal/configs/configschema"
 )
 
 // TestComposeMockValueBySchema ensures different configschema.Block values
@@ -175,6 +177,131 @@ func TestComposeMockValueBySchema(t *testing.T) {
 					"sensitive-required": cty.NullVal(cty.String),
 					"sensitive-computed": cty.StringVal("ionwj3qrsh4xyC9"),
 				}),
+			}),
+		},
+		"structural-attr-single": {
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"nested": {
+						NestedType: &configschema.Object{
+							Nesting: configschema.NestingSingle,
+							Attributes: map[string]*configschema.Attribute{
+								"attr": {
+									Type:     cty.Number,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			config: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.NullVal(cty.DynamicPseudoType),
+			}),
+			wantVal: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.NullVal(cty.Object(map[string]cty.Type{
+					"attr": cty.Number,
+				})),
+			}),
+		},
+		"structural-attr-group": {
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"nested": {
+						NestedType: &configschema.Object{
+							Nesting: configschema.NestingGroup,
+							Attributes: map[string]*configschema.Attribute{
+								"attr": {
+									Type:     cty.Number,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			config: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.NullVal(cty.DynamicPseudoType),
+			}),
+			wantVal: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.ObjectVal(map[string]cty.Value{
+					"attr": cty.NullVal(cty.Number),
+				}),
+			}),
+		},
+		"structural-attr-list": {
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"nested": {
+						NestedType: &configschema.Object{
+							Nesting: configschema.NestingList,
+							Attributes: map[string]*configschema.Attribute{
+								"attr": {
+									Type:     cty.Number,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			config: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.NullVal(cty.DynamicPseudoType),
+			}),
+			wantVal: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.NullVal(cty.List(cty.Object(map[string]cty.Type{
+					"attr": cty.Number,
+				}))),
+			}),
+		},
+		"structural-attr-map": {
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"nested": {
+						NestedType: &configschema.Object{
+							Nesting: configschema.NestingMap,
+							Attributes: map[string]*configschema.Attribute{
+								"attr": {
+									Type:     cty.Number,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			config: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.NullVal(cty.DynamicPseudoType),
+			}),
+			wantVal: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.NullVal(cty.Map(cty.Object(map[string]cty.Type{
+					"attr": cty.Number,
+				}))),
+			}),
+		},
+		"structural-attr-set": {
+			schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"nested": {
+						NestedType: &configschema.Object{
+							Nesting: configschema.NestingSet,
+							Attributes: map[string]*configschema.Attribute{
+								"attr": {
+									Type:     cty.Number,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			config: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.NullVal(cty.DynamicPseudoType),
+			}),
+			wantVal: cty.ObjectVal(map[string]cty.Value{
+				"nested": cty.NullVal(cty.Set(cty.Object(map[string]cty.Type{
+					"attr": cty.Number,
+				}))),
 			}),
 		},
 		"basic-group-block": {
@@ -558,7 +685,7 @@ func TestComposeMockValueBySchema(t *testing.T) {
 				t.Fatalf("Got unexpected error diags: %v", gotDiags.ErrWithWarnings())
 
 			case !test.wantVal.RawEquals(gotVal):
-				t.Fatalf("Got unexpected value: %v", gotVal.GoString())
+				t.Fatalf("Wrong value\ngot: %swant: %sdiff: %s", ctydebug.ValueString(gotVal), ctydebug.ValueString(test.wantVal), ctydebug.DiffValues(test.wantVal, gotVal))
 			}
 		})
 	}

--- a/internal/configs/hcl2shim/mock_value_composer_test.go
+++ b/internal/configs/hcl2shim/mock_value_composer_test.go
@@ -223,11 +223,7 @@ func TestComposeMockValueBySchema(t *testing.T) {
 			config: cty.ObjectVal(map[string]cty.Value{
 				"nested": cty.NullVal(cty.DynamicPseudoType),
 			}),
-			wantVal: cty.ObjectVal(map[string]cty.Value{
-				"nested": cty.ObjectVal(map[string]cty.Value{
-					"attr": cty.NullVal(cty.Number),
-				}),
-			}),
+			wantError: true, // This should not be hit in today's tofu/providers.  If that assumption ever changes, we want to handle it gracefully.
 		},
 		"structural-attr-list": {
 			schema: &configschema.Block{


### PR DESCRIPTION
Directly accessing the "Type" attribute of configschema.Attribute is not correct because there are actually two different "flavors" of attribute type in modern OpenTofu: "simple" attributes use the Type field, while structural-typed attributes use the NestedType field to specify a more block-like schema that can support extra detail such as having a mixture of config-specified and provider-specified values within the same attribute.

Calling the ImpliedType method instead hides this distinction by taking the implied type of the NestedType if set, but returning the simple Type if not.

This fixes https://github.com/opentofu/opentofu/issues/2993. If merged, this should be backported to the `v1.10` branch and so its changelog entry would be included in that backport.

---

Although my initial draft of this prevents the panic that was reported, it does so in a rather naive way that treats both simple-typed and structural-typed attributes identically, whereas other parts of OpenTofu treat structural-typed attributes more like nested block types and so perhaps it would be more appropriate to add a new codepath for the structural-typed attributes that treats them more like `MockValueComposer.getMockValueForBlock` does, doing recursive "compositions" of the nested attributes too. :thinking: 

Unfortunately whatever behavior we implement here will become a compatibility constraint, so I don't think we can "just" fix the bug without making some permanent design decisions about how mocks ought to behave for structural-typed attributes. Therefore I'm going to leave this in draft right now so we can have some discussion about it and then revisit next week.

(The existing test failure shows one way that this is already _not quite right_: the definition of `NestingGroup` is that a block or attribute of that nesting mode is never null and instead a null value in config gets automatically promoted to a non-null object value with all of its attributes set to null, but calling `Attribute.ImpliedType` erases the distinction between `NestingSingle` and `NestingGroup` and so it's not currently honoring that requirement. The handling of nested block types seems to get away with this by going in the opposite direction: it effectively treats `NestingSingle` as if it were `NestingGroup`, always recursively expanding a non-nil object of the attribute's implied object type. :man_shrugging: )
