### PR TITLE
fix `internal/getprovider` tests on Windows using `lf` line breaks

### DIFF
--- a/internal/providercache/testdata/.gitattributes
+++ b/internal/providercache/testdata/.gitattributes
@@ -1,0 +1,1 @@
+**/* text eol=lf


### PR DESCRIPTION
Relates to #1201 

[#3273](https://github.com/opentofu/opentofu/pull/3273) previously fixed this, but it was reintroduced as a regression due to a bad merge and changing where `.gitattributes` were stored at https://github.com/opentofu/opentofu/pull/3275. `.gitattributes` were previously being saved at the root folder with the path to the sub-folders, but then we changed to use a `.gitattributes` in the sub-folder itself.

This PR fixes:
 
```
2025-09-16T12:44:15.0876856Z --- FAIL: TestEnsureProviderVersions (0.21s)
2025-09-16T12:44:15.0877985Z     --- FAIL: TestEnsureProviderVersions/successful_initial_install_of_one_provider_through_a_cold_global_cache (0.02s)
2025-09-16T12:44:15.0964468Z     --- FAIL: TestEnsureProviderVersions/successful_initial_install_of_one_provider_through_a_warm_global_cache_without_a_lock_file_entry_but_allowing_the_cache_to_break_the_lock_file (0.02s)
2025-09-16T12:44:15.1054347Z     --- FAIL: TestEnsureProviderVersions/successful_reinstall_of_one_previously-locked_provider (0.01s)
2025-09-16T12:44:15.1130031Z     --- FAIL: TestEnsureProviderVersions/successful_upgrade_of_one_previously-locked_provider (0.01s)
2025-09-16T12:44:15.1199781Z     --- FAIL: TestEnsureProviderVersions/successful_initial_install_of_one_provider_from_a_.zip_archive (0.01s)
2025-09-16T12:44:15.1276164Z     --- FAIL: TestEnsureProviderVersions/successful_initial_install_of_one_provider_through_a_warm_global_cache_but_without_a_lock_file_entry (0.01s)
2025-09-16T12:44:15.1351348Z     --- FAIL: TestEnsureProviderVersions/force_mode_ignores_hashes (0.01s)
2025-09-16T12:44:15.1408741Z     --- FAIL: TestEnsureProviderVersions/successful_initial_install_of_one_provider_through_a_warm_global_cache_and_correct_locked_checksum (0.01s)
2025-09-16T12:44:15.1645322Z     --- FAIL: TestEnsureProviderVersions/skipped_install_of_one_previously-locked_and_installed_provider (0.01s)
2025-09-16T12:44:15.1698859Z     --- FAIL: TestEnsureProviderVersions/remove_no-longer-needed_provider_from_lock_file (0.01s)
2025-09-16T12:44:15.1766097Z     --- FAIL: TestEnsureProviderVersions/successful_initial_install_of_one_provider (0.01s)
2025-09-16T12:44:15.1951197Z     --- FAIL: TestEnsureProviderVersions/successful_initial_install_of_one_provider_through_a_warm_global_cache_with_an_incompatible_checksum (0.01s)
2025-09-16T12:44:15.1999491Z --- FAIL: TestEnsureProviderVersions_local_source (0.07s)
```

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
