### PR TITLE
website: S3 module sources now support all standard AWS credential sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ UPGRADE NOTES:
 * Testing mocks previously only followed a subset of the rules defined in provider schemas. The provider schema now drives the mocking to ensure the schema is correctly followed. ([#3069](https://github.com/opentofu/opentofu/pull/3069))
 
     In rare cases this change might result in some previously-passing tests now failing, due to invalid mocks or overrides that were not detected in earlier versions.
+* When installing module packages from Amazon S3 buckets using [S3 source addresses](https://opentofu.org/docs/language/modules/sources/#s3-bucket), OpenTofu now uses the same methods for finding AWS credentials as the AWS CLI and SDKs instead of using its own custom credentials search sequence.
+
+    This might mean that OpenTofu v1.11.0 will choose AWS credentials from a different location than previous versions did, if your AWS authentication configuration describes credential sources that were not previously supported. Generally, OpenTofu should choose credentials in the same way that the AWS CLI would by default when accessing the same S3 object.
 * OpenTofu no longer accepts SHA-1 signatures in TLS handshakes, as recommended in [RFC 9155](https://www.rfc-editor.org/rfc/rfc9155.html).
 * OpenTofu's remote provisioners, when using SSH to connect to a remote server using certificate-based authentication, no longer accept a certificate key as the signature key for a certificate, as required by [draft-miller-ssh-cert-03 section 2.1.1](https://datatracker.ietf.org/doc/html/draft-miller-ssh-cert-03#section-2.1.1).
 
@@ -26,6 +29,7 @@ ENHANCEMENTS:
 * Add full support for -var, -var-file, and TF_VARS during `tofu apply` to support plan encryption ([#1998](https://github.com/opentofu/opentofu/pull/1998))
 * The S3 state backend now supports arguments to specify tags of the state and lock files. [#3038](https://github.com/opentofu/opentofu/pull/3038)
 * Plan UI now explicitly states that the "update in-place" notation is "current -> planned", as part of the existing description of the meaning of each change type symbol. ([#3159](https://github.com/opentofu/opentofu/pull/3159))
+* When installing module packages from Amazon S3 source addresses, OpenTofu now follows similar rules for finding AWS credentials as the AWS CLI does, and similar to the S3 backend. In particular this means OpenTofu supports some newer authentication schemes, such as [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html). ([#3269](https://github.com/opentofu/opentofu/pull/3269))
 * Upgrade go from 1.24.4 to 1.24.6 to fix [GO-2025-3849](https://pkg.go.dev/vuln/GO-2025-3849) ([3127](https://github.com/opentofu/opentofu/pull/3127))
 * Improved error messages when a submodule is not found in a module ([#3144]https://github.com/opentofu/opentofu/pull/3144)
 * Add support for the `for_each` attribute in the `mock_provider` block. ([#3087](https://github.com/opentofu/opentofu/pull/3087))

--- a/website/docs/language/modules/sources.mdx
+++ b/website/docs/language/modules/sources.mdx
@@ -452,13 +452,10 @@ The resulting object must be an archive with one of the same file
 extensions as for [archives over standard HTTP](#fetching-archives-over-http).
 OpenTofu will extract the archive to obtain the module source tree.
 
-The module installer looks for AWS credentials in the following locations,
-preferring those earlier in the list when multiple are available:
-
-- The `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
-- The default profile in the `.aws/credentials` file in your home directory.
-- If running on an EC2 instance, temporary credentials associated with the
-  instance's IAM Instance Profile.
+The module installer searches for AWS credentials in a similar way to AWS CLI,
+and so you should not typically need any additional configuration to use S3
+module sources as long as AWS CLI on your system would be able to access the
+same S3 objects.
 
 ## GCS Bucket
 


### PR DESCRIPTION
As of go-getter v1.8.0, which we already upgraded to in https://github.com/opentofu/opentofu/pull/3269, the S3 "getter" now uses the AWS SDK's default credentials chain configuration and so follows the same set of credentials-searching strategies that AWS CLI and other AWS SDK applications would follow.

We learned this only after having already merged that upgrade, so this is a retroactive documentation and changelog update to describe the change. Since go-getter is now delegating this whole question to the AWS SDK, our future upgrades of the AWS SDK will automatically adopt any upstream changes to the default credentials chain and so our documentation about this is now more general than before: the intention is that our users can generally assume that OpenTofu should support everything that is documented as supported for the AWS CLI, instead of us listing out an explicit search sequence that will be long and inevitably become outdated again.

Closes https://github.com/opentofu/opentofu/issues/1789. (IRSA is one of the credential methods that is now included in the default credentials chain of the SDK, as confirmed in https://github.com/opentofu/opentofu/issues/1789#issuecomment-3323332299.)
