### PR TITLE
Allow ephemeral resource in plan during `-refresh-only`

### DIFF
--- a/internal/plans/changes.go
+++ b/internal/plans/changes.go
@@ -73,6 +73,23 @@ func (c *Changes) Empty() bool {
 	return true
 }
 
+// ActionableResources returns all the [Changes.Resources] that are changes that would actually
+// update the resources.
+// This method's main purpose is to exclude from [Changes.Resources] the changes that are
+// in the plan strictly for building the graph and are not going to change the resource state.
+// In case of [Open] actions, these are needed to build the required ephemeral nodes
+// in [DiffTransformer].
+func (c *Changes) ActionableResources() []*ResourceInstanceChangeSrc {
+	var ret []*ResourceInstanceChangeSrc
+	for _, r := range c.Resources {
+		if r.Action == Open {
+			continue
+		}
+		ret = append(ret, r)
+	}
+	return ret
+}
+
 // ResourceInstance returns the planned change for the current object of the
 // resource instance of the given address, if any. Returns nil if no change is
 // planned.

--- a/internal/tofu/context_plan.go
+++ b/internal/tofu/context_plan.go
@@ -386,10 +386,13 @@ func (c *Context) refreshOnlyPlan(ctx context.Context, config *configs.Config, p
 	// to refresh only, the set of resource changes should always be empty.
 	// We'll safety-check that here so we can return a clear message about it,
 	// rather than probably just generating confusing output at the UI layer.
-	if len(plan.Changes.Resources) != 0 {
+	// Because the ephemeral resources changes in the plan are meant to be used
+	// later to build the apply graph, those shouldn't be counted when we are
+	// doing this check.
+	if changes := plan.Changes.ActionableResources(); len(changes) != 0 {
 		// Some extra context in the logs in case the user reports this message
 		// as a bug, as a starting point for debugging.
-		for _, rc := range plan.Changes.Resources {
+		for _, rc := range changes {
 			if depKey := rc.DeposedKey; depKey == states.NotDeposed {
 				log.Printf("[DEBUG] Refresh-only plan includes %s change for %s", rc.Action, rc.Addr)
 			} else {

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -2751,6 +2751,14 @@ func TestContext2Plan_refreshOnlyMode_ephemeral(t *testing.T) {
 	if gotResAddr := plan.Changes.Resources[0].Addr; !gotResAddr.Equal(addr) {
 		t.Errorf("plan contains one resource and that's NOT an ephemeral as expected; instead, got %s", gotResAddr)
 	}
+	if got, want := len(plan.Changes.ActionableResources()), 0; got != want {
+		t.Errorf(
+			"changes.ActionableResources() returned more than %d resources, meaning that didn't exclude ephemeral resources. Instead returned %d\nChanges:\n%s",
+			want,
+			got,
+			spew.Sdump(plan.Changes.Resources),
+		)
+	}
 
 	if instState := plan.PlannedState.ResourceInstance(addr); instState == nil {
 		t.Errorf("%s has no planned state, but it should have since it's needed to build the apply graph correctly", addr)


### PR DESCRIPTION
Resolves #3774 

The "correct" fix would have been to [not return a change for ephemeral resources](https://github.com/opentofu/opentofu/blob/70c1ab9be6a2b06f7e6140ff5381d0ec4526d438/internal/tofu/node_resource_abstract_instance.go#L3389) during planning.

The problem with that approach is that it would break the way apply graph is built. That's because in [DiffTransformer](https://github.com/opentofu/opentofu/blob/70c1ab9be6a2b06f7e6140ff5381d0ec4526d438/internal/tofu/transform_diff.go#L170) we rely on the plan contained changes to build the necessary nodes for the ephemeral resources.
Not building those, would result in missing dependencies between the graph nodes which can lead to unexpected errors.

Therefore, counting only actionable changes from the plan, in this case it's the right way to fix this.

ℹ️ This needs to be backported to v1.11.
## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
