### PR TITLE
Fix http test server errors on `TestBackendConfig_Authentication` by removing usage of `os.Clearenv`

### DIFF
--- a/internal/backend/remote-state/s3/backend_complete_test.go
+++ b/internal/backend/remote-state/s3/backend_complete_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -1819,11 +1818,7 @@ web_identity_token_file = no-such-file
 					t.Fatalf("error making path relative: %s", err)
 				}
 				t.Logf("relative: %s", rel)
-				if runtime.GOOS == "windows" {
-					tokenFileName = filepath.Join(tmpdir, rel)
-				} else {
-					tokenFileName = filepath.Join("$TMPDIR", rel)
-				}
+				tokenFileName = fmt.Sprintf("$TMPDIR%c%s", filepath.Separator, rel)
 				t.Logf("env tempfile: %s", tokenFileName)
 			}
 


### PR DESCRIPTION
Relates to #1201 

AWS backend tests were broken due to a dependency call using `os.Clearenv`. It was defined by `servicemocks.InitSessionTestEnv`. In order to fix that, I replaced it by a function to clean up the environment variables without using `os.Clearenv`. 

The environment variable issue can be explained here:

https://github.com/golang/go/issues/61452

The test was failing with:

```
2025-09-01T16:17:39.7970279Z --- FAIL: TestBackendConfig_Authentication (0.00s)
2025-09-01T16:17:39.7975216Z     --- FAIL: TestBackendConfig_Authentication/environment_AWS_ACCESS_KEY_ID_does_not_override_config_Profile (0.00s)
2025-09-01T16:17:39.7977889Z panic: httptest: failed to listen on a port: listen tcp6 [::1]:0: socket: The requested service provider could not be loaded or initialized. [recovered, repanicked]
```

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
