### PR TITLE
Do not prune the ephemeral expansion node - temp solution

### DIFF
--- a/internal/tofu/transform_diff.go
+++ b/internal/tofu/transform_diff.go
@@ -205,7 +205,14 @@ func (t *DiffTransformer) Transform(_ context.Context, g *Graph) error {
 
 			g.Add(node)
 			rsrcAddr := addr.ContainingResource().String()
-			for _, rsrcNode := range resourceNodes[rsrcAddr] {
+			resources := resourceNodes[rsrcAddr]
+			if len(resources) == 0 && addr.Resource.Resource.Mode == addrs.EphemeralResourceMode {
+				ephAddr := addr.ContainingResource()
+				ephAddr.Module = ephAddr.Module.Module().UnkeyedInstanceShim()
+				ephRsrcAddr := ephAddr.String()
+				resources = resourceNodes[ephRsrcAddr]
+			}
+			for _, rsrcNode := range resources {
 				g.Connect(dag.BasicEdge(node, rsrcNode))
 			}
 		}


### PR DESCRIPTION
The main issue is that the instance node of the ephemeral resource that comes from the plan changes (where the expansion is done in a different way than the apply one) but cannot match the expansion node which is generated based on the configuration.
Therefore, in the DiffTransformer, we want to map the resource instance address to an absolute (unkeyed) address to be able to find the expansion nodes generated by the config transformer.

Another approach for #3492
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves # 

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [ ] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [ ] I have not used an AI coding assistant to create this PR.
- [ ] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [ ] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
