### PR TITLE
Mention in logs and version output when FIPS-140-3 mode is enabled

### DIFF
--- a/cmd/tofu/main.go
+++ b/cmd/tofu/main.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"context"
+	"crypto/fips140"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -128,6 +129,9 @@ func realMain() int {
 		log.Printf("[DEBUG] using %s %s", depMod.Path, depMod.Version)
 	}
 	log.Printf("[INFO] Go runtime version: %s", runtime.Version())
+	if fips140.Enabled() {
+		log.Printf("[WARNING] Go runtime FIPS 140-3 mode is enabled; OpenTofu is not supported in this configuration, which may cause undesirable behavior")
+	}
 	log.Printf("[INFO] CLI args: %#v", os.Args)
 	if experimentsAreAllowed() {
 		log.Printf("[INFO] This build of OpenTofu allows using experimental features")

--- a/internal/command/version.go
+++ b/internal/command/version.go
@@ -7,6 +7,7 @@ package command
 
 import (
 	"bytes"
+	"crypto/fips140"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -29,6 +30,7 @@ type VersionCommand struct {
 type VersionOutput struct {
 	Version            string            `json:"terraform_version"`
 	Platform           string            `json:"platform"`
+	FIPS140Enabled     bool              `json:"fips140,omitempty"`
 	ProviderSelections map[string]string `json:"provider_selections"`
 }
 
@@ -108,6 +110,7 @@ func (c *VersionCommand) Run(args []string) int {
 			Version:            versionOutput,
 			Platform:           c.Platform.String(),
 			ProviderSelections: selectionsOutput,
+			FIPS140Enabled:     fips140.Enabled(),
 		}
 
 		jsonOutput, err := json.MarshalIndent(output, "", "  ")
@@ -120,6 +123,9 @@ func (c *VersionCommand) Run(args []string) int {
 	} else {
 		c.Ui.Output(versionString.String())
 		c.Ui.Output(fmt.Sprintf("on %s", c.Platform))
+		if fips140.Enabled() {
+			c.Ui.Output("running in FIPS 140-3 mode (not yet supported)")
+		}
 
 		if len(providerVersions) != 0 {
 			sort.Strings(providerVersions)


### PR DESCRIPTION
Unfortunately the Go team has unilaterally decided that all programs built with Go 1.24 and later always allow enabling FIPS-140-3 mode -- both in its "on" and "only" configurations -- regardless of whether the authors of that software intend to support running in that restricted mode, or whether they are even testing their application in that configuration. The library checks the `GODEBUG` environment variable during early startup, before any of our code gets an opportunity to force it either on or off.

We have not yet made a final decision on how and whether we intend to support this mode in our official builds, but we _do_ know that current OpenTofu cannot function correctly with this mode enabled because it relies on standard library features and external libraries that are not available in that case.

Therefore in the meantime we'll mention explicitly in both the internal logs and in the `tofu version` output if we appear to be running in that mode, meaning that if someone tries to use it and finds that it doesn't work properly then if they open a GitHub issue and share those two artifacts (as requested by our bug report template) then we can know that we might need to turn on the special mode in order to reproduce the reported problem, rather than wasting time trying to reproduce it in the standard mode.

We do still need to make a final decision (in https://github.com/opentofu/opentofu/issues/2026) about what we want to do with this in the long run, but this is intended as an short-term compromise that allows folks to experiment with this unsupported mode if they wish while hopefully making it clearer that in the meantime we may deprioritize fixing problems that only occur when this unusual mode is enabled.

---

If this is accepted then I intend to also backport it to v1.11 branch so that the forthcoming v1.11.0 release will include these additional messages, and we'll carry these messages forward _at least_ through the whole v1.11.x series since the v1.12 series is the earliest time we'd possibly make the needed adjustments for OpenTofu to work properly in FIPS 140-3 mode.

This situation also applies to the OpenTofu v1.10 series, but I don't think it's worth the churn to backport this all the way there because folks are unlikely to upgrade to a new patch release only to get a new warning about something being unsupported.

I do not intend to add a changelog entry for this because it's primarily to help us in responding to bug reports, not something that end-users would directly care about.
