### PR TITLE
main: Warn in logs if `GODEBUG` environment variable is set

### DIFF
--- a/cmd/tofu/main.go
+++ b/cmd/tofu/main.go
@@ -129,8 +129,11 @@ func realMain() int {
 		log.Printf("[DEBUG] using %s %s", depMod.Path, depMod.Version)
 	}
 	log.Printf("[INFO] Go runtime version: %s", runtime.Version())
+	if dynamicGodebug := os.Getenv("GODEBUG"); dynamicGodebug != "" {
+		log.Printf("[WARN] GODEBUG environment variable is set to %q, which may activate unsupported and untested behavior", dynamicGodebug)
+	}
 	if fips140.Enabled() {
-		log.Printf("[WARNING] Go runtime FIPS 140-3 mode is enabled; OpenTofu is not supported in this configuration, which may cause undesirable behavior")
+		log.Printf("[WARN] Go runtime FIPS 140-3 mode is enabled; OpenTofu is not supported in this configuration, which may cause undesirable behavior")
 	}
 	log.Printf("[INFO] CLI args: %#v", os.Args)
 	if experimentsAreAllowed() {


### PR DESCRIPTION
The `GODEBUG` environment variable is a side-channel that allows dynamically opting in to a million billion different variations of Go runtime and standard library behavior, and we can obviously not routinely test OpenTofu's behavior across all of those different variations.

Some of these differences are subtle, such as slight tweaks to how TLS clients negotiate algorithms with servers, and others have more substantial effects such as making parts of the standard library panic immediately when called. There are too many of these settings for us to review them all, and even if we could the documentation for them is often vague and difficult for a non-expert to understand the full implications.

Just in case someone encounters a problem caused by running OpenTofu with a combination of settings that are not enabled in our default build configuration, we'll include an explicit note in the logs so that we can tell when we're investigating a bug report that it might only be reproducible when the Go runtime behavior has been overridden in this way, and so that someone debugging their own problem can notice that they are using OpenTofu in an unsupported way and could potentially solve their own problem by unsetting that environment variable.

This is a generalization of the previous addition of a log message when running in FIPS 140-3 mode, which is also updated here to use `[WARN]` instead of `[WARNING]` as the prefix because our logging system does not actually understand "WARNING" as a valid prefix. Keeping the separate specialized message for FIPS 140-3 mode is warranted because we _know_ that OpenTofu does not behave as intended when that mode is enabled, while we've not tested with any other combination of settings so we cannot predict whether they will cause misbehavior or not.

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
