### PR TITLE
Use test-virtualizable filesystem for cliconfig

### DIFF
--- a/cmd/tofu/plugins.go
+++ b/cmd/tofu/plugins.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"fmt"
+	"io/fs"
 	"log"
 	"path/filepath"
 	"runtime"
@@ -20,10 +21,10 @@ import (
 // Earlier entries in this slice get priority over later when multiple copies
 // of the same plugin version are found, but newer versions always override
 // older versions where both satisfy the provider version constraints.
-func globalPluginDirs() []string {
+func globalPluginDirs(fileSystem fs.FS) []string {
 	var ret []string
 	// Look in ~/.terraform.d/plugins/, $XDG_DATA_HOME/opentofu/plugins, or its equivalent on non-UNIX platforms
-	dirs, err := cliconfig.DataDirs()
+	dirs, err := cliconfig.DataDirs(fileSystem)
 	if err != nil {
 		log.Printf("[ERROR] Error finding global plugin directories: %s", err)
 	} else {

--- a/cmd/tofu/provider_source.go
+++ b/cmd/tofu/provider_source.go
@@ -8,6 +8,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"log"
 	"net/url"
 	"os"
@@ -28,6 +29,7 @@ import (
 // command, unless overridden by the special -plugin-dir option.
 func providerSource(
 	ctx context.Context,
+	fileSystem fs.FS,
 	configs []*cliconfig.ProviderInstallation,
 	registryClientConfig *cliconfig.RegistryProtocolsConfig,
 	services *disco.Disco,
@@ -38,7 +40,7 @@ func providerSource(
 		// If there's no explicit installation configuration then we'll build
 		// up an implicit one with direct registry installation along with
 		// some automatically-selected local filesystem mirrors.
-		return implicitProviderSource(ctx, registryClientConfig, services, originalWorkingDir), nil
+		return implicitProviderSource(ctx, fileSystem, registryClientConfig, services, originalWorkingDir), nil
 	}
 
 	// There should only be zero or one configurations, which is checked by
@@ -107,6 +109,7 @@ func explicitProviderSource(
 // "exclude" argument in the direct provider source in the CLI config.
 func implicitProviderSource(
 	ctx context.Context,
+	fileSystem fs.FS,
 	registryClientConfig *cliconfig.RegistryProtocolsConfig,
 	services *disco.Disco,
 	originalWorkingDir string,
@@ -170,7 +173,7 @@ func implicitProviderSource(
 	// Check and add the "terraform.d/plugins" directory in the original working directory
 	addLocalDir(filepath.Join(originalWorkingDir, "terraform.d/plugins"))
 
-	cliDataDirs, err := cliconfig.DataDirs()
+	cliDataDirs, err := cliconfig.DataDirs(fileSystem)
 	if err == nil {
 		for _, cliDataDir := range cliDataDirs {
 			addLocalDir(filepath.Join(cliDataDir, "plugins"))

--- a/cmd/tofu/provider_source_test.go
+++ b/cmd/tofu/provider_source_test.go
@@ -115,9 +115,12 @@ func TestProviderSource(t *testing.T) {
 				return ociauthconfig.CredentialsConfigs{}, nil
 			}
 
+			fileSystem := cliconfig.RootFileSystem()
+
 			// Call the function under test
 			source, diags := providerSource(
 				context.Background(),
+				fileSystem,
 				[]*cliconfig.ProviderInstallation{},
 				&cliconfig.RegistryProtocolsConfig{
 					RetryCount:        1,

--- a/internal/command/cliconfig/config_locations_helper_test.go
+++ b/internal/command/cliconfig/config_locations_helper_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cliconfig
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"path/filepath"
+	"text/template"
+)
+
+type locationTestParameters struct {
+	name        string
+	files       []string
+	directories []string
+	envVars     map[string]string
+}
+
+// locationTest fully specifies the relevant filesystem contents and the expected config.
+// The config files are automatically generated with the getFile function, which only
+// generates host information, so we only compare expected and actual host field.
+type locationTest struct {
+	locationTestParameters
+	expected map[string]*ConfigHost
+}
+
+// directoryLocationTest specifies which directories are present in the filesystem and
+// the expected directories.
+type directoryLocationTest struct {
+	locationTestParameters
+	expected []string
+}
+
+type testTemplateInfo struct {
+	Subdomains []string
+	Index      int
+}
+
+// getFile generates an example configuration file for use in the locations tests.
+// The generated configuration needs to satisfy two criteria. When looking at the
+// final configuration, we should be able to determine:
+//   - which files contributed to it
+//   - the order those files were merged
+//
+// These are satisfied with a index host and a pairwise "comparison host", whose "module.vX"
+// value recieves X from the index of the configuration file with highest precedence.
+// The resulting configuration will only have hosts information, which is sufficient
+// for the purposes of the location tests.
+func getFile(i, n int) ([]byte, error) {
+	subDs := make([]string, n-1)
+	adjust := 0
+	for x := range n {
+		if x == i {
+			adjust = 1
+			continue
+		}
+		j, k := i, x
+		if x < i {
+			j, k = x, i
+		}
+		subDs[x-adjust] = fmt.Sprintf("%dand%d", j, k)
+	}
+
+	templateFileName := "config-location.tpl"
+	templateFileLocation := filepath.Join(fixtureDir, templateFileName)
+
+	tpl := template.Must(template.ParseFiles(templateFileLocation))
+
+	byteW := new(bytes.Buffer)
+	err := tpl.ExecuteTemplate(byteW, templateFileName, testTemplateInfo{Subdomains: subDs, Index: i})
+	if err != nil {
+		return nil, err
+	}
+	outB, err := io.ReadAll(byteW)
+	if err != nil {
+		return nil, err
+	}
+	return outB, nil
+}

--- a/internal/command/cliconfig/config_locations_macos_test.go
+++ b/internal/command/cliconfig/config_locations_macos_test.go
@@ -1,0 +1,279 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build darwin
+// +build darwin
+
+package cliconfig
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+func TestConfigFileLocations(t *testing.T) {
+	home := os.Getenv("HOME")
+	xdgDir := filepath.Join(home, ".myconfig")
+	tests := []locationTest{
+		{
+			locationTestParameters: locationTestParameters{
+				name:  ".tofurc only",
+				files: []string{filepath.Join(home, ".tofurc")},
+			},
+			expected: map[string]*ConfigHost{
+				"config0.example.com": {
+					Services: map[string]interface{}{
+						"modules.v0": "https://config0.example.com/",
+					},
+				},
+			},
+		},
+		{
+			locationTestParameters: locationTestParameters{
+				name:  ".terraformrc only",
+				files: []string{filepath.Join(home, ".terraformrc")},
+			},
+			expected: map[string]*ConfigHost{
+				"config0.example.com": {
+					Services: map[string]interface{}{
+						"modules.v0": "https://config0.example.com/",
+					},
+				},
+			},
+		},
+		{
+			locationTestParameters: locationTestParameters{
+				name:  ".tofurc and .terraformrc",
+				files: []string{filepath.Join(home, ".terraformrc"), filepath.Join(home, ".tofurc")},
+			},
+			expected: map[string]*ConfigHost{
+				"config1.example.com": {
+					Services: map[string]interface{}{
+						"modules.v1": "https://config1.example.com/",
+					},
+				},
+				"0and1.example.com": {
+					Services: map[string]interface{}{
+						"modules.v1": "https://0and1.example.com/",
+					},
+				},
+			},
+		},
+		{
+			locationTestParameters: locationTestParameters{
+				name:  ".tofurc and .terraformrc",
+				files: []string{filepath.Join(home, ".terraformrc"), filepath.Join(home, ".tofurc")},
+			},
+			expected: map[string]*ConfigHost{
+				"config1.example.com": {
+					Services: map[string]interface{}{
+						"modules.v1": "https://config1.example.com/",
+					},
+				},
+				"0and1.example.com": {
+					Services: map[string]interface{}{
+						"modules.v1": "https://0and1.example.com/",
+					},
+				},
+			},
+		},
+		{
+			locationTestParameters: locationTestParameters{
+				name:        "xdg directory, but with .tofurc and .terraformrc present",
+				files:       []string{filepath.Join(home, ".terraformrc"), filepath.Join(home, ".tofurc"), filepath.Join(xdgDir, "opentofu", "tofurc")},
+				directories: []string{xdgDir},
+				envVars:     map[string]string{"XDG_CONFIG_HOME": xdgDir},
+			},
+			expected: map[string]*ConfigHost{
+				"config1.example.com": {
+					Services: map[string]interface{}{
+						"modules.v1": "https://config1.example.com/",
+					},
+				},
+				"0and1.example.com": {
+					Services: map[string]interface{}{
+						"modules.v1": "https://0and1.example.com/",
+					},
+				},
+				"1and2.example.com": {
+					Services: map[string]interface{}{
+						"modules.v1": "https://1and2.example.com/",
+					},
+				},
+			},
+		},
+		{
+			locationTestParameters: locationTestParameters{
+				name:        "xdg directory without .tofurc and .terraformrc present",
+				files:       []string{filepath.Join(xdgDir, "opentofu", "tofurc")},
+				directories: []string{xdgDir},
+				envVars:     map[string]string{"XDG_CONFIG_HOME": xdgDir},
+			},
+			expected: map[string]*ConfigHost{
+				"config0.example.com": {
+					Services: map[string]interface{}{
+						"modules.v0": "https://config0.example.com/",
+					},
+				},
+			},
+		},
+		{
+			locationTestParameters: locationTestParameters{
+				name:    "ignore everything else when env override is present",
+				files:   []string{filepath.Join(home, "mytofufile"), filepath.Join(home, ".terraformrc"), filepath.Join(home, ".tofurc")},
+				envVars: map[string]string{"TF_CLI_CONFIG_FILE": filepath.Join(home, "mytofufile")},
+			},
+			expected: map[string]*ConfigHost{
+				"config0.example.com": {
+					Services: map[string]interface{}{
+						"modules.v0": "https://config0.example.com/",
+					},
+				},
+				"0and1.example.com": {
+					Services: map[string]interface{}{
+						"modules.v0": "https://0and1.example.com/",
+					},
+				},
+				"0and2.example.com": {
+					Services: map[string]interface{}{
+						"modules.v0": "https://0and2.example.com/",
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fileSystem := fstest.MapFS{}
+			n := len(test.files)
+			for i, file := range test.files {
+				b, err := getFile(i, n)
+				if err != nil {
+					t.Fatalf("failed to generate file %s: %v", file, err)
+				}
+				fileSystem[strings.TrimLeft(file, string(os.PathSeparator))] = &fstest.MapFile{
+					Data: b,
+					Mode: 0o600,
+				}
+			}
+			for _, directory := range test.directories {
+				fileSystem[strings.TrimLeft(directory, string(os.PathSeparator))] = &fstest.MapFile{
+					Data: nil,
+					Mode: fs.ModeDir | 0o755,
+				}
+			}
+			for k, v := range test.envVars {
+				t.Setenv(k, v)
+			}
+			actual, diags := LoadConfig(t.Context(), fileSystem)
+			if diags.HasErrors() {
+				t.Fatalf("no errors expected, got errors from diags")
+			}
+			if !reflect.DeepEqual(actual.Hosts, test.expected) {
+				t.Errorf("wrong result\ngot:  %s\nwant: %s", spew.Sdump(actual.Hosts), spew.Sdump(test.expected))
+			}
+		})
+	}
+}
+
+func TestConfigDirLocations(t *testing.T) {
+	home := os.Getenv("HOME")
+	xdgDir := filepath.Join(home, ".myconfig")
+	terraformD := filepath.Join(home, ".terraform.d")
+	tests := []directoryLocationTest{
+		{
+			locationTestParameters: locationTestParameters{
+				name: "default directory",
+			},
+			expected: []string{terraformD},
+		},
+		{
+			locationTestParameters: locationTestParameters{
+				name:        "xdg directory",
+				envVars:     map[string]string{"XDG_CONFIG_HOME": xdgDir},
+				directories: []string{xdgDir},
+			},
+			expected: []string{filepath.Join(xdgDir, "opentofu")},
+		},
+		{
+			locationTestParameters: locationTestParameters{
+				name:        "xdg directory, but with extant .terraform.d directory",
+				envVars:     map[string]string{"XDG_CONFIG_HOME": xdgDir},
+				directories: []string{xdgDir, terraformD},
+			},
+			expected: []string{terraformD},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fileSystem := fstest.MapFS{}
+			for _, directory := range test.directories {
+				fileSystem[strings.TrimLeft(directory, string(os.PathSeparator))] = &fstest.MapFile{
+					Data: nil,
+					Mode: fs.ModeDir | 0o755,
+				}
+			}
+			for k, v := range test.envVars {
+				t.Setenv(k, v)
+			}
+			actual, err := ConfigDir(fileSystem)
+			if err != nil {
+				t.Fatalf("no errors expected, got errors from diags")
+			}
+			if actual != test.expected[0] {
+				t.Errorf("wrong result\ngot:  %s\nwant: %s", actual, test.expected[0])
+			}
+		})
+	}
+}
+func TestDataDirLocations(t *testing.T) {
+	home := os.Getenv("HOME")
+	xdgDir := filepath.Join(home, ".mydata")
+	terraformD := filepath.Join(home, ".terraform.d")
+	// Note that neither of these tests depend on the existence of the underlying directories.
+	tests := []directoryLocationTest{
+		{
+			locationTestParameters: locationTestParameters{
+				name: "default directory",
+			},
+			expected: []string{terraformD},
+		},
+		{
+			locationTestParameters: locationTestParameters{
+				name:    "xdg directory",
+				envVars: map[string]string{"XDG_DATA_HOME": xdgDir},
+			},
+			expected: []string{terraformD, filepath.Join(xdgDir, "opentofu")},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fileSystem := fstest.MapFS{}
+			for _, directory := range test.directories {
+				fileSystem[strings.TrimLeft(directory, string(os.PathSeparator))] = &fstest.MapFile{
+					Data: nil,
+					Mode: fs.ModeDir | 0o755,
+				}
+			}
+			for k, v := range test.envVars {
+				t.Setenv(k, v)
+			}
+			actual, err := DataDirs(fileSystem)
+			if err != nil {
+				t.Fatalf("no errors expected, got errors from diags")
+			}
+			if !reflect.DeepEqual(actual, test.expected) {
+				t.Errorf("wrong result\ngot:  %s\nwant: %s", spew.Sdump(actual), spew.Sdump(test.expected))
+			}
+		})
+	}
+}

--- a/internal/command/cliconfig/config_locations_unix_test.go
+++ b/internal/command/cliconfig/config_locations_unix_test.go
@@ -1,0 +1,279 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !windows && !darwin
+// +build !windows,!darwin
+
+package cliconfig
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+func TestConfigFileLocations(t *testing.T) {
+	home := os.Getenv("HOME")
+	xdgDir := filepath.Join(home, ".myconfig")
+	tests := []locationTest{
+		{
+			locationTestParameters: locationTestParameters{
+				name:  ".tofurc only",
+				files: []string{filepath.Join(home, ".tofurc")},
+			},
+			expected: map[string]*ConfigHost{
+				"config0.example.com": {
+					Services: map[string]interface{}{
+						"modules.v0": "https://config0.example.com/",
+					},
+				},
+			},
+		},
+		{
+			locationTestParameters: locationTestParameters{
+				name:  ".terraformrc only",
+				files: []string{filepath.Join(home, ".terraformrc")},
+			},
+			expected: map[string]*ConfigHost{
+				"config0.example.com": {
+					Services: map[string]interface{}{
+						"modules.v0": "https://config0.example.com/",
+					},
+				},
+			},
+		},
+		{
+			locationTestParameters: locationTestParameters{
+				name:  ".tofurc and .terraformrc",
+				files: []string{filepath.Join(home, ".terraformrc"), filepath.Join(home, ".tofurc")},
+			},
+			expected: map[string]*ConfigHost{
+				"config1.example.com": {
+					Services: map[string]interface{}{
+						"modules.v1": "https://config1.example.com/",
+					},
+				},
+				"0and1.example.com": {
+					Services: map[string]interface{}{
+						"modules.v1": "https://0and1.example.com/",
+					},
+				},
+			},
+		},
+		{
+			locationTestParameters: locationTestParameters{
+				name:  ".tofurc and .terraformrc",
+				files: []string{filepath.Join(home, ".terraformrc"), filepath.Join(home, ".tofurc")},
+			},
+			expected: map[string]*ConfigHost{
+				"config1.example.com": {
+					Services: map[string]interface{}{
+						"modules.v1": "https://config1.example.com/",
+					},
+				},
+				"0and1.example.com": {
+					Services: map[string]interface{}{
+						"modules.v1": "https://0and1.example.com/",
+					},
+				},
+			},
+		},
+		{
+			locationTestParameters: locationTestParameters{
+				name:        "xdg directory, but with .tofurc and .terraformrc present",
+				files:       []string{filepath.Join(home, ".terraformrc"), filepath.Join(home, ".tofurc"), filepath.Join(xdgDir, "opentofu", "tofurc")},
+				directories: []string{xdgDir},
+				envVars:     map[string]string{"XDG_CONFIG_HOME": xdgDir},
+			},
+			expected: map[string]*ConfigHost{
+				"config1.example.com": {
+					Services: map[string]interface{}{
+						"modules.v1": "https://config1.example.com/",
+					},
+				},
+				"0and1.example.com": {
+					Services: map[string]interface{}{
+						"modules.v1": "https://0and1.example.com/",
+					},
+				},
+				"1and2.example.com": {
+					Services: map[string]interface{}{
+						"modules.v1": "https://1and2.example.com/",
+					},
+				},
+			},
+		},
+		{
+			locationTestParameters: locationTestParameters{
+				name:        "xdg directory without .tofurc and .terraformrc present",
+				files:       []string{filepath.Join(xdgDir, "opentofu", "tofurc")},
+				directories: []string{xdgDir},
+				envVars:     map[string]string{"XDG_CONFIG_HOME": xdgDir},
+			},
+			expected: map[string]*ConfigHost{
+				"config0.example.com": {
+					Services: map[string]interface{}{
+						"modules.v0": "https://config0.example.com/",
+					},
+				},
+			},
+		},
+		{
+			locationTestParameters: locationTestParameters{
+				name:    "ignore everything else when env override is present",
+				files:   []string{filepath.Join(home, "mytofufile"), filepath.Join(home, ".terraformrc"), filepath.Join(home, ".tofurc")},
+				envVars: map[string]string{"TF_CLI_CONFIG_FILE": filepath.Join(home, "mytofufile")},
+			},
+			expected: map[string]*ConfigHost{
+				"config0.example.com": {
+					Services: map[string]interface{}{
+						"modules.v0": "https://config0.example.com/",
+					},
+				},
+				"0and1.example.com": {
+					Services: map[string]interface{}{
+						"modules.v0": "https://0and1.example.com/",
+					},
+				},
+				"0and2.example.com": {
+					Services: map[string]interface{}{
+						"modules.v0": "https://0and2.example.com/",
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fileSystem := fstest.MapFS{}
+			n := len(test.files)
+			for i, file := range test.files {
+				b, err := getFile(i, n)
+				if err != nil {
+					t.Fatalf("failed to generate file %s: %v", file, err)
+				}
+				fileSystem[strings.TrimLeft(file, string(os.PathSeparator))] = &fstest.MapFile{
+					Data: b,
+					Mode: 0o600,
+				}
+			}
+			for _, directory := range test.directories {
+				fileSystem[strings.TrimLeft(directory, string(os.PathSeparator))] = &fstest.MapFile{
+					Data: nil,
+					Mode: fs.ModeDir | 0o755,
+				}
+			}
+			for k, v := range test.envVars {
+				t.Setenv(k, v)
+			}
+			actual, diags := LoadConfig(t.Context(), fileSystem)
+			if diags.HasErrors() {
+				t.Fatalf("no errors expected, got errors from diags")
+			}
+			if !reflect.DeepEqual(actual.Hosts, test.expected) {
+				t.Errorf("wrong result\ngot:  %s\nwant: %s", spew.Sdump(actual.Hosts), spew.Sdump(test.expected))
+			}
+		})
+	}
+}
+
+func TestConfigDirLocations(t *testing.T) {
+	home := os.Getenv("HOME")
+	xdgDir := filepath.Join(home, ".myconfig")
+	terraformD := filepath.Join(home, ".terraform.d")
+	tests := []directoryLocationTest{
+		{
+			locationTestParameters: locationTestParameters{
+				name: "default directory",
+			},
+			expected: []string{terraformD},
+		},
+		{
+			locationTestParameters: locationTestParameters{
+				name:        "xdg directory",
+				envVars:     map[string]string{"XDG_CONFIG_HOME": xdgDir},
+				directories: []string{xdgDir},
+			},
+			expected: []string{filepath.Join(xdgDir, "opentofu")},
+		},
+		{
+			locationTestParameters: locationTestParameters{
+				name:        "xdg directory, but with extant .terraform.d directory",
+				envVars:     map[string]string{"XDG_CONFIG_HOME": xdgDir},
+				directories: []string{xdgDir, terraformD},
+			},
+			expected: []string{terraformD},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fileSystem := fstest.MapFS{}
+			for _, directory := range test.directories {
+				fileSystem[strings.TrimLeft(directory, string(os.PathSeparator))] = &fstest.MapFile{
+					Data: nil,
+					Mode: fs.ModeDir | 0o755,
+				}
+			}
+			for k, v := range test.envVars {
+				t.Setenv(k, v)
+			}
+			actual, err := ConfigDir(fileSystem)
+			if err != nil {
+				t.Fatalf("no errors expected, got errors from diags")
+			}
+			if actual != test.expected[0] {
+				t.Errorf("wrong result\ngot:  %s\nwant: %s", actual, test.expected[0])
+			}
+		})
+	}
+}
+func TestDataDirLocations(t *testing.T) {
+	home := os.Getenv("HOME")
+	xdgDir := filepath.Join(home, ".mydata")
+	terraformD := filepath.Join(home, ".terraform.d")
+	// Note that neither of these tests depend on the existence of the underlying directories.
+	tests := []directoryLocationTest{
+		{
+			locationTestParameters: locationTestParameters{
+				name: "default directory",
+			},
+			expected: []string{terraformD},
+		},
+		{
+			locationTestParameters: locationTestParameters{
+				name:    "xdg directory",
+				envVars: map[string]string{"XDG_DATA_HOME": xdgDir},
+			},
+			expected: []string{terraformD, filepath.Join(xdgDir, "opentofu")},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fileSystem := fstest.MapFS{}
+			for _, directory := range test.directories {
+				fileSystem[strings.TrimLeft(directory, string(os.PathSeparator))] = &fstest.MapFile{
+					Data: nil,
+					Mode: fs.ModeDir | 0o755,
+				}
+			}
+			for k, v := range test.envVars {
+				t.Setenv(k, v)
+			}
+			actual, err := DataDirs(fileSystem)
+			if err != nil {
+				t.Fatalf("no errors expected, got errors from diags")
+			}
+			if !reflect.DeepEqual(actual, test.expected) {
+				t.Errorf("wrong result\ngot:  %s\nwant: %s", spew.Sdump(actual), spew.Sdump(test.expected))
+			}
+		})
+	}
+}

--- a/internal/command/cliconfig/config_locations_windows_test.go
+++ b/internal/command/cliconfig/config_locations_windows_test.go
@@ -1,0 +1,176 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build windows
+// +build windows
+
+package cliconfig
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+func TestConfigFileLocations(t *testing.T) {
+	configDir := os.Getenv("APPDATA")
+	tests := []locationTest{
+		{
+			locationTestParameters: locationTestParameters{
+				name:  "tofu.rc only",
+				files: []string{filepath.Join(configDir, "tofu.rc")},
+			},
+			expected: map[string]*ConfigHost{
+				"config0.example.com": {
+					Services: map[string]interface{}{
+						"modules.v0": "https://config0.example.com/",
+					},
+				},
+			},
+		},
+		{
+			locationTestParameters: locationTestParameters{
+				name:  "terraform.rc only",
+				files: []string{filepath.Join(configDir, "terraform.rc")},
+			},
+			expected: map[string]*ConfigHost{
+				"config0.example.com": {
+					Services: map[string]interface{}{
+						"modules.v0": "https://config0.example.com/",
+					},
+				},
+			},
+		},
+		{
+			locationTestParameters: locationTestParameters{
+				name:  "tofu.rc and terraform.rc",
+				files: []string{filepath.Join(configDir, "terraform.rc"), filepath.Join(configDir, "tofu.rc")},
+			},
+			expected: map[string]*ConfigHost{
+				"config1.example.com": {
+					Services: map[string]interface{}{
+						"modules.v1": "https://config1.example.com/",
+					},
+				},
+				"0and1.example.com": {
+					Services: map[string]interface{}{
+						"modules.v1": "https://0and1.example.com/",
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fileSystem := fstest.MapFS{}
+			n := len(test.files)
+			for i, file := range test.files {
+				b, err := getFile(i, n)
+				if err != nil {
+					t.Fatalf("failed to generate file %s: %v", file, err)
+				}
+				// TODO trim correctly
+				s, _ := strings.CutPrefix(file, "C:\\")
+				fileSystem[filepath.ToSlash(s)] = &fstest.MapFile{
+					Data: b,
+					Mode: 0o600,
+				}
+			}
+			for _, directory := range test.directories {
+				s, _ := strings.CutPrefix(directory, "C:\\")
+				fileSystem[filepath.ToSlash(s)] = &fstest.MapFile{
+					Data: nil,
+					Mode: fs.ModeDir | 0o755,
+				}
+			}
+			for k, v := range test.envVars {
+				t.Setenv(k, v)
+			}
+			actual, diags := LoadConfig(t.Context(), fileSystem)
+			if diags.HasErrors() {
+				t.Fatalf("no errors expected, got errors from diags")
+			}
+			if !reflect.DeepEqual(actual.Hosts, test.expected) {
+				t.Errorf("wrong result\ngot:  %s\nwant: %s", spew.Sdump(actual.Hosts), spew.Sdump(test.expected))
+			}
+		})
+	}
+}
+
+func TestConfigDirLocations(t *testing.T) {
+	configDir := os.Getenv("APPDATA")
+	terraformD := filepath.Join(configDir, "terraform.d")
+	tests := []directoryLocationTest{
+		{
+			locationTestParameters: locationTestParameters{
+				name: "default directory",
+			},
+			expected: []string{terraformD},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fileSystem := fstest.MapFS{}
+			for _, directory := range test.directories {
+				s, _ := strings.CutPrefix(directory, "C:\\")
+				fileSystem[filepath.ToSlash(s)] = &fstest.MapFile{
+					Data: nil,
+					Mode: fs.ModeDir | 0o755,
+				}
+			}
+			for k, v := range test.envVars {
+				t.Setenv(k, v)
+			}
+			actual, err := ConfigDir(fileSystem)
+			if err != nil {
+				t.Fatalf("no errors expected, got errors from diags")
+			}
+			if actual != test.expected[0] {
+				t.Errorf("wrong result\ngot:  %s\nwant: %s", actual, test.expected[0])
+			}
+		})
+	}
+}
+func TestDataDirLocations(t *testing.T) {
+	configDir := os.Getenv("APPDATA")
+	terraformD := filepath.Join(configDir, "terraform.d")
+	// Note that neither of these tests depend on the existence of the underlying directories.
+	tests := []directoryLocationTest{
+		{
+			locationTestParameters: locationTestParameters{
+				name: "default directory",
+			},
+			expected: []string{terraformD},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fileSystem := fstest.MapFS{}
+			for _, directory := range test.directories {
+				s, _ := strings.CutPrefix(directory, "C:\\")
+				fileSystem[filepath.ToSlash(s)] = &fstest.MapFile{
+					Data: nil,
+					Mode: fs.ModeDir | 0o755,
+				}
+			}
+			for k, v := range test.envVars {
+				t.Setenv(k, v)
+			}
+			actual, err := DataDirs(fileSystem)
+			if err != nil {
+				t.Fatalf("no errors expected, got errors from diags")
+			}
+			if !reflect.DeepEqual(actual, test.expected) {
+				t.Errorf("wrong result\ngot:  %s\nwant: %s", spew.Sdump(actual), spew.Sdump(test.expected))
+			}
+		})
+	}
+}

--- a/internal/command/cliconfig/credentials.go
+++ b/internal/command/cliconfig/credentials.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
@@ -29,8 +30,8 @@ import (
 // credentialsConfigFile returns the path for the special configuration file
 // that the credentials source will use when asked to save or forget credentials
 // and when a "credentials helper" program is not active.
-func credentialsConfigFile() (string, error) {
-	configDir, err := ConfigDir()
+func credentialsConfigFile(fileSystem fs.FS) (string, error) {
+	configDir, err := ConfigDir(fileSystem)
 	if err != nil {
 		return "", err
 	}
@@ -40,8 +41,8 @@ func credentialsConfigFile() (string, error) {
 // CredentialsSource creates and returns a service credentials source whose
 // behavior depends on which "credentials" and "credentials_helper" blocks,
 // if any, are present in the receiving config.
-func (c *Config) CredentialsSource(helperPlugins pluginDiscovery.PluginMetaSet) (*CredentialsSource, error) {
-	credentialsFilePath, err := credentialsConfigFile()
+func (c *Config) CredentialsSource(fileSystem fs.FS, helperPlugins pluginDiscovery.PluginMetaSet) (*CredentialsSource, error) {
+	credentialsFilePath, err := credentialsConfigFile(fileSystem)
 	if err != nil {
 		// If we managed to load a Config object at all then we would already
 		// have located this file, so this error is very unlikely.

--- a/internal/command/cliconfig/oci_credentials_test.go
+++ b/internal/command/cliconfig/oci_credentials_test.go
@@ -92,8 +92,9 @@ func TestLoadConfig_ociDefaultCredentials(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
+			fileSystem := RootFileSystem()
 			fixtureFile := filepath.Join("testdata", name)
-			gotConfig, diags := loadConfigFile(fixtureFile)
+			gotConfig, diags := loadConfigFile(fileSystem, fixtureFile)
 			if diags.HasErrors() {
 				errStr := diags.Err().Error()
 				if test.wantErr == "" {
@@ -117,17 +118,18 @@ func TestLoadConfig_ociDefaultCredentials(t *testing.T) {
 	}
 
 	t.Run("oci-default-credentials-duplicate", func(t *testing.T) {
+		fileSystem := RootFileSystem()
 		// This one is different than all of the others because it
 		// only gets detected as invalid during the validation step,
 		// so that (in the normal case) we can check it only after
 		// we've merged all of the separate CLI config files together.
 		fixtureFile := filepath.Join("testdata", "oci-default-credentials-duplicate")
-		gotConfig, loadDiags := loadConfigFile(fixtureFile)
+		gotConfig, loadDiags := loadConfigFile(fileSystem, fixtureFile)
 		if loadDiags.HasErrors() {
 			t.Errorf("unexpected errors from loadConfigFile: %s", loadDiags.Err().Error())
 		}
 
-		validateDiags := gotConfig.Validate()
+		validateDiags := gotConfig.Validate(fileSystem)
 		wantErr := `No more than one oci_default_credentials block may be specified`
 		if !validateDiags.HasErrors() {
 			t.Fatalf("unexpected success\nwant error with substring: %s", wantErr)
@@ -269,8 +271,9 @@ func TestLoadConfig_ociCredentials(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
+			fileSystem := RootFileSystem()
 			fixtureFile := filepath.Join("testdata", name)
-			gotConfig, diags := loadConfigFile(fixtureFile)
+			gotConfig, diags := loadConfigFile(fileSystem, fixtureFile)
 			if diags.HasErrors() {
 				errStr := diags.Err().Error()
 				if test.wantErr == "" {
@@ -291,17 +294,18 @@ func TestLoadConfig_ociCredentials(t *testing.T) {
 	}
 
 	t.Run("oci-credentials-duplicate", func(t *testing.T) {
+		fileSystem := RootFileSystem()
 		// This one is different than all of the others because it
 		// only gets detected as invalid during the validation step,
 		// so that (in the normal case) we can check it only after
 		// we've merged all of the separate CLI config files together.
 		fixtureFile := filepath.Join("testdata", "oci-credentials-duplicate")
-		gotConfig, loadDiags := loadConfigFile(fixtureFile)
+		gotConfig, loadDiags := loadConfigFile(fileSystem, fixtureFile)
 		if loadDiags.HasErrors() {
 			t.Errorf("unexpected errors from loadConfigFile: %s", loadDiags.Err().Error())
 		}
 
-		validateDiags := gotConfig.Validate()
+		validateDiags := gotConfig.Validate(fileSystem)
 		wantErr := `Duplicate oci_credentials block for "example.com"`
 		if !validateDiags.HasErrors() {
 			t.Fatalf("unexpected success\nwant error with substring: %s", wantErr)
@@ -636,6 +640,7 @@ func TestConfigOCICredentialsPolicy(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
+			fileSystem := RootFileSystem()
 			var osName string
 			if lastDashIdx := strings.LastIndexByte(name, '-'); lastDashIdx == -1 {
 				t.Fatalf("test name does not include -osname suffix")
@@ -648,11 +653,11 @@ func TestConfigOCICredentialsPolicy(t *testing.T) {
 			if err != nil {
 				t.Fatalf("can't get absolute path for %s", configDir)
 			}
-			cfg, diags := loadConfigDir(configDir)
+			cfg, diags := loadConfigDir(fileSystem, configDir)
 			if diags.HasErrors() {
 				t.Fatalf("errors loading config: %s", diags.Err().Error())
 			}
-			diags = cfg.Validate()
+			diags = cfg.Validate(fileSystem)
 			if diags.HasErrors() {
 				t.Fatalf("invalid config:\n%s", diags.Err().Error())
 			}

--- a/internal/command/cliconfig/provider_installation_test.go
+++ b/internal/command/cliconfig/provider_installation_test.go
@@ -20,7 +20,8 @@ import (
 func TestLoadConfig_providerInstallation(t *testing.T) {
 	for _, configFile := range []string{"provider-installation", "provider-installation.json"} {
 		t.Run(configFile, func(t *testing.T) {
-			got, diags := loadConfigFile(filepath.Join(fixtureDir, configFile))
+			fileSystem := RootFileSystem()
+			got, diags := loadConfigFile(fileSystem, filepath.Join(fixtureDir, configFile))
 			if diags.HasErrors() {
 				t.Errorf("unexpected diagnostics: %s", diags.Err().Error())
 			}
@@ -63,7 +64,8 @@ func TestLoadConfig_providerInstallation(t *testing.T) {
 }
 
 func TestLoadConfig_providerInstallationErrors(t *testing.T) {
-	_, diags := loadConfigFile(filepath.Join(fixtureDir, "provider-installation-errors"))
+	fileSystem := RootFileSystem()
+	_, diags := loadConfigFile(fileSystem, filepath.Join(fixtureDir, "provider-installation-errors"))
 	want := `7 problems:
 
 - Invalid provider_installation method block: Unknown provider installation method "not_a_thing" at 2:3.
@@ -87,7 +89,8 @@ func TestLoadConfig_providerInstallationErrors(t *testing.T) {
 func TestLoadConfig_providerInstallationOCIMirror(t *testing.T) {
 	for _, configFile := range []string{"provider-installation-oci", "provider-installation-oci.json"} {
 		t.Run(configFile, func(t *testing.T) {
-			gotConfig, diags := loadConfigFile(filepath.Join(fixtureDir, configFile))
+			fileSystem := RootFileSystem()
+			gotConfig, diags := loadConfigFile(fileSystem, filepath.Join(fixtureDir, configFile))
 			if diags.HasErrors() {
 				t.Fatalf("unexpected diagnostics: %s", diags.Err().Error())
 			}
@@ -180,7 +183,8 @@ func TestLoadConfig_providerInstallationOCIMirror(t *testing.T) {
 
 func TestLoadConfig_providerInstallationOCIMirrorErrors(t *testing.T) {
 	t.Run("missing hostname reference", func(t *testing.T) {
-		_, diags := loadConfigFile(filepath.Join(fixtureDir, "provider-installation-oci-missinghostname"))
+		fileSystem := RootFileSystem()
+		_, diags := loadConfigFile(fileSystem, filepath.Join(fixtureDir, "provider-installation-oci-missinghostname"))
 		if !diags.HasErrors() {
 			t.Fatalf("unexpected success; want error")
 		}
@@ -189,7 +193,8 @@ func TestLoadConfig_providerInstallationOCIMirrorErrors(t *testing.T) {
 		}
 	})
 	t.Run("missing namespace reference", func(t *testing.T) {
-		_, diags := loadConfigFile(filepath.Join(fixtureDir, "provider-installation-oci-missingnamespace"))
+		fileSystem := RootFileSystem()
+		_, diags := loadConfigFile(fileSystem, filepath.Join(fixtureDir, "provider-installation-oci-missingnamespace"))
 		if !diags.HasErrors() {
 			t.Fatalf("unexpected success; want error")
 		}
@@ -198,7 +203,8 @@ func TestLoadConfig_providerInstallationOCIMirrorErrors(t *testing.T) {
 		}
 	})
 	t.Run("missing type reference", func(t *testing.T) {
-		_, diags := loadConfigFile(filepath.Join(fixtureDir, "provider-installation-oci-missingtype"))
+		fileSystem := RootFileSystem()
+		_, diags := loadConfigFile(fileSystem, filepath.Join(fixtureDir, "provider-installation-oci-missingtype"))
 		if !diags.HasErrors() {
 			t.Fatalf("unexpected success; want error")
 		}
@@ -207,7 +213,8 @@ func TestLoadConfig_providerInstallationOCIMirrorErrors(t *testing.T) {
 		}
 	})
 	t.Run("type error in template", func(t *testing.T) {
-		_, diags := loadConfigFile(filepath.Join(fixtureDir, "provider-installation-oci-typeerror"))
+		fileSystem := RootFileSystem()
+		_, diags := loadConfigFile(fileSystem, filepath.Join(fixtureDir, "provider-installation-oci-typeerror"))
 		if !diags.HasErrors() {
 			t.Fatalf("unexpected success; want error")
 		}
@@ -216,7 +223,8 @@ func TestLoadConfig_providerInstallationOCIMirrorErrors(t *testing.T) {
 		}
 	})
 	t.Run("value error in template", func(t *testing.T) {
-		_, diags := loadConfigFile(filepath.Join(fixtureDir, "provider-installation-oci-valueerror"))
+		fileSystem := RootFileSystem()
+		_, diags := loadConfigFile(fileSystem, filepath.Join(fixtureDir, "provider-installation-oci-valueerror"))
 		if !diags.HasErrors() {
 			t.Fatalf("unexpected success; want error")
 		}
@@ -225,7 +233,8 @@ func TestLoadConfig_providerInstallationOCIMirrorErrors(t *testing.T) {
 		}
 	})
 	t.Run("dynamic error in template", func(t *testing.T) {
-		cfg, diags := loadConfigFile(filepath.Join(fixtureDir, "provider-installation-oci-dynerror"))
+		fileSystem := RootFileSystem()
+		cfg, diags := loadConfigFile(fileSystem, filepath.Join(fixtureDir, "provider-installation-oci-dynerror"))
 		if diags.HasErrors() {
 			t.Fatalf("unexpected error for configuration load (error should be only during template evaluation)")
 		}
@@ -246,6 +255,7 @@ func TestLoadConfig_providerInstallationOCIMirrorErrors(t *testing.T) {
 		}
 	})
 	t.Run("unmappable characters in provider source address", func(t *testing.T) {
+		fileSystem := RootFileSystem()
 		// This deals with a particularly-annoying case: OpenTofu provider source addresses
 		// support a wide range of unicode characters with the intent that folks can name
 		// their private providers using the alphabet of their native language, but OCI Distribution
@@ -255,7 +265,7 @@ func TestLoadConfig_providerInstallationOCIMirrorErrors(t *testing.T) {
 		// providers, but we can't tell whether they are more common in private provider
 		// registries. For now we treat this as an error but we might try to find a better
 		// answer for this in a future release if it proves to be a problem in practice.
-		cfg, diags := loadConfigFile(filepath.Join(fixtureDir, "provider-installation-oci-passthru"))
+		cfg, diags := loadConfigFile(fileSystem, filepath.Join(fixtureDir, "provider-installation-oci-passthru"))
 		if diags.HasErrors() {
 			t.Fatalf("unexpected error for configuration load (error should be only during template evaluation)")
 		}

--- a/internal/command/cliconfig/registry_protocols_test.go
+++ b/internal/command/cliconfig/registry_protocols_test.go
@@ -226,6 +226,7 @@ func TestLoadConfig_registryProtocols(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
+			fileSystem := RootFileSystem()
 			fixtureFile := filepath.Join("testdata", test.fixture)
 
 			// We set the file to load using this environment variable because
@@ -247,7 +248,7 @@ func TestLoadConfig_registryProtocols(t *testing.T) {
 				t.Setenv("TF_REGISTRY_CLIENT_TIMEOUT", "")
 			}
 
-			gotConfig, diags := LoadConfig(t.Context())
+			gotConfig, diags := LoadConfig(t.Context(), fileSystem)
 			if diags.HasErrors() {
 				errStr := diags.Err().Error()
 				if test.wantErr == "" {

--- a/internal/command/cliconfig/testdata/config-location.tpl
+++ b/internal/command/cliconfig/testdata/config-location.tpl
@@ -1,0 +1,13 @@
+{{$index := .Index}}
+host "config{{$index}}.example.com" {
+  services = {
+    "modules.v{{$index}}" = "https://config{{$index}}.example.com/",
+  }
+}
+{{range .Subdomains}}
+host "{{.}}.example.com" {
+  services = {
+    "modules.v{{$index}}" = "https://{{.}}.example.com/",
+  }
+}
+{{end}}

--- a/internal/command/cliconfig/util.go
+++ b/internal/command/cliconfig/util.go
@@ -5,13 +5,16 @@
 
 package cliconfig
 
-import "os"
+import (
+	"errors"
+	"io/fs"
+)
 
-func getNewOrLegacyPath(newPath string, legacyPath string) (string, error) {
+func getNewOrLegacyPath(fileSystem fs.FS, newPath string, legacyPath string) (string, error) {
 	// If the legacy directory exists, but the new directory does not, then use the legacy directory, for backwards compatibility reasons.
 	// Otherwise, use the new directory.
-	if _, err := os.Stat(legacyPath); err == nil {
-		if _, err := os.Stat(newPath); os.IsNotExist(err) {
+	if _, err := fs.Stat(fileSystem, fsRelativize(legacyPath)); err == nil {
+		if _, err := fs.Stat(fileSystem, fsRelativize(newPath)); errors.Is(err, fs.ErrNotExist) {
 			return legacyPath, nil
 		}
 	}


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

This is the first part of addressing the problem of nonstandard CLI configuration directories in OpenTofu. See #2655.

Before any functionality is changed, the current behavior of how CLI configuration files are loaded should be thoroughly tested. We do have `cliconfig` tests already, but those heavily depend on environment variables. Moreover, they do not consider the precedence with which different configurations might be loaded. Finally, they don't actually check the local filesystem; this is probably because a test looking at the real file system of the developer isn't feasible.

Therefore, I've virtualized the filesystem and added regression tests looking at real locations. There were a couple of surprisingly difficult design decisions in this feature, especially since the `fs.FS` virtual filesystem depends solely on relative directories; pay special attention to `fsRelativize`, which I feel is the most suspect part of the code.

A future pull request will add functionality differences between Mac and Unix. So, while the test files are completely identical in this PR, the next change will cause them to diverge.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
