### PR TITLE
fix: Temp data cleanup in windows

### DIFF
--- a/internal/getproviders/package_location_http_archive.go
+++ b/internal/getproviders/package_location_http_archive.go
@@ -83,8 +83,8 @@ func (p PackageHTTPURL) InstallProviderPackage(ctx context.Context, meta Package
 	if err != nil {
 		return nil, fmt.Errorf("failed to open temporary file to download from %s: %w", url, err)
 	}
-	defer f.Close()
 	defer os.Remove(f.Name())
+	defer f.Close()
 
 	// We'll borrow go-getter's "cancelable copy" implementation here so that
 	// the download can potentially be interrupted partway through.


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves #2843 

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.

### Summary
Fixed an issue where temporary Terraform provider files (e.g., terraform-providerXXXXX) were not cleaned up properly on Windows systems.

Before applying the fix, temporary provider files were left behind in the %TEMP% directory after running tofu init.
<img width="1103" alt="before_temp_data_bug_fix" src="https://github.com/user-attachments/assets/46ea0ee6-0776-467f-9799-d0a3ab061a9f" />

After applying the fix, the provider temporary file is removed correctly upon completion.
<img width="1105" alt="after_temp_databug_fix" src="https://github.com/user-attachments/assets/50c0f8ce-3366-4823-adc8-9c7915d946ff" />


