### PR TITLE
Remove direct uses of `golang.org/x/exp`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.38.0
 	go.uber.org/mock v0.4.0
 	golang.org/x/crypto v0.41.0
-	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/mod v0.26.0
 	golang.org/x/net v0.43.0
 	golang.org/x/oauth2 v0.32.0
@@ -129,6 +128,7 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
+	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 )
 
 require (

--- a/internal/collections/set.go
+++ b/internal/collections/set.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"strings"
 
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 // Set is a container that can hold each item only once and has a fast lookup time.

--- a/internal/command/test.go
+++ b/internal/command/test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log"
 	"path"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -19,7 +20,6 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
-	"golang.org/x/exp/slices"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/backend"

--- a/internal/tofu/context_apply2_test.go
+++ b/internal/tofu/context_apply2_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -20,7 +21,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
-	"golang.org/x/exp/slices"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/checks"


### PR DESCRIPTION
We were previously using this module to access the then-experimental "slices" package, but equivalent functionality is now available in a standard library package so we no longer need to use the experimental version.

This remains as an indirect dependency just because some of the tools we use depend on it.
