### PR TITLE
fix(encryption): correct AWS KMS documentation URL and remove TODO

### DIFF
--- a/internal/encryption/keyprovider/aws_kms/config.go
+++ b/internal/encryption/keyprovider/aws_kms/config.go
@@ -137,7 +137,7 @@ func (c Config) asAWSBase() (*awsbase.Config, error) {
 
 	return &awsbase.Config{
 		AccessKey:               c.AccessKey,
-		CallerDocumentationURL:  "https://opentofu.org/docs/language/settings/backends/s3", // TODO
+		CallerDocumentationURL:  "https://opentofu.org/docs/language/state/encryption/#aws-kms",
 		CallerName:              "KMS Key Provider",
 		IamEndpoint:             stringAttrEnvFallback(endpoints.IAM, "AWS_ENDPOINT_URL_IAM"),
 		MaxRetries:              c.MaxRetries,

--- a/internal/encryption/keyprovider/aws_kms/config_test.go
+++ b/internal/encryption/keyprovider/aws_kms/config_test.go
@@ -37,7 +37,7 @@ func TestConfig_asAWSBase(t *testing.T) {
 				region = "magic-mountain"`,
 			expected: awsbase.Config{
 				Region:                 "magic-mountain",
-				CallerDocumentationURL: "https://opentofu.org/docs/language/settings/backends/s3",
+				CallerDocumentationURL: "https://opentofu.org/docs/language/state/encryption/#aws-kms",
 				CallerName:             "KMS Key Provider",
 				MaxRetries:             5,
 				APNInfo: &awsbase.APNInfo{
@@ -105,7 +105,7 @@ func TestConfig_asAWSBase(t *testing.T) {
 				retry_mode = "adaptive"
 				`,
 			expected: awsbase.Config{
-				CallerDocumentationURL: "https://opentofu.org/docs/language/settings/backends/s3",
+				CallerDocumentationURL: "https://opentofu.org/docs/language/state/encryption/#aws-kms",
 				CallerName:             "KMS Key Provider",
 				APNInfo: &awsbase.APNInfo{
 					PartnerName: "OpenTofu-AWS-KMS",


### PR DESCRIPTION
# Pull Request Description

The `CallerDocumentationURL` was pointing to `/backends/s3` when it should be pointing to `/encryption`

I think this was introduced in #1349 in a copy and paste, and the URL change was forgotten about because there was a TODO. I could be wrong though.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: -->

- [x] I have run golangci-lint on my change and received no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
