### PR TITLE
Fix `internal/command/validate_test.go`: `TestValidate_json*`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
-internal/*.tf text eol=lf
-internal/*.tofu text eol=lf
-internal/*.json text eol=lf
+internal/**/*.tf text eol=lf
+internal/**/*.tofu text eol=lf
+internal/**/*.json text eol=lf

--- a/internal/command/validate_test.go
+++ b/internal/command/validate_test.go
@@ -10,6 +10,8 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -352,6 +354,43 @@ func TestValidate_json(t *testing.T) {
 		{"validate-invalid/missing_defined_var", true},
 	}
 
+	cmpOpts := cmp.Options{
+		// Filenames are defined as Unix paths in `output.json`, this
+		// is needed to convert them to the correct path for the current OS.
+		cmp.FilterPath(
+			func(p cmp.Path) bool {
+				field := p.Last().String()
+				return field == `["filename"]`
+			},
+			//
+			cmp.Transformer("filename", func(filename interface{}) string {
+				convertedFilename, ok := filename.(string)
+				if !ok {
+					t.Fatalf("failed to convert filename to string: %v", filename)
+				}
+				return filepath.FromSlash(convertedFilename)
+			}),
+		),
+		// Detail field contains file path along with other information. '/' are
+		// being replaced if Windows is the current OS.
+		cmp.FilterPath(
+			func(p cmp.Path) bool {
+				field := p.Last().String()
+				return field == `["detail"]`
+			},
+			cmp.Transformer("detail", func(detail interface{}) string {
+				convertedDetail, ok := detail.(string)
+				if !ok {
+					t.Fatalf("failed to convert detail to string: %v", detail)
+				}
+				if runtime.GOOS == "windows" {
+					convertedDetail = strings.ReplaceAll(convertedDetail, `\`, `/`)
+				}
+				return convertedDetail
+			}),
+		),
+	}
+
 	for _, tc := range tests {
 		t.Run(tc.path, func(t *testing.T) {
 			var want, got map[string]interface{}
@@ -378,7 +417,7 @@ func TestValidate_json(t *testing.T) {
 				t.Fatalf("failed to unmarshal actual JSON: %s", err)
 			}
 
-			if !cmp.Equal(got, want) {
+			if !cmp.Equal(got, want, cmpOpts) {
 				t.Errorf("wrong output:\n %v\n", cmp.Diff(got, want))
 				t.Errorf("raw output:\n%s\n", gotString)
 			}


### PR DESCRIPTION
Blocked by #3210 
Blocked by #3212
Relates to #1201 

This is the best solution I could think of to enable these tests on Windows. The detailed solution is:

1. Adding `*.json` to `.gitattributes` to fix the byte differences on the `Diagnostics`;
2. Use `filepath.FromSlash` on the `filename` field;
3. Use `replaceAll("/", "\") on the `detail` field`; (I'm not happy about this one, though)


Here's an example of an `output.json` being tested:

```
{
  "format_version": "1.0",
  "valid": false,
  "error_count": 1,
  "warning_count": 0,
  "diagnostics": [
    {
      "severity": "error",
      "summary": "Duplicate import configuration for \"aws_instance.web\"",
      "detail": "An import block for the resource \"aws_instance.web\" was already declared at testdata/validate-invalid/duplicate_import_targets/main.tf:4,1-7. A resource can have only one import block.",
      "range": {
        "filename": "testdata/validate-invalid/duplicate_import_targets/main.tf",
        "start": {
          "line": 9,
          "column": 1,
          "byte": 85
        },
        "end": {
          "line": 9,
          "column": 7,
          "byte": 91
        }
      },
      "snippet": {
        "context": null,
        "code": "import {",
        "start_line": 9,
        "highlight_start_offset": 0,
        "highlight_end_offset": 6,
        "values": []
      }
    }
  ]
}
``` 

These changes fix the following tests:

- TestValidate_json/validate-invalid 
- TestValidate_json/validate-invalid/missing_quote
- TestValidate_json/validate-invalid/missing_var
- TestValidate_json/validate-invalid/multiple_providers
- TestValidate_json/validate-invalid/multiple_modules
- TestValidate_json/validate-invalid/multiple_resources
- TestValidate_json/validate-invalid/duplicate_import_targets
- TestValidate_json/validate-invalid/outputs
- TestValidate_json/validate-invalid/incorrectmodulename
- TestValidate_json/validate-invalid/interpolation

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
