### PR TITLE
Add expanders for `enabled` meta-argument

### DIFF
--- a/internal/configs/resource.go
+++ b/internal/configs/resource.go
@@ -28,6 +28,7 @@ type Resource struct {
 	Config  hcl.Body
 	Count   hcl.Expression
 	ForEach hcl.Expression
+	Enabled hcl.Expression
 
 	ProviderConfigRef *ProviderConfigRef
 	Provider          addrs.Provider

--- a/internal/instances/expander.go
+++ b/internal/instances/expander.go
@@ -87,6 +87,12 @@ func (e *Expander) SetResourceCount(moduleAddr addrs.ModuleInstance, resourceAdd
 	e.setResourceExpansion(moduleAddr, resourceAddr, expansionCount(count))
 }
 
+// SetResourceEnabled records that the given resource inside the given module
+// uses the "enabled" repetition argument, with the given value.
+func (e *Expander) SetResourceEnabled(moduleAddr addrs.ModuleInstance, resourceAddr addrs.Resource, enabled bool) {
+	e.setResourceExpansion(moduleAddr, resourceAddr, expansionEnabled(enabled))
+}
+
 // SetResourceForEach records that the given resource inside the given module
 // uses the "for_each" repetition argument, with the given map value.
 //

--- a/internal/instances/expansion_mode.go
+++ b/internal/instances/expansion_mode.go
@@ -42,6 +42,24 @@ func (e expansionSingle) repetitionData(key addrs.InstanceKey) RepetitionData {
 	return RepetitionData{}
 }
 
+// expansionEnabled is the expansion corresponding to the "enabled" argument,
+// producing either no instances or one instance with no instance key.
+type expansionEnabled bool
+
+func (e expansionEnabled) instanceKeys() []addrs.InstanceKey {
+	if !bool(e) {
+		return nil
+	}
+	return singleKeys
+}
+
+func (e expansionEnabled) repetitionData(key addrs.InstanceKey) RepetitionData {
+	if key != addrs.NoKey {
+		panic("cannot use instance key with non-repeating object")
+	}
+	return RepetitionData{}
+}
+
 // expansionCount is the expansion corresponding to the "count" argument.
 type expansionCount int
 

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -516,6 +516,20 @@ func (n *NodeAbstractResource) writeResourceState(ctx context.Context, evalCtx E
 		state.SetResourceProvider(addr, n.ResolvedProvider.ProviderConfig)
 		expander.SetResourceCount(addr.Module, n.Addr.Resource, count)
 
+	case n.Config != nil && n.Config.Enabled != nil:
+		// TODO: Conditional enable work
+		enabled := true
+		enabledDiags := tfdiags.Diagnostics{}
+		// TODO: Put it back after merging https://github.com/opentofu/opentofu/pull/3250
+		// enabled, enabledDiags := evaluateEnabledExpression(ctx, n.Config.Enabled, evalCtx)
+		diags = diags.Append(enabledDiags)
+		if enabledDiags.HasErrors() {
+			return diags
+		}
+
+		state.SetResourceProvider(addr, n.ResolvedProvider.ProviderConfig)
+		expander.SetResourceEnabled(addr.Module, n.Addr.Resource, enabled)
+
 	case n.Config != nil && n.Config.ForEach != nil:
 		forEach, forEachDiags := evaluateForEachExpression(ctx, n.Config.ForEach, evalCtx, addr)
 		diags = diags.Append(forEachDiags)


### PR DESCRIPTION
Relates to https://github.com/opentofu/opentofu/issues/3247

This PR focuses on adding the expander for the enabled field work. Expander instances are responsible for converting repetition data (like for_each or count) into instance data. For enabled, we're using a boolean, returning the addrs.NoKey when the `enabled` field is defined, otherwise, returning nil.
There are no unit tests for it, but the integration tests should cover them in future PRs.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
