### PR TITLE
tools/find-dep-upgrades: Clustering of interdependent upgrades, and general simplification

### DIFF
--- a/tools/find-dep-upgrades/model.go
+++ b/tools/find-dep-upgrades/model.go
@@ -15,6 +15,9 @@ import (
 // ModulePath is a string containing a Go module path.
 type ModulePath string
 
+// ModulePaths represents an unordered set of [ModulePath] values.
+type ModulePaths map[ModulePath]struct{}
+
 // Version is a convenience alias for [versions.Version]
 type Version = versions.Version
 
@@ -30,6 +33,14 @@ type PendingUpgrade struct {
 	LatestVersion  Version
 	Prereqs        map[ModulePath]Version
 }
+
+// PendingUpgradeCluster is one or more [PendingUpgrade] which need to happen
+// as a single unit.
+//
+// Clusters with more than one upgrade result from dependency cycles between
+// the modules, making it impossible to upgrade one without also upgrading
+// the others.
+type PendingUpgradeCluster []PendingUpgrade
 
 func parseVersion(raw string) (Version, error) {
 	if !strings.HasPrefix(raw, "v") {


### PR DESCRIPTION
This is the tool I regularly use when I have a small amount of time to spare and want to take care of a few easy dependency upgrade tasks. For example, it's what prompted me to recently propose https://github.com/opentofu/opentofu/pull/3560, https://github.com/opentofu/opentofu/pull/3561, and https://github.com/opentofu/opentofu/pull/3573.

My original motivation in writing it was to untangle the huge mess of stale dependencies we'd accumulated by just getting them into a _rough_ order where I could work through them gradually without upgrading too many things at once, and so I designed it to make a best-effort topological sort by just deleting edges heuristically until the dependency graph became acyclic and then sorting that slightly-pruned graph.

Now that we've got the dependency situation under better control, two new questions have become far more relevant to my regular use of this tool:

- **What can be upgraded in isolation without affecting anything else?**

    We tend to need to carefully review the changes in our dependencies when we upgrade in case we need to describe the effects of those changes in our own changelog, and so it's helpful to upgrade as little as possible in each PR.

    Therefore I always start with the modules that don't depend on upgrading anything else first -- the set that I call the "ready upgrades" in the code. The output also includes the "blocked" upgrades in a topological order just because that's sometimes helpful in deciding which of the ready upgrades to work on first, to unblock as many blocked upgrades as possible.

- **Which collections of modules need to be upgraded together because they are all interdependent?**

    Now I have some experience with doing this a few times I've learned that the `golang.org/x/...` and `go.opentelemetry.io/otel/...` families of modules are the main culprits here because the maintainers tend to bump their inderdependencies regularly so they tend to all need to be upgraded together every time any one member changes.

    I was previously figuring out the necessary groupings myself by reading the dependencies in the output, with results like https://github.com/opentofu/opentofu/pull/3561, but it's far easier to have the computer do it. :grinning: 

The previous version of this dealt with the first question indirectly by just inserting a dividing line before the first module that had prerequisites so it was easy to see which ones were ready to perform, and it didn't deal with the second question at all.

This new version is focused mainly on answering those two questions, and so first it finds any strongly-connected components with more than one member ("cycles") and reduces them to a single graph node, and then does all of the remaining work based on those groups so that families of interdependent modules now just get handled together.

As before this is focused on being minimally functional and useful rather than being efficient or well-designed, since this is just an optional helper I use to keep on top of dependency upgrades on a best-effort basis. I'm proposing to merge this into `main` largely just because I've been repeatedly rebasing a local branch containing these updates for a while now and it's getting kinda tedious!

I have no expectation that anyone else should be regularly running this, though if anyone else wants to occasionally work on dependency upgrades I hope it will be useful to them too.
