### PR TITLE
Allow interpolated references in state.method too

### DIFF
--- a/internal/encryption/targets.go
+++ b/internal/encryption/targets.go
@@ -31,8 +31,8 @@ func methodConfigsFromTarget(cfg *config.EncryptionConfig, target *config.Target
 		case l > 1:
 			travDiags = travDiags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
-				Summary:  "Invalid target expression",
-				Detail:   fmt.Sprintf("Found %d expressions but 'target' is meant to have just 1.", len(traversals)),
+				Summary:  "Invalid encryption method expression",
+				Detail:   fmt.Sprintf(`Found %d expressions but "method" is meant to have just 1.`, len(traversals)),
 				Subject:  target.Method.Range().Ptr(),
 			})
 		default:

--- a/internal/encryption/targets_test.go
+++ b/internal/encryption/targets_test.go
@@ -386,7 +386,7 @@ func TestBaseEncryption_methodConfigsFromTargetAndSetup(t *testing.T) {
 					method = "${method.aes_gcm.nonexistent}${method.unencrypted.for_migration}"
 				}
 			`,
-			wantErr: `Test Config Source:11,15-81: Invalid target expression; Found 2 expressions but 'target' is meant to have just 1.`,
+			wantErr: `Test Config Source:11,15-81: Invalid encryption method expression; Found 2 expressions but "method" is meant to have just 1.`,
 		},
 		// In https://github.com/opentofu/opentofu/issues/3482 was discovered that interpolation for
 		// target.method does not work, but only literal reference.


### PR DESCRIPTION

<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves #3482

In HCL syntax, there is no interpolation used in general for state encryption. Therefore, we didn't catch this during #2551. But when it comes to JSON syntax, the references of the methods and key_providers need to be interpolated. Therefore, the parsing of the expression in state.method needs to be able to work with interpolation too, and not only raw references.

The changes in here allow both options, since there might be users out there that already rely on literal references in `state.method`.

❓ For those well versed in HCL API, I would appreciate to let me know in the comments if there are other, better, ways to extract the traversals from an interpolated expression.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
