### PR TITLE
docs: Include link to search.opentofu.org in use-cases.mdx

### DIFF
--- a/website/docs/intro/use-cases.mdx
+++ b/website/docs/intro/use-cases.mdx
@@ -17,7 +17,7 @@ Provisioning infrastructure across multiple clouds increases fault-tolerance, al
 
 ### Resources
 
-- Browse the [Public OpenTofu Registry](https://github.com/opentofu/registry/tree/main/providers) to find thousands of publicly available providers.
+- Use the [OpenTofu Registry Search](https://search.opentofu.org/) to discover and browse providers and modules with a user-friendly interface. This search tool is backed by the [Public OpenTofu Registry](https://github.com/opentofu/registry/) repository metadata.
 
 ## Application Infrastructure Deployment, Scaling, and Monitoring Tools
 


### PR DESCRIPTION
Previously this was pointing to just the registry github repo, but now we have search.opentofu.org we should direct new users there instead as it's much more user friendly

Resolves https://github.com/opentofu/registry/issues/2830

---

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
