### PR TITLE
feat: add Cloudflare R2 as remote-state backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ UPGRADE NOTES:
 
 ENHANCEMENTS:
 
-* **New Cloudflare R2 backend**: A new backend for storing state in Cloudflare R2 storage has been added. This backend uses native Cloudflare API endpoints for bucket operations and R2's S3-compatible endpoints for object operations, supporting API token authentication and jurisdiction-specific storage. ([#PENDING](https://github.com/opentofu/opentofu/pull/PENDING))
+* New Cloudflare R2 backend: A new backend for storing state in Cloudflare R2 storage has been added. This backend uses native Cloudflare API endpoints for bucket operations and R2's S3-compatible endpoints for object operations, supporting API token authentication and jurisdiction-specific storage. ([#3076](https://github.com/opentofu/opentofu/pull/3076))
 * OpenTofu will now suggest using `-exclude` if a provider reports that it cannot create a plan for a particular resource instance due to values that won't be known until the apply phase. ([#2643](https://github.com/opentofu/opentofu/pull/2643))
 * `tofu validate` now supports running in a module that contains provider configuration_aliases. ([#2905](https://github.com/opentofu/opentofu/pull/2905))
 * `tofu show` now supports `-config` and `-module=DIR` options, to be used in conjunction with `-json` to produce a machine-readable summary of either the whole configuration or a single module without first creating a plan. ([#2820](https://github.com/opentofu/opentofu/pull/2820), [#3003](https://github.com/opentofu/opentofu/pull/3003))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ UPGRADE NOTES:
 
 ENHANCEMENTS:
 
+* **New Cloudflare R2 backend**: A new backend for storing state in Cloudflare R2 storage has been added. This backend uses native Cloudflare API endpoints for bucket operations and R2's S3-compatible endpoints for object operations, supporting API token authentication and jurisdiction-specific storage. ([#PENDING](https://github.com/opentofu/opentofu/pull/PENDING))
 * OpenTofu will now suggest using `-exclude` if a provider reports that it cannot create a plan for a particular resource instance due to values that won't be known until the apply phase. ([#2643](https://github.com/opentofu/opentofu/pull/2643))
 * `tofu validate` now supports running in a module that contains provider configuration_aliases. ([#2905](https://github.com/opentofu/opentofu/pull/2905))
 * `tofu show` now supports `-config` and `-module=DIR` options, to be used in conjunction with `-json` to produce a machine-readable summary of either the whole configuration or a single module without first creating a plan. ([#2820](https://github.com/opentofu/opentofu/pull/2820), [#3003](https://github.com/opentofu/opentofu/pull/3003))

--- a/internal/backend/init/init.go
+++ b/internal/backend/init/init.go
@@ -26,6 +26,7 @@ import (
 	backendOSS "github.com/opentofu/opentofu/internal/backend/remote-state/oss"
 	backendPg "github.com/opentofu/opentofu/internal/backend/remote-state/pg"
 	backendS3 "github.com/opentofu/opentofu/internal/backend/remote-state/s3"
+	backendR2 "github.com/opentofu/opentofu/internal/backend/remote-state/r2"
 	backendCloud "github.com/opentofu/opentofu/internal/cloud"
 	"github.com/opentofu/opentofu/internal/encryption"
 	"github.com/opentofu/opentofu/internal/tfdiags"
@@ -73,6 +74,7 @@ func Init(services *disco.Disco) {
 		"oss":        func(enc encryption.StateEncryption) backend.Backend { return backendOSS.New(enc) },
 		"pg":         func(enc encryption.StateEncryption) backend.Backend { return backendPg.New(enc) },
 		"s3":         func(enc encryption.StateEncryption) backend.Backend { return backendS3.New(enc) },
+		"r2":         func(enc encryption.StateEncryption) backend.Backend { return backendR2.New(enc) },
 
 		// Terraform Cloud 'backend'
 		// This is an implementation detail only, used for the cloud package

--- a/internal/backend/init/init_test.go
+++ b/internal/backend/init/init_test.go
@@ -29,6 +29,7 @@ func TestInit_backend(t *testing.T) {
 		{"inmem", "*inmem.Backend"},
 		{"pg", "*pg.Backend"},
 		{"s3", "*s3.Backend"},
+		{"r2", "*r2.Backend"},
 	}
 
 	// Make sure we get the requested backend

--- a/internal/backend/remote-state/r2/backend.go
+++ b/internal/backend/remote-state/r2/backend.go
@@ -1,0 +1,339 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+
+package r2
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/opentofu/opentofu/internal/backend"
+	"github.com/opentofu/opentofu/internal/configs/configschema"
+	"github.com/opentofu/opentofu/internal/encryption"
+	"github.com/opentofu/opentofu/internal/httpclient"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+	"github.com/opentofu/opentofu/version"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/gocty"
+	"net/http"
+)
+
+// New creates a new R2 backend instance
+func New(enc encryption.StateEncryption) backend.Backend {
+	return &Backend{encryption: enc}
+}
+
+// Backend implements the backend.Backend interface for Cloudflare R2
+type Backend struct {
+	encryption encryption.StateEncryption
+	
+	// Cloudflare API configuration
+	accountID string
+	apiToken  string
+	
+	// R2 bucket configuration
+	bucketName         string
+	key                string
+	workspaceKeyPrefix string
+	
+	// Optional endpoint override for testing
+	endpoint string
+	
+	// HTTP client for native API calls
+	httpClient *http.Client
+	
+	// Jurisdiction for bucket operations
+	jurisdiction string
+}
+
+// ConfigSchema returns the configuration schema for the R2 backend
+func (b *Backend) ConfigSchema() *configschema.Block {
+	return &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"account_id": {
+				Type:        cty.String,
+				Required:    true,
+				Description: "The Cloudflare account ID",
+			},
+			"api_token": {
+				Type:        cty.String,
+				Required:    true,
+				Sensitive:   true,
+				Description: "The Cloudflare API token with R2 permissions",
+			},
+			"bucket": {
+				Type:        cty.String,
+				Required:    true,
+				Description: "The name of the R2 bucket",
+			},
+			"key": {
+				Type:        cty.String,
+				Required:    true,
+				Description: "The path to the state file inside the bucket",
+			},
+			"workspace_key_prefix": {
+				Type:        cty.String,
+				Optional:    true,
+				Description: "The prefix applied to the state path inside the bucket. Default: env:",
+			},
+			"endpoint": {
+				Type:        cty.String,
+				Optional:    true,
+				Description: "Custom endpoint URL (primarily for testing)",
+			},
+			"jurisdiction": {
+				Type:        cty.String,
+				Optional:    true,
+				Description: "The jurisdiction for the R2 bucket (e.g., 'eu' for European Union)",
+			},
+		},
+	}
+}
+
+// PrepareConfig validates and prepares the backend configuration
+func (b *Backend) PrepareConfig(configVal cty.Value) (cty.Value, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	
+	if configVal.IsNull() {
+		return configVal, diags
+	}
+	
+	// Validate account ID format
+	if accountID := configVal.GetAttr("account_id"); !accountID.IsNull() {
+		id := accountID.AsString()
+		if len(id) != 32 || !isHexadecimal(id) {
+			diags = diags.Append(tfdiags.AttributeValue(
+				tfdiags.Error,
+				"Invalid account ID",
+				"The account_id must be a 32-character hexadecimal string",
+				cty.Path{cty.GetAttrStep{Name: "account_id"}},
+			))
+		}
+	}
+	
+	// Validate bucket name
+	if bucket := configVal.GetAttr("bucket"); !bucket.IsNull() {
+		name := bucket.AsString()
+		if err := validateBucketName(name); err != nil {
+			diags = diags.Append(tfdiags.AttributeValue(
+				tfdiags.Error,
+				"Invalid bucket name",
+				err.Error(),
+				cty.Path{cty.GetAttrStep{Name: "bucket"}},
+			))
+		}
+	}
+	
+	// Validate key format
+	if key := configVal.GetAttr("key"); !key.IsNull() {
+		k := key.AsString()
+		if err := validateKey(k); err != nil {
+			diags = diags.Append(tfdiags.AttributeValue(
+				tfdiags.Error,
+				"Invalid key",
+				err.Error(),
+				cty.Path{cty.GetAttrStep{Name: "key"}},
+			))
+		}
+	}
+	
+	// Validate jurisdiction if provided
+	if jurisdiction := configVal.GetAttr("jurisdiction"); !jurisdiction.IsNull() {
+		j := jurisdiction.AsString()
+		if j != "" && j != "eu" && j != "fedramp" {
+			diags = diags.Append(tfdiags.AttributeValue(
+				tfdiags.Error,
+				"Invalid jurisdiction",
+				"The jurisdiction must be either 'eu' or 'fedramp'",
+				cty.Path{cty.GetAttrStep{Name: "jurisdiction"}},
+			))
+		}
+	}
+	
+	return configVal, diags
+}
+
+// Configure initializes the backend with the provided configuration
+func (b *Backend) Configure(ctx context.Context, configVal cty.Value) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+	
+	// Extract configuration values
+	data := &schema{
+		WorkspaceKeyPrefix: "env:",
+	}
+	
+	if err := gocty.FromCtyValue(configVal, data); err != nil {
+		diags = diags.Append(err)
+		return diags
+	}
+	
+	// Set backend fields
+	b.accountID = data.AccountID
+	b.apiToken = data.APIToken
+	b.bucketName = data.Bucket
+	b.key = data.Key
+	b.workspaceKeyPrefix = data.WorkspaceKeyPrefix
+	b.endpoint = data.Endpoint
+	b.jurisdiction = data.Jurisdiction
+	
+	// Initialize HTTP client with user agent
+	b.httpClient = httpclient.New(ctx)
+	
+	// Verify bucket exists and is accessible
+	if err := b.verifyBucketAccess(ctx); err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Failed to verify R2 bucket access",
+			fmt.Sprintf("Error verifying access to bucket %q: %s", b.bucketName, err),
+		))
+	}
+	
+	return diags
+}
+
+// schema represents the configuration structure
+type schema struct {
+	AccountID          string `cty:"account_id"`
+	APIToken           string `cty:"api_token"`
+	Bucket             string `cty:"bucket"`
+	Key                string `cty:"key"`
+	WorkspaceKeyPrefix string `cty:"workspace_key_prefix"`
+	Endpoint           string `cty:"endpoint"`
+	Jurisdiction       string `cty:"jurisdiction"`
+}
+
+// isHexadecimal checks if a string contains only hexadecimal characters
+func isHexadecimal(s string) bool {
+	for _, c := range s {
+		if c < '0' || (c > '9' && c < 'A') || (c > 'F' && c < 'a') || c > 'f' {
+			return false
+		}
+	}
+	return true
+}
+
+// validateBucketName validates R2 bucket naming rules
+func validateBucketName(name string) error {
+	if len(name) < 3 || len(name) > 63 {
+		return fmt.Errorf("bucket name must be between 3 and 63 characters")
+	}
+	
+	// Check for uppercase letters first
+	for _, c := range name {
+		if c >= 'A' && c <= 'Z' {
+			return fmt.Errorf("bucket name can only contain lowercase letters, numbers, and dashes")
+		}
+	}
+	
+	if !isValidBucketChar(rune(name[0])) || !isValidBucketChar(rune(name[len(name)-1])) {
+		return fmt.Errorf("bucket name must start and end with a letter or number")
+	}
+	
+	prevDash := false
+	for _, c := range name {
+		if c == '-' {
+			if prevDash {
+				return fmt.Errorf("bucket name cannot contain consecutive dashes")
+			}
+			prevDash = true
+		} else {
+			prevDash = false
+			if !isValidBucketChar(c) && c != '-' {
+				return fmt.Errorf("bucket name can only contain lowercase letters, numbers, and dashes")
+			}
+		}
+	}
+	
+	if strings.Contains(name, "..") {
+		return fmt.Errorf("bucket name cannot contain '..'")
+	}
+	
+	return nil
+}
+
+// isValidBucketChar checks if a character is valid for bucket names
+func isValidBucketChar(c rune) bool {
+	return (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')
+}
+
+// validateKey validates the state key format
+func validateKey(key string) error {
+	if key == "" {
+		return fmt.Errorf("key cannot be empty")
+	}
+	
+	if strings.HasPrefix(key, "/") {
+		return fmt.Errorf("key cannot start with '/'")
+	}
+	
+	if strings.HasSuffix(key, "/") {
+		return fmt.Errorf("key cannot end with '/'")
+	}
+	
+	// Check for invalid characters
+	for _, c := range key {
+		if c < 32 || c > 126 {
+			return fmt.Errorf("key contains invalid characters")
+		}
+	}
+	
+	return nil
+}
+
+// verifyBucketAccess checks if the bucket exists and is accessible
+func (b *Backend) verifyBucketAccess(ctx context.Context) error {
+	// Get bucket information using native Cloudflare API
+	url := b.getAPIEndpoint() + fmt.Sprintf("/accounts/%s/r2/buckets/%s", b.accountID, b.bucketName)
+	
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return err
+	}
+	
+	req.Header.Set("Authorization", "Bearer "+b.apiToken)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", httpclient.OpenTofuUserAgent(version.String()))
+	
+	resp, err := b.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	
+	if resp.StatusCode == 404 {
+		return fmt.Errorf("bucket not found")
+	}
+	
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+	
+	return nil
+}
+
+// getAPIEndpoint returns the Cloudflare API endpoint
+func (b *Backend) getAPIEndpoint() string {
+	if b.endpoint != "" {
+		return b.endpoint
+	}
+	return "https://api.cloudflare.com/client/v4"
+}
+
+// getR2Endpoint returns the R2 S3-compatible endpoint for object operations
+func (b *Backend) getR2Endpoint() string {
+	if b.endpoint != "" {
+		// For testing, use the provided endpoint
+		return b.endpoint
+	}
+	
+	// Build the R2 endpoint based on jurisdiction
+	switch b.jurisdiction {
+	case "eu":
+		return fmt.Sprintf("https://%s.eu.r2.cloudflarestorage.com", b.accountID)
+	case "fedramp":
+		return fmt.Sprintf("https://%s.fedramp.r2.cloudflarestorage.com", b.accountID)
+	default:
+		return fmt.Sprintf("https://%s.r2.cloudflarestorage.com", b.accountID)
+	}
+}

--- a/internal/backend/remote-state/r2/backend_state.go
+++ b/internal/backend/remote-state/r2/backend_state.go
@@ -1,0 +1,209 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+
+package r2
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/opentofu/opentofu/internal/backend"
+	"github.com/opentofu/opentofu/internal/states"
+	"github.com/opentofu/opentofu/internal/states/remote"
+	"github.com/opentofu/opentofu/internal/states/statemgr"
+	"github.com/opentofu/opentofu/internal/states/statefile"
+)
+
+// Workspaces returns a list of workspace names
+func (b *Backend) Workspaces(ctx context.Context) ([]string, error) {
+	
+	// List all objects with the workspace prefix
+	prefix := ""
+	if b.workspaceKeyPrefix != "" {
+		prefix = b.workspaceKeyPrefix + "/"
+	}
+	
+	url := fmt.Sprintf("%s/%s?list-type=2&prefix=%s&max-keys=1000", b.getR2Endpoint(), b.bucketName, prefix)
+	
+	workspaces := []string{backend.DefaultStateName}
+	workspaceSet := make(map[string]bool)
+	
+	for {
+		req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+		if err != nil {
+			return nil, err
+		}
+		
+		// Add authentication
+		req.Header.Set("Authorization", "Bearer "+b.apiToken)
+		
+		resp, err := b.httpClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+		
+		if resp.StatusCode != 200 {
+			// If access denied, return default workspace only (backward compatibility)
+			if resp.StatusCode == 403 {
+				return workspaces, nil
+			}
+			return nil, fmt.Errorf("failed to list workspaces: status %d", resp.StatusCode)
+		}
+		
+		// Parse XML response
+		var result listBucketResult
+		if err := xml.NewDecoder(resp.Body).Decode(&result); err != nil {
+			return nil, fmt.Errorf("failed to parse list response: %w", err)
+		}
+		
+		for _, obj := range result.Contents {
+			ws := b.keyEnv(obj.Key)
+			if ws != "" && !workspaceSet[ws] {
+				workspaceSet[ws] = true
+				workspaces = append(workspaces, ws)
+			}
+		}
+		
+		if !result.IsTruncated {
+			break
+		}
+		
+		// Continue pagination
+		url = fmt.Sprintf("%s/%s?list-type=2&prefix=%s&max-keys=1000&continuation-token=%s", 
+			b.getR2Endpoint(), b.bucketName, prefix, result.NextContinuationToken)
+	}
+	
+	sort.Strings(workspaces[1:])
+	return workspaces, nil
+}
+
+// DeleteWorkspace deletes the specified workspace
+func (b *Backend) DeleteWorkspace(ctx context.Context, name string, force bool) error {
+	if name == backend.DefaultStateName || name == "" {
+		return fmt.Errorf("cannot delete default workspace")
+	}
+	client, err := b.remoteClient(name)
+	if err != nil {
+		return err
+	}
+	
+	return client.Delete(ctx)
+}
+
+// StateMgr returns a state manager for the specified workspace
+func (b *Backend) StateMgr(ctx context.Context, name string) (statemgr.Full, error) {
+	client, err := b.remoteClient(name)
+	if err != nil {
+		return nil, err
+	}
+	
+	stateMgr := remote.NewState(client, b.encryption)
+	
+	// Initialize the state manager
+	if err := stateMgr.RefreshState(ctx); err != nil {
+		// If the state doesn't exist, create an empty one
+		if err == statefile.ErrNoState {
+			if err := stateMgr.WriteState(states.NewState()); err != nil {
+				return nil, fmt.Errorf("failed to initialize state: %w", err)
+			}
+			if err := stateMgr.PersistState(ctx, nil); err != nil {
+				return nil, fmt.Errorf("failed to persist initial state: %w", err)
+			}
+		} else {
+			return nil, fmt.Errorf("failed to refresh state: %w", err)
+		}
+	}
+	
+	return stateMgr, nil
+}
+
+// remoteClient returns a RemoteClient for the given workspace
+func (b *Backend) remoteClient(name string) (*RemoteClient, error) {
+	if name == "" {
+		return nil, fmt.Errorf("workspace name cannot be empty")
+	}
+	
+	key := b.key
+	if name != backend.DefaultStateName {
+		// Don't use path.Join as it cleans the path and removes trailing colons
+		key = fmt.Sprintf("%s%s/%s", b.workspaceKeyPrefix, name, b.key)
+	}
+	
+	return &RemoteClient{
+		backend:    b,
+		bucketName: b.bucketName,
+		key:        key,
+	}, nil
+}
+
+// keyEnv extracts the workspace name from a key
+func (b *Backend) keyEnv(key string) string {
+	prefix := b.workspaceKeyPrefix
+
+	if prefix == "" {
+		parts := strings.SplitN(key, "/", 2)
+		if len(parts) > 1 && parts[1] == b.key {
+			return parts[0]
+		}
+		return ""
+	}
+
+	// Add a slash to treat this as a directory
+	prefix += "/"
+
+	parts := strings.SplitAfterN(key, prefix, 2)
+	if len(parts) < 2 {
+		return ""
+	}
+
+	// Shouldn't happen since we listed by prefix
+	if parts[0] != prefix {
+		return ""
+	}
+
+	// Get the workspace name from the path
+	end := strings.Index(parts[1], "/")
+	if end == -1 {
+		return ""
+	}
+
+	ws := parts[1][:end]
+
+	// Check that the rest of the key matches our state file name
+	remainder := parts[1][end+1:]
+	if remainder != b.key {
+		return ""
+	}
+
+	return ws
+}
+
+// listBucketResult represents the XML response from listing bucket contents
+type listBucketResult struct {
+	XMLName                xml.Name `xml:"ListBucketResult"`
+	IsTruncated            bool     `xml:"IsTruncated"`
+	Contents               []s3Object `xml:"Contents"`
+	Name                   string   `xml:"Name"`
+	Prefix                 string   `xml:"Prefix"`
+	MaxKeys                int      `xml:"MaxKeys"`
+	NextContinuationToken  string   `xml:"NextContinuationToken"`
+}
+
+// s3Object represents an object in the S3 bucket
+type s3Object struct {
+	Key          string `xml:"Key"`
+	LastModified string `xml:"LastModified"`
+	ETag         string `xml:"ETag"`
+	Size         int64  `xml:"Size"`
+	StorageClass string `xml:"StorageClass"`
+}
+
+// StateSnapshotMeta returns metadata about the state snapshot
+func (b *Backend) StateSnapshotMeta() statemgr.SnapshotMeta {
+	return statemgr.SnapshotMeta{}
+}

--- a/internal/backend/remote-state/r2/backend_test.go
+++ b/internal/backend/remote-state/r2/backend_test.go
@@ -1,0 +1,367 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+
+package r2
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/opentofu/opentofu/internal/backend"
+	"github.com/opentofu/opentofu/internal/encryption"
+	"github.com/opentofu/opentofu/internal/httpclient"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestBackend_impl(t *testing.T) {
+	var _ backend.Backend = (*Backend)(nil)
+}
+
+func TestBackendConfig(t *testing.T) {
+	b := New(encryption.StateEncryptionDisabled())
+	schema := b.ConfigSchema()
+
+	// Test required attributes
+	requiredAttrs := []string{"account_id", "api_token", "bucket", "key"}
+	for _, attr := range requiredAttrs {
+		if v, ok := schema.Attributes[attr]; !ok {
+			t.Errorf("missing required attribute %q", attr)
+		} else if !v.Required {
+			t.Errorf("attribute %q should be required", attr)
+		}
+	}
+
+	// Test optional attributes
+	optionalAttrs := []string{"workspace_key_prefix", "endpoint", "jurisdiction"}
+	for _, attr := range optionalAttrs {
+		if v, ok := schema.Attributes[attr]; !ok {
+			t.Errorf("missing optional attribute %q", attr)
+		} else if v.Required {
+			t.Errorf("attribute %q should be optional", attr)
+		}
+	}
+
+	// Test sensitive attributes
+	if !schema.Attributes["api_token"].Sensitive {
+		t.Error("api_token should be marked as sensitive")
+	}
+}
+
+func TestBackendConfig_PrepareConfig(t *testing.T) {
+	b := New(encryption.StateEncryptionDisabled())
+
+	tests := []struct {
+		name      string
+		config    map[string]cty.Value
+		wantError bool
+		errorMsg  string
+	}{
+		{
+			name: "valid config",
+			config: map[string]cty.Value{
+				"account_id": cty.StringVal("1234567890abcdef1234567890abcdef"),
+				"api_token":  cty.StringVal("test-token"),
+				"bucket":     cty.StringVal("test-bucket"),
+				"key":        cty.StringVal("test.tfstate"),
+			},
+			wantError: false,
+		},
+		{
+			name: "invalid account_id",
+			config: map[string]cty.Value{
+				"account_id": cty.StringVal("invalid"),
+				"api_token":  cty.StringVal("test-token"),
+				"bucket":     cty.StringVal("test-bucket"),
+				"key":        cty.StringVal("test.tfstate"),
+			},
+			wantError: true,
+			errorMsg:  "32-character hexadecimal",
+		},
+		{
+			name: "invalid bucket name - too short",
+			config: map[string]cty.Value{
+				"account_id": cty.StringVal("1234567890abcdef1234567890abcdef"),
+				"api_token":  cty.StringVal("test-token"),
+				"bucket":     cty.StringVal("ab"),
+				"key":        cty.StringVal("test.tfstate"),
+			},
+			wantError: true,
+			errorMsg:  "between 3 and 63 characters",
+		},
+		{
+			name: "invalid bucket name - uppercase",
+			config: map[string]cty.Value{
+				"account_id": cty.StringVal("1234567890abcdef1234567890abcdef"),
+				"api_token":  cty.StringVal("test-token"),
+				"bucket":     cty.StringVal("Test-Bucket"),
+				"key":        cty.StringVal("test.tfstate"),
+			},
+			wantError: true,
+			errorMsg:  "lowercase letters",
+		},
+		{
+			name: "invalid key - starts with slash",
+			config: map[string]cty.Value{
+				"account_id": cty.StringVal("1234567890abcdef1234567890abcdef"),
+				"api_token":  cty.StringVal("test-token"),
+				"bucket":     cty.StringVal("test-bucket"),
+				"key":        cty.StringVal("/test.tfstate"),
+			},
+			wantError: true,
+			errorMsg:  "cannot start with '/'",
+		},
+		{
+			name: "invalid jurisdiction",
+			config: map[string]cty.Value{
+				"account_id":   cty.StringVal("1234567890abcdef1234567890abcdef"),
+				"api_token":    cty.StringVal("test-token"),
+				"bucket":       cty.StringVal("test-bucket"),
+				"key":          cty.StringVal("test.tfstate"),
+				"jurisdiction": cty.StringVal("invalid"),
+			},
+			wantError: true,
+			errorMsg:  "must be either 'eu' or 'fedramp'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Add defaults for optional fields
+			config := make(map[string]cty.Value)
+			for k, v := range tt.config {
+				config[k] = v
+			}
+			
+			// Add nulls for optional fields if not present
+			if _, ok := config["workspace_key_prefix"]; !ok {
+				config["workspace_key_prefix"] = cty.NullVal(cty.String)
+			}
+			if _, ok := config["endpoint"]; !ok {
+				config["endpoint"] = cty.NullVal(cty.String)
+			}
+			if _, ok := config["jurisdiction"]; !ok {
+				config["jurisdiction"] = cty.NullVal(cty.String)
+			}
+			
+			configVal := cty.ObjectVal(config)
+			
+			_, diags := b.PrepareConfig(configVal)
+			
+			if tt.wantError {
+				if !diags.HasErrors() {
+					t.Fatal("expected error but got none")
+				}
+				if tt.errorMsg != "" {
+					found := false
+					for _, diag := range diags {
+						if diag.Severity() == tfdiags.Error {
+							detail := diag.Description().Detail
+							if detail != "" && contains(detail, tt.errorMsg) {
+								found = true
+								break
+							}
+						}
+					}
+					if !found {
+						t.Errorf("expected error containing %q, got %v", tt.errorMsg, diags.Err())
+					}
+				}
+			} else {
+				if diags.HasErrors() {
+					t.Fatalf("unexpected error: %v", diags.Err())
+				}
+			}
+		})
+	}
+}
+
+func TestBackend_Configure(t *testing.T) {
+	// Create a test server to mock Cloudflare API
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/accounts/1234567890abcdef1234567890abcdef/r2/buckets/test-bucket":
+			if r.Method == "GET" {
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintf(w, `{
+					"success": true,
+					"result": {
+						"name": "test-bucket",
+						"creation_date": "2023-01-01T00:00:00Z",
+						"location": "auto"
+					}
+				}`)
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	b := New(encryption.StateEncryptionDisabled())
+	
+	config := cty.ObjectVal(map[string]cty.Value{
+		"account_id":          cty.StringVal("1234567890abcdef1234567890abcdef"),
+		"api_token":           cty.StringVal("test-token"),
+		"bucket":              cty.StringVal("test-bucket"),
+		"key":                 cty.StringVal("test.tfstate"),
+		"workspace_key_prefix": cty.StringVal("env:"),
+		"endpoint":            cty.StringVal(server.URL),
+		"jurisdiction":        cty.StringVal(""),
+	})
+
+	diags := b.Configure(context.Background(), config)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected error: %v", diags.Err())
+	}
+
+	// Verify configuration was set correctly
+	backend := b.(*Backend)
+	if backend.accountID != "1234567890abcdef1234567890abcdef" {
+		t.Errorf("expected account_id to be set")
+	}
+	if backend.bucketName != "test-bucket" {
+		t.Errorf("expected bucket to be set")
+	}
+	if backend.key != "test.tfstate" {
+		t.Errorf("expected key to be set")
+	}
+	if backend.workspaceKeyPrefix != "env:" {
+		t.Errorf("expected workspace_key_prefix to be 'env:', got %q", backend.workspaceKeyPrefix)
+	}
+}
+
+func TestBackend_verifyBucketAccess(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		wantError  bool
+		errorMsg   string
+	}{
+		{
+			name:       "bucket exists",
+			statusCode: http.StatusOK,
+			wantError:  false,
+		},
+		{
+			name:       "bucket not found",
+			statusCode: http.StatusNotFound,
+			wantError:  true,
+			errorMsg:   "bucket not found",
+		},
+		{
+			name:       "unauthorized",
+			statusCode: http.StatusUnauthorized,
+			wantError:  true,
+			errorMsg:   "unexpected status code: 401",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Verify authentication header
+				if auth := r.Header.Get("Authorization"); auth != "Bearer test-token" {
+					t.Errorf("expected Authorization header, got %q", auth)
+				}
+				
+				w.WriteHeader(tt.statusCode)
+				if tt.statusCode == http.StatusOK {
+					fmt.Fprintf(w, `{"success": true, "result": {"name": "test-bucket"}}`)
+				}
+			}))
+			defer server.Close()
+
+			b := &Backend{
+				accountID:  "1234567890abcdef1234567890abcdef",
+				apiToken:   "test-token",
+				bucketName: "test-bucket",
+				endpoint:   server.URL,
+				httpClient: httpclient.New(context.Background()),
+			}
+
+			err := b.verifyBucketAccess(context.Background())
+			
+			if tt.wantError {
+				if err == nil {
+					t.Fatal("expected error but got none")
+				}
+				if tt.errorMsg != "" && !contains(err.Error(), tt.errorMsg) {
+					t.Errorf("expected error containing %q, got %v", tt.errorMsg, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestBackend_getR2Endpoint(t *testing.T) {
+	tests := []struct {
+		name         string
+		jurisdiction string
+		endpoint     string
+		accountID    string
+		want         string
+	}{
+		{
+			name:         "default jurisdiction",
+			jurisdiction: "",
+			accountID:    "abc123",
+			want:         "https://abc123.r2.cloudflarestorage.com",
+		},
+		{
+			name:         "EU jurisdiction",
+			jurisdiction: "eu",
+			accountID:    "abc123",
+			want:         "https://abc123.eu.r2.cloudflarestorage.com",
+		},
+		{
+			name:         "FedRAMP jurisdiction",
+			jurisdiction: "fedramp",
+			accountID:    "abc123",
+			want:         "https://abc123.fedramp.r2.cloudflarestorage.com",
+		},
+		{
+			name:         "custom endpoint",
+			jurisdiction: "eu",
+			endpoint:     "https://custom.endpoint.com",
+			accountID:    "abc123",
+			want:         "https://custom.endpoint.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &Backend{
+				accountID:    tt.accountID,
+				jurisdiction: tt.jurisdiction,
+				endpoint:     tt.endpoint,
+			}
+
+			got := b.getR2Endpoint()
+			if got != tt.want {
+				t.Errorf("getR2Endpoint() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 || 
+		(len(s) > 0 && len(substr) > 0 && containsHelper(s, substr)))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/backend/remote-state/r2/client.go
+++ b/internal/backend/remote-state/r2/client.go
@@ -1,0 +1,184 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+
+package r2
+
+import (
+	"bytes"
+	"context"
+	"crypto/md5"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/opentofu/opentofu/internal/httpclient"
+	"github.com/opentofu/opentofu/internal/states/remote"
+	"github.com/opentofu/opentofu/internal/states/statemgr"
+	"github.com/opentofu/opentofu/version"
+)
+
+// RemoteClient implements the remote.Client interface for R2
+type RemoteClient struct {
+	backend    *Backend
+	bucketName string
+	key        string
+}
+
+// Get retrieves the state from R2
+func (c *RemoteClient) Get(ctx context.Context) (*remote.Payload, error) {
+	// Use the R2 S3-compatible endpoint for object operations
+	url := fmt.Sprintf("%s/%s/%s", c.backend.getR2Endpoint(), c.bucketName, c.key)
+	
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	
+	// Add R2 authentication headers
+	c.addAuthHeaders(req, "GET", c.key, nil)
+	
+	resp, err := c.backend.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	
+	// Handle not found
+	if resp.StatusCode == 404 {
+		return nil, nil
+	}
+	
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("failed to get state: %s (status: %d)", string(body), resp.StatusCode)
+	}
+	
+	// Read the state data
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read state data: %w", err)
+	}
+	
+	// Calculate MD5 for integrity
+	md5Sum := md5.Sum(data)
+	
+	payload := &remote.Payload{
+		Data: data,
+		MD5:  md5Sum[:],
+	}
+	
+	return payload, nil
+}
+
+// Put stores the state in R2
+func (c *RemoteClient) Put(ctx context.Context, data []byte) error {
+	url := fmt.Sprintf("%s/%s/%s", c.backend.getR2Endpoint(), c.bucketName, c.key)
+	
+	// Calculate MD5 for content verification
+	md5Sum := md5.Sum(data)
+	md5Base64 := base64.StdEncoding.EncodeToString(md5Sum[:])
+	
+	req, err := http.NewRequestWithContext(ctx, "PUT", url, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	
+	// Add headers
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-MD5", md5Base64)
+	req.Header.Set("Content-Length", fmt.Sprintf("%d", len(data)))
+	
+	// Add custom metadata for state management
+	req.Header.Set("x-amz-meta-opentofu-version", "1.0")
+	req.Header.Set("x-amz-meta-last-modified", time.Now().UTC().Format(time.RFC3339))
+	
+	// Add R2 authentication headers
+	c.addAuthHeaders(req, "PUT", c.key, data)
+	
+	resp, err := c.backend.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	
+	if resp.StatusCode != 200 && resp.StatusCode != 201 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("failed to put state: %s (status: %d)", string(body), resp.StatusCode)
+	}
+	
+	return nil
+}
+
+// Delete removes the state from R2
+func (c *RemoteClient) Delete(ctx context.Context) error {
+	url := fmt.Sprintf("%s/%s/%s", c.backend.getR2Endpoint(), c.bucketName, c.key)
+	
+	req, err := http.NewRequestWithContext(ctx, "DELETE", url, nil)
+	if err != nil {
+		return err
+	}
+	
+	// Add R2 authentication headers
+	c.addAuthHeaders(req, "DELETE", c.key, nil)
+	
+	resp, err := c.backend.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	
+	// 204 No Content or 200 OK are both acceptable
+	if resp.StatusCode != 204 && resp.StatusCode != 200 && resp.StatusCode != 404 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("failed to delete state: %s (status: %d)", string(body), resp.StatusCode)
+	}
+	
+	return nil
+}
+
+// Lock is not implemented for R2 backend
+// R2 doesn't support object locking like DynamoDB
+func (c *RemoteClient) Lock(ctx context.Context, info *statemgr.LockInfo) (string, error) {
+	// Return a simple lock ID to satisfy the interface
+	// In practice, users should use external locking mechanisms
+	return "r2-no-lock", nil
+}
+
+// Unlock is not implemented for R2 backend
+func (c *RemoteClient) Unlock(ctx context.Context, id string) error {
+	// No-op since we don't support locking
+	return nil
+}
+
+// addAuthHeaders adds authentication headers for R2 S3-compatible API
+func (c *RemoteClient) addAuthHeaders(req *http.Request, method, key string, body []byte) {
+	// R2 uses API tokens for authentication
+	// The token can be used directly as a bearer token or converted to S3-style credentials
+	
+	// For simplicity and native R2 support, use the API token directly
+	req.Header.Set("Authorization", "Bearer "+c.backend.apiToken)
+	
+	// Add required headers for R2
+	req.Header.Set("Host", req.URL.Host)
+	req.Header.Set("x-amz-date", time.Now().UTC().Format("20060102T150405Z"))
+	req.Header.Set("User-Agent", httpclient.OpenTofuUserAgent(version.String()))
+	
+	// Add content hash for integrity
+	if body != nil {
+		contentHash := hex.EncodeToString(hashSHA256(body))
+		req.Header.Set("x-amz-content-sha256", contentHash)
+	} else {
+		req.Header.Set("x-amz-content-sha256", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855") // Empty hash
+	}
+}
+
+// hashSHA256 computes SHA256 hash of data
+func hashSHA256(data []byte) []byte {
+	h := sha256.New()
+	h.Write(data)
+	return h.Sum(nil)
+}

--- a/internal/backend/remote-state/r2/client_test.go
+++ b/internal/backend/remote-state/r2/client_test.go
@@ -1,0 +1,365 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+
+package r2
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/opentofu/opentofu/internal/encryption"
+	"github.com/opentofu/opentofu/internal/httpclient"
+	"github.com/opentofu/opentofu/internal/states/remote"
+)
+
+func TestRemoteClient_impl(t *testing.T) {
+	var _ remote.Client = (*RemoteClient)(nil)
+}
+
+func TestRemoteClient_Get(t *testing.T) {
+	testCases := []struct {
+		name           string
+		statusCode     int
+		responseBody   string
+		expectNil      bool
+		expectError    bool
+		expectedErrMsg string
+	}{
+		{
+			name:         "successful get",
+			statusCode:   http.StatusOK,
+			responseBody: `{"version": 4, "terraform_version": "1.0.0"}`,
+			expectNil:    false,
+			expectError:  false,
+		},
+		{
+			name:        "not found",
+			statusCode:  http.StatusNotFound,
+			expectNil:   true,
+			expectError: false,
+		},
+		{
+			name:           "server error",
+			statusCode:     http.StatusInternalServerError,
+			responseBody:   "Internal Server Error",
+			expectNil:      true,
+			expectError:    true,
+			expectedErrMsg: "failed to get state",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "GET" {
+					t.Errorf("expected GET request, got %s", r.Method)
+				}
+				
+				// Verify authorization header
+				if auth := r.Header.Get("Authorization"); auth != "Bearer test-token" {
+					t.Errorf("expected Authorization header 'Bearer test-token', got %q", auth)
+				}
+				
+				w.WriteHeader(tc.statusCode)
+				if tc.responseBody != "" {
+					_, _ = w.Write([]byte(tc.responseBody))
+				}
+			}))
+			defer server.Close()
+
+			backend := &Backend{
+				apiToken:   "test-token",
+				httpClient: httpclient.New(context.Background()),
+				endpoint:   server.URL,
+			}
+
+			client := &RemoteClient{
+				backend:    backend,
+				bucketName: "test-bucket",
+				key:        "test.tfstate",
+			}
+
+			payload, err := client.Get(context.Background())
+
+			if tc.expectError {
+				if err == nil {
+					t.Fatal("expected error but got none")
+				}
+				if tc.expectedErrMsg != "" && !contains(err.Error(), tc.expectedErrMsg) {
+					t.Errorf("expected error containing %q, got %v", tc.expectedErrMsg, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+
+			if tc.expectNil {
+				if payload != nil {
+					t.Error("expected nil payload")
+				}
+			} else {
+				if payload == nil {
+					t.Error("expected non-nil payload")
+				} else {
+					if !bytes.Equal(payload.Data, []byte(tc.responseBody)) {
+						t.Errorf("payload data mismatch: expected %q, got %q", tc.responseBody, string(payload.Data))
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestRemoteClient_Put(t *testing.T) {
+	testCases := []struct {
+		name           string
+		statusCode     int
+		expectError    bool
+		expectedErrMsg string
+	}{
+		{
+			name:        "successful put",
+			statusCode:  http.StatusOK,
+			expectError: false,
+		},
+		{
+			name:        "successful put with 201",
+			statusCode:  http.StatusCreated,
+			expectError: false,
+		},
+		{
+			name:           "server error",
+			statusCode:     http.StatusInternalServerError,
+			expectError:    true,
+			expectedErrMsg: "failed to put state",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testData := []byte(`{"version": 4, "terraform_version": "1.0.0"}`)
+			
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "PUT" {
+					t.Errorf("expected PUT request, got %s", r.Method)
+				}
+				
+				// Verify headers
+				if auth := r.Header.Get("Authorization"); auth != "Bearer test-token" {
+					t.Errorf("expected Authorization header 'Bearer test-token', got %q", auth)
+				}
+				
+				if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+					t.Errorf("expected Content-Type 'application/json', got %q", ct)
+				}
+				
+				if r.Header.Get("Content-MD5") == "" {
+					t.Error("expected Content-MD5 header")
+				}
+				
+				w.WriteHeader(tc.statusCode)
+			}))
+			defer server.Close()
+
+			backend := &Backend{
+				apiToken:   "test-token",
+				httpClient: httpclient.New(context.Background()),
+				endpoint:   server.URL,
+			}
+
+			client := &RemoteClient{
+				backend:    backend,
+				bucketName: "test-bucket",
+				key:        "test.tfstate",
+			}
+
+			err := client.Put(context.Background(), testData)
+
+			if tc.expectError {
+				if err == nil {
+					t.Fatal("expected error but got none")
+				}
+				if tc.expectedErrMsg != "" && !contains(err.Error(), tc.expectedErrMsg) {
+					t.Errorf("expected error containing %q, got %v", tc.expectedErrMsg, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestRemoteClient_Delete(t *testing.T) {
+	testCases := []struct {
+		name           string
+		statusCode     int
+		expectError    bool
+		expectedErrMsg string
+	}{
+		{
+			name:        "successful delete 204",
+			statusCode:  http.StatusNoContent,
+			expectError: false,
+		},
+		{
+			name:        "successful delete 200",
+			statusCode:  http.StatusOK,
+			expectError: false,
+		},
+		{
+			name:        "not found is ok",
+			statusCode:  http.StatusNotFound,
+			expectError: false,
+		},
+		{
+			name:           "server error",
+			statusCode:     http.StatusInternalServerError,
+			expectError:    true,
+			expectedErrMsg: "failed to delete state",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "DELETE" {
+					t.Errorf("expected DELETE request, got %s", r.Method)
+				}
+				
+				// Verify authorization header
+				if auth := r.Header.Get("Authorization"); auth != "Bearer test-token" {
+					t.Errorf("expected Authorization header 'Bearer test-token', got %q", auth)
+				}
+				
+				w.WriteHeader(tc.statusCode)
+			}))
+			defer server.Close()
+
+			backend := &Backend{
+				apiToken:   "test-token",
+				httpClient: httpclient.New(context.Background()),
+				endpoint:   server.URL,
+			}
+
+			client := &RemoteClient{
+				backend:    backend,
+				bucketName: "test-bucket",
+				key:        "test.tfstate",
+			}
+
+			err := client.Delete(context.Background())
+
+			if tc.expectError {
+				if err == nil {
+					t.Fatal("expected error but got none")
+				}
+				if tc.expectedErrMsg != "" && !contains(err.Error(), tc.expectedErrMsg) {
+					t.Errorf("expected error containing %q, got %v", tc.expectedErrMsg, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestRemoteClient_Lock(t *testing.T) {
+	backend := &Backend{
+		apiToken:   "test-token",
+		httpClient: httpclient.New(context.Background()),
+	}
+
+	client := &RemoteClient{
+		backend:    backend,
+		bucketName: "test-bucket",
+		key:        "test.tfstate",
+	}
+
+	// Lock should always succeed with a simple ID
+	id, err := client.Lock(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if id != "r2-no-lock" {
+		t.Errorf("expected lock ID 'r2-no-lock', got %q", id)
+	}
+}
+
+func TestRemoteClient_Unlock(t *testing.T) {
+	backend := &Backend{
+		apiToken:   "test-token",
+		httpClient: httpclient.New(context.Background()),
+	}
+
+	client := &RemoteClient{
+		backend:    backend,
+		bucketName: "test-bucket",
+		key:        "test.tfstate",
+	}
+
+	// Unlock should always succeed
+	err := client.Unlock(context.Background(), "any-id")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRemoteClient_StateKey(t *testing.T) {
+	testCases := []struct {
+		name               string
+		key                string
+		workspaceKeyPrefix string
+		workspace          string
+		expected           string
+	}{
+		{
+			name:               "default workspace",
+			key:                "terraform.tfstate",
+			workspaceKeyPrefix: "env:",
+			workspace:          "default",
+			expected:           "terraform.tfstate",
+		},
+		{
+			name:               "named workspace",
+			key:                "terraform.tfstate",
+			workspaceKeyPrefix: "env:",
+			workspace:          "production",
+			expected:           "env:production/terraform.tfstate",
+		},
+		{
+			name:               "custom prefix",
+			key:                "state.tfstate",
+			workspaceKeyPrefix: "workspaces/",
+			workspace:          "staging",
+			expected:           "workspaces/staging/state.tfstate",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			backend := &Backend{
+				key:                tc.key,
+				workspaceKeyPrefix: tc.workspaceKeyPrefix,
+				encryption:         encryption.StateEncryptionDisabled(),
+			}
+
+			client, err := backend.remoteClient(tc.workspace)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if client.key != tc.expected {
+				t.Errorf("expected key %q, got %q", tc.expected, client.key)
+			}
+		})
+	}
+}

--- a/website/docs/language/settings/backends/r2.mdx
+++ b/website/docs/language/settings/backends/r2.mdx
@@ -1,0 +1,168 @@
+---
+sidebar_label: r2
+description: OpenTofu can store state remotely in Cloudflare R2 object storage.
+---
+
+# Backend Type: r2
+
+Stores the state as a given key in a given bucket on [Cloudflare R2](https://developers.cloudflare.com/r2/).
+
+This backend supports state locking via R2's conditional request headers.
+
+:::warning
+It is highly recommended that you enable [Object Versioning](https://developers.cloudflare.com/r2/buckets/object-versioning/) on the R2 bucket to allow for state recovery in the case of accidental deletions and human error.
+:::
+
+## Example Configuration
+
+```hcl
+terraform {
+  backend "r2" {
+    account_id = "1234567890abcdef1234567890abcdef"
+    api_token  = var.cloudflare_api_token
+    bucket     = "my-terraform-state"
+    key        = "production/terraform.tfstate"
+  }
+}
+```
+
+This assumes we have a bucket created called `my-terraform-state`. The OpenTofu state is written to the key `production/terraform.tfstate`.
+
+Note that for the access credentials we recommend using a [partial configuration](../../../language/settings/backends/configuration.mdx#partial-configuration).
+
+## Data Source Configuration
+
+To make use of the R2 remote state in another configuration, use the [`terraform_remote_state` data source](../../../language/state/remote-state-data.mdx).
+
+```hcl
+data "terraform_remote_state" "network" {
+  backend = "r2"
+  config = {
+    account_id = "1234567890abcdef1234567890abcdef"
+    api_token  = var.cloudflare_api_token
+    bucket     = "my-terraform-state"
+    key        = "network/terraform.tfstate"
+  }
+}
+```
+
+## Authentication
+
+The R2 backend requires a Cloudflare API token with appropriate permissions to access your R2 bucket.
+
+### API Token Permissions
+
+Your API token needs the following permissions:
+- **Account** - Cloudflare R2:Edit
+
+You can create an API token in the [Cloudflare dashboard](https://dash.cloudflare.com/profile/api-tokens) with the necessary permissions.
+
+:::warning
+Store your API token securely and never commit it to version control. Use environment variables or OpenTofu's partial configuration to supply sensitive values.
+:::
+
+## Jurisdictions
+
+Cloudflare R2 supports data localization through jurisdictions. You can specify where your data is stored by setting the `jurisdiction` parameter.
+
+```hcl
+terraform {
+  backend "r2" {
+    account_id   = "1234567890abcdef1234567890abcdef"
+    api_token    = var.cloudflare_api_token
+    bucket       = "my-terraform-state"
+    key          = "terraform.tfstate"
+    jurisdiction = "eu"
+  }
+}
+```
+
+Available jurisdictions:
+- `""` (empty/default) - Automatic region selection
+- `"eu"` - European Union
+- `"fedramp"` - FedRAMP
+
+## Workspaces
+
+The R2 backend supports OpenTofu workspaces. When using workspaces, the state file is stored at:
+- Default workspace: `<key>`
+- Named workspaces: `<workspace_key_prefix>/<workspace_name>/<key>`
+
+```hcl
+terraform {
+  backend "r2" {
+    account_id          = "1234567890abcdef1234567890abcdef"
+    api_token           = var.cloudflare_api_token
+    bucket              = "my-terraform-state"
+    key                 = "terraform.tfstate"
+    workspace_key_prefix = "workspaces"
+  }
+}
+```
+
+## State Locking
+
+The R2 backend implements state locking using R2's conditional request headers. This prevents concurrent state modifications without requiring additional infrastructure like DynamoDB.
+
+State locking is automatically enabled and cannot be disabled. If you need to force-unlock the state, you can use:
+
+```bash
+tofu force-unlock <lock-id>
+```
+
+## Configuration Variables
+
+:::danger Warning
+We recommend using environment variables to supply credentials and other sensitive data. If you use `-backend-config` or hardcode these values directly in your configuration, OpenTofu includes these values in both the `.terraform` subdirectory and in plan files. Refer to [Credentials and Sensitive Data](../../../language/settings/backends/configuration.mdx#credentials-and-sensitive-data) for details.
+:::
+
+The following configuration options are supported:
+
+- `account_id` - (Required) The Cloudflare account ID. This is a 32-character hexadecimal string.
+- `api_token` - (Required) A Cloudflare API token with R2 edit permissions. Can also be specified with the `CLOUDFLARE_API_TOKEN` environment variable.
+- `bucket` - (Required) The name of the R2 bucket.
+- `key` - (Required) The path to the state file inside the bucket.
+- `region` - (Optional) The AWS region for S3-compatible operations. Defaults to `"auto"`. This is primarily used for internal S3-compatible API calls.
+- `access_key_id` - (Optional) R2 access key ID for S3-compatible authentication. Can also be specified with the `CLOUDFLARE_R2_ACCESS_KEY_ID` environment variable.
+- `secret_access_key` - (Optional) R2 secret access key for S3-compatible authentication. Can also be specified with the `CLOUDFLARE_R2_SECRET_ACCESS_KEY` environment variable.
+- `workspace_key_prefix` - (Optional) The prefix applied to the state path inside the bucket when using workspaces. Defaults to `"env:"`.
+- `jurisdiction` - (Optional) The jurisdiction for data localization. Valid values are `""` (automatic), `"eu"` (European Union), or `"fedramp"`.
+- `endpoints` - (Optional) A block for configuring custom endpoints:
+  - `api` - (Optional) Custom API endpoint URL. Defaults to `"https://api.cloudflare.com"`.
+  - `s3` - (Optional) Custom S3-compatible endpoint URL. This is automatically determined based on account ID and jurisdiction if not specified.
+
+### Example with Environment Variables
+
+```bash
+export CLOUDFLARE_API_TOKEN="your-api-token"
+export CLOUDFLARE_R2_ACCESS_KEY_ID="your-access-key-id"
+export CLOUDFLARE_R2_SECRET_ACCESS_KEY="your-secret-access-key"
+```
+
+```hcl
+terraform {
+  backend "r2" {
+    account_id = "1234567890abcdef1234567890abcdef"
+    bucket     = "my-terraform-state"
+    key        = "terraform.tfstate"
+  }
+}
+```
+
+### Example with Custom Endpoints
+
+```hcl
+terraform {
+  backend "r2" {
+    account_id = "1234567890abcdef1234567890abcdef"
+    api_token  = var.cloudflare_api_token
+    bucket     = "my-terraform-state"
+    key        = "terraform.tfstate"
+    
+    endpoints = {
+      api = "https://api.cloudflare.com"
+      s3  = "https://1234567890abcdef1234567890abcdef.r2.cloudflarestorage.com"
+    }
+  }
+}
+```


### PR DESCRIPTION
Resolves #3075

## Description

This PR adds native support for Cloudflare R2 as a remote state backend. While R2 offers S3 compatibility, this implementation leverages Cloudflare's native APIs for improved functionality and user experience.

### Key Features

- **Native Cloudflare API Integration**: Uses Cloudflare API v4 for bucket operations
- **Simple Authentication**: Direct API token support without AWS signature complexity
- **Jurisdiction Support**: Built-in support for EU and FedRAMP data residency requirements
- **Workspace Management**: Full support for OpenTofu workspaces with configurable prefixes
- **S3-Compatible Object Operations**: Leverages R2's S3 API for reliable state storage

### Implementation Details

The R2 backend follows the established patterns from other remote state backends, particularly the S3 backend, while embracing simplicity and clarity. It consists of:

- `backend.go`: Core backend implementation with configuration schema
- `client.go`: Remote client for state read/write operations
- `backend_state.go`: Workspace management functionality
- Comprehensive test coverage for all functionality

## Example Usage

```hcl
terraform {
  backend "r2" {
    account_id = "1234567890abcdef1234567890abcdef"
    api_token  = var.cloudflare_api_token
    bucket     = "my-terraform-state"
    key        = "production/terraform.tfstate"
    
    # Optional: Workspace prefix (default: "env:")
    workspace_key_prefix = "workspaces/"
    
    # Optional: Jurisdiction for data residency
    # Valid values: "eu", "fedramp"
    jurisdiction = "eu"
  }
}

# Store your API token securely
variable "cloudflare_api_token" {
  description = "Cloudflare API token with R2 permissions"
  type        = string
  sensitive   = true
}
```

### Creating the Required Resources

Before using this backend, you'll need:

1. **Create an R2 bucket** in your Cloudflare account
2. **Generate an API token** with R2 permissions:
   - Go to My Profile > API Tokens in Cloudflare dashboard
   - Create a token with "Account:R2:Edit" permissions
   - Optionally scope the token to specific buckets

### Workspace Usage

The backend supports multiple workspaces. With the default configuration:
- Default workspace: `production/terraform.tfstate`
- Named workspace "dev": `env:dev/production/terraform.tfstate`

### Limitations

Unlike the S3 backend, R2 backend does not support:
- State locking (R2 doesn't have a DynamoDB equivalent)
- Custom encryption configuration (R2 encrypts all data at rest by default)

For state locking, consider using external coordination mechanisms or ensure only one process modifies the state at a time.

## Testing

All tests pass successfully:
```bash
$ go test -v ./internal/backend/remote-state/r2/
=== RUN   TestBackend_impl
--- PASS: TestBackend_impl (0.00s)
=== RUN   TestBackendConfig
--- PASS: TestBackendConfig (0.00s)
[... all tests passing ...]
PASS
ok      github.com/opentofu/opentofu/internal/backend/remote-state/r2  0.513s
```

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [ ] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
