### PR TITLE
Added tests for UnmarkDeepWithPathsDeprecated

### DIFF
--- a/internal/command/e2etest/automation_test.go
+++ b/internal/command/e2etest/automation_test.go
@@ -244,36 +244,3 @@ func TestPlanOnlyInAutomation(t *testing.T) {
 	}
 }
 
-func TestPlanOnDeprecated(t *testing.T) {
-	t.Parallel()
-
-	fixturePath := filepath.Join("testdata", "deprecated-values")
-	tf := e2e.NewBinary(t, tofuBin, fixturePath)
-
-	//// INIT
-	_, stderr, err := tf.Run("init", "-input=false")
-	if err != nil {
-		t.Fatalf("unexpected init error: %s\nstderr:\n%s", err, stderr)
-	}
-
-	//// PLAN
-	stdout, stderr, err := tf.Run("plan")
-	if err != nil {
-		t.Fatalf("unexpected plan error: %s\nstderr:\n%s", err, stderr)
-	}
-
-	expected := []string{
-		`Variable marked as deprecated by the module author`,
-		`Variable "input" is marked as deprecated with the following message`,
-		`This var is deprecated`,
-		`Value derived from a deprecated source`,
-		`This value is derived from module.call.output, which is deprecated with the`,
-		`following message:`,
-		`this output is deprecated`,
-	}
-	for _, want := range expected {
-		if !strings.Contains(stdout, want) {
-			t.Errorf("invalid plan output. expected to contain %q but it does not:\n%s", want, stdout)
-		}
-	}
-}

--- a/internal/command/e2etest/plan_test.go
+++ b/internal/command/e2etest/plan_test.go
@@ -94,3 +94,76 @@ found no differences, so no changes are needed.
 		}
 	})
 }
+
+func TestPlanOnDeprecated(t *testing.T) {
+	t.Parallel()
+
+	fixturePath := filepath.Join("testdata", "deprecated-values")
+	tf := e2e.NewBinary(t, tofuBin, fixturePath)
+
+	//// INIT
+	_, stderr, err := tf.Run("init", "-input=false")
+	if err != nil {
+		t.Fatalf("unexpected init error: %s\nstderr:\n%s", err, stderr)
+	}
+
+	//// PLAN
+	stdout, stderr, err := tf.Run("plan")
+	if err != nil {
+		t.Fatalf("unexpected plan error: %s\nstderr:\n%s", err, stderr)
+	}
+
+	expected := []string{
+		`Variable marked as deprecated by the module author`,
+		`Variable "input" is marked as deprecated with the following message`,
+		`This var is deprecated`,
+		`Value derived from a deprecated source`,
+		`This value is derived from module.call.output, which is deprecated with the`,
+		`following message:`,
+		`this output is deprecated`,
+	}
+	for _, want := range expected {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("invalid plan output. expected to contain %q but it does not:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestPlanOnMultipleDeprecatedMarksSliceBug(t *testing.T) {
+	t.Parallel()
+
+	// Test for the bug where modifying pathMarks slice during iteration
+	// would cause slice bounds errors when multiple deprecated marks exist
+	fixturePath := filepath.Join("testdata", "multiple-deprecated-marks-slice-bug")
+	tf := e2e.NewBinary(t, tofuBin, fixturePath)
+
+	t.Run("multiple deprecated marks slice bug", func(t *testing.T) {
+		_, initErr, err := tf.Run("init")
+		if err != nil {
+			t.Fatalf("expected no errors on init, got error %v: %s", err, initErr)
+		}
+
+		planStdout, planErr, err := tf.Run("plan")
+		if err != nil {
+			t.Fatalf("expected no errors on plan, got error %v: %s", err, planErr)
+		}
+
+		// Should not crash and should show deprecation warnings for all outputs
+		expectedContents := []string{
+			"Changes to Outputs:",
+			"trigger = {",
+			"Value derived from a deprecated source",
+			"Use new_out1",
+			"Use new_out2", 
+			"Use new_out3",
+		}
+
+		// Strip ANSI codes for consistent testing
+		cleanOutput := stripAnsi(planStdout)
+		for _, want := range expectedContents {
+			if !strings.Contains(cleanOutput, want) {
+				t.Errorf("plan output missing expected content %q:\n%s", want, cleanOutput)
+			}
+		}
+	})
+}

--- a/internal/command/e2etest/testdata/multiple-deprecated-marks-slice-bug/main.tf
+++ b/internal/command/e2etest/testdata/multiple-deprecated-marks-slice-bug/main.tf
@@ -1,0 +1,19 @@
+module "test" {
+  source = "./module"
+}
+
+# This creates a SINGLE value with MULTIPLE deprecated marks at different paths
+# Each field gets its own PathValueMark with ONLY a deprecation mark
+# This pattern triggers the slice modification bug in unmarkDeepWithPathsDeprecated
+locals {
+  all_deprecated = {
+    a = module.test.out1
+    b = module.test.out2
+    c = module.test.out3
+  }
+}
+
+# Force evaluation by using in an output
+output "trigger" {
+  value = local.all_deprecated
+}

--- a/internal/command/e2etest/testdata/multiple-deprecated-marks-slice-bug/module/main.tf
+++ b/internal/command/e2etest/testdata/multiple-deprecated-marks-slice-bug/module/main.tf
@@ -1,0 +1,14 @@
+output "out1" {
+  value = "value1"
+  deprecated = "Use new_out1"
+}
+
+output "out2" {
+  value = "value2"
+  deprecated = "Use new_out2"
+}
+
+output "out3" {
+  value = "value3"
+  deprecated = "Use new_out3"
+}

--- a/internal/lang/marks/marks.go
+++ b/internal/lang/marks/marks.go
@@ -10,9 +10,10 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // valueMarks allow creating strictly typed values for use as cty.Value marks.
@@ -188,6 +189,8 @@ func ExtractDeprecatedDiagnosticsWithExpr(val cty.Value, expr hcl.Expression) (c
 	return val, diags
 }
 
+// unmarkDeepWithPathsDeprecated removes all deprecation marks from a value and returns them separately.
+// It returns both the input value with all deprecation marks removed whilst preserving other marks, and a slice of PathValueMarks where marks were removed.
 func unmarkDeepWithPathsDeprecated(val cty.Value) (cty.Value, []cty.PathValueMarks) {
 	unmarked, pathMarks := val.UnmarkDeepWithPaths()
 


### PR DESCRIPTION
Resolves #3104

This PR also does the following

- Introduces an end2end test for this scenario
- Improves test coverage around deprecation mark detection and unmarking
- Moves planning with deprecation e2e tests into a more "intuitive" location

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [ ] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [ ] I have not used an AI coding assistant to create this PR.
- [ ] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [ ] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.