### PR TITLE
planning: Add -refresh=config mode to skip refresh for unchanged resources

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -256,10 +256,11 @@ type Operation struct {
 	//
 	// PlanOutBackend is the backend to store with the plan. This is the
 	// backend that will be used when applying the plan.
-	PlanId         string
-	PlanRefresh    bool   // PlanRefresh will do a refresh before a plan
-	PlanOutPath    string // PlanOutPath is the path to save the plan
-	PlanOutBackend *plans.Backend
+	PlanId          string
+	PlanRefresh     bool             // PlanRefresh will do a refresh before a plan (legacy, use PlanRefreshMode)
+	PlanRefreshMode tofu.RefreshMode // PlanRefreshMode specifies the refresh mode: RefreshAll, RefreshNone, RefreshConfig
+	PlanOutPath     string           // PlanOutPath is the path to save the plan
+	PlanOutBackend  *plans.Backend
 
 	// ConfigDir is the path to the directory containing the configuration's
 	// root module.

--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -209,6 +209,7 @@ func (b *Local) localRunDirect(ctx context.Context, op *backend.Operation, run *
 		ForceReplace:       op.ForceReplace,
 		SetVariables:       variables,
 		SkipRefresh:        op.Type != backend.OperationTypeRefresh && !op.PlanRefresh,
+		RefreshMode:        op.PlanRefreshMode,
 		GenerateConfigPath: op.GenerateConfigOut,
 	}
 	run.PlanOpts = planOpts

--- a/internal/backend/remote/backend_plan.go
+++ b/internal/backend/remote/backend_plan.go
@@ -25,6 +25,7 @@ import (
 	"github.com/opentofu/opentofu/internal/logging"
 	"github.com/opentofu/opentofu/internal/plans"
 	"github.com/opentofu/opentofu/internal/tfdiags"
+	"github.com/opentofu/opentofu/internal/tofu"
 )
 
 var planConfigurationVersionsPollInterval = 500 * time.Millisecond
@@ -151,6 +152,14 @@ func (b *Remote) opPlan(ctx, stopCtx, cancelCtx context.Context, op *backend.Ope
 				),
 			))
 		}
+	}
+
+	if op.PlanRefreshMode == tofu.RefreshConfig {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Warning,
+			"-refresh=config is not supported by remote backend",
+			"The remote backend does not support selective refresh mode. The plan will use standard refresh behavior instead. Selective refresh is only available when running plans locally.",
+		))
 	}
 
 	if len(op.ForceReplace) != 0 {

--- a/internal/cloud/backend_plan.go
+++ b/internal/cloud/backend_plan.go
@@ -30,6 +30,7 @@ import (
 	"github.com/opentofu/opentofu/internal/genconfig"
 	"github.com/opentofu/opentofu/internal/plans"
 	"github.com/opentofu/opentofu/internal/tfdiags"
+	"github.com/opentofu/opentofu/internal/tofu"
 )
 
 var planConfigurationVersionsPollInterval = 500 * time.Millisecond
@@ -89,6 +90,14 @@ func (b *Cloud) opPlan(ctx, stopCtx, cancelCtx context.Context, op *backend.Oper
 
 	if len(op.GenerateConfigOut) > 0 {
 		diags = diags.Append(genconfig.ValidateTargetFile(op.GenerateConfigOut))
+	}
+
+	if op.PlanRefreshMode == tofu.RefreshConfig {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Warning,
+			"-refresh=config is not supported by cloud backend",
+			"The cloud backend does not support selective refresh mode. The plan will use standard refresh behavior instead. Selective refresh is only available when running plans locally.",
+		))
 	}
 
 	// Return if there are any errors.

--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -275,7 +275,8 @@ func (c *ApplyCommand) OperationRequest(
 	opReq.PlanMode = applyArgs.Operation.PlanMode
 	opReq.Hooks = view.Hooks()
 	opReq.PlanFile = planFile
-	opReq.PlanRefresh = applyArgs.Operation.Refresh
+	opReq.PlanRefresh = applyArgs.Operation.Refresh.RefreshEnabled()
+	opReq.PlanRefreshMode = applyArgs.Operation.Refresh.Mode
 	opReq.Targets = applyArgs.Operation.Targets
 	opReq.Excludes = applyArgs.Operation.Excludes
 	opReq.ForceReplace = applyArgs.Operation.ForceReplace

--- a/internal/command/arguments/apply_test.go
+++ b/internal/command/arguments/apply_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/opentofu/opentofu/internal/tfdiags"
+	"github.com/opentofu/opentofu/internal/tofu"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -37,7 +38,7 @@ func TestParseApply_basicValid(t *testing.T) {
 				Operation: &Operation{
 					PlanMode:    plans.NormalMode,
 					Parallelism: 10,
-					Refresh:     true,
+					Refresh:     RefreshFlagValue{Mode: tofu.RefreshAll},
 				},
 			},
 		},
@@ -55,7 +56,7 @@ func TestParseApply_basicValid(t *testing.T) {
 				Operation: &Operation{
 					PlanMode:    plans.NormalMode,
 					Parallelism: 10,
-					Refresh:     true,
+					Refresh:     RefreshFlagValue{Mode: tofu.RefreshAll},
 				},
 			},
 		},
@@ -73,7 +74,7 @@ func TestParseApply_basicValid(t *testing.T) {
 				Operation: &Operation{
 					PlanMode:    plans.DestroyMode,
 					Parallelism: 10,
-					Refresh:     true,
+					Refresh:     RefreshFlagValue{Mode: tofu.RefreshAll},
 				},
 			},
 		},
@@ -91,7 +92,7 @@ func TestParseApply_basicValid(t *testing.T) {
 				Operation: &Operation{
 					PlanMode:    plans.NormalMode,
 					Parallelism: 10,
-					Refresh:     true,
+					Refresh:     RefreshFlagValue{Mode: tofu.RefreshAll},
 				},
 			},
 		},
@@ -778,7 +779,7 @@ func TestParseApplyDestroy_basicValid(t *testing.T) {
 				Operation: &Operation{
 					PlanMode:    plans.DestroyMode,
 					Parallelism: 10,
-					Refresh:     true,
+					Refresh:     RefreshFlagValue{Mode: tofu.RefreshAll},
 				},
 			},
 		},
@@ -795,7 +796,7 @@ func TestParseApplyDestroy_basicValid(t *testing.T) {
 				Operation: &Operation{
 					PlanMode:    plans.DestroyMode,
 					Parallelism: 10,
-					Refresh:     true,
+					Refresh:     RefreshFlagValue{Mode: tofu.RefreshAll},
 				},
 			},
 		},

--- a/internal/command/arguments/extended_test.go
+++ b/internal/command/arguments/extended_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package arguments
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/opentofu/opentofu/internal/tofu"
+)
+
+func TestRefreshFlagValue_Set(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    tofu.RefreshMode
+		wantErr bool
+	}{
+		{"true", "true", tofu.RefreshAll, false},
+		{"TRUE", "TRUE", tofu.RefreshAll, false},
+		{"false", "false", tofu.RefreshNone, false},
+		{"FALSE", "FALSE", tofu.RefreshNone, false},
+		{"config", "config", tofu.RefreshConfig, false},
+		{"CONFIG", "CONFIG", tofu.RefreshConfig, false},
+		{"Config", "Config", tofu.RefreshConfig, false},
+		{"empty string", "", tofu.RefreshAll, false},
+		{"invalid", "invalid", 0, true},
+		{"maybe", "maybe", 0, true},
+		{"1", "1", 0, true},
+		{"0", "0", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var r RefreshFlagValue
+			err := r.Set(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Set(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && r.Mode != tt.want {
+				t.Errorf("Set(%q) mode = %v, want %v", tt.input, r.Mode, tt.want)
+			}
+		})
+	}
+}
+
+func TestRefreshFlagValue_String(t *testing.T) {
+	tests := []struct {
+		mode tofu.RefreshMode
+		want string
+	}{
+		{tofu.RefreshAll, "true"},
+		{tofu.RefreshNone, "false"},
+		{tofu.RefreshConfig, "config"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			r := &RefreshFlagValue{Mode: tt.mode}
+			got := r.String()
+			if got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRefreshFlagValue_RefreshEnabled(t *testing.T) {
+	tests := []struct {
+		mode tofu.RefreshMode
+		want bool
+	}{
+		{tofu.RefreshAll, true},
+		{tofu.RefreshNone, false},
+		{tofu.RefreshConfig, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.mode.String(), func(t *testing.T) {
+			r := &RefreshFlagValue{Mode: tt.mode}
+			got := r.RefreshEnabled()
+			if got != tt.want {
+				t.Errorf("RefreshEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRefreshFlagValue_IsBoolFlag(t *testing.T) {
+	r := &RefreshFlagValue{}
+	if !r.IsBoolFlag() {
+		t.Error("IsBoolFlag() should return true for backward compatibility")
+	}
+}
+
+func TestRefreshFlagValue_Get(t *testing.T) {
+	r := &RefreshFlagValue{Mode: tofu.RefreshConfig}
+	got := r.Get()
+	if got != tofu.RefreshConfig {
+		t.Errorf("Get() = %v, want %v", got, tofu.RefreshConfig)
+	}
+}
+
+func TestParsePlan_refreshConfig(t *testing.T) {
+	testCases := map[string]struct {
+		args    []string
+		wantErr string
+	}{
+		"refresh=config": {
+			args: []string{"-refresh=config"},
+		},
+		"refresh=config with refresh-only": {
+			args:    []string{"-refresh=config", "-refresh-only"},
+			wantErr: "Incompatible refresh options",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, _, diags := ParsePlan(tc.args)
+			if tc.wantErr != "" {
+				if !diags.HasErrors() {
+					t.Fatalf("expected error containing %q, got none", tc.wantErr)
+				}
+				errStr := diags.Err().Error()
+				if !strings.Contains(errStr, tc.wantErr) {
+					t.Errorf("expected error containing %q, got: %s", tc.wantErr, errStr)
+				}
+			} else {
+				if diags.HasErrors() {
+					t.Fatalf("unexpected errors: %s", diags.Err())
+				}
+				if got.Operation.Refresh.Mode != tofu.RefreshConfig {
+					t.Errorf("expected refresh mode RefreshConfig, got %v", got.Operation.Refresh.Mode)
+				}
+			}
+		})
+	}
+}

--- a/internal/command/arguments/plan_test.go
+++ b/internal/command/arguments/plan_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/opentofu/opentofu/internal/tfdiags"
+	"github.com/opentofu/opentofu/internal/tofu"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -37,7 +38,7 @@ func TestParsePlan_basicValid(t *testing.T) {
 				Operation: &Operation{
 					PlanMode:    plans.NormalMode,
 					Parallelism: 10,
-					Refresh:     true,
+					Refresh:     RefreshFlagValue{Mode: tofu.RefreshAll},
 				},
 			},
 		},
@@ -55,7 +56,7 @@ func TestParsePlan_basicValid(t *testing.T) {
 				Operation: &Operation{
 					PlanMode:    plans.DestroyMode,
 					Parallelism: 10,
-					Refresh:     true,
+					Refresh:     RefreshFlagValue{Mode: tofu.RefreshAll},
 				},
 			},
 		},
@@ -73,7 +74,7 @@ func TestParsePlan_basicValid(t *testing.T) {
 				Operation: &Operation{
 					PlanMode:    plans.NormalMode,
 					Parallelism: 10,
-					Refresh:     true,
+					Refresh:     RefreshFlagValue{Mode: tofu.RefreshAll},
 				},
 			},
 		},

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -167,7 +167,8 @@ func (c *PlanCommand) OperationRequest(
 	opReq.ConfigDir = "."
 	opReq.PlanMode = args.PlanMode
 	opReq.Hooks = view.Hooks()
-	opReq.PlanRefresh = args.Refresh
+	opReq.PlanRefresh = args.Refresh.RefreshEnabled()
+	opReq.PlanRefreshMode = args.Refresh.Mode
 	opReq.PlanOutPath = planOutPath
 	opReq.GenerateConfigOut = generateConfigOut
 	opReq.Targets = args.Targets
@@ -234,6 +235,11 @@ Plan Customization Options:
                           planning faster, but at the expense of possibly
                           planning against a stale record of the remote system
                           state.
+
+  -refresh=config         Only refresh resources whose configuration has changed
+                          (literals, variables, locals). This mode does not
+                          detect drift or changes propagated through resource
+                          dependencies.
 
   -replace=resource       Force replacement of a particular resource instance
                           using its resource address. If the plan would've

--- a/internal/tofu/context_plan_refresh_config_test.go
+++ b/internal/tofu/context_plan_refresh_config_test.go
@@ -1,0 +1,681 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tofu
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/plans"
+	"github.com/opentofu/opentofu/internal/providers"
+	"github.com/opentofu/opentofu/internal/states"
+)
+
+// TestContext2Plan_refreshConfigUnchangedSkipsRefresh verifies that when
+// RefreshMode is RefreshConfig and the resource configuration hasn't changed,
+// the provider's ReadResource is not called.
+func TestContext2Plan_refreshConfigUnchangedSkipsRefresh(t *testing.T) {
+	p := testProvider("test")
+	p.PlanResourceChangeFn = testDiffFn
+
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_instance" "a" {
+  ami = "bar"
+}
+`,
+	})
+
+	state := states.NewState()
+	root := state.EnsureModule(addrs.RootModuleInstance)
+	root.SetResourceInstanceCurrent(
+		mustResourceInstanceAddr("test_instance.a").Resource,
+		&states.ResourceInstanceObjectSrc{
+			Status:       states.ObjectReady,
+			AttrsJSON:    []byte(`{"id":"a","ami":"bar","type":"test_instance"}`),
+			Dependencies: []addrs.ConfigResource{},
+		},
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.NoKey,
+	)
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
+		Mode:        plans.NormalMode,
+		RefreshMode: RefreshConfig,
+	})
+	assertNoErrors(t, diags)
+
+	if p.ReadResourceCalled {
+		t.Fatal("ReadResource should NOT have been called when config is unchanged")
+	}
+
+	for _, c := range plan.Changes.Resources {
+		if c.Action != plans.NoOp {
+			t.Fatalf("expected NoOp, got %s for %q", c.Action, c.Addr)
+		}
+	}
+}
+
+// TestContext2Plan_refreshConfigChangedTriggersRefresh verifies that when
+// RefreshMode is RefreshConfig and the resource configuration HAS changed,
+// the provider's ReadResource IS called.
+func TestContext2Plan_refreshConfigChangedTriggersRefresh(t *testing.T) {
+	p := testProvider("test")
+	p.PlanResourceChangeFn = testDiffFn
+
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_instance" "a" {
+  ami = "new-ami"
+}
+`,
+	})
+
+	state := states.NewState()
+	root := state.EnsureModule(addrs.RootModuleInstance)
+	root.SetResourceInstanceCurrent(
+		mustResourceInstanceAddr("test_instance.a").Resource,
+		&states.ResourceInstanceObjectSrc{
+			Status:       states.ObjectReady,
+			AttrsJSON:    []byte(`{"id":"a","ami":"old-ami","type":"test_instance"}`),
+			Dependencies: []addrs.ConfigResource{},
+		},
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.NoKey,
+	)
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
+		Mode:        plans.NormalMode,
+		RefreshMode: RefreshConfig,
+	})
+	assertNoErrors(t, diags)
+
+	if !p.ReadResourceCalled {
+		t.Fatal("ReadResource SHOULD have been called when config has changed")
+	}
+}
+
+// TestContext2Plan_refreshConfigDataSourceUnchangedNoManagedDep verifies that
+// a data source with no managed resource dependencies and unchanged config
+// is skipped under RefreshConfig mode.
+func TestContext2Plan_refreshConfigDataSourceUnchangedNoManagedDep(t *testing.T) {
+	p := testProvider("test")
+
+	var readDataCalled atomic.Bool
+	p.ReadDataSourceFn = func(req providers.ReadDataSourceRequest) providers.ReadDataSourceResponse {
+		readDataCalled.Store(true)
+		return providers.ReadDataSourceResponse{
+			State: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("data-id"),
+				"foo": cty.StringVal("bar"),
+			}),
+		}
+	}
+
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+data "test_data_source" "d" {
+  foo = "bar"
+}
+`,
+	})
+
+	state := states.NewState()
+	root := state.EnsureModule(addrs.RootModuleInstance)
+	root.SetResourceInstanceCurrent(
+		mustResourceInstanceAddr("data.test_data_source.d").Resource,
+		&states.ResourceInstanceObjectSrc{
+			Status:    states.ObjectReady,
+			AttrsJSON: []byte(`{"id":"data-id","foo":"bar"}`),
+		},
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.NoKey,
+	)
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
+		Mode:        plans.NormalMode,
+		RefreshMode: RefreshConfig,
+	})
+	assertNoErrors(t, diags)
+
+	if readDataCalled.Load() {
+		t.Fatal("ReadDataSource should NOT have been called for unchanged data source with no managed deps")
+	}
+}
+
+// TestContext2Plan_refreshConfigDataSourceChangedExecutes verifies that
+// a data source whose config has changed IS executed even in RefreshConfig mode.
+func TestContext2Plan_refreshConfigDataSourceChangedExecutes(t *testing.T) {
+	p := testProvider("test")
+
+	var readDataCalled atomic.Bool
+	p.ReadDataSourceFn = func(req providers.ReadDataSourceRequest) providers.ReadDataSourceResponse {
+		readDataCalled.Store(true)
+		return providers.ReadDataSourceResponse{
+			State: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("data-id"),
+				"foo": cty.StringVal("new-value"),
+			}),
+		}
+	}
+
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+data "test_data_source" "d" {
+  foo = "new-value"
+}
+`,
+	})
+
+	state := states.NewState()
+	root := state.EnsureModule(addrs.RootModuleInstance)
+	root.SetResourceInstanceCurrent(
+		mustResourceInstanceAddr("data.test_data_source.d").Resource,
+		&states.ResourceInstanceObjectSrc{
+			Status:    states.ObjectReady,
+			AttrsJSON: []byte(`{"id":"data-id","foo":"old-value"}`),
+		},
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.NoKey,
+	)
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
+		Mode:        plans.NormalMode,
+		RefreshMode: RefreshConfig,
+	})
+	assertNoErrors(t, diags)
+
+	if !readDataCalled.Load() {
+		t.Fatal("ReadDataSource SHOULD have been called when data source config changed")
+	}
+}
+
+// TestContext2Plan_refreshConfigDataSourceWithManagedDepAlwaysExecutes verifies
+// that a data source with a dependency on a managed resource always executes,
+// even if its own configuration is unchanged.
+func TestContext2Plan_refreshConfigDataSourceWithManagedDepAlwaysExecutes(t *testing.T) {
+	p := testProvider("test")
+	p.PlanResourceChangeFn = testDiffFn
+
+	var readDataCalled atomic.Bool
+	p.ReadDataSourceFn = func(req providers.ReadDataSourceRequest) providers.ReadDataSourceResponse {
+		readDataCalled.Store(true)
+		return providers.ReadDataSourceResponse{
+			State: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("data-id"),
+				"foo": cty.StringVal("bar"),
+			}),
+		}
+	}
+
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_instance" "a" {
+  ami = "bar"
+}
+
+data "test_data_source" "d" {
+  foo = "bar"
+  depends_on = [test_instance.a]
+}
+`,
+	})
+
+	state := states.NewState()
+	root := state.EnsureModule(addrs.RootModuleInstance)
+	root.SetResourceInstanceCurrent(
+		mustResourceInstanceAddr("test_instance.a").Resource,
+		&states.ResourceInstanceObjectSrc{
+			Status:       states.ObjectReady,
+			AttrsJSON:    []byte(`{"id":"a","ami":"bar","type":"test_instance"}`),
+			Dependencies: []addrs.ConfigResource{},
+		},
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.NoKey,
+	)
+	root.SetResourceInstanceCurrent(
+		mustResourceInstanceAddr("data.test_data_source.d").Resource,
+		&states.ResourceInstanceObjectSrc{
+			Status:    states.ObjectReady,
+			AttrsJSON: []byte(`{"id":"data-id","foo":"bar"}`),
+			Dependencies: []addrs.ConfigResource{
+				{
+					Resource: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "test_instance",
+						Name: "a",
+					},
+				},
+			},
+		},
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.NoKey,
+	)
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
+		Mode:        plans.NormalMode,
+		RefreshMode: RefreshConfig,
+	})
+	assertNoErrors(t, diags)
+
+	if !readDataCalled.Load() {
+		t.Fatal("ReadDataSource SHOULD have been called for data source with managed resource dependency")
+	}
+}
+
+// TestContext2Plan_refreshConfigStatsCounters verifies the RefreshStats
+// correctly counts managed resources and data sources.
+func TestContext2Plan_refreshConfigStatsCounters(t *testing.T) {
+	p := testProvider("test")
+	p.PlanResourceChangeFn = testDiffFn
+	p.ReadDataSourceFn = func(req providers.ReadDataSourceRequest) providers.ReadDataSourceResponse {
+		return providers.ReadDataSourceResponse{
+			State: cty.ObjectVal(map[string]cty.Value{
+				"id":  cty.StringVal("data-id"),
+				"foo": cty.NullVal(cty.String),
+			}),
+		}
+	}
+
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_instance" "unchanged" {
+  ami = "bar"
+}
+
+resource "test_instance" "changed" {
+  ami = "new-ami"
+}
+
+data "test_data_source" "d" {
+  foo = "bar"
+}
+`,
+	})
+
+	state := states.NewState()
+	root := state.EnsureModule(addrs.RootModuleInstance)
+	root.SetResourceInstanceCurrent(
+		mustResourceInstanceAddr("test_instance.unchanged").Resource,
+		&states.ResourceInstanceObjectSrc{
+			Status:       states.ObjectReady,
+			AttrsJSON:    []byte(`{"id":"u","ami":"bar","type":"test_instance"}`),
+			Dependencies: []addrs.ConfigResource{},
+		},
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.NoKey,
+	)
+	root.SetResourceInstanceCurrent(
+		mustResourceInstanceAddr("test_instance.changed").Resource,
+		&states.ResourceInstanceObjectSrc{
+			Status:       states.ObjectReady,
+			AttrsJSON:    []byte(`{"id":"c","ami":"old-ami","type":"test_instance"}`),
+			Dependencies: []addrs.ConfigResource{},
+		},
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.NoKey,
+	)
+	root.SetResourceInstanceCurrent(
+		mustResourceInstanceAddr("data.test_data_source.d").Resource,
+		&states.ResourceInstanceObjectSrc{
+			Status:    states.ObjectReady,
+			AttrsJSON: []byte(`{"id":"data-id","foo":"bar"}`),
+		},
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.NoKey,
+	)
+
+	stats := NewRefreshStats()
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
+		Mode:         plans.NormalMode,
+		RefreshMode:  RefreshConfig,
+		RefreshStats: stats,
+	})
+	assertNoErrors(t, diags)
+
+	managedTotal, managedRefreshed, managedSkipped := stats.ManagedCounts()
+	if managedTotal != 2 {
+		t.Errorf("managed total = %d, want 2", managedTotal)
+	}
+	if managedRefreshed != 1 {
+		t.Errorf("managed refreshed = %d, want 1 (the changed resource)", managedRefreshed)
+	}
+	if managedSkipped != 1 {
+		t.Errorf("managed skipped = %d, want 1 (the unchanged resource)", managedSkipped)
+	}
+
+	dataTotal, _, _ := stats.DataSourceCounts()
+	if dataTotal != 1 {
+		t.Errorf("data source total = %d, want 1", dataTotal)
+	}
+}
+
+// TestContext2Plan_refreshConfigWithRefreshOnlyError verifies that combining
+// RefreshConfig mode with RefreshOnly mode produces an error.
+func TestContext2Plan_refreshConfigWithRefreshOnlyError(t *testing.T) {
+	p := testProvider("test")
+
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_instance" "a" {
+  ami = "bar"
+}
+`,
+	})
+
+	state := states.NewState()
+	root := state.EnsureModule(addrs.RootModuleInstance)
+	root.SetResourceInstanceCurrent(
+		mustResourceInstanceAddr("test_instance.a").Resource,
+		&states.ResourceInstanceObjectSrc{
+			Status:       states.ObjectReady,
+			AttrsJSON:    []byte(`{"id":"a","ami":"bar","type":"test_instance"}`),
+			Dependencies: []addrs.ConfigResource{},
+		},
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.NoKey,
+	)
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
+		Mode:        plans.RefreshOnlyMode,
+		RefreshMode: RefreshConfig,
+	})
+
+	if !diags.HasErrors() {
+		t.Fatal("expected error for RefreshConfig + RefreshOnlyMode, got none")
+	}
+
+	found := false
+	for _, d := range diags {
+		desc := d.Description()
+		if strings.Contains(desc.Detail, "refresh=config") || strings.Contains(desc.Detail, "refresh-only") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected error about refresh=config incompatible with refresh-only, got: %s", diags.Err())
+	}
+}
+
+// TestContext2Plan_refreshConfigStatsWarning verifies that the stats warning
+// is emitted when using RefreshConfig mode.
+func TestContext2Plan_refreshConfigStatsWarning(t *testing.T) {
+	p := testProvider("test")
+	p.PlanResourceChangeFn = testDiffFn
+
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_instance" "a" {
+  ami = "bar"
+}
+`,
+	})
+
+	state := states.NewState()
+	root := state.EnsureModule(addrs.RootModuleInstance)
+	root.SetResourceInstanceCurrent(
+		mustResourceInstanceAddr("test_instance.a").Resource,
+		&states.ResourceInstanceObjectSrc{
+			Status:       states.ObjectReady,
+			AttrsJSON:    []byte(`{"id":"a","ami":"bar","type":"test_instance"}`),
+			Dependencies: []addrs.ConfigResource{},
+		},
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.NoKey,
+	)
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
+		Mode:        plans.NormalMode,
+		RefreshMode: RefreshConfig,
+	})
+
+	// Should not have errors
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Err())
+	}
+
+	// Should have a warning about selective refresh
+	foundWarning := false
+	for _, d := range diags {
+		desc := d.Description()
+		if strings.Contains(desc.Summary, "Selective refresh") ||
+			strings.Contains(desc.Detail, "Selective refresh mode") {
+			foundWarning = true
+			break
+		}
+	}
+	if !foundWarning {
+		t.Error("expected 'Selective refresh' warning, but none was found in diagnostics")
+	}
+}
+
+// TestContext2Plan_refreshConfigNewResourceRefreshes verifies that a new
+// resource (not in state) is always refreshed even in RefreshConfig mode.
+func TestContext2Plan_refreshConfigNewResourceRefreshes(t *testing.T) {
+	p := testProvider("test")
+	p.PlanResourceChangeFn = testDiffFn
+
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_instance" "a" {
+  ami = "bar"
+}
+`,
+	})
+
+	// Empty state - the resource doesn't exist yet
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), &PlanOpts{
+		Mode:        plans.NormalMode,
+		RefreshMode: RefreshConfig,
+	})
+	assertNoErrors(t, diags)
+
+	// Should plan a Create action for the new resource
+	foundCreate := false
+	for _, c := range plan.Changes.Resources {
+		if c.Addr.String() == "test_instance.a" && c.Action == plans.Create {
+			foundCreate = true
+		}
+	}
+	if !foundCreate {
+		t.Fatal("expected Create action for new resource test_instance.a")
+	}
+}
+
+// TestContext2Plan_refreshConfigOrphanRefreshes verifies that orphan resources
+// (in state but not in config) always refresh in RefreshConfig mode.
+func TestContext2Plan_refreshConfigOrphanRefreshes(t *testing.T) {
+	p := testProvider("test")
+	p.PlanResourceChangeFn = testDiffFn
+
+	// Config has no resources
+	m := testModuleInline(t, map[string]string{
+		"main.tf": ``,
+	})
+
+	state := states.NewState()
+	root := state.EnsureModule(addrs.RootModuleInstance)
+	root.SetResourceInstanceCurrent(
+		mustResourceInstanceAddr("test_instance.a").Resource,
+		&states.ResourceInstanceObjectSrc{
+			Status:       states.ObjectReady,
+			AttrsJSON:    []byte(`{"id":"a","ami":"bar","type":"test_instance"}`),
+			Dependencies: []addrs.ConfigResource{},
+		},
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.NoKey,
+	)
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
+		Mode:        plans.NormalMode,
+		RefreshMode: RefreshConfig,
+	})
+	assertNoErrors(t, diags)
+
+	// Orphans should be planned for deletion
+	foundDelete := false
+	for _, c := range plan.Changes.Resources {
+		if c.Addr.String() == "test_instance.a" && c.Action == plans.Delete {
+			foundDelete = true
+		}
+	}
+	if !foundDelete {
+		t.Fatal("expected Delete action for orphan resource test_instance.a")
+	}
+
+	// ReadResource should be called for the orphan since it has no config
+	if !p.ReadResourceCalled {
+		t.Fatal("ReadResource should have been called for orphan resource (no config = always refresh)")
+	}
+}
+
+// TestContext2Plan_refreshConfigMultipleResources verifies a mixed scenario
+// with multiple managed resources where some change and some don't.
+func TestContext2Plan_refreshConfigMultipleResources(t *testing.T) {
+	p := testProvider("test")
+	p.PlanResourceChangeFn = testDiffFn
+
+	var readCount atomic.Int32
+	p.ReadResourceFn = func(req providers.ReadResourceRequest) providers.ReadResourceResponse {
+		readCount.Add(1)
+		return providers.ReadResourceResponse{
+			NewState: req.PriorState,
+		}
+	}
+
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_instance" "unchanged1" {
+  ami = "same"
+}
+
+resource "test_instance" "unchanged2" {
+  ami = "same2"
+}
+
+resource "test_instance" "changed" {
+  ami = "new-value"
+}
+`,
+	})
+
+	state := states.NewState()
+	root := state.EnsureModule(addrs.RootModuleInstance)
+	root.SetResourceInstanceCurrent(
+		mustResourceInstanceAddr("test_instance.unchanged1").Resource,
+		&states.ResourceInstanceObjectSrc{
+			Status:       states.ObjectReady,
+			AttrsJSON:    []byte(`{"id":"u1","ami":"same","type":"test_instance"}`),
+			Dependencies: []addrs.ConfigResource{},
+		},
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.NoKey,
+	)
+	root.SetResourceInstanceCurrent(
+		mustResourceInstanceAddr("test_instance.unchanged2").Resource,
+		&states.ResourceInstanceObjectSrc{
+			Status:       states.ObjectReady,
+			AttrsJSON:    []byte(`{"id":"u2","ami":"same2","type":"test_instance"}`),
+			Dependencies: []addrs.ConfigResource{},
+		},
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.NoKey,
+	)
+	root.SetResourceInstanceCurrent(
+		mustResourceInstanceAddr("test_instance.changed").Resource,
+		&states.ResourceInstanceObjectSrc{
+			Status:       states.ObjectReady,
+			AttrsJSON:    []byte(`{"id":"c","ami":"old-value","type":"test_instance"}`),
+			Dependencies: []addrs.ConfigResource{},
+		},
+		mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`),
+		addrs.NoKey,
+	)
+
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		},
+	})
+
+	_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
+		Mode:        plans.NormalMode,
+		RefreshMode: RefreshConfig,
+	})
+	assertNoErrors(t, diags)
+
+	// Only the changed resource should have triggered a ReadResource call
+	count := readCount.Load()
+	if count != 1 {
+		t.Errorf("ReadResource called %d times, want 1 (only the changed resource)", count)
+	}
+}

--- a/internal/tofu/detect_config_change_test.go
+++ b/internal/tofu/detect_config_change_test.go
@@ -1,0 +1,179 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tofu
+
+import (
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/opentofu/opentofu/internal/configs/configschema"
+)
+
+func TestValuesEqualIgnoringNulls(t *testing.T) {
+	schema := &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"name": {Type: cty.String, Optional: true},
+			"tags": {Type: cty.Map(cty.String), Optional: true},
+		},
+	}
+
+	tests := []struct {
+		name   string
+		a      cty.Value
+		b      cty.Value
+		schema *configschema.Block
+		want   bool
+	}{
+		{
+			name: "both null",
+			a:    cty.NullVal(cty.String),
+			b:    cty.NullVal(cty.String),
+			want: true,
+		},
+		{
+			name: "equal strings",
+			a:    cty.StringVal("hello"),
+			b:    cty.StringVal("hello"),
+			want: true,
+		},
+		{
+			name: "different strings",
+			a:    cty.StringVal("hello"),
+			b:    cty.StringVal("world"),
+			want: false,
+		},
+		{
+			name: "null vs empty object",
+			a:    cty.NullVal(cty.EmptyObject),
+			b:    cty.EmptyObjectVal,
+			want: true,
+		},
+		{
+			name: "null vs empty map",
+			a:    cty.NullVal(cty.Map(cty.String)),
+			b:    cty.MapValEmpty(cty.String),
+			want: true,
+		},
+		{
+			name: "null vs non-empty map",
+			a:    cty.NullVal(cty.Map(cty.String)),
+			b:    cty.MapVal(map[string]cty.Value{"k": cty.StringVal("v")}),
+			want: false,
+		},
+		{
+			name: "equal objects",
+			a: cty.ObjectVal(map[string]cty.Value{
+				"name": cty.StringVal("foo"),
+				"tags": cty.MapVal(map[string]cty.Value{"env": cty.StringVal("test")}),
+			}),
+			b: cty.ObjectVal(map[string]cty.Value{
+				"name": cty.StringVal("foo"),
+				"tags": cty.MapVal(map[string]cty.Value{"env": cty.StringVal("test")}),
+			}),
+			schema: schema,
+			want:   true,
+		},
+		{
+			name: "different object attribute",
+			a: cty.ObjectVal(map[string]cty.Value{
+				"name": cty.StringVal("foo"),
+				"tags": cty.NullVal(cty.Map(cty.String)),
+			}),
+			b: cty.ObjectVal(map[string]cty.Value{
+				"name": cty.StringVal("bar"),
+				"tags": cty.NullVal(cty.Map(cty.String)),
+			}),
+			schema: schema,
+			want:   false,
+		},
+		{
+			name: "object with null vs empty map attribute",
+			a: cty.ObjectVal(map[string]cty.Value{
+				"name": cty.StringVal("foo"),
+				"tags": cty.NullVal(cty.Map(cty.String)),
+			}),
+			b: cty.ObjectVal(map[string]cty.Value{
+				"name": cty.StringVal("foo"),
+				"tags": cty.MapValEmpty(cty.String),
+			}),
+			schema: schema,
+			want:   true,
+		},
+		{
+			name:   "equal lists",
+			a:      cty.ListVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")}),
+			b:      cty.ListVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")}),
+			schema: nil,
+			want:   true,
+		},
+		{
+			name:   "different lists",
+			a:      cty.ListVal([]cty.Value{cty.StringVal("a")}),
+			b:      cty.ListVal([]cty.Value{cty.StringVal("b")}),
+			schema: nil,
+			want:   false,
+		},
+		{
+			name:   "different list lengths",
+			a:      cty.ListVal([]cty.Value{cty.StringVal("a")}),
+			b:      cty.ListVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")}),
+			schema: nil,
+			want:   false,
+		},
+		{
+			name: "equal maps",
+			a:    cty.MapVal(map[string]cty.Value{"k1": cty.StringVal("v1")}),
+			b:    cty.MapVal(map[string]cty.Value{"k1": cty.StringVal("v1")}),
+			want: true,
+		},
+		{
+			name: "different map values",
+			a:    cty.MapVal(map[string]cty.Value{"k1": cty.StringVal("v1")}),
+			b:    cty.MapVal(map[string]cty.Value{"k1": cty.StringVal("v2")}),
+			want: false,
+		},
+		{
+			name: "different map keys",
+			a:    cty.MapVal(map[string]cty.Value{"k1": cty.StringVal("v1")}),
+			b:    cty.MapVal(map[string]cty.Value{"k2": cty.StringVal("v1")}),
+			want: false,
+		},
+		{
+			name: "different types",
+			a:    cty.StringVal("hello"),
+			b:    cty.NumberIntVal(42),
+			want: false,
+		},
+		{
+			name: "equal booleans",
+			a:    cty.True,
+			b:    cty.True,
+			want: true,
+		},
+		{
+			name: "different booleans",
+			a:    cty.True,
+			b:    cty.False,
+			want: false,
+		},
+		{
+			name: "equal numbers",
+			a:    cty.NumberIntVal(42),
+			b:    cty.NumberIntVal(42),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := valuesEqualIgnoringNulls(tt.a, tt.b, tt.schema)
+			if got != tt.want {
+				t.Errorf("valuesEqualIgnoringNulls() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tofu/graph_builder_plan.go
+++ b/internal/tofu/graph_builder_plan.go
@@ -59,6 +59,12 @@ type PlanGraphBuilder struct {
 	// skipRefresh indicates that we should skip refreshing managed resources
 	skipRefresh bool
 
+	// refreshMode specifies how refresh should be handled (all, none, or config).
+	refreshMode RefreshMode
+
+	// refreshStats tracks refresh decisions during planning.
+	refreshStats *RefreshStats
+
 	// preDestroyRefresh indicates that we are executing the refresh which
 	// happens immediately before a destroy plan, which happens to use the
 	// normal planing mode so skipPlanChanges cannot be set.
@@ -297,6 +303,8 @@ func (b *PlanGraphBuilder) initPlan() {
 		return &nodeExpandPlannableResource{
 			NodeAbstractResource: a,
 			skipRefresh:          b.skipRefresh,
+			refreshMode:          b.refreshMode,
+			refreshStats:         b.refreshStats,
 			skipPlanChanges:      b.skipPlanChanges,
 			preDestroyRefresh:    b.preDestroyRefresh,
 			forceReplace:         b.ForceReplace,
@@ -307,6 +315,8 @@ func (b *PlanGraphBuilder) initPlan() {
 		return &NodePlannableResourceInstanceOrphan{
 			NodeAbstractResourceInstance: a,
 			skipRefresh:                  b.skipRefresh,
+			refreshMode:                  b.refreshMode,
+			refreshStats:                 b.refreshStats,
 			skipPlanChanges:              b.skipPlanChanges,
 			RemoveStatements:             b.RemoveStatements,
 		}
@@ -318,6 +328,8 @@ func (b *PlanGraphBuilder) initPlan() {
 			DeposedKey:                   key,
 
 			skipRefresh:      b.skipRefresh,
+			refreshMode:      b.refreshMode,
+			refreshStats:     b.refreshStats,
 			skipPlanChanges:  b.skipPlanChanges,
 			RemoveStatements: b.RemoveStatements,
 		}

--- a/internal/tofu/node_resource_plan.go
+++ b/internal/tofu/node_resource_plan.go
@@ -32,6 +32,12 @@ type nodeExpandPlannableResource struct {
 	// skipRefresh indicates that we should skip refreshing individual instances
 	skipRefresh bool
 
+	// refreshMode specifies how refresh should be handled (all, none, or config).
+	refreshMode RefreshMode
+
+	// refreshStats tracks refresh decisions during planning.
+	refreshStats *RefreshStats
+
 	preDestroyRefresh bool
 
 	// skipPlanChanges indicates we should skip trying to plan change actions
@@ -147,6 +153,8 @@ func (n *nodeExpandPlannableResource) DynamicExpand(evalCtx EvalContext) (*Graph
 		return &NodePlannableResourceInstanceOrphan{
 			NodeAbstractResourceInstance: a,
 			skipRefresh:                  n.skipRefresh,
+			refreshMode:                  n.refreshMode,
+			refreshStats:                 n.refreshStats,
 			skipPlanChanges:              n.skipPlanChanges,
 		}
 	}
@@ -385,6 +393,8 @@ func (n *nodeExpandPlannableResource) resourceInstanceSubgraph(ctx context.Conte
 			// nodes that have it.
 			ForceCreateBeforeDestroy: n.CreateBeforeDestroy(),
 			skipRefresh:              n.skipRefresh,
+			refreshMode:              n.refreshMode,
+			refreshStats:             n.refreshStats,
 			skipPlanChanges:          n.skipPlanChanges,
 			forceReplace:             n.forceReplace,
 		}
@@ -415,6 +425,8 @@ func (n *nodeExpandPlannableResource) resourceInstanceSubgraph(ctx context.Conte
 		return &NodePlannableResourceInstanceOrphan{
 			NodeAbstractResourceInstance: a,
 			skipRefresh:                  n.skipRefresh,
+			refreshMode:                  n.refreshMode,
+			refreshStats:                 n.refreshStats,
 			skipPlanChanges:              n.skipPlanChanges,
 		}
 	}

--- a/internal/tofu/refresh.go
+++ b/internal/tofu/refresh.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2026 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tofu
+
+import "sync/atomic"
+
+// RefreshMode specifies how refresh should be handled during planning.
+type RefreshMode int
+
+const (
+	// RefreshAll refreshes all resources (default behavior).
+	RefreshAll RefreshMode = iota
+	// RefreshNone skips refresh for all resources (equivalent to -refresh=false).
+	RefreshNone
+	// RefreshConfig refreshes only resources whose configuration changed.
+	RefreshConfig
+)
+
+// String returns a human-readable name for the refresh mode.
+func (m RefreshMode) String() string {
+	switch m {
+	case RefreshAll:
+		return "all"
+	case RefreshNone:
+		return "none"
+	case RefreshConfig:
+		return "config"
+	default:
+		return "unknown"
+	}
+}
+
+// RefreshStats tracks refresh behavior for managed resources and data sources.
+type RefreshStats struct {
+	managedTotal     atomic.Int64
+	managedRefreshed atomic.Int64
+	dataTotal        atomic.Int64
+	dataRefreshed    atomic.Int64
+}
+
+// NewRefreshStats creates an empty RefreshStats instance.
+func NewRefreshStats() *RefreshStats {
+	return &RefreshStats{}
+}
+
+// RecordManaged records whether a managed resource was refreshed.
+func (s *RefreshStats) RecordManaged(refreshed bool) {
+	s.managedTotal.Add(1)
+	if refreshed {
+		s.managedRefreshed.Add(1)
+	}
+}
+
+// RecordDataSource records whether a data source was executed.
+func (s *RefreshStats) RecordDataSource(executed bool) {
+	s.dataTotal.Add(1)
+	if executed {
+		s.dataRefreshed.Add(1)
+	}
+}
+
+// ManagedCounts returns total/refreshed/skipped for managed resources.
+func (s *RefreshStats) ManagedCounts() (total, refreshed, skipped int64) {
+	total = s.managedTotal.Load()
+	refreshed = s.managedRefreshed.Load()
+	skipped = total - refreshed
+	return total, refreshed, skipped
+}
+
+// DataSourceCounts returns total/executed/skipped for data sources.
+func (s *RefreshStats) DataSourceCounts() (total, executed, skipped int64) {
+	total = s.dataTotal.Load()
+	executed = s.dataRefreshed.Load()
+	skipped = total - executed
+	return total, executed, skipped
+}

--- a/internal/tofu/refresh_test.go
+++ b/internal/tofu/refresh_test.go
@@ -1,0 +1,132 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tofu
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestRefreshMode_String(t *testing.T) {
+	tests := []struct {
+		mode RefreshMode
+		want string
+	}{
+		{RefreshAll, "all"},
+		{RefreshNone, "none"},
+		{RefreshConfig, "config"},
+		{RefreshMode(99), "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := tt.mode.String()
+			if got != tt.want {
+				t.Errorf("RefreshMode(%d).String() = %q, want %q", tt.mode, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRefreshStats_ManagedCounts(t *testing.T) {
+	s := NewRefreshStats()
+
+	s.RecordManaged(true)
+	s.RecordManaged(true)
+	s.RecordManaged(false)
+	s.RecordManaged(false)
+	s.RecordManaged(false)
+
+	total, refreshed, skipped := s.ManagedCounts()
+	if total != 5 {
+		t.Errorf("total = %d, want 5", total)
+	}
+	if refreshed != 2 {
+		t.Errorf("refreshed = %d, want 2", refreshed)
+	}
+	if skipped != 3 {
+		t.Errorf("skipped = %d, want 3", skipped)
+	}
+}
+
+func TestRefreshStats_DataSourceCounts(t *testing.T) {
+	s := NewRefreshStats()
+
+	s.RecordDataSource(true)
+	s.RecordDataSource(false)
+	s.RecordDataSource(true)
+
+	total, executed, skipped := s.DataSourceCounts()
+	if total != 3 {
+		t.Errorf("total = %d, want 3", total)
+	}
+	if executed != 2 {
+		t.Errorf("executed = %d, want 2", executed)
+	}
+	if skipped != 1 {
+		t.Errorf("skipped = %d, want 1", skipped)
+	}
+}
+
+func TestRefreshStats_Empty(t *testing.T) {
+	s := NewRefreshStats()
+
+	total, refreshed, skipped := s.ManagedCounts()
+	if total != 0 || refreshed != 0 || skipped != 0 {
+		t.Errorf("empty managed counts: total=%d, refreshed=%d, skipped=%d", total, refreshed, skipped)
+	}
+
+	total, executed, skipped := s.DataSourceCounts()
+	if total != 0 || executed != 0 || skipped != 0 {
+		t.Errorf("empty data source counts: total=%d, executed=%d, skipped=%d", total, executed, skipped)
+	}
+}
+
+func TestRefreshStats_ConcurrentSafety(t *testing.T) {
+	s := NewRefreshStats()
+	const goroutines = 100
+	const recordsPerGoroutine = 50
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+
+	// Half goroutines record managed, half record data sources
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < recordsPerGoroutine; j++ {
+				s.RecordManaged(j%2 == 0)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for j := 0; j < recordsPerGoroutine; j++ {
+				s.RecordDataSource(j%3 == 0)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	managedTotal, managedRefreshed, managedSkipped := s.ManagedCounts()
+	dataTotal, dataExecuted, dataSkipped := s.DataSourceCounts()
+
+	expectedManagedTotal := int64(goroutines * recordsPerGoroutine)
+	expectedDataTotal := int64(goroutines * recordsPerGoroutine)
+
+	if managedTotal != expectedManagedTotal {
+		t.Errorf("managed total = %d, want %d", managedTotal, expectedManagedTotal)
+	}
+	if managedRefreshed+managedSkipped != managedTotal {
+		t.Errorf("managed refreshed(%d) + skipped(%d) != total(%d)", managedRefreshed, managedSkipped, managedTotal)
+	}
+	if dataTotal != expectedDataTotal {
+		t.Errorf("data total = %d, want %d", dataTotal, expectedDataTotal)
+	}
+	if dataExecuted+dataSkipped != dataTotal {
+		t.Errorf("data executed(%d) + skipped(%d) != total(%d)", dataExecuted, dataSkipped, dataTotal)
+	}
+}

--- a/website/docs/cli/commands/plan.mdx
+++ b/website/docs/cli/commands/plan.mdx
@@ -112,6 +112,8 @@ In addition to alternate [planning modes](#planning-modes), there are several op
 - `-refresh=false` - Disables the default behavior of synchronizing the
   OpenTofu state with remote objects before checking for configuration changes. This can make the planning operation faster by reducing the number of remote API requests. However, setting `refresh=false` causes OpenTofu to ignore external changes, which could result in an incomplete or incorrect plan. You cannot use `refresh=false` in refresh-only planning mode because it would effectively disable the entirety of the planning operation.
 
+- `-refresh=config` - Refreshes only resources whose configuration has changed since the last state snapshot. This can reduce the number of remote API requests in large configurations while still detecting configuration-driven changes. Data sources are refreshed only when their configuration changes or when they depend on managed resources that are being refreshed. You cannot use `refresh=config` in refresh-only planning mode.
+
 - `-replace=ADDRESS` - Instructs OpenTofu to plan to replace the
   resource instance with the given address. This is helpful when one or more remote objects have become degraded, and you can use replacement objects with the same configuration to align with immutable infrastructure patterns. OpenTofu will use a "replace" action if the specified resource would normally cause an "update" action or no action at all. Include this option multiple times to replace several objects at once. You cannot use `-replace` with the `-destroy` option.
 


### PR DESCRIPTION
## Summary

Add a third refresh mode (`-refresh=config`) for `tofu plan` and `tofu apply` that only refreshes resources whose HCL configuration has changed compared to the prior state. This dramatically reduces plan times for large configurations (25k+ resources) by skipping provider `ReadResource` API calls for unchanged resources.

## Motivation

In large-scale OpenTofu configurations, the `tofu plan` command can be slow because it refreshes every resource by calling the provider's `ReadResource` API — even when the vast majority of resources haven't changed. The `-refresh=config` flag enables selective refresh: only resources with actual configuration changes are refreshed, while unchanged resources retain their prior state.

## Design Decisions

- **No state schema changes** — detection is done at plan time by comparing `ProposedNew` vs prior state; no hashes stored in state
- **Dynamic reference masking** — references to other resources, data sources, modules, and outputs are replaced with `cty.DynamicVal` during comparison, so upstream value changes don't force a refresh; only the resource's own literal config changes trigger refresh
- **Three-value flag** — `-refresh=true` (default), `-refresh=false`, `-refresh=config`
- **Data source handling** — data sources are skipped if their config hasn't changed AND they don't depend on managed resources
- **Destroy plans force full refresh** — the pre-destroy refresh pass overrides `RefreshConfig` to `RefreshAll`
- **Incompatible with refresh-only** — `-refresh=config` with `-refresh-only` produces an error
- **Orphans and deposed objects** — participate in config change detection; orphans with no config default to "changed" (refresh)
- **Stats warning** — at end of plan, emits a warning with counts: managed resources refreshed/skipped, data sources executed/skipped

## Changes

### Core engine (`internal/tofu/`)
- **`refresh.go`** — `RefreshMode` enum (`RefreshAll`, `RefreshNone`, `RefreshConfig`), `RefreshStats` with atomic counters
- **`context_plan.go`** — `PlanOpts` extended with `RefreshMode`/`RefreshStats`; validation, stats warning emission, destroy override
- **`node_resource_abstract_instance.go`** — Core detection logic: `detectConfigChange`, `maskDynamicReferences`, `valuesEqualIgnoringNulls`
- **`node_resource_plan_instance.go`** — Integration in `managedResourceExecute` and `dataResourceExecute`
- **`node_resource_plan_orphan.go`** / **`node_resource_deposed.go`** — Same pattern for orphans and deposed objects
- **`graph_builder_plan.go`** / **`node_resource_plan.go`** — Propagation of refresh mode and stats through the graph

### CLI layer (`internal/command/`)
- **`arguments/extended.go`** — `RefreshFlagValue` implementing `flag.Value` with `Set("true"/"false"/"config")`
- **`plan.go`** / **`apply.go`** — Propagation to backend operations

### Backend layer
- **`backend/backend.go`** — `PlanRefreshMode` field on `Operation`
- **`backend/local/`** — Passes mode to `PlanOpts`
- **`backend/remote/`** / **`cloud/`** — Warning when `RefreshConfig` used with remote/cloud backends

### Tests
- Unit tests for `RefreshMode`, `RefreshStats`, `valuesEqualIgnoringNulls`, `RefreshFlagValue`
- 11 integration tests covering: unchanged skip, changed refresh, data source skip/execute, managed dependency detection, stats counters, stats warning, new resources, orphans, multiple resources, refresh-only incompatibility

### Documentation
- **`website/docs/cli/commands/plan.mdx`** — Added `-refresh=config` entry