### PR TITLE
CHANGELOG: Support for v1.11 ends in August 2026

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+The v1.11.x release series supported until **August 1 2026**.
+
 ## 1.11.0 (Unreleased)
 
 This release has some changes that might require special attention when upgrading from an earlier release. Refer to "UPGRADE NOTES" below for more information.


### PR DESCRIPTION
We're intending to explicitly document the end of support for each of our release series moving forward, starting with the v1.11.x series here.

This seemingly-arbitrary cutoff is actually aligned with the date when Go v1.25 is expected to reach end of security support, since we cannot feasibly provide security support longer than the language and standard library that OpenTofu's functionality depends on. We don't know exactly what day of August the Go release will land on, so this conservatively specifies August 1st while leaving us the option of providing additional weeks of support in August depending on when exactly the Go release happens.

(We are intending to say more about this in an updated `SECURITY.md` in a forthcoming PR, but doing this work a little out of order just because the v1.11 release is imminent and we want to be explicit about its security period as part of publishing the final release.)