### PR TITLE
fix `internal/command` tests by triggering garbage collection

### DIFF
--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -873,6 +873,12 @@ func testLockState(t *testing.T, sourceDir, path string) (func(), error) {
 		_ = locker.Wait()
 
 		t.Logf("closed statelocker stdin and finished.")
+
+		// Trigger garbage collection to ensure that all open file handles are closed.
+		// This prevents TempDir RemoveAll cleanup errors on Windows.
+		if runtime.GOOS == "windows" {
+			runtime.GC()
+		}
 	}
 
 	// wait for the process to lock


### PR DESCRIPTION
Relates to #1201 

This PR fixes by triggering garbage collection to avoid `TempDir RemoveAll cleanup: unlinkat` errors on Windows.

```
2025-09-16T19:19:31.6695853Z --- FAIL: TestTaint_lockedState (7.02s)
2025-09-16T19:19:31.6696705Z     command_test.go:888: statelocker locked LOCKID 952b0473-c9ac-0611-a0ee-f6c500ab3c4e
2025-09-16T19:19:31.6697669Z     command_test.go:875: closed statelocker stdin and finished.
2025-09-16T19:19:31.6699704Z     testing.go:1369: TempDir RemoveAll cleanup: unlinkat C:\Users\RUNNER~1\AppData\Local\Temp\TestTaint_lockedState3907807133\001\state.tfstate: The process cannot access the file because it is being used by another process.
2025-09-16T19:19:31.6701219Z --- FAIL: TestUntaint_lockedState (5.74s)
2025-09-16T19:19:31.6702051Z     command_test.go:888: statelocker locked LOCKID 8326bbe0-d2ce-115e-9e38-64620adb6c8e
2025-09-16T19:19:31.6702954Z     command_test.go:875: closed statelocker stdin and finished.
2025-09-16T19:19:31.6705389Z     testing.go:1369: TempDir RemoveAll cleanup: unlinkat C:\Users\RUNNER~1\AppData\Local\Temp\TestUntaint_lockedState647253672\001\state.tfstate: The process cannot access the file because it is being used by another process.
```

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
