### PR TITLE
Fix test crash when using deprecated outputs in the root module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ BUG FIXES:
 * Ensure that generated mock values for testing correctly follows the provider schema. ([#3069](https://github.com/opentofu/opentofu/pull/3069))
 * Remote provisioners now reject SSH certificates whose signature key is a certificate key, as required by the current SSH Certificate Format specification draft. ([#3180](https://github.com/opentofu/opentofu/pull/3180))
 * `tofu import` command now correctly validates when the target address contains non-existent for_each key ([#3106](https://github.com/opentofu/opentofu/pull/3106))
+* Fix crash in tofu test when using deprecated outputs ([#3249](https://github.com/opentofu/opentofu/pull/3249))
 
 BREAKING CHANGES:
 * In the `azurerm` backend, the following backend variables have been changed ([#3034](https://github.com/opentofu/opentofu/pull/3034)):

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -1609,3 +1609,27 @@ func TestTest_MockProviderValidationForEach(t *testing.T) {
 		t.Fatalf("expected status code 0 but got %d: %s", code, output.All())
 	}
 }
+
+// See https://github.com/opentofu/opentofu/issues/3246
+func TestTest_DeprecatedOutputs(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("test/deprecated_outputs"), td)
+	t.Chdir(td)
+
+	view, done := testView(t)
+	ui := new(cli.MockUi)
+	meta := Meta{
+		Ui:   ui,
+		View: view,
+	}
+
+	testCmd := &TestCommand{
+		Meta: meta,
+	}
+
+	code := testCmd.Run(nil)
+	output := done(t)
+	if code != 0 {
+		t.Fatalf("expected status code 0 but got %d: %s", code, output.All())
+	}
+}

--- a/internal/command/testdata/test/deprecated_outputs/main.tf
+++ b/internal/command/testdata/test/deprecated_outputs/main.tf
@@ -1,0 +1,4 @@
+output "example" {
+  value = "example"
+  deprecated = "for reasons"
+}

--- a/internal/command/testdata/test/deprecated_outputs/main.tftest.hcl
+++ b/internal/command/testdata/test/deprecated_outputs/main.tftest.hcl
@@ -1,0 +1,8 @@
+run "example" {
+  command = plan
+
+  assert {
+    condition = output.example == "example"
+    error_message = "ruh-roh"
+  }
+}

--- a/internal/lang/marks/marks.go
+++ b/internal/lang/marks/marks.go
@@ -117,6 +117,12 @@ func Deprecated(v cty.Value, cause DeprecationCause) cty.Value {
 // DeprecatedOutput marks a given values as deprecated constructing a DeprecationCause
 // from module output specific data.
 func DeprecatedOutput(v cty.Value, addr addrs.AbsOutputValue, msg string, isFromRemoteModule bool) cty.Value {
+	if addr.Module.IsRoot() {
+		// Marking a root output as deprecated has no impact.
+		// We hit this case when using the test framework on a module however.
+		// This is requried as the ModuleCallOutput() below will panic on the root module.
+		return v
+	}
 	_, callOutAddr := addr.ModuleCallOutput()
 	return Deprecated(v, DeprecationCause{
 		IsFromRemoteModule: isFromRemoteModule,


### PR DESCRIPTION
Marking a root output as deprecated has no impact. We hit this case when using the test framework on a module.


<!-- If your PR resolves an issue, please add it here. -->
Resolves #3246 

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

