### PR TITLE
fix missing `TestConsole*` tests on Windows

### DIFF
--- a/internal/command/console_test.go
+++ b/internal/command/console_test.go
@@ -84,11 +84,13 @@ func TestConsole_tfvars(t *testing.T) {
 	}
 	ui := cli.NewMockUi()
 	view, _ := testView(t)
+	streams, _ := terminal.StreamsForTesting(t)
 	c := &ConsoleCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
 			View:             view,
+			Streams:          streams,
 		},
 	}
 
@@ -136,11 +138,13 @@ func TestConsole_unsetRequiredVars(t *testing.T) {
 	}
 	ui := cli.NewMockUi()
 	view, _ := testView(t)
+	streams, _ := terminal.StreamsForTesting(t)
 	c := &ConsoleCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
 			View:             view,
+			Streams:          streams,
 		},
 	}
 
@@ -169,11 +173,13 @@ func TestConsole_variables(t *testing.T) {
 	p := testProvider()
 	ui := cli.NewMockUi()
 	view, _ := testView(t)
+	streams, _ := terminal.StreamsForTesting(t)
 	c := &ConsoleCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
 			View:             view,
+			Streams:          streams,
 		},
 	}
 
@@ -211,12 +217,13 @@ func TestConsole_modules(t *testing.T) {
 	p := applyFixtureProvider()
 	ui := cli.NewMockUi()
 	view, _ := testView(t)
-
+	streams, _ := terminal.StreamsForTesting(t)
 	c := &ConsoleCommand{
 		Meta: Meta{
 			testingOverrides: metaOverridesForProvider(p),
 			Ui:               ui,
 			View:             view,
+			Streams:          streams,
 		},
 	}
 


### PR DESCRIPTION
Relates to #1201 

Fixes the following tests:

```
--- FAIL: TestConsole_tfvars (0.02s)
    console_test.go:108: bad: "\r\b\r\b\x1b[J> \r\b\r\b\x1b[J> v\r\b\r\b\r\b\x1b[J> va\r\b\r\b\r\b\r\b\x1b[J> var\r\b\r\b\r\b\r\b\r\b\x1b[J> var.\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> var.f\r\b\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> var.fo\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> var.foo\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> var.foo\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> var.foo\n\"bar\"\n\r\b\r\b\x1b[J> \r\b\r\b\x1b[J"
--- FAIL: TestConsole_unsetRequiredVars (0.01s)
    console_test.go:160: unexpected output
         got: "\r\b\r\b\x1b[J> \r\b\r\b\x1b[J> v\r\b\r\b\r\b\x1b[J> va\r\b\r\b\r\b\r\b\x1b[J> var\r\b\r\b\r\b\r\b\r\b\x1b[J> var.\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> var.f\r\b\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> var.fo\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> var.foo\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> var.foo\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> var.foo\n(known after apply)\n\r\b\r\b\x1b[J> \r\b\r\b\x1b[J"
        want: "(known after apply)\n"
--- FAIL: TestConsole_variables (0.02s)
    console_test.go:201: bad: "\r\b\r\b\x1b[J> \r\b\r\b\x1b[J> v\r\b\r\b\r\b\x1b[J> va\r\b\r\b\r\b\r\b\x1b[J> var\r\b\r\b\r\b\r\b\r\b\x1b[J> var.\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> var.f\r\b\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> var.fo\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> var.foo\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> var.foo\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> var.foo\n\"bar\"\n\r\b\r\b\x1b[J> \r\b\r\b\x1b[J", expected "\"bar\"\n"
--- FAIL: TestConsole_modules (0.05s)
    console_test.go:243: bad: "\r\b\r\b\x1b[J> \r\b\r\b\x1b[J> m\r\b\r\b\r\b\x1b[J> mo\r\b\r\b\r\b\r\b\x1b[J> mod\r\b\r\b\r\b\r\b\r\b\x1b[J> modu\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> modul\r\b\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> module\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> module.\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> module.c\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> module.ch\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> module.chi\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> module.chil\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> module.child\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> module.child.\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> module.child.m\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> module.child.my\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> module.child.myo\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\r\b\x1b[J> module.child.myou\r\b\r\b
```

Uses the same idea of https://github.com/opentofu/opentofu/pull/3205

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
