### PR TITLE
Destroy nodes with dependencies on ephemeral resources

### DIFF
--- a/internal/command/e2etest/primary_test.go
+++ b/internal/command/e2etest/primary_test.go
@@ -285,18 +285,29 @@ OpenTofu will perform the following actions:
       + value = "initial data value-with-renew"
     }
 
-Plan: 1 to add, 0 to change, 0 to destroy.
-`
+  # simple_resource.test_res_second_provider will be created
+  + resource "simple_resource" "test_res_second_provider" {
+      + value = "just a simple resource to ensure that the second provider it's working fine"
+    }
+
+Plan: 2 to add, 0 to change, 0 to destroy.
+
+Changes to Outputs:
+  + final_output = "just a simple resource to ensure that the second provider it's working fine"`
 			// [0-2]+ allows max 2 seconds for slower runs inside CI pipelines
 			expectedResourcesUpdates := map[string]bool{
 				"data.simple_resource.test_data1: Reading...":                                                               true,
 				"data.simple_resource.test_data1: Read complete after [0-2]+s \\[id=static_id\\]":                           true,
 				"ephemeral.simple_resource.test_ephemeral\\[0\\]: Opening...":                                               true,
 				"ephemeral.simple_resource.test_ephemeral\\[0\\]: Open complete after [0-2]+s \\[id=static-ephemeral-id\\]": true,
+				"ephemeral.simple_resource.test_ephemeral\\[1\\]: Opening...":                                               true,
+				"ephemeral.simple_resource.test_ephemeral\\[1\\]: Open complete after [0-2]+s \\[id=static-ephemeral-id\\]": true,
 				"data.simple_resource.test_data2: Reading...":                                                               true,
 				"data.simple_resource.test_data2: Read complete after [0-2]+s \\[id=static_id\\]":                           true,
 				"ephemeral.simple_resource.test_ephemeral\\[0\\]: Closing...":                                               true,
 				"ephemeral.simple_resource.test_ephemeral\\[0\\]: Close complete after [0-2]+s":                             true,
+				"ephemeral.simple_resource.test_ephemeral\\[1\\]: Closing...":                                               true,
+				"ephemeral.simple_resource.test_ephemeral\\[1\\]: Close complete after [0-2]+s":                             true,
 			}
 			out := stripAnsi(stdout)
 
@@ -362,7 +373,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 				}
 			}
 
-			expectedChangesOutput := `Apply complete! Resources: 1 added, 0 changed, 0 destroyed.`
+			expectedChangesOutput := `Apply complete! Resources: 2 added, 0 changed, 0 destroyed.`
 			// NOTE: [0-2]+ allows max 2 seconds for slower runs inside CI pipelines
 			// NOTE: the non-required ones are dependent on performance of the platform that this test is running on.
 			// In CI, if we would make this required, this test might be flaky.
@@ -372,11 +383,13 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 				"ephemeral.simple_resource.test_ephemeral\\[1\\]: Opening...":                                               true,
 				"ephemeral.simple_resource.test_ephemeral\\[1\\]: Open complete after [0-2]+s \\[id=static-ephemeral-id\\]": true,
 				"simple_resource.test_res: Creating...":                                                                     true,
+				"simple_resource.test_res_second_provider: Creating...":                                                     true,
 				"ephemeral.simple_resource.test_ephemeral\\[0\\]: Renewing...":                                              false,
 				"ephemeral.simple_resource.test_ephemeral\\[0\\]: Renew complete after [0-2]+s":                             false,
 				"ephemeral.simple_resource.test_ephemeral\\[1\\]: Renewing...":                                              false,
 				"ephemeral.simple_resource.test_ephemeral\\[1\\]: Renew complete after [0-2]+s":                             false,
 				"simple_resource.test_res: Creation complete after [0-3]+s":                                                 true,
+				"simple_resource.test_res_second_provider: Creation complete after [0-1]+s":                                 true,
 				"ephemeral.simple_resource.test_ephemeral\\[0\\]: Closing...":                                               true,
 				"ephemeral.simple_resource.test_ephemeral\\[0\\]: Close complete after [0-2]+s":                             true,
 				"ephemeral.simple_resource.test_ephemeral\\[1\\]: Closing...":                                               true,
@@ -407,8 +420,8 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 				t.Fatalf("unexpected destroy error: %s\nstderr:\n%s", err, stderr)
 			}
 
-			if !strings.Contains(stdout, "Resources: 1 destroyed") {
-				t.Errorf("incorrect destroy tally; want 1 destroyed:\n%s", stdout)
+			if !strings.Contains(stdout, "Resources: 2 destroyed") {
+				t.Errorf("incorrect destroy tally; want 2 destroyed:\n%s", stdout)
 			}
 
 			state, err := tf.LocalState()

--- a/internal/command/e2etest/testdata/ephemeral-workflow/proto5/main.tf
+++ b/internal/command/e2etest/testdata/ephemeral-workflow/proto5/main.tf
@@ -47,13 +47,13 @@ provider "simple" {
   // This is needed in two cases: during plan/apply and also during destroy.
   // This test has been updated when DestroyEdgeTransformer was updated to
   // not create dependencies between ephemeral resources and the destroy nodes.
-  // The "cfg" field is just a simple configuration attribute of the provider
+  // The "i_depend_on" field is just a simple configuration attribute of the provider
   // to allow creation of dependencies between a resources from a previously
   // initialized provider and the provider that is configured here.
-  // The "cfg" field is having no functionality behind, in the provider context,
+  // The "i_depend_on" field is having no functionality behind, in the provider context,
   // but it's just a way for the "provider" block to create depedencies
   // to other blocks.
-  cfg = local.simple_provider_cfg
+  i_depend_on = local.simple_provider_cfg
 }
 
 resource "simple_resource" "test_res_second_provider" {

--- a/internal/command/e2etest/testdata/ephemeral-workflow/proto5/main.tf
+++ b/internal/command/e2etest/testdata/ephemeral-workflow/proto5/main.tf
@@ -47,6 +47,12 @@ provider "simple" {
   // This is needed in two cases: during plan/apply and also during destroy.
   // This test has been updated when DestroyEdgeTransformer was updated to
   // not create dependencies between ephemeral resources and the destroy nodes.
+  // The "cfg" field is just a simple configuration attribute of the provider
+  // to allow creation of dependencies between a resources from a previously
+  // initialized provider and the provider that is configured here.
+  // The "cfg" field is having no functionality behind, in the provider context,
+  // but it's just a way for the "provider" block to create depedencies
+  // to other blocks.
   cfg = local.simple_provider_cfg
 }
 

--- a/internal/command/e2etest/testdata/ephemeral-workflow/proto6/main.tf
+++ b/internal/command/e2etest/testdata/ephemeral-workflow/proto6/main.tf
@@ -47,13 +47,13 @@ provider "simple" {
   // This is needed in two cases: during plan/apply and also during destroy.
   // This test has been updated when DestroyEdgeTransformer was updated to
   // not create dependencies between ephemeral resources and the destroy nodes.
-  // The "cfg" field is just a simple configuration attribute of the provider
+  // The "i_depend_on" field is just a simple configuration attribute of the provider
   // to allow creation of dependencies between a resources from a previously
   // initialized provider and the provider that is configured here.
-  // The "cfg" field is having no functionality behind, in the provider context,
+  // The "i_depend_on" field is having no functionality behind, in the provider context,
   // but it's just a way for the "provider" block to create depedencies
   // to other blocks.
-  cfg = local.simple_provider_cfg
+  i_depend_on = local.simple_provider_cfg
 }
 
 resource "simple_resource" "test_res_second_provider" {

--- a/internal/command/e2etest/testdata/ephemeral-workflow/proto6/main.tf
+++ b/internal/command/e2etest/testdata/ephemeral-workflow/proto6/main.tf
@@ -47,6 +47,12 @@ provider "simple" {
   // This is needed in two cases: during plan/apply and also during destroy.
   // This test has been updated when DestroyEdgeTransformer was updated to
   // not create dependencies between ephemeral resources and the destroy nodes.
+  // The "cfg" field is just a simple configuration attribute of the provider
+  // to allow creation of dependencies between a resources from a previously
+  // initialized provider and the provider that is configured here.
+  // The "cfg" field is having no functionality behind, in the provider context,
+  // but it's just a way for the "provider" block to create depedencies
+  // to other blocks.
   cfg = local.simple_provider_cfg
 }
 

--- a/internal/command/e2etest/testdata/ephemeral-workflow/proto6/main.tf
+++ b/internal/command/e2etest/testdata/ephemeral-workflow/proto6/main.tf
@@ -2,28 +2,29 @@
 // test binaries instead of reaching out to the registry.
 terraform {
   required_providers {
-    # simple6 = {
-    #   source = "registry.opentofu.org/hashicorp/simple"
-    # }
-    simple6 = {
+    simple = {
       source = "registry.opentofu.org/hashicorp/simple6"
     }
   }
 }
 
+provider "simple" {
+  alias = "s1"
+}
+
 data "simple_resource" "test_data1" {
-  provider = simple6
+  provider = simple.s1
   value = "initial data value"
 }
 
 ephemeral "simple_resource" "test_ephemeral" {
   count = 2
-  provider = simple6
+  provider = simple.s1
   value = "${data.simple_resource.test_data1.value}-with-renew"
 }
 
 resource "simple_resource" "test_res" {
-  provider = simple6
+  provider = simple.s1
   // NOTE this is wrongly configured on purpose to force a revisit of the test once ephemeral marks are implemented.
   // Once write only arguments are also implemented, adjust the implementation of the provider to support that too
   // and use that new field instead.
@@ -31,11 +32,29 @@ resource "simple_resource" "test_res" {
 }
 
 data "simple_resource" "test_data2" {
-  provider = simple6
+  provider = simple.s1
   // NOTE this is wrongly configured on purpose to force a revisit of the test once ephemeral marks are implemented
   value = ephemeral.simple_resource.test_ephemeral[0].value
 }
 
 locals{
-  tmp = data.simple_resource.test_data2.value
+  simple_provider_cfg = ephemeral.simple_resource.test_ephemeral[0].value
+}
+
+provider "simple" {
+  alias = "s2"
+  // NOTE: Ensure that ephemeral values can be used to configure a provider.
+  // This is needed in two cases: during plan/apply and also during destroy.
+  // This test has been updated when DestroyEdgeTransformer was updated to
+  // not create dependencies between ephemeral resources and the destroy nodes.
+  cfg = local.simple_provider_cfg
+}
+
+resource "simple_resource" "test_res_second_provider" {
+  provider = simple.s2
+  value = "just a simple resource to ensure that the second provider it's working fine"
+}
+
+output "final_output" {
+  value = simple_resource.test_res_second_provider.value
 }

--- a/internal/provider-simple-v6/provider.go
+++ b/internal/provider-simple-v6/provider.go
@@ -42,17 +42,18 @@ func Provider() providers.Interface {
 	return simple{
 		schema: providers.GetProviderSchemaResponse{
 			Provider: providers.Schema{
-				// The "cfg" field is just a simple configuration attribute of the provider
+				// The "i_depend_on" field is just a simple configuration attribute of the provider
 				// to allow creation of dependencies between a resources from a previously
 				// initialized provider and this provider.
-				// The "cfg" field is having no functionality behind, in the provider context,
+				// The "i_depend_on" field is having no functionality behind, in the provider context,
 				// but it's just a way for the "provider" block to create depedencies
 				// to other blocks.
 				Block: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
-						"cfg": {
-							Type:     cty.String,
-							Optional: true,
+						"i_depend_on": {
+							Type:        cty.String,
+							Description: "Non-functional configuration attribute of the provider. This is meant to be used only to create depedencies of other resources to the provider block",
+							Optional:    true,
 						},
 					},
 				},

--- a/internal/provider-simple-v6/provider.go
+++ b/internal/provider-simple-v6/provider.go
@@ -42,8 +42,12 @@ func Provider() providers.Interface {
 	return simple{
 		schema: providers.GetProviderSchemaResponse{
 			Provider: providers.Schema{
-				// schema of the provider to be able to pass an optional
-				// argument in the ConfigProvider
+				// The "cfg" field is just a simple configuration attribute of the provider
+				// to allow creation of dependencies between a resources from a previously
+				// initialized provider and this provider.
+				// The "cfg" field is having no functionality behind, in the provider context,
+				// but it's just a way for the "provider" block to create depedencies
+				// to other blocks.
 				Block: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"cfg": {

--- a/internal/provider-simple-v6/provider.go
+++ b/internal/provider-simple-v6/provider.go
@@ -42,7 +42,16 @@ func Provider() providers.Interface {
 	return simple{
 		schema: providers.GetProviderSchemaResponse{
 			Provider: providers.Schema{
-				Block: nil,
+				// schema of the provider to be able to pass an optional
+				// argument in the ConfigProvider
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"cfg": {
+							Type:     cty.String,
+							Optional: true,
+						},
+					},
+				},
 			},
 			ResourceTypes: map[string]providers.Schema{
 				"simple_resource": simpleResource,
@@ -101,6 +110,7 @@ func (s simple) UpgradeResourceState(_ context.Context, req providers.UpgradeRes
 }
 
 func (s simple) ConfigureProvider(context.Context, providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
+	fmt.Println("CONFIGURE SIMPLE6 PROVIDER")
 	return resp
 }
 

--- a/internal/provider-simple-v6/provider.go
+++ b/internal/provider-simple-v6/provider.go
@@ -110,7 +110,6 @@ func (s simple) UpgradeResourceState(_ context.Context, req providers.UpgradeRes
 }
 
 func (s simple) ConfigureProvider(context.Context, providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {
-	fmt.Println("CONFIGURE SIMPLE6 PROVIDER")
 	return resp
 }
 

--- a/internal/provider-simple/provider.go
+++ b/internal/provider-simple/provider.go
@@ -41,8 +41,12 @@ func Provider() providers.Interface {
 	return simple{
 		schema: providers.GetProviderSchemaResponse{
 			Provider: providers.Schema{
-				// schema of the provider to be able to pass an optional
-				// argument in the ConfigProvider
+				// The "cfg" field is just a simple configuration attribute of the provider
+				// to allow creation of dependencies between a resources from a previously
+				// initialized provider and this provider.
+				// The "cfg" field is having no functionality behind, in the provider context,
+				// but it's just a way for the "provider" block to create depedencies
+				// to other blocks.
 				Block: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
 						"cfg": {

--- a/internal/provider-simple/provider.go
+++ b/internal/provider-simple/provider.go
@@ -41,17 +41,18 @@ func Provider() providers.Interface {
 	return simple{
 		schema: providers.GetProviderSchemaResponse{
 			Provider: providers.Schema{
-				// The "cfg" field is just a simple configuration attribute of the provider
+				// The "i_depend_on" field is just a simple configuration attribute of the provider
 				// to allow creation of dependencies between a resources from a previously
 				// initialized provider and this provider.
-				// The "cfg" field is having no functionality behind, in the provider context,
+				// The "i_depend_on" field is having no functionality behind, in the provider context,
 				// but it's just a way for the "provider" block to create depedencies
 				// to other blocks.
 				Block: &configschema.Block{
 					Attributes: map[string]*configschema.Attribute{
-						"cfg": {
-							Type:     cty.String,
-							Optional: true,
+						"i_depend_on": {
+							Type:        cty.String,
+							Description: "Non-functional configuration attribute of the provider. This is meant to be used only to create depedencies of other resources to the provider block",
+							Optional:    true,
 						},
 					},
 				},

--- a/internal/provider-simple/provider.go
+++ b/internal/provider-simple/provider.go
@@ -41,7 +41,16 @@ func Provider() providers.Interface {
 	return simple{
 		schema: providers.GetProviderSchemaResponse{
 			Provider: providers.Schema{
-				Block: nil,
+				// schema of the provider to be able to pass an optional
+				// argument in the ConfigProvider
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"cfg": {
+							Type:     cty.String,
+							Optional: true,
+						},
+					},
+				},
 			},
 			ResourceTypes: map[string]providers.Schema{
 				"simple_resource": simpleResource,

--- a/internal/tofu/node_resource_plan_destroy.go
+++ b/internal/tofu/node_resource_plan_destroy.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/opentofu/opentofu/internal/dag"
 	otelAttr "go.opentelemetry.io/otel/attribute"
 	otelTrace "go.opentelemetry.io/otel/trace"
 
@@ -41,7 +42,13 @@ var (
 	_ GraphNodeAttachResourceState  = (*NodePlanDestroyableResourceInstance)(nil)
 	_ GraphNodeExecutable           = (*NodePlanDestroyableResourceInstance)(nil)
 	_ GraphNodeProviderConsumer     = (*NodePlanDestroyableResourceInstance)(nil)
+	_ dag.NamedVertex               = (*NodePlanDestroyableResourceInstance)(nil)
 )
+
+// dag.NamedVertex
+func (n *NodePlanDestroyableResourceInstance) Name() string {
+	return n.NodeAbstractResourceInstance.Name() + " (destroy)"
+}
 
 // GraphNodeDestroyer
 func (n *NodePlanDestroyableResourceInstance) DestroyAddr() *addrs.AbsResourceInstance {

--- a/internal/tofu/testdata/transform-config-mode-data/main.tf
+++ b/internal/tofu/testdata/transform-config-mode-data/main.tf
@@ -1,3 +1,5 @@
 data "aws_ami" "foo" {}
 
 resource "aws_instance" "web" {}
+
+ephemeral "aws_secret" "secret" {}

--- a/internal/tofu/transform_config.go
+++ b/internal/tofu/transform_config.go
@@ -31,12 +31,12 @@ type ConfigTransformer struct {
 	// Module is the module to add resources from.
 	Config *configs.Config
 
-	// Mode will only add resources that match the given mode
-	ModeFilter bool
-	Mode       addrs.ResourceMode
-
-	// Do not apply this transformer.
-	skip bool
+	// ModeFilter can be used choose what resource types to skip from being
+	// added into the graph from the configuration.
+	// When this function is not defined, all the resources are allowed.
+	// When this function is defined, the transformer will add only the
+	// resources that this function returns "true" on.
+	ModeFilter func(mode addrs.ResourceMode) bool
 
 	// importTargets specifies a slice of addresses that will have state
 	// imported for them.
@@ -53,10 +53,6 @@ type ConfigTransformer struct {
 }
 
 func (t *ConfigTransformer) Transform(_ context.Context, g *Graph) error {
-	if t.skip {
-		return nil
-	}
-
 	// If no configuration is available, we don't do anything
 	if t.Config == nil {
 		return nil
@@ -121,8 +117,9 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config, ge
 	for _, r := range allResources {
 		relAddr := r.Addr()
 
-		if t.ModeFilter && relAddr.Mode != t.Mode {
+		if t.ModeFilter != nil && t.ModeFilter(relAddr.Mode) {
 			// Skip non-matching modes
+			log.Printf("[TRACE] config transformer skipped resource %q", relAddr)
 			continue
 		}
 
@@ -177,6 +174,11 @@ func (t *ConfigTransformer) transformSingle(g *Graph, config *configs.Config, ge
 	// We'll add the nodes that we know will fail, and catch them again later
 	// in the processing when we are in a position to raise a much more helpful
 	// error message.
+	//
+	// We checked this during the removal of the "skip" argument.
+	// On walkPlanDestroy, the importTargets it's not even passed across to the plan graph builder.
+	// Therefore, this is having no impact on the actual behavior of the destroy planning process,
+	// so we decided not to add additional logic to skip this part.
 	for _, i := range importTargets {
 		if len(generateConfigPath) > 0 {
 			// Create a node with the resource and import target. This node will take care of the config generation


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Part of #2834

_same comment with the one in the commit_

During testing references of an ephemeral resource in a provider block
configuration, we found out that the ephemeral resources were not
planned to be opened in order to provide the relevant information to
destroy the second provider related resources.

Consider the following config:
```
provider "testprovider" {
  alias = "prov1"
}

ephemeral "testprovider_ephemeral" "res" {
  provider = testprovider.prov1
  ...
}

provider "testprovider" {
  alias = "prov2"
  cfg = ephemeral.testprovider_ephemeral.res // <- HERE
}

resource "testprovider_resource" "res2" {
  provider = testprovider.prov2
  ...
}
```

As can be seen, during destroy, in order to destroy "res2", we need to
have configured the testprovider.prov2 with the value coming from an
ephemeral resource.
In order to do so, the following has been done in this commit:
* During walkPlanDestroy, in the `PlanGraphBuilder`, we don't skip the
  `ConfigTransformer` entirely now. Instead, we want the transformer to add the
  ephemeral resource into the graph. This is needed because otherwise
  ephemeral resources cannot get into the graph since they have no state
  saved.
* In `pruneUnusedNodesTransformer`, we added a new case where we are not
  pruning the edge between a resource and a provider node to allow the
  ephemeral resource to be opened.
* After the steps above were done, we hit another issue: in
  `DestroyEdgeTransformer`, the ephemeral resources were considered as
  `creators`, ending up in creating destroy nodes dependencies on the
  ephemeral nodes. This ended up in graph cycles. Logically speaking, the
  ephemeral resource opening must have no dependencies on nodes
  destruction, only on opening, reading or other types of actions.
  Therefore, the fix was quite simple, just exclude resources with Open
  action from being labeled as `creators`.


## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
