### PR TITLE
jsonconfig: Additional details about input variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ ENHANCEMENTS:
 * OpenTofu will now suggest using `-exclude` if a provider reports that it cannot create a plan for a particular resource instance due to values that won't be known until the apply phase. ([#2643](https://github.com/opentofu/opentofu/pull/2643))
 * `tofu validate` now supports running in a module that contains provider configuration_aliases. ([#2905](https://github.com/opentofu/opentofu/pull/2905))
 * `tofu show` now supports `-config` and `-module=DIR` options, to be used in conjunction with `-json` to produce a machine-readable summary of either the whole configuration or a single module without first creating a plan. ([#2820](https://github.com/opentofu/opentofu/pull/2820), [#3003](https://github.com/opentofu/opentofu/pull/3003))
+* [The JSON representation of configuration](https://opentofu.org/docs/internals/json-format/#configuration-representation) returned by `tofu show` in `-json` mode now includes type constraint information for input variables and whether each input variable is required, in addition to the existing properties related to input variables. ([#3013](https://github.com/opentofu/opentofu/pull/3013))
 
 BUG FIXES:
 

--- a/internal/command/jsonconfig/config_test.go
+++ b/internal/command/jsonconfig/config_test.go
@@ -6,9 +6,12 @@
 package jsonconfig
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/tofu"
@@ -110,38 +113,165 @@ func TestFindSourceProviderConfig(t *testing.T) {
 }
 
 func TestMarshalModule(t *testing.T) {
-	t.Run("validate variables marshalling with all the required fields", func(t *testing.T) {
-		varCfg := &configs.Variable{
-			Name:        "myvar",
-			Description: "myvar description",
-			Deprecated:  "myvar deprecated message",
-		}
-		modCfg := configs.Config{
-			Module: &configs.Module{
-				Variables: map[string]*configs.Variable{
-					"myvar": varCfg,
+	emptySchemas := &tofu.Schemas{}
+
+	tests := map[string]struct {
+		Input   *configs.Config
+		Schemas *tofu.Schemas
+		Want    module
+	}{
+		"empty": {
+			Input: &configs.Config{
+				Module: &configs.Module{},
+			},
+			Schemas: emptySchemas,
+			Want: module{
+				Outputs:     map[string]output{},
+				ModuleCalls: map[string]moduleCall{},
+			},
+		},
+		"variable, minimal": {
+			Input: &configs.Config{
+				Module: &configs.Module{
+					Variables: map[string]*configs.Variable{
+						"example": &configs.Variable{
+							Name: "example",
+						},
+					},
 				},
 			},
-		}
-		modCfg.Root = &modCfg
-
-		out, err := marshalModule(&modCfg, &tofu.Schemas{}, addrs.RootModule.String())
-		if err != nil {
-			t.Fatalf("unexpected error during marshalling module: %s", err)
-		}
-
-		expected := module{
-			Outputs:     map[string]output{},
-			ModuleCalls: map[string]moduleCall{},
-			Variables: map[string]*variable{
-				"myvar": {
-					Description: varCfg.Description,
-					Deprecated:  varCfg.Deprecated,
+			Schemas: emptySchemas,
+			Want: module{
+				Outputs:     map[string]output{},
+				ModuleCalls: map[string]moduleCall{},
+				Variables: variables{
+					"example": {
+						Required: true,
+					},
 				},
 			},
-		}
-		if diff := cmp.Diff(expected, out); diff != "" {
-			t.Errorf("unexpected diff: \n%s", diff)
-		}
-	})
+		},
+		"variable, elaborate": {
+			Input: &configs.Config{
+				Module: &configs.Module{
+					Variables: map[string]*configs.Variable{
+						"example": {
+							Name:           "example",
+							Description:    "description",
+							Deprecated:     "deprecation message",
+							Sensitive:      true,
+							ConstraintType: cty.String,
+							Type:           cty.String, // similar to ConstraintType; unfortunate historical quirk
+							Default:        cty.StringVal("hello"),
+						},
+					},
+				},
+			},
+			Schemas: emptySchemas,
+			Want: module{
+				Outputs:     map[string]output{},
+				ModuleCalls: map[string]moduleCall{},
+				Variables: variables{
+					"example": {
+						Type:        json.RawMessage(`"string"`),
+						Default:     json.RawMessage(`"hello"`),
+						Required:    false,
+						Description: "description",
+						Deprecated:  "deprecation message",
+						Sensitive:   true,
+					},
+				},
+			},
+		},
+		"variable, collection type": {
+			Input: &configs.Config{
+				Module: &configs.Module{
+					Variables: map[string]*configs.Variable{
+						"example": {
+							Name:           "example",
+							ConstraintType: cty.List(cty.String),
+							Type:           cty.List(cty.String), // similar to ConstraintType; unfortunate historical quirk
+						},
+					},
+				},
+			},
+			Schemas: emptySchemas,
+			Want: module{
+				Outputs:     map[string]output{},
+				ModuleCalls: map[string]moduleCall{},
+				Variables: variables{
+					"example": {
+						// The following is how cty serializes collection types
+						// as JSON: a two-element array where the first is
+						// the kind of collection and the second is the
+						// element type.
+						Type:     json.RawMessage(`["list","string"]`),
+						Required: true,
+					},
+				},
+			},
+		},
+		"variable, object type": {
+			Input: &configs.Config{
+				Module: &configs.Module{
+					Variables: map[string]*configs.Variable{
+						"example": {
+							Name: "example",
+							ConstraintType: cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+								"foo": cty.String,
+								"bar": cty.String,
+							}, []string{"bar"}),
+							Type: cty.Object(map[string]cty.Type{
+								"foo": cty.String,
+							}),
+						},
+					},
+				},
+			},
+			Schemas: emptySchemas,
+			Want: module{
+				Outputs:     map[string]output{},
+				ModuleCalls: map[string]moduleCall{},
+				Variables: variables{
+					"example": {
+						// The following is how cty serializes structural types
+						// as JSON: a two- or three-element array where the
+						// first is the kind of structure and the second is the
+						// kind-specific structure description, which in
+						// this case is a JSON object mapping attribute names
+						// to their types. For object types in particular,
+						// when at least one optional attribute is included
+						// the array has a third element listing the names
+						// of the optional attributes.
+						Type:     json.RawMessage(`["object",{"bar":"string","foo":"string"},["bar"]]`),
+						Required: true,
+					},
+				},
+			},
+		},
+		// TODO: More test cases covering things other than input variables.
+		// (For now the other details are mainly tested in package command,
+		// as part of the tests for "tofu show".)
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			schemas := test.Schemas
+
+			// We'll make the input a little more realistic by including some
+			// of the cyclic pointers that would normally be inserted by the
+			// config loader.
+			input := *test.Input
+			input.Root = &input
+			input.Parent = &input
+
+			got, err := marshalModule(&input, schemas, addrs.RootModule.String())
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if diff := cmp.Diff(test.Want, got); diff != "" {
+				t.Error("wrong result\n" + diff)
+			}
+		})
+	}
 }

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -660,8 +660,8 @@ func TestShow_json_output(t *testing.T) {
 			// Disregard format version to reduce needless test fixture churn
 			want.FormatVersion = got.FormatVersion
 
-			if !cmp.Equal(got, want) {
-				t.Fatalf("wrong result:\n %v\n", cmp.Diff(got, want))
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Fatal("wrong result:\n" + diff)
 			}
 		})
 	}
@@ -857,8 +857,8 @@ func TestShow_json_output_conditions_refresh_only(t *testing.T) {
 	// Disregard format version to reduce needless test fixture churn
 	want.FormatVersion = got.FormatVersion
 
-	if !cmp.Equal(got, want) {
-		t.Fatalf("wrong result:\n %v\n", cmp.Diff(got, want))
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatal("wrong result:\n" + diff)
 	}
 }
 
@@ -1651,6 +1651,8 @@ func TestShow_module(t *testing.T) {
 			},
 			"variables": map[string]any{
 				"foo": map[string]any{
+					"type":      "string",
+					"required":  true,
 					"sensitive": true,
 				},
 			},

--- a/internal/command/testdata/show-json/conditions/output-refresh-only.json
+++ b/internal/command/testdata/show-json/conditions/output-refresh-only.json
@@ -130,9 +130,11 @@
       ],
       "variables": {
         "ami": {
+          "type": "string",
           "default": "ami-test"
         },
         "id_minimum_length": {
+          "type": "number",
           "default": 10
         }
       }

--- a/internal/command/testdata/show-json/conditions/output.json
+++ b/internal/command/testdata/show-json/conditions/output.json
@@ -149,9 +149,11 @@
       ],
       "variables": {
         "ami": {
+          "type": "string",
           "default": "ami-test"
         },
         "id_minimum_length": {
+          "type": "number",
           "default": 10
         }
       }

--- a/testing/equivalence-tests/outputs/data_read/plan.json
+++ b/testing/equivalence-tests/outputs/data_read/plan.json
@@ -79,7 +79,10 @@
               }
             ],
             "variables": {
-              "contents": {}
+              "contents": {
+                "required": true,
+                "type": "string"
+              }
             }
           },
           "source": "./create"

--- a/testing/equivalence-tests/outputs/variables_and_outputs/plan.json
+++ b/testing/equivalence-tests/outputs/variables_and_outputs/plan.json
@@ -40,27 +40,110 @@
       },
       "variables": {
         "list_empty_default": {
-          "default": []
+          "default": [],
+          "type": [
+            "list",
+            [
+              "object",
+              {
+                "optional_attribute": "string",
+                "optional_attribute_with_default": "string",
+                "required_attribute": "string"
+              },
+              [
+                "optional_attribute",
+                "optional_attribute_with_default"
+              ]
+            ]
+          ]
         },
-        "list_no_default": {},
+        "list_no_default": {
+          "required": true,
+          "type": [
+            "list",
+            [
+              "object",
+              {
+                "optional_attribute": "string",
+                "optional_attribute_with_default": "string",
+                "required_attribute": "string"
+              },
+              [
+                "optional_attribute",
+                "optional_attribute_with_default"
+              ]
+            ]
+          ]
+        },
         "nested_optional_object": {
           "default": {
             "nested_object": null
-          }
+          },
+          "type": [
+            "object",
+            {
+              "nested_object": [
+                "object",
+                {
+                  "flag": "bool"
+                },
+                [
+                  "flag"
+                ]
+              ]
+            },
+            [
+              "nested_object"
+            ]
+          ]
         },
         "nested_optional_object_with_default": {
           "default": {
             "nested_object": {
               "flag": false
             }
-          }
+          },
+          "type": [
+            "object",
+            {
+              "nested_object": [
+                "object",
+                {
+                  "flag": "bool"
+                },
+                [
+                  "flag"
+                ]
+              ]
+            },
+            [
+              "nested_object"
+            ]
+          ]
         },
         "nested_optional_object_with_embedded_default": {
           "default": {
             "nested_object": {
               "flag": false
             }
-          }
+          },
+          "type": [
+            "object",
+            {
+              "nested_object": [
+                "object",
+                {
+                  "flag": "bool"
+                },
+                [
+                  "flag"
+                ]
+              ]
+            },
+            [
+              "nested_object"
+            ]
+          ]
         }
       }
     }

--- a/website/docs/internals/json-format.mdx
+++ b/website/docs/internals/json-format.mdx
@@ -422,6 +422,54 @@ Because the configuration models are produced at a stage prior to expression eva
   // as the root of a tree of similar objects describing descendent modules.
   "root_module": {
 
+    // "variables" describes the input variable configurations in the module.
+    "variables": {
+
+      // Property names here are the input variable names
+      "example": {
+        // "type" describes the type constraint of the input variable, if any.
+        // This property is omitted for an unconstrained input variable.
+        //
+        // When present, its value is either a single string representing a
+        // primitive type, or an array with two or three elements describing a
+        // complex type:
+        // - "string", "number", or "bool" for the primitive types.
+        // - ["list", <type>] for a list type, where the second array element
+        //   is the list element type described in the same notation. The
+        //   collection type kinds are "list", "map", and "set".
+        // - ["object", <attributes>] for an object type, where the second
+        //   array element is a JSON object describing the object attributes
+        //   and their associated types. For an object type with optional
+        //   attributes, the array has a third element that is a JSON array
+        //   listing the attributes that are optional.
+        // - ["tuple", <elements>] for a tuple type, where the second array
+        //   element is a JSON array describing the tuple element types.
+        "type": "string",
+
+        // "default" is the default value of the input variable, serialized
+        // as JSON using the same mappings as OpenTofu's built-in "jsonencode"
+        // function.
+        "default": "Example",
+
+        // "required" is included and set to true if callers are required to
+        // provide a value for this variable, or omitted if it is optional.
+        "required": true,
+
+        // "description" is the author-provided description associated with
+        // this input variable, if any.
+        "description": "Example",
+
+        // "sensitive" is included and set to true if the input variable is
+        // declared as being "sensitive", or omitted if not.
+        "sensitive": true,
+
+        // "deprecated" is included and set to a deprecation message for
+        // any input variable that is declared as deprecated, or omitted for
+        // non-deprecated input variables.
+        "deprecated": "Example",
+      }
+    },
+
     // "outputs" describes the output value configurations in the module.
     "outputs": {
 


### PR DESCRIPTION
The JSON object describing an input variable can now include two additional
properties:

- `"type"` provides a JSON representation of the variable's type constraint, if one is set. Omitted if either there is no constraint declared at all or if it's set to `any`, which are equivalent and both mean that the type is completely unconstrained.

  This uses the usual `cty` representation of a type constraint, which matches how OpenTofu already describes types and type constraints in the provider protocol, in state snapshots, and in saved plan files.

- `"required"` directly represents whether callers are required to provide a value for the variable. This is technically redundant since it is set to true unless `"default"` is also present, but this avoids the need for consuming software to reimplement that rule and potentially allows us to make this rule more complicated/subtle in future if needed (though we don't currently have any specific plans to do that).

For some reason the documentation about the JSON configuration representation did not previously mention the `"variables"` property at all, so this adds documentation for both the new properties and the pre-existing properties.

This is some continued work on https://github.com/opentofu/opentofu/issues/2901, as discussed while reviewing https://github.com/opentofu/opentofu/pull/3003.
