### PR TITLE
[Backport][v1.11] Add logger to the registry client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The v1.11.x release series is supported until **August 1 2026**.
 BUG FIXES:
 
 * The `azurerm` backend's MSI authentication method will now respect the provided client ID ([#3586](https://github.com/opentofu/opentofu/issues/3586))
+* Using a network mirror for the providers source does not print debug logs without being asked for ([#3736](https://github.com/opentofu/opentofu/issues/3736))
 
 ## 1.11.4
 

--- a/internal/httpclient/registry_client.go
+++ b/internal/httpclient/registry_client.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/opentofu/opentofu/internal/logging"
 )
 
 // NewForRegistryRequests is a variant of [New] that deals with some additional
@@ -49,6 +50,7 @@ func NewForRegistryRequests(ctx context.Context, retryCount int, timeout time.Du
 	retryableClient.RetryMax = retryCount
 	retryableClient.RequestLogHook = registryRequestLogHook
 	retryableClient.ErrorHandler = registryMaxRetryErrorHandler
+	retryableClient.Logger = logging.HCLogger()
 
 	return retryableClient
 }


### PR DESCRIPTION
Part of #3732 
This backports the logger fix for the http registry client to v1.11. (#3736)

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
