### PR TITLE
Use root context when evaluating import.id expressions

### DIFF
--- a/internal/tofu/context_import.go
+++ b/internal/tofu/context_import.go
@@ -147,12 +147,12 @@ func (ri *ImportResolver) ValidateImportIDs(ctx context.Context, importTarget *I
 		}
 
 		for _, keyData := range repetitions {
-			evalDiags = validateImportIdExpression(importTarget.Config.ID, evalCtx, keyData)
+			evalDiags = validateImportIdExpression(importTarget.Config.ID, rootCtx, keyData)
 			diags = diags.Append(evalDiags)
 		}
 	} else {
 		// The import target is singular, no need to expand
-		evalDiags := validateImportIdExpression(importTarget.Config.ID, evalCtx, EvalDataForNoInstanceKey)
+		evalDiags := validateImportIdExpression(importTarget.Config.ID, rootCtx, EvalDataForNoInstanceKey)
 		diags = diags.Append(evalDiags)
 	}
 

--- a/internal/tofu/context_validate_test.go
+++ b/internal/tofu/context_validate_test.go
@@ -2641,3 +2641,113 @@ func TestContext2Validate_importWithForEachOnUnknown(t *testing.T) {
 		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
 	}
 }
+
+func TestContext2Validate_importIntoModuleResource(t *testing.T) {
+	// This test checks that whenever an import is performed into a module resource
+	// the right context is used to evaluate the variables used in the "import" block.
+	// This was added to double check a bug that was discovered in [ImportResolver#ValidateImportIDs]
+	// where the context used for evaluating the `id` expression was wrong (the rootCtx was meant to be
+	// used but was used the node context instead)
+	// Related to: https://github.com/opentofu/opentofu/issues/3562
+	cases := map[string]map[string]string{
+		"direct import": {
+			"mod/main.tf": `
+					variable "mod_var" {
+					  type = string
+					}
+					resource "test_object" "a" {
+						test_string = var.mod_var
+					}
+		`,
+			"main.tf": `
+					variable "root_var" {
+					  type    = string
+					  default = "test"
+					}
+		
+					module "call" {
+					  source  = "./mod"
+					  mod_var = var.root_var
+					}
+		
+					import {
+					  to = module.call.test_object.a
+					  id = var.root_var
+					}
+		`,
+		},
+		"import with for_each": {
+			"mod/main.tf": `
+					variable "mod_var" {
+					  type = string
+					}
+					resource "test_object" "a" {
+						test_string = var.mod_var
+					}
+		`,
+			"main.tf": `
+					variable "root_var" {
+					  type    = string
+					  default = "test"
+					}
+		
+					module "call" {
+					  source  = "./mod"
+					  mod_var = var.root_var
+                      for_each = toset(["0"])
+					}
+		
+					import {
+					  to = module.call[each.key].test_object.a
+					  id = var.root_var
+                      for_each = toset(["0"])
+					}
+		`,
+		},
+	}
+	p := simpleMockProvider()
+	hook := new(MockHook)
+	ctx := testContext2(t, &ContextOpts{
+		Hooks: []Hook{hook},
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+	p.ReadResourceFn = func(request providers.ReadResourceRequest) providers.ReadResourceResponse {
+		return providers.ReadResourceResponse{
+			NewState: cty.ObjectVal(map[string]cty.Value{
+				"test_string": cty.StringVal("foo"),
+				"test_number": cty.NullVal(cty.Number),
+				"test_bool":   cty.NullVal(cty.Bool),
+				"test_list":   cty.NullVal(cty.List(cty.String)),
+				"test_map":    cty.NullVal(cty.Map(cty.String)),
+			}),
+		}
+	}
+	p.ImportResourceStateFn = func(request providers.ImportResourceStateRequest) providers.ImportResourceStateResponse {
+		return providers.ImportResourceStateResponse{
+			ImportedResources: []providers.ImportedResource{
+				{
+					TypeName: "test_object",
+					State: cty.ObjectVal(map[string]cty.Value{
+						"test_string": cty.StringVal("foo"),
+						"test_number": cty.NullVal(cty.Number),
+						"test_bool":   cty.NullVal(cty.Bool),
+						"test_list":   cty.NullVal(cty.List(cty.String)),
+						"test_map":    cty.NullVal(cty.Map(cty.String)),
+					}),
+				},
+			},
+		}
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			m := testModuleInline(t, tt)
+			diags := ctx.Validate(context.Background(), m)
+			if diags.HasErrors() {
+				t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
When evaluating the "id" field of an import block, the context to be used where the information is resolved from, should be the root context.

This commit fixes that and adds unit tests to validate the behavior.

<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves #3562

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
