### PR TITLE
planning: Include provider instance config deps in execution graph

### DIFF
--- a/internal/engine/planning/execgraph_resource.go
+++ b/internal/engine/planning/execgraph_resource.go
@@ -167,10 +167,15 @@ func (b *execGraphBuilder) AddResourceInstanceObjectSubgraphs(
 		}
 	}
 
-	// FIXME: We also need a loop to add in all of the explicit dependencies
-	// from provider instance to resource instances, using the callbacks in
-	// addProviderConfigDeps. But to do that we'll first need to extend the
-	// [resourceInstanceObjects] type to capture those dependencies.
+	// We also need explicit dependency relationships whenever a provider
+	// instance's configuration refers to information from a resource instance.
+	for _, elem := range addProviderConfigDeps.Elems {
+		providerInstAddr := elem.Key
+		addConfigDep := elem.Value
+		for dependency := range objs.ProviderInstanceDependencies(providerInstAddr) {
+			addConfigDep(ensureResourceInstanceObjectResultRef(dependency, resultRefs, b))
+		}
+	}
 }
 
 func ensureResourceInstanceObjectResultRef(addr addrs.AbsResourceInstanceObject, knownResults addrs.Map[addrs.AbsResourceInstanceObject, execgraph.ResourceInstanceResultRef], b *execGraphBuilder) execgraph.ResourceInstanceResultRef {

--- a/internal/engine/planning/providers.go
+++ b/internal/engine/planning/providers.go
@@ -88,6 +88,15 @@ func (pi *providerInstances) ProviderClient(ctx context.Context, addr addrs.AbsP
 		}
 		configVal := config.ConfigVal
 
+		// Since we've already evaluated the configuration now anyway, we'll
+		// take this opportunity to record what it depends on for the benefit
+		// of later analysis passes in the planning engine.
+		// FIXME: We should probably have a more explicit API for this so that
+		// we're not interacting directly with the unexported details of both
+		// [planGlue] and [planCtx] here, but we'll wait to see how the rest
+		// of the code in this package settles before deciding how to do it.
+		planGlue.planCtx.resourceInstObjs.PutProviderInstanceDependencies(addr, config.RequiredResourceInstances)
+
 		// If _this_ call fails then unfortunately we'll end up duplicating
 		// its diagnostics for every resource instance that depends on this
 		// provider instance, which is not ideal but we don't currently have


### PR DESCRIPTION
(This is for https://github.com/opentofu/opentofu/issues/3414.)

We'll now remember what configuration dependencies we found when we instantiated each provider instance during the planning phase and include the same explicit dependencies in the execution graph.

We still have an open question of what to do with ephemeral dependencies such as those between provider instances and ephemeral resources, since those are allowed vary between plan and apply. There are existing TODOs about that in the ephemeral resource planning codepaths, but for now we're focused mainly on managed resource instances for our "walking skeleton" milestone and so we'll slightly-incorrectly assume that the dependencies will be the same during the apply phase for now until we complete that later planned design work.
