### PR TITLE
rfc: Improvements for Contribution Documents

### DIFF
--- a/rfc/20251211-contribution-docs.md
+++ b/rfc/20251211-contribution-docs.md
@@ -40,7 +40,7 @@ A casual contributor should, at a glance, be able to understand all expectations
 
 Note that none of those guidelines are specific to any development. We may have some development guidelines which are in a supervised repository's `CONTRIBUTING.md`. However, if those were moved to their own document, then `CONTRIBUTING.md` could be standardized and mostly identical across all supervised repositories.
 
-This also means that [any fixes](https://github.com/opentofu/org/issues/26) done to `CONTRIBUTING.md` and `MAINTAINERS.md` could propagate across all relevant repositories.
+This also means that [any fixes](https://github.com/opentofu/org/issues/26) done to some central `CONTRIBUTING.md` and `MAINTAINERS.md` documents in `org` could be referred to across all relevant repositories.
 
 We may also want to list different ways to contribute that [may not include code](https://opensource.guide/how-to-contribute/#what-it-means-to-contribute), or code contributions ancillary to the main repository (like CI/CD).
 


### PR DESCRIPTION
[Read the RFC](https://github.com/opentofu/opentofu/blob/contribution_rfc/rfc/20251211-contribution-docs.md)

Back in late October 2025, @cam72cam and I went through each of the (non-forked) repositories in the `opentofu` GitHub organization and made some notes for improvements. I cobbled together a set of issues, but the general feedback was that they all seemed fairly unrelated. It was requested that an RFC be made, for the sake of understanding the greater context and having a venue to provide feedback on the overall direction of this effort.

All but one of these issues are related to community outreach. I've included a profile for the platonic "casual contributor" based on some admittedly perfunctory research. I believe that casual contributors are the first step towards more long-term contributors, and that improving our efforts to court this type of developer will increase the size of the funnel, so to speak.

This also includes the issue about maintaining forks, which is unrelated but still part of the repository upkeep tracker I made back in October. I don't know whether it needs to be included here, but I thought it worth a mention, if only to cross my "t"s and dot my "i"s.