### PR TITLE
Implement resource identity support

### DIFF
--- a/internal/backend/local/testing.go
+++ b/internal/backend/local/testing.go
@@ -69,10 +69,14 @@ func TestLocalProvider(t *testing.T, b *Local, name string, schema providers.Pro
 			return resp
 		}
 
-		rSchema, _ := schema.SchemaForResourceType(addrs.ManagedResourceMode, req.TypeName)
-		if rSchema == nil {
-			rSchema = &configschema.Block{} // default schema is empty
+		var rSchema configschema.Block
+		rSchemaForType, _ := schema.SchemaForResourceType(addrs.ManagedResourceMode, req.TypeName)
+		if rSchemaForType == nil {
+			rSchema = configschema.Block{} // default schema is empty
+		} else {
+			rSchema = *rSchemaForType.Block
 		}
+
 		plannedVals := map[string]cty.Value{}
 		for name, attrS := range rSchema.Attributes {
 			val := req.ProposedNewState.GetAttr(name)
@@ -111,7 +115,6 @@ func TestLocalProvider(t *testing.T, b *Local, name string, schema providers.Pro
 	}, nil)
 
 	return p
-
 }
 
 // TestLocalSingleState is a backend implementation that wraps Local

--- a/internal/builtin/providers/tf/provider.go
+++ b/internal/builtin/providers/tf/provider.go
@@ -51,10 +51,6 @@ func (p *Provider) GetProviderSchema(_ context.Context) providers.GetProviderSch
 	}
 }
 
-// GetResourceIdentitySchemas fetches the identity schemas for terraform_data
-func (p *Provider) GetResourceIdentitySchemas(context.Context) providers.GetResourceIdentitySchemasResponse {
-	return providers.GetResourceIdentitySchemasResponse{}
-}
 
 // ValidateProviderConfig is used to validate the configuration values.
 func (p *Provider) ValidateProviderConfig(_ context.Context, req providers.ValidateProviderConfigRequest) providers.ValidateProviderConfigResponse {

--- a/internal/builtin/providers/tf/provider.go
+++ b/internal/builtin/providers/tf/provider.go
@@ -11,10 +11,11 @@ import (
 	"log"
 	"strings"
 
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/encryption"
 	"github.com/opentofu/opentofu/internal/providers"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // Provider is an implementation of providers.Interface
@@ -37,7 +38,7 @@ func (p *Provider) getFunctionSpecs() map[string]providers.FunctionSpec {
 	return funcSpecs
 }
 
-// GetSchema returns the complete schema for the provider.
+// GetProviderSchema returns the complete schema for the provider.
 func (p *Provider) GetProviderSchema(_ context.Context) providers.GetProviderSchemaResponse {
 	return providers.GetProviderSchemaResponse{
 		DataSources: map[string]providers.Schema{
@@ -48,6 +49,11 @@ func (p *Provider) GetProviderSchema(_ context.Context) providers.GetProviderSch
 		},
 		Functions: p.getFunctionSpecs(),
 	}
+}
+
+// GetResourceIdentitySchemas fetches the identity schemas for terraform_data
+func (p *Provider) GetResourceIdentitySchemas(context.Context) providers.GetResourceIdentitySchemasResponse {
+	return providers.GetResourceIdentitySchemasResponse{}
 }
 
 // ValidateProviderConfig is used to validate the configuration values.
@@ -160,6 +166,10 @@ func (p *Provider) Stop(_ context.Context) error {
 // result is used for any further processing.
 func (p *Provider) UpgradeResourceState(_ context.Context, req providers.UpgradeResourceStateRequest) providers.UpgradeResourceStateResponse {
 	return upgradeDataStoreResourceState(req)
+}
+
+func (p *Provider) UpgradeResourceIdentity(context.Context, providers.UpgradeResourceIdentityRequest) providers.UpgradeResourceIdentityResponse {
+	return providers.UpgradeResourceIdentityResponse{}
 }
 
 // ReadResource refreshes a resource and returns its current state.

--- a/internal/builtin/providers/tf/resource_data.go
+++ b/internal/builtin/providers/tf/resource_data.go
@@ -9,11 +9,12 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-uuid"
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
+
 	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
-	ctyjson "github.com/zclconf/go-cty/cty/json"
 )
 
 func dataStoreResourceSchema() providers.Schema {
@@ -66,7 +67,6 @@ func nullResourceSchema() providers.Schema {
 			},
 		},
 	}
-
 }
 
 func moveDataStoreResourceState(req providers.MoveResourceStateRequest) providers.MoveResourceStateResponse {
@@ -206,8 +206,9 @@ func applyDataStoreResourceChange(req providers.ApplyResourceChangeRequest) (res
 // once the configuration is available during import.
 func importDataStore(req providers.ImportResourceStateRequest) (resp providers.ImportResourceStateResponse) {
 	schema := dataStoreResourceSchema()
+
 	v := cty.ObjectVal(map[string]cty.Value{
-		"id": cty.StringVal(req.ID),
+		"id": cty.StringVal(req.Target.ID),
 	})
 	state, err := schema.Block.CoerceValue(v)
 	resp.Diagnostics = resp.Diagnostics.Append(err)

--- a/internal/command/jsonconfig/config.go
+++ b/internal/command/jsonconfig/config.go
@@ -563,7 +563,7 @@ func marshalResources(resources map[string]*configs.Resource, schemas *tofu.Sche
 				return nil, fmt.Errorf("no schema found for %s (in provider %s)", v.Addr().String(), v.Provider)
 			}
 			r.SchemaVersion = &schemaVer
-			r.Expressions = marshalExpressions(v.Config, schema)
+			r.Expressions = marshalExpressions(v.Config, schema.Block)
 		}
 
 		// Managed is populated only for Mode = addrs.ManagedResourceMode

--- a/internal/command/jsonentities/diagnostic.go
+++ b/internal/command/jsonentities/diagnostic.go
@@ -381,7 +381,6 @@ func newDiagnosticDifference(diag tfdiags.Diagnostic) *jsonplan.Change {
 	}
 
 	return change
-
 }
 
 func newDiagnosticExpressionValues(diag tfdiags.Diagnostic) []DiagnosticExpressionValue {

--- a/internal/command/jsonentities/importing.go
+++ b/internal/command/jsonentities/importing.go
@@ -5,6 +5,8 @@
 
 package jsonentities
 
+import "encoding/json"
+
 // Importing contains metadata about a resource change that includes an import
 // action.
 //
@@ -12,7 +14,9 @@ package jsonentities
 // make a guarantee that they will retain the format of this change.
 //
 // Consumers should be capable of rendering/parsing the Importing struct even
-// if it does not have the ID field set.
+// if it does not have the ID or Identity fields set.
 type Importing struct {
 	ID string `json:"id,omitempty"`
+
+	Identity json.RawMessage `json:"identity,omitempty"`
 }

--- a/internal/command/jsonformat/plan.go
+++ b/internal/command/jsonformat/plan.go
@@ -587,9 +587,9 @@ func resourceChangeComment(resource jsonplan.ResourceChange, action plans.Action
 		// as an empty string
 		if len(resource.Change.Importing.ID) > 0 {
 			buf.WriteString(fmt.Sprintf("  # [reset](imported from \"%s\")\n", resource.Change.Importing.ID))
+		} else if len(resource.Change.Importing.Identity) > 0 {
+			buf.WriteString(fmt.Sprintf("  # [reset](imported via identity %s)\n", string(resource.Change.Importing.Identity)))
 		} else {
-			// This means we're trying to render a plan from a future version
-			// and we didn't get given the ID. So we'll do our best.
 			buf.WriteString("  # [reset](will be imported first)\n")
 		}
 	}

--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -156,6 +156,9 @@ type Importing struct {
 	// The original ID of this resource used to target it as part of planned
 	// import operation.
 	ID string `json:"id,omitempty"`
+
+	// The identity of this resource used to target it
+	Identity json.RawMessage `json:"identity,omitempty"`
 }
 
 type Output struct {
@@ -410,11 +413,11 @@ func MarshalResourceChanges(resources []*plans.ResourceInstanceChangeSrc, schema
 			rc.ChangeSrc.Before = nil
 			rc.ChangeSrc.After = nil
 		}
-		dataSource := addr.Resource.Resource.Mode == addrs.DataResourceMode
+		isDataSource := addr.Resource.Resource.Mode == addrs.DataResourceMode
 		// We create "delete" actions for data resources so we can clean up
 		// their entries in state, but this is an implementation detail that
 		// users shouldn't see.
-		if dataSource && rc.Action == plans.Delete {
+		if isDataSource && rc.Action == plans.Delete {
 			continue
 		}
 
@@ -427,7 +430,7 @@ func MarshalResourceChanges(resources []*plans.ResourceInstanceChangeSrc, schema
 			return nil, fmt.Errorf("no schema found for %s (in provider %s)", r.Address, rc.ProviderAddr.Provider)
 		}
 
-		changeV, err := rc.Decode(schema.ImpliedType())
+		changeV, err := rc.Decode(schema)
 		if err != nil {
 			return nil, err
 		}
@@ -446,8 +449,8 @@ func MarshalResourceChanges(resources []*plans.ResourceInstanceChangeSrc, schema
 				return nil, err
 			}
 			valMarks := rc.BeforeValMarks
-			if schema.ContainsMarks() {
-				valMarks = append(valMarks, schema.ValueMarks(changeV.Before, nil)...)
+			if schema.Block.ContainsMarks() {
+				valMarks = append(valMarks, schema.Block.ValueMarks(changeV.Before, nil)...)
 			}
 			if err := ensureEphemeralMarksAreValid(addr, valMarks); err != nil {
 				return nil, err
@@ -478,8 +481,8 @@ func MarshalResourceChanges(resources []*plans.ResourceInstanceChangeSrc, schema
 				afterUnknown = unknownAsBool(changeV.After)
 			}
 			valMarks := rc.AfterValMarks
-			if schema.ContainsMarks() {
-				valMarks = append(valMarks, schema.ValueMarks(changeV.After, nil)...)
+			if schema.Block.ContainsMarks() {
+				valMarks = append(valMarks, schema.Block.ValueMarks(changeV.After, nil)...)
 			}
 			if err := ensureEphemeralMarksAreValid(addr, valMarks); err != nil {
 				return nil, err
@@ -502,7 +505,22 @@ func MarshalResourceChanges(resources []*plans.ResourceInstanceChangeSrc, schema
 
 		var importing *Importing
 		if rc.Importing != nil {
-			importing = &Importing{ID: rc.Importing.ID}
+			importing = &Importing{}
+			if rc.Importing.ID != "" {
+				importing.ID = rc.Importing.ID
+			} else if rc.Importing.Identity != nil && schema.IdentitySchema != nil {
+				identity, err := rc.Importing.Identity.Decode(schema.IdentitySchema.ImpliedType())
+				if err != nil {
+					return nil, err
+				}
+
+				identityJSON, err := ctyjson.Marshal(identity, identity.Type())
+				if err != nil {
+					return nil, err
+				}
+				importing.Identity = identityJSON
+			}
+
 		}
 
 		r.Change = Change{

--- a/internal/command/jsonplan/resource.go
+++ b/internal/command/jsonplan/resource.go
@@ -44,6 +44,14 @@ type Resource struct {
 	// SensitiveValues is similar to AttributeValues, but with all sensitive
 	// values replaced with true, and all non-sensitive leaf values omitted.
 	SensitiveValues json.RawMessage `json:"sensitive_values,omitempty"`
+
+	// Identity is the JSON representation of the resource's identity attributes,
+	// if the provider supports resource identity for this type.
+	Identity json.RawMessage `json:"identity,omitempty"`
+
+	// IdentitySchemaVersion indicates which version of the resource identity
+	// schema the "identity" property conforms to.
+	IdentitySchemaVersion *uint64 `json:"identity_schema_version,omitempty"`
 }
 
 // ResourceChange is a description of an individual change action that OpenTofu

--- a/internal/command/jsonplan/values.go
+++ b/internal/command/jsonplan/values.go
@@ -92,7 +92,6 @@ func marshalPlannedOutputs(changes *plans.Changes) (map[string]Output, error) {
 	}
 
 	return ret, nil
-
 }
 
 func marshalPlannedValues(changes *plans.Changes, schemas *tofu.Schemas) (Module, error) {
@@ -223,7 +222,7 @@ func marshalPlanResources(changeMap map[string]*plans.ResourceInstanceChangeSrc,
 			return nil, fmt.Errorf("no schema found for %s", r.Addr.String())
 		}
 		resource.SchemaVersion = schemaVer
-		changeV, err := r.Decode(schema.ImpliedType())
+		changeV, err := r.Decode(schema)
 		if err != nil {
 			return nil, err
 		}
@@ -239,10 +238,10 @@ func marshalPlanResources(changeMap map[string]*plans.ResourceInstanceChangeSrc,
 
 		if changeV.After != cty.NilVal {
 			if changeV.After.IsWhollyKnown() {
-				resource.AttributeValues = marshalAttributeValues(changeV.After, schema)
+				resource.AttributeValues = marshalAttributeValues(changeV.After, schema.Block)
 			} else {
 				knowns := omitUnknowns(changeV.After)
-				resource.AttributeValues = marshalAttributeValues(knowns, schema)
+				resource.AttributeValues = marshalAttributeValues(knowns, schema.Block)
 			}
 		}
 
@@ -252,6 +251,16 @@ func marshalPlanResources(changeMap map[string]*plans.ResourceInstanceChangeSrc,
 			return nil, err
 		}
 		resource.SensitiveValues = v
+
+		if changeV.PlannedIdentity != cty.NilVal && !changeV.PlannedIdentity.IsNull() {
+			identityJSON, err := ctyjson.Marshal(changeV.PlannedIdentity, changeV.PlannedIdentity.Type())
+			if err != nil {
+				return nil, err
+			}
+			resource.Identity = identityJSON
+			idSchemaVersion := uint64(schema.IdentitySchemaVersion)
+			resource.IdentitySchemaVersion = &idSchemaVersion
+		}
 
 		ret = append(ret, resource)
 	}
@@ -272,7 +281,6 @@ func marshalPlanModules(
 	moduleMap map[string][]addrs.ModuleInstance,
 	moduleResourceMap map[string][]addrs.AbsResourceInstance,
 ) ([]Module, error) {
-
 	var ret []Module
 
 	for _, child := range childModules {

--- a/internal/command/views/hook_ui.go
+++ b/internal/command/views/hook_ui.go
@@ -24,8 +24,10 @@ import (
 	"github.com/opentofu/opentofu/internal/tofu"
 )
 
-const defaultPeriodicUiTimer = 10 * time.Second
-const maxIdLen = 80
+const (
+	defaultPeriodicUiTimer = 10 * time.Second
+	maxIdLen               = 80
+)
 
 func NewUiHook(view *View) *UiHook {
 	return &UiHook{
@@ -314,29 +316,43 @@ func (h *UiHook) PostImportState(addr addrs.AbsResourceInstance, imported []prov
 	return tofu.HookActionContinue, nil
 }
 
-func (h *UiHook) PrePlanImport(addr addrs.AbsResourceInstance, importID string) (tofu.HookAction, error) {
+func (h *UiHook) PrePlanImport(addr addrs.AbsResourceInstance, target providers.ImportTarget) (tofu.HookAction, error) {
 	h.println(fmt.Sprintf(
 		h.view.colorize.Color("[reset][bold]%s: Preparing import... [id=%s]"),
-		addr, importID,
+		addr, target.String(), // TODO: Look at if .String() is good enough here...
 	))
 
 	return tofu.HookActionContinue, nil
 }
 
 func (h *UiHook) PreApplyImport(addr addrs.AbsResourceInstance, importing plans.ImportingSrc) (tofu.HookAction, error) {
-	h.println(fmt.Sprintf(
-		h.view.colorize.Color("[reset][bold]%s: Importing... [id=%s]"),
-		addr, importing.ID,
-	))
+	if importing.ID != "" {
+		h.println(fmt.Sprintf(
+			h.view.colorize.Color("[reset][bold]%s: Importing... [id=%s]"),
+			addr, importing.ID,
+		))
+	} else {
+		h.println(fmt.Sprintf(
+			h.view.colorize.Color("[reset][bold]%s: Importing... [identity=%s]"),
+			addr, importing.String(),
+		))
+	}
 
 	return tofu.HookActionContinue, nil
 }
 
 func (h *UiHook) PostApplyImport(addr addrs.AbsResourceInstance, importing plans.ImportingSrc) (tofu.HookAction, error) {
-	h.println(fmt.Sprintf(
-		h.view.colorize.Color("[reset][bold]%s: Import complete [id=%s]"),
-		addr, importing.ID,
-	))
+	if importing.ID != "" {
+		h.println(fmt.Sprintf(
+			h.view.colorize.Color("[reset][bold]%s: Import complete [id=%s]"),
+			addr, importing.ID,
+		))
+	} else {
+		h.println(fmt.Sprintf(
+			h.view.colorize.Color("[reset][bold]%s: Import complete [identity=%s]"),
+			addr, importing.String(),
+		))
+	}
 
 	return tofu.HookActionContinue, nil
 }

--- a/internal/command/views/operation_test.go
+++ b/internal/command/views/operation_test.go
@@ -82,7 +82,6 @@ func TestOperation_emergencyDumpState(t *testing.T) {
 }
 
 func TestOperation_planNoChanges(t *testing.T) {
-
 	tests := map[string]struct {
 		plan     func(schemas *tofu.Schemas) *plans.Plan
 		wantText string
@@ -126,7 +125,7 @@ func TestOperation_planNoChanges(t *testing.T) {
 					addr.Resource.Resource.Mode,
 					addr.Resource.Resource.Type,
 				)
-				ty := schema.ImpliedType()
+				ty := schema.Block.ImpliedType()
 				rc := &plans.ResourceInstanceChange{
 					Addr:        addr,
 					PrevRunAddr: addr,
@@ -142,7 +141,7 @@ func TestOperation_planNoChanges(t *testing.T) {
 						}),
 					},
 				}
-				rcs, err := rc.Encode(ty)
+				rcs, err := rc.Encode(schema)
 				if err != nil {
 					panic(err)
 				}
@@ -167,7 +166,7 @@ func TestOperation_planNoChanges(t *testing.T) {
 					addr.Resource.Resource.Mode,
 					addr.Resource.Resource.Type,
 				)
-				ty := schema.ImpliedType()
+				ty := schema.Block.ImpliedType()
 				rc := &plans.ResourceInstanceChange{
 					Addr:        addr,
 					PrevRunAddr: addr,
@@ -183,7 +182,7 @@ func TestOperation_planNoChanges(t *testing.T) {
 						}),
 					},
 				}
-				rcs, err := rc.Encode(ty)
+				rcs, err := rc.Encode(schema)
 				if err != nil {
 					panic(err)
 				}
@@ -214,7 +213,7 @@ func TestOperation_planNoChanges(t *testing.T) {
 					addr.Resource.Resource.Mode,
 					addr.Resource.Resource.Type,
 				)
-				ty := schema.ImpliedType()
+				ty := schema.Block.ImpliedType()
 				rc := &plans.ResourceInstanceChange{
 					Addr:        addr,
 					PrevRunAddr: addr,
@@ -230,7 +229,7 @@ func TestOperation_planNoChanges(t *testing.T) {
 						}),
 					},
 				}
-				rcs, err := rc.Encode(ty)
+				rcs, err := rc.Encode(schema)
 				if err != nil {
 					panic(err)
 				}
@@ -260,7 +259,6 @@ func TestOperation_planNoChanges(t *testing.T) {
 					addr.Resource.Resource.Mode,
 					addr.Resource.Resource.Type,
 				)
-				ty := schema.ImpliedType()
 				rc := &plans.ResourceInstanceChange{
 					Addr:        addr,
 					PrevRunAddr: addrPrev,
@@ -279,7 +277,7 @@ func TestOperation_planNoChanges(t *testing.T) {
 						}),
 					},
 				}
-				rcs, err := rc.Encode(ty)
+				rcs, err := rc.Encode(schema)
 				if err != nil {
 					panic(err)
 				}

--- a/internal/configs/configschema/decoder_spec.go
+++ b/internal/configs/configschema/decoder_spec.go
@@ -196,7 +196,7 @@ func (a *Attribute) decoderSpec(name string) hcldec.Spec {
 			panic("Invalid attribute schema: NestedType and Type cannot both be set. This is a bug in the provider.")
 		}
 
-		ty := a.NestedType.specType()
+		ty := a.NestedType.SpecType()
 		ret.Type = ty
 		ret.Required = a.Required
 		return ret

--- a/internal/configs/configschema/implied_type.go
+++ b/internal/configs/configschema/implied_type.go
@@ -88,7 +88,7 @@ func (b *Block) ContainsMarks() bool {
 // cause this method to fall back on defaults and assumptions.
 func (a *Attribute) ImpliedType() cty.Type {
 	if a.NestedType != nil {
-		return a.NestedType.specType().WithoutOptionalAttributesDeep()
+		return a.NestedType.SpecType().WithoutOptionalAttributesDeep()
 	}
 	return a.Type
 }
@@ -101,12 +101,12 @@ func (a *Attribute) ImpliedType() cty.Type {
 // using the InternalValidate method to detect any inconsistencies that would
 // cause this method to fall back on defaults and assumptions.
 func (o *Object) ImpliedType() cty.Type {
-	return o.specType().WithoutOptionalAttributesDeep()
+	return o.SpecType().WithoutOptionalAttributesDeep()
 }
 
-// specType returns the cty.Type used for decoding a NestedType Attribute using
+// SpecType returns the cty.Type used for decoding a NestedType Attribute using
 // the receiving block schema.
-func (o *Object) specType() cty.Type {
+func (o *Object) SpecType() cty.Type {
 	if o == nil {
 		return cty.EmptyObject
 	}
@@ -114,7 +114,7 @@ func (o *Object) specType() cty.Type {
 	attrTys := make(map[string]cty.Type, len(o.Attributes))
 	for name, attrS := range o.Attributes {
 		if attrS.NestedType != nil {
-			attrTys[name] = attrS.NestedType.specType()
+			attrTys[name] = attrS.NestedType.SpecType()
 		} else {
 			attrTys[name] = attrS.Type
 		}

--- a/internal/configs/configschema/implied_type_test.go
+++ b/internal/configs/configschema/implied_type_test.go
@@ -56,7 +56,7 @@ func TestBlockImpliedType(t *testing.T) {
 		"blocks": {
 			&Block{
 				BlockTypes: map[string]*NestedBlock{
-					"single": &NestedBlock{
+					"single": {
 						Nesting: NestingSingle,
 						Block: Block{
 							Attributes: map[string]*Attribute{
@@ -67,13 +67,13 @@ func TestBlockImpliedType(t *testing.T) {
 							},
 						},
 					},
-					"list": &NestedBlock{
+					"list": {
 						Nesting: NestingList,
 					},
-					"set": &NestedBlock{
+					"set": {
 						Nesting: NestingSet,
 					},
-					"map": &NestedBlock{
+					"map": {
 						Nesting: NestingMap,
 					},
 				},
@@ -90,15 +90,15 @@ func TestBlockImpliedType(t *testing.T) {
 		"deep block nesting": {
 			&Block{
 				BlockTypes: map[string]*NestedBlock{
-					"single": &NestedBlock{
+					"single": {
 						Nesting: NestingSingle,
 						Block: Block{
 							BlockTypes: map[string]*NestedBlock{
-								"list": &NestedBlock{
+								"list": {
 									Nesting: NestingList,
 									Block: Block{
 										BlockTypes: map[string]*NestedBlock{
-											"set": &NestedBlock{
+											"set": {
 												Nesting: NestingSet,
 											},
 										},
@@ -220,7 +220,6 @@ func TestBlockContainsSensitive(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestObjectImpliedType(t *testing.T) {
@@ -463,7 +462,6 @@ func TestObjectContainsSensitive(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 // Nested attribute should return optional object attributes for decoding.
@@ -600,7 +598,7 @@ func TestObjectSpecType(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := test.Schema.specType()
+			got := test.Schema.SpecType()
 			if !got.Equals(test.Want) {
 				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Want)
 			}

--- a/internal/configs/import.go
+++ b/internal/configs/import.go
@@ -131,7 +131,7 @@ func decodeImportBlock(block *hcl.Block) (*Import, hcl.Diagnostics) {
 		imp.ForEach = attr.Expr
 	}
 
-	// We need atleast one of ID or Identity to be set
+	// We need at least one of ID or Identity to be set
 	if !idExists && !identityExists {
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,

--- a/internal/engine/internal/execgraph/operations_test.go
+++ b/internal/engine/internal/execgraph/operations_test.go
@@ -325,6 +325,16 @@ func (m *managedResourceInstanceMockProvider) UpgradeResourceState(context.Conte
 	panic("unimplemented")
 }
 
+// GetResourceIdentitySchemas implements providers.Configured.
+func (m *managedResourceInstanceMockProvider) GetResourceIdentitySchemas(context.Context) providers.GetResourceIdentitySchemasResponse {
+	return providers.GetResourceIdentitySchemasResponse{}
+}
+
+// UpgradeResourceIdentity implements providers.Configured.
+func (m *managedResourceInstanceMockProvider) UpgradeResourceIdentity(context.Context, providers.UpgradeResourceIdentityRequest) providers.UpgradeResourceIdentityResponse {
+	panic("unimplemented")
+}
+
 // ValidateDataResourceConfig implements providers.Configured.
 func (m *managedResourceInstanceMockProvider) ValidateDataResourceConfig(context.Context, providers.ValidateDataResourceConfigRequest) providers.ValidateDataResourceConfigResponse {
 	panic("unimplemented")

--- a/internal/engine/internal/execgraph/operations_test.go
+++ b/internal/engine/internal/execgraph/operations_test.go
@@ -325,10 +325,6 @@ func (m *managedResourceInstanceMockProvider) UpgradeResourceState(context.Conte
 	panic("unimplemented")
 }
 
-// GetResourceIdentitySchemas implements providers.Configured.
-func (m *managedResourceInstanceMockProvider) GetResourceIdentitySchemas(context.Context) providers.GetResourceIdentitySchemasResponse {
-	return providers.GetResourceIdentitySchemasResponse{}
-}
 
 // UpgradeResourceIdentity implements providers.Configured.
 func (m *managedResourceInstanceMockProvider) UpgradeResourceIdentity(context.Context, providers.UpgradeResourceIdentityRequest) providers.UpgradeResourceIdentityResponse {

--- a/internal/engine/planning/plan.go
+++ b/internal/engine/planning/plan.go
@@ -216,7 +216,7 @@ func buildPlanChanges(
 			continue // can't encode a change without a schema
 		}
 
-		changeSrc, err := change.Encode(schema.Block.ImpliedType())
+		changeSrc, err := change.Encode(schema)
 		if err != nil {
 			// TODO: Make this a proper diagnostic, since this can potentially
 			// be user-facing if the provider returned something that's somehow

--- a/internal/grpcwrap/provider.go
+++ b/internal/grpcwrap/provider.go
@@ -22,10 +22,29 @@ import (
 // This is useful for creating a test binary out of an internal provider
 // implementation.
 func Provider(p providers.Interface) tfplugin5.ProviderServer {
+	schema := p.GetProviderSchema(context.TODO())
 	return &provider{
 		provider:        p,
-		schema:          p.GetProviderSchema(context.TODO()),
-		identitySchemas: p.GetResourceIdentitySchemas(context.TODO()),
+		schema:          schema,
+		identitySchemas: identitySchemasFromProviderSchema(schema),
+	}
+}
+
+// identitySchemasFromProviderSchema derives the identity schemas from the
+// provider schema response, since identity schemas are embedded in each
+// resource type's Schema.
+func identitySchemasFromProviderSchema(schema providers.GetProviderSchemaResponse) providers.GetResourceIdentitySchemasResponse {
+	identitySchemas := make(map[string]providers.ResourceIdentitySchema)
+	for typeName, s := range schema.ResourceTypes {
+		if s.IdentitySchema != nil {
+			identitySchemas[typeName] = providers.ResourceIdentitySchema{
+				Version: s.IdentitySchemaVersion,
+				Body:    s.IdentitySchema,
+			}
+		}
+	}
+	return providers.GetResourceIdentitySchemasResponse{
+		IdentitySchemas: identitySchemas,
 	}
 }
 

--- a/internal/grpcwrap/provider.go
+++ b/internal/grpcwrap/provider.go
@@ -33,7 +33,7 @@ func Provider(p providers.Interface) tfplugin5.ProviderServer {
 // identitySchemasFromProviderSchema derives the identity schemas from the
 // provider schema response, since identity schemas are embedded in each
 // resource type's Schema.
-func identitySchemasFromProviderSchema(schema providers.GetProviderSchemaResponse) providers.GetResourceIdentitySchemasResponse {
+func identitySchemasFromProviderSchema(schema providers.GetProviderSchemaResponse) map[string]providers.ResourceIdentitySchema {
 	identitySchemas := make(map[string]providers.ResourceIdentitySchema)
 	for typeName, s := range schema.ResourceTypes {
 		if s.IdentitySchema != nil {
@@ -43,15 +43,13 @@ func identitySchemasFromProviderSchema(schema providers.GetProviderSchemaRespons
 			}
 		}
 	}
-	return providers.GetResourceIdentitySchemasResponse{
-		IdentitySchemas: identitySchemas,
-	}
+	return identitySchemas
 }
 
 type provider struct {
 	provider        providers.Interface
 	schema          providers.GetProviderSchemaResponse
-	identitySchemas providers.GetResourceIdentitySchemasResponse
+	identitySchemas map[string]providers.ResourceIdentitySchema
 
 	tfplugin5.UnimplementedProviderServer
 }
@@ -112,12 +110,10 @@ func (p *provider) GetResourceIdentitySchemas(_ context.Context, req *tfplugin5.
 		Diagnostics:     []*tfplugin5.Diagnostic{},
 	}
 
-	for resourceIdentity, schema := range p.identitySchemas.IdentitySchemas {
+	for resourceIdentity, schema := range p.identitySchemas {
 		resp.IdentitySchemas[resourceIdentity] = convert.ResourceIdentitySchemaToProto(&schema)
 	}
 
-	// include any diagnostics from the original GetResourceIdentitySchemas call
-	resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, p.identitySchemas.Diagnostics)
 	return resp, nil
 }
 
@@ -267,7 +263,7 @@ func (p *provider) ReadResource(ctx context.Context, req *tfplugin5.ReadResource
 		ProviderMeta: metaVal,
 	}
 	if req.CurrentIdentity != nil && req.CurrentIdentity.IdentityData != nil {
-		if identitySchema, ok := p.identitySchemas.IdentitySchemas[req.TypeName]; ok {
+		if identitySchema, ok := p.identitySchemas[req.TypeName]; ok {
 			identityVal, err := decodeDynamicValue(req.CurrentIdentity.IdentityData, identitySchema.Body.ImpliedType())
 			if err != nil {
 				resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
@@ -292,7 +288,7 @@ func (p *provider) ReadResource(ctx context.Context, req *tfplugin5.ReadResource
 	resp.NewState = dv
 
 	if !readResp.NewIdentity.IsNull() {
-		if identitySchema, ok := p.identitySchemas.IdentitySchemas[req.TypeName]; ok {
+		if identitySchema, ok := p.identitySchemas[req.TypeName]; ok {
 			identityDV, err := encodeDynamicValue(readResp.NewIdentity, identitySchema.Body.ImpliedType())
 			if err != nil {
 				resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
@@ -343,7 +339,7 @@ func (p *provider) PlanResourceChange(ctx context.Context, req *tfplugin5.PlanRe
 		ProviderMeta:     metaVal,
 	}
 	if req.PriorIdentity != nil && req.PriorIdentity.IdentityData != nil {
-		if identitySchema, ok := p.identitySchemas.IdentitySchemas[req.TypeName]; ok {
+		if identitySchema, ok := p.identitySchemas[req.TypeName]; ok {
 			identityVal, err := decodeDynamicValue(req.PriorIdentity.IdentityData, identitySchema.Body.ImpliedType())
 			if err != nil {
 				resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
@@ -372,7 +368,7 @@ func (p *provider) PlanResourceChange(ctx context.Context, req *tfplugin5.PlanRe
 	}
 
 	if !planResp.PlannedIdentity.IsNull() {
-		if identitySchema, ok := p.identitySchemas.IdentitySchemas[req.TypeName]; ok {
+		if identitySchema, ok := p.identitySchemas[req.TypeName]; ok {
 			identityDV, err := encodeDynamicValue(planResp.PlannedIdentity, identitySchema.Body.ImpliedType())
 			if err != nil {
 				resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
@@ -423,7 +419,7 @@ func (p *provider) ApplyResourceChange(ctx context.Context, req *tfplugin5.Apply
 		ProviderMeta:   metaVal,
 	}
 	if req.PlannedIdentity != nil && req.PlannedIdentity.IdentityData != nil {
-		if identitySchema, ok := p.identitySchemas.IdentitySchemas[req.TypeName]; ok {
+		if identitySchema, ok := p.identitySchemas[req.TypeName]; ok {
 			identityVal, err := decodeDynamicValue(req.PlannedIdentity.IdentityData, identitySchema.Body.ImpliedType())
 			if err != nil {
 				resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
@@ -448,7 +444,7 @@ func (p *provider) ApplyResourceChange(ctx context.Context, req *tfplugin5.Apply
 	}
 
 	if !applyResp.NewIdentity.IsNull() {
-		if identitySchema, ok := p.identitySchemas.IdentitySchemas[req.TypeName]; ok {
+		if identitySchema, ok := p.identitySchemas[req.TypeName]; ok {
 			identityDV, err := encodeDynamicValue(applyResp.NewIdentity, identitySchema.Body.ImpliedType())
 			if err != nil {
 				resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
@@ -471,7 +467,7 @@ func (p *provider) ImportResourceState(ctx context.Context, req *tfplugin5.Impor
 	if req.Identity != nil {
 		// If identity isn't nil, then we need to instead import by identity
 		// We should use the schema to decode the identity value
-		identitySchema, ok := p.identitySchemas.IdentitySchemas[req.TypeName]
+		identitySchema, ok := p.identitySchemas[req.TypeName]
 		if !ok {
 			resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, fmt.Errorf("no identity schema found for resource type %q", req.TypeName))
 			return resp, nil
@@ -674,7 +670,7 @@ func (p *provider) UpgradeResourceIdentity(ctx context.Context, req *tfplugin5.U
 		return resp, nil
 	}
 
-	schema, ok := p.identitySchemas.IdentitySchemas[req.TypeName]
+	schema, ok := p.identitySchemas[req.TypeName]
 	if !ok {
 		resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, fmt.Errorf("no identity schema found for resource type %q", req.TypeName))
 		return resp, nil

--- a/internal/grpcwrap/provider6.go
+++ b/internal/grpcwrap/provider6.go
@@ -33,7 +33,7 @@ func Provider6(p providers.Interface) tfplugin6.ProviderServer {
 type provider6 struct {
 	provider        providers.Interface
 	schema          providers.GetProviderSchemaResponse
-	identitySchemas providers.GetResourceIdentitySchemasResponse
+	identitySchemas map[string]providers.ResourceIdentitySchema
 
 	tfplugin6.UnimplementedProviderServer
 }
@@ -234,7 +234,7 @@ func (p *provider6) ReadResource(ctx context.Context, req *tfplugin6.ReadResourc
 		ProviderMeta: metaVal,
 	}
 	if req.CurrentIdentity != nil && req.CurrentIdentity.IdentityData != nil {
-		if identitySchema, ok := p.identitySchemas.IdentitySchemas[req.TypeName]; ok {
+		if identitySchema, ok := p.identitySchemas[req.TypeName]; ok {
 			identityVal, err := decodeDynamicValue6(req.CurrentIdentity.IdentityData, identitySchema.Body.ImpliedType())
 			if err != nil {
 				resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
@@ -259,7 +259,7 @@ func (p *provider6) ReadResource(ctx context.Context, req *tfplugin6.ReadResourc
 	resp.NewState = dv
 
 	if !readResp.NewIdentity.IsNull() {
-		if identitySchema, ok := p.identitySchemas.IdentitySchemas[req.TypeName]; ok {
+		if identitySchema, ok := p.identitySchemas[req.TypeName]; ok {
 			identityDV, err := encodeDynamicValue6(readResp.NewIdentity, identitySchema.Body.ImpliedType())
 			if err != nil {
 				resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
@@ -310,7 +310,7 @@ func (p *provider6) PlanResourceChange(ctx context.Context, req *tfplugin6.PlanR
 		ProviderMeta:     metaVal,
 	}
 	if req.PriorIdentity != nil && req.PriorIdentity.IdentityData != nil {
-		if identitySchema, ok := p.identitySchemas.IdentitySchemas[req.TypeName]; ok {
+		if identitySchema, ok := p.identitySchemas[req.TypeName]; ok {
 			identityVal, err := decodeDynamicValue6(req.PriorIdentity.IdentityData, identitySchema.Body.ImpliedType())
 			if err != nil {
 				resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
@@ -339,7 +339,7 @@ func (p *provider6) PlanResourceChange(ctx context.Context, req *tfplugin6.PlanR
 	}
 
 	if !planResp.PlannedIdentity.IsNull() {
-		if identitySchema, ok := p.identitySchemas.IdentitySchemas[req.TypeName]; ok {
+		if identitySchema, ok := p.identitySchemas[req.TypeName]; ok {
 			identityDV, err := encodeDynamicValue6(planResp.PlannedIdentity, identitySchema.Body.ImpliedType())
 			if err != nil {
 				resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
@@ -390,7 +390,7 @@ func (p *provider6) ApplyResourceChange(ctx context.Context, req *tfplugin6.Appl
 		ProviderMeta:   metaVal,
 	}
 	if req.PlannedIdentity != nil && req.PlannedIdentity.IdentityData != nil {
-		if identitySchema, ok := p.identitySchemas.IdentitySchemas[req.TypeName]; ok {
+		if identitySchema, ok := p.identitySchemas[req.TypeName]; ok {
 			identityVal, err := decodeDynamicValue6(req.PlannedIdentity.IdentityData, identitySchema.Body.ImpliedType())
 			if err != nil {
 				resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
@@ -415,7 +415,7 @@ func (p *provider6) ApplyResourceChange(ctx context.Context, req *tfplugin6.Appl
 	}
 
 	if !applyResp.NewIdentity.IsNull() {
-		if identitySchema, ok := p.identitySchemas.IdentitySchemas[req.TypeName]; ok {
+		if identitySchema, ok := p.identitySchemas[req.TypeName]; ok {
 			identityDV, err := encodeDynamicValue6(applyResp.NewIdentity, identitySchema.Body.ImpliedType())
 			if err != nil {
 				resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, err)
@@ -438,7 +438,7 @@ func (p *provider6) ImportResourceState(ctx context.Context, req *tfplugin6.Impo
 	if req.Identity != nil {
 		// If identity isn't nil, then we need to instead import by identity
 		// We should use the schema to decode the identity value
-		identitySchema, ok := p.identitySchemas.IdentitySchemas[req.TypeName]
+		identitySchema, ok := p.identitySchemas[req.TypeName]
 		if !ok {
 			resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, fmt.Errorf("no identity schema found for resource type %q", req.TypeName))
 			return resp, nil
@@ -629,11 +629,10 @@ func (p *provider6) GetResourceIdentitySchemas(ctx context.Context, req *tfplugi
 		IdentitySchemas: make(map[string]*tfplugin6.ResourceIdentitySchema),
 		Diagnostics:     []*tfplugin6.Diagnostic{},
 	}
-	for ri, schema := range p.identitySchemas.IdentitySchemas {
+	for ri, schema := range p.identitySchemas {
 		resp.IdentitySchemas[ri] = convert.ResourceIdentitySchemaToProto(&schema)
 	}
 
-	resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, p.identitySchemas.Diagnostics)
 	return resp, nil
 }
 
@@ -656,7 +655,7 @@ func (p *provider6) UpgradeResourceIdentity(ctx context.Context, req *tfplugin6.
 		return resp, nil
 	}
 
-	schema, ok := p.identitySchemas.IdentitySchemas[req.TypeName]
+	schema, ok := p.identitySchemas[req.TypeName]
 	if !ok {
 		resp.Diagnostics = convert.AppendProtoDiag(resp.Diagnostics, fmt.Errorf("no identity schema found for resource type %q", req.TypeName))
 		return resp, nil

--- a/internal/grpcwrap/provider6.go
+++ b/internal/grpcwrap/provider6.go
@@ -22,10 +22,11 @@ import (
 // plugin protocol v6. This is useful for creating a test binary out of an
 // internal provider implementation.
 func Provider6(p providers.Interface) tfplugin6.ProviderServer {
+	schema := p.GetProviderSchema(context.TODO())
 	return &provider6{
 		provider:        p,
-		schema:          p.GetProviderSchema(context.TODO()),
-		identitySchemas: p.GetResourceIdentitySchemas(context.TODO()),
+		schema:          schema,
+		identitySchemas: identitySchemasFromProviderSchema(schema),
 	}
 }
 

--- a/internal/plans/changes.go
+++ b/internal/plans/changes.go
@@ -9,6 +9,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/states"
 )
 
@@ -77,7 +78,6 @@ func (c *Changes) ResourceInstance(addr addrs.AbsResourceInstance) *ResourceInst
 	}
 
 	return nil
-
 }
 
 // InstancesForAbsResource returns the planned change for the current objects
@@ -194,6 +194,9 @@ func (c *Changes) SyncWrapper() *ChangesSync {
 
 // ResourceInstanceChange describes a change to a particular resource instance
 // object.
+// Note for developers: If you are adding new properties for this, ensure that the
+// Simplify() method is updated to copy those properties when it creates new simplified changes.
+// otherwise there could be data loss
 type ResourceInstanceChange struct {
 	// Addr is the absolute address of the resource instance that the change
 	// will apply to.
@@ -263,8 +266,8 @@ type ResourceInstanceChange struct {
 // Encode produces a variant of the receiver that has its change values
 // serialized so it can be written to a plan file. Pass the implied type of the
 // corresponding resource type schema for correct operation.
-func (rc *ResourceInstanceChange) Encode(ty cty.Type) (*ResourceInstanceChangeSrc, error) {
-	cs, err := rc.Change.Encode(ty)
+func (rc *ResourceInstanceChange) Encode(schema *providers.Schema) (*ResourceInstanceChangeSrc, error) {
+	cs, err := rc.Change.Encode(schema)
 	if err != nil {
 		return nil, err
 	}
@@ -324,6 +327,7 @@ func (rc *ResourceInstanceChange) Simplify(destroying bool) *ResourceInstanceCha
 					After:           cty.NullVal(rc.Before.Type()),
 					Importing:       rc.Importing,
 					GeneratedConfig: rc.GeneratedConfig,
+					PlannedIdentity: rc.PlannedIdentity,
 				},
 			}
 		default:
@@ -338,6 +342,7 @@ func (rc *ResourceInstanceChange) Simplify(destroying bool) *ResourceInstanceCha
 					After:           rc.Before,
 					Importing:       rc.Importing,
 					GeneratedConfig: rc.GeneratedConfig,
+					PlannedIdentity: rc.PlannedIdentity,
 				},
 			}
 		}
@@ -355,6 +360,7 @@ func (rc *ResourceInstanceChange) Simplify(destroying bool) *ResourceInstanceCha
 					After:           rc.Before,
 					Importing:       rc.Importing,
 					GeneratedConfig: rc.GeneratedConfig,
+					PlannedIdentity: rc.PlannedIdentity,
 				},
 			}
 		case CreateThenDelete, DeleteThenCreate, ForgetThenCreate:
@@ -369,6 +375,7 @@ func (rc *ResourceInstanceChange) Simplify(destroying bool) *ResourceInstanceCha
 					After:           rc.After,
 					Importing:       rc.Importing,
 					GeneratedConfig: rc.GeneratedConfig,
+					PlannedIdentity: rc.PlannedIdentity,
 				},
 			}
 		}
@@ -516,7 +523,7 @@ type OutputChange struct {
 // Encode produces a variant of the receiver that has its change values
 // serialized so it can be written to a plan file.
 func (oc *OutputChange) Encode() (*OutputChangeSrc, error) {
-	cs, err := oc.Change.Encode(cty.DynamicPseudoType)
+	cs, err := oc.Change.Encode(nil) // we don't have schemas here, so just pass through nil
 	if err != nil {
 		return nil, err
 	}
@@ -535,6 +542,10 @@ func (oc *OutputChange) Encode() (*OutputChangeSrc, error) {
 type Importing struct {
 	// ID is the original ID of the imported resource.
 	ID string
+
+	// Identity is an alterate identity value for the imported resource.
+	// Mutually exclusive with ID.
+	Identity cty.Value
 }
 
 // Change describes a single change with a given action.
@@ -570,6 +581,11 @@ type Change struct {
 	// should be true. However, not all Importing changes contain generated
 	// config.
 	GeneratedConfig string
+
+	// PlannedIdentity is the identity value returned by the provider during
+	// planning. This is used to pass identity data through to the apply phase.
+	// Only relevant for managed resources, not outputs.
+	PlannedIdentity cty.Value
 }
 
 // Encode produces a variant of the receiver that has its change values
@@ -580,7 +596,16 @@ type Change struct {
 // Where a Change is embedded in some other struct, it's generally better
 // to call the corresponding Encode method of that struct rather than working
 // directly with its embedded Change.
-func (c *Change) Encode(ty cty.Type) (*ChangeSrc, error) {
+func (c *Change) Encode(schema *providers.Schema) (*ChangeSrc, error) {
+	var ty cty.Type
+
+	if schema == nil {
+		// we've been passed a nil set of schema, we should use a dynamic type here
+		ty = cty.DynamicPseudoType
+	} else {
+		ty = schema.Block.ImpliedType()
+	}
+
 	// Storing unmarked values so that we can encode unmarked values
 	// and save the PathValueMarks for re-marking the values later
 	var beforeVM, afterVM []cty.PathValueMarks
@@ -605,7 +630,34 @@ func (c *Change) Encode(ty cty.Type) (*ChangeSrc, error) {
 
 	var importing *ImportingSrc
 	if c.Importing != nil {
-		importing = &ImportingSrc{ID: c.Importing.ID}
+		var idVal DynamicValue
+
+		// Only encode identity if it's present and schema has IdentitySchema
+		if c.Importing.Identity != cty.NilVal && !c.Importing.Identity.IsNull() && schema != nil && schema.IdentitySchema != nil {
+			identityType := schema.IdentitySchema.ImpliedType()
+			id, dvErr := NewDynamicValue(c.Importing.Identity, identityType)
+			if dvErr != nil {
+				return nil, dvErr
+			}
+			idVal = id
+		}
+
+		importing = &ImportingSrc{
+			ID:       c.Importing.ID,
+			Identity: idVal,
+		}
+	}
+
+	var plannedIdentityDV DynamicValue
+	if c.PlannedIdentity != cty.NilVal && !c.PlannedIdentity.IsNull() {
+		identityTy := c.PlannedIdentity.Type()
+		if schema != nil && schema.IdentitySchema != nil {
+			identityTy = schema.IdentitySchema.ImpliedType()
+		}
+		plannedIdentityDV, err = NewDynamicValue(c.PlannedIdentity, identityTy)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &ChangeSrc{
@@ -616,5 +668,6 @@ func (c *Change) Encode(ty cty.Type) (*ChangeSrc, error) {
 		AfterValMarks:   afterVM,
 		Importing:       importing,
 		GeneratedConfig: c.GeneratedConfig,
+		PlannedIdentity: plannedIdentityDV,
 	}, nil
 }

--- a/internal/plans/changes_test.go
+++ b/internal/plans/changes_test.go
@@ -146,12 +146,12 @@ func TestChangeEncodeSensitive(t *testing.T) {
 				After:  v,
 			}
 
-			encoded, err := change.Encode(v.Type())
+			encoded, err := change.Encode(nil)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			decoded, err := encoded.Decode(v.Type())
+			decoded, err := encoded.Decode(nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/plans/internal/planproto/planfile.pb.go
+++ b/internal/plans/internal/planproto/planfile.pb.go
@@ -681,6 +681,10 @@ type Change struct {
 	// GeneratedConfig contains any configuration that was generated as part of
 	// the change, as an HCL string.
 	GeneratedConfig string `protobuf:"bytes,6,opt,name=generated_config,json=generatedConfig,proto3" json:"generated_config,omitempty"`
+	// PlannedIdentity is the identity value returned by the provider during
+	// planning. This is used to pass identity data through to the apply phase.
+	// Only relevant for managed resources, not outputs.
+	PlannedIdentity *DynamicValue `protobuf:"bytes,7,opt,name=planned_identity,json=plannedIdentity,proto3" json:"planned_identity,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -755,6 +759,13 @@ func (x *Change) GetGeneratedConfig() string {
 		return x.GeneratedConfig
 	}
 	return ""
+}
+
+func (x *Change) GetPlannedIdentity() *DynamicValue {
+	if x != nil {
+		return x.PlannedIdentity
+	}
+	return nil
 }
 
 type ResourceInstanceChange struct {
@@ -1130,7 +1141,9 @@ func (x *Path) GetSteps() []*Path_Step {
 type Importing struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The original ID of the resource.
-	Id            string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// The Identity that we are importing, this is mutually exclusive with the id field
+	Identity      *DynamicValue `protobuf:"bytes,2,opt,name=identity,proto3" json:"identity,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1170,6 +1183,13 @@ func (x *Importing) GetId() string {
 		return x.Id
 	}
 	return ""
+}
+
+func (x *Importing) GetIdentity() *DynamicValue {
+	if x != nil {
+		return x.Identity
+	}
+	return nil
 }
 
 type PlanResourceAttr struct {
@@ -1402,14 +1422,15 @@ const file_planfile_proto_rawDesc = "" +
 	"\aBackend\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12,\n" +
 	"\x06config\x18\x02 \x01(\v2\x14.tfplan.DynamicValueR\x06config\x12\x1c\n" +
-	"\tworkspace\x18\x03 \x01(\tR\tworkspace\"\xc0\x02\n" +
+	"\tworkspace\x18\x03 \x01(\tR\tworkspace\"\x81\x03\n" +
 	"\x06Change\x12&\n" +
 	"\x06action\x18\x01 \x01(\x0e2\x0e.tfplan.ActionR\x06action\x12,\n" +
 	"\x06values\x18\x02 \x03(\v2\x14.tfplan.DynamicValueR\x06values\x12B\n" +
 	"\x16before_sensitive_paths\x18\x03 \x03(\v2\f.tfplan.PathR\x14beforeSensitivePaths\x12@\n" +
 	"\x15after_sensitive_paths\x18\x04 \x03(\v2\f.tfplan.PathR\x13afterSensitivePaths\x12/\n" +
 	"\timporting\x18\x05 \x01(\v2\x11.tfplan.ImportingR\timporting\x12)\n" +
-	"\x10generated_config\x18\x06 \x01(\tR\x0fgeneratedConfig\"\xd3\x02\n" +
+	"\x10generated_config\x18\x06 \x01(\tR\x0fgeneratedConfig\x12?\n" +
+	"\x10planned_identity\x18\a \x01(\v2\x14.tfplan.DynamicValueR\x0fplannedIdentity\"\xd3\x02\n" +
 	"\x16ResourceInstanceChange\x12\x12\n" +
 	"\x04addr\x18\r \x01(\tR\x04addr\x12\"\n" +
 	"\rprev_run_addr\x18\x0e \x01(\tR\vprevRunAddr\x12\x1f\n" +
@@ -1457,9 +1478,10 @@ const file_planfile_proto_rawDesc = "" +
 	"\velement_key\x18\x02 \x01(\v2\x14.tfplan.DynamicValueH\x00R\n" +
 	"elementKeyB\n" +
 	"\n" +
-	"\bselector\"\x1b\n" +
+	"\bselector\"M\n" +
 	"\tImporting\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02id*1\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x120\n" +
+	"\bidentity\x18\x02 \x01(\v2\x14.tfplan.DynamicValueR\bidentity*1\n" +
 	"\x04Mode\x12\n" +
 	"\n" +
 	"\x06NORMAL\x10\x00\x12\v\n" +
@@ -1549,23 +1571,25 @@ var file_planfile_proto_depIdxs = []int32{
 	12, // 11: tfplan.Change.before_sensitive_paths:type_name -> tfplan.Path
 	12, // 12: tfplan.Change.after_sensitive_paths:type_name -> tfplan.Path
 	13, // 13: tfplan.Change.importing:type_name -> tfplan.Importing
-	7,  // 14: tfplan.ResourceInstanceChange.change:type_name -> tfplan.Change
-	12, // 15: tfplan.ResourceInstanceChange.required_replace:type_name -> tfplan.Path
-	2,  // 16: tfplan.ResourceInstanceChange.action_reason:type_name -> tfplan.ResourceInstanceActionReason
-	7,  // 17: tfplan.OutputChange.change:type_name -> tfplan.Change
-	4,  // 18: tfplan.CheckResults.kind:type_name -> tfplan.CheckResults.ObjectKind
-	3,  // 19: tfplan.CheckResults.status:type_name -> tfplan.CheckResults.Status
-	16, // 20: tfplan.CheckResults.objects:type_name -> tfplan.CheckResults.ObjectResult
-	17, // 21: tfplan.Path.steps:type_name -> tfplan.Path.Step
-	11, // 22: tfplan.Plan.VariablesEntry.value:type_name -> tfplan.DynamicValue
-	12, // 23: tfplan.Plan.resource_attr.attr:type_name -> tfplan.Path
-	3,  // 24: tfplan.CheckResults.ObjectResult.status:type_name -> tfplan.CheckResults.Status
-	11, // 25: tfplan.Path.Step.element_key:type_name -> tfplan.DynamicValue
-	26, // [26:26] is the sub-list for method output_type
-	26, // [26:26] is the sub-list for method input_type
-	26, // [26:26] is the sub-list for extension type_name
-	26, // [26:26] is the sub-list for extension extendee
-	0,  // [0:26] is the sub-list for field type_name
+	11, // 14: tfplan.Change.planned_identity:type_name -> tfplan.DynamicValue
+	7,  // 15: tfplan.ResourceInstanceChange.change:type_name -> tfplan.Change
+	12, // 16: tfplan.ResourceInstanceChange.required_replace:type_name -> tfplan.Path
+	2,  // 17: tfplan.ResourceInstanceChange.action_reason:type_name -> tfplan.ResourceInstanceActionReason
+	7,  // 18: tfplan.OutputChange.change:type_name -> tfplan.Change
+	4,  // 19: tfplan.CheckResults.kind:type_name -> tfplan.CheckResults.ObjectKind
+	3,  // 20: tfplan.CheckResults.status:type_name -> tfplan.CheckResults.Status
+	16, // 21: tfplan.CheckResults.objects:type_name -> tfplan.CheckResults.ObjectResult
+	17, // 22: tfplan.Path.steps:type_name -> tfplan.Path.Step
+	11, // 23: tfplan.Importing.identity:type_name -> tfplan.DynamicValue
+	11, // 24: tfplan.Plan.VariablesEntry.value:type_name -> tfplan.DynamicValue
+	12, // 25: tfplan.Plan.resource_attr.attr:type_name -> tfplan.Path
+	3,  // 26: tfplan.CheckResults.ObjectResult.status:type_name -> tfplan.CheckResults.Status
+	11, // 27: tfplan.Path.Step.element_key:type_name -> tfplan.DynamicValue
+	28, // [28:28] is the sub-list for method output_type
+	28, // [28:28] is the sub-list for method input_type
+	28, // [28:28] is the sub-list for extension type_name
+	28, // [28:28] is the sub-list for extension extendee
+	0,  // [0:28] is the sub-list for field type_name
 }
 
 func init() { file_planfile_proto_init() }

--- a/internal/plans/internal/planproto/planfile.proto
+++ b/internal/plans/internal/planproto/planfile.proto
@@ -183,6 +183,11 @@ message Change {
     // GeneratedConfig contains any configuration that was generated as part of
     // the change, as an HCL string.
     string generated_config = 6;
+
+    // PlannedIdentity is the identity value returned by the provider during
+    // planning. This is used to pass identity data through to the apply phase.
+    // Only relevant for managed resources, not outputs.
+    DynamicValue planned_identity = 7;
 }
 
 // ResourceInstanceActionReason sometimes provides some additional user-facing
@@ -350,4 +355,7 @@ message Path {
 message Importing {
     // The original ID of the resource.
     string id = 1;
+
+    // The Identity that we are importing, this is mutually exclusive with the id field
+    DynamicValue identity = 2;
 }

--- a/internal/plans/planfile/tfplan.go
+++ b/internal/plans/planfile/tfplan.go
@@ -23,8 +23,10 @@ import (
 	"github.com/opentofu/opentofu/version"
 )
 
-const tfplanFormatVersion = 3
-const tfplanFilename = "tfplan"
+const (
+	tfplanFormatVersion = 3
+	tfplanFilename      = "tfplan"
+)
 
 // ---------------------------------------------------------------------------
 // This file deals with the internal structure of the "tfplan" sub-file within
@@ -466,8 +468,24 @@ func changeFromTfplan(rawChange *planproto.Change) (*plans.ChangeSrc, error) {
 		ret.Importing = &plans.ImportingSrc{
 			ID: rawChange.Importing.Id,
 		}
+
+		if rawChange.Importing.Identity != nil {
+			identity, err := valueFromTfplan(rawChange.Importing.Identity)
+			if err != nil {
+				return nil, fmt.Errorf("invalid importing identity value: %w", err)
+			}
+			ret.Importing.Identity = identity
+		}
 	}
 	ret.GeneratedConfig = rawChange.GeneratedConfig
+
+	if rawChange.PlannedIdentity != nil {
+		plannedIdentity, err := valueFromTfplan(rawChange.PlannedIdentity)
+		if err != nil {
+			return nil, fmt.Errorf("invalid planned identity value: %w", err)
+		}
+		ret.PlannedIdentity = plannedIdentity
+	}
 
 	sensitive := cty.NewValueMarks(marks.Sensitive)
 	beforeValMarks, err := pathValueMarksFromTfplan(rawChange.BeforeSensitivePaths, sensitive)
@@ -832,8 +850,15 @@ func changeToTfplan(change *plans.ChangeSrc) (*planproto.Change, error) {
 			Id: change.Importing.ID,
 		}
 
+		if len(change.Importing.Identity) > 0 {
+			ret.Importing.Identity = valueToTfplan(change.Importing.Identity)
+		}
 	}
 	ret.GeneratedConfig = change.GeneratedConfig
+
+	if len(change.PlannedIdentity) > 0 {
+		ret.PlannedIdentity = valueToTfplan(change.PlannedIdentity)
+	}
 
 	switch change.Action {
 	case plans.NoOp:

--- a/internal/plans/planfile/tfplan_test.go
+++ b/internal/plans/planfile/tfplan_test.go
@@ -15,9 +15,11 @@ import (
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/checks"
+	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/lang/globalref"
 	"github.com/opentofu/opentofu/internal/lang/marks"
 	"github.com/opentofu/opentofu/internal/plans"
+	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/states"
 )
 
@@ -419,8 +421,15 @@ func TestTFPlanRoundTripDestroy(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	objSchema := &providers.Schema{
+		Block: &configschema.Block{
+			Attributes: map[string]*configschema.Attribute{
+				"id": {Type: cty.String, Optional: true},
+			},
+		},
+	}
 	for _, rics := range newPlan.Changes.Resources {
-		ric, err := rics.Decode(objTy)
+		ric, err := rics.Decode(objSchema)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/plugin/convert/diagnostics_test.go
+++ b/internal/plugin/convert/diagnostics_test.go
@@ -23,6 +23,8 @@ var ignoreUnexported = cmpopts.IgnoreUnexported(
 	proto.Schema_Block{},
 	proto.Schema_NestedBlock{},
 	proto.Schema_Attribute{},
+	proto.ResourceIdentitySchema{},
+	proto.ResourceIdentitySchema_IdentityAttribute{},
 )
 
 func TestProtoDiagnostics(t *testing.T) {

--- a/internal/plugin/convert/schema.go
+++ b/internal/plugin/convert/schema.go
@@ -7,8 +7,12 @@ package convert
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"sort"
+
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
 
 	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/providers"
@@ -55,6 +59,79 @@ func ConfigSchemaToProto(b *configschema.Block) *proto.Schema_Block {
 	}
 
 	return block
+}
+
+func ProtoToResourceIdentitySchema(s *proto.ResourceIdentitySchema) *providers.ResourceIdentitySchema {
+	// This method is taking a similar approach to ProtoToConfigSchema below, basically
+
+	// We cant convert these, and so we should return nil here.
+	if s == nil {
+		return nil
+	}
+
+	attributes := make(map[string]*configschema.Attribute, len(s.IdentityAttributes))
+	for _, a := range s.IdentityAttributes {
+		attribute := &configschema.Attribute{
+			Description: a.Description,
+			Required:    a.RequiredForImport,
+			Optional:    a.OptionalForImport,
+		}
+
+		if a.Type != nil {
+			t, err := ctyjson.UnmarshalType(a.Type)
+			if err != nil {
+				panic(fmt.Errorf("failed to unmarshal attribute type for resource identity: %w", err))
+			}
+			attribute.Type = t
+		}
+		attributes[a.Name] = attribute
+	}
+
+	return &providers.ResourceIdentitySchema{
+		Version: s.Version,
+
+		Body: &configschema.Object{
+			Attributes: attributes,
+			Nesting:    configschema.NestingSingle, // We dont allow nested schema here, hence we're using an Object and not a Block
+		},
+	}
+}
+
+// ResourceIdentitySchemaToProto takes a *configschema.Object and converts it to a
+// proto.ResourceIdentitySchema
+func ResourceIdentitySchemaToProto(schema *providers.ResourceIdentitySchema) *proto.ResourceIdentitySchema {
+	if schema == nil {
+		return nil
+	}
+
+	body := schema.Body
+
+	identityAttributes := make([]*proto.ResourceIdentitySchema_IdentityAttribute, 0, len(body.Attributes))
+	for _, name := range sortedKeys(body.Attributes) {
+		attribute := body.Attributes[name]
+
+		attr := &proto.ResourceIdentitySchema_IdentityAttribute{
+			Name:              name,
+			Description:       attribute.Description,
+			RequiredForImport: attribute.Required,
+			OptionalForImport: attribute.Optional,
+		}
+
+		if attribute.Type != cty.NilType {
+			ty, err := json.Marshal(attribute.Type)
+			if err != nil {
+				panic(fmt.Errorf("failed to marshal attribute type for resource identity: %w", err))
+			}
+			attr.Type = ty
+		}
+
+		identityAttributes = append(identityAttributes, attr)
+	}
+
+	return &proto.ResourceIdentitySchema{
+		Version:            schema.Version,
+		IdentityAttributes: identityAttributes,
+	}
 }
 
 func protoStringKind(k configschema.StringKind) proto.StringKind {

--- a/internal/plugin/convert/schema.go
+++ b/internal/plugin/convert/schema.go
@@ -61,16 +61,16 @@ func ConfigSchemaToProto(b *configschema.Block) *proto.Schema_Block {
 	return block
 }
 
-func ProtoToResourceIdentitySchema(s *proto.ResourceIdentitySchema) *providers.ResourceIdentitySchema {
+func ProtoToResourceIdentitySchema(schema *proto.ResourceIdentitySchema) *providers.ResourceIdentitySchema {
 	// This method is taking a similar approach to ProtoToConfigSchema below, basically
 
-	// We cant convert these, and so we should return nil here.
-	if s == nil {
+	// We can't convert these, and so we should return nil here.
+	if schema == nil {
 		return nil
 	}
 
-	attributes := make(map[string]*configschema.Attribute, len(s.IdentityAttributes))
-	for _, a := range s.IdentityAttributes {
+	attributes := make(map[string]*configschema.Attribute, len(schema.IdentityAttributes))
+	for _, a := range schema.IdentityAttributes {
 		attribute := &configschema.Attribute{
 			Description: a.Description,
 			Required:    a.RequiredForImport,
@@ -88,11 +88,11 @@ func ProtoToResourceIdentitySchema(s *proto.ResourceIdentitySchema) *providers.R
 	}
 
 	return &providers.ResourceIdentitySchema{
-		Version: s.Version,
+		Version: schema.Version,
 
 		Body: &configschema.Object{
 			Attributes: attributes,
-			Nesting:    configschema.NestingSingle, // We dont allow nested schema here, hence we're using an Object and not a Block
+			Nesting:    configschema.NestingSingle, // We don't allow nested schema here, hence we're using an Object and not a Block
 		},
 	}
 }

--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -11,11 +11,14 @@ import (
 	"fmt"
 
 	plugin "github.com/hashicorp/go-plugin"
-	"github.com/opentofu/opentofu/internal/plugin/validation"
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 	"github.com/zclconf/go-cty/cty/msgpack"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/opentofu/opentofu/internal/plugin/validation"
 
 	"github.com/opentofu/opentofu/internal/logging"
 	"github.com/opentofu/opentofu/internal/plugin/convert"
@@ -89,6 +92,50 @@ type GRPCProvider struct {
 	hasFetchedSchema bool
 }
 
+func (p *GRPCProvider) UpgradeResourceIdentity(ctx context.Context, req providers.UpgradeResourceIdentityRequest) (resp providers.UpgradeResourceIdentityResponse) {
+	logger.Trace("GRPCProvider: UpgradeResourceIdentity")
+
+	protoReq := &proto.UpgradeResourceIdentity_Request{
+		TypeName: req.TypeName,
+		Version:  req.Version,
+		RawIdentity: &proto.RawState{
+			Json: req.RawIdentityJSON,
+		},
+	}
+
+	protoResp, err := p.client.UpgradeResourceIdentity(ctx, protoReq)
+	if err != nil {
+		resp.Diagnostics = resp.Diagnostics.Append(grpcErr(err))
+		return resp
+	}
+	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))
+
+	if protoResp.UpgradedIdentity == nil || protoResp.UpgradedIdentity.IdentityData == nil {
+		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("call to UpgradeResourceIdentity returned nil for IdentityData, this should be non-nil"))
+		return resp
+	}
+
+	identitySchemas := p.GetResourceIdentitySchemas(ctx)
+	if identitySchemas.Diagnostics.HasErrors() {
+		resp.Diagnostics = resp.Diagnostics.Append(identitySchemas.Diagnostics)
+		return resp
+	}
+	identitySchema, ok := identitySchemas.IdentitySchemas[req.TypeName]
+	if !ok {
+		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("no identity schema for %q", req.TypeName))
+		return resp
+	}
+
+	identity, err := decodeDynamicValue(protoResp.UpgradedIdentity.IdentityData, identitySchema.Body.ImpliedType())
+	if err != nil {
+		resp.Diagnostics = resp.Diagnostics.Append(err)
+		return resp
+	}
+	resp.UpgradedIdentity = identity
+
+	return resp
+}
+
 var _ providers.Interface = new(GRPCProvider)
 
 func (p *GRPCProvider) GetProviderSchema(ctx context.Context) (resp providers.GetProviderSchemaResponse) {
@@ -155,6 +202,24 @@ func (p *GRPCProvider) getProviderSchema(ctx context.Context) (resp providers.Ge
 		resp.Functions[name] = convert.ProtoToFunctionSpec(fn)
 	}
 
+	identitySchemas := p.GetResourceIdentitySchemas(ctx)
+	if identitySchemas.Diagnostics.HasErrors() {
+		// Identity schemas are an optional enhancement. A provider bug in
+		// identity schemas should not prevent the provider from being used
+		// for all other operations, so we log the error and continue
+		// without identity schema support.
+		logger.Warn("failed to fetch resource identity schemas, identity-based features will be unavailable",
+			identitySchemas.Diagnostics.Err())
+	} else {
+		for name, idSchema := range identitySchemas.IdentitySchemas {
+			if resSchema, ok := resp.ResourceTypes[name]; ok {
+				resSchema.IdentitySchema = idSchema.Body
+				resSchema.IdentitySchemaVersion = idSchema.Version
+				resp.ResourceTypes[name] = resSchema
+			}
+		}
+	}
+
 	if protoResp.ServerCapabilities != nil {
 		resp.ServerCapabilities.PlanDestroy = protoResp.ServerCapabilities.PlanDestroy
 		resp.ServerCapabilities.GetProviderSchemaOptional = protoResp.ServerCapabilities.GetProviderSchemaOptional
@@ -181,6 +246,41 @@ func (p *GRPCProvider) getProtoProviderSchema(ctx context.Context) (*proto.GetPr
 	p.hasFetchedSchema = true
 
 	return resp, err
+}
+
+func (p *GRPCProvider) GetResourceIdentitySchemas(ctx context.Context) providers.GetResourceIdentitySchemasResponse {
+	logger.Trace("GRPCProvider: GetResourceIdentitySchemas")
+
+	// Caching is not needed here: callers should use resSchema.IdentitySchema
+	// from the cached GetProviderSchema response instead of calling this directly.
+	// This method is only used by GetProviderSchema (to merge identity schemas)
+	// and UpgradeResourceIdentity (called once per stale resource).
+	resp := providers.GetResourceIdentitySchemasResponse{
+		IdentitySchemas: make(map[string]providers.ResourceIdentitySchema),
+	}
+
+	protoResponse, err := p.client.GetResourceIdentitySchemas(ctx, new(proto.GetResourceIdentitySchemas_Request))
+	if err != nil {
+		// Providers that don't implement identity schemas return Unimplemented;
+		// this is expected and not an error — just return an empty response.
+		if status.Code(err) == codes.Unimplemented {
+			return resp
+		}
+		resp.Diagnostics = resp.Diagnostics.Append(grpcErr(err))
+		return resp
+	}
+
+	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResponse.Diagnostics))
+
+	if resp.Diagnostics.HasErrors() {
+		return resp
+	}
+
+	for resource, schema := range protoResponse.IdentitySchemas {
+		resp.IdentitySchemas[resource] = *convert.ProtoToResourceIdentitySchema(schema)
+	}
+
+	return resp
 }
 
 func (p *GRPCProvider) ValidateProviderConfig(ctx context.Context, r providers.ValidateProviderConfigRequest) (resp providers.ValidateProviderConfigResponse) {
@@ -462,6 +562,18 @@ func (p *GRPCProvider) ReadResource(ctx context.Context, r providers.ReadResourc
 		ClientCapabilities: clientCapabilities,
 	}
 
+	// Attach the identity if it is available
+	if !r.PriorIdentity.IsNull() && resSchema.IdentitySchema != nil {
+		identityMP, err := msgpack.Marshal(r.PriorIdentity, resSchema.IdentitySchema.ImpliedType())
+		if err != nil {
+			resp.Diagnostics = resp.Diagnostics.Append(err)
+			return resp
+		}
+		protoReq.CurrentIdentity = &proto.ResourceIdentityData{
+			IdentityData: &proto.DynamicValue{Msgpack: identityMP},
+		}
+	}
+
 	if metaSchema.Block != nil {
 		metaMP, err := msgpack.Marshal(r.ProviderMeta, metaSchema.Block.ImpliedType())
 		if err != nil {
@@ -485,6 +597,16 @@ func (p *GRPCProvider) ReadResource(ctx context.Context, r providers.ReadResourc
 	}
 	resp.NewState = state
 	resp.Private = protoResp.Private
+
+	// Process identity from response
+	if protoResp.NewIdentity != nil && protoResp.NewIdentity.IdentityData != nil && resSchema.IdentitySchema != nil {
+		identity, err := decodeDynamicValue(protoResp.NewIdentity.IdentityData, resSchema.IdentitySchema.ImpliedType())
+		if err != nil {
+			resp.Diagnostics = resp.Diagnostics.Append(err)
+			return resp
+		}
+		resp.NewIdentity = identity
+	}
 
 	resp.Diagnostics = resp.Diagnostics.Append(validation.WriteOnlyAttributes(resSchema.Block, resp.NewState, r.TypeName))
 
@@ -544,6 +666,17 @@ func (p *GRPCProvider) PlanResourceChange(ctx context.Context, r providers.PlanR
 		ClientCapabilities: clientCapabilities,
 	}
 
+	if !r.PriorIdentity.IsNull() && resSchema.IdentitySchema != nil {
+		identityMP, err := msgpack.Marshal(r.PriorIdentity, resSchema.IdentitySchema.ImpliedType())
+		if err != nil {
+			resp.Diagnostics = resp.Diagnostics.Append(err)
+			return resp
+		}
+		protoReq.PriorIdentity = &proto.ResourceIdentityData{
+			IdentityData: &proto.DynamicValue{Msgpack: identityMP},
+		}
+	}
+
 	if metaSchema.Block != nil {
 		metaMP, err := msgpack.Marshal(r.ProviderMeta, metaSchema.Block.ImpliedType())
 		if err != nil {
@@ -559,6 +692,15 @@ func (p *GRPCProvider) PlanResourceChange(ctx context.Context, r providers.PlanR
 		return resp
 	}
 	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))
+
+	if protoResp.PlannedIdentity != nil && protoResp.PlannedIdentity.IdentityData != nil && resSchema.IdentitySchema != nil {
+		identity, err := decodeDynamicValue(protoResp.PlannedIdentity.IdentityData, resSchema.IdentitySchema.ImpliedType())
+		if err != nil {
+			resp.Diagnostics = resp.Diagnostics.Append(err)
+			return resp
+		}
+		resp.PlannedIdentity = identity
+	}
 
 	state, err := decodeDynamicValue(protoResp.PlannedState, resSchema.Block.ImpliedType())
 	if err != nil {
@@ -628,6 +770,18 @@ func (p *GRPCProvider) ApplyResourceChange(ctx context.Context, r providers.Appl
 		PlannedPrivate: r.PlannedPrivate,
 	}
 
+	// Attach the proposed identity from the plan if it exists
+	if !r.PlannedIdentity.IsNull() && resSchema.IdentitySchema != nil {
+		identityMP, err := msgpack.Marshal(r.PlannedIdentity, resSchema.IdentitySchema.ImpliedType())
+		if err != nil {
+			resp.Diagnostics = resp.Diagnostics.Append(err)
+			return resp
+		}
+		protoReq.PlannedIdentity = &proto.ResourceIdentityData{
+			IdentityData: &proto.DynamicValue{Msgpack: identityMP},
+		}
+	}
+
 	if metaSchema.Block != nil {
 		metaMP, err := msgpack.Marshal(r.ProviderMeta, metaSchema.Block.ImpliedType())
 		if err != nil {
@@ -645,6 +799,15 @@ func (p *GRPCProvider) ApplyResourceChange(ctx context.Context, r providers.Appl
 	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))
 
 	resp.Private = protoResp.Private
+
+	if protoResp.NewIdentity != nil && protoResp.NewIdentity.IdentityData != nil && resSchema.IdentitySchema != nil {
+		identity, err := decodeDynamicValue(protoResp.NewIdentity.IdentityData, resSchema.IdentitySchema.ImpliedType())
+		if err != nil {
+			resp.Diagnostics = resp.Diagnostics.Append(err)
+			return resp
+		}
+		resp.NewIdentity = identity
+	}
 
 	state, err := decodeDynamicValue(protoResp.NewState, resSchema.Block.ImpliedType())
 	if err != nil {
@@ -671,8 +834,29 @@ func (p *GRPCProvider) ImportResourceState(ctx context.Context, r providers.Impo
 
 	protoReq := &proto.ImportResourceState_Request{
 		TypeName:           r.TypeName,
-		Id:                 r.ID,
 		ClientCapabilities: clientCapabilities,
+	}
+
+	// If importing by identity, encode the identity value
+	if r.Target.IsIdentityBased() {
+		resSchema, ok := schema.ResourceTypes[r.TypeName]
+		if !ok || resSchema.IdentitySchema == nil {
+			resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("no identity schema found for resource type %q", r.TypeName))
+			return resp
+		}
+
+		identityMP, err := msgpack.Marshal(r.Target.Identity, resSchema.IdentitySchema.ImpliedType())
+		if err != nil {
+			resp.Diagnostics = resp.Diagnostics.Append(err)
+			return resp
+		}
+
+		protoReq.Identity = &proto.ResourceIdentityData{
+			IdentityData: &proto.DynamicValue{Msgpack: identityMP},
+		}
+	} else {
+		// We're ID based
+		protoReq.Id = r.Target.ID
 	}
 
 	protoResp, err := p.client.ImportResourceState(ctx, protoReq)
@@ -692,6 +876,17 @@ func (p *GRPCProvider) ImportResourceState(ctx context.Context, r providers.Impo
 		if !ok {
 			resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unknown resource type %q", r.TypeName))
 			continue
+		}
+
+		if imported.Identity != nil && imported.Identity.IdentityData != nil {
+			if resSchema.IdentitySchema != nil {
+				identity, err := decodeDynamicValue(imported.Identity.IdentityData, resSchema.IdentitySchema.ImpliedType())
+				if err != nil {
+					resp.Diagnostics = resp.Diagnostics.Append(err)
+					continue
+				}
+				resource.Identity = identity
+			}
 		}
 
 		state, err := decodeDynamicValue(imported.State, resSchema.Block.ImpliedType())
@@ -1000,13 +1195,12 @@ func (p *GRPCProvider) CallFunction(ctx context.Context, r providers.CallFunctio
 					FunctionArgument: i,
 				}
 			}
-
 		}
 
 		encodedArg, err := msgpack.Marshal(arg, paramSpec.Type)
 		if err != nil {
 			resp.Error = err
-			return
+			return resp
 		}
 
 		protoReq.Arguments[i] = &proto.DynamicValue{
@@ -1017,7 +1211,7 @@ func (p *GRPCProvider) CallFunction(ctx context.Context, r providers.CallFunctio
 	protoResp, err := p.client.CallFunction(ctx, protoReq)
 	if err != nil {
 		resp.Error = err
-		return
+		return resp
 	}
 
 	if protoResp.Error != nil {
@@ -1028,11 +1222,11 @@ func (p *GRPCProvider) CallFunction(ctx context.Context, r providers.CallFunctio
 			err.FunctionArgument = int(*protoResp.Error.FunctionArgument)
 		}
 		resp.Error = err
-		return
+		return resp
 	}
 
 	resp.Result, resp.Error = decodeDynamicValue(protoResp.Result, spec.Return)
-	return
+	return resp
 }
 
 // closing the grpc connection is final, and tofu will call it at the end of every phase.

--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -23,6 +23,7 @@ import (
 	"github.com/opentofu/opentofu/internal/logging"
 	"github.com/opentofu/opentofu/internal/plugin/convert"
 	"github.com/opentofu/opentofu/internal/providers"
+	"github.com/opentofu/opentofu/internal/tfdiags"
 	proto "github.com/opentofu/opentofu/internal/tfplugin5"
 )
 
@@ -111,7 +112,13 @@ func (p *GRPCProvider) UpgradeResourceIdentity(ctx context.Context, req provider
 	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))
 
 	if protoResp.UpgradedIdentity == nil || protoResp.UpgradedIdentity.IdentityData == nil {
-		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("call to UpgradeResourceIdentity returned nil for IdentityData, this should be non-nil"))
+		if !resp.Diagnostics.HasErrors() {
+			resp.Diagnostics = resp.Diagnostics.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Provider returned no identity after upgrade",
+				fmt.Sprintf("The provider returned a nil identity for %q after UpgradeResourceIdentity without reporting an error. This is a bug in the provider.", req.TypeName),
+			))
+		}
 		return resp
 	}
 

--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -122,18 +122,19 @@ func (p *GRPCProvider) UpgradeResourceIdentity(ctx context.Context, req provider
 		return resp
 	}
 
-	identitySchemas := p.GetResourceIdentitySchemas(ctx)
-	if identitySchemas.Diagnostics.HasErrors() {
-		resp.Diagnostics = resp.Diagnostics.Append(identitySchemas.Diagnostics)
+	// Now we need to look up the resource identity schema from the provider resource schemas.
+	providerSchema := p.GetProviderSchema(ctx)
+	if providerSchema.Diagnostics.HasErrors() {
+		resp.Diagnostics = resp.Diagnostics.Append(providerSchema.Diagnostics)
 		return resp
 	}
-	identitySchema, ok := identitySchemas.IdentitySchemas[req.TypeName]
-	if !ok {
+	resSchema, ok := providerSchema.ResourceTypes[req.TypeName]
+	if !ok || resSchema.IdentitySchema == nil {
 		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("no identity schema for %q", req.TypeName))
 		return resp
 	}
 
-	identity, err := decodeDynamicValue(protoResp.UpgradedIdentity.IdentityData, identitySchema.Body.ImpliedType())
+	identity, err := decodeDynamicValue(protoResp.UpgradedIdentity.IdentityData, resSchema.IdentitySchema.ImpliedType())
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp
@@ -209,7 +210,7 @@ func (p *GRPCProvider) getProviderSchema(ctx context.Context) (resp providers.Ge
 		resp.Functions[name] = convert.ProtoToFunctionSpec(fn)
 	}
 
-	identitySchemas := p.GetResourceIdentitySchemas(ctx)
+	identitySchemas := p.getResourceIdentitySchemas(ctx)
 	if identitySchemas.Diagnostics.HasErrors() {
 		// Identity schemas are an optional enhancement. A provider bug in
 		// identity schemas should not prevent the provider from being used
@@ -255,8 +256,8 @@ func (p *GRPCProvider) getProtoProviderSchema(ctx context.Context) (*proto.GetPr
 	return resp, err
 }
 
-func (p *GRPCProvider) GetResourceIdentitySchemas(ctx context.Context) providers.GetResourceIdentitySchemasResponse {
-	logger.Trace("GRPCProvider: GetResourceIdentitySchemas")
+func (p *GRPCProvider) getResourceIdentitySchemas(ctx context.Context) providers.GetResourceIdentitySchemasResponse {
+	logger.Trace("GRPCProvider: getResourceIdentitySchemas")
 
 	// Caching is not needed here: callers should use resSchema.IdentitySchema
 	// from the cached GetProviderSchema response instead of calling this directly.

--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -130,7 +130,11 @@ func (p *GRPCProvider) UpgradeResourceIdentity(ctx context.Context, req provider
 	}
 	resSchema, ok := providerSchema.ResourceTypes[req.TypeName]
 	if !ok || resSchema.IdentitySchema == nil {
-		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("no identity schema for %q", req.TypeName))
+		resp.Diagnostics = resp.Diagnostics.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"No identity schema found",
+			fmt.Sprintf("No identity schema available for resource type %q.", req.TypeName),
+		))
 		return resp
 	}
 
@@ -847,7 +851,11 @@ func (p *GRPCProvider) ImportResourceState(ctx context.Context, r providers.Impo
 	if r.Target.IsIdentityBased() {
 		resSchema, ok := schema.ResourceTypes[r.TypeName]
 		if !ok || resSchema.IdentitySchema == nil {
-			resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("no identity schema found for resource type %q", r.TypeName))
+			resp.Diagnostics = resp.Diagnostics.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"No identity schema found",
+				fmt.Sprintf("No identity schema available for resource type %q.", r.TypeName),
+			))
 			return resp
 		}
 

--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -18,10 +18,9 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/opentofu/opentofu/internal/plugin/validation"
-
 	"github.com/opentofu/opentofu/internal/logging"
 	"github.com/opentofu/opentofu/internal/plugin/convert"
+	"github.com/opentofu/opentofu/internal/plugin/validation"
 	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	proto "github.com/opentofu/opentofu/internal/tfplugin5"
@@ -159,16 +158,15 @@ func (p *GRPCProvider) getProviderSchema(ctx context.Context) (resp providers.Ge
 		resp.Functions[name] = convert.ProtoToFunctionSpec(fn)
 	}
 
-	identitySchemas := p.getResourceIdentitySchemas(ctx)
-	if identitySchemas.Diagnostics.HasErrors() {
+	identitySchemas, idsDiags := p.getResourceIdentitySchemas(ctx)
+	if idsDiags.HasErrors() {
 		// Identity schemas are an optional enhancement. A provider bug in
 		// identity schemas should not prevent the provider from being used
 		// for all other operations, so we log the error and continue
 		// without identity schema support.
-		logger.Warn("failed to fetch resource identity schemas, identity-based features will be unavailable",
-			identitySchemas.Diagnostics.Err())
+		logger.Warn("failed to fetch resource identity schemas, identity-based features will be unavailable", idsDiags.Err())
 	} else {
-		for name, idSchema := range identitySchemas.IdentitySchemas {
+		for name, idSchema := range identitySchemas {
 			if resSchema, ok := resp.ResourceTypes[name]; ok {
 				resSchema.IdentitySchema = idSchema.Body
 				resSchema.IdentitySchemaVersion = idSchema.Version
@@ -208,34 +206,31 @@ func (p *GRPCProvider) getProtoProviderSchema(ctx context.Context) (*proto.GetPr
 // getResourceIdentitySchemas should ONLY be called from GetProviderSchema, which
 // merges the identity schemas into the cached provider schema response. All other
 // callers should use resSchema.IdentitySchema from the GetProviderSchema response.
-func (p *GRPCProvider) getResourceIdentitySchemas(ctx context.Context) providers.GetResourceIdentitySchemasResponse {
+func (p *GRPCProvider) getResourceIdentitySchemas(ctx context.Context) (map[string]providers.ResourceIdentitySchema, tfdiags.Diagnostics) {
 	logger.Trace("GRPCProvider: getResourceIdentitySchemas")
-	resp := providers.GetResourceIdentitySchemasResponse{
-		IdentitySchemas: make(map[string]providers.ResourceIdentitySchema),
-	}
+	var diags tfdiags.Diagnostics
 
 	protoResponse, err := p.client.GetResourceIdentitySchemas(ctx, new(proto.GetResourceIdentitySchemas_Request))
 	if err != nil {
 		// Providers that don't implement identity schemas return Unimplemented;
 		// this is expected and not an error — just return an empty response.
 		if status.Code(err) == codes.Unimplemented {
-			return resp
+			return nil, diags
 		}
-		resp.Diagnostics = resp.Diagnostics.Append(grpcErr(err))
-		return resp
+		diags = diags.Append(grpcErr(err))
+		return nil, diags
 	}
 
-	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResponse.Diagnostics))
-
-	if resp.Diagnostics.HasErrors() {
-		return resp
+	diags = diags.Append(convert.ProtoToDiagnostics(protoResponse.Diagnostics))
+	if diags.HasErrors() || len(protoResponse.IdentitySchemas) == 0 {
+		return nil, diags
 	}
 
-	for resource, schema := range protoResponse.IdentitySchemas {
-		resp.IdentitySchemas[resource] = *convert.ProtoToResourceIdentitySchema(schema)
+	identitySchemas := make(map[string]providers.ResourceIdentitySchema, len(protoResponse.IdentitySchemas))
+	for resourceType, schema := range protoResponse.IdentitySchemas {
+		identitySchemas[resourceType] = *convert.ProtoToResourceIdentitySchema(schema)
 	}
-
-	return resp
+	return identitySchemas, diags
 }
 
 func (p *GRPCProvider) ValidateProviderConfig(ctx context.Context, r providers.ValidateProviderConfigRequest) (resp providers.ValidateProviderConfigResponse) {

--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -93,61 +93,6 @@ type GRPCProvider struct {
 	hasFetchedSchema bool
 }
 
-func (p *GRPCProvider) UpgradeResourceIdentity(ctx context.Context, req providers.UpgradeResourceIdentityRequest) (resp providers.UpgradeResourceIdentityResponse) {
-	logger.Trace("GRPCProvider: UpgradeResourceIdentity")
-
-	protoReq := &proto.UpgradeResourceIdentity_Request{
-		TypeName: req.TypeName,
-		Version:  req.Version,
-		RawIdentity: &proto.RawState{
-			Json: req.RawIdentityJSON,
-		},
-	}
-
-	protoResp, err := p.client.UpgradeResourceIdentity(ctx, protoReq)
-	if err != nil {
-		resp.Diagnostics = resp.Diagnostics.Append(grpcErr(err))
-		return resp
-	}
-	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))
-
-	if protoResp.UpgradedIdentity == nil || protoResp.UpgradedIdentity.IdentityData == nil {
-		if !resp.Diagnostics.HasErrors() {
-			resp.Diagnostics = resp.Diagnostics.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Provider returned no identity after upgrade",
-				fmt.Sprintf("The provider returned a nil identity for %q after UpgradeResourceIdentity without reporting an error. This is a bug in the provider.", req.TypeName),
-			))
-		}
-		return resp
-	}
-
-	// Now we need to look up the resource identity schema from the provider resource schemas.
-	providerSchema := p.GetProviderSchema(ctx)
-	if providerSchema.Diagnostics.HasErrors() {
-		resp.Diagnostics = resp.Diagnostics.Append(providerSchema.Diagnostics)
-		return resp
-	}
-	resSchema, ok := providerSchema.ResourceTypes[req.TypeName]
-	if !ok || resSchema.IdentitySchema == nil {
-		resp.Diagnostics = resp.Diagnostics.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"No identity schema found",
-			fmt.Sprintf("No identity schema available for resource type %q.", req.TypeName),
-		))
-		return resp
-	}
-
-	identity, err := decodeDynamicValue(protoResp.UpgradedIdentity.IdentityData, resSchema.IdentitySchema.ImpliedType())
-	if err != nil {
-		resp.Diagnostics = resp.Diagnostics.Append(err)
-		return resp
-	}
-	resp.UpgradedIdentity = identity
-
-	return resp
-}
-
 var _ providers.Interface = new(GRPCProvider)
 
 func (p *GRPCProvider) GetProviderSchema(ctx context.Context) (resp providers.GetProviderSchemaResponse) {
@@ -483,6 +428,61 @@ func (p *GRPCProvider) UpgradeResourceState(ctx context.Context, r providers.Upg
 	resp.UpgradedState = state
 
 	resp.Diagnostics = resp.Diagnostics.Append(validation.WriteOnlyAttributes(resSchema.Block, resp.UpgradedState, r.TypeName))
+
+	return resp
+}
+
+func (p *GRPCProvider) UpgradeResourceIdentity(ctx context.Context, req providers.UpgradeResourceIdentityRequest) (resp providers.UpgradeResourceIdentityResponse) {
+	logger.Trace("GRPCProvider: UpgradeResourceIdentity")
+
+	protoReq := &proto.UpgradeResourceIdentity_Request{
+		TypeName: req.TypeName,
+		Version:  req.Version,
+		RawIdentity: &proto.RawState{
+			Json: req.RawIdentityJSON,
+		},
+	}
+
+	protoResp, err := p.client.UpgradeResourceIdentity(ctx, protoReq)
+	if err != nil {
+		resp.Diagnostics = resp.Diagnostics.Append(grpcErr(err))
+		return resp
+	}
+	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))
+
+	if protoResp.UpgradedIdentity == nil || protoResp.UpgradedIdentity.IdentityData == nil {
+		if !resp.Diagnostics.HasErrors() {
+			resp.Diagnostics = resp.Diagnostics.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Provider returned no identity after upgrade",
+				fmt.Sprintf("The provider returned a nil identity for %q after UpgradeResourceIdentity without reporting an error. This is a bug in the provider.", req.TypeName),
+			))
+		}
+		return resp
+	}
+
+	// Now we need to look up the resource identity schema from the provider resource schemas.
+	providerSchema := p.GetProviderSchema(ctx)
+	if providerSchema.Diagnostics.HasErrors() {
+		resp.Diagnostics = resp.Diagnostics.Append(providerSchema.Diagnostics)
+		return resp
+	}
+	resSchema, ok := providerSchema.ResourceTypes[req.TypeName]
+	if !ok || resSchema.IdentitySchema == nil {
+		resp.Diagnostics = resp.Diagnostics.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"No identity schema found",
+			fmt.Sprintf("No identity schema available for resource type %q.", req.TypeName),
+		))
+		return resp
+	}
+
+	identity, err := decodeDynamicValue(protoResp.UpgradedIdentity.IdentityData, resSchema.IdentitySchema.ImpliedType())
+	if err != nil {
+		resp.Diagnostics = resp.Diagnostics.Append(err)
+		return resp
+	}
+	resp.UpgradedIdentity = identity
 
 	return resp
 }

--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -256,13 +256,11 @@ func (p *GRPCProvider) getProtoProviderSchema(ctx context.Context) (*proto.GetPr
 	return resp, err
 }
 
+// getResourceIdentitySchemas should ONLY be called from GetProviderSchema, which
+// merges the identity schemas into the cached provider schema response. All other
+// callers should use resSchema.IdentitySchema from the GetProviderSchema response.
 func (p *GRPCProvider) getResourceIdentitySchemas(ctx context.Context) providers.GetResourceIdentitySchemasResponse {
 	logger.Trace("GRPCProvider: getResourceIdentitySchemas")
-
-	// Caching is not needed here: callers should use resSchema.IdentitySchema
-	// from the cached GetProviderSchema response instead of calling this directly.
-	// This method is only used by GetProviderSchema (to merge identity schemas)
-	// and UpgradeResourceIdentity (called once per stale resource).
 	resp := providers.GetResourceIdentitySchemasResponse{
 		IdentitySchemas: make(map[string]providers.ResourceIdentitySchema),
 	}

--- a/internal/plugin/grpc_provider_test.go
+++ b/internal/plugin/grpc_provider_test.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/legacy/hcl2shim"
 	mockproto "github.com/opentofu/opentofu/internal/plugin/mock_proto"
 	"github.com/opentofu/opentofu/internal/providers"
@@ -413,29 +414,29 @@ func TestGRPCProvider_UpgradeResourceIdentity(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	client := mockproto.NewMockProviderClient(ctrl)
 
-	// initial identity
-	client.EXPECT().GetResourceIdentitySchemas(
-		gomock.Any(),
-		gomock.Any(),
-	).Return(&proto.GetResourceIdentitySchemas_Response{
-		IdentitySchemas: map[string]*proto.ResourceIdentitySchema{
-			"test_resource": {
-				Version: 1,
-				IdentityAttributes: []*proto.ResourceIdentitySchema_IdentityAttribute{
-					{
-						Name:              "id",
-						Type:              []byte(`"string"`),
-						RequiredForImport: true,
+	// Assert that no schema RPCs are made: the schema cache is pre-warmed and
+	// UpgradeResourceIdentity must not bypass it by calling schema RPCs directly.
+	client.EXPECT().GetSchema(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	client.EXPECT().GetResourceIdentitySchemas(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	cache := providers.NewSchemaCache()
+	cache(func() providers.GetProviderSchemaResponse {
+		return providers.GetProviderSchemaResponse{
+			ServerCapabilities: providers.ServerCapabilities{GetProviderSchemaOptional: true},
+			ResourceTypes: map[string]providers.Schema{
+				"test_resource": {
+					IdentitySchema: &configschema.Object{
+						Nesting: configschema.NestingSingle,
+						Attributes: map[string]*configschema.Attribute{
+							"id":     {Type: cty.String},
+							"region": {Type: cty.String},
+						},
 					},
-					{
-						Name:              "region",
-						Type:              []byte(`"string"`),
-						RequiredForImport: true,
-					},
+					IdentitySchemaVersion: 1,
 				},
 			},
-		},
-	}, nil)
+		}
+	})
 
 	// upgraded entity from the provider
 	upgradedIdentity := cty.ObjectVal(map[string]cty.Value{
@@ -456,8 +457,7 @@ func TestGRPCProvider_UpgradeResourceIdentity(t *testing.T) {
 		},
 	}, nil)
 
-	// Ensure that our UpgradeResourceIdentity logic does what it should
-	p := newGRPCProvider(client)
+	p := &GRPCProvider{client: client, SchemaCache: cache}
 	resp := p.UpgradeResourceIdentity(t.Context(), providers.UpgradeResourceIdentityRequest{
 		TypeName:        "test_resource",
 		Version:         1,

--- a/internal/plugin6/convert/diagnostics_test.go
+++ b/internal/plugin6/convert/diagnostics_test.go
@@ -21,6 +21,8 @@ var ignoreUnexported = cmpopts.IgnoreUnexported(
 	proto.Schema_Block{},
 	proto.Schema_NestedBlock{},
 	proto.Schema_Attribute{},
+	proto.ResourceIdentitySchema{},
+	proto.ResourceIdentitySchema_IdentityAttribute{},
 )
 
 func TestProtoDiagnostics(t *testing.T) {

--- a/internal/plugin6/convert/schema.go
+++ b/internal/plugin6/convert/schema.go
@@ -7,13 +7,16 @@ package convert
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"sort"
+
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
 
 	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/providers"
 	proto "github.com/opentofu/opentofu/internal/tfplugin6"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // ConfigSchemaToProto takes a *configschema.Block and converts it to a
@@ -102,6 +105,78 @@ func ProtoToProviderSchema(s *proto.Schema) providers.Schema {
 	return providers.Schema{
 		Version: s.Version,
 		Block:   ProtoToConfigSchema(s.Block),
+	}
+}
+
+func ProtoToResourceIdentitySchema(s *proto.ResourceIdentitySchema) *providers.ResourceIdentitySchema {
+	// This method is taking a similar approach to ProtoToConfigSchema below, basically
+
+	// We cant convert these
+	if s == nil {
+		return nil
+	}
+
+	attributes := make(map[string]*configschema.Attribute, len(s.IdentityAttributes))
+	for _, a := range s.IdentityAttributes {
+		attribute := &configschema.Attribute{
+			Description: a.Description,
+			Required:    a.RequiredForImport,
+			Optional:    a.OptionalForImport,
+		}
+		if a.Type != nil {
+			t, err := ctyjson.UnmarshalType(a.Type)
+			if err != nil {
+				panic(fmt.Errorf("failed to unmarshal attribute type for resource identity: %w", err))
+			}
+			attribute.Type = t
+		}
+		attributes[a.Name] = attribute
+	}
+
+	return &providers.ResourceIdentitySchema{
+		Version: s.Version,
+
+		Body: &configschema.Object{
+			Attributes: attributes,
+			Nesting:    configschema.NestingSingle, // We dont allow nested schema here, hence we're using an Object and not a Block
+		},
+	}
+}
+
+// ResourceIdentitySchemaToProto takes a *configschema.Object and converts it to a
+// proto.ResourceIdentitySchema
+func ResourceIdentitySchemaToProto(schema *providers.ResourceIdentitySchema) *proto.ResourceIdentitySchema {
+	if schema == nil {
+		return nil
+	}
+
+	body := schema.Body
+
+	identityAttributes := make([]*proto.ResourceIdentitySchema_IdentityAttribute, 0, len(body.Attributes))
+	for _, name := range sortedKeys(body.Attributes) {
+		attribute := body.Attributes[name]
+
+		attr := &proto.ResourceIdentitySchema_IdentityAttribute{
+			Name:              name,
+			Description:       attribute.Description,
+			RequiredForImport: attribute.Required,
+			OptionalForImport: attribute.Optional,
+		}
+
+		if attribute.Type != cty.NilType {
+			ty, err := json.Marshal(attribute.Type)
+			if err != nil {
+				panic(fmt.Errorf("failed to marshal attribute type for resource identity: %w", err))
+			}
+			attr.Type = ty
+		}
+
+		identityAttributes = append(identityAttributes, attr)
+	}
+
+	return &proto.ResourceIdentitySchema{
+		Version:            schema.Version,
+		IdentityAttributes: identityAttributes,
 	}
 }
 

--- a/internal/plugin6/convert/schema.go
+++ b/internal/plugin6/convert/schema.go
@@ -111,7 +111,7 @@ func ProtoToProviderSchema(s *proto.Schema) providers.Schema {
 func ProtoToResourceIdentitySchema(s *proto.ResourceIdentitySchema) *providers.ResourceIdentitySchema {
 	// This method is taking a similar approach to ProtoToConfigSchema below, basically
 
-	// We cant convert these
+	// We can't convert these
 	if s == nil {
 		return nil
 	}
@@ -138,7 +138,7 @@ func ProtoToResourceIdentitySchema(s *proto.ResourceIdentitySchema) *providers.R
 
 		Body: &configschema.Object{
 			Attributes: attributes,
-			Nesting:    configschema.NestingSingle, // We dont allow nested schema here, hence we're using an Object and not a Block
+			Nesting:    configschema.NestingSingle, // We don't allow nested schema here, hence we're using an Object and not a Block
 		},
 	}
 }

--- a/internal/plugin6/convert/schema_test.go
+++ b/internal/plugin6/convert/schema_test.go
@@ -11,8 +11,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
+	"github.com/opentofu/opentofu/internal/providers"
 	proto "github.com/opentofu/opentofu/internal/tfplugin6"
 	"github.com/zclconf/go-cty/cty"
+	"google.golang.org/protobuf/testing/protocmp"
 )
 
 var (
@@ -376,16 +378,16 @@ func TestConvertSchemaBlocks(t *testing.T) {
 			},
 			&configschema.Block{
 				BlockTypes: map[string]*configschema.NestedBlock{
-					"list": &configschema.NestedBlock{
+					"list": {
 						Nesting: configschema.NestingList,
 					},
-					"map": &configschema.NestedBlock{
+					"map": {
 						Nesting: configschema.NestingMap,
 					},
-					"set": &configschema.NestedBlock{
+					"set": {
 						Nesting: configschema.NestingSet,
 					},
-					"single": &configschema.NestedBlock{
+					"single": {
 						Nesting: configschema.NestingSingle,
 						Block: configschema.Block{
 							Attributes: map[string]*configschema.Attribute{
@@ -431,15 +433,15 @@ func TestConvertSchemaBlocks(t *testing.T) {
 			},
 			&configschema.Block{
 				BlockTypes: map[string]*configschema.NestedBlock{
-					"single": &configschema.NestedBlock{
+					"single": {
 						Nesting: configschema.NestingSingle,
 						Block: configschema.Block{
 							BlockTypes: map[string]*configschema.NestedBlock{
-								"list": &configschema.NestedBlock{
+								"list": {
 									Nesting: configschema.NestingList,
 									Block: configschema.Block{
 										BlockTypes: map[string]*configschema.NestedBlock{
-											"set": &configschema.NestedBlock{
+											"set": {
 												Nesting: configschema.NestingSet,
 											},
 										},
@@ -566,16 +568,16 @@ func TestConvertProtoSchemaBlocks(t *testing.T) {
 			},
 			&configschema.Block{
 				BlockTypes: map[string]*configschema.NestedBlock{
-					"list": &configschema.NestedBlock{
+					"list": {
 						Nesting: configschema.NestingList,
 					},
-					"map": &configschema.NestedBlock{
+					"map": {
 						Nesting: configschema.NestingMap,
 					},
-					"set": &configschema.NestedBlock{
+					"set": {
 						Nesting: configschema.NestingSet,
 					},
-					"single": &configschema.NestedBlock{
+					"single": {
 						Nesting: configschema.NestingSingle,
 						Block: configschema.Block{
 							Attributes: map[string]*configschema.Attribute{
@@ -621,15 +623,15 @@ func TestConvertProtoSchemaBlocks(t *testing.T) {
 			},
 			&configschema.Block{
 				BlockTypes: map[string]*configschema.NestedBlock{
-					"single": &configschema.NestedBlock{
+					"single": {
 						Nesting: configschema.NestingSingle,
 						Block: configschema.Block{
 							BlockTypes: map[string]*configschema.NestedBlock{
-								"list": &configschema.NestedBlock{
+								"list": {
 									Nesting: configschema.NestingList,
 									Block: configschema.Block{
 										BlockTypes: map[string]*configschema.NestedBlock{
-											"set": &configschema.NestedBlock{
+											"set": {
 												Nesting: configschema.NestingSet,
 											},
 										},
@@ -648,6 +650,254 @@ func TestConvertProtoSchemaBlocks(t *testing.T) {
 			converted := ConfigSchemaToProto(tc.Block)
 			if !cmp.Equal(converted, tc.Want, typeComparer, equateEmpty, ignoreUnexported) {
 				t.Fatal(cmp.Diff(converted, tc.Want, typeComparer, equateEmpty, ignoreUnexported))
+			}
+		})
+	}
+}
+
+func TestProtoToResourceIdentitySchema(t *testing.T) {
+	tests := map[string]struct {
+		Schema *proto.ResourceIdentitySchema
+		Want   *providers.ResourceIdentitySchema
+	}{
+		"nil schema should return nil": {
+			Schema: nil,
+			Want:   nil,
+		},
+		"simple schema should convert with no errors": {
+			Schema: &proto.ResourceIdentitySchema{
+				Version: 1,
+				IdentityAttributes: []*proto.ResourceIdentitySchema_IdentityAttribute{
+					{
+						Name:        "simple",
+						Type:        []byte(`"string"`),
+						Description: "A simple string attribute",
+					},
+				},
+			},
+			Want: &providers.ResourceIdentitySchema{
+				Version: 1,
+				Body: &configschema.Object{
+					Attributes: map[string]*configschema.Attribute{
+						"simple": {
+							Type:            cty.String,
+							Description:     "A simple string attribute",
+							DescriptionKind: configschema.StringPlain,
+						},
+					},
+					Nesting: configschema.NestingSingle,
+				},
+			},
+		},
+		"schema with required attribute shoud convert with no errors": {
+			Schema: &proto.ResourceIdentitySchema{
+				Version: 1,
+				IdentityAttributes: []*proto.ResourceIdentitySchema_IdentityAttribute{
+					{
+						Name:              "required",
+						Type:              []byte(`"string"`),
+						Description:       "A required string attribute",
+						RequiredForImport: true,
+					},
+				},
+			},
+			Want: &providers.ResourceIdentitySchema{
+				Version: 1,
+				Body: &configschema.Object{
+					Attributes: map[string]*configschema.Attribute{
+						"required": {
+							Type:            cty.String,
+							Description:     "A required string attribute",
+							DescriptionKind: configschema.StringPlain,
+							Required:        true,
+						},
+					},
+					Nesting: configschema.NestingSingle,
+				},
+			},
+		},
+		"schema with optional attribute shoud convert with no errors": {
+			Schema: &proto.ResourceIdentitySchema{
+				Version: 1,
+				IdentityAttributes: []*proto.ResourceIdentitySchema_IdentityAttribute{
+					{
+						Name:              "optional",
+						Type:              []byte(`"string"`),
+						Description:       "An optional string attribute",
+						OptionalForImport: true,
+					},
+				},
+			},
+			Want: &providers.ResourceIdentitySchema{
+				Version: 1,
+				Body: &configschema.Object{
+					Attributes: map[string]*configschema.Attribute{
+						"optional": {
+							Type:            cty.String,
+							Description:     "An optional string attribute",
+							DescriptionKind: configschema.StringPlain,
+							Optional:        true,
+						},
+					},
+					Nesting: configschema.NestingSingle,
+				},
+			},
+		},
+		"schema with an attribute that has a description should convert with no errors": {
+			Schema: &proto.ResourceIdentitySchema{
+				Version: 1,
+				IdentityAttributes: []*proto.ResourceIdentitySchema_IdentityAttribute{
+					{
+						Name:        "described",
+						Type:        []byte(`"string"`),
+						Description: "A described string attribute",
+					},
+				},
+			},
+			Want: &providers.ResourceIdentitySchema{
+				Version: 1,
+				Body: &configschema.Object{
+					Attributes: map[string]*configschema.Attribute{
+						"described": {
+							Type:            cty.String,
+							Description:     "A described string attribute",
+							DescriptionKind: configschema.StringPlain,
+						},
+					},
+					Nesting: configschema.NestingSingle,
+				},
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			converted := ProtoToResourceIdentitySchema(tc.Schema)
+			if !cmp.Equal(converted, tc.Want, typeComparer, equateEmpty, ignoreUnexported) {
+				t.Fatal(cmp.Diff(converted, tc.Want, typeComparer, equateEmpty, ignoreUnexported))
+			}
+		})
+	}
+}
+
+func TestResourceIdentitySchemaToProto(t *testing.T) {
+	tests := map[string]struct {
+		Want   *proto.ResourceIdentitySchema
+		Schema *providers.ResourceIdentitySchema
+	}{
+		"nil schema should return nil": {
+			Schema: nil,
+			Want:   nil,
+		},
+		"simple schema should convert with no errors": {
+			Schema: &providers.ResourceIdentitySchema{
+				Version: 1,
+				Body: &configschema.Object{
+					Attributes: map[string]*configschema.Attribute{
+						"simple": {
+							Type:            cty.String,
+							Description:     "A simple string attribute",
+							DescriptionKind: configschema.StringPlain,
+						},
+					},
+					Nesting: configschema.NestingSingle,
+				},
+			},
+			Want: &proto.ResourceIdentitySchema{
+				Version: 1,
+				IdentityAttributes: []*proto.ResourceIdentitySchema_IdentityAttribute{
+					{
+						Name:        "simple",
+						Type:        []byte(`"string"`),
+						Description: "A simple string attribute",
+					},
+				},
+			},
+		},
+		"schema with required attribute shoud convert with no errors": {
+			Schema: &providers.ResourceIdentitySchema{
+				Version: 1,
+				Body: &configschema.Object{
+					Attributes: map[string]*configschema.Attribute{
+						"required": {
+							Type:            cty.String,
+							Description:     "A required string attribute",
+							DescriptionKind: configschema.StringPlain,
+							Required:        true,
+						},
+					},
+					Nesting: configschema.NestingSingle,
+				},
+			},
+			Want: &proto.ResourceIdentitySchema{
+				Version: 1,
+				IdentityAttributes: []*proto.ResourceIdentitySchema_IdentityAttribute{
+					{
+						Name:              "required",
+						Type:              []byte(`"string"`),
+						Description:       "A required string attribute",
+						RequiredForImport: true,
+					},
+				},
+			},
+		},
+		"schema with optional attribute shoud convert with no errors": {
+			Schema: &providers.ResourceIdentitySchema{
+				Version: 1,
+				Body: &configschema.Object{
+					Attributes: map[string]*configschema.Attribute{
+						"optional": {
+							Type:            cty.String,
+							Description:     "An optional string attribute",
+							DescriptionKind: configschema.StringPlain,
+							Optional:        true,
+						},
+					},
+					Nesting: configschema.NestingSingle,
+				},
+			},
+			Want: &proto.ResourceIdentitySchema{
+				Version: 1,
+				IdentityAttributes: []*proto.ResourceIdentitySchema_IdentityAttribute{
+					{
+						Name:              "optional",
+						Type:              []byte(`"string"`),
+						Description:       "An optional string attribute",
+						OptionalForImport: true,
+					},
+				},
+			},
+		},
+		"schema with an attribute that has a description should convert with no errors": {
+			Schema: &providers.ResourceIdentitySchema{
+				Version: 1,
+				Body: &configschema.Object{
+					Attributes: map[string]*configschema.Attribute{
+						"described": {
+							Type:            cty.String,
+							Description:     "A described string attribute",
+							DescriptionKind: configschema.StringPlain,
+						},
+					},
+					Nesting: configschema.NestingSingle,
+				},
+			},
+			Want: &proto.ResourceIdentitySchema{
+				Version: 1,
+				IdentityAttributes: []*proto.ResourceIdentitySchema_IdentityAttribute{
+					{
+						Name:        "described",
+						Type:        []byte(`"string"`),
+						Description: "A described string attribute",
+					},
+				},
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			converted := ResourceIdentitySchemaToProto(tc.Schema)
+			if !cmp.Equal(converted, tc.Want, protocmp.Transform(), typeComparer, equateEmpty, ignoreUnexported) {
+				t.Fatal(cmp.Diff(converted, tc.Want, protocmp.Transform(), typeComparer, equateEmpty, ignoreUnexported))
 			}
 		})
 	}

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -204,61 +204,6 @@ func (p *GRPCProvider) getProtoProviderSchema(ctx context.Context) (*proto6.GetP
 	return resp, err
 }
 
-func (p *GRPCProvider) UpgradeResourceIdentity(ctx context.Context, req providers.UpgradeResourceIdentityRequest) (resp providers.UpgradeResourceIdentityResponse) {
-	logger.Trace("GRPCProvider.v6: UpgradeResourceIdentity")
-
-	protoReq := &proto6.UpgradeResourceIdentity_Request{
-		TypeName: req.TypeName,
-		Version:  req.Version,
-		RawIdentity: &proto6.RawState{
-			Json: req.RawIdentityJSON,
-		},
-	}
-
-	protoResp, err := p.client.UpgradeResourceIdentity(ctx, protoReq)
-	if err != nil {
-		resp.Diagnostics = resp.Diagnostics.Append(grpcErr(err))
-		return resp
-	}
-	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))
-
-	if protoResp.UpgradedIdentity == nil || protoResp.UpgradedIdentity.IdentityData == nil {
-		if !resp.Diagnostics.HasErrors() {
-			resp.Diagnostics = resp.Diagnostics.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Provider returned no identity after upgrade",
-				fmt.Sprintf("The provider returned a nil identity for %q after UpgradeResourceIdentity without reporting an error. This is a bug in the provider.", req.TypeName),
-			))
-		}
-		return resp
-	}
-
-	// Now we need to look up the resource identity schema from the provider resource schemas.
-	providerSchema := p.GetProviderSchema(ctx)
-	if providerSchema.Diagnostics.HasErrors() {
-		resp.Diagnostics = resp.Diagnostics.Append(providerSchema.Diagnostics)
-		return resp
-	}
-	resSchema, ok := providerSchema.ResourceTypes[req.TypeName]
-	if !ok || resSchema.IdentitySchema == nil {
-		resp.Diagnostics = resp.Diagnostics.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"No identity schema found",
-			fmt.Sprintf("No identity schema available for resource type %q.", req.TypeName),
-		))
-		return resp
-	}
-
-	identity, err := decodeDynamicValue(protoResp.UpgradedIdentity.IdentityData, resSchema.IdentitySchema.ImpliedType())
-	if err != nil {
-		resp.Diagnostics = resp.Diagnostics.Append(err)
-		return resp
-	}
-	resp.UpgradedIdentity = identity
-
-	return resp
-}
-
 // getResourceIdentitySchemas should ONLY be called from GetProviderSchema, which
 // merges the identity schemas into the cached provider schema response. All other
 // callers should use resSchema.IdentitySchema from the GetProviderSchema response.
@@ -475,6 +420,61 @@ func (p *GRPCProvider) UpgradeResourceState(ctx context.Context, r providers.Upg
 	resp.UpgradedState = state
 
 	resp.Diagnostics = resp.Diagnostics.Append(validation.WriteOnlyAttributes(resSchema.Block, resp.UpgradedState, r.TypeName))
+
+	return resp
+}
+
+func (p *GRPCProvider) UpgradeResourceIdentity(ctx context.Context, req providers.UpgradeResourceIdentityRequest) (resp providers.UpgradeResourceIdentityResponse) {
+	logger.Trace("GRPCProvider.v6: UpgradeResourceIdentity")
+
+	protoReq := &proto6.UpgradeResourceIdentity_Request{
+		TypeName: req.TypeName,
+		Version:  req.Version,
+		RawIdentity: &proto6.RawState{
+			Json: req.RawIdentityJSON,
+		},
+	}
+
+	protoResp, err := p.client.UpgradeResourceIdentity(ctx, protoReq)
+	if err != nil {
+		resp.Diagnostics = resp.Diagnostics.Append(grpcErr(err))
+		return resp
+	}
+	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))
+
+	if protoResp.UpgradedIdentity == nil || protoResp.UpgradedIdentity.IdentityData == nil {
+		if !resp.Diagnostics.HasErrors() {
+			resp.Diagnostics = resp.Diagnostics.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Provider returned no identity after upgrade",
+				fmt.Sprintf("The provider returned a nil identity for %q after UpgradeResourceIdentity without reporting an error. This is a bug in the provider.", req.TypeName),
+			))
+		}
+		return resp
+	}
+
+	// Now we need to look up the resource identity schema from the provider resource schemas.
+	providerSchema := p.GetProviderSchema(ctx)
+	if providerSchema.Diagnostics.HasErrors() {
+		resp.Diagnostics = resp.Diagnostics.Append(providerSchema.Diagnostics)
+		return resp
+	}
+	resSchema, ok := providerSchema.ResourceTypes[req.TypeName]
+	if !ok || resSchema.IdentitySchema == nil {
+		resp.Diagnostics = resp.Diagnostics.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"No identity schema found",
+			fmt.Sprintf("No identity schema available for resource type %q.", req.TypeName),
+		))
+		return resp
+	}
+
+	identity, err := decodeDynamicValue(protoResp.UpgradedIdentity.IdentityData, resSchema.IdentitySchema.ImpliedType())
+	if err != nil {
+		resp.Diagnostics = resp.Diagnostics.Append(err)
+		return resp
+	}
+	resp.UpgradedIdentity = identity
 
 	return resp
 }

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -23,6 +23,7 @@ import (
 	"github.com/opentofu/opentofu/internal/logging"
 	"github.com/opentofu/opentofu/internal/plugin6/convert"
 	"github.com/opentofu/opentofu/internal/providers"
+	"github.com/opentofu/opentofu/internal/tfdiags"
 	proto6 "github.com/opentofu/opentofu/internal/tfplugin6"
 )
 
@@ -222,7 +223,13 @@ func (p *GRPCProvider) UpgradeResourceIdentity(ctx context.Context, req provider
 	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))
 
 	if protoResp.UpgradedIdentity == nil || protoResp.UpgradedIdentity.IdentityData == nil {
-		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("call to UpgradeResourceIdentity returned nil for IdentityData, this should be non-nil"))
+		if !resp.Diagnostics.HasErrors() {
+			resp.Diagnostics = resp.Diagnostics.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Provider returned no identity after upgrade",
+				fmt.Sprintf("The provider returned a nil identity for %q after UpgradeResourceIdentity without reporting an error. This is a bug in the provider.", req.TypeName),
+			))
+		}
 		return resp
 	}
 

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -159,7 +159,7 @@ func (p *GRPCProvider) getProviderSchema(ctx context.Context) (resp providers.Ge
 		resp.EphemeralResources[name] = convert.ProtoToEphemeralProviderSchema(res)
 	}
 
-	identitySchemas := p.GetResourceIdentitySchemas(ctx)
+	identitySchemas := p.getResourceIdentitySchemas(ctx)
 	if identitySchemas.Diagnostics.HasErrors() {
 		// Identity schemas are an optional enhancement. A provider bug in
 		// identity schemas should not prevent the provider from being used
@@ -233,18 +233,19 @@ func (p *GRPCProvider) UpgradeResourceIdentity(ctx context.Context, req provider
 		return resp
 	}
 
-	identitySchemas := p.GetResourceIdentitySchemas(ctx)
-	if identitySchemas.Diagnostics.HasErrors() {
-		resp.Diagnostics = resp.Diagnostics.Append(identitySchemas.Diagnostics)
+	// Now we need to look up the resource identity schema from the provider resource schemas.
+	providerSchema := p.GetProviderSchema(ctx)
+	if providerSchema.Diagnostics.HasErrors() {
+		resp.Diagnostics = resp.Diagnostics.Append(providerSchema.Diagnostics)
 		return resp
 	}
-	identitySchema, ok := identitySchemas.IdentitySchemas[req.TypeName]
-	if !ok {
+	resSchema, ok := providerSchema.ResourceTypes[req.TypeName]
+	if !ok || resSchema.IdentitySchema == nil {
 		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("no identity schema for %q", req.TypeName))
 		return resp
 	}
 
-	identity, err := decodeDynamicValue(protoResp.UpgradedIdentity.IdentityData, identitySchema.Body.ImpliedType())
+	identity, err := decodeDynamicValue(protoResp.UpgradedIdentity.IdentityData, resSchema.IdentitySchema.ImpliedType())
 	if err != nil {
 		resp.Diagnostics = resp.Diagnostics.Append(err)
 		return resp
@@ -254,8 +255,8 @@ func (p *GRPCProvider) UpgradeResourceIdentity(ctx context.Context, req provider
 	return resp
 }
 
-func (p *GRPCProvider) GetResourceIdentitySchemas(ctx context.Context) providers.GetResourceIdentitySchemasResponse {
-	logger.Trace("GRPCProvider.v6: GetResourceIdentitySchemas")
+func (p *GRPCProvider) getResourceIdentitySchemas(ctx context.Context) providers.GetResourceIdentitySchemasResponse {
+	logger.Trace("GRPCProvider.v6: getResourceIdentitySchemas")
 
 	// Caching is not needed here: callers should use resSchema.IdentitySchema
 	// from the cached GetProviderSchema response instead of calling this directly.

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -255,13 +255,11 @@ func (p *GRPCProvider) UpgradeResourceIdentity(ctx context.Context, req provider
 	return resp
 }
 
+// getResourceIdentitySchemas should ONLY be called from GetProviderSchema, which
+// merges the identity schemas into the cached provider schema response. All other
+// callers should use resSchema.IdentitySchema from the GetProviderSchema response.
 func (p *GRPCProvider) getResourceIdentitySchemas(ctx context.Context) providers.GetResourceIdentitySchemasResponse {
 	logger.Trace("GRPCProvider.v6: getResourceIdentitySchemas")
-
-	// Caching is not needed here: callers should use resSchema.IdentitySchema
-	// from the cached GetProviderSchema response instead of calling this directly.
-	// This method is only used by GetProviderSchema (to merge identity schemas)
-	// and UpgradeResourceIdentity (called once per stale resource).
 	resp := providers.GetResourceIdentitySchemasResponse{
 		IdentitySchemas: make(map[string]providers.ResourceIdentitySchema),
 	}

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -18,10 +18,9 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/opentofu/opentofu/internal/plugin6/validation"
-
 	"github.com/opentofu/opentofu/internal/logging"
 	"github.com/opentofu/opentofu/internal/plugin6/convert"
+	"github.com/opentofu/opentofu/internal/plugin6/validation"
 	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	proto6 "github.com/opentofu/opentofu/internal/tfplugin6"
@@ -159,15 +158,15 @@ func (p *GRPCProvider) getProviderSchema(ctx context.Context) (resp providers.Ge
 		resp.EphemeralResources[name] = convert.ProtoToEphemeralProviderSchema(res)
 	}
 
-	identitySchemas := p.getResourceIdentitySchemas(ctx)
-	if identitySchemas.Diagnostics.HasErrors() {
+	identitySchemas, idsDiags := p.getResourceIdentitySchemas(ctx)
+	if idsDiags.HasErrors() {
 		// Identity schemas are an optional enhancement. A provider bug in
 		// identity schemas should not prevent the provider from being used
 		// for all other operations, so we log the error and continue
 		// without identity schema support.
-		logger.Warn("failed to fetch resource identity schemas, identity-based features will be unavailable. error: %s", identitySchemas.Diagnostics.Err())
+		logger.Warn("failed to fetch resource identity schemas, identity-based features will be unavailable. error: %s", idsDiags.Err())
 	} else {
-		for name, idSchema := range identitySchemas.IdentitySchemas {
+		for name, idSchema := range identitySchemas {
 			if resSchema, ok := resp.ResourceTypes[name]; ok {
 				resSchema.IdentitySchema = idSchema.Body
 				resSchema.IdentitySchemaVersion = idSchema.Version
@@ -207,34 +206,31 @@ func (p *GRPCProvider) getProtoProviderSchema(ctx context.Context) (*proto6.GetP
 // getResourceIdentitySchemas should ONLY be called from GetProviderSchema, which
 // merges the identity schemas into the cached provider schema response. All other
 // callers should use resSchema.IdentitySchema from the GetProviderSchema response.
-func (p *GRPCProvider) getResourceIdentitySchemas(ctx context.Context) providers.GetResourceIdentitySchemasResponse {
+func (p *GRPCProvider) getResourceIdentitySchemas(ctx context.Context) (map[string]providers.ResourceIdentitySchema, tfdiags.Diagnostics) {
 	logger.Trace("GRPCProvider.v6: getResourceIdentitySchemas")
-	resp := providers.GetResourceIdentitySchemasResponse{
-		IdentitySchemas: make(map[string]providers.ResourceIdentitySchema),
-	}
+	var diags tfdiags.Diagnostics
 
 	protoResponse, err := p.client.GetResourceIdentitySchemas(ctx, new(proto6.GetResourceIdentitySchemas_Request))
 	if err != nil {
 		// Providers that don't implement identity schemas return Unimplemented;
 		// this is expected and not an error — just return an empty response.
 		if status.Code(err) == codes.Unimplemented {
-			return resp
+			return nil, diags
 		}
-		resp.Diagnostics = resp.Diagnostics.Append(grpcErr(err))
-		return resp
+		diags = diags.Append(grpcErr(err))
+		return nil, diags
 	}
 
-	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResponse.Diagnostics))
-
-	if resp.Diagnostics.HasErrors() {
-		return resp
+	diags = diags.Append(convert.ProtoToDiagnostics(protoResponse.Diagnostics))
+	if diags.HasErrors() || len(protoResponse.IdentitySchemas) == 0 {
+		return nil, diags
 	}
 
-	for resource, schema := range protoResponse.IdentitySchemas {
-		resp.IdentitySchemas[resource] = *convert.ProtoToResourceIdentitySchema(schema)
+	identitySchemas := make(map[string]providers.ResourceIdentitySchema, len(protoResponse.IdentitySchemas))
+	for resourceType, schema := range protoResponse.IdentitySchemas {
+		identitySchemas[resourceType] = *convert.ProtoToResourceIdentitySchema(schema)
 	}
-
-	return resp
+	return identitySchemas, diags
 }
 
 func (p *GRPCProvider) ValidateProviderConfig(ctx context.Context, r providers.ValidateProviderConfigRequest) (resp providers.ValidateProviderConfigResponse) {

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -241,7 +241,11 @@ func (p *GRPCProvider) UpgradeResourceIdentity(ctx context.Context, req provider
 	}
 	resSchema, ok := providerSchema.ResourceTypes[req.TypeName]
 	if !ok || resSchema.IdentitySchema == nil {
-		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("no identity schema for %q", req.TypeName))
+		resp.Diagnostics = resp.Diagnostics.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"No identity schema found",
+			fmt.Sprintf("No identity schema available for resource type %q.", req.TypeName),
+		))
 		return resp
 	}
 
@@ -838,7 +842,11 @@ func (p *GRPCProvider) ImportResourceState(ctx context.Context, r providers.Impo
 	if r.Target.IsIdentityBased() {
 		resSchema, ok := schema.ResourceTypes[r.TypeName]
 		if !ok || resSchema.IdentitySchema == nil {
-			resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("no identity schema found for resource type %q", r.TypeName))
+			resp.Diagnostics = resp.Diagnostics.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"No identity schema found",
+				fmt.Sprintf("No identity schema available for resource type %q.", r.TypeName),
+			))
 			return resp
 		}
 

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -11,11 +11,14 @@ import (
 	"fmt"
 
 	plugin "github.com/hashicorp/go-plugin"
-	"github.com/opentofu/opentofu/internal/plugin6/validation"
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 	"github.com/zclconf/go-cty/cty/msgpack"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/opentofu/opentofu/internal/plugin6/validation"
 
 	"github.com/opentofu/opentofu/internal/logging"
 	"github.com/opentofu/opentofu/internal/plugin6/convert"
@@ -155,6 +158,23 @@ func (p *GRPCProvider) getProviderSchema(ctx context.Context) (resp providers.Ge
 		resp.EphemeralResources[name] = convert.ProtoToEphemeralProviderSchema(res)
 	}
 
+	identitySchemas := p.GetResourceIdentitySchemas(ctx)
+	if identitySchemas.Diagnostics.HasErrors() {
+		// Identity schemas are an optional enhancement. A provider bug in
+		// identity schemas should not prevent the provider from being used
+		// for all other operations, so we log the error and continue
+		// without identity schema support.
+		logger.Warn("failed to fetch resource identity schemas, identity-based features will be unavailable. error: %s", identitySchemas.Diagnostics.Err())
+	} else {
+		for name, idSchema := range identitySchemas.IdentitySchemas {
+			if resSchema, ok := resp.ResourceTypes[name]; ok {
+				resSchema.IdentitySchema = idSchema.Body
+				resSchema.IdentitySchemaVersion = idSchema.Version
+				resp.ResourceTypes[name] = resSchema
+			}
+		}
+	}
+
 	if protoResp.ServerCapabilities != nil {
 		resp.ServerCapabilities.PlanDestroy = protoResp.ServerCapabilities.PlanDestroy
 		resp.ServerCapabilities.GetProviderSchemaOptional = protoResp.ServerCapabilities.GetProviderSchemaOptional
@@ -181,6 +201,85 @@ func (p *GRPCProvider) getProtoProviderSchema(ctx context.Context) (*proto6.GetP
 	p.hasFetchedSchema = true
 
 	return resp, err
+}
+
+func (p *GRPCProvider) UpgradeResourceIdentity(ctx context.Context, req providers.UpgradeResourceIdentityRequest) (resp providers.UpgradeResourceIdentityResponse) {
+	logger.Trace("GRPCProvider.v6: UpgradeResourceIdentity")
+
+	protoReq := &proto6.UpgradeResourceIdentity_Request{
+		TypeName: req.TypeName,
+		Version:  req.Version,
+		RawIdentity: &proto6.RawState{
+			Json: req.RawIdentityJSON,
+		},
+	}
+
+	protoResp, err := p.client.UpgradeResourceIdentity(ctx, protoReq)
+	if err != nil {
+		resp.Diagnostics = resp.Diagnostics.Append(grpcErr(err))
+		return resp
+	}
+	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResp.Diagnostics))
+
+	if protoResp.UpgradedIdentity == nil || protoResp.UpgradedIdentity.IdentityData == nil {
+		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("call to UpgradeResourceIdentity returned nil for IdentityData, this should be non-nil"))
+		return resp
+	}
+
+	identitySchemas := p.GetResourceIdentitySchemas(ctx)
+	if identitySchemas.Diagnostics.HasErrors() {
+		resp.Diagnostics = resp.Diagnostics.Append(identitySchemas.Diagnostics)
+		return resp
+	}
+	identitySchema, ok := identitySchemas.IdentitySchemas[req.TypeName]
+	if !ok {
+		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("no identity schema for %q", req.TypeName))
+		return resp
+	}
+
+	identity, err := decodeDynamicValue(protoResp.UpgradedIdentity.IdentityData, identitySchema.Body.ImpliedType())
+	if err != nil {
+		resp.Diagnostics = resp.Diagnostics.Append(err)
+		return resp
+	}
+	resp.UpgradedIdentity = identity
+
+	return resp
+}
+
+func (p *GRPCProvider) GetResourceIdentitySchemas(ctx context.Context) providers.GetResourceIdentitySchemasResponse {
+	logger.Trace("GRPCProvider.v6: GetResourceIdentitySchemas")
+
+	// Caching is not needed here: callers should use resSchema.IdentitySchema
+	// from the cached GetProviderSchema response instead of calling this directly.
+	// This method is only used by GetProviderSchema (to merge identity schemas)
+	// and UpgradeResourceIdentity (called once per stale resource).
+	resp := providers.GetResourceIdentitySchemasResponse{
+		IdentitySchemas: make(map[string]providers.ResourceIdentitySchema),
+	}
+
+	protoResponse, err := p.client.GetResourceIdentitySchemas(ctx, new(proto6.GetResourceIdentitySchemas_Request))
+	if err != nil {
+		// Providers that don't implement identity schemas return Unimplemented;
+		// this is expected and not an error — just return an empty response.
+		if status.Code(err) == codes.Unimplemented {
+			return resp
+		}
+		resp.Diagnostics = resp.Diagnostics.Append(grpcErr(err))
+		return resp
+	}
+
+	resp.Diagnostics = resp.Diagnostics.Append(convert.ProtoToDiagnostics(protoResponse.Diagnostics))
+
+	if resp.Diagnostics.HasErrors() {
+		return resp
+	}
+
+	for resource, schema := range protoResponse.IdentitySchemas {
+		resp.IdentitySchemas[resource] = *convert.ProtoToResourceIdentitySchema(schema)
+	}
+
+	return resp
 }
 
 func (p *GRPCProvider) ValidateProviderConfig(ctx context.Context, r providers.ValidateProviderConfigRequest) (resp providers.ValidateProviderConfigResponse) {
@@ -451,6 +550,18 @@ func (p *GRPCProvider) ReadResource(ctx context.Context, r providers.ReadResourc
 		ClientCapabilities: clientCapabilities,
 	}
 
+	// Attach the identity if it is available
+	if !r.PriorIdentity.IsNull() && resSchema.IdentitySchema != nil {
+		identityMP, err := msgpack.Marshal(r.PriorIdentity, resSchema.IdentitySchema.ImpliedType())
+		if err != nil {
+			resp.Diagnostics = resp.Diagnostics.Append(err)
+			return resp
+		}
+		protoReq.CurrentIdentity = &proto6.ResourceIdentityData{
+			IdentityData: &proto6.DynamicValue{Msgpack: identityMP},
+		}
+	}
+
 	if metaSchema.Block != nil {
 		metaMP, err := msgpack.Marshal(r.ProviderMeta, metaSchema.Block.ImpliedType())
 		if err != nil {
@@ -474,6 +585,16 @@ func (p *GRPCProvider) ReadResource(ctx context.Context, r providers.ReadResourc
 	}
 	resp.NewState = state
 	resp.Private = protoResp.Private
+
+	// Process identity from response
+	if protoResp.NewIdentity != nil && protoResp.NewIdentity.IdentityData != nil && resSchema.IdentitySchema != nil {
+		identity, err := decodeDynamicValue(protoResp.NewIdentity.IdentityData, resSchema.IdentitySchema.ImpliedType())
+		if err != nil {
+			resp.Diagnostics = resp.Diagnostics.Append(err)
+			return resp
+		}
+		resp.NewIdentity = identity
+	}
 
 	resp.Diagnostics = resp.Diagnostics.Append(validation.WriteOnlyAttributes(resSchema.Block, resp.NewState, r.TypeName))
 
@@ -533,6 +654,18 @@ func (p *GRPCProvider) PlanResourceChange(ctx context.Context, r providers.PlanR
 		ClientCapabilities: clientCapabilities,
 	}
 
+	// Attach prior identity if available
+	if !r.PriorIdentity.IsNull() && resSchema.IdentitySchema != nil {
+		identityMP, err := msgpack.Marshal(r.PriorIdentity, resSchema.IdentitySchema.ImpliedType())
+		if err != nil {
+			resp.Diagnostics = resp.Diagnostics.Append(err)
+			return resp
+		}
+		protoReq.PriorIdentity = &proto6.ResourceIdentityData{
+			IdentityData: &proto6.DynamicValue{Msgpack: identityMP},
+		}
+	}
+
 	if metaSchema.Block != nil {
 		metaMP, err := msgpack.Marshal(r.ProviderMeta, metaSchema.Block.ImpliedType())
 		if err != nil {
@@ -561,6 +694,16 @@ func (p *GRPCProvider) PlanResourceChange(ctx context.Context, r providers.PlanR
 	}
 
 	resp.PlannedPrivate = protoResp.PlannedPrivate
+
+	// Process planned identity from response
+	if protoResp.PlannedIdentity != nil && protoResp.PlannedIdentity.IdentityData != nil && resSchema.IdentitySchema != nil {
+		identity, err := decodeDynamicValue(protoResp.PlannedIdentity.IdentityData, resSchema.IdentitySchema.ImpliedType())
+		if err != nil {
+			resp.Diagnostics = resp.Diagnostics.Append(err)
+			return resp
+		}
+		resp.PlannedIdentity = identity
+	}
 
 	resp.LegacyTypeSystem = protoResp.LegacyTypeSystem
 
@@ -617,6 +760,18 @@ func (p *GRPCProvider) ApplyResourceChange(ctx context.Context, r providers.Appl
 		PlannedPrivate: r.PlannedPrivate,
 	}
 
+	// Add planned identity to request if available
+	if !r.PlannedIdentity.IsNull() && resSchema.IdentitySchema != nil {
+		identityMP, err := msgpack.Marshal(r.PlannedIdentity, resSchema.IdentitySchema.ImpliedType())
+		if err != nil {
+			resp.Diagnostics = resp.Diagnostics.Append(err)
+			return resp
+		}
+		protoReq.PlannedIdentity = &proto6.ResourceIdentityData{
+			IdentityData: &proto6.DynamicValue{Msgpack: identityMP},
+		}
+	}
+
 	if metaSchema.Block != nil {
 		metaMP, err := msgpack.Marshal(r.ProviderMeta, metaSchema.Block.ImpliedType())
 		if err != nil {
@@ -642,6 +797,16 @@ func (p *GRPCProvider) ApplyResourceChange(ctx context.Context, r providers.Appl
 	}
 	resp.NewState = state
 
+	// Decode new identity from response if present
+	if protoResp.NewIdentity != nil && protoResp.NewIdentity.IdentityData != nil && resSchema.IdentitySchema != nil {
+		identity, err := decodeDynamicValue(protoResp.NewIdentity.IdentityData, resSchema.IdentitySchema.ImpliedType())
+		if err != nil {
+			resp.Diagnostics = resp.Diagnostics.Append(err)
+			return resp
+		}
+		resp.NewIdentity = identity
+	}
+
 	resp.LegacyTypeSystem = protoResp.LegacyTypeSystem
 
 	resp.Diagnostics = resp.Diagnostics.Append(validation.WriteOnlyAttributes(resSchema.Block, resp.NewState, r.TypeName))
@@ -660,8 +825,29 @@ func (p *GRPCProvider) ImportResourceState(ctx context.Context, r providers.Impo
 
 	protoReq := &proto6.ImportResourceState_Request{
 		TypeName:           r.TypeName,
-		Id:                 r.ID,
 		ClientCapabilities: clientCapabilities,
+	}
+
+	// If importing by identity, encode the identity value
+	if r.Target.IsIdentityBased() {
+		resSchema, ok := schema.ResourceTypes[r.TypeName]
+		if !ok || resSchema.IdentitySchema == nil {
+			resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("no identity schema found for resource type %q", r.TypeName))
+			return resp
+		}
+
+		identityMP, err := msgpack.Marshal(r.Target.Identity, resSchema.IdentitySchema.ImpliedType())
+		if err != nil {
+			resp.Diagnostics = resp.Diagnostics.Append(err)
+			return resp
+		}
+
+		protoReq.Identity = &proto6.ResourceIdentityData{
+			IdentityData: &proto6.DynamicValue{Msgpack: identityMP},
+		}
+	} else {
+		// we want to set the ID
+		protoReq.Id = r.Target.ID
 	}
 
 	protoResp, err := p.client.ImportResourceState(ctx, protoReq)
@@ -681,6 +867,17 @@ func (p *GRPCProvider) ImportResourceState(ctx context.Context, r providers.Impo
 		if !ok {
 			resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("unknown resource type %q", r.TypeName))
 			continue
+		}
+
+		if imported.Identity != nil && imported.Identity.IdentityData != nil {
+			if resSchema.IdentitySchema != nil {
+				identity, err := decodeDynamicValue(imported.Identity.IdentityData, resSchema.IdentitySchema.ImpliedType())
+				if err != nil {
+					resp.Diagnostics = resp.Diagnostics.Append(err)
+					continue
+				}
+				resource.Identity = identity
+			}
 		}
 
 		state, err := decodeDynamicValue(imported.State, resSchema.Block.ImpliedType())
@@ -989,13 +1186,12 @@ func (p *GRPCProvider) CallFunction(ctx context.Context, r providers.CallFunctio
 					FunctionArgument: i,
 				}
 			}
-
 		}
 
 		encodedArg, err := msgpack.Marshal(arg, paramSpec.Type)
 		if err != nil {
 			resp.Error = err
-			return
+			return resp
 		}
 
 		protoReq.Arguments[i] = &proto6.DynamicValue{
@@ -1006,7 +1202,7 @@ func (p *GRPCProvider) CallFunction(ctx context.Context, r providers.CallFunctio
 	protoResp, err := p.client.CallFunction(ctx, protoReq)
 	if err != nil {
 		resp.Error = err
-		return
+		return resp
 	}
 
 	if protoResp.Error != nil {
@@ -1017,11 +1213,11 @@ func (p *GRPCProvider) CallFunction(ctx context.Context, r providers.CallFunctio
 			err.FunctionArgument = int(*protoResp.Error.FunctionArgument)
 		}
 		resp.Error = err
-		return
+		return resp
 	}
 
 	resp.Result, resp.Error = decodeDynamicValue(protoResp.Result, spec.Return)
-	return
+	return resp
 }
 
 // closing the grpc connection is final, and tofu will call it at the end of every phase.

--- a/internal/plugin6/grpc_provider_test.go
+++ b/internal/plugin6/grpc_provider_test.go
@@ -65,6 +65,14 @@ func mockProviderClientWithSchema(t *testing.T, schema *proto.GetProviderSchema_
 		gomock.Any(),
 	).Return(schema, nil)
 
+	// we also always need GetResourceIdentitySchemas since GetProviderSchema calls it
+	client.EXPECT().GetResourceIdentitySchemas(
+		gomock.Any(),
+		gomock.Any(),
+	).Return(&proto.GetResourceIdentitySchemas_Response{
+		IdentitySchemas: map[string]*proto.ResourceIdentitySchema{},
+	}, nil).AnyTimes()
+
 	return client
 }
 
@@ -147,7 +155,7 @@ func providerProtoSchema() *proto.GetProviderSchema_Response {
 			},
 		},
 		Functions: map[string]*proto.Function{
-			"fn": &proto.Function{
+			"fn": {
 				Parameters: []*proto.Function_Parameter{{
 					Name:               "par_a",
 					Type:               []byte(`"string"`),
@@ -188,6 +196,85 @@ func TestGRPCProvider_GetSchema(t *testing.T) {
 		checkResources(t, resp.ResourceTypes, false)
 		checkResources(t, resp.DataSources, false)
 		checkResources(t, resp.EphemeralResources, true)
+	}
+}
+
+func TestGRPCProvider_GetSchema_WithResourceIdentitySchemas(t *testing.T) {
+	// This test ensures that the provider client correctly attaches the resource identities to the resource schemas
+	// when you call GetProviderSchema.
+
+	ctrl := gomock.NewController(t)
+	client := mockproto.NewMockProviderClient(ctrl)
+
+	resourceName := "test_resource"
+	resourceSchema := &proto.Schema{
+		Version: 1,
+		Block: &proto.Schema_Block{
+			Attributes: []*proto.Schema_Attribute{
+				{
+					Name:     "id",
+					Type:     []byte(`"string"`),
+					Required: true,
+				},
+				{
+					Name:     "name",
+					Type:     []byte(`"string"`),
+					Optional: true,
+				},
+			},
+		},
+	}
+
+	identitySchema := &proto.ResourceIdentitySchema{
+		Version: 1,
+		IdentityAttributes: []*proto.ResourceIdentitySchema_IdentityAttribute{
+			{
+				Name:              "id",
+				Type:              []byte(`"string"`),
+				RequiredForImport: true,
+			},
+		},
+	}
+
+	client.EXPECT().GetProviderSchema(gomock.Any(), gomock.Any(), gomock.Any()).Return(&proto.GetProviderSchema_Response{
+		Provider: &proto.Schema{
+			Block: &proto.Schema_Block{},
+		},
+		ResourceSchemas: map[string]*proto.Schema{
+			resourceName: resourceSchema,
+		},
+	}, nil)
+
+	client.EXPECT().GetResourceIdentitySchemas(
+		gomock.Any(),
+		gomock.Any(),
+	).Return(&proto.GetResourceIdentitySchemas_Response{
+		IdentitySchemas: map[string]*proto.ResourceIdentitySchema{
+			resourceName: identitySchema,
+		},
+	}, nil)
+
+	p := newGRPCProvider(client)
+	resp := p.GetProviderSchema(t.Context())
+
+	checkDiags(t, resp.Diagnostics)
+
+	resource, ok := resp.ResourceTypes[resourceName]
+	if !ok {
+		t.Fatalf("expected resource %q to be in response", resourceName)
+	}
+
+	// Main part of the test: Ensure that the resource identity schema was attached correctly
+	if resource.IdentitySchema == nil {
+		t.Fatal("expected IdentitySchema to be populated, got nil")
+	}
+
+	if resource.IdentitySchemaVersion != 1 {
+		t.Errorf("expected IdentitySchemaVersion to be %d, got %d", 1, resource.IdentitySchemaVersion)
+	}
+
+	if !resource.IdentitySchema.ImpliedType().HasAttribute("id") {
+		t.Errorf("expected IdentitySchema to have attribute 'id'")
 	}
 }
 
@@ -256,6 +343,13 @@ func TestGRPCProvider_GetSchema_GlobalCacheEnabled(t *testing.T) {
 		ServerCapabilities: &proto.ServerCapabilities{GetProviderSchemaOptional: true},
 	}, nil)
 
+	client.EXPECT().GetResourceIdentitySchemas(
+		gomock.Any(),
+		gomock.Any(),
+	).Times(1).Return(&proto.GetResourceIdentitySchemas_Response{
+		IdentitySchemas: map[string]*proto.ResourceIdentitySchema{},
+	}, nil)
+
 	// Run GetProviderTwice, expect GetSchema to be called once
 	// Re-initialize the provider before each run to avoid usage of the local cache
 	p := newGRPCProvider(client)
@@ -292,7 +386,14 @@ func TestGRPCProvider_GetSchema_GlobalCacheDisabled(t *testing.T) {
 		ServerCapabilities: &proto.ServerCapabilities{GetProviderSchemaOptional: false},
 	}, nil)
 
-	// Run GetProviderTwice, expect GetSchema to be called once
+	client.EXPECT().GetResourceIdentitySchemas(
+		gomock.Any(),
+		gomock.Any(),
+	).Times(2).Return(&proto.GetResourceIdentitySchemas_Response{
+		IdentitySchemas: map[string]*proto.ResourceIdentitySchema{},
+	}, nil)
+
+	// Run GetProviderTwice, expect GetSchema to be called twice
 	// Re-initialize the provider before each run to avoid usage of the local cache
 	p := newGRPCProvider(client)
 	resp := p.GetProviderSchema(t.Context())
@@ -308,6 +409,89 @@ func TestGRPCProvider_GetSchema_GlobalCacheDisabled(t *testing.T) {
 	checkDiags(t, resp.Diagnostics)
 	if !cmp.Equal(resp.Provider.Version, mockedProviderResponse.Version) {
 		t.Fatal(cmp.Diff(resp.Provider.Version, mockedProviderResponse.Version))
+	}
+}
+
+func TestGRPCProvider_UpgradeResourceIdentity(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	client := mockproto.NewMockProviderClient(ctrl)
+
+	// initial identity
+	client.EXPECT().GetResourceIdentitySchemas(
+		gomock.Any(),
+		gomock.Any(),
+	).Return(&proto.GetResourceIdentitySchemas_Response{
+		IdentitySchemas: map[string]*proto.ResourceIdentitySchema{
+			"test_resource": {
+				Version: 1,
+				IdentityAttributes: []*proto.ResourceIdentitySchema_IdentityAttribute{
+					{
+						Name:              "id",
+						Type:              []byte(`"string"`),
+						RequiredForImport: true,
+					},
+					{
+						Name:              "region",
+						Type:              []byte(`"string"`),
+						RequiredForImport: true,
+					},
+				},
+			},
+		},
+	}, nil)
+
+	// upgraded entity from the provider
+	upgradedIdentity := cty.ObjectVal(map[string]cty.Value{
+		"id":     cty.StringVal("resource-123"),
+		"region": cty.StringVal("eu-west-1"),
+	})
+
+	upgradedBytes, err := msgpack.Marshal(upgradedIdentity, upgradedIdentity.Type())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client.EXPECT().UpgradeResourceIdentity(gomock.Any(), gomock.Any()).Return(&proto.UpgradeResourceIdentity_Response{
+		UpgradedIdentity: &proto.ResourceIdentityData{
+			IdentityData: &proto.DynamicValue{
+				Msgpack: upgradedBytes,
+			},
+		},
+	}, nil)
+
+	// Ensure that our UpgradeResourceIdentity logic does what it should
+	p := newGRPCProvider(client)
+	resp := p.UpgradeResourceIdentity(t.Context(), providers.UpgradeResourceIdentityRequest{
+		TypeName:        "test_resource",
+		Version:         1,
+		RawIdentityJSON: []byte(`{"id":"resource-123"}`),
+	})
+
+	checkDiags(t, resp.Diagnostics)
+
+	if !resp.UpgradedIdentity.RawEquals(upgradedIdentity) {
+		t.Errorf("unexpected upgraded identity:\ngot:  %#v\nwant: %#v",
+			resp.UpgradedIdentity, upgradedIdentity)
+	}
+}
+
+func TestGRPCProvider_UpgradeResourceIdentity_ProviderError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	client := mockproto.NewMockProviderClient(ctrl)
+
+	client.EXPECT().UpgradeResourceIdentity(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("mock error"))
+
+	p := newGRPCProvider(client)
+	resp := p.UpgradeResourceIdentity(t.Context(), providers.UpgradeResourceIdentityRequest{
+		TypeName:        "test_resource",
+		Version:         1,
+		RawIdentityJSON: []byte(`{"id":"123"}`),
+	})
+
+	checkDiagsHasError(t, resp.Diagnostics)
+
+	if !strings.Contains(resp.Diagnostics.Err().Error(), "mock error") {
+		t.Errorf("Expected mock error")
 	}
 }
 
@@ -1050,7 +1234,7 @@ func TestGRPCProvider_ImportResourceState(t *testing.T) {
 
 	resp := p.ImportResourceState(t.Context(), providers.ImportResourceStateRequest{
 		TypeName: "resource",
-		ID:       "foo",
+		Target:   providers.ImportTarget{ID: "foo"},
 	})
 
 	checkDiags(t, resp.Diagnostics)
@@ -1068,6 +1252,7 @@ func TestGRPCProvider_ImportResourceState(t *testing.T) {
 		t.Fatal(cmp.Diff(expectedResource, imported, typeComparer, valueComparer, equateEmpty))
 	}
 }
+
 func TestGRPCProvider_ImportResourceStateJSON(t *testing.T) {
 	client := mockProviderClient(t)
 	p := newGRPCProvider(client)
@@ -1091,7 +1276,6 @@ func TestGRPCProvider_ImportResourceStateJSON(t *testing.T) {
 
 	resp := p.ImportResourceState(t.Context(), providers.ImportResourceStateRequest{
 		TypeName: "resource",
-		ID:       "foo",
 	})
 
 	checkDiags(t, resp.Diagnostics)

--- a/internal/plugin6/grpc_provider_test.go
+++ b/internal/plugin6/grpc_provider_test.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/legacy/hcl2shim"
 	mockproto "github.com/opentofu/opentofu/internal/plugin6/mock_proto"
 	"github.com/opentofu/opentofu/internal/providers"
@@ -417,29 +418,29 @@ func TestGRPCProvider_UpgradeResourceIdentity(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	client := mockproto.NewMockProviderClient(ctrl)
 
-	// initial identity
-	client.EXPECT().GetResourceIdentitySchemas(
-		gomock.Any(),
-		gomock.Any(),
-	).Return(&proto.GetResourceIdentitySchemas_Response{
-		IdentitySchemas: map[string]*proto.ResourceIdentitySchema{
-			"test_resource": {
-				Version: 1,
-				IdentityAttributes: []*proto.ResourceIdentitySchema_IdentityAttribute{
-					{
-						Name:              "id",
-						Type:              []byte(`"string"`),
-						RequiredForImport: true,
+	// Assert that no schema RPCs are made: the schema cache is pre-warmed and
+	// UpgradeResourceIdentity must not bypass it by calling schema RPCs directly.
+	client.EXPECT().GetProviderSchema(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	client.EXPECT().GetResourceIdentitySchemas(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	cache := providers.NewSchemaCache()
+	cache(func() providers.GetProviderSchemaResponse {
+		return providers.GetProviderSchemaResponse{
+			ServerCapabilities: providers.ServerCapabilities{GetProviderSchemaOptional: true},
+			ResourceTypes: map[string]providers.Schema{
+				"test_resource": {
+					IdentitySchema: &configschema.Object{
+						Nesting: configschema.NestingSingle,
+						Attributes: map[string]*configschema.Attribute{
+							"id":     {Type: cty.String},
+							"region": {Type: cty.String},
+						},
 					},
-					{
-						Name:              "region",
-						Type:              []byte(`"string"`),
-						RequiredForImport: true,
-					},
+					IdentitySchemaVersion: 1,
 				},
 			},
-		},
-	}, nil)
+		}
+	})
 
 	// upgraded entity from the provider
 	upgradedIdentity := cty.ObjectVal(map[string]cty.Value{
@@ -460,8 +461,7 @@ func TestGRPCProvider_UpgradeResourceIdentity(t *testing.T) {
 		},
 	}, nil)
 
-	// Ensure that our UpgradeResourceIdentity logic does what it should
-	p := newGRPCProvider(client)
+	p := &GRPCProvider{client: client, SchemaCache: cache}
 	resp := p.UpgradeResourceIdentity(t.Context(), providers.UpgradeResourceIdentityRequest{
 		TypeName:        "test_resource",
 		Version:         1,

--- a/internal/plugin6/grpc_provider_test.go
+++ b/internal/plugin6/grpc_provider_test.go
@@ -199,9 +199,10 @@ func TestGRPCProvider_GetSchema(t *testing.T) {
 	}
 }
 
+// TestGRPCProvider_GetSchema_WithResourceIdentitySchemas ensures that the provider client correctly
+// attaches the resource identities to the resource schemas
+// when you call GetProviderSchema.
 func TestGRPCProvider_GetSchema_WithResourceIdentitySchemas(t *testing.T) {
-	// This test ensures that the provider client correctly attaches the resource identities to the resource schemas
-	// when you call GetProviderSchema.
 
 	ctrl := gomock.NewController(t)
 	client := mockproto.NewMockProviderClient(ctrl)

--- a/internal/provider-simple-v6/provider.go
+++ b/internal/provider-simple-v6/provider.go
@@ -112,20 +112,6 @@ func (s simple) GetProviderSchema(_ context.Context) providers.GetProviderSchema
 	return s.schema
 }
 
-func (s simple) GetResourceIdentitySchemas(_ context.Context) providers.GetResourceIdentitySchemasResponse {
-	identitySchemas := make(map[string]providers.ResourceIdentitySchema, len(s.schema.ResourceTypes))
-	for typeName, schema := range s.schema.ResourceTypes {
-		if schema.IdentitySchema != nil {
-			identitySchemas[typeName] = providers.ResourceIdentitySchema{
-				Version: schema.IdentitySchemaVersion,
-				Body:    schema.IdentitySchema,
-			}
-		}
-	}
-	return providers.GetResourceIdentitySchemasResponse{
-		IdentitySchemas: identitySchemas,
-	}
-}
 
 func (s simple) ValidateProviderConfig(_ context.Context, req providers.ValidateProviderConfigRequest) (resp providers.ValidateProviderConfigResponse) {
 	return resp

--- a/internal/provider-simple-v6/provider.go
+++ b/internal/provider-simple-v6/provider.go
@@ -38,6 +38,16 @@ func Provider() providers.Interface {
 					},
 				},
 			},
+			IdentitySchemaVersion: 1,
+			IdentitySchema: &configschema.Object{
+				Nesting: configschema.NestingSingle,
+				Attributes: map[string]*configschema.Attribute{
+					"id": {
+						Type:     cty.String,
+						Required: true,
+					},
+				},
+			},
 		}
 		if withWoField {
 			ret.Block.Attributes["value_wo"] = &configschema.Attribute{
@@ -102,6 +112,21 @@ func (s simple) GetProviderSchema(_ context.Context) providers.GetProviderSchema
 	return s.schema
 }
 
+func (s simple) GetResourceIdentitySchemas(_ context.Context) providers.GetResourceIdentitySchemasResponse {
+	identitySchemas := make(map[string]providers.ResourceIdentitySchema, len(s.schema.ResourceTypes))
+	for typeName, schema := range s.schema.ResourceTypes {
+		if schema.IdentitySchema != nil {
+			identitySchemas[typeName] = providers.ResourceIdentitySchema{
+				Version: schema.IdentitySchemaVersion,
+				Body:    schema.IdentitySchema,
+			}
+		}
+	}
+	return providers.GetResourceIdentitySchemasResponse{
+		IdentitySchemas: identitySchemas,
+	}
+}
+
 func (s simple) ValidateProviderConfig(_ context.Context, req providers.ValidateProviderConfigRequest) (resp providers.ValidateProviderConfigResponse) {
 	return resp
 }
@@ -129,6 +154,7 @@ func (s simple) MoveResourceState(_ context.Context, req providers.MoveResourceS
 	resp.TargetPrivate = req.SourcePrivate
 	return resp
 }
+
 func (s simple) UpgradeResourceState(_ context.Context, req providers.UpgradeResourceStateRequest) providers.UpgradeResourceStateResponse {
 	var resp providers.UpgradeResourceStateResponse
 	ty := s.schema.ResourceTypes[req.TypeName].Block.ImpliedType()
@@ -136,6 +162,10 @@ func (s simple) UpgradeResourceState(_ context.Context, req providers.UpgradeRes
 	resp.Diagnostics = resp.Diagnostics.Append(err)
 	resp.UpgradedState = val
 	return resp
+}
+
+func (s simple) UpgradeResourceIdentity(context.Context, providers.UpgradeResourceIdentityRequest) providers.UpgradeResourceIdentityResponse {
+	return providers.UpgradeResourceIdentityResponse{}
 }
 
 func (s simple) ConfigureProvider(context.Context, providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {

--- a/internal/provider-simple/provider.go
+++ b/internal/provider-simple/provider.go
@@ -112,20 +112,6 @@ func (s simple) GetProviderSchema(_ context.Context) providers.GetProviderSchema
 	return s.schema
 }
 
-func (s simple) GetResourceIdentitySchemas(_ context.Context) providers.GetResourceIdentitySchemasResponse {
-	identitySchemas := make(map[string]providers.ResourceIdentitySchema, len(s.schema.ResourceTypes))
-	for typeName, schema := range s.schema.ResourceTypes {
-		if schema.IdentitySchema != nil {
-			identitySchemas[typeName] = providers.ResourceIdentitySchema{
-				Version: schema.IdentitySchemaVersion,
-				Body:    schema.IdentitySchema,
-			}
-		}
-	}
-	return providers.GetResourceIdentitySchemasResponse{
-		IdentitySchemas: identitySchemas,
-	}
-}
 
 func (s simple) ValidateProviderConfig(_ context.Context, req providers.ValidateProviderConfigRequest) (resp providers.ValidateProviderConfigResponse) {
 	return resp

--- a/internal/provider-simple/provider.go
+++ b/internal/provider-simple/provider.go
@@ -38,6 +38,16 @@ func Provider() providers.Interface {
 					},
 				},
 			},
+			IdentitySchemaVersion: 1,
+			IdentitySchema: &configschema.Object{
+				Nesting: configschema.NestingSingle,
+				Attributes: map[string]*configschema.Attribute{
+					"id": {
+						Type:     cty.String,
+						Required: true,
+					},
+				},
+			},
 		}
 		if withWoField {
 			ret.Block.Attributes["value_wo"] = &configschema.Attribute{
@@ -102,6 +112,21 @@ func (s simple) GetProviderSchema(_ context.Context) providers.GetProviderSchema
 	return s.schema
 }
 
+func (s simple) GetResourceIdentitySchemas(_ context.Context) providers.GetResourceIdentitySchemasResponse {
+	identitySchemas := make(map[string]providers.ResourceIdentitySchema, len(s.schema.ResourceTypes))
+	for typeName, schema := range s.schema.ResourceTypes {
+		if schema.IdentitySchema != nil {
+			identitySchemas[typeName] = providers.ResourceIdentitySchema{
+				Version: schema.IdentitySchemaVersion,
+				Body:    schema.IdentitySchema,
+			}
+		}
+	}
+	return providers.GetResourceIdentitySchemasResponse{
+		IdentitySchemas: identitySchemas,
+	}
+}
+
 func (s simple) ValidateProviderConfig(_ context.Context, req providers.ValidateProviderConfigRequest) (resp providers.ValidateProviderConfigResponse) {
 	return resp
 }
@@ -129,6 +154,7 @@ func (s simple) MoveResourceState(_ context.Context, req providers.MoveResourceS
 	resp.TargetPrivate = req.SourcePrivate
 	return resp
 }
+
 func (s simple) UpgradeResourceState(_ context.Context, req providers.UpgradeResourceStateRequest) providers.UpgradeResourceStateResponse {
 	var resp providers.UpgradeResourceStateResponse
 	ty := s.schema.ResourceTypes[req.TypeName].Block.ImpliedType()
@@ -136,6 +162,10 @@ func (s simple) UpgradeResourceState(_ context.Context, req providers.UpgradeRes
 	resp.Diagnostics = resp.Diagnostics.Append(err)
 	resp.UpgradedState = val
 	return resp
+}
+
+func (s simple) UpgradeResourceIdentity(context.Context, providers.UpgradeResourceIdentityRequest) providers.UpgradeResourceIdentityResponse {
+	return providers.UpgradeResourceIdentityResponse{}
 }
 
 func (s simple) ConfigureProvider(context.Context, providers.ConfigureProviderRequest) (resp providers.ConfigureProviderResponse) {

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -767,3 +767,4 @@ type CallFunctionArgumentError struct {
 func (err *CallFunctionArgumentError) Error() string {
 	return err.Text
 }
+

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -192,14 +192,6 @@ type GetProviderSchemaResponse struct {
 	EphemeralResources map[string]Schema
 }
 
-// GetResourceIdentitySchemasResponse is the return type for GetResourceIdentitySchemas,
-type GetResourceIdentitySchemasResponse struct {
-	// IdentitySchemas maps the resource type name to that type's identity schema.
-	IdentitySchemas map[string]ResourceIdentitySchema
-
-	Diagnostics tfdiags.Diagnostics
-}
-
 type ResourceIdentitySchema struct {
 	// Version is the version of the identity schema. As per the comments in terraform-plugin-go,
 	// this should be a monotonically incrementing number, when OpenTofu comes across an identity stored in state
@@ -767,4 +759,3 @@ type CallFunctionArgumentError struct {
 func (err *CallFunctionArgumentError) Error() string {
 	return err.Text
 }
-

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -27,10 +27,6 @@ type Unconfigured interface {
 	// GetSchema returns the complete schema for the provider.
 	GetProviderSchema(context.Context) GetProviderSchemaResponse
 
-	// GetResourceIdentitySchemas returns the identity schemas for all resources
-	// in the provider.
-	GetResourceIdentitySchemas(context.Context) GetResourceIdentitySchemasResponse
-
 	// ValidateProviderConfig allows the provider to validate the configuration.
 	// The ValidateProviderConfigResponse.PreparedConfig field is unused. The
 	// final configuration is not stored in the state, and any modifications

--- a/internal/providers/schemas.go
+++ b/internal/providers/schemas.go
@@ -10,27 +10,37 @@ import (
 	"sync"
 
 	"github.com/opentofu/opentofu/internal/addrs"
-	"github.com/opentofu/opentofu/internal/configs/configschema"
 )
 
-// ProviderSchema is an overall container for all of the schemas for all
+// ProviderSchema is an overall container for all the schemas for all
 // configurable objects defined within a particular provider. All storage of
 // provider schemas should use this type.
 type ProviderSchema = GetProviderSchemaResponse
 
 // SchemaForResourceType attempts to find a schema for the given mode and type.
 // Returns nil if no such schema is available.
-func (ss ProviderSchema) SchemaForResourceType(mode addrs.ResourceMode, typeName string) (schema *configschema.Block, version uint64) {
+func (ss ProviderSchema) SchemaForResourceType(mode addrs.ResourceMode, typeName string) (schema *Schema, version uint64) {
 	switch mode {
 	case addrs.ManagedResourceMode:
-		res := ss.ResourceTypes[typeName]
-		return res.Block, uint64(res.Version)
+		res, ok := ss.ResourceTypes[typeName]
+		if !ok {
+			return nil, 0
+		}
+		return &res, uint64(res.Version)
 	case addrs.DataResourceMode:
 		// Data resources don't have schema versions right now, since state is discarded for each refresh
-		return ss.DataSources[typeName].Block, 0
+		datasource, ok := ss.DataSources[typeName]
+		if !ok {
+			return nil, 0
+		}
+		return &datasource, 0
 	case addrs.EphemeralResourceMode:
 		// Ephemeral resources don't have schema versions right now, since state is discarded for each refresh
-		return ss.EphemeralResources[typeName].Block, 0
+		ephemeral, ok := ss.EphemeralResources[typeName]
+		if !ok {
+			return nil, 0
+		}
+		return &ephemeral, 0
 	default:
 		// Shouldn't happen, because the above cases are comprehensive.
 		return nil, 0
@@ -39,7 +49,7 @@ func (ss ProviderSchema) SchemaForResourceType(mode addrs.ResourceMode, typeName
 
 // SchemaForResourceAddr attempts to find a schema for the mode and type from
 // the given resource address. Returns nil if no such schema is available.
-func (ss ProviderSchema) SchemaForResourceAddr(addr addrs.Resource) (schema *configschema.Block, version uint64) {
+func (ss ProviderSchema) SchemaForResourceAddr(addr addrs.Resource) (schema *Schema, version uint64) {
 	return ss.SchemaForResourceType(addr.Mode, addr.Type)
 }
 

--- a/internal/states/instance_object.go
+++ b/internal/states/instance_object.go
@@ -33,7 +33,7 @@ type ResourceInstanceObject struct {
 	// a provider can use it for retaining any necessary private state.
 	Private []byte
 
-	// TODO: godoc
+	// Identity is the resource identity for this instance
 	Identity cty.Value
 
 	// Status represents the "readiness" of the object as of the last time

--- a/internal/states/instance_object.go
+++ b/internal/states/instance_object.go
@@ -33,6 +33,9 @@ type ResourceInstanceObject struct {
 	// a provider can use it for retaining any necessary private state.
 	Private []byte
 
+	// TODO: godoc
+	Identity cty.Value
+
 	// Status represents the "readiness" of the object as of the last time
 	// it was updated.
 	Status ObjectStatus
@@ -100,13 +103,13 @@ const (
 // The returned object may share internal references with the receiver and
 // so the caller must not mutate the receiver any further once once this
 // method is called.
-func (o *ResourceInstanceObject) Encode(ty cty.Type, schemaVersion uint64) (*ResourceInstanceObjectSrc, error) {
+func (o *ResourceInstanceObject) Encode(ty cty.Type, schemaVersion uint64, identitySchemaVersion uint64) (*ResourceInstanceObjectSrc, error) {
 	// If it contains marks, remove these marks before traversing the
 	// structure with UnknownAsNull, and save the PathValueMarks
 	// so we can save them in state.
 	val, allPVMs := o.Value.UnmarkDeepWithPaths()
 
-	var sensitivePVMs = make([]cty.PathValueMarks, 0, len(allPVMs))
+	sensitivePVMs := make([]cty.PathValueMarks, 0, len(allPVMs))
 
 	for _, pvm := range allPVMs {
 		if _, ok := pvm.Marks[marks.Sensitive]; ok {
@@ -145,12 +148,28 @@ func (o *ResourceInstanceObject) Encode(ty cty.Type, schemaVersion uint64) (*Res
 
 	sort.Slice(dependencies, func(i, j int) bool { return dependencies[i].String() < dependencies[j].String() })
 
+	// Encode identity if present
+	var identityJSON []byte
+	if o.Identity != cty.NilVal && !o.Identity.IsNull() {
+		identityJSON, err = ctyjson.Marshal(o.Identity, o.Identity.Type())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var identitySchemaVer *uint64
+	if identityJSON != nil {
+		identitySchemaVer = &identitySchemaVersion
+	}
+
 	return &ResourceInstanceObjectSrc{
 		SchemaVersion:           schemaVersion,
+		IdentitySchemaVersion:   identitySchemaVer,
 		AttrsJSON:               src,
 		AttrSensitivePaths:      sensitivePVMs,
 		TransientPathValueMarks: allPVMs,
 		Private:                 o.Private,
+		IdentityJSON:            identityJSON,
 		Status:                  o.Status,
 		Dependencies:            dependencies,
 		CreateBeforeDestroy:     o.CreateBeforeDestroy,

--- a/internal/states/instance_object_src.go
+++ b/internal/states/instance_object_src.go
@@ -77,10 +77,10 @@ type ResourceInstanceObjectSrc struct {
 	// When this is "true", the evaluator will return an unknown value.
 	Deferred bool
 
-	// TODO: godoc
-	IdentityJSON []byte
-
-	// TODO: godoc
+	// IdentityJSON contains a JSON-encoded representation of the resourcde identity for this
+	// resource instance. Similar to AttrsJSON, this is handled in JSON format because
+	// schema versions change over time.
+	IdentityJSON          []byte
 	IdentitySchemaVersion *uint64
 }
 

--- a/internal/states/instance_object_src.go
+++ b/internal/states/instance_object_src.go
@@ -9,11 +9,10 @@ import (
 	"bytes"
 	"reflect"
 
-	"github.com/zclconf/go-cty/cty"
-	ctyjson "github.com/zclconf/go-cty/cty/json"
-
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/legacy/hcl2shim"
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
 )
 
 // ResourceInstanceObjectSrc is a not-fully-decoded version of
@@ -77,7 +76,7 @@ type ResourceInstanceObjectSrc struct {
 	// When this is "true", the evaluator will return an unknown value.
 	Deferred bool
 
-	// IdentityJSON contains a JSON-encoded representation of the resourcde identity for this
+	// IdentityJSON contains a JSON-encoded representation of the resource identity for this
 	// resource instance. Similar to AttrsJSON, this is handled in JSON format because
 	// schema versions change over time.
 	IdentityJSON          []byte

--- a/internal/states/instance_object_src.go
+++ b/internal/states/instance_object_src.go
@@ -76,6 +76,12 @@ type ResourceInstanceObjectSrc struct {
 	// Deferred is meant for the ephemeral resources state information.
 	// When this is "true", the evaluator will return an unknown value.
 	Deferred bool
+
+	// TODO: godoc
+	IdentityJSON []byte
+
+	// TODO: godoc
+	IdentitySchemaVersion *uint64
 }
 
 // Compare two lists using an given element equal function, ignoring order and duplicates
@@ -169,6 +175,18 @@ func (os *ResourceInstanceObjectSrc) Equal(other *ResourceInstanceObjectSrc) boo
 		return false
 	}
 
+	if !bytes.Equal(os.IdentityJSON, other.IdentityJSON) {
+		return false
+	}
+
+	if (os.IdentitySchemaVersion == nil) != (other.IdentitySchemaVersion == nil) {
+		return false
+	}
+
+	if os.IdentitySchemaVersion != nil && other.IdentitySchemaVersion != nil && *os.IdentitySchemaVersion != *other.IdentitySchemaVersion {
+		return false
+	}
+
 	return true
 }
 
@@ -213,11 +231,25 @@ func (os *ResourceInstanceObjectSrc) Decode(ty cty.Type) (*ResourceInstanceObjec
 		}
 	}
 
+	// Decode identity if present
+	var identity cty.Value
+	if len(os.IdentityJSON) > 0 {
+		identityType, err := ctyjson.ImpliedType(os.IdentityJSON)
+		if err != nil {
+			return nil, err
+		}
+		identity, err = ctyjson.Unmarshal(os.IdentityJSON, identityType)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return &ResourceInstanceObject{
 		Value:               val,
 		Status:              os.Status,
 		Dependencies:        os.Dependencies,
 		Private:             os.Private,
+		Identity:            identity,
 		CreateBeforeDestroy: os.CreateBeforeDestroy,
 		SkipDestroy:         os.SkipDestroy,
 		Deferred:            os.Deferred,

--- a/internal/states/instance_object_src_test.go
+++ b/internal/states/instance_object_src_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package states
+
+import (
+	"testing"
+)
+
+func uint64Ptr(v uint64) *uint64 {
+	return &v
+}
+
+func TestResourceInstanceObjectSrcEqual(t *testing.T) {
+	tests := map[string]struct {
+		a    *ResourceInstanceObjectSrc
+		b    *ResourceInstanceObjectSrc
+		want bool
+	}{
+		"identical base objects": {
+			a:    &ResourceInstanceObjectSrc{Status: ObjectReady, AttrsJSON: []byte(`{"id":"foo"}`)},
+			b:    &ResourceInstanceObjectSrc{Status: ObjectReady, AttrsJSON: []byte(`{"id":"foo"}`)},
+			want: true,
+		},
+		"identity schema version both nil": {
+			a:    &ResourceInstanceObjectSrc{Status: ObjectReady, AttrsJSON: []byte(`{"id":"foo"}`), IdentitySchemaVersion: nil},
+			b:    &ResourceInstanceObjectSrc{Status: ObjectReady, AttrsJSON: []byte(`{"id":"foo"}`), IdentitySchemaVersion: nil},
+			want: true,
+		},
+		"identity schema version first nil": {
+			a:    &ResourceInstanceObjectSrc{Status: ObjectReady, AttrsJSON: []byte(`{"id":"foo"}`), IdentitySchemaVersion: nil},
+			b:    &ResourceInstanceObjectSrc{Status: ObjectReady, AttrsJSON: []byte(`{"id":"foo"}`), IdentitySchemaVersion: uint64Ptr(1)},
+			want: false,
+		},
+		"identity schema version second nil": {
+			a:    &ResourceInstanceObjectSrc{Status: ObjectReady, AttrsJSON: []byte(`{"id":"foo"}`), IdentitySchemaVersion: uint64Ptr(1)},
+			b:    &ResourceInstanceObjectSrc{Status: ObjectReady, AttrsJSON: []byte(`{"id":"foo"}`), IdentitySchemaVersion: nil},
+			want: false,
+		},
+		"identity schema version different values": {
+			a:    &ResourceInstanceObjectSrc{Status: ObjectReady, AttrsJSON: []byte(`{"id":"foo"}`), IdentitySchemaVersion: uint64Ptr(1)},
+			b:    &ResourceInstanceObjectSrc{Status: ObjectReady, AttrsJSON: []byte(`{"id":"foo"}`), IdentitySchemaVersion: uint64Ptr(2)},
+			want: false,
+		},
+		"identity schema version same values": {
+			a:    &ResourceInstanceObjectSrc{Status: ObjectReady, AttrsJSON: []byte(`{"id":"foo"}`), IdentitySchemaVersion: uint64Ptr(1)},
+			b:    &ResourceInstanceObjectSrc{Status: ObjectReady, AttrsJSON: []byte(`{"id":"foo"}`), IdentitySchemaVersion: uint64Ptr(1)},
+			want: true,
+		},
+		"same identity json different schema version": {
+			a:    &ResourceInstanceObjectSrc{Status: ObjectReady, AttrsJSON: []byte(`{"id":"foo"}`), IdentityJSON: []byte(`{"name":"bar"}`), IdentitySchemaVersion: uint64Ptr(1)},
+			b:    &ResourceInstanceObjectSrc{Status: ObjectReady, AttrsJSON: []byte(`{"id":"foo"}`), IdentityJSON: []byte(`{"name":"bar"}`), IdentitySchemaVersion: uint64Ptr(2)},
+			want: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := tc.a.Equal(tc.b); got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/states/instance_object_test.go
+++ b/internal/states/instance_object_test.go
@@ -68,7 +68,7 @@ func TestResourceInstanceObject_encode(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			rios, err := obj.Encode(value.Type(), 0)
+			rios, err := obj.Encode(value.Type(), 0, 0)
 			if err != nil {
 				t.Errorf("unexpected error: %s", err)
 			}
@@ -142,7 +142,7 @@ func TestResourceInstanceObject_encode_sensitivity(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		encoded, err := test.inputObj.Encode(test.inputObj.Value.Type(), 0)
+		encoded, err := test.inputObj.Encode(test.inputObj.Value.Type(), 0, 0)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}

--- a/internal/states/state_deepcopy.go
+++ b/internal/states/state_deepcopy.go
@@ -177,6 +177,18 @@ func (os *ResourceInstanceObjectSrc) DeepCopy() *ResourceInstanceObjectSrc {
 		copy(dependencies, os.Dependencies)
 	}
 
+	var identityJSON []byte
+	if os.IdentityJSON != nil {
+		identityJSON = make([]byte, len(os.IdentityJSON))
+		copy(identityJSON, os.IdentityJSON)
+	}
+
+	var identitySchemaVersion *uint64
+	if os.IdentitySchemaVersion != nil {
+		v := *os.IdentitySchemaVersion
+		identitySchemaVersion = &v
+	}
+
 	return &ResourceInstanceObjectSrc{
 		Status:                  os.Status,
 		SchemaVersion:           os.SchemaVersion,
@@ -189,6 +201,8 @@ func (os *ResourceInstanceObjectSrc) DeepCopy() *ResourceInstanceObjectSrc {
 		CreateBeforeDestroy:     os.CreateBeforeDestroy,
 		SkipDestroy:             os.SkipDestroy,
 		Deferred:                os.Deferred,
+		IdentityJSON:            identityJSON,
+		IdentitySchemaVersion:   identitySchemaVersion,
 	}
 }
 
@@ -223,6 +237,7 @@ func (o *ResourceInstanceObject) DeepCopy() *ResourceInstanceObject {
 		Value:               o.Value,
 		Status:              o.Status,
 		Private:             private,
+		Identity:            o.Identity,
 		Dependencies:        dependencies,
 		CreateBeforeDestroy: o.CreateBeforeDestroy,
 		SkipDestroy:         o.SkipDestroy,

--- a/internal/states/statefile/version4.go
+++ b/internal/states/statefile/version4.go
@@ -241,6 +241,21 @@ func prepareStateV4(sV4 *stateV4) (*File, tfdiags.Diagnostics) {
 				obj.Private = raw
 			}
 
+			// Read identity from state file
+			if isV4.Identity != nil {
+				identityJSON, err := json.Marshal(isV4.Identity)
+				if err != nil {
+					diags = diags.Append(tfdiags.Sourceless(
+						tfdiags.Error,
+						"Invalid resource identity in state",
+						fmt.Sprintf("Instance %s has an invalid identity: %s.", instAddr.Absolute(moduleAddr), err),
+					))
+				} else {
+					obj.IdentityJSON = identityJSON
+					obj.IdentitySchemaVersion = isV4.IdentitySchemaVersion
+				}
+			}
+
 			{
 				depsRaw := isV4.Dependencies
 				deps := make([]addrs.ConfigResource, 0, len(depsRaw))
@@ -577,6 +592,11 @@ func appendInstanceObjectStateV4(rs *states.Resource, is *states.ResourceInstanc
 	attributeSensitivePaths, pathsDiags := marshalPaths(paths)
 	diags = diags.Append(pathsDiags)
 
+	var identity json.RawMessage
+	if obj.IdentityJSON != nil {
+		identity = obj.IdentityJSON
+	}
+
 	return append(isV4s, instanceObjectStateV4{
 		IndexKey:                rawKey,
 		Deposed:                 string(deposed),
@@ -590,6 +610,8 @@ func appendInstanceObjectStateV4(rs *states.Resource, is *states.ResourceInstanc
 		Dependencies:            deps,
 		CreateBeforeDestroy:     obj.CreateBeforeDestroy,
 		SkipDestroy:             obj.SkipDestroy,
+		Identity:                identity,
+		IdentitySchemaVersion:   obj.IdentitySchemaVersion,
 	}), diags
 }
 
@@ -808,6 +830,9 @@ type instanceObjectStateV4 struct {
 
 	CreateBeforeDestroy bool `json:"create_before_destroy,omitempty"`
 	SkipDestroy         bool `json:"skip_destroy,omitempty"`
+
+	Identity              json.RawMessage `json:"identity,omitempty"`
+	IdentitySchemaVersion *uint64         `json:"identity_schema_version,omitempty"`
 }
 
 type checkResultsV4 struct {

--- a/internal/tofu/context_apply_test.go
+++ b/internal/tofu/context_apply_test.go
@@ -283,9 +283,9 @@ func TestContext2Apply_unstable(t *testing.T) {
 		Type: "test_resource",
 		Name: "foo",
 	}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance)
-	schema := p.GetProviderSchemaResponse.ResourceTypes["test_resource"].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes["test_resource"]
 	rds := plan.Changes.ResourceInstance(addr)
-	rd, err := rds.Decode(schema.ImpliedType())
+	rd, err := rds.Decode(&schema)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -305,7 +305,7 @@ func TestContext2Apply_unstable(t *testing.T) {
 		t.Fatalf("wrong number of resources %d; want 1", len(mod.Resources))
 	}
 
-	rs, err := rss.Current.Decode(schema.ImpliedType())
+	rs, err := rss.Current.Decode(schema.Block.ImpliedType())
 	if err != nil {
 		t.Fatalf("decode error: %v", err)
 	}

--- a/internal/tofu/context_import.go
+++ b/internal/tofu/context_import.go
@@ -118,7 +118,7 @@ func NewImportResolver() *ImportResolver {
 func (ri *ImportResolver) ValidateImportIDs(ctx context.Context, importTarget *ImportTarget, evalCtx EvalContext) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
-	getIdentitySchemaType := func(ctx context.Context, importTarget *ImportTarget, evalCtx EvalContext, keyData instances.RepetitionData) (tfdiags.Diagnostics, cty.Type) {
+	getIdentitySchemaType := func(ctx context.Context, importTarget *ImportTarget, evalCtx EvalContext, keyData instances.RepetitionData) (cty.Type, tfdiags.Diagnostics) {
 		var diags tfdiags.Diagnostics
 		if importTarget.Config.Provider.Type == "" {
 			diags = diags.Append(&hcl.Diagnostic{
@@ -182,7 +182,7 @@ func (ri *ImportResolver) ValidateImportIDs(ctx context.Context, importTarget *I
 				evalDiags = validateImportIdExpression(ctx, importTarget.Config.ID, rootCtx, keyData)
 				diags = diags.Append(evalDiags)
 			} else if importTarget.Config.Identity != nil {
-				identityDiags, identityType := getIdentitySchemaType(ctx, importTarget, evalCtx, keyData)
+				identityType, identityDiags := getIdentitySchemaType(ctx, importTarget, evalCtx, keyData)
 				diags = diags.Append(identityDiags)
 				if !identityDiags.HasErrors() {
 					evalDiags = validateImportIdentityExpression(ctx, importTarget.Config.Identity, rootCtx, keyData, identityType)
@@ -197,7 +197,7 @@ func (ri *ImportResolver) ValidateImportIDs(ctx context.Context, importTarget *I
 			evalDiags := validateImportIdExpression(ctx, importTarget.Config.ID, rootCtx, EvalDataForNoInstanceKey)
 			diags = diags.Append(evalDiags)
 		} else if importTarget.Config.Identity != nil {
-			identityDiags, identityType := getIdentitySchemaType(ctx, importTarget, evalCtx, EvalDataForNoInstanceKey)
+			identityType, identityDiags := getIdentitySchemaType(ctx, importTarget, evalCtx, EvalDataForNoInstanceKey)
 			diags = diags.Append(identityDiags)
 			if !identityDiags.HasErrors() {
 				evalDiags := validateImportIdentityExpression(ctx, importTarget.Config.Identity, rootCtx, EvalDataForNoInstanceKey, identityType)

--- a/internal/tofu/context_import.go
+++ b/internal/tofu/context_import.go
@@ -137,37 +137,15 @@ func (ri *ImportResolver) ValidateImportIDs(ctx context.Context, importTarget *I
 			providerAddr.Alias = importTarget.Config.ProviderConfigRef.Alias
 		}
 
-		var resolvedProviderKey addrs.InstanceKey
-		if importTarget.Config.ProviderConfigRef != nil && importTarget.Config.ProviderConfigRef.KeyExpression != nil {
-			keyScope := evalCtx.EvaluationScope(nil, nil, keyData)
-			var keyDiags tfdiags.Diagnostics
-			resolvedProviderKey, keyDiags = resolveProviderInstance(ctx, importTarget.Config.ProviderConfigRef.KeyExpression, keyScope, importTarget.Config.StaticTo.String())
-			diags = diags.Append(keyDiags)
-			if keyDiags.HasErrors() {
-				return diags, cty.DynamicPseudoType
-			}
-		}
-
-		provider := evalCtx.Provider(ctx, providerAddr, resolvedProviderKey)
-		if provider == nil {
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Unable to determine provider for import identity",
-				Detail:   fmt.Sprintf("The provider %q could not be found when trying to validate the import of resource %q. Please ensure the provider is declared and configured properly.", providerAddr, importTarget.Config.StaticTo),
-				Subject:  importTarget.Config.Identity.Range().Ptr(),
-			})
-			return diags, cty.DynamicPseudoType
-		}
-
-		identitySchemasResponse := provider.GetResourceIdentitySchemas(ctx)
-		if identitySchemasResponse.Diagnostics.HasErrors() {
-			diags = diags.Append(identitySchemasResponse.Diagnostics)
+		providerSchema, schemaDiags := evalCtx.Providers().GetProviderSchema(ctx, providerAddr.Provider)
+		diags = diags.Append(schemaDiags)
+		if diags.HasErrors() {
 			return diags, cty.DynamicPseudoType
 		}
 
 		resourceType := importTarget.Config.StaticTo.Resource.Type
-		identitySchema, exists := identitySchemasResponse.IdentitySchemas[resourceType]
-		if !exists {
+		resourceSchema, exists := providerSchema.ResourceTypes[resourceType]
+		if !exists || resourceSchema.IdentitySchema == nil {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Unable to determine identity schema for import identity",
@@ -177,7 +155,7 @@ func (ri *ImportResolver) ValidateImportIDs(ctx context.Context, importTarget *I
 			return diags, cty.DynamicPseudoType
 		}
 
-		return diags, identitySchema.Body.SpecType()
+		return diags, resourceSchema.IdentitySchema.SpecType()
 	}
 
 	// The import block expressions are declared within the root module.
@@ -332,33 +310,14 @@ func (ri *ImportResolver) resolveImport(ctx context.Context, importTarget *Impor
 			providerAddr.Alias = importTarget.Config.ProviderConfigRef.Alias
 		}
 
-		var resolvedProviderKey addrs.InstanceKey
-		if importTarget.Config.ProviderConfigRef != nil && importTarget.Config.ProviderConfigRef.KeyExpression != nil {
-			keyScope := evalCtx.EvaluationScope(nil, nil, keyData)
-			resolvedProviderKey, diags = resolveProviderInstance(ctx, importTarget.Config.ProviderConfigRef.KeyExpression, keyScope, importAddress.String())
-			if diags.HasErrors() {
-				return diags
-			}
-		}
-
-		provider := evalCtx.Provider(ctx, providerAddr, resolvedProviderKey)
-		if provider == nil {
-			return diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Unable to determine provider for import identity",
-				Detail:   fmt.Sprintf("The provider %q could not be found when trying to import the resource %q. Please ensure the provider is declared and configured properly.", providerAddr, importAddress),
-				Subject:  importTarget.Config.Identity.Range().Ptr(),
-			})
-		}
-
-		identitySchemasResponse := provider.GetResourceIdentitySchemas(ctx)
-		diags = diags.Append(identitySchemasResponse.Diagnostics)
+		providerSchema, shcemaDiags := evalCtx.Providers().GetProviderSchema(ctx, providerAddr.Provider)
+		diags = diags.Append(shcemaDiags)
 		if diags.HasErrors() {
 			return diags
 		}
 
-		identitySchema, exists := identitySchemasResponse.IdentitySchemas[resourceType]
-		if !exists {
+		resourceSchema, exists := providerSchema.ResourceTypes[resourceType]
+		if !exists || resourceSchema.IdentitySchema == nil {
 			return diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Unable to determine identity schema for import identity",
@@ -367,8 +326,7 @@ func (ri *ImportResolver) resolveImport(ctx context.Context, importTarget *Impor
 			})
 		}
 
-		resourceIdentityType := identitySchema.Body.SpecType()
-
+		resourceIdentityType := resourceSchema.IdentitySchema.SpecType()
 		importIdentity, evalDiags = evaluateImportIdentityExpression(ctx, importTarget.Config.Identity, evalCtx, keyData, resourceIdentityType)
 		diags = diags.Append(evalDiags)
 		if diags.HasErrors() {

--- a/internal/tofu/context_import.go
+++ b/internal/tofu/context_import.go
@@ -127,7 +127,7 @@ func (ri *ImportResolver) ValidateImportIDs(ctx context.Context, importTarget *I
 				Detail:   fmt.Sprintf("The provider for import target %q could not be determined. Please ensure the import block has a valid provider configuration.", importTarget.Config.StaticTo),
 				Subject:  importTarget.Config.Identity.Range().Ptr(),
 			})
-			return diags, cty.DynamicPseudoType
+			return cty.DynamicPseudoType, diags
 		}
 
 		schema, schemaDiags := getIdentitySchema(
@@ -140,9 +140,9 @@ func (ri *ImportResolver) ValidateImportIDs(ctx context.Context, importTarget *I
 			importTarget.Config.StaticTo.String())
 		diags = diags.Append(schemaDiags)
 		if diags.HasErrors() {
-			return diags, cty.DynamicPseudoType
+			return cty.DynamicPseudoType, diags
 		}
-		return diags, schema.SpecType()
+		return schema.SpecType(), diags
 	}
 
 	// The import block expressions are declared within the root module.

--- a/internal/tofu/context_import.go
+++ b/internal/tofu/context_import.go
@@ -133,8 +133,6 @@ func (ri *ImportResolver) ValidateImportIDs(ctx context.Context, importTarget *I
 		schema, schemaDiags := getIdentitySchema(
 			ctx, evalCtx,
 			importTarget.Config.Provider,
-			importTarget.Config.ProviderConfigRef,
-			addrs.RootModule,
 			importTarget.Config.StaticTo.Resource.Type,
 			importTarget.Config.Identity.Range(),
 			importTarget.Config.StaticTo.String())
@@ -291,8 +289,6 @@ func (ri *ImportResolver) resolveImport(ctx context.Context, importTarget *Impor
 		identitySchema, schemaDiags := getIdentitySchema(
 			ctx, evalCtx,
 			importTarget.Config.Provider,
-			importTarget.Config.ProviderConfigRef,
-			importAddress.Module.Module(),
 			importAddress.Resource.Resource.Type,
 			importTarget.Config.Identity.Range(),
 			importAddress.String(),
@@ -349,27 +345,15 @@ func getIdentitySchema(
 	ctx context.Context,
 	evalCtx EvalContext,
 	provider addrs.Provider,
-	providerConfigRef *configs.ProviderConfigRef,
-	module addrs.Module,
 	resourceType string,
 	identityRange hcl.Range,
 	subjectStr string,
 ) (*configschema.Object, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	providerAddr := addrs.AbsProviderConfig{
-		Module:   module,
-		Provider: provider,
-	}
-
-	// be sure to propagate the provider config ref alias to the provider address
-	if providerConfigRef != nil {
-		providerAddr.Alias = providerConfigRef.Alias
-	}
-
 	// We are assuming that the provider schema should have the resource identity schema attached here,
 	// so we need to look up the provider schema first
-	providerSchema, schemaDiags := evalCtx.Providers().GetProviderSchema(ctx, providerAddr.Provider)
+	providerSchema, schemaDiags := evalCtx.Providers().GetProviderSchema(ctx, provider)
 	diags = diags.Append(schemaDiags)
 	if diags.HasErrors() {
 		return nil, diags
@@ -381,14 +365,13 @@ func getIdentitySchema(
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Unable to determine identity schema for import identity",
-			Detail:   fmt.Sprintf("The provider %q does not provide an identity schema for the resource type %q, which is required when trying to import the resource %q using identity-based import. Please ensure the resource type supports identity-based import.", providerAddr, resourceType, subjectStr),
+			Detail:   fmt.Sprintf("The provider %q does not provide an identity schema for the resource type %q, which is required when trying to import the resource %q using identity-based import. Please ensure the resource type supports identity-based import.", provider, resourceType, subjectStr),
 			Subject:  identityRange.Ptr(),
 		})
 		return nil, diags
 	}
 
 	return resourceSchema.IdentitySchema, diags
-
 }
 
 // GetAllImports returns all resolved imports

--- a/internal/tofu/context_import.go
+++ b/internal/tofu/context_import.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
+	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/instances"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
@@ -129,33 +130,19 @@ func (ri *ImportResolver) ValidateImportIDs(ctx context.Context, importTarget *I
 			return diags, cty.DynamicPseudoType
 		}
 
-		providerAddr := addrs.AbsProviderConfig{
-			Module:   addrs.RootModule, // Import blocks are only allowed in the root module, this code assumes that the validation around that has happened already
-			Provider: importTarget.Config.Provider,
-		}
-		if importTarget.Config.ProviderConfigRef != nil {
-			providerAddr.Alias = importTarget.Config.ProviderConfigRef.Alias
-		}
-
-		providerSchema, schemaDiags := evalCtx.Providers().GetProviderSchema(ctx, providerAddr.Provider)
+		schema, schemaDiags := getIdentitySchema(
+			ctx, evalCtx,
+			importTarget.Config.Provider,
+			importTarget.Config.ProviderConfigRef,
+			addrs.RootModule,
+			importTarget.Config.StaticTo.Resource.Type,
+			importTarget.Config.Identity.Range(),
+			importTarget.Config.StaticTo.String())
 		diags = diags.Append(schemaDiags)
 		if diags.HasErrors() {
 			return diags, cty.DynamicPseudoType
 		}
-
-		resourceType := importTarget.Config.StaticTo.Resource.Type
-		resourceSchema, exists := providerSchema.ResourceTypes[resourceType]
-		if !exists || resourceSchema.IdentitySchema == nil {
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Unable to determine identity schema for import identity",
-				Detail:   fmt.Sprintf("The provider %q does not provide an identity schema for the resource type %q, which is required when trying to validate the import of resource %q using identity-based import. Please ensure the resource type supports identity-based import.", providerAddr, resourceType, importTarget.Config.StaticTo),
-				Subject:  importTarget.Config.Identity.Range().Ptr(),
-			})
-			return diags, cty.DynamicPseudoType
-		}
-
-		return diags, resourceSchema.IdentitySchema.SpecType()
+		return diags, schema.SpecType()
 	}
 
 	// The import block expressions are declared within the root module.
@@ -301,32 +288,21 @@ func (ri *ImportResolver) resolveImport(ctx context.Context, importTarget *Impor
 		// Identity-based import
 		var evalDiags tfdiags.Diagnostics
 
-		resourceType := importAddress.Resource.Resource.Type
-		providerAddr := addrs.AbsProviderConfig{
-			Module:   importAddress.Module.Module(),
-			Provider: importTarget.Config.Provider,
-		}
-		if importTarget.Config.ProviderConfigRef != nil {
-			providerAddr.Alias = importTarget.Config.ProviderConfigRef.Alias
-		}
-
-		providerSchema, shcemaDiags := evalCtx.Providers().GetProviderSchema(ctx, providerAddr.Provider)
-		diags = diags.Append(shcemaDiags)
+		identitySchema, schemaDiags := getIdentitySchema(
+			ctx, evalCtx,
+			importTarget.Config.Provider,
+			importTarget.Config.ProviderConfigRef,
+			importAddress.Module.Module(),
+			importAddress.Resource.Resource.Type,
+			importTarget.Config.Identity.Range(),
+			importAddress.String(),
+		)
+		diags = diags.Append(schemaDiags)
 		if diags.HasErrors() {
 			return diags
 		}
 
-		resourceSchema, exists := providerSchema.ResourceTypes[resourceType]
-		if !exists || resourceSchema.IdentitySchema == nil {
-			return diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Unable to determine identity schema for import identity",
-				Detail:   fmt.Sprintf("The provider %q does not provide an identity schema for the resource type %q, which is required when trying to import the resource %q using identity-based import. Please ensure the resource type supports identity-based import.", providerAddr, resourceType, importAddress),
-				Subject:  importTarget.Config.Identity.Range().Ptr(),
-			})
-		}
-
-		resourceIdentityType := resourceSchema.IdentitySchema.SpecType()
+		resourceIdentityType := identitySchema.SpecType()
 		importIdentity, evalDiags = evaluateImportIdentityExpression(ctx, importTarget.Config.Identity, evalCtx, keyData, resourceIdentityType)
 		diags = diags.Append(evalDiags)
 		if diags.HasErrors() {
@@ -362,6 +338,57 @@ func (ri *ImportResolver) resolveImport(ctx context.Context, importTarget *Impor
 	}
 
 	return diags
+}
+
+// getIdentitySchema resolves the identity schema for a resource type by looking it up
+// from the provider schema. It is used during both validation and resolution of identity-based
+// imports to avoid duplicating the provider lookup and schema existence checks.
+// Returns nil with diagnostics if the provider schema cannot be fetched or if the
+// resource type does not support identity-based import.
+func getIdentitySchema(
+	ctx context.Context,
+	evalCtx EvalContext,
+	provider addrs.Provider,
+	providerConfigRef *configs.ProviderConfigRef,
+	module addrs.Module,
+	resourceType string,
+	identityRange hcl.Range,
+	subjectStr string,
+) (*configschema.Object, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	providerAddr := addrs.AbsProviderConfig{
+		Module:   module,
+		Provider: provider,
+	}
+
+	// be sure to propagate the provider config ref alias to the provider address
+	if providerConfigRef != nil {
+		providerAddr.Alias = providerConfigRef.Alias
+	}
+
+	// We are assuming that the provider schema should have the resource identity schema attached here,
+	// so we need to look up the provider schema first
+	providerSchema, schemaDiags := evalCtx.Providers().GetProviderSchema(ctx, providerAddr.Provider)
+	diags = diags.Append(schemaDiags)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	// Find the resource type to get its schema for us to pull the RI schema from
+	resourceSchema, exists := providerSchema.ResourceTypes[resourceType]
+	if !exists || resourceSchema.IdentitySchema == nil {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Unable to determine identity schema for import identity",
+			Detail:   fmt.Sprintf("The provider %q does not provide an identity schema for the resource type %q, which is required when trying to import the resource %q using identity-based import. Please ensure the resource type supports identity-based import.", providerAddr, resourceType, subjectStr),
+			Subject:  identityRange.Ptr(),
+		})
+		return nil, diags
+	}
+
+	return resourceSchema.IdentitySchema, diags
+
 }
 
 // GetAllImports returns all resolved imports

--- a/internal/tofu/context_import.go
+++ b/internal/tofu/context_import.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/instances"
@@ -108,12 +110,75 @@ func NewImportResolver() *ImportResolver {
 	return &ImportResolver{imports: make(map[string]EvaluatedConfigImportTarget)}
 }
 
-// ValidateImportIDs is used during the validation phase to validate the import IDs of all import targets.
-// This function works similarly to ExpandAndResolveImport, but it only validates the IDs of the import targets and does not modify the EvalContext.
-// We only validate the IDs during the validation phase. Otherwise, we might cause a false positive,
+// ValidateImportIDs is used during the validation phase to validate the import IDs/Identities of all import targets.
+// This function works similarly to ExpandAndResolveImport, but it only validates the IDs/Identities of the import targets and does not modify the EvalContext.
+// We only validate the IDs/Identities during the validation phase. Otherwise, we might cause a false positive,
 // since we do not know if the user intends to use the '-generate-config-out' option to generate additional configuration, which would make invalid Addresses valid
 func (ri *ImportResolver) ValidateImportIDs(ctx context.Context, importTarget *ImportTarget, evalCtx EvalContext) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
+
+	getIdentitySchemaType := func(ctx context.Context, importTarget *ImportTarget, evalCtx EvalContext, keyData instances.RepetitionData) (tfdiags.Diagnostics, cty.Type) {
+		var diags tfdiags.Diagnostics
+		if importTarget.Config.Provider.Type == "" {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Unable to determine provider for import identity",
+				Detail:   fmt.Sprintf("The provider for import target %q could not be determined. Please ensure the import block has a valid provider configuration.", importTarget.Config.StaticTo),
+				Subject:  importTarget.Config.Identity.Range().Ptr(),
+			})
+			return diags, cty.DynamicPseudoType
+		}
+
+		providerAddr := addrs.AbsProviderConfig{
+			Module:   addrs.RootModule, // Import blocks are only allowed in the root module, this code assumes that the validation around that has happened already
+			Provider: importTarget.Config.Provider,
+		}
+		if importTarget.Config.ProviderConfigRef != nil {
+			providerAddr.Alias = importTarget.Config.ProviderConfigRef.Alias
+		}
+
+		var resolvedProviderKey addrs.InstanceKey
+		if importTarget.Config.ProviderConfigRef != nil && importTarget.Config.ProviderConfigRef.KeyExpression != nil {
+			keyScope := evalCtx.EvaluationScope(nil, nil, keyData)
+			var keyDiags tfdiags.Diagnostics
+			resolvedProviderKey, keyDiags = resolveProviderInstance(ctx, importTarget.Config.ProviderConfigRef.KeyExpression, keyScope, importTarget.Config.StaticTo.String())
+			diags = diags.Append(keyDiags)
+			if keyDiags.HasErrors() {
+				return diags, cty.DynamicPseudoType
+			}
+		}
+
+		provider := evalCtx.Provider(ctx, providerAddr, resolvedProviderKey)
+		if provider == nil {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Unable to determine provider for import identity",
+				Detail:   fmt.Sprintf("The provider %q could not be found when trying to validate the import of resource %q. Please ensure the provider is declared and configured properly.", providerAddr, importTarget.Config.StaticTo),
+				Subject:  importTarget.Config.Identity.Range().Ptr(),
+			})
+			return diags, cty.DynamicPseudoType
+		}
+
+		identitySchemasResponse := provider.GetResourceIdentitySchemas(ctx)
+		if identitySchemasResponse.Diagnostics.HasErrors() {
+			diags = diags.Append(identitySchemasResponse.Diagnostics)
+			return diags, cty.DynamicPseudoType
+		}
+
+		resourceType := importTarget.Config.StaticTo.Resource.Type
+		identitySchema, exists := identitySchemasResponse.IdentitySchemas[resourceType]
+		if !exists {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Unable to determine identity schema for import identity",
+				Detail:   fmt.Sprintf("The provider %q does not provide an identity schema for the resource type %q, which is required when trying to validate the import of resource %q using identity-based import. Please ensure the resource type supports identity-based import.", providerAddr, resourceType, importTarget.Config.StaticTo),
+				Subject:  importTarget.Config.Identity.Range().Ptr(),
+			})
+			return diags, cty.DynamicPseudoType
+		}
+
+		return diags, identitySchema.Body.SpecType()
+	}
 
 	// The import block expressions are declared within the root module.
 	// We need to explicitly use the context with the path of the root module, so that all references will be
@@ -147,13 +212,33 @@ func (ri *ImportResolver) ValidateImportIDs(ctx context.Context, importTarget *I
 		}
 
 		for _, keyData := range repetitions {
-			evalDiags = validateImportIdExpression(importTarget.Config.ID, rootCtx, keyData)
-			diags = diags.Append(evalDiags)
+			// Validate either ID or Identity depending on which is set
+			if importTarget.Config.ID != nil {
+				evalDiags = validateImportIdExpression(ctx, importTarget.Config.ID, rootCtx, keyData)
+				diags = diags.Append(evalDiags)
+			} else if importTarget.Config.Identity != nil {
+				identityDiags, identityType := getIdentitySchemaType(ctx, importTarget, evalCtx, keyData)
+				diags = diags.Append(identityDiags)
+				if !identityDiags.HasErrors() {
+					evalDiags = validateImportIdentityExpression(ctx, importTarget.Config.Identity, rootCtx, keyData, identityType)
+					diags = diags.Append(evalDiags)
+				}
+			}
 		}
 	} else {
 		// The import target is singular, no need to expand
-		evalDiags := validateImportIdExpression(importTarget.Config.ID, rootCtx, EvalDataForNoInstanceKey)
-		diags = diags.Append(evalDiags)
+		// Validate either ID or Identity depending on which is set
+		if importTarget.Config.ID != nil {
+			evalDiags := validateImportIdExpression(ctx, importTarget.Config.ID, rootCtx, EvalDataForNoInstanceKey)
+			diags = diags.Append(evalDiags)
+		} else if importTarget.Config.Identity != nil {
+			identityDiags, identityType := getIdentitySchemaType(ctx, importTarget, evalCtx, EvalDataForNoInstanceKey)
+			diags = diags.Append(identityDiags)
+			if !identityDiags.HasErrors() {
+				evalDiags := validateImportIdentityExpression(ctx, importTarget.Config.Identity, rootCtx, EvalDataForNoInstanceKey, identityType)
+				diags = diags.Append(evalDiags)
+			}
+		}
 	}
 
 	return diags
@@ -197,34 +282,98 @@ func (ri *ImportResolver) ExpandAndResolveImport(ctx context.Context, importTarg
 		}
 
 		for _, keyData := range repetitions {
-			diags = diags.Append(ri.resolveImport(importTarget, rootCtx, keyData))
+			diags = diags.Append(ri.resolveImport(ctx, importTarget, rootCtx, keyData))
 		}
 	} else {
 		// The import target is singular, no need to expand
-		diags = diags.Append(ri.resolveImport(importTarget, rootCtx, EvalDataForNoInstanceKey))
+		diags = diags.Append(ri.resolveImport(ctx, importTarget, rootCtx, EvalDataForNoInstanceKey))
 	}
 
 	return diags
 }
 
-// resolveImport resolves the ID and address of an ImportTarget originating from an import block,
+// resolveImport resolves the ID/Identity and address of an ImportTarget originating from an import block,
 // when we have the context necessary to resolve them. The resolved import target would be an
 // EvaluatedConfigImportTarget.
 // This function mutates the EvalContext's ImportResolver, adding the resolved import target.
-// The function errors if we failed to evaluate the ID or the address.
-func (ri *ImportResolver) resolveImport(importTarget *ImportTarget, ctx EvalContext, keyData instances.RepetitionData) tfdiags.Diagnostics {
+// The function errors if we failed to evaluate the ID/Identity or the address.
+func (ri *ImportResolver) resolveImport(ctx context.Context, importTarget *ImportTarget, evalCtx EvalContext, keyData instances.RepetitionData) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
-	importId, evalDiags := evaluateImportIdExpression(importTarget.Config.ID, ctx, keyData)
-	diags = diags.Append(evalDiags)
+	// Evaluate the import address first
+	importAddress, addressDiags := evaluateImportAddress(ctx, evalCtx, importTarget.Config.To, keyData)
+	diags = diags.Append(addressDiags)
 	if diags.HasErrors() {
 		return diags
 	}
 
-	importAddress, addressDiags := evaluateImportAddress(ctx, importTarget.Config.To, keyData)
-	diags = diags.Append(addressDiags)
-	if diags.HasErrors() {
-		return diags
+	// Evaluate either ID or Identity depending on which is set
+	var importId string
+	var importIdentity cty.Value
+
+	if importTarget.Config.ID != nil {
+		// ID-based import
+		var evalDiags tfdiags.Diagnostics
+		importId, evalDiags = evaluateImportIdExpression(ctx, importTarget.Config.ID, evalCtx, keyData)
+		diags = diags.Append(evalDiags)
+		if diags.HasErrors() {
+			return diags
+		}
+	} else if importTarget.Config.Identity != nil {
+		// Identity-based import
+		var evalDiags tfdiags.Diagnostics
+
+		resourceType := importAddress.Resource.Resource.Type
+		providerAddr := addrs.AbsProviderConfig{
+			Module:   importAddress.Module.Module(),
+			Provider: importTarget.Config.Provider,
+		}
+		if importTarget.Config.ProviderConfigRef != nil {
+			providerAddr.Alias = importTarget.Config.ProviderConfigRef.Alias
+		}
+
+		var resolvedProviderKey addrs.InstanceKey
+		if importTarget.Config.ProviderConfigRef != nil && importTarget.Config.ProviderConfigRef.KeyExpression != nil {
+			keyScope := evalCtx.EvaluationScope(nil, nil, keyData)
+			resolvedProviderKey, diags = resolveProviderInstance(ctx, importTarget.Config.ProviderConfigRef.KeyExpression, keyScope, importAddress.String())
+			if diags.HasErrors() {
+				return diags
+			}
+		}
+
+		provider := evalCtx.Provider(ctx, providerAddr, resolvedProviderKey)
+		if provider == nil {
+			return diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Unable to determine provider for import identity",
+				Detail:   fmt.Sprintf("The provider %q could not be found when trying to import the resource %q. Please ensure the provider is declared and configured properly.", providerAddr, importAddress),
+				Subject:  importTarget.Config.Identity.Range().Ptr(),
+			})
+		}
+
+		identitySchemasResponse := provider.GetResourceIdentitySchemas(ctx)
+		diags = diags.Append(identitySchemasResponse.Diagnostics)
+		if diags.HasErrors() {
+			return diags
+		}
+
+		identitySchema, exists := identitySchemasResponse.IdentitySchemas[resourceType]
+		if !exists {
+			return diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Unable to determine identity schema for import identity",
+				Detail:   fmt.Sprintf("The provider %q does not provide an identity schema for the resource type %q, which is required when trying to import the resource %q using identity-based import. Please ensure the resource type supports identity-based import.", providerAddr, resourceType, importAddress),
+				Subject:  importTarget.Config.Identity.Range().Ptr(),
+			})
+		}
+
+		resourceIdentityType := identitySchema.Body.SpecType()
+
+		importIdentity, evalDiags = evaluateImportIdentityExpression(ctx, importTarget.Config.Identity, evalCtx, keyData, resourceIdentityType)
+		diags = diags.Append(evalDiags)
+		if diags.HasErrors() {
+			return diags
+		}
 	}
 
 	ri.mu.Lock()
@@ -242,9 +391,10 @@ func (ri *ImportResolver) resolveImport(importTarget *ImportTarget, ctx EvalCont
 	}
 
 	ri.imports[resolvedImportKey] = EvaluatedConfigImportTarget{
-		Config: importTarget.Config,
-		Addr:   importAddress,
-		ID:     importId,
+		Config:   importTarget.Config,
+		Addr:     importAddress,
+		ID:       importId,
+		Identity: importIdentity,
 	}
 
 	if keyData == EvalDataForNoInstanceKey {

--- a/internal/tofu/context_import_test.go
+++ b/internal/tofu/context_import_test.go
@@ -79,7 +79,8 @@ provider "aws" {
 resource "aws_instance" "foo" {
   count = 2
 }
-`})
+`,
+	})
 
 	ctx := testContext2(t, &ContextOpts{
 		Plugins: plugins.NewLibrary(map[addrs.Provider]providers.Factory{
@@ -151,7 +152,8 @@ func TestContextImport_multiInstanceProviderConfig(t *testing.T) {
 				for_each = { "foo" = "a" }
 				provider = test.multi[each.value]
 			}
-		`})
+		`,
+	})
 
 	resourceTypeSchema := providers.Schema{
 		Block: &configschema.Block{
@@ -217,7 +219,7 @@ func TestContextImport_multiInstanceProviderConfig(t *testing.T) {
 					{
 						TypeName: "test_thing",
 						State: cty.ObjectVal(map[string]cty.Value{
-							"id":             cty.StringVal(req.ID),
+							"id":             cty.StringVal(req.Target.ID),
 							"import_marker":  configuredMarker,
 							"refresh_marker": cty.NullVal(cty.String), // we'll populate this in ReadResource
 						}),
@@ -318,7 +320,8 @@ resource "aws_instance" "foo" {
   id = "bar"
   var = data.aws_sensitive_data_source.source.value
 }
-`})
+`,
+	})
 
 	ctx := testContext2(t, &ContextOpts{
 		Plugins: plugins.NewLibrary(map[addrs.Provider]providers.Factory{
@@ -734,7 +737,8 @@ resource "aws_instance" "bar" {
 data "aws_data_source" "bar" {
   foo = aws_instance.bar.id
 }
-`})
+`,
+	})
 
 	ctx := testContext2(t, &ContextOpts{
 		Plugins: plugins.NewLibrary(map[addrs.Provider]providers.Factory{
@@ -1236,7 +1240,8 @@ resource "test_resource" "two" {
 
 resource "test_resource" "test" {
 }
-`})
+`,
+	})
 
 	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
@@ -1402,6 +1407,174 @@ aws_instance_thing.foo-1:
   ID = qux
   provider = provider["registry.opentofu.org/hashicorp/aws"]
 `
+
+func TestContextImport_multiInstanceProviderIdentity(t *testing.T) {
+	// This test verifies that identity-based import blocks correctly resolve
+	// the provider instance key when the provider uses for_each and also an alias.
+
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+			terraform {
+				required_providers {
+					test = {
+						source = "terraform.io/builtin/test"
+					}
+				}
+			}
+
+			provider "test" {
+				alias = "multi"
+				for_each = {
+					a = {}
+					b = {}
+				}
+
+				marker = each.key
+			}
+
+			resource "test_thing" "test" {
+				for_each = { "foo" = "a" }
+				provider = test.multi[each.value]
+			//}
+
+			import {
+				to       = test_thing.test["foo"]
+				identity = {
+					name = "my-resource"
+				}
+				provider = test.multi["a"]
+			}
+		`,
+	})
+
+	identitySchemaObj := &configschema.Object{
+		Attributes: map[string]*configschema.Attribute{
+			"name": {Type: cty.String, Required: true},
+		},
+		Nesting: configschema.NestingSingle,
+	}
+	identitySchema := providers.ResourceIdentitySchema{
+		Version: 1,
+		Body:    identitySchemaObj,
+	}
+
+	resourceTypeSchema := providers.Schema{
+		Block: &configschema.Block{
+			Attributes: map[string]*configschema.Attribute{
+				"id": {
+					Type:     cty.String,
+					Computed: true,
+				},
+				"name": {
+					Type:     cty.String,
+					Computed: true,
+				},
+			},
+		},
+		IdentitySchema:        identitySchemaObj,
+		IdentitySchemaVersion: 1,
+	}
+	providerSchema := &providers.GetProviderSchemaResponse{
+		Provider: providers.Schema{
+			Block: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"marker": {
+						Type:     cty.String,
+						Required: true,
+					},
+				},
+			},
+		},
+		ResourceTypes: map[string]providers.Schema{
+			"test_thing": resourceTypeSchema,
+		},
+	}
+
+	providerFactory := func() (providers.Interface, error) {
+		ret := &MockProvider{}
+		var configuredMarker cty.Value
+
+		log.Printf("[TRACE] TestContextImport_multiInstanceProviderIdentity: creating new instance of provider 'test' at %p", ret)
+
+		ret.GetProviderSchemaResponse = providerSchema
+		ret.GetResourceIdentitySchemasResponse = &providers.GetResourceIdentitySchemasResponse{
+			IdentitySchemas: map[string]providers.ResourceIdentitySchema{
+				"test_thing": identitySchema,
+			},
+		}
+		ret.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) providers.ConfigureProviderResponse {
+			configuredMarker = req.Config.GetAttr("marker")
+			log.Printf("[TRACE] TestContextImport_multiInstanceProviderIdentity: ConfigureProvider for %p with marker = %#v", ret, configuredMarker)
+			return providers.ConfigureProviderResponse{}
+		}
+		ret.ImportResourceStateFn = func(req providers.ImportResourceStateRequest) providers.ImportResourceStateResponse {
+			log.Printf("[TRACE] TestContextImport_multiInstanceProviderIdentity: ImportResourceState for %p with marker = %#v", ret, configuredMarker)
+			if configuredMarker == cty.NilVal {
+				return providers.ImportResourceStateResponse{
+					Diagnostics: tfdiags.Diagnostics{}.Append(fmt.Errorf("ImportResourceState before ConfigureProvider")),
+				}
+			}
+			return providers.ImportResourceStateResponse{
+				ImportedResources: []providers.ImportedResource{
+					{
+						TypeName: "test_thing",
+						State: cty.ObjectVal(map[string]cty.Value{
+							"id":   cty.StringVal("imported-123"),
+							"name": configuredMarker,
+						}),
+					},
+				},
+			}
+		}
+		ret.ReadResourceFn = func(req providers.ReadResourceRequest) providers.ReadResourceResponse {
+			log.Printf("[TRACE] TestContextImport_multiInstanceProviderIdentity: ReadResource for %p with marker = %#v", ret, configuredMarker)
+			if configuredMarker == cty.NilVal {
+				return providers.ReadResourceResponse{
+					Diagnostics: tfdiags.Diagnostics{}.Append(fmt.Errorf("ReadResource before ConfigureProvider")),
+				}
+			}
+			return providers.ReadResourceResponse{
+				NewState: cty.ObjectVal(map[string]cty.Value{
+					"id":   req.PriorState.GetAttr("id"),
+					"name": req.PriorState.GetAttr("name"),
+				}),
+			}
+		}
+		return ret, nil
+	}
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewBuiltInProvider("test"): providerFactory,
+		},
+	})
+
+	plan, diags := ctx.Plan(t.Context(), m, states.NewState(), DefaultPlanOpts)
+	assertNoErrors(t, diags)
+
+	if len(plan.Changes.Resources) == 0 {
+		t.Fatal("expected import to create resource changes")
+	}
+
+	first := plan.Changes.Resources[0]
+	if first.Importing == nil {
+		t.Fatal("expected resource change to be an import")
+	}
+
+	identityType := identitySchemaObj.ImpliedType()
+	decodedIdentity, err := first.Importing.Identity.Decode(identityType)
+	if err != nil {
+		t.Fatalf("failed to decode importing identity: %s", err)
+	}
+
+	expectedIdentity := cty.ObjectVal(map[string]cty.Value{
+		"name": cty.StringVal("my-resource"),
+	})
+
+	if !decodedIdentity.RawEquals(expectedIdentity) {
+		t.Errorf("unexpected imported identity:\ngot:  %#v\nwant: %#v", decodedIdentity, expectedIdentity)
+	}
+}
 
 const testImportRefreshStr = `
 aws_instance.foo:

--- a/internal/tofu/context_import_test.go
+++ b/internal/tofu/context_import_test.go
@@ -1453,11 +1453,6 @@ func TestContextImport_multiInstanceProviderIdentity(t *testing.T) {
 		},
 		Nesting: configschema.NestingSingle,
 	}
-	identitySchema := providers.ResourceIdentitySchema{
-		Version: 1,
-		Body:    identitySchemaObj,
-	}
-
 	resourceTypeSchema := providers.Schema{
 		Block: &configschema.Block{
 			Attributes: map[string]*configschema.Attribute{
@@ -1497,11 +1492,6 @@ func TestContextImport_multiInstanceProviderIdentity(t *testing.T) {
 		log.Printf("[TRACE] TestContextImport_multiInstanceProviderIdentity: creating new instance of provider 'test' at %p", ret)
 
 		ret.GetProviderSchemaResponse = providerSchema
-		ret.GetResourceIdentitySchemasResponse = &providers.GetResourceIdentitySchemasResponse{
-			IdentitySchemas: map[string]providers.ResourceIdentitySchema{
-				"test_thing": identitySchema,
-			},
-		}
 		ret.ConfigureProviderFn = func(req providers.ConfigureProviderRequest) providers.ConfigureProviderResponse {
 			configuredMarker = req.Config.GetAttr("marker")
 			log.Printf("[TRACE] TestContextImport_multiInstanceProviderIdentity: ConfigureProvider for %p with marker = %#v", ret, configuredMarker)

--- a/internal/tofu/context_import_test.go
+++ b/internal/tofu/context_import_test.go
@@ -1435,7 +1435,7 @@ func TestContextImport_multiInstanceProviderIdentity(t *testing.T) {
 			resource "test_thing" "test" {
 				for_each = { "foo" = "a" }
 				provider = test.multi[each.value]
-			//}
+			}
 
 			import {
 				to       = test_thing.test["foo"]
@@ -1544,9 +1544,9 @@ func TestContextImport_multiInstanceProviderIdentity(t *testing.T) {
 	}
 
 	ctx := testContext2(t, &ContextOpts{
-		Providers: map[addrs.Provider]providers.Factory{
+		Plugins: plugins.NewLibrary(map[addrs.Provider]providers.Factory{
 			addrs.NewBuiltInProvider("test"): providerFactory,
-		},
+		}, nil),
 	})
 
 	plan, diags := ctx.Plan(t.Context(), m, states.NewState(), DefaultPlanOpts)

--- a/internal/tofu/context_plan.go
+++ b/internal/tofu/context_plan.go
@@ -988,7 +988,7 @@ func (c *Context) driftedResources(ctx context.Context, config *configs.Config, 
 					))
 					continue
 				}
-				ty := schema.ImpliedType()
+				ty := schema.Block.ImpliedType()
 
 				oldObj, err := oldIS.Current.Decode(ty)
 				if err != nil {
@@ -1057,7 +1057,7 @@ func (c *Context) driftedResources(ctx context.Context, config *configs.Config, 
 					},
 				}
 
-				changeSrc, err := change.Encode(ty)
+				changeSrc, err := change.Encode(schema)
 				if err != nil {
 					diags = diags.Append(err)
 					return nil, diags

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -6009,7 +6009,7 @@ func TestContext2Plan_importWithInvalidForEach(t *testing.T) {
 	configurations := []TestConfiguration{
 		{
 			Description:   "for_each value is null",
-			expectedError: "Invalid import id argument: The import ID cannot be null",
+			expectedError: "Invalid import id argument: The import id cannot be null",
 			inlineConfiguration: map[string]string{
 				"main.tf": `
 locals {
@@ -6155,7 +6155,7 @@ import {
 		},
 		{
 			Description:   "for_each value is sensitive",
-			expectedError: "Invalid import id argument: The import ID cannot be sensitive.",
+			expectedError: "Invalid import id argument: The import id cannot be sensitive.",
 			inlineConfiguration: map[string]string{
 				"main.tf": `
 locals {
@@ -6640,6 +6640,132 @@ func TestContext2Plan_importIdReference(t *testing.T) {
 	}
 }
 
+func TestContext2Plan_importWithIdentityExpression(t *testing.T) {
+	p := testProvider("test")
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_instance" "foo" {
+}
+
+import {
+  to = test_instance.foo
+  identity = {
+    name   = "my-resource"
+    region = "us-west-2"
+  }
+}
+`,
+	})
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	identitySchema := providers.ResourceIdentitySchema{
+		Version: 1,
+		Body: &configschema.Object{
+			Attributes: map[string]*configschema.Attribute{
+				"name":   {Type: cty.String, Required: true},
+				"region": {Type: cty.String, Required: true},
+			},
+			Nesting: configschema.NestingSingle,
+		},
+	}
+
+	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
+		ResourceTypes: map[string]providers.Schema{
+			"test_instance": {
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"id":     {Type: cty.String, Computed: true},
+						"name":   {Type: cty.String, Optional: true},
+						"region": {Type: cty.String, Optional: true},
+					},
+				},
+				IdentitySchema:        identitySchema.Body,
+				IdentitySchemaVersion: identitySchema.Version,
+			},
+		},
+	}
+
+	// Setup identity schema
+	p.GetResourceIdentitySchemasResponse = &providers.GetResourceIdentitySchemasResponse{
+		IdentitySchemas: map[string]providers.ResourceIdentitySchema{
+			"test_instance": identitySchema,
+		},
+	}
+
+	// Capture the import request to verify identity was passed correctly
+	var capturedImportRequest providers.ImportResourceStateRequest
+
+	// ImportResourceState should receive the identity
+	p.ImportResourceStateFn = func(req providers.ImportResourceStateRequest) providers.ImportResourceStateResponse {
+		capturedImportRequest = req
+
+		return providers.ImportResourceStateResponse{
+			ImportedResources: []providers.ImportedResource{
+				{
+					TypeName: "test_instance",
+					State: cty.ObjectVal(map[string]cty.Value{
+						"id":     cty.StringVal("imported-123"),
+						"name":   cty.StringVal("my-resource"),
+						"region": cty.StringVal("us-west-2"),
+					}),
+				},
+			},
+		}
+	}
+
+	plan, diags := ctx.Plan(t.Context(), m, states.NewState(), &PlanOpts{})
+
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Err())
+	}
+
+	if !p.ImportResourceStateCalled {
+		t.Fatal("ImportResourceState should have been called")
+	}
+
+	if capturedImportRequest.Target.ID != "" {
+		t.Errorf("expected ID to be empty for identity-based import, got %q", capturedImportRequest.Target.ID)
+	}
+
+	if capturedImportRequest.Target.Identity.IsNull() {
+		t.Fatal("expected Identity to be set for identity-based import")
+	}
+
+	expectedIdentity := cty.ObjectVal(map[string]cty.Value{
+		"name":   cty.StringVal("my-resource"),
+		"region": cty.StringVal("us-west-2"),
+	})
+
+	if !capturedImportRequest.Target.Identity.RawEquals(expectedIdentity) {
+		t.Errorf("unexpected identity:\ngot:  %#v\nwant: %#v", capturedImportRequest.Target.Identity, expectedIdentity)
+	}
+
+	if len(plan.Changes.Resources) == 0 {
+		t.Fatal("expected import to create resource changes")
+	}
+
+	// there should be one change, and that should be the import!
+	first := plan.Changes.Resources[0]
+	if first.Importing == nil {
+		t.Fatal("expected resource change to be an import")
+	}
+
+	identityType := identitySchema.Body.ImpliedType()
+	decodedIdentity, err := first.Importing.Identity.Decode(identityType)
+	if err != nil {
+		t.Fatalf("failed to decode importing identity: %s", err)
+	}
+
+	if !decodedIdentity.RawEquals(expectedIdentity) {
+		t.Errorf("unexpected imported identity:\ngot:  %#v\nwant: %#v", decodedIdentity, expectedIdentity)
+	}
+}
+
 func TestContext2Plan_importIdFunc(t *testing.T) {
 	p := testProvider("aws")
 	m := testModule(t, "import-id-func")
@@ -6786,7 +6912,7 @@ func TestContext2Plan_importIdInvalidNull(t *testing.T) {
 	if !diags.HasErrors() {
 		t.Fatal("succeeded; want errors")
 	}
-	if got, want := diags.Err().Error(), "The import ID cannot be null"; !strings.Contains(got, want) {
+	if got, want := diags.Err().Error(), "The import id cannot be null"; !strings.Contains(got, want) {
 		t.Fatalf("wrong error:\ngot:  %s\nwant: message containing %q", got, want)
 	}
 }

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -369,7 +369,8 @@ data "test_data_source" "d" {
 resource "test_resource" "b" {
   value = data.test_data_source.d.id
 }
-`})
+`,
+	})
 
 	oldDataAddr := mustResourceInstanceAddr(`module.mod["old"].data.test_data_source.d`)
 
@@ -657,7 +658,8 @@ data "test_data_source" "a" {
 		}
 	}
 }
-`})
+`,
+	})
 
 	managedAddr := mustResourceInstanceAddr(`test_resource.a`)
 	dataAddr := mustResourceInstanceAddr(`data.test_data_source.a`)
@@ -742,7 +744,6 @@ data "test_data_source" "a" {
 	if got, want := validVal, cty.True; got != want {
 		t.Errorf("wrong final valid value\ngot:  %#v\nwant: %#v", got, want)
 	}
-
 }
 
 func TestContext2Plan_managedResourceChecksOtherManagedResourceChange(t *testing.T) {
@@ -870,7 +871,8 @@ resource "test_resource" "b" {
 		}
 	}
 }
-`})
+`,
+	})
 
 	managedAddrA := mustResourceInstanceAddr(`test_resource.a`)
 	managedAddrB := mustResourceInstanceAddr(`test_resource.b`)
@@ -3367,7 +3369,7 @@ func TestContext2Plan_moduleImplicitMove(t *testing.T) {
 	// Modules are being moved implicitly to use the `enabled` field when nothing
 	// is declared on the block. Alternatively, they are implicitly being moved from
 	// using `enabled` as true or without declaring `enabled` to use count.
-	var tests = map[string]struct {
+	tests := map[string]struct {
 		name         string
 		expectedAddr addrs.AbsResourceInstance
 		prevAddr     addrs.AbsResourceInstance
@@ -4889,7 +4891,8 @@ resource "test_object" "b" {
   provider = test.other
   in = "a"
 }
-`})
+`,
+	})
 
 	testProvider := &MockProvider{
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
@@ -4904,7 +4907,7 @@ resource "test_object" "b" {
 				},
 			},
 			ResourceTypes: map[string]providers.Schema{
-				"test_object": providers.Schema{
+				"test_object": {
 					Block: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"in": {
@@ -5009,7 +5012,8 @@ output "out" {
     error_message = "should not block destroy"
   }
 }
-`})
+`,
+	})
 
 	p := simpleMockProvider()
 
@@ -5077,7 +5081,8 @@ resource "test_object" "a" {
 output "out" {
   value = test_object.a.test_string
 }
-`})
+`,
+	})
 
 	p := simpleMockProvider()
 
@@ -5140,12 +5145,13 @@ resource "test_object" "a" {
     new   = sensitive("ignored")
   }
 }
-`})
+`,
+	})
 
 	testProvider := &MockProvider{
 		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 			ResourceTypes: map[string]providers.Schema{
-				"test_object": providers.Schema{
+				"test_object": {
 					Block: &configschema.Block{
 						Attributes: map[string]*configschema.Attribute{
 							"map": {
@@ -5543,7 +5549,6 @@ import {
 
 	for _, configuration := range configurations {
 		t.Run(configuration.Description, func(t *testing.T) {
-
 			// Format the configuration with the import ID
 			formattedConfiguration := make(map[string]string)
 			for configFileName, configFileContent := range configuration.inlineConfiguration {
@@ -5558,10 +5563,10 @@ import {
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 					Provider: providers.Schema{Block: simpleTestSchema()},
 					ResourceTypes: map[string]providers.Schema{
-						"test_object": providers.Schema{Block: simpleTestSchema()},
+						"test_object": {Block: simpleTestSchema()},
 					},
 					DataSources: map[string]providers.Schema{
-						"test_object": providers.Schema{
+						"test_object": {
 							Block: &configschema.Block{
 								Attributes: map[string]*configschema.Attribute{
 									"test_string": {
@@ -5763,7 +5768,7 @@ import {
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 					Provider: providers.Schema{Block: providerSchema},
 					ResourceTypes: map[string]providers.Schema{
-						"test_object": providers.Schema{Block: providerSchema},
+						"test_object": {Block: providerSchema},
 					},
 				},
 			}
@@ -6250,7 +6255,7 @@ import {
 				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
 					Provider: providers.Schema{Block: providerSchema},
 					ResourceTypes: map[string]providers.Schema{
-						"test_object": providers.Schema{Block: providerSchema},
+						"test_object": {Block: providerSchema},
 					},
 				},
 			}
@@ -6658,9 +6663,9 @@ import {
 	})
 
 	ctx := testContext2(t, &ContextOpts{
-		Providers: map[addrs.Provider]providers.Factory{
+		Plugins: plugins.NewLibrary(map[addrs.Provider]providers.Factory{
 			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
-		},
+		}, nil),
 	})
 
 	identitySchema := providers.ResourceIdentitySchema{

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -6695,13 +6695,6 @@ import {
 		},
 	}
 
-	// Setup identity schema
-	p.GetResourceIdentitySchemasResponse = &providers.GetResourceIdentitySchemasResponse{
-		IdentitySchemas: map[string]providers.ResourceIdentitySchema{
-			"test_instance": identitySchema,
-		},
-	}
-
 	// Capture the import request to verify identity was passed correctly
 	var capturedImportRequest providers.ImportResourceStateRequest
 

--- a/internal/tofu/context_plan_test.go
+++ b/internal/tofu/context_plan_test.go
@@ -56,10 +56,9 @@ func TestContext2Plan_basic(t *testing.T) {
 		t.Fatalf("wrong number of resources %d; want fewer than two\n%s", l, spew.Sdump(plan.Changes.Resources))
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 	for _, r := range plan.Changes.Resources {
-		ric, err := r.Decode(ty)
+		ric, err := r.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -136,8 +135,7 @@ func TestContext2Plan_createBefore_deposed(t *testing.T) {
 		t.Fatalf("\nexpected: %q\ngot:      %q\n", expectedState, plan.PriorState.String())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	type InstanceGen struct {
 		Addr       string
@@ -168,7 +166,7 @@ func TestContext2Plan_createBefore_deposed(t *testing.T) {
 	}
 
 	{
-		ric, err := changes[InstanceGen{Addr: "aws_instance.foo"}].Decode(ty)
+		ric, err := changes[InstanceGen{Addr: "aws_instance.foo"}].Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -178,7 +176,7 @@ func TestContext2Plan_createBefore_deposed(t *testing.T) {
 		}
 
 		// the existing instance should only have an unchanged id
-		expected, err := schema.CoerceValue(cty.ObjectVal(map[string]cty.Value{
+		expected, err := schema.Block.CoerceValue(cty.ObjectVal(map[string]cty.Value{
 			"id":   cty.StringVal("baz"),
 			"type": cty.StringVal("aws_instance"),
 		}))
@@ -190,7 +188,7 @@ func TestContext2Plan_createBefore_deposed(t *testing.T) {
 	}
 
 	{
-		ric, err := changes[InstanceGen{Addr: "aws_instance.foo", DeposedKey: states.DeposedKey("00000001")}].Decode(ty)
+		ric, err := changes[InstanceGen{Addr: "aws_instance.foo", DeposedKey: states.DeposedKey("00000001")}].Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -297,15 +295,14 @@ func TestContext2Plan_escapedVar(t *testing.T) {
 		t.Fatalf("expected resource creation, got %s", res.Action)
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
-	ric, err := res.Decode(ty)
+	ric, err := res.Decode(&schema)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	expected := objectVal(t, schema, map[string]cty.Value{
+	expected := objectVal(t, schema.Block, map[string]cty.Value{
 		"id":   cty.UnknownVal(cty.String),
 		"foo":  cty.StringVal("bar-${baz}"),
 		"type": cty.UnknownVal(cty.String),
@@ -370,16 +367,15 @@ func TestContext2Plan_modules(t *testing.T) {
 		t.Error("expected 3 resource in plan, got", len(plan.Changes.Resources))
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
-	expectFoo := objectVal(t, schema, map[string]cty.Value{
+	expectFoo := objectVal(t, schema.Block, map[string]cty.Value{
 		"id":   cty.UnknownVal(cty.String),
 		"foo":  cty.StringVal("2"),
 		"type": cty.UnknownVal(cty.String),
 	})
 
-	expectNum := objectVal(t, schema, map[string]cty.Value{
+	expectNum := objectVal(t, schema.Block, map[string]cty.Value{
 		"id":   cty.UnknownVal(cty.String),
 		"num":  cty.NumberIntVal(2),
 		"type": cty.UnknownVal(cty.String),
@@ -389,7 +385,7 @@ func TestContext2Plan_modules(t *testing.T) {
 		if res.Action != plans.Create {
 			t.Fatalf("expected resource creation, got %s", res.Action)
 		}
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -424,8 +420,7 @@ func TestContext2Plan_moduleExpand(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	expected := map[string]struct{}{
 		`aws_instance.foo["a"]`:                          {},
@@ -441,7 +436,7 @@ func TestContext2Plan_moduleExpand(t *testing.T) {
 		if res.Action != plans.Create {
 			t.Fatalf("expected resource creation, got %s", res.Action)
 		}
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -484,8 +479,7 @@ func TestContext2Plan_moduleCycle(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 2 {
 		t.Fatal("expected 2 changes, got", len(plan.Changes.Resources))
@@ -495,7 +489,7 @@ func TestContext2Plan_moduleCycle(t *testing.T) {
 		if res.Action != plans.Create {
 			t.Fatalf("expected resource creation, got %s", res.Action)
 		}
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -503,12 +497,12 @@ func TestContext2Plan_moduleCycle(t *testing.T) {
 		var expected cty.Value
 		switch i := ric.Addr.String(); i {
 		case "aws_instance.b":
-			expected = objectVal(t, schema, map[string]cty.Value{
+			expected = objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"type": cty.UnknownVal(cty.String),
 			})
 		case "aws_instance.c":
-			expected = objectVal(t, schema, map[string]cty.Value{
+			expected = objectVal(t, schema.Block, map[string]cty.Value{
 				"id":         cty.UnknownVal(cty.String),
 				"some_input": cty.UnknownVal(cty.String),
 				"type":       cty.UnknownVal(cty.String),
@@ -538,19 +532,18 @@ func TestContext2Plan_moduleDeadlock(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-		ty := schema.ImpliedType()
+		schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 		for _, res := range plan.Changes.Resources {
 			if res.Action != plans.Create {
 				t.Fatalf("expected resource creation, got %s", res.Action)
 			}
-			ric, err := res.Decode(ty)
+			ric, err := res.Decode(&schema)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			expected := objectVal(t, schema, map[string]cty.Value{
+			expected := objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"type": cty.UnknownVal(cty.String),
 			})
@@ -582,8 +575,7 @@ func TestContext2Plan_moduleInput(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 2 {
 		t.Fatal("expected 2 changes, got", len(plan.Changes.Resources))
@@ -593,7 +585,7 @@ func TestContext2Plan_moduleInput(t *testing.T) {
 		if res.Action != plans.Create {
 			t.Fatalf("expected resource creation, got %s", res.Action)
 		}
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -602,13 +594,13 @@ func TestContext2Plan_moduleInput(t *testing.T) {
 
 		switch i := ric.Addr.String(); i {
 		case "aws_instance.bar":
-			expected = objectVal(t, schema, map[string]cty.Value{
+			expected = objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("2"),
 				"type": cty.UnknownVal(cty.String),
 			})
 		case "module.child.aws_instance.foo":
-			expected = objectVal(t, schema, map[string]cty.Value{
+			expected = objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("42"),
 				"type": cty.UnknownVal(cty.String),
@@ -636,8 +628,7 @@ func TestContext2Plan_moduleInputComputed(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 2 {
 		t.Fatal("expected 2 changes, got", len(plan.Changes.Resources))
@@ -647,21 +638,21 @@ func TestContext2Plan_moduleInputComputed(t *testing.T) {
 		if res.Action != plans.Create {
 			t.Fatalf("expected resource creation, got %s", res.Action)
 		}
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		switch i := ric.Addr.String(); i {
 		case "aws_instance.bar":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":      cty.UnknownVal(cty.String),
 				"foo":     cty.UnknownVal(cty.String),
 				"type":    cty.UnknownVal(cty.String),
 				"compute": cty.StringVal("foo"),
 			}), ric.After)
 		case "module.child.aws_instance.foo":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.UnknownVal(cty.String),
 				"type": cty.UnknownVal(cty.String),
@@ -695,8 +686,7 @@ func TestContext2Plan_moduleInputFromVar(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 2 {
 		t.Fatal("expected 2 changes, got", len(plan.Changes.Resources))
@@ -706,20 +696,20 @@ func TestContext2Plan_moduleInputFromVar(t *testing.T) {
 		if res.Action != plans.Create {
 			t.Fatalf("expected resource creation, got %s", res.Action)
 		}
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		switch i := ric.Addr.String(); i {
 		case "aws_instance.bar":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("2"),
 				"type": cty.UnknownVal(cty.String),
 			}), ric.After)
 		case "module.child.aws_instance.foo":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("52"),
 				"type": cty.UnknownVal(cty.String),
@@ -756,8 +746,7 @@ func TestContext2Plan_moduleMultiVar(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 5 {
 		t.Fatal("expected 5 changes, got", len(plan.Changes.Resources))
@@ -768,32 +757,32 @@ func TestContext2Plan_moduleMultiVar(t *testing.T) {
 			t.Fatalf("expected resource creation, got %s", res.Action)
 		}
 
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		switch i := ric.Addr.String(); i {
 		case "aws_instance.parent[0]":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id": cty.UnknownVal(cty.String),
 			}), ric.After)
 		case "aws_instance.parent[1]":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id": cty.UnknownVal(cty.String),
 			}), ric.After)
 		case "module.child.aws_instance.bar[0]":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":  cty.UnknownVal(cty.String),
 				"baz": cty.StringVal("baz"),
 			}), ric.After)
 		case "module.child.aws_instance.bar[1]":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":  cty.UnknownVal(cty.String),
 				"baz": cty.StringVal("baz"),
 			}), ric.After)
 		case "module.child.aws_instance.foo":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":  cty.UnknownVal(cty.String),
 				"foo": cty.StringVal("baz,baz"),
 			}), ric.After)
@@ -830,8 +819,7 @@ func TestContext2Plan_moduleOrphans(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 2 {
 		t.Fatal("expected 2 changes, got", len(plan.Changes.Resources))
@@ -839,7 +827,7 @@ func TestContext2Plan_moduleOrphans(t *testing.T) {
 
 	for _, res := range plan.Changes.Resources {
 
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -849,7 +837,7 @@ func TestContext2Plan_moduleOrphans(t *testing.T) {
 			if res.Action != plans.Create {
 				t.Fatalf("expected resource creation, got %s", res.Action)
 			}
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"num":  cty.NumberIntVal(2),
 				"type": cty.UnknownVal(cty.String),
@@ -926,8 +914,7 @@ func TestContext2Plan_moduleOrphansWithProvisioner(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 3 {
 		t.Error("expected 3 planned resources, got", len(plan.Changes.Resources))
@@ -935,7 +922,7 @@ func TestContext2Plan_moduleOrphansWithProvisioner(t *testing.T) {
 
 	for _, res := range plan.Changes.Resources {
 
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1197,8 +1184,7 @@ func TestContext2Plan_moduleProviderVar(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 1 {
 		t.Fatal("expected 1 changes, got", len(plan.Changes.Resources))
@@ -1208,14 +1194,14 @@ func TestContext2Plan_moduleProviderVar(t *testing.T) {
 		if res.Action != plans.Create {
 			t.Fatalf("expected resource creation, got %s", res.Action)
 		}
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		switch i := ric.Addr.String(); i {
 		case "module.child.aws_instance.test":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"value": cty.StringVal("hello"),
 			}), ric.After)
 		default:
@@ -1239,8 +1225,7 @@ func TestContext2Plan_moduleVar(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 2 {
 		t.Fatal("expected 2 changes, got", len(plan.Changes.Resources))
@@ -1250,7 +1235,7 @@ func TestContext2Plan_moduleVar(t *testing.T) {
 		if res.Action != plans.Create {
 			t.Fatalf("expected resource creation, got %s", res.Action)
 		}
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1259,13 +1244,13 @@ func TestContext2Plan_moduleVar(t *testing.T) {
 
 		switch i := ric.Addr.String(); i {
 		case "aws_instance.bar":
-			expected = objectVal(t, schema, map[string]cty.Value{
+			expected = objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("2"),
 				"type": cty.UnknownVal(cty.String),
 			})
 		case "module.child.aws_instance.foo":
-			expected = objectVal(t, schema, map[string]cty.Value{
+			expected = objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"num":  cty.NumberIntVal(2),
 				"type": cty.UnknownVal(cty.String),
@@ -1337,8 +1322,7 @@ func TestContext2Plan_moduleVarComputed(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 2 {
 		t.Fatal("expected 2 changes, got", len(plan.Changes.Resources))
@@ -1348,20 +1332,20 @@ func TestContext2Plan_moduleVarComputed(t *testing.T) {
 		if res.Action != plans.Create {
 			t.Fatalf("expected resource creation, got %s", res.Action)
 		}
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		switch i := ric.Addr.String(); i {
 		case "aws_instance.bar":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.UnknownVal(cty.String),
 				"type": cty.UnknownVal(cty.String),
 			}), ric.After)
 		case "module.child.aws_instance.foo":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":      cty.UnknownVal(cty.String),
 				"foo":     cty.UnknownVal(cty.String),
 				"type":    cty.UnknownVal(cty.String),
@@ -2117,8 +2101,7 @@ func TestContext2Plan_computed(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 2 {
 		t.Fatal("expected 2 changes, got", len(plan.Changes.Resources))
@@ -2128,20 +2111,20 @@ func TestContext2Plan_computed(t *testing.T) {
 		if res.Action != plans.Create {
 			t.Fatalf("expected resource creation, got %s", res.Action)
 		}
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		switch i := ric.Addr.String(); i {
 		case "aws_instance.bar":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.UnknownVal(cty.String),
 				"type": cty.UnknownVal(cty.String),
 			}), ric.After)
 		case "aws_instance.foo":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":      cty.UnknownVal(cty.String),
 				"foo":     cty.UnknownVal(cty.String),
 				"num":     cty.NumberIntVal(2),
@@ -2257,8 +2240,7 @@ func TestContext2Plan_computedDataResource(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.DataSources["aws_vpc"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.DataSources["aws_vpc"]
 
 	if rc := plan.Changes.ResourceInstance(addrs.Resource{Mode: addrs.ManagedResourceMode, Type: "aws_instance", Name: "foo"}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance)); rc == nil {
 		t.Fatalf("missing diff for aws_instance.foo")
@@ -2272,7 +2254,7 @@ func TestContext2Plan_computedDataResource(t *testing.T) {
 		t.Fatalf("missing diff for data.aws_vpc.bar")
 	}
 
-	rc, err := rcs.Decode(ty)
+	rc, err := rcs.Decode(&schema)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2441,8 +2423,7 @@ func TestContext2Plan_dataResourceBecomesComputed(t *testing.T) {
 		}
 	}
 
-	schema := p.GetProviderSchemaResponse.DataSources["aws_data_source"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.DataSources["aws_data_source"]
 
 	p.ReadDataSourceResponse = &providers.ReadDataSourceResponse{
 		// This should not be called, because the configuration for the
@@ -2483,7 +2464,7 @@ func TestContext2Plan_dataResourceBecomesComputed(t *testing.T) {
 		t.Fatalf("missing diff for data.aws_data_resource.foo")
 	}
 
-	rc, err := rcs.Decode(ty)
+	rc, err := rcs.Decode(&schema)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2527,8 +2508,7 @@ func TestContext2Plan_computedList(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 2 {
 		t.Fatal("expected 2 changes, got", len(plan.Changes.Resources))
@@ -2538,18 +2518,18 @@ func TestContext2Plan_computedList(t *testing.T) {
 		if res.Action != plans.Create {
 			t.Fatalf("expected resource creation, got %s", res.Action)
 		}
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		switch i := ric.Addr.String(); i {
 		case "aws_instance.bar":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"foo": cty.UnknownVal(cty.String),
 			}), ric.After)
 		case "aws_instance.foo":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"list":    cty.UnknownVal(cty.List(cty.String)),
 				"num":     cty.NumberIntVal(2),
 				"compute": cty.StringVal("list.#"),
@@ -2590,8 +2570,7 @@ func TestContext2Plan_computedMultiIndex(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 3 {
 		t.Fatal("expected 3 changes, got", len(plan.Changes.Resources))
@@ -2601,26 +2580,26 @@ func TestContext2Plan_computedMultiIndex(t *testing.T) {
 		if res.Action != plans.Create {
 			t.Fatalf("expected resource creation, got %s", res.Action)
 		}
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		switch i := ric.Addr.String(); i {
 		case "aws_instance.foo[0]":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"ip":      cty.UnknownVal(cty.List(cty.String)),
 				"foo":     cty.NullVal(cty.List(cty.String)),
 				"compute": cty.StringVal("ip.#"),
 			}), ric.After)
 		case "aws_instance.foo[1]":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"ip":      cty.UnknownVal(cty.List(cty.String)),
 				"foo":     cty.NullVal(cty.List(cty.String)),
 				"compute": cty.StringVal("ip.#"),
 			}), ric.After)
 		case "aws_instance.bar[0]":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"foo": cty.UnknownVal(cty.List(cty.String)),
 			}), ric.After)
 		default:
@@ -2644,8 +2623,7 @@ func TestContext2Plan_count(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 6 {
 		t.Fatal("expected 6 changes, got", len(plan.Changes.Resources))
@@ -2655,44 +2633,44 @@ func TestContext2Plan_count(t *testing.T) {
 		if res.Action != plans.Create {
 			t.Fatalf("expected resource creation, got %s", res.Action)
 		}
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		switch i := ric.Addr.String(); i {
 		case "aws_instance.bar":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("foo,foo,foo,foo,foo"),
 				"type": cty.UnknownVal(cty.String),
 			}), ric.After)
 		case "aws_instance.foo[0]":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("foo"),
 				"type": cty.UnknownVal(cty.String),
 			}), ric.After)
 		case "aws_instance.foo[1]":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("foo"),
 				"type": cty.UnknownVal(cty.String),
 			}), ric.After)
 		case "aws_instance.foo[2]":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("foo"),
 				"type": cty.UnknownVal(cty.String),
 			}), ric.After)
 		case "aws_instance.foo[3]":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("foo"),
 				"type": cty.UnknownVal(cty.String),
 			}), ric.After)
 		case "aws_instance.foo[4]":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("foo"),
 				"type": cty.UnknownVal(cty.String),
@@ -2752,8 +2730,7 @@ func TestContext2Plan_countModuleStatic(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 3 {
 		t.Fatal("expected 3 changes, got", len(plan.Changes.Resources))
@@ -2763,24 +2740,24 @@ func TestContext2Plan_countModuleStatic(t *testing.T) {
 		if res.Action != plans.Create {
 			t.Fatalf("expected resource creation, got %s", res.Action)
 		}
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		switch i := ric.Addr.String(); i {
 		case "module.child.aws_instance.foo[0]":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"type": cty.UnknownVal(cty.String),
 			}), ric.After)
 		case "module.child.aws_instance.foo[1]":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"type": cty.UnknownVal(cty.String),
 			}), ric.After)
 		case "module.child.aws_instance.foo[2]":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"type": cty.UnknownVal(cty.String),
 			}), ric.After)
@@ -2805,8 +2782,7 @@ func TestContext2Plan_countModuleStaticGrandchild(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 3 {
 		t.Fatal("expected 3 changes, got", len(plan.Changes.Resources))
@@ -2816,24 +2792,24 @@ func TestContext2Plan_countModuleStaticGrandchild(t *testing.T) {
 		if res.Action != plans.Create {
 			t.Fatalf("expected resource creation, got %s", res.Action)
 		}
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		switch i := ric.Addr.String(); i {
 		case "module.child.module.child.aws_instance.foo[0]":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"type": cty.UnknownVal(cty.String),
 			}), ric.After)
 		case "module.child.module.child.aws_instance.foo[1]":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"type": cty.UnknownVal(cty.String),
 			}), ric.After)
 		case "module.child.module.child.aws_instance.foo[2]":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"type": cty.UnknownVal(cty.String),
 			}), ric.After)
@@ -2858,8 +2834,7 @@ func TestContext2Plan_countIndex(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 2 {
 		t.Fatal("expected 2 changes, got", len(plan.Changes.Resources))
@@ -2869,20 +2844,20 @@ func TestContext2Plan_countIndex(t *testing.T) {
 		if res.Action != plans.Create {
 			t.Fatalf("expected resource creation, got %s", res.Action)
 		}
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		switch i := ric.Addr.String(); i {
 		case "aws_instance.foo[0]":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("0"),
 				"type": cty.UnknownVal(cty.String),
 			}), ric.After)
 		case "aws_instance.foo[1]":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("1"),
 				"type": cty.UnknownVal(cty.String),
@@ -2915,8 +2890,7 @@ func TestContext2Plan_countVar(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 4 {
 		t.Fatal("expected 4 changes, got", len(plan.Changes.Resources))
@@ -2926,32 +2900,32 @@ func TestContext2Plan_countVar(t *testing.T) {
 		if res.Action != plans.Create {
 			t.Fatalf("expected resource creation, got %s", res.Action)
 		}
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		switch i := ric.Addr.String(); i {
 		case "aws_instance.bar":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("foo,foo,foo"),
 				"type": cty.UnknownVal(cty.String),
 			}), ric.After)
 		case "aws_instance.foo[0]":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("foo"),
 				"type": cty.UnknownVal(cty.String),
 			}), ric.After)
 		case "aws_instance.foo[1]":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("foo"),
 				"type": cty.UnknownVal(cty.String),
 			}), ric.After)
 		case "aws_instance.foo[2]":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("foo"),
 				"type": cty.UnknownVal(cty.String),
@@ -2992,8 +2966,7 @@ func TestContext2Plan_countZero(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 1 {
 		t.Fatal("expected 1 changes, got", len(plan.Changes.Resources))
@@ -3004,7 +2977,7 @@ func TestContext2Plan_countZero(t *testing.T) {
 	if res.Action != plans.Create {
 		t.Fatalf("expected resource creation, got %s", res.Action)
 	}
-	ric, err := res.Decode(ty)
+	ric, err := res.Decode(&schema)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3033,8 +3006,7 @@ func TestContext2Plan_countOneIndex(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 2 {
 		t.Fatal("expected 2 changes, got", len(plan.Changes.Resources))
@@ -3044,20 +3016,20 @@ func TestContext2Plan_countOneIndex(t *testing.T) {
 		if res.Action != plans.Create {
 			t.Fatalf("expected resource creation, got %s", res.Action)
 		}
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		switch i := ric.Addr.String(); i {
 		case "aws_instance.bar":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("foo"),
 				"type": cty.UnknownVal(cty.String),
 			}), ric.After)
 		case "aws_instance.foo[0]":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("foo"),
 				"type": cty.UnknownVal(cty.String),
@@ -3113,8 +3085,7 @@ func TestContext2Plan_countDecreaseToOne(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 4 {
 		t.Fatal("expected 4 changes, got", len(plan.Changes.Resources))
@@ -3122,7 +3093,7 @@ func TestContext2Plan_countDecreaseToOne(t *testing.T) {
 
 	for _, res := range plan.Changes.Resources {
 
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3132,7 +3103,7 @@ func TestContext2Plan_countDecreaseToOne(t *testing.T) {
 			if res.Action != plans.Create {
 				t.Fatalf("expected resource create, got %s", res.Action)
 			}
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("bar"),
 				"type": cty.UnknownVal(cty.String),
@@ -3198,8 +3169,7 @@ func TestContext2Plan_countIncreaseFromNotSet(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 4 {
 		t.Fatal("expected 4 changes, got", len(plan.Changes.Resources))
@@ -3207,7 +3177,7 @@ func TestContext2Plan_countIncreaseFromNotSet(t *testing.T) {
 
 	for _, res := range plan.Changes.Resources {
 
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3217,7 +3187,7 @@ func TestContext2Plan_countIncreaseFromNotSet(t *testing.T) {
 			if res.Action != plans.Create {
 				t.Fatalf("expected resource create, got %s", res.Action)
 			}
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("bar"),
 				"type": cty.UnknownVal(cty.String),
@@ -3230,7 +3200,7 @@ func TestContext2Plan_countIncreaseFromNotSet(t *testing.T) {
 			if res.Action != plans.Create {
 				t.Fatalf("expected resource create, got %s", res.Action)
 			}
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("foo"),
 				"type": cty.UnknownVal(cty.String),
@@ -3239,7 +3209,7 @@ func TestContext2Plan_countIncreaseFromNotSet(t *testing.T) {
 			if res.Action != plans.Create {
 				t.Fatalf("expected resource create, got %s", res.Action)
 			}
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("foo"),
 				"type": cty.UnknownVal(cty.String),
@@ -3276,8 +3246,7 @@ func TestContext2Plan_countIncreaseFromOne(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 4 {
 		t.Fatal("expected 4 changes, got", len(plan.Changes.Resources))
@@ -3285,7 +3254,7 @@ func TestContext2Plan_countIncreaseFromOne(t *testing.T) {
 
 	for _, res := range plan.Changes.Resources {
 
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3295,7 +3264,7 @@ func TestContext2Plan_countIncreaseFromOne(t *testing.T) {
 			if res.Action != plans.Create {
 				t.Fatalf("expected resource create, got %s", res.Action)
 			}
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("bar"),
 				"type": cty.UnknownVal(cty.String),
@@ -3308,7 +3277,7 @@ func TestContext2Plan_countIncreaseFromOne(t *testing.T) {
 			if res.Action != plans.Create {
 				t.Fatalf("expected resource create, got %s", res.Action)
 			}
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("foo"),
 				"type": cty.UnknownVal(cty.String),
@@ -3317,7 +3286,7 @@ func TestContext2Plan_countIncreaseFromOne(t *testing.T) {
 			if res.Action != plans.Create {
 				t.Fatalf("expected resource create, got %s", res.Action)
 			}
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("foo"),
 				"type": cty.UnknownVal(cty.String),
@@ -3369,8 +3338,7 @@ func TestContext2Plan_countIncreaseFromOneCorrupted(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 5 {
 		t.Fatal("expected 5 changes, got", len(plan.Changes.Resources))
@@ -3378,7 +3346,7 @@ func TestContext2Plan_countIncreaseFromOneCorrupted(t *testing.T) {
 
 	for _, res := range plan.Changes.Resources {
 
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3388,7 +3356,7 @@ func TestContext2Plan_countIncreaseFromOneCorrupted(t *testing.T) {
 			if res.Action != plans.Create {
 				t.Fatalf("expected resource create, got %s", res.Action)
 			}
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("bar"),
 				"type": cty.UnknownVal(cty.String),
@@ -3405,7 +3373,7 @@ func TestContext2Plan_countIncreaseFromOneCorrupted(t *testing.T) {
 			if res.Action != plans.Create {
 				t.Fatalf("expected resource create, got %s", res.Action)
 			}
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("foo"),
 				"type": cty.UnknownVal(cty.String),
@@ -3414,7 +3382,7 @@ func TestContext2Plan_countIncreaseFromOneCorrupted(t *testing.T) {
 			if res.Action != plans.Create {
 				t.Fatalf("expected resource create, got %s", res.Action)
 			}
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("foo"),
 				"type": cty.UnknownVal(cty.String),
@@ -3498,15 +3466,14 @@ func TestContext2Plan_countIncreaseWithSplatReference(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 6 {
 		t.Fatal("expected 6 changes, got", len(plan.Changes.Resources))
 	}
 
 	for _, res := range plan.Changes.Resources {
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3552,8 +3519,7 @@ func TestContext2Plan_forEach(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 8 {
 		t.Fatal("expected 8 changes, got", len(plan.Changes.Resources))
@@ -3563,7 +3529,7 @@ func TestContext2Plan_forEach(t *testing.T) {
 		if res.Action != plans.Create {
 			t.Fatalf("expected resource creation, got %s", res.Action)
 		}
-		_, err := res.Decode(ty)
+		_, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3650,15 +3616,14 @@ func TestContext2Plan_destroy(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 2 {
 		t.Fatal("expected 2 changes, got", len(plan.Changes.Resources))
 	}
 
 	for _, res := range plan.Changes.Resources {
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3713,15 +3678,14 @@ func TestContext2Plan_moduleDestroy(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 2 {
 		t.Fatal("expected 2 changes, got", len(plan.Changes.Resources))
 	}
 
 	for _, res := range plan.Changes.Resources {
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3778,15 +3742,14 @@ func TestContext2Plan_moduleDestroyCycle(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 2 {
 		t.Fatal("expected 2 changes, got", len(plan.Changes.Resources))
 	}
 
 	for _, res := range plan.Changes.Resources {
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3841,15 +3804,14 @@ func TestContext2Plan_moduleDestroyMultivar(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 2 {
 		t.Fatal("expected 2 changes, got", len(plan.Changes.Resources))
 	}
 
 	for _, res := range plan.Changes.Resources {
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3897,15 +3859,14 @@ func TestContext2Plan_pathVar(t *testing.T) {
 		t.Fatalf("err: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 1 {
 		t.Fatal("expected 1 changes, got", len(plan.Changes.Resources))
 	}
 
 	for _, res := range plan.Changes.Resources {
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3915,7 +3876,7 @@ func TestContext2Plan_pathVar(t *testing.T) {
 			if res.Action != plans.Create {
 				t.Fatalf("resource %s should be created", i)
 			}
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"cwd":    cty.StringVal(filepath.ToSlash(cwd + "/barpath")),
 				"module": cty.StringVal(filepath.ToSlash(m.Module.SourceDir + "/foopath")),
 				"root":   cty.StringVal(filepath.ToSlash(m.Module.SourceDir + "/barpath")),
@@ -3953,15 +3914,14 @@ func TestContext2Plan_diffVar(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 2 {
 		t.Fatal("expected 2 changes, got", len(plan.Changes.Resources))
 	}
 
 	for _, res := range plan.Changes.Resources {
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3971,7 +3931,7 @@ func TestContext2Plan_diffVar(t *testing.T) {
 			if res.Action != plans.Create {
 				t.Fatalf("resource %s should be created", i)
 			}
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"num":  cty.NumberIntVal(3),
 				"type": cty.UnknownVal(cty.String),
@@ -3980,12 +3940,12 @@ func TestContext2Plan_diffVar(t *testing.T) {
 			if res.Action != plans.Update {
 				t.Fatalf("resource %s should be updated", i)
 			}
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.StringVal("bar"),
 				"num":  cty.NumberIntVal(2),
 				"type": cty.StringVal("aws_instance"),
 			}), ric.Before)
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.StringVal("bar"),
 				"num":  cty.NumberIntVal(3),
 				"type": cty.StringVal("aws_instance"),
@@ -4069,15 +4029,14 @@ func TestContext2Plan_orphan(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 2 {
 		t.Fatal("expected 2 changes, got", len(plan.Changes.Resources))
 	}
 
 	for _, res := range plan.Changes.Resources {
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -4097,7 +4056,7 @@ func TestContext2Plan_orphan(t *testing.T) {
 			if got, want := ric.ActionReason, plans.ResourceInstanceChangeNoReason; got != want {
 				t.Errorf("wrong action reason\ngot:  %s\nwant: %s", got, want)
 			}
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"num":  cty.NumberIntVal(2),
 				"type": cty.UnknownVal(cty.String),
@@ -4154,15 +4113,14 @@ func TestContext2Plan_state(t *testing.T) {
 	if len(plan.Changes.Resources) < 2 {
 		t.Fatalf("bad: %#v", plan.Changes.Resources)
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 2 {
 		t.Fatal("expected 2 changes, got", len(plan.Changes.Resources))
 	}
 
 	for _, res := range plan.Changes.Resources {
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -4175,7 +4133,7 @@ func TestContext2Plan_state(t *testing.T) {
 			if got, want := ric.ActionReason, plans.ResourceInstanceChangeNoReason; got != want {
 				t.Errorf("wrong action reason\ngot:  %s\nwant: %s", got, want)
 			}
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("2"),
 				"type": cty.UnknownVal(cty.String),
@@ -4187,12 +4145,12 @@ func TestContext2Plan_state(t *testing.T) {
 			if got, want := ric.ActionReason, plans.ResourceInstanceChangeNoReason; got != want {
 				t.Errorf("wrong action reason\ngot:  %s\nwant: %s", got, want)
 			}
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.StringVal("bar"),
 				"num":  cty.NullVal(cty.Number),
 				"type": cty.NullVal(cty.String),
 			}), ric.Before)
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.StringVal("bar"),
 				"num":  cty.NumberIntVal(2),
 				"type": cty.UnknownVal(cty.String),
@@ -4255,8 +4213,7 @@ func TestContext2Plan_requiresReplace(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["test_thing"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["test_thing"]
 
 	if got, want := len(plan.Changes.Resources), 1; got != want {
 		t.Fatalf("got %d changes; want %d", got, want)
@@ -4264,7 +4221,7 @@ func TestContext2Plan_requiresReplace(t *testing.T) {
 
 	for _, res := range plan.Changes.Resources {
 		t.Run(res.Addr.String(), func(t *testing.T) {
-			ric, err := res.Decode(ty)
+			ric, err := res.Decode(&schema)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -4277,7 +4234,7 @@ func TestContext2Plan_requiresReplace(t *testing.T) {
 				if got, want := ric.ActionReason, plans.ResourceInstanceReplaceBecauseCannotUpdate; got != want {
 					t.Errorf("wrong action reason\ngot:  %s\nwant: %s", got, want)
 				}
-				checkVals(t, objectVal(t, schema, map[string]cty.Value{
+				checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 					"v": cty.StringVal("goodbye"),
 				}), ric.After)
 			default:
@@ -4323,8 +4280,7 @@ func TestContext2Plan_taint(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 2 {
 		t.Fatal("expected 2 changes, got", len(plan.Changes.Resources))
@@ -4332,7 +4288,7 @@ func TestContext2Plan_taint(t *testing.T) {
 
 	for _, res := range plan.Changes.Resources {
 		t.Run(res.Addr.String(), func(t *testing.T) {
-			ric, err := res.Decode(ty)
+			ric, err := res.Decode(&schema)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -4345,7 +4301,7 @@ func TestContext2Plan_taint(t *testing.T) {
 				if got, want := res.ActionReason, plans.ResourceInstanceReplaceBecauseTainted; got != want {
 					t.Errorf("wrong action reason\ngot:  %s\nwant: %s", got, want)
 				}
-				checkVals(t, objectVal(t, schema, map[string]cty.Value{
+				checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 					"id":   cty.UnknownVal(cty.String),
 					"foo":  cty.StringVal("2"),
 					"type": cty.UnknownVal(cty.String),
@@ -4402,15 +4358,14 @@ func TestContext2Plan_taintIgnoreChanges(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 1 {
 		t.Fatal("expected 1 changes, got", len(plan.Changes.Resources))
 	}
 
 	for _, res := range plan.Changes.Resources {
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -4423,12 +4378,12 @@ func TestContext2Plan_taintIgnoreChanges(t *testing.T) {
 			if got, want := res.ActionReason, plans.ResourceInstanceReplaceBecauseTainted; got != want {
 				t.Errorf("wrong action reason\ngot:  %s\nwant: %s", got, want)
 			}
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.StringVal("foo"),
 				"vars": cty.StringVal("foo"),
 				"type": cty.StringVal("aws_instance"),
 			}), ric.Before)
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"vars": cty.StringVal("foo"),
 				"type": cty.UnknownVal(cty.String),
@@ -4486,15 +4441,14 @@ func TestContext2Plan_taintDestroyInterpolatedCountRace(t *testing.T) {
 			t.Fatalf("unexpected errors: %s", diags.Err())
 		}
 
-		schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-		ty := schema.ImpliedType()
+		schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 		if len(plan.Changes.Resources) != 3 {
 			t.Fatal("expected 3 changes, got", len(plan.Changes.Resources))
 		}
 
 		for _, res := range plan.Changes.Resources {
-			ric, err := res.Decode(ty)
+			ric, err := res.Decode(&schema)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -4507,11 +4461,11 @@ func TestContext2Plan_taintDestroyInterpolatedCountRace(t *testing.T) {
 				if got, want := ric.ActionReason, plans.ResourceInstanceReplaceBecauseTainted; got != want {
 					t.Errorf("wrong action reason\ngot:  %s\nwant: %s", got, want)
 				}
-				checkVals(t, objectVal(t, schema, map[string]cty.Value{
+				checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 					"id":   cty.StringVal("bar"),
 					"type": cty.StringVal("aws_instance"),
 				}), ric.Before)
-				checkVals(t, objectVal(t, schema, map[string]cty.Value{
+				checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 					"id":   cty.UnknownVal(cty.String),
 					"type": cty.UnknownVal(cty.String),
 				}), ric.After)
@@ -4547,15 +4501,14 @@ func TestContext2Plan_targeted(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 1 {
 		t.Fatal("expected 1 changes, got", len(plan.Changes.Resources))
 	}
 
 	for _, res := range plan.Changes.Resources {
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -4565,7 +4518,7 @@ func TestContext2Plan_targeted(t *testing.T) {
 			if res.Action != plans.Create {
 				t.Fatalf("resource %s should be created", i)
 			}
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"num":  cty.NumberIntVal(2),
 				"type": cty.UnknownVal(cty.String),
@@ -4598,15 +4551,14 @@ func TestContext2Plan_excluded(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 1 {
 		t.Fatal("expected 1 changes, got", len(plan.Changes.Resources))
 	}
 
 	for _, res := range plan.Changes.Resources {
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -4616,7 +4568,7 @@ func TestContext2Plan_excluded(t *testing.T) {
 			if res.Action != plans.Create {
 				t.Fatalf("resource %s should be created", i)
 			}
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"num":  cty.NumberIntVal(2),
 				"type": cty.UnknownVal(cty.String),
@@ -4648,15 +4600,14 @@ func TestContext2Plan_targetedCrossModule(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 2 {
 		t.Fatal("expected 2 changes, got", len(plan.Changes.Resources))
 	}
 
 	for _, res := range plan.Changes.Resources {
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -4665,13 +4616,13 @@ func TestContext2Plan_targetedCrossModule(t *testing.T) {
 		}
 		switch i := ric.Addr.String(); i {
 		case "module.A.aws_instance.foo":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.StringVal("bar"),
 				"type": cty.UnknownVal(cty.String),
 			}), ric.After)
 		case "module.B.aws_instance.bar":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"foo":  cty.UnknownVal(cty.String),
 				"type": cty.UnknownVal(cty.String),
@@ -4741,15 +4692,14 @@ func TestContext2Plan_targetedModuleWithProvider(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["null_resource"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["null_resource"]
 
 	if len(plan.Changes.Resources) != 1 {
 		t.Fatal("expected 1 changes, got", len(plan.Changes.Resources))
 	}
 
 	res := plan.Changes.Resources[0]
-	ric, err := res.Decode(ty)
+	ric, err := res.Decode(&schema)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4791,15 +4741,14 @@ func TestContext2Plan_excludedModuleWithProvider(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["null_resource"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["null_resource"]
 
 	if len(plan.Changes.Resources) != 1 {
 		t.Fatal("expected 1 changes, got", len(plan.Changes.Resources))
 	}
 
 	res := plan.Changes.Resources[0]
-	ric, err := res.Decode(ty)
+	ric, err := res.Decode(&schema)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4852,15 +4801,14 @@ func TestContext2Plan_targetedOrphan(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 1 {
 		t.Fatal("expected 1 changes, got", len(plan.Changes.Resources))
 	}
 
 	for _, res := range plan.Changes.Resources {
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -4919,15 +4867,14 @@ func TestContext2Plan_excludedOrphan(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 1 {
 		t.Fatal("expected 1 changes, got", len(plan.Changes.Resources))
 	}
 
 	for _, res := range plan.Changes.Resources {
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -4987,15 +4934,14 @@ func TestContext2Plan_targetedModuleOrphan(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 1 {
 		t.Fatal("expected 1 changes, got", len(plan.Changes.Resources))
 	}
 
 	res := plan.Changes.Resources[0]
-	ric, err := res.Decode(ty)
+	ric, err := res.Decode(&schema)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -5051,15 +4997,14 @@ func TestContext2Plan_excludedModuleOrphan(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 1 {
 		t.Fatal("expected 1 changes, got", len(plan.Changes.Resources))
 	}
 
 	res := plan.Changes.Resources[0]
-	ric, err := res.Decode(ty)
+	ric, err := res.Decode(&schema)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -5094,15 +5039,14 @@ func TestContext2Plan_targetedModuleUntargetedVariable(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 2 {
 		t.Fatal("expected 2 changes, got", len(plan.Changes.Resources))
 	}
 
 	for _, res := range plan.Changes.Resources {
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -5111,12 +5055,12 @@ func TestContext2Plan_targetedModuleUntargetedVariable(t *testing.T) {
 		}
 		switch i := ric.Addr.String(); i {
 		case "aws_instance.blue":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"type": cty.UnknownVal(cty.String),
 			}), ric.After)
 		case "module.blue_mod.aws_instance.mod":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":    cty.UnknownVal(cty.String),
 				"value": cty.UnknownVal(cty.String),
 				"type":  cty.UnknownVal(cty.String),
@@ -5149,15 +5093,14 @@ func TestContext2Plan_excludedModuleUntargetedVariable(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 2 {
 		t.Fatal("expected 2 changes, got", len(plan.Changes.Resources))
 	}
 
 	for _, res := range plan.Changes.Resources {
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -5166,12 +5109,12 @@ func TestContext2Plan_excludedModuleUntargetedVariable(t *testing.T) {
 		}
 		switch i := ric.Addr.String(); i {
 		case "aws_instance.blue":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"type": cty.UnknownVal(cty.String),
 			}), ric.After)
 		case "module.blue_mod.aws_instance.mod":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":    cty.UnknownVal(cty.String),
 				"value": cty.UnknownVal(cty.String),
 				"type":  cty.UnknownVal(cty.String),
@@ -5218,11 +5161,10 @@ func TestContext2Plan_outputContainsUntargetedResource(t *testing.T) {
 		t.Fatalf("expected 0 output changes, but got %d", len(plan.Changes.Outputs))
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	res := plan.Changes.Resources[0]
-	ric, err := res.Decode(ty)
+	ric, err := res.Decode(&schema)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -5269,11 +5211,10 @@ func TestContext2Plan_outputContainsExcludedResource(t *testing.T) {
 		t.Fatalf("expected 0 output changes, but got %d", len(plan.Changes.Outputs))
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	res := plan.Changes.Resources[0]
-	ric, err := res.Decode(ty)
+	ric, err := res.Decode(&schema)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -5327,11 +5268,10 @@ func TestContext2Plan_targetedOverTen(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	for _, res := range plan.Changes.Resources {
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -5382,11 +5322,10 @@ func TestContext2Plan_excludedOverTen(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	for _, res := range plan.Changes.Resources {
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -5482,15 +5421,14 @@ func TestContext2Plan_ignoreChanges(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 1 {
 		t.Fatal("expected 1 changes, got", len(plan.Changes.Resources))
 	}
 
 	res := plan.Changes.Resources[0]
-	ric, err := res.Decode(ty)
+	ric, err := res.Decode(&schema)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -5499,7 +5437,7 @@ func TestContext2Plan_ignoreChanges(t *testing.T) {
 		t.Fatalf("unexpected resource: %s", ric.Addr)
 	}
 
-	checkVals(t, objectVal(t, schema, map[string]cty.Value{
+	checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 		"id":   cty.StringVal("bar"),
 		"ami":  cty.StringVal("ami-abcd1234"),
 		"type": cty.StringVal("aws_instance"),
@@ -5615,15 +5553,14 @@ func TestContext2Plan_ignoreChangesInMap(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["test_ignore_changes_map"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["test_ignore_changes_map"]
 
 	if got, want := len(plan.Changes.Resources), 1; got != want {
 		t.Fatalf("wrong number of changes %d; want %d", got, want)
 	}
 
 	res := plan.Changes.Resources[0]
-	ric, err := res.Decode(ty)
+	ric, err := res.Decode(&schema)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -5635,7 +5572,7 @@ func TestContext2Plan_ignoreChangesInMap(t *testing.T) {
 		t.Fatalf("unexpected resource address %s; want %s", got, want)
 	}
 
-	checkVals(t, objectVal(t, schema, map[string]cty.Value{
+	checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 		"tags": cty.MapVal(map[string]cty.Value{
 			"ignored": cty.StringVal("from state"),
 			"other":   cty.StringVal("from config"),
@@ -5679,15 +5616,14 @@ func TestContext2Plan_ignoreChangesSensitive(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 1 {
 		t.Fatal("expected 1 changes, got", len(plan.Changes.Resources))
 	}
 
 	res := plan.Changes.Resources[0]
-	ric, err := res.Decode(ty)
+	ric, err := res.Decode(&schema)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -5696,7 +5632,7 @@ func TestContext2Plan_ignoreChangesSensitive(t *testing.T) {
 		t.Fatalf("unexpected resource: %s", ric.Addr)
 	}
 
-	checkVals(t, objectVal(t, schema, map[string]cty.Value{
+	checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 		"id":   cty.StringVal("bar"),
 		"ami":  cty.StringVal("ami-abcd1234"),
 		"type": cty.StringVal("aws_instance"),
@@ -5788,9 +5724,9 @@ func TestContext2Plan_computedValueInMap(t *testing.T) {
 	}
 
 	for _, res := range plan.Changes.Resources {
-		schema := p.GetProviderSchemaResponse.ResourceTypes[res.Addr.Resource.Resource.Type].Block
+		schema := p.GetProviderSchemaResponse.ResourceTypes[res.Addr.Resource.Resource.Type]
 
-		ric, err := res.Decode(schema.ImpliedType())
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -5801,11 +5737,11 @@ func TestContext2Plan_computedValueInMap(t *testing.T) {
 
 		switch i := ric.Addr.String(); i {
 		case "aws_computed_source.intermediates":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"computed_read_only": cty.UnknownVal(cty.String),
 			}), ric.After)
 		case "module.test_mod.aws_instance.inner2":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"looked_up": cty.UnknownVal(cty.String),
 			}), ric.After)
 		default:
@@ -5843,9 +5779,9 @@ func TestContext2Plan_moduleVariableFromSplat(t *testing.T) {
 	}
 
 	for _, res := range plan.Changes.Resources {
-		schema := p.GetProviderSchemaResponse.ResourceTypes[res.Addr.Resource.Resource.Type].Block
+		schema := p.GetProviderSchemaResponse.ResourceTypes[res.Addr.Resource.Resource.Type]
 
-		ric, err := res.Decode(schema.ImpliedType())
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -5859,7 +5795,7 @@ func TestContext2Plan_moduleVariableFromSplat(t *testing.T) {
 			"module.mod1.aws_instance.test[1]",
 			"module.mod2.aws_instance.test[0]",
 			"module.mod2.aws_instance.test[1]":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"thing": cty.StringVal("doesnt"),
 			}), ric.After)
 		default:
@@ -5930,7 +5866,7 @@ func TestContext2Plan_createBeforeDestroy_depends_datasource(t *testing.T) {
 			schema = p.GetProviderSchemaResponse.ResourceTypes[res.Addr.Resource.Resource.Type].Block
 		}
 
-		ric, err := res.Decode(schema.ImpliedType())
+		ric, err := res.Decode(&providers.Schema{Block: schema})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -6068,9 +6004,9 @@ func TestContext2Plan_ignoreChangesWithFlatmaps(t *testing.T) {
 	}
 
 	res := plan.Changes.Resources[0]
-	schema := p.GetProviderSchemaResponse.ResourceTypes[res.Addr.Resource.Resource.Type].Block
+	schema := p.GetProviderSchemaResponse.ResourceTypes[res.Addr.Resource.Resource.Type]
 
-	ric, err := res.Decode(schema.ImpliedType())
+	ric, err := res.Decode(&schema)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -6083,7 +6019,7 @@ func TestContext2Plan_ignoreChangesWithFlatmaps(t *testing.T) {
 		t.Fatalf("unknown resource: %s", ric.Addr)
 	}
 
-	checkVals(t, objectVal(t, schema, map[string]cty.Value{
+	checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 		"lst": cty.ListVal([]cty.Value{
 			cty.StringVal("j"),
 			cty.StringVal("k"),
@@ -6498,8 +6434,7 @@ func TestContext2Plan_variableSensitivity(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 1 {
 		t.Fatal("expected 1 changes, got", len(plan.Changes.Resources))
@@ -6509,14 +6444,14 @@ func TestContext2Plan_variableSensitivity(t *testing.T) {
 		if res.Action != plans.Create {
 			t.Fatalf("expected resource creation, got %s", res.Action)
 		}
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		switch i := ric.Addr.String(); i {
 		case "aws_instance.foo":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"foo": cty.StringVal("foo").Mark(marks.Sensitive),
 			}), ric.After)
 			if len(res.ChangeSrc.BeforeValMarks) != 0 {
@@ -6567,8 +6502,7 @@ func TestContext2Plan_variableSensitivityModule(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 1 {
 		t.Fatal("expected 1 changes, got", len(plan.Changes.Resources))
@@ -6578,14 +6512,14 @@ func TestContext2Plan_variableSensitivityModule(t *testing.T) {
 		if res.Action != plans.Create {
 			t.Fatalf("expected resource creation, got %s", res.Action)
 		}
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		switch i := ric.Addr.String(); i {
 		case "module.child.aws_instance.foo":
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"foo":   cty.StringVal("foo").Mark(marks.Sensitive),
 				"value": cty.StringVal("boop").Mark(marks.Sensitive),
 			}), ric.After)
@@ -6669,8 +6603,7 @@ func TestContext2Plan_requiredModuleOutput(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["test_resource"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["test_resource"]
 
 	if len(plan.Changes.Resources) != 2 {
 		t.Fatal("expected 2 changes, got", len(plan.Changes.Resources))
@@ -6681,7 +6614,7 @@ func TestContext2Plan_requiredModuleOutput(t *testing.T) {
 			if res.Action != plans.Create {
 				t.Fatalf("expected resource creation, got %s", res.Action)
 			}
-			ric, err := res.Decode(ty)
+			ric, err := res.Decode(&schema)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -6689,12 +6622,12 @@ func TestContext2Plan_requiredModuleOutput(t *testing.T) {
 			var expected cty.Value
 			switch i := ric.Addr.String(); i {
 			case "test_resource.root":
-				expected = objectVal(t, schema, map[string]cty.Value{
+				expected = objectVal(t, schema.Block, map[string]cty.Value{
 					"id":       cty.UnknownVal(cty.String),
 					"required": cty.UnknownVal(cty.String),
 				})
 			case "module.mod.test_resource.for_output":
-				expected = objectVal(t, schema, map[string]cty.Value{
+				expected = objectVal(t, schema.Block, map[string]cty.Value{
 					"id":       cty.UnknownVal(cty.String),
 					"required": cty.StringVal("val"),
 				})
@@ -6732,8 +6665,7 @@ func TestContext2Plan_requiredModuleObject(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 
-	schema := p.GetProviderSchemaResponse.ResourceTypes["test_resource"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["test_resource"]
 
 	if len(plan.Changes.Resources) != 2 {
 		t.Fatal("expected 2 changes, got", len(plan.Changes.Resources))
@@ -6744,7 +6676,7 @@ func TestContext2Plan_requiredModuleObject(t *testing.T) {
 			if res.Action != plans.Create {
 				t.Fatalf("expected resource creation, got %s", res.Action)
 			}
-			ric, err := res.Decode(ty)
+			ric, err := res.Decode(&schema)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -6752,12 +6684,12 @@ func TestContext2Plan_requiredModuleObject(t *testing.T) {
 			var expected cty.Value
 			switch i := ric.Addr.String(); i {
 			case "test_resource.root":
-				expected = objectVal(t, schema, map[string]cty.Value{
+				expected = objectVal(t, schema.Block, map[string]cty.Value{
 					"id":       cty.UnknownVal(cty.String),
 					"required": cty.UnknownVal(cty.String),
 				})
 			case "module.mod.test_resource.for_output":
-				expected = objectVal(t, schema, map[string]cty.Value{
+				expected = objectVal(t, schema.Block, map[string]cty.Value{
 					"id":       cty.UnknownVal(cty.String),
 					"required": cty.StringVal("val"),
 				})
@@ -7328,15 +7260,14 @@ func TestContext2Plan_targetedModuleInstance(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 1 {
 		t.Fatal("expected 1 changes, got", len(plan.Changes.Resources))
 	}
 
 	for _, res := range plan.Changes.Resources {
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -7346,7 +7277,7 @@ func TestContext2Plan_targetedModuleInstance(t *testing.T) {
 			if res.Action != plans.Create {
 				t.Fatalf("resource %s should be created", i)
 			}
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"num":  cty.NumberIntVal(2),
 				"type": cty.UnknownVal(cty.String),
@@ -7379,15 +7310,14 @@ func TestContext2Plan_excludedModuleInstance(t *testing.T) {
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
-	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"].Block
-	ty := schema.ImpliedType()
+	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
 	if len(plan.Changes.Resources) != 1 {
 		t.Fatal("expected 1 changes, got", len(plan.Changes.Resources))
 	}
 
 	for _, res := range plan.Changes.Resources {
-		ric, err := res.Decode(ty)
+		ric, err := res.Decode(&schema)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -7397,7 +7327,7 @@ func TestContext2Plan_excludedModuleInstance(t *testing.T) {
 			if res.Action != plans.Create {
 				t.Fatalf("resource %s should be created", i)
 			}
-			checkVals(t, objectVal(t, schema, map[string]cty.Value{
+			checkVals(t, objectVal(t, schema.Block, map[string]cty.Value{
 				"id":   cty.UnknownVal(cty.String),
 				"num":  cty.NumberIntVal(2),
 				"type": cty.UnknownVal(cty.String),

--- a/internal/tofu/context_plugins.go
+++ b/internal/tofu/context_plugins.go
@@ -69,7 +69,10 @@ func (cp *contextPlugins) ResourceTypeSchema(ctx context.Context, providerAddr a
 	}
 
 	schema, version := providerSchema.SchemaForResourceType(resourceMode, resourceType)
-	return schema, version, diags
+	if schema == nil {
+		return nil, 0, diags
+	}
+	return schema.Block, version, diags
 }
 
 // ProvisionerSchema uses a temporary instance of the provisioner with the

--- a/internal/tofu/context_plugins.go
+++ b/internal/tofu/context_plugins.go
@@ -69,9 +69,6 @@ func (cp *contextPlugins) ResourceTypeSchema(ctx context.Context, providerAddr a
 	}
 
 	schema, version := providerSchema.SchemaForResourceType(resourceMode, resourceType)
-	if schema == nil {
-		return nil, 0, diags
-	}
 	return schema.Block, version, diags
 }
 

--- a/internal/tofu/context_plugins.go
+++ b/internal/tofu/context_plugins.go
@@ -69,6 +69,9 @@ func (cp *contextPlugins) ResourceTypeSchema(ctx context.Context, providerAddr a
 	}
 
 	schema, version := providerSchema.SchemaForResourceType(resourceMode, resourceType)
+	if schema == nil {
+		return nil, 0, diags
+	}
 	return schema.Block, version, diags
 }
 

--- a/internal/tofu/eval_context_builtin.go
+++ b/internal/tofu/eval_context_builtin.go
@@ -178,7 +178,6 @@ func (c *BuiltinEvalContext) EvaluateExpr(ctx context.Context, expr hcl.Expressi
 }
 
 func (c *BuiltinEvalContext) EvaluateReplaceTriggeredBy(ctx context.Context, expr hcl.Expression, repData instances.RepetitionData) (*addrs.Reference, bool, tfdiags.Diagnostics) {
-
 	// get the reference to lookup changes in the plan
 	ref, diags := evalReplaceTriggeredByExpr(expr, repData)
 	if diags.HasErrors() {
@@ -258,7 +257,15 @@ func (c *BuiltinEvalContext) EvaluateReplaceTriggeredBy(ctx context.Context, exp
 
 	resAddr := change.Addr.ContainingResource().Resource
 	resSchema, _ := schema.SchemaForResourceType(resAddr.Mode, resAddr.Type)
-	ty := resSchema.ImpliedType()
+	var ty cty.Type
+	if resSchema == nil {
+		// The logic for an implied type of an empty configschema.Block
+		// is different to that of a nil block. So, for this reason we construct
+		// a new empty block here.
+		ty = (&configschema.Block{}).ImpliedType()
+	} else {
+		ty = resSchema.Block.ImpliedType()
+	}
 
 	before, err := change.ChangeSrc.Before.Decode(ty)
 	if err != nil {

--- a/internal/tofu/eval_import_test.go
+++ b/internal/tofu/eval_import_test.go
@@ -29,22 +29,22 @@ func TestEvaluateImportIdExpression_SensitiveValue(t *testing.T) {
 		{
 			name:    "sensitive_value",
 			expr:    hcltest.MockExprLiteral(cty.StringVal("value").Mark(marks.Sensitive)),
-			wantErr: "Invalid import id argument: The import ID cannot be sensitive.",
+			wantErr: "Invalid import id argument: The import id cannot be sensitive.",
 		},
 		{
 			name:    "ephemeral_value",
 			expr:    hcltest.MockExprLiteral(cty.StringVal("value").Mark(marks.Ephemeral)),
-			wantErr: "Invalid import id argument: The import ID cannot be ephemeral.",
+			wantErr: "Invalid import id argument: The import id cannot be ephemeral.",
 		},
 		{
 			name:    "expr_is_nil",
 			expr:    nil,
-			wantErr: "Invalid import id argument: The import ID cannot be null.",
+			wantErr: "Invalid import id argument: The import id cannot be null.",
 		},
 		{
 			name:    "evaluates_to_null",
 			expr:    hcltest.MockExprLiteral(cty.NullVal(cty.String)),
-			wantErr: "Invalid import id argument: The import ID cannot be null.",
+			wantErr: "Invalid import id argument: The import id cannot be null.",
 		},
 		{
 			name:    "evaluates_to_unknown",
@@ -60,13 +60,87 @@ func TestEvaluateImportIdExpression_SensitiveValue(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, diags := evaluateImportIdExpression(tc.expr, ctx, EvalDataForNoInstanceKey)
+			_, diags := evaluateImportIdExpression(t.Context(), tc.expr, ctx, EvalDataForNoInstanceKey)
 
 			if tc.wantErr != "" {
 				if len(diags) != 1 {
 					t.Errorf("expected diagnostics, got %s", spew.Sdump(diags))
 				} else if diags.Err().Error() != tc.wantErr {
-					t.Errorf("unexpected error diagnostic %s", diags.Err().Error())
+					t.Errorf("unexpected error diagnostic. wanted %q got %q", tc.wantErr, diags.Err().Error())
+				}
+			} else {
+				if len(diags) != 0 {
+					t.Errorf("unexpected diagnostics %s", spew.Sdump(diags))
+				}
+			}
+		})
+	}
+}
+
+// TestEvaluateImportIdentityExpression_NestedMarks verifies that sensitive and
+// ephemeral marks are detected on nested attributes inside identity objects,
+// not just on the top-level value.
+//
+// Without deep mark checking, an identity like:
+//
+//	import {
+//	  identity = { id = var.secret_id }  // var.secret_id is sensitive
+//	  to       = aws_instance.example
+//	}
+//
+// would pass validation because the outer object is not marked -- only the
+// nested "id" attribute carries the sensitive mark. This would leak the
+// sensitive value into import state without any warning.
+// This is mainly intended to ensure that we do not regress on this behaviour
+func TestEvaluateImportIdentityExpression_NestedMarks(t *testing.T) {
+	ctx := &MockEvalContext{}
+	ctx.installSimpleEval()
+	ctx.EvaluationScopeScope = &lang.Scope{}
+
+	testCases := []struct {
+		name    string
+		expr    hcl.Expression
+		wantErr string
+	}{
+		{
+			name: "nested_sensitive_attribute",
+			expr: hcltest.MockExprLiteral(cty.ObjectVal(map[string]cty.Value{
+				"id": cty.StringVal("secret").Mark(marks.Sensitive),
+			})),
+			wantErr: "Invalid import identity argument: The import identity cannot be sensitive.",
+		},
+		{
+			name: "nested_ephemeral_attribute",
+			expr: hcltest.MockExprLiteral(cty.ObjectVal(map[string]cty.Value{
+				"id": cty.StringVal("temp").Mark(marks.Ephemeral),
+			})),
+			wantErr: "Invalid import identity argument: The import identity cannot be ephemeral.",
+		},
+		{
+			name: "top_level_sensitive_object",
+			expr: hcltest.MockExprLiteral(cty.ObjectVal(map[string]cty.Value{
+				"id": cty.StringVal("value"),
+			}).Mark(marks.Sensitive)),
+			wantErr: "Invalid import identity argument: The import identity cannot be sensitive.",
+		},
+		{
+			name: "valid_identity",
+			expr: hcltest.MockExprLiteral(cty.ObjectVal(map[string]cty.Value{
+				"id": cty.StringVal("value"),
+			})),
+			wantErr: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, diags := evaluateImportIdentityExpression(t.Context(), tc.expr, ctx, EvalDataForNoInstanceKey, cty.DynamicPseudoType)
+
+			if tc.wantErr != "" {
+				if len(diags) != 1 {
+					t.Errorf("expected diagnostics, got %s", spew.Sdump(diags))
+				} else if diags.Err().Error() != tc.wantErr {
+					t.Errorf("unexpected error diagnostic. wanted %q got %q", tc.wantErr, diags.Err().Error())
 				}
 			} else {
 				if len(diags) != 0 {

--- a/internal/tofu/evaluate_test.go
+++ b/internal/tofu/evaluate_test.go
@@ -588,7 +588,7 @@ func TestEvaluatorGetResource_changes(t *testing.T) {
 	}
 	schema, _ := schemas.ResourceTypeConfig(addrs.NewDefaultProvider("test"), addr.Mode, addr.Type)
 	// This encoding separates out the After's marks into its AfterValMarks
-	csrc, _ := change.Encode(schema.ImpliedType())
+	csrc, _ := change.Encode(schema)
 	changesSync.AppendResourceInstanceChange(csrc)
 
 	evaluator := &Evaluator{

--- a/internal/tofu/hook.go
+++ b/internal/tofu/hook.go
@@ -84,7 +84,7 @@ type Hook interface {
 
 	// PrePlanImport and PostPlanImport are called during a plan before and after planning to import
 	// a new resource using the configuration-driven import workflow.
-	PrePlanImport(addr addrs.AbsResourceInstance, importID string) (HookAction, error)
+	PrePlanImport(addr addrs.AbsResourceInstance, importID providers.ImportTarget) (HookAction, error)
 	PostPlanImport(addr addrs.AbsResourceInstance, imported []providers.ImportedResource) (HookAction, error)
 
 	// PreApplyImport and PostApplyImport are called during an apply for each imported resource when
@@ -197,7 +197,7 @@ func (*NilHook) PostImportState(addr addrs.AbsResourceInstance, imported []provi
 	return HookActionContinue, nil
 }
 
-func (h *NilHook) PrePlanImport(addr addrs.AbsResourceInstance, importID string) (HookAction, error) {
+func (h *NilHook) PrePlanImport(addr addrs.AbsResourceInstance, target providers.ImportTarget) (HookAction, error) {
 	return HookActionContinue, nil
 }
 

--- a/internal/tofu/hook_mock.go
+++ b/internal/tofu/hook_mock.go
@@ -337,7 +337,7 @@ func (h *MockHook) PostImportState(addr addrs.AbsResourceInstance, imported []pr
 	return h.PostImportStateReturn, h.PostImportStateError
 }
 
-func (h *MockHook) PrePlanImport(addr addrs.AbsResourceInstance, importID string) (HookAction, error) {
+func (h *MockHook) PrePlanImport(addr addrs.AbsResourceInstance, target providers.ImportTarget) (HookAction, error) {
 	h.Lock()
 	defer h.Unlock()
 

--- a/internal/tofu/hook_stop.go
+++ b/internal/tofu/hook_stop.go
@@ -76,7 +76,7 @@ func (h *stopHook) PostImportState(addr addrs.AbsResourceInstance, imported []pr
 	return h.hook()
 }
 
-func (h *stopHook) PrePlanImport(addr addrs.AbsResourceInstance, importID string) (HookAction, error) {
+func (h *stopHook) PrePlanImport(addr addrs.AbsResourceInstance, target providers.ImportTarget) (HookAction, error) {
 	return h.hook()
 }
 

--- a/internal/tofu/hook_test.go
+++ b/internal/tofu/hook_test.go
@@ -129,7 +129,7 @@ func (h *testHook) PostImportState(addr addrs.AbsResourceInstance, imported []pr
 	return HookActionContinue, nil
 }
 
-func (h *testHook) PrePlanImport(addr addrs.AbsResourceInstance, importID string) (HookAction, error) {
+func (h *testHook) PrePlanImport(addr addrs.AbsResourceInstance, target providers.ImportTarget) (HookAction, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.Calls = append(h.Calls, &testHookCall{"PrePlanImport", addr.String()})

--- a/internal/tofu/node_resource_abstract_instance.go
+++ b/internal/tofu/node_resource_abstract_instance.go
@@ -416,7 +416,7 @@ func (n *NodeAbstractResourceInstance) readDiff(evalCtx EvalContext, providerSch
 		return nil, nil
 	}
 
-	change, err := csrc.Decode(schema.ImpliedType())
+	change, err := csrc.Decode(schema)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode planned changes for %s: %w", n.Addr, err)
 	}
@@ -762,8 +762,10 @@ func (n *NodeAbstractResourceInstance) writeResourceInstanceStateImpl(ctx contex
 		return fmt.Errorf("failed to encode %s in state: no resource type schema available", absAddr)
 	}
 
-	obj.Value = schema.RemoveEphemeralFromWriteOnly(obj.Value)
-	src, err := obj.Encode(schema.ImpliedType(), currentVersion)
+	identitySchemaVersion := providerSchema.ResourceTypes[n.Addr.ContainingResource().Resource.Type].IdentitySchemaVersion
+
+	obj.Value = schema.Block.RemoveEphemeralFromWriteOnly(obj.Value)
+	src, err := obj.Encode(schema.Block.ImpliedType(), currentVersion, uint64(identitySchemaVersion))
 	if err != nil {
 		return fmt.Errorf("failed to encode %s in state: %w", absAddr, err)
 	}
@@ -859,6 +861,7 @@ func (n *NodeAbstractResourceInstance) planDestroy(ctx context.Context, evalCtx 
 		ProposedNewState: nullVal,
 		PriorPrivate:     currentState.Private,
 		ProviderMeta:     metaConfigVal,
+		PriorIdentity:    currentState.Identity,
 	})
 
 	// We may not have a config for all destroys, but we want to reference it in
@@ -891,9 +894,10 @@ func (n *NodeAbstractResourceInstance) planDestroy(ctx context.Context, evalCtx 
 		PrevRunAddr: n.prevRunAddr(evalCtx),
 		DeposedKey:  deposedKey,
 		Change: plans.Change{
-			Action: plans.Delete,
-			Before: currentState.Value,
-			After:  nullVal,
+			Action:          plans.Delete,
+			Before:          currentState.Value,
+			After:           nullVal,
+			PlannedIdentity: resp.PlannedIdentity,
 		},
 		Private:      resp.PlannedPrivate,
 		ProviderAddr: n.ResolvedProvider.ProviderConfig,
@@ -945,9 +949,9 @@ func (n *NodeAbstractResourceInstance) writeChange(ctx context.Context, evalCtx 
 		return fmt.Errorf("provider does not support resource type %q", ri.Resource.Type)
 	}
 
-	change.Before = schema.RemoveEphemeralFromWriteOnly(change.Before)
-	change.After = schema.RemoveEphemeralFromWriteOnly(change.After)
-	csrc, err := change.Encode(schema.ImpliedType())
+	change.Before = schema.Block.RemoveEphemeralFromWriteOnly(change.Before)
+	change.After = schema.Block.RemoveEphemeralFromWriteOnly(change.After)
+	csrc, err := change.Encode(schema)
 	if err != nil {
 		return fmt.Errorf("failed to encode planned changes for %s: %w", n.Addr, err)
 	}
@@ -1017,10 +1021,11 @@ func (n *NodeAbstractResourceInstance) refresh(ctx context.Context, evalCtx Eval
 	}
 
 	providerReq := providers.ReadResourceRequest{
-		TypeName:     n.Addr.Resource.Resource.Type,
-		PriorState:   priorVal,
-		Private:      state.Private,
-		ProviderMeta: metaConfigVal,
+		TypeName:      n.Addr.Resource.Resource.Type,
+		PriorState:    priorVal,
+		Private:       state.Private,
+		ProviderMeta:  metaConfigVal,
+		PriorIdentity: state.Identity,
 	}
 
 	resp := provider.ReadResource(ctx, providerReq)
@@ -1040,7 +1045,7 @@ func (n *NodeAbstractResourceInstance) refresh(ctx context.Context, evalCtx Eval
 		panic("new state is cty.NilVal")
 	}
 
-	for _, err := range resp.NewState.Type().TestConformance(schema.ImpliedType()) {
+	for _, err := range resp.NewState.Type().TestConformance(schema.Block.ImpliedType()) {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Provider produced invalid object",
@@ -1054,7 +1059,7 @@ func (n *NodeAbstractResourceInstance) refresh(ctx context.Context, evalCtx Eval
 		return state, diags
 	}
 
-	newState := objchange.NormalizeObjectFromLegacySDK(resp.NewState, schema)
+	newState := objchange.NormalizeObjectFromLegacySDK(resp.NewState, schema.Block)
 	if !newState.RawEquals(resp.NewState) {
 		// We had to fix up this object in some way, and we still need to
 		// accept any changes for compatibility, so all we can do is log a
@@ -1065,12 +1070,13 @@ func (n *NodeAbstractResourceInstance) refresh(ctx context.Context, evalCtx Eval
 	ret := state.DeepCopy()
 	ret.Value = newState
 	ret.Private = resp.Private
+	ret.Identity = resp.NewIdentity
 
 	// We have no way to exempt provider using the legacy SDK from this check,
 	// so we can only log inconsistencies with the updated state values.
 	// In most cases these are not errors anyway, and represent "drift" from
 	// external changes which will be handled by the subsequent plan.
-	if errs := objchange.AssertObjectCompatible(schema, priorVal, ret.Value); len(errs) > 0 {
+	if errs := objchange.AssertObjectCompatible(schema.Block, priorVal, ret.Value); len(errs) > 0 {
 		var buf strings.Builder
 		fmt.Fprintf(&buf, "[WARN] Provider %q produced an unexpected new value for %s during refresh.", n.ResolvedProvider.ProviderConfig.Provider.String(), absAddr)
 		for _, err := range errs {
@@ -1090,7 +1096,7 @@ func (n *NodeAbstractResourceInstance) refresh(ctx context.Context, evalCtx Eval
 	// Bring in the marks from the schema for the value, this will be merged with the marks from the
 	// previous value to preserve user-marked values, for example: someone passing a sensitive arg to a non-sensitive
 	// prop on a resource
-	marks := combinePathValueMarks(priorPaths, schema.ValueMarks(ret.Value, nil))
+	marks := combinePathValueMarks(priorPaths, schema.Block.ValueMarks(ret.Value, nil))
 
 	// we only want to mark the value if it has marks
 	if len(marks) > 0 {
@@ -1174,7 +1180,7 @@ func (n *NodeAbstractResourceInstance) plan(
 		return plannedChange, currentState.DeepCopy(), keyData, diags
 	}
 
-	origConfigVal, _, configDiags := evalCtx.EvaluateBlock(ctx, config.Config, schema, nil, keyData)
+	origConfigVal, _, configDiags := evalCtx.EvaluateBlock(ctx, config.Config, schema.Block, nil, keyData)
 	// configDiags.InConfigBody(...) has been added after the initial implementation, to add
 	// additional context to the diagnostics generated by the ephemeral values references validation.
 	diags = diags.Append(configDiags.InConfigBody(config.Config, n.Addr.String()))
@@ -1191,10 +1197,12 @@ func (n *NodeAbstractResourceInstance) plan(
 	var priorVal cty.Value
 	var priorValTainted cty.Value
 	var priorPrivate []byte
+	var priorIdentity cty.Value
 	if currentState != nil {
 		if currentState.Status != states.ObjectTainted {
 			priorVal = currentState.Value
 			priorPrivate = currentState.Private
+			priorIdentity = currentState.Identity
 		} else {
 			// If the prior state is tainted then we'll proceed below like
 			// we're creating an entirely new object, but then turn it into
@@ -1202,10 +1210,10 @@ func (n *NodeAbstractResourceInstance) plan(
 			// result as if the provider had marked at least one argument
 			// change as "requires replacement".
 			priorValTainted = currentState.Value
-			priorVal = cty.NullVal(schema.ImpliedType())
+			priorVal = cty.NullVal(schema.Block.ImpliedType())
 		}
 	} else {
-		priorVal = cty.NullVal(schema.ImpliedType())
+		priorVal = cty.NullVal(schema.Block.ImpliedType())
 	}
 
 	log.Printf("[TRACE] Re-validating config for %q", n.Addr)
@@ -1236,7 +1244,7 @@ func (n *NodeAbstractResourceInstance) plan(
 	// starting values.
 	// Here we operate on the marked values, so as to revert any changes to the
 	// marks as well as the value.
-	configValIgnored, ignoreChangeDiags := n.processIgnoreChanges(priorVal, origConfigVal, schema)
+	configValIgnored, ignoreChangeDiags := n.processIgnoreChanges(priorVal, origConfigVal, schema.Block)
 	diags = diags.Append(ignoreChangeDiags)
 	if ignoreChangeDiags.HasErrors() {
 		return nil, nil, keyData, diags
@@ -1248,7 +1256,7 @@ func (n *NodeAbstractResourceInstance) plan(
 	unmarkedConfigVal, unmarkedPaths := configValIgnored.UnmarkDeepWithPaths()
 	unmarkedPriorVal, _ := priorVal.UnmarkDeepWithPaths()
 
-	proposedNewVal := objchange.ProposedNew(schema, unmarkedPriorVal, unmarkedConfigVal)
+	proposedNewVal := objchange.ProposedNew(schema.Block, unmarkedPriorVal, unmarkedConfigVal)
 
 	// Call pre-diff hook
 	diags = diags.Append(evalCtx.Hook(func(h Hook) (HookAction, error) {
@@ -1272,6 +1280,7 @@ func (n *NodeAbstractResourceInstance) plan(
 		ProposedNewState: proposedNewVal,
 		PriorPrivate:     priorPrivate,
 		ProviderMeta:     metaConfigVal,
+		PriorIdentity:    priorIdentity,
 	})
 
 	diags = diags.Append(resp.Diagnostics.InConfigBody(config.Config, n.Addr.String()))
@@ -1283,6 +1292,7 @@ func (n *NodeAbstractResourceInstance) plan(
 	// Store an unmarked version of our planned new value because the `plan` now marks properties correctly with the config marks
 	unmarkedPlannedNewVal, _ := plannedNewVal.UnmarkDeep()
 	plannedPrivate := resp.PlannedPrivate
+	plannedIdentity := resp.PlannedIdentity
 
 	if plannedNewVal == cty.NilVal {
 		// Should never happen. Since real-world providers return via RPC a nil
@@ -1295,7 +1305,7 @@ func (n *NodeAbstractResourceInstance) plan(
 	// here, since that allows the provider to do special logic like a
 	// DiffSuppressFunc, but we still require that the provider produces
 	// a value whose type conforms to the schema.
-	for _, err := range plannedNewVal.Type().TestConformance(schema.ImpliedType()) {
+	for _, err := range plannedNewVal.Type().TestConformance(schema.Block.ImpliedType()) {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Provider produced invalid plan",
@@ -1309,7 +1319,7 @@ func (n *NodeAbstractResourceInstance) plan(
 		return nil, nil, keyData, diags
 	}
 
-	if errs := objchange.AssertPlanValid(schema, unmarkedPriorVal, unmarkedConfigVal, unmarkedPlannedNewVal); len(errs) > 0 {
+	if errs := objchange.AssertPlanValid(schema.Block, unmarkedPriorVal, unmarkedConfigVal, unmarkedPlannedNewVal); len(errs) > 0 {
 		if resp.LegacyTypeSystem {
 			// The shimming of the old type system in the legacy SDK is not precise
 			// enough to pass this consistency check, so we'll give it a pass here,
@@ -1362,7 +1372,7 @@ func (n *NodeAbstractResourceInstance) plan(
 
 	// Add the marks back to the planned new value -- this must happen after ignore changes
 	// have been processed
-	marks := combinePathValueMarks(unmarkedPaths, schema.ValueMarks(plannedNewVal, nil))
+	marks := combinePathValueMarks(unmarkedPaths, schema.Block.ValueMarks(plannedNewVal, nil))
 	if len(marks) > 0 {
 		plannedNewVal = plannedNewVal.MarkWithPaths(marks)
 	}
@@ -1432,7 +1442,7 @@ func (n *NodeAbstractResourceInstance) plan(
 			// reqRep just because it's write-only.
 			// Needed because there is no way to apply the path based on the equivalence
 			// of the before/after values of this, since both are meant to always be null.
-			schemaAttr := schema.AttributeByPath(path)
+			schemaAttr := schema.Block.AttributeByPath(path)
 			isWo := schemaAttr != nil && schemaAttr.WriteOnly
 			if isWo {
 				reqRep.Add(path)
@@ -1487,7 +1497,7 @@ func (n *NodeAbstractResourceInstance) plan(
 	switch {
 	case priorVal.IsNull():
 		action = plans.Create
-	case schema.PathSetContainsWriteOnly(unmarkedPlannedNewVal, reqRep):
+	case schema.Block.PathSetContainsWriteOnly(unmarkedPlannedNewVal, reqRep):
 		replaceResAction()
 	case eq && !matchedForceReplace:
 		action = plans.NoOp
@@ -1511,7 +1521,7 @@ func (n *NodeAbstractResourceInstance) plan(
 		// The resulting change should show any computed attributes changing
 		// from known prior values to unknown values, unless the provider is
 		// able to predict new values for any of these computed attributes.
-		nullPriorVal := cty.NullVal(schema.ImpliedType())
+		nullPriorVal := cty.NullVal(schema.Block.ImpliedType())
 
 		// Since there is no prior state to compare after replacement, we need
 		// a new unmarked config from our original with no ignored values.
@@ -1521,7 +1531,14 @@ func (n *NodeAbstractResourceInstance) plan(
 		}
 
 		// create a new proposed value from the null state and the config
-		proposedNewVal = objchange.ProposedNew(schema, nullPriorVal, unmarkedConfigVal)
+		proposedNewVal = objchange.ProposedNew(schema.Block, nullPriorVal, unmarkedConfigVal)
+
+		// used in the PriorIdentity, if we dont know the type due to a missing schema then we
+		// will want to fall back to DPT here
+		identitySchemaType := cty.DynamicPseudoType
+		if schema.IdentitySchema != nil {
+			identitySchemaType = schema.IdentitySchema.ImpliedType()
+		}
 
 		resp = provider.PlanResourceChange(ctx, providers.PlanResourceChangeRequest{
 			TypeName:         n.Addr.Resource.Resource.Type,
@@ -1530,6 +1547,7 @@ func (n *NodeAbstractResourceInstance) plan(
 			ProposedNewState: proposedNewVal,
 			PriorPrivate:     plannedPrivate,
 			ProviderMeta:     metaConfigVal,
+			PriorIdentity:    cty.NullVal(identitySchemaType), // null for create portion of replace
 		})
 		// We need to tread carefully here, since if there are any warnings
 		// in here they probably also came out of our previous call to
@@ -1542,12 +1560,13 @@ func (n *NodeAbstractResourceInstance) plan(
 		}
 		plannedNewVal = resp.PlannedState
 		plannedPrivate = resp.PlannedPrivate
+		plannedIdentity = resp.PlannedIdentity
 
 		if len(unmarkedPaths) > 0 {
 			plannedNewVal = plannedNewVal.MarkWithPaths(unmarkedPaths)
 		}
 
-		for _, err := range plannedNewVal.Type().TestConformance(schema.ImpliedType()) {
+		for _, err := range plannedNewVal.Type().TestConformance(schema.Block.ImpliedType()) {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
 				"Provider produced invalid plan",
@@ -1634,6 +1653,7 @@ func (n *NodeAbstractResourceInstance) plan(
 			// Marks will be removed when encoding.
 			After:           plannedNewVal,
 			GeneratedConfig: n.generatedConfigHCL,
+			PlannedIdentity: plannedIdentity,
 		},
 		ActionReason:    actionReason,
 		RequiredReplace: reqRep,
@@ -1650,6 +1670,7 @@ func (n *NodeAbstractResourceInstance) plan(
 		Status:      states.ObjectPlanned,
 		Value:       plannedNewVal,
 		Private:     plannedPrivate,
+		Identity:    plannedIdentity,
 		SkipDestroy: skipDestroy,
 	}
 
@@ -1970,10 +1991,10 @@ func (n *NodeAbstractResourceInstance) readDataSource(ctx context.Context, evalC
 	if newVal == cty.NilVal {
 		// This can happen with incompletely-configured mocks. We'll allow it
 		// and treat it as an alias for a properly-typed null value.
-		newVal = cty.NullVal(schema.ImpliedType())
+		newVal = cty.NullVal(schema.Block.ImpliedType())
 	}
 
-	for _, err := range newVal.Type().TestConformance(schema.ImpliedType()) {
+	for _, err := range newVal.Type().TestConformance(schema.Block.ImpliedType()) {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Provider produced invalid object",
@@ -2075,7 +2096,7 @@ func (n *NodeAbstractResourceInstance) openEphemeralResource(ctx context.Context
 	newVal, closeFn, openDiags := shared.OpenEphemeralResourceInstance(
 		ctx,
 		n.Addr,
-		schema,
+		schema.Block,
 		n.ResolvedProvider.ProviderConfig.Correct().Instance(n.ResolvedProviderKey),
 		provider,
 		configVal,
@@ -2156,7 +2177,7 @@ func (n *NodeAbstractResourceInstance) planDataSource(ctx context.Context, evalC
 		return nil, nil, keyData, diags
 	}
 
-	objTy := schema.ImpliedType()
+	objTy := schema.Block.ImpliedType()
 	priorVal := cty.NullVal(objTy)
 
 	forEach, _ := evaluateForEachExpression(ctx, config.ForEach, evalCtx, n.Addr)
@@ -2175,7 +2196,7 @@ func (n *NodeAbstractResourceInstance) planDataSource(ctx context.Context, evalC
 	}
 
 	var configDiags tfdiags.Diagnostics
-	configVal, _, configDiags = evalCtx.EvaluateBlock(ctx, config.Config, schema, nil, keyData)
+	configVal, _, configDiags = evalCtx.EvaluateBlock(ctx, config.Config, schema.Block, nil, keyData)
 	// configDiags.InConfigBody(...) has been added after the initial implementation, to add
 	// additional context to the diagnostics generated by the ephemeral values references validation.
 	diags = diags.Append(configDiags.InConfigBody(n.Config.Config, n.Addr.String()))
@@ -2241,7 +2262,7 @@ func (n *NodeAbstractResourceInstance) planDataSource(ctx context.Context, evalC
 		}
 
 		unmarkedConfigVal, configMarkPaths := configVal.UnmarkDeepWithPaths()
-		proposedNewVal := objchange.PlannedUnknownObject(schema, unmarkedConfigVal)
+		proposedNewVal := objchange.PlannedUnknownObject(schema.Block, unmarkedConfigVal)
 		proposedNewVal = proposedNewVal.MarkWithPaths(configMarkPaths)
 
 		// Apply detects that the data source will need to be read by the After
@@ -2302,7 +2323,7 @@ func (n *NodeAbstractResourceInstance) planDataSource(ctx context.Context, evalC
 			// If we had errors, then we can cover that up by marking the new
 			// state as unknown.
 			unmarkedConfigVal, configMarkPaths := configVal.UnmarkDeepWithPaths()
-			newVal = objchange.PlannedUnknownObject(schema, unmarkedConfigVal)
+			newVal = objchange.PlannedUnknownObject(schema.Block, unmarkedConfigVal)
 			newVal = newVal.MarkWithPaths(configMarkPaths)
 
 			// We still want to report the check as failed even if we are still
@@ -2478,7 +2499,7 @@ func (n *NodeAbstractResourceInstance) applyDataSource(ctx context.Context, eval
 		return nil, keyData, diags
 	}
 
-	configVal, _, configDiags := evalCtx.EvaluateBlock(ctx, config.Config, schema, nil, keyData)
+	configVal, _, configDiags := evalCtx.EvaluateBlock(ctx, config.Config, schema.Block, nil, keyData)
 	diags = diags.Append(configDiags)
 	if configDiags.HasErrors() {
 		return nil, keyData, diags
@@ -2847,7 +2868,7 @@ func (n *NodeAbstractResourceInstance) apply(
 	configVal := cty.NullVal(cty.DynamicPseudoType)
 	if applyConfig != nil {
 		var configDiags tfdiags.Diagnostics
-		configVal, _, configDiags = evalCtx.EvaluateBlock(ctx, applyConfig.Config, schema, nil, keyData)
+		configVal, _, configDiags = evalCtx.EvaluateBlock(ctx, applyConfig.Config, schema.Block, nil, keyData)
 		diags = diags.Append(configDiags)
 		if configDiags.HasErrors() {
 			return nil, diags
@@ -2908,6 +2929,7 @@ func (n *NodeAbstractResourceInstance) apply(
 			SkipDestroy:         state.SkipDestroy,
 			Dependencies:        state.Dependencies,
 			Private:             state.Private,
+			Identity:            state.Identity,
 			Status:              state.Status,
 			Value:               change.After,
 		}
@@ -2915,12 +2937,13 @@ func (n *NodeAbstractResourceInstance) apply(
 	}
 
 	resp := provider.ApplyResourceChange(ctx, providers.ApplyResourceChangeRequest{
-		TypeName:       n.Addr.Resource.Resource.Type,
-		PriorState:     unmarkedBefore,
-		Config:         unmarkedConfigVal,
-		PlannedState:   unmarkedAfter,
-		PlannedPrivate: change.Private,
-		ProviderMeta:   metaConfigVal,
+		TypeName:        n.Addr.Resource.Resource.Type,
+		PriorState:      unmarkedBefore,
+		Config:          unmarkedConfigVal,
+		PlannedState:    unmarkedAfter,
+		PlannedPrivate:  change.Private,
+		PlannedIdentity: change.Change.PlannedIdentity,
+		ProviderMeta:    metaConfigVal,
 	})
 
 	applyDiags := resp.Diagnostics
@@ -2937,7 +2960,7 @@ func (n *NodeAbstractResourceInstance) apply(
 	newVal := resp.NewState
 
 	// If we have paths to mark, mark those on this new value
-	newValMarks := combinePathValueMarks(afterPaths, schema.ValueMarks(newVal, nil))
+	newValMarks := combinePathValueMarks(afterPaths, schema.Block.ValueMarks(newVal, nil))
 	if len(newValMarks) > 0 {
 		newVal = newVal.MarkWithPaths(newValMarks)
 	}
@@ -2953,7 +2976,7 @@ func (n *NodeAbstractResourceInstance) apply(
 		// we were trying to execute a delete, because the provider in this case
 		// probably left the newVal unset intending it to be interpreted as "null".
 		if change.After.IsNull() {
-			newVal = cty.NullVal(schema.ImpliedType())
+			newVal = cty.NullVal(schema.Block.ImpliedType())
 		}
 
 		if !diags.HasErrors() {
@@ -2969,7 +2992,7 @@ func (n *NodeAbstractResourceInstance) apply(
 	}
 
 	var conformDiags tfdiags.Diagnostics
-	for _, err := range newVal.Type().TestConformance(schema.ImpliedType()) {
+	for _, err := range newVal.Type().TestConformance(schema.Block.ImpliedType()) {
 		conformDiags = conformDiags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Provider produced invalid object",
@@ -3042,7 +3065,7 @@ func (n *NodeAbstractResourceInstance) apply(
 		// a pass since the other errors are usually the explanation for
 		// this one and so it's more helpful to let the user focus on the
 		// root cause rather than distract with this extra problem.
-		if errs := objchange.AssertObjectCompatible(schema, change.After, newVal); len(errs) > 0 {
+		if errs := objchange.AssertObjectCompatible(schema.Block, change.After, newVal); len(errs) > 0 {
 			if resp.LegacyTypeSystem {
 				// The shimming of the old type system in the legacy SDK is not precise
 				// enough to pass this consistency check, so we'll give it a pass here,
@@ -3123,6 +3146,7 @@ func (n *NodeAbstractResourceInstance) apply(
 			Status:              state.Status,
 			Value:               newVal,
 			Private:             resp.Private,
+			Identity:            resp.NewIdentity,
 			CreateBeforeDestroy: createBeforeDestroy,
 			SkipDestroy:         state.SkipDestroy,
 		}
@@ -3141,6 +3165,7 @@ func (n *NodeAbstractResourceInstance) apply(
 			Status:              states.ObjectReady,
 			Value:               newVal,
 			Private:             resp.Private,
+			Identity:            resp.NewIdentity,
 			CreateBeforeDestroy: createBeforeDestroy,
 			SkipDestroy:         skipDestroy,
 		}
@@ -3243,7 +3268,7 @@ func (n *NodeAbstractResourceInstance) applyEphemeralResource(ctx context.Contex
 	}
 
 	var configDiags tfdiags.Diagnostics
-	configVal, _, configDiags = evalCtx.EvaluateBlock(ctx, n.Config.Config, schema, nil, keyData)
+	configVal, _, configDiags = evalCtx.EvaluateBlock(ctx, n.Config.Config, schema.Block, nil, keyData)
 	diags = diags.Append(configDiags)
 	if configDiags.HasErrors() {
 		return nil, keyData, diags
@@ -3302,7 +3327,7 @@ func (n *NodeAbstractResourceInstance) planEphemeralResource(ctx context.Context
 		return nil, keyData, diags
 	}
 
-	objTy := schema.ImpliedType()
+	objTy := schema.Block.ImpliedType()
 	priorVal := cty.NullVal(objTy)
 
 	forEach, _ := evaluateForEachExpression(ctx, config.ForEach, evalCtx, n.Addr)
@@ -3321,7 +3346,7 @@ func (n *NodeAbstractResourceInstance) planEphemeralResource(ctx context.Context
 	}
 
 	var configDiags tfdiags.Diagnostics
-	configVal, _, configDiags = evalCtx.EvaluateBlock(ctx, config.Config, schema, nil, keyData)
+	configVal, _, configDiags = evalCtx.EvaluateBlock(ctx, config.Config, schema.Block, nil, keyData)
 	diags = diags.Append(configDiags)
 	if configDiags.HasErrors() {
 		return nil, keyData, diags
@@ -3354,7 +3379,7 @@ func (n *NodeAbstractResourceInstance) planEphemeralResource(ctx context.Context
 			reason = "pending dependencies"
 		}
 
-		plannedNewState, deferDiags := n.deferEphemeralResource(evalCtx, schema, configVal, reason)
+		plannedNewState, deferDiags := n.deferEphemeralResource(evalCtx, schema.Block, configVal, reason)
 		diags = diags.Append(deferDiags)
 		return plannedNewState, keyData, diags
 	}

--- a/internal/tofu/node_resource_abstract_instance.go
+++ b/internal/tofu/node_resource_abstract_instance.go
@@ -762,10 +762,8 @@ func (n *NodeAbstractResourceInstance) writeResourceInstanceStateImpl(ctx contex
 		return fmt.Errorf("failed to encode %s in state: no resource type schema available", absAddr)
 	}
 
-	identitySchemaVersion := providerSchema.ResourceTypes[n.Addr.ContainingResource().Resource.Type].IdentitySchemaVersion
-
 	obj.Value = schema.Block.RemoveEphemeralFromWriteOnly(obj.Value)
-	src, err := obj.Encode(schema.Block.ImpliedType(), currentVersion, uint64(identitySchemaVersion))
+	src, err := obj.Encode(schema.Block.ImpliedType(), currentVersion, uint64(schema.IdentitySchemaVersion))
 	if err != nil {
 		return fmt.Errorf("failed to encode %s in state: %w", absAddr, err)
 	}

--- a/internal/tofu/node_resource_apply_instance.go
+++ b/internal/tofu/node_resource_apply_instance.go
@@ -515,7 +515,7 @@ func (n *NodeApplyableResourceInstance) checkPlannedChange(evalCtx EvalContext, 
 		}
 	}
 
-	errs := objchange.AssertObjectCompatible(schema, plannedChange.After, actualChange.After)
+	errs := objchange.AssertObjectCompatible(schema.Block, plannedChange.After, actualChange.After)
 	for _, err := range errs {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,

--- a/internal/tofu/node_resource_deposed.go
+++ b/internal/tofu/node_resource_deposed.go
@@ -400,8 +400,10 @@ func (n *NodeDestroyDeposedResourceInstanceObject) writeResourceInstanceState(ct
 		return fmt.Errorf("failed to encode %s in state: no resource type schema available", absAddr)
 	}
 
-	obj.Value = schema.RemoveEphemeralFromWriteOnly(obj.Value)
-	src, err := obj.Encode(schema.ImpliedType(), currentVersion)
+	identitySchemaVersion := providerSchema.ResourceTypes[n.Addr.ContainingResource().Resource.Type].IdentitySchemaVersion
+
+	obj.Value = schema.Block.RemoveEphemeralFromWriteOnly(obj.Value)
+	src, err := obj.Encode(schema.Block.ImpliedType(), currentVersion, uint64(identitySchemaVersion))
 	if err != nil {
 		return fmt.Errorf("failed to encode %s in state: %w", absAddr, err)
 	}

--- a/internal/tofu/node_resource_deposed.go
+++ b/internal/tofu/node_resource_deposed.go
@@ -400,10 +400,8 @@ func (n *NodeDestroyDeposedResourceInstanceObject) writeResourceInstanceState(ct
 		return fmt.Errorf("failed to encode %s in state: no resource type schema available", absAddr)
 	}
 
-	identitySchemaVersion := providerSchema.ResourceTypes[n.Addr.ContainingResource().Resource.Type].IdentitySchemaVersion
-
 	obj.Value = schema.Block.RemoveEphemeralFromWriteOnly(obj.Value)
-	src, err := obj.Encode(schema.Block.ImpliedType(), currentVersion, uint64(identitySchemaVersion))
+	src, err := obj.Encode(schema.Block.ImpliedType(), currentVersion, uint64(schema.IdentitySchemaVersion))
 	if err != nil {
 		return fmt.Errorf("failed to encode %s in state: %w", absAddr, err)
 	}

--- a/internal/tofu/node_resource_plan_instance.go
+++ b/internal/tofu/node_resource_plan_instance.go
@@ -72,7 +72,13 @@ type EvaluatedConfigImportTarget struct {
 	Addr addrs.AbsResourceInstance
 
 	// ID is the string ID of the resource to import. This is resource-instance specific.
+	// This is used for ID-based imports (when the import block uses the "id" argument).
 	ID string
+
+	// Identity is the identity value for identity-based imports (when the import block uses the "identity" argument).
+	// This will be a cty.Value containing an object with the identity attributes.
+	// Either ID or Identity will be set, but not both.
+	Identity cty.Value
 }
 
 var (
@@ -284,7 +290,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx context.Conte
 	// If the resource is to be imported, we now ask the provider for an Import
 	// and a Refresh, and save the resulting state to instanceRefreshState.
 	if importing {
-		instanceRefreshState, diags = n.importState(ctx, evalCtx, addr, n.importTarget.ID, provider, providerSchema)
+		instanceRefreshState, diags = n.importState(ctx, evalCtx, addr, providers.ImportTarget{ID: n.importTarget.ID, Identity: n.importTarget.Identity}, provider, providerSchema)
 	} else {
 		var readDiags tfdiags.Diagnostics
 		instanceRefreshState, readDiags = n.readResourceInstanceState(ctx, evalCtx, addr)
@@ -412,7 +418,10 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx context.Conte
 		}
 
 		if importing {
-			change.Importing = &plans.Importing{ID: n.importTarget.ID}
+			change.Importing = &plans.Importing{
+				ID:       n.importTarget.ID,
+				Identity: n.importTarget.Identity,
+			}
 		}
 
 		// FIXME: here we update the change to reflect the reason for
@@ -559,12 +568,12 @@ func (n *NodePlannableResourceInstance) replaceTriggered(ctx context.Context, ev
 	return diags
 }
 
-func (n *NodePlannableResourceInstance) importState(ctx context.Context, evalCtx EvalContext, addr addrs.AbsResourceInstance, importId string, provider providers.Interface, providerSchema providers.ProviderSchema) (*states.ResourceInstanceObject, tfdiags.Diagnostics) {
+func (n *NodePlannableResourceInstance) importState(ctx context.Context, evalCtx EvalContext, addr addrs.AbsResourceInstance, importTarget providers.ImportTarget, provider providers.Interface, providerSchema providers.ProviderSchema) (*states.ResourceInstanceObject, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	absAddr := addr.Resource.Absolute(evalCtx.Path())
 
 	diags = diags.Append(evalCtx.Hook(func(h Hook) (HookAction, error) {
-		return h.PrePlanImport(absAddr, importId)
+		return h.PrePlanImport(absAddr, importTarget)
 	}))
 	if diags.HasErrors() {
 		return nil, diags
@@ -572,7 +581,7 @@ func (n *NodePlannableResourceInstance) importState(ctx context.Context, evalCtx
 
 	resp := provider.ImportResourceState(ctx, providers.ImportResourceStateRequest{
 		TypeName: addr.Resource.Resource.Type,
-		ID:       importId,
+		Target:   importTarget,
 	})
 	diags = diags.Append(resp.Diagnostics)
 	if diags.HasErrors() {
@@ -587,13 +596,13 @@ func (n *NodePlannableResourceInstance) importState(ctx context.Context, evalCtx
 			"Import returned no resources",
 			fmt.Sprintf("While attempting to import with ID %s, the provider"+
 				"returned no instance states.",
-				importId,
+				importTarget.String(),
 			),
 		))
 		return nil, diags
 	}
 	for _, obj := range imported {
-		log.Printf("[TRACE] graphNodeImportState: import %s %q produced instance object of type %s", absAddr.String(), importId, obj.TypeName)
+		log.Printf("[TRACE] graphNodeImportState: import %s %q produced instance object of type %s", absAddr.String(), importTarget.String(), obj.TypeName)
 	}
 	if len(imported) > 1 {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -602,7 +611,7 @@ func (n *NodePlannableResourceInstance) importState(ctx context.Context, evalCtx
 			fmt.Sprintf("While attempting to import with ID %s, the provider "+
 				"returned multiple resource instance states. This "+
 				"is not currently supported.",
-				importId,
+				importTarget.String(),
 			),
 		))
 		return nil, diags
@@ -621,12 +630,16 @@ func (n *NodePlannableResourceInstance) importState(ctx context.Context, evalCtx
 	importedState := imported[0].AsInstanceObject()
 
 	if importedState.Value.IsNull() {
+		importDesc := n.importTarget.ID
+		if importDesc == "" {
+			importDesc = n.importTarget.Identity.GoString()
+		}
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Import returned null resource",
-			fmt.Sprintf("While attempting to import with ID %s, the provider"+
+			fmt.Sprintf("While attempting to import with %s, the provider "+
 				"returned an instance with no state.",
-				n.importTarget.ID,
+				importDesc,
 			),
 		))
 	}
@@ -653,8 +666,8 @@ func (n *NodePlannableResourceInstance) importState(ctx context.Context, evalCtx
 			"Cannot import non-existent remote object",
 			fmt.Sprintf(
 				"While attempting to import an existing object to %q, "+
-					"the provider detected that no object exists with the given id. "+
-					"Only pre-existing objects can be imported; check that the id "+
+					"the provider detected that no object exists with the given id or identity. "+
+					"Only pre-existing objects can be imported; check that the id or identity "+
 					"is correct and that it is associated with the provider's "+
 					"configured region or endpoint, or use \"tofu apply\" to "+
 					"create a new remote object for this resource.",
@@ -710,7 +723,7 @@ func (n *NodePlannableResourceInstance) importState(ctx context.Context, evalCtx
 		// First we generate the contents of the resource block for use within
 		// the planning node. Then we wrap it in an enclosing resource block to
 		// pass into the plan for rendering.
-		generatedHCLAttributes, generatedDiags := n.generateHCLStringAttributes(n.Addr, instanceRefreshState, schema)
+		generatedHCLAttributes, generatedDiags := n.generateHCLStringAttributes(n.Addr, instanceRefreshState, schema.Block)
 		diags = diags.Append(generatedDiags)
 
 		n.generatedConfigHCL = genconfig.WrapResourceContents(n.Addr, generatedHCLAttributes)
@@ -747,7 +760,7 @@ func (n *NodePlannableResourceInstance) importState(ctx context.Context, evalCtx
 }
 
 func (n *NodePlannableResourceInstance) shouldImport(evalCtx EvalContext) bool {
-	if n.importTarget.ID == "" {
+	if n.importTarget.ID == "" && (n.importTarget.Identity == cty.NilVal || n.importTarget.Identity.IsNull()) {
 		return false
 	}
 

--- a/internal/tofu/node_resource_validate.go
+++ b/internal/tofu/node_resource_validate.go
@@ -285,8 +285,8 @@ func (n *NodeValidatableResource) validateResource(ctx context.Context, evalCtx 
 	// in the provider abstraction.
 	switch n.Config.Mode {
 	case addrs.ManagedResourceMode:
-		schema, _ := providerSchema.SchemaForResourceType(n.Config.Mode, n.Config.Type)
-		if schema == nil {
+		schemaForType, _ := providerSchema.SchemaForResourceType(n.Config.Mode, n.Config.Type)
+		if schemaForType == nil {
 			suggestion := n.noResourceSchemaSuggestion(providerSchema)
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
@@ -297,7 +297,7 @@ func (n *NodeValidatableResource) validateResource(ctx context.Context, evalCtx 
 			return diags
 		}
 
-		configVal, _, valDiags := evalCtx.EvaluateBlock(ctx, n.Config.Config, schema, nil, keyData)
+		configVal, _, valDiags := evalCtx.EvaluateBlock(ctx, n.Config.Config, schemaForType.Block, nil, keyData)
 		diags = diags.Append(valDiags.InConfigBody(n.Config.Config, n.Addr.String()))
 		if valDiags.HasErrors() {
 			return diags
@@ -306,7 +306,7 @@ func (n *NodeValidatableResource) validateResource(ctx context.Context, evalCtx 
 		if n.Config.Managed != nil { // can be nil only in tests with poorly-configured mocks
 			for _, traversal := range n.Config.Managed.IgnoreChanges {
 				// validate the ignore_changes traversals apply.
-				moreDiags := schema.StaticValidateTraversal(traversal)
+				moreDiags := schemaForType.Block.StaticValidateTraversal(traversal)
 				diags = diags.Append(moreDiags)
 
 				// ignore_changes cannot be used for Computed attributes,
@@ -317,7 +317,7 @@ func (n *NodeValidatableResource) validateResource(ctx context.Context, evalCtx 
 				if !diags.HasErrors() {
 					path := traversalToPath(traversal)
 
-					attrSchema := schema.AttributeByPath(path)
+					attrSchema := schemaForType.Block.AttributeByPath(path)
 
 					if attrSchema != nil && !attrSchema.Optional && attrSchema.Computed {
 						// ignore_changes uses absolute traversal syntax in config despite
@@ -347,8 +347,8 @@ func (n *NodeValidatableResource) validateResource(ctx context.Context, evalCtx 
 		diags = diags.Append(resp.Diagnostics.InConfigBody(n.Config.Config, n.Addr.String()))
 
 	case addrs.DataResourceMode:
-		schema, _ := providerSchema.SchemaForResourceType(n.Config.Mode, n.Config.Type)
-		if schema == nil {
+		schemaForType, _ := providerSchema.SchemaForResourceType(n.Config.Mode, n.Config.Type)
+		if schemaForType == nil {
 			suggestion := n.noResourceSchemaSuggestion(providerSchema)
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
@@ -358,8 +358,7 @@ func (n *NodeValidatableResource) validateResource(ctx context.Context, evalCtx 
 			})
 			return diags
 		}
-
-		configVal, _, valDiags := evalCtx.EvaluateBlock(ctx, n.Config.Config, schema, nil, keyData)
+		configVal, _, valDiags := evalCtx.EvaluateBlock(ctx, n.Config.Config, schemaForType.Block, nil, keyData)
 		diags = diags.Append(valDiags.InConfigBody(n.Config.Config, n.Addr.String()))
 		if valDiags.HasErrors() {
 			return diags
@@ -387,7 +386,7 @@ func (n *NodeValidatableResource) validateResource(ctx context.Context, evalCtx 
 			return diags
 		}
 
-		configVal, _, valDiags := evalCtx.EvaluateBlock(ctx, n.Config.Config, schema, nil, keyData)
+		configVal, _, valDiags := evalCtx.EvaluateBlock(ctx, n.Config.Config, schema.Block, nil, keyData)
 		diags = diags.Append(valDiags)
 		if valDiags.HasErrors() {
 			return diags
@@ -447,8 +446,9 @@ func (n *NodeValidatableResource) noResourceSchemaSuggestion(providerSchema prov
 func nodeValidationAlternateBlockModeSuggestion(schema providers.ProviderSchema, mode addrs.ResourceMode, resourceType string) (addrs.ResourceMode, *configschema.Block) {
 	filterOnOtherModes := func(targetModes []addrs.ResourceMode) (addrs.ResourceMode, *configschema.Block) {
 		for _, candidateMode := range targetModes {
-			if b, _ := schema.SchemaForResourceType(candidateMode, resourceType); b != nil {
-				return candidateMode, b
+			b, _ := schema.SchemaForResourceType(candidateMode, resourceType)
+			if b != nil && b.Block != nil {
+				return candidateMode, b.Block
 			}
 		}
 		return addrs.InvalidResourceMode, nil

--- a/internal/tofu/node_resource_validate.go
+++ b/internal/tofu/node_resource_validate.go
@@ -446,8 +446,7 @@ func (n *NodeValidatableResource) noResourceSchemaSuggestion(providerSchema prov
 func nodeValidationAlternateBlockModeSuggestion(schema providers.ProviderSchema, mode addrs.ResourceMode, resourceType string) (addrs.ResourceMode, *configschema.Block) {
 	filterOnOtherModes := func(targetModes []addrs.ResourceMode) (addrs.ResourceMode, *configschema.Block) {
 		for _, candidateMode := range targetModes {
-			b, _ := schema.SchemaForResourceType(candidateMode, resourceType)
-			if b != nil && b.Block != nil {
+			if b, _ := schema.SchemaForResourceType(candidateMode, resourceType); b != nil {
 				return candidateMode, b.Block
 			}
 		}

--- a/internal/tofu/provider_for_test_framework.go
+++ b/internal/tofu/provider_for_test_framework.go
@@ -10,12 +10,13 @@ import (
 	"fmt"
 	"hash/fnv"
 
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/configs/hcl2shim"
 	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 var _ providers.Interface = &providerForTest{}
@@ -68,14 +69,15 @@ func (p providerForTest) PlanResourceChange(_ context.Context, r providers.PlanR
 	}
 
 	resSchema, _ := p.schema.SchemaForResourceType(addrs.ManagedResourceMode, r.TypeName)
+	schema := resSchema.Block
 
 	// Filter out computed-only attributes from the schema to avoid them being used incorrectly
 	// later on. This resolves https://github.com/opentofu/opentofu/issues/3644
-	filteredConfig := filterComputedOnlyAttributes(resSchema, r.Config)
+	filteredConfig := filterComputedOnlyAttributes(schema, r.Config)
 
 	var resp providers.PlanResourceChangeResponse
 	resp.PlannedState, resp.Diagnostics = newMockValueComposer(r.TypeName).
-		ComposeBySchema(resSchema, filteredConfig, p.overrideValues)
+		ComposeBySchema(schema, filteredConfig, p.overrideValues)
 
 	return resp
 }
@@ -107,11 +109,9 @@ func (p providerForTest) ApplyResourceChange(_ context.Context, r providers.Appl
 
 func (p providerForTest) ReadDataSource(_ context.Context, r providers.ReadDataSourceRequest) providers.ReadDataSourceResponse {
 	resSchema, _ := p.schema.SchemaForResourceType(addrs.DataResourceMode, r.TypeName)
-
+	
 	var resp providers.ReadDataSourceResponse
-
-	resp.State, resp.Diagnostics = newMockValueComposer(r.TypeName).
-		ComposeBySchema(resSchema, r.Config, p.overrideValues)
+	resp.State, resp.Diagnostics = newMockValueComposer(r.TypeName).ComposeBySchema(resSchema.Block, r.Config, p.overrideValues)
 
 	return resp
 }
@@ -149,6 +149,11 @@ func (p providerForTest) GetProviderSchema(ctx context.Context) providers.GetPro
 	return providerSchema
 }
 
+func (p providerForTest) GetResourceIdentitySchemas(ctx context.Context) providers.GetResourceIdentitySchemasResponse {
+	// TODO: Check if this is the correct way to handle this, im 95% certain it is
+	return p.internal.GetResourceIdentitySchemas(ctx)
+}
+
 // providerForTest doesn't configure its internal provider because it is mocked.
 func (p providerForTest) ConfigureProvider(context.Context, providers.ConfigureProviderRequest) providers.ConfigureProviderResponse {
 	return providers.ConfigureProviderResponse{}
@@ -176,6 +181,10 @@ func (p providerForTest) ValidateDataResourceConfig(ctx context.Context, r provi
 
 func (p providerForTest) UpgradeResourceState(ctx context.Context, r providers.UpgradeResourceStateRequest) providers.UpgradeResourceStateResponse {
 	return p.internal.UpgradeResourceState(ctx, r)
+}
+
+func (p providerForTest) UpgradeResourceIdentity(ctx context.Context, r providers.UpgradeResourceIdentityRequest) providers.UpgradeResourceIdentityResponse {
+	return p.internal.UpgradeResourceIdentity(ctx, r)
 }
 
 func (p providerForTest) ValidateEphemeralConfig(ctx context.Context, request providers.ValidateEphemeralConfigRequest) providers.ValidateEphemeralConfigResponse {

--- a/internal/tofu/provider_for_test_framework.go
+++ b/internal/tofu/provider_for_test_framework.go
@@ -149,9 +149,6 @@ func (p providerForTest) GetProviderSchema(ctx context.Context) providers.GetPro
 	return providerSchema
 }
 
-func (p providerForTest) GetResourceIdentitySchemas(ctx context.Context) providers.GetResourceIdentitySchemasResponse {
-	return p.internal.GetResourceIdentitySchemas(ctx)
-}
 
 // providerForTest doesn't configure its internal provider because it is mocked.
 func (p providerForTest) ConfigureProvider(context.Context, providers.ConfigureProviderRequest) providers.ConfigureProviderResponse {

--- a/internal/tofu/provider_for_test_framework.go
+++ b/internal/tofu/provider_for_test_framework.go
@@ -109,7 +109,7 @@ func (p providerForTest) ApplyResourceChange(_ context.Context, r providers.Appl
 
 func (p providerForTest) ReadDataSource(_ context.Context, r providers.ReadDataSourceRequest) providers.ReadDataSourceResponse {
 	resSchema, _ := p.schema.SchemaForResourceType(addrs.DataResourceMode, r.TypeName)
-	
+
 	var resp providers.ReadDataSourceResponse
 	resp.State, resp.Diagnostics = newMockValueComposer(r.TypeName).ComposeBySchema(resSchema.Block, r.Config, p.overrideValues)
 
@@ -150,7 +150,6 @@ func (p providerForTest) GetProviderSchema(ctx context.Context) providers.GetPro
 }
 
 func (p providerForTest) GetResourceIdentitySchemas(ctx context.Context) providers.GetResourceIdentitySchemasResponse {
-	// TODO: Check if this is the correct way to handle this, im 95% certain it is
 	return p.internal.GetResourceIdentitySchemas(ctx)
 }
 

--- a/internal/tofu/provider_mock.go
+++ b/internal/tofu/provider_mock.go
@@ -32,9 +32,6 @@ type MockProvider struct {
 	GetProviderSchemaCalled   bool
 	GetProviderSchemaResponse *providers.GetProviderSchemaResponse
 
-	GetResourceIdentitySchemasCalled   bool
-	GetResourceIdentitySchemasResponse *providers.GetResourceIdentitySchemasResponse
-
 	ValidateProviderConfigCalled   bool
 	ValidateProviderConfigResponse *providers.ValidateProviderConfigResponse
 	ValidateProviderConfigRequest  providers.ValidateProviderConfigRequest
@@ -158,29 +155,6 @@ func (p *MockProvider) getProviderSchema() providers.GetProviderSchemaResponse {
 		DataSources:        map[string]providers.Schema{},
 		ResourceTypes:      map[string]providers.Schema{},
 		EphemeralResources: map[string]providers.Schema{},
-	}
-}
-
-func (p *MockProvider) GetResourceIdentitySchemas(context.Context) providers.GetResourceIdentitySchemasResponse {
-	tracing.ContextProbeReport(context.Background(), 0)
-	p.Lock()
-	defer p.Unlock()
-	p.GetResourceIdentitySchemasCalled = true
-	return p.getResourceIdentitySchemas()
-}
-
-func (p *MockProvider) getResourceIdentitySchemas() providers.GetResourceIdentitySchemasResponse {
-	// Similar to getProviderSchema above,
-	// This version of getResourceIdentitySchemas doesn't do any locking, so it's suitable to
-	// call from other methods of this mock as long as they are already
-	// holding the lock.
-
-	if p.GetResourceIdentitySchemasResponse != nil {
-		return *p.GetResourceIdentitySchemasResponse
-	}
-
-	return providers.GetResourceIdentitySchemasResponse{
-		IdentitySchemas: map[string]providers.ResourceIdentitySchema{},
 	}
 }
 

--- a/internal/tofu/schemas.go
+++ b/internal/tofu/schemas.go
@@ -47,10 +47,10 @@ func (ss *Schemas) ProviderConfig(provider addrs.Provider) *configschema.Block {
 //
 // In many cases the provider type is inferable from the resource type name,
 // but this is not always true because users can override the provider for
-// a resource using the "provider" meta-argument. Therefore it's important to
+// a resource using the "provider" meta-argument. Therefore, it's important to
 // always pass the correct provider name, even though it many cases it feels
 // redundant.
-func (ss *Schemas) ResourceTypeConfig(provider addrs.Provider, resourceMode addrs.ResourceMode, resourceType string) (block *configschema.Block, schemaVersion uint64) {
+func (ss *Schemas) ResourceTypeConfig(provider addrs.Provider, resourceMode addrs.ResourceMode, resourceType string) (block *providers.Schema, schemaVersion uint64) {
 	ps := ss.ProviderSchema(provider)
 	return ps.SchemaForResourceType(resourceMode, resourceType)
 }
@@ -64,7 +64,7 @@ func (ss *Schemas) ProvisionerConfig(name string) *configschema.Block {
 // loadSchemas searches the given configuration, state  and plan (any of which
 // may be nil) for constructs that have an associated schema, requests the
 // necessary schemas from the given component factory (which must _not_ be nil),
-// and returns a single object representing all of the necessary schemas.
+// and returns a single object representing all the necessary schemas.
 //
 // If an error is returned, it may be a wrapped tfdiags.Diagnostics describing
 // errors across multiple separate objects. Errors here will usually indicate

--- a/internal/tofu/validate_selfref.go
+++ b/internal/tofu/validate_selfref.go
@@ -33,9 +33,19 @@ func validateSelfRef(addr addrs.Referenceable, config hcl.Body, providerSchema p
 	var schema *configschema.Block
 	switch tAddr := addr.(type) {
 	case addrs.Resource:
-		schema, _ = providerSchema.SchemaForResourceAddr(tAddr)
+		sc, _ := providerSchema.SchemaForResourceAddr(tAddr)
+		if sc == nil {
+			diags = diags.Append(fmt.Errorf("no schema available for %s to validate for self-references; this is a bug in OpenTofu and should be reported", addr))
+			return diags
+		}
+		schema = sc.Block
 	case addrs.ResourceInstance:
-		schema, _ = providerSchema.SchemaForResourceAddr(tAddr.ContainingResource())
+		sc, _ := providerSchema.SchemaForResourceAddr(tAddr.ContainingResource())
+		if sc == nil {
+			diags = diags.Append(fmt.Errorf("no schema available for %s to validate for self-references; this is a bug in OpenTofu and should be reported", addr))
+			return diags
+		}
+		schema = sc.Block
 	}
 
 	if schema == nil {


### PR DESCRIPTION
Disclosure: Whilst I have checked the following item below
> I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.

I have used AI to help me summarize the contents in this branch for the PR description here

---
# End User Experience

## Importing via Resource Identity

The `import` block now supports a new `identity` argument as an alternative to `id`. Instead of an opaque ID string, you provide structured attributes that uniquely identify the resource — as defined by the provider.

`id` and `identity` are **mutually exclusive** — you use one or the other.

```hcl
import {
  to = aws_s3_bucket.example
  identity = {
    region = "eu-west-1"
    bucket = "buckety-742cd422c0c2"
  }
}

resource "aws_s3_bucket" "example" {
  # ...
}
```

## State File

Each resource instance in the state file now includes `identity` and `identity_schema_version` fields (when the provider supports resource identity for that type):

```json
{
  "mode": "managed",
  "type": "aws_s3_bucket",
  "name": "example",
  "instances": [
    {
      "schema_version": 0,
      "attributes": { "bucket": "buckety-742cd422c0c2", "..." : "..." },
      "identity": {
        "account_id": "993368827828",
        "bucket": "buckety-742cd422c0c2",
        "region": "eu-west-1"
      },
      "identity_schema_version": 0
    }
  ]
}
```

## `tofu show -json` Output

Identity appears in the JSON output for both state and plan under each resource:

```json
{
  "address": "aws_s3_bucket.example",
  "type": "aws_s3_bucket",
  "values": { "..." : "..." },
  "identity": {
    "account_id": "993368827828",
    "bucket": "buckety-742cd422c0c2",
    "region": "eu-west-1"
  },
  "identity_schema_version": 0
}
```

## Plan Output

When importing via identity, the human-readable plan output shows:

```
# aws_s3_bucket.example will be imported
  # (imported via identity {"account_id":"993368827828","bucket":"buckety-742cd422c0c2","region":"eu-west-1"})
```

## Apply Output

During `tofu apply`, import progress is shown with the identity as JSON:

```
aws_s3_bucket.example: Importing... [identity={"bucket":"buckety-742cd422c0c2","region":"eu-west-1"}]
aws_s3_bucket.example: Import complete [identity={"bucket":"buckety-742cd422c0c2","region":"eu-west-1"}]
```

## Provider-Driven

Identity schemas are defined by providers — not all resource types will have identity support. The provider declares which attributes form a resource's identity (e.g., for `aws_s3_bucket`: `account_id`, `bucket`, `region`). Identity is populated automatically by the provider during create, read, and import operations.

## Error Messages

**Using both `id` and `identity`:**
```
Error: Conflicting import arguments

Only one of 'id' or 'identity' can be specified in an import block. 'id' identifies the
resource instance by its ID, while 'identity' identifies the resource instance by its
Resource Identity. Choose one method to identify the resource instance to import.
```

**Missing both `id` and `identity`:**
```
Error: Missing required import argument

One of 'id' or 'identity' must be specified in an import block to identify the resource
instance to import.
```

**Provider doesn't support identity for this resource type:**
```
Error: Unable to determine identity schema for import identity

The provider "registry.opentofu.org/hashicorp/aws" does not provide an identity schema
for the resource type "aws_some_resource", which is required when trying to import the
resource "aws_some_resource.example" using identity-based import. Please ensure the
resource type supports identity-based import.
```

---

# Implementation Details

The PR adds a **schema-versioned structured identity** that runs parallel to the existing state and import-by-ID mechanisms:

1. **Provider protocol** — Two new RPCs: `GetResourceIdentitySchemas` (returns flat attribute schemas per resource type) and `UpgradeResourceIdentity` (handles schema version migrations, like `UpgradeResourceState`). Both plugin v5 and v6 are updated. Providers that don't implement these return gRPC `Unimplemented`, which is handled gracefully.

2. **Lifecycle threading** — Identity flows as a `cty.Value` through every lifecycle method: `PlanResourceChange` (PriorIdentity/PlannedIdentity), `ApplyResourceChange` (PlannedIdentity/NewIdentity), `ReadResource` (PriorIdentity/NewIdentity), and `ImportResourceState` (request carries identity, response includes it per imported resource).

3. **State persistence** — `ResourceInstanceObjectSrc` stores `IdentityJSON` and `IdentitySchemaVersion`. The v4 state file format gains `identity` and `identity_schema_version` fields.

4. **Plan persistence** — `ChangeSrc` gains `PlannedIdentity` and `ImportingSrc` gains `Identity`, both as `DynamicValue`. The planfile proto adds corresponding fields.

5. **Schema refactor** — `SchemaForResourceType` now returns `*providers.Schema` (containing `Block`, `IdentitySchema`, `IdentitySchemaVersion`) instead of `*configschema.Block`. This touches many call sites across the codebase.

6. **Config layer** — The `import` block schema accepts an optional `identity` expression attribute, with validation enforcing mutual exclusivity with `id`.

Resolves #2854

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.