### PR TITLE
go.mod: go get go.uber.org/mock@v0.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/sdk v1.38.0
 	go.opentelemetry.io/otel/trace v1.38.0
-	go.uber.org/mock v0.4.0
+	go.uber.org/mock v0.6.0
 	golang.org/x/crypto v0.43.0
 	golang.org/x/mod v0.29.0
 	golang.org/x/net v0.46.0

--- a/go.sum
+++ b/go.sum
@@ -973,8 +973,8 @@ go.opentelemetry.io/proto/otlp v1.7.1/go.mod h1:b2rVh6rfI/s2pHWNlB7ILJcRALpcNDzK
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
-go.uber.org/mock v0.4.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
+go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
+go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/internal/backend/remote-state/http/mock_server_test.go
+++ b/internal/backend/remote-state/http/mock_server_test.go
@@ -20,6 +20,7 @@ import (
 type MockHttpServerCallback struct {
 	ctrl     *gomock.Controller
 	recorder *MockHttpServerCallbackMockRecorder
+	isgomock struct{}
 }
 
 // MockHttpServerCallbackMockRecorder is the mock recorder for MockHttpServerCallback.

--- a/internal/plugin/mock_proto/mock.go
+++ b/internal/plugin/mock_proto/mock.go
@@ -23,6 +23,7 @@ import (
 type MockProviderClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockProviderClientMockRecorder
+	isgomock struct{}
 }
 
 // MockProviderClientMockRecorder is the mock recorder for MockProviderClient.
@@ -43,10 +44,10 @@ func (m *MockProviderClient) EXPECT() *MockProviderClientMockRecorder {
 }
 
 // ApplyResourceChange mocks base method.
-func (m *MockProviderClient) ApplyResourceChange(arg0 context.Context, arg1 *tfplugin5.ApplyResourceChange_Request, arg2 ...grpc.CallOption) (*tfplugin5.ApplyResourceChange_Response, error) {
+func (m *MockProviderClient) ApplyResourceChange(ctx context.Context, in *tfplugin5.ApplyResourceChange_Request, opts ...grpc.CallOption) (*tfplugin5.ApplyResourceChange_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "ApplyResourceChange", varargs...)
@@ -56,17 +57,17 @@ func (m *MockProviderClient) ApplyResourceChange(arg0 context.Context, arg1 *tfp
 }
 
 // ApplyResourceChange indicates an expected call of ApplyResourceChange.
-func (mr *MockProviderClientMockRecorder) ApplyResourceChange(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) ApplyResourceChange(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyResourceChange", reflect.TypeOf((*MockProviderClient)(nil).ApplyResourceChange), varargs...)
 }
 
 // CallFunction mocks base method.
-func (m *MockProviderClient) CallFunction(arg0 context.Context, arg1 *tfplugin5.CallFunction_Request, arg2 ...grpc.CallOption) (*tfplugin5.CallFunction_Response, error) {
+func (m *MockProviderClient) CallFunction(ctx context.Context, in *tfplugin5.CallFunction_Request, opts ...grpc.CallOption) (*tfplugin5.CallFunction_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "CallFunction", varargs...)
@@ -76,17 +77,17 @@ func (m *MockProviderClient) CallFunction(arg0 context.Context, arg1 *tfplugin5.
 }
 
 // CallFunction indicates an expected call of CallFunction.
-func (mr *MockProviderClientMockRecorder) CallFunction(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) CallFunction(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CallFunction", reflect.TypeOf((*MockProviderClient)(nil).CallFunction), varargs...)
 }
 
 // CloseEphemeralResource mocks base method.
-func (m *MockProviderClient) CloseEphemeralResource(arg0 context.Context, arg1 *tfplugin5.CloseEphemeralResource_Request, arg2 ...grpc.CallOption) (*tfplugin5.CloseEphemeralResource_Response, error) {
+func (m *MockProviderClient) CloseEphemeralResource(ctx context.Context, in *tfplugin5.CloseEphemeralResource_Request, opts ...grpc.CallOption) (*tfplugin5.CloseEphemeralResource_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "CloseEphemeralResource", varargs...)
@@ -96,17 +97,17 @@ func (m *MockProviderClient) CloseEphemeralResource(arg0 context.Context, arg1 *
 }
 
 // CloseEphemeralResource indicates an expected call of CloseEphemeralResource.
-func (mr *MockProviderClientMockRecorder) CloseEphemeralResource(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) CloseEphemeralResource(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseEphemeralResource", reflect.TypeOf((*MockProviderClient)(nil).CloseEphemeralResource), varargs...)
 }
 
 // Configure mocks base method.
-func (m *MockProviderClient) Configure(arg0 context.Context, arg1 *tfplugin5.Configure_Request, arg2 ...grpc.CallOption) (*tfplugin5.Configure_Response, error) {
+func (m *MockProviderClient) Configure(ctx context.Context, in *tfplugin5.Configure_Request, opts ...grpc.CallOption) (*tfplugin5.Configure_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Configure", varargs...)
@@ -116,17 +117,17 @@ func (m *MockProviderClient) Configure(arg0 context.Context, arg1 *tfplugin5.Con
 }
 
 // Configure indicates an expected call of Configure.
-func (mr *MockProviderClientMockRecorder) Configure(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) Configure(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Configure", reflect.TypeOf((*MockProviderClient)(nil).Configure), varargs...)
 }
 
 // GetFunctions mocks base method.
-func (m *MockProviderClient) GetFunctions(arg0 context.Context, arg1 *tfplugin5.GetFunctions_Request, arg2 ...grpc.CallOption) (*tfplugin5.GetFunctions_Response, error) {
+func (m *MockProviderClient) GetFunctions(ctx context.Context, in *tfplugin5.GetFunctions_Request, opts ...grpc.CallOption) (*tfplugin5.GetFunctions_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "GetFunctions", varargs...)
@@ -136,17 +137,17 @@ func (m *MockProviderClient) GetFunctions(arg0 context.Context, arg1 *tfplugin5.
 }
 
 // GetFunctions indicates an expected call of GetFunctions.
-func (mr *MockProviderClientMockRecorder) GetFunctions(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) GetFunctions(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFunctions", reflect.TypeOf((*MockProviderClient)(nil).GetFunctions), varargs...)
 }
 
 // GetMetadata mocks base method.
-func (m *MockProviderClient) GetMetadata(arg0 context.Context, arg1 *tfplugin5.GetMetadata_Request, arg2 ...grpc.CallOption) (*tfplugin5.GetMetadata_Response, error) {
+func (m *MockProviderClient) GetMetadata(ctx context.Context, in *tfplugin5.GetMetadata_Request, opts ...grpc.CallOption) (*tfplugin5.GetMetadata_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "GetMetadata", varargs...)
@@ -156,17 +157,17 @@ func (m *MockProviderClient) GetMetadata(arg0 context.Context, arg1 *tfplugin5.G
 }
 
 // GetMetadata indicates an expected call of GetMetadata.
-func (mr *MockProviderClientMockRecorder) GetMetadata(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) GetMetadata(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadata", reflect.TypeOf((*MockProviderClient)(nil).GetMetadata), varargs...)
 }
 
 // GetResourceIdentitySchemas mocks base method.
-func (m *MockProviderClient) GetResourceIdentitySchemas(arg0 context.Context, arg1 *tfplugin5.GetResourceIdentitySchemas_Request, arg2 ...grpc.CallOption) (*tfplugin5.GetResourceIdentitySchemas_Response, error) {
+func (m *MockProviderClient) GetResourceIdentitySchemas(ctx context.Context, in *tfplugin5.GetResourceIdentitySchemas_Request, opts ...grpc.CallOption) (*tfplugin5.GetResourceIdentitySchemas_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "GetResourceIdentitySchemas", varargs...)
@@ -176,17 +177,17 @@ func (m *MockProviderClient) GetResourceIdentitySchemas(arg0 context.Context, ar
 }
 
 // GetResourceIdentitySchemas indicates an expected call of GetResourceIdentitySchemas.
-func (mr *MockProviderClientMockRecorder) GetResourceIdentitySchemas(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) GetResourceIdentitySchemas(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourceIdentitySchemas", reflect.TypeOf((*MockProviderClient)(nil).GetResourceIdentitySchemas), varargs...)
 }
 
 // GetSchema mocks base method.
-func (m *MockProviderClient) GetSchema(arg0 context.Context, arg1 *tfplugin5.GetProviderSchema_Request, arg2 ...grpc.CallOption) (*tfplugin5.GetProviderSchema_Response, error) {
+func (m *MockProviderClient) GetSchema(ctx context.Context, in *tfplugin5.GetProviderSchema_Request, opts ...grpc.CallOption) (*tfplugin5.GetProviderSchema_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "GetSchema", varargs...)
@@ -196,17 +197,17 @@ func (m *MockProviderClient) GetSchema(arg0 context.Context, arg1 *tfplugin5.Get
 }
 
 // GetSchema indicates an expected call of GetSchema.
-func (mr *MockProviderClientMockRecorder) GetSchema(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) GetSchema(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSchema", reflect.TypeOf((*MockProviderClient)(nil).GetSchema), varargs...)
 }
 
 // ImportResourceState mocks base method.
-func (m *MockProviderClient) ImportResourceState(arg0 context.Context, arg1 *tfplugin5.ImportResourceState_Request, arg2 ...grpc.CallOption) (*tfplugin5.ImportResourceState_Response, error) {
+func (m *MockProviderClient) ImportResourceState(ctx context.Context, in *tfplugin5.ImportResourceState_Request, opts ...grpc.CallOption) (*tfplugin5.ImportResourceState_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "ImportResourceState", varargs...)
@@ -216,17 +217,17 @@ func (m *MockProviderClient) ImportResourceState(arg0 context.Context, arg1 *tfp
 }
 
 // ImportResourceState indicates an expected call of ImportResourceState.
-func (mr *MockProviderClientMockRecorder) ImportResourceState(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) ImportResourceState(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportResourceState", reflect.TypeOf((*MockProviderClient)(nil).ImportResourceState), varargs...)
 }
 
 // MoveResourceState mocks base method.
-func (m *MockProviderClient) MoveResourceState(arg0 context.Context, arg1 *tfplugin5.MoveResourceState_Request, arg2 ...grpc.CallOption) (*tfplugin5.MoveResourceState_Response, error) {
+func (m *MockProviderClient) MoveResourceState(ctx context.Context, in *tfplugin5.MoveResourceState_Request, opts ...grpc.CallOption) (*tfplugin5.MoveResourceState_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "MoveResourceState", varargs...)
@@ -236,17 +237,17 @@ func (m *MockProviderClient) MoveResourceState(arg0 context.Context, arg1 *tfplu
 }
 
 // MoveResourceState indicates an expected call of MoveResourceState.
-func (mr *MockProviderClientMockRecorder) MoveResourceState(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) MoveResourceState(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveResourceState", reflect.TypeOf((*MockProviderClient)(nil).MoveResourceState), varargs...)
 }
 
 // OpenEphemeralResource mocks base method.
-func (m *MockProviderClient) OpenEphemeralResource(arg0 context.Context, arg1 *tfplugin5.OpenEphemeralResource_Request, arg2 ...grpc.CallOption) (*tfplugin5.OpenEphemeralResource_Response, error) {
+func (m *MockProviderClient) OpenEphemeralResource(ctx context.Context, in *tfplugin5.OpenEphemeralResource_Request, opts ...grpc.CallOption) (*tfplugin5.OpenEphemeralResource_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "OpenEphemeralResource", varargs...)
@@ -256,17 +257,17 @@ func (m *MockProviderClient) OpenEphemeralResource(arg0 context.Context, arg1 *t
 }
 
 // OpenEphemeralResource indicates an expected call of OpenEphemeralResource.
-func (mr *MockProviderClientMockRecorder) OpenEphemeralResource(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) OpenEphemeralResource(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenEphemeralResource", reflect.TypeOf((*MockProviderClient)(nil).OpenEphemeralResource), varargs...)
 }
 
 // PlanResourceChange mocks base method.
-func (m *MockProviderClient) PlanResourceChange(arg0 context.Context, arg1 *tfplugin5.PlanResourceChange_Request, arg2 ...grpc.CallOption) (*tfplugin5.PlanResourceChange_Response, error) {
+func (m *MockProviderClient) PlanResourceChange(ctx context.Context, in *tfplugin5.PlanResourceChange_Request, opts ...grpc.CallOption) (*tfplugin5.PlanResourceChange_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "PlanResourceChange", varargs...)
@@ -276,17 +277,17 @@ func (m *MockProviderClient) PlanResourceChange(arg0 context.Context, arg1 *tfpl
 }
 
 // PlanResourceChange indicates an expected call of PlanResourceChange.
-func (mr *MockProviderClientMockRecorder) PlanResourceChange(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) PlanResourceChange(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PlanResourceChange", reflect.TypeOf((*MockProviderClient)(nil).PlanResourceChange), varargs...)
 }
 
 // PrepareProviderConfig mocks base method.
-func (m *MockProviderClient) PrepareProviderConfig(arg0 context.Context, arg1 *tfplugin5.PrepareProviderConfig_Request, arg2 ...grpc.CallOption) (*tfplugin5.PrepareProviderConfig_Response, error) {
+func (m *MockProviderClient) PrepareProviderConfig(ctx context.Context, in *tfplugin5.PrepareProviderConfig_Request, opts ...grpc.CallOption) (*tfplugin5.PrepareProviderConfig_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "PrepareProviderConfig", varargs...)
@@ -296,17 +297,17 @@ func (m *MockProviderClient) PrepareProviderConfig(arg0 context.Context, arg1 *t
 }
 
 // PrepareProviderConfig indicates an expected call of PrepareProviderConfig.
-func (mr *MockProviderClientMockRecorder) PrepareProviderConfig(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) PrepareProviderConfig(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareProviderConfig", reflect.TypeOf((*MockProviderClient)(nil).PrepareProviderConfig), varargs...)
 }
 
 // ReadDataSource mocks base method.
-func (m *MockProviderClient) ReadDataSource(arg0 context.Context, arg1 *tfplugin5.ReadDataSource_Request, arg2 ...grpc.CallOption) (*tfplugin5.ReadDataSource_Response, error) {
+func (m *MockProviderClient) ReadDataSource(ctx context.Context, in *tfplugin5.ReadDataSource_Request, opts ...grpc.CallOption) (*tfplugin5.ReadDataSource_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "ReadDataSource", varargs...)
@@ -316,17 +317,17 @@ func (m *MockProviderClient) ReadDataSource(arg0 context.Context, arg1 *tfplugin
 }
 
 // ReadDataSource indicates an expected call of ReadDataSource.
-func (mr *MockProviderClientMockRecorder) ReadDataSource(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) ReadDataSource(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadDataSource", reflect.TypeOf((*MockProviderClient)(nil).ReadDataSource), varargs...)
 }
 
 // ReadResource mocks base method.
-func (m *MockProviderClient) ReadResource(arg0 context.Context, arg1 *tfplugin5.ReadResource_Request, arg2 ...grpc.CallOption) (*tfplugin5.ReadResource_Response, error) {
+func (m *MockProviderClient) ReadResource(ctx context.Context, in *tfplugin5.ReadResource_Request, opts ...grpc.CallOption) (*tfplugin5.ReadResource_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "ReadResource", varargs...)
@@ -336,17 +337,17 @@ func (m *MockProviderClient) ReadResource(arg0 context.Context, arg1 *tfplugin5.
 }
 
 // ReadResource indicates an expected call of ReadResource.
-func (mr *MockProviderClientMockRecorder) ReadResource(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) ReadResource(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadResource", reflect.TypeOf((*MockProviderClient)(nil).ReadResource), varargs...)
 }
 
 // RenewEphemeralResource mocks base method.
-func (m *MockProviderClient) RenewEphemeralResource(arg0 context.Context, arg1 *tfplugin5.RenewEphemeralResource_Request, arg2 ...grpc.CallOption) (*tfplugin5.RenewEphemeralResource_Response, error) {
+func (m *MockProviderClient) RenewEphemeralResource(ctx context.Context, in *tfplugin5.RenewEphemeralResource_Request, opts ...grpc.CallOption) (*tfplugin5.RenewEphemeralResource_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "RenewEphemeralResource", varargs...)
@@ -356,17 +357,17 @@ func (m *MockProviderClient) RenewEphemeralResource(arg0 context.Context, arg1 *
 }
 
 // RenewEphemeralResource indicates an expected call of RenewEphemeralResource.
-func (mr *MockProviderClientMockRecorder) RenewEphemeralResource(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) RenewEphemeralResource(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenewEphemeralResource", reflect.TypeOf((*MockProviderClient)(nil).RenewEphemeralResource), varargs...)
 }
 
 // Stop mocks base method.
-func (m *MockProviderClient) Stop(arg0 context.Context, arg1 *tfplugin5.Stop_Request, arg2 ...grpc.CallOption) (*tfplugin5.Stop_Response, error) {
+func (m *MockProviderClient) Stop(ctx context.Context, in *tfplugin5.Stop_Request, opts ...grpc.CallOption) (*tfplugin5.Stop_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Stop", varargs...)
@@ -376,17 +377,17 @@ func (m *MockProviderClient) Stop(arg0 context.Context, arg1 *tfplugin5.Stop_Req
 }
 
 // Stop indicates an expected call of Stop.
-func (mr *MockProviderClientMockRecorder) Stop(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) Stop(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockProviderClient)(nil).Stop), varargs...)
 }
 
 // UpgradeResourceIdentity mocks base method.
-func (m *MockProviderClient) UpgradeResourceIdentity(arg0 context.Context, arg1 *tfplugin5.UpgradeResourceIdentity_Request, arg2 ...grpc.CallOption) (*tfplugin5.UpgradeResourceIdentity_Response, error) {
+func (m *MockProviderClient) UpgradeResourceIdentity(ctx context.Context, in *tfplugin5.UpgradeResourceIdentity_Request, opts ...grpc.CallOption) (*tfplugin5.UpgradeResourceIdentity_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "UpgradeResourceIdentity", varargs...)
@@ -396,17 +397,17 @@ func (m *MockProviderClient) UpgradeResourceIdentity(arg0 context.Context, arg1 
 }
 
 // UpgradeResourceIdentity indicates an expected call of UpgradeResourceIdentity.
-func (mr *MockProviderClientMockRecorder) UpgradeResourceIdentity(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) UpgradeResourceIdentity(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeResourceIdentity", reflect.TypeOf((*MockProviderClient)(nil).UpgradeResourceIdentity), varargs...)
 }
 
 // UpgradeResourceState mocks base method.
-func (m *MockProviderClient) UpgradeResourceState(arg0 context.Context, arg1 *tfplugin5.UpgradeResourceState_Request, arg2 ...grpc.CallOption) (*tfplugin5.UpgradeResourceState_Response, error) {
+func (m *MockProviderClient) UpgradeResourceState(ctx context.Context, in *tfplugin5.UpgradeResourceState_Request, opts ...grpc.CallOption) (*tfplugin5.UpgradeResourceState_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "UpgradeResourceState", varargs...)
@@ -416,17 +417,17 @@ func (m *MockProviderClient) UpgradeResourceState(arg0 context.Context, arg1 *tf
 }
 
 // UpgradeResourceState indicates an expected call of UpgradeResourceState.
-func (mr *MockProviderClientMockRecorder) UpgradeResourceState(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) UpgradeResourceState(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeResourceState", reflect.TypeOf((*MockProviderClient)(nil).UpgradeResourceState), varargs...)
 }
 
 // ValidateDataSourceConfig mocks base method.
-func (m *MockProviderClient) ValidateDataSourceConfig(arg0 context.Context, arg1 *tfplugin5.ValidateDataSourceConfig_Request, arg2 ...grpc.CallOption) (*tfplugin5.ValidateDataSourceConfig_Response, error) {
+func (m *MockProviderClient) ValidateDataSourceConfig(ctx context.Context, in *tfplugin5.ValidateDataSourceConfig_Request, opts ...grpc.CallOption) (*tfplugin5.ValidateDataSourceConfig_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "ValidateDataSourceConfig", varargs...)
@@ -436,17 +437,17 @@ func (m *MockProviderClient) ValidateDataSourceConfig(arg0 context.Context, arg1
 }
 
 // ValidateDataSourceConfig indicates an expected call of ValidateDataSourceConfig.
-func (mr *MockProviderClientMockRecorder) ValidateDataSourceConfig(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) ValidateDataSourceConfig(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateDataSourceConfig", reflect.TypeOf((*MockProviderClient)(nil).ValidateDataSourceConfig), varargs...)
 }
 
 // ValidateEphemeralResourceConfig mocks base method.
-func (m *MockProviderClient) ValidateEphemeralResourceConfig(arg0 context.Context, arg1 *tfplugin5.ValidateEphemeralResourceConfig_Request, arg2 ...grpc.CallOption) (*tfplugin5.ValidateEphemeralResourceConfig_Response, error) {
+func (m *MockProviderClient) ValidateEphemeralResourceConfig(ctx context.Context, in *tfplugin5.ValidateEphemeralResourceConfig_Request, opts ...grpc.CallOption) (*tfplugin5.ValidateEphemeralResourceConfig_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "ValidateEphemeralResourceConfig", varargs...)
@@ -456,17 +457,17 @@ func (m *MockProviderClient) ValidateEphemeralResourceConfig(arg0 context.Contex
 }
 
 // ValidateEphemeralResourceConfig indicates an expected call of ValidateEphemeralResourceConfig.
-func (mr *MockProviderClientMockRecorder) ValidateEphemeralResourceConfig(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) ValidateEphemeralResourceConfig(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateEphemeralResourceConfig", reflect.TypeOf((*MockProviderClient)(nil).ValidateEphemeralResourceConfig), varargs...)
 }
 
 // ValidateResourceTypeConfig mocks base method.
-func (m *MockProviderClient) ValidateResourceTypeConfig(arg0 context.Context, arg1 *tfplugin5.ValidateResourceTypeConfig_Request, arg2 ...grpc.CallOption) (*tfplugin5.ValidateResourceTypeConfig_Response, error) {
+func (m *MockProviderClient) ValidateResourceTypeConfig(ctx context.Context, in *tfplugin5.ValidateResourceTypeConfig_Request, opts ...grpc.CallOption) (*tfplugin5.ValidateResourceTypeConfig_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "ValidateResourceTypeConfig", varargs...)
@@ -476,9 +477,9 @@ func (m *MockProviderClient) ValidateResourceTypeConfig(arg0 context.Context, ar
 }
 
 // ValidateResourceTypeConfig indicates an expected call of ValidateResourceTypeConfig.
-func (mr *MockProviderClientMockRecorder) ValidateResourceTypeConfig(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) ValidateResourceTypeConfig(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateResourceTypeConfig", reflect.TypeOf((*MockProviderClient)(nil).ValidateResourceTypeConfig), varargs...)
 }
 
@@ -486,6 +487,7 @@ func (mr *MockProviderClientMockRecorder) ValidateResourceTypeConfig(arg0, arg1 
 type MockProvisionerClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockProvisionerClientMockRecorder
+	isgomock struct{}
 }
 
 // MockProvisionerClientMockRecorder is the mock recorder for MockProvisionerClient.
@@ -506,10 +508,10 @@ func (m *MockProvisionerClient) EXPECT() *MockProvisionerClientMockRecorder {
 }
 
 // GetSchema mocks base method.
-func (m *MockProvisionerClient) GetSchema(arg0 context.Context, arg1 *tfplugin5.GetProvisionerSchema_Request, arg2 ...grpc.CallOption) (*tfplugin5.GetProvisionerSchema_Response, error) {
+func (m *MockProvisionerClient) GetSchema(ctx context.Context, in *tfplugin5.GetProvisionerSchema_Request, opts ...grpc.CallOption) (*tfplugin5.GetProvisionerSchema_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "GetSchema", varargs...)
@@ -519,17 +521,17 @@ func (m *MockProvisionerClient) GetSchema(arg0 context.Context, arg1 *tfplugin5.
 }
 
 // GetSchema indicates an expected call of GetSchema.
-func (mr *MockProvisionerClientMockRecorder) GetSchema(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProvisionerClientMockRecorder) GetSchema(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSchema", reflect.TypeOf((*MockProvisionerClient)(nil).GetSchema), varargs...)
 }
 
 // ProvisionResource mocks base method.
-func (m *MockProvisionerClient) ProvisionResource(arg0 context.Context, arg1 *tfplugin5.ProvisionResource_Request, arg2 ...grpc.CallOption) (tfplugin5.Provisioner_ProvisionResourceClient, error) {
+func (m *MockProvisionerClient) ProvisionResource(ctx context.Context, in *tfplugin5.ProvisionResource_Request, opts ...grpc.CallOption) (tfplugin5.Provisioner_ProvisionResourceClient, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "ProvisionResource", varargs...)
@@ -539,17 +541,17 @@ func (m *MockProvisionerClient) ProvisionResource(arg0 context.Context, arg1 *tf
 }
 
 // ProvisionResource indicates an expected call of ProvisionResource.
-func (mr *MockProvisionerClientMockRecorder) ProvisionResource(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProvisionerClientMockRecorder) ProvisionResource(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProvisionResource", reflect.TypeOf((*MockProvisionerClient)(nil).ProvisionResource), varargs...)
 }
 
 // Stop mocks base method.
-func (m *MockProvisionerClient) Stop(arg0 context.Context, arg1 *tfplugin5.Stop_Request, arg2 ...grpc.CallOption) (*tfplugin5.Stop_Response, error) {
+func (m *MockProvisionerClient) Stop(ctx context.Context, in *tfplugin5.Stop_Request, opts ...grpc.CallOption) (*tfplugin5.Stop_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Stop", varargs...)
@@ -559,17 +561,17 @@ func (m *MockProvisionerClient) Stop(arg0 context.Context, arg1 *tfplugin5.Stop_
 }
 
 // Stop indicates an expected call of Stop.
-func (mr *MockProvisionerClientMockRecorder) Stop(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProvisionerClientMockRecorder) Stop(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockProvisionerClient)(nil).Stop), varargs...)
 }
 
 // ValidateProvisionerConfig mocks base method.
-func (m *MockProvisionerClient) ValidateProvisionerConfig(arg0 context.Context, arg1 *tfplugin5.ValidateProvisionerConfig_Request, arg2 ...grpc.CallOption) (*tfplugin5.ValidateProvisionerConfig_Response, error) {
+func (m *MockProvisionerClient) ValidateProvisionerConfig(ctx context.Context, in *tfplugin5.ValidateProvisionerConfig_Request, opts ...grpc.CallOption) (*tfplugin5.ValidateProvisionerConfig_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "ValidateProvisionerConfig", varargs...)
@@ -579,9 +581,9 @@ func (m *MockProvisionerClient) ValidateProvisionerConfig(arg0 context.Context, 
 }
 
 // ValidateProvisionerConfig indicates an expected call of ValidateProvisionerConfig.
-func (mr *MockProvisionerClientMockRecorder) ValidateProvisionerConfig(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProvisionerClientMockRecorder) ValidateProvisionerConfig(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateProvisionerConfig", reflect.TypeOf((*MockProvisionerClient)(nil).ValidateProvisionerConfig), varargs...)
 }
 
@@ -589,6 +591,7 @@ func (mr *MockProvisionerClientMockRecorder) ValidateProvisionerConfig(arg0, arg
 type MockProvisioner_ProvisionResourceClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockProvisioner_ProvisionResourceClientMockRecorder
+	isgomock struct{}
 }
 
 // MockProvisioner_ProvisionResourceClientMockRecorder is the mock recorder for MockProvisioner_ProvisionResourceClient.
@@ -667,31 +670,31 @@ func (mr *MockProvisioner_ProvisionResourceClientMockRecorder) Recv() *gomock.Ca
 }
 
 // RecvMsg mocks base method.
-func (m *MockProvisioner_ProvisionResourceClient) RecvMsg(arg0 any) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RecvMsg", arg0)
+func (m_2 *MockProvisioner_ProvisionResourceClient) RecvMsg(m any) error {
+	m_2.ctrl.T.Helper()
+	ret := m_2.ctrl.Call(m_2, "RecvMsg", m)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RecvMsg indicates an expected call of RecvMsg.
-func (mr *MockProvisioner_ProvisionResourceClientMockRecorder) RecvMsg(arg0 any) *gomock.Call {
+func (mr *MockProvisioner_ProvisionResourceClientMockRecorder) RecvMsg(m any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecvMsg", reflect.TypeOf((*MockProvisioner_ProvisionResourceClient)(nil).RecvMsg), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecvMsg", reflect.TypeOf((*MockProvisioner_ProvisionResourceClient)(nil).RecvMsg), m)
 }
 
 // SendMsg mocks base method.
-func (m *MockProvisioner_ProvisionResourceClient) SendMsg(arg0 any) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SendMsg", arg0)
+func (m_2 *MockProvisioner_ProvisionResourceClient) SendMsg(m any) error {
+	m_2.ctrl.T.Helper()
+	ret := m_2.ctrl.Call(m_2, "SendMsg", m)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SendMsg indicates an expected call of SendMsg.
-func (mr *MockProvisioner_ProvisionResourceClientMockRecorder) SendMsg(arg0 any) *gomock.Call {
+func (mr *MockProvisioner_ProvisionResourceClientMockRecorder) SendMsg(m any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMsg", reflect.TypeOf((*MockProvisioner_ProvisionResourceClient)(nil).SendMsg), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMsg", reflect.TypeOf((*MockProvisioner_ProvisionResourceClient)(nil).SendMsg), m)
 }
 
 // Trailer mocks base method.
@@ -712,6 +715,7 @@ func (mr *MockProvisioner_ProvisionResourceClientMockRecorder) Trailer() *gomock
 type MockProvisioner_ProvisionResourceServer struct {
 	ctrl     *gomock.Controller
 	recorder *MockProvisioner_ProvisionResourceServerMockRecorder
+	isgomock struct{}
 }
 
 // MockProvisioner_ProvisionResourceServerMockRecorder is the mock recorder for MockProvisioner_ProvisionResourceServer.
@@ -746,17 +750,17 @@ func (mr *MockProvisioner_ProvisionResourceServerMockRecorder) Context() *gomock
 }
 
 // RecvMsg mocks base method.
-func (m *MockProvisioner_ProvisionResourceServer) RecvMsg(arg0 any) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RecvMsg", arg0)
+func (m_2 *MockProvisioner_ProvisionResourceServer) RecvMsg(m any) error {
+	m_2.ctrl.T.Helper()
+	ret := m_2.ctrl.Call(m_2, "RecvMsg", m)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RecvMsg indicates an expected call of RecvMsg.
-func (mr *MockProvisioner_ProvisionResourceServerMockRecorder) RecvMsg(arg0 any) *gomock.Call {
+func (mr *MockProvisioner_ProvisionResourceServerMockRecorder) RecvMsg(m any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecvMsg", reflect.TypeOf((*MockProvisioner_ProvisionResourceServer)(nil).RecvMsg), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecvMsg", reflect.TypeOf((*MockProvisioner_ProvisionResourceServer)(nil).RecvMsg), m)
 }
 
 // Send mocks base method.
@@ -788,17 +792,17 @@ func (mr *MockProvisioner_ProvisionResourceServerMockRecorder) SendHeader(arg0 a
 }
 
 // SendMsg mocks base method.
-func (m *MockProvisioner_ProvisionResourceServer) SendMsg(arg0 any) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SendMsg", arg0)
+func (m_2 *MockProvisioner_ProvisionResourceServer) SendMsg(m any) error {
+	m_2.ctrl.T.Helper()
+	ret := m_2.ctrl.Call(m_2, "SendMsg", m)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SendMsg indicates an expected call of SendMsg.
-func (mr *MockProvisioner_ProvisionResourceServerMockRecorder) SendMsg(arg0 any) *gomock.Call {
+func (mr *MockProvisioner_ProvisionResourceServerMockRecorder) SendMsg(m any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMsg", reflect.TypeOf((*MockProvisioner_ProvisionResourceServer)(nil).SendMsg), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMsg", reflect.TypeOf((*MockProvisioner_ProvisionResourceServer)(nil).SendMsg), m)
 }
 
 // SetHeader mocks base method.

--- a/internal/plugin6/mock_proto/mock.go
+++ b/internal/plugin6/mock_proto/mock.go
@@ -22,6 +22,7 @@ import (
 type MockProviderClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockProviderClientMockRecorder
+	isgomock struct{}
 }
 
 // MockProviderClientMockRecorder is the mock recorder for MockProviderClient.
@@ -42,10 +43,10 @@ func (m *MockProviderClient) EXPECT() *MockProviderClientMockRecorder {
 }
 
 // ApplyResourceChange mocks base method.
-func (m *MockProviderClient) ApplyResourceChange(arg0 context.Context, arg1 *tfplugin6.ApplyResourceChange_Request, arg2 ...grpc.CallOption) (*tfplugin6.ApplyResourceChange_Response, error) {
+func (m *MockProviderClient) ApplyResourceChange(ctx context.Context, in *tfplugin6.ApplyResourceChange_Request, opts ...grpc.CallOption) (*tfplugin6.ApplyResourceChange_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "ApplyResourceChange", varargs...)
@@ -55,17 +56,17 @@ func (m *MockProviderClient) ApplyResourceChange(arg0 context.Context, arg1 *tfp
 }
 
 // ApplyResourceChange indicates an expected call of ApplyResourceChange.
-func (mr *MockProviderClientMockRecorder) ApplyResourceChange(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) ApplyResourceChange(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyResourceChange", reflect.TypeOf((*MockProviderClient)(nil).ApplyResourceChange), varargs...)
 }
 
 // CallFunction mocks base method.
-func (m *MockProviderClient) CallFunction(arg0 context.Context, arg1 *tfplugin6.CallFunction_Request, arg2 ...grpc.CallOption) (*tfplugin6.CallFunction_Response, error) {
+func (m *MockProviderClient) CallFunction(ctx context.Context, in *tfplugin6.CallFunction_Request, opts ...grpc.CallOption) (*tfplugin6.CallFunction_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "CallFunction", varargs...)
@@ -75,17 +76,17 @@ func (m *MockProviderClient) CallFunction(arg0 context.Context, arg1 *tfplugin6.
 }
 
 // CallFunction indicates an expected call of CallFunction.
-func (mr *MockProviderClientMockRecorder) CallFunction(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) CallFunction(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CallFunction", reflect.TypeOf((*MockProviderClient)(nil).CallFunction), varargs...)
 }
 
 // CloseEphemeralResource mocks base method.
-func (m *MockProviderClient) CloseEphemeralResource(arg0 context.Context, arg1 *tfplugin6.CloseEphemeralResource_Request, arg2 ...grpc.CallOption) (*tfplugin6.CloseEphemeralResource_Response, error) {
+func (m *MockProviderClient) CloseEphemeralResource(ctx context.Context, in *tfplugin6.CloseEphemeralResource_Request, opts ...grpc.CallOption) (*tfplugin6.CloseEphemeralResource_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "CloseEphemeralResource", varargs...)
@@ -95,17 +96,17 @@ func (m *MockProviderClient) CloseEphemeralResource(arg0 context.Context, arg1 *
 }
 
 // CloseEphemeralResource indicates an expected call of CloseEphemeralResource.
-func (mr *MockProviderClientMockRecorder) CloseEphemeralResource(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) CloseEphemeralResource(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseEphemeralResource", reflect.TypeOf((*MockProviderClient)(nil).CloseEphemeralResource), varargs...)
 }
 
 // ConfigureProvider mocks base method.
-func (m *MockProviderClient) ConfigureProvider(arg0 context.Context, arg1 *tfplugin6.ConfigureProvider_Request, arg2 ...grpc.CallOption) (*tfplugin6.ConfigureProvider_Response, error) {
+func (m *MockProviderClient) ConfigureProvider(ctx context.Context, in *tfplugin6.ConfigureProvider_Request, opts ...grpc.CallOption) (*tfplugin6.ConfigureProvider_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "ConfigureProvider", varargs...)
@@ -115,17 +116,17 @@ func (m *MockProviderClient) ConfigureProvider(arg0 context.Context, arg1 *tfplu
 }
 
 // ConfigureProvider indicates an expected call of ConfigureProvider.
-func (mr *MockProviderClientMockRecorder) ConfigureProvider(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) ConfigureProvider(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigureProvider", reflect.TypeOf((*MockProviderClient)(nil).ConfigureProvider), varargs...)
 }
 
 // GetFunctions mocks base method.
-func (m *MockProviderClient) GetFunctions(arg0 context.Context, arg1 *tfplugin6.GetFunctions_Request, arg2 ...grpc.CallOption) (*tfplugin6.GetFunctions_Response, error) {
+func (m *MockProviderClient) GetFunctions(ctx context.Context, in *tfplugin6.GetFunctions_Request, opts ...grpc.CallOption) (*tfplugin6.GetFunctions_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "GetFunctions", varargs...)
@@ -135,17 +136,17 @@ func (m *MockProviderClient) GetFunctions(arg0 context.Context, arg1 *tfplugin6.
 }
 
 // GetFunctions indicates an expected call of GetFunctions.
-func (mr *MockProviderClientMockRecorder) GetFunctions(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) GetFunctions(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFunctions", reflect.TypeOf((*MockProviderClient)(nil).GetFunctions), varargs...)
 }
 
 // GetMetadata mocks base method.
-func (m *MockProviderClient) GetMetadata(arg0 context.Context, arg1 *tfplugin6.GetMetadata_Request, arg2 ...grpc.CallOption) (*tfplugin6.GetMetadata_Response, error) {
+func (m *MockProviderClient) GetMetadata(ctx context.Context, in *tfplugin6.GetMetadata_Request, opts ...grpc.CallOption) (*tfplugin6.GetMetadata_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "GetMetadata", varargs...)
@@ -155,17 +156,17 @@ func (m *MockProviderClient) GetMetadata(arg0 context.Context, arg1 *tfplugin6.G
 }
 
 // GetMetadata indicates an expected call of GetMetadata.
-func (mr *MockProviderClientMockRecorder) GetMetadata(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) GetMetadata(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadata", reflect.TypeOf((*MockProviderClient)(nil).GetMetadata), varargs...)
 }
 
 // GetProviderSchema mocks base method.
-func (m *MockProviderClient) GetProviderSchema(arg0 context.Context, arg1 *tfplugin6.GetProviderSchema_Request, arg2 ...grpc.CallOption) (*tfplugin6.GetProviderSchema_Response, error) {
+func (m *MockProviderClient) GetProviderSchema(ctx context.Context, in *tfplugin6.GetProviderSchema_Request, opts ...grpc.CallOption) (*tfplugin6.GetProviderSchema_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "GetProviderSchema", varargs...)
@@ -175,17 +176,17 @@ func (m *MockProviderClient) GetProviderSchema(arg0 context.Context, arg1 *tfplu
 }
 
 // GetProviderSchema indicates an expected call of GetProviderSchema.
-func (mr *MockProviderClientMockRecorder) GetProviderSchema(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) GetProviderSchema(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProviderSchema", reflect.TypeOf((*MockProviderClient)(nil).GetProviderSchema), varargs...)
 }
 
 // GetResourceIdentitySchemas mocks base method.
-func (m *MockProviderClient) GetResourceIdentitySchemas(arg0 context.Context, arg1 *tfplugin6.GetResourceIdentitySchemas_Request, arg2 ...grpc.CallOption) (*tfplugin6.GetResourceIdentitySchemas_Response, error) {
+func (m *MockProviderClient) GetResourceIdentitySchemas(ctx context.Context, in *tfplugin6.GetResourceIdentitySchemas_Request, opts ...grpc.CallOption) (*tfplugin6.GetResourceIdentitySchemas_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "GetResourceIdentitySchemas", varargs...)
@@ -195,17 +196,17 @@ func (m *MockProviderClient) GetResourceIdentitySchemas(arg0 context.Context, ar
 }
 
 // GetResourceIdentitySchemas indicates an expected call of GetResourceIdentitySchemas.
-func (mr *MockProviderClientMockRecorder) GetResourceIdentitySchemas(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) GetResourceIdentitySchemas(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourceIdentitySchemas", reflect.TypeOf((*MockProviderClient)(nil).GetResourceIdentitySchemas), varargs...)
 }
 
 // ImportResourceState mocks base method.
-func (m *MockProviderClient) ImportResourceState(arg0 context.Context, arg1 *tfplugin6.ImportResourceState_Request, arg2 ...grpc.CallOption) (*tfplugin6.ImportResourceState_Response, error) {
+func (m *MockProviderClient) ImportResourceState(ctx context.Context, in *tfplugin6.ImportResourceState_Request, opts ...grpc.CallOption) (*tfplugin6.ImportResourceState_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "ImportResourceState", varargs...)
@@ -215,17 +216,17 @@ func (m *MockProviderClient) ImportResourceState(arg0 context.Context, arg1 *tfp
 }
 
 // ImportResourceState indicates an expected call of ImportResourceState.
-func (mr *MockProviderClientMockRecorder) ImportResourceState(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) ImportResourceState(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportResourceState", reflect.TypeOf((*MockProviderClient)(nil).ImportResourceState), varargs...)
 }
 
 // MoveResourceState mocks base method.
-func (m *MockProviderClient) MoveResourceState(arg0 context.Context, arg1 *tfplugin6.MoveResourceState_Request, arg2 ...grpc.CallOption) (*tfplugin6.MoveResourceState_Response, error) {
+func (m *MockProviderClient) MoveResourceState(ctx context.Context, in *tfplugin6.MoveResourceState_Request, opts ...grpc.CallOption) (*tfplugin6.MoveResourceState_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "MoveResourceState", varargs...)
@@ -235,17 +236,17 @@ func (m *MockProviderClient) MoveResourceState(arg0 context.Context, arg1 *tfplu
 }
 
 // MoveResourceState indicates an expected call of MoveResourceState.
-func (mr *MockProviderClientMockRecorder) MoveResourceState(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) MoveResourceState(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveResourceState", reflect.TypeOf((*MockProviderClient)(nil).MoveResourceState), varargs...)
 }
 
 // OpenEphemeralResource mocks base method.
-func (m *MockProviderClient) OpenEphemeralResource(arg0 context.Context, arg1 *tfplugin6.OpenEphemeralResource_Request, arg2 ...grpc.CallOption) (*tfplugin6.OpenEphemeralResource_Response, error) {
+func (m *MockProviderClient) OpenEphemeralResource(ctx context.Context, in *tfplugin6.OpenEphemeralResource_Request, opts ...grpc.CallOption) (*tfplugin6.OpenEphemeralResource_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "OpenEphemeralResource", varargs...)
@@ -255,17 +256,17 @@ func (m *MockProviderClient) OpenEphemeralResource(arg0 context.Context, arg1 *t
 }
 
 // OpenEphemeralResource indicates an expected call of OpenEphemeralResource.
-func (mr *MockProviderClientMockRecorder) OpenEphemeralResource(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) OpenEphemeralResource(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenEphemeralResource", reflect.TypeOf((*MockProviderClient)(nil).OpenEphemeralResource), varargs...)
 }
 
 // PlanResourceChange mocks base method.
-func (m *MockProviderClient) PlanResourceChange(arg0 context.Context, arg1 *tfplugin6.PlanResourceChange_Request, arg2 ...grpc.CallOption) (*tfplugin6.PlanResourceChange_Response, error) {
+func (m *MockProviderClient) PlanResourceChange(ctx context.Context, in *tfplugin6.PlanResourceChange_Request, opts ...grpc.CallOption) (*tfplugin6.PlanResourceChange_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "PlanResourceChange", varargs...)
@@ -275,17 +276,17 @@ func (m *MockProviderClient) PlanResourceChange(arg0 context.Context, arg1 *tfpl
 }
 
 // PlanResourceChange indicates an expected call of PlanResourceChange.
-func (mr *MockProviderClientMockRecorder) PlanResourceChange(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) PlanResourceChange(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PlanResourceChange", reflect.TypeOf((*MockProviderClient)(nil).PlanResourceChange), varargs...)
 }
 
 // ReadDataSource mocks base method.
-func (m *MockProviderClient) ReadDataSource(arg0 context.Context, arg1 *tfplugin6.ReadDataSource_Request, arg2 ...grpc.CallOption) (*tfplugin6.ReadDataSource_Response, error) {
+func (m *MockProviderClient) ReadDataSource(ctx context.Context, in *tfplugin6.ReadDataSource_Request, opts ...grpc.CallOption) (*tfplugin6.ReadDataSource_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "ReadDataSource", varargs...)
@@ -295,17 +296,17 @@ func (m *MockProviderClient) ReadDataSource(arg0 context.Context, arg1 *tfplugin
 }
 
 // ReadDataSource indicates an expected call of ReadDataSource.
-func (mr *MockProviderClientMockRecorder) ReadDataSource(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) ReadDataSource(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadDataSource", reflect.TypeOf((*MockProviderClient)(nil).ReadDataSource), varargs...)
 }
 
 // ReadResource mocks base method.
-func (m *MockProviderClient) ReadResource(arg0 context.Context, arg1 *tfplugin6.ReadResource_Request, arg2 ...grpc.CallOption) (*tfplugin6.ReadResource_Response, error) {
+func (m *MockProviderClient) ReadResource(ctx context.Context, in *tfplugin6.ReadResource_Request, opts ...grpc.CallOption) (*tfplugin6.ReadResource_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "ReadResource", varargs...)
@@ -315,17 +316,17 @@ func (m *MockProviderClient) ReadResource(arg0 context.Context, arg1 *tfplugin6.
 }
 
 // ReadResource indicates an expected call of ReadResource.
-func (mr *MockProviderClientMockRecorder) ReadResource(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) ReadResource(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadResource", reflect.TypeOf((*MockProviderClient)(nil).ReadResource), varargs...)
 }
 
 // RenewEphemeralResource mocks base method.
-func (m *MockProviderClient) RenewEphemeralResource(arg0 context.Context, arg1 *tfplugin6.RenewEphemeralResource_Request, arg2 ...grpc.CallOption) (*tfplugin6.RenewEphemeralResource_Response, error) {
+func (m *MockProviderClient) RenewEphemeralResource(ctx context.Context, in *tfplugin6.RenewEphemeralResource_Request, opts ...grpc.CallOption) (*tfplugin6.RenewEphemeralResource_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "RenewEphemeralResource", varargs...)
@@ -335,17 +336,17 @@ func (m *MockProviderClient) RenewEphemeralResource(arg0 context.Context, arg1 *
 }
 
 // RenewEphemeralResource indicates an expected call of RenewEphemeralResource.
-func (mr *MockProviderClientMockRecorder) RenewEphemeralResource(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) RenewEphemeralResource(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenewEphemeralResource", reflect.TypeOf((*MockProviderClient)(nil).RenewEphemeralResource), varargs...)
 }
 
 // StopProvider mocks base method.
-func (m *MockProviderClient) StopProvider(arg0 context.Context, arg1 *tfplugin6.StopProvider_Request, arg2 ...grpc.CallOption) (*tfplugin6.StopProvider_Response, error) {
+func (m *MockProviderClient) StopProvider(ctx context.Context, in *tfplugin6.StopProvider_Request, opts ...grpc.CallOption) (*tfplugin6.StopProvider_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "StopProvider", varargs...)
@@ -355,17 +356,17 @@ func (m *MockProviderClient) StopProvider(arg0 context.Context, arg1 *tfplugin6.
 }
 
 // StopProvider indicates an expected call of StopProvider.
-func (mr *MockProviderClientMockRecorder) StopProvider(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) StopProvider(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopProvider", reflect.TypeOf((*MockProviderClient)(nil).StopProvider), varargs...)
 }
 
 // UpgradeResourceIdentity mocks base method.
-func (m *MockProviderClient) UpgradeResourceIdentity(arg0 context.Context, arg1 *tfplugin6.UpgradeResourceIdentity_Request, arg2 ...grpc.CallOption) (*tfplugin6.UpgradeResourceIdentity_Response, error) {
+func (m *MockProviderClient) UpgradeResourceIdentity(ctx context.Context, in *tfplugin6.UpgradeResourceIdentity_Request, opts ...grpc.CallOption) (*tfplugin6.UpgradeResourceIdentity_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "UpgradeResourceIdentity", varargs...)
@@ -375,17 +376,17 @@ func (m *MockProviderClient) UpgradeResourceIdentity(arg0 context.Context, arg1 
 }
 
 // UpgradeResourceIdentity indicates an expected call of UpgradeResourceIdentity.
-func (mr *MockProviderClientMockRecorder) UpgradeResourceIdentity(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) UpgradeResourceIdentity(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeResourceIdentity", reflect.TypeOf((*MockProviderClient)(nil).UpgradeResourceIdentity), varargs...)
 }
 
 // UpgradeResourceState mocks base method.
-func (m *MockProviderClient) UpgradeResourceState(arg0 context.Context, arg1 *tfplugin6.UpgradeResourceState_Request, arg2 ...grpc.CallOption) (*tfplugin6.UpgradeResourceState_Response, error) {
+func (m *MockProviderClient) UpgradeResourceState(ctx context.Context, in *tfplugin6.UpgradeResourceState_Request, opts ...grpc.CallOption) (*tfplugin6.UpgradeResourceState_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "UpgradeResourceState", varargs...)
@@ -395,17 +396,17 @@ func (m *MockProviderClient) UpgradeResourceState(arg0 context.Context, arg1 *tf
 }
 
 // UpgradeResourceState indicates an expected call of UpgradeResourceState.
-func (mr *MockProviderClientMockRecorder) UpgradeResourceState(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) UpgradeResourceState(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeResourceState", reflect.TypeOf((*MockProviderClient)(nil).UpgradeResourceState), varargs...)
 }
 
 // ValidateDataResourceConfig mocks base method.
-func (m *MockProviderClient) ValidateDataResourceConfig(arg0 context.Context, arg1 *tfplugin6.ValidateDataResourceConfig_Request, arg2 ...grpc.CallOption) (*tfplugin6.ValidateDataResourceConfig_Response, error) {
+func (m *MockProviderClient) ValidateDataResourceConfig(ctx context.Context, in *tfplugin6.ValidateDataResourceConfig_Request, opts ...grpc.CallOption) (*tfplugin6.ValidateDataResourceConfig_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "ValidateDataResourceConfig", varargs...)
@@ -415,17 +416,17 @@ func (m *MockProviderClient) ValidateDataResourceConfig(arg0 context.Context, ar
 }
 
 // ValidateDataResourceConfig indicates an expected call of ValidateDataResourceConfig.
-func (mr *MockProviderClientMockRecorder) ValidateDataResourceConfig(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) ValidateDataResourceConfig(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateDataResourceConfig", reflect.TypeOf((*MockProviderClient)(nil).ValidateDataResourceConfig), varargs...)
 }
 
 // ValidateEphemeralResourceConfig mocks base method.
-func (m *MockProviderClient) ValidateEphemeralResourceConfig(arg0 context.Context, arg1 *tfplugin6.ValidateEphemeralResourceConfig_Request, arg2 ...grpc.CallOption) (*tfplugin6.ValidateEphemeralResourceConfig_Response, error) {
+func (m *MockProviderClient) ValidateEphemeralResourceConfig(ctx context.Context, in *tfplugin6.ValidateEphemeralResourceConfig_Request, opts ...grpc.CallOption) (*tfplugin6.ValidateEphemeralResourceConfig_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "ValidateEphemeralResourceConfig", varargs...)
@@ -435,17 +436,17 @@ func (m *MockProviderClient) ValidateEphemeralResourceConfig(arg0 context.Contex
 }
 
 // ValidateEphemeralResourceConfig indicates an expected call of ValidateEphemeralResourceConfig.
-func (mr *MockProviderClientMockRecorder) ValidateEphemeralResourceConfig(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) ValidateEphemeralResourceConfig(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateEphemeralResourceConfig", reflect.TypeOf((*MockProviderClient)(nil).ValidateEphemeralResourceConfig), varargs...)
 }
 
 // ValidateProviderConfig mocks base method.
-func (m *MockProviderClient) ValidateProviderConfig(arg0 context.Context, arg1 *tfplugin6.ValidateProviderConfig_Request, arg2 ...grpc.CallOption) (*tfplugin6.ValidateProviderConfig_Response, error) {
+func (m *MockProviderClient) ValidateProviderConfig(ctx context.Context, in *tfplugin6.ValidateProviderConfig_Request, opts ...grpc.CallOption) (*tfplugin6.ValidateProviderConfig_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "ValidateProviderConfig", varargs...)
@@ -455,17 +456,17 @@ func (m *MockProviderClient) ValidateProviderConfig(arg0 context.Context, arg1 *
 }
 
 // ValidateProviderConfig indicates an expected call of ValidateProviderConfig.
-func (mr *MockProviderClientMockRecorder) ValidateProviderConfig(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) ValidateProviderConfig(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateProviderConfig", reflect.TypeOf((*MockProviderClient)(nil).ValidateProviderConfig), varargs...)
 }
 
 // ValidateResourceConfig mocks base method.
-func (m *MockProviderClient) ValidateResourceConfig(arg0 context.Context, arg1 *tfplugin6.ValidateResourceConfig_Request, arg2 ...grpc.CallOption) (*tfplugin6.ValidateResourceConfig_Response, error) {
+func (m *MockProviderClient) ValidateResourceConfig(ctx context.Context, in *tfplugin6.ValidateResourceConfig_Request, opts ...grpc.CallOption) (*tfplugin6.ValidateResourceConfig_Response, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []any{ctx, in}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "ValidateResourceConfig", varargs...)
@@ -475,8 +476,8 @@ func (m *MockProviderClient) ValidateResourceConfig(arg0 context.Context, arg1 *
 }
 
 // ValidateResourceConfig indicates an expected call of ValidateResourceConfig.
-func (mr *MockProviderClientMockRecorder) ValidateResourceConfig(arg0, arg1 any, arg2 ...any) *gomock.Call {
+func (mr *MockProviderClientMockRecorder) ValidateResourceConfig(ctx, in any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
+	varargs := append([]any{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateResourceConfig", reflect.TypeOf((*MockProviderClient)(nil).ValidateResourceConfig), varargs...)
 }


### PR DESCRIPTION
This is just a routine upgrade. We use this dependency only in our tests, so this upgrade does not risk changing OpenTofu's behavior. There do not seem to be any concerning changes upstream.

There are some systematic changes to the shape of the generated mock code, with the results also included in this commit.

**[Changes since v0.4.0](https://github.com/uber-go/mock/compare/v0.4.0...v0.6.0)**