### PR TITLE
fix `internal/command/cliconfig` tests on Windows

### DIFF
--- a/internal/command/cliconfig/oci_credentials_test.go
+++ b/internal/command/cliconfig/oci_credentials_test.go
@@ -23,7 +23,8 @@ import (
 func TestLoadConfig_ociDefaultCredentials(t *testing.T) {
 	// Due to path handling differences between Windows and Unix-like
 	// systems, `/foo/bar` is an absolute path on Unix but is converted
-	// to `\foo\bar`, a relative path on Windows.
+	// to `\foo\bar`, a relative path on Windows. `filepath.Abs` is used to
+	// convert the path to an absolute path on Windows.
 	authJsonPath := "/foo/bar/auth.json"
 	if runtime.GOOS == "windows" {
 		authJsonPath, _ = filepath.Abs(filepath.FromSlash("testdata/foo/bar/auth.json"))


### PR DESCRIPTION
Related to #3165 

My reasoning for this fix is at https://github.com/opentofu/opentofu/pull/3196/files#diff-37d81d3f1e25147e4aa9e2c0a1f95d536afdf31d0e8a62239a4b098d5bf98162R24-R26

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
