### PR TITLE
statemgr: Do not read the state file before acquiring a lock

### DIFF
--- a/internal/states/statemgr/filesystem.go
+++ b/internal/states/statemgr/filesystem.go
@@ -173,7 +173,7 @@ func (s *Filesystem) persistState(schemas *tofu.Schemas) error {
 		if err := s.createStateFiles(); err != nil {
 			return nil
 		}
-		if err := s.writeBackupFile(); err != nil {
+		if err := s.prepareBackupFile(); err != nil {
 			return nil
 		}
 	}
@@ -363,7 +363,7 @@ func (s *Filesystem) Lock(_ context.Context, info *LockInfo) (string, error) {
 		return "", lockErr
 	}
 
-	if err := s.writeBackupFile(); err != nil {
+	if err := s.prepareBackupFile(); err != nil {
 		return "", fmt.Errorf("failed to write backup file: %w", err)
 	}
 
@@ -510,7 +510,7 @@ func (s *Filesystem) createStateFiles() error {
 	return nil
 }
 
-func (s *Filesystem) writeBackupFile() error {
+func (s *Filesystem) prepareBackupFile() error {
 	// If the file already existed with content then that'll be the content
 	// of our backup file if we write a change later.
 	var err error


### PR DESCRIPTION

<!-- If your PR resolves an issue, please add it here. -->
Blocked by https://github.com/opentofu/opentofu/pull/3206
Resolves #3239

This PR waits to write a backup file on file systems where we haven't yet acquired a lock. 
This PR splits the `createStateFiles` function and only writes to the backup file after the lock is acquired.

It fixes `TestApply_lockedStateWait` on Windows.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
