### PR TITLE
CHANGELOG: Upgrade note about macOS 12 Monterey support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 UPGRADE NOTES:
 
+- This is the last OpenTofu release series that will support macOS 12 Monterey. We expect that OpenTofu v1.13 will require macOS 13 Ventura or later.
 - On Unix systems OpenTofu now considers the `BROWSER` environment variable as a possible override for the default behavior for launching a web browser.
 
     If you run OpenTofu in a context where an environment variable of that name is already set, it may cause OpenTofu to now open a web browser in a different way than previous versions would have. Unsetting that environment variable will restore the previous platform-specific behavior.


### PR DESCRIPTION
The Go team has preannounced that they will stop supporting macOS 12 in Go 1.27, which is likely to be the Go release we'll use for OpenTofu v1.13.

Therefore we'll echo the Go team's preannouncement by making our own equivalent preannouncement.
