### PR TITLE
skip timeout lock tests on windows

### DIFF
--- a/internal/backend/remote/backend_apply_test.go
+++ b/internal/backend/remote/backend_apply_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"runtime"
 	"strings"
 	"syscall"
 	"testing"
@@ -1091,6 +1092,10 @@ func TestRemote_applyWorkspaceWithoutOperations(t *testing.T) {
 }
 
 func TestRemote_applyLockTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("lockTimeout is implemented using signals. Windows doesn't support sending signals, so we skip this test.")
+	}
+
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 
@@ -1156,10 +1161,10 @@ func TestRemote_applyLockTimeout(t *testing.T) {
 		t.Fatalf("expected lock timeout error in output: %s", output)
 	}
 	if strings.Contains(output, "1 to add, 0 to change, 0 to destroy") {
-		t.Fatalf("unexpected plan summery in output: %s", output)
+		t.Fatalf("unexpected plan summary in output: %s", output)
 	}
 	if strings.Contains(output, "1 added, 0 changed, 0 destroyed") {
-		t.Fatalf("unexpected apply summery in output: %s", output)
+		t.Fatalf("unexpected apply summary in output: %s", output)
 	}
 }
 

--- a/internal/backend/remote/backend_plan_test.go
+++ b/internal/backend/remote/backend_plan_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"runtime"
 	"strings"
 	"syscall"
 	"testing"
@@ -836,6 +837,10 @@ func TestRemote_planWorkspaceWithoutOperations(t *testing.T) {
 }
 
 func TestRemote_planLockTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("lockTimeout is implemented using signals. Windows doesn't support sending signals, so we skip this test.")
+	}
+
 	b, bCleanup := testBackendDefault(t)
 	defer bCleanup()
 


### PR DESCRIPTION
Relates to #1201 

Skipping tests with lockTimeout on Windows. They use a signal-based implementation:

https://github.com/opentofu/opentofu/blob/ff9657f5b7fe1c211fc1b8f32a678563177a0612/internal/cloud/backend_plan.go#L322-L329

I tried to build one implementation for Windows, but it seems the PowerShell debugger was getting the process and killing it, failing the tests: https://github.com/opentofu/opentofu/actions/runs/17802558976/job/50605973443

As a reference, what I've tried: https://github.com/opentofu/opentofu/pull/3286

Unless we can change this implementation, we need to skip these tests for now. This PR skips them:

```
2025-09-17T15:26:15.7350596Z --- FAIL: TestRemote_applyLockTimeout (0.21s)
2025-09-17T15:26:15.7352080Z     backend_apply_test.go:1144: expected lock timeout after 50 milliseconds, waited 200 milliseconds
2025-09-17T15:26:15.7358704Z --- FAIL: TestRemote_planLockTimeout (0.20s)
2025-09-17T15:26:15.7360308Z     backend_plan_test.go:889: expected lock timeout after 50 milliseconds, waited 200 milliseconds
2025-09-17T15:26:15.7384846Z FAIL
```

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
