### PR TITLE
Fix crash with sensitive for_each set elements

### DIFF
--- a/internal/lang/evalchecks/eval_for_each.go
+++ b/internal/lang/evalchecks/eval_for_each.go
@@ -225,8 +225,8 @@ func performSetValueChecks(expr hcl.Expression, hclCtx *hcl.EvalContext, forEach
 
 	// A set of strings may contain null, which makes it impossible to
 	// convert to a map, so we must return an error
-	forEachVal, _ = forEachVal.UnmarkDeep()
-	it := forEachVal.ElementIterator()
+	forEachValUnmarked, _ := forEachVal.UnmarkDeep()
+	it := forEachValUnmarked.ElementIterator()
 	for it.Next() {
 		item, _ := it.Element()
 		if item.IsNull() {

--- a/internal/lang/evalchecks/eval_for_each.go
+++ b/internal/lang/evalchecks/eval_for_each.go
@@ -225,6 +225,7 @@ func performSetValueChecks(expr hcl.Expression, hclCtx *hcl.EvalContext, forEach
 
 	// A set of strings may contain null, which makes it impossible to
 	// convert to a map, so we must return an error
+	forEachVal, _ = forEachVal.UnmarkDeep()
 	it := forEachVal.ElementIterator()
 	for it.Next() {
 		item, _ := it.Element()

--- a/internal/lang/evalchecks/eval_for_each_test.go
+++ b/internal/lang/evalchecks/eval_for_each_test.go
@@ -744,6 +744,25 @@ func TestEvaluateForEach(t *testing.T) {
 			},
 			PlanReturnValue: map[string]cty.Value{},
 		},
+		"sensitive_set_elements": {
+			Input: cty.SetVal([]cty.Value{cty.StringVal("a").Mark(marks.Sensitive)}),
+			ValidateExpectedErrs: []expectedErr{
+				{
+					Summary:           "Invalid for_each argument",
+					Detail:            "Sensitive values, or values derived from sensitive values, cannot be used as for_each arguments",
+					CausedByUnknown:   false,
+					CausedBySensitive: true,
+				}},
+			ValidateReturnValue: cty.NullVal(cty.Set(cty.String)),
+			PlanExpectedErrs: []expectedErr{
+				{
+					Summary:           "Invalid for_each argument",
+					Detail:            "Sensitive values, or values derived from sensitive values, cannot be used as for_each arguments",
+					CausedByUnknown:   false,
+					CausedBySensitive: true,
+				}},
+			PlanReturnValue: map[string]cty.Value{},
+		},
 		"string": {
 			Input: cty.StringVal("i am definitely a set"),
 			ValidateExpectedErrs: []expectedErr{

--- a/internal/lang/evalchecks/eval_for_each_test.go
+++ b/internal/lang/evalchecks/eval_for_each_test.go
@@ -744,6 +744,25 @@ func TestEvaluateForEach(t *testing.T) {
 			},
 			PlanReturnValue: map[string]cty.Value{},
 		},
+		"sensitive_set": {
+			Input: cty.SetVal([]cty.Value{cty.StringVal("a")}).Mark(marks.Sensitive),
+			ValidateExpectedErrs: []expectedErr{
+				{
+					Summary:           "Invalid for_each argument",
+					Detail:            "Sensitive values, or values derived from sensitive values, cannot be used as for_each arguments",
+					CausedByUnknown:   false,
+					CausedBySensitive: true,
+				}},
+			ValidateReturnValue: cty.NullVal(cty.Set(cty.String)),
+			PlanExpectedErrs: []expectedErr{
+				{
+					Summary:           "Invalid for_each argument",
+					Detail:            "Sensitive values, or values derived from sensitive values, cannot be used as for_each arguments",
+					CausedByUnknown:   false,
+					CausedBySensitive: true,
+				}},
+			PlanReturnValue: map[string]cty.Value{},
+		},
 		"sensitive_set_elements": {
 			Input: cty.SetVal([]cty.Value{cty.StringVal("a").Mark(marks.Sensitive)}),
 			ValidateExpectedErrs: []expectedErr{


### PR DESCRIPTION
Will need to be backported to 1.10, originated in the rewrite of for_each https://github.com/opentofu/opentofu/pull/2597

<!-- If your PR resolves an issue, please add it here. -->
Resolves #3065 

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

