### PR TITLE
fix `TestApply_plan_backup` test on Windows by using garbage collection

### DIFF
--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -754,6 +755,10 @@ func TestApply_plan_backup(t *testing.T) {
 
 	// Should have a backup file
 	testStateRead(t, backupPath)
+
+	// Force a garbage collection to ensure the backup file is closed
+	// to avoid TempDir RemoveAll cleanup errors on Windows.
+	runtime.GC()
 }
 
 func TestApply_plan_noBackup(t *testing.T) {


### PR DESCRIPTION
Related to #1201 

This PR fixes `TestApply_plan_backup` by triggering garbage collection to avoid `TempDir RemoveAll cleanup` errors.

```
--- FAIL: TestApply_plan_backup (1.34s)
    testing.go:1369: TempDir RemoveAll cleanup: unlinkat C:\Users\RUNNER~1\AppData\Local\Temp\TestApply_plan_backup257766278\001\state.tfstate: The process cannot access the file because it is being used by another process.
2025/09/30 18:14:55 [DEBUG] GET http://127.0.0.1:53955/providers/v1/hashicorp/frob/versions
2025/09/30 18:14:55 [DEBUG] GET http://127.0.0.1:53955/providers/v1/-/frob/versions
2025/09/30 18:14:55 [DEBUG] GET http://127.0.0.1:53955/providers/v1/hashicorp/foo/versions
2025/09/30 18:14:55 [DEBUG] GET http://127.0.0.1:53955/providers/v1/hashicorp/baz/versions
2025/09/30 18:14:55 [DEBUG] GET http://127.0.0.1:53955/providers/v1/-/baz/versions
2025/09/30 18:14:55 [DEBUG] GET http://127.0.0.1:53961/providers/v1/hashicorp/bar/versions
2025/09/30 18:14:55 [DEBUG] GET http://127.0.0.1:53961/providers/v1/opentofu/foo/versions
2025/09/30 18:14:55 [DEBUG] GET http://127.0.0.1:53961/providers/v1/hashicorp/foo/versions
FAIL
FAIL	github.com/opentofu/opentofu/internal/command	119.984s
```

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
