### PR TITLE
plan diff: summarize the current -> planned notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ ENHANCEMENTS:
 * Multiline string updates in arrays are now diffed line-by-line, rather than as a single element, making it easier to see changes in the plan output. ([#3030](https://github.com/opentofu/opentofu/pull/3030))
 * Add full support for -var, -var-file, and TF_VARS during `tofu apply` to support plan encryption ([#1998](https://github.com/opentofu/opentofu/pull/1998))
 * The S3 state backend now supports arguments to specify tags of the state and lock files. [#3038](https://github.com/opentofu/opentofu/pull/3038)
+* Plan UI now explicitly states that the "update in-place" notation is "current -> planned", as part of the existing description of the meaning of each change type symbol. ([#3159](https://github.com/opentofu/opentofu/pull/3159))
 * Upgrade go from 1.24.4 to 1.24.6 to fix [GO-2025-3849](https://pkg.go.dev/vuln/GO-2025-3849) ([3127](https://github.com/opentofu/opentofu/pull/3127))
 * Improved error messages when a submodule is not found in a module ([#3144]https://github.com/opentofu/opentofu/pull/3144)
 * Add support for the `for_each` attribute in the `mock_provider` block. ([#3087](https://github.com/opentofu/opentofu/pull/3087))

--- a/internal/command/jsonformat/plan.go
+++ b/internal/command/jsonformat/plan.go
@@ -570,7 +570,7 @@ func actionDescription(action plans.Action) string {
 	case plans.Delete:
 		return "  [red]-[reset] destroy"
 	case plans.Update:
-		return "  [yellow]~[reset] update in-place"
+		return "  [yellow]~[reset] update in-place (current -> planned)"
 	case plans.CreateThenDelete:
 		return "[green]+[reset]/[red]-[reset] create replacement and then destroy"
 	case plans.DeleteThenCreate:

--- a/internal/command/jsonformat/plan_test.go
+++ b/internal/command/jsonformat/plan_test.go
@@ -259,7 +259,7 @@ Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.
 			output: `
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 
@@ -303,7 +303,7 @@ Plan: 1 to import, 0 to add, 1 to change, 0 to destroy.
 			output: `
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 
@@ -344,7 +344,7 @@ Plan: 1 to import, 0 to add, 1 to change, 0 to destroy.
 			output: `
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -1041,7 +1041,7 @@ Plan: 1 to add, 0 to change, 0 to destroy.
 
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 
@@ -1056,7 +1056,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
 
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 

--- a/testing/equivalence-tests/outputs/basic_json_string_update/plan
+++ b/testing/equivalence-tests/outputs/basic_json_string_update/plan
@@ -2,7 +2,7 @@ tfcoremock_simple_resource.json: Refreshing state... [id=5a3fd9b3-e852-8956-8c0a
 
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 

--- a/testing/equivalence-tests/outputs/basic_list_empty/plan
+++ b/testing/equivalence-tests/outputs/basic_list_empty/plan
@@ -2,7 +2,7 @@ tfcoremock_list.list: Refreshing state... [id=985820B3-ACF9-4F00-94AD-F81C5EA336
 
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 

--- a/testing/equivalence-tests/outputs/basic_list_null/plan
+++ b/testing/equivalence-tests/outputs/basic_list_null/plan
@@ -2,7 +2,7 @@ tfcoremock_list.list: Refreshing state... [id=985820B3-ACF9-4F00-94AD-F81C5EA336
 
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 

--- a/testing/equivalence-tests/outputs/basic_list_update/plan
+++ b/testing/equivalence-tests/outputs/basic_list_update/plan
@@ -2,7 +2,7 @@ tfcoremock_list.list: Refreshing state... [id=985820B3-ACF9-4F00-94AD-F81C5EA336
 
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 

--- a/testing/equivalence-tests/outputs/basic_map_empty/plan
+++ b/testing/equivalence-tests/outputs/basic_map_empty/plan
@@ -2,7 +2,7 @@ tfcoremock_map.map: Refreshing state... [id=50E1A46E-E64A-4C1F-881C-BA85A5440964
 
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 

--- a/testing/equivalence-tests/outputs/basic_map_null/plan
+++ b/testing/equivalence-tests/outputs/basic_map_null/plan
@@ -2,7 +2,7 @@ tfcoremock_map.map: Refreshing state... [id=50E1A46E-E64A-4C1F-881C-BA85A5440964
 
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 

--- a/testing/equivalence-tests/outputs/basic_map_update/plan
+++ b/testing/equivalence-tests/outputs/basic_map_update/plan
@@ -2,7 +2,7 @@ tfcoremock_map.map: Refreshing state... [id=50E1A46E-E64A-4C1F-881C-BA85A5440964
 
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 

--- a/testing/equivalence-tests/outputs/basic_multiline_string_update/plan
+++ b/testing/equivalence-tests/outputs/basic_multiline_string_update/plan
@@ -2,7 +2,7 @@ tfcoremock_simple_resource.multiline: Refreshing state... [id=69fe5233-e77a-804f
 
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 

--- a/testing/equivalence-tests/outputs/basic_set_empty/plan
+++ b/testing/equivalence-tests/outputs/basic_set_empty/plan
@@ -2,7 +2,7 @@ tfcoremock_set.set: Refreshing state... [id=046952C9-B832-4106-82C0-C217F7C73E18
 
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 

--- a/testing/equivalence-tests/outputs/basic_set_null/plan
+++ b/testing/equivalence-tests/outputs/basic_set_null/plan
@@ -2,7 +2,7 @@ tfcoremock_set.set: Refreshing state... [id=046952C9-B832-4106-82C0-C217F7C73E18
 
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 

--- a/testing/equivalence-tests/outputs/basic_set_update/plan
+++ b/testing/equivalence-tests/outputs/basic_set_update/plan
@@ -2,7 +2,7 @@ tfcoremock_set.set: Refreshing state... [id=046952C9-B832-4106-82C0-C217F7C73E18
 
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 

--- a/testing/equivalence-tests/outputs/drift_relevant_attributes/plan
+++ b/testing/equivalence-tests/outputs/drift_relevant_attributes/plan
@@ -22,7 +22,7 @@ actions to undo or respond to these changes.
 
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 

--- a/testing/equivalence-tests/outputs/drift_simple/plan
+++ b/testing/equivalence-tests/outputs/drift_simple/plan
@@ -2,7 +2,7 @@ tfcoremock_simple_resource.drift: Refreshing state... [id=f3c6ddc5-37d5-0170-64f
 
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 

--- a/testing/equivalence-tests/outputs/fully_populated_complex_update/plan
+++ b/testing/equivalence-tests/outputs/fully_populated_complex_update/plan
@@ -2,7 +2,7 @@ tfcoremock_complex_resource.complex: Refreshing state... [id=64564E36-BFCB-458B-
 
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 

--- a/testing/equivalence-tests/outputs/moved_with_drift/plan
+++ b/testing/equivalence-tests/outputs/moved_with_drift/plan
@@ -22,7 +22,7 @@ actions to undo or respond to these changes.
 
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 

--- a/testing/equivalence-tests/outputs/moved_with_update/plan
+++ b/testing/equivalence-tests/outputs/moved_with_update/plan
@@ -2,7 +2,7 @@ tfcoremock_simple_resource.moved: Refreshing state... [id=7da63aeb-f908-a112-988
 
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 

--- a/testing/equivalence-tests/outputs/multiple_block_types_update/plan
+++ b/testing/equivalence-tests/outputs/multiple_block_types_update/plan
@@ -2,7 +2,7 @@ tfcoremock_multiple_blocks.multiple_blocks: Refreshing state... [id=DA051126-BAD
 
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 

--- a/testing/equivalence-tests/outputs/nested_list_update/plan
+++ b/testing/equivalence-tests/outputs/nested_list_update/plan
@@ -2,7 +2,7 @@ tfcoremock_nested_list.nested_list: Refreshing state... [id=DA051126-BAD6-4EB2-9
 
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 

--- a/testing/equivalence-tests/outputs/nested_map_update/plan
+++ b/testing/equivalence-tests/outputs/nested_map_update/plan
@@ -2,7 +2,7 @@ tfcoremock_nested_map.nested_map: Refreshing state... [id=502B0348-B796-4F6A-869
 
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 

--- a/testing/equivalence-tests/outputs/nested_objects_update/plan
+++ b/testing/equivalence-tests/outputs/nested_objects_update/plan
@@ -2,7 +2,7 @@ tfcoremock_nested_object.nested_object: Refreshing state... [id=B2491EF0-9361-40
 
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 

--- a/testing/equivalence-tests/outputs/nested_set_update/plan
+++ b/testing/equivalence-tests/outputs/nested_set_update/plan
@@ -2,7 +2,7 @@ tfcoremock_nested_set.nested_set: Refreshing state... [id=510598F6-83FE-4090-898
 
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 

--- a/testing/equivalence-tests/outputs/simple_object_empty/plan
+++ b/testing/equivalence-tests/outputs/simple_object_empty/plan
@@ -2,7 +2,7 @@ tfcoremock_object.object: Refreshing state... [id=00e14fba-4d56-6cc5-b685-633555
 
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 

--- a/testing/equivalence-tests/outputs/simple_object_null/plan
+++ b/testing/equivalence-tests/outputs/simple_object_null/plan
@@ -2,7 +2,7 @@ tfcoremock_object.object: Refreshing state... [id=00e14fba-4d56-6cc5-b685-633555
 
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 

--- a/testing/equivalence-tests/outputs/simple_object_update/plan
+++ b/testing/equivalence-tests/outputs/simple_object_update/plan
@@ -2,7 +2,7 @@ tfcoremock_object.object: Refreshing state... [id=00e14fba-4d56-6cc5-b685-633555
 
 OpenTofu used the selected providers to generate the following execution
 plan. Resource actions are indicated with the following symbols:
-  ~ update in-place
+  ~ update in-place (current -> planned)
 
 OpenTofu will perform the following actions:
 


### PR DESCRIPTION
The human-oriented plan output includes a short summary of the meaning of all of the different "icons" used to describe different kinds of change, but nothing was previously describing how OpenTofu uses `->` to describe the transition between current and planned values for update in-place, `~`.

We'll now include a concise note about that as part of the icon summary, keeping things still relatively compact but nonetheless giving something to refer to if a reader is unsure about the meaning of this notation.

Closes https://github.com/opentofu/opentofu/issues/3158.
