### PR TITLE
docs: Document and test logical operator short-circuiting (Fixes #3501)

### DIFF
--- a/internal/command/testdata/test/short_circuit_validation/main.tf
+++ b/internal/command/testdata/test/short_circuit_validation/main.tf
@@ -1,0 +1,8 @@
+variable "foo" {
+  default = null
+  type    = object({ bar = optional(bool, true) })
+  validation {
+    condition     = (var.foo == null || var.foo.bar)
+    error_message = "Error! bar should be true!"
+  }
+}

--- a/internal/command/testdata/test/short_circuit_validation/main.tftest.hcl
+++ b/internal/command/testdata/test/short_circuit_validation/main.tftest.hcl
@@ -1,0 +1,16 @@
+variables {
+  foo = null
+}
+
+run "valid_when_null" {
+  command = plan
+}
+
+run "valid_when_true" {
+  command = plan
+  variables {
+    foo = {
+      bar = true
+    }
+  }
+}

--- a/website/docs/language/expressions/custom-conditions.mdx
+++ b/website/docs/language/expressions/custom-conditions.mdx
@@ -30,6 +30,10 @@ Add one or more `validation` blocks within the `variable` block to specify custo
 
 If the condition evaluates to `false`, OpenTofu produces an [error message](#error-messages) that includes the result of the `error_message` expression. If you declare multiple validations, OpenTofu returns error messages for all failed conditions.
 
+:::note
+The [logical operators](operators.mdx#logical-operators) used in condition expressions are short-circuiting. This allows you to safely check for optional values without causing errors. For example, `var.foo == null || var.foo.bar` will not error if `var.foo` is `null`.
+:::
+
 The following example checks whether the AMI ID has valid syntax.
 
 ```hcl


### PR DESCRIPTION
Fixes #3501. This PR adds a regression test for the short-circuiting behavior of logical operators in validation blocks and explicitly documents this behavior in the custom conditions validation guide to prevent future confusion.

<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves # 

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [X] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [X] I have not used an AI coding assistant to create this PR.
- [X] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [X] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [X] I have run golangci-lint on my change and receive no errors relevant to my code.
- [X] I have run existing tests to ensure my code doesn't break anything.
- [X] I have added tests for all relevant use cases of my code, and those tests are passing.
- [X] I have only exported functions, variables and structs that should be used from other packages.
- [X] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [X] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.