### PR TITLE
.github/workflows: Add windows_amd64 to unit test matrix

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -62,9 +62,7 @@ jobs:
           - { runson: ubuntu-latest, goos: linux, goarch: "386" }
           - { runson: ubuntu-latest, goos: linux, goarch: "arm" }
           - { runson: macos-latest, goos: darwin, goarch: "arm64" }
-          # - { runson: windows-latest, goos: windows, goarch: "amd64" }
-          # https://github.com/opentofu/opentofu/issues/1201 if fixed
-          #  ^ un-comment the  windows-latest line
+          - { runson: windows-latest, goos: windows, goarch: "amd64" }
       fail-fast: false
     steps:
       # 👇🏾 GH actions supports only "AMD64 arch", so we are using this action


### PR DESCRIPTION
Blocked by https://github.com/opentofu/opentofu/pull/3320
This resolves https://github.com/opentofu/opentofu/issues/1201.

However, I've created it today mainly just to use it to find out what's still failing when we run the tests on this platform, and it'll remain in draft until all of the tests have been made to pass by other subissues of https://github.com/opentofu/opentofu/issues/1201.

I intend to rebase this each time we merge test fixes for Windows so that we can re-run the tests and keep track of progress.
