### PR TITLE
fix: typo on the function's comment

### DIFF
--- a/internal/addrs/module_instance.go
+++ b/internal/addrs/module_instance.go
@@ -500,7 +500,7 @@ func (m ModuleInstance) HasSameModule(other ModuleInstance) bool {
 	return true
 }
 
-// HasSameModule returns true if calling [ModuleInstance.Module] on the
+// IsForModule returns true if calling [ModuleInstance.Module] on the
 // receiver would return a [Module] address equal to the one given as
 // an argument.
 //


### PR DESCRIPTION
This function's comment is referring to another name instead of the name being used on the function.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
