### PR TITLE
lint: reintroduce ST1003 static check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,7 @@ linters:
     staticcheck:
       # For now, we will disable some static checks to match golang-ci-lint@v1 functionality.
       # These should be addressed once the --new-from-rev work is taken care of.
-      checks: ["all", "-QF1008", "-ST1003", "-ST1005", "-ST1012", "-ST1016"]
+      checks: ["all", "-QF1008", "-ST1005", "-ST1012", "-ST1016"]
   exclusions:
     generated: lax
     presets:


### PR DESCRIPTION
This draft pull request for removing a linter static check exclusion is for demonstration purposes only. None of the violations to [ST1003](https://staticcheck.dev/docs/checks/#ST1003) have been fixed in this PR.