### PR TITLE
Fix azure backend tests

### DIFF
--- a/internal/backend/remote-state/azure/backend_test.go
+++ b/internal/backend/remote-state/azure/backend_test.go
@@ -114,7 +114,7 @@ func TestAccBackendAccessKeyBasic(t *testing.T) {
 
 	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
+		if err := armClient.destroyTestResources(t, res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -142,7 +142,7 @@ func TestAccBackendSASTokenBasic(t *testing.T) {
 
 	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
+		if err := armClient.destroyTestResources(t, res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -175,7 +175,7 @@ func TestAccBackendOIDCBasic(t *testing.T) {
 
 	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
+		if err := armClient.destroyTestResources(t, res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -206,7 +206,7 @@ func TestAccBackendManagedServiceIdentityBasic(t *testing.T) {
 
 	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
+		if err := armClient.destroyTestResources(t, res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -244,7 +244,7 @@ func TestAccBackendServicePrincipalClientCertificateBasic(t *testing.T) {
 
 	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
+		if err := armClient.destroyTestResources(t, res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -277,7 +277,7 @@ func TestAccBackendServicePrincipalClientSecretBasic(t *testing.T) {
 
 	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
+		if err := armClient.destroyTestResources(t, res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -316,7 +316,7 @@ func TestAccBackendServicePrincipalClientSecretCustomEndpoint(t *testing.T) {
 
 	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
+		if err := armClient.destroyTestResources(t, res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -348,7 +348,7 @@ func TestAccBackendAccessKeyLocked(t *testing.T) {
 
 	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
+		if err := armClient.destroyTestResources(t, res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -389,7 +389,7 @@ func TestAccBackendServicePrincipalLocked(t *testing.T) {
 
 	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
+		if err := armClient.destroyTestResources(t, res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})

--- a/internal/backend/remote-state/azure/client.go
+++ b/internal/backend/remote-state/azure/client.go
@@ -42,7 +42,7 @@ func (c *RemoteClient) Get(ctx context.Context) (*remote.Payload, error) {
 	defer ctxCancel()
 	blob, err := c.giovanniBlobClient.Get(ctx, c.accountName, c.containerName, c.keyName, blobs.GetInput{LeaseID: c.leaseID})
 	if err != nil {
-		if blob.Response.IsHTTPStatus(http.StatusNotFound) {
+		if blob.IsHTTPStatus(http.StatusNotFound) {
 			return nil, nil
 		}
 		return nil, err
@@ -73,7 +73,7 @@ func (c *RemoteClient) Put(ctx context.Context, data []byte) error {
 
 	properties, err := c.getBlobProperties(ctx)
 	if err != nil {
-		if properties.StatusCode != http.StatusNotFound {
+		if !properties.IsHTTPStatus(http.StatusNotFound) {
 			return err
 		}
 	}
@@ -134,7 +134,7 @@ func (c *RemoteClient) Lock(ctx context.Context, info *statemgr.LockInfo) (strin
 	properties, err := c.getBlobProperties(ctx)
 	if err != nil {
 		// error if we had issues getting the blob
-		if !properties.Response.IsHTTPStatus(http.StatusNotFound) {
+		if !properties.IsHTTPStatus(http.StatusNotFound) {
 			return "", getLockInfoErr(err)
 		}
 		// if we don't find the blob, we need to build it

--- a/internal/backend/remote-state/azure/client_test.go
+++ b/internal/backend/remote-state/azure/client_test.go
@@ -29,7 +29,7 @@ func TestRemoteClientAccessKeyBasic(t *testing.T) {
 
 	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
+		if err := armClient.destroyTestResources(t, res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -62,7 +62,7 @@ func TestRemoteClientManagedServiceIdentityBasic(t *testing.T) {
 
 	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
+		if err := armClient.destroyTestResources(t, res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -98,7 +98,7 @@ func TestRemoteClientSasTokenBasic(t *testing.T) {
 
 	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
+		if err := armClient.destroyTestResources(t, res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -136,7 +136,7 @@ func TestRemoteClientServicePrincipalBasic(t *testing.T) {
 
 	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
+		if err := armClient.destroyTestResources(t, res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -173,7 +173,7 @@ func TestRemoteClientAccessKeyLocks(t *testing.T) {
 
 	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
+		if err := armClient.destroyTestResources(t, res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -220,7 +220,7 @@ func TestRemoteClientServicePrincipalLocks(t *testing.T) {
 
 	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
+		if err := armClient.destroyTestResources(t, res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -275,7 +275,7 @@ func TestPutMaintainsMetaData(t *testing.T) {
 
 	err := armClient.buildTestResources(t, t.Context(), &res)
 	t.Cleanup(func() {
-		if err := armClient.destroyTestResources(t, t.Context(), res); err != nil {
+		if err := armClient.destroyTestResources(t, res); err != nil {
 			t.Fatalf("error when destroying resources: %q", err)
 		}
 	})
@@ -312,9 +312,10 @@ func TestPutMaintainsMetaData(t *testing.T) {
 
 	// update the metadata using the Backend
 	remoteClient := RemoteClient{
-		keyName:       res.storageKeyName,
-		containerName: res.storageContainerName,
-		accountName:   res.storageAccountName,
+		keyName:        res.storageKeyName,
+		containerName:  res.storageContainerName,
+		accountName:    res.storageAccountName,
+		timeoutSeconds: defaultTimeout,
 
 		giovanniBlobClient: *client,
 	}

--- a/internal/backend/remote-state/azure/helpers_test.go
+++ b/internal/backend/remote-state/azure/helpers_test.go
@@ -89,6 +89,7 @@ func buildTestClient(t *testing.T, res resourceNames) *ArmClient {
 		StorageAccountName:            res.storageAccountName,
 		UseMsi:                        msiEnabled,
 		UseAzureADAuthentication:      res.useAzureADAuth,
+		TimeoutSeconds:                defaultTimeout,
 	})
 	if err != nil {
 		t.Fatalf("Failed to build ArmClient: %+v", err)
@@ -208,7 +209,9 @@ func (c *ArmClient) buildTestResources(t *testing.T, ctx context.Context, names 
 	return nil
 }
 
-func (c ArmClient) destroyTestResources(t *testing.T, ctx context.Context, resources resourceNames) error {
+func (c ArmClient) destroyTestResources(t *testing.T, resources resourceNames) error {
+	ctx := context.Background() // t.Context() is invalid during t.Cleanup
+
 	t.Helper()
 	t.Logf("[DEBUG] Deleting Resource Group %q..", resources.resourceGroup)
 	future, err := c.groupsClient.Delete(ctx, resources.resourceGroup)


### PR DESCRIPTION
* Panic in azure/client.go from nil embedded response
* Unset timeouts causing sporatic context errors
* Removing usages of t.Context() within t.Cleanup (not a valid context)

<!-- If your PR resolves an issue, please add it here. -->
Fixes tests on main for https://github.com/opentofu/opentofu/pull/3083

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
