### PR TITLE
Fix OTEL init from semconv conflict

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -5,6 +5,11 @@ This document describes how to use and implement tracing in OpenTofu Core using 
 > [!NOTE]  
 > For background on the design decisions and motivation behind OpenTofu's tracing implementation, see the [OpenTelemetry Tracing RFC](https://github.com/opentofu/opentofu/blob/main/rfc/20250129-Tracing-For-Extra-Context.md).
 
+> [!NOTE]
+> If you are upgrading any dependent libraries which pull in a new OTEL version, you *MUST* update the semconv version in tracing/init.go to the latest version.
+> Failing to do this will result in an error "Could not initialize telemetry: failed to create resource: error detecting resource: conflicting Schema URL".
+> This sets the *maximum* supported schema version in our OTEL context. Semconv is backwards compatible with older versions, but the newest must be specified.
+
 ## Overview
 
 OpenTofu provides distributed tracing capabilities via OpenTelemetry to help end users understand the execution flow and performance characteristics of OpenTofu operations. Tracing is particularly useful for:

--- a/internal/tracing/init.go
+++ b/internal/tracing/init.go
@@ -18,7 +18,10 @@ import (
 	"go.opentelemetry.io/otel/sdk"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+
+	// This *MUST* always be updated to the latest version when OTEL dependencies are updated in OpenTofu
+	// Failing to do so will prevent OpenTofu from initializing tracing.
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 
 	"github.com/opentofu/opentofu/version"
 )


### PR DESCRIPTION
Add documentation on how this breaks.

```bash
tofu plan
Could not initialize telemetry: failed to create resource: error detecting resource: conflicting Schema URL: https://opentelemetry.io/schemas/1.26.0 and https://opentelemetry.io/schemas/1.37.0
Unset environment variable OTEL_TRACES_EXPORTER if you don't intend to collect telemetry from OpenTofu.
```

This will need to be backported to the v1.11 branch

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
