### PR TITLE
fix `internal/backend/local` tests by closing file handle properly

### DIFF
--- a/internal/backend/local/backend_test.go
+++ b/internal/backend/local/backend_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -31,6 +32,12 @@ func TestLocal_backend(t *testing.T) {
 	b := New(encryption.StateEncryptionDisabled())
 	backend.TestBackendStates(t, b)
 	backend.TestBackendStateLocks(t, b, b)
+
+	// On Windows, the file open handles is not closed due to multiple
+	// rounds of locking and reading the state.
+	if runtime.GOOS == "windows" {
+		runtime.GC()
+	}
 }
 
 func checkState(t *testing.T, path, expected string) {

--- a/internal/backend/testing.go
+++ b/internal/backend/testing.go
@@ -190,12 +190,24 @@ func TestBackendStates(t *testing.T, b Backend) {
 		fooState := states.NewState()
 		barState := states.NewState()
 
+		// Lock before writing
+		lockInfo := statemgr.NewLockInfo()
+		lockInfo.Operation = "init"
+		lockId, err := foo.Lock(t.Context(), lockInfo)
+		if err != nil {
+			t.Fatalf("error locking foo: %s", err)
+		}
 		// write a known state to foo
 		if err := foo.WriteState(fooState); err != nil {
 			t.Fatal("error writing foo state:", err)
 		}
 		if err := foo.PersistState(t.Context(), nil); err != nil {
 			t.Fatal("error persisting foo state:", err)
+		}
+
+		// Unlock the state after writing
+		if err := foo.Unlock(t.Context(), lockId); err != nil {
+			t.Fatalf("error unlocking foo: %s", err)
 		}
 
 		// We'll make "bar" different by adding a fake resource state to it.


### PR DESCRIPTION
Relates to #1201 

There are two parts to this PR:

1. The state file is not being closed after `PersistState`, so when DeleteWorkspace is called at `TestLocal_backup`, it doesn't work because the file remains open on Windows. To fix this, the only way to close the file handle is to call `Unlock`. That's why I added a call to `Lock` before persisting and then unlocking it afterward.

https://github.com/opentofu/opentofu/blob/197135b4af4dde49068c55000073a2dbbd0699f1/internal/states/statemgr/filesystem.go#L436

2. runtime.GC is still needed to close the open file handles to avoid `TempDir RemoveAll cleanup: unlinkat` errors.

This PR fixes:

```
--- FAIL: TestLocal_backend (1.63s)
    backend_test.go:32: delete workspace foo err: unlinkat terraform.tfstate.d\foo\terraform.tfstate: The process cannot access the file because it is being used by another process.
    testing.go:1369: TempDir RemoveAll cleanup: unlinkat C:\Users\RUNNER~1\AppData\Local\Temp\TestLocal_backend96626496\001\terraform.tfstate.d\bar\terraform.tfstate: The process cannot access the file because it is being used by another process.
FAIL
FAIL	github.com/opentofu/opentofu/internal/backend/local	3.[42](https://github.com/opentofu/opentofu/actions/runs/17794392461/job/50578690287#step:5:43)1s
```

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
