### PR TITLE
version: Update which dependencies we consider "interesting"

### DIFF
--- a/cmd/tofu/main.go
+++ b/cmd/tofu/main.go
@@ -125,8 +125,10 @@ func realMain() int {
 	}
 
 	log.Printf("[INFO] OpenTofu version: %s %s", Version, VersionPrerelease)
-	for _, depMod := range version.InterestingDependencies() {
-		log.Printf("[DEBUG] using %s %s", depMod.Path, depMod.Version)
+	if logging.IsDebugOrHigher() {
+		for _, depMod := range version.InterestingDependencies() {
+			log.Printf("[DEBUG] using %s %s", depMod.Path, depMod.Version)
+		}
 	}
 	log.Printf("[INFO] Go runtime version: %s", runtime.Version())
 	if dynamicGodebug := os.Getenv("GODEBUG"); dynamicGodebug != "" {

--- a/version/dependencies.go
+++ b/version/dependencies.go
@@ -11,15 +11,18 @@ import "runtime/debug"
 // intended to mean here. We should keep this set relatively small to avoid
 // bloating the logs too much.
 var interestingDependencies = map[string]struct{}{
-	"github.com/hashicorp/hcl/v2":            {},
-	"github.com/zclconf/go-cty":              {},
-	"github.com/hashicorp/go-tfe":            {},
-	"github.com/hashicorp/terraform-svchost": {},
+	"github.com/opentofu/provider-client":     {},
+	"github.com/opentofu/registry-address/v2": {},
+	"github.com/opentofu/svchost":             {},
+	"github.com/hashicorp/go-getter":          {},
+	"github.com/hashicorp/hcl":                {},
+	"github.com/hashicorp/hcl/v2":             {},
+	"github.com/zclconf/go-cty":               {},
 }
 
 // InterestingDependencies returns the compiled-in module version info for
-// a small number of dependencies that Terraform uses broadly and which we
-// tend to upgrade relatively often as part of improvements to Terraform.
+// a small number of dependencies that OpenTofu uses broadly and which we
+// tend to upgrade relatively often as part of improvements to OpenTofu.
 //
 // The set of dependencies this reports might change over time if our
 // opinions change about what's "interesting". This is here only to create


### PR DESCRIPTION
`InterestingDependencies` is used to include version information in our `TF_LOG=debug` logs for a small subset of our dependencies whose behavior is directly exposed in the OpenTofu UX, such as including a parser for some syntax that OpenTofu relies on and that is covered by our compatibility promises.

Unfortunately we recently switched to using our own forks of certain libraries and hadn't updated this to match, so the corresponding logs had become less complete. This updates those to the dependencies we actually use, and also adds a few new ones that have similar characteristics.

We'll also now skip calling `InterestingDependencies` altogether if the log level isn't high enough for the results to be visible, since that avoids us wasting time generating a data structure that will not be used.

There is no changelog entry because these logs are primarily for maintainers' own benefit, when folks share their trace logs as part of opening a bug report issue.

---

Note that this intentionally continues to refer to `github.com/hashicorp/hcl/v2` because the `InterestingDependencies` function first matches by the primary module path we depend on and then detects if a `replace` directive is present for it, so this _will_ actually report `github.com/opentofu/hcl/v2` in the logs in practice.
