### PR TITLE
Remove deferral capability leftover

### DIFF
--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -32,14 +32,6 @@ type GRPCProviderPlugin struct {
 }
 
 var clientCapabilities = &proto6.ClientCapabilities{
-	// DeferralAllowed tells the provider that it is allowed to respond to
-	// all of the various post-configuration requests (as described by the
-	// [providers.Configured] interface) by reporting that the request
-	// must be "deferred" because there isn't yet enough information to
-	// satisfy the request. Setting this means that we need to be prepared
-	// for there to be a "deferred" object in the response from various
-	// other provider RPC functions.
-	DeferralAllowed: true,
 	// WriteOnlyAttributesAllowed indicates that the current system version
 	// supports write-only attributes.
 	// This enables the SDK to run specific validations and enable the


### PR DESCRIPTION
This cleans up the deferral capability that was left in the plugin6 during #3592.

In #3592 we forgot to remove that capability which led to the following situation:
* Configuring the helm provider with that capability **and** a partially known provider configuration leads a global deferral reason for the whole provider.
* Any call to a helm provider instance configured this way will automatically return the proposed new state back to OpenTofu.

By removing this we disable this unwanted behavior from the helm provider.

---

⚠️ Before closing #3675, backport this change to the v1.11 branch and add a changelog when doing so.

Part of #3675

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
