### PR TITLE
Normalize paths at `internal/lang/funcs` tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -62,7 +62,7 @@ jobs:
           - { runson: ubuntu-latest, goos: linux, goarch: "386" }
           - { runson: ubuntu-latest, goos: linux, goarch: "arm" }
           - { runson: macos-latest, goos: darwin, goarch: "arm64" }
-          - { runson: windows-latest, goos: windows, goarch: "amd64" }
+          # - { runson: windows-latest, goos: windows, goarch: "amd64" }
           # https://github.com/opentofu/opentofu/issues/1201 if fixed
           #  ^ un-comment the  windows-latest line
       fail-fast: false


### PR DESCRIPTION
Relates to #1201 

This PR covers:

1. Removed [one test](https://github.com/opentofu/opentofu/pull/3223/commits/3a004743b9f38fafb1e8df9fc5a16e833a376574) that didn't make sense on Windows;
1. [Normalize paths](https://github.com/opentofu/opentofu/pull/3223/commits/50136dbedbaea59282d8682bd9d14cfab526970e) in `TestDirname`;
1. Skipping two tests in TestFileExists. Since `MakeFileExistsFunc` uses os.Stat, the chmod 0000 call won't work on Windows.

Fixes:

```
2025-09-04T19:07:19.3896796Z --- FAIL: TestFileExists (0.00s)
2025-09-04T19:07:19.3897372Z     --- FAIL: TestFileExists/FileExists(".",_cty.StringVal("testdata/unreadable/foobar")) (0.00s)
2025-09-04T19:07:19.3897758Z         filesystem_test.go:342: succeeded; want error
2025-09-04T19:07:19.3898525Z     --- FAIL: TestFileExists/FileExists(".",_cty.StringVal("testdata/unreadable/foobar").Mark(marks.Sensitive)) (0.00s)
2025-09-04T19:07:19.3900326Z         filesystem_test.go:342: succeeded; want error
2025-09-04T19:07:19.3900471Z --- FAIL: TestFileSet (0.00s)
2025-09-04T19:07:19.3900966Z     --- FAIL: TestFileSet/FileSet(".",_cty.StringVal("."),_cty.StringVal("\\")) (0.00s)
2025-09-04T19:07:19.3901323Z         filesystem_test.go:564: succeeded; want error
2025-09-04T19:07:19.3901467Z --- FAIL: TestDirname (0.00s)
2025-09-04T19:07:19.3901955Z     --- FAIL: TestDirname/Dirname(cty.StringVal("testdata/foo/hello.txt")) (0.00s)
2025-09-04T19:07:19.3902251Z         filesystem_test.go:709: wrong result
2025-09-04T19:07:19.3902580Z             got:  cty.StringVal("testdata\\foo")
2025-09-04T19:07:19.3902894Z             want: cty.StringVal("testdata/foo")
```

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
