### PR TITLE
fix: typos in comments

### DIFF
--- a/internal/cloud/cloud_integration.go
+++ b/internal/cloud/cloud_integration.go
@@ -16,7 +16,7 @@ import (
 	"github.com/opentofu/opentofu/internal/backend"
 )
 
-// IntegrationOutputWriter is an interface used to to write output tailored for
+// IntegrationOutputWriter is an interface used to write output tailored for
 // Terraform Cloud integrations
 type IntegrationOutputWriter interface {
 	End()

--- a/internal/command/clistate/state.go
+++ b/internal/command/clistate/state.go
@@ -82,7 +82,7 @@ var _ Locker = (*locker)(nil)
 
 // Create a new Locker.
 // This Locker uses state.LockWithContext to retry the lock until the provided
-// timeout is reached, or the context is canceled. Lock progress will be be
+// timeout is reached, or the context is canceled. Lock progress will be
 // reported to the user through the provided UI.
 func NewLocker(timeout time.Duration, view views.StateLocker) Locker {
 	return &locker{

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -1018,7 +1018,7 @@ func TestPlan_resource_variable_inputs(t *testing.T) {
 // Because this potential problem is in the collaboration between three separate
 // subsystems, we test it here so we can exercise all three in a relatively
 // realistic way. This is therefore an integration test of these three
-// components working together, rather than a test of of the plan command
+// components working together, rather than a test of the plan command
 // specifically.
 func TestPlan_withInvalidReferencesInTry(t *testing.T) {
 	td := t.TempDir()

--- a/internal/communicator/ssh/communicator.go
+++ b/internal/communicator/ssh/communicator.go
@@ -48,7 +48,7 @@ var (
 	// enable ssh keepalive probes by default
 	keepAliveInterval = 2 * time.Second
 
-	// max time to wait for for a KeepAlive response before considering the
+	// max time to wait for a KeepAlive response before considering the
 	// connection to be dead.
 	maxKeepAliveDelay = 120 * time.Second
 )

--- a/internal/legacy/helper/schema/field_reader_map.go
+++ b/internal/legacy/helper/schema/field_reader_map.go
@@ -47,7 +47,7 @@ func (r *MapFieldReader) readMap(k string, schema *Schema) (FieldReadResult, err
 
 	// If the name of the map field is directly in the map with an
 	// empty string, it means that the map is being deleted, so mark
-	// that is is set.
+	// that is set.
 	if v, ok := r.Map.Access(k); ok && v == "" {
 		resultSet = true
 	}

--- a/internal/tofu/context_test.go
+++ b/internal/tofu/context_test.go
@@ -1076,7 +1076,7 @@ func assertDiagnosticsMatch(t testing.TB, got, want tfdiags.Diagnostics) {
 	}
 }
 
-// logDiagnostics is a test helper that logs the given diagnostics to to the
+// logDiagnostics is a test helper that logs the given diagnostics to the
 // given testing.T using t.Log, in a way that is hopefully useful in debugging
 // a test. It does not generate any errors or fail the test. See
 // assertNoDiagnostics and assertNoErrors for more specific helpers that can


### PR DESCRIPTION
Fix typos in comments: duplicated words like "the the", "to to", etc.

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

- [ ] ~I have run golangci-lint on my change and receive no errors relevant to my code.~ (comment-only changes)
- [ ] ~I have run existing tests to ensure my code doesn't break anything.~ (comment-only changes)
- [ ] ~I have added tests for all relevant use cases of my code, and those tests are passing.~ (not applicable - typo fix only)
- [ ] ~I have only exported functions, variables and structs that should be used from other packages.~ (not applicable)
- [ ] ~I have added meaningful comments to all exported functions, variables, and structs.~ (not applicable)

### Website/documentation checklist

- [ ] ~I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.~ (not applicable)