### PR TITLE
Fix nil entry in state resource instance map from state hook

### DIFF
--- a/internal/states/module.go
+++ b/internal/states/module.go
@@ -90,7 +90,11 @@ func (ms *Module) SetResourceInstance(addr addrs.ResourceInstance, inst *Resourc
 		ms.SetResourceProvider(addr.Resource, provider)
 		rs = ms.Resource(addr.Resource)
 	}
-	rs.Instances[addr.Key] = inst
+	if inst != nil {
+		rs.Instances[addr.Key] = inst
+	} else {
+		delete(rs.Instances, addr.Key)
+	}
 }
 
 // SetResourceInstanceCurrent saves the given instance object as the current

--- a/internal/tofu/update_state_hook.go
+++ b/internal/tofu/update_state_hook.go
@@ -21,6 +21,9 @@ func updateStateHook(evalCtx EvalContext, addr addrs.AbsResourceInstance) error 
 				// See the documentation of ResourceProvider for more details
 				s.RemoveResource(addr.ContainingResource())
 			} else {
+				// The individual instance may be nil, but that can happen when destroying
+				// some but not all instances of a resource (or when that is in-progress).
+				// SetResourceInstance handles that nil correctly and updates the state accordingly.
 				s.SetResourceInstance(addr, evalCtx.State().ResourceInstance(addr), *provider)
 			}
 		})

--- a/internal/tofu/update_state_hook_test.go
+++ b/internal/tofu/update_state_hook_test.go
@@ -49,3 +49,60 @@ func TestUpdateStateHook(t *testing.T) {
 		t.Fatalf("wrong state passed to hook: %s", spew.Sdump(target))
 	}
 }
+
+func TestUpdateStateHookRemoved(t *testing.T) {
+	mockHook := new(MockHook)
+
+	resAddr0 := addrs.Resource{
+		Mode: addrs.ManagedResourceMode,
+		Type: "foo",
+		Name: "bar",
+	}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance)
+	resAddr1 := addrs.Resource{
+		Mode: addrs.ManagedResourceMode,
+		Type: "foo",
+		Name: "bar",
+	}.Instance(addrs.IntKey(1)).Absolute(addrs.RootModuleInstance)
+
+	providerAddr, _ := addrs.ParseAbsProviderConfigStr(`provider["registry.opentofu.org/org/foo"]`)
+	resData := &states.ResourceInstanceObjectSrc{
+		SchemaVersion: 42,
+	}
+
+	state := states.NewState()
+	state.Module(addrs.RootModuleInstance).SetResourceInstanceCurrent(resAddr0.Resource, resData, providerAddr, addrs.NoKey)
+
+	ctx := new(MockEvalContext)
+	ctx.HookHook = mockHook
+	ctx.StateState = state.SyncWrapper()
+
+	target := states.NewState()
+
+	// Write resource instance 0
+	if err := updateStateHook(ctx, resAddr0); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Flush
+	if !mockHook.PostStateUpdateCalled {
+		t.Fatal("should call PostStateUpdate")
+	}
+	mockHook.PostStateUpdateCalled = false
+	mockHook.PostStateUpdateFn(target.SyncWrapper())
+
+	// Will remove the entry if it exists
+	if err := updateStateHook(ctx, resAddr1); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Flush
+	if !mockHook.PostStateUpdateCalled {
+		t.Fatal("should call PostStateUpdate")
+	}
+	mockHook.PostStateUpdateFn(target.SyncWrapper())
+
+	// Comparison
+	if !state.ManagedResourcesEqual(target) {
+		t.Fatalf("wrong state passed to hook: %s \nExpected:\n %s", spew.Sdump(target), spew.Sdump(state))
+	}
+}


### PR DESCRIPTION
This was introduced in the recent set of changes to optimize state writing (DeepCopy reduction/removal).

The SetResourceInstance function accidentally allowed nil entries in resource instance state map.  This would cause crashes in the state hook persist function as that partial state could not be serialized.

<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves #3477

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

