### PR TITLE
tracing: Don't panic on OpenTelemetry errors

### DIFF
--- a/internal/tracing/init.go
+++ b/internal/tracing/init.go
@@ -170,7 +170,7 @@ func OpenTelemetryInit(ctx context.Context) (context.Context, error) {
 	otel.SetLogger(logger)
 
 	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
-		panic(fmt.Sprintf("OpenTelemetry error: %v", err))
+		log.Printf("[ERROR] OpenTelemetry error: %s", err)
 	}))
 
 	return ctx, nil


### PR DESCRIPTION
Previously our global OpenTelemetry error handler would panic. It's not appropriate for a telemetry-related error to crash the entire process, so instead we'll just generate an `[ERROR]` log line for it.

Fixes https://github.com/opentofu/opentofu/issues/3234

This is intentionally a very small fix because we're intending to backport it into earlier release series and so want to keep it simple and low-risk.

---

While @cam72cam and I were investigating this we learned some other things that I'm going to note here for posterity even though we decided not to act on them right now:

- We're using a very old version of some of the OpenTelemetry libraries. It seems likely that we inherited those dependencies from our predecessor at the time of the fork and haven't upgraded them yet.

    Upgrading OpenTelemetry libraries is notorious for causing dependency hell, so it would not be an appropriate thing to attempt in a patch release.

    We did nonetheless try using newer versions out of curiosity but found that it only changed the text of the error message and did not actually fix the error, likely because of the next point.

- The OpenTelemetry Go libraries for Go cannot handle Unix sockets for the OLTP gRPC transport, so it's intentional that this doesn't work although in the current version we are running the error handling for this case is not implemented very well. (Newer versions fail better, but still fail.)

    I know from experience with `hashicorp/go-plugin` that it takes some quite interesting workarounds to convince the gRPC libraries to use a Unix socket, so I'm not surprised that it doesn't work.

- In our misadventures in trying to upgrade we noticed that certain errors with the OTel libraries cause OpenTofu to fail hard with an error message on startup.

    While that's certainly better than panicking, it's arguably still not appropriate for OpenTofu to fail just because there's ambient OTel settings in environment variables, because lots of execution systems (apparently including `docker build`, according to https://github.com/opentofu/opentofu/issues/3234) set these environment variables _just in case_ their workload happens to generate some interesting traces.

    I think that in a future PR we should also turn those startup errors into `[ERROR]` log lines, because philosophically I don't think it's good behavior for incorrectly-configured telemetry to ever block the execution of the workload it was supposed to be monitoring. However, we did not include that change here because we don't yet have any specific reports of it causing problems and we want to keep the scope of this narrow for low-risk backporting.
