### PR TITLE
Backports[v1.11]: fix: use variables at `enabled` in nested modules 

### DIFF
--- a/internal/tofu/node_module_expand.go
+++ b/internal/tofu/node_module_expand.go
@@ -147,17 +147,7 @@ func (n *nodeExpandModule) Execute(ctx context.Context, evalCtx EvalContext, op 
 			expander.SetModuleForEach(module, call, forEach)
 
 		case n.ModuleCall.Enabled != nil:
-			// For enabled expressions, we need to evaluate in the parent module context
-			// since the expression may reference variables defined in the parent module. e.g.
-			// variable "on" { type = bool }
-			// module "mod1" {
-			// 	 source = "./mod1"
-			// 	 lifecycle {
-			// 	   enabled = var.on
-			// 	 }
-			// }
-			parentEvalCtx := evalCtx.WithPath(module.Parent())
-			enabled, enDiags := evaluateEnabledExpression(ctx, n.ModuleCall.Enabled, parentEvalCtx)
+			enabled, enDiags := evaluateEnabledExpression(ctx, n.ModuleCall.Enabled, evalCtx)
 			diags = diags.Append(enDiags)
 			if diags.HasErrors() {
 				return diags


### PR DESCRIPTION
Backporting https://github.com/opentofu/opentofu/pull/3475 to v1.11.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
