### PR TITLE
Add e2etest to cover telemetry initialization issues

### DIFF
--- a/internal/command/e2etest/init_test.go
+++ b/internal/command/e2etest/init_test.go
@@ -623,9 +623,7 @@ func escapeStringJSON(v string) string {
 // telemetry due to conflicting OpenTelemetry schema URLs from different semconv versions.
 //
 // The issue occurs because different parts of the codebase import different versions
-// of go.opentelemetry.io/otel/semconv:
-// - internal/tracing/init.go can be using a different versions from other parts of the
-// codebase.
+// of go.opentelemetry.io/otel/semconv, like internal/tracing/init.go.
 //
 // When OTEL_* variables are set, OpenTelemetry tries to initialize and
 // detects these conflicting schema URLs, causing conflicting schema errors.
@@ -638,7 +636,9 @@ func TestTelemetrySchemaConflict(t *testing.T) {
 
 	// Set the environment variable that triggers telemetry initialization errors
 	tf.AddEnv("OTEL_TRACES_EXPORTER=otlp")
-	tf.AddEnv("OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317")
+	// We're actually using an invalid endpoint because the key error is the
+	// initialization error. Sending the traces themselves is not relevant to this test.
+	tf.AddEnv("OTEL_EXPORTER_OTLP_ENDPOINT=http://invalid/")
 	tf.AddEnv("OTEL_EXPORTER_OTLP_INSECURE=true")
 
 	_, stderr, err := tf.Run("init")


### PR DESCRIPTION
Related to #3446 

TestTelemetrySchemaConflict reproduces the issue where OpenTofu fails to initialize telemetry because of conflicting OpenTelemetry schema URLs across different semconv versions.

The issue occurs because different parts of the codebase import different versions of go.opentelemetry.io/otel/semconv.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
