### PR TITLE
funcs: issensitive returns unknown when given an unknown value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 1.11.0 (Unreleased)
 
+UPGRADE NOTES:
+
+* The `issensitive` function previously incorrectly returned known results when given unknown values, which has now been corrected to avoid confusing consistency check failures during the apply phase, as reported in [issue #2415](https://github.com/opentofu/opentofu/issues/2415).
+
+    If your module was previously assigning something derived from an `issensitive` result to a context where unknown values are not allowed during the planning phase, such as `count`/`for_each` arguments for resources or modules, this will now fail during the planning phase and so you will need to choose a new approach where either the `issensitive` argument is always known during the planning phase or where the sensitivity of an unknown value is not used as part of the decision.
+
 ENHANCEMENTS:
 
 * OpenTofu will now suggest using `-exclude` if a provider reports that it cannot create a plan for a particular resource instance due to values that won't be known until the apply phase. ([#2643](https://github.com/opentofu/opentofu/pull/2643))
@@ -11,6 +17,7 @@ BUG FIXES:
 * The `tofu.rc` configuration file now properly takes precedence over `terraform.rc` on Windows ([#2891](https://github.com/opentofu/opentofu/pull/2891))
 * S3 backend now correctly sends the `x-amz-server-side-encryption` header for the lockfile ([#2870](https://github.com/opentofu/opentofu/issues/2970))
 * Allow function calls in test variable blocks ([#2947](https://github.com/opentofu/opentofu/pull/2947))
+* The `issensitive` function now returns an unknown result when its argument is unknown, since a sensitive unknown value can potentially become non-sensitive once more information is available. ([#3008](https://github.com/opentofu/opentofu/pull/3008))
 
 ## Previous Releases
 

--- a/internal/lang/funcs/sensitive_test.go
+++ b/internal/lang/funcs/sensitive_test.go
@@ -180,39 +180,47 @@ func TestNonsensitive(t *testing.T) {
 func TestIsSensitive(t *testing.T) {
 	tests := []struct {
 		Input       cty.Value
-		IsSensitive bool
+		IsSensitive cty.Value
 	}{
 		{
 			cty.NumberIntVal(1).Mark(marks.Sensitive),
-			true,
+			cty.True,
 		},
 		{
 			cty.NumberIntVal(1),
-			false,
+			cty.False,
 		},
 		{
 			cty.DynamicVal.Mark(marks.Sensitive),
-			true,
+			cty.UnknownVal(cty.Bool).RefineNotNull(),
 		},
 		{
 			cty.DynamicVal,
-			false,
+			cty.UnknownVal(cty.Bool).RefineNotNull(),
 		},
 		{
 			cty.UnknownVal(cty.String).Mark(marks.Sensitive),
-			true,
+			cty.UnknownVal(cty.Bool).RefineNotNull(),
 		},
 		{
 			cty.UnknownVal(cty.String),
-			false,
+			cty.UnknownVal(cty.Bool).RefineNotNull(),
 		},
 		{
 			cty.NullVal(cty.EmptyObject).Mark(marks.Sensitive),
-			true,
+			cty.True,
 		},
 		{
 			cty.NullVal(cty.EmptyObject),
-			false,
+			cty.False,
+		},
+		{
+			cty.NullVal(cty.DynamicPseudoType).Mark(marks.Sensitive),
+			cty.True,
+		},
+		{
+			cty.NullVal(cty.DynamicPseudoType),
+			cty.False,
 		},
 	}
 
@@ -224,8 +232,8 @@ func TestIsSensitive(t *testing.T) {
 				t.Fatalf("unexpected error: %s", err)
 			}
 
-			if got.Equals(cty.BoolVal(test.IsSensitive)).False() {
-				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, cty.BoolVal(test.IsSensitive))
+			if !got.RawEquals(test.IsSensitive) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.IsSensitive)
 			}
 		})
 	}


### PR DESCRIPTION
Other parts of the language allow deciding the sensitivity of a value based on results that won't be known until the apply phase, which means that in practice we cannot predict the final sensitivity of an unknown value.

Previously this function assumed that an unknown value would always be a placeholder for a final value of the same sensitivity, which is not a valid assumption in practice and so using the results of this function could cause downstream value consistency checks to fail.

---

This does unfortunately create a situation where a new version of OpenTofu will return an unknown value in a situation that was previously always known, which could therefore begin causing a plan-time error if the result is then used to populate something that is required to be known at plan time.

However, the previous behavior caused OpenTofu to produce confusing errors (blaming a provider for OpenTofu's mistake) during the apply phase, and so the potential new plan-time errors are arguably better than the previous behavior. Nonetheless, I recommend that we _don't_ backport this to earlier releases and warn about the narrow risk of new errors in the v1.11 changelog.

(I'm assuming that in practice it should be pretty rare to use the sensitivity of an unknown value as part of populating something that can't be unknown during the planning phase, and therefore this change will lead to more benefit than harm overall.)

---

Any unknown result is refined as definitely not null to shrink the potential impact: other parts of the language will still be able to assume that the result of this function is not null even if it's not yet known.

This fixes #2415.
