### PR TITLE
Show a change reason on enabled meta-argument when deleting

### DIFF
--- a/internal/command/jsonentities/change.go
+++ b/internal/command/jsonentities/change.go
@@ -113,6 +113,7 @@ const (
 	ReasonDeleteBecauseNoResourceConfig ChangeReason = "delete_because_no_resource_config"
 	ReasonDeleteBecauseWrongRepetition  ChangeReason = "delete_because_wrong_repetition"
 	ReasonDeleteBecauseCountIndex       ChangeReason = "delete_because_count_index"
+	ReasonDeleteBecauseEnabledFalse     ChangeReason = "delete_because_enabled_false"
 	ReasonDeleteBecauseEachKey          ChangeReason = "delete_because_each_key"
 	ReasonDeleteBecauseNoModule         ChangeReason = "delete_because_no_module"
 	ReasonDeleteBecauseNoMoveTarget     ChangeReason = "delete_because_no_move_target"
@@ -139,6 +140,8 @@ func changeReason(reason plans.ResourceInstanceChangeActionReason) ChangeReason 
 		return ReasonDeleteBecauseWrongRepetition
 	case plans.ResourceInstanceDeleteBecauseCountIndex:
 		return ReasonDeleteBecauseCountIndex
+	case plans.ResourceInstanceDeleteBecauseEnabledFalse:
+		return ReasonDeleteBecauseEnabledFalse
 	case plans.ResourceInstanceDeleteBecauseEachKey:
 		return ReasonDeleteBecauseEachKey
 	case plans.ResourceInstanceDeleteBecauseNoModule:

--- a/internal/command/jsonformat/plan.go
+++ b/internal/command/jsonformat/plan.go
@@ -489,6 +489,8 @@ func resourceChangeComment(resource jsonplan.ResourceChange, action plans.Action
 			}
 		case jsonplan.ResourceInstanceDeleteBecauseCountIndex:
 			buf.WriteString(fmt.Sprintf("\n  # (because index [%s] is out of range for count)", resource.Index))
+		case jsonplan.ResourceInstanceDeleteBecauseEnabledFalse:
+			buf.WriteString("\n  # (because enabled is false)")
 		case jsonplan.ResourceInstanceDeleteBecauseEachKey:
 			buf.WriteString(fmt.Sprintf("\n  # (because key [%s] is not in for_each map)", resource.Index))
 		}

--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -41,6 +41,7 @@ const (
 	ResourceInstanceDeleteBecauseNoResourceConfig = "delete_because_no_resource_config"
 	ResourceInstanceDeleteBecauseWrongRepetition  = "delete_because_wrong_repetition"
 	ResourceInstanceDeleteBecauseCountIndex       = "delete_because_count_index"
+	ResourceInstanceDeleteBecauseEnabledFalse     = "delete_because_enabled_false"
 	ResourceInstanceDeleteBecauseEachKey          = "delete_because_each_key"
 	ResourceInstanceDeleteBecauseNoModule         = "delete_because_no_module"
 	ResourceInstanceDeleteBecauseNoMoveTarget     = "delete_because_no_move_target"
@@ -560,6 +561,8 @@ func MarshalResourceChanges(resources []*plans.ResourceInstanceChangeSrc, schema
 			r.ActionReason = ResourceInstanceDeleteBecauseCountIndex
 		case plans.ResourceInstanceDeleteBecauseEachKey:
 			r.ActionReason = ResourceInstanceDeleteBecauseEachKey
+		case plans.ResourceInstanceDeleteBecauseEnabledFalse:
+			r.ActionReason = ResourceInstanceDeleteBecauseEnabledFalse
 		case plans.ResourceInstanceDeleteBecauseNoModule:
 			r.ActionReason = ResourceInstanceDeleteBecauseNoModule
 		case plans.ResourceInstanceDeleteBecauseNoMoveTarget:

--- a/internal/plans/changes.go
+++ b/internal/plans/changes.go
@@ -448,6 +448,10 @@ const (
 	// "for_each" value.
 	ResourceInstanceDeleteBecauseEachKey ResourceInstanceChangeActionReason = 'E'
 
+	// ResourceInstanceDeleteBecauseEnabledFalse indicates that the resource
+	// instance is planned to be deleted because its enabled argument is false.
+	ResourceInstanceDeleteBecauseEnabledFalse ResourceInstanceChangeActionReason = 'L'
+
 	// ResourceInstanceDeleteBecauseNoModule indicates that the resource
 	// instance is planned to be deleted because it belongs to a module
 	// instance that's no longer declared in the configuration.

--- a/internal/plans/resourceinstancechangeactionreason_string.go
+++ b/internal/plans/resourceinstancechangeactionreason_string.go
@@ -17,6 +17,7 @@ func _() {
 	_ = x[ResourceInstanceDeleteBecauseWrongRepetition-87]
 	_ = x[ResourceInstanceDeleteBecauseCountIndex-67]
 	_ = x[ResourceInstanceDeleteBecauseEachKey-69]
+	_ = x[ResourceInstanceDeleteBecauseEnabledFalse-76]
 	_ = x[ResourceInstanceDeleteBecauseNoModule-77]
 	_ = x[ResourceInstanceDeleteBecauseNoMoveTarget-65]
 	_ = x[ResourceInstanceReadBecauseConfigUnknown-63]
@@ -31,7 +32,7 @@ const (
 	_ResourceInstanceChangeActionReason_name_3 = "ResourceInstanceReadBecauseConfigUnknown"
 	_ResourceInstanceChangeActionReason_name_4 = "ResourceInstanceDeleteBecauseNoMoveTarget"
 	_ResourceInstanceChangeActionReason_name_5 = "ResourceInstanceDeleteBecauseCountIndexResourceInstanceReplaceByTriggersResourceInstanceDeleteBecauseEachKeyResourceInstanceReplaceBecauseCannotUpdate"
-	_ResourceInstanceChangeActionReason_name_6 = "ResourceInstanceDeleteBecauseNoModuleResourceInstanceDeleteBecauseNoResourceConfig"
+	_ResourceInstanceChangeActionReason_name_6 = "ResourceInstanceDeleteBecauseEnabledFalseResourceInstanceDeleteBecauseNoModuleResourceInstanceDeleteBecauseNoResourceConfig"
 	_ResourceInstanceChangeActionReason_name_7 = "ResourceInstanceReplaceByRequest"
 	_ResourceInstanceChangeActionReason_name_8 = "ResourceInstanceReplaceBecauseTainted"
 	_ResourceInstanceChangeActionReason_name_9 = "ResourceInstanceDeleteBecauseWrongRepetition"
@@ -39,7 +40,7 @@ const (
 
 var (
 	_ResourceInstanceChangeActionReason_index_5 = [...]uint8{0, 39, 72, 108, 150}
-	_ResourceInstanceChangeActionReason_index_6 = [...]uint8{0, 37, 82}
+	_ResourceInstanceChangeActionReason_index_6 = [...]uint8{0, 41, 78, 123}
 )
 
 func (i ResourceInstanceChangeActionReason) String() string {
@@ -57,8 +58,8 @@ func (i ResourceInstanceChangeActionReason) String() string {
 	case 67 <= i && i <= 70:
 		i -= 67
 		return _ResourceInstanceChangeActionReason_name_5[_ResourceInstanceChangeActionReason_index_5[i]:_ResourceInstanceChangeActionReason_index_5[i+1]]
-	case 77 <= i && i <= 78:
-		i -= 77
+	case 76 <= i && i <= 78:
+		i -= 76
 		return _ResourceInstanceChangeActionReason_name_6[_ResourceInstanceChangeActionReason_index_6[i]:_ResourceInstanceChangeActionReason_index_6[i+1]]
 	case i == 82:
 		return _ResourceInstanceChangeActionReason_name_7

--- a/internal/tofu/node_resource_plan_orphan.go
+++ b/internal/tofu/node_resource_plan_orphan.go
@@ -271,6 +271,11 @@ func (n *NodePlannableResourceInstanceOrphan) deleteActionReason(evalCtx EvalCon
 
 	switch n.Addr.Resource.Key.(type) {
 	case nil: // no instance key at all
+		// TODO: Conditional enable work
+		// Uncomment this when Enabled field exists on Cfg
+		// if cfg.Enabled != nil {
+		// 	return plans.ResourceInstanceDeleteBecauseEnabledFalse
+		// }
 		if cfg.Count != nil || cfg.ForEach != nil {
 			return plans.ResourceInstanceDeleteBecauseWrongRepetition
 		}


### PR DESCRIPTION
Relates to #3247 

> Originally from Martin's comment: https://github.com/opentofu/opentofu/pull/3042#discussion_r2220347261

This PR creates an extra hint comment to be clear that it was the `enabled` argument that caused it to be planned for destroy:

<img width="1158" height="456" alt="image" src="https://github.com/user-attachments/assets/2cc2004e-293b-4554-9edf-91868ce259bf" />

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
