### PR TITLE
RFC: conditional  `enabled` field

### DIFF
--- a/rfc/2025-07-22-conditional-enable.md
+++ b/rfc/2025-07-22-conditional-enable.md
@@ -51,7 +51,8 @@ module "modcall" {
 1. Support for conditional enabling on:
     1. Resources - Add a new field on the `lifecycle` block called `enabled`;
     2. Modules - Add a new `lifecycle` block for modules but only supporting the new `enabled` field.
-2. Raise errors if a resource is used while being disabled and the dependent resources are not disabled too;
+2. By default, this field is enabled if not otherwise specified.
+3. Raise errors if a resource is used while being disabled and the dependent resources are not disabled too;
 
 ## Technical Approach
 
@@ -87,7 +88,8 @@ OpenTofu will perform the following actions:
 Plan: 0 to add, 0 to change, 0 to destroy.
 ```
 
-This behavior applies only to resources. For modules, you must write an explicit `move` block:
+This behavior only exists for resources at the moment. As part of the RFC, support will be written for implied moves within modules.
+Until then, this can be done with:
 
 ```
 moved {
@@ -165,7 +167,7 @@ The only available data access patterns for possibly disabled resources are:
 This can be extended using custom provider-defined functions. For example, if someone wanted to create a function that adds a warning instead of raising an error when trying to access the attribute,
 they could do:
 
-- `provider::custom::warning_enabled(null_resource.example.id, "default value")
+- `provider::custom::warning_enabled(null_resource.example.id, "default value")`
 
 For now, we offer the three options above. 
 `try` is the most concise option, but it should be used carefully since it can silently mask errors not caused by null value access. `can` and `!= null` are more verbose but more reliable for doing what you're trying to do.


### PR DESCRIPTION
Relates to #1306 

To read the RFC: https://github.com/opentofu/opentofu/blob/rfc-direct-conditional-support/rfc/2025-07-22-conditional-enable.md

This RFC aims to consolidate all design decisions regarding an `enabled` field in single-instance resources and modules. A prototype with most of these decisions is implemented at #3042.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
