### PR TITLE
fix: ephemeral end-to-end tests on Windows

### DIFF
--- a/internal/command/e2etest/ephemeral_test.go
+++ b/internal/command/e2etest/ephemeral_test.go
@@ -7,6 +7,7 @@ package e2etest
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -185,7 +186,8 @@ func TestEphemeralErrors_outputs(t *testing.T) {
 			t.Errorf("unexpected err: %s;\nstderr:\n%s\nstdout:\n%s", err, serr, sout)
 		}
 		sanitized := SanitizeStderr(serr)
-		if !strings.Contains(sanitized, `Output does not allow ephemeral value    on __mod-with-regular-output-got-ephemeral-value/main.tf`) ||
+		filename := filepath.FromSlash("__mod-with-regular-output-got-ephemeral-value/main.tf")
+		if !strings.Contains(sanitized, `Output does not allow ephemeral value    on `+filename) ||
 			!strings.Contains(sanitized, `The value that was generated for the output is ephemeral, but it is not configured to allow one`) {
 			t.Errorf("unexpected stderr: %s;\nstderr:\n%s\nstdout:\n%s", err, serr, sout)
 			t.Logf("sanitized serr: %s", sanitized)
@@ -200,15 +202,16 @@ func TestEphemeralErrors_outputs(t *testing.T) {
 		}
 		sanitizedSerr := SanitizeStderr(serr)
 		sanitizedSout := SanitizeStderr(sout)
-		if !strings.Contains(sanitizedSerr, `Module output value precondition failed    on __mod-ephemeral-output-with-precondition/main.tf`) ||
+		filename := filepath.FromSlash("__mod-ephemeral-output-with-precondition/main.tf")
+		if !strings.Contains(sanitizedSerr, `Module output value precondition failed    on `+filename) ||
 			!strings.Contains(sanitizedSerr, `This check failed, but has an invalid error message as described in the other accompanying messages`) ||
 			strings.Contains(sanitizedSerr, `"notdefaultvalue" -> "default value"`) {
 			t.Errorf("unexpected stderr: %s;\nstderr:\n%s\nstdout:\n%s", err, serr, sout)
 			t.Logf("sanitized serr: %s", sanitizedSerr)
 		}
-		if !strings.Contains(sanitizedSout, `Warning: Error message refers to ephemeral values    on __mod-ephemeral-output-with-precondition/main.tf`) ||
+		if !strings.Contains(sanitizedSout, `Warning: Error message refers to ephemeral values    on `+filename) ||
 			!strings.Contains(sanitizedSout, `The error expression used to explain this condition refers to ephemeral values, so OpenTofu will not display the resulting message.  You can correct this by removing references to ephemeral values`) {
-			t.Errorf("unexpected stdout: %s;\nstdout:\n%s\nstdout:\n%s", err, serr, sout)
+			t.Errorf("unexpected stdout: %s;\nstderr:\n%s\nstdout:\n%s", err, serr, sout)
 			t.Logf("sanitized sout: %s", sanitizedSerr)
 		}
 	})


### PR DESCRIPTION
Fixes by updating the filename in ephemeral end-to-end tests to use backslashes on Windows.

https://github.com/opentofu/opentofu/actions/runs/17612689167/job/50038116186
https://github.com/opentofu/opentofu/actions/runs/17612689167/job/50038116156

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
