### PR TITLE
lint: reintroduce ST1005 static check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,7 @@ linters:
     staticcheck:
       # For now, we will disable some static checks to match golang-ci-lint@v1 functionality.
       # These should be addressed once the --new-from-rev work is taken care of.
-      checks: ["all", "-QF1008", "-ST1003", "-ST1005", "-ST1012", "-ST1016"]
+      checks: ["all", "-QF1008", "-ST1003", "-ST1012", "-ST1016"]
   exclusions:
     generated: lax
     presets:


### PR DESCRIPTION
This draft pull request for removing a linter static check exclusion is for demonstration purposes only.

For the sake of user friendliness, we capitalize some errors and add punctuation at the end as well. This chafes against [ST1005](https://staticcheck.dev/docs/checks/#ST1005), which is concerned with the composability of error messages. I will recommend a couple different paths:

- Maintain the status quo: keep this linter disabled.
- Adjust all error messages to conform to Golang best practices, and modify error messages as complete sentences when they reach a system/user interface.

I have my preference, but I'll keep it close to the vest for the sake of healthy conversation.