### PR TITLE
lang/eval: Propagate provider instances between modules

### DIFF
--- a/internal/lang/eval/internal/evalglue/module.go
+++ b/internal/lang/eval/internal/evalglue/module.go
@@ -71,6 +71,24 @@ type ModuleCall struct {
 	// or compilation is likely to fail with a potentially-confusing error.
 	InputValues exprs.Valuer
 
+	// ProvidersFromParent are values representing provider instances passed in
+	// through our side-channel using the "providers" meta argument in the
+	// calling module block.
+	//
+	// These valuers MUST return values of types returned by
+	// [configgraph.ProviderInstanceRefType], which are capsule types that
+	// carry [configgraph.ProviderInstance] values. It's implemented this
+	// way so that [configgraph] can think of provider instance references as
+	// just normal values and not be aware of the current weird situation where
+	// they have their own special reference expression syntax and pass
+	// between modules via completely different rules than other values.
+	//
+	// (One day we'd like to actually offer provider instance references as
+	// normal values in the surface language too, but it's not obvious how
+	// to get there from our current language without splitting the ecosystem
+	// between old-style and new-style modules.)
+	ProvidersFromParent map[addrs.LocalProviderConfig]exprs.Valuer
+
 	// AllowImpureFunctions controls whether to allow full use of a small
 	// number of functions that produce different results each time they are
 	// called, such as "timestamp".

--- a/internal/lang/eval/internal/tofu2024/uncompiled.go
+++ b/internal/lang/eval/internal/tofu2024/uncompiled.go
@@ -106,6 +106,7 @@ func (u *uncompiledModule) CompileModuleInstance(ctx context.Context, calleeAddr
 		EvaluationGlue:       call.EvaluationGlue,
 		AllowImpureFunctions: call.AllowImpureFunctions,
 		EvalContext:          call.EvalContext,
+		ProvidersFromParent:  call.ProvidersFromParent,
 	}
 	rootModuleInstance := CompileModuleInstance(ctx, u.mod, u.sourceAddr, rootModuleCall)
 	return rootModuleInstance, nil


### PR DESCRIPTION
(This is for https://github.com/opentofu/opentofu/issues/3414.)

Earlier work dealt with the problem of evaluating the references in a "providers" argument in a module call, but we didn't actually plumb it through the code that "compiles" the config representation into our internal configgraph representation.

Filling in this gap means that it's now possible to declare a provider instance in the root module and then use it in a child module, at the expense of unfortunately spreading around this "providers side-channel" special case to some more parts of the system. That seems inevitable though, since that special case is part of the user-facing language.

