### PR TITLE
[v1.11][Backport] Remove deferral capability leftover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The v1.11.x release series is supported until **August 1 2026**.
 BUG FIXES:
 
 * In JSON syntax, the state encryption method configuration now allows specifying keys using both normal expression syntax and using template interpolation syntax. Previously only the template interpolation syntax was allowed, which was inconsistent with other parts of the encryption configuration. ([#3654](https://github.com/opentofu/opentofu/issues/3654))
-
+* Providers are not configured anymore with `DeferralAllowed` capability of OpenTofu since having that created unwanted behaviour from some providers. ([#3676](https://github.com/opentofu/opentofu/pull/3676))
 
 ## 1.11.3
 

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -34,14 +34,6 @@ type GRPCProviderPlugin struct {
 }
 
 var clientCapabilities = &proto6.ClientCapabilities{
-	// DeferralAllowed tells the provider that it is allowed to respond to
-	// all of the various post-configuration requests (as described by the
-	// [providers.Configured] interface) by reporting that the request
-	// must be "deferred" because there isn't yet enough information to
-	// satisfy the request. Setting this means that we need to be prepared
-	// for there to be a "deferred" object in the response from various
-	// other provider RPC functions.
-	DeferralAllowed: true,
 	// WriteOnlyAttributesAllowed indicates that the current system version
 	// supports write-only attributes.
 	// This enables the SDK to run specific validations and enable the


### PR DESCRIPTION
This backports #3676 to v1.11.
Resolves #3675 

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
