### PR TITLE
fix: `filepath.Separator` was used to parse URLs

### DIFF
--- a/internal/backend/remote-state/http/server_test.go
+++ b/internal/backend/remote-state/http/server_test.go
@@ -20,7 +20,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -91,7 +90,7 @@ func newHttpServer(opts ...httpServerOpt) *httpServer {
 }
 
 func (h *httpServer) getResource(req *http.Request) string {
-	switch pathParts := strings.SplitN(req.URL.Path, string(filepath.Separator), 3); len(pathParts) {
+	switch pathParts := strings.SplitN(req.URL.Path, "/", 3); len(pathParts) {
 	case 3:
 		return pathParts[2]
 	default:


### PR DESCRIPTION
Related to #1201 

https://github.com/opentofu/opentofu/commit/75e5ae27a258122fe6bf122beb943324c69de5b1#diff-406413feed6412534321e869ce8e6972ab099969538621a3f012f0fa0e760188R85

`filepath.Separator` was used to parse URLs, causing the URLs to be empty on Windows.

This PR fixes `TestMTLSServer_WithCertPasses`.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
