### PR TITLE
fix: Prevent nil panic in marshalProviderConfigs when inSingleModuleMode

### DIFF
--- a/internal/command/jsonconfig/config.go
+++ b/internal/command/jsonconfig/config.go
@@ -290,6 +290,16 @@ func marshalProviderConfigs(
 		m[key] = p
 	}
 
+	// If we have gotten here from calling [MarshalSingleModule], then
+	// we do not recurse into child modules, because they are not
+	// available in that mode. In this mode c.Children will be nil and
+	// this means that we do not have the ability to get the provider_configs for
+	// the child modules.
+	// See the doc comment for [MarshalSingleModule] for more information.
+	if inSingleModuleMode(schemas) {
+		return
+	}
+
 	// Must also visit our child modules, recursively.
 	for name, mc := range c.Module.ModuleCalls {
 		// Keys in c.Children are guaranteed to match those in c.Module.ModuleCalls
@@ -323,11 +333,7 @@ func marshalProviderConfigs(
 		// Finally, marshal any other provider configs within the called module.
 		// It is safe to do this last because it is invalid to configure a
 		// provider which has passed provider configs in the module call.
-		// We don't recurse in single-module mode, because cc will be nil in
-		// that case.
-		if !inSingleModuleMode(schemas) {
-			marshalProviderConfigs(cc, schemas, m)
-		}
+		marshalProviderConfigs(cc, schemas, m)
 	}
 }
 


### PR DESCRIPTION
When calling `tofu show -json -module=DIR` (introduced in #3003 and (called another module) it would cause a panic due to a nil reference.

This is because in single module mode we do not populate the children for the module. So it's impossible to recurse down

This commit aims to fix that by exiting a little bit earlier if we are in single module mode

---

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
