### PR TITLE
tofu: Warn if object literal includes unused attribute for input variable

### DIFF
--- a/internal/tofu/node_module_variable_test.go
+++ b/internal/tofu/node_module_variable_test.go
@@ -12,8 +12,10 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -304,6 +306,54 @@ func TestNodeModuleVariableConstraints(t *testing.T) {
 
 		if !found {
 			t.Fatalf("missing expected error\nwant summary: %s\ngot: %s", wantSummary, diags.Err().Error())
+		}
+	})
+}
+
+func TestNodeModuleVariable_warningDiags(t *testing.T) {
+	t.Run("unused object attribute", func(t *testing.T) {
+		n := &nodeModuleVariable{
+			Addr: addrs.InputVariable{Name: "foo"}.Absolute(addrs.RootModuleInstance),
+			Config: &configs.Variable{
+				Name: "foo",
+				ConstraintType: cty.Object(map[string]cty.Type{
+					"foo": cty.String,
+					"bar": cty.String,
+				}),
+			},
+			Expr: &hclsyntax.ObjectConsExpr{
+				Items: []hclsyntax.ObjectConsItem{
+					{
+						KeyExpr: &hclsyntax.LiteralValueExpr{
+							Val: cty.StringVal("baz"),
+							SrcRange: hcl.Range{
+								Filename: "test.tofu",
+							},
+						},
+						ValueExpr: &hclsyntax.LiteralValueExpr{
+							Val: cty.StringVal("..."),
+						},
+					},
+				},
+			},
+			ModuleInstance: addrs.RootModuleInstance,
+		}
+		// We use the "ForRPC" representation of the diagnostics just because
+		// it's more friendly for comparison and we care only about the
+		// user-facing information in the diagnostics, not their concrete types.
+		gotDiags := n.warningDiags(t.Context()).ForRPC()
+		var wantDiags tfdiags.Diagnostics
+		wantDiags = wantDiags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Summary:  "Object attribute is ignored",
+			Detail:   `The object type for input variable "foo" does not include an attribute named "baz", so this definition is unused. Did you mean to set attribute "bar" instead?`,
+			Subject: &hcl.Range{
+				Filename: "test.tofu",
+			},
+		})
+		wantDiags = wantDiags.ForRPC()
+		if diff := cmp.Diff(wantDiags, gotDiags, ctydebug.CmpOptions); diff != "" {
+			t.Error("wrong diagnostics\n" + diff)
 		}
 	})
 }


### PR DESCRIPTION
We intentionally allow assigning object types with a superset of the attributes included in an input variable's object type constraints because it makes it possible to assign a whole object for which only some of the attributes are relevant for one input variable but a different subset might be relevant when the object value is used in a different part of the configuration.

However, when the variable is defined using an object literal expression there is no possible way an unexpected attribute could be useful in a different part of the configuration, and so that's very very likely to be a mistake rather than intentional. Therefore we'll generate a "linter-like" warning in that case to help the author notice their mistake without introducing any new "strict-mode" language features, or other complexity that would be harder to maintain and evolve over time.

This is currently just a prototype of a compromise I suggested in https://github.com/opentofu/opentofu/issues/3271. It's currently a draft because that issue has not yet been accepted. I'll close this PR without merging if either that issue is not accepted or if we decide that this compromise is insufficient to meet it.

---

The essence of the compromise I'm proposing here is that although there _are_ valid reasons to assign an object type with more attributes than necessary to an input variable -- if that object is intended for use in multiple different parts of the configuration, for example -- in the common case where the object is written directly in the `module` block as an object constructor expression there is no reason at all to write an unexpected attribute, because it will just be immediately discarded and so would not be reachable by any expressions anywhere.

Given a pair of modules similar to the ones motivating https://github.com/opentofu/opentofu/issues/3271...

```hcl
module "child" {
  source = "./child"

  obj = {
    foo = "a"
    baz = "b"
  }
}
```

```hcl
variable "obj" {
  type = object({
    foo = optional(string)
    bar = optional(string)
  })
}
```

...this change causes OpenTofu to generate a warning during the validation phase:

<img width="716" height="259" alt="(screenshot of the error message immediately below this image)" src="https://github.com/user-attachments/assets/a346f93b-da4f-427c-aff6-9285795188e5" />

```
╷
│ Warning: Object attribute is ignored
│ 
│   on unused-var-attr-warning.tf line 7, in module "child":
│    7:     baz = "b"
│ 
│ The object type for input variable "obj" does not include an
│ attribute named "baz", so this definition is unused. Did you mean
│ to set attribute "bar" instead?
╵
```

This compromise has the following limitations, however:

- The warning can only appear when the expression assigned to the variable's argument is an object constructor expression.

    This is an _intentional_ limitation, because it's the use of an inline object constructor that makes it reasonable to assume that the unexpected attribute definition is a mistake.

- This implementation of it only works shallowly. The warning will not appear for an object appearing in a list of objects, for example, or for an object nested inside another object.

    A key advantage of this being a linter-like warning instead of a hard error is that we can accept this partial solution to start and then gradually improve it to catch more situations over time! As long as the rules we gradually add all fit the criteria of "very, very likely to be a mistake" then we can continue adding more complexity here without causing any breaking changes to the language.

    It should be technically possible to extend this to detecting problems with nested objects as long as all of the intermediate nesting levels are either object constructor expressions `{ ... }` or tuple constructor expressions `[ ... ]`, but of course the code would then be more complicated.

    I think it would also be possible to work with object literals nested inside `{ for ... }` and `[ for ... ]` expressions that correspond to list or map types in the type constraint, because then we can compare the result part of the `for` expression with the element type of the collection even though we wouldn't yet know how many elements the `for` expression would produce.

- If the author uses an object constructor expression but specifies the attribute name dynamically, like `{ (any_expression) = "foo" }`, then the simple static analysis technique used here will just ignore that particular item from the object constructor.

    Again my focus here is to catch the most common cases first and gradually improve over time based on experience with what mistakes are most common. Supporting dynamic references here is possible _in principle_ since we're allowed to evaluate the key expression during our visit to the input variable's graph node, but it'd make this code harder to read and maintain so I think warranted only if it would allow us to catch a common mistake, and I don't think there's any evidence of that yet.


