### PR TITLE
[Backport][v1.11] Add `-show-sensitive` to the commands docs (#3720)

### DIFF
--- a/website/docs/cli/commands/output.mdx
+++ b/website/docs/cli/commands/output.mdx
@@ -52,6 +52,7 @@ The command-line flags are all optional. The following flags are available:
   root module of the configuration, using definitions from a
   ["tfvars" file](../../language/values/variables.mdx#variable-definitions-tfvars-files).
   Use this option multiple times to include values from more than one file.
+* `-show-sensitive` - If specified, sensitive values will be displayed.
 
 There are several other ways to set values for input variables in the root
 module, aside from the `-var` and `-var-file` options. Refer to

--- a/website/docs/cli/commands/show.mdx
+++ b/website/docs/cli/commands/show.mdx
@@ -43,6 +43,7 @@ This command also accepts the following additional options:
 - `-var` and `-var-file`: Specifies values for any input variables
   used in module source addresses or backend settings in the
   current configuration.
+- `-show-sensitive`: If specified, sensitive values will be displayed.
 
 Unless using the `-module=DIR` option, this command relies on schema information
 from provider plugins to fully understand the provider-specific data structures

--- a/website/docs/cli/commands/state/show.mdx
+++ b/website/docs/cli/commands/state/show.mdx
@@ -46,6 +46,8 @@ The command-line flags are all optional. The following flags are available:
   ["tfvars" file](../../../language/values/variables.mdx#variable-definitions-tfvars-files).
   Use this option multiple times to include values from more than one file.
 
+* `-show-sensitive` - If specified, sensitive values will be displayed.
+
 There are several other ways to set values for input variables in the root
 module, aside from the `-var` and `-var-file` options. Refer to
 [Assigning Values to Root Module Variables](../../../language/values/variables.mdx#assigning-values-to-root-module-variables) for more information.


### PR DESCRIPTION
Backports #3720 to v1.11 as part of #3717.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
