### PR TITLE
fix `cmd/tofu` tests by using `t.Chdir` instead of `os.Chdir`

### DIFF
--- a/cmd/tofu/provider_source_test.go
+++ b/cmd/tofu/provider_source_test.go
@@ -100,17 +100,11 @@ func TestProviderSource(t *testing.T) {
 			// Setup test environment
 			originalWorkingDir, overrideWd := tt.setupFunc(t)
 
-			err := os.Chdir(originalWorkingDir)
-			if err != nil {
-				t.Fatalf("Failed to change to original working directory: %v", err)
-			}
+			t.Chdir(originalWorkingDir)
 
 			// If we have an override directory, change to it (simulating -chdir behavior)
 			if overrideWd != "" {
-				err := os.Chdir(overrideWd)
-				if err != nil {
-					t.Fatalf("Failed to change to override directory: %v", err)
-				}
+				t.Chdir(overrideWd)
 			}
 
 			// Create a mock disco service


### PR DESCRIPTION
Relates to #1201 

Using `t.Chdir` instead of `os.Chdir` to clean up the temporary test directory properly.

This PR fixes:

```
--- FAIL: TestProviderSource (3.29s)
    --- FAIL: TestProviderSource/without_overrideWd_-_should_use_terraform.d/plugins_in_original_working_directory (1.84s)
        provider_source_test.go:158: Source created successfully for test case: without overrideWd - should use terraform.d/plugins in original working directory
        provider_source_test.go:159: Provider: registry.opentofu.org/hashicorp/test-provider
        provider_source_test.go:161: Available versions: [1.0.0]
        testing.go:1369: TempDir RemoveAll cleanup: unlinkat C:\Users\RUNNER~1\AppData\Local\Temp\TestProviderSourcewithout_overrideWd_-_should_use_terraform.dp289[24](https://github.com/opentofu/opentofu/actions/runs/17797854610/job/50589674500#step:5:25)19399\001: The process cannot access the file because it is being used by another process.
    --- FAIL: TestProviderSource/with_overrideWd_-_should_still_use_terraform.d/plugins_in_original_working_directory (1.45s)
        provider_source_test.go:158: Source created successfully for test case: with overrideWd - should still use terraform.d/plugins in original working directory
        provider_source_test.go:159: Provider: registry.opentofu.org/hashicorp/test-provider
        provider_source_test.go:161: Available versions: [1.0.0]
        testing.go:1369: TempDir RemoveAll cleanup: unlinkat C:\Users\RUNNER~1\AppData\Local\Temp\TestProviderSourcewith_overrideWd_-_should_still_use_terraform.16873154[28](https://github.com/opentofu/opentofu/actions/runs/17797854610/job/50589674500#step:5:29)\001\override: The process cannot access the file because it is being used by another process.
FAIL
FAIL	github.com/opentofu/opentofu/cmd/tofu	4.940s
```

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
