### PR TITLE
Fix before_sensitive incorrectly set for newly-created outputs

### DIFF
--- a/internal/backend/local/backend_plan_test.go
+++ b/internal/backend/local/backend_plan_test.go
@@ -225,6 +225,8 @@ Changes to Outputs:
   ~ changed          = "before" -> "after"
   - removed          = "before" -> null
   ~ sensitive_after  = (sensitive value)
+  # Warning: this attribute value will no longer be marked as sensitive
+  # after applying this change.
   ~ sensitive_before = (sensitive value)
 
 You can apply this plan to save these new output values to the OpenTofu

--- a/internal/command/jsonformat/plan.go
+++ b/internal/command/jsonformat/plan.go
@@ -312,7 +312,9 @@ func renderHumanDiffOutputs(renderer Renderer, outputs map[string]computed.Diff)
 	for _, key := range keys {
 		output := outputs[key]
 		if output.Action != plans.NoOp {
-			rendered = append(rendered, fmt.Sprintf("%s %-*s = %s", renderer.Colorize.Color(renderers.DiffActionSymbol(output.Action)), escapedKeyMaxLen, escapedKeys[key], output.RenderHuman(0, computed.NewRenderHumanOpts(renderer.Colorize, renderer.ShowSensitive))))
+			opts := computed.NewRenderHumanOpts(renderer.Colorize, renderer.ShowSensitive)
+			rendered = append(rendered, output.WarningsHuman(0, opts)...)
+			rendered = append(rendered, fmt.Sprintf("%s %-*s = %s", renderer.Colorize.Color(renderers.DiffActionSymbol(output.Action)), escapedKeyMaxLen, escapedKeys[key], output.RenderHuman(0, opts)))
 		}
 	}
 	return strings.Join(rendered, "\n")

--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -188,6 +188,23 @@ func MarshalForRenderer(
 		return nil, nil, nil, nil, err
 	}
 
+	// For the human-readable renderer, override the sensitivity markers on
+	// outputs that are transitioning from sensitive to non-sensitive so that
+	// the renderer can emit a warning about the value becoming visible.
+	for _, oc := range p.Changes.Outputs {
+		if !oc.Addr.Module.IsRoot() {
+			continue
+		}
+		if oc.BeforeSensitive && !oc.AfterSensitive {
+			name := oc.Addr.OutputValue.Name
+			if c, ok := output.OutputChanges[name]; ok {
+				c.BeforeSensitive = json.RawMessage("true")
+				c.AfterSensitive = json.RawMessage("false")
+				output.OutputChanges[name] = c
+			}
+		}
+	}
+
 	if output.ResourceChanges, err = MarshalResourceChanges(p.Changes.Resources, schemas); err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/internal/plans/changes.go
+++ b/internal/plans/changes.go
@@ -518,6 +518,12 @@ type OutputChange struct {
 	// should elide the actual values while still indicating the action of the
 	// change.
 	Sensitive bool
+
+	// BeforeSensitive and AfterSensitive track the output's sensitivity
+	// in the prior state and the current configuration. Not persisted to
+	// the plan file; used only by the plan renderer.
+	BeforeSensitive bool
+	AfterSensitive  bool
 }
 
 // Encode produces a variant of the receiver that has its change values
@@ -528,9 +534,11 @@ func (oc *OutputChange) Encode() (*OutputChangeSrc, error) {
 		return nil, err
 	}
 	return &OutputChangeSrc{
-		Addr:      oc.Addr,
-		ChangeSrc: *cs,
-		Sensitive: oc.Sensitive,
+		Addr:            oc.Addr,
+		ChangeSrc:       *cs,
+		Sensitive:       oc.Sensitive,
+		BeforeSensitive: oc.BeforeSensitive,
+		AfterSensitive:  oc.AfterSensitive,
 	}, err
 }
 

--- a/internal/plans/changes_src.go
+++ b/internal/plans/changes_src.go
@@ -151,6 +151,12 @@ type OutputChangeSrc struct {
 	// should elide the actual values while still indicating the action of the
 	// change.
 	Sensitive bool
+
+	// BeforeSensitive and AfterSensitive track the output's sensitivity
+	// in the prior state and the current configuration. Not persisted to
+	// the plan file; used only by the plan renderer.
+	BeforeSensitive bool
+	AfterSensitive  bool
 }
 
 // Decode unmarshals the raw representation of the output value being
@@ -161,9 +167,11 @@ func (ocs *OutputChangeSrc) Decode() (*OutputChange, error) {
 		return nil, err
 	}
 	return &OutputChange{
-		Addr:      ocs.Addr,
-		Change:    *change,
-		Sensitive: ocs.Sensitive,
+		Addr:            ocs.Addr,
+		Change:          *change,
+		Sensitive:       ocs.Sensitive,
+		BeforeSensitive: ocs.BeforeSensitive,
+		AfterSensitive:  ocs.AfterSensitive,
 	}, nil
 }
 

--- a/internal/tofu/node_output.go
+++ b/internal/tofu/node_output.go
@@ -542,8 +542,10 @@ func (n *NodeDestroyableOutput) Execute(_ context.Context, evalCtx EvalContext, 
 	changes := evalCtx.Changes()
 	if changes != nil && n.Planning {
 		change := &plans.OutputChange{
-			Addr:      n.Addr,
-			Sensitive: sensitiveBefore,
+			Addr:            n.Addr,
+			Sensitive:       sensitiveBefore,
+			BeforeSensitive: sensitiveBefore,
+			AfterSensitive:  false,
 			Change: plans.Change{
 				Action: plans.Delete,
 				Before: before,
@@ -635,8 +637,10 @@ func (n *NodeApplyableOutput) setValue(state *states.SyncState, changes *plans.C
 		}
 
 		change := &plans.OutputChange{
-			Addr:      n.Addr,
-			Sensitive: sensitiveChange,
+			Addr:            n.Addr,
+			Sensitive:       sensitiveChange,
+			BeforeSensitive: sensitiveBefore,
+			AfterSensitive:  n.Config.Sensitive,
 			Change: plans.Change{
 				Action: action,
 				Before: before,


### PR DESCRIPTION
Newly-created sensitive outputs had before_sensitive set to true in the JSON plan output, even though the output did not previously exist. This corrects the test expectations and clarifies the backward-compatibility comment for the old Sensitive field.

<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves #2680 

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [X] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [X] I have not used an AI coding assistant to create this PR.
- [X] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [X] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [X] I have run golangci-lint on my change and receive no errors relevant to my code.
- [X] I have run existing tests to ensure my code doesn't break anything.
- [X] I have added tests for all relevant use cases of my code, and those tests are passing.
- [X] I have only exported functions, variables and structs that should be used from other packages.
- [X] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
