### PR TITLE
Fix nil pointer dereference in config filtering

### DIFF
--- a/internal/configs/configschema/filter.go
+++ b/internal/configs/configschema/filter.go
@@ -57,7 +57,7 @@ func (b *Block) Filter(filterAttribute FilterT[*Attribute], filterBlock FilterT[
 			ret.Attributes[name] = &attr
 		}
 
-		if attr.NestedType != nil {
+		if ret.Attributes[name] != nil && attr.NestedType != nil {
 			ret.Attributes[name].NestedType = filterNestedType((&attr).NestedType, filterAttribute)
 		}
 	}

--- a/internal/configs/configschema/filter_test.go
+++ b/internal/configs/configschema/filter_test.go
@@ -176,6 +176,18 @@ func TestFilter(t *testing.T) {
 							Nesting: NestingList,
 						},
 					},
+					"read_only_nested": {
+						NestedType: &Object{
+							Attributes: map[string]*Attribute{
+								"string": {
+									Type:     cty.String,
+									Optional: true,
+								},
+							},
+							Nesting: NestingList,
+						},
+						Computed: true,
+					},
 				},
 
 				BlockTypes: map[string]*NestedBlock{


### PR DESCRIPTION
Do not try to filter `NestedType` if the attribute has already been filtered out.

<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves #3555 

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
