### PR TITLE
provisioners/local-exec: Detect errors in "stop" test

### DIFF
--- a/internal/builtin/provisioners/local-exec/resource_provisioner_test.go
+++ b/internal/builtin/provisioners/local-exec/resource_provisioner_test.go
@@ -58,10 +58,17 @@ func TestResourceProvider_stop(t *testing.T) {
 	p := New()
 	schema := p.GetSchema().Provisioner
 
+	command := "sleep 30; sleep 30"
+	if runtime.GOOS == "windows" {
+		// On Windows the local-exec provisioner uses cmd.exe by default,
+		// and that uses "&" as a command separator instead of ";".
+		command = "sleep 30 & sleep 30"
+	}
+
 	c, err := schema.CoerceValue(cty.ObjectVal(map[string]cty.Value{
 		// bash/zsh/ksh will exec a single command in the same process. This
 		// makes certain there's a subprocess in the shell.
-		"command": cty.StringVal("sleep 30; sleep 30"),
+		"command": cty.StringVal(command),
 	}))
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Previously this test was just assuming that the provisioner run would succeed and only requiring that it run for more than 50ms before exiting. That meant that it could potentially false-positive succeed if the provisioner happened to return an error but take more than 50ms to do so.

Now we'll test for failure before we ask the provisioner to stop, which narrows the false-positive window. This still isn't completely robust because we don't have any way to test whether the provisioner failed due to being canceled or for some other reason. The error message returned on cancellation varies depending on what state the provisioner was in when it got the cancellation message and what platform we're running on, so it's not currently feasible to write a robust check that would definitely distinguish between the expected error vs. unexpected errors.

(I originally spotted this in https://github.com/opentofu/opentofu/pull/3343#issuecomment-3383570421, but it also affected the first test run for https://github.com/opentofu/opentofu/pull/3342 that doesn't yet include the Go version upgrade, so it seems like this was just one of those timing things that occurs at certain times of day based on load variations on the GitHub actions worker nodes.)
