### PR TITLE
fix `TestJSON*` tests on Windows

### DIFF
--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -267,7 +268,12 @@ func TestShow_json_argsPlanFileDoesNotExist(t *testing.T) {
 
 			got := output.Stderr()
 			want1 := `couldn't load the provided path`
+
 			want2 := `open doesNotExist.tfplan: no such file or directory`
+			if runtime.GOOS == "windows" {
+				want2 = `open doesNotExist.tfplan: The system cannot find the file specified`
+			}
+
 			if !strings.Contains(got, want1) {
 				t.Errorf("unexpected output\ngot: %s\nwant:\n%s", got, want1)
 			}


### PR DESCRIPTION
Relates to #1201 

When files are not found on Windows, error messages are different. In the fixed tests, they were expecting `no such file or directory`. But Windows tests are raising different error messages, like:

```
2025-08-28T23:08:31.4320639Z     --- FAIL: TestShow_argsPlanFileDoesNotExist/modern (0.00s)
2025-08-28T23:08:31.4321637Z         show_test.go:213: unexpected output
2025-08-28T23:08:31.4322212Z             got: 
2025-08-28T23:08:31.4324914Z             Error: couldn't load the provided path as either a local plan file (open doesNotExist.tfplan: The system cannot find the file specified.) or a saved cloud plan (open doesNotExist.tfplan: The system cannot find the file specified.)
```

This PR fixes the following tests:

- TestShow_argsPlanFileDoesNotExist/modern
- TestShow_argsPlanFileDoesNotExist/legacy

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
