### PR TITLE
Replace github.com/go-test/deep with go-cmp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/dylanmei/winrmtest v0.0.0-20210303004826-fbc9ae56efb6
 	github.com/go-logr/stdr v1.2.2
-	github.com/go-test/deep v1.1.0
 	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0

--- a/internal/addrs/output_value_test.go
+++ b/internal/addrs/output_value_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestAbsOutputValueInstanceEqual_true(t *testing.T) {
@@ -116,8 +116,8 @@ func TestParseAbsOutputValueStr(t *testing.T) {
 	for input, tc := range tests {
 		t.Run(input, func(t *testing.T) {
 			got, diags := ParseAbsOutputValueStr(input)
-			for _, problem := range deep.Equal(got, tc.want) {
-				t.Errorf("%s", problem)
+			if diff := cmp.Diff(tc.want, got, CmpOptionsForTesting); diff != "" {
+				t.Error("wrong result:\n" + diff)
 			}
 			if len(diags) > 0 {
 				gotErr := diags.Err().Error()

--- a/internal/addrs/parse_ref_test.go
+++ b/internal/addrs/parse_ref_test.go
@@ -8,7 +8,7 @@ package addrs
 import (
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
@@ -115,8 +115,8 @@ func TestParseRefInTestingScope(t *testing.T) {
 				return
 			}
 
-			for _, problem := range deep.Equal(got, test.Want) {
-				t.Errorf("%s", problem)
+			if diff := cmp.Diff(test.Want, got, CmpOptionsForTesting); diff != "" {
+				t.Error("wrong result:\n" + diff)
 			}
 		})
 	}
@@ -1028,8 +1028,8 @@ func TestParseRef(t *testing.T) {
 				return
 			}
 
-			for _, problem := range deep.Equal(got, test.Want) {
-				t.Errorf("%s", problem)
+			if diff := cmp.Diff(test.Want, got, CmpOptionsForTesting); diff != "" {
+				t.Error("wrong result:\n" + diff)
 			}
 		})
 	}

--- a/internal/addrs/parse_target_test.go
+++ b/internal/addrs/parse_target_test.go
@@ -8,9 +8,10 @@ package addrs
 import (
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
@@ -536,8 +537,8 @@ func TestParseTarget(t *testing.T) {
 				return
 			}
 
-			for _, problem := range deep.Equal(got, test.Want) {
-				t.Errorf("%s", problem)
+			if diff := cmp.Diff(test.Want, got, CmpOptionsForTesting); diff != "" {
+				t.Error("wrong result:\n" + diff)
 			}
 		})
 	}

--- a/internal/addrs/provider_config_test.go
+++ b/internal/addrs/provider_config_test.go
@@ -9,8 +9,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-test/deep"
-
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 )
@@ -180,8 +179,8 @@ func TestParseAbsProviderConfigInstances(t *testing.T) {
 				}
 			}
 
-			for _, problem := range deep.Equal(got, test.Want) {
-				t.Error(problem)
+			if diff := cmp.Diff(test.Want, got, CmpOptionsForTesting); diff != "" {
+				t.Error("wrong result:\n" + diff)
 			}
 
 			if test.WantKey != key {

--- a/internal/addrs/provider_test.go
+++ b/internal/addrs/provider_test.go
@@ -8,7 +8,7 @@ package addrs
 import (
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/opentofu/svchost"
 )
 
@@ -433,8 +433,8 @@ func TestParseProviderSourceStr(t *testing.T) {
 
 	for name, test := range tests {
 		got, diags := ParseProviderSourceString(name)
-		for _, problem := range deep.Equal(got, test.Want) {
-			t.Errorf("%s", problem)
+		if diff := cmp.Diff(test.Want, got, CmpOptionsForTesting); diff != "" {
+			t.Error("wrong result:\n" + diff)
 		}
 		if len(diags) > 0 {
 			if test.Err == false {

--- a/internal/addrs/testing.go
+++ b/internal/addrs/testing.go
@@ -1,0 +1,47 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package addrs
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+)
+
+// CmpOptionsForTesting are a common set of options for
+// github.com/google/go-cmp/cmp's [cmp.Diff] that arrange for comparisons to
+// ignore irrelevant unexported parts of various addrs types, such as interface
+// implementation sigils, which are used for compile-time checks rather than
+// runtime checks and so don't need to be compared in our tests.
+//
+// This also includes the options from go-cty-debug that arrange for [cty.Value]
+// and [cty.Type] to be comparable, because those tend to arise as part of
+// results from functions in this package.
+var CmpOptionsForTesting cmp.Options = cmp.Options{
+	// Types that embed [referenceable] as part of their implementations of
+	// [Referenceable].
+	cmpopts.IgnoreUnexported(
+		CountAttr{},
+		ForEachAttr{},
+		InputVariable{},
+		LocalValue{},
+		ModuleCallInstance{},
+		ModuleCallInstanceOutput{},
+		PathAttr{},
+		TerraformAttr{},
+	),
+	// HCL's "Traverser" implementations also use an unexported field to
+	// represent their implementation of that interface. We return
+	// raw traversals from functions like [ParseRef], so it's helpful
+	// to ignore the unexported parts of these too.
+	cmpopts.IgnoreUnexported(
+		hcl.TraverseAttr{},
+		hcl.TraverseIndex{},
+		hcl.TraverseRoot{},
+	),
+	ctydebug.CmpOptions,
+}

--- a/internal/configs/config_test.go
+++ b/internal/configs/config_test.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-test/deep"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/hcl/v2"
@@ -52,8 +51,8 @@ func TestConfigProviderTypes(t *testing.T) {
 		addrs.NewDefaultProvider("template"),
 		addrs.NewDefaultProvider("test"),
 	}
-	for _, problem := range deep.Equal(got, want) {
-		t.Error(problem)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Error("wrong result:\n" + diff)
 	}
 }
 
@@ -78,8 +77,8 @@ func TestConfigProviderTypes_nested(t *testing.T) {
 		addrs.NewDefaultProvider("test"),
 	}
 
-	for _, problem := range deep.Equal(got, want) {
-		t.Error(problem)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Error("wrong result:\n" + diff)
 	}
 }
 

--- a/internal/configs/configload/loader_snapshot_test.go
+++ b/internal/configs/configload/loader_snapshot_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/opentofu/opentofu/internal/configs"
 )
@@ -50,11 +50,8 @@ func TestLoadConfigWithSnapshot(t *testing.T) {
 		for key, module := range wantModuleDirs {
 			wantModuleDirs[key] = filepath.Clean(module)
 		}
-		problems := deep.Equal(wantModuleDirs, gotModuleDirs)
-		for _, problem := range problems {
-			t.Errorf("%s", problem)
-		}
-		if len(problems) > 0 {
+		if diff := cmp.Diff(wantModuleDirs, gotModuleDirs); diff != "" {
+			t.Error("wrong module dirs:\n" + diff)
 			return
 		}
 	}

--- a/internal/configs/provider_test.go
+++ b/internal/configs/provider_test.go
@@ -9,9 +9,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 )
 
@@ -92,8 +93,8 @@ func TestParseProviderConfigCompact(t *testing.T) {
 				}
 			}
 
-			for _, problem := range deep.Equal(got, test.Want) {
-				t.Error(problem)
+			if diff := cmp.Diff(test.Want, got); diff != "" {
+				t.Error("wrong result:\n" + diff)
 			}
 		})
 	}
@@ -146,8 +147,8 @@ func TestParseProviderConfigCompactStr(t *testing.T) {
 				}
 			}
 
-			for _, problem := range deep.Equal(got, test.Want) {
-				t.Error(problem)
+			if diff := cmp.Diff(test.Want, got); diff != "" {
+				t.Error("wrong result:\n" + diff)
 			}
 		})
 	}

--- a/internal/initwd/module_install_test.go
+++ b/internal/initwd/module_install_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/go-test/deep"
 	"github.com/google/go-cmp/cmp"
 	version "github.com/hashicorp/go-version"
 	"github.com/opentofu/svchost"
@@ -1107,12 +1106,13 @@ func assertDiagnosticSummary(t *testing.T, diags tfdiags.Diagnostics, want strin
 	return true
 }
 
-func assertResultDeepEqual(t *testing.T, got, want interface{}) bool {
+func assertResultDeepEqual(t *testing.T, got, want any) bool {
+	// Note that, unlike some "assert" functions elsewhere, this function
+	// returns true to indicate that the assertion _failed_, and false
+	// to indicate that it succeeded.
 	t.Helper()
-	if diff := deep.Equal(got, want); diff != nil {
-		for _, problem := range diff {
-			t.Errorf("%s", problem)
-		}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Error("wrong result:\n" + diff)
 		return true
 	}
 	return false

--- a/internal/legacy/hcl2shim/flatmap_test.go
+++ b/internal/legacy/hcl2shim/flatmap_test.go
@@ -9,8 +9,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/go-test/deep"
-
+	"github.com/google/go-cmp/cmp"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -246,9 +245,8 @@ func TestFlatmapValueFromHCL2(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Value.GoString(), func(t *testing.T) {
 			got := FlatmapValueFromHCL2(test.Value)
-
-			for _, problem := range deep.Equal(got, test.Want) {
-				t.Error(problem)
+			if diff := cmp.Diff(test.Want, got); diff != "" {
+				t.Error("wrong result:\n" + diff)
 			}
 		})
 	}
@@ -314,9 +312,8 @@ func TestFlatmapValueFromHCL2FromFlatmap(t *testing.T) {
 			}
 
 			got := FlatmapValueFromHCL2(val)
-
-			for _, problem := range deep.Equal(got, test.Map) {
-				t.Error(problem)
+			if diff := cmp.Diff(test.Map, got); diff != "" {
+				t.Error("wrong result:\n" + diff)
 			}
 		})
 	}

--- a/internal/plans/plan_test.go
+++ b/internal/plans/plan_test.go
@@ -8,12 +8,12 @@ package plans
 import (
 	"testing"
 
-	"github.com/go-test/deep"
-	"github.com/opentofu/opentofu/internal/configs"
+	"github.com/google/go-cmp/cmp"
 	"github.com/zclconf/go-cty/cty"
 	ctymsgpack "github.com/zclconf/go-cty/cty/msgpack"
 
 	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/configs"
 )
 
 func TestProviderAddrs(t *testing.T) {
@@ -62,18 +62,17 @@ func TestProviderAddrs(t *testing.T) {
 
 	got := plan.ProviderAddrs()
 	want := []addrs.AbsProviderConfig{
-		addrs.AbsProviderConfig{
+		{
 			Module:   addrs.RootModule.Child("foo"),
 			Provider: addrs.NewDefaultProvider("test"),
 		},
-		addrs.AbsProviderConfig{
+		{
 			Module:   addrs.RootModule,
 			Provider: addrs.NewDefaultProvider("test"),
 		},
 	}
-
-	for _, problem := range deep.Equal(got, want) {
-		t.Error(problem)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Error("wrong result:\n" + diff)
 	}
 }
 

--- a/internal/plans/planfile/tfplan_test.go
+++ b/internal/plans/planfile/tfplan_test.go
@@ -10,7 +10,8 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -343,18 +344,8 @@ func TestTFPlanRoundTrip(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	{
-		oldDepth := deep.MaxDepth
-		oldCompare := deep.CompareUnexportedFields
-		deep.MaxDepth = 20
-		deep.CompareUnexportedFields = true
-		defer func() {
-			deep.MaxDepth = oldDepth
-			deep.CompareUnexportedFields = oldCompare
-		}()
-	}
-	for _, problem := range deep.Equal(newPlan, plan) {
-		t.Error(problem)
+	if diff := cmp.Diff(plan, newPlan, ctydebug.CmpOptions); diff != "" {
+		t.Error("wrong result:\n" + diff)
 	}
 }
 

--- a/internal/providers/addressed_types_test.go
+++ b/internal/providers/addressed_types_test.go
@@ -8,7 +8,7 @@ package providers
 import (
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 )
@@ -44,7 +44,7 @@ func TestAddressedTypesAbs(t *testing.T) {
 		addrs.NewDefaultProvider("azure"),
 		addrs.NewDefaultProvider("null"),
 	}
-	for _, problem := range deep.Equal(got, want) {
-		t.Error(problem)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Error("wrong result:\n" + diff)
 	}
 }

--- a/internal/states/state_test.go
+++ b/internal/states/state_test.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -163,21 +163,8 @@ func TestState(t *testing.T) {
 		},
 	}
 
-	{
-		// Our structure goes deep, so we need to temporarily override the
-		// deep package settings to ensure that we visit the full structure.
-		oldDeepDepth := deep.MaxDepth
-		oldDeepCompareUnexp := deep.CompareUnexportedFields
-		deep.MaxDepth = 50
-		deep.CompareUnexportedFields = true
-		defer func() {
-			deep.MaxDepth = oldDeepDepth
-			deep.CompareUnexportedFields = oldDeepCompareUnexp
-		}()
-	}
-
-	for _, problem := range deep.Equal(state, want) {
-		t.Error(problem)
+	if diff := cmp.Diff(want, state); diff != "" {
+		t.Error("wrong result:\n" + diff)
 	}
 
 	expectedOutputs := map[string]string{

--- a/internal/states/statefile/roundtrip_test.go
+++ b/internal/states/statefile/roundtrip_test.go
@@ -9,11 +9,12 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/opentofu/opentofu/internal/encryption"
 	"github.com/opentofu/opentofu/internal/encryption/enctest"
 )
@@ -72,10 +73,8 @@ func TestRoundtrip(t *testing.T) {
 				t.Fatal(diags.Err())
 			}
 
-			problems := deep.Equal(oGot, oWant)
-			sort.Strings(problems)
-			for _, problem := range problems {
-				t.Error(problem)
+			if diff := cmp.Diff(oWant, oGot, cmpopts.IgnoreFields(File{}, "TerraformVersion")); diff != "" {
+				t.Error("wrong result:\n" + diff)
 			}
 		})
 	}
@@ -130,9 +129,7 @@ func TestRoundtripEncryption(t *testing.T) {
 	originalState.EncryptionStatus = newState.EncryptionStatus
 
 	// Compare before/after encryption workflow
-	problems := deep.Equal(newState, originalState)
-	sort.Strings(problems)
-	for _, problem := range problems {
-		t.Error(problem)
+	if diff := cmp.Diff(originalState, newState, cmpopts.IgnoreFields(File{}, "TerraformVersion")); diff != "" {
+		t.Error("wrong result:\n" + diff)
 	}
 }

--- a/internal/states/statemgr/filesystem_test.go
+++ b/internal/states/statemgr/filesystem_test.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	version "github.com/hashicorp/go-version"
 	"github.com/zclconf/go-cty/cty"
 
@@ -178,8 +178,8 @@ func TestFilesystem_backup(t *testing.T) {
 	}
 	origState := TestFullInitialState()
 	if !bf.State.Equal(origState) {
-		for _, problem := range deep.Equal(origState, bf.State) {
-			t.Error(problem)
+		if diff := cmp.Diff(bf.State, origState); diff != "" {
+			t.Error("wrong backup state:\n" + diff)
 		}
 	}
 }

--- a/internal/tfdiags/contextual_test.go
+++ b/internal/tfdiags/contextual_test.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
@@ -558,8 +558,8 @@ simple_attr = "val"
 				t.Error("missing detail address")
 			}
 
-			for _, problem := range deep.Equal(gotRange, tc.ExpectedRange) {
-				t.Error(problem)
+			if diff := cmp.Diff(tc.ExpectedRange, gotRange); diff != "" {
+				t.Error("wrong source range:\n" + diff)
 			}
 		})
 	}

--- a/internal/tofu/node_module_variable_test.go
+++ b/internal/tofu/node_module_variable_test.go
@@ -11,7 +11,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-test/deep"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -102,8 +101,8 @@ func TestNodeModuleVariableReference(t *testing.T) {
 		},
 	}
 	got := n.References()
-	for _, problem := range deep.Equal(got, want) {
-		t.Error(problem)
+	if diff := cmp.Diff(want, got, addrs.CmpOptionsForTesting); diff != "" {
+		t.Error("wrong references\n" + diff)
 	}
 }
 
@@ -130,8 +129,8 @@ func TestNodeModuleVariableReference_grandchild(t *testing.T) {
 		},
 	}
 	got := n.References()
-	for _, problem := range deep.Equal(got, want) {
-		t.Error(problem)
+	if diff := cmp.Diff(want, got, addrs.CmpOptionsForTesting); diff != "" {
+		t.Error("wrong references\n" + diff)
 	}
 }
 


### PR DESCRIPTION
My original intention here was just to reduce our number of dependencies by standardizing on a single comparison library, but in the process of doing so I found various examples of the kinds of problems that caused this codebase to begin adopting `go-cmp` instead of `go-test/deep` in the first place, which make it easy to accidentally write a false-positive test that doesn't actually check what the author thinks is being checked:

- `deep.Equal` silently ignores unexported fields, so comparing two values that differ only in data in unexported fields succeeds even when it ought not to.

  `TestContext2Apply_multiVarComprehensive` in package tofu was an excellent example of this problem: it had various test assertions that were actually checking absolutely nothing, despite appearing to compare pairs of `cty.Value`. Those tests are now effective, but it did require writing the tests in a somewhat-unusual way to preserve some assumptions made by the original test author to avoid significantly changing the description of the expected values.

- `deep.Equal` also silently ignores anything below a certain level of nesting, and so comparison of deep data structures can appear to succeed even though they don't actually match.

  There were a few examples where that problem had already been found and fixed by temporarily overriding the package deep global settings, but with `go-cmp` the default behavior already visits everything, or panics if it cannot, so we no longer need any special settings for those deep structures.

This does mean that in a few cases this needed some more elaborate options to `cmp.Diff` to align with the previous behavior, which is a little annoying but overall I think better to be explicit about what each test is relying on. Perhaps we can rework these tests to need fewer unusual `cmp` options in future, but for this commit I want to keep focused on the smallest possible changes to remove our dependency on `github.com/go-test/deep` .
