### PR TITLE
website: `tofu providers schema` `"nested_type"` docs

### DIFF
--- a/website/docs/cli/commands/providers/schema.mdx
+++ b/website/docs/cli/commands/providers/schema.mdx
@@ -125,6 +125,25 @@ A block representation contains "attributes" and "block_types" (which represent 
       // that the attribute's value must conform to.
       "type": "string",
 
+      // Some attributes use "nested_type" instead of "type",
+      // describing an object type or a collection of an object type
+      // in a similar way as for nested block types. This should take
+      // priority over "type" if both are present, but for most
+      // providers only one of the two attributes is returned.
+      "nested_type": {
+        // "nesting_mode" describes the nesting mode for the
+        // attribute value, with the same values as for
+        // the corresponding property in "block_types" below.
+        "nesting_mode": "list",
+
+        // "attributes" describes the attributes that are
+        // expected for each nested object, using the same
+        // structure as the top-level "attributes" property.
+        "attributes": {
+          // ...
+        }
+      },
+
       // "description" is an English-language description of
       // the purpose and usage of the attribute.
       "description": "string",


### PR DESCRIPTION
At some point after this documentation was originally written the schema structure grew to include the possibility of structural attribute types, represented using "nested_type" instead of "type" in the attribute definition, but it seems that the documentation was not updated to mention that.

This is just a minimal extra note about that focused mainly on just acknowledging that this possibility exists at all, in case anyone is relying on these docs to build something to parse this format. It would probably be helpful to expand both this and the existing documentation to specify the format more precisely, but my focus here is just on quickly filling in this missing piece so that the documentation is complete, even if not detailed and precise.

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
