### PR TITLE
internal/states: add nil-receiver test for deposeCurrentObject (retur…

### DIFF
--- a/internal/states/resource_test.go
+++ b/internal/states/resource_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestResourceInstanceDeposeCurrentObject(t *testing.T) {
+	// The same test was missing in Terraform's codebase: https://github.com/hashicorp/terraform/pull/37650
 	t.Run("nil receiver returns NotDeposed", func(t *testing.T) {
 		var ri *ResourceInstance
 		key := ri.deposeCurrentObject(NotDeposed)

--- a/internal/states/resource_test.go
+++ b/internal/states/resource_test.go
@@ -10,6 +10,13 @@ import (
 )
 
 func TestResourceInstanceDeposeCurrentObject(t *testing.T) {
+	t.Run("nil receiver returns NotDeposed", func(t *testing.T) {
+		var ri *ResourceInstance
+		key := ri.deposeCurrentObject(NotDeposed)
+		if key != NotDeposed {
+			t.Fatalf("want NotDeposed, got %q", key)
+		}
+	})
 	obj := &ResourceInstanceObjectSrc{
 		// Empty for the sake of this test, because we're just going to
 		// compare by pointer below anyway.


### PR DESCRIPTION

<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves #3310 
Add a test that calls a nil receiver: `(*ResourceInstance)(nil).deposeCurrentObject(NotDeposed)` and asserts it returns NotDeposed without panicking. The missing test was uncovered while doing mutation testing and is described in more detail in the corresponding issue.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
