### PR TITLE
rfc: Minor revision to "Miscellaneous Configuration Settings in Modules"

### DIFF
--- a/rfc/20250730-module-misc-settings.md
+++ b/rfc/20250730-module-misc-settings.md
@@ -117,13 +117,17 @@ recommend that authors create both a `.tf` file and a `.tofu` file of the
 same basename, and place the Terraform version constraint in the `.tf` file
 and the OpenTofu constraint in the `.tofu` file.
 
-This document does not propose to change anything about that behavior, so
-that all existing uses of that pattern will retain their current meaning.
+As part of implementing this proposal, we would _slightly_ change the existing
+behavior so that OpenTofu will always completely ignore `required_providers`
+settings in `.tf` and `.tf.json` files, assuming that they are intended for
+Terraform. OpenTofu will continue to honor `required_providers` arguments
+in `.tofu` and `.tofu.json` files, so existing modules already using that
+pattern will retain their current meaning.
 
 Module authors that wish to support OpenTofu versions prior to the introduction
 of the `language` block type should continue following the existing pattern.
 Authors should adopt a `language` block and nested `compatible_with` block
-only once the minimum required OpenTofu version is one that supports that
+only once the minimum required OpenTofu version is one that supports the new
 syntax.
 
 Authors of broadly-shared modules might prefer to delay adopting the new syntax


### PR DESCRIPTION
This is a small revision to the RFC previously accepted in https://github.com/opentofu/opentofu/pull/3085.

While drafting this RFC originally I had intended to carve out an exception of ignoring `required_version` arguments in `.tf` files while continuing to support them in `.tofu` files, but apparently I lost that detail during some copyediting and so the current draft implies that OpenTofu would continue to use `required_version` in `.tf` files unless there's an OpenTofu-specific declaration that takes precedence.

This update aims to clarify the proposal's handling of modules that are written only for Terraform without using any OpenTofu-specific mechanisms: in that case, we must just make a best effort to load the module in OpenTofu and let it fail with a more specific error if the module happens to be using language features that OpenTofu does not support, so that loading can succeed when the module is only using the subset of features that are cross-compatible between both systems.

(I discovered this omission after noticing that the RFC text did not agree with all of the claims I made in https://github.com/opentofu/opentofu/issues/3347#issuecomment-3412661034. After this modification, this proposal then _does_ solve the problem of allowing OpenTofu to work with modules that include Terraform-oriented version requirements that OpenTofu cannot evaluate because it does not know what is supported in each version of Terraform.)
