### PR TITLE
Fix `TestShow*` error messages on Windows tests

### DIFF
--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -207,6 +207,9 @@ func TestShow_argsPlanFileDoesNotExist(t *testing.T) {
 			got := output.Stderr()
 			want1 := `couldn't load the provided path`
 			want2 := `open doesNotExist.tfplan: no such file or directory`
+			if runtime.GOOS == "windows" {
+				want2 = "open doesNotExist.tfplan: The system cannot find the file specified"
+			}
 			if !strings.Contains(got, want1) {
 				t.Errorf("unexpected output\ngot: %s\nwant:\n%s", got, want1)
 			}

--- a/internal/plans/planfile/planfile_test.go
+++ b/internal/plans/planfile/planfile_test.go
@@ -192,11 +192,9 @@ func TestWrappedError(t *testing.T) {
 	}
 
 	// Open something that doesn't exist: should error
-	var missingFileError string
+	missingFileError := "no such file or directory"
 	if runtime.GOOS == "windows" {
 		missingFileError = "The system cannot find the file specified"
-	} else {
-		missingFileError = "no such file or directory"
 	}
 	_, err = OpenWrapped(filepath.Join("testdata", "absent.tfplan"), encryption.PlanEncryptionDisabled())
 	if !strings.Contains(err.Error(), missingFileError) {


### PR DESCRIPTION
Relates to #1201 

File openings in Unix return "no such file or directory" when the file is not found. This test expects that message, but it fails on Windows, so the PR addresses that issue.

This PR also includes a minor refactoring to `internal/plans/planfile/planfile_test.go`, to do the same behavior with one less line to define the error message.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
