### PR TITLE
Smarter approach to .Equals on state objects for unordered lists

### DIFF
--- a/internal/states/resource.go
+++ b/internal/states/resource.go
@@ -59,6 +59,33 @@ func (rs *Resource) EnsureInstance(key addrs.InstanceKey) *ResourceInstance {
 	return ret
 }
 
+func (rs *Resource) Equal(other *Resource) bool {
+	if rs == other {
+		// Handles both pointers being nil
+		return true
+	}
+	if rs == nil || other == nil {
+		// Handles one pointer being nil
+		return false
+	}
+
+	if !rs.Addr.Equal(other.Addr) || rs.ProviderConfig.String() != other.ProviderConfig.String() {
+		return false
+	}
+
+	if len(rs.Instances) != len(other.Instances) {
+		return false
+	}
+
+	for key, inst := range rs.Instances {
+		if !inst.Equal(other.Instances[key]) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // ResourceInstance represents the state of a particular instance of a resource.
 type ResourceInstance struct {
 	// Current, if non-nil, is the remote object that is currently represented
@@ -103,6 +130,40 @@ func (i *ResourceInstance) HasDeposed(key DeposedKey) bool {
 // deposed objects.
 func (i *ResourceInstance) HasAnyDeposed() bool {
 	return i != nil && len(i.Deposed) > 0
+}
+
+func (i *ResourceInstance) Equal(other *ResourceInstance) bool {
+	if i == other {
+		// Handles both pointers being nil
+		return true
+	}
+	if i == nil || other == nil {
+		// Handles one pointer being nil
+		return false
+	}
+
+	if !i.Current.Equal(other.Current) {
+		return false
+	}
+
+	if (i.ProviderKey == nil) != (other.ProviderKey == nil) {
+		return false
+	}
+	if i.ProviderKey != nil && i.ProviderKey.Value().Equals(other.ProviderKey.Value()).False() {
+		return false
+	}
+
+	if len(i.Deposed) != len(other.Deposed) {
+		return false
+	}
+
+	for key, dep := range i.Deposed {
+		if !dep.Equal(other.Deposed[key]) {
+			return false
+		}
+	}
+
+	return true
 }
 
 // HasObjects returns true if this resource has any objects at all, whether

--- a/internal/states/state_equal.go
+++ b/internal/states/state_equal.go
@@ -62,7 +62,7 @@ func sameManagedResources(s1, s2 *State) bool {
 				continue
 			}
 			otherRS := s2.Resource(addr)
-			if !reflect.DeepEqual(rs, otherRS) {
+			if !rs.Equal(otherRS) {
 				return false
 			}
 		}


### PR DESCRIPTION
Reflect.DeepEqual cares about what order of lists it is comparing.  For many of the attributes in the state resource objects, we don't care.

An alternative to this PR is to make sure the contents of the list are always sorted.  I believe that this would be more error prone and require a more thorough review of all of the places it is used within the codebase.

Resolves #3015

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
