### PR TITLE
lang/exprs: Expression evaluation helpers

### DIFF
--- a/internal/lang/exprs/attribute.go
+++ b/internal/lang/exprs/attribute.go
@@ -1,0 +1,51 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package exprs
+
+// Attribute is implemented for the fixed set of types that can be returned
+// from [SymbolTable.ResolveAttr] implementations.
+//
+// This is a closed interface implemented only by types within this package.
+type Attribute interface {
+	attributeImpl()
+}
+
+// NestedSymbolTable constructs an [Attribute] representing a nested symbol
+// table, which must therefore be traversed through by a subsequent attribute
+// step.
+//
+// For example, a module instance acting as a symbol table would respond to
+// a lookup of the attribute "var" by returning a nested symbol table whose
+// symbols correspond to all of the input variables declared in the module,
+// so that a reference like "var.foo" would then look up "foo" in the nested
+// table.
+func NestedSymbolTable(table SymbolTable) Attribute {
+	return nestedSymbolTable{table}
+}
+
+// ValueOf constructs an [Attribute] representing the endpoint of a static
+// traversal, where a dynamic value should be placed.
+func ValueOf(v Valuer) Attribute {
+	return valueOf{v}
+}
+
+// nestedSymbolTable is the [Attribute] implementation for symbols that act as
+// nested symbol tables, resolving another set of child attributes within.
+type nestedSymbolTable struct {
+	SymbolTable
+}
+
+// scopeStep implements [Attribute].
+func (n nestedSymbolTable) attributeImpl() {}
+
+// valueOf is the [Attribute] implementation for symbols that correspond to
+// leaf values, produced by implementations of [Valuer].
+type valueOf struct {
+	Valuer
+}
+
+// scopeStep implements [Attribute].
+func (v valueOf) attributeImpl() {}

--- a/internal/lang/exprs/closure.go
+++ b/internal/lang/exprs/closure.go
@@ -1,0 +1,51 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package exprs
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/opentofu/opentofu/internal/tfdiags"
+)
+
+// Closure is an [Evalable] bound to the [Scope] where it was declared, so
+// that the two can travel together.
+//
+// Closure essentially turns an [Evalable] into a [Valuer], allowing it
+// to be evaluated without separately tracking the scope it belongs to.
+type Closure struct {
+	evalable Evalable
+	scope    Scope
+}
+
+var _ Valuer = (*Closure)(nil)
+
+// NewClosure associates the given [Evalable] with the given [Scope] so that
+// it can be evaluated somewhere else later without losing track of what symbols
+// and functions were available where it was declared.
+func NewClosure(evalable Evalable, scope Scope) *Closure {
+	return &Closure{evalable, scope}
+}
+
+// StaticCheckTraversal checks whether the given traversal could apply to any
+// possible result from [Closure.Value] on this closure, returning error
+// diagnostics if not.
+func (c *Closure) StaticCheckTraversal(traversal hcl.Traversal) tfdiags.Diagnostics {
+	return StaticCheckTraversal(traversal, c.evalable)
+}
+
+// Value returns the result of evaluating the enclosed [Evalable] in the
+// enclosed [Scope].
+//
+// Some [Evalable] implementations block on potentially-time-consuming
+// operations, in which case they should respond gracefully to cancellation
+// of the given context.
+func (c *Closure) Value(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
+	return Evaluate(ctx, c.evalable, c.scope)
+}

--- a/internal/lang/exprs/doc.go
+++ b/internal/lang/exprs/doc.go
@@ -1,0 +1,13 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+// Package exprs contains supporting code for expression evaluation.
+//
+// This package is designed to know nothing about the referenceable symbol tree
+// in any particular language, so that knowledge can be kept closer to the
+// other code implementing the relevant language. This can therefore be shared
+// across many different HCL-based languages, and across different evaluation
+// phases of the same language.
+package exprs

--- a/internal/lang/exprs/evalable.go
+++ b/internal/lang/exprs/evalable.go
@@ -1,0 +1,163 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package exprs
+
+import (
+	"context"
+	"iter"
+	"slices"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hcldec"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/opentofu/opentofu/internal/tfdiags"
+)
+
+// Evalable is implemented by types that encapsulate expressions that can be
+// evaluated in some evaluation scope decided by a caller.
+//
+// An Evalable implementation must include any supporting metadata needed to
+// analyze and evaluate the expressions inside. For example, an [Evalable]
+// representing a HCL body must also include the expected schema for that body.
+type Evalable interface {
+	// References returns a sequence of references this Evalable makes to
+	// values in its containing scope.
+	References() iter.Seq[hcl.Traversal]
+
+	// FunctionCalls returns a sequence of all of the function calls that
+	// could be made if this were evaluated.
+	//
+	// TODO: Perhaps References and FunctionCalls should be combined together
+	// somehow to return a tree that shows when a reference appears as part
+	// of an argument to a function, to address the problem described in
+	// this issue:
+	//     https://github.com/opentofu/opentofu/issues/2630
+	FunctionCalls() iter.Seq[*hcl.StaticCall]
+
+	// Evaluate performs the actual expression evaluation, using the given
+	// HCL evaluation context to satisfy any references.
+	//
+	// Callers must first use the References method to discover what the
+	// wrapped expressions refer to, and make sure that the given evaluation
+	// context contains at least the variables required to satisfy those
+	// references.
+	//
+	// This method takes a [context.Context] because some implementations
+	// may internally block on the completion of a potentially-time-consuming
+	// operation, in which case they should respond gracefully to the
+	// cancellation or deadline of the given context.
+	Evaluate(ctx context.Context, hclCtx *hcl.EvalContext) (cty.Value, tfdiags.Diagnostics)
+
+	// ResultTypeConstraint returns a type constrant that all possible results
+	// from method Evaluate would conform to.
+	//
+	// This is used for static type checking. Return [cty.DynamicPseudoType]
+	// if it's impossible to predict any single type constraint for the
+	// possible results.
+	//
+	// TODO: Some implementations of this would be able to do better if they
+	// knew the types of everything that'd be passed in hclCtx when calling
+	// Evaluate. Is there some way we can approximate that?
+	ResultTypeConstraint() cty.Type
+}
+
+func StaticCheckTraversal(traversal hcl.Traversal, evalable Evalable) tfdiags.Diagnostics {
+	return StaticCheckTraversalThroughType(traversal, evalable.ResultTypeConstraint())
+}
+
+func StaticCheckTraversalThroughType(traversal hcl.Traversal, typeConstraint cty.Type) tfdiags.Diagnostics {
+	// We perform a static check by attempting to apply the traversal to
+	// an unknown value of the given type constraint, which will fail if
+	// no possible value meeting that type constraint could possibly support
+	// the traversal.
+	var diags tfdiags.Diagnostics
+	placeholder := cty.UnknownVal(typeConstraint)
+	_, hclDiags := traversal.TraverseRel(placeholder)
+	diags = diags.Append(hclDiags)
+	return diags
+}
+
+// hclExpression implements [Evalable] for a standalone [hcl.Expression].
+type hclExpression struct {
+	expr hcl.Expression
+}
+
+// EvalableHCLExpression returns an [Evalable] that is just a thin wrapper
+// around the given HCL expression.
+func EvalableHCLExpression(expr hcl.Expression) Evalable {
+	return hclExpression{expr}
+}
+
+// Evaluate implements Evalable.
+func (h hclExpression) Evaluate(ctx context.Context, hclCtx *hcl.EvalContext) (cty.Value, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	v, hclDiags := h.expr.Value(hclCtx)
+	diags = diags.Append(hclDiags)
+	return v, diags
+}
+
+// FunctionCalls implements Evalable.
+func (h hclExpression) FunctionCalls() iter.Seq[*hcl.StaticCall] {
+	// For now this is not implemented because the underlying HCL API
+	// isn't the right shape to implement this method.
+	return func(yield func(*hcl.StaticCall) bool) {}
+}
+
+// References implements Evalable.
+func (h hclExpression) References() iter.Seq[hcl.Traversal] {
+	return slices.Values(h.expr.Variables())
+}
+
+// ResultTypeConstraint implements Evalable.
+func (h hclExpression) ResultTypeConstraint() cty.Type {
+	// We can only predict the result type of the expression if it doesn't
+	// include any references or function calls.
+	v, hclDiags := h.expr.Value(nil)
+	if hclDiags.HasErrors() {
+		return cty.DynamicPseudoType
+	}
+	// For an expression that only uses constants, its type is guaranteed
+	// to always be the same.
+	return v.Type()
+}
+
+// hclBody implements [Evalable] for a [hcl.Body] and associated [hcldec.Spec].
+type hclBody struct {
+	body hcl.Body
+	spec hcldec.Spec
+}
+
+// EvalableHCLBody returns an [Evalable] that evaluates the given HCL body
+// using the given [hcldec] specification.
+func EvalableHCLBody(body hcl.Body, spec hcldec.Spec) Evalable {
+	return &hclBody{body, spec}
+}
+
+// Evaluate implements Evalable.
+func (h *hclBody) Evaluate(ctx context.Context, hclCtx *hcl.EvalContext) (cty.Value, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	v, hclDiags := hcldec.Decode(h.body, h.spec, hclCtx)
+	diags = diags.Append(hclDiags)
+	return v, diags
+}
+
+// FunctionCalls implements Evalable.
+func (h hclBody) FunctionCalls() iter.Seq[*hcl.StaticCall] {
+	// For now this is not implemented because the underlying HCL API
+	// isn't the right shape to implement this method.
+	return func(yield func(*hcl.StaticCall) bool) {}
+}
+
+// References implements Evalable.
+func (h *hclBody) References() iter.Seq[hcl.Traversal] {
+	return slices.Values(hcldec.Variables(h.body, h.spec))
+}
+
+// ResultTypeConstraint implements Evalable.
+func (h *hclBody) ResultTypeConstraint() cty.Type {
+	return hcldec.ImpliedType(h.spec)
+}

--- a/internal/lang/exprs/evaluate.go
+++ b/internal/lang/exprs/evaluate.go
@@ -1,0 +1,176 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package exprs
+
+import (
+	"context"
+	"iter"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+
+	"github.com/opentofu/opentofu/internal/tfdiags"
+)
+
+// Evaluate attempts to evaluate the given [Evaluable] in the given [Scope],
+// either returning the resulting value or some error diagnostics describing
+// problems that prevented successful evaluation.
+//
+// Some [Evaluable] implementations (or the symbols they refer to) can block
+// on potentially-time-consuming operations, in which case they should respond
+// gracefully to cancellation of the given context.
+func Evaluate(ctx context.Context, what Evalable, scope Scope) (cty.Value, tfdiags.Diagnostics) {
+	hclCtx, diags := buildHCLEvalContext(ctx, what, scope)
+	if diags.HasErrors() {
+		return cty.DynamicVal, diags
+	}
+	val, moreDiags := what.Evaluate(ctx, hclCtx)
+	diags = diags.Append(moreDiags)
+	return val, diags
+}
+
+func buildHCLEvalContext(ctx context.Context, what Evalable, scope Scope) (*hcl.EvalContext, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	ret := &hcl.EvalContext{}
+
+	symbols, moreDiags := buildSymbolTable(ctx, what.References(), scope)
+	ret.Variables = symbols
+	diags = diags.Append(moreDiags)
+
+	funcs, moreDiags := buildFunctionTable(ctx, what.FunctionCalls(), scope)
+	ret.Functions = funcs
+	diags = diags.Append(moreDiags)
+
+	return ret, diags
+}
+
+func buildSymbolTable(ctx context.Context, refs iter.Seq[hcl.Traversal], scope Scope) (map[string]cty.Value, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	// We'll first build an intermediate representation of the nested symbol
+	// tables, because a cty.ObjectVal result is immutable and so we need to
+	// collect up all of the attribute values in a mutable data structure
+	// and then freeze it into an immutable tree once complete.
+	nodes := make(map[string]*symbolTableTempNode)
+References:
+	for traversal := range refs {
+		currentChildren := nodes
+		currentTable := SymbolTable(scope)
+		for i, step := range traversal {
+			// For our purposes here the distinction between TraverseAttr
+			// and TraverseRoot is unimportant, so we'll normalize to
+			// TraverseAttr.
+			if rootStep, ok := step.(hcl.TraverseRoot); ok {
+				step = hcl.TraverseAttr{
+					Name:     rootStep.Name,
+					SrcRange: rootStep.SrcRange,
+				}
+			}
+
+			switch step := step.(type) {
+			case hcl.TraverseAttr:
+				attr, moreDiags := currentTable.ResolveAttr(step)
+				diags = diags.Append(moreDiags)
+				if moreDiags.HasErrors() {
+					continue
+				}
+
+				switch attr := attr.(type) {
+				case nestedSymbolTable:
+					if _, ok := currentChildren[step.Name]; !ok {
+						currentChildren[step.Name] = &symbolTableTempNode{
+							children: make(map[string]*symbolTableTempNode),
+						}
+					}
+					currentChildren = currentChildren[step.Name].children
+					currentTable = attr.SymbolTable
+					continue
+				case valueOf:
+					currentChildren[step.Name] = &symbolTableTempNode{
+						val:    attr.Valuer,
+						remain: traversal[i+1:],
+					}
+					continue References // any remaining steps are dynamic steps through the final value, captured in "remain" above
+				}
+			default:
+				moreDiags := currentTable.HandleInvalidStep(tfdiags.SourceRangeFromHCL(step.SourceRange()))
+				diags = diags.Append(moreDiags)
+				continue References
+			}
+		}
+		// If we get here then we ran out of steps before we encountered a
+		// leaf Valuer, so this reference is incomplete and therefore invalid.
+		moreDiags := currentTable.HandleInvalidStep(tfdiags.SourceRangeFromHCL(traversal.SourceRange()))
+		diags = diags.Append(moreDiags)
+	}
+
+	ret, moreDiags := valuesForSymbolTableTempNodes(ctx, nodes)
+	diags = diags.Append(moreDiags)
+	return ret, diags
+}
+
+// symbolTableTempNode is an implementation detail of [buildSymbolTable] used
+// as a mutable intermediate representation of the symbol table so that we
+// can gradually assemble nested symbol tables and then turn them into
+// immutable cty object values only at the end when the work is complete.
+//
+// A value of this type has EITHER val+remain or children alone populated.
+type symbolTableTempNode struct {
+	val    Valuer
+	remain hcl.Traversal
+
+	children map[string]*symbolTableTempNode
+}
+
+// valuesForSymbolTableTempNodes returns a map of [cty.Value] providing a
+// frozen representation of the symbol tree rooted at the given map.
+func valuesForSymbolTableTempNodes(ctx context.Context, symbols map[string]*symbolTableTempNode) (map[string]cty.Value, tfdiags.Diagnostics) {
+	if len(symbols) == 0 {
+		return nil, nil
+	}
+
+	var diags tfdiags.Diagnostics
+	ret := make(map[string]cty.Value, len(symbols))
+	for name, node := range symbols {
+		if node.val != nil {
+			// This is a leaf node, with a dynamic value associated with it.
+			moreDiags := node.val.StaticCheckTraversal(node.remain)
+			diags = diags.Append(moreDiags)
+			if moreDiags.HasErrors() {
+				ret[name] = cty.DynamicVal
+				continue
+			}
+
+			val, moreDiags := node.val.Value(ctx)
+			diags = diags.Append(moreDiags)
+			ret[name] = val
+			continue
+		}
+
+		// This is a nested symbol table, so we'll analyze its content recursively.
+		childVals, moreDiags := valuesForSymbolTableTempNodes(ctx, node.children)
+		diags = diags.Append(moreDiags)
+		ret[name] = cty.ObjectVal(childVals)
+	}
+
+	return ret, diags
+}
+
+func buildFunctionTable(_ context.Context, calls iter.Seq[*hcl.StaticCall], scope Scope) (map[string]function.Function, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	ret := make(map[string]function.Function)
+	for call := range calls {
+		funcName := call.Name
+		impl, moreDiags := scope.ResolveFunc(call)
+		diags = diags.Append(moreDiags)
+		if moreDiags.HasErrors() {
+			continue
+		}
+		ret[funcName] = impl
+	}
+	return ret, diags
+}

--- a/internal/lang/exprs/example_test.go
+++ b/internal/lang/exprs/example_test.go
@@ -1,0 +1,495 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package exprs_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+	"github.com/zclconf/go-cty/cty/function"
+
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/configs/configschema"
+	"github.com/opentofu/opentofu/internal/lang/exprs"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+)
+
+// The main code in this package is intentionally completely unaware of
+// any specific symbol table structures in the language, with that logic
+// living in concrete implementations of [Scope], [SymbolTable] and [Valuer]
+// in other language-specific packages, but for testing purposes here we have a
+// contrived "mini-language" that is intentionally shaped like a subset of the
+// OpenTofu module language to prove that this design is sufficient to handle
+// that and to act as a relatively-concise overview of how a "real" use of this
+// package might look.
+//
+// If a real implementation _were_ shaped like this then all of the types
+// defined below would belong to some other package that implements the
+// OpenTofu planning phase. Variations of this could also appear in a package
+// that implements the validation phase, but in that case it would deal only
+// in unexpanded modules and resources. In both cases the types implementing
+// [Scope] and [Valuer] would ideally also implement all of the other business
+// logic related to whatever they represent to keep e.g. all of the logic
+// related to resource evaluation together in one place, but package exprs only
+// cares about their implementations of its interfaces.
+//
+// This example implementation has the significant limitation that it doesn't
+// have any way of detecting and reporting reference cycles. If any appear then
+// it'll just attempt infinite recursion and smash the stack. A real
+// implementation would need to somehow detect and report cyclic references,
+// e.g. by internally doing something like what this package does:
+//    https://pkg.go.dev/github.com/apparentlymart/go-workgraph/workgraph
+
+func Example_simple() {
+	varDefs := exampleMustParseTfvars(`
+		name = "stephen"
+	`)
+	modInst := exampleMustParseModule(`
+		variable "name" {}
+
+		resource "example" "foo" {
+			name = var.name
+		}
+
+		resource "example" "bar" {
+			name = example.foo.name
+		}
+	`, varDefs)
+
+	barR := modInst.Resource(addrs.Resource{
+		Mode: addrs.ManagedResourceMode,
+		Type: "example",
+		Name: "bar",
+	})
+	barV, diags := barR.Value(context.Background())
+	if diags.HasErrors() {
+		panic(spew.Sdump(diags.ForRPC()))
+	}
+
+	fmt.Println(ctydebug.ValueString(barV))
+
+	// Output:
+	// cty.ObjectVal(map[string]cty.Value{
+	//     "name": cty.StringVal("stephen"),
+	// })
+}
+
+// testResource represents a module instance, implementing [Scope].
+type testModuleInstance struct {
+	variables map[addrs.InputVariable]*testInputVariable
+	resources map[addrs.Resource]*testResource
+}
+
+var _ exprs.Scope = (*testModuleInstance)(nil)
+
+// Resource returns the resource with the given address, or nil if there is
+// no such resource declared in the module.
+func (t *testModuleInstance) Resource(addr addrs.Resource) *testResource {
+	return t.resources[addr]
+}
+
+// HandleInvalidStep implements Scope.
+func (t *testModuleInstance) HandleInvalidStep(rng tfdiags.SourceRange) tfdiags.Diagnostics {
+	// NOTE: It isn't possible to get here in practice because we only use
+	// this as a top-level scope and HCL's parser only allows TraverseRoot
+	// at the start of a reference anyway, so we could only get in here
+	// if an [Evalable.References] implementation returns something odd.
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(&hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  "Invalid reference",
+		Detail:   "Expected the name of a top-level symbol.",
+		Subject:  rng.ToHCL().Ptr(),
+	})
+	return diags
+}
+
+// ResolveAttr implements Scope.
+func (t *testModuleInstance) ResolveAttr(ref hcl.TraverseAttr) (exprs.Attribute, tfdiags.Diagnostics) {
+	// Note that handling this as part of the implementation a module, rather
+	// than separately in package addrs, makes it easier for the resolution
+	// rules to vary depending on which language edition and language
+	// experiments the module is using, because in a real implementation this
+	// object would have access to the module configuration.
+	//
+	// The extra symbols supported in .tftest.hcl files can also be handled
+	// by having the test scenario type also implement Scope, handle the
+	// test-language-specific symbols first, and then delegate to a wrapped
+	// module object for everything else.
+
+	switch ref.Name {
+	case "var":
+		return exprs.NestedSymbolTable(testInputVariables(t.variables)), nil
+	case "resource":
+		return exprs.NestedSymbolTable(&testResourcesOfMode{
+			mode:         addrs.ManagedResourceMode,
+			allResources: t.resources,
+		}), nil
+	case "data":
+		return exprs.NestedSymbolTable(&testResourcesOfMode{
+			mode:         addrs.DataResourceMode,
+			allResources: t.resources,
+		}), nil
+	case "ephemeral":
+		return exprs.NestedSymbolTable(&testResourcesOfMode{
+			mode:         addrs.EphemeralResourceMode,
+			allResources: t.resources,
+		}), nil
+	default:
+		return exprs.NestedSymbolTable(&testResourcesOfType{
+			mode:         addrs.ManagedResourceMode,
+			typeName:     ref.Name,
+			allResources: t.resources,
+		}), nil
+	}
+}
+
+// ResolveFunc implements Scope.
+func (t *testModuleInstance) ResolveFunc(call *hcl.StaticCall) (function.Function, tfdiags.Diagnostics) {
+	// A real implementation of this would probably look the function name up
+	// in a map built elsewhere, rather than like this.
+	switch call.Name {
+	case "upper":
+		return function.New(&function.Spec{
+			Params: []function.Parameter{
+				{
+					Name: "str",
+					Type: cty.String,
+				},
+			},
+			Type: function.StaticReturnType(cty.String),
+			Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+				// NOTE: This is not a robust implementation of "upper", just
+				// a placeholder for the sake of this example.
+				return cty.StringVal(strings.ToUpper(args[0].AsString())), nil
+			},
+		}), nil
+	default:
+		var diags tfdiags.Diagnostics
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Call to unknown function",
+			Detail:   fmt.Sprintf("There is no function named %q.", call.Name),
+			Subject:  &call.NameRange,
+		})
+		return function.Function{}, diags
+	}
+}
+
+// testInputVariables is an intermediate [SymbolTable] dealing with the
+// symbols under "var.".
+type testInputVariables map[addrs.InputVariable]*testInputVariable
+
+var _ exprs.SymbolTable = testInputVariables(nil)
+
+// HandleInvalidStep implements exprs.SymbolTable.
+func (t testInputVariables) HandleInvalidStep(rng tfdiags.SourceRange) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(&hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  "Invalid reference to input variable",
+		Detail:   "Expected an attribute name matching an input variable declared in this module.",
+		Subject:  rng.ToHCL().Ptr(),
+	})
+	return diags
+}
+
+// ResolveAttr implements exprs.SymbolTable.
+func (t testInputVariables) ResolveAttr(ref hcl.TraverseAttr) (exprs.Attribute, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	iv, ok := t[addrs.InputVariable{Name: ref.Name}]
+	if !ok {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Reference to undeclared input variable",
+			Detail:   fmt.Sprintf("There is no input variable named %q declared in this module.", ref.Name),
+			Subject:  &ref.SrcRange,
+		})
+		return nil, diags
+	}
+	return exprs.ValueOf(iv), diags
+}
+
+type testInputVariable struct {
+	addr       addrs.InputVariable
+	targetType cty.Type
+	rawVal     cty.Value
+	valRange   tfdiags.SourceRange
+}
+
+var _ exprs.Valuer = (*testInputVariable)(nil)
+
+// StaticCheckTraversal implements exprs.Valuer.
+func (t *testInputVariable) TypeConstraint() cty.Type {
+	// An input variable's "type" is a target type for conversion rather than
+	// just a type constraint, so we need to discard any optional attribute
+	// information to get a plain type constraint.
+	return t.targetType.WithoutOptionalAttributesDeep()
+}
+
+// StaticCheckTraversal implements exprs.Valuer.
+func (t *testInputVariable) StaticCheckTraversal(traversal hcl.Traversal) tfdiags.Diagnostics {
+	return exprs.StaticCheckTraversalThroughType(traversal, t.TypeConstraint())
+}
+
+// Value implements exprs.Valuer.
+func (t *testInputVariable) Value(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	// In a real implementation this type would probably not have the value
+	// directly and would instead have an expression from an argument in
+	// the calling "module" block, but we'll keep this relatively simple
+	// for the sake of example.
+	v, err := convert.Convert(t.rawVal, t.targetType)
+	if err != nil {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid value for input variable",
+			Detail:   fmt.Sprintf("Unsuitable value for input variable %q: %s.", t.addr.Name, err),
+			Subject:  t.valRange.ToHCL().Ptr(),
+		})
+		v = cty.UnknownVal(t.TypeConstraint())
+	}
+	return v, diags
+}
+
+// testInputVariables is an intermediate [SymbolTable] implementation dealing
+// with symbols under "resource.", "data.", and "ephemeral.".
+type testResourcesOfMode struct {
+	mode         addrs.ResourceMode
+	allResources map[addrs.Resource]*testResource
+}
+
+var _ exprs.SymbolTable = (*testResourcesOfMode)(nil)
+
+// HandleInvalidStep implements exprs.SymbolTable.
+func (t *testResourcesOfMode) HandleInvalidStep(rng tfdiags.SourceRange) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(&hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  "Invalid reference to resource",
+		Detail:   "Expected an attribute name matching the type of the resource to refer to.",
+		Subject:  rng.ToHCL().Ptr(),
+	})
+	return diags
+}
+
+// ResolveAttr implements exprs.SymbolTable.
+func (t *testResourcesOfMode) ResolveAttr(ref hcl.TraverseAttr) (exprs.Attribute, tfdiags.Diagnostics) {
+	// For now we'll just accept anything here and wait until we've collected
+	// enough steps to form a complete addrs.Resource value.
+	return exprs.NestedSymbolTable(&testResourcesOfType{
+		mode:         t.mode,
+		typeName:     ref.Name,
+		allResources: t.allResources,
+	}), nil
+}
+
+// testInputVariables is an intermediate [SymbolTable] implementation dealing
+// with symbols under "resource.ANYTHING.", "data.ANYTHING.",
+// "ephemeral.ANYTHING.", and "ANYTHING.".
+type testResourcesOfType struct {
+	mode         addrs.ResourceMode
+	typeName     string
+	allResources map[addrs.Resource]*testResource
+}
+
+var _ exprs.SymbolTable = (*testResourcesOfType)(nil)
+
+// HandleInvalidStep implements exprs.SymbolTable.
+func (t *testResourcesOfType) HandleInvalidStep(rng tfdiags.SourceRange) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(&hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  "Invalid reference to resource",
+		Detail:   "Expected an attribute name matching the name of the resource to refer to.",
+		Subject:  rng.ToHCL().Ptr(),
+	})
+	return diags
+}
+
+// ResolveAttr implements exprs.SymbolTable.
+func (t *testResourcesOfType) ResolveAttr(ref hcl.TraverseAttr) (exprs.Attribute, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	// Once we reach this step we've collected enough information to
+	// form a resource address.
+	addr := addrs.Resource{
+		Mode: t.mode,
+		Type: t.typeName,
+		Name: ref.Name,
+	}
+	rsrc, ok := t.allResources[addr]
+	if !ok {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Reference to undeclared resource",
+			Detail:   fmt.Sprintf("There is no resource %s declared in this module.", addr),
+			Subject:  &ref.SrcRange,
+		})
+		return nil, diags
+	}
+	return exprs.ValueOf(rsrc), diags
+}
+
+// testResource represents a resource, implementing [Valuer].
+//
+// A real implementation of this would need to deal with multi-instance resources
+// using count/for_each too, probably delegating to another type representing
+// each individual resource instance, but we ignore that here because that
+// complexity is an implementation detail irrelevant to package exprs.
+type testResource struct {
+	// config is the [Valuer] for the resource's configuration body.
+	//
+	// In practice this is an [*exprs.Closure] associating the actual HCL body
+	// with the module instance where it was declared, but that is a concern
+	// only for the code that constructs this object; the testResource
+	// implementation only knows that it can obtain a value from here when
+	// needed, without worrying about how that is achieved.
+	//
+	// (in a real implementation that supported multiple resource instances
+	// we'd need to delay constructing the exprs.Valuer until constructing
+	// individual resource instances, because in that case the resource instance
+	// configs must close over a child scope that also has instance-specific
+	// each.key/each.value/count.index in it, but this example is already
+	// complicated enough so we'll skip that here.)
+	config exprs.Valuer
+}
+
+var _ exprs.Valuer = (*testResource)(nil)
+
+// StaticCheckTraversal implements exprs.Valuer.
+func (t *testResource) StaticCheckTraversal(traversal hcl.Traversal) tfdiags.Diagnostics {
+	return t.config.StaticCheckTraversal(traversal)
+}
+
+// Value implements exprs.Valuer.
+func (t *testResource) Value(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
+	return t.config.Value(ctx)
+}
+
+// exampleMustParseTfvars is a helper function just to make these contrived
+// examples a little more concise, which tries to interpret the given string
+// in a similar way to how OpenTofu would normally deal with a ".tfvars" file.
+func exampleMustParseTfvars(src string) map[string]variableDef {
+	f, hclDiags := hclsyntax.ParseConfig([]byte(src), "example.tfvars", hcl.InitialPos)
+	if hclDiags.HasErrors() {
+		panic(fmt.Sprintf("invalid tfvars: %s", hclDiags.Error()))
+	}
+	attrs, hclDiags := f.Body.JustAttributes()
+	if hclDiags.HasErrors() {
+		panic(fmt.Sprintf("invalid tfvars: %s", hclDiags.Error()))
+	}
+	ret := make(map[string]variableDef, len(attrs))
+	for name, attr := range attrs {
+		v, hclDiags := attr.Expr.Value(nil)
+		if hclDiags.HasErrors() {
+			panic(fmt.Sprintf("invalid tfvars: %s", hclDiags.Error()))
+		}
+		ret[name] = variableDef{
+			val: v,
+			rng: tfdiags.SourceRangeFromHCL(attr.Expr.Range()),
+		}
+	}
+	return ret
+}
+
+// exampleMustParseTfvars is a helper function just to make these contrived
+// examples a little more concise, which tries to interpret the given string
+// as the mini-language implemented in this example.
+func exampleMustParseModule(src string, inputVals map[string]variableDef) *testModuleInstance {
+	f, hclDiags := hclsyntax.ParseConfig([]byte(src), "config.minitofu", hcl.InitialPos)
+	if hclDiags.HasErrors() {
+		panic(fmt.Sprintf("invalid module: %s", hclDiags.Error()))
+	}
+
+	rootSchema := hcl.BodySchema{
+		Blocks: []hcl.BlockHeaderSchema{
+			{Type: "variable", LabelNames: []string{"name"}},
+			{Type: "resource", LabelNames: []string{"type", "name"}},
+			{Type: "data", LabelNames: []string{"type", "name"}},
+			{Type: "ephemeral", LabelNames: []string{"type", "name"}},
+		},
+	}
+	content, hclDiags := f.Body.Content(&rootSchema)
+	if hclDiags.HasErrors() {
+		panic(fmt.Sprintf("invalid module: %s", hclDiags.Error()))
+	}
+
+	modInst := &testModuleInstance{
+		variables: make(map[addrs.InputVariable]*testInputVariable),
+		resources: make(map[addrs.Resource]*testResource),
+	}
+	for _, block := range content.Blocks {
+		switch block.Type {
+		case "variable":
+			addr := addrs.InputVariable{Name: block.Labels[0]}
+			def, ok := inputVals[addr.Name]
+			if !ok {
+				panic(fmt.Sprintf("no value for input variable %q", addr.Name))
+			}
+			modInst.variables[addr] = &testInputVariable{
+				addr:       addr,
+				targetType: cty.String, // only strings to keep this example simpler
+				rawVal:     def.val,
+				valRange:   def.rng,
+			}
+		case "resource", "data", "ephemeral":
+			addr := addrs.Resource{
+				Mode: map[string]addrs.ResourceMode{
+					"resource":  addrs.ManagedResourceMode,
+					"data":      addrs.DataResourceMode,
+					"ephemeral": addrs.EphemeralResourceMode,
+				}[block.Type],
+				Type: block.Labels[0],
+				Name: block.Labels[1],
+			}
+			typeAddr := resourceType{
+				Mode: addr.Mode,
+				Name: addr.Type,
+			}
+			schema, ok := resourceTypes[typeAddr]
+			if !ok {
+				panic(fmt.Sprintf("unsupported resource type %#v", typeAddr))
+			}
+			modInst.resources[addr] = &testResource{
+				config: exprs.NewClosure(
+					exprs.EvalableHCLBody(block.Body, schema.DecoderSpec()),
+					modInst,
+				),
+			}
+		}
+	}
+	return modInst
+}
+
+type variableDef struct {
+	val cty.Value
+	rng tfdiags.SourceRange
+}
+
+type resourceType struct {
+	Mode addrs.ResourceMode
+	Name string
+}
+
+var resourceTypes = map[resourceType]*configschema.Block{
+	resourceType{addrs.ManagedResourceMode, "example"}: &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"name": &configschema.Attribute{
+				Type:     cty.String,
+				Required: true,
+			},
+		},
+	},
+}

--- a/internal/lang/exprs/scope.go
+++ b/internal/lang/exprs/scope.go
@@ -1,0 +1,31 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package exprs
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+// Scope is implemented by types representing containers that can have
+// expressions evaluated within them.
+//
+// For example, it might make sense for a type representing a module instance
+// to implement this interface to describe the symbols and functions that
+// result from the declarations in that module instance. In that case, the
+// module instance _is_ the scope, rather than the scope being a separate thing
+// derived from that module instance.
+//
+// A Scope is essentially just an extension of [SymbolTable] which also includes
+// a table of functions.
+type Scope interface {
+	SymbolTable
+
+	// ResolveFunc looks up a function by name, either returning its
+	// implementation or error diagnostics if no such function exists.
+	ResolveFunc(call *hcl.StaticCall) (function.Function, tfdiags.Diagnostics)
+}

--- a/internal/lang/exprs/symbol_table.go
+++ b/internal/lang/exprs/symbol_table.go
@@ -1,0 +1,33 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package exprs
+
+import (
+	"github.com/hashicorp/hcl/v2"
+
+	"github.com/opentofu/opentofu/internal/tfdiags"
+)
+
+// SymbolTable is an interface implemented by types that have an associated
+// symbol table, meaning that they contain a set of attributes that can be
+// looked up by name.
+type SymbolTable interface {
+	// ResolveSymbol looks up a symbol by name, either returning what it
+	// refers to or error diagnostics if no such symbol exists.
+	ResolveAttr(ref hcl.TraverseAttr) (Attribute, tfdiags.Diagnostics)
+
+	// HandleInvalidStep is called if a reference contains anything other
+	// than an attribute access at a position handled by a symbol table,
+	// so that the symbol table can produce a specialized error message
+	// explaining what kind of attributes are expected.
+	//
+	// The given source range refers either to the non-attribute step that
+	// was encountered or, if the problem is that nothing was present at all,
+	// then to the entire reference expression visited so far.
+	//
+	// The result of this method MUST include at least one error diagnostic.
+	HandleInvalidStep(rng tfdiags.SourceRange) tfdiags.Diagnostics
+}

--- a/internal/lang/exprs/valuer.go
+++ b/internal/lang/exprs/valuer.go
@@ -1,0 +1,53 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package exprs
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/opentofu/opentofu/internal/tfdiags"
+)
+
+// Valuer is implemented by objects that can be directly represented by a
+// [cty.Value].
+//
+// This is a similar idea to [Evalable], but with a subtle difference: a
+// [Valuer] represents a value directly, whereas an [Evalable] represents an
+// expression that can be evaluated to produce a value. In practice some
+// [Valuer]s will produce their result by evaluating an [Evalable], but
+// that's an implementation detail that the consumer of this interface is
+// not aware of.
+//
+// An [Evalable] can be turned into a [Valuer] by associating it with a
+// [Scope], using [NewClosure].
+type Valuer interface {
+	// Value returns the [cty.Value] representation of this object.
+	//
+	// This method takes a [context.Context] because some implementations
+	// may internally block on the completion of a potentially-time-consuming
+	// operation, in which case they should respond gracefully to the
+	// cancellation or deadline of the given context.
+	Value(ctx context.Context) (cty.Value, tfdiags.Diagnostics)
+
+	// StaticCheckTraversal checks whether the given relative traversal would
+	// be valid to apply to all values that the ExprValue method could possibly
+	// return without doing any expensive work to finalize that value, returning
+	// diagnostics describing any problems.
+	//
+	// A typical implementation of this would be to check whether the
+	// traversal makes sense for whatever type constraint applies to all of
+	// the values that could possibly be returned. However, it's valid to
+	// just immediately return no diagnostics if it's impossible to predict
+	// anything about the value, in which case errors will be caught dynamically
+	// once the value has been finalized.
+	//
+	// This function should only return errors that should not be interceptable
+	// by the "try" or "can" functions in the OpenTofu language.
+	StaticCheckTraversal(traversal hcl.Traversal) tfdiags.Diagnostics
+}


### PR DESCRIPTION
This package provides a more generic version of what's currently modeled by the likes of `lang.Scope` and `lang.Data`, designed to avoid having a huge single type that must know about everything in the language and, for this package's purposes alone, to avoid knowing anything about the language at all except that it uses HCL.

This is currently just an experiment not used by anything, and so is dead code aside from the contrived mini-language implemented in [`example_test.go`](https://github.com/opentofu/opentofu/blob/f-lang-exprs/internal/lang/exprs/example_test.go) to try to illustrate how other parts of the system might use this.

I wrote this as an idea for one small part of what https://github.com/opentofu/opentofu/pull/2921 might turn into. The main idea here is to have a single generic implementation of the low-level machinery  of expression evaluation that can then be used in multiple different ways to implement the different phases of OpenTofu's main language execution and also other related-but-separate languages like the `.tftest.hcl` language, [a hypothetical language for "stacks"](https://gist.github.com/apparentlymart/8b895867777a099727454e1ebce5e5b3#early-evaluation-with-stacks), or [hypothetical "symbol libraries" language](https://github.com/opentofu/opentofu/issues/2063#issuecomment-2436577040).

