### PR TITLE
Adapt `TestInit` hashes to work on Windows

### DIFF
--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -13,7 +13,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -1773,14 +1772,8 @@ func TestInit_providerSource(t *testing.T) {
 			getproviders.MustParseVersion("1.2.4"),
 			getproviders.MustParseVersionConstraints("= 1.2.4"),
 			[]getproviders.Hash{
-				getproviders.HashScheme1.New(getHash(expectedHash{
-					windows: "/dyBt3WaisluLlSpOENiVJAEbIokRW+QtTNCHjZtEX8=",
-					linux:   "vEthLkqAecdQimaW6JHZ0SBRNtHibLnOb31tX9ZXlcI=",
-				})),
-				getproviders.HashSchemeZip.New(getHash(expectedHash{
-					windows: "f775fac6a9cfc81f74ffd8b6a803d212c0cde0d97a2f5c8cdb47f37f8ea59cd1",
-					linux:   "ec7c3fd6eb575c06f0e6957e1ee8531a588805c4eeb8abb5e4156911e080eb31",
-				})),
+				getproviders.HashScheme1.New("vEthLkqAecdQimaW6JHZ0SBRNtHibLnOb31tX9ZXlcI="),
+				getproviders.HashSchemeZip.New("ec7c3fd6eb575c06f0e6957e1ee8531a588805c4eeb8abb5e4156911e080eb31"),
 			},
 		),
 		addrs.NewDefaultProvider("test"): depsfile.NewProviderLock(
@@ -1788,14 +1781,8 @@ func TestInit_providerSource(t *testing.T) {
 			getproviders.MustParseVersion("1.2.3"),
 			getproviders.MustParseVersionConstraints("= 1.2.3"),
 			[]getproviders.Hash{
-				getproviders.HashScheme1.New(getHash(expectedHash{
-					windows: "ozjxc9yUgF+m7s0sCXPN83nTdzVYUsW2DV0hXd+Id0g",
-					linux:   "8CjxaUBuegKZSFnRos39Fs+CS78ax0Dyb7aIA5XBiNI=",
-				})),
-				getproviders.HashSchemeZip.New(getHash(expectedHash{
-					windows: "9e2b8467dded89b85aa271561a2e913543f59643f601785981ddaed0a182c813",
-					linux:   "6f85a1f747dd09455cd77683c0e06da647d8240461b8b36b304b9056814d91f2",
-				})),
+				getproviders.HashScheme1.New("8CjxaUBuegKZSFnRos39Fs+CS78ax0Dyb7aIA5XBiNI="),
+				getproviders.HashSchemeZip.New("6f85a1f747dd09455cd77683c0e06da647d8240461b8b36b304b9056814d91f2"),
 			},
 		),
 		addrs.NewDefaultProvider("source"): depsfile.NewProviderLock(
@@ -1803,14 +1790,8 @@ func TestInit_providerSource(t *testing.T) {
 			getproviders.MustParseVersion("1.2.3"),
 			getproviders.MustParseVersionConstraints("= 1.2.3"),
 			[]getproviders.Hash{
-				getproviders.HashScheme1.New(getHash(expectedHash{
-					windows: "3bAYmLQMCiu4o/yhFxm2EmnfVXpX4fLl+PgZohrlVe0=",
-					linux:   "ACYytVQ2Q6JfoEs7xxCqa1yGFf9HwF3SEHzJKBoJfo0=",
-				})),
-				getproviders.HashSchemeZip.New(getHash(expectedHash{
-					windows: "599f3f0ecfdbe255f5560eb177a8ba0d9091af93291d4c99f707ad8f8eb7f4f0",
-					linux:   "69f700dbf9eda586abef22ab08e3a3896760e01885f6cbda4460ceeca4e3c0ba",
-				})),
+				getproviders.HashScheme1.New("ACYytVQ2Q6JfoEs7xxCqa1yGFf9HwF3SEHzJKBoJfo0="),
+				getproviders.HashSchemeZip.New("69f700dbf9eda586abef22ab08e3a3896760e01885f6cbda4460ceeca4e3c0ba"),
 			},
 		),
 	}
@@ -2049,14 +2030,8 @@ func TestInit_getUpgradePlugins(t *testing.T) {
 			getproviders.MustParseVersion("2.3.4"),
 			getproviders.MustParseVersionConstraints("> 1.0.0, < 3.0.0"),
 			[]getproviders.Hash{
-				getproviders.HashScheme1.New(getHash(expectedHash{
-					windows: "HBLrdZys0HCQ8qO+Jty0sn0neSjc0ExpjsOjsx8NAlQ=",
-					linux:   "ntfa04OlRqIfGL/Gkd+nGMJSHGWyAgMQplFWk7WEsOk=",
-				})),
-				getproviders.HashSchemeZip.New(getHash(expectedHash{
-					windows: "8d097e83a6ce9c6f83754e3c19e4af9337f512b7acd50a11ea6eea6a1ce15b4b",
-					linux:   "29e1045215056680ac59fe95554f0eb1323534a3d411aae2a7a04495ac884258",
-				})),
+				getproviders.HashScheme1.New("ntfa04OlRqIfGL/Gkd+nGMJSHGWyAgMQplFWk7WEsOk="),
+				getproviders.HashSchemeZip.New("29e1045215056680ac59fe95554f0eb1323534a3d411aae2a7a04495ac884258"),
 			},
 		),
 		addrs.NewDefaultProvider("exact"): depsfile.NewProviderLock(
@@ -2064,14 +2039,8 @@ func TestInit_getUpgradePlugins(t *testing.T) {
 			getproviders.MustParseVersion("1.2.3"),
 			getproviders.MustParseVersionConstraints("= 1.2.3"),
 			[]getproviders.Hash{
-				getproviders.HashScheme1.New(getHash(expectedHash{
-					windows: "B75BmVQvrHgtkrEwiQI7ALadRQLwz/QpyVzYLdgbKMw=",
-					linux:   "Xgk+LFrzi9Mop6+d01TCTaD3kgSrUASCAUU1aDsEsJU=",
-				})),
-				getproviders.HashSchemeZip.New(getHash(expectedHash{
-					windows: "0aa0ad387a092f16cdd998432ae3862f2070880d2692ef0b8948936ad1ea96d4",
-					linux:   "9cb7a3006b9c1344b2d838a5bb03c1e0f04b8c046beb38901eaf3cc99fceb870",
-				})),
+				getproviders.HashScheme1.New("Xgk+LFrzi9Mop6+d01TCTaD3kgSrUASCAUU1aDsEsJU="),
+				getproviders.HashSchemeZip.New("9cb7a3006b9c1344b2d838a5bb03c1e0f04b8c046beb38901eaf3cc99fceb870"),
 			},
 		),
 		addrs.NewDefaultProvider("greater-than"): depsfile.NewProviderLock(
@@ -2079,14 +2048,8 @@ func TestInit_getUpgradePlugins(t *testing.T) {
 			getproviders.MustParseVersion("2.3.4"),
 			getproviders.MustParseVersionConstraints(">= 2.3.3"),
 			[]getproviders.Hash{
-				getproviders.HashScheme1.New(getHash(expectedHash{
-					windows: "RcVlVgb5iQ5x6gMHGKAOhpPezPBGw0TBq+oPs5vI894=",
-					linux:   "8M5DXICmUiVjbkxNNO0zXNsV6duCVNWzq3/Kf0mNIo4=",
-				})),
-				getproviders.HashSchemeZip.New(getHash(expectedHash{
-					windows: "58f57c608fc83a06f876e28219c03e2191c0d2be23385c7498042510211adbcd",
-					linux:   "bfb683ee94027efb191986484352ada8219cd45e856d25c2ddcb489e100a9a02",
-				})),
+				getproviders.HashScheme1.New("8M5DXICmUiVjbkxNNO0zXNsV6duCVNWzq3/Kf0mNIo4="),
+				getproviders.HashSchemeZip.New("bfb683ee94027efb191986484352ada8219cd45e856d25c2ddcb489e100a9a02"),
 			},
 		),
 	}
@@ -2259,7 +2222,7 @@ func TestInit_providerLockFile(t *testing.T) {
 	buf = bytes.TrimSpace(buf)
 	// The hashes in here are for the fake package that newMockProviderSource produces
 	// (so they'll change if newMockProviderSource starts producing different contents)
-	wantLockFile := strings.TrimSpace(fmt.Sprintf(`
+	wantLockFile := strings.TrimSpace(`
 # This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
@@ -2267,18 +2230,11 @@ provider "registry.opentofu.org/hashicorp/test" {
   version     = "1.2.3"
   constraints = "1.2.3"
   hashes = [
-    %q,
-    %q,
+    "h1:8CjxaUBuegKZSFnRos39Fs+CS78ax0Dyb7aIA5XBiNI=",
+    "zh:6f85a1f747dd09455cd77683c0e06da647d8240461b8b36b304b9056814d91f2",
   ]
-}`, getproviders.HashScheme1.New(getHash(expectedHash{
-		windows: "ozjxc9yUgF+m7s0sCXPN83nTdzVYUsW2DV0hXd+Id0g=",
-		linux:   "8CjxaUBuegKZSFnRos39Fs+CS78ax0Dyb7aIA5XBiNI=",
-	})),
-		getproviders.HashSchemeZip.New(getHash(expectedHash{
-			windows: "9e2b8467dded89b85aa271561a2e913543f59643f601785981ddaed0a182c813",
-			linux:   "6f85a1f747dd09455cd77683c0e06da647d8240461b8b36b304b9056814d91f2",
-		})),
-	))
+}
+`)
 	if diff := cmp.Diff(wantLockFile, string(buf)); diff != "" {
 		t.Errorf("wrong dependency lock file contents\n%s", diff)
 	}
@@ -2600,10 +2556,7 @@ func TestInit_pluginDirProviders(t *testing.T) {
 			getproviders.MustParseVersion("2.3.4"),
 			getproviders.MustParseVersionConstraints("> 1.0.0, < 3.0.0"),
 			[]getproviders.Hash{
-				getproviders.HashScheme1.New(getHash(expectedHash{
-					windows: "HBLrdZys0HCQ8qO+Jty0sn0neSjc0ExpjsOjsx8NAlQ=",
-					linux:   "ntfa04OlRqIfGL/Gkd+nGMJSHGWyAgMQplFWk7WEsOk=",
-				})),
+				getproviders.HashScheme1.New("ntfa04OlRqIfGL/Gkd+nGMJSHGWyAgMQplFWk7WEsOk="),
 			},
 		),
 		addrs.NewDefaultProvider("exact"): depsfile.NewProviderLock(
@@ -2611,10 +2564,7 @@ func TestInit_pluginDirProviders(t *testing.T) {
 			getproviders.MustParseVersion("1.2.3"),
 			getproviders.MustParseVersionConstraints("= 1.2.3"),
 			[]getproviders.Hash{
-				getproviders.HashScheme1.New(getHash(expectedHash{
-					windows: "B75BmVQvrHgtkrEwiQI7ALadRQLwz/QpyVzYLdgbKMw=",
-					linux:   "Xgk+LFrzi9Mop6+d01TCTaD3kgSrUASCAUU1aDsEsJU=",
-				})),
+				getproviders.HashScheme1.New("Xgk+LFrzi9Mop6+d01TCTaD3kgSrUASCAUU1aDsEsJU="),
 			},
 		),
 		addrs.NewDefaultProvider("greater-than"): depsfile.NewProviderLock(
@@ -2622,10 +2572,7 @@ func TestInit_pluginDirProviders(t *testing.T) {
 			getproviders.MustParseVersion("2.3.4"),
 			getproviders.MustParseVersionConstraints(">= 2.3.3"),
 			[]getproviders.Hash{
-				getproviders.HashScheme1.New(getHash(expectedHash{
-					windows: "RcVlVgb5iQ5x6gMHGKAOhpPezPBGw0TBq+oPs5vI894=",
-					linux:   "8M5DXICmUiVjbkxNNO0zXNsV6duCVNWzq3/Kf0mNIo4=",
-				})),
+				getproviders.HashScheme1.New("8M5DXICmUiVjbkxNNO0zXNsV6duCVNWzq3/Kf0mNIo4="),
 			},
 		),
 	}
@@ -3365,18 +3312,4 @@ func expectedPackageInstallPath(name, version string) string {
 	return filepath.ToSlash(filepath.Join(
 		baseDir, fmt.Sprintf("registry.opentofu.org/hashicorp/%s/%s/%s", name, version, platform),
 	))
-}
-
-type expectedHash struct {
-	windows string
-	linux   string
-}
-
-func getHash(expected expectedHash) string {
-	switch runtime.GOOS {
-	case "windows":
-		return expected.windows
-	default:
-		return expected.linux
-	}
 }

--- a/internal/getproviders/mock_source.go
+++ b/internal/getproviders/mock_source.go
@@ -166,10 +166,6 @@ func FakeInstallablePackageMeta(provider addrs.Provider, version Version, protoc
 
 	if execFilename == "" {
 		execFilename = fmt.Sprintf("terraform-provider-%s_%s", provider.Type, version.String())
-		if target.OS == "windows" {
-			// For a little more (technically unnecessary) realism...
-			execFilename += ".exe"
-		}
 	}
 
 	zw := zip.NewWriter(f)


### PR DESCRIPTION
Relates to #1201 

This PR involves two different parts:

1. There was dead code on `expectedPackageInstallPath` where the `exe` argument was always false. I've removed it.
3. Hashes are statically checked on `TestInit_getUpgradePlugins` and `TestInit_providerLockFile` test functions. The solution I think is the most suitable is to return statically the hash depending on the OS. By default, the Linux hash is going to be returned; instead, on Windows, we return the `Windows` one.

This PR fixes: 

- TestInit_getUpgradePlugins
- TestInit_providerLockFile

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
