### PR TITLE
fix: `DirFromModule` related tests on Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,10 @@ module github.com/opentofu/opentofu
 // At the time of adding this configuration, the new Go feature introduced here https://github.com/golang/go/issues/67061,
 // was having a good amount of issues linked to, affecting AWS Firewall, GCP various services and a lot more.
 // In go1.23 the godebug flag for this was named 'tlskyber', renamed in go1.24 to 'tlsmlkem'. https://tip.golang.org/doc/godebug#go-124
-godebug tlsmlkem=0
+godebug (
+	tlsmlkem=0
+	winsymlink=0 // See https://github.com/opentofu/opentofu/pull/3289
+)
 
 require (
 	cloud.google.com/go/kms v1.15.5

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -118,6 +119,14 @@ func TestInit_fromModule_cwdDest(t *testing.T) {
 func TestInit_fromModule_dstInSrc(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
+
+	defer func() {
+		// Trigger garbage collection to ensure that all open file handles are closed.
+		// This prevents TempDir RemoveAll cleanup errors on Windows.
+		if runtime.GOOS == "windows" {
+			runtime.GC()
+		}
+	}()
 	if err := os.Mkdir("foo", os.ModePerm); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Relates to #1201 

This PR fixes: 

```
2025-09-19T16:05:07.2037384Z --- FAIL: TestInit_fromModule_cwdDest (0.03s)
2025-09-19T16:05:07.2040243Z     init_test.go:113: err: GetFileAttributesEx C:\Users\RUNNER~1\AppData\Local\Temp\TestInit_fromModule_cwdDest590778471\001\hello.tf: The system cannot find the file specified.
2025-09-19T16:05:07.2041621Z --- FAIL: TestInit_fromModule_dstInSrc (1.80s)
2025-09-19T16:05:07.2043525Z     init_test.go:153: err: GetFileAttributesEx C:\Users\RUNNER~1\AppData\Local\Temp\TestInit_fromModule_dstInSrc2437525736\001\foo\issue518.tf: The system cannot find the file specified.
2025-09-19T16:05:07.2046282Z     testing.go:1369: TempDir RemoveAll cleanup: unlinkat C:\Users\RUNNER~1\AppData\Local\Temp\TestInit_fromModule_dstInSrc2437525736\001\issue518.tf: The process cannot access the file because it is being used by another process.
2025-09-19T16:05:23.6945382Z --- FAIL: TestModuleInstaller_explicitPackageBoundary (0.03s)
2025-09-19T16:05:23.6947648Z     module_install_test.go:197: tempChdir switched to C:\Users\RUNNER~1\AppData\Local\Temp\TestModuleInstaller_explicitPackageBoundary2444935348\001 after copying from testdata\load-module-package-prefix
2025-09-19T16:05:23.6949252Z     module_install_test.go:229: unexpected errors
2025-09-19T16:05:23.6949817Z         2 problems:
2025-09-19T16:05:23.6950163Z         
2025-09-19T16:05:23.6951231Z         - Unreadable module directory: Unable to evaluate directory symlink: The system cannot find the path specified.
2025-09-19T16:05:23.6954300Z         - Unreadable module directory: The directory  could not be read for module "grandchild" at C:\Users\RUNNER~1\AppData\Local\Temp\TestModuleInstaller_explicitPackageBoundary2444935348\001\.terraform\modules\child\child\package-prefix-child.tf:1.
2025-09-19T16:05:23.6955947Z FAIL
2025-09-19T16:05:23.6956406Z FAIL	github.com/opentofu/opentofu/internal/initwd	0.330s
```

This PR partially fixes: 

```
2025-09-20T00:38:27.3417959Z --- FAIL: TestDirFromModule_submodules (0.05s)
2025-09-20T00:38:27.3438707Z --- FAIL: TestDirFromModule_rel_submodules (0.04s)
```

There are two fixes on this PR:

- There's a need to call the `runtime.GC` on the `TestInit_fromModule_dstInSrc` test itself to avoid Cleanup errors. 

There was a subtle one that was introduced by Go 1.23:

```
[os](https://tip.golang.org/pkg/os/)[¶](https://tip.golang.org/doc/go1.23#ospkgos)
The [Stat](https://tip.golang.org/pkg/os#Stat) function now sets the [ModeSocket](https://tip.golang.org/pkg/os#ModeSocket) bit for files that are Unix sockets on Windows. These files are identified by having a reparse tag set to IO_REPARSE_TAG_AF_UNIX.

On Windows, the mode bits reported by [Lstat](https://tip.golang.org/pkg/os#Lstat) and [Stat](https://tip.golang.org/pkg/os#Stat) for reparse points changed. Mount points no longer have [ModeSymlink](https://tip.golang.org/pkg/os#ModeSymlink) set, and reparse points that are not symlinks, Unix sockets, or dedup files now always have [ModeIrregular](https://tip.golang.org/pkg/os#ModeIrregular) set. This behavior is controlled by the winsymlink setting. For Go 1.23, it defaults to winsymlink=1. Previous versions default to winsymlink=0.
```

When modules are being installed at `DirFromModule`, there's a symlink from the module itself to the folder that was being copied:

```
C:\Users\runneradmin\AppData\Local\Temp\TestDirFromModule_submodules3133071126\001\child_b != D:\a\opentofu\opentofu\internal\initwd\testdata\local-modules\child_a\child_b

# Before the change
File Mode: ?rw-rw-rw- 

# After the change:
File Mode: Lrw-rw-rw-
```

On GitHub actions, there are two different volumes, one where the code is, and another one for the temporary folders. When Go is upgraded, these symlinks are not seen as symlinks anymore, and they are seen as ModeIrregular instead, because these are mount points. This PR is reverting to the legacy way these symlinks are treated.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
