### PR TITLE
tofu: `TestContext2Plan_preventDestroy_dynamicFromDataResource` should use `synctest.Wait`

### DIFF
--- a/internal/tofu/context_plan_test.go
+++ b/internal/tofu/context_plan_test.go
@@ -1745,6 +1745,7 @@ func TestContext2Plan_preventDestroy_dynamicFromDataResource(t *testing.T) {
 				// shorter than the one in the other provider below. Refer to
 				// the comment there for more information.
 				time.Sleep(5 * time.Second)
+				synctest.Wait()
 				log.Printf("[TRACE] TestContext2Plan_preventDestroy_dynamicFromDataResource: test_instance.foo plan")
 			} else {
 				log.Printf("[TRACE] TestContext2Plan_preventDestroy_dynamicFromDataResource: test_instance.foo followup plan")
@@ -1778,6 +1779,7 @@ func TestContext2Plan_preventDestroy_dynamicFromDataResource(t *testing.T) {
 				// actually cause a "real" sleep, and instead just interacts
 				// with the synctest bubble's fake clock.
 				time.Sleep(10 * time.Second)
+				synctest.Wait()
 				log.Printf("[TRACE] TestContext2Plan_preventDestroy_dynamicFromDataResource: data.source.foo read")
 				return providers.ReadDataSourceResponse{
 					State: cty.ObjectVal(map[string]cty.Value{


### PR DESCRIPTION
The fake time implementation in [`testing/synctest`](https://pkg.go.dev/testing/synctest) does not create a synchronization point itself, so the previous version of this test was technically incorrect, though it was passing in practice due to other effective constraints on the execution behavior.

A [`synctest.Wait`](https://pkg.go.dev/testing/synctest#Wait) after each faked `time.Sleep` creates a synchronization point that helps ensure the correct execution order and no data races without relying on unrelated implementation details such as the mutexes around the planned changes and in-memory state data.

This does not actually change the current test behavior in any significant way, but would avoid this test becoming more flaky if implementation details of the language runtime were to change significantly in future. (That seems pretty unlikely in practice -- we're intending to write a new one instead of evolving this one significantly -- but I think it's still worth making the effort to use the `synctest` API correctly as part of learning to make effective use of it.)

(I was trying different permutations of this as I was getting more familiar with how `synctest` works while working on https://github.com/opentofu/opentofu/pull/3474, and when I looked at the code again today I realized I'd accidentally cherry-picked an older version I'd kept in a separate branch while I was experimenting, rather than this final version that had `synctest.Wait` included in it, because they were so similar to one another and both were actually passing in practice. :confounded:)
