### PR TITLE
dependencies: Stop using github.com/apparentlymart/go-dump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/aliyun/aliyun-oss-go-sdk v2.2.9+incompatible
 	github.com/aliyun/aliyun-tablestore-go-sdk v4.1.2+incompatible
 	github.com/apparentlymart/go-cidr v1.1.0
-	github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0
 	github.com/apparentlymart/go-shquot v0.0.1
 	github.com/apparentlymart/go-userdirs v0.0.0-20200915174352-b0c018a67c13
 	github.com/apparentlymart/go-versions v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,6 @@ github.com/antchfx/xpath v1.1.10/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByN
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apparentlymart/go-cidr v1.1.0 h1:2mAhrMoF+nhXqxTzSZMUzDHkLjmIHC+Zzn4tdgBZjnU=
 github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
-github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0 h1:MzVXffFUye+ZcSR6opIgz9Co7WcDx6ZcY+RjfFHoA0I=
-github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
 github.com/apparentlymart/go-shquot v0.0.1 h1:MGV8lwxF4zw75lN7e0MGs7o6AFYn7L6AZaExUpLh0Mo=
 github.com/apparentlymart/go-shquot v0.0.1/go.mod h1:lw58XsE5IgUXZ9h0cxnypdx31p9mPFIVEQ9P3c7MlrU=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=

--- a/internal/builtin/providers/tf/data_source_state_test.go
+++ b/internal/builtin/providers/tf/data_source_state_test.go
@@ -11,7 +11,9 @@ import (
 	"log"
 	"testing"
 
-	"github.com/apparentlymart/go-dump/dump"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/backend"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
@@ -19,7 +21,6 @@ import (
 	"github.com/opentofu/opentofu/internal/lang/marks"
 	"github.com/opentofu/opentofu/internal/states/statemgr"
 	"github.com/opentofu/opentofu/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func TestResource(t *testing.T) {
@@ -350,7 +351,7 @@ func TestState_basic(t *testing.T) {
 			}
 
 			if test.Want != cty.NilVal && !test.Want.RawEquals(got) {
-				t.Errorf("wrong result\nconfig: %sgot:    %swant:   %s", dump.Value(config), dump.Value(got), dump.Value(test.Want))
+				t.Errorf("wrong result\nconfig: %sgot:    %swant:   %s", ctydebug.ValueString(config), ctydebug.ValueString(got), ctydebug.ValueString(test.Want))
 			}
 		})
 	}

--- a/internal/configs/configschema/decoder_spec_test.go
+++ b/internal/configs/configschema/decoder_spec_test.go
@@ -9,13 +9,13 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/apparentlymart/go-dump/dump"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/hcl/v2/hcltest"
+	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -414,7 +414,7 @@ func TestBlockDecoderSpec(t *testing.T) {
 
 			if !got.RawEquals(test.Want) {
 				t.Logf("[INFO] implied schema is %s", spew.Sdump(hcldec.ImpliedSchema(spec)))
-				t.Errorf("wrong result\ngot:  %s\nwant: %s", dump.Value(got), dump.Value(test.Want))
+				t.Errorf("wrong result\ngot:  %s\nwant: %s", ctydebug.ValueString(got), ctydebug.ValueString(test.Want))
 			}
 
 			// Double-check that we're producing consistent results for DecoderSpec
@@ -856,7 +856,7 @@ func TestAttributeDecoderSpec(t *testing.T) {
 
 			if !got.RawEquals(test.Want) {
 				t.Logf("[INFO] implied schema is %s", spew.Sdump(hcldec.ImpliedSchema(spec)))
-				t.Errorf("wrong result\ngot:  %s\nwant: %s", dump.Value(got), dump.Value(test.Want))
+				t.Errorf("wrong result\ngot:  %s\nwant: %s", ctydebug.ValueString(got), ctydebug.ValueString(test.Want))
 			}
 		})
 	}

--- a/internal/configs/configschema/empty_value_test.go
+++ b/internal/configs/configschema/empty_value_test.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/apparentlymart/go-dump/dump"
 	"github.com/davecgh/go-spew/spew"
+	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -168,7 +168,7 @@ func TestBlockEmptyValue(t *testing.T) {
 		t.Run(fmt.Sprintf("%#v", test.Schema), func(t *testing.T) {
 			got := test.Schema.EmptyValue()
 			if !test.Want.RawEquals(got) {
-				t.Errorf("wrong result\nschema: %s\ngot: %s\nwant: %s", spew.Sdump(test.Schema), dump.Value(got), dump.Value(test.Want))
+				t.Errorf("wrong result\nschema: %s\ngot: %s\nwant: %s", spew.Sdump(test.Schema), ctydebug.ValueString(got), ctydebug.ValueString(test.Want))
 			}
 		})
 	}
@@ -255,7 +255,7 @@ func TestAttributeEmptyValue(t *testing.T) {
 		t.Run(fmt.Sprintf("%#v", test.Schema), func(t *testing.T) {
 			got := test.Schema.EmptyValue()
 			if !test.Want.RawEquals(got) {
-				t.Errorf("wrong result\nschema: %s\ngot: %s\nwant: %s", spew.Sdump(test.Schema), dump.Value(got), dump.Value(test.Want))
+				t.Errorf("wrong result\nschema: %s\ngot: %s\nwant: %s", spew.Sdump(test.Schema), ctydebug.ValueString(got), ctydebug.ValueString(test.Want))
 			}
 		})
 	}

--- a/internal/plans/objchange/compatible_test.go
+++ b/internal/plans/objchange/compatible_test.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/apparentlymart/go-dump/dump"
+	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/configs/configschema"
@@ -1424,7 +1424,7 @@ func TestAssertObjectCompatible(t *testing.T) {
 				wantErrs[msg] = struct{}{}
 			}
 
-			t.Logf("\nplanned: %sactual:  %s", dump.Value(test.Planned), dump.Value(test.Actual))
+			t.Logf("\nplanned: %sactual:  %s", ctydebug.ValueString(test.Planned), ctydebug.ValueString(test.Actual))
 			for msg := range wantErrs {
 				if _, ok := gotErrs[msg]; !ok {
 					t.Errorf("missing expected error: %s", msg)

--- a/internal/plans/objchange/normalize_obj_test.go
+++ b/internal/plans/objchange/normalize_obj_test.go
@@ -8,9 +8,10 @@ package objchange
 import (
 	"testing"
 
-	"github.com/apparentlymart/go-dump/dump"
-	"github.com/opentofu/opentofu/internal/configs/configschema"
+	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/opentofu/opentofu/internal/configs/configschema"
 )
 
 func TestNormalizeObjectFromLegacySDK(t *testing.T) {
@@ -305,7 +306,7 @@ func TestNormalizeObjectFromLegacySDK(t *testing.T) {
 			if !got.RawEquals(test.Want) {
 				t.Errorf(
 					"wrong result\ngot:  %s\nwant: %s",
-					dump.Value(got), dump.Value(test.Want),
+					ctydebug.ValueString(got), ctydebug.ValueString(test.Want),
 				)
 			}
 		})

--- a/internal/plans/objchange/objchange_test.go
+++ b/internal/plans/objchange/objchange_test.go
@@ -8,7 +8,7 @@ package objchange
 import (
 	"testing"
 
-	"github.com/apparentlymart/go-dump/dump"
+	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/configs/configschema"
@@ -2736,7 +2736,7 @@ func TestProposedNew(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got := ProposedNew(test.Schema, test.Prior, test.Config)
 			if !got.RawEquals(test.Want) {
-				t.Errorf("wrong result\ngot:  %swant: %s", dump.Value(got), dump.Value(test.Want))
+				t.Errorf("wrong result\ngot:  %swant: %s", ctydebug.ValueString(got), ctydebug.ValueString(test.Want))
 			}
 		})
 	}

--- a/internal/plans/objchange/plan_valid_test.go
+++ b/internal/plans/objchange/plan_valid_test.go
@@ -8,7 +8,7 @@ package objchange
 import (
 	"testing"
 
-	"github.com/apparentlymart/go-dump/dump"
+	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/configs/configschema"
@@ -2339,9 +2339,9 @@ func TestAssertPlanValid(t *testing.T) {
 
 			t.Logf(
 				"\nprior:  %sconfig:  %splanned: %s",
-				dump.Value(test.Prior),
-				dump.Value(test.Config),
-				dump.Value(test.Planned),
+				ctydebug.ValueString(test.Prior),
+				ctydebug.ValueString(test.Config),
+				ctydebug.ValueString(test.Planned),
 			)
 			for msg := range wantErrs {
 				if _, ok := gotErrs[msg]; !ok {


### PR DESCRIPTION
This upstream library (which I wrote a long time ago, independently of my work on OpenTofu) came about because "go-spew" tended to produce unreadable representations of certain types commonly used in OpenTofu, whereas "go-dump" is really just a pretty-printer for whatever a type might produce when formatted using the `%#v` verb in `package fmt`.

Over time the uses of this seem to have decreased only to some leftover situations where we wanted to pretty-print a `cty.Value` in a test, but we already depend on `go-cty-debug` that has a more specialized implementation of that behavior and so switching the few remaining callers over to that allows us to remove one dependency.

(And, FWIW, that upstream dependency is effectively unmaintained; I don't know of any callers of it other than OpenTofu itself, and after merging this even OpenTofu won't depend on it anymore.)

