### PR TITLE
.github/workflows: Treat workflow changes as Go changes

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,9 +40,8 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - id: diff 
         run: |
-          echo "Comparing head_commit ${{github.event.push.head_commit}} to base_ref ${{github.event.push.base_ref}}"
           git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin ${{github.event.pull_request.base.ref}}
-          echo "go=$(git diff --name-only origin/${{github.event.pull_request.base.ref}} | grep '\.go' | wc -l)" | tee -a "$GITHUB_OUTPUT"
+          echo "go=$(git diff --name-only origin/${{github.event.pull_request.base.ref}} | grep -e '\.go' -e '\.github' | wc -l)" | tee -a "$GITHUB_OUTPUT"
     outputs:
       go: ${{ steps.diff.outputs.go }}
     


### PR DESCRIPTION
We have some logic to try to skip running the Go tests when no Go source files have changed, but that means that a commit that only changes the workflows won't run the unit tests.

To work around this, we'll also treat changes under the .github directory as if they are "Go changes", since _everything_ should run when we're changing the workflows so that we can make sure the workflows actually still all work.

This started as part of https://github.com/opentofu/opentofu/pull/3055, but it's a general rule that applies to more than just unit tests running on Windows so I've split it out here for separate review and perhaps being merged long before we're ready to enable unit tests runs on Windows.
