### PR TITLE
PROTOTYPE: `memory` built-in provider

### DIFF
--- a/internal/builtin/providers/memory/provider.go
+++ b/internal/builtin/providers/memory/provider.go
@@ -1,0 +1,61 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package memory
+
+import (
+	"context"
+
+	"github.com/opentofu/opentofu/internal/configs/configschema"
+	"github.com/opentofu/opentofu/internal/providers"
+)
+
+// Provider is an implementation of providers.Interface
+type Provider struct {
+}
+
+// NewProvider returns a new instance of the "memory" provider.
+func NewProvider() providers.Interface {
+	return &Provider{}
+}
+
+// Close implements providers.Interface.
+func (p *Provider) Close(context.Context) error {
+	return nil
+}
+
+// ConfigureProvider implements providers.Interface.
+func (p *Provider) ConfigureProvider(context.Context, providers.ConfigureProviderRequest) providers.ConfigureProviderResponse {
+	return providers.ConfigureProviderResponse{}
+}
+
+// GetFunctions implements providers.Interface.
+func (p *Provider) GetFunctions(context.Context) providers.GetFunctionsResponse {
+	return providers.GetFunctionsResponse{}
+}
+
+// GetProviderSchema implements providers.Interface.
+func (p *Provider) GetProviderSchema(context.Context) providers.GetProviderSchemaResponse {
+	return providers.GetProviderSchemaResponse{
+		Provider: providers.Schema{
+			Block: &configschema.Block{
+				// This provider expects no configuration arguments.
+			},
+		},
+		ResourceTypes: map[string]providers.Schema{
+			"memory": resourceTypeSchema(),
+		},
+	}
+}
+
+// Stop implements providers.Interface.
+func (p *Provider) Stop(context.Context) error {
+	return nil
+}
+
+// ValidateProviderConfig implements providers.Interface.
+func (p *Provider) ValidateProviderConfig(context.Context, providers.ValidateProviderConfigRequest) providers.ValidateProviderConfigResponse {
+	return providers.ValidateProviderConfigResponse{}
+}

--- a/internal/builtin/providers/memory/resource.go
+++ b/internal/builtin/providers/memory/resource.go
@@ -1,0 +1,293 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package memory
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
+
+	"github.com/opentofu/opentofu/internal/configs/configschema"
+	"github.com/opentofu/opentofu/internal/providers"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+)
+
+// This provider has only a single resource type, and so the implementation
+// of that resource type is directly inside the provider's managed-resource-type
+// related methods.
+
+func resourceTypeSchema() providers.Schema {
+	return providers.Schema{
+		Block: &configschema.Block{
+			Attributes: map[string]*configschema.Attribute{
+				"value": {
+					// "value" is the currently-stored value. This is unknown
+					// during planning whenever a change is pending, and then
+					// becomes known again during the apply phase once the
+					// change is committed. If no change is pending then this
+					// just retains the most recently-written value.
+					Type:     cty.DynamicPseudoType,
+					Computed: true,
+				},
+
+				"initial_value": {
+					// "initial_value" is used to populate "value" during
+					// initial creation if either there is no update requested
+					// at the same time or if the requested update is derived
+					// from a previously-stored value.
+					//
+					// For example, if using "add_value" to apply a numeric
+					// offset to the previously-stored value then this should
+					// be set to a number that the adjustment would be applied
+					// to whenever there is no previous value to use.
+					Type:     cty.DynamicPseudoType,
+					Required: true,
+					// This is write-only so that it's possible to set it from
+					// an ephemeral resource, if needed, just like with
+					// new_value.
+					WriteOnly: true,
+				},
+
+				// Zero or one of the following attributes can be set to
+				// request a change to the stored value. These arguments
+				// are mutually-exclusive so that it's always unambiguous
+				// whether a change is requested and what kind of change
+				// is being requested.
+				//
+				// The "nullness" of these values must remain consistent
+				// between plan and apply in order to actually cause a change
+				// to happen, but the actual value of the one that is non-null
+				// is allowed to change.
+				//
+				// These are both intentionally write-only so that they can be
+				// set from an ephemeral resource when needed. It also means
+				// OpenTofu will never show a diff relative to a previously-set
+				// value, which would probably just confuse people.
+				"new_value": {
+					// "new_value" represents the most straightforward change:
+					// just overwriting any existing value with
+					Type:      cty.DynamicPseudoType,
+					Optional:  true,
+					WriteOnly: true,
+				},
+				"add_to_value": {
+					// "add_to_value" represents adding the given number to
+					// whatever number was previously stored. If the previous
+					// value was not something that can convert to a number
+					// then it's invalid to set this argument.
+					//
+					// Setting this to zero is treated as a write even though
+					// the new value would not change, because the given
+					// value may be ephemeral and so might be nonzero during
+					// apply even if it was zero during planning.
+					Type:      cty.Number,
+					Optional:  true,
+					WriteOnly: true,
+				},
+			},
+		},
+	}
+}
+
+// ValidateResourceConfig implements providers.Interface.
+func (p *Provider) ValidateResourceConfig(_ context.Context, req providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
+	var resp providers.ValidateResourceConfigResponse
+
+	newValue := req.Config.GetAttr("new_value")
+	addToValue := req.Config.GetAttr("add_to_value")
+	if !newValue.IsNull() && !addToValue.IsNull() {
+		resp.Diagnostics = resp.Diagnostics.Append(tfdiags.AttributeValue(
+			tfdiags.Error,
+			"Conflicting write arguments for memory",
+			"Cannot set both \"new_value\" and \"add_to_value\" at the same time.",
+			// We arbitrarily "blame" the add_to_value argument because that's
+			// the least general of the two.
+			cty.GetAttrPath("add_to_value"),
+		))
+	}
+
+	return resp
+}
+
+// PlanResourceChange implements providers.Interface.
+func (p *Provider) PlanResourceChange(_ context.Context, req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+	var resp providers.PlanResourceChangeResponse
+	// The following assumes that the caller previously called
+	// ValidateResourceConfig and so we don't need to repeat any checks already
+	// made by that function.
+
+	if req.Config == cty.NilVal || req.Config.IsNull() {
+		// We're planning to destroy the memory object then, and so we'll just
+		// confirm to the caller that it's okay to do that.
+		return resp
+	}
+
+	plannedNewValue := cty.DynamicVal
+	if req.PriorState != cty.NilVal && !req.PriorState.IsNull() {
+		plannedNewValue = req.PriorState.GetAttr("value")
+	}
+
+	// Due to ValidateResourceConfig's checks we can assume that at most one
+	// of the following is non-null.
+	newValue := req.Config.GetAttr("new_value")
+	addToValue := req.Config.GetAttr("add_to_value")
+	if !newValue.IsNull() || !addToValue.IsNull() {
+		// The value will be finalized during the apply step. The unknown-ness
+		// of this value signals to the apply step that a change was expected.
+		plannedNewValue = cty.DynamicVal
+	}
+
+	resp.PlannedState = memoryInstanceObject(plannedNewValue)
+	return resp
+}
+
+// ApplyResourceChange implements providers.Interface.
+func (p *Provider) ApplyResourceChange(_ context.Context, req providers.ApplyResourceChangeRequest) providers.ApplyResourceChangeResponse {
+	var resp providers.ApplyResourceChangeResponse
+	// The following assumes that the caller previously called both
+	// ValidateResourceConfig and PlanResourceChange and so we don't need to
+	// repeat any checks previously made and the planned new state matches
+	// what PlanResourceChange would've produced.
+
+	if req.PlannedState == cty.NilVal || req.PlannedState.IsNull() {
+		// We're applying a "destroy" plan, so we've nothing to do except
+		// signal that it was successful.
+		// We'll create a stub response value just to avoid duplicating
+		// the type information here to return a correctly-typed null result.
+		stubVal := memoryInstanceObject(cty.NullVal(cty.DynamicPseudoType))
+		resp.NewState = cty.NullVal(stubVal.Type())
+		return resp
+	}
+
+	var oldValue cty.Value
+	if req.PriorState != cty.NilVal && !req.PriorState.IsNull() {
+		oldValue = req.PriorState.GetAttr("value")
+	} else {
+		// If we're creating a "memory" for the first time then we use
+		// initial_value as a placeholder for the old value, so that the
+		// rest of the logic doesn't need to distinguish between
+		// creating and updating.
+		oldValue = req.Config.GetAttr("initial_value")
+	}
+
+	if plannedValue := req.PlannedState.GetAttr("value"); plannedValue.IsKnown() {
+		// If we knew the new value during planning then that means we aren't
+		// making a change at all, and so we'll just echo back whatever
+		// we were given.
+		resp.NewState = memoryInstanceObject(plannedValue)
+		return resp
+	}
+	if !oldValue.IsKnown() {
+		// This should not be possible: neither "value" nor "initial_value"
+		// can be unknown during the apply phase because prior state is
+		// always known and during the apply phase config is also wholly
+		// known.
+		resp.Diagnostics = resp.Diagnostics.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Inconsistent values in \"memory\" object",
+			"Previous value for memory is unknown during apply. This is a bug in OpenTofu.",
+		))
+		return resp
+	}
+
+	// Due to ValidateResourceConfig's checks we can assume that at most one
+	// of the following is non-null.
+	wantNewValue := req.Config.GetAttr("new_value")
+	wantAddToValue := req.Config.GetAttr("add_to_value")
+	if !wantNewValue.IsNull() {
+		resp.NewState = memoryInstanceObject(wantNewValue)
+	} else if !wantAddToValue.IsNull() {
+		// In this case the old value must be something we can convert to
+		// a number that we'll add the argument value to.
+		oldNum, err := convert.Convert(oldValue, cty.Number)
+		if err != nil {
+			resp.Diagnostics = resp.Diagnostics.Append(tfdiags.AttributeValue(
+				tfdiags.Error,
+				"Cannot add to non-numeric memory value",
+				fmt.Sprintf("The \"add_to_value\" argument requires that the previous value be a number, so that the argument value can be added to it. The current memory value is %s.", oldValue.Type().FriendlyName()),
+				cty.GetAttrPath("add_to_value"),
+			))
+			return resp
+		}
+		resp.NewState = memoryInstanceObject(oldNum.Add(wantAddToValue))
+	} else {
+		// No change at all, so the new value is equal to the old value.
+		resp.NewState = memoryInstanceObject(oldValue)
+	}
+	return resp
+}
+
+func memoryInstanceObject(value cty.Value) cty.Value {
+	return cty.ObjectVal(map[string]cty.Value{
+		"value": value,
+		// The write-only attributes must all be set to null, per the usual
+		// rules for attributes of that kind.
+		"initial_value": cty.NullVal(cty.DynamicPseudoType),
+		"new_value":     cty.NullVal(cty.DynamicPseudoType),
+		"add_to_value":  cty.NullVal(cty.Number),
+	})
+}
+
+// ReadResource implements providers.Interface.
+func (p *Provider) ReadResource(_ context.Context, req providers.ReadResourceRequest) providers.ReadResourceResponse {
+	// There is no remote data associated with this resource type, so we just
+	// echo back whatever we were given.
+	return providers.ReadResourceResponse{
+		NewState: req.PriorState,
+		Private:  req.Private,
+	}
+}
+
+// ImportResourceState implements providers.Interface.
+func (p *Provider) ImportResourceState(context.Context, providers.ImportResourceStateRequest) providers.ImportResourceStateResponse {
+	// Perhaps once OpenTofu supports import-by-resource-identity we can allow
+	// importing with a value specified in there, but for now we just disallow
+	// importing altogether.
+	var resp providers.ImportResourceStateResponse
+	resp.Diagnostics = resp.Diagnostics.Append(tfdiags.Sourceless(
+		tfdiags.Error,
+		"Cannot import \"memory\" object",
+		"Importing into a memory object is not supported.",
+	))
+	return resp
+}
+
+// MoveResourceState implements providers.Interface.
+func (p *Provider) MoveResourceState(_ context.Context, req providers.MoveResourceStateRequest) providers.MoveResourceStateResponse {
+	// No other resource type can be converted to a "memory".
+	var resp providers.MoveResourceStateResponse
+	resp.Diagnostics = resp.Diagnostics.Append(tfdiags.Sourceless(
+		tfdiags.Error,
+		"Cannot convert to \"memory\" object",
+		fmt.Sprintf("A resource instance of type %q cannot be converted into a \"memory\" object.", req.SourceTypeName),
+	))
+	return resp
+}
+
+// UpgradeResourceState implements providers.Interface.
+func (p *Provider) UpgradeResourceState(_ context.Context, req providers.UpgradeResourceStateRequest) providers.UpgradeResourceStateResponse {
+	var resp providers.UpgradeResourceStateResponse
+	// This is awkward because we get given the prior state in JSON format
+	// and need to convert it back to the cty representation here just to
+	// satisfy the provider API. This doesn't achieve anything particularly
+	// useful, though this _is_ where we might catch some problems if someone
+	// did manual state surgery and made the JSON representation invalid.
+	schema := resourceTypeSchema()
+	v, err := ctyjson.Unmarshal(req.RawStateJSON, schema.Block.ImpliedType())
+	if err != nil {
+		resp.Diagnostics = resp.Diagnostics.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Invalid prior state for \"memory\" instance",
+			fmt.Sprintf("Failed to decode prior state for \"memory\" object: %s.", tfdiags.FormatError(err)),
+		))
+		return resp
+	}
+	resp.UpgradedState = v
+	return resp
+}

--- a/internal/builtin/providers/memory/unimplemented.go
+++ b/internal/builtin/providers/memory/unimplemented.go
@@ -1,0 +1,51 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package memory
+
+import (
+	"context"
+
+	"github.com/opentofu/opentofu/internal/providers"
+)
+
+// The following are all of the methods of providers.Interface that this
+// provider does not implement because they relate to features that do not
+// appear in the provider's schema at all.
+
+// CallFunction implements providers.Interface.
+func (p *Provider) CallFunction(context.Context, providers.CallFunctionRequest) providers.CallFunctionResponse {
+	panic("unimplemented")
+}
+
+// CloseEphemeralResource implements providers.Interface.
+func (p *Provider) CloseEphemeralResource(context.Context, providers.CloseEphemeralResourceRequest) providers.CloseEphemeralResourceResponse {
+	panic("unimplemented")
+}
+
+// OpenEphemeralResource implements providers.Interface.
+func (p *Provider) OpenEphemeralResource(context.Context, providers.OpenEphemeralResourceRequest) providers.OpenEphemeralResourceResponse {
+	panic("unimplemented")
+}
+
+// ReadDataSource implements providers.Interface.
+func (p *Provider) ReadDataSource(context.Context, providers.ReadDataSourceRequest) providers.ReadDataSourceResponse {
+	panic("unimplemented")
+}
+
+// RenewEphemeralResource implements providers.Interface.
+func (p *Provider) RenewEphemeralResource(context.Context, providers.RenewEphemeralResourceRequest) (resp providers.RenewEphemeralResourceResponse) {
+	panic("unimplemented")
+}
+
+// ValidateDataResourceConfig implements providers.Interface.
+func (p *Provider) ValidateDataResourceConfig(context.Context, providers.ValidateDataResourceConfigRequest) providers.ValidateDataResourceConfigResponse {
+	panic("unimplemented")
+}
+
+// ValidateEphemeralConfig implements providers.Interface.
+func (p *Provider) ValidateEphemeralConfig(context.Context, providers.ValidateEphemeralConfigRequest) providers.ValidateEphemeralConfigResponse {
+	panic("unimplemented")
+}

--- a/internal/command/meta_providers.go
+++ b/internal/command/meta_providers.go
@@ -18,6 +18,7 @@ import (
 	plugin "github.com/hashicorp/go-plugin"
 
 	"github.com/opentofu/opentofu/internal/addrs"
+	memoryProvider "github.com/opentofu/opentofu/internal/builtin/providers/memory"
 	terraformProvider "github.com/opentofu/opentofu/internal/builtin/providers/tf"
 	"github.com/opentofu/opentofu/internal/getproviders"
 	"github.com/opentofu/opentofu/internal/logging"
@@ -344,6 +345,14 @@ func (m *Meta) internalProviders() map[string]providers.Factory {
 	return map[string]providers.Factory{
 		"terraform": func() (providers.Interface, error) {
 			return terraformProvider.NewProvider(), nil
+		},
+		// FIXME: If we actually decide to ship this one then we should
+		// rework this so that the "terraform" provider belongs to
+		// the "terraform.io/builtin/" namespace, but "memory" belongs to
+		// the "opentofu.org/builtin/" namespace, because the Terraform-flavored
+		// namespace is not controlled by the OpenTofu project.
+		"memory": func() (providers.Interface, error) {
+			return memoryProvider.NewProvider(), nil
 		},
 	}
 }


### PR DESCRIPTION
This is a prototype of a partial solution to a notable gap in how write-only arguments have been implemented in most providers so far, as discussed in the following issues/PRs/discussions:

- https://github.com/hashicorp/terraform-provider-aws/pull/41371#issuecomment-2685859231
- https://github.com/hashicorp/terraform-provider-aws/issues/44590
- https://github.com/hashicorp/terraform-provider-aws/issues/42441
- https://github.com/hashicorp/terraform/issues/36941
- https://github.com/hashicorp/terraform/issues/37493
- **[Write-only attribute "version" changes that depend on changes to other resources](https://discuss.hashicorp.com/t/write-only-attribute-version-changes-that-depend-on-changes-to-other-resources/76775)**

Each of these is describing a slightly different consequence of the problem, but at its root the common thread is that provider developers chose to require a change to a special "version" attribute in order to signal that an associated write-only attribute has some meaningful content to use, but there isn't really any good workflow to coordinate changes to those attributes to ensure that everything gets updated consistently when required and that nothing happens at all in other cases.

Hopefully eventually one of those issues results in the design being adjusted somehow upstream, but in the meantime I tried a few different workarounds and ended up creating [the `apparentlymart/memory` provider](https://search.opentofu.org/provider/apparentlymart/memory/latest/docs/resources/memory), which provides a building block for "remembering" the most recently used version number.

This PR is implementing a built-in version of that provider, extended with a new idea I came up with after experimenting more with my previous provider: in addition to allowing the previously-stored value to be completely overwritten, it also allows for treating the previous value as a number and adding a new value to it so that the step of incrementing the version number can _also_ be encapsulated within the configuration, and so the operator doesn't need to think about version numbers at all.

---

I'm going to demonstrate this using the following somewhat-contrived configuration:

```hcl
terraform {
  required_providers {
    aws = {
      source = "hashicorp/aws"
    }
    memory = {
      # NOTE: If OpenTofu chooses to ship this it should get renamed to
      # "opentofu.org/builtin/memory" instead, but is squatting in this
      # namespace for now just because we'd have some refactoring to do
      # before we could introduce the first provider into OpenTofu's own
      # "builtin" namespace.
      source = "terraform.io/builtin/memory"
    }
    random = {
      source = "hashicorp/random"
    }
  }
}

variable "reset_password" {
  type     = bool
  default  = false
  nullable = false

  description = "If set to true, the database password will be reset during the apply phase."
}

resource "memory" "password_version" {
  initial_value = 0

  # If the operator requested to reset the password then we'll increment
  # the version number by one to force the other resources to pay attention
  # to the write-only attribute containing the new password.
  add_to_value  = var.reset_password ? 1 : null
}

ephemeral "random_password" "new_password" {
  length = 24
}

provider "aws" {
  region = "us-west-2"
}

resource "aws_secretsmanager_secret" "password" {
  name = "apparentlymart-test-password-blah"
}

resource "aws_secretsmanager_secret_version" "password" {
  secret_id = aws_secretsmanager_secret.password.id

  secret_string_wo         = ephemeral.random_password.new_password.result
  secret_string_wo_version = memory.password_version.value
}
```

During initial creation, the "memory" gets set to zero and so the Secrets Manager secret's `secret_string_wo_version` is initialized to zero:

```shellsession
$ tofu apply
ephemeral.random_password.new_password: Opening...
ephemeral.random_password.new_password: Open complete after 0s
ephemeral.random_password.new_password: Closing...
ephemeral.random_password.new_password: Close complete after 0s

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # aws_secretsmanager_secret.password will be created
  + resource "aws_secretsmanager_secret" "password" {
      + arn                            = (known after apply)
      + force_overwrite_replica_secret = false
      + id                             = (known after apply)
      + name                           = "apparentlymart-test-password-blah"
      + name_prefix                    = (known after apply)
      + policy                         = (known after apply)
      + recovery_window_in_days        = 30
      + region                         = "us-west-2"
      + tags_all                       = (known after apply)

      + replica (known after apply)
    }

  # aws_secretsmanager_secret_version.password will be created
  + resource "aws_secretsmanager_secret_version" "password" {
      + arn                      = (known after apply)
      + has_secret_string_wo     = (known after apply)
      + id                       = (known after apply)
      + region                   = "us-west-2"
      + secret_id                = (known after apply)
      + secret_string_wo         = (write-only attribute)
      + secret_string_wo_version = (known after apply)
      + version_id               = (known after apply)
      + version_stages           = (known after apply)
    }

  # memory.password_version will be created
  + resource "memory" "password_version" {
      + add_to_value  = (write-only attribute)
      + initial_value = (write-only attribute)
      + new_value     = (write-only attribute)
      + value         = (known after apply)
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  OpenTofu will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

memory.password_version: Creating...
memory.password_version: Creation complete after 0s
ephemeral.random_password.new_password: Opening...
ephemeral.random_password.new_password: Open complete after 0s
aws_secretsmanager_secret.password: Creating...
aws_secretsmanager_secret.password: Creation complete after 0s [id=arn:aws:secretsmanager:us-west-2:0000000000:secret:apparentlymart-test-password-blah-Lo78iA]
aws_secretsmanager_secret_version.password: Creating...
aws_secretsmanager_secret_version.password: Creation complete after 0s [id=arn:aws:secretsmanager:us-west-2:0000000000:secret:apparentlymart-test-password-blah-Lo78iA|terraform-20251113011206298400000002]
ephemeral.random_password.new_password: Closing...
ephemeral.random_password.new_password: Close complete after 0s

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

$ tofu show

# aws_secretsmanager_secret.password:
resource "aws_secretsmanager_secret" "password" {
    arn                            = "arn:aws:secretsmanager:us-west-2:0000000000:secret:apparentlymart-test-password-blah-Lo78iA"
    force_overwrite_replica_secret = false
    id                             = "arn:aws:secretsmanager:us-west-2:0000000000:secret:apparentlymart-test-password-blah-Lo78iA"
    name                           = "apparentlymart-test-password-blah"
    recovery_window_in_days        = 30
    region                         = "us-west-2"
    tags_all                       = {}
}

# aws_secretsmanager_secret_version.password:
resource "aws_secretsmanager_secret_version" "password" {
    arn                      = "arn:aws:secretsmanager:us-west-2:0000000000:secret:apparentlymart-test-password-blah-Lo78iA"
    has_secret_string_wo     = true
    id                       = "arn:aws:secretsmanager:us-west-2:0000000000:secret:apparentlymart-test-password-blah-Lo78iA|terraform-20251113011206298400000002"
    region                   = "us-west-2"
    secret_id                = "arn:aws:secretsmanager:us-west-2:0000000000:secret:apparentlymart-test-password-blah-Lo78iA"
    secret_string_wo         = (write-only attribute)
    secret_string_wo_version = 0
    version_id               = "terraform-20251113011206298400000002"
    version_stages           = [
        "AWSCURRENT",
    ]
}

# memory.password_version:
resource "memory" "password_version" {
    add_to_value  = (write-only attribute)
    initial_value = (write-only attribute)
    new_value     = (write-only attribute)
    value         = 0
}
```

Running apply again without any special arguments leaves the password unchanged:

```shellsession
$ tofu apply
memory.password_version: Refreshing state...
ephemeral.random_password.new_password: Opening...
ephemeral.random_password.new_password: Open complete after 0s
aws_secretsmanager_secret.password: Refreshing state... [id=arn:aws:secretsmanager:us-west-2:0000000000:secret:apparentlymart-test-password-blah-Lo78iA]
aws_secretsmanager_secret_version.password: Refreshing state... [id=arn:aws:secretsmanager:us-west-2:0000000000:secret:apparentlymart-test-password-blah-Lo78iA|terraform-20251113011206298400000002]
ephemeral.random_password.new_password: Closing...
ephemeral.random_password.new_password: Close complete after 0s

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
ephemeral.random_password.new_password: Opening...
ephemeral.random_password.new_password: Open complete after 0s
ephemeral.random_password.new_password: Closing...
ephemeral.random_password.new_password: Close complete after 0s

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

If the password were compromised, or needs to be rotated for any other reason, the input variable can be set to `true` during planning to activate everything needed to make that happen:

```shellsession
$ tofu apply -var=reset_password=true
memory.password_version: Refreshing state...
ephemeral.random_password.new_password: Opening...
ephemeral.random_password.new_password: Open complete after 0s
aws_secretsmanager_secret.password: Refreshing state... [id=arn:aws:secretsmanager:us-west-2:0000000000:secret:apparentlymart-test-password-blah-Lo78iA]
aws_secretsmanager_secret_version.password: Refreshing state... [id=arn:aws:secretsmanager:us-west-2:0000000000:secret:apparentlymart-test-password-blah-Lo78iA|terraform-20251113011206298400000002]
ephemeral.random_password.new_password: Closing...
ephemeral.random_password.new_password: Close complete after 0s

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place (current -> planned)
-/+ destroy and then create replacement

OpenTofu will perform the following actions:

  # aws_secretsmanager_secret_version.password must be replaced
-/+ resource "aws_secretsmanager_secret_version" "password" {
      ~ arn                      = "arn:aws:secretsmanager:us-west-2:0000000000:secret:apparentlymart-test-password-blah-Lo78iA" -> (known after apply)
      ~ has_secret_string_wo     = true -> (known after apply)
      ~ id                       = "arn:aws:secretsmanager:us-west-2:0000000000:secret:apparentlymart-test-password-blah-Lo78iA|terraform-20251113011206298400000002" -> (known after apply)
      ~ secret_string_wo         = (write-only attribute)
      ~ secret_string_wo_version = 0 -> (known after apply) # forces replacement
      ~ version_id               = "terraform-20251113011206298400000002" -> (known after apply)
      ~ version_stages           = [
          - "AWSCURRENT",
        ] -> (known after apply)
        # (2 unchanged attributes hidden)
    }

  # memory.password_version will be updated in-place
  ~ resource "memory" "password_version" {
      ~ initial_value = (write-only attribute)
      ~ new_value     = (write-only attribute)
      ~ value         = 0 -> (known after apply)
        # (1 unchanged attribute hidden)
    }

Plan: 1 to add, 1 to change, 1 to destroy.

Do you want to perform these actions?
  OpenTofu will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

ephemeral.random_password.new_password: Opening...
ephemeral.random_password.new_password: Open complete after 0s
aws_secretsmanager_secret_version.password: Destroying... [id=arn:aws:secretsmanager:us-west-2:0000000000:secret:apparentlymart-test-password-blah-Lo78iA|terraform-20251113011206298400000002]
aws_secretsmanager_secret_version.password: Destruction complete after 0s
memory.password_version: Modifying...
memory.password_version: Modifications complete after 0s
aws_secretsmanager_secret_version.password: Creating...
aws_secretsmanager_secret_version.password: Creation complete after 1s [id=arn:aws:secretsmanager:us-west-2:0000000000:secret:apparentlymart-test-password-blah-Lo78iA|terraform-20251113011509414900000001]
ephemeral.random_password.new_password: Closing...
ephemeral.random_password.new_password: Close complete after 0s

Apply complete! Resources: 1 added, 1 changed, 1 destroyed.

$ tofu show
# aws_secretsmanager_secret.password:
resource "aws_secretsmanager_secret" "password" {
    arn                            = "arn:aws:secretsmanager:us-west-2:0000000000:secret:apparentlymart-test-password-blah-Lo78iA"
    force_overwrite_replica_secret = false
    id                             = "arn:aws:secretsmanager:us-west-2:0000000000:secret:apparentlymart-test-password-blah-Lo78iA"
    name                           = "apparentlymart-test-password-blah"
    recovery_window_in_days        = 30
    region                         = "us-west-2"
    tags                           = {}
    tags_all                       = {}
}

# aws_secretsmanager_secret_version.password:
resource "aws_secretsmanager_secret_version" "password" {
    arn                      = "arn:aws:secretsmanager:us-west-2:0000000000:secret:apparentlymart-test-password-blah-Lo78iA"
    has_secret_string_wo     = true
    id                       = "arn:aws:secretsmanager:us-west-2:0000000000:secret:apparentlymart-test-password-blah-Lo78iA|terraform-20251113011509414900000001"
    region                   = "us-west-2"
    secret_id                = "arn:aws:secretsmanager:us-west-2:0000000000:secret:apparentlymart-test-password-blah-Lo78iA"
    secret_string_wo         = (write-only attribute)
    secret_string_wo_version = 1
    version_id               = "terraform-20251113011509414900000001"
    version_stages           = [
        "AWSCURRENT",
    ]
}

# memory.password_version:
resource "memory" "password_version" {
    add_to_value  = (write-only attribute)
    initial_value = (write-only attribute)
    new_value     = (write-only attribute)
    value         = 1
}
```

Notice that `secret_string_wo_version` has now incremented to 1, matching the updated value stored in the `memory` resource.

---

This is admittedly still pretty clunky, but I think it encapsulates the memory helper as well as we can within the constraints of implementing this as a provider.

One notable annoyance with it is that `ephemeral.random_password.new_password` gets "opened" on every run even though it's only used when the version number is changing. If this were a built-in language feature rather than just a provider with a managed resource type then we could solve that by having the memory object expose an additional ephemeral attribute `changing` which is true only when there's a pending change to the memory value, and then that could be used to conditionally enable the ephemeral resource:

```hcl
ephemeral "random_password" "new_password" {
  length = 24

  lifecycle {
    enabled = memory.password_version.changing
  }
}
```

A managed resource type cannot export an ephemeral value in today's OpenTofu, and so it isn't possible to achieve that within the bounds of what a provider can do. We could potentially decide to make something like this "memory" idea a built-in language feature to help fill that remaining gap, which [I previously investigated elsewhere](https://gist.github.com/apparentlymart/958704eda4fa8f7ce1c5ce22961b8089).

What I've implemented here can come _close_ to this by setting `enabled = var.reset_password`, but that would fail unless that variable were set on the initial creation round because we need a randomly-generated password unconditionally on the first round.

For this particular problem I think the most ideal design would be one that allows a resource type with write-only attributes, like `aws_secrets_manager_secret_version` in this example, to generate an explicit signal during planning that it intends to use the write-only attribute value during the apply step, and then we could expose a boolean value based on that which directly specifies whether the value is needed and therefore whether the ephemeral resource needs to be enabled. However, that would require a provider protocol change, whereas this prototype is focused on what we can achieve entirely within OpenTofu without changing the provider protocol.

---

Although it's not related to what motivated me to prototype this, there's also [an old Terraform community forum post](https://discuss.hashicorp.com/t/how-to-implement-sticky-variables-in-terraform/3439) that asks about "sticky" variables. That is both a potential additional use-case for this built-in provider and also an idea for another way to approach this as a built-in language feature: by allowing _variables themselves_ to optionally act as "memory" tracked in state.

