### PR TITLE
fix: use variables at `enabled` in nested modules 

### DIFF
--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -3522,25 +3522,51 @@ func TestContext2Plan_moduleImplicitMove(t *testing.T) {
 		"from nested enabled-module multiple-resource to enabled-module single-resource": {
 			config: testModuleInline(t, map[string]string{
 				"main.tf": `
+					module "parent" {
+						source        = "./parent"
+						child_enabled = true
+					}`,
+				"parent/main.tf": `
+					variable "child_enabled" {
+						type = bool
+					}
+
 					module "child" {
-						source = "./child"
+						source   = "../child"
+						lifecycle {
+							enabled = var.child_enabled
+						}
+						grandchild1_enabled = true
 					}`,
 				"child/main.tf": `
-					variable "enabled" { default = true }
-					module "grandchild" {
-						source = "./grandchild"
+					variable "grandchild1_enabled" {
+						type = bool
+					}
+					variable "grandchild2_enabled" {
+						type    = bool
+						default = true
+					}
+					module "grandchild1" {
+						source = "../grandchild"
 						lifecycle {
-							enabled = var.enabled
+							enabled = var.grandchild1_enabled
 						}
-					}`,
-				"child/grandchild/main.tf": `resource "test_object" "a" {
+					}
+					module "grandchild2" {
+						source = "../grandchild"
+						lifecycle {
+							enabled = var.grandchild2_enabled
+						}
+					}
+					`,
+				"grandchild/main.tf": `resource "test_object" "a" {
 					count = 1
 				}`,
 			}),
-			expectedAddr: mustResourceInstanceAddr("module.child.module.grandchild[0].test_object.a"),
-			prevAddr:     mustResourceInstanceAddr("module.child.module.grandchild.test_object.a"),
+			expectedAddr: mustResourceInstanceAddr("module.parent.module.child.module.grandchild1.test_object.a[0]"),
+			prevAddr:     mustResourceInstanceAddr("module.parent.module.child.module.grandchild1.test_object.a"),
 			prevState: states.BuildState(func(s *states.SyncState) {
-				s.SetResourceInstanceCurrent(mustResourceInstanceAddr("module.child.module.grandchild.test_object.a"), &states.ResourceInstanceObjectSrc{
+				s.SetResourceInstanceCurrent(mustResourceInstanceAddr("module.parent.module.child.module.grandchild1.test_object.a"), &states.ResourceInstanceObjectSrc{
 					AttrsJSON: []byte(`{}`),
 					Status:    states.ObjectReady,
 				}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`), addrs.NoKey)

--- a/internal/tofu/node_module_expand.go
+++ b/internal/tofu/node_module_expand.go
@@ -147,17 +147,7 @@ func (n *nodeExpandModule) Execute(ctx context.Context, evalCtx EvalContext, op 
 			expander.SetModuleForEach(module, call, forEach)
 
 		case n.ModuleCall.Enabled != nil:
-			// For enabled expressions, we need to evaluate in the parent module context
-			// since the expression may reference variables defined in the parent module. e.g.
-			// variable "on" { type = bool }
-			// module "mod1" {
-			// 	 source = "./mod1"
-			// 	 lifecycle {
-			// 	   enabled = var.on
-			// 	 }
-			// }
-			parentEvalCtx := evalCtx.WithPath(module.Parent())
-			enabled, enDiags := evaluateEnabledExpression(ctx, n.ModuleCall.Enabled, parentEvalCtx)
+			enabled, enDiags := evaluateEnabledExpression(ctx, n.ModuleCall.Enabled, evalCtx)
 			diags = diags.Append(enDiags)
 			if diags.HasErrors() {
 				return diags


### PR DESCRIPTION
Resolves https://cloud-native.slack.com/archives/C05PXGAB05R/p1762418361124039?thread_ts=1761238300.596699&cid=C05PXGAB05R

From Roger Siegenthaler:

```
Finally got around to testing the 1.11-rc1 release and am encountering an issue with the new enabled meta-argument on modules.
I have a variable that controls whether a client_secret is needed. This controls the creation of a blue/green timer (in a module) aswell as a few other resources. The enabled argument works for the resources (including correctly identifying the implicit “moved” blocks), however for the module I’m receiving an error:
│ Error: Reference to undeclared input variable
│ 
│   on .terraform/modules/.../service-account.tf line 27, in module "bg_rotation":
│    8:     enabled = var.client_secret.enabled
│ 
│ An input variable with the name "client_secret" has not been declared. This variable can be declared with a variable "client_secret" {} block.
This happens if I reference the module without setting the client_secret input or if I set it to {enabled = false} or = true.
Code snippet:
variable "client_secret" {
  description = "A config for the client secret."
  type = object({
    enabled       = bool
    duration_in_M = optional(number, 24)
    overlap_in_M  = optional(number, 3)
  })
  default = {
    enabled = false
  }
  validation {
    # ...
  }
}

module "bg_rotation" {
  source = "..."

  duration_in_M = var.client_secret.duration_in_M
  overlap_in_M  = var.client_secret.overlap_in_M

  lifecycle {
    enabled = var.client_secret.enabled
  }
}

resource "azuread_application_password" "blue" {
  display_name   = "..."
  application_id = azuread_application_registration.app_registration.id

  start_date = module.bg_rotation.blue_start_date
  end_date   = module.bg_rotation.blue_end_date

  rotate_when_changed = {
    rotation = module.bg_rotation.blue_rotation_date
  }

  lifecycle {
    enabled = var.client_secret.enabled
  }
}
```

For some reason I had the context evaluation from the parent on the module because using the already existing `evalCtx` didn't work properly. But now, after re-testing, it seems this works fine even with variables defined in the parent and this is what other fields use as well (like `for_each` and `count`). I've added a regression test too.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
