### PR TITLE
Update .devcontainer.json to Go 1.25.6

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "Go",
-	"image": "mcr.microsoft.com/devcontainers/go:1-1.22-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/go:1.25-bookworm",
 	"customizations": {
 		"vscode": {
 			"extensions": [


### PR DESCRIPTION
The current version used in the devcontainer, 1.22, does not understand the godebug options in go.mod. This update fixes it.

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
