### PR TITLE
Plan now renders write-only attributes that require replace

### DIFF
--- a/internal/command/jsonformat/differ/attribute.go
+++ b/internal/command/jsonformat/differ/attribute.go
@@ -104,5 +104,13 @@ func unmarshalAttribute(attribute *jsonprovider.Attribute) cty.Type {
 }
 
 func computeAttributeDiffAsWriteOnly(change structured.Change, parentAction plans.Action) computed.Diff {
+	// If the provider returned this write-only attribute in the require_replace list,
+	// we want to be sure that the action is not plans.NoOp.
+	// plans.Update might be the wrong one
+	// We want to do this to be sure that the user is informed about the fields that forces
+	// the replacement of the resource.
+	if parentAction == plans.NoOp && change.ReplacePaths.Matches() {
+		parentAction = plans.Update
+	}
 	return asDiffWithInheritedAction(change, parentAction, renderers.WriteOnly())
 }

--- a/internal/command/jsonformat/differ/differ_test.go
+++ b/internal/command/jsonformat/differ/differ_test.go
@@ -166,6 +166,30 @@ func TestValue_SimpleBlocks(t *testing.T) {
 				"write_only_attribute": renderers.ValidateWriteOnly(plans.Create, false),
 			}, nil, nil, nil, nil, plans.Create, false),
 		},
+		"update_with_write_only_value": {
+			input: structured.Change{
+				Before: map[string]any{
+					"write_only_attribute": nil,
+				},
+				After: map[string]any{
+					"write_only_attribute": nil,
+				},
+				BeforeSensitive: false,
+				AfterSensitive:  false,
+				ReplacePaths:    &attribute_path.PathMatcher{Paths: [][]interface{}{{"write_only_attribute"}}},
+			},
+			block: &jsonprovider.Block{
+				Attributes: map[string]*jsonprovider.Attribute{
+					"write_only_attribute": {
+						AttributeType: unmarshalType(t, cty.String),
+						WriteOnly:     true,
+					},
+				},
+			},
+			validate: renderers.ValidateBlock(map[string]renderers.ValidateDiffFunction{
+				"write_only_attribute": renderers.ValidateWriteOnly(plans.Update, true),
+			}, nil, nil, nil, nil, plans.Update, false),
+		},
 	}
 	for name, tc := range tcs {
 		// Set some default values


### PR DESCRIPTION
Ensure that when a write-only attribute is returned from the provider as the field that requires replacement of the whole resource, that is rendered into the plan so the user to know what field triggered that.

With the changes added here, the write-only attribute that forced replacement will always be shown in the plan:
<img width="758" height="165" alt="Screenshot 2025-09-22 at 14 21 38" src="https://github.com/user-attachments/assets/fbb6cf11-be12-4bd6-9045-d285ce0f5c9e" />

<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves #3293

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
