### PR TITLE
Use parallel errgroup to increase file copy speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ ENHANCEMENTS:
 * Reduced the CPU and Memory overhead of managing large state files in OpenTofu. ([#3110](https://github.com/opentofu/opentofu/pull/3110))
   * These improvements are primarilly visible in projects with thousands of resources
 * Upgrade github.com/hashicorp/go-getter to v1.7.9 to fix [GO-2025-3892](https://pkg.go.dev/vuln/GO-2025-3892). ([#3227](https://github.com/opentofu/opentofu/pull/3227))
+* The module installer will copy files in parallel to improve performance of `init` ([#3214](https://github.com/opentofu/opentofu/pull/3214))
 
 BUG FIXES:
 

--- a/go.mod
+++ b/go.mod
@@ -104,6 +104,7 @@ require (
 	golang.org/x/mod v0.26.0
 	golang.org/x/net v0.43.0
 	golang.org/x/oauth2 v0.30.0
+	golang.org/x/sync v0.16.0
 	golang.org/x/sys v0.35.0
 	golang.org/x/term v0.34.0
 	golang.org/x/text v0.28.0
@@ -257,7 +258,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.35.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20221208152030-732eee02a75a // indirect
-	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/time v0.11.0 // indirect
 	golang.org/x/tools/go/expect v0.1.1-deprecated // indirect
 	google.golang.org/genproto v0.0.0-20240123012728-ef4313101c80 // indirect


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Reduces the impact of the issue reported in #1086 

More specifically: When using monorepo/centralized modules with lots of files, this starts multiple IO copies in parallel.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
