### PR TITLE
Add support for the `enabled` field in resource lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ UPGRADE NOTES:
 
 ENHANCEMENTS:
 
+* The conditional enabled field is now supported for all types of resources within the `lifecycle` block. ([#3042](https://github.com/opentofu/opentofu/pull/3042))
 * OpenTofu will now suggest using `-exclude` if a provider reports that it cannot create a plan for a particular resource instance due to values that won't be known until the apply phase. ([#2643](https://github.com/opentofu/opentofu/pull/2643))
 * `tofu validate` now supports running in a module that contains provider configuration_aliases. ([#2905](https://github.com/opentofu/opentofu/pull/2905))
 * The `regex` and `regexall` functions now support using `\p` and `\P` sequences with the long-form names for Unicode general character properties. For example, `\p{Letter}` now has the same meaning as `\p{L}`. ([#3166](https://github.com/opentofu/opentofu/pull/3166))

--- a/internal/configs/parser_config_test.go
+++ b/internal/configs/parser_config_test.go
@@ -128,13 +128,19 @@ func TestParserLoadConfigFileFailureMessages(t *testing.T) {
 			"invalid-files/resource-count-and-for_each.tf",
 			hcl.DiagError,
 			`Invalid combination of "count" and "for_each"`,
-			`The "count" and "for_each" meta-arguments are mutually-exclusive, only one should be used to be explicit about the number of resources to be created.`,
+			`The "count" and "for_each" meta-arguments are mutually-exclusive. Only one may be used to be explicit about the number of resources to be created.`,
+		},
+		{
+			"invalid-files/resource-count-and-for_each-and-enabled.tf",
+			hcl.DiagError,
+			`Invalid combination of "count", "enabled", and "for_each"`,
+			`The "count", "enabled", and "for_each" meta-arguments are mutually-exclusive. Only one may be used to be explicit about the number of resources to be created.`,
 		},
 		{
 			"invalid-files/data-count-and-for_each.tf",
 			hcl.DiagError,
 			`Invalid combination of "count" and "for_each"`,
-			`The "count" and "for_each" meta-arguments are mutually-exclusive, only one should be used to be explicit about the number of resources to be created.`,
+			`The "count" and "for_each" meta-arguments are mutually-exclusive. Only one may be used to be explicit about the number of resources to be created.`,
 		},
 		{
 			"invalid-files/resource-lifecycle-badbool.tf",

--- a/internal/configs/parser_config_test.go
+++ b/internal/configs/parser_config_test.go
@@ -125,6 +125,12 @@ func TestParserLoadConfigFileFailureMessages(t *testing.T) {
 			`Blocks of type "varyable" are not expected here. Did you mean "variable"?`,
 		},
 		{
+			"invalid-files/ephemeral-count-and-for_each-and-enabled.tf",
+			hcl.DiagError,
+			`Invalid combination of "count", "enabled", and "for_each"`,
+			`The "count", "enabled", and "for_each" meta-arguments are mutually-exclusive. Only one may be used to be explicit about the number of resources to be created.`,
+		},
+		{
 			"invalid-files/resource-count-and-for_each.tf",
 			hcl.DiagError,
 			`Invalid combination of "count" and "for_each"`,
@@ -141,6 +147,12 @@ func TestParserLoadConfigFileFailureMessages(t *testing.T) {
 			hcl.DiagError,
 			`Invalid combination of "count" and "for_each"`,
 			`The "count" and "for_each" meta-arguments are mutually-exclusive. Only one may be used to be explicit about the number of resources to be created.`,
+		},
+		{
+			"invalid-files/data-count-and-for_each-and-enabled.tf",
+			hcl.DiagError,
+			`Invalid combination of "count", "enabled", and "for_each"`,
+			`The "count", "enabled", and "for_each" meta-arguments are mutually-exclusive. Only one may be used to be explicit about the number of resources to be created.`,
 		},
 		{
 			"invalid-files/resource-lifecycle-badbool.tf",

--- a/internal/configs/parser_config_test.go
+++ b/internal/configs/parser_config_test.go
@@ -128,7 +128,7 @@ func TestParserLoadConfigFileFailureMessages(t *testing.T) {
 			"invalid-files/ephemeral-count-and-for_each-and-enabled.tf",
 			hcl.DiagError,
 			`Invalid combination of "count", "enabled", and "for_each"`,
-			`The "count", "enabled", and "for_each" meta-arguments are mutually-exclusive. Only one may be used to be explicit about the number of resources to be created.`,
+			`The "count", "enabled", and "for_each" meta-arguments are mutually-exclusive. Only one may be used to be explicit about the number of ephemeral resources to be created.`,
 		},
 		{
 			"invalid-files/resource-count-and-for_each.tf",
@@ -146,13 +146,13 @@ func TestParserLoadConfigFileFailureMessages(t *testing.T) {
 			"invalid-files/data-count-and-for_each.tf",
 			hcl.DiagError,
 			`Invalid combination of "count" and "for_each"`,
-			`The "count" and "for_each" meta-arguments are mutually-exclusive. Only one may be used to be explicit about the number of resources to be created.`,
+			`The "count" and "for_each" meta-arguments are mutually-exclusive. Only one may be used to be explicit about the number of data sources to be created.`,
 		},
 		{
 			"invalid-files/data-count-and-for_each-and-enabled.tf",
 			hcl.DiagError,
 			`Invalid combination of "count", "enabled", and "for_each"`,
-			`The "count", "enabled", and "for_each" meta-arguments are mutually-exclusive. Only one may be used to be explicit about the number of resources to be created.`,
+			`The "count", "enabled", and "for_each" meta-arguments are mutually-exclusive. Only one may be used to be explicit about the number of data sources to be created.`,
 		},
 		{
 			"invalid-files/resource-lifecycle-badbool.tf",

--- a/internal/configs/resource.go
+++ b/internal/configs/resource.go
@@ -622,7 +622,7 @@ func decodeDataBlock(block *hcl.Block, override, nested bool) (*Resource, hcl.Di
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  fmt.Sprintf(`Invalid combination of %s`, complainMsg),
-			Detail:   fmt.Sprintf(`The %s meta-arguments are mutually-exclusive. Only one may be used to be explicit about the number of resources to be created.`, complainMsg),
+			Detail:   fmt.Sprintf(`The %s meta-arguments are mutually-exclusive. Only one may be used to be explicit about the number of data sources to be created.`, complainMsg),
 			Subject:  complainRng,
 		})
 	}
@@ -806,7 +806,7 @@ func decodeEphemeralBlock(block *hcl.Block, override bool) (*Resource, hcl.Diagn
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  fmt.Sprintf(`Invalid combination of %s`, complainMsg),
-			Detail:   fmt.Sprintf(`The %s meta-arguments are mutually-exclusive. Only one may be used to be explicit about the number of resources to be created.`, complainMsg),
+			Detail:   fmt.Sprintf(`The %s meta-arguments are mutually-exclusive. Only one may be used to be explicit about the number of ephemeral resources to be created.`, complainMsg),
 			Subject:  complainRng,
 		})
 	}

--- a/internal/configs/resource.go
+++ b/internal/configs/resource.go
@@ -7,6 +7,8 @@ package configs
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
@@ -27,6 +29,7 @@ type Resource struct {
 	Type    string
 	Config  hcl.Body
 	Count   hcl.Expression
+	Enabled hcl.Expression
 	ForEach hcl.Expression
 
 	ProviderConfigRef *ProviderConfigRef
@@ -149,21 +152,18 @@ func decodeResourceBlock(block *hcl.Block, override bool) (*Resource, hcl.Diagno
 		})
 	}
 
+	repetitionArgs := 0
+	var countRng, forEachRng, enabledRng hcl.Range
 	if attr, exists := content.Attributes["count"]; exists {
 		r.Count = attr.Expr
+		countRng = attr.NameRange
+		repetitionArgs++
 	}
 
 	if attr, exists := content.Attributes["for_each"]; exists {
 		r.ForEach = attr.Expr
-		// Cannot have count and for_each on the same resource block
-		if r.Count != nil {
-			diags = append(diags, &hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  `Invalid combination of "count" and "for_each"`,
-				Detail:   `The "count" and "for_each" meta-arguments are mutually-exclusive, only one should be used to be explicit about the number of resources to be created.`,
-				Subject:  &attr.NameRange,
-			})
-		}
+		forEachRng = attr.NameRange
+		repetitionArgs++
 	}
 
 	if attr, exists := content.Attributes["provider"]; exists {
@@ -202,6 +202,12 @@ func decodeResourceBlock(block *hcl.Block, override bool) (*Resource, hcl.Diagno
 				valDiags := gohcl.DecodeExpression(attr.Expr, nil, &r.Managed.CreateBeforeDestroy)
 				diags = append(diags, valDiags...)
 				r.Managed.CreateBeforeDestroySet = true
+			}
+
+			if attr, exists := lcContent.Attributes["enabled"]; exists {
+				r.Enabled = attr.Expr
+				enabledRng = attr.NameRange
+				repetitionArgs++
 			}
 
 			if attr, exists := lcContent.Attributes["prevent_destroy"]; exists {
@@ -357,6 +363,17 @@ func decodeResourceBlock(block *hcl.Block, override bool) (*Resource, hcl.Diagno
 		}
 	}
 
+	if repetitionArgs > 1 {
+		complainRng, complainMsg := complainRngAndMsg(countRng, enabledRng, forEachRng)
+
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  fmt.Sprintf(`Invalid combination of %s`, complainMsg),
+			Detail:   fmt.Sprintf(`The %s meta-arguments are mutually-exclusive. Only one may be used to be explicit about the number of resources to be created.`, complainMsg),
+			Subject:  complainRng,
+		})
+	}
+
 	// Now we can validate the connection block references if there are any destroy provisioners.
 	// TODO: should we eliminate standalone connection blocks?
 	if r.Managed.Connection != nil {
@@ -369,6 +386,43 @@ func decodeResourceBlock(block *hcl.Block, override bool) (*Resource, hcl.Diagno
 	}
 
 	return r, diags
+}
+
+func complainRngAndMsg(countRng, enabledRng, forEachRng hcl.Range) (*hcl.Range, string) {
+	var complainRngs []hcl.Range
+	var complainAttrs []string
+	if !countRng.Empty() {
+		complainRngs = append(complainRngs, countRng)
+		complainAttrs = append(complainAttrs, "\"count\"")
+	}
+	if !enabledRng.Empty() {
+		complainRngs = append(complainRngs, enabledRng)
+		complainAttrs = append(complainAttrs, "\"enabled\"")
+	}
+	if !forEachRng.Empty() {
+		complainRngs = append(complainRngs, forEachRng)
+		complainAttrs = append(complainAttrs, "\"for_each\"")
+	}
+
+	// We sort the complain ranges in order to understood who appeared first,
+	// and we use that as the valid one
+	sort.SliceStable(complainRngs, func(i, j int) bool {
+		return complainRngs[i].Start.Byte < complainRngs[j].Start.Byte
+	})
+
+	lastIndex := len(complainAttrs) - 1
+	complainRng := complainRngs[lastIndex]
+
+	var complainMsg string
+	if len(complainAttrs) >= 3 {
+		// Add an oxford comma to the last attribute
+		complainAttrs[lastIndex] = "and " + complainAttrs[lastIndex]
+		complainMsg = strings.Join(complainAttrs, ", ")
+	} else {
+		complainMsg = strings.Join(complainAttrs, " and ")
+	}
+
+	return &complainRng, complainMsg
 }
 
 func decodeDataBlock(block *hcl.Block, override, nested bool) (*Resource, hcl.Diagnostics) {
@@ -421,7 +475,7 @@ func decodeDataBlock(block *hcl.Block, override, nested bool) (*Resource, hcl.Di
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  `Invalid combination of "count" and "for_each"`,
-				Detail:   `The "count" and "for_each" meta-arguments are mutually-exclusive, only one should be used to be explicit about the number of resources to be created.`,
+				Detail:   `The "count" and "for_each" meta-arguments are mutually-exclusive. Only one may be used to be explicit about the number of resources to be created.`,
 				Subject:  &attr.NameRange,
 			})
 		}
@@ -502,6 +556,11 @@ func decodeDataBlock(block *hcl.Block, override, nested bool) (*Resource, hcl.Di
 			// managed resources only, so we can emit a common error message
 			// for any given attributes that HCL accepted.
 			for name, attr := range lcContent.Attributes {
+				// Enabled is a special case, it is allowed for data resources
+				if name == "enabled" {
+					r.Enabled = attr.Expr
+					continue
+				}
 				diags = append(diags, &hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Invalid data resource lifecycle argument",
@@ -1077,6 +1136,9 @@ var resourceLifecycleBlockSchema = &hcl.BodySchema{
 		},
 		{
 			Name: "replace_triggered_by",
+		},
+		{
+			Name: "enabled",
 		},
 	},
 	Blocks: []hcl.BlockHeaderSchema{

--- a/internal/configs/testdata/invalid-files/data-count-and-for_each-and-enabled.tf
+++ b/internal/configs/testdata/invalid-files/data-count-and-for_each-and-enabled.tf
@@ -1,0 +1,7 @@
+data "test" "foo" {
+  lifecycle {
+    enabled = true
+  }
+  count    = 2
+  for_each = ["a"]
+}

--- a/internal/configs/testdata/invalid-files/ephemeral-count-and-for_each-and-enabled.tf
+++ b/internal/configs/testdata/invalid-files/ephemeral-count-and-for_each-and-enabled.tf
@@ -1,0 +1,7 @@
+ephemeral "test" "foo" {
+  lifecycle {
+    enabled = true
+  }
+  count    = 2
+  for_each = ["a"]
+}

--- a/internal/configs/testdata/invalid-files/resource-count-and-for_each-and-enabled.tf
+++ b/internal/configs/testdata/invalid-files/resource-count-and-for_each-and-enabled.tf
@@ -1,0 +1,7 @@
+resource "test" "foo" {
+  lifecycle {
+    enabled = true
+  }
+  count    = 2
+  for_each = ["a"]
+}

--- a/internal/instances/expander.go
+++ b/internal/instances/expander.go
@@ -87,6 +87,12 @@ func (e *Expander) SetResourceCount(moduleAddr addrs.ModuleInstance, resourceAdd
 	e.setResourceExpansion(moduleAddr, resourceAddr, expansionCount(count))
 }
 
+// SetResourceEnabled records that the given resource inside the given module
+// uses the "enabled" repetition argument, with the given value.
+func (e *Expander) SetResourceEnabled(moduleAddr addrs.ModuleInstance, resourceAddr addrs.Resource, enabled bool) {
+	e.setResourceExpansion(moduleAddr, resourceAddr, expansionEnabled(enabled))
+}
+
 // SetResourceForEach records that the given resource inside the given module
 // uses the "for_each" repetition argument, with the given map value.
 //

--- a/internal/instances/expander.go
+++ b/internal/instances/expander.go
@@ -15,8 +15,9 @@ import (
 )
 
 // Expander instances serve as a coordination point for gathering object
-// repetition values (count and for_each in configuration) and then later
-// making use of them to fully enumerate all of the instances of an object.
+// repetition values (count, enabled and for_each in configuration) and
+// then later making use of them to fully enumerate all of the instances
+// of an object.
 //
 // The two repeatable object types in OpenTofu are modules and resources.
 // Because resources belong to modules and modules can nest inside other

--- a/internal/instances/expansion_mode.go
+++ b/internal/instances/expansion_mode.go
@@ -42,6 +42,24 @@ func (e expansionSingle) repetitionData(key addrs.InstanceKey) RepetitionData {
 	return RepetitionData{}
 }
 
+// expansionEnabled is the expansion corresponding to the "enabled" argument,
+// producing either no instances or one instance with no instance key.
+type expansionEnabled bool
+
+func (e expansionEnabled) instanceKeys() []addrs.InstanceKey {
+	if !bool(e) {
+		return nil
+	}
+	return singleKeys
+}
+
+func (e expansionEnabled) repetitionData(key addrs.InstanceKey) RepetitionData {
+	if key != addrs.NoKey {
+		panic("cannot use instance key with non-repeating object")
+	}
+	return RepetitionData{}
+}
+
 // expansionCount is the expansion corresponding to the "count" argument.
 type expansionCount int
 

--- a/internal/lang/evalchecks/eval_lifecycle_enabled.go
+++ b/internal/lang/evalchecks/eval_lifecycle_enabled.go
@@ -83,6 +83,10 @@ func EvaluateEnabledExpression(expr hcl.Expression, hclCtxFunc ContextFunc) (boo
 		})
 	}
 
+	if diags.HasErrors() {
+		return false, diags
+	}
+
 	enabledVal, err := convert.Convert(rawEnabledVal, cty.Bool)
 	if err != nil {
 		diags = diags.Append(&hcl.Diagnostic{

--- a/internal/lang/evalchecks/eval_lifecycle_enabled.go
+++ b/internal/lang/evalchecks/eval_lifecycle_enabled.go
@@ -50,18 +50,6 @@ func EvaluateEnabledExpression(expr hcl.Expression, hclCtxFunc ContextFunc) (boo
 		})
 	}
 
-	enabledVal, err := convert.Convert(rawEnabledVal, cty.Bool)
-	if err != nil {
-		diags = diags.Append(&hcl.Diagnostic{
-			Severity:    hcl.DiagError,
-			Summary:     "Invalid enabled argument",
-			Detail:      fmt.Sprintf(`The given "enabled" argument value is unsuitable: %s.`, err),
-			Subject:     expr.Range().Ptr(),
-			Expression:  expr,
-			EvalContext: hclCtx,
-		})
-	}
-
 	if rawEnabledVal.HasMark(marks.Ephemeral) {
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity:    hcl.DiagError,
@@ -92,6 +80,18 @@ func EvaluateEnabledExpression(expr hcl.Expression, hclCtxFunc ContextFunc) (boo
 			Expression:  expr,
 			EvalContext: hclCtx,
 			Extra:       DiagnosticCausedByUnknown(true),
+		})
+	}
+
+	enabledVal, err := convert.Convert(rawEnabledVal, cty.Bool)
+	if err != nil {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity:    hcl.DiagError,
+			Summary:     "Invalid enabled argument",
+			Detail:      fmt.Sprintf(`The given "enabled" argument value is unsuitable: %s.`, err),
+			Subject:     expr.Range().Ptr(),
+			Expression:  expr,
+			EvalContext: hclCtx,
 		})
 	}
 

--- a/internal/lang/evalchecks/eval_lifecycle_enabled.go
+++ b/internal/lang/evalchecks/eval_lifecycle_enabled.go
@@ -46,7 +46,7 @@ func EvaluateEnabledExpression(expr hcl.Expression, hclCtxFunc ContextFunc) (boo
 			Subject:     expr.Range().Ptr(),
 			Expression:  expr,
 			EvalContext: hclCtx,
-			Extra:       DiagnosticCausedBySensitive(true),
+			Extra:       DiagnosticCausedByUnknown(true),
 		})
 	}
 

--- a/internal/lang/evalchecks/eval_lifecycle_enabled.go
+++ b/internal/lang/evalchecks/eval_lifecycle_enabled.go
@@ -1,0 +1,105 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+package evalchecks
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/lang"
+	"github.com/opentofu/opentofu/internal/lang/marks"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+)
+
+// EvaluateEnabledExpression evaluates an expression assigned to an "enabled"
+// meta-argument and returns either its boolean result or errors describing
+// why such a result cannot be evaluated.
+func EvaluateEnabledExpression(expr hcl.Expression, hclCtxFunc ContextFunc) (bool, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	if expr == nil {
+		return false, diags
+	}
+
+	refs, refsDiags := lang.ReferencesInExpr(addrs.ParseRef, expr)
+	diags = diags.Append(refsDiags)
+	var hclCtx *hcl.EvalContext
+	hclCtx, refsDiags = hclCtxFunc(refs)
+	diags = diags.Append(refsDiags)
+	if diags.HasErrors() { // Can't continue if we don't even have a valid scope
+		return false, diags
+	}
+
+	rawEnabledVal, enabledDiags := expr.Value(hclCtx)
+	diags = diags.Append(enabledDiags)
+
+	if rawEnabledVal.HasMark(marks.Sensitive) {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity:    hcl.DiagError,
+			Summary:     "Invalid enabled argument",
+			Detail:      "Sensitive values, or values derived from sensitive values, cannot be used in \"enabled\" arguments. If used, the sensitive value would be exposed by whether an instance is present.",
+			Subject:     expr.Range().Ptr(),
+			Expression:  expr,
+			EvalContext: hclCtx,
+			Extra:       DiagnosticCausedBySensitive(true),
+		})
+	}
+
+	enabledVal, err := convert.Convert(rawEnabledVal, cty.Bool)
+	if err != nil {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity:    hcl.DiagError,
+			Summary:     "Invalid enabled argument",
+			Detail:      fmt.Sprintf(`The given "enabled" argument value is unsuitable: %s.`, err),
+			Subject:     expr.Range().Ptr(),
+			Expression:  expr,
+			EvalContext: hclCtx,
+		})
+	}
+
+	if rawEnabledVal.HasMark(marks.Ephemeral) {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity:    hcl.DiagError,
+			Summary:     "Invalid enabled argument",
+			Detail:      `The given "enabled" argument value is unsuitable: the given value is ephemeral.`,
+			Subject:     expr.Range().Ptr(),
+			Expression:  expr,
+			EvalContext: hclCtx,
+		})
+	}
+
+	if rawEnabledVal.IsNull() {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity:    hcl.DiagError,
+			Summary:     "Invalid enabled argument",
+			Detail:      `The given "enabled" argument value is unsuitable: the given value is null.`,
+			Subject:     expr.Range().Ptr(),
+			Expression:  expr,
+			EvalContext: hclCtx,
+		})
+	}
+	if !rawEnabledVal.IsKnown() {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity:    hcl.DiagError,
+			Summary:     "Invalid enabled argument",
+			Detail:      `The given "enabled" argument value is derived from a value that won't be known until the apply phase, so OpenTofu cannot determine whether an instance of this object is declared or not.`,
+			Subject:     expr.Range().Ptr(),
+			Expression:  expr,
+			EvalContext: hclCtx,
+			Extra:       DiagnosticCausedByUnknown(true),
+		})
+	}
+
+	if diags.HasErrors() {
+		return false, diags
+	}
+
+	// If we get here then we've eliminated all of the reasons why the
+	// following could potentially panic.
+	return enabledVal.True(), diags
+}

--- a/internal/lang/evalchecks/eval_lifecycle_enabled_test.go
+++ b/internal/lang/evalchecks/eval_lifecycle_enabled_test.go
@@ -1,0 +1,190 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+package evalchecks
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hcltest"
+	"github.com/opentofu/opentofu/internal/lang/marks"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestEvaluateEnabledExpression_valid(t *testing.T) {
+	tests := map[string]struct {
+		expr     hcl.Expression
+		expected bool
+	}{
+		"true": {
+			hcltest.MockExprLiteral(cty.BoolVal(true)),
+			true,
+		},
+		"equal condition": {
+			&hclsyntax.BinaryOpExpr{
+				LHS: &hclsyntax.LiteralValueExpr{
+					Val: cty.StringVal("5"),
+				},
+				RHS: &hclsyntax.LiteralValueExpr{
+					Val: cty.StringVal("5"),
+				},
+				Op: hclsyntax.OpEqual,
+			},
+			true,
+		},
+		"unequal condition": {
+			&hclsyntax.BinaryOpExpr{
+				LHS: &hclsyntax.LiteralValueExpr{
+					Val: cty.StringVal("3"),
+				},
+				RHS: &hclsyntax.LiteralValueExpr{
+					Val: cty.StringVal("5"),
+				},
+				Op: hclsyntax.OpEqual,
+			},
+			false,
+		},
+		"false": {
+			hcltest.MockExprLiteral(cty.BoolVal(false)),
+			false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual, diags := EvaluateEnabledExpression(test.expr, mockRefsFunc())
+
+			if len(diags) != 0 {
+				t.Errorf("unexpected diagnostics %s", spew.Sdump(diags))
+			}
+
+			if !reflect.DeepEqual(actual, test.expected) {
+				t.Errorf(
+					"wrong map value\ngot:  %swant: %s",
+					spew.Sdump(actual), spew.Sdump(test.expected),
+				)
+			}
+		})
+	}
+}
+
+type WantedError struct {
+	Summary         string
+	DetailSubstring string
+}
+
+func TestEvaluateEnabledExpression_errors(t *testing.T) {
+	tests := map[string]struct {
+		val    cty.Value
+		Wanted []WantedError
+	}{
+		"null": {
+			cty.NullVal(cty.Number),
+			[]WantedError{
+				{
+					"Invalid enabled argument",
+					`The given "enabled" argument value is unsuitable: bool required, but have number.`,
+				},
+				{
+					"Invalid enabled argument",
+					`The given "enabled" argument value is unsuitable: the given value is null.`,
+				},
+			},
+		},
+		"1": {
+			cty.NumberIntVal(1),
+			[]WantedError{
+				{
+					"Invalid enabled argument",
+					`The given "enabled" argument value is unsuitable: bool required, but have number.`,
+				},
+			},
+		},
+		"negative": {
+			cty.NumberIntVal(-1),
+			[]WantedError{
+				{
+					"Invalid enabled argument",
+					`The given "enabled" argument value is unsuitable: bool required, but have number.`,
+				},
+			},
+		},
+		"list": {
+			cty.ListVal([]cty.Value{cty.StringVal("a"), cty.StringVal("a")}),
+			[]WantedError{
+				{
+					"Invalid enabled argument",
+					"The given \"enabled\" argument value is unsuitable: bool required, but have list of string.",
+				},
+			},
+		},
+		"tuple": {
+			cty.TupleVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")}),
+			[]WantedError{
+				{
+					"Invalid enabled argument",
+					"The given \"enabled\" argument value is unsuitable: bool required, but have tuple.",
+				},
+			},
+		},
+		"unknown": {
+			cty.UnknownVal(cty.Number),
+			[]WantedError{
+				{
+					"Invalid enabled argument",
+					"The given \"enabled\" argument value is unsuitable: bool required, but have number.",
+				},
+				{
+					"Invalid enabled argument",
+					`The given "enabled" argument value is derived from a value that won't be known until the apply phase, so OpenTofu cannot determine whether an instance of this object is declared or not.`,
+				},
+			},
+		},
+		"sensitive": {
+			cty.StringVal("1").Mark(marks.Sensitive),
+			[]WantedError{
+				{
+					"Invalid enabled argument",
+					`Sensitive values, or values derived from sensitive values, cannot be used in "enabled" arguments. If used, the sensitive value would be exposed by whether an instance is present.`,
+				},
+			},
+		},
+		"ephemeral": {
+			cty.StringVal("1").Mark(marks.Ephemeral),
+			[]WantedError{
+				{
+					"Invalid enabled argument",
+					`The given "enabled" argument value is unsuitable: the given value is ephemeral.`,
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, diags := EvaluateEnabledExpression(hcltest.MockExprLiteral(test.val), mockRefsFunc())
+
+			if len(diags) != len(test.Wanted) {
+				t.Fatalf("wrong diagnostics size: (want %d, got %d):\n", len(test.Wanted), len(diags))
+			}
+
+			for i, wanted := range test.Wanted {
+				diag := diags[i]
+				if diff := cmp.Diff(diag.Description().Summary, wanted.Summary); diff != "" {
+					t.Errorf("%d: wrong summary (-want +got):\n%s", i, diff)
+				}
+
+				if diff := cmp.Diff(diag.Description().Detail, wanted.DetailSubstring); diff != "" {
+					t.Errorf("%d: wrong description (-want +got):\n%s", i, diff)
+				}
+			}
+
+		})
+	}
+}

--- a/internal/lang/evalchecks/eval_lifecycle_enabled_test.go
+++ b/internal/lang/evalchecks/eval_lifecycle_enabled_test.go
@@ -89,15 +89,15 @@ func TestEvaluateEnabledExpression_errors(t *testing.T) {
 			[]WantedError{
 				{
 					"Invalid enabled argument",
-					`The given "enabled" argument value is unsuitable: bool required, but have number.`,
+					`The given "enabled" argument value is unsuitable: the given value is null.`,
 				},
 				{
 					"Invalid enabled argument",
-					`The given "enabled" argument value is unsuitable: the given value is null.`,
+					`The given "enabled" argument value is unsuitable: bool required, but have number.`,
 				},
 			},
 		},
-		"1": {
+		"positive number": {
 			cty.NumberIntVal(1),
 			[]WantedError{
 				{
@@ -106,7 +106,7 @@ func TestEvaluateEnabledExpression_errors(t *testing.T) {
 				},
 			},
 		},
-		"negative": {
+		"negative number": {
 			cty.NumberIntVal(-1),
 			[]WantedError{
 				{
@@ -138,11 +138,11 @@ func TestEvaluateEnabledExpression_errors(t *testing.T) {
 			[]WantedError{
 				{
 					"Invalid enabled argument",
-					"The given \"enabled\" argument value is unsuitable: bool required, but have number.",
+					`The given "enabled" argument value is derived from a value that won't be known until the apply phase, so OpenTofu cannot determine whether an instance of this object is declared or not.`,
 				},
 				{
 					"Invalid enabled argument",
-					`The given "enabled" argument value is derived from a value that won't be known until the apply phase, so OpenTofu cannot determine whether an instance of this object is declared or not.`,
+					"The given \"enabled\" argument value is unsuitable: bool required, but have number.",
 				},
 			},
 		},

--- a/internal/tofu/context_apply2_test.go
+++ b/internal/tofu/context_apply2_test.go
@@ -6198,3 +6198,160 @@ func TestMergePlanAndApplyVariables(t *testing.T) {
 		})
 	}
 }
+
+func TestContext2Apply_enabledForResource(t *testing.T) {
+	m := testModule(t, "apply-enabled-resource")
+	p := &MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			ResourceTypes: map[string]providers.Schema{
+				"test": {
+					Block: &configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"name": {
+								Type:     cty.String,
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	p.PlanResourceChangeFn = func(prcr providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+		return providers.PlanResourceChangeResponse{
+			PlannedState: prcr.ProposedNewState,
+		}
+	}
+	p.ApplyResourceChangeFn = func(arcr providers.ApplyResourceChangeRequest) providers.ApplyResourceChangeResponse {
+		return providers.ApplyResourceChangeResponse{
+			NewState: arcr.PlannedState,
+		}
+	}
+	tfCtx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+	resourceInstAddr := addrs.Resource{
+		Mode: addrs.ManagedResourceMode,
+		Type: "test",
+		Name: "test",
+	}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance)
+	outputAddr := addrs.OutputValue{
+		Name: "result",
+	}.Absolute(addrs.RootModuleInstance)
+
+	// We'll overwrite this after each round, but it starts empty.
+	state := states.NewState()
+
+	{
+		t.Logf("First round: var.on = false")
+
+		plan, diags := tfCtx.Plan(context.Background(), m, state, &PlanOpts{
+			Mode: plans.NormalMode,
+			SetVariables: InputValues{
+				"on": &InputValue{
+					Value: cty.False,
+				},
+			},
+		})
+		assertNoDiagnostics(t, diags)
+
+		if change := plan.Changes.ResourceInstance(resourceInstAddr); change != nil {
+			t.Fatalf("unexpected plan for %s (should be disabled)", resourceInstAddr)
+		}
+
+		newState, diags := tfCtx.Apply(context.Background(), plan, m)
+		assertNoDiagnostics(t, diags)
+
+		if instState := newState.ResourceInstance(resourceInstAddr); instState != nil {
+			t.Fatalf("unexpected state entry for %s (should be disabled)", resourceInstAddr)
+		}
+
+		outputState := newState.OutputValue(outputAddr)
+		if outputState == nil {
+			t.Errorf("missing state entry for %s", outputAddr)
+		} else if got := outputState.Value.Index(cty.Zero); !got.IsNull() {
+			t.Errorf("unexpected value for %s %#v; want null", outputAddr, got)
+		}
+
+		state = newState // "persist" the state for the next round
+	}
+	{
+		t.Logf("Second round: var.on = true")
+
+		plan, diags := tfCtx.Plan(context.Background(), m, state, &PlanOpts{
+			Mode: plans.NormalMode,
+			SetVariables: InputValues{
+				"on": &InputValue{
+					Value: cty.True,
+				},
+			},
+		})
+		assertNoDiagnostics(t, diags)
+
+		change := plan.Changes.ResourceInstance(resourceInstAddr)
+		if change == nil {
+			t.Fatalf("missing plan for %s", resourceInstAddr)
+		}
+		if got, want := change.Action, plans.Create; got != want {
+			t.Fatalf("plan for %s has wrong action %s; want %s", resourceInstAddr, got, want)
+		}
+
+		newState, diags := tfCtx.Apply(context.Background(), plan, m)
+		assertNoDiagnostics(t, diags)
+
+		instState := newState.ResourceInstance(resourceInstAddr)
+		if instState == nil {
+			t.Fatalf("missing state entry for %s", resourceInstAddr)
+		}
+
+		outputState := newState.OutputValue(outputAddr)
+		if outputState == nil {
+			t.Errorf("missing state entry for %s", outputAddr)
+		} else if got, want := outputState.Value.Index(cty.Zero), cty.StringVal("boop"); !want.RawEquals(got) {
+			t.Errorf("unexpected value for %s\ngot:  %#v\nwant: %#v", outputAddr, got, want)
+		}
+
+		state = newState // "persist" the state for the next round
+	}
+	{
+		t.Logf("Third round: var.on = false, again")
+
+		plan, diags := tfCtx.Plan(context.Background(), m, state, &PlanOpts{
+			Mode: plans.NormalMode,
+			SetVariables: InputValues{
+				"on": &InputValue{
+					Value: cty.False,
+				},
+			},
+		})
+		assertNoDiagnostics(t, diags)
+
+		change := plan.Changes.ResourceInstance(resourceInstAddr)
+		if change == nil {
+			t.Fatalf("missing plan for %s", resourceInstAddr)
+		}
+		if got, want := change.Action, plans.Delete; got != want {
+			t.Fatalf("plan for %s has wrong action %s; want %s", resourceInstAddr, got, want)
+		}
+
+		if got, want := change.ActionReason, plans.ResourceInstanceDeleteBecauseEnabledFalse; got != want {
+			t.Errorf("wrong action reason for %s %s; want %s", resourceInstAddr, got, want)
+		}
+
+		newState, diags := tfCtx.Apply(context.Background(), plan, m)
+		assertNoDiagnostics(t, diags)
+
+		if instState := newState.ResourceInstance(resourceInstAddr); instState != nil {
+			t.Fatalf("unexpected state entry for %s (should be disabled)", resourceInstAddr)
+		}
+
+		outputState := newState.OutputValue(outputAddr)
+		if outputState == nil {
+			t.Errorf("missing state entry for %s", outputAddr)
+		} else if got := outputState.Value.Index(cty.Zero); !got.IsNull() {
+			t.Errorf("unexpected value for %s %#v; want null", outputAddr, got)
+		}
+	}
+}

--- a/internal/tofu/context_apply2_test.go
+++ b/internal/tofu/context_apply2_test.go
@@ -6261,7 +6261,7 @@ func TestContext2Apply_enabledForResource(t *testing.T) {
 			t.Fatalf("unexpected plan for %s (should be disabled)", resourceInstAddr)
 		}
 
-		newState, diags := tfCtx.Apply(context.Background(), plan, m)
+		newState, diags := tfCtx.Apply(context.Background(), plan, m, nil)
 		assertNoDiagnostics(t, diags)
 
 		if instState := newState.ResourceInstance(resourceInstAddr); instState != nil {
@@ -6271,7 +6271,7 @@ func TestContext2Apply_enabledForResource(t *testing.T) {
 		outputState := newState.OutputValue(outputAddr)
 		if outputState == nil {
 			t.Errorf("missing state entry for %s", outputAddr)
-		} else if got := outputState.Value.Index(cty.Zero); !got.IsNull() {
+		} else if got, want := outputState.Value, cty.StringVal("default"); !want.RawEquals(got) {
 			t.Errorf("unexpected value for %s %#v; want null", outputAddr, got)
 		}
 
@@ -6298,7 +6298,7 @@ func TestContext2Apply_enabledForResource(t *testing.T) {
 			t.Fatalf("plan for %s has wrong action %s; want %s", resourceInstAddr, got, want)
 		}
 
-		newState, diags := tfCtx.Apply(context.Background(), plan, m)
+		newState, diags := tfCtx.Apply(context.Background(), plan, m, nil)
 		assertNoDiagnostics(t, diags)
 
 		instState := newState.ResourceInstance(resourceInstAddr)
@@ -6309,7 +6309,7 @@ func TestContext2Apply_enabledForResource(t *testing.T) {
 		outputState := newState.OutputValue(outputAddr)
 		if outputState == nil {
 			t.Errorf("missing state entry for %s", outputAddr)
-		} else if got, want := outputState.Value.Index(cty.Zero), cty.StringVal("boop"); !want.RawEquals(got) {
+		} else if got, want := outputState.Value, cty.StringVal("boop"); !want.RawEquals(got) {
 			t.Errorf("unexpected value for %s\ngot:  %#v\nwant: %#v", outputAddr, got, want)
 		}
 
@@ -6340,7 +6340,7 @@ func TestContext2Apply_enabledForResource(t *testing.T) {
 			t.Errorf("wrong action reason for %s %s; want %s", resourceInstAddr, got, want)
 		}
 
-		newState, diags := tfCtx.Apply(context.Background(), plan, m)
+		newState, diags := tfCtx.Apply(context.Background(), plan, m, nil)
 		assertNoDiagnostics(t, diags)
 
 		if instState := newState.ResourceInstance(resourceInstAddr); instState != nil {
@@ -6350,8 +6350,8 @@ func TestContext2Apply_enabledForResource(t *testing.T) {
 		outputState := newState.OutputValue(outputAddr)
 		if outputState == nil {
 			t.Errorf("missing state entry for %s", outputAddr)
-		} else if got := outputState.Value.Index(cty.Zero); !got.IsNull() {
-			t.Errorf("unexpected value for %s %#v; want null", outputAddr, got)
+		} else if got, want := outputState.Value, cty.StringVal("default"); !want.RawEquals(got) {
+			t.Errorf("unexpected value for %s\ngot:  %#v\nwant: %#v", outputAddr, got, want)
 		}
 	}
 }

--- a/internal/tofu/eval_expansion.go
+++ b/internal/tofu/eval_expansion.go
@@ -38,6 +38,10 @@ func evaluateForEachExpression(ctx context.Context, expr hcl.Expression, evalCtx
 	return evalchecks.EvaluateForEachExpression(expr, evalContextScope(ctx, evalCtx), excludeableAddr)
 }
 
+func evaluateEnabledExpression(ctx context.Context, expr hcl.Expression, evalCtx EvalContext) (bool, tfdiags.Diagnostics) {
+	return evalchecks.EvaluateEnabledExpression(expr, evalContextScope(ctx, evalCtx))
+}
+
 func evaluateForEachExpressionValue(ctx context.Context, expr hcl.Expression, evalCtx EvalContext, allowUnknown bool, allowTuple bool, excludeableAddr addrs.Targetable) (cty.Value, tfdiags.Diagnostics) {
 	return evalchecks.EvaluateForEachExpressionValue(expr, evalContextScope(ctx, evalCtx), allowUnknown, allowTuple, excludeableAddr)
 }

--- a/internal/tofu/evaluate.go
+++ b/internal/tofu/evaluate.go
@@ -726,6 +726,8 @@ func (d *evaluationStateData) GetResource(ctx context.Context, addr addrs.Resour
 				return cty.EmptyTupleVal, diags
 			case config.ForEach != nil:
 				return cty.EmptyObjectVal, diags
+			case config.Enabled != nil:
+				return cty.NullVal(ty), diags
 			default:
 				// While we can reference an expanded resource with 0
 				// instances, we cannot reference instances that do not exist.
@@ -958,7 +960,10 @@ func (d *evaluationStateData) GetResource(ctx context.Context, addr addrs.Resour
 		} else {
 			ret = cty.EmptyObjectVal
 		}
-
+	case config.Enabled != nil:
+		// There is no need to check if the instance is there, because if not,
+		// we need to propagate the null value
+		ret = instances[addrs.NoKey]
 	default:
 		val, ok := instances[addrs.NoKey]
 		if !ok {

--- a/internal/tofu/evaluate.go
+++ b/internal/tofu/evaluate.go
@@ -961,9 +961,15 @@ func (d *evaluationStateData) GetResource(ctx context.Context, addr addrs.Resour
 			ret = cty.EmptyObjectVal
 		}
 	case config.Enabled != nil:
-		// There is no need to check if the instance is there, because if not,
-		// we need to propagate the null value
-		ret = instances[addrs.NoKey]
+		val, ok := instances[addrs.NoKey]
+		if ok {
+			ret = val
+		} else {
+			// When we're using enabled, it's okay to have no
+			// instance, and the entire object is null because
+			// this needs to be propagated to the caller.
+			ret = cty.NullVal(ty)
+		}
 	default:
 		val, ok := instances[addrs.NoKey]
 		if !ok {

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -186,6 +186,8 @@ func (n *NodeAbstractResource) References() []*addrs.Reference {
 		result = append(result, refs...)
 		refs, _ = lang.ReferencesInExpr(addrs.ParseRef, c.ForEach)
 		result = append(result, refs...)
+		refs, _ = lang.ReferencesInExpr(addrs.ParseRef, c.Enabled)
+		result = append(result, refs...)
 
 		if c.ProviderConfigRef != nil && c.ProviderConfigRef.KeyExpression != nil {
 			providerRefs, _ := lang.ReferencesInExpr(addrs.ParseRef, c.ProviderConfigRef.KeyExpression)

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -516,6 +516,16 @@ func (n *NodeAbstractResource) writeResourceState(ctx context.Context, evalCtx E
 		state.SetResourceProvider(addr, n.ResolvedProvider.ProviderConfig)
 		expander.SetResourceCount(addr.Module, n.Addr.Resource, count)
 
+	case n.Config != nil && n.Config.Enabled != nil:
+		enabled, enabledDiags := evaluateEnabledExpression(ctx, n.Config.Enabled, evalCtx)
+		diags = diags.Append(enabledDiags)
+		if enabledDiags.HasErrors() {
+			return diags
+		}
+
+		state.SetResourceProvider(addr, n.ResolvedProvider.ProviderConfig)
+		expander.SetResourceEnabled(addr.Module, n.Addr.Resource, enabled)
+
 	case n.Config != nil && n.Config.ForEach != nil:
 		forEach, forEachDiags := evaluateForEachExpression(ctx, n.Config.ForEach, evalCtx, addr)
 		diags = diags.Append(forEachDiags)

--- a/internal/tofu/node_resource_plan_instance.go
+++ b/internal/tofu/node_resource_plan_instance.go
@@ -365,18 +365,12 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx context.Conte
 	}
 
 	// Plan the instance, unless we're in the refresh-only mode
+	expander := evalCtx.InstanceExpander()
 	if !n.skipPlanChanges {
 
 		// add this instance to n.forceReplace if replacement is triggered by
 		// another change
-		repData := instances.RepetitionData{}
-		switch k := addr.Resource.Key.(type) {
-		case addrs.IntKey:
-			repData.CountIndex = k.Value()
-		case addrs.StringKey:
-			repData.EachKey = k.Value()
-			repData.EachValue = cty.DynamicVal
-		}
+		repData := expander.GetResourceInstanceRepetitionData(n.Addr)
 
 		diags = diags.Append(n.replaceTriggered(ctx, evalCtx, repData))
 		if diags.HasErrors() {

--- a/internal/tofu/node_resource_plan_orphan.go
+++ b/internal/tofu/node_resource_plan_orphan.go
@@ -271,11 +271,9 @@ func (n *NodePlannableResourceInstanceOrphan) deleteActionReason(evalCtx EvalCon
 
 	switch n.Addr.Resource.Key.(type) {
 	case nil: // no instance key at all
-		// TODO: Conditional enable work
-		// Uncomment this when Enabled field exists on Cfg
-		// if cfg.Enabled != nil {
-		// 	return plans.ResourceInstanceDeleteBecauseEnabledFalse
-		// }
+		if cfg.Enabled != nil {
+			return plans.ResourceInstanceDeleteBecauseEnabledFalse
+		}
 		if cfg.Count != nil || cfg.ForEach != nil {
 			return plans.ResourceInstanceDeleteBecauseWrongRepetition
 		}

--- a/internal/tofu/testdata/apply-enabled-resource/apply-enabled-resource.tf
+++ b/internal/tofu/testdata/apply-enabled-resource/apply-enabled-resource.tf
@@ -1,0 +1,19 @@
+variable "on" {
+  type = bool
+}
+
+resource "test" "test" {
+  lifecycle {
+    enabled = var.on
+  }
+
+  name = "boop"
+}
+
+output "result" {
+  // This is in a 1-tuple just because OpenTofu treats a fully-null
+  // root module output value as if it wasn't declared at all,
+  // but we want to make sure we're actually testing the result
+  // of this resource directly.
+  value = [one(test.test[*].name)]
+}

--- a/internal/tofu/testdata/apply-enabled-resource/apply-enabled-resource.tf
+++ b/internal/tofu/testdata/apply-enabled-resource/apply-enabled-resource.tf
@@ -15,5 +15,5 @@ output "result" {
   // root module output value as if it wasn't declared at all,
   // but we want to make sure we're actually testing the result
   // of this resource directly.
-  value = [one(test.test[*].name)]
+  value = test.test != null ? test.test.name : "default"
 }


### PR DESCRIPTION
Relates to #3247 
Resolves #1306
Related to #3244

> I'm gonna write the user-facing documentation in another PR. This one is focused on the implementation itself. Please refer to #3247 

Implementation of the RFC #3066 focused on resources.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
