### PR TITLE
tofu: Make a few tests more robust against panicking

### DIFF
--- a/internal/tofu/context_apply2_test.go
+++ b/internal/tofu/context_apply2_test.go
@@ -2395,12 +2395,12 @@ locals {
 
 	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), nil)
 	if diags.HasErrors() {
-		t.Errorf("expected no errors, but got %s", diags)
+		t.Fatalf("expected no errors, but got %s", diags)
 	}
 
 	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
-		t.Errorf("expected no errors, but got %s", diags)
+		t.Fatalf("expected no errors, but got %s", diags)
 	}
 
 	// We didn't specify any external references, so the unreferenced local
@@ -2438,12 +2438,12 @@ locals {
 		},
 	})
 	if diags.HasErrors() {
-		t.Errorf("expected no errors, but got %s", diags)
+		t.Fatalf("expected no errors, but got %s", diags)
 	}
 
 	state, diags := ctx.Apply(context.Background(), plan, m)
 	if diags.HasErrors() {
-		t.Errorf("expected no errors, but got %s", diags)
+		t.Fatalf("expected no errors, but got %s", diags)
 	}
 
 	// We did specify the local value in the external references, so it should

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -4217,6 +4217,9 @@ func TestContext2Plan_preconditionErrors(t *testing.T) {
 				t.Fatal("succeeded; want errors")
 			}
 
+			if plan == nil {
+				t.Fatal("result from plan is nil; expected a plan marked as errored")
+			}
 			if !plan.Errored {
 				t.Fatal("plan failed to record error")
 			}
@@ -4901,6 +4904,9 @@ func TestContext2Plan_dataSourceReadPlanError(t *testing.T) {
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if !diags.HasErrors() {
 		t.Fatalf("expected plan error")
+	}
+	if plan == nil {
+		t.Fatal("plan returned nil result; expected a non-nil plan marked as errored")
 	}
 
 	// make sure we can serialize the plan even if there were an error
@@ -7512,6 +7518,9 @@ import {
 		t.Fatal("expected error")
 	}
 
+	if plan == nil {
+		t.Fatal("plan returned nil result; expected a plan marked as errored")
+	}
 	instPlan := plan.Changes.ResourceInstance(addr)
 	if instPlan == nil {
 		t.Fatalf("no plan for %s at all", addr)
@@ -7648,6 +7657,10 @@ locals {
 
 	if len(module.Resources) > 0 {
 		t.Errorf("expected no resources in the state but found %d", len(module.LocalValues))
+	}
+
+	if plan == nil {
+		t.Fatal("plan returned nil result; expected a non-nil plan marked as errored")
 	}
 
 	// But, this makes it hard for the testing framework to valid things about


### PR DESCRIPTION
Some of our test cases expect that planning will fail but will still return a non-nil plan with `Errored` set to true, and some other cases were not expecting plan to fail at all, and in all of those cases a failure to meet that expectation caused a panic rather than a test failure.

When debugging a problem that affects many tests it's annoying when the test run panics partway through, so these small changes make these tests a little more resilient to the system not behaving in the way they were expecting, without affecting the behavior when the system behaves as expected.

---

I originally did this as part of https://github.com/opentofu/opentofu/pull/2849. The main change in that PR didn't work out, but this test fixup is independent and was only included there because I found these problems while working on that change.
