### PR TITLE
go.mod: List our own tools in the "tools" directive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ generate:
 # versions of protoc and the protoc Go plugins.
 .PHONY: protobuf
 protobuf:
-	go run ./tools/protobuf-compile .
+	go tool protobuf-compile .
 
 # Golangci-lint is installed first and then run twice to cover all platforms.
 .PHONY: golangci-lint

--- a/go.mod
+++ b/go.mod
@@ -324,6 +324,10 @@ replace github.com/hashicorp/hcl/v2 v2.20.1 => github.com/opentofu/hcl/v2 v2.20.
 tool (
 	github.com/hashicorp/copywrite
 	github.com/mitchellh/gox
+	github.com/opentofu/opentofu/cmd/tofu
+	github.com/opentofu/opentofu/tools/find-dep-upgrades
+	github.com/opentofu/opentofu/tools/loggraphdiff
+	github.com/opentofu/opentofu/tools/protobuf-compile
 	go.uber.org/mock/mockgen
 	golang.org/x/tools/cmd/stringer
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc

--- a/tools/protobuf-compile/protobuf-compile.go
+++ b/tools/protobuf-compile/protobuf-compile.go
@@ -69,7 +69,7 @@ var protocSteps = []protocStep{
 
 func main() {
 	if len(os.Args) != 2 {
-		log.Fatal("Usage: go run github.com/opentofu/opentofu/tools/protobuf-compile <basedir>")
+		log.Fatal("Usage: go tool protobuf-compile <basedir>")
 	}
 	baseDir := os.Args[1]
 	workDir := filepath.Join(baseDir, "tools/protobuf-compile/.workdir")


### PR DESCRIPTION
We previously adopted the new "tools" mechanism for the third-party tools we use for go:generate, etc. However, it's also acceptable to include tools from our own module in this list, which then makes it possible to run them using the same "go tool" shorthand.

For example, it's now possible to run `go tool protobuf-compile` to rebuild the protocol buffers schemas, or `go tool tofu` as a shorthand way to compile and run OpenTofu CLI itself.

It still remains possible to run these tools in the same ways they used to work. This is just a new way to get the same results through a more modern Go toolchain feature. The specified tools are also now discoverable by running `go tool` with no arguments.

This doesn't change anything about the user-visible behavior of OpenTofu, so no changelog entry is needed.
