### PR TITLE
website: Boolean operator short-circuit was added in OpenTofu v1.10

### DIFF
--- a/website/docs/language/expressions/operators.mdx
+++ b/website/docs/language/expressions/operators.mdx
@@ -103,4 +103,8 @@ OpenTofu does not have an operator for the "exclusive OR" operation. If you
 know that both operators are boolean values then exclusive OR is equivalent
 to the `!=` ("not equal") operator.
 
-The logical operators in OpenTofu are short-circuiting, meaning `var.foo == null || var.foo.bar == 1` will not produce an error message if `var.foo` is `null` because `var.foo.bar` is not evaluated.
+In OpenTofu v1.10 and later the logical operators in OpenTofu are
+short-circuiting, meaning `var.foo == null || var.foo.bar == 1` will not produce
+an error message if `var.foo` is `null` because `var.foo.bar` is not evaluated.
+Any skipped expression is still subject to static validation, such as checking
+whether there's a `variable "foo"` block that `var.foo` refers to.


### PR DESCRIPTION
Although we don't typically mention the behavior of older versions in our docs, the lack of support for short-circuit operators in older OpenTofu versions is a subtle behavior difference that module authors will need to keep in mind if they want to be portable to older OpenTofu versions.

While in the area anyway this also adds an extra note to clarify that only dynamic expression evaluation is skipped by short-circuit, and so static validation such as whether references are valid still occurs. We know from previous experience with language features like [the `try` function](https://opentofu.org/docs/language/functions/try/) that some authors are not aware of OpenTofu's distinction between static checks and evaluation, so this will hopefully give a reader a clue that there's a difference between these without including an overwhelming amount of detail about it.

Finally, this paragraph is now hard-wrapped to match the other paragraphs in the file, since it was previously inconsistent.

Closes https://github.com/opentofu/opentofu/issues/3501

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
