### PR TITLE
Ensure we use goreleaser-pro for release build workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,7 @@ jobs:
         uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5.1.0
         with:
           version: v1.21.2
+          distribution: goreleaser-pro
           args: release --clean --timeout=60m --snapshot=${{ !startsWith(inputs.tag, 'v') }}
         env:
           # Note: the GPG_FINGERPRINT and GPG_KEY_FILE are defined in the task above. If they are not set,


### PR DESCRIPTION
We currently use goreleaser pro to build and deploy opentofu. However, when we introduced the new `nightlies` feature, we forgot to update our `release.yml` github workflow file to use the go-releaser pro version. This resulted in goreleaser saying that the `nightly` value in the yaml file is unknown.