### PR TITLE
Validations should only be run during non-destroy operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ BUG FIXES:
 * The `issensitive` function now returns an unknown result when its argument is unknown, since a sensitive unknown value can potentially become non-sensitive once more information is available. ([#3008](https://github.com/opentofu/opentofu/pull/3008))
 * Provider references like "null.some_alias[each.key]" in .tf.json files are now correctly parsed ([#2915](https://github.com/opentofu/opentofu/issues/2915))
 * Fixed crash when processing multiple deprecated marks on a complex object ([#3105](https://github.com/opentofu/opentofu/pull/3105))
+* Variables with validation no longer interfere with the destroy process ([#3131](https://github.com/opentofu/opentofu/pull/3131))
 
 ## Previous Releases
 

--- a/internal/tofu/graph_builder_apply.go
+++ b/internal/tofu/graph_builder_apply.go
@@ -194,7 +194,9 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		// We need to remove configuration nodes that are not used at all, as
 		// they may not be able to evaluate, especially during destroy.
 		// These include variables, locals, and instance expanders.
-		&pruneUnusedNodesTransformer{},
+		&pruneUnusedNodesTransformer{
+			Op: b.Operation,
+		},
 
 		// Target
 		&TargetingTransformer{Targets: b.Targets, Excludes: b.Excludes},

--- a/internal/tofu/graph_builder_plan.go
+++ b/internal/tofu/graph_builder_plan.go
@@ -248,7 +248,7 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		},
 
 		&pruneUnusedNodesTransformer{
-			skip: b.Operation != walkPlanDestroy,
+			Op: b.Operation,
 		},
 
 		// Target

--- a/internal/tofu/node_local.go
+++ b/internal/tofu/node_local.go
@@ -39,7 +39,7 @@ var (
 func (n *nodeExpandLocal) expandsInstances() {}
 
 // graphNodeTemporaryValue
-func (n *nodeExpandLocal) temporaryValue() bool {
+func (n *nodeExpandLocal) temporaryValue(_ walkOperation) bool {
 	return true
 }
 
@@ -103,7 +103,7 @@ var (
 )
 
 // graphNodeTemporaryValue
-func (n *NodeLocal) temporaryValue() bool {
+func (n *NodeLocal) temporaryValue(_ walkOperation) bool {
 	return true
 }
 

--- a/internal/tofu/node_module_variable.go
+++ b/internal/tofu/node_module_variable.go
@@ -41,7 +41,7 @@ var (
 
 func (n *nodeExpandModuleVariable) expandsInstances() {}
 
-func (n *nodeExpandModuleVariable) temporaryValue() bool {
+func (n *nodeExpandModuleVariable) temporaryValue(_ walkOperation) bool {
 	return true
 }
 
@@ -130,7 +130,7 @@ var (
 	_ dag.GraphNodeDotter     = (*nodeModuleVariable)(nil)
 )
 
-func (n *nodeModuleVariable) temporaryValue() bool {
+func (n *nodeModuleVariable) temporaryValue(_ walkOperation) bool {
 	return true
 }
 

--- a/internal/tofu/node_output.go
+++ b/internal/tofu/node_output.go
@@ -52,7 +52,7 @@ var (
 
 func (n *nodeExpandOutput) expandsInstances() {}
 
-func (n *nodeExpandOutput) temporaryValue() bool {
+func (n *nodeExpandOutput) temporaryValue(_ walkOperation) bool {
 	// non root outputs are temporary
 	return !n.Module.IsRoot()
 }
@@ -220,7 +220,7 @@ var (
 	_ dag.GraphNodeDotter       = (*NodeApplyableOutput)(nil)
 )
 
-func (n *NodeApplyableOutput) temporaryValue() bool {
+func (n *NodeApplyableOutput) temporaryValue(_ walkOperation) bool {
 	// this must always be evaluated if it is a root module output
 	return !n.Addr.Module.IsRoot()
 }
@@ -499,7 +499,7 @@ func (n *NodeDestroyableOutput) ModulePath() addrs.Module {
 	return n.Addr.Module.Module()
 }
 
-func (n *NodeDestroyableOutput) temporaryValue() bool {
+func (n *NodeDestroyableOutput) temporaryValue(_ walkOperation) bool {
 	// this must always be evaluated if it is a root module output
 	return !n.Addr.Module.IsRoot()
 }

--- a/internal/tofu/node_value.go
+++ b/internal/tofu/node_value.go
@@ -11,5 +11,5 @@ package tofu
 // A boolean return value allows a node which may need to be saved to
 // conditionally do so.
 type graphNodeTemporaryValue interface {
-	temporaryValue() bool
+	temporaryValue(op walkOperation) bool
 }

--- a/internal/tofu/node_variable_reference.go
+++ b/internal/tofu/node_variable_reference.go
@@ -45,8 +45,8 @@ var (
 func (n *nodeVariableReference) expandsInstances() {}
 
 // Abuse graphNodeTemporaryValue to keep the validation rule around
-func (n *nodeVariableReference) temporaryValue() bool {
-	return len(n.Config.Validations) == 0
+func (n *nodeVariableReference) temporaryValue(op walkOperation) bool {
+	return len(n.Config.Validations) == 0 || op == walkDestroy || op == walkPlanDestroy
 }
 
 // GraphNodeDynamicExpandable

--- a/internal/tofu/transform_destroy_edge_test.go
+++ b/internal/tofu/transform_destroy_edge_test.go
@@ -411,7 +411,7 @@ func TestPruneUnusedNodesTransformer_rootModuleOutputValues(t *testing.T) {
 			},
 			&ReferenceTransformer{},
 			&AttachDependenciesTransformer{},
-			&pruneUnusedNodesTransformer{},
+			&pruneUnusedNodesTransformer{Op: walkDestroy},
 			&CloseRootModuleTransformer{},
 		},
 	}

--- a/internal/tofu/transform_targets.go
+++ b/internal/tofu/transform_targets.go
@@ -204,6 +204,7 @@ func (t *TargetingTransformer) getTargetedOutputNodes(targetedNodes dag.Set, gra
 
 		// root module outputs indicate that while they are an output type,
 		// they not temporary and will return false here.
+		// We use walkInvalid here as we only care about the op as a workaround for nodeVariableReference, which does not apply here
 		if tv.temporaryValue(walkInvalid) {
 			continue
 		}

--- a/internal/tofu/transform_targets.go
+++ b/internal/tofu/transform_targets.go
@@ -204,7 +204,7 @@ func (t *TargetingTransformer) getTargetedOutputNodes(targetedNodes dag.Set, gra
 
 		// root module outputs indicate that while they are an output type,
 		// they not temporary and will return false here.
-		if tv.temporaryValue() {
+		if tv.temporaryValue(walkInvalid) {
 			continue
 		}
 


### PR DESCRIPTION
This fixes an issue I originally introduced in https://github.com/opentofu/opentofu/pull/2216.  The original PR and this PR try to modify the graph transformation process as little as possible due to it's complexity.

Unfortunately, I introduced a path in #2216 for apply that does not apply to destroy operations.  In both apply and destroy, we aggressively prune the graph to minimize what actually needs to be evaluated in order to make the necessary changes.  This work is done in the pruneUnusedNodesTransformer and relies upon some very specific interface implementation and dense logic.

For #2216, I needed to ensure that variable blocks that have validations are not pruned out from the graph between plan -> apply.  I introduced an interface implementation that allows the node to say "Hey!  I still need to exist!  Don't prune me!".  That worked reasonably well for the standard apply scenario, and I added a test to confirm.

However, I did not fully understand the implications for destroy.  During a destroy action, the variables should be pruned from the graph and the check not run, as the data it's targeting won't exist (the reason for the check/validation).  When it is not pruned, it keeps "configuration" nodes within the apply graph which do not function correctly during destroy operations.

This is not an ideal solution, but it has a very small likelihood of breaking existing workflows.  As evidenced by the complexity described above, this is a very tricky thing to modify correctly, and the smaller the change we can make, the better.  Longer term, I hope that something that comes out of #3078 will allow us to simplify this whole process.

I still need to add a bespoke test case to context_apply2_test.go and update the changelog

<!-- If your PR resolves an issue, please add it here. -->
Resolves #3126 

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
