### PR TITLE
Fix the ephemeral resources diagnostics block range

### DIFF
--- a/internal/configs/resource.go
+++ b/internal/configs/resource.go
@@ -607,20 +607,20 @@ func decodeEphemeralBlock(block *hcl.Block, override bool) (*Resource, hcl.Diagn
 		r.DependsOn = append(r.DependsOn, deps...)
 	}
 
-	invalidEphemeralLifecycleAttributeDiag := func(field string) *hcl.Diagnostic {
+	invalidEphemeralLifecycleAttributeDiag := func(field string, subj hcl.Range) *hcl.Diagnostic {
 		return &hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Invalid lifecycle configuration for ephemeral resource",
 			Detail:   fmt.Sprintf("The lifecycle argument %q cannot be used in ephemeral resources. This is meant to be used strictly in \"resource\" blocks.", field),
-			Subject:  &block.DefRange,
+			Subject:  &subj,
 		}
 	}
-	invalidEphemeralBlockDiag := func(field string) *hcl.Diagnostic {
+	invalidEphemeralBlockDiag := func(field string, subj hcl.Range) *hcl.Diagnostic {
 		return &hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Invalid configuration block for ephemeral resource",
 			Detail:   fmt.Sprintf("The block type %q cannot be used in ephemeral resources. This is meant to be used strictly in \"resource\" blocks.", field),
-			Subject:  &block.DefRange,
+			Subject:  &subj,
 		}
 	}
 	var seenLifecycle *hcl.Block
@@ -643,16 +643,16 @@ func decodeEphemeralBlock(block *hcl.Block, override bool) (*Resource, hcl.Diagn
 			diags = append(diags, lcDiags...)
 
 			if _, exists := lcContent.Attributes["create_before_destroy"]; exists {
-				diags = append(diags, invalidEphemeralLifecycleAttributeDiag("create_before_destroy"))
+				diags = append(diags, invalidEphemeralLifecycleAttributeDiag("create_before_destroy", block.DefRange))
 			}
 			if _, exists := lcContent.Attributes["prevent_destroy"]; exists {
-				diags = append(diags, invalidEphemeralLifecycleAttributeDiag("prevent_destroy"))
+				diags = append(diags, invalidEphemeralLifecycleAttributeDiag("prevent_destroy", block.DefRange))
 			}
 			if _, exists := lcContent.Attributes["replace_triggered_by"]; exists {
-				diags = append(diags, invalidEphemeralLifecycleAttributeDiag("replace_triggered_by"))
+				diags = append(diags, invalidEphemeralLifecycleAttributeDiag("replace_triggered_by", block.DefRange))
 			}
 			if _, exists := lcContent.Attributes["ignore_changes"]; exists {
-				diags = append(diags, invalidEphemeralLifecycleAttributeDiag("ignore_changes"))
+				diags = append(diags, invalidEphemeralLifecycleAttributeDiag("ignore_changes", block.DefRange))
 			}
 			for _, block := range lcContent.Blocks {
 				switch block.Type {
@@ -677,10 +677,10 @@ func decodeEphemeralBlock(block *hcl.Block, override bool) (*Resource, hcl.Diagn
 			}
 
 		case "connection":
-			diags = append(diags, invalidEphemeralBlockDiag("connection"))
+			diags = append(diags, invalidEphemeralBlockDiag("connection", block.DefRange))
 
 		case "provisioner":
-			diags = append(diags, invalidEphemeralBlockDiag("provisioner"))
+			diags = append(diags, invalidEphemeralBlockDiag("provisioner", block.DefRange))
 
 		case "_":
 			if seenEscapeBlock != nil {


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Part of #2834
Initially, the function to generate diags was using the root block `hcl.Range`. Now, it points directly to the affected sub-block.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
