### PR TITLE
command: `go fix` on various files we've changed recently anyway

### DIFF
--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -340,7 +340,7 @@ func TestApply_parallelism(t *testing.T) {
 	// here. They will all have the same mock implementation function assigned
 	// but crucially they will each have their own mutex.
 	providerFactories := map[addrs.Provider]providers.Factory{}
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		name := fmt.Sprintf("test%d", i)
 		provider := &tofu.MockProvider{}
 		provider.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{

--- a/internal/command/cliconfig/cliconfig_test.go
+++ b/internal/command/cliconfig/cliconfig_test.go
@@ -33,7 +33,7 @@ func TestLoadConfig_ignore_providers_provisioners(t *testing.T) {
 	expected := &Config{
 		Hosts: map[string]*ConfigHost{
 			"example.com": {
-				Services: map[string]interface{}{
+				Services: map[string]any{
 					"modules.v1": "https://example.com/",
 				},
 			},
@@ -213,7 +213,7 @@ func TestLoadConfig_hosts(t *testing.T) {
 	want := &Config{
 		Hosts: map[string]*ConfigHost{
 			"example.com": {
-				Services: map[string]interface{}{
+				Services: map[string]any{
 					"modules.v1": "https://example.com/",
 				},
 			},
@@ -232,11 +232,11 @@ func TestLoadConfig_credentials(t *testing.T) {
 	}
 
 	want := &Config{
-		Credentials: map[string]map[string]interface{}{
-			"example.com": map[string]interface{}{
+		Credentials: map[string]map[string]any{
+			"example.com": map[string]any{
 				"token": "foo the bar baz",
 			},
-			"example.net": map[string]interface{}{
+			"example.net": map[string]any{
 				"username": "foo",
 				"password": "baz",
 			},
@@ -284,8 +284,8 @@ func TestConfigValidate(t *testing.T) {
 		},
 		"credentials good": {
 			&Config{
-				Credentials: map[string]map[string]interface{}{
-					"example.com": map[string]interface{}{
+				Credentials: map[string]map[string]any{
+					"example.com": map[string]any{
 						"token": "foo",
 					},
 				},
@@ -294,8 +294,8 @@ func TestConfigValidate(t *testing.T) {
 		},
 		"credentials with bad hostname": {
 			&Config{
-				Credentials: map[string]map[string]interface{}{
-					"example..com": map[string]interface{}{
+				Credentials: map[string]map[string]any{
+					"example..com": map[string]any{
 						"token": "foo",
 					},
 				},
@@ -367,12 +367,12 @@ func TestConfig_Merge(t *testing.T) {
 	c1 := &Config{
 		Hosts: map[string]*ConfigHost{
 			"example.com": {
-				Services: map[string]interface{}{
+				Services: map[string]any{
 					"modules.v1": "http://example.com/",
 				},
 			},
 		},
-		Credentials: map[string]map[string]interface{}{
+		Credentials: map[string]map[string]any{
 			"foo": {
 				"bar": "baz",
 			},
@@ -409,12 +409,12 @@ func TestConfig_Merge(t *testing.T) {
 	c2 := &Config{
 		Hosts: map[string]*ConfigHost{
 			"example.net": {
-				Services: map[string]interface{}{
+				Services: map[string]any{
 					"modules.v1": "https://example.net/",
 				},
 			},
 		},
-		Credentials: map[string]map[string]interface{}{
+		Credentials: map[string]map[string]any{
 			"fee": {
 				"bur": "bez",
 			},
@@ -446,17 +446,17 @@ func TestConfig_Merge(t *testing.T) {
 	expected := &Config{
 		Hosts: map[string]*ConfigHost{
 			"example.com": {
-				Services: map[string]interface{}{
+				Services: map[string]any{
 					"modules.v1": "http://example.com/",
 				},
 			},
 			"example.net": {
-				Services: map[string]interface{}{
+				Services: map[string]any{
 					"modules.v1": "https://example.net/",
 				},
 			},
 		},
-		Credentials: map[string]map[string]interface{}{
+		Credentials: map[string]map[string]any{
 			"foo": {
 				"bar": "baz",
 			},

--- a/internal/command/cliconfig/config_locations_unix_test.go
+++ b/internal/command/cliconfig/config_locations_unix_test.go
@@ -39,7 +39,7 @@ func TestConfigFileLocations(t *testing.T) {
 			},
 			expected: map[string]*ConfigHost{
 				"config0.example.com": {
-					Services: map[string]interface{}{
+					Services: map[string]any{
 						"modules.v0": "https://config0.example.com/",
 					},
 				},
@@ -52,7 +52,7 @@ func TestConfigFileLocations(t *testing.T) {
 			},
 			expected: map[string]*ConfigHost{
 				"config0.example.com": {
-					Services: map[string]interface{}{
+					Services: map[string]any{
 						"modules.v0": "https://config0.example.com/",
 					},
 				},
@@ -65,12 +65,12 @@ func TestConfigFileLocations(t *testing.T) {
 			},
 			expected: map[string]*ConfigHost{
 				"config1.example.com": {
-					Services: map[string]interface{}{
+					Services: map[string]any{
 						"modules.v1": "https://config1.example.com/",
 					},
 				},
 				"0and1.example.com": {
-					Services: map[string]interface{}{
+					Services: map[string]any{
 						"modules.v1": "https://0and1.example.com/",
 					},
 				},
@@ -85,17 +85,17 @@ func TestConfigFileLocations(t *testing.T) {
 			},
 			expected: map[string]*ConfigHost{
 				"config1.example.com": {
-					Services: map[string]interface{}{
+					Services: map[string]any{
 						"modules.v1": "https://config1.example.com/",
 					},
 				},
 				"0and1.example.com": {
-					Services: map[string]interface{}{
+					Services: map[string]any{
 						"modules.v1": "https://0and1.example.com/",
 					},
 				},
 				"1and2.example.com": {
-					Services: map[string]interface{}{
+					Services: map[string]any{
 						"modules.v1": "https://1and2.example.com/",
 					},
 				},
@@ -110,7 +110,7 @@ func TestConfigFileLocations(t *testing.T) {
 			},
 			expected: map[string]*ConfigHost{
 				"config0.example.com": {
-					Services: map[string]interface{}{
+					Services: map[string]any{
 						"modules.v0": "https://config0.example.com/",
 					},
 				},
@@ -124,17 +124,17 @@ func TestConfigFileLocations(t *testing.T) {
 			},
 			expected: map[string]*ConfigHost{
 				"config0.example.com": {
-					Services: map[string]interface{}{
+					Services: map[string]any{
 						"modules.v0": "https://config0.example.com/",
 					},
 				},
 				"0and1.example.com": {
-					Services: map[string]interface{}{
+					Services: map[string]any{
 						"modules.v0": "https://0and1.example.com/",
 					},
 				},
 				"0and2.example.com": {
-					Services: map[string]interface{}{
+					Services: map[string]any{
 						"modules.v0": "https://0and2.example.com/",
 					},
 				},

--- a/internal/command/cliconfig/oci_credentials_test.go
+++ b/internal/command/cliconfig/oci_credentials_test.go
@@ -392,31 +392,31 @@ func TestConfigOCICredentialsPolicy(t *testing.T) {
 					// If this fails trying to use a credhelper called "superseded-by-explicit-config"
 					// then we incorrectly preferred the ambient config's setting for this.
 					wantSpecificity: ociauthconfig.GlobalCredentialsSpecificity,
-					wantCredentials: ptrTo(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.org")),
+					wantCredentials: new(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.org")),
 				},
 				"example.com": {
 					// This domain has a conflicting entry in the ambient Docker-style config,
 					// but the explicit configuration should "win".
 					wantSpecificity: ociauthconfig.DomainCredentialsSpecificity,
-					wantCredentials: ptrTo(ociauthconfig.NewBasicAuthCredentials("example.com user", "example.com password")),
+					wantCredentials: new(ociauthconfig.NewBasicAuthCredentials("example.com user", "example.com password")),
 				},
 				"example.com/foo": {
 					wantSpecificity: ociauthconfig.RepositoryCredentialsSpecificity(1),
-					wantCredentials: ptrTo(ociauthconfig.NewBasicAuthCredentials("example.com/foo user", "example.com/foo password")),
+					wantCredentials: new(ociauthconfig.NewBasicAuthCredentials("example.com/foo user", "example.com/foo password")),
 				},
 				"example.com/bar": {
 					// These credentials come from the base64-encoded "auth" string in the
 					// ambient Docker-style config file.
 					wantSpecificity: ociauthconfig.RepositoryCredentialsSpecificity(1),
-					wantCredentials: ptrTo(ociauthconfig.NewBasicAuthCredentials("ambient-example.com-user", "ambient-password")),
+					wantCredentials: new(ociauthconfig.NewBasicAuthCredentials("ambient-example.com-user", "ambient-password")),
 				},
 				"example.com/not-foo": {
 					wantSpecificity: ociauthconfig.DomainCredentialsSpecificity,
-					wantCredentials: ptrTo(ociauthconfig.NewBasicAuthCredentials("example.com user", "example.com password")),
+					wantCredentials: new(ociauthconfig.NewBasicAuthCredentials("example.com user", "example.com password")),
 				},
 				"example.com/not-bar": {
 					wantSpecificity: ociauthconfig.DomainCredentialsSpecificity,
-					wantCredentials: ptrTo(ociauthconfig.NewBasicAuthCredentials("example.com user", "example.com password")),
+					wantCredentials: new(ociauthconfig.NewBasicAuthCredentials("example.com user", "example.com password")),
 				},
 			},
 		},
@@ -434,35 +434,35 @@ func TestConfigOCICredentialsPolicy(t *testing.T) {
 				},
 				"example.com": {
 					wantSpecificity: ociauthconfig.DomainCredentialsSpecificity,
-					wantCredentials: ptrTo(ociauthconfig.NewBasicAuthCredentials("example.com user", "example.com password")),
+					wantCredentials: new(ociauthconfig.NewBasicAuthCredentials("example.com user", "example.com password")),
 				},
 				"example.com/foo": {
 					wantSpecificity: ociauthconfig.RepositoryCredentialsSpecificity(1),
-					wantCredentials: ptrTo(ociauthconfig.NewBasicAuthCredentials("example.com/foo user", "example.com/foo password")),
+					wantCredentials: new(ociauthconfig.NewBasicAuthCredentials("example.com/foo user", "example.com/foo password")),
 				},
 				"example.com/foo/bar": {
 					wantSpecificity: ociauthconfig.RepositoryCredentialsSpecificity(2),
-					wantCredentials: ptrTo(ociauthconfig.NewBasicAuthCredentials("example.com/foo/bar user", "example.com/foo/bar password")),
+					wantCredentials: new(ociauthconfig.NewBasicAuthCredentials("example.com/foo/bar user", "example.com/foo/bar password")),
 				},
 				"example.com/foo/not-bar": {
 					wantSpecificity: ociauthconfig.RepositoryCredentialsSpecificity(1),
-					wantCredentials: ptrTo(ociauthconfig.NewBasicAuthCredentials("example.com/foo user", "example.com/foo password")),
+					wantCredentials: new(ociauthconfig.NewBasicAuthCredentials("example.com/foo user", "example.com/foo password")),
 				},
 				"example.com/not-foo/not-bar": {
 					wantSpecificity: ociauthconfig.DomainCredentialsSpecificity,
-					wantCredentials: ptrTo(ociauthconfig.NewBasicAuthCredentials("example.com user", "example.com password")),
+					wantCredentials: new(ociauthconfig.NewBasicAuthCredentials("example.com user", "example.com password")),
 				},
 				"example.net": {
 					wantSpecificity: ociauthconfig.DomainCredentialsSpecificity,
-					wantCredentials: ptrTo(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.net")),
+					wantCredentials: new(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.net")),
 				},
 				"example.net/foo": {
 					wantSpecificity: ociauthconfig.RepositoryCredentialsSpecificity(1),
-					wantCredentials: ptrTo(ociauthconfig.NewOAuthCredentials("example.net/foo access", "example.net/foo refresh")),
+					wantCredentials: new(ociauthconfig.NewOAuthCredentials("example.net/foo access", "example.net/foo refresh")),
 				},
 				"example.net/not-foo": {
 					wantSpecificity: ociauthconfig.DomainCredentialsSpecificity,
-					wantCredentials: ptrTo(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.net")),
+					wantCredentials: new(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.net")),
 				},
 			},
 		},
@@ -473,11 +473,11 @@ func TestConfigOCICredentialsPolicy(t *testing.T) {
 			subtests: map[string]Subtest{
 				"example.com/foo/bar": {
 					wantSpecificity: ociauthconfig.GlobalCredentialsSpecificity,
-					wantCredentials: ptrTo(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.com")),
+					wantCredentials: new(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.com")),
 				},
 				"example.net": {
 					wantSpecificity: ociauthconfig.GlobalCredentialsSpecificity,
-					wantCredentials: ptrTo(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.net")),
+					wantCredentials: new(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.net")),
 				},
 			},
 		},
@@ -501,11 +501,11 @@ func TestConfigOCICredentialsPolicy(t *testing.T) {
 			subtests: map[string]Subtest{
 				"example.com/foo/bar": {
 					wantSpecificity: ociauthconfig.GlobalCredentialsSpecificity,
-					wantCredentials: ptrTo(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.com")),
+					wantCredentials: new(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.com")),
 				},
 				"example.net": {
 					wantSpecificity: ociauthconfig.GlobalCredentialsSpecificity,
-					wantCredentials: ptrTo(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.net")),
+					wantCredentials: new(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.net")),
 				},
 			},
 		},
@@ -516,7 +516,7 @@ func TestConfigOCICredentialsPolicy(t *testing.T) {
 			subtests: map[string]Subtest{
 				"example.net": {
 					wantSpecificity: ociauthconfig.GlobalCredentialsSpecificity,
-					wantCredentials: ptrTo(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.net")),
+					wantCredentials: new(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.net")),
 				},
 			},
 		},
@@ -527,7 +527,7 @@ func TestConfigOCICredentialsPolicy(t *testing.T) {
 			subtests: map[string]Subtest{
 				"example.net": {
 					wantSpecificity: ociauthconfig.GlobalCredentialsSpecificity,
-					wantCredentials: ptrTo(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.net")),
+					wantCredentials: new(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.net")),
 				},
 			},
 		},
@@ -538,7 +538,7 @@ func TestConfigOCICredentialsPolicy(t *testing.T) {
 			subtests: map[string]Subtest{
 				"example.net": {
 					wantSpecificity: ociauthconfig.GlobalCredentialsSpecificity,
-					wantCredentials: ptrTo(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.net")),
+					wantCredentials: new(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.net")),
 				},
 			},
 		},
@@ -549,7 +549,7 @@ func TestConfigOCICredentialsPolicy(t *testing.T) {
 			subtests: map[string]Subtest{
 				"example.net": {
 					wantSpecificity: ociauthconfig.GlobalCredentialsSpecificity,
-					wantCredentials: ptrTo(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.net")),
+					wantCredentials: new(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.net")),
 				},
 			},
 		},
@@ -565,7 +565,7 @@ func TestConfigOCICredentialsPolicy(t *testing.T) {
 					// If this fails trying to use a different credentials helper
 					// then that suggests that we're not respecting file preference order.
 					wantSpecificity: ociauthconfig.GlobalCredentialsSpecificity,
-					wantCredentials: ptrTo(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.net")),
+					wantCredentials: new(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.net")),
 				},
 			},
 		},
@@ -585,7 +585,7 @@ func TestConfigOCICredentialsPolicy(t *testing.T) {
 					// If this fails trying to use a different credentials helper
 					// then that suggests that we're not respecting file preference order.
 					wantSpecificity: ociauthconfig.GlobalCredentialsSpecificity,
-					wantCredentials: ptrTo(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.net")),
+					wantCredentials: new(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.net")),
 				},
 			},
 		},
@@ -605,7 +605,7 @@ func TestConfigOCICredentialsPolicy(t *testing.T) {
 					// If this fails trying to use a different credentials helper
 					// then that suggests that we're not respecting file preference order.
 					wantSpecificity: ociauthconfig.GlobalCredentialsSpecificity,
-					wantCredentials: ptrTo(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.net")),
+					wantCredentials: new(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.net")),
 				},
 			},
 		},
@@ -625,7 +625,7 @@ func TestConfigOCICredentialsPolicy(t *testing.T) {
 					// If this fails trying to use a different credentials helper
 					// then that suggests that we're not respecting file preference order.
 					wantSpecificity: ociauthconfig.GlobalCredentialsSpecificity,
-					wantCredentials: ptrTo(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.net")),
+					wantCredentials: new(ociauthconfig.NewBasicAuthCredentials("from-cred-helper", "for https://example.net")),
 				},
 			},
 		},
@@ -791,13 +791,4 @@ func (f *fakeOCICredLookupEnvironment) QueryDockerCredentialHelper(ctx context.C
 		Username:  "from-cred-helper",
 		Secret:    "for " + serverURL,
 	}, nil
-}
-
-// ptrTo is a helper to compensate for the fact that Go doesn't allow
-// using the '&' operator unless the operand is directly addressable.
-//
-// Instead then, this function returns a pointer to a copy of the given
-// value.
-func ptrTo[T any](v T) *T {
-	return &v
 }

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -970,7 +970,7 @@ func testServices(t *testing.T) (services *disco.Disco, cleanup func()) {
 	server := httptest.NewServer(http.HandlerFunc(fakeRegistryHandler))
 
 	services = disco.New()
-	services.ForceHostServices(svchost.Hostname("registry.opentofu.org"), map[string]interface{}{
+	services.ForceHostServices(svchost.Hostname("registry.opentofu.org"), map[string]any{
 		"providers.v1": server.URL + "/providers/v1/",
 	})
 
@@ -1115,10 +1115,10 @@ func checkGoldenReference(t *testing.T, output *terminal.TestOutput, fixturePath
 	}
 
 	// Compare the rest of the lines against the golden reference
-	var gotLineMaps []map[string]interface{}
+	var gotLineMaps []map[string]any
 	for i, line := range gotLines[1:] {
 		index := i + 1
-		var gotMap map[string]interface{}
+		var gotMap map[string]any
 		if err := json.Unmarshal([]byte(line), &gotMap); err != nil {
 			t.Errorf("failed to unmarshal got line %d: %s\n%s", index, err, gotLines[index])
 		}
@@ -1130,10 +1130,10 @@ func checkGoldenReference(t *testing.T, output *terminal.TestOutput, fixturePath
 		gotLineMaps = append(gotLineMaps, gotMap)
 	}
 
-	var wantLineMaps []map[string]interface{}
+	var wantLineMaps []map[string]any
 	for i, line := range wantLines[1:] {
 		index := i + 1
-		var wantMap map[string]interface{}
+		var wantMap map[string]any
 		if err := json.Unmarshal([]byte(line), &wantMap); err != nil {
 			t.Errorf("failed to unmarshal want line %d: %s\n%s", index, err, gotLines[index])
 		}
@@ -1148,8 +1148,8 @@ func checkGoldenReference(t *testing.T, output *terminal.TestOutput, fixturePath
 	}
 }
 
-func deleteMapField(fieldMap map[string]interface{}, rootField, field string) map[string]interface{} {
-	rootMap, ok := fieldMap[rootField].(map[string]interface{})
+func deleteMapField(fieldMap map[string]any, rootField, field string) map[string]any {
+	rootMap, ok := fieldMap[rootField].(map[string]any)
 	if !ok {
 		return fieldMap
 	}

--- a/internal/command/e2etest/provider_plugin_test.go
+++ b/internal/command/e2etest/provider_plugin_test.go
@@ -126,16 +126,14 @@ func TestProviderGlobalCache(t *testing.T) {
 
 	var wg sync.WaitGroup
 
-	for i := 0; i < 16; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 16 {
+		wg.Go(func() {
 			tf := e2e.NewBinary(t, tofuBin, "testdata/provider-global-cache")
 			tf.AddEnv(fmt.Sprintf("TF_CLI_CONFIG_FILE=%s", rcLoc))
 
 			stdout, stderr, err := tf.Run("init")
 			tofuResult{t, stdout, stderr, err}.Success()
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/internal/command/flags/flag_kv.go
+++ b/internal/command/flags/flag_kv.go
@@ -21,8 +21,8 @@ func (v *FlagStringKV) String() string {
 }
 
 func (v *FlagStringKV) Set(raw string) error {
-	idx := strings.Index(raw, "=")
-	if idx == -1 {
+	before, after, ok := strings.Cut(raw, "=")
+	if !ok {
 		return fmt.Errorf("No '=' value in arg: %s", raw)
 	}
 
@@ -30,7 +30,7 @@ func (v *FlagStringKV) Set(raw string) error {
 		*v = make(map[string]string)
 	}
 
-	key, value := raw[0:idx], raw[idx+1:]
+	key, value := before, after
 	(*v)[key] = value
 	return nil
 }

--- a/internal/command/format/diagnostic.go
+++ b/internal/command/format/diagnostic.go
@@ -186,8 +186,8 @@ func DiagnosticPlainFromJSON(diag *jsonentities.Diagnostic, width int) string {
 
 	if diag.Detail != "" {
 		if width > 1 {
-			lines := strings.Split(diag.Detail, "\n")
-			for _, line := range lines {
+			lines := strings.SplitSeq(diag.Detail, "\n")
+			for line := range lines {
 				if !strings.HasPrefix(line, " ") {
 					line = wordwrap.WrapString(line, uint(width-1))
 				}
@@ -278,10 +278,7 @@ func appendSourceSnippets(buf *bytes.Buffer, diag *jsonentities.Diagnostic, colo
 		// Only buggy diagnostics can have an end range before the start, but
 		// we need to ensure we don't crash here if that happens.
 		if end < start {
-			end = start + 1
-			if end > len(code) {
-				end = len(code)
-			}
+			end = min(start+1, len(code))
 		}
 
 		// If either start or end is out of range for the code buffer then

--- a/internal/command/format/diagnostic_test.go
+++ b/internal/command/format/diagnostic_test.go
@@ -26,7 +26,7 @@ import (
 func TestDiagnostic(t *testing.T) {
 
 	tests := map[string]struct {
-		Diag interface{}
+		Diag any
 		Want string
 	}{
 		"sourceless error": {
@@ -486,7 +486,7 @@ func TestDiagnostic(t *testing.T) {
 func TestDiagnosticPlain(t *testing.T) {
 
 	tests := map[string]struct {
-		Diag interface{}
+		Diag any
 		Want string
 	}{
 		"sourceless error": {

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"log"
 	"reflect"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -956,9 +956,7 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 		if len(incompleteProviders) > 0 {
 			// We don't really care about the order here, we just want the
 			// output to be deterministic.
-			sort.Slice(incompleteProviders, func(i, j int) bool {
-				return incompleteProviders[i] < incompleteProviders[j]
-			})
+			slices.Sort(incompleteProviders)
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Warning,
 				incompleteLockFileInformationHeader,

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -741,7 +741,7 @@ func TestInit_backendConfigKVReInit(t *testing.T) {
 
 	// make sure the backend is configured how we expect
 	configState := testDataStateRead(t, filepath.Join(workdir.DefaultDataDir, arguments.DefaultStateFilename))
-	cfg := map[string]interface{}{}
+	cfg := map[string]any{}
 	if err := json.Unmarshal(configState.Backend.ConfigRaw, &cfg); err != nil {
 		t.Fatal(err)
 	}
@@ -757,7 +757,7 @@ func TestInit_backendConfigKVReInit(t *testing.T) {
 
 	// make sure the backend is configured how we expect
 	configState = testDataStateRead(t, filepath.Join(workdir.DefaultDataDir, arguments.DefaultStateFilename))
-	cfg = map[string]interface{}{}
+	cfg = map[string]any{}
 	if err := json.Unmarshal(configState.Backend.ConfigRaw, &cfg); err != nil {
 		t.Fatal(err)
 	}
@@ -808,7 +808,7 @@ func TestInit_backendConfigKVReInitWithConfigDiff(t *testing.T) {
 
 	// make sure the backend is configured how we expect
 	configState := testDataStateRead(t, filepath.Join(workdir.DefaultDataDir, arguments.DefaultStateFilename))
-	cfg := map[string]interface{}{}
+	cfg := map[string]any{}
 	if err := json.Unmarshal(configState.Backend.ConfigRaw, &cfg); err != nil {
 		t.Fatal(err)
 	}
@@ -1435,18 +1435,18 @@ func TestInit_getProvider(t *testing.T) {
 
 		// Construct a mock state file from the far future
 		type FutureState struct {
-			Version          uint                     `json:"version"`
-			Lineage          string                   `json:"lineage"`
-			TerraformVersion string                   `json:"terraform_version"`
-			Outputs          map[string]interface{}   `json:"outputs"`
-			Resources        []map[string]interface{} `json:"resources"`
+			Version          uint             `json:"version"`
+			Lineage          string           `json:"lineage"`
+			TerraformVersion string           `json:"terraform_version"`
+			Outputs          map[string]any   `json:"outputs"`
+			Resources        []map[string]any `json:"resources"`
 		}
 		fs := &FutureState{
 			Version:          999,
 			Lineage:          "123-456-789",
 			TerraformVersion: "999.0.0",
-			Outputs:          make(map[string]interface{}),
-			Resources:        make([]map[string]interface{}, 0),
+			Outputs:          make(map[string]any),
+			Resources:        make([]map[string]any, 0),
 		}
 		src, err := json.MarshalIndent(fs, "", "  ")
 		if err != nil {

--- a/internal/command/jsonformat/differ/differ_test.go
+++ b/internal/command/jsonformat/differ/differ_test.go
@@ -53,11 +53,11 @@ func TestValue_SimpleBlocks(t *testing.T) {
 	}{
 		"delete_with_null_sensitive_value": {
 			input: structured.Change{
-				Before: map[string]interface{}{
+				Before: map[string]any{
 					"normal_attribute": "some value",
 				},
 				After: nil,
-				BeforeSensitive: map[string]interface{}{
+				BeforeSensitive: map[string]any{
 					"sensitive_attribute": true,
 				},
 				AfterSensitive: false,
@@ -79,10 +79,10 @@ func TestValue_SimpleBlocks(t *testing.T) {
 		"create_with_null_sensitive_value": {
 			input: structured.Change{
 				Before: nil,
-				After: map[string]interface{}{
+				After: map[string]any{
 					"normal_attribute": "some value",
 				},
-				BeforeSensitive: map[string]interface{}{
+				BeforeSensitive: map[string]any{
 					"sensitive_attribute": true,
 				},
 				AfterSensitive: false,
@@ -236,7 +236,7 @@ func TestValue_SimpleBlocks(t *testing.T) {
 				},
 				BeforeSensitive: false,
 				AfterSensitive:  false,
-				ReplacePaths:    &attribute_path.PathMatcher{Paths: [][]interface{}{{"write_only_attribute"}}},
+				ReplacePaths:    &attribute_path.PathMatcher{Paths: [][]any{{"write_only_attribute"}}},
 			},
 			block: &jsonprovider.Block{
 				Attributes: map[string]*jsonprovider.Attribute{
@@ -290,7 +290,7 @@ func TestValue_ObjectAttributes(t *testing.T) {
 		"create": {
 			input: structured.Change{
 				Before: nil,
-				After: map[string]interface{}{
+				After: map[string]any{
 					"attribute_one": "new",
 				},
 			},
@@ -305,7 +305,7 @@ func TestValue_ObjectAttributes(t *testing.T) {
 		},
 		"delete": {
 			input: structured.Change{
-				Before: map[string]interface{}{
+				Before: map[string]any{
 					"attribute_one": "old",
 				},
 				After: nil,
@@ -322,7 +322,7 @@ func TestValue_ObjectAttributes(t *testing.T) {
 		"create_sensitive": {
 			input: structured.Change{
 				Before: nil,
-				After: map[string]interface{}{
+				After: map[string]any{
 					"attribute_one": "new",
 				},
 				AfterSensitive: true,
@@ -347,7 +347,7 @@ func TestValue_ObjectAttributes(t *testing.T) {
 		},
 		"delete_sensitive": {
 			input: structured.Change{
-				Before: map[string]interface{}{
+				Before: map[string]any{
 					"attribute_one": "old",
 				},
 				BeforeSensitive: true,
@@ -376,7 +376,7 @@ func TestValue_ObjectAttributes(t *testing.T) {
 		},
 		"update_unknown": {
 			input: structured.Change{
-				Before: map[string]interface{}{
+				Before: map[string]any{
 					"attribute_one": "old",
 				},
 				After:   nil,
@@ -406,8 +406,8 @@ func TestValue_ObjectAttributes(t *testing.T) {
 		},
 		"create_attribute": {
 			input: structured.Change{
-				Before: map[string]interface{}{},
-				After: map[string]interface{}{
+				Before: map[string]any{},
+				After: map[string]any{
 					"attribute_one": "new",
 				},
 			},
@@ -436,10 +436,10 @@ func TestValue_ObjectAttributes(t *testing.T) {
 		},
 		"create_attribute_from_explicit_null": {
 			input: structured.Change{
-				Before: map[string]interface{}{
+				Before: map[string]any{
 					"attribute_one": nil,
 				},
-				After: map[string]interface{}{
+				After: map[string]any{
 					"attribute_one": "new",
 				},
 			},
@@ -468,10 +468,10 @@ func TestValue_ObjectAttributes(t *testing.T) {
 		},
 		"delete_attribute": {
 			input: structured.Change{
-				Before: map[string]interface{}{
+				Before: map[string]any{
 					"attribute_one": "old",
 				},
-				After: map[string]interface{}{},
+				After: map[string]any{},
 			},
 			attributes: map[string]cty.Type{
 				"attribute_one": cty.String,
@@ -498,10 +498,10 @@ func TestValue_ObjectAttributes(t *testing.T) {
 		},
 		"delete_attribute_to_explicit_null": {
 			input: structured.Change{
-				Before: map[string]interface{}{
+				Before: map[string]any{
 					"attribute_one": "old",
 				},
-				After: map[string]interface{}{
+				After: map[string]any{
 					"attribute_one": nil,
 				},
 			},
@@ -530,10 +530,10 @@ func TestValue_ObjectAttributes(t *testing.T) {
 		},
 		"update_attribute": {
 			input: structured.Change{
-				Before: map[string]interface{}{
+				Before: map[string]any{
 					"attribute_one": "old",
 				},
-				After: map[string]interface{}{
+				After: map[string]any{
 					"attribute_one": "new",
 				},
 			},
@@ -564,11 +564,11 @@ func TestValue_ObjectAttributes(t *testing.T) {
 		},
 		"create_sensitive_attribute": {
 			input: structured.Change{
-				Before: map[string]interface{}{},
-				After: map[string]interface{}{
+				Before: map[string]any{},
+				After: map[string]any{
 					"attribute_one": "new",
 				},
-				AfterSensitive: map[string]interface{}{
+				AfterSensitive: map[string]any{
 					"attribute_one": true,
 				},
 			},
@@ -597,13 +597,13 @@ func TestValue_ObjectAttributes(t *testing.T) {
 		},
 		"delete_sensitive_attribute": {
 			input: structured.Change{
-				Before: map[string]interface{}{
+				Before: map[string]any{
 					"attribute_one": "old",
 				},
-				BeforeSensitive: map[string]interface{}{
+				BeforeSensitive: map[string]any{
 					"attribute_one": true,
 				},
-				After: map[string]interface{}{},
+				After: map[string]any{},
 			},
 			attributes: map[string]cty.Type{
 				"attribute_one": cty.String,
@@ -630,16 +630,16 @@ func TestValue_ObjectAttributes(t *testing.T) {
 		},
 		"update_sensitive_attribute": {
 			input: structured.Change{
-				Before: map[string]interface{}{
+				Before: map[string]any{
 					"attribute_one": "old",
 				},
-				BeforeSensitive: map[string]interface{}{
+				BeforeSensitive: map[string]any{
 					"attribute_one": true,
 				},
-				After: map[string]interface{}{
+				After: map[string]any{
 					"attribute_one": "new",
 				},
-				AfterSensitive: map[string]interface{}{
+				AfterSensitive: map[string]any{
 					"attribute_one": true,
 				},
 			},
@@ -670,9 +670,9 @@ func TestValue_ObjectAttributes(t *testing.T) {
 		},
 		"create_computed_attribute": {
 			input: structured.Change{
-				Before: map[string]interface{}{},
-				After:  map[string]interface{}{},
-				Unknown: map[string]interface{}{
+				Before: map[string]any{},
+				After:  map[string]any{},
+				Unknown: map[string]any{
 					"attribute_one": true,
 				},
 			},
@@ -687,11 +687,11 @@ func TestValue_ObjectAttributes(t *testing.T) {
 		},
 		"update_computed_attribute": {
 			input: structured.Change{
-				Before: map[string]interface{}{
+				Before: map[string]any{
 					"attribute_one": "old",
 				},
-				After: map[string]interface{}{},
-				Unknown: map[string]interface{}{
+				After: map[string]any{},
+				Unknown: map[string]any{
 					"attribute_one": true,
 				},
 			},
@@ -725,8 +725,8 @@ func TestValue_ObjectAttributes(t *testing.T) {
 		},
 		"ignores_unset_fields": {
 			input: structured.Change{
-				Before: map[string]interface{}{},
-				After:  map[string]interface{}{},
+				Before: map[string]any{},
+				After:  map[string]any{},
 			},
 			attributes: map[string]cty.Type{
 				"attribute_one": cty.String,
@@ -737,14 +737,14 @@ func TestValue_ObjectAttributes(t *testing.T) {
 		},
 		"update_replace_self": {
 			input: structured.Change{
-				Before: map[string]interface{}{
+				Before: map[string]any{
 					"attribute_one": "old",
 				},
-				After: map[string]interface{}{
+				After: map[string]any{
 					"attribute_one": "new",
 				},
 				ReplacePaths: &attribute_path.PathMatcher{
-					Paths: [][]interface{}{
+					Paths: [][]any{
 						{},
 					},
 				},
@@ -776,14 +776,14 @@ func TestValue_ObjectAttributes(t *testing.T) {
 		},
 		"update_replace_attribute": {
 			input: structured.Change{
-				Before: map[string]interface{}{
+				Before: map[string]any{
 					"attribute_one": "old",
 				},
-				After: map[string]interface{}{
+				After: map[string]any{
 					"attribute_one": "new",
 				},
 				ReplacePaths: &attribute_path.PathMatcher{
-					Paths: [][]interface{}{
+					Paths: [][]any{
 						{"attribute_one"},
 					},
 				},
@@ -815,16 +815,16 @@ func TestValue_ObjectAttributes(t *testing.T) {
 		},
 		"update_includes_relevant_attributes": {
 			input: structured.Change{
-				Before: map[string]interface{}{
+				Before: map[string]any{
 					"attribute_one": "old_one",
 					"attribute_two": "old_two",
 				},
-				After: map[string]interface{}{
+				After: map[string]any{
 					"attribute_one": "new_one",
 					"attribute_two": "new_two",
 				},
 				RelevantAttributes: &attribute_path.PathMatcher{
-					Paths: [][]interface{}{
+					Paths: [][]any{
 						{"attribute_one"},
 					},
 				},
@@ -1183,15 +1183,15 @@ func TestValue_BlockAttributesAndNestedBlocks(t *testing.T) {
 	// different block types.
 
 	tcs := map[string]struct {
-		before      interface{}
-		after       interface{}
+		before      any
+		after       any
 		block       *jsonprovider.Block
 		validate    renderers.ValidateDiffFunction
 		validateSet []renderers.ValidateDiffFunction
 	}{
 		"create_attribute": {
-			before: map[string]interface{}{},
-			after: map[string]interface{}{
+			before: map[string]any{},
+			after: map[string]any{
 				"attribute_one": "new",
 			},
 			block: &jsonprovider.Block{
@@ -1212,10 +1212,10 @@ func TestValue_BlockAttributesAndNestedBlocks(t *testing.T) {
 			},
 		},
 		"update_attribute": {
-			before: map[string]interface{}{
+			before: map[string]any{
 				"attribute_one": "old",
 			},
-			after: map[string]interface{}{
+			after: map[string]any{
 				"attribute_one": "new",
 			},
 			block: &jsonprovider.Block{
@@ -1238,10 +1238,10 @@ func TestValue_BlockAttributesAndNestedBlocks(t *testing.T) {
 			},
 		},
 		"delete_attribute": {
-			before: map[string]interface{}{
+			before: map[string]any{
 				"attribute_one": "old",
 			},
-			after: map[string]interface{}{},
+			after: map[string]any{},
 			block: &jsonprovider.Block{
 				Attributes: map[string]*jsonprovider.Attribute{
 					"attribute_one": {
@@ -1260,9 +1260,9 @@ func TestValue_BlockAttributesAndNestedBlocks(t *testing.T) {
 			},
 		},
 		"create_block": {
-			before: map[string]interface{}{},
-			after: map[string]interface{}{
-				"block_one": map[string]interface{}{
+			before: map[string]any{},
+			after: map[string]any{
+				"block_one": map[string]any{
 					"attribute_one": "new",
 				},
 			},
@@ -1295,13 +1295,13 @@ func TestValue_BlockAttributesAndNestedBlocks(t *testing.T) {
 			},
 		},
 		"update_block": {
-			before: map[string]interface{}{
-				"block_one": map[string]interface{}{
+			before: map[string]any{
+				"block_one": map[string]any{
 					"attribute_one": "old",
 				},
 			},
-			after: map[string]interface{}{
-				"block_one": map[string]interface{}{
+			after: map[string]any{
+				"block_one": map[string]any{
 					"attribute_one": "new",
 				},
 			},
@@ -1338,12 +1338,12 @@ func TestValue_BlockAttributesAndNestedBlocks(t *testing.T) {
 			},
 		},
 		"delete_block": {
-			before: map[string]interface{}{
-				"block_one": map[string]interface{}{
+			before: map[string]any{
+				"block_one": map[string]any{
 					"attribute_one": "old",
 				},
 			},
-			after: map[string]interface{}{},
+			after: map[string]any{},
 			block: &jsonprovider.Block{
 				BlockTypes: map[string]*jsonprovider.BlockType{
 					"block_one": {
@@ -1379,10 +1379,10 @@ func TestValue_BlockAttributesAndNestedBlocks(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Run("single", func(t *testing.T) {
 				input := structured.Change{
-					Before: map[string]interface{}{
+					Before: map[string]any{
 						"block_type": tc.before,
 					},
-					After: map[string]interface{}{
+					After: map[string]any{
 						"block_type": tc.after,
 					},
 					ReplacePaths:       &attribute_path.PathMatcher{},
@@ -1405,13 +1405,13 @@ func TestValue_BlockAttributesAndNestedBlocks(t *testing.T) {
 			})
 			t.Run("map", func(t *testing.T) {
 				input := structured.Change{
-					Before: map[string]interface{}{
-						"block_type": map[string]interface{}{
+					Before: map[string]any{
+						"block_type": map[string]any{
 							"one": tc.before,
 						},
 					},
-					After: map[string]interface{}{
-						"block_type": map[string]interface{}{
+					After: map[string]any{
+						"block_type": map[string]any{
 							"one": tc.after,
 						},
 					},
@@ -1437,13 +1437,13 @@ func TestValue_BlockAttributesAndNestedBlocks(t *testing.T) {
 			})
 			t.Run("list", func(t *testing.T) {
 				input := structured.Change{
-					Before: map[string]interface{}{
-						"block_type": []interface{}{
+					Before: map[string]any{
+						"block_type": []any{
 							tc.before,
 						},
 					},
-					After: map[string]interface{}{
-						"block_type": []interface{}{
+					After: map[string]any{
+						"block_type": []any{
 							tc.after,
 						},
 					},
@@ -1469,13 +1469,13 @@ func TestValue_BlockAttributesAndNestedBlocks(t *testing.T) {
 			})
 			t.Run("set", func(t *testing.T) {
 				input := structured.Change{
-					Before: map[string]interface{}{
-						"block_type": []interface{}{
+					Before: map[string]any{
+						"block_type": []any{
 							tc.before,
 						},
 					},
-					After: map[string]interface{}{
-						"block_type": []interface{}{
+					After: map[string]any{
+						"block_type": []any{
 							tc.after,
 						},
 					},
@@ -1521,7 +1521,7 @@ func TestValue_Outputs(t *testing.T) {
 		"object_create": {
 			input: structured.Change{
 				Before: nil,
-				After: map[string]interface{}{
+				After: map[string]any{
 					"element_one": "new_one",
 					"element_two": "new_two",
 				},
@@ -1534,7 +1534,7 @@ func TestValue_Outputs(t *testing.T) {
 		"list_create": {
 			input: structured.Change{
 				Before: nil,
-				After: []interface{}{
+				After: []any{
 					"new_one",
 					"new_two",
 				},
@@ -1553,11 +1553,11 @@ func TestValue_Outputs(t *testing.T) {
 		},
 		"object_update": {
 			input: structured.Change{
-				Before: map[string]interface{}{
+				Before: map[string]any{
 					"element_one": "old_one",
 					"element_two": "old_two",
 				},
-				After: map[string]interface{}{
+				After: map[string]any{
 					"element_one": "new_one",
 					"element_two": "new_two",
 				},
@@ -1569,11 +1569,11 @@ func TestValue_Outputs(t *testing.T) {
 		},
 		"list_update": {
 			input: structured.Change{
-				Before: []interface{}{
+				Before: []any{
 					"old_one",
 					"old_two",
 				},
-				After: []interface{}{
+				After: []any{
 					"new_one",
 					"new_two",
 				},
@@ -1594,7 +1594,7 @@ func TestValue_Outputs(t *testing.T) {
 		},
 		"object_delete": {
 			input: structured.Change{
-				Before: map[string]interface{}{
+				Before: map[string]any{
 					"element_one": "old_one",
 					"element_two": "old_two",
 				},
@@ -1607,7 +1607,7 @@ func TestValue_Outputs(t *testing.T) {
 		},
 		"list_delete": {
 			input: structured.Change{
-				Before: []interface{}{
+				Before: []any{
 					"old_one",
 					"old_two",
 				},
@@ -1621,7 +1621,7 @@ func TestValue_Outputs(t *testing.T) {
 		"primitive_to_list": {
 			input: structured.Change{
 				Before: "old",
-				After: []interface{}{
+				After: []any{
 					"new_one",
 					"new_two",
 				},
@@ -1636,7 +1636,7 @@ func TestValue_Outputs(t *testing.T) {
 		"primitive_to_object": {
 			input: structured.Change{
 				Before: "old",
-				After: map[string]interface{}{
+				After: map[string]any{
 					"element_one": "new_one",
 					"element_two": "new_two",
 				},
@@ -1650,7 +1650,7 @@ func TestValue_Outputs(t *testing.T) {
 		},
 		"list_to_primitive": {
 			input: structured.Change{
-				Before: []interface{}{
+				Before: []any{
 					"old_one",
 					"old_two",
 				},
@@ -1666,11 +1666,11 @@ func TestValue_Outputs(t *testing.T) {
 		},
 		"list_to_object": {
 			input: structured.Change{
-				Before: []interface{}{
+				Before: []any{
 					"old_one",
 					"old_two",
 				},
-				After: map[string]interface{}{
+				After: map[string]any{
 					"element_one": "new_one",
 					"element_two": "new_two",
 				},
@@ -1687,7 +1687,7 @@ func TestValue_Outputs(t *testing.T) {
 		},
 		"object_to_primitive": {
 			input: structured.Change{
-				Before: map[string]interface{}{
+				Before: map[string]any{
 					"element_one": "old_one",
 					"element_two": "old_two",
 				},
@@ -1703,11 +1703,11 @@ func TestValue_Outputs(t *testing.T) {
 		},
 		"object_to_list": {
 			input: structured.Change{
-				Before: map[string]interface{}{
+				Before: map[string]any{
 					"element_one": "old_one",
 					"element_two": "old_two",
 				},
-				After: []interface{}{
+				After: []any{
 					"new_one",
 					"new_two",
 				},
@@ -1749,11 +1749,11 @@ func TestValue_MultilineStringsInList(t *testing.T) {
 	}{
 		"multiline_string_list_update": {
 			input: structured.Change{
-				Before: []interface{}{
+				Before: []any{
 					"line1\nline2",
 					"line1",
 				},
-				After: []interface{}{
+				After: []any{
 					"line1\nline2+",
 					"line1\nline2",
 				},
@@ -1765,13 +1765,13 @@ func TestValue_MultilineStringsInList(t *testing.T) {
 		},
 		"multiline_string_list_update_2": {
 			input: structured.Change{
-				Before: []interface{}{
+				Before: []any{
 					"unchanged line",
 					"deleted line",
 					"line1\nline2",
 					"line1",
 				},
-				After: []interface{}{
+				After: []any{
 					"unchanged line",
 					"line1\nline2+",
 					"line1\nline2",
@@ -1923,7 +1923,7 @@ func TestValue_PrimitiveAttributes(t *testing.T) {
 				Before: "old",
 				After:  "new",
 				ReplacePaths: &attribute_path.PathMatcher{
-					Paths: [][]interface{}{
+					Paths: [][]any{
 						{}, // An empty path suggests replace should be true.
 					},
 				},
@@ -2057,7 +2057,7 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		"map_create_empty": {
 			input: structured.Change{
 				Before: nil,
-				After:  map[string]interface{}{},
+				After:  map[string]any{},
 			},
 			attribute: &jsonprovider.Attribute{
 				AttributeType: unmarshalType(t, cty.Map(cty.String)),
@@ -2067,7 +2067,7 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		"map_create_populated": {
 			input: structured.Change{
 				Before: nil,
-				After: map[string]interface{}{
+				After: map[string]any{
 					"element_one": "one",
 					"element_two": "two",
 				},
@@ -2082,7 +2082,7 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		},
 		"map_delete_empty": {
 			input: structured.Change{
-				Before: map[string]interface{}{},
+				Before: map[string]any{},
 				After:  nil,
 			},
 			attribute: &jsonprovider.Attribute{
@@ -2092,7 +2092,7 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		},
 		"map_delete_populated": {
 			input: structured.Change{
-				Before: map[string]interface{}{
+				Before: map[string]any{
 					"element_one": "one",
 					"element_two": "two",
 				},
@@ -2109,7 +2109,7 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		"map_create_sensitive": {
 			input: structured.Change{
 				Before:         nil,
-				After:          map[string]interface{}{},
+				After:          map[string]any{},
 				AfterSensitive: true,
 			},
 			attribute: &jsonprovider.Attribute{
@@ -2119,11 +2119,11 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		},
 		"map_update_sensitive": {
 			input: structured.Change{
-				Before: map[string]interface{}{
+				Before: map[string]any{
 					"element": "one",
 				},
 				BeforeSensitive: true,
-				After:           map[string]interface{}{},
+				After:           map[string]any{},
 				AfterSensitive:  true,
 			},
 			attribute: &jsonprovider.Attribute{
@@ -2135,7 +2135,7 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		},
 		"map_delete_sensitive": {
 			input: structured.Change{
-				Before:          map[string]interface{}{},
+				Before:          map[string]any{},
 				BeforeSensitive: true,
 				After:           nil,
 			},
@@ -2147,7 +2147,7 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		"map_create_unknown": {
 			input: structured.Change{
 				Before:  nil,
-				After:   map[string]interface{}{},
+				After:   map[string]any{},
 				Unknown: true,
 			},
 			attribute: &jsonprovider.Attribute{
@@ -2157,8 +2157,8 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		},
 		"map_update_unknown": {
 			input: structured.Change{
-				Before: map[string]interface{}{},
-				After: map[string]interface{}{
+				Before: map[string]any{},
+				After: map[string]any{
 					"element": "one",
 				},
 				Unknown: true,
@@ -2171,7 +2171,7 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		"list_create_empty": {
 			input: structured.Change{
 				Before: nil,
-				After:  []interface{}{},
+				After:  []any{},
 			},
 			attribute: &jsonprovider.Attribute{
 				AttributeType: unmarshalType(t, cty.List(cty.String)),
@@ -2181,7 +2181,7 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		"list_create_populated": {
 			input: structured.Change{
 				Before: nil,
-				After:  []interface{}{"one", "two"},
+				After:  []any{"one", "two"},
 			},
 			attribute: &jsonprovider.Attribute{
 				AttributeType: unmarshalType(t, cty.List(cty.String)),
@@ -2193,7 +2193,7 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		},
 		"list_delete_empty": {
 			input: structured.Change{
-				Before: []interface{}{},
+				Before: []any{},
 				After:  nil,
 			},
 			attribute: &jsonprovider.Attribute{
@@ -2203,7 +2203,7 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		},
 		"list_delete_populated": {
 			input: structured.Change{
-				Before: []interface{}{"one", "two"},
+				Before: []any{"one", "two"},
 				After:  nil,
 			},
 			attribute: &jsonprovider.Attribute{
@@ -2217,7 +2217,7 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		"list_create_sensitive": {
 			input: structured.Change{
 				Before:         nil,
-				After:          []interface{}{},
+				After:          []any{},
 				AfterSensitive: true,
 			},
 			attribute: &jsonprovider.Attribute{
@@ -2227,9 +2227,9 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		},
 		"list_update_sensitive": {
 			input: structured.Change{
-				Before:          []interface{}{"one"},
+				Before:          []any{"one"},
 				BeforeSensitive: true,
-				After:           []interface{}{},
+				After:           []any{},
 				AfterSensitive:  true,
 			},
 			attribute: &jsonprovider.Attribute{
@@ -2241,7 +2241,7 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		},
 		"list_delete_sensitive": {
 			input: structured.Change{
-				Before:          []interface{}{},
+				Before:          []any{},
 				BeforeSensitive: true,
 				After:           nil,
 			},
@@ -2253,7 +2253,7 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		"list_create_unknown": {
 			input: structured.Change{
 				Before:  nil,
-				After:   []interface{}{},
+				After:   []any{},
 				Unknown: true,
 			},
 			attribute: &jsonprovider.Attribute{
@@ -2263,8 +2263,8 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		},
 		"list_update_unknown": {
 			input: structured.Change{
-				Before:  []interface{}{},
-				After:   []interface{}{"one"},
+				Before:  []any{},
+				After:   []any{"one"},
 				Unknown: true,
 			},
 			attribute: &jsonprovider.Attribute{
@@ -2275,7 +2275,7 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		"set_create_empty": {
 			input: structured.Change{
 				Before: nil,
-				After:  []interface{}{},
+				After:  []any{},
 			},
 			attribute: &jsonprovider.Attribute{
 				AttributeType: unmarshalType(t, cty.Set(cty.String)),
@@ -2285,7 +2285,7 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		"set_create_populated": {
 			input: structured.Change{
 				Before: nil,
-				After:  []interface{}{"one", "two"},
+				After:  []any{"one", "two"},
 			},
 			attribute: &jsonprovider.Attribute{
 				AttributeType: unmarshalType(t, cty.Set(cty.String)),
@@ -2297,7 +2297,7 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		},
 		"set_delete_empty": {
 			input: structured.Change{
-				Before: []interface{}{},
+				Before: []any{},
 				After:  nil,
 			},
 			attribute: &jsonprovider.Attribute{
@@ -2307,7 +2307,7 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		},
 		"set_delete_populated": {
 			input: structured.Change{
-				Before: []interface{}{"one", "two"},
+				Before: []any{"one", "two"},
 				After:  nil,
 			},
 			attribute: &jsonprovider.Attribute{
@@ -2321,7 +2321,7 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		"set_create_sensitive": {
 			input: structured.Change{
 				Before:         nil,
-				After:          []interface{}{},
+				After:          []any{},
 				AfterSensitive: true,
 			},
 			attribute: &jsonprovider.Attribute{
@@ -2331,9 +2331,9 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		},
 		"set_update_sensitive": {
 			input: structured.Change{
-				Before:          []interface{}{"one"},
+				Before:          []any{"one"},
 				BeforeSensitive: true,
-				After:           []interface{}{},
+				After:           []any{},
 				AfterSensitive:  true,
 			},
 			attribute: &jsonprovider.Attribute{
@@ -2345,7 +2345,7 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		},
 		"set_delete_sensitive": {
 			input: structured.Change{
-				Before:          []interface{}{},
+				Before:          []any{},
 				BeforeSensitive: true,
 				After:           nil,
 			},
@@ -2357,7 +2357,7 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		"set_create_unknown": {
 			input: structured.Change{
 				Before:  nil,
-				After:   []interface{}{},
+				After:   []any{},
 				Unknown: true,
 			},
 			attribute: &jsonprovider.Attribute{
@@ -2367,8 +2367,8 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		},
 		"set_update_unknown": {
 			input: structured.Change{
-				Before:  []interface{}{},
-				After:   []interface{}{"one"},
+				Before:  []any{},
+				After:   []any{"one"},
 				Unknown: true,
 			},
 			attribute: &jsonprovider.Attribute{
@@ -2378,12 +2378,12 @@ func TestValue_CollectionAttributes(t *testing.T) {
 		},
 		"tuple_primitive": {
 			input: structured.Change{
-				Before: []interface{}{
+				Before: []any{
 					"one",
 					json.Number("2"),
 					"three",
 				},
-				After: []interface{}{
+				After: []any{
 					"one",
 					json.Number("4"),
 					"three",
@@ -2423,16 +2423,16 @@ func TestRelevantAttributes(t *testing.T) {
 	}{
 		"simple_attributes": {
 			input: structured.Change{
-				Before: map[string]interface{}{
+				Before: map[string]any{
 					"id":     "old_id",
 					"ignore": "doesn't matter",
 				},
-				After: map[string]interface{}{
+				After: map[string]any{
 					"id":     "new_id",
 					"ignore": "doesn't matter but modified",
 				},
 				RelevantAttributes: &attribute_path.PathMatcher{
-					Paths: [][]interface{}{
+					Paths: [][]any{
 						{
 							"id",
 						},
@@ -2456,28 +2456,28 @@ func TestRelevantAttributes(t *testing.T) {
 		},
 		"nested_attributes": {
 			input: structured.Change{
-				Before: map[string]interface{}{
-					"list_block": []interface{}{
-						map[string]interface{}{
+				Before: map[string]any{
+					"list_block": []any{
+						map[string]any{
 							"id": "old_one",
 						},
-						map[string]interface{}{
+						map[string]any{
 							"id": "ignored",
 						},
 					},
 				},
-				After: map[string]interface{}{
-					"list_block": []interface{}{
-						map[string]interface{}{
+				After: map[string]any{
+					"list_block": []any{
+						map[string]any{
 							"id": "new_one",
 						},
-						map[string]interface{}{
+						map[string]any{
 							"id": "ignored_but_changed",
 						},
 					},
 				},
 				RelevantAttributes: &attribute_path.PathMatcher{
-					Paths: [][]interface{}{
+					Paths: [][]any{
 						{
 							"list_block",
 							float64(0),
@@ -2513,19 +2513,19 @@ func TestRelevantAttributes(t *testing.T) {
 		},
 		"nested_attributes_in_object": {
 			input: structured.Change{
-				Before: map[string]interface{}{
-					"object": map[string]interface{}{
+				Before: map[string]any{
+					"object": map[string]any{
 						"id": "old_id",
 					},
 				},
-				After: map[string]interface{}{
-					"object": map[string]interface{}{
+				After: map[string]any{
+					"object": map[string]any{
 						"id": "new_id",
 					},
 				},
 				RelevantAttributes: &attribute_path.PathMatcher{
 					Propagate: true,
-					Paths: [][]interface{}{
+					Paths: [][]any{
 						{
 							"object", // Even though we just specify object, it should now include every below object as well.
 						},
@@ -2549,18 +2549,18 @@ func TestRelevantAttributes(t *testing.T) {
 		},
 		"elements_in_list": {
 			input: structured.Change{
-				Before: map[string]interface{}{
-					"list": []interface{}{
+				Before: map[string]any{
+					"list": []any{
 						json.Number("0"), json.Number("1"), json.Number("2"), json.Number("3"), json.Number("4"),
 					},
 				},
-				After: map[string]interface{}{
-					"list": []interface{}{
+				After: map[string]any{
+					"list": []any{
 						json.Number("0"), json.Number("5"), json.Number("6"), json.Number("7"), json.Number("4"),
 					},
 				},
 				RelevantAttributes: &attribute_path.PathMatcher{
-					Paths: [][]interface{}{ // The list is actually just going to ignore this.
+					Paths: [][]any{ // The list is actually just going to ignore this.
 						{
 							"list",
 							0.0,
@@ -2600,22 +2600,22 @@ func TestRelevantAttributes(t *testing.T) {
 		},
 		"elements_in_map": {
 			input: structured.Change{
-				Before: map[string]interface{}{
-					"map": map[string]interface{}{
+				Before: map[string]any{
+					"map": map[string]any{
 						"key_one":   "value_one",
 						"key_two":   "value_two",
 						"key_three": "value_three",
 					},
 				},
-				After: map[string]interface{}{
-					"map": map[string]interface{}{
+				After: map[string]any{
+					"map": map[string]any{
 						"key_one":  "value_three",
 						"key_two":  "value_seven",
 						"key_four": "value_four",
 					},
 				},
 				RelevantAttributes: &attribute_path.PathMatcher{
-					Paths: [][]interface{}{
+					Paths: [][]any{
 						{
 							"map",
 							"key_one",
@@ -2649,19 +2649,19 @@ func TestRelevantAttributes(t *testing.T) {
 		},
 		"elements_in_set": {
 			input: structured.Change{
-				Before: map[string]interface{}{
-					"set": []interface{}{
+				Before: map[string]any{
+					"set": []any{
 						json.Number("0"), json.Number("1"), json.Number("2"), json.Number("3"), json.Number("4"),
 					},
 				},
-				After: map[string]interface{}{
-					"set": []interface{}{
+				After: map[string]any{
+					"set": []any{
 						json.Number("0"), json.Number("2"), json.Number("4"), json.Number("5"), json.Number("6"),
 					},
 				},
 				RelevantAttributes: &attribute_path.PathMatcher{
 					Propagate: true,
-					Paths: [][]interface{}{
+					Paths: [][]any{
 						{
 							"set",
 						},
@@ -2689,37 +2689,37 @@ func TestRelevantAttributes(t *testing.T) {
 		},
 		"dynamic_types": {
 			input: structured.Change{
-				Before: map[string]interface{}{
-					"dynamic_nested_type": map[string]interface{}{
+				Before: map[string]any{
+					"dynamic_nested_type": map[string]any{
 						"nested_id": "nomatch",
-						"nested_object": map[string]interface{}{
+						"nested_object": map[string]any{
 							"nested_nested_id": "matched",
 						},
 					},
-					"dynamic_nested_type_match": map[string]interface{}{
+					"dynamic_nested_type_match": map[string]any{
 						"nested_id": "allmatch",
-						"nested_object": map[string]interface{}{
+						"nested_object": map[string]any{
 							"nested_nested_id": "allmatch",
 						},
 					},
 				},
-				After: map[string]interface{}{
-					"dynamic_nested_type": map[string]interface{}{
+				After: map[string]any{
+					"dynamic_nested_type": map[string]any{
 						"nested_id": "nomatch_changed",
-						"nested_object": map[string]interface{}{
+						"nested_object": map[string]any{
 							"nested_nested_id": "matched",
 						},
 					},
-					"dynamic_nested_type_match": map[string]interface{}{
+					"dynamic_nested_type_match": map[string]any{
 						"nested_id": "allmatch",
-						"nested_object": map[string]interface{}{
+						"nested_object": map[string]any{
 							"nested_nested_id": "allmatch",
 						},
 					},
 				},
 				RelevantAttributes: &attribute_path.PathMatcher{
 					Propagate: true,
-					Paths: [][]interface{}{
+					Paths: [][]any{
 						{
 							"dynamic_nested_type",
 							"nested_object",
@@ -2775,12 +2775,12 @@ func TestDynamicPseudoType(t *testing.T) {
 		"after_sensitive_in_dynamic_type": {
 			input: structured.Change{
 				Before: nil,
-				After: map[string]interface{}{
+				After: map[string]any{
 					"key": "value",
 				},
 				Unknown:         false,
 				BeforeSensitive: false,
-				AfterSensitive: map[string]interface{}{
+				AfterSensitive: map[string]any{
 					"key": true,
 				},
 				ReplacePaths:       attribute_path.Empty(false),
@@ -2792,12 +2792,12 @@ func TestDynamicPseudoType(t *testing.T) {
 		},
 		"before_sensitive_in_dynamic_type": {
 			input: structured.Change{
-				Before: map[string]interface{}{
+				Before: map[string]any{
 					"key": "value",
 				},
 				After:   nil,
 				Unknown: false,
-				BeforeSensitive: map[string]interface{}{
+				BeforeSensitive: map[string]any{
 					"key": true,
 				},
 				AfterSensitive:     false,
@@ -2810,17 +2810,17 @@ func TestDynamicPseudoType(t *testing.T) {
 		},
 		"sensitive_in_dynamic_type": {
 			input: structured.Change{
-				Before: map[string]interface{}{
+				Before: map[string]any{
 					"key": "before",
 				},
-				After: map[string]interface{}{
+				After: map[string]any{
 					"key": "after",
 				},
 				Unknown: false,
-				BeforeSensitive: map[string]interface{}{
+				BeforeSensitive: map[string]any{
 					"key": true,
 				},
-				AfterSensitive: map[string]interface{}{
+				AfterSensitive: map[string]any{
 					"key": true,
 				},
 				ReplacePaths:       attribute_path.Empty(false),
@@ -2833,8 +2833,8 @@ func TestDynamicPseudoType(t *testing.T) {
 		"create_unknown_in_dynamic_type": {
 			input: structured.Change{
 				Before: nil,
-				After:  map[string]interface{}{},
-				Unknown: map[string]interface{}{
+				After:  map[string]any{},
+				Unknown: map[string]any{
 					"key": true,
 				},
 				BeforeSensitive:    false,
@@ -2848,11 +2848,11 @@ func TestDynamicPseudoType(t *testing.T) {
 		},
 		"update_unknown_in_dynamic_type": {
 			input: structured.Change{
-				Before: map[string]interface{}{
+				Before: map[string]any{
 					"key": "before",
 				},
-				After: map[string]interface{}{},
-				Unknown: map[string]interface{}{
+				After: map[string]any{},
+				Unknown: map[string]any{
 					"key": true,
 				},
 				BeforeSensitive:    false,
@@ -2884,18 +2884,18 @@ func TestSpecificCases(t *testing.T) {
 		"issues/33016/unknown": {
 			input: structured.Change{
 				Before: nil,
-				After: map[string]interface{}{
-					"triggers": map[string]interface{}{},
+				After: map[string]any{
+					"triggers": map[string]any{},
 				},
-				Unknown: map[string]interface{}{
+				Unknown: map[string]any{
 					"id": true,
-					"triggers": map[string]interface{}{
+					"triggers": map[string]any{
 						"rotation": true,
 					},
 				},
 				BeforeSensitive: false,
-				AfterSensitive: map[string]interface{}{
-					"triggers": map[string]interface{}{},
+				AfterSensitive: map[string]any{
+					"triggers": map[string]any{},
 				},
 				ReplacePaths:       attribute_path.Empty(false),
 				RelevantAttributes: attribute_path.AlwaysMatcher(),
@@ -2920,18 +2920,18 @@ func TestSpecificCases(t *testing.T) {
 		"issues/33016/null": {
 			input: structured.Change{
 				Before: nil,
-				After: map[string]interface{}{
-					"triggers": map[string]interface{}{
+				After: map[string]any{
+					"triggers": map[string]any{
 						"rotation": nil,
 					},
 				},
-				Unknown: map[string]interface{}{
+				Unknown: map[string]any{
 					"id":       true,
-					"triggers": map[string]interface{}{},
+					"triggers": map[string]any{},
 				},
 				BeforeSensitive: false,
-				AfterSensitive: map[string]interface{}{
-					"triggers": map[string]interface{}{},
+				AfterSensitive: map[string]any{
+					"triggers": map[string]any{},
 				},
 				ReplacePaths:       attribute_path.Empty(false),
 				RelevantAttributes: attribute_path.AlwaysMatcher(),
@@ -2967,16 +2967,16 @@ func TestSpecificCases(t *testing.T) {
 
 		"issues/33472/expected": {
 			input: structured.Change{
-				Before: map[string]interface{}{
-					"list": []interface{}{
-						map[string]interface{}{
+				Before: map[string]any{
+					"list": []any{
+						map[string]any{
 							"number": json.Number("-1"),
 						},
 					},
 				},
-				After: map[string]interface{}{
-					"list": []interface{}{
-						map[string]interface{}{
+				After: map[string]any{
+					"list": []any{
+						map[string]any{
 							"number": json.Number("2"),
 						},
 					},
@@ -2987,7 +2987,7 @@ func TestSpecificCases(t *testing.T) {
 				ReplacePaths:    attribute_path.Empty(false),
 				RelevantAttributes: &attribute_path.PathMatcher{
 					Propagate: true,
-					Paths: [][]interface{}{
+					Paths: [][]any{
 						{
 							"list",
 							0.0, // This is normal and expected so easy case.
@@ -3016,16 +3016,16 @@ func TestSpecificCases(t *testing.T) {
 
 		"issues/33472/coerce": {
 			input: structured.Change{
-				Before: map[string]interface{}{
-					"list": []interface{}{
-						map[string]interface{}{
+				Before: map[string]any{
+					"list": []any{
+						map[string]any{
 							"number": json.Number("-1"),
 						},
 					},
 				},
-				After: map[string]interface{}{
-					"list": []interface{}{
-						map[string]interface{}{
+				After: map[string]any{
+					"list": []any{
+						map[string]any{
 							"number": json.Number("2"),
 						},
 					},
@@ -3036,7 +3036,7 @@ func TestSpecificCases(t *testing.T) {
 				ReplacePaths:    attribute_path.Empty(false),
 				RelevantAttributes: &attribute_path.PathMatcher{
 					Propagate: true,
-					Paths: [][]interface{}{
+					Paths: [][]any{
 						{
 							"list",
 							"0", // Difficult but allowed, we need to handle this.
@@ -3068,10 +3068,10 @@ func TestSpecificCases(t *testing.T) {
 		"issues/1805/create_with_unknown_dynamic_nested_block": {
 			input: structured.Change{
 				Before: nil,
-				After: map[string]interface{}{
+				After: map[string]any{
 					"attribute_one": "test",
 				},
-				Unknown: map[string]interface{}{
+				Unknown: map[string]any{
 					"nested_unknown_block": true,
 				},
 				ReplacePaths:       &attribute_path.PathMatcher{},
@@ -3104,14 +3104,14 @@ func TestSpecificCases(t *testing.T) {
 		},
 		"issues/1805/update_with_unknown_dynamic_nested_block": {
 			input: structured.Change{
-				Before: map[string]interface{}{
+				Before: map[string]any{
 					"attribute_one": "before_value_attr_1",
 					"attribute_two": "before_value_attr_2",
 				},
-				After: map[string]interface{}{
+				After: map[string]any{
 					"attribute_one": "after_value_attr_1",
 				},
-				Unknown: map[string]interface{}{
+				Unknown: map[string]any{
 					"nested_unknown_block": true,
 				},
 				ReplacePaths:       &attribute_path.PathMatcher{},
@@ -3594,15 +3594,15 @@ func unmarshalType(t *testing.T, ctyType cty.Type) json.RawMessage {
 // wrapChangeInSlice does the same as wrapChangeInMap, except it wraps it into a
 // slice internally.
 func wrapChangeInSlice(input structured.Change) structured.Change {
-	return wrapChange(input, float64(0), func(value interface{}, unknown interface{}, explicit bool) interface{} {
+	return wrapChange(input, float64(0), func(value any, unknown any, explicit bool) any {
 		switch value.(type) {
 		case nil:
 			if set, ok := unknown.(bool); (set && ok) || explicit {
-				return []interface{}{nil}
+				return []any{nil}
 			}
-			return []interface{}{}
+			return []any{}
 		default:
-			return []interface{}{value}
+			return []any{value}
 		}
 	})
 }
@@ -3611,27 +3611,27 @@ func wrapChangeInSlice(input structured.Change) structured.Change {
 // structured.Change that represents a map with a single element. That single
 // element is the input value.
 func wrapChangeInMap(input structured.Change) structured.Change {
-	return wrapChange(input, "element", func(value interface{}, unknown interface{}, explicit bool) interface{} {
+	return wrapChange(input, "element", func(value any, unknown any, explicit bool) any {
 		switch value.(type) {
 		case nil:
 			if set, ok := unknown.(bool); (set && ok) || explicit {
-				return map[string]interface{}{
+				return map[string]any{
 					"element": nil,
 				}
 			}
-			return map[string]interface{}{}
+			return map[string]any{}
 		default:
-			return map[string]interface{}{
+			return map[string]any{
 				"element": value,
 			}
 		}
 	})
 }
 
-func wrapChange(input structured.Change, step interface{}, wrap func(interface{}, interface{}, bool) interface{}) structured.Change {
+func wrapChange(input structured.Change, step any, wrap func(any, any, bool) any) structured.Change {
 	replacePaths := &attribute_path.PathMatcher{}
 	for _, path := range input.ReplacePaths.(*attribute_path.PathMatcher).Paths {
-		var updated []interface{}
+		var updated []any
 		updated = append(updated, step)
 		updated = append(updated, path...)
 		replacePaths.Paths = append(replacePaths.Paths, updated)
@@ -3644,7 +3644,7 @@ func wrapChange(input structured.Change, step interface{}, wrap func(interface{}
 	if concrete, ok := relevantAttributes.(*attribute_path.PathMatcher); ok {
 		newRelevantAttributes := &attribute_path.PathMatcher{}
 		for _, path := range concrete.Paths {
-			var updated []interface{}
+			var updated []any
 			updated = append(updated, step)
 			updated = append(updated, path...)
 			newRelevantAttributes.Paths = append(newRelevantAttributes.Paths, updated)

--- a/internal/command/login.go
+++ b/internal/command/login.go
@@ -266,8 +266,8 @@ func (c *LoginCommand) Run(rawArgs []string) int {
 	view.UiSeparator()
 	if hostname == hcpTerraformHost { // HCP Terraform
 		var motd struct {
-			Message string        `json:"msg"`
-			Errors  []interface{} `json:"errors"`
+			Message string `json:"msg"`
+			Errors  []any  `json:"errors"`
 		}
 
 		// Throughout the entire process of fetching a MOTD from TFC, use a default
@@ -767,7 +767,7 @@ func (c *LoginCommand) listenerForCallback(minPort, maxPort uint16) (net.Listene
 	// another.
 	maxTries := availCount + (availCount / 2)
 
-	for tries := 0; tries < maxTries; tries++ {
+	for range maxTries {
 		port := rand.Intn(availCount) + int(minPort)
 		addr := fmt.Sprintf("127.0.0.1:%d", port)
 		log.Printf("[TRACE] login: trying %s as a listen address for temporary OAuth callback server", addr)

--- a/internal/command/login_test.go
+++ b/internal/command/login_test.go
@@ -60,8 +60,8 @@ func TestLogin(t *testing.T) {
 				disco.WithHTTPClient(httpclient.New(t.Context())),
 			)
 
-			svcs.ForceHostServices(svchost.Hostname("example.com"), map[string]interface{}{
-				"login.v1": map[string]interface{}{
+			svcs.ForceHostServices(svchost.Hostname("example.com"), map[string]any{
+				"login.v1": map[string]any{
 					// For this fake hostname we'll use a conventional OAuth flow,
 					// with browser-based consent that we'll mock away using a
 					// mock browser launcher below.
@@ -70,17 +70,17 @@ func TestLogin(t *testing.T) {
 					"token":  s.URL + "/token",
 				},
 			})
-			svcs.ForceHostServices(svchost.Hostname("with-scopes.example.com"), map[string]interface{}{
-				"login.v1": map[string]interface{}{
+			svcs.ForceHostServices(svchost.Hostname("with-scopes.example.com"), map[string]any{
+				"login.v1": map[string]any{
 					// with scopes
 					// mock browser launcher below.
 					"client": "scopes_test",
 					"authz":  s.URL + "/authz",
 					"token":  s.URL + "/token",
-					"scopes": []interface{}{"app1.full_access", "app2.read_only"},
+					"scopes": []any{"app1.full_access", "app2.read_only"},
 				},
 			})
-			svcs.ForceHostServices(svchost.Hostname(hcpTerraformHost), map[string]interface{}{
+			svcs.ForceHostServices(svchost.Hostname(hcpTerraformHost), map[string]any{
 				// This represents Terraform Cloud, which does not yet support the
 				// login API, but does support its own bespoke tokens API.
 				"tfe.v2":   ts.URL + "/api/v2",
@@ -88,14 +88,14 @@ func TestLogin(t *testing.T) {
 				"tfe.v2.2": ts.URL + "/api/v2",
 				"motd.v1":  ts.URL + "/api/terraform/motd",
 			})
-			svcs.ForceHostServices(svchost.Hostname("tfe.acme.com"), map[string]interface{}{
+			svcs.ForceHostServices(svchost.Hostname("tfe.acme.com"), map[string]any{
 				// This represents a Terraform Enterprise instance which does not
 				// yet support the login API, but does support its own bespoke tokens API.
 				"tfe.v2":   ts.URL + "/api/v2",
 				"tfe.v2.1": ts.URL + "/api/v2",
 				"tfe.v2.2": ts.URL + "/api/v2",
 			})
-			svcs.ForceHostServices(svchost.Hostname("unsupported.example.net"), map[string]interface{}{
+			svcs.ForceHostServices(svchost.Hostname("unsupported.example.net"), map[string]any{
 				// This host intentionally left blank.
 			})
 

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"maps"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -341,9 +342,7 @@ func (m *Meta) StateOutPath() string {
 // Colorize returns the colorization structure for a command.
 func (m *Meta) Colorize() *colorstring.Colorize {
 	colors := make(map[string]string)
-	for k, v := range colorstring.DefaultColors {
-		colors[k] = v
-	}
+	maps.Copy(colors, colorstring.DefaultColors)
 	colors["purple"] = "38;5;57"
 
 	return &colorstring.Colorize{
@@ -722,7 +721,7 @@ func (m *Meta) confirm(opts *tofu.InputOpts) (bool, error) {
 		return false, errors.New("input is disabled")
 	}
 
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		v, err := m.UIInput().Input(context.Background(), opts)
 		if err != nil {
 			return false, fmt.Errorf(
@@ -748,7 +747,7 @@ func (m *Meta) confirm(opts *tofu.InputOpts) (bool, error) {
 //
 // Internally this function uses Diagnostics.Append, and so it will panic
 // if given unsupported value types, just as Append does.
-func (m *Meta) showDiagnostics(vals ...interface{}) {
+func (m *Meta) showDiagnostics(vals ...any) {
 
 	var diags tfdiags.Diagnostics
 	diags = diags.Append(vals...)

--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -683,7 +683,7 @@ func (m *Meta) backendMigrateState_S_TFC(ctx context.Context, opts *backendMigra
 	// state we will not prompt the user for a new name because empty workspaces
 	// do not get migrated.
 	defaultNewName := map[string]string{}
-	for i := 0; i < len(sourceWorkspaces); i++ {
+	for i := range sourceWorkspaces {
 		if sourceWorkspaces[i] == backend.DefaultStateName {
 			// For the default workspace we want to look to see if there is any state
 			// before we ask for a workspace name to migrate the default workspace into.

--- a/internal/command/meta_providers.go
+++ b/internal/command/meta_providers.go
@@ -391,7 +391,7 @@ func providerFactory(meta *providercache.CachedProvider) providers.Factory {
 
 // initializeProviderInstance uses the plugin dispensed by the RPC client, and initializes a plugin instance
 // per the protocol version
-func initializeProviderInstance(plugin interface{}, protoVer int, pluginClient *plugin.Client, schemaCache providers.SchemaCache) (providers.Interface, error) {
+func initializeProviderInstance(plugin any, protoVer int, pluginClient *plugin.Client, schemaCache providers.SchemaCache) (providers.Interface, error) {
 	// store the client so that the plugin can kill the child process
 	switch protoVer {
 	case 5:

--- a/internal/command/plugins.go
+++ b/internal/command/plugins.go
@@ -8,6 +8,7 @@ package command
 import (
 	"fmt"
 	"log"
+	"maps"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -110,9 +111,7 @@ func (m *Meta) provisionerFactories() map[string]provisioners.Factory {
 
 	// Wire up the internal provisioners first. These might be overridden
 	// by discovered provisioners below.
-	for name, factory := range internalProvisionerFactories() {
-		factories[name] = factory
-	}
+	maps.Copy(factories, internalProvisionerFactories())
 
 	byName := plugins.ByName()
 	for name, metas := range byName {

--- a/internal/command/providers_schema_test.go
+++ b/internal/command/providers_schema_test.go
@@ -125,10 +125,10 @@ type providerSchemas struct {
 }
 
 type providerSchema struct {
-	Provider          interface{}            `json:"provider,omitempty"`
-	ResourceSchemas   map[string]interface{} `json:"resource_schemas,omitempty"`
-	DataSourceSchemas map[string]interface{} `json:"data_source_schemas,omitempty"`
-	Functions         map[string]interface{} `json:"functions,omitempty"`
+	Provider          any            `json:"provider,omitempty"`
+	ResourceSchemas   map[string]any `json:"resource_schemas,omitempty"`
+	DataSourceSchemas map[string]any `json:"data_source_schemas,omitempty"`
+	Functions         map[string]any `json:"functions,omitempty"`
 }
 
 // testProvider returns a mock provider that is configured for basic

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -957,10 +957,10 @@ func TestShow_json_output_state(t *testing.T) {
 
 			// compare ui output to wanted output
 			type state struct {
-				FormatVersion    string                 `json:"format_version,omitempty"`
-				TerraformVersion string                 `json:"terraform_version"`
-				Values           map[string]interface{} `json:"values,omitempty"`
-				SensitiveValues  map[string]bool        `json:"sensitive_values,omitempty"`
+				FormatVersion    string          `json:"format_version,omitempty"`
+				TerraformVersion string          `json:"terraform_version"`
+				Values           map[string]any  `json:"values,omitempty"`
+				SensitiveValues  map[string]bool `json:"sensitive_values,omitempty"`
 			}
 			var got, want state
 
@@ -1343,21 +1343,21 @@ func showFixturePlanFile(t *testing.T, action plans.Action) string {
 // to avoid needing to constantly update the expected output; as a potential
 // TODO we could write a jsonplan compare function.
 type plan struct {
-	FormatVersion   string                 `json:"format_version,omitempty"`
-	Variables       map[string]interface{} `json:"variables,omitempty"`
-	PlannedValues   map[string]interface{} `json:"planned_values,omitempty"`
-	ResourceDrift   []interface{}          `json:"resource_drift,omitempty"`
-	ResourceChanges []interface{}          `json:"resource_changes,omitempty"`
-	OutputChanges   map[string]interface{} `json:"output_changes,omitempty"`
-	PriorState      priorState             `json:"prior_state,omitempty"`
-	Config          map[string]interface{} `json:"configuration,omitempty"`
-	Errored         bool                   `json:"errored"`
+	FormatVersion   string         `json:"format_version,omitempty"`
+	Variables       map[string]any `json:"variables,omitempty"`
+	PlannedValues   map[string]any `json:"planned_values,omitempty"`
+	ResourceDrift   []any          `json:"resource_drift,omitempty"`
+	ResourceChanges []any          `json:"resource_changes,omitempty"`
+	OutputChanges   map[string]any `json:"output_changes,omitempty"`
+	PriorState      priorState     `json:"prior_state"`
+	Config          map[string]any `json:"configuration,omitempty"`
+	Errored         bool           `json:"errored"`
 }
 
 type priorState struct {
-	FormatVersion   string                 `json:"format_version,omitempty"`
-	Values          map[string]interface{} `json:"values,omitempty"`
-	SensitiveValues map[string]bool        `json:"sensitive_values,omitempty"`
+	FormatVersion   string          `json:"format_version,omitempty"`
+	Values          map[string]any  `json:"values,omitempty"`
+	SensitiveValues map[string]bool `json:"sensitive_values,omitempty"`
 }
 
 func TestShow_config(t *testing.T) {
@@ -1410,7 +1410,7 @@ func TestShow_config(t *testing.T) {
 	}
 
 	// Verify that the output is valid JSON
-	var got map[string]interface{}
+	var got map[string]any
 	if err := json.Unmarshal([]byte(output.Stdout()), &got); err != nil {
 		t.Fatalf("invalid JSON output: %s\n%s", err, output.Stdout())
 	}
@@ -1421,11 +1421,11 @@ func TestShow_config(t *testing.T) {
 	}
 
 	// Verify that module_calls (and its child entry) are included
-	rootModule, ok := got["root_module"].(map[string]interface{})
+	rootModule, ok := got["root_module"].(map[string]any)
 	if !ok {
 		t.Fatal("root_module is not a map")
 	}
-	moduleCalls, ok := rootModule["module_calls"].(map[string]interface{})
+	moduleCalls, ok := rootModule["module_calls"].(map[string]any)
 	if !ok || len(moduleCalls) == 0 {
 		t.Errorf("missing or empty module_calls in configuration output. Actual output: %v", got)
 	}
@@ -1517,7 +1517,7 @@ func TestShow_config_withModule(t *testing.T) {
 	}
 
 	// Verify that the output is valid JSON
-	var got map[string]interface{}
+	var got map[string]any
 	if err := json.Unmarshal([]byte(output.Stdout()), &got); err != nil {
 		t.Fatalf("invalid JSON output: %s\n%s", err, output.Stdout())
 	}
@@ -1528,11 +1528,11 @@ func TestShow_config_withModule(t *testing.T) {
 	}
 
 	// Verify that module_calls (and its child entry) are included
-	rootModule, ok := got["root_module"].(map[string]interface{})
+	rootModule, ok := got["root_module"].(map[string]any)
 	if !ok {
 		t.Fatal("root_module is not a map")
 	}
-	moduleCalls, ok := rootModule["module_calls"].(map[string]interface{})
+	moduleCalls, ok := rootModule["module_calls"].(map[string]any)
 	if !ok || len(moduleCalls) == 0 {
 		t.Errorf("missing or empty module_calls in configuration output. Actual output: %v", got)
 	}

--- a/internal/command/test.go
+++ b/internal/command/test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"maps"
 	"path"
 	"slices"
 	"sort"
@@ -1339,9 +1340,7 @@ func (runner *TestFileRunner) prepareInputVariablesForAssertions(config *configs
 	// First, take a backup of the existing configuration so we can easily
 	// restore it later.
 	currentVars := make(map[string]*configs.Variable)
-	for name, variable := range config.Module.Variables {
-		currentVars[name] = variable
-	}
+	maps.Copy(currentVars, config.Module.Variables)
 
 	// Next, let's go through our entire inputs and add any that aren't already
 	// defined into the config.

--- a/internal/command/validate_test.go
+++ b/internal/command/validate_test.go
@@ -375,7 +375,7 @@ func TestValidate_json(t *testing.T) {
 				return field == `["filename"]`
 			},
 			//
-			cmp.Transformer("filename", func(filename interface{}) string {
+			cmp.Transformer("filename", func(filename any) string {
 				convertedFilename, ok := filename.(string)
 				if !ok {
 					t.Fatalf("failed to convert filename to string: %v", filename)
@@ -390,7 +390,7 @@ func TestValidate_json(t *testing.T) {
 				field := p.Last().String()
 				return field == `["detail"]`
 			},
-			cmp.Transformer("detail", func(detail interface{}) string {
+			cmp.Transformer("detail", func(detail any) string {
 				convertedDetail, ok := detail.(string)
 				if !ok {
 					t.Fatalf("failed to convert detail to string: %v", detail)
@@ -405,7 +405,7 @@ func TestValidate_json(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.path, func(t *testing.T) {
-			var want, got map[string]interface{}
+			var want, got map[string]any
 
 			wantFile, err := os.Open(path.Join(testFixturePath(tc.path), "output.json"))
 			if err != nil {

--- a/internal/command/views/apply_test.go
+++ b/internal/command/views/apply_test.go
@@ -263,19 +263,19 @@ func TestApplyJSON_outputs(t *testing.T) {
 		"password":   {Value: cty.StringVal("horse-battery").Mark(marks.Sensitive), Sensitive: true},
 	})
 
-	want := []map[string]interface{}{
+	want := []map[string]any{
 		{
 			"@level":   "info",
 			"@message": "Outputs: 2",
 			"@module":  "tofu.ui",
 			"type":     "outputs",
-			"outputs": map[string]interface{}{
-				"boop_count": map[string]interface{}{
+			"outputs": map[string]any{
+				"boop_count": map[string]any{
 					"sensitive": false,
 					"value":     float64(92),
 					"type":      "number",
 				},
-				"password": map[string]interface{}{
+				"password": map[string]any{
 					"sensitive": true,
 					"type":      "string",
 				},

--- a/internal/command/views/hook_json_test.go
+++ b/internal/command/views/hook_json_test.go
@@ -102,7 +102,7 @@ func TestJSONHook_create(t *testing.T) {
 	}
 	hook.applyingLock.Unlock()
 
-	wantResource := map[string]interface{}{
+	wantResource := map[string]any{
 		"addr":             string("test_instance.boop"),
 		"implied_provider": string("test"),
 		"module":           string(""),
@@ -111,13 +111,13 @@ func TestJSONHook_create(t *testing.T) {
 		"resource_name":    string("boop"),
 		"resource_type":    string("test_instance"),
 	}
-	want := []map[string]interface{}{
+	want := []map[string]any{
 		{
 			"@level":   "info",
 			"@message": "test_instance.boop: Creating...",
 			"@module":  "tofu.ui",
 			"type":     "apply_start",
-			"hook": map[string]interface{}{
+			"hook": map[string]any{
 				"action":   string("create"),
 				"resource": wantResource,
 			},
@@ -127,7 +127,7 @@ func TestJSONHook_create(t *testing.T) {
 			"@message": "test_instance.boop: Provisioning with 'local-exec'...",
 			"@module":  "tofu.ui",
 			"type":     "provision_start",
-			"hook": map[string]interface{}{
+			"hook": map[string]any{
 				"provisioner": "local-exec",
 				"resource":    wantResource,
 			},
@@ -137,7 +137,7 @@ func TestJSONHook_create(t *testing.T) {
 			"@message": `test_instance.boop: (local-exec): Executing: ["/bin/sh" "-c" "touch /etc/motd"]`,
 			"@module":  "tofu.ui",
 			"type":     "provision_progress",
-			"hook": map[string]interface{}{
+			"hook": map[string]any{
 				"output":      `Executing: ["/bin/sh" "-c" "touch /etc/motd"]`,
 				"provisioner": "local-exec",
 				"resource":    wantResource,
@@ -148,7 +148,7 @@ func TestJSONHook_create(t *testing.T) {
 			"@message": "test_instance.boop: (local-exec) Provisioning complete",
 			"@module":  "tofu.ui",
 			"type":     "provision_complete",
-			"hook": map[string]interface{}{
+			"hook": map[string]any{
 				"provisioner": "local-exec",
 				"resource":    wantResource,
 			},
@@ -158,7 +158,7 @@ func TestJSONHook_create(t *testing.T) {
 			"@message": "test_instance.boop: Still creating... [10s elapsed]",
 			"@module":  "tofu.ui",
 			"type":     "apply_progress",
-			"hook": map[string]interface{}{
+			"hook": map[string]any{
 				"action":          string("create"),
 				"elapsed_seconds": float64(10),
 				"resource":        wantResource,
@@ -169,7 +169,7 @@ func TestJSONHook_create(t *testing.T) {
 			"@message": "test_instance.boop: Still creating... [20s elapsed]",
 			"@module":  "tofu.ui",
 			"type":     "apply_progress",
-			"hook": map[string]interface{}{
+			"hook": map[string]any{
 				"action":          string("create"),
 				"elapsed_seconds": float64(20),
 				"resource":        wantResource,
@@ -180,7 +180,7 @@ func TestJSONHook_create(t *testing.T) {
 			"@message": "test_instance.boop: Creation complete after 22s [id=test]",
 			"@module":  "tofu.ui",
 			"type":     "apply_complete",
-			"hook": map[string]interface{}{
+			"hook": map[string]any{
 				"action":          string("create"),
 				"elapsed_seconds": float64(22),
 				"id_key":          "id",
@@ -234,7 +234,7 @@ func TestJSONHook_errors(t *testing.T) {
 	}
 	hook.applyingLock.Unlock()
 
-	wantResource := map[string]interface{}{
+	wantResource := map[string]any{
 		"addr":             string("test_instance.boop"),
 		"implied_provider": string("test"),
 		"module":           string(""),
@@ -243,13 +243,13 @@ func TestJSONHook_errors(t *testing.T) {
 		"resource_name":    string("boop"),
 		"resource_type":    string("test_instance"),
 	}
-	want := []map[string]interface{}{
+	want := []map[string]any{
 		{
 			"@level":   "info",
 			"@message": "test_instance.boop: Destroying...",
 			"@module":  "tofu.ui",
 			"type":     "apply_start",
-			"hook": map[string]interface{}{
+			"hook": map[string]any{
 				"action":   string("delete"),
 				"resource": wantResource,
 			},
@@ -259,7 +259,7 @@ func TestJSONHook_errors(t *testing.T) {
 			"@message": "test_instance.boop: (local-exec) Provisioning errored",
 			"@module":  "tofu.ui",
 			"type":     "provision_errored",
-			"hook": map[string]interface{}{
+			"hook": map[string]any{
 				"provisioner": "local-exec",
 				"resource":    wantResource,
 			},
@@ -269,7 +269,7 @@ func TestJSONHook_errors(t *testing.T) {
 			"@message": "test_instance.boop: Destruction errored after 0s",
 			"@module":  "tofu.ui",
 			"type":     "apply_errored",
-			"hook": map[string]interface{}{
+			"hook": map[string]any{
 				"action":          string("delete"),
 				"elapsed_seconds": float64(0),
 				"resource":        wantResource,
@@ -302,7 +302,7 @@ func TestJSONHook_refresh(t *testing.T) {
 	action, err = hook.PostRefresh(addr, states.CurrentGen, state, state)
 	testHookReturnValues(t, action, err)
 
-	wantResource := map[string]interface{}{
+	wantResource := map[string]any{
 		"addr":             string("data.test_data_source.beep"),
 		"implied_provider": string("test"),
 		"module":           string(""),
@@ -311,13 +311,13 @@ func TestJSONHook_refresh(t *testing.T) {
 		"resource_name":    string("beep"),
 		"resource_type":    string("test_data_source"),
 	}
-	want := []map[string]interface{}{
+	want := []map[string]any{
 		{
 			"@level":   "info",
 			"@message": "data.test_data_source.beep: Refreshing state... [id=honk]",
 			"@module":  "tofu.ui",
 			"type":     "refresh_start",
-			"hook": map[string]interface{}{
+			"hook": map[string]any{
 				"resource": wantResource,
 				"id_key":   "id",
 				"id_value": "honk",
@@ -328,7 +328,7 @@ func TestJSONHook_refresh(t *testing.T) {
 			"@message": "data.test_data_source.beep: Refresh complete [id=honk]",
 			"@module":  "tofu.ui",
 			"type":     "refresh_complete",
-			"hook": map[string]interface{}{
+			"hook": map[string]any{
 				"resource": wantResource,
 				"id_key":   "id",
 				"id_value": "honk",
@@ -350,7 +350,7 @@ func TestJSONHook_ephemeral(t *testing.T) {
 		name  string
 		preF  func(hook tofu.Hook) (tofu.HookAction, error)
 		postF func(hook tofu.Hook) (tofu.HookAction, error)
-		want  []map[string]interface{}
+		want  []map[string]any
 	}{
 		{
 			name: "opening",
@@ -360,7 +360,7 @@ func TestJSONHook_ephemeral(t *testing.T) {
 			postF: func(hook tofu.Hook) (tofu.HookAction, error) {
 				return hook.PostOpen(addr, nil)
 			},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":   "info",
 					"@message": "ephemeral.test_instance.foo: Opening...",
@@ -407,7 +407,7 @@ func TestJSONHook_ephemeral(t *testing.T) {
 			postF: func(hook tofu.Hook) (tofu.HookAction, error) {
 				return hook.PostRenew(addr, nil)
 			},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":   "info",
 					"@message": "ephemeral.test_instance.foo: Renewing...",
@@ -454,7 +454,7 @@ func TestJSONHook_ephemeral(t *testing.T) {
 			postF: func(hook tofu.Hook) (tofu.HookAction, error) {
 				return hook.PostClose(addr, nil)
 			},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":   "info",
 					"@message": "ephemeral.test_instance.foo: Closing...",

--- a/internal/command/views/hook_module_install_test.go
+++ b/internal/command/views/hook_module_install_test.go
@@ -99,7 +99,7 @@ func testModuleInstallationHookHuman(t *testing.T, call func(init initwd.ModuleI
 	}
 }
 
-func testModuleInstallationHookJson(t *testing.T, call func(init initwd.ModuleInstallHooks), showLocalPaths bool, want []map[string]interface{}) {
+func testModuleInstallationHookJson(t *testing.T, call func(init initwd.ModuleInstallHooks), showLocalPaths bool, want []map[string]any) {
 	// New type just to assert the fields that we are interested in
 	view, done := testView(t)
 	moduleInstallationViewCall := moduleInstallationHookJSON{v: NewJSONView(view, nil), showLocalPaths: showLocalPaths}
@@ -112,7 +112,7 @@ func testModuleInstallationHookJson(t *testing.T, call func(init initwd.ModuleIn
 	testJSONViewOutputEquals(t, output.Stdout(), want)
 }
 
-func testModuleInstallationHookMulti(t *testing.T, call func(init initwd.ModuleInstallHooks), showLocalPaths bool, wantStdout string, wantStderr string, want []map[string]interface{}) {
+func testModuleInstallationHookMulti(t *testing.T, call func(init initwd.ModuleInstallHooks), showLocalPaths bool, wantStdout string, wantStderr string, want []map[string]any) {
 	jsonInto, err := os.CreateTemp(t.TempDir(), "json-into-*")
 	if err != nil {
 		t.Fatalf("failed to create the file to write json content into: %s", err)

--- a/internal/command/views/init_test.go
+++ b/internal/command/views/init_test.go
@@ -623,7 +623,7 @@ func testInitHuman(t *testing.T, call func(init Init), wantStdout, wantStderr st
 	}
 }
 
-func testInitJson(t *testing.T, call func(init Init), want []map[string]interface{}) {
+func testInitJson(t *testing.T, call func(init Init), want []map[string]any) {
 	// New type just to assert the fields that we are interested in
 	view, done := testView(t)
 	initView := NewInit(arguments.ViewOptions{ViewType: arguments.ViewJSON}, view)
@@ -636,7 +636,7 @@ func testInitJson(t *testing.T, call func(init Init), want []map[string]interfac
 	testJSONViewOutputEquals(t, output.Stdout(), want)
 }
 
-func testInitMulti(t *testing.T, call func(init Init), wantStdout string, wantStderr string, want []map[string]interface{}) {
+func testInitMulti(t *testing.T, call func(init Init), wantStdout string, wantStderr string, want []map[string]any) {
 	jsonInto, err := os.CreateTemp(t.TempDir(), "json-into-*")
 	if err != nil {
 		t.Fatalf("failed to create the file to write json content into: %s", err)

--- a/internal/command/views/json_view.go
+++ b/internal/command/views/json_view.go
@@ -78,12 +78,12 @@ func (v *JSONView) StateDump(state string) {
 	)
 }
 
-func (v *JSONView) Diagnostics(diags tfdiags.Diagnostics, metadata ...interface{}) {
+func (v *JSONView) Diagnostics(diags tfdiags.Diagnostics, metadata ...any) {
 	sources := v.view.configSources()
 	for _, diag := range diags {
 		diagnostic := jsonentities.NewDiagnostic(diag, sources)
 
-		args := []interface{}{"type", json.MessageDiagnostic, "diagnostic", diagnostic}
+		args := []any{"type", json.MessageDiagnostic, "diagnostic", diagnostic}
 		args = append(args, metadata...)
 
 		switch diag.Severity() {

--- a/internal/command/views/json_view_test.go
+++ b/internal/command/views/json_view_test.go
@@ -30,7 +30,7 @@ func TestNewJSONView(t *testing.T) {
 	NewJSONView(NewView(streams), nil)
 
 	version := tfversion.String()
-	want := []map[string]interface{}{
+	want := []map[string]any{
 		{
 			"@level":   "info",
 			"@message": fmt.Sprintf("OpenTofu %s", version),
@@ -48,12 +48,12 @@ func TestJSONView_Log(t *testing.T) {
 	testCases := []struct {
 		caseName string
 		input    string
-		want     []map[string]interface{}
+		want     []map[string]any
 	}{
 		{
 			"log with regular character",
 			"hello, world",
-			[]map[string]interface{}{
+			[]map[string]any{
 				{
 					"@level":   "info",
 					"@message": "hello, world",
@@ -65,7 +65,7 @@ func TestJSONView_Log(t *testing.T) {
 		{
 			"log with special character",
 			"hello, special char, <>&",
-			[]map[string]interface{}{
+			[]map[string]any{
 				{
 					"@level":   "info",
 					"@message": "hello, special char, <>&",
@@ -105,13 +105,13 @@ func TestJSONView_Diagnostics(t *testing.T) {
 
 	jv.Diagnostics(diags)
 
-	want := []map[string]interface{}{
+	want := []map[string]any{
 		{
 			"@level":   "warn",
 			"@message": `Warning: Improper use of "less"`,
 			"@module":  "tofu.ui",
 			"type":     "diagnostic",
-			"diagnostic": map[string]interface{}{
+			"diagnostic": map[string]any{
 				"severity": "warning",
 				"summary":  `Improper use of "less"`,
 				"detail":   `You probably mean "10 buckets or fewer"`,
@@ -122,7 +122,7 @@ func TestJSONView_Diagnostics(t *testing.T) {
 			"@message": "Error: Unusually stripey cat detected",
 			"@module":  "tofu.ui",
 			"type":     "diagnostic",
-			"diagnostic": map[string]interface{}{
+			"diagnostic": map[string]any{
 				"severity": "error",
 				"summary":  "Unusually stripey cat detected",
 				"detail":   "Are you sure this random_pet isn't a cheetah?",
@@ -150,13 +150,13 @@ func TestJSONView_DiagnosticsWithMetadata(t *testing.T) {
 
 	jv.Diagnostics(diags, "@meta", "extra_info")
 
-	want := []map[string]interface{}{
+	want := []map[string]any{
 		{
 			"@level":   "warn",
 			"@message": `Warning: Improper use of "less"`,
 			"@module":  "tofu.ui",
 			"type":     "diagnostic",
-			"diagnostic": map[string]interface{}{
+			"diagnostic": map[string]any{
 				"severity": "warning",
 				"summary":  `Improper use of "less"`,
 				"detail":   `You probably mean "10 buckets or fewer"`,
@@ -168,7 +168,7 @@ func TestJSONView_DiagnosticsWithMetadata(t *testing.T) {
 			"@message": "Error: Unusually stripey cat detected",
 			"@module":  "tofu.ui",
 			"type":     "diagnostic",
-			"diagnostic": map[string]interface{}{
+			"diagnostic": map[string]any{
 				"severity": "error",
 				"summary":  "Unusually stripey cat detected",
 				"detail":   "Are you sure this random_pet isn't a cheetah?",
@@ -197,15 +197,15 @@ func TestJSONView_PlannedChange(t *testing.T) {
 	}
 	jv.PlannedChange(jsonentities.NewResourceInstanceChange(cs))
 
-	want := []map[string]interface{}{
+	want := []map[string]any{
 		{
 			"@level":   "info",
 			"@message": `module.foo.test_instance.bar["boop"]: Plan to create`,
 			"@module":  "tofu.ui",
 			"type":     "planned_change",
-			"change": map[string]interface{}{
+			"change": map[string]any{
 				"action": "create",
-				"resource": map[string]interface{}{
+				"resource": map[string]any{
 					"addr":             `module.foo.test_instance.bar["boop"]`,
 					"implied_provider": "test",
 					"module":           "module.foo",
@@ -238,15 +238,15 @@ func TestJSONView_ResourceDrift(t *testing.T) {
 	}
 	jv.ResourceDrift(jsonentities.NewResourceInstanceChange(cs))
 
-	want := []map[string]interface{}{
+	want := []map[string]any{
 		{
 			"@level":   "info",
 			"@message": `module.foo.test_instance.bar["boop"]: Drift detected (update)`,
 			"@module":  "tofu.ui",
 			"type":     "resource_drift",
-			"change": map[string]interface{}{
+			"change": map[string]any{
 				"action": "update",
-				"resource": map[string]interface{}{
+				"resource": map[string]any{
 					"addr":             `module.foo.test_instance.bar["boop"]`,
 					"implied_provider": "test",
 					"module":           "module.foo",
@@ -272,13 +272,13 @@ func TestJSONView_ChangeSummary(t *testing.T) {
 		Operation: viewsjson.OperationApplied,
 	})
 
-	want := []map[string]interface{}{
+	want := []map[string]any{
 		{
 			"@level":   "info",
 			"@message": "Apply complete! Resources: 1 added, 2 changed, 3 destroyed.",
 			"@module":  "tofu.ui",
 			"type":     "change_summary",
-			"changes": map[string]interface{}{
+			"changes": map[string]any{
 				"add":       float64(1),
 				"import":    float64(0),
 				"change":    float64(2),
@@ -303,13 +303,13 @@ func TestJSONView_ChangeSummaryWithImport(t *testing.T) {
 		Operation: viewsjson.OperationApplied,
 	})
 
-	want := []map[string]interface{}{
+	want := []map[string]any{
 		{
 			"@level":   "info",
 			"@message": "Apply complete! Resources: 1 imported, 1 added, 2 changed, 3 destroyed.",
 			"@module":  "tofu.ui",
 			"type":     "change_summary",
-			"changes": map[string]interface{}{
+			"changes": map[string]any{
 				"add":       float64(1),
 				"change":    float64(2),
 				"remove":    float64(3),
@@ -334,13 +334,13 @@ func TestJSONView_ChangeSummaryWithForget(t *testing.T) {
 		Operation: viewsjson.OperationApplied,
 	})
 
-	want := []map[string]interface{}{
+	want := []map[string]any{
 		{
 			"@level":   "info",
 			"@message": "Apply complete! Resources: 1 added, 2 changed, 3 destroyed, 1 forgotten.",
 			"@module":  "tofu.ui",
 			"type":     "change_summary",
-			"changes": map[string]interface{}{
+			"changes": map[string]any{
 				"add":       float64(1),
 				"change":    float64(2),
 				"remove":    float64(3),
@@ -367,14 +367,14 @@ func TestJSONView_Hook(t *testing.T) {
 
 	jv.Hook(hook)
 
-	want := []map[string]interface{}{
+	want := []map[string]any{
 		{
 			"@level":   "info",
 			"@message": `module.foo.test_instance.bar["boop"]: Creation complete after 34s [id=boop-beep]`,
 			"@module":  "tofu.ui",
 			"type":     "apply_complete",
-			"hook": map[string]interface{}{
-				"resource": map[string]interface{}{
+			"hook": map[string]any{
+				"resource": map[string]any{
 					"addr":             `module.foo.test_instance.bar["boop"]`,
 					"implied_provider": "test",
 					"module":           "module.foo",
@@ -410,19 +410,19 @@ func TestJSONView_Outputs(t *testing.T) {
 		},
 	})
 
-	want := []map[string]interface{}{
+	want := []map[string]any{
 		{
 			"@level":   "info",
 			"@message": "Outputs: 2",
 			"@module":  "tofu.ui",
 			"type":     "outputs",
-			"outputs": map[string]interface{}{
-				"boop_count": map[string]interface{}{
+			"outputs": map[string]any{
+				"boop_count": map[string]any{
 					"sensitive": false,
 					"value":     float64(92),
 					"type":      "number",
 				},
-				"password": map[string]interface{}{
+				"password": map[string]any{
 					"sensitive": true,
 					"value":     "horse-battery",
 					"type":      "string",
@@ -437,7 +437,7 @@ func TestJSONView_Outputs(t *testing.T) {
 // against a slice of structs representing the desired log messages. It
 // verifies that the output of JSONView is in JSON log format, one message per
 // line.
-func testJSONViewOutputEqualsFull(t *testing.T, output string, want []map[string]interface{}, options ...cmp.Option) {
+func testJSONViewOutputEqualsFull(t *testing.T, output string, want []map[string]any, options ...cmp.Option) {
 	t.Helper()
 
 	// Remove final trailing newline
@@ -452,7 +452,7 @@ func testJSONViewOutputEqualsFull(t *testing.T, output string, want []map[string
 
 	// Unmarshal each line and compare to the expected value
 	for i := range gotLines {
-		var gotStruct map[string]interface{}
+		var gotStruct map[string]any
 		if i >= len(want) {
 			t.Error("reached end of want messages too soon")
 			break
@@ -488,7 +488,7 @@ func testJSONViewOutputEqualsFull(t *testing.T, output string, want []map[string
 
 // testJSONViewOutputEquals skips the first line of output, since it ought to
 // be a version message that we don't care about for most of our tests.
-func testJSONViewOutputEquals(t *testing.T, output string, want []map[string]interface{}, options ...cmp.Option) {
+func testJSONViewOutputEquals(t *testing.T, output string, want []map[string]any, options ...cmp.Option) {
 	t.Helper()
 
 	// Remove up to the first newline

--- a/internal/command/views/login_test.go
+++ b/internal/command/views/login_test.go
@@ -375,7 +375,7 @@ func testLoginHuman(t *testing.T, call func(login Login), wantStdout, wantStderr
 	}
 }
 
-func testLoginJson(t *testing.T, call func(login Login), want []map[string]interface{}) {
+func testLoginJson(t *testing.T, call func(login Login), want []map[string]any) {
 	view, done := testView(t)
 	loginView := NewLogin(arguments.ViewOptions{ViewType: arguments.ViewJSON}, view)
 	call(loginView)
@@ -387,7 +387,7 @@ func testLoginJson(t *testing.T, call func(login Login), want []map[string]inter
 	testJSONViewOutputEquals(t, output.Stdout(), want)
 }
 
-func testLoginMulti(t *testing.T, call func(login Login), wantStdout string, wantStderr string, want []map[string]interface{}) {
+func testLoginMulti(t *testing.T, call func(login Login), wantStdout string, wantStderr string, want []map[string]any) {
 	jsonInto, err := os.CreateTemp(t.TempDir(), "json-into-*")
 	if err != nil {
 		t.Fatalf("failed to create the file to write json content into: %s", err)

--- a/internal/command/views/operation_test.go
+++ b/internal/command/views/operation_test.go
@@ -75,7 +75,7 @@ func TestOperation_emergencyDumpState(t *testing.T) {
 
 	// Check that the result (on stderr) looks like JSON state
 	raw := done(t).Stderr()
-	var state map[string]interface{}
+	var state map[string]any
 	if err := json.Unmarshal([]byte(raw), &state); err != nil {
 		t.Fatalf("unexpected error parsing dumped state: %s\nraw:\n%s", err, raw)
 	}
@@ -525,7 +525,7 @@ func TestOperationJSON_logs(t *testing.T) {
 	v.Interrupted()
 	v.FatalInterrupt()
 
-	want := []map[string]interface{}{
+	want := []map[string]any{
 		{
 			"@level":   "info",
 			"@message": "Apply cancelled",
@@ -575,7 +575,7 @@ func TestOperationJSON_emergencyDumpState(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var stateJSON map[string]interface{}
+	var stateJSON map[string]any
 	err = json.Unmarshal(stateBuf.Bytes(), &stateJSON)
 	if err != nil {
 		t.Fatal(err)
@@ -586,7 +586,7 @@ func TestOperationJSON_emergencyDumpState(t *testing.T) {
 		t.Fatalf("unexpected error dumping state: %s", err)
 	}
 
-	want := []map[string]interface{}{
+	want := []map[string]any{
 		{
 			"@level":   "info",
 			"@message": "Emergency state dump",
@@ -608,13 +608,13 @@ func TestOperationJSON_planNoChanges(t *testing.T) {
 	}
 	v.Plan(plan, nil)
 
-	want := []map[string]interface{}{
+	want := []map[string]any{
 		{
 			"@level":   "info",
 			"@message": "Plan: 0 to add, 0 to change, 0 to destroy.",
 			"@module":  "tofu.ui",
 			"type":     "change_summary",
-			"changes": map[string]interface{}{
+			"changes": map[string]any{
 				"operation": "plan",
 				"add":       float64(0),
 				"import":    float64(0),
@@ -680,16 +680,16 @@ func TestOperationJSON_plan(t *testing.T) {
 	}
 	v.Plan(plan, testSchemas())
 
-	want := []map[string]interface{}{
+	want := []map[string]any{
 		// Create-then-delete should result in replace
 		{
 			"@level":   "info",
 			"@message": "test_resource.boop[0]: Plan to replace",
 			"@module":  "tofu.ui",
 			"type":     "planned_change",
-			"change": map[string]interface{}{
+			"change": map[string]any{
 				"action": "replace",
-				"resource": map[string]interface{}{
+				"resource": map[string]any{
 					"addr":             `test_resource.boop[0]`,
 					"implied_provider": "test",
 					"module":           "",
@@ -706,9 +706,9 @@ func TestOperationJSON_plan(t *testing.T) {
 			"@message": "test_resource.boop[1]: Plan to create",
 			"@module":  "tofu.ui",
 			"type":     "planned_change",
-			"change": map[string]interface{}{
+			"change": map[string]any{
 				"action": "create",
-				"resource": map[string]interface{}{
+				"resource": map[string]any{
 					"addr":             `test_resource.boop[1]`,
 					"implied_provider": "test",
 					"module":           "",
@@ -725,9 +725,9 @@ func TestOperationJSON_plan(t *testing.T) {
 			"@message": "module.vpc.test_resource.boop[0]: Plan to delete",
 			"@module":  "tofu.ui",
 			"type":     "planned_change",
-			"change": map[string]interface{}{
+			"change": map[string]any{
 				"action": "delete",
-				"resource": map[string]interface{}{
+				"resource": map[string]any{
 					"addr":             `module.vpc.test_resource.boop[0]`,
 					"implied_provider": "test",
 					"module":           "module.vpc",
@@ -744,9 +744,9 @@ func TestOperationJSON_plan(t *testing.T) {
 			"@message": "test_resource.beep: Plan to replace",
 			"@module":  "tofu.ui",
 			"type":     "planned_change",
-			"change": map[string]interface{}{
+			"change": map[string]any{
 				"action": "replace",
-				"resource": map[string]interface{}{
+				"resource": map[string]any{
 					"addr":             `test_resource.beep`,
 					"implied_provider": "test",
 					"module":           "",
@@ -763,9 +763,9 @@ func TestOperationJSON_plan(t *testing.T) {
 			"@message": "module.vpc.test_resource.beep: Plan to update",
 			"@module":  "tofu.ui",
 			"type":     "planned_change",
-			"change": map[string]interface{}{
+			"change": map[string]any{
 				"action": "update",
-				"resource": map[string]interface{}{
+				"resource": map[string]any{
 					"addr":             `module.vpc.test_resource.beep`,
 					"implied_provider": "test",
 					"module":           "module.vpc",
@@ -783,7 +783,7 @@ func TestOperationJSON_plan(t *testing.T) {
 			"@message": "Plan: 3 to add, 1 to change, 3 to destroy.",
 			"@module":  "tofu.ui",
 			"type":     "change_summary",
-			"changes": map[string]interface{}{
+			"changes": map[string]any{
 				"operation": "plan",
 				"add":       float64(3),
 				"import":    float64(0),
@@ -837,16 +837,16 @@ func TestOperationJSON_planWithImport(t *testing.T) {
 	}
 	v.Plan(plan, testSchemas())
 
-	want := []map[string]interface{}{
+	want := []map[string]any{
 		// Simple import
 		{
 			"@level":   "info",
 			"@message": "module.vpc.test_resource.boop[0]: Plan to import",
 			"@module":  "tofu.ui",
 			"type":     "planned_change",
-			"change": map[string]interface{}{
+			"change": map[string]any{
 				"action": "import",
-				"resource": map[string]interface{}{
+				"resource": map[string]any{
 					"addr":             `module.vpc.test_resource.boop[0]`,
 					"implied_provider": "test",
 					"module":           "module.vpc",
@@ -855,7 +855,7 @@ func TestOperationJSON_planWithImport(t *testing.T) {
 					"resource_name":    "boop",
 					"resource_type":    "test_resource",
 				},
-				"importing": map[string]interface{}{
+				"importing": map[string]any{
 					"id": "DECD6D77",
 				},
 			},
@@ -866,9 +866,9 @@ func TestOperationJSON_planWithImport(t *testing.T) {
 			"@message": "module.vpc.test_resource.boop[1]: Plan to delete",
 			"@module":  "tofu.ui",
 			"type":     "planned_change",
-			"change": map[string]interface{}{
+			"change": map[string]any{
 				"action": "delete",
-				"resource": map[string]interface{}{
+				"resource": map[string]any{
 					"addr":             `module.vpc.test_resource.boop[1]`,
 					"implied_provider": "test",
 					"module":           "module.vpc",
@@ -877,7 +877,7 @@ func TestOperationJSON_planWithImport(t *testing.T) {
 					"resource_name":    "boop",
 					"resource_type":    "test_resource",
 				},
-				"importing": map[string]interface{}{
+				"importing": map[string]any{
 					"id": "DECD6D77",
 				},
 			},
@@ -888,9 +888,9 @@ func TestOperationJSON_planWithImport(t *testing.T) {
 			"@message": "test_resource.boop[0]: Plan to replace",
 			"@module":  "tofu.ui",
 			"type":     "planned_change",
-			"change": map[string]interface{}{
+			"change": map[string]any{
 				"action": "replace",
-				"resource": map[string]interface{}{
+				"resource": map[string]any{
 					"addr":             `test_resource.boop[0]`,
 					"implied_provider": "test",
 					"module":           "",
@@ -899,7 +899,7 @@ func TestOperationJSON_planWithImport(t *testing.T) {
 					"resource_name":    "boop",
 					"resource_type":    "test_resource",
 				},
-				"importing": map[string]interface{}{
+				"importing": map[string]any{
 					"id": "DECD6D77",
 				},
 			},
@@ -910,9 +910,9 @@ func TestOperationJSON_planWithImport(t *testing.T) {
 			"@message": "test_resource.beep: Plan to update",
 			"@module":  "tofu.ui",
 			"type":     "planned_change",
-			"change": map[string]interface{}{
+			"change": map[string]any{
 				"action": "update",
-				"resource": map[string]interface{}{
+				"resource": map[string]any{
 					"addr":             `test_resource.beep`,
 					"implied_provider": "test",
 					"module":           "",
@@ -921,7 +921,7 @@ func TestOperationJSON_planWithImport(t *testing.T) {
 					"resource_name":    "beep",
 					"resource_type":    "test_resource",
 				},
-				"importing": map[string]interface{}{
+				"importing": map[string]any{
 					"id": "DECD6D77",
 				},
 			},
@@ -931,7 +931,7 @@ func TestOperationJSON_planWithImport(t *testing.T) {
 			"@message": "Plan: 4 to import, 1 to add, 1 to change, 2 to destroy.",
 			"@module":  "tofu.ui",
 			"type":     "change_summary",
-			"changes": map[string]interface{}{
+			"changes": map[string]any{
 				"operation": "plan",
 				"add":       float64(1),
 				"import":    float64(4),
@@ -987,16 +987,16 @@ func TestOperationJSON_planDriftWithMove(t *testing.T) {
 	}
 	v.Plan(plan, testSchemas())
 
-	want := []map[string]interface{}{
+	want := []map[string]any{
 		// Drift detected: delete
 		{
 			"@level":   "info",
 			"@message": "test_resource.beep: Drift detected (delete)",
 			"@module":  "tofu.ui",
 			"type":     "resource_drift",
-			"change": map[string]interface{}{
+			"change": map[string]any{
 				"action": "delete",
-				"resource": map[string]interface{}{
+				"resource": map[string]any{
 					"addr":             "test_resource.beep",
 					"implied_provider": "test",
 					"module":           "",
@@ -1013,9 +1013,9 @@ func TestOperationJSON_planDriftWithMove(t *testing.T) {
 			"@message": "test_resource.boop: Drift detected (update)",
 			"@module":  "tofu.ui",
 			"type":     "resource_drift",
-			"change": map[string]interface{}{
+			"change": map[string]any{
 				"action": "update",
-				"resource": map[string]interface{}{
+				"resource": map[string]any{
 					"addr":             "test_resource.boop",
 					"implied_provider": "test",
 					"module":           "",
@@ -1024,7 +1024,7 @@ func TestOperationJSON_planDriftWithMove(t *testing.T) {
 					"resource_name":    "boop",
 					"resource_type":    "test_resource",
 				},
-				"previous_resource": map[string]interface{}{
+				"previous_resource": map[string]any{
 					"addr":             "test_resource.blep",
 					"implied_provider": "test",
 					"module":           "",
@@ -1041,9 +1041,9 @@ func TestOperationJSON_planDriftWithMove(t *testing.T) {
 			"@message": `test_resource.honk["bonk"]: Plan to move`,
 			"@module":  "tofu.ui",
 			"type":     "planned_change",
-			"change": map[string]interface{}{
+			"change": map[string]any{
 				"action": "move",
-				"resource": map[string]interface{}{
+				"resource": map[string]any{
 					"addr":             `test_resource.honk["bonk"]`,
 					"implied_provider": "test",
 					"module":           "",
@@ -1052,7 +1052,7 @@ func TestOperationJSON_planDriftWithMove(t *testing.T) {
 					"resource_name":    "honk",
 					"resource_type":    "test_resource",
 				},
-				"previous_resource": map[string]interface{}{
+				"previous_resource": map[string]any{
 					"addr":             `test_resource.honk[0]`,
 					"implied_provider": "test",
 					"module":           "",
@@ -1069,7 +1069,7 @@ func TestOperationJSON_planDriftWithMove(t *testing.T) {
 			"@message": "Plan: 0 to add, 0 to change, 0 to destroy.",
 			"@module":  "tofu.ui",
 			"type":     "change_summary",
-			"changes": map[string]interface{}{
+			"changes": map[string]any{
 				"operation": "plan",
 				"add":       float64(0),
 				"import":    float64(0),
@@ -1119,16 +1119,16 @@ func TestOperationJSON_planDriftWithMoveRefreshOnly(t *testing.T) {
 	}
 	v.Plan(plan, testSchemas())
 
-	want := []map[string]interface{}{
+	want := []map[string]any{
 		// Drift detected: delete
 		{
 			"@level":   "info",
 			"@message": "test_resource.beep: Drift detected (delete)",
 			"@module":  "tofu.ui",
 			"type":     "resource_drift",
-			"change": map[string]interface{}{
+			"change": map[string]any{
 				"action": "delete",
-				"resource": map[string]interface{}{
+				"resource": map[string]any{
 					"addr":             "test_resource.beep",
 					"implied_provider": "test",
 					"module":           "",
@@ -1145,9 +1145,9 @@ func TestOperationJSON_planDriftWithMoveRefreshOnly(t *testing.T) {
 			"@message": "test_resource.boop: Drift detected (update)",
 			"@module":  "tofu.ui",
 			"type":     "resource_drift",
-			"change": map[string]interface{}{
+			"change": map[string]any{
 				"action": "update",
-				"resource": map[string]interface{}{
+				"resource": map[string]any{
 					"addr":             "test_resource.boop",
 					"implied_provider": "test",
 					"module":           "",
@@ -1156,7 +1156,7 @@ func TestOperationJSON_planDriftWithMoveRefreshOnly(t *testing.T) {
 					"resource_name":    "boop",
 					"resource_type":    "test_resource",
 				},
-				"previous_resource": map[string]interface{}{
+				"previous_resource": map[string]any{
 					"addr":             "test_resource.blep",
 					"implied_provider": "test",
 					"module":           "",
@@ -1173,9 +1173,9 @@ func TestOperationJSON_planDriftWithMoveRefreshOnly(t *testing.T) {
 			"@message": `test_resource.honk["bonk"]: Drift detected (move)`,
 			"@module":  "tofu.ui",
 			"type":     "resource_drift",
-			"change": map[string]interface{}{
+			"change": map[string]any{
 				"action": "move",
-				"resource": map[string]interface{}{
+				"resource": map[string]any{
 					"addr":             `test_resource.honk["bonk"]`,
 					"implied_provider": "test",
 					"module":           "",
@@ -1184,7 +1184,7 @@ func TestOperationJSON_planDriftWithMoveRefreshOnly(t *testing.T) {
 					"resource_name":    "honk",
 					"resource_type":    "test_resource",
 				},
-				"previous_resource": map[string]interface{}{
+				"previous_resource": map[string]any{
 					"addr":             `test_resource.honk[0]`,
 					"implied_provider": "test",
 					"module":           "",
@@ -1201,7 +1201,7 @@ func TestOperationJSON_planDriftWithMoveRefreshOnly(t *testing.T) {
 			"@message": "Plan: 0 to add, 0 to change, 0 to destroy.",
 			"@module":  "tofu.ui",
 			"type":     "change_summary",
-			"changes": map[string]interface{}{
+			"changes": map[string]any{
 				"operation": "plan",
 				"add":       float64(0),
 				"import":    float64(0),
@@ -1255,14 +1255,14 @@ func TestOperationJSON_planOutputChanges(t *testing.T) {
 	}
 	v.Plan(plan, testSchemas())
 
-	want := []map[string]interface{}{
+	want := []map[string]any{
 		// No resource changes
 		{
 			"@level":   "info",
 			"@message": "Plan: 0 to add, 0 to change, 0 to destroy.",
 			"@module":  "tofu.ui",
 			"type":     "change_summary",
-			"changes": map[string]interface{}{
+			"changes": map[string]any{
 				"operation": "plan",
 				"add":       float64(0),
 				"import":    float64(0),
@@ -1277,20 +1277,20 @@ func TestOperationJSON_planOutputChanges(t *testing.T) {
 			"@message": "Outputs: 4",
 			"@module":  "tofu.ui",
 			"type":     "outputs",
-			"outputs": map[string]interface{}{
-				"boop": map[string]interface{}{
+			"outputs": map[string]any{
+				"boop": map[string]any{
 					"action":    "noop",
 					"sensitive": false,
 				},
-				"beep": map[string]interface{}{
+				"beep": map[string]any{
 					"action":    "create",
 					"sensitive": false,
 				},
-				"bonk": map[string]interface{}{
+				"bonk": map[string]any{
 					"action":    "delete",
 					"sensitive": false,
 				},
-				"honk": map[string]interface{}{
+				"honk": map[string]any{
 					"action":    "update",
 					"sensitive": true,
 				},
@@ -1332,16 +1332,16 @@ func TestOperationJSON_plannedChange(t *testing.T) {
 	})
 
 	// Expect only two messages, as the data source deletion should be a no-op
-	want := []map[string]interface{}{
+	want := []map[string]any{
 		{
 			"@level":   "info",
 			"@message": "test_instance.boop[0]: Plan to replace",
 			"@module":  "tofu.ui",
 			"type":     "planned_change",
-			"change": map[string]interface{}{
+			"change": map[string]any{
 				"action": "replace",
 				"reason": "requested",
-				"resource": map[string]interface{}{
+				"resource": map[string]any{
 					"addr":             `test_instance.boop[0]`,
 					"implied_provider": "test",
 					"module":           "",
@@ -1357,9 +1357,9 @@ func TestOperationJSON_plannedChange(t *testing.T) {
 			"@message": "test_instance.boop[1]: Plan to create",
 			"@module":  "tofu.ui",
 			"type":     "planned_change",
-			"change": map[string]interface{}{
+			"change": map[string]any{
 				"action": "create",
-				"resource": map[string]interface{}{
+				"resource": map[string]any{
 					"addr":             `test_instance.boop[1]`,
 					"implied_provider": "test",
 					"module":           "",

--- a/internal/command/views/refresh_test.go
+++ b/internal/command/views/refresh_test.go
@@ -89,19 +89,19 @@ func TestRefreshJSON_outputs(t *testing.T) {
 		"password":   {Value: cty.StringVal("horse-battery").Mark(marks.Sensitive), Sensitive: true},
 	})
 
-	want := []map[string]interface{}{
+	want := []map[string]any{
 		{
 			"@level":   "info",
 			"@message": "Outputs: 2",
 			"@module":  "tofu.ui",
 			"type":     "outputs",
-			"outputs": map[string]interface{}{
-				"boop_count": map[string]interface{}{
+			"outputs": map[string]any{
+				"boop_count": map[string]any{
 					"sensitive": false,
 					"value":     float64(92),
 					"type":      "number",
 				},
-				"password": map[string]interface{}{
+				"password": map[string]any{
 					"sensitive": true,
 					"type":      "string",
 				},

--- a/internal/command/views/test.go
+++ b/internal/command/views/test.go
@@ -544,7 +544,7 @@ func (t *TestJSON) DestroySummary(diags tfdiags.Diagnostics, run *moduletest.Run
 }
 
 func (t *TestJSON) Diagnostics(run *moduletest.Run, file *moduletest.File, diags tfdiags.Diagnostics) {
-	var metadata []interface{}
+	var metadata []any
 	if file != nil {
 		metadata = append(metadata, "@testfile", file.Name)
 	}

--- a/internal/command/views/test_test.go
+++ b/internal/command/views/test_test.go
@@ -1329,7 +1329,7 @@ OpenTofu was in the process of creating the following resources for
 func TestTestJSON_Abstract(t *testing.T) {
 	tcs := map[string]struct {
 		suite *moduletest.Suite
-		want  []map[string]interface{}
+		want  []map[string]any
 	}{
 		"single": {
 			suite: &moduletest.Suite{
@@ -1343,13 +1343,13 @@ func TestTestJSON_Abstract(t *testing.T) {
 					},
 				},
 			},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":   "info",
 					"@message": "Found 1 file and 1 run block",
 					"@module":  "tofu.ui",
-					"test_abstract": map[string]interface{}{
-						"main.tftest.hcl": []interface{}{
+					"test_abstract": map[string]any{
+						"main.tftest.hcl": []any{
 							"setup",
 						},
 					},
@@ -1379,17 +1379,17 @@ func TestTestJSON_Abstract(t *testing.T) {
 					},
 				},
 			},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":   "info",
 					"@message": "Found 2 files and 3 run blocks",
 					"@module":  "tofu.ui",
-					"test_abstract": map[string]interface{}{
-						"main.tftest.hcl": []interface{}{
+					"test_abstract": map[string]any{
+						"main.tftest.hcl": []any{
 							"setup",
 							"test",
 						},
-						"other.tftest.hcl": []interface{}{
+						"other.tftest.hcl": []any{
 							"test",
 						},
 					},
@@ -1412,16 +1412,16 @@ func TestTestJSON_Abstract(t *testing.T) {
 func TestTestJSON_Conclusion(t *testing.T) {
 	tcs := map[string]struct {
 		suite *moduletest.Suite
-		want  []map[string]interface{}
+		want  []map[string]any
 	}{
 		"no tests": {
 			suite: &moduletest.Suite{},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":   "info",
 					"@message": "Executed 0 tests.",
 					"@module":  "tofu.ui",
-					"test_summary": map[string]interface{}{
+					"test_summary": map[string]any{
 						"status":  "pending",
 						"errored": 0.0,
 						"failed":  0.0,
@@ -1475,12 +1475,12 @@ func TestTestJSON_Conclusion(t *testing.T) {
 					},
 				},
 			},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":   "info",
 					"@message": "Executed 0 tests, 6 skipped.",
 					"@module":  "tofu.ui",
-					"test_summary": map[string]interface{}{
+					"test_summary": map[string]any{
 						"status":  "skip",
 						"errored": 0.0,
 						"failed":  0.0,
@@ -1534,12 +1534,12 @@ func TestTestJSON_Conclusion(t *testing.T) {
 					},
 				},
 			},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":   "info",
 					"@message": "Success! 6 passed, 0 failed.",
 					"@module":  "tofu.ui",
-					"test_summary": map[string]interface{}{
+					"test_summary": map[string]any{
 						"status":  "pass",
 						"errored": 0.0,
 						"failed":  0.0,
@@ -1593,12 +1593,12 @@ func TestTestJSON_Conclusion(t *testing.T) {
 					},
 				},
 			},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":   "info",
 					"@message": "Success! 4 passed, 0 failed, 2 skipped.",
 					"@module":  "tofu.ui",
-					"test_summary": map[string]interface{}{
+					"test_summary": map[string]any{
 						"status":  "pass",
 						"errored": 0.0,
 						"failed":  0.0,
@@ -1652,12 +1652,12 @@ func TestTestJSON_Conclusion(t *testing.T) {
 					},
 				},
 			},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":   "info",
 					"@message": "Failure! 0 passed, 6 failed.",
 					"@module":  "tofu.ui",
-					"test_summary": map[string]interface{}{
+					"test_summary": map[string]any{
 						"status":  "fail",
 						"errored": 0.0,
 						"failed":  6.0,
@@ -1711,12 +1711,12 @@ func TestTestJSON_Conclusion(t *testing.T) {
 					},
 				},
 			},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":   "info",
 					"@message": "Failure! 0 passed, 4 failed, 2 skipped.",
 					"@module":  "tofu.ui",
-					"test_summary": map[string]interface{}{
+					"test_summary": map[string]any{
 						"status":  "fail",
 						"errored": 0.0,
 						"failed":  4.0,
@@ -1770,12 +1770,12 @@ func TestTestJSON_Conclusion(t *testing.T) {
 					},
 				},
 			},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":   "info",
 					"@message": "Failure! 2 passed, 2 failed, 2 skipped.",
 					"@module":  "tofu.ui",
-					"test_summary": map[string]interface{}{
+					"test_summary": map[string]any{
 						"status":  "fail",
 						"errored": 0.0,
 						"failed":  2.0,
@@ -1829,12 +1829,12 @@ func TestTestJSON_Conclusion(t *testing.T) {
 					},
 				},
 			},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":   "info",
 					"@message": "Failure! 0 passed, 6 failed.",
 					"@module":  "tofu.ui",
-					"test_summary": map[string]interface{}{
+					"test_summary": map[string]any{
 						"status":  "error",
 						"errored": 3.0,
 						"failed":  3.0,
@@ -1888,12 +1888,12 @@ func TestTestJSON_Conclusion(t *testing.T) {
 					},
 				},
 			},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":   "info",
 					"@message": "Failure! 2 passed, 2 failed, 2 skipped.",
 					"@module":  "tofu.ui",
-					"test_summary": map[string]interface{}{
+					"test_summary": map[string]any{
 						"status":  "error",
 						"errored": 1.0,
 						"failed":  1.0,
@@ -1922,7 +1922,7 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 		run   *moduletest.Run
 		state *states.State
 		diags tfdiags.Diagnostics
-		want  []map[string]interface{}
+		want  []map[string]any
 	}{
 		"empty_state_only_warnings": {
 			diags: tfdiags.Diagnostics{
@@ -1931,13 +1931,13 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 			},
 			file:  &moduletest.File{Name: "main.tftest.hcl"},
 			state: states.NewState(),
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":    "warn",
 					"@message":  "Warning: first warning",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
-					"diagnostic": map[string]interface{}{
+					"diagnostic": map[string]any{
 						"detail":   "something not very bad happened",
 						"severity": "warning",
 						"summary":  "first warning",
@@ -1949,7 +1949,7 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 					"@message":  "Warning: second warning",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
-					"diagnostic": map[string]interface{}{
+					"diagnostic": map[string]any{
 						"detail":   "something not very bad happened again",
 						"severity": "warning",
 						"summary":  "second warning",
@@ -1966,13 +1966,13 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 			},
 			file:  &moduletest.File{Name: "main.tftest.hcl"},
 			state: states.NewState(),
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":    "warn",
 					"@message":  "Warning: first warning",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
-					"diagnostic": map[string]interface{}{
+					"diagnostic": map[string]any{
 						"detail":   "something not very bad happened",
 						"severity": "warning",
 						"summary":  "first warning",
@@ -1984,7 +1984,7 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 					"@message":  "Warning: second warning",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
-					"diagnostic": map[string]interface{}{
+					"diagnostic": map[string]any{
 						"detail":   "something not very bad happened again",
 						"severity": "warning",
 						"summary":  "second warning",
@@ -1996,7 +1996,7 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 					"@message":  "Error: first error",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
-					"diagnostic": map[string]interface{}{
+					"diagnostic": map[string]any{
 						"detail":   "this time it is very bad",
 						"severity": "error",
 						"summary":  "first error",
@@ -2023,16 +2023,16 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 						Provider: addrs.NewDefaultProvider("test"),
 					}, addrs.NoKey)
 			}),
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":    "error",
 					"@message":  "OpenTofu left some resources in state after executing main.tftest.hcl/run_block, these left-over resources can be viewed by reading the statefile written to disk(errored_test.tfstate) and they need to be cleaned up manually:",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
 					"@testrun":  "run_block",
-					"test_cleanup": map[string]interface{}{
-						"failed_resources": []interface{}{
-							map[string]interface{}{
+					"test_cleanup": map[string]any{
+						"failed_resources": []any{
+							map[string]any{
 								"instance": "test.foo",
 							},
 						},
@@ -2089,22 +2089,22 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 						Provider: addrs.NewDefaultProvider("test"),
 					}, addrs.NoKey)
 			}),
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":    "error",
 					"@message":  "OpenTofu left some resources in state after executing main.tftest.hcl, these left-over resources can be viewed by reading the statefile written to disk(errored_test.tfstate) and they need to be cleaned up manually:",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
-					"test_cleanup": map[string]interface{}{
-						"failed_resources": []interface{}{
-							map[string]interface{}{
+					"test_cleanup": map[string]any{
+						"failed_resources": []any{
+							map[string]any{
 								"instance": "test.bar",
 							},
-							map[string]interface{}{
+							map[string]any{
 								"instance":    "test.bar",
 								"deposed_key": "0fcb640a",
 							},
-							map[string]interface{}{
+							map[string]any{
 								"instance": "test.foo",
 							},
 						},
@@ -2116,7 +2116,7 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 					"@message":  "Warning: first warning",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
-					"diagnostic": map[string]interface{}{
+					"diagnostic": map[string]any{
 						"detail":   "something not very bad happened",
 						"severity": "warning",
 						"summary":  "first warning",
@@ -2128,7 +2128,7 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 					"@message":  "Warning: second warning",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
-					"diagnostic": map[string]interface{}{
+					"diagnostic": map[string]any{
 						"detail":   "something not very bad happened again",
 						"severity": "warning",
 						"summary":  "second warning",
@@ -2186,22 +2186,22 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 						Provider: addrs.NewDefaultProvider("test"),
 					}, addrs.NoKey)
 			}),
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":    "error",
 					"@message":  "OpenTofu left some resources in state after executing main.tftest.hcl, these left-over resources can be viewed by reading the statefile written to disk(errored_test.tfstate) and they need to be cleaned up manually:",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
-					"test_cleanup": map[string]interface{}{
-						"failed_resources": []interface{}{
-							map[string]interface{}{
+					"test_cleanup": map[string]any{
+						"failed_resources": []any{
+							map[string]any{
 								"instance": "test.bar",
 							},
-							map[string]interface{}{
+							map[string]any{
 								"instance":    "test.bar",
 								"deposed_key": "0fcb640a",
 							},
-							map[string]interface{}{
+							map[string]any{
 								"instance": "test.foo",
 							},
 						},
@@ -2213,7 +2213,7 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 					"@message":  "Warning: first warning",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
-					"diagnostic": map[string]interface{}{
+					"diagnostic": map[string]any{
 						"detail":   "something not very bad happened",
 						"severity": "warning",
 						"summary":  "first warning",
@@ -2225,7 +2225,7 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 					"@message":  "Warning: second warning",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
-					"diagnostic": map[string]interface{}{
+					"diagnostic": map[string]any{
 						"detail":   "something not very bad happened again",
 						"severity": "warning",
 						"summary":  "second warning",
@@ -2237,7 +2237,7 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 					"@message":  "Error: first error",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
-					"diagnostic": map[string]interface{}{
+					"diagnostic": map[string]any{
 						"detail":   "this time it is very bad",
 						"severity": "error",
 						"summary":  "first error",
@@ -2291,18 +2291,18 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 						Module:   addrs.RootModule,
 						Provider: addrs.NewDefaultProvider("null"),
 					}, addrs.NoKey)
-			}), want: []map[string]interface{}{
+			}), want: []map[string]any{
 				{
 					"@level":    "error",
 					"@message":  "OpenTofu left some resources in state after executing main.tftest.hcl, these left-over resources can be viewed by reading the statefile written to disk(errored_test.tfstate) and they need to be cleaned up manually:",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
-					"test_cleanup": map[string]interface{}{
-						"failed_resources": []interface{}{
-							map[string]interface{}{
+					"test_cleanup": map[string]any{
+						"failed_resources": []any{
+							map[string]any{
 								"instance": "null_resource.failing",
 							},
-							map[string]interface{}{
+							map[string]any{
 								"instance": "null_resource.failing_will_depend_on_me",
 							},
 						},
@@ -2314,7 +2314,7 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 					"@message":  "Warning: first warning",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
-					"diagnostic": map[string]interface{}{
+					"diagnostic": map[string]any{
 						"detail":   "something not very bad happened",
 						"severity": "warning",
 						"summary":  "first warning",
@@ -2326,7 +2326,7 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 					"@message":  "Warning: second warning",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
-					"diagnostic": map[string]interface{}{
+					"diagnostic": map[string]any{
 						"detail":   "something not very bad happened again",
 						"severity": "warning",
 						"summary":  "second warning",
@@ -2338,7 +2338,7 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 					"@message":  "Error: first error",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
-					"diagnostic": map[string]interface{}{
+					"diagnostic": map[string]any{
 						"detail":   "this time it is very bad",
 						"severity": "error",
 						"summary":  "first error",
@@ -2362,17 +2362,17 @@ func TestTestJSON_DestroySummary(t *testing.T) {
 func TestTestJSON_File(t *testing.T) {
 	tcs := map[string]struct {
 		file *moduletest.File
-		want []map[string]interface{}
+		want []map[string]any
 	}{
 		"pass": {
 			file: &moduletest.File{Name: "main.tf", Status: moduletest.Pass},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":    "info",
 					"@message":  "main.tf... pass",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tf",
-					"test_file": map[string]interface{}{
+					"test_file": map[string]any{
 						"path":   "main.tf",
 						"status": "pass",
 					},
@@ -2383,13 +2383,13 @@ func TestTestJSON_File(t *testing.T) {
 
 		"pending": {
 			file: &moduletest.File{Name: "main.tf", Status: moduletest.Pending},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":    "info",
 					"@message":  "main.tf... pending",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tf",
-					"test_file": map[string]interface{}{
+					"test_file": map[string]any{
 						"path":   "main.tf",
 						"status": "pending",
 					},
@@ -2400,13 +2400,13 @@ func TestTestJSON_File(t *testing.T) {
 
 		"skip": {
 			file: &moduletest.File{Name: "main.tf", Status: moduletest.Skip},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":    "info",
 					"@message":  "main.tf... skip",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tf",
-					"test_file": map[string]interface{}{
+					"test_file": map[string]any{
 						"path":   "main.tf",
 						"status": "skip",
 					},
@@ -2417,13 +2417,13 @@ func TestTestJSON_File(t *testing.T) {
 
 		"fail": {
 			file: &moduletest.File{Name: "main.tf", Status: moduletest.Fail},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":    "info",
 					"@message":  "main.tf... fail",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tf",
-					"test_file": map[string]interface{}{
+					"test_file": map[string]any{
 						"path":   "main.tf",
 						"status": "fail",
 					},
@@ -2434,13 +2434,13 @@ func TestTestJSON_File(t *testing.T) {
 
 		"error": {
 			file: &moduletest.File{Name: "main.tf", Status: moduletest.Error},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":    "info",
 					"@message":  "main.tf... fail",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tf",
-					"test_file": map[string]interface{}{
+					"test_file": map[string]any{
 						"path":   "main.tf",
 						"status": "error",
 					},
@@ -2463,18 +2463,18 @@ func TestTestJSON_File(t *testing.T) {
 func TestTestJSON_Run(t *testing.T) {
 	tcs := map[string]struct {
 		run  *moduletest.Run
-		want []map[string]interface{}
+		want []map[string]any
 	}{
 		"pass": {
 			run: &moduletest.Run{Name: "run_block", Status: moduletest.Pass},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":    "info",
 					"@message":  "  \"run_block\"... pass",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
 					"@testrun":  "run_block",
-					"test_run": map[string]interface{}{
+					"test_run": map[string]any{
 						"path":   "main.tftest.hcl",
 						"run":    "run_block",
 						"status": "pass",
@@ -2490,14 +2490,14 @@ func TestTestJSON_Run(t *testing.T) {
 				Status:      moduletest.Pass,
 				Diagnostics: tfdiags.Diagnostics{tfdiags.Sourceless(tfdiags.Warning, "a warning occurred", "some warning happened during this test")},
 			},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":    "info",
 					"@message":  "  \"run_block\"... pass",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
 					"@testrun":  "run_block",
-					"test_run": map[string]interface{}{
+					"test_run": map[string]any{
 						"path":   "main.tftest.hcl",
 						"run":    "run_block",
 						"status": "pass",
@@ -2510,7 +2510,7 @@ func TestTestJSON_Run(t *testing.T) {
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
 					"@testrun":  "run_block",
-					"diagnostic": map[string]interface{}{
+					"diagnostic": map[string]any{
 						"detail":   "some warning happened during this test",
 						"severity": "warning",
 						"summary":  "a warning occurred",
@@ -2522,14 +2522,14 @@ func TestTestJSON_Run(t *testing.T) {
 
 		"pending": {
 			run: &moduletest.Run{Name: "run_block", Status: moduletest.Pending},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":    "info",
 					"@message":  "  \"run_block\"... pending",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
 					"@testrun":  "run_block",
-					"test_run": map[string]interface{}{
+					"test_run": map[string]any{
 						"path":   "main.tftest.hcl",
 						"run":    "run_block",
 						"status": "pending",
@@ -2541,14 +2541,14 @@ func TestTestJSON_Run(t *testing.T) {
 
 		"skip": {
 			run: &moduletest.Run{Name: "run_block", Status: moduletest.Skip},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":    "info",
 					"@message":  "  \"run_block\"... skip",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
 					"@testrun":  "run_block",
-					"test_run": map[string]interface{}{
+					"test_run": map[string]any{
 						"path":   "main.tftest.hcl",
 						"run":    "run_block",
 						"status": "skip",
@@ -2560,14 +2560,14 @@ func TestTestJSON_Run(t *testing.T) {
 
 		"fail": {
 			run: &moduletest.Run{Name: "run_block", Status: moduletest.Fail},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":    "info",
 					"@message":  "  \"run_block\"... fail",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
 					"@testrun":  "run_block",
-					"test_run": map[string]interface{}{
+					"test_run": map[string]any{
 						"path":   "main.tftest.hcl",
 						"run":    "run_block",
 						"status": "fail",
@@ -2586,14 +2586,14 @@ func TestTestJSON_Run(t *testing.T) {
 					tfdiags.Sourceless(tfdiags.Error, "a second comparison failed", "other details"),
 				},
 			},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":    "info",
 					"@message":  "  \"run_block\"... fail",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
 					"@testrun":  "run_block",
-					"test_run": map[string]interface{}{
+					"test_run": map[string]any{
 						"path":   "main.tftest.hcl",
 						"run":    "run_block",
 						"status": "fail",
@@ -2606,7 +2606,7 @@ func TestTestJSON_Run(t *testing.T) {
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
 					"@testrun":  "run_block",
-					"diagnostic": map[string]interface{}{
+					"diagnostic": map[string]any{
 						"detail":   "details details details",
 						"severity": "error",
 						"summary":  "a comparison failed",
@@ -2619,7 +2619,7 @@ func TestTestJSON_Run(t *testing.T) {
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
 					"@testrun":  "run_block",
-					"diagnostic": map[string]interface{}{
+					"diagnostic": map[string]any{
 						"detail":   "other details",
 						"severity": "error",
 						"summary":  "a second comparison failed",
@@ -2631,14 +2631,14 @@ func TestTestJSON_Run(t *testing.T) {
 
 		"error": {
 			run: &moduletest.Run{Name: "run_block", Status: moduletest.Error},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":    "info",
 					"@message":  "  \"run_block\"... fail",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
 					"@testrun":  "run_block",
-					"test_run": map[string]interface{}{
+					"test_run": map[string]any{
 						"path":   "main.tftest.hcl",
 						"run":    "run_block",
 						"status": "error",
@@ -2654,14 +2654,14 @@ func TestTestJSON_Run(t *testing.T) {
 				Status:      moduletest.Error,
 				Diagnostics: tfdiags.Diagnostics{tfdiags.Sourceless(tfdiags.Error, "an error occurred", "something bad happened during this test")},
 			},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":    "info",
 					"@message":  "  \"run_block\"... fail",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
 					"@testrun":  "run_block",
-					"test_run": map[string]interface{}{
+					"test_run": map[string]any{
 						"path":   "main.tftest.hcl",
 						"run":    "run_block",
 						"status": "error",
@@ -2674,7 +2674,7 @@ func TestTestJSON_Run(t *testing.T) {
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
 					"@testrun":  "run_block",
-					"diagnostic": map[string]interface{}{
+					"diagnostic": map[string]any{
 						"detail":   "something bad happened during this test",
 						"severity": "error",
 						"summary":  "an error occurred",
@@ -2766,14 +2766,14 @@ func TestTestJSON_Run(t *testing.T) {
 					},
 				},
 			},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":    "info",
 					"@message":  "  \"run_block\"... pass",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
 					"@testrun":  "run_block",
-					"test_run": map[string]interface{}{
+					"test_run": map[string]any{
 						"path":   "main.tftest.hcl",
 						"run":    "run_block",
 						"status": "pass",
@@ -2786,39 +2786,39 @@ func TestTestJSON_Run(t *testing.T) {
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
 					"@testrun":  "run_block",
-					"test_plan": map[string]interface{}{
-						"configuration": map[string]interface{}{
-							"root_module": map[string]interface{}{},
+					"test_plan": map[string]any{
+						"configuration": map[string]any{
+							"root_module": map[string]any{},
 						},
 						"errored": false,
-						"planned_values": map[string]interface{}{
-							"root_module": map[string]interface{}{
-								"resources": []interface{}{
-									map[string]interface{}{
+						"planned_values": map[string]any{
+							"root_module": map[string]any{
+								"resources": []any{
+									map[string]any{
 										"address":          "test_resource.creating",
 										"mode":             "managed",
 										"name":             "creating",
 										"provider_name":    "registry.opentofu.org/hashicorp/test",
 										"schema_version":   0.0,
-										"sensitive_values": map[string]interface{}{},
+										"sensitive_values": map[string]any{},
 										"type":             "test_resource",
-										"values": map[string]interface{}{
+										"values": map[string]any{
 											"value": "foobar",
 										},
 									},
 								},
 							},
 						},
-						"resource_changes": []interface{}{
-							map[string]interface{}{
+						"resource_changes": []any{
+							map[string]any{
 								"address": "test_resource.creating",
-								"change": map[string]interface{}{
-									"actions": []interface{}{"create"},
-									"after": map[string]interface{}{
+								"change": map[string]any{
+									"actions": []any{"create"},
+									"after": map[string]any{
 										"value": "foobar",
 									},
-									"after_sensitive":  map[string]interface{}{},
-									"after_unknown":    map[string]interface{}{},
+									"after_sensitive":  map[string]any{},
+									"after_unknown":    map[string]any{},
 									"before":           nil,
 									"before_sensitive": false,
 								},
@@ -2890,14 +2890,14 @@ func TestTestJSON_Run(t *testing.T) {
 					},
 				},
 			},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":    "info",
 					"@message":  "  \"run_block\"... pass",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
 					"@testrun":  "run_block",
-					"test_run": map[string]interface{}{
+					"test_run": map[string]any{
 						"path":   "main.tftest.hcl",
 						"run":    "run_block",
 						"status": "pass",
@@ -2910,19 +2910,19 @@ func TestTestJSON_Run(t *testing.T) {
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
 					"@testrun":  "run_block",
-					"test_state": map[string]interface{}{
-						"values": map[string]interface{}{
-							"root_module": map[string]interface{}{
-								"resources": []interface{}{
-									map[string]interface{}{
+					"test_state": map[string]any{
+						"values": map[string]any{
+							"root_module": map[string]any{
+								"resources": []any{
+									map[string]any{
 										"address":          "test_resource.creating",
 										"mode":             "managed",
 										"name":             "creating",
 										"provider_name":    "registry.opentofu.org/hashicorp/test",
 										"schema_version":   0.0,
-										"sensitive_values": map[string]interface{}{},
+										"sensitive_values": map[string]any{},
 										"type":             "test_resource",
-										"values": map[string]interface{}{
+										"values": map[string]any{
 											"value": "foobar",
 										},
 									},
@@ -2954,7 +2954,7 @@ func TestTestJSON_FatalInterruptSummary(t *testing.T) {
 	tcs := map[string]struct {
 		states  map[*moduletest.Run]*states.State
 		changes []*plans.ResourceInstanceChangeSrc
-		want    []map[string]interface{}
+		want    []map[string]any
 	}{
 		"no_state_only_plan": {
 			states: make(map[*moduletest.Run]*states.State),
@@ -2990,14 +2990,14 @@ func TestTestJSON_FatalInterruptSummary(t *testing.T) {
 					},
 				},
 			},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":    "error",
 					"@message":  "OpenTofu was interrupted during test execution, and may not have performed the expected cleanup operations.",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
-					"test_interrupt": map[string]interface{}{
-						"planned": []interface{}{
+					"test_interrupt": map[string]any{
+						"planned": []any{
 							"test_instance.one",
 							"test_instance.two",
 						},
@@ -3039,18 +3039,18 @@ func TestTestJSON_FatalInterruptSummary(t *testing.T) {
 				}),
 			},
 			changes: nil,
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":    "error",
 					"@message":  "OpenTofu was interrupted during test execution, and may not have performed the expected cleanup operations.",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
-					"test_interrupt": map[string]interface{}{
-						"state": []interface{}{
-							map[string]interface{}{
+					"test_interrupt": map[string]any{
+						"state": []any{
+							map[string]any{
 								"instance": "test_instance.one",
 							},
-							map[string]interface{}{
+							map[string]any{
 								"instance": "test_instance.two",
 							},
 						},
@@ -3092,19 +3092,19 @@ func TestTestJSON_FatalInterruptSummary(t *testing.T) {
 				}),
 			},
 			changes: nil,
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":    "error",
 					"@message":  "OpenTofu was interrupted during test execution, and may not have performed the expected cleanup operations.",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
-					"test_interrupt": map[string]interface{}{
-						"states": map[string]interface{}{
-							"setup_block": []interface{}{
-								map[string]interface{}{
+					"test_interrupt": map[string]any{
+						"states": map[string]any{
+							"setup_block": []any{
+								map[string]any{
 									"instance": "test_instance.one",
 								},
-								map[string]interface{}{
+								map[string]any{
 									"instance": "test_instance.two",
 								},
 							},
@@ -3207,32 +3207,32 @@ func TestTestJSON_FatalInterruptSummary(t *testing.T) {
 					},
 				},
 			},
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":    "error",
 					"@message":  "OpenTofu was interrupted during test execution, and may not have performed the expected cleanup operations.",
 					"@module":   "tofu.ui",
 					"@testfile": "main.tftest.hcl",
-					"test_interrupt": map[string]interface{}{
-						"state": []interface{}{
-							map[string]interface{}{
+					"test_interrupt": map[string]any{
+						"state": []any{
+							map[string]any{
 								"instance": "test_instance.one",
 							},
-							map[string]interface{}{
+							map[string]any{
 								"instance": "test_instance.two",
 							},
 						},
-						"states": map[string]interface{}{
-							"setup_block": []interface{}{
-								map[string]interface{}{
+						"states": map[string]any{
+							"setup_block": []any{
+								map[string]any{
 									"instance": "test_instance.setup_one",
 								},
-								map[string]interface{}{
+								map[string]any{
 									"instance": "test_instance.setup_two",
 								},
 							},
 						},
-						"planned": []interface{}{
+						"planned": []any{
 							"test_instance.new_one",
 							"test_instance.new_two",
 						},
@@ -3262,7 +3262,7 @@ func TestSaveErroredStateFile(t *testing.T) {
 		run    *moduletest.Run
 		file   *moduletest.File
 		stderr string
-		want   interface{}
+		want   any
 	}{
 		"state_foo_bar_human": {
 			file: &moduletest.File{Name: "main.tftest.hcl"},
@@ -3366,7 +3366,7 @@ Writing state to file: errored_test.tfstate
 		run    *moduletest.Run
 		file   *moduletest.File
 		stderr string
-		want   interface{}
+		want   any
 	}{
 		"state_with_run_json": {
 			file: &moduletest.File{Name: "main.tftest.hcl"},
@@ -3387,7 +3387,7 @@ Writing state to file: errored_test.tfstate
 					}, addrs.NoKey)
 			}),
 			stderr: "",
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":   "info",
 					"@message": "Writing state to file: errored_test.tfstate",
@@ -3440,7 +3440,7 @@ Writing state to file: errored_test.tfstate
 					}, addrs.NoKey)
 			}),
 			stderr: "",
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":   "info",
 					"@message": "Writing state to file: errored_test.tfstate",
@@ -3490,7 +3490,7 @@ Writing state to file: errored_test.tfstate
 					}, addrs.NoKey)
 			}),
 			stderr: "",
-			want: []map[string]interface{}{
+			want: []map[string]any{
 				{
 					"@level":   "info",
 					"@message": "Writing state to file: errored_test.tfstate",
@@ -3511,7 +3511,7 @@ func runTestSaveErroredStateFile(t *testing.T, tc map[string]struct {
 	run    *moduletest.Run
 	file   *moduletest.File
 	stderr string
-	want   interface{}
+	want   any
 }, viewType arguments.ViewType) {
 	for name, data := range tc {
 		t.Run(name, func(t *testing.T) {
@@ -3539,7 +3539,7 @@ func runTestSaveErroredStateFile(t *testing.T, tc map[string]struct {
 			case arguments.ViewJSON:
 				view := NewTest(arguments.ViewOptions{ViewType: arguments.ViewJSON}, NewView(streams))
 				SaveErroredTestStateFile(data.state, data.run, data.file, view)
-				want, ok := data.want.([]map[string]interface{})
+				want, ok := data.want.([]map[string]any)
 				if !ok {
 					t.Fatalf("Failed to assert want as []map[string]interface{}")
 				}

--- a/internal/command/views/validate_test.go
+++ b/internal/command/views/validate_test.go
@@ -128,7 +128,7 @@ func TestValidateJSON(t *testing.T) {
 
 			// Make sure the result looks like JSON; we comprehensively test
 			// the structure of this output in the command package tests.
-			var result map[string]interface{}
+			var result map[string]any
 
 			if err := json.Unmarshal([]byte(got), &result); err != nil {
 				t.Fatal(err)

--- a/internal/command/workspace_delete.go
+++ b/internal/command/workspace_delete.go
@@ -8,6 +8,7 @@ package command
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/mitchellh/cli"
@@ -109,13 +110,7 @@ func (c *WorkspaceDeleteCommand) Run(rawArgs []string) int {
 	}
 
 	workspace := args.WorkspaceName
-	exists := false
-	for _, ws := range workspaces {
-		if workspace == ws {
-			exists = true
-			break
-		}
-	}
+	exists := slices.Contains(workspaces, workspace)
 
 	if !exists {
 		view.WorkspaceDoesNotExist(workspace)

--- a/internal/command/workspace_new.go
+++ b/internal/command/workspace_new.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/mitchellh/cli"
@@ -124,11 +125,9 @@ func (c *WorkspaceNewCommand) Run(rawArgs []string) int {
 		)})
 		return 1
 	}
-	for _, ws := range workspaces {
-		if workspace == ws {
-			view.WorkspaceAlreadyExists(workspace)
-			return 1
-		}
+	if slices.Contains(workspaces, workspace) {
+		view.WorkspaceAlreadyExists(workspace)
+		return 1
 	}
 
 	_, err = b.StateMgr(ctx, workspace)


### PR DESCRIPTION
This is a first round of changes under the policy we adopted in https://github.com/opentofu/opentofu/issues/3773. 

I've started with the `command` package here because the work in https://github.com/opentofu/opentofu/issues/3765 has already made a lot of changes in this package, and so the likelihood of successful automatic backporting to an earlier release branch is low already.

My rules for what to include or not are admittedly quite "vibes-based", but the general idea was:

 - If the existing diff in a file is already significantly larger than the changes the fixer proposed to make, or if the fixer is proposing to change a line that was already changed in this development period.
 - More willing to include "_test.go" files than non-test files, even if they hadn't changed as much already, just because backports from test files for bug fixes tend to be entirely new test cases more than they are modifications to existing test cases, and so the risk of conflicts is lower there.

Everything here was changed by `go fix`, except that I manually removed the `ptrTo` function from `oci_credentials_test.go` because all of the calls to it got replaced with the `new` builtin and so the linter was complaining about it now being dead code. :grinning: 

I expect to get a stronger intuition of what changes to include or not as we practice more with applying this policy, but I think this is a relatively safe set of fixes to start with.
