### PR TITLE
Add steps to alter version/VERSION for the nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,6 +24,13 @@ jobs:
         with:
           go-version-file: "go.mod"
 
+      # Prepare the nightly version to be able to have it returned correctly when running `tofu --version`.
+      - name: Prepare version file
+        run: |
+          commit_created_at=`git show --no-patch --format=%cd --date=format:%Y%m%d%H%M%S ${GITHUB_SHA}`
+          short_commit=`git rev-parse --short=12 ${GITHUB_SHA}`
+          sed -i "s/-dev/-nightly${commit_created_at}-${short_commit}/" version/VERSION
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
         with:
@@ -35,6 +42,11 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           RELEASE_FLAG_LATEST: "false"
           RELEASE_FLAG_PRERELEASE: "true"
+
+      # The step before goreleaser one updated version/VERSION to have it stored in the binary, but we want to bring the
+      # repo to a clean state now.
+      - name: Restore version
+        run: git restore version/VERSION
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Resolves #3197

When creating nightly builds, we want to have the date and the commit hash used in `tofu --version` to be able to pinpoint the commit that was used to create the build.

To achieve this, checking [version.go](https://github.com/opentofu/opentofu/blob/8481608b529d97759a252bb5ca1ff4944bbc24db/version/version.go#L48), can be seen that the prerelease information is used to print information on `tofu --version`. That information is [read from version/VERSION](https://github.com/opentofu/opentofu/blob/8481608b529d97759a252bb5ca1ff4944bbc24db/version/version.go#L23-L24) so we want to update that temporarily to allow the build done by goreleaser to embedded it in the final binary.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
