### PR TITLE
fix: `TestExecutable` on Windows - expected error message is wrong

### DIFF
--- a/internal/providercache/cached_provider_test.go
+++ b/internal/providercache/cached_provider_test.go
@@ -6,6 +6,7 @@
 package providercache
 
 import (
+	"runtime"
 	"syscall"
 	"testing"
 
@@ -103,7 +104,7 @@ func TestExecutableFile(t *testing.T) {
 				Version:    getproviders.MustParseVersion("2.0.0"),
 				PackageDir: "testdata/cachedir/registry.opentofu.org/missing/packagedir/2.0.0/linux_amd64",
 			},
-			err: "could not read package directory: open testdata/cachedir/registry.opentofu.org/missing/packagedir/2.0.0/linux_amd64: " + syscall.ENOENT.Error(),
+			err: "could not read package directory: open testdata/cachedir/registry.opentofu.org/missing/packagedir/2.0.0/linux_amd64: " + missingDirError(),
 		},
 	}
 
@@ -120,4 +121,11 @@ func TestExecutableFile(t *testing.T) {
 			}
 		})
 	}
+}
+
+func missingDirError() string {
+	if runtime.GOOS == "windows" {
+		return syscall.ENOTDIR.Error()
+	}
+	return syscall.ENOENT.Error()
 }


### PR DESCRIPTION
Relates to https://github.com/opentofu/opentofu/issues/1201

TestExecutable is using `syscall.ENOENT.Error()` which on Windows returns: `The system cannot find the file specified.`

For this specific test, instead, there's an invalid path, so the error returned is `The system cannot find the path specified.`.

This PR fixes:

```
2025-09-16T12:44:15.0870405Z     --- FAIL: TestExecutableFile/missing-dir (0.00s)
2025-09-16T12:44:15.0871152Z         cached_provider_test.go:119: wrong error
2025-09-16T12:44:15.0873051Z              got: "could not read package directory: open testdata/cachedir/registry.opentofu.org/missing/packagedir/2.0.0/linux_amd64: The system cannot find the path specified."
2025-09-16T12:44:15.0875628Z             want: "could not read package directory: open testdata/cachedir/registry.opentofu.org/missing/packagedir/2.0.0/linux_amd64: The system cannot find the file specified."
```

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
