### PR TITLE
tofu show: -module=DIR mode, for showing just a single module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ ENHANCEMENTS:
 
 * OpenTofu will now suggest using `-exclude` if a provider reports that it cannot create a plan for a particular resource instance due to values that won't be known until the apply phase. ([#2643](https://github.com/opentofu/opentofu/pull/2643))
 * `tofu validate` now supports running in a module that contains provider configuration_aliases. ([#2905](https://github.com/opentofu/opentofu/pull/2905))
-* `tofu show` now supports a `-config` option, to be used in conjunction with `-json` to produce a machine-readable summary of the configuration without first creating a plan. ([#2820](https://github.com/opentofu/opentofu/pull/2820))
+* `tofu show` now supports `-config` and `-module=DIR` options, to be used in conjunction with `-json` to produce a machine-readable summary of either the whole configuration or a single module without first creating a plan. ([#2820](https://github.com/opentofu/opentofu/pull/2820), [#3003](https://github.com/opentofu/opentofu/pull/3003))
 
 BUG FIXES:
 

--- a/internal/command/arguments/show.go
+++ b/internal/command/arguments/show.go
@@ -54,6 +54,13 @@ const (
 	//
 	// This target type does not use [Show.TargetArg].
 	ShowConfig
+
+	// ShowModule represents a request to show just one module in isolation,
+	// without requiring any of its dependencies to be installed.
+	//
+	// For this target type, [Show.TargetArg] is a path to the directory
+	// containing the module.
+	ShowModule
 )
 
 // ParseShow processes CLI arguments, returning a Show value and errors.
@@ -69,12 +76,14 @@ func ParseShow(args []string) (*Show, tfdiags.Diagnostics) {
 	var stateTarget bool
 	var planTarget string
 	var configTarget bool
+	var moduleTarget string
 	cmdFlags := extendedFlagSet("show", nil, nil, show.Vars)
 	cmdFlags.BoolVar(&jsonOutput, "json", false, "json")
 	cmdFlags.BoolVar(&show.ShowSensitive, "show-sensitive", false, "displays sensitive values")
 	cmdFlags.BoolVar(&stateTarget, "state", false, "show the latest state snapshot")
 	cmdFlags.StringVar(&planTarget, "plan", "", "show the plan from a saved plan file")
 	cmdFlags.BoolVar(&configTarget, "config", false, "show the current configuration")
+	cmdFlags.StringVar(&moduleTarget, "module", "", "show metadata about one module")
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -84,12 +93,20 @@ func ParseShow(args []string) (*Show, tfdiags.Diagnostics) {
 		))
 	}
 
-	// If -config is specified, -json is required
+	// If -config or -module=... is selected, -json is required
 	if configTarget && !jsonOutput {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"JSON output required for configuration",
 			"The -config option requires -json to be specified.",
+		))
+		return show, diags
+	}
+	if moduleTarget != "" && !jsonOutput {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"JSON output required for module",
+			"The -module=DIR option requires -json to be specified.",
 		))
 		return show, diags
 	}
@@ -101,7 +118,7 @@ func ParseShow(args []string) (*Show, tfdiags.Diagnostics) {
 		show.ViewType = ViewHuman
 	}
 
-	if planTarget == "" && !stateTarget && !configTarget {
+	if planTarget == "" && moduleTarget == "" && !stateTarget && !configTarget {
 		// If none of the target type options was provided then we're
 		// in the legacy mode where the target type is implied by
 		// the number of arguments.
@@ -153,11 +170,16 @@ func ParseShow(args []string) (*Show, tfdiags.Diagnostics) {
 		show.TargetType = ShowConfig
 		show.TargetArg = ""
 	}
+	if moduleTarget != "" {
+		targetTypes++
+		show.TargetType = ShowModule
+		show.TargetArg = moduleTarget
+	}
 	if targetTypes != 1 {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Conflicting object types to show",
-			"The -state, -plan=FILENAME, and -config options are mutually-exclusive, to specify which kind of object to show.",
+			"The -state, -plan=FILENAME, -config, and -module=DIR options are mutually-exclusive, to specify which kind of object to show.",
 		))
 	}
 	return show, diags

--- a/internal/command/arguments/show_test.go
+++ b/internal/command/arguments/show_test.go
@@ -90,6 +90,14 @@ func TestParseShow_valid(t *testing.T) {
 				ViewType:   ViewJSON,
 			},
 		},
+		"module with json": {
+			[]string{"-module=foo", "-json"},
+			&Show{
+				TargetType: ShowModule,
+				TargetArg:  "foo",
+				ViewType:   ViewJSON,
+			},
+		},
 	}
 
 	for name, tc := range testCases {
@@ -163,7 +171,7 @@ func TestParseShow_invalid(t *testing.T) {
 				tfdiags.Sourceless(
 					tfdiags.Error,
 					"Conflicting object types to show",
-					"The -state, -plan=FILENAME, and -config options are mutually-exclusive, to specify which kind of object to show.",
+					"The -state, -plan=FILENAME, -config, and -module=DIR options are mutually-exclusive, to specify which kind of object to show.",
 				),
 			},
 		},
@@ -217,7 +225,7 @@ func TestParseShow_invalid(t *testing.T) {
 				tfdiags.Sourceless(
 					tfdiags.Error,
 					"Conflicting object types to show",
-					"The -state, -plan=FILENAME, and -config options are mutually-exclusive, to specify which kind of object to show.",
+					"The -state, -plan=FILENAME, -config, and -module=DIR options are mutually-exclusive, to specify which kind of object to show.",
 				),
 			},
 		},
@@ -232,7 +240,65 @@ func TestParseShow_invalid(t *testing.T) {
 				tfdiags.Sourceless(
 					tfdiags.Error,
 					"Conflicting object types to show",
-					"The -state, -plan=FILENAME, and -config options are mutually-exclusive, to specify which kind of object to show.",
+					"The -state, -plan=FILENAME, -config, and -module=DIR options are mutually-exclusive, to specify which kind of object to show.",
+				),
+			},
+		},
+		"module without json": {
+			[]string{"-module=foo"},
+			&Show{
+				ViewType: ViewNone,
+			},
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"JSON output required for module",
+					"The -module=DIR option requires -json to be specified.",
+				),
+			},
+		},
+		"module with state": {
+			[]string{"-module=foo", "-state", "-json"},
+			&Show{
+				TargetType: ShowModule,
+				TargetArg:  "foo",
+				ViewType:   ViewJSON,
+			},
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Conflicting object types to show",
+					"The -state, -plan=FILENAME, -config, and -module=DIR options are mutually-exclusive, to specify which kind of object to show.",
+				),
+			},
+		},
+		"module with plan": {
+			[]string{"-module=foo", "-plan=tfplan", "-json"},
+			&Show{
+				TargetType: ShowModule,
+				TargetArg:  "foo",
+				ViewType:   ViewJSON,
+			},
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Conflicting object types to show",
+					"The -state, -plan=FILENAME, -config, and -module=DIR options are mutually-exclusive, to specify which kind of object to show.",
+				),
+			},
+		},
+		"module with config": {
+			[]string{"-module=foo", "-config", "-json"},
+			&Show{
+				TargetType: ShowModule,
+				TargetArg:  "foo",
+				ViewType:   ViewJSON,
+			},
+			tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Conflicting object types to show",
+					"The -state, -plan=FILENAME, -config, and -module=DIR options are mutually-exclusive, to specify which kind of object to show.",
 				),
 			},
 		},

--- a/internal/command/arguments/showtargettype_string.go
+++ b/internal/command/arguments/showtargettype_string.go
@@ -12,11 +12,12 @@ func _() {
 	_ = x[ShowState-1]
 	_ = x[ShowPlan-2]
 	_ = x[ShowConfig-3]
+	_ = x[ShowModule-4]
 }
 
-const _ShowTargetType_name = "ShowUnknownTypeShowStateShowPlanShowConfig"
+const _ShowTargetType_name = "ShowUnknownTypeShowStateShowPlanShowConfigShowModule"
 
-var _ShowTargetType_index = [...]uint8{0, 15, 24, 32, 42}
+var _ShowTargetType_index = [...]uint8{0, 15, 24, 32, 42, 52}
 
 func (i ShowTargetType) String() string {
 	if i < 0 || i >= ShowTargetType(len(_ShowTargetType_index)-1) {

--- a/internal/command/jsonconfig/config.go
+++ b/internal/command/jsonconfig/config.go
@@ -31,12 +31,12 @@ type config struct {
 // provider configurations are the one concept in OpenTofu that can span across
 // module boundaries.
 type providerConfig struct {
-	Name              string                 `json:"name,omitempty"`
-	FullName          string                 `json:"full_name,omitempty"`
-	Alias             string                 `json:"alias,omitempty"`
-	VersionConstraint string                 `json:"version_constraint,omitempty"`
-	ModuleAddress     string                 `json:"module_address,omitempty"`
-	Expressions       map[string]interface{} `json:"expressions,omitempty"`
+	Name              string         `json:"name,omitempty"`
+	FullName          string         `json:"full_name,omitempty"`
+	Alias             string         `json:"alias,omitempty"`
+	VersionConstraint string         `json:"version_constraint,omitempty"`
+	ModuleAddress     string         `json:"module_address,omitempty"`
+	Expressions       map[string]any `json:"expressions,omitempty"`
 	parentKey         string
 }
 
@@ -50,13 +50,13 @@ type module struct {
 }
 
 type moduleCall struct {
-	Source            string                 `json:"source,omitempty"`
-	Expressions       map[string]interface{} `json:"expressions,omitempty"`
-	CountExpression   *expression            `json:"count_expression,omitempty"`
-	ForEachExpression *expression            `json:"for_each_expression,omitempty"`
-	Module            *module                `json:"module,omitempty"`
-	VersionConstraint string                 `json:"version_constraint,omitempty"`
-	DependsOn         []string               `json:"depends_on,omitempty"`
+	Source            string         `json:"source,omitempty"`
+	Expressions       map[string]any `json:"expressions,omitempty"`
+	CountExpression   *expression    `json:"count_expression,omitempty"`
+	ForEachExpression *expression    `json:"for_each_expression,omitempty"`
+	Module            *module        `json:"module,omitempty"`
+	VersionConstraint string         `json:"version_constraint,omitempty"`
+	DependsOn         []string       `json:"depends_on,omitempty"`
 }
 
 // variables is the JSON representation of the variables provided to the current
@@ -95,7 +95,7 @@ type resource struct {
 
 	// Expressions" describes the resource-type-specific  content of the
 	// configuration block.
-	Expressions map[string]interface{} `json:"expressions,omitempty"`
+	Expressions map[string]any `json:"expressions,omitempty"`
 
 	// SchemaVersion indicates which version of the resource type schema the
 	// "values" property conforms to.
@@ -119,8 +119,8 @@ type output struct {
 }
 
 type provisioner struct {
-	Type        string                 `json:"type,omitempty"`
-	Expressions map[string]interface{} `json:"expressions,omitempty"`
+	Type        string         `json:"type,omitempty"`
+	Expressions map[string]any `json:"expressions,omitempty"`
 }
 
 // Marshal returns the json encoding of tofu configuration.

--- a/internal/command/jsonconfig/expression.go
+++ b/internal/command/jsonconfig/expression.go
@@ -92,7 +92,7 @@ func (e *expression) Empty() bool {
 // expressions is used to represent the entire content of a block. Attribute
 // arguments are mapped directly with the attribute name as key and an
 // expression as value.
-type expressions map[string]interface{}
+type expressions map[string]any
 
 // marshalExpressions returns a representation of the expressions in the given
 // body after analyzing based on the given schema.
@@ -151,16 +151,16 @@ func marshalExpressions(body hcl.Body, schema *configschema.Block) expressions {
 			ret[typeName] = marshalExpressions(block.Body, &blockS.Block)
 		case configschema.NestingList, configschema.NestingSet:
 			if _, exists := ret[typeName]; !exists {
-				ret[typeName] = make([]map[string]interface{}, 0, 1)
+				ret[typeName] = make([]map[string]any, 0, 1)
 			}
-			ret[typeName] = append(ret[typeName].([]map[string]interface{}), marshalExpressions(block.Body, &blockS.Block))
+			ret[typeName] = append(ret[typeName].([]map[string]any), marshalExpressions(block.Body, &blockS.Block))
 		case configschema.NestingMap:
 			if _, exists := ret[typeName]; !exists {
-				ret[typeName] = make(map[string]map[string]interface{})
+				ret[typeName] = make(map[string]map[string]any)
 			}
 			// NestingMap blocks always have the key in the first (and only) label
 			key := block.Labels[0]
-			retMap := ret[typeName].(map[string]map[string]interface{})
+			retMap := ret[typeName].(map[string]map[string]any)
 			retMap[key] = marshalExpressions(block.Body, &blockS.Block)
 		}
 	}

--- a/internal/command/jsonconfig/expression.go
+++ b/internal/command/jsonconfig/expression.go
@@ -94,7 +94,18 @@ func (e *expression) Empty() bool {
 // expression as value.
 type expressions map[string]interface{}
 
+// marshalExpressions returns a representation of the expressions in the given
+// body after analyzing based on the given schema.
+//
+// If [inSingleModuleMode] returns true when given schema, the result is always
+// nil to represent that expression information is not available in
+// single-module mode.
 func marshalExpressions(body hcl.Body, schema *configschema.Block) expressions {
+	if inSingleModuleMode(schema) {
+		// We never generate any expressions in single-module mode.
+		return nil
+	}
+
 	// Since we want the raw, un-evaluated expressions we need to use the
 	// low-level HCL API here, rather than the hcldec decoder API. That means we
 	// need the low-level schema.

--- a/internal/command/jsonconfig/expression_test.go
+++ b/internal/command/jsonconfig/expression_test.go
@@ -10,11 +10,11 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/zclconf/go-cty/cty"
-
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hcltest"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/configs/configschema"
 )
 
@@ -129,6 +129,24 @@ func TestMarshalExpressions(t *testing.T) {
 		if !reflect.DeepEqual(got, test.Want) {
 			t.Errorf("wrong result:\nGot: %#v\nWant: %#v\n", got, test.Want)
 		}
+	}
+}
+
+func TestMarshalExpressions_singleModuleMode(t *testing.T) {
+	// In single-module mode the given schema is nil, which should
+	// cause the result to always be nil. Refer to the docs on
+	// [inSingleExpressionMode] for more information.
+	input := hcltest.MockBody(&hcl.BodyContent{
+		Attributes: hcl.Attributes{
+			"foo": {
+				Name: "foo",
+				Expr: hcltest.MockExprTraversalSrc(`var.list[1]`),
+			},
+		},
+	})
+	got := marshalExpressions(input, nil)
+	if got != nil {
+		t.Errorf("wrong result:\nGot: %#v\nWant: <nil>", got)
 	}
 }
 

--- a/internal/command/jsonconfig/single_module.go
+++ b/internal/command/jsonconfig/single_module.go
@@ -1,0 +1,80 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package jsonconfig
+
+import (
+	"github.com/opentofu/opentofu/internal/configs"
+	"github.com/opentofu/opentofu/internal/configs/configschema"
+	"github.com/opentofu/opentofu/internal/tofu"
+)
+
+// MarshalSingleModule is a variant of [Marshal] that describes only a single
+// module, without any references to its child modules or associated provider
+// schemas.
+//
+// This uses only a subset of the typical configuration representation, due to
+// schema and child module information being unavailable:
+//   - Module calls omit the "module" property that would normally describe the
+//     content of the child module.
+//   - Resource descriptions omit the "schema_version" property because no
+//     schema-based information is included.
+//   - Expression-related properties are omitted in all cases. Technically only
+//     expressions passed to providers _need_ to be omitted, but for now we
+//     just consistently omit all of them because that's an easier rule to
+//     explain and avoids exposing what is and is not provider-based so that
+//     we could potentially change those details in future.
+func MarshalSingleModule(m *configs.Module) ([]byte, error) {
+	// Our shared codepaths are built to work with a full config tree rather
+	// than a single module, so we'll construct a synthetic [configs.Config]
+	// that only has a root module and then downstream shared functions will
+	// use the nil-ness of the schemas argument to handle the special
+	// treatments required in single-module mode.
+	cfg := &configs.Config{
+		Module: m,
+		// Everything else intentionally not populated because single module
+		// mode should not attempt to access anything else.
+	}
+	return marshal(cfg, nil)
+}
+
+// inSingleModuleMode returns true if the given schema value indicates that
+// we should be rendering in "single module" mode, meaning that we're producing
+// a result for [MarshalSingleModule] rather than [Marshal].
+//
+// Currently the rule is only that a nil schemas represents single-module mode;
+// this simple rule is factored out into this helper function only so we can
+// centralize it underneath this doc comment explaining the special convention.
+//
+// (This rather odd design is a consequence of how this code evolved; we
+// retrofitted the single-module mode later while using this strange treatment
+// to minimize the risk to the existing working codepaths. Maybe we'll change
+// the appoach to this in future; this is only an implementation detail
+// within this package so we'll be able to those changes without affecting
+// callers.)
+func inSingleModuleMode[S schemaObject](schema S) bool {
+	return schema == nil
+}
+
+// mapSchema is a helper that uses the given function to transform the given
+// schema object only if it isn't nil, or immediately returns nil otherwise.
+//
+// This is part of our strategy to retrofit the single-module mode without
+// a risky refactor of the already-working code, intended to be used in
+// conjunction with [inSingleModuleMode] to smuggle the flag for whether we're
+// in that mode through the nil-ness of the schema objects.
+func mapSchema[In, Out schemaObject](schema In, f func(In) Out) Out {
+	if schema == nil {
+		return nil
+	}
+	return f(schema)
+}
+
+// schemaObject is a helper interface to allow [inSingleModuleMode] to be
+// generic over the different nilable schema types used by different parts
+// of the implementation in this package.
+type schemaObject interface {
+	*tofu.Schemas | *configschema.Block
+}

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -1576,3 +1576,113 @@ func TestShow_config_conflictingOptions(t *testing.T) {
 		t.Errorf("unexpected output\ngot: %s\nwant:\n%s", got, want)
 	}
 }
+
+func TestShow_module(t *testing.T) {
+	// We intentionally don't cause the effect of a "tofu init" for this one,
+	// because the single-module mode is required to work without any
+	// dependencies installed and without a backend initialized so it can
+	// be used by the OpenTofu module registry indexing process.
+
+	view, done := testView(t)
+	c := &ShowCommand{
+		Meta: Meta{
+			View: view,
+		},
+	}
+
+	args := []string{
+		"-module=testdata/show-config-single-module",
+		"-json",
+		"-no-color",
+	}
+	code := c.Run(args)
+	output := done(t)
+
+	if code != 0 {
+		t.Fatalf("wrong exit status %d; want 0\ngot: %s", code, output.Stderr())
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(output.Stdout()), &got); err != nil {
+		t.Fatalf("invalid JSON output: %s\n%s", err, output.Stdout())
+	}
+	want := map[string]any{
+		"provider_config": map[string]any{
+			"test": map[string]any{
+				"full_name":          "example.com/bar/test",
+				"name":               "test",
+				"version_constraint": "~> 2.0.0",
+				// "expressions" intentionally omitted in single-module mode
+			},
+		},
+		"root_module": map[string]any{
+			"module_calls": map[string]any{
+				"child": map[string]any{
+					"source":             "example.com/not/actually/used",
+					"version_constraint": "~> 1.0.0",
+					// "module" intentionally omitted in single-module mode
+					// "expressions" intentionally omitted in single-module mode
+				},
+			},
+			"outputs": map[string]any{
+				"foo": map[string]any{
+					// "expression" intentionally omitted in single-module mode
+					"sensitive": true,
+				},
+			},
+			"resources": []any{
+				map[string]any{
+					"address":             "test_instance.foo",
+					"mode":                "managed",
+					"type":                "test_instance",
+					"name":                "foo",
+					"provider_config_key": "test",
+					// "expressions" intentionally omitted in single-module mode
+					// "schema_version" intentionally omitted in single-module mode (because we're not including anything that's schema-sensitive)
+					// "for_each_expression" intentionally omitted in single-module mode
+
+					"provisioners": []any{
+						map[string]any{
+							"type": "local-exec",
+							// "expressions" intentionally omitted in single-module mode
+						},
+					},
+				},
+			},
+			"variables": map[string]any{
+				"foo": map[string]any{
+					"sensitive": true,
+				},
+			},
+		},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Error("wrong result\n" + diff)
+	}
+}
+
+func TestShow_module_noJson(t *testing.T) {
+	view, done := testView(t)
+	c := &ShowCommand{
+		Meta: Meta{
+			View: view,
+		},
+	}
+
+	args := []string{
+		"-module=testdata/show-config-module",
+		"-no-color",
+	}
+	code := c.Run(args)
+	output := done(t)
+
+	if code != 1 {
+		t.Fatalf("unexpected exit status %d; want 1\ngot: %s", code, output.Stdout())
+	}
+
+	got := output.Stderr()
+	want := "JSON output required for module"
+	if !strings.Contains(got, want) {
+		t.Errorf("unexpected output\ngot: %s\nwant:\n%s", got, want)
+	}
+}

--- a/internal/command/testdata/show-config-single-module/main.tf
+++ b/internal/command/testdata/show-config-single-module/main.tf
@@ -1,0 +1,42 @@
+terraform {
+  required_providers {
+    test = {
+      source = "example.com/bar/test"
+      version = "~> 2.0.0"
+    }
+  }
+}
+
+variable "foo" {
+  type = string
+
+  sensitive = true
+}
+
+provider "test" {
+  foo = var.foo
+}
+
+resource "test_instance" "foo" {
+  count = 5
+
+  foo = var.foo
+
+  provisioner "local-exec" {
+    command = "echo 'not actually executed'"
+  }
+}
+
+module "child" {
+  # The single-module mode of "tofu show" is supposed to work without
+  # installing any dependencies, so it's okay that this refers to
+  # a fake location.
+  source  = "example.com/not/actually/used"
+  version = "~> 1.0.0"
+}
+
+output "foo" {
+  value = test_instance.foo[0].foo
+
+  sensitive = true
+}

--- a/website/docs/cli/commands/show.mdx
+++ b/website/docs/cli/commands/show.mdx
@@ -28,7 +28,8 @@ to inspect:
 
 - `-state`: Inspect the latest state snapshot, if any.
 - `-plan=FILENAME`: Inspect the plan stored in the given saved plan file.
-- `-config`: Inspect the current configuration (requires `-json`).
+- `-config`: Inspect the current full configuration (requires `-json`).
+- `-module=DIR`: Inspect the configuration of just a single module in the given directory, without requiring any dependencies to be installed (requires `-json`).
 
 The `-state` option is the default if none of these options are used. The
 target-selection options are mutually-exclusive.
@@ -43,11 +44,11 @@ This command also accepts the following additional options:
   used in module source addresses or backend settings in the
   current configuration.
 
-This command relies on schema information from provider plugins to fully
-understand the provider-specific data structures in state, plan, and
-configuration artifacts. If you are currently using different provider
-versions than were used when creating the selected artifact then
-you may need to use `tofu apply` (or similar) to allow OpenTofu to
+Unless using the `-module=DIR` option, this command relies on schema information
+from provider plugins to fully understand the provider-specific data structures
+in state, plan, and configuration artifacts. If you are currently using
+different provider versions than were used when creating the selected artifact
+then you may need to use `tofu apply` (or similar) to allow OpenTofu to
 upgrade the stored data to match the latest provider schemas.
 
 ## JSON Output
@@ -62,6 +63,14 @@ depends on the selected artifact type:
 - `-config` returns [the JSON configuration representation](../../internals/json-format.mdx#configuration-representation),
   providing exactly the same configuration-related information that the plan representation would include,
   but without requiring a plan to be created first.
+- `-module=DIR` returns a subset of [the JSON configuration representation](../../internals/json-format.mdx#configuration-representation), where:
+    - The `"module"` property of each module call is omitted.
+    - The `"schema_version"` property of each resource is omitted.
+    - All expression-related properties are omitted.
+
+    These omissions together allow this particular mode to work without first
+    executing `tofu init`, and thus without first installing the module's
+    dependencies.
 
 ## Legacy Usage
 


### PR DESCRIPTION
We previously added the `-config` mode for showing the entire assembled configuration tree, including the content of any descendent modules, but that mode requires first running `tofu init` to install all of the provider and module dependencies of the configuration.

This new `-module=DIR` mode returns a subset of the same JSON representation for only a single module that can be generated without first installing any dependencies, making this mode more appropriate for situations like generating documentation for a single module when importing it into the OpenTofu Registry. The registry generation process does not want to endure the overhead of installing other providers and modules when all it actually needs is metadata about the top-level declarations in the module.

As with `-config`, this initially has only a `-json` output mode, since we don't have any existing human-oriented config representation aside from the original configuration source code.

This closes https://github.com/opentofu/opentofu/issues/2901. If this is merged then I'll make a new issue in the OpenTofu Registry UI repository to replace [the current use of the unreleased `tofu metadata dump` command](https://github.com/opentofu/registry-ui/blob/c4ea85ab9a4c077a31440f694991050daf8fe6ab/backend/internal/moduleindex/moduleschema/tofu.go#L93) once this new functionality is available in a stable release.

The second commit is just a small code modernization attempt in this package per our usual practice of improving things "while we're in the area". It just replaces `interface{}` with `any`, to adopt the modern (post-Go1.18) idiom.

---

To minimize the risk to the already-working full-config JSON representation while still reusing most of its code, the implementation details of `package jsonconfig` are a little awkward here.

Since this code changes relatively infrequently and is implementing an external interface subject to compatibility constraints, and since this new behavior is relatively marginal and intended primarily for our own OpenTofu Registry purposes, this is a pragmatic tradeoff that is hopefully compensated for well enough by the code comments that aim to explain what's going on for the benefit of future maintainers.

If we _do_ find ourselves making substantial changes to this code at a later date then we can consider a more significant
restructure of the code at that point; the weird stuff is intentionally encapsulated inside `package jsonconfig` so it can change later without changing any callers.
