### PR TITLE
[v1.11][Backport] Render write-only attributes after rendered all of the other attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ BUG FIXES:
 
 * In JSON syntax, the state encryption method configuration now allows specifying keys using both normal expression syntax and using template interpolation syntax. Previously only the template interpolation syntax was allowed, which was inconsistent with other parts of the encryption configuration. ([#3654](https://github.com/opentofu/opentofu/issues/3654))
 * Providers are not configured anymore with `DeferralAllowed` capability of OpenTofu since having that created unwanted behaviour from some providers. ([#3676](https://github.com/opentofu/opentofu/pull/3676))
+* Resources containing write-only attributes now are rendered consistently during planning. ([#3667](https://github.com/opentofu/opentofu/pull/3667)) 
 
 ## 1.11.3
 

--- a/internal/command/jsonformat/differ/block.go
+++ b/internal/command/jsonformat/differ/block.go
@@ -28,44 +28,40 @@ func ComputeDiffForBlock(change structured.Change, block *jsonprovider.Block) co
 	blockValue := change.AsMap()
 
 	attributes := make(map[string]computed.Diff)
+
+	// In the first iteration we generate the diffs for all non write-only attributes
+	// and only collect the write-only attributes for a second run.
+	// This is necessary because [block.Attributes] is a map and since the order is not
+	// guarantee in a map we cannot reliably include all the write-only attributes
+	// in the rendered diff. Therefore, we generate the diffs for all non write-only attributes,
+	// which will generate the actual action of the resource, action that will decide if write-only
+	// attributes will be included in the rendered output or not.
+	var writeOnlyAttributes []string
 	for key, attr := range block.Attributes {
-		childValue := blockValue.GetChild(key)
-
-		if !childValue.RelevantAttributes.MatchesPartial() {
-			// Mark non-relevant attributes as unchanged.
-			childValue = childValue.AsNoOp()
+		if attr.WriteOnly {
+			writeOnlyAttributes = append(writeOnlyAttributes, key)
+			continue
 		}
-
-		// Empty strings in blocks should be considered null for legacy reasons.
-		// The SDK doesn't support null strings yet, so we work around this now.
-		if before, ok := childValue.Before.(string); ok && len(before) == 0 {
-			childValue.Before = nil
+		attrChange := blockValue.GetChild(key)
+		childChange := diffChildAttribute(attrChange, attr, current)
+		if childChange == nil {
+			continue
 		}
-		if after, ok := childValue.After.(string); ok && len(after) == 0 {
-			childValue.After = nil
-		}
-
-		// Always treat changes to blocks as implicit.
-		childValue.BeforeExplicit = false
-		childValue.AfterExplicit = false
-
-		// Because we want to print also the write-only attributes, we need to pass in the parent block
-		// action instead of the child one.
-		// This is because the child action will always result in NoOp since for write-only attributes, the
-		// values returned will be null.
-		childChange := ComputeDiffForAttribute(childValue, attr, current)
-		if childChange.Action == plans.NoOp && childValue.Before == nil && childValue.After == nil {
-			// This validation is specifically added for `tofu show`.
-			// Since "current" will be NoOp during rendering the output for `tofu show`,
-			// we need this validation to include the write-only attributes in the output.
-			if !attr.WriteOnly {
-				// Don't record nil values at all in blocks.
-				continue
-			}
-		}
-
-		attributes[key] = childChange
 		current = collections.CompareActions(current, childChange.Action)
+		attributes[key] = *childChange
+	}
+	// In the second iteration, now that the action of the resource is decided, we process only the write-only
+	// attributes. If the [current] action is NoOp, then none of the write-only attributes will be included,
+	// otherwise, will include all the write-only attributes.
+	for _, key := range writeOnlyAttributes {
+		attr := block.Attributes[key]
+		attrChange := blockValue.GetChild(key)
+		childChange := diffChildAttribute(attrChange, attr, current)
+		if childChange == nil {
+			continue
+		}
+		current = collections.CompareActions(current, childChange.Action)
+		attributes[key] = *childChange
 	}
 
 	blocks := renderers.Blocks{
@@ -137,4 +133,44 @@ func ComputeDiffForBlock(change structured.Change, block *jsonprovider.Block) co
 	}
 
 	return computed.NewDiff(renderers.Block(attributes, blocks), current, change.ReplacePaths.Matches())
+}
+
+// diffChildAttribute computes a new [compute.Diff] for the given attribute change and its schema.
+// When a resource for which the diff is built contains also write-only attributes, we want to process first
+// all the non write-only attributes to get the actual change action on that resource, action that will decide
+// if the write-only attributes will or not be included in the rendered output.
+func diffChildAttribute(attrChange structured.Change, attrSchema *jsonprovider.Attribute, currentAction plans.Action) *computed.Diff {
+	if !attrChange.RelevantAttributes.MatchesPartial() {
+		// Mark non-relevant attributes as unchanged.
+		attrChange = attrChange.AsNoOp()
+	}
+
+	// Empty strings in blocks should be considered null for legacy reasons.
+	// The SDK doesn't support null strings yet, so we work around this now.
+	if before, ok := attrChange.Before.(string); ok && len(before) == 0 {
+		attrChange.Before = nil
+	}
+	if after, ok := attrChange.After.(string); ok && len(after) == 0 {
+		attrChange.After = nil
+	}
+
+	// Always treat changes to blocks as implicit.
+	attrChange.BeforeExplicit = false
+	attrChange.AfterExplicit = false
+
+	// Because we want to render also the write-only attributes, we need to pass in the parent block
+	// action instead of the child one.
+	// This is because the child action will always result in NoOp since for write-only attributes, the
+	// values returned will be null.
+	childChange := ComputeDiffForAttribute(attrChange, attrSchema, currentAction)
+	if childChange.Action == plans.NoOp && attrChange.Before == nil && attrChange.After == nil {
+		// This validation is specifically added for `tofu show`.
+		// Since "current" will be NoOp during rendering the output for `tofu show`,
+		// we need this validation to include the write-only attributes in the output.
+		if !attrSchema.WriteOnly {
+			// Don't record nil values at all in blocks.
+			return nil
+		}
+	}
+	return &childChange
 }


### PR DESCRIPTION
This backports #3667 to v1.11.
Part of #3640

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
