### PR TITLE
Normalize paths in `TestNewDiagnostic` test

### DIFF
--- a/internal/command/jsonentities/diagnostic_test.go
+++ b/internal/command/jsonentities/diagnostic_test.go
@@ -1176,11 +1176,6 @@ func TestNewDiagnostic(t *testing.T) {
 	}
 }
 
-// Function to normalise newlines in a string for Windows
-func normaliseNewlines(s string) string {
-	return strings.ReplaceAll(s, "\r\n", "\n")
-}
-
 // Helper function to make constructing literal Diagnostics easier. There
 // are fields which are pointer-to-string to ensure that the rendered JSON
 // results in `null` for an empty value, rather than `""`.


### PR DESCRIPTION
Relates to #1201

This PR normalizes paths in `TestNewDiagnostic` to ensure consistency across different environments.
This can be achieved by using `filepath.FromSlash` on the file paths.
This test was only broken on Windows.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
