### PR TITLE
Remove nil check that was returning nil schema for actual existing resources

### DIFF
--- a/internal/tofu/schemas.go
+++ b/internal/tofu/schemas.go
@@ -51,9 +51,6 @@ func (ss *Schemas) ProviderConfig(provider addrs.Provider) *configschema.Block {
 // redundant.
 func (ss *Schemas) ResourceTypeConfig(provider addrs.Provider, resourceMode addrs.ResourceMode, resourceType string) (block *configschema.Block, schemaVersion uint64) {
 	ps := ss.ProviderSchema(provider)
-	if ps.ResourceTypes == nil {
-		return nil, 0
-	}
 	return ps.SchemaForResourceType(resourceMode, resourceType)
 }
 


### PR DESCRIPTION
The nil check removed was buggy in the sense that for a provider with no managed resource schemas, it would have returned nil schema for existing data or ephemeral resources.
The only reason why this didn't create issues was that in the proto layer, when the schema is retrieved from the provider, the managed resource map was always initialised. ([proto5](https://github.com/opentofu/opentofu/blob/82fdad27fcea6654fed8f1084d94223a7e6043c5/internal/plugin/grpc_provider.go#L129) and [proto6](https://github.com/opentofu/opentofu/blob/82fdad27fcea6654fed8f1084d94223a7e6043c5/internal/plugin6/grpc_provider.go#L129))

Initially I added the unit test visible in this PR and then removed the check. As expected, the tests were failing in the expected fashion:
<img width="630" height="439" alt="image" src="https://github.com/user-attachments/assets/62de3d44-2c70-4fd6-a244-da093a5751b2" />

<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves _no issue existing for this as it was discovered during ephemeral implementation_

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
