### PR TITLE
website: Reorganize and tidy some lifecycle-related information

### DIFF
--- a/website/docs/cli/commands/test/index.mdx
+++ b/website/docs/cli/commands/test/index.mdx
@@ -323,13 +323,12 @@ This can be useful when you need to pass values between different test cases.
 
 ### The `run.expect_failures` list
 
-In some cases you may want to test deliberate failures of your code, for example to ensure your validation is working.
+You can use `expect_failures` inside a `run` block to test
+[custom conditions](../../../language/expressions/custom-conditions.mdx) such as
+preconditions and postconditions or input variable validation rules.
 
-You can use the `expect_failures` inside a `run` block to specify which variables or resources should fail when the
-code is run with the given parameters.
-
-For example, the test case below checks if the `instances` variable correctly fails validation when supplied with a
-negative number:
+For example, the test case below checks if the `instances` input variable
+correctly fails validation when defined as a negative number:
 
 <Tabs>
     <TabItem value={"test"} label={"main.tftest.hcl"} default>
@@ -339,16 +338,6 @@ negative number:
         <CodeBlock language={"hcl"}>{ExpectFailureVariablesMain}</CodeBlock>
     </TabItem>
 </Tabs>
-
-You can also use the `expect_failure` clause to check [lifecycle](../../../language/meta-arguments/lifecycle.mdx) events like
-pre- or postconditions as well as the results of checks.
-
-:::warning Limitation
-
-The `expect_failure` list currently does not support testing resource creation failures. You must provide a
-[lifecycle](../../../language/meta-arguments/lifecycle.mdx) event in order to use `expect_failure`.
-
-:::
 
 The example below checks if the misconfigured healthcheck fails. This ensures that the health check does not always
 return, even when it is running against the wrong endpoint.
@@ -361,6 +350,15 @@ return, even when it is running against the wrong endpoint.
         <CodeBlock language={"hcl"}>{ExpectFailureResourcesMain}</CodeBlock>
     </TabItem>
 </Tabs>
+
+:::note Configured condition checks only
+
+The `expect_failure` argument is only for testing failures of
+[custom conditions](../../../language/expressions/custom-conditions.mdx) written
+in the configuration. It does not test problems detected by validation logic
+inside providers.
+
+:::
 
 ### The `run.command` setting and the `run.plan_options` block
 

--- a/website/docs/language/data-sources/index.mdx
+++ b/website/docs/language/data-sources/index.mdx
@@ -68,10 +68,10 @@ specific to the selected data source, and these arguments can make full
 use of [expressions](../../language/expressions/index.mdx) and other dynamic
 OpenTofu language features.
 
-However, there are some "meta-arguments" that are defined by OpenTofu itself
-and apply across all data sources. These arguments often have additional
-restrictions on what language features can be used with them, and are described
-in more detail in the following sections.
+However, there are some [meta-arguments](#meta-arguments) that are defined by
+OpenTofu itself and apply across all data resource types. These arguments often
+have additional restrictions on what language features can be used with them,
+and are described in more detail in the following sections.
 
 ## Data Resource Behavior
 
@@ -92,6 +92,48 @@ Refer to [Data Resource Dependencies](#data-resource-dependencies) for details
 on what it means for a data resource to depend on other objects. Any resulting
 attribute of such a data resource will be unknown during planning, so it cannot
 be used in situations where values must be fully known.
+
+## Meta-Arguments
+
+The OpenTofu language defines several meta-arguments, which can be used with
+any data resource type to change the behavior of resources.
+
+The following meta-arguments are documented on separate pages:
+
+- [`depends_on`, for specifying hidden dependencies](../../language/meta-arguments/depends_on.mdx)
+- [`enabled`, for creating conditionally single-resource instances according to a expression](../../language/meta-arguments/enabled.mdx)
+- [`count`, for creating multiple resource instances according to a count](../../language/meta-arguments/count.mdx)
+- [`for_each`, to create multiple instances according to a map, or set of strings](../../language/meta-arguments/for_each.mdx)
+- [`provider`, for selecting a non-default provider configuration](../../language/meta-arguments/resource-provider.mdx)
+- [`lifecycle`, for lifecycle customizations](#lifecycle-customizations)
+
+## Lifecycle Customizations
+
+A `lifecycle` block inside a `data` block allows some customization of
+OpenTofu's behavior relating to instances of a resource at different phases
+of its lifecycle.
+
+```hcl
+data "example" "example" {
+  # ...normal resource arguments...
+
+  lifecycle {
+    # ...lifecycle arguments...
+  }
+}
+```
+
+The following arguments and nested block types are supported in the `lifecycle`
+block for a data resource:
+
+* `enabled` (bool) - Controls whether the data resource will be read by OpenTofu.
+  When set to `false`, the resource is excluded from the configuration as if it
+  didn't exist. When set to `true` (the default), the resource operates normally.
+
+  For more information, refer to [the `enabled` meta-argument](../../language/meta-arguments/enabled.mdx).
+
+* `precondition` and `postcondition` blocks, as described in
+  [Custom Conditions](../../language/expressions/custom-conditions.mdx#preconditions-and-postconditions).
 
 ## Local-only Data Sources
 
@@ -146,94 +188,6 @@ Custom conditions can help capture assumptions, helping future maintainers under
 
 Refer to [Custom Condition Checks](../../language/expressions/custom-conditions.mdx#preconditions-and-postconditions) for more details.
 
-
-## Multiple Resource Instances
-
-Data resources support [`count`](../../language/meta-arguments/count.mdx)
-and [`for_each`](../../language/meta-arguments/for_each.mdx)
-meta-arguments as defined for managed resources, with the same syntax and behavior.
-
-As with managed resources, when `count` or `for_each` is present it is important to
-distinguish the resource itself from the multiple resource _instances_ it
-creates. Each instance will separately read from its data source with its
-own variant of the constraint arguments, producing an indexed result.
-
-## Selecting a Non-default Provider Configuration
-
-Data resources support [the `provider` meta-argument](../../language/meta-arguments/resource-provider.mdx)
-as defined for managed resources, with the same syntax and behavior.
-
-## Lifecycle Customizations
-
-Data resources support a `lifecycle` block that includes the [`enabled`](../../language/meta-arguments/enabled.mdx) argument to conditionally enable or disable the data resource.
-
-```hcl
-variable "fetch_ami_data" {
-  type    = bool
-  default = true
-}
-
-data "aws_ami" "example" {
-  most_recent = true
-  owners      = ["self"]
-
-  lifecycle {
-    enabled = var.fetch_ami_data
-  }
-}
-```
-
-## Example
-
-A data source configuration looks like the following:
-
-```hcl
-# Find the latest available AMI that is tagged with Component = web
-data "aws_ami" "web" {
-  filter {
-    name   = "state"
-    values = ["available"]
-  }
-
-  filter {
-    name   = "tag:Component"
-    values = ["web"]
-  }
-
-  most_recent = true
-}
-```
-
-## Description
-
-The `data` block creates a data instance of the given _type_ (first
-block label) and _name_ (second block label). The combination of the type
-and name must be unique.
-
-Within the block (the `{ }`) is configuration for the data instance. The
-configuration is dependent on the type; as with
-[resources](../../language/resources/index.mdx), each provider on the
-[Public OpenTofu Registry](https://registry.opentofu.org) has its own
-documentation for configuring and using the data types it provides.
-
-Each data instance will export one or more attributes, which can be
-used in other resources as reference expressions of the form
-`data.<TYPE>.<NAME>.<ATTRIBUTE>`. For example:
-
-```hcl
-resource "aws_instance" "web" {
-  ami           = data.aws_ami.web.id
-  instance_type = "t1.micro"
-}
-```
-
-## Meta-Arguments
-
-As data sources are essentially a read-only subset of resources, they also
-support the same [meta-arguments](../../language/resources/syntax.mdx#meta-arguments) as resources
-with the exception of a slightly simpler version of the
-[`lifecycle` configuration block](../../language/meta-arguments/lifecycle.mdx).
-
 ### Non-Default Provider Configurations
 
 Similarly to [resources](../../language/resources/index.mdx), when
@@ -251,19 +205,3 @@ data "aws_ami" "web" {
 See
 [The Resource `provider` Meta-Argument](../../language/meta-arguments/resource-provider.mdx)
 for more information.
-
-## Data Source Lifecycle
-
-If the arguments of a data instance contain no references to computed values,
-such as attributes of resources that have not yet been created, then the
-data instance will be read and its state updated during OpenTofu's "refresh"
-phase, which by default runs prior to creating a plan. This ensures that the
-retrieved data is available for use during planning and the diff will show
-the real values obtained.
-
-Data instance arguments may refer to computed values, in which case the
-attributes of the instance itself cannot be resolved until all of its
-arguments are defined. In this case, refreshing the data instance will be
-deferred until the "apply" phase, and all interpolations of the data instance
-attributes will show as "computed" in the plan since the values are not yet
-known.

--- a/website/docs/language/ephemerality/ephemeral-resources.mdx
+++ b/website/docs/language/ephemerality/ephemeral-resources.mdx
@@ -39,9 +39,41 @@ Besides the attributes in the schema of an ephemeral resource, the block support
 * [`count`](../../language/meta-arguments/count.mdx)
 * [`for_each`](../../language/meta-arguments/for_each.mdx)
 * [`provider`](../../language/meta-arguments/resource-provider.mdx)
-* [`lifecycle`](../../language/meta-arguments/lifecycle.mdx)
-  * [`enabled`](../../language/meta-arguments/enabled.mdx) for conditional enabling
-  * [`precondition` and `postcondition`](../../language/expressions/custom-conditions.mdx#preconditions-and-postconditions)
+* [`lifecycle`](#lifecycle-customizations)
+
+## Lifecycle Customizations
+A `lifecycle` block inside an `ephemeral` block allows some customization of
+OpenTofu's behavior relating to instances of a resource at different phases
+of its lifecycle.
+
+```hcl
+ephemeral "example" "example" {
+  # ...normal resource arguments...
+
+  lifecycle {
+    # ...lifecycle arguments...
+  }
+}
+```
+
+The following arguments and nested block types are supported in the `lifecycle`
+block for an ephemeral resource:
+
+* `enabled` (bool) - Controls whether the ephemeral resource will be used by
+  OpenTofu. When set to `false`, the resource is excluded from the configuration
+  as if it didn't exist. When set to `true` (the default), the resource operates
+  normally.
+
+  For ephemeral resources in particular, you can use the boolean
+  `terraform.applying` value with `enabled` to specify that a particular
+  ephemeral resource should be active only during the apply phase, which can
+  be useful for values used only by managed resource provisioners because
+  provisioners are active only during the apply phase.
+
+  For more information, refer to [the `enabled` meta-argument](../../language/meta-arguments/enabled.mdx).
+
+* `precondition` and `postcondition` blocks, as described in
+  [Custom Conditions](../../language/expressions/custom-conditions.mdx#preconditions-and-postconditions).
 
 ## Deferred opening
 By design, the ephemeral resources cannot be opened if the configuration is not fully known.

--- a/website/docs/language/functions/timestamp.mdx
+++ b/website/docs/language/functions/timestamp.mdx
@@ -18,7 +18,7 @@ The result of this function will change every second, so using this function
 directly with resource attributes will cause a diff to be detected on every
 OpenTofu run. We do not recommend using this function in resource attributes,
 but in rare cases it can be used in conjunction with
-[the `ignore_changes` lifecycle meta-argument](../../language/meta-arguments/lifecycle.mdx#ignore_changes)
+[the `ignore_changes` lifecycle meta-argument](../../language/resources/behavior.mdx#ignore_changes)
 to take the timestamp only on initial creation of the resource. For more stable
 time handling, see the [Time Provider](https://registry.terraform.io/providers/hashicorp/time).
 

--- a/website/docs/language/functions/uuid.mdx
+++ b/website/docs/language/functions/uuid.mdx
@@ -16,7 +16,7 @@ This function produces a new value each time it is called, and so using it
 directly in resource arguments will result in spurious diffs. We do not
 recommend using the `uuid` function in resource configurations, but it can
 be used with care in conjunction with
-[the `ignore_changes` lifecycle meta-argument](../../language/meta-arguments/lifecycle.mdx#ignore_changes).
+[the `ignore_changes` lifecycle meta-argument](../../language/resources/behavior.mdx#ignore_changes).
 
 In most cases we recommend using [the `random` provider](https://registry.terraform.io/providers/hashicorp/random/latest/docs)
 instead, since it allows the one-time generation of random values that are

--- a/website/docs/language/meta-arguments/lifecycle.mdx
+++ b/website/docs/language/meta-arguments/lifecycle.mdx
@@ -4,183 +4,21 @@ description: >-
   behavior.
 ---
 
-# The `lifecycle` Meta-Argument
+# `lifecycle` Blocks
 
-The [Resource Behavior](../../language/resources/behavior.mdx) page describes the general lifecycle for resources. Some details of
-that behavior can be customized using the special nested `lifecycle` block
-within a resource block body:
+Several different declaration types in the OpenTofu language support a nested
+block named `lifecycle` which includes settings that customize the plan and
+apply behavior of the associated object.
 
-```hcl
-resource "azurerm_resource_group" "example" {
-  # ...
+Each different type of declaration relates to objects that have a different
+lifecycle, and so the arguments available in these blocks are distinct for
+each parent block type:
 
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-```
+* [`resource` block lifecycle](../../language/resources/behavior.mdx#lifecycle-customizations), for managed resources.
+* [`data` block lifecycle](../../language/data-sources/index.mdx#lifecycle-customizations), for data resources.
+* [`ephemeral` block lifecycle](../../language/ephemerality/ephemeral-resources.mdx#lifecycle-customizations), for ephemeral resources.
+* [`module` block lifecycle](../../language/modules/syntax.mdx#module-lifecycle), for settings that relate to an overall module call instead of the individual resources inside it.
 
-## Syntax and Arguments
-
-`lifecycle` is a nested block that can appear within a resource block.
-The `lifecycle` block and its contents are meta-arguments, available
-for all `resource` blocks regardless of type.
-
-The arguments available within a `lifecycle` block are `enabled`,
-`create_before_destroy`, `prevent_destroy`, `ignore_changes`, and `replace_triggered_by`.
-
-* `enabled` (bool) - Controls whether a resource is created and managed by OpenTofu.
-  When set to `false`, the resource is excluded from the configuration as if it didn't exist,
-  and any existing infrastructure object will be destroyed. When set to `true` (the default),
-  the resource operates normally.
-
-  For full details about the `enabled` meta-argument, see [its documentation](../../language/meta-arguments/enabled.mdx).
-
-* `create_before_destroy` (bool) - By default, when OpenTofu must change
-  a resource argument that cannot be updated in-place due to
-  remote API limitations, OpenTofu will instead destroy the existing object
-  and then create a new replacement object with the new configured arguments.
-
-  The `create_before_destroy` meta-argument changes this behavior so that
-  the new replacement object is created _first,_ and the prior object
-  is destroyed after the replacement is created.
-
-  This is an opt-in behavior because many remote object types have unique
-  name requirements or other constraints that must be accommodated for
-  both a new and an old object to exist concurrently. Some resource types
-  offer special options to append a random suffix onto each object name to
-  avoid collisions, for example. OpenTofu CLI cannot automatically activate
-  such features, so you must understand the constraints for each resource
-  type before using `create_before_destroy` with it.
-
-  Note that OpenTofu propagates and applies the `create_before_destroy` meta-attribute
-  behaviour to all resource dependencies. For example, if `create_before_destroy` is enabled on resource A but not on resource B, but resource A is dependent on resource B, then OpenTofu enables `create_before_destroy` for resource B
-  implicitly by default and stores it to the state file. You cannot override `create_before_destroy`
-  to `false` on resource B because that would imply dependency cycles in the graph.
-
-  Destroy provisioners of this resource do not run if `create_before_destroy`
-  is set to `true`. This [GitHub issue](https://github.com/hashicorp/terraform/issues/13549) contains more details.
-
-* `prevent_destroy` (bool) - This meta-argument, when set to `true`, will
-  cause OpenTofu to reject with an error any plan that would destroy the
-  infrastructure object associated with the resource, as long as the argument
-  remains present in the configuration.
-
-  This can be used as a measure of safety against the accidental replacement
-  of objects that may be costly to reproduce, such as database instances.
-  However, it will make certain configuration changes impossible to apply,
-  and will prevent the use of the `tofu destroy` command once such
-  objects are created, and so this option should be used sparingly.
-
-  Since this argument must be present in configuration for the protection to
-  apply, note that this setting does not prevent the remote object from
-  being destroyed if the `resource` block were removed from configuration
-  entirely: in that case, the `prevent_destroy` setting is removed along
-  with it, and so OpenTofu will allow the destroy operation to succeed.
-
-* `ignore_changes` (list of attribute names) - By default, OpenTofu detects
-  any difference in the current settings of a real infrastructure object
-  and plans to update the remote object to match configuration.
-
-  The `ignore_changes` feature is intended to be used when a resource is
-  created with references to data that may change in the future, but should
-  not affect said resource after its creation. In some rare cases, settings
-  of a remote object are modified by processes outside of OpenTofu, which
-  OpenTofu would then attempt to "fix" on the next run. In order to make
-  OpenTofu share management responsibilities of a single object with a
-  separate process, the `ignore_changes` meta-argument specifies resource
-  attributes that OpenTofu should ignore when planning updates to the
-  associated remote object.
-
-  The arguments corresponding to the given attribute names are considered
-  when planning a _create_ operation, but are ignored when planning an
-  _update_. The arguments are the relative address of the attributes in the
-  resource. Map and list elements can be referenced using index notation,
-  like `tags["Name"]` and `list[0]` respectively.
-
-  ```hcl
-  resource "aws_instance" "example" {
-    # ...
-
-    lifecycle {
-      ignore_changes = [
-        # Ignore changes to tags, e.g. because a management agent
-        # updates these based on some ruleset managed elsewhere.
-        tags,
-      ]
-    }
-  }
-  ```
-
-  Instead of a list, the special keyword `all` may be used to instruct
-  OpenTofu to ignore _all_ attributes, which means that OpenTofu can
-  create and destroy the remote object but will never propose updates to it.
-
-  Only attributes defined by the resource type can be ignored.
-  `ignore_changes` cannot be applied to itself or to any other meta-arguments.
-
-* `replace_triggered_by` (list of resource or attribute references) -
-  Replaces the resource when any of the referenced
-  items change. Supply a list of expressions referencing managed resources,
-  instances, or instance attributes. When used in a resource that uses `count`
-  or `for_each`, you can use `count.index` or `each.key` in the expression to
-  reference specific instances of other resources that are configured with the
-  same count or collection.
-
-  References trigger replacement in the following conditions:
-
-  - If the reference is to a resource with multiple instances, a plan to
-    update or replace any instance will trigger replacement.
-  - If the reference is to a single resource instance, a plan to update or
-    replace that instance will trigger replacement.
-  - If the reference is to a single attribute of a resource instance, any
-    change to the attribute value will trigger replacement.
-
-  You can only reference managed resources in `replace_triggered_by`
-  expressions. This lets you modify these expressions without forcing
-  replacement.
-
-  ```hcl
-  resource "aws_appautoscaling_target" "ecs_target" {
-    # ...
-    lifecycle {
-      replace_triggered_by = [
-        # Replace `aws_appautoscaling_target` each time this instance of
-        # the `aws_ecs_service` is replaced.
-        aws_ecs_service.svc.id
-      ]
-    }
-  }
-  ```
-
-  `replace_triggered_by` allows only resource addresses because the decision is based on the planned actions for all of the given resources. Plain values such as local values or input variables do not have planned actions of their own, but you can treat them with a resource-like lifecycle by using them with [the `terraform_data` resource type](../../language/resources/tf-data.mdx).
-
-## Custom Condition Checks
-
-You can add `precondition` and `postcondition` blocks with a `lifecycle` block to specify assumptions and guarantees about how resources and data sources operate. The following examples creates a precondition that checks whether the AMI is properly configured.
-
-```hcl
-resource "aws_instance" "example" {
-  instance_type = "t2.micro"
-  ami           = "ami-abc123"
-
-  lifecycle {
-    # The AMI ID must refer to an AMI that contains an operating system
-    # for the `x86_64` architecture.
-    precondition {
-      condition     = data.aws_ami.example.architecture == "x86_64"
-      error_message = "The selected AMI must be for the x86_64 architecture."
-    }
-  }
-}
-```
-
-Custom conditions can help capture assumptions, helping future maintainers understand the configuration design and intent. They also return useful information about errors earlier and in context, helping consumers more easily diagnose issues in their configurations.
-
-Refer to [Custom Conditions](../../language/expressions/custom-conditions.mdx#preconditions-and-postconditions) for more details.
-
-## Literal Values Only
-
-The `lifecycle` settings all affect how OpenTofu constructs and traverses
-the dependency graph. As a result, only literal values can be used because
-the processing happens too early for arbitrary expression evaluation.
+Although all of these features involve a block type named `lifecycle`, the
+expected arguments and associated behavior is defined separately for each
+context where a block of that type is allowed to appear.

--- a/website/docs/language/modules/syntax.mdx
+++ b/website/docs/language/modules/syntax.mdx
@@ -130,32 +130,33 @@ described in more detail in the following pages:
   [the `depends_on` page](../../language/meta-arguments/depends_on.mdx)
   for details.
 
-- `lifecycle` - Allows lifecycle customizations for modules. Currently only
-  supports the `enabled` argument.
+- `lifecycle` - Allows lifecycle customizations for modules, as described
+  in [Module Lifecycle](#module-lifecycle) below.
 
 ## Module Lifecycle
 
-The `lifecycle` block can be used within a `module` block to customize module behavior.
-Currently, it only supports the `enabled` argument for conditionally enabling or disabling
-entire modules:
+A `lifecycle` block inside a `module` block allows some customization of
+OpenTofu's behavior relating to the overall module call, rather than to
+individual resources inside the module.
 
 ```hcl
-variable "enable_monitoring" {
-  type    = bool
-  default = true
-}
-
-module "monitoring" {
-  source = "./monitoring"
+module "example" {
+  # ...normal module call arguments...
 
   lifecycle {
-    enabled = var.enable_monitoring
+    # ...lifecycle arguments...
   }
 }
 ```
 
-For complete details about the `enabled` argument, including restrictions and migration
-from the `count` workaround, see the [`lifecycle` meta-argument documentation](../../language/meta-arguments/lifecycle.mdx).
+Module call lifecycle currently supports only a single argument:
+
+* `enabled` (bool) - Controls whether the module call will be used by OpenTofu.
+  When set to `false`, the content of the module is excluded from the
+  configuration as if the call didn't exist. When set to `true` (the default),
+  the module operates normally.
+
+  For more information, refer to [the `enabled` meta-argument](../../language/meta-arguments/enabled.mdx).
 
 ## Accessing Module Output Values
 

--- a/website/docs/language/resources/behavior.mdx
+++ b/website/docs/language/resources/behavior.mdx
@@ -89,7 +89,162 @@ cases,
 [the `depends_on` meta-argument](../../language/meta-arguments/depends_on.mdx)
 can explicitly specify a dependency.
 
-You can also use the [`replace_triggered_by` meta-argument](../../language/meta-arguments/lifecycle.mdx#replace_triggered_by) to add dependencies between otherwise independent resources. It forces OpenTofu to replace the parent resource when there is a change to a referenced resource or resource attribute.
+You can also use the [`replace_triggered_by` lifecycle argument](#replace_triggered_by) to add dependencies between otherwise independent resources. It forces OpenTofu to replace the parent resource when there is a change to a referenced resource or resource attribute.
+
+## Lifecycle Customizations
+
+A `lifecycle` block inside a `resource` block allows some customization of
+OpenTofu's behavior relating to instances of a resource at different phases
+of its lifecycle.
+
+```hcl
+resource "example" "example" {
+  # ...normal resource arguments...
+
+  lifecycle {
+    # ...lifecycle arguments...
+  }
+}
+```
+
+The following arguments and nested block types are supported in the `lifecycle`
+block for a managed resource:
+
+* `create_before_destroy` (bool) - By default, when OpenTofu must change
+  a resource argument that cannot be updated in-place due to
+  remote API limitations, OpenTofu will instead destroy the existing object
+  and then create a new replacement object with the new configured arguments.
+
+  The `create_before_destroy` meta-argument changes this behavior so that
+  the new replacement object is created _first,_ and the prior object
+  is destroyed after the replacement is created.
+
+  This is an opt-in behavior because many remote object types have unique
+  name requirements or other constraints that must be accommodated for
+  both a new and an old object to exist concurrently. Some resource types
+  offer special options to append a random suffix onto each object name to
+  avoid collisions, for example. OpenTofu CLI cannot automatically activate
+  such features, so you must understand the constraints for each resource
+  type before using `create_before_destroy` with it.
+
+  Note that OpenTofu propagates and applies the `create_before_destroy` meta-attribute
+  behaviour to all resource dependencies. For example, if `create_before_destroy`
+  is enabled on resource A but not on resource B, but resource A is dependent on
+  resource B, then OpenTofu enables `create_before_destroy` for resource B
+  implicitly by default and stores it in state snapshots. You cannot override
+  `create_before_destroy` to `false` on resource B because that would cause
+  dependency cycles in the graph.
+
+  Destroy provisioners of this resource do not run during replacement if
+  `create_before_destroy` is set to `true`. [GitHub issue #13549](https://github.com/hashicorp/terraform/issues/13549) contains more details.
+
+* `enabled` (bool) - Controls whether a resource is created and managed by OpenTofu.
+  When set to `false`, the resource is excluded from the configuration as if it didn't exist,
+  and any existing infrastructure object will be destroyed. When set to `true` (the default),
+  the resource operates normally.
+
+  For more information, refer to [the `enabled` meta-argument](../../language/meta-arguments/enabled.mdx).
+
+* `prevent_destroy` (bool) - This meta-argument, when set to `true`, will
+  cause OpenTofu to reject with an error any plan that would destroy the
+  infrastructure object associated with the resource, as long as the argument
+  remains present in the configuration.
+
+  This can be used as a measure of safety against the accidental replacement
+  of objects that may be costly to reproduce, such as database instances.
+  However, it will make certain configuration changes impossible to apply,
+  and will prevent the use of the `tofu destroy` command once such
+  objects are created, and so this option should be used sparingly.
+
+  Since this argument must be present in configuration for the protection to
+  be active, this setting cannot prevent the remote object from being destroyed
+  when the `resource` block is removed from configuration entirely: in that
+  case, the `prevent_destroy` setting is removed along with it, and so OpenTofu
+  would allow the destroy operation to succeed.
+
+* <span id="ignore_changes">`ignore_changes`</span> (list of attribute names) - By default, OpenTofu detects
+  any difference in the current settings of a real infrastructure object
+  and plans to update the remote object to match configuration.
+
+  The `ignore_changes` feature is intended to be used when a resource is
+  created with references to data that may change in the future, but should
+  not affect said resource after its creation. In some rare cases, settings
+  of a remote object are modified by processes outside of OpenTofu, which
+  OpenTofu would then attempt to "fix" on the next run. In order to make
+  OpenTofu share management responsibilities of a single object with a
+  separate process, the `ignore_changes` meta-argument specifies resource
+  attributes that OpenTofu should ignore when planning updates to the
+  associated remote object.
+
+  The arguments corresponding to the given attribute names are considered
+  when planning a _create_ operation, but are ignored when planning an
+  _update_. The arguments are the relative address of the attributes in the
+  resource. Map and list elements can be referenced using index notation,
+  like `tags["Name"]` and `list[0]` respectively.
+
+  ```hcl
+  resource "aws_instance" "example" {
+    # ...
+
+    lifecycle {
+      ignore_changes = [
+        # Ignore changes to tags, e.g. because a management agent
+        # updates these based on some ruleset managed elsewhere.
+        tags,
+      ]
+    }
+  }
+  ```
+
+  Use the special keyword `all` instead of an attribute list to instruct
+  OpenTofu to ignore changes to _all_ attributes, which means that OpenTofu can
+  create and destroy the remote object but will never propose updates to it.
+
+  Only attributes defined by the resource type can be ignored.
+  `ignore_changes` cannot be applied to itself or to any other meta-arguments.
+
+* `precondition` and `postcondition` blocks, as described in
+  [Custom Conditions](../../language/expressions/custom-conditions.mdx#preconditions-and-postconditions).
+
+* <span id="replace_triggered_by">`replace_triggered_by`</span> (list of resource or attribute references) -
+  Replaces the resource when any of the referenced
+  items change. Write a list of expressions referencing managed resources,
+  resource instances, or instance attributes. When used in a resource that
+  uses `count` or `for_each`, you can use `count.index` or `each.key` in the
+  expression to refer to specific instances of other resources that are
+  configured with the same count or collection.
+
+  References trigger replacement in the following conditions:
+
+  - If the reference is to a resource with multiple instances, a plan to
+    update or replace any instance will trigger replacement.
+  - If the reference is to a single resource instance, a plan to update or
+    replace that instance will trigger replacement.
+  - If the reference is to a single attribute of a resource instance, any
+    change to the attribute value will trigger replacement.
+
+  You can only refer to managed resources in `replace_triggered_by`
+  expressions. This lets you modify these expressions without forcing
+  replacement.
+
+  ```hcl
+  resource "aws_appautoscaling_target" "ecs_target" {
+    # ...
+    lifecycle {
+      replace_triggered_by = [
+        # Replace `aws_appautoscaling_target` each time this instance of
+        # the `aws_ecs_service` is replaced.
+        aws_ecs_service.svc.id
+      ]
+    }
+  }
+  ```
+
+  `replace_triggered_by` allows only resource addresses because the decision is
+  based on the planned actions for all of the given resources. Plain values such
+  as local values or input variables do not have planned actions of their own,
+  but you can treat them with a resource-like lifecycle by using them with
+  [the `terraform_data` resource type](tf-data.mdx).
 
 ## Local-only Resources
 

--- a/website/docs/language/resources/index.mdx
+++ b/website/docs/language/resources/index.mdx
@@ -11,6 +11,9 @@ Each resource block describes one or more infrastructure objects, such
 as virtual networks, compute instances, or higher-level components such
 as DNS records.
 
+This section discusses the main kind of resource, known as a "managed resource",
+which represents an infrastructure object managed by OpenTofu.
+
 - [Resource Blocks](../../language/resources/syntax.mdx) documents
   the syntax for declaring resources.
 
@@ -19,15 +22,24 @@ as DNS records.
   configuration.
 
 - The Meta-Arguments section documents special arguments that can be used with
-  every resource type, including
+  any managed resource type, including
   [`depends_on`](../../language/meta-arguments/depends_on.mdx),
   [`count`](../../language/meta-arguments/count.mdx),
   [`for_each`](../../language/meta-arguments/for_each.mdx),
   [`provider`](../../language/meta-arguments/resource-provider.mdx),
-  and [`lifecycle`](../../language/meta-arguments/lifecycle.mdx).
+  and [`lifecycle`](behavior.mdx#lifecycle-customizations).
 
-- [Provisioners](../../language/resources/provisioners/syntax.mdx)
-  documents configuring post-creation actions for a resource using the
-  `provisioner` and `connection` blocks. Since provisioners are non-declarative
-  and potentially unpredictable, we strongly recommend that you treat them as a
-  last resort.
+- [Provisioners](provisioners/syntax.mdx) are post-creation actions for a
+  resource using the `provisioner` and `connection` blocks. Since provisioners
+  are non-declarative and potentially unpredictable, we strongly recommend that
+  you treat them as a last resort.
+
+There are two other kinds of resources that play different roles within an
+OpenTofu configuration:
+
+- [Data resources](../../language/data-sources/index.mdx) declare that a
+  configuration depends on information read from a data source outside of the
+  configuration.
+- [Ephemeral resources](../../language/ephemerality/ephemeral-resources.mdx)
+  declare transient objects that are opened only for the duration of a single
+  OpenTofu phase, such as temporary session credentials.

--- a/website/docs/language/resources/syntax.mdx
+++ b/website/docs/language/resources/syntax.mdx
@@ -185,7 +185,7 @@ For more information about provisioners, you can refer to this [page](./provisio
 ## Meta-Arguments
 
 The OpenTofu language defines several meta-arguments, which can be used with
-any resource type to change the behavior of resources.
+any managed resource type to change the behavior of resources.
 
 The following meta-arguments are documented on separate pages:
 
@@ -194,7 +194,7 @@ The following meta-arguments are documented on separate pages:
 - [`count`, for creating multiple resource instances according to a count](../../language/meta-arguments/count.mdx)
 - [`for_each`, to create multiple instances according to a map, or set of strings](../../language/meta-arguments/for_each.mdx)
 - [`provider`, for selecting a non-default provider configuration](../../language/meta-arguments/resource-provider.mdx)
-- [`lifecycle`, for lifecycle customizations](../../language/meta-arguments/lifecycle.mdx)
+- [`lifecycle`, for lifecycle customizations](behavior.mdx#lifecycle-customizations)
 - [`provisioner`, for taking extra actions after resource creation](../../language/resources/provisioners/syntax.mdx)
 
 ## Custom Condition Checks

--- a/website/docs/language/resources/tf-data.mdx
+++ b/website/docs/language/resources/tf-data.mdx
@@ -15,7 +15,7 @@ The `terraform_data` resource is useful for storing values which need to follow 
 ## Example Usage (data for `replace_triggered_by`)
 
 
-[The `replace_triggered_by` lifecycle argument](../../language/meta-arguments/lifecycle.mdx#replace_triggered_by) requires all of the given addresses to be for resources, because the decision to force replacement is based on the planned actions for all of the mentioned resources.
+[The `replace_triggered_by` lifecycle argument](behavior.mdx#replace_triggered_by) requires all of the given addresses to be for resources, because the decision to force replacement is based on the planned actions for all of the mentioned resources.
 
 Plain data values such as [Local Values](../../language/values/locals.mdx) and [Input Variables](../../language/values/variables.mdx) don't have any side-effects to plan against and so they aren't valid in `replace_triggered_by`. You can use `terraform_data`'s behavior of planning an action each time `input` changes to _indirectly_ use a plain value to trigger replacement.
 


### PR DESCRIPTION
Over time the discussion about "lifecycle" blocks in the documentation became confusing because the docs originally written for managed resource lifecycle got partially generalized for resources of other modes and for module calls, even though each of those has a completely different lifecycle and thus a different set of lifecycle settings.

This is a first pass at trying to reorganize that so that the "lifecycle" page is really just an index of all of the different kinds of lifecycle blocks that exist in the language, while the main documentation for each use of that block type now belongs with the documentation of the block it's nested within.

While working on this I also found that there was some duplication inside the "data sources" page where the same information was described multiple times, and a few other cases where things had become inconsistent over time. This also includes a little extra content to try to clarify the difference between managed, data, and ephemeral resources and to make it explicit that the "Resources" section is focused only on managed resources because that is the primary resource mode.

As usual there's lots more that could be done here -- this documentation has gradually evolved over time and is full of weird quirks due to that evolution -- but I decided to draw a line here so that the diff wouldn't get too large.

Closes https://github.com/opentofu/opentofu/issues/3387
