### PR TITLE
.github/workflows: Run unit tests when go.mod/go.sum files change

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,7 +41,7 @@ jobs:
       - id: diff 
         run: |
           git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin ${{github.event.pull_request.base.ref}}
-          echo "go=$(git diff --name-only origin/${{github.event.pull_request.base.ref}} | grep -e '\.go' -e '\.github' | wc -l)" | tee -a "$GITHUB_OUTPUT"
+          echo "go=$(git diff --name-only origin/${{github.event.pull_request.base.ref}} | grep -e '\.go' -e '\.github' -e 'go\.mod' -e 'go\.sum' | wc -l)" | tee -a "$GITHUB_OUTPUT"
     outputs:
       go: ${{ steps.diff.outputs.go }}
     


### PR DESCRIPTION
In our checks workflow we try to skip running unit tests unless Go files have changed, but we didn't previously consider "go.mod" and "go.sum" as "Go files".

Changes to our dependencies can change the results of our tests, so we should run tests even if only the dependencies have changed.
