### PR TITLE
fix `internal/configs/` on Windows

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -62,7 +62,7 @@ jobs:
           - { runson: ubuntu-latest, goos: linux, goarch: "386" }
           - { runson: ubuntu-latest, goos: linux, goarch: "arm" }
           - { runson: macos-latest, goos: darwin, goarch: "arm64" }
-          - { runson: windows-latest, goos: windows, goarch: "amd64" }
+          # - { runson: windows-latest, goos: windows, goarch: "amd64" }
           # https://github.com/opentofu/opentofu/issues/1201 if fixed
           #  ^ un-comment the  windows-latest line
       fail-fast: false

--- a/internal/configs/module_merge_test.go
+++ b/internal/configs/module_merge_test.go
@@ -100,7 +100,7 @@ func TestModuleOverrideOutput(t *testing.T) {
 					&hclsyntax.LiteralValueExpr{
 						Val: cty.StringVal("b_override"),
 						SrcRange: hcl.Range{
-							Filename: "testdata/valid-modules/override-output/b_override.tf",
+							Filename: filepath.FromSlash("testdata/valid-modules/override-output/b_override.tf"),
 							Start: hcl.Pos{
 								Line:   2,
 								Column: 12,
@@ -115,7 +115,7 @@ func TestModuleOverrideOutput(t *testing.T) {
 					},
 				},
 				SrcRange: hcl.Range{
-					Filename: "testdata/valid-modules/override-output/b_override.tf",
+					Filename: filepath.FromSlash("testdata/valid-modules/override-output/b_override.tf"),
 					Start: hcl.Pos{
 						Line:   2,
 						Column: 11,
@@ -154,7 +154,7 @@ func TestModuleOverrideOutput(t *testing.T) {
 					&hclsyntax.LiteralValueExpr{
 						Val: cty.StringVal("b_override partial"),
 						SrcRange: hcl.Range{
-							Filename: "testdata/valid-modules/override-output/b_override.tf",
+							Filename: filepath.FromSlash("testdata/valid-modules/override-output/b_override.tf"),
 							Start: hcl.Pos{
 								Line:   9,
 								Column: 12,
@@ -169,7 +169,7 @@ func TestModuleOverrideOutput(t *testing.T) {
 					},
 				},
 				SrcRange: hcl.Range{
-					Filename: "testdata/valid-modules/override-output/b_override.tf",
+					Filename: filepath.FromSlash("testdata/valid-modules/override-output/b_override.tf"),
 					Start: hcl.Pos{
 						Line:   9,
 						Column: 11,

--- a/internal/configs/testdata/.gitattributes
+++ b/internal/configs/testdata/.gitattributes
@@ -1,0 +1,1 @@
+**/* text eol=lf


### PR DESCRIPTION
Relates to #1201 

This PR standardizes the line breaks from `internal/configs/testdata` and OS separators in `Ref`, `SourceRange`,  `DeclRange` fields.

This PR fixes:

```
2025-09-16T16:40:56.8376660Z --- FAIL: TestConfigProviderRequirements (0.01s)
2025-09-16T16:40:56.8377251Z     config_test.go:231: wrong qualifs result
2025-09-16T16:40:56.8378398Z           &getproviders.ProvidersQualification{
2025-09-16T16:40:56.8379375Z           	Implicit: map[regaddr.Provider][]getproviders.ResourceRef{
2025-09-16T16:40:56.8380233Z           		s"registry.opentofu.org/hashicorp/grandchild": {
2025-09-16T16:40:56.8380809Z           			{
2025-09-16T16:40:56.8381477Z           				CfgRes: s"module.kinder.module.nested.grandchild_foo.bar",
2025-09-16T16:40:56.8382403Z           				Ref: tfdiags.SourceRange{
2025-09-16T16:40:56.8382982Z           					Filename: strings.Join({
2025-09-16T16:40:56.8383514Z           						"testdata",
2025-09-16T16:40:56.8384236Z         - 						"/provider-reqs/child/grandchild/",
2025-09-16T16:40:56.8385311Z         + 						`\provider-reqs\child\grandchild\`,
2025-09-16T16:40:56.8385986Z           						"provider-reqs-grandchild.tf",
2025-09-16T16:40:56.8386498Z           					}, ""),
2025-09-16T16:40:56.8387111Z           					Start: {Line: 3, Column: 1, Byte: 136},
2025-09-16T16:40:56.8387764Z           					End:   {Line: 3, Column: 32, Byte: 167},
2025-09-16T16:40:56.8388329Z           				},
2025-09-16T16:40:56.8388813Z           				ProviderAttribute: false,
2025-09-16T16:40:56.8389312Z           			},
2025-09-16T16:40:56.8389664Z           		},
2025-09-16T16:40:56.8390272Z           		s"registry.opentofu.org/hashicorp/implied": {
2025-09-16T16:40:56.8390812Z           			{
2025-09-16T16:40:56.8391284Z           				CfgRes: s"implied_foo.bar",
2025-09-16T16:40:56.8391890Z           				Ref: tfdiags.SourceRange{
2025-09-16T16:40:56.8392446Z           					Filename: strings.Join({
2025-09-16T16:40:56.8392987Z           						"testdata",
2025-09-16T16:40:56.8393460Z         - 						"/provider-reqs/",
2025-09-16T16:40:56.8393998Z         + 						`\provider-reqs\`,
2025-09-16T16:40:56.8394535Z           						"provider-reqs-root.tf",
2025-09-16T16:40:56.8395062Z           					}, ""),
2025-09-16T16:40:56.8395639Z           					Start: {Line: 16, Column: 1, Byte: 317},
2025-09-16T16:40:56.8396293Z           					End:   {Line: 16, Column: 29, Byte: 345},
2025-09-16T16:40:56.8396818Z           				},
2025-09-16T16:40:56.8397270Z           				ProviderAttribute: false,
2025-09-16T16:40:56.8397763Z           			},
2025-09-16T16:40:56.8398106Z           		},
2025-09-16T16:40:56.8398741Z           		s"registry.opentofu.org/hashicorp/importexplicit": {
2025-09-16T16:40:56.8399291Z           			{
2025-09-16T16:40:56.8399840Z           				CfgRes: s"importimplied.targetB",
2025-09-16T16:40:56.8400481Z           				Ref: tfdiags.SourceRange{
2025-09-16T16:40:56.8401046Z           					Filename: strings.Join({
2025-09-16T16:40:56.8401673Z           						"testdata",
2025-09-16T16:40:56.8402146Z         - 						"/provider-reqs/",
2025-09-16T16:40:56.8402687Z         + 						`\provider-reqs\`,
2025-09-16T16:40:56.8403229Z           						"provider-reqs-root.tf",
2025-09-16T16:40:56.8403782Z           					}, ""),
2025-09-16T16:40:56.8404345Z           					Start: {Line: 42, Column: 1, Byte: 939},
2025-09-16T16:40:56.8405329Z           					End:   {Line: 42, Column: 7, Byte: 945},
2025-09-16T16:40:56.8405906Z           				},
2025-09-16T16:40:56.8406379Z           				ProviderAttribute: false,
2025-09-16T16:40:56.8406867Z           			},
2025-09-16T16:40:56.8407215Z           		},
2025-09-16T16:40:56.8407853Z           		s"registry.opentofu.org/hashicorp/importimplied": {
2025-09-16T16:40:56.8408435Z           			{
2025-09-16T16:40:56.8408984Z           				CfgRes: s"importimplied.targetA",
2025-09-16T16:40:56.8409573Z           				Ref: tfdiags.SourceRange{
2025-09-16T16:40:56.8410177Z           					Filename: strings.Join({
2025-09-16T16:40:56.8410686Z           						"testdata",
2025-09-16T16:40:56.8411209Z         - 						"/provider-reqs/",
2025-09-16T16:40:56.8411770Z         + 						`\provider-reqs\`,
2025-09-16T16:40:56.8412330Z           						"provider-reqs-root.tf",
2025-09-16T16:40:56.8412864Z           					}, ""),
2025-09-16T16:40:56.8413406Z           					Start: {Line: 37, Column: 1, Byte: 886},
2025-09-16T16:40:56.8414084Z           					End:   {Line: 37, Column: 7, Byte: 892},
2025-09-16T16:40:56.8414554Z           				},
2025-09-16T16:40:56.8415064Z           				ProviderAttribute: false,
2025-09-16T16:40:56.8415527Z           			},
2025-09-16T16:40:56.8415915Z           		},
2025-09-16T16:40:56.8416445Z           		s"terraform.io/builtin/terraform": {
2025-09-16T16:40:56.8416918Z           			{
2025-09-16T16:40:56.8418257Z           				CfgRes: s"data.terraform_remote_state.bar",
2025-09-16T16:40:56.8418936Z           				Ref: tfdiags.SourceRange{
2025-09-16T16:40:56.8420252Z           					Filename: strings.Join({
2025-09-16T16:40:56.8420777Z           						"testdata",
2025-09-16T16:40:56.8421317Z         - 						"/provider-reqs/",
2025-09-16T16:40:56.8421852Z         + 						`\provider-reqs\`,
2025-09-16T16:40:56.8422435Z           						"provider-reqs-root.tf",
2025-09-16T16:40:56.8422911Z           					}, ""),
2025-09-16T16:40:56.8423481Z           					Start: {Line: 27, Column: 1, Byte: 628},
2025-09-16T16:40:56.8424179Z           					End:   {Line: 27, Column: 36, Byte: 663},
2025-09-16T16:40:56.8424664Z           				},
2025-09-16T16:40:56.8425480Z           				ProviderAttribute: false,
2025-09-16T16:40:56.8425953Z           			},
2025-09-16T16:40:56.8426325Z           		},
2025-09-16T16:40:56.8426667Z           	},
2025-09-16T16:40:56.8428482Z           	Explicit: {s"tf.example.com/awesomecorp/happycloud": {}, s"registry.opentofu.org/hashicorp/null": {}, s"registry.opentofu.org/hashicorp/random": {}, s"registry.opentofu.org/hashicorp/tls": {}},
2025-09-16T16:40:56.8429870Z           }
2025-09-16T16:40:56.8430316Z --- FAIL: TestConfigProviderRequirementsInclTests (0.00s)
2025-09-16T16:40:56.8431027Z     config_test.go:293: wrong qualifs result
2025-09-16T16:40:56.8431730Z           &getproviders.ProvidersQualification{
2025-09-16T16:40:56.8432595Z           	Implicit: map[regaddr.Provider][]getproviders.ResourceRef{
2025-09-16T16:40:56.8433381Z           		s"registry.opentofu.org/hashicorp/implied": {
2025-09-16T16:40:56.8433931Z           			{
2025-09-16T16:40:56.8434387Z           				CfgRes: s"implied_foo.bar",
2025-09-16T16:40:56.8434989Z           				Ref: tfdiags.SourceRange{
2025-09-16T16:40:56.8435583Z           					Filename: strings.Join({
2025-09-16T16:40:56.8436089Z           						"testdata",
2025-09-16T16:40:56.8436566Z         - 						"/",
2025-09-16T16:40:56.8436963Z         + 						`\`,
2025-09-16T16:40:56.8437523Z           						"provider-reqs-with-tests",
2025-09-16T16:40:56.8438078Z         - 						"/",
2025-09-16T16:40:56.8438515Z         + 						`\`,
2025-09-16T16:40:56.8439469Z           						"provider-reqs-root.tf",
2025-09-16T16:40:56.8440063Z           					}, ""),
2025-09-16T16:40:56.8440739Z           					Start: {Line: 12, Column: 1, Byte: 247},
2025-09-16T16:40:56.8441546Z           					End:   {Line: 12, Column: 29, Byte: 275},
2025-09-16T16:40:56.8442108Z           				},
2025-09-16T16:40:56.8442671Z           				ProviderAttribute: false,
2025-09-16T16:40:56.8443183Z           			},
2025-09-16T16:40:56.8443453Z           		},
2025-09-16T16:40:56.8443782Z           		s"terraform.io/builtin/terraform": {
2025-09-16T16:40:56.8444116Z           			{
2025-09-16T16:40:56.8444465Z           				CfgRes: s"data.terraform_remote_state.bar",
2025-09-16T16:40:56.8445077Z           				Ref: tfdiags.SourceRange{
2025-09-16T16:40:56.8445716Z           					Filename: strings.Join({
2025-09-16T16:40:56.8446037Z           						"testdata",
2025-09-16T16:40:56.8446340Z         - 						"/",
2025-09-16T16:40:56.8446601Z         + 						`\`,
2025-09-16T16:40:56.8446944Z           						"provider-reqs-with-tests",
2025-09-16T16:40:56.8447255Z         - 						"/",
2025-09-16T16:40:56.8447544Z         + 						`\`,
2025-09-16T16:40:56.8448090Z           						"provider-reqs-root.tf",
2025-09-16T16:40:56.8448464Z           					}, ""),
2025-09-16T16:40:56.8448948Z           					Start: {Line: 19, Column: 1, Byte: 516},
2025-09-16T16:40:56.8449402Z           					End:   {Line: 19, Column: 36, Byte: 551},
2025-09-16T16:40:56.8449743Z           				},
2025-09-16T16:40:56.8450042Z           				ProviderAttribute: false,
2025-09-16T16:40:56.8450370Z           			},
2025-09-16T16:40:56.8450599Z           		},
2025-09-16T16:40:56.8450852Z           	},
2025-09-16T16:40:56.8452161Z           	Explicit: {s"registry.opentofu.org/hashicorp/null": {}, s"registry.opentofu.org/hashicorp/random": {}, s"registry.opentofu.org/hashicorp/tls": {}},
2025-09-16T16:40:56.8452851Z           }
2025-09-16T16:40:56.8453179Z --- FAIL: TestModuleOverrideOutput (0.00s)
2025-09-16T16:40:56.8453586Z     module_merge_test.go:201: wrong result
2025-09-16T16:40:56.8454217Z         got: (map[string]*configs.Output) (len=2) {
2025-09-16T16:40:56.8454695Z          (string) (len=16) "fully_overridden": (*configs.Output)(0xc000000d20)({
2025-09-16T16:40:56.8455175Z           Name: (string) (len=16) "fully_overridden",
2025-09-16T16:40:56.8455609Z           Description: (string) (len=22) "b_override description",
2025-09-16T16:40:56.8456070Z           Expr: (*hclsyntax.TemplateExpr)(0xc00047cba0)({
2025-09-16T16:40:56.8456483Z            Parts: ([]hclsyntax.Expression) (len=1 cap=1) {
2025-09-16T16:40:56.8456925Z             (*hclsyntax.LiteralValueExpr)(0xc00047cb40)({
2025-09-16T16:40:56.8457290Z              Val: (cty.Value) {
2025-09-16T16:40:56.8457583Z               ty: (cty.Type) {
2025-09-16T16:40:56.8457951Z                typeImpl: (cty.primitiveType) {
2025-09-16T16:40:56.8458351Z                 typeImplSigil: (cty.typeImplSigil) {
2025-09-16T16:40:56.8458678Z                 },
2025-09-16T16:40:56.8458993Z                 Kind: (cty.primitiveTypeKind) 83
2025-09-16T16:40:56.8459319Z                }
2025-09-16T16:40:56.8459651Z               },
2025-09-16T16:40:56.8460090Z               v: (string) (len=10) "b_override"
2025-09-16T16:40:56.8460399Z              },
2025-09-16T16:40:56.8460907Z              SrcRange: (hcl.Range) testdata\valid-modules\override-output\b_override.tf:2,12-22
2025-09-16T16:40:56.8461336Z             })
2025-09-16T16:40:56.8461529Z            },
2025-09-16T16:40:56.8462025Z            SrcRange: (hcl.Range) testdata\valid-modules\override-output\b_override.tf:2,11-23
2025-09-16T16:40:56.8462410Z           }),
2025-09-16T16:40:56.8462707Z           DependsOn: ([]hcl.Traversal) <nil>,
2025-09-16T16:40:56.8463030Z           Sensitive: (bool) false,
2025-09-16T16:40:56.8463451Z           Deprecated: (string) (len=21) "b_override deprecated",
2025-09-16T16:40:56.8463836Z           Ephemeral: (bool) false,
2025-09-16T16:40:56.8464742Z           Preconditions: ([]*configs.CheckRule) <nil>,
2025-09-16T16:40:56.8465163Z           DescriptionSet: (bool) true,
2025-09-16T16:40:56.8465626Z           SensitiveSet: (bool) false,
2025-09-16T16:40:56.8466179Z           EphemeralSet: (bool) true,
2025-09-16T16:40:56.8466702Z           DeclRange: (hcl.Range) testdata\valid-modules\override-output\primary.tf:1,1-26,
2025-09-16T16:40:56.8467175Z           IsOverridden: (bool) false,
2025-09-16T16:40:56.8467528Z           OverrideValue: (*cty.Value)(<nil>)
2025-09-16T16:40:56.8467800Z          }),
2025-09-16T16:40:56.8468230Z          (string) (len=20) "partially_overridden": (*configs.Output)(0xc000000e00)({
2025-09-16T16:40:56.8468895Z           Name: (string) (len=20) "partially_overridden",
2025-09-16T16:40:56.8469353Z           Description: (string) (len=16) "base description",
2025-09-16T16:40:56.8469760Z           Expr: (*hclsyntax.TemplateExpr)(0xc00047d9e0)({
2025-09-16T16:40:56.8470204Z            Parts: ([]hclsyntax.Expression) (len=1 cap=1) {
2025-09-16T16:40:56.8470611Z             (*hclsyntax.LiteralValueExpr)(0xc00047d980)({
2025-09-16T16:40:56.8470965Z              Val: (cty.Value) {
2025-09-16T16:40:56.8471274Z               ty: (cty.Type) {
2025-09-16T16:40:56.8471612Z                typeImpl: (cty.primitiveType) {
2025-09-16T16:40:56.8472296Z                 typeImplSigil: (cty.typeImplSigil) {
2025-09-16T16:40:56.8472598Z                 },
2025-09-16T16:40:56.8472948Z                 Kind: (cty.primitiveTypeKind) 83
2025-09-16T16:40:56.8473242Z                }
2025-09-16T16:40:56.8473477Z               },
2025-09-16T16:40:56.8473797Z               v: (string) (len=18) "b_override partial"
2025-09-16T16:40:56.8474103Z              },
2025-09-16T16:40:56.8474810Z              SrcRange: (hcl.Range) testdata\valid-modules\override-output\b_override.tf:9,12-30
2025-09-16T16:40:56.8475224Z             })
2025-09-16T16:40:56.8475496Z            },
2025-09-16T16:40:56.8476070Z            SrcRange: (hcl.Range) testdata\valid-modules\override-output\b_override.tf:9,11-31
2025-09-16T16:40:56.8476489Z           }),
2025-09-16T16:40:56.8476766Z           DependsOn: ([]hcl.Traversal) <nil>,
2025-09-16T16:40:56.8477127Z           Sensitive: (bool) false,
2025-09-16T16:40:56.8477519Z           Deprecated: (string) (len=21) "b_override deprecated",
2025-09-16T16:40:56.8478161Z           Ephemeral: (bool) false,
2025-09-16T16:40:56.8478818Z           Preconditions: ([]*configs.CheckRule) <nil>,
2025-09-16T16:40:56.8479535Z           DescriptionSet: (bool) true,
2025-09-16T16:40:56.8480220Z           SensitiveSet: (bool) false,
2025-09-16T16:40:56.8480728Z           EphemeralSet: (bool) false,
2025-09-16T16:40:56.8481289Z           DeclRange: (hcl.Range) testdata\valid-modules\override-output\primary.tf:6,1-30,
2025-09-16T16:40:56.8481739Z           IsOverridden: (bool) false,
2025-09-16T16:40:56.8482092Z           OverrideValue: (*cty.Value)(<nil>)
2025-09-16T16:40:56.8482389Z          })
2025-09-16T16:40:56.8482578Z         }
2025-09-16T16:40:56.8482881Z         want: (map[string]*configs.Output) (len=2) {
2025-09-16T16:40:56.8483345Z          (string) (len=16) "fully_overridden": (*configs.Output)(0xc000001c00)({
2025-09-16T16:40:56.8484053Z           Name: (string) (len=16) "fully_overridden",
2025-09-16T16:40:56.8484497Z           Description: (string) (len=22) "b_override description",
2025-09-16T16:40:56.8484987Z           Expr: (*hclsyntax.TemplateExpr)(0xc0005ac1e0)({
2025-09-16T16:40:56.8485392Z            Parts: ([]hclsyntax.Expression) (len=1 cap=1) {
2025-09-16T16:40:56.8485983Z             (*hclsyntax.LiteralValueExpr)(0xc0005ac180)({
2025-09-16T16:40:56.8486363Z              Val: (cty.Value) {
2025-09-16T16:40:56.8486643Z               ty: (cty.Type) {
2025-09-16T16:40:56.8487035Z                typeImpl: (cty.primitiveType) {
2025-09-16T16:40:56.8487442Z                 typeImplSigil: (cty.typeImplSigil) {
2025-09-16T16:40:56.8487775Z                 },
2025-09-16T16:40:56.8488091Z                 Kind: (cty.primitiveTypeKind) 83
2025-09-16T16:40:56.8488398Z                }
2025-09-16T16:40:56.8488602Z               },
2025-09-16T16:40:56.8489115Z               v: (string) (len=10) "b_override"
2025-09-16T16:40:56.8489412Z              },
2025-09-16T16:40:56.8490155Z              SrcRange: (hcl.Range) testdata/valid-modules/override-output/b_override.tf:2,12-22
2025-09-16T16:40:56.8490672Z             })
2025-09-16T16:40:56.8490869Z            },
2025-09-16T16:40:56.8491373Z            SrcRange: (hcl.Range) testdata/valid-modules/override-output/b_override.tf:2,11-23
2025-09-16T16:40:56.8491760Z           }),
2025-09-16T16:40:56.8492048Z           DependsOn: ([]hcl.Traversal) <nil>,
2025-09-16T16:40:56.8492588Z           Sensitive: (bool) false,
2025-09-16T16:40:56.8493253Z           Deprecated: (string) (len=21) "b_override deprecated",
2025-09-16T16:40:56.8493899Z           Ephemeral: (bool) false,
2025-09-16T16:40:56.8494434Z           Preconditions: ([]*configs.CheckRule) <nil>,
2025-09-16T16:40:56.8494984Z           DescriptionSet: (bool) true,
2025-09-16T16:40:56.8495512Z           SensitiveSet: (bool) false,
2025-09-16T16:40:56.8496058Z           EphemeralSet: (bool) true,
2025-09-16T16:40:56.8496926Z           DeclRange: (hcl.Range) testdata\valid-modules\override-output\primary.tf:1,1-26,
2025-09-16T16:40:56.8497689Z           IsOverridden: (bool) false,
2025-09-16T16:40:56.8498205Z           OverrideValue: (*cty.Value)(<nil>)
2025-09-16T16:40:56.8498664Z          }),
2025-09-16T16:40:56.8499367Z          (string) (len=20) "partially_overridden": (*configs.Output)(0xc000001ce0)({
2025-09-16T16:40:56.8500146Z           Name: (string) (len=20) "partially_overridden",
2025-09-16T16:40:56.8500867Z           Description: (string) (len=16) "base description",
2025-09-16T16:40:56.8501798Z           Expr: (*hclsyntax.TemplateExpr)(0xc0005ac2a0)({
2025-09-16T16:40:56.8502581Z            Parts: ([]hclsyntax.Expression) (len=1 cap=1) {
2025-09-16T16:40:56.8503578Z             (*hclsyntax.LiteralValueExpr)(0xc0005ac240)({
2025-09-16T16:40:56.8504163Z              Val: (cty.Value) {
2025-09-16T16:40:56.8504669Z               ty: (cty.Type) {
2025-09-16T16:40:56.8505257Z                typeImpl: (cty.primitiveType) {
2025-09-16T16:40:56.8505986Z                 typeImplSigil: (cty.typeImplSigil) {
2025-09-16T16:40:56.8506448Z                 },
2025-09-16T16:40:56.8545045Z                 Kind: (cty.primitiveTypeKind) 83
2025-09-16T16:40:56.8545567Z                }
2025-09-16T16:40:56.8545892Z               },
2025-09-16T16:40:56.8546415Z               v: (string) (len=18) "b_override partial"
2025-09-16T16:40:56.8546863Z              },
2025-09-16T16:40:56.8547686Z              SrcRange: (hcl.Range) testdata/valid-modules/override-output/b_override.tf:9,12-30
2025-09-16T16:40:56.8548309Z             })
2025-09-16T16:40:56.8548553Z            },
2025-09-16T16:40:56.8549273Z            SrcRange: (hcl.Range) testdata/valid-modules/override-output/b_override.tf:9,11-31
2025-09-16T16:40:56.8549909Z           }),
2025-09-16T16:40:56.8550325Z           DependsOn: ([]hcl.Traversal) <nil>,
2025-09-16T16:40:56.8550829Z           Sensitive: (bool) false,
2025-09-16T16:40:56.8551460Z           Deprecated: (string) (len=21) "b_override deprecated",
2025-09-16T16:40:56.8551983Z           Ephemeral: (bool) false,
2025-09-16T16:40:56.8552498Z           Preconditions: ([]*configs.CheckRule) <nil>,
2025-09-16T16:40:56.8552927Z           DescriptionSet: (bool) true,
2025-09-16T16:40:56.8553362Z           SensitiveSet: (bool) false,
2025-09-16T16:40:56.8553824Z           EphemeralSet: (bool) false,
2025-09-16T16:40:56.8554317Z           DeclRange: (hcl.Range) testdata\valid-modules\override-output\primary.tf:6,1-30,
2025-09-16T16:40:56.8554950Z           IsOverridden: (bool) false,
2025-09-16T16:40:56.8555457Z           OverrideValue: (*cty.Value)(<nil>)
2025-09-16T16:40:56.8555819Z          })
2025-09-16T16:40:56.8556068Z         }
2025-09-16T16:40:56.8556273Z FAIL
2025-09-16T16:40:56.8556621Z FAIL	github.com/opentofu/opentofu/internal/configs	0.320s
```

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
