### PR TITLE
Close the file handlers in `TestWorkspace_deleteWithState` after use

### DIFF
--- a/internal/command/workspace_command_test.go
+++ b/internal/command/workspace_command_test.go
@@ -401,10 +401,10 @@ func TestWorkspace_deleteWithState(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer f.Close()
 	if err := legacy.WriteState(originalState, f); err != nil {
 		t.Fatal(err)
 	}
+	f.Close()
 
 	ui := cli.NewMockUi()
 	view, _ := testView(t)


### PR DESCRIPTION
Relates to #1201 

The file handle was opened when attempting to delete the workspace because of the use of `defer f.Close()` before the `legacy.WriteState` call. We can safely close the file after this call.
This test was only failing on **Windows**.

## Checklist

<!-- Please check off ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
