### PR TITLE
go.mod: go get oras.land/oras-go/v2@v2.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/nishanths/exhaustive v0.7.11
 	github.com/openbao/openbao/api/v2 v2.3.0
 	github.com/opencontainers/go-digest v1.0.0
-	github.com/opencontainers/image-spec v1.1.0
+	github.com/opencontainers/image-spec v1.1.1
 	github.com/opentofu/registry-address/v2 v2.0.0-20250611143131-d0a99bd8acdd
 	github.com/opentofu/svchost v0.0.0-20250610175836-86c9e5e3d8c8
 	github.com/packer-community/winrmcp v0.0.0-20180921211025-c76d91c1e7db
@@ -117,7 +117,7 @@ require (
 	k8s.io/apimachinery v0.23.4
 	k8s.io/client-go v0.23.4
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed
-	oras.land/oras-go/v2 v2.5.0
+	oras.land/oras-go/v2 v2.6.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -920,8 +920,8 @@ github.com/openbao/openbao/api/v2 v2.3.0 h1:61FO3ILtpKoxbD9kTWeGaCq8pz1sdt4dv2cm
 github.com/openbao/openbao/api/v2 v2.3.0/go.mod h1:T47WKHb7DqHa3Ms3xicQtl5EiPE+U8diKjb9888okWs=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
-github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
-github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
+github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
+github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/opentofu/hcl/v2 v2.20.2-0.20250121132637-504036cd70e7 h1:QHUIrylb/q3pQdQcnAr74cGWsXS1lmA8GqP+RWFMK6U=
 github.com/opentofu/hcl/v2 v2.20.2-0.20250121132637-504036cd70e7/go.mod h1:k+HgkLpoWu9OS81sy4j1XKDXaWm/rLysG33v5ibdDnc=
 github.com/opentofu/registry-address/v2 v2.0.0-20250611143131-d0a99bd8acdd h1:YAAnzmyOoMvm5SuGXL4hhlfBgqz92XDfORGPV3kmQFc=
@@ -1791,8 +1791,8 @@ k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65/go.mod h1:sX9MT8g7NVZM5lV
 k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20211116205334-6203023598ed h1:ck1fRPWPJWsMd8ZRFsWc6mh/zHp5fZ/shhbrgPUxDAE=
 k8s.io/utils v0.0.0-20211116205334-6203023598ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-oras.land/oras-go/v2 v2.5.0 h1:o8Me9kLY74Vp5uw07QXPiitjsw7qNXi8Twd+19Zf02c=
-oras.land/oras-go/v2 v2.5.0/go.mod h1:z4eisnLP530vwIOUOJeBIj0aGI0L1C3d53atvCBqZHg=
+oras.land/oras-go/v2 v2.6.0 h1:X4ELRsiGkrbeox69+9tzTu492FMUu7zJQW6eJU+I2oc=
+oras.land/oras-go/v2 v2.6.0/go.mod h1:magiQDfG6H1O9APp+rOsvCPcW1GD2MM7vgnKY0Y+u1o=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/internal/getmodules/oci_getter.go
+++ b/internal/getmodules/oci_getter.go
@@ -283,7 +283,7 @@ func (g *ociDistributionGetter) resolveManifestDescriptor(ctx context.Context, r
 		)
 		desc, err = store.Resolve(ctx, wantTag)
 		if err != nil {
-			return ociv1.Descriptor{}, prepErr(fmt.Errorf("resolving tag %q: %w", wantTag, err))
+			return ociv1.Descriptor{}, prepErr(fmt.Errorf("resolving tag: %w", err))
 		}
 	} else {
 		// If we're requesting a specific digest then we still need to
@@ -298,7 +298,7 @@ func (g *ociDistributionGetter) resolveManifestDescriptor(ctx context.Context, r
 		)
 		desc, err = store.Resolve(ctx, wantDigest.String())
 		if err != nil {
-			return ociv1.Descriptor{}, prepErr(fmt.Errorf("resolving digest %q: %w", wantDigest, err))
+			return ociv1.Descriptor{}, prepErr(fmt.Errorf("resolving digest: %w", err))
 		}
 	}
 

--- a/internal/getmodules/oci_getter_test.go
+++ b/internal/getmodules/oci_getter_test.go
@@ -137,11 +137,11 @@ func TestOCIDistributionGetter(t *testing.T) {
 		},
 		{
 			source:    "oci://example.com/empty",
-			wantError: `error downloading 'oci://example.com/empty': resolving tag "latest": not found`,
+			wantError: `error downloading 'oci://example.com/empty': resolving tag: latest: not found`,
 		},
 		{
 			source:    "oci://example.com/empty?tag=baz",
-			wantError: `error downloading 'oci://example.com/empty?tag=baz': resolving tag "baz": not found`,
+			wantError: `error downloading 'oci://example.com/empty?tag=baz': resolving tag: baz: not found`,
 		},
 		{
 			source:    "oci://example.com/empty?tag=in$valid", // invalid tag name syntax, per OCI distribution spec
@@ -149,7 +149,7 @@ func TestOCIDistributionGetter(t *testing.T) {
 		},
 		{
 			source:    "oci://example.com/empty?digest=sha256:1d57d25084effd3fdfd902eca00020b34b1fb020253b84d7dd471301606015ac",
-			wantError: `error downloading 'oci://example.com/empty?digest=sha256%3A1d57d25084effd3fdfd902eca00020b34b1fb020253b84d7dd471301606015ac': resolving digest "sha256:1d57d25084effd3fdfd902eca00020b34b1fb020253b84d7dd471301606015ac": not found`,
+			wantError: `error downloading 'oci://example.com/empty?digest=sha256%3A1d57d25084effd3fdfd902eca00020b34b1fb020253b84d7dd471301606015ac': resolving digest: sha256:1d57d25084effd3fdfd902eca00020b34b1fb020253b84d7dd471301606015ac: not found`,
 		},
 		{
 			source:    "oci://example.com/empty?tag=",


### PR DESCRIPTION
This upgrades our ORAS and OCI image format dependencies to the latest available releases.

- [Changes in ORAS-Go](https://github.com/oras-project/oras-go/compare/v2.5.0...v2.6.0)
- [Changes in image-spec](https://github.com/opencontainers/image-spec/compare/v1.1.0...v1.1.1)

The ORAS-Go upgrade made a few of our tests fail, so I'm creating this as a draft for now and will investigate further later.
