### PR TITLE
addrs: Target is a fmt.Stringer

### DIFF
--- a/internal/addrs/parse_target.go
+++ b/internal/addrs/parse_target.go
@@ -445,3 +445,10 @@ func (t *Target) ModuleAddr() ModuleInstance {
 		panic(fmt.Sprintf("unsupported target address type %T", addr))
 	}
 }
+
+func (t *Target) String() string {
+	if t == nil || t.Subject == nil {
+		return "<nil>"
+	}
+	return t.Subject.String()
+}


### PR DESCRIPTION
We have some test code that includes `*addrs.Target` values in `fmt` calls with the `%s` and `%q` verbs, but that type was not actually a `fmt.Stringer` before.

Go 1.26 is introducing some new checks that cause those uses to cause failures when building those tests. We could potentially change the tests to produce the string representation in a different way, but we typically expect our address types to be "stringable" like this, so instead we'll just make Target be a `fmt.Stringer`, delegating to the `String` method of the underlying `addrs.Targetable` implementation. The `addrs.Targetable` interface requires a `String` method, so all implementations are guaranteed to support this.

Note that we're not actually using Go 1.26 yet at the time of this commit, but this is an early fix to make the upgrade easier later. I verified this using go1.26rc1.
