### PR TITLE
go.mod: Upgrade to Go 1.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+The v1.12.x release series is supported until **February 1 2027**.
+
 ## 1.12.0 (Unreleased)
 
 UPGRADE NOTES:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opentofu/opentofu
 
-go 1.25.6
+go 1.26
 
 // At the time of adding this configuration, the new Go feature introduced here https://github.com/golang/go/issues/67061,
 // was having a good amount of issues linked to, affecting AWS Firewall, GCP various services and a lot more.


### PR DESCRIPTION
This is just a routine upgrade, with the intention that the forthcoming OpenTofu v1.12 series will be based on this Go release series and so will be under security support until February 2027 when this Go release will cease to be supported.

As with the v1.11 series, we cannot predict exactly which day of February Go 1.28 will be released on and so we'll be conservative and promise support until the first day of that month, but in practice we're likely to continue adopting relevant Go 1.26 minor releases for additional weeks of February until the Go team stops publishing them.

This Go upgrade does not immediately cause any new user-facing behavior changes that we'd want to mention in our changelog, aside from the announcement that this will be the last release to support macOS 12 Monterey which we added previously in https://github.com/opentofu/opentofu/pull/3618.

Closes https://github.com/opentofu/opentofu/issues/3613
