### PR TITLE
resources: A new package for resource-related operations

### DIFF
--- a/internal/engine/applying/operations_resource_managed.go
+++ b/internal/engine/applying/operations_resource_managed.go
@@ -9,15 +9,14 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/engine/internal/exec"
 	"github.com/opentofu/opentofu/internal/lang/eval"
-	"github.com/opentofu/opentofu/internal/plans/objchange"
 	"github.com/opentofu/opentofu/internal/providers"
+	"github.com/opentofu/opentofu/internal/resources"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
@@ -27,7 +26,7 @@ func (ops *execOperations) ManagedFinalPlan(
 	ctx context.Context,
 	desired *eval.DesiredResourceInstance,
 	prior *exec.ResourceInstanceObject,
-	plannedVal cty.Value,
+	initialPlannedVal cty.Value,
 	providerClient *exec.ProviderClient,
 ) (*exec.ManagedResourceObjectFinalPlan, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
@@ -55,111 +54,68 @@ func (ops *execOperations) ManagedFinalPlan(
 		log.Printf("[TRACE] apply phase: ManagedFinalPlan without either desired or prior state, so no change is needed")
 		return nil, diags
 	}
-	if deposedKey == states.NotDeposed {
-		log.Printf("[TRACE] apply phase: ManagedFinalPlan %s using %s", instAddr, providerClient.InstanceAddr)
-	} else {
-		log.Printf("[TRACE] apply phase: ManagedFinalPlan %s deposed object %s using %s", instAddr, deposedKey, providerClient.InstanceAddr)
-	}
-
-	// TODO: Find a good place to centralize a function for asking a provider
-	// to produce a plan, which we can then share between this operation and
-	// the equivalent step in the planning engine. But we'll need to figure
-	// out how best to frame that shared operation because the planning engine
-	// has the additional need of recognizing whether an "update" operation
-	// needs to be treated as a "replace", whereas the execution graph should
-	// already have "replace" actions decomposed into separate create and
-	// destroy actions.
-	//
-	// For now we just have a simple implementation inline, which is good
-	// enough as a proof-of-concept.
+	objAddr := instAddr.Object(deposedKey)
+	log.Printf("[TRACE] apply phase: ManagedFinalPlan %s using %s", objAddr, providerClient.InstanceAddr)
 
 	providerAddr := providerClient.InstanceAddr.Config.Config.Provider
-	schema, moreDiags := ops.plugins.ResourceTypeSchema(
-		ctx,
-		providerAddr,
-		addrs.ManagedResourceMode,
-		resourceTypeName,
-	)
+	resourceType := resources.NewManagedResourceType(providerAddr, resourceTypeName, providerClient.Ops)
+
+	var desiredVal, currentVal cty.Value
+	var currentPrivate []byte
+	if desired != nil {
+		desiredVal = desired.ConfigVal
+	}
+	if prior != nil {
+		currentVal = prior.State.Value
+		currentPrivate = prior.State.Private
+	}
+
+	resp, moreDiags := resourceType.PlanChanges(ctx, &resources.ManagedResourcePlanRequest{
+		Current: resources.ValueWithPrivate{
+			Value:   currentVal,
+			Private: currentPrivate,
+		},
+		DesiredValue: desiredVal,
+		// TODO: Do we want to still support ProviderMeta? If so, who is
+		// responsible for propagating its value into here?
+		ProviderMetaValue: cty.NilVal,
+	}, objAddr)
 	diags = diags.Append(moreDiags)
 	if moreDiags.HasErrors() {
 		return nil, diags
 	}
 
-	var configVal, priorVal cty.Value
-	var priorPrivate []byte
-	if desired != nil {
-		configVal = desired.ConfigVal
-	} else {
-		configVal = cty.NullVal(cty.DynamicPseudoType)
-	}
-	if prior != nil {
-		priorVal = prior.State.Value
-		priorPrivate = prior.State.Private
-	} else {
-		priorVal = cty.NullVal(cty.DynamicPseudoType)
-	}
-	proposedVal := objchange.ProposedNew(schema.Block, priorVal, configVal)
-
-	// TODO: We should preserve the marks from prior and config and reapply
-	// them to the result.
-	priorValUnmarked, _ := priorVal.UnmarkDeep()
-	configValUnmarked, _ := configVal.UnmarkDeep()
-	proposedValUnmarked, _ := proposedVal.UnmarkDeep()
-
-	resp := providerClient.Ops.PlanResourceChange(ctx, providers.PlanResourceChangeRequest{
-		TypeName:         resourceTypeName,
-		PriorState:       priorValUnmarked,
-		Config:           configValUnmarked,
-		ProposedNewState: proposedValUnmarked,
-		PriorPrivate:     priorPrivate,
-		// TODO: Do we want to still support ProviderMeta? If so, who is
-		// responsible for propagating its value into here?
-		ProviderMeta: cty.NullVal(cty.DynamicPseudoType),
-	})
-	diags = diags.Append(resp.Diagnostics)
-	if resp.Diagnostics.HasErrors() {
+	// The final plan must be a valid concretization of the initial plan,
+	// which includes the rule that any known values from the initial plan
+	// remain unchanged in the final plan.
+	moreDiags = resourceType.ValidateFinalPlan(ctx, initialPlannedVal, resp.Planned.Value, objAddr)
+	diags = diags.Append(moreDiags)
+	if moreDiags.HasErrors() {
 		return nil, diags
 	}
-
-	if errs := objchange.AssertPlanValid(schema.Block, priorValUnmarked, configValUnmarked, plannedVal); len(errs) > 0 {
-		if resp.LegacyTypeSystem {
-			// The shimming of the old type system in the legacy SDK is not precise
-			// enough to pass this consistency check, so we'll give it a pass here,
-			// but we will generate a warning about it so that we are more likely
-			// to notice in the logs if an inconsistency beyond the type system
-			// leads to a downstream provider failure.
-			var buf strings.Builder
-			fmt.Fprintf(&buf,
-				"[WARN] Provider %q produced an invalid plan for %s, but we are tolerating it because it is using the legacy plugin SDK.\n    The following problems may be the cause of any confusing errors from downstream operations:",
-				providerAddr, instAddr,
-			)
-			for _, err := range errs {
-				fmt.Fprintf(&buf, "\n      - %s", tfdiags.FormatError(err))
-			}
-			log.Print(buf.String())
-		} else {
-			for _, err := range errs {
-				diags = diags.Append(tfdiags.Sourceless(
-					tfdiags.Error,
-					"Provider produced invalid plan",
-					fmt.Sprintf(
-						"Provider %q planned an invalid value for %s.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
-						providerAddr, tfdiags.FormatErrorPrefixed(err, instAddr.String()),
-					),
-				))
-			}
-			return nil, diags
-		}
+	if len(resp.RequiresReplace) != 0 {
+		// There should never be any "requires replace" in a final plan because
+		// by this point any planned replace should've already been decomposed
+		// into separate create and delete changes, and we should be making the
+		// final plan for either one of those.
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Provider produced inconsistent final plan",
+			fmt.Sprintf(
+				"When producing a final plan for %s provider %s reported that this change cannot be applied in-place, which is a different answer than during the planning phase.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
+				objAddr, providerAddr,
+			),
+		))
 	}
 
 	return &exec.ManagedResourceObjectFinalPlan{
 		InstanceAddr:    instAddr,
 		DeposedKey:      deposedKey,
 		ResourceType:    resourceTypeName,
-		PriorStateVal:   priorVal,
-		ConfigVal:       configVal,
-		PlannedVal:      resp.PlannedState,
-		ProviderPrivate: resp.PlannedPrivate,
+		PriorStateVal:   resp.Current.Value,
+		ConfigVal:       resp.DesiredValue,
+		PlannedVal:      resp.Planned.Value,
+		ProviderPrivate: resp.Planned.Private,
 	}, diags
 }
 
@@ -219,11 +175,26 @@ func (ops *execOperations) ManagedApply(
 		return nil, diags
 	}
 
+	// TODO: Encapsulate most of the following logic into a method of
+	// [resources.ManagedResourceType].
+
 	// TODO: We should preserve the marks from prior and config and reapply
 	// them to the result.
 	priorValUnmarked, _ := plan.PriorStateVal.UnmarkDeep()
 	configValUnmarked, _ := plan.ConfigVal.UnmarkDeep()
 	plannedValUnmarked, _ := plan.PlannedVal.UnmarkDeep()
+
+	// Some provider client implementations can't tolerate the values being
+	// completely nil, so we'll substitute null values to avoid crashes.
+	if priorValUnmarked == cty.NilVal {
+		priorValUnmarked = cty.NullVal(schema.Block.ImpliedType())
+	}
+	if configValUnmarked == cty.NilVal {
+		configValUnmarked = cty.NullVal(schema.Block.ImpliedType())
+	}
+	if plannedValUnmarked == cty.NilVal {
+		plannedValUnmarked = cty.NullVal(schema.Block.ImpliedType())
+	}
 
 	resp := providerClient.Ops.ApplyResourceChange(ctx, providers.ApplyResourceChangeRequest{
 		TypeName:       plan.ResourceType,

--- a/internal/engine/planning/plan_eval_glue.go
+++ b/internal/engine/planning/plan_eval_glue.go
@@ -16,7 +16,6 @@ import (
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/collections"
 	"github.com/opentofu/opentofu/internal/lang/eval"
-	"github.com/opentofu/opentofu/internal/plans/objchange"
 	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
@@ -298,31 +297,6 @@ func (p *planGlue) desiredResourceInstanceMustBeDeferred(inst *eval.DesiredResou
 	// of this to a later round. The following is not exhaustive but is a
 	// placeholder to show where deferral might fit in.
 	return inst.IsPlaceholder() || inst.ProviderInstance == nil || derivedFromDeferredVal(inst.ConfigVal)
-}
-
-func (p *planGlue) resourceInstancePlaceholderValue(ctx context.Context, providerAddr addrs.Provider, resourceMode addrs.ResourceMode, resourceType string, priorVal, configVal cty.Value) cty.Value {
-	evalCtx := p.oracle.EvalContext(ctx)
-	schema, diags := evalCtx.Providers.ResourceTypeSchema(ctx, providerAddr, resourceMode, resourceType)
-	if diags.HasErrors() {
-		// If we can't get any schema information then we'll just return
-		// a completely-unknown object as our placeholder. We should get here
-		// only if the eval system already failed to use the provider to decode
-		// or validate the configuration, and so it should already have reported
-		// a related error upstream.
-		return cty.DynamicVal
-	}
-
-	if configVal.IsNull() {
-		return cty.NullVal(schema.Block.ImpliedType().WithoutOptionalAttributesDeep())
-	}
-	if !configVal.IsKnown() {
-		return cty.UnknownVal(schema.Block.ImpliedType().WithoutOptionalAttributesDeep())
-	}
-	return objchange.ProposedNew(
-		schema.Block,
-		priorVal,
-		configVal,
-	)
 }
 
 // resourceInstancesFilter returns a sequence of resource instances from the

--- a/internal/engine/planning/plan_managed.go
+++ b/internal/engine/planning/plan_managed.go
@@ -8,15 +8,13 @@ package planning
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/lang/eval"
 	"github.com/opentofu/opentofu/internal/plans"
-	"github.com/opentofu/opentofu/internal/plans/objchange"
-	"github.com/opentofu/opentofu/internal/providers"
+	"github.com/opentofu/opentofu/internal/resources"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
@@ -66,12 +64,27 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 		ret.ReplaceOrder = replaceCreateThenDestroy
 	}
 
-	evalCtx := p.oracle.EvalContext(ctx)
-	schema, schemaDiags := evalCtx.Providers.ResourceTypeSchema(ctx,
-		inst.Provider,
-		inst.Addr.Resource.Resource.Mode,
-		inst.Addr.Resource.Resource.Type,
-	)
+	if inst.ProviderInstance == nil {
+		// If we don't even know which provider instance we're supposed to be
+		// talking to then we can't proceed any further.
+		return ret, diags
+	}
+	providerClient, moreDiags := p.providerClient(ctx, *inst.ProviderInstance)
+	if providerClient == nil {
+		moreDiags = moreDiags.Append(tfdiags.AttributeValue(
+			tfdiags.Error,
+			"Provider instance not available",
+			fmt.Sprintf("Cannot plan %s because its associated provider instance %s cannot initialize.", inst.Addr, *inst.ProviderInstance),
+			nil,
+		))
+	}
+	diags = diags.Append(moreDiags)
+	if moreDiags.HasErrors() {
+		return ret, diags
+	}
+
+	resourceType := resources.NewManagedResourceType(inst.Provider, inst.Addr.Resource.Resource.Type, providerClient)
+	schema, schemaDiags := resourceType.LoadSchema(ctx)
 	if schemaDiags.HasErrors() {
 		// We don't return the schema-loading diagnostics directly here because
 		// they should have already been returned by earlier code, but we do
@@ -89,7 +102,7 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 		return ret, diags
 	}
 
-	validateDiags := p.planCtx.providers.ValidateResourceConfig(ctx, inst.Provider, inst.ResourceMode, inst.ResourceType, inst.ConfigVal)
+	validateDiags := resourceType.ValidateConfig(ctx, inst.ConfigVal)
 	diags = diags.Append(validateDiags)
 	if diags.HasErrors() {
 		return ret, diags
@@ -127,59 +140,22 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 		prevRoundVal = cty.NullVal(schema.Block.ImpliedType())
 	}
 
-	proposedNewVal := p.resourceInstancePlaceholderValue(ctx,
-		inst.Provider,
-		inst.Addr.Resource.Resource.Mode,
-		inst.Addr.Resource.Resource.Type,
-		prevRoundVal,
-		inst.ConfigVal,
-	)
-
-	if inst.ProviderInstance == nil {
-		// If we don't even know which provider instance we're supposed to be
-		// talking to then we can't proceed any further, but we can at least
-		// improve our placeholder value based on what we learned from the
-		// configuration and prior state.
-		ret.PlaceholderValue = proposedNewVal
-		return ret, diags
-	}
-
-	providerClient, moreDiags := p.providerClient(ctx, *inst.ProviderInstance)
-	if providerClient == nil {
-		moreDiags = moreDiags.Append(tfdiags.AttributeValue(
-			tfdiags.Error,
-			"Provider instance not available",
-			fmt.Sprintf("Cannot plan %s because its associated provider instance %s cannot initialize.", inst.Addr, *inst.ProviderInstance),
-			nil,
-		))
-	}
-	diags = diags.Append(moreDiags)
-	if moreDiags.HasErrors() {
-		return ret, diags
-	}
-
 	// TODO: If inst.IgnoreChangesPaths has any entries then we need to
 	// transform effectiveConfigVal so that any paths specified in there are
 	// forced to match the corresponding value from prevRoundVal, if any.
 	effectiveConfigVal := inst.ConfigVal
 
-	// TODO: Call providerClient.ReadResource and update the "refreshed state"
+	// TODO: Call resourceType.RefreshObject, update the "refreshed state",
 	// and reassign this refreshedVal to the refreshed result.
 	refreshedVal := prevRoundVal
 	refreshedPrivate := prevRoundPrivate
 
-	// As long as we have a provider instance we should be able to ask the
-	// provider to plan _something_. If this is a placeholder for zero or more
-	// instances of a resource whose expansion isn't yet known then we're asking
-	// the provider to produce a speculative plan for all of them at once,
-	// so we can catch whatever subset of problems are already obvious across
-	// all of the potential resource instances.
-	planResp := providerClient.PlanResourceChange(ctx, providers.PlanResourceChangeRequest{
-		TypeName:         inst.ResourceType,
-		PriorState:       refreshedVal,
-		ProposedNewState: proposedNewVal,
-		Config:           effectiveConfigVal,
-		PriorPrivate:     refreshedPrivate,
+	planResp, planDiags := resourceType.PlanChanges(ctx, &resources.ManagedResourcePlanRequest{
+		Current: resources.ValueWithPrivate{
+			Value:   refreshedVal,
+			Private: refreshedPrivate,
+		},
+		DesiredValue: effectiveConfigVal,
 
 		// TODO: ProviderMeta is a rarely-used feature that only really makes
 		// sense when the module and provider are both written by the same
@@ -187,34 +163,10 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 		// transport module usage telemetry. We should decide whether we want
 		// to keep supporting that, and if so design a way for the relevant
 		// meta value to get from the evaluator into here.
-		ProviderMeta: cty.NullVal(cty.DynamicPseudoType),
-	})
-	for _, err := range objchange.AssertPlanValid(schema.Block, refreshedVal, effectiveConfigVal, planResp.PlannedState) {
-		if planResp.LegacyTypeSystem {
-			// This provider seems to be using the legacy Terraform plugin SDK
-			// that cannot implement the modern protocol correctly, so we'll
-			// treat these errors as internal log warnings instead of reporting
-			// them. This compromise means that things can work for providers
-			// that are only incorrect _because_ they are using the legacy SDK,
-			// while still providing some information about the problem in case
-			// it's useful for debugging a real issue with a provider.
-			//
-			// TODO: Bring over the full version of this log message from
-			// the original runtime.
-			log.Printf("[WARN] Provider produced invalid plan: %s", tfdiags.FormatError(err))
-			continue
-		}
-		planResp.Diagnostics = planResp.Diagnostics.Append(tfdiags.AttributeValue(
-			tfdiags.Error,
-			"Provider produced invalid plan",
-			// TODO: Bring over the full version of this error case from the
-			// original runtime.
-			fmt.Sprintf("Invalid planned new value: %s.", tfdiags.FormatError(err)),
-			nil,
-		))
-	}
-	diags = diags.Append(planResp.Diagnostics)
-	if planResp.Diagnostics.HasErrors() {
+		ProviderMetaValue: cty.NilVal,
+	}, ret.Addr)
+	diags = diags.Append(planDiags)
+	if planDiags.HasErrors() {
 		return ret, diags
 	}
 
@@ -225,7 +177,7 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 	// that case, but we would need to mark it as deferred and _not_ record a
 	// proposed change for it.
 
-	if eq, _ := planResp.PlannedState.Equals(refreshedVal).Unmark(); !eq.IsKnown() || eq.True() {
+	if eq, _ := planResp.Planned.Value.Equals(refreshedVal).Unmark(); !eq.IsKnown() || eq.True() {
 		// There is no change to make, so we'll return early without actually
 		// recording any change. In this case our resource instance will be
 		// included in the execution graph only if some other resource instance
@@ -242,6 +194,13 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 	if prevRoundState == nil {
 		plannedAction = plans.Create
 	} else if len(planResp.RequiresReplace) != 0 {
+		// FIXME: In this case we ought to call resourceType.PlanChanges
+		// again with the "current value" unset, to get the provider to plan
+		// to create the new object, and then record _that_ result as the
+		// planned new value. Currently we're just saving the planned new
+		// value from the initial call, which is likely to contain values from
+		// the old object that would not match a newly-created object of the
+		// same type.
 		if inst.CreateBeforeDestroy {
 			plannedAction = plans.CreateThenDelete
 		} else {
@@ -263,11 +222,11 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 			Alias:    (*inst.ProviderInstance).Config.Config.Alias,
 		},
 		RequiredReplace: cty.NewPathSet(planResp.RequiresReplace...),
-		Private:         planResp.PlannedPrivate,
+		Private:         planResp.Planned.Private,
 		Change: plans.Change{
 			Action: plannedAction,
-			Before: refreshedVal,
-			After:  planResp.PlannedState,
+			Before: planResp.Current.Value,
+			After:  planResp.Planned.Value,
 		},
 
 		// TODO: ActionReason, but need to figure out how to get the information
@@ -321,13 +280,33 @@ func (p *planGlue) planOrphanManagedResourceInstance(
 	// handle it as an object that is in both the prior and desired state,
 	// albeit with different addresses in each.
 
+	// FIXME: Currently this fails if the only mention of a particular provider
+	// instance is in the state, because this function relies on provider
+	// config information from the evaluator and thus only from the config.
+	// If you get the error about the provider not being able to initialize
+	// then you might currently need to add an explicit empty provider config
+	// block for the provider, if you were testing with a provider like
+	// hashicorp/null where an explicit configuration is not normally required.
+	//
+	// There's another FIXME comment further down the callstack beneath this
+	// function identifying the main location of the problem.
 	providerAddr := stateSrc.ProviderInstanceAddr.Config.Config.Provider
-	evalCtx := p.oracle.EvalContext(ctx)
-	schema, schemaDiags := evalCtx.Providers.ResourceTypeSchema(ctx,
-		providerAddr,
-		addr.Resource.Resource.Mode,
-		addr.Resource.Resource.Type,
-	)
+	providerClient, moreDiags := p.providerClient(ctx, stateSrc.ProviderInstanceAddr)
+	if providerClient == nil {
+		moreDiags = moreDiags.Append(tfdiags.AttributeValue(
+			tfdiags.Error,
+			"Provider instance not available",
+			fmt.Sprintf("Cannot plan %s because its associated provider instance %s cannot initialize.", addr, stateSrc.ProviderInstanceAddr),
+			nil,
+		))
+	}
+	diags = diags.Append(moreDiags)
+	if moreDiags.HasErrors() {
+		return ret, diags
+	}
+
+	resourceType := resources.NewManagedResourceType(providerAddr, addr.Resource.Resource.Type, providerClient)
+	schema, schemaDiags := resourceType.LoadSchema(ctx)
 	if schemaDiags.HasErrors() {
 		// We don't return the schema-loading diagnostics directly here because
 		// they should have already been returned by earlier code, but we do
@@ -363,30 +342,6 @@ func (p *planGlue) planOrphanManagedResourceInstance(
 	prevRoundVal = prevRoundState.Value
 	prevRoundPrivate = prevRoundState.Private
 
-	// FIXME: Currently this fails if the only mention of a particular provider
-	// instance is in the state, because this function relies on provider
-	// config information from the evaluator and thus only from the config.
-	// If you get the error about the provider not being able to initialize
-	// then you might currently need to add an explicit empty provider config
-	// block for the provider, if you were testing with a provider like
-	// hashicorp/null where an explicit configuration is not normally required.
-	//
-	// There's another FIXME comment further down the callstack beneath this
-	// function identifying the main location of the problem.
-	providerClient, moreDiags := p.providerClient(ctx, prevRoundState.ProviderInstanceAddr)
-	if providerClient == nil {
-		moreDiags = moreDiags.Append(tfdiags.AttributeValue(
-			tfdiags.Error,
-			"Provider instance not available",
-			fmt.Sprintf("Cannot plan %s because its associated provider instance %s cannot initialize.", addr, prevRoundState.ProviderInstanceAddr),
-			nil,
-		))
-	}
-	diags = diags.Append(moreDiags)
-	if moreDiags.HasErrors() {
-		return ret, diags
-	}
-
 	// TODO: Call providerClient.ReadResource and update the "refreshed state"
 	// and reassign this refreshedVal to the refreshed result.
 	refreshedVal := prevRoundVal
@@ -399,17 +354,12 @@ func (p *planGlue) planOrphanManagedResourceInstance(
 		return ret, diags
 	}
 
-	newVal := cty.NullVal(schema.Block.ImpliedType())
-	// FIXME: Whether the provider gets involved in planning to delete something
-	// is a dynamically-negotiable protocol feature, with older providers unable
-	// to handle requests like this. We ought to skip the following call unless
-	// we know the provider has negotiated the relevant capability.
-	planResp := providerClient.PlanResourceChange(ctx, providers.PlanResourceChangeRequest{
-		TypeName:         addr.Resource.Resource.Type,
-		PriorState:       refreshedVal,
-		ProposedNewState: newVal,
-		Config:           newVal,
-		PriorPrivate:     refreshedPrivate,
+	planResp, planDiags := resourceType.PlanChanges(ctx, &resources.ManagedResourcePlanRequest{
+		Current: resources.ValueWithPrivate{
+			Value:   refreshedVal,
+			Private: refreshedPrivate,
+		},
+		DesiredValue: cty.NilVal, // we want to destroy this object
 
 		// TODO: ProviderMeta is a rarely-used feature that only really makes
 		// sense when the module and provider are both written by the same
@@ -417,11 +367,12 @@ func (p *planGlue) planOrphanManagedResourceInstance(
 		// transport module usage telemetry. We should decide whether we want
 		// to keep supporting that, and if so design a way for the relevant
 		// meta value to get from the evaluator into here.
-		ProviderMeta: cty.NullVal(cty.DynamicPseudoType),
-	})
-	// TODO: Check that the provider's planned value is compatible with what
-	// we sent in Config, which was a null value and therefore the planned
-	// value must also be null.
+		ProviderMetaValue: cty.NilVal,
+	}, addr.CurrentObject())
+	diags = diags.Append(planDiags)
+	if planDiags.HasErrors() {
+		return ret, diags
+	}
 
 	ret.PlannedChange = &plans.ResourceInstanceChange{
 		Addr:        addr,
@@ -436,11 +387,11 @@ func (p *planGlue) planOrphanManagedResourceInstance(
 			Alias:    prevRoundState.ProviderInstanceAddr.Config.Config.Alias,
 		},
 		RequiredReplace: cty.NewPathSet(planResp.RequiresReplace...),
-		Private:         planResp.PlannedPrivate,
+		Private:         planResp.Planned.Private,
 		Change: plans.Change{
 			Action: plans.Delete,
 			Before: refreshedVal,
-			After:  planResp.PlannedState,
+			After:  planResp.Planned.Value,
 		},
 
 		// TODO: ActionReason, but need to figure out how to get the information

--- a/internal/resources/doc.go
+++ b/internal/resources/doc.go
@@ -1,0 +1,10 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+// Package resources contains helpers that encapsulate the main interactions
+// OpenTofu has with resource instance objects, wrapping the raw provider client
+// calls with certain preprocessing, postprocessing, and validation logic that
+// ought to happen regardless of why OpenTofu is asking each of these questions.
+package resources

--- a/internal/resources/managed.go
+++ b/internal/resources/managed.go
@@ -1,0 +1,100 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resources
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/providers"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+)
+
+// ManagedResourceType represents a named resource type in a specific provider,
+// and also carries a client for interacting with that provider.
+//
+// Most methods of this type relate to managed-resource-related operations in
+// the underlying provider protocol, but also include additional OpenTofu-level
+// logic such as verifying that the provider is correctly implementing the
+// protocol's constraints on how objects are allowed to change.
+type ManagedResourceType struct {
+	// providerAddr is the provider that this resource type belongs to.
+	providerAddr addrs.Provider
+
+	// typeName is the resource type name as expected by the associated provider.
+	typeName string
+
+	// client is the client to use to interact with the provider that this
+	// resource type belongs to.
+	client providers.Interface
+}
+
+var _ ResourceType = (*ManagedResourceType)(nil)
+
+// NewManagedResourceType constructs a new [ManagedResourceType] for the
+// given resource type name in the provider whose client is provided.
+//
+// It's the caller's responsibility to make sure that the given client is
+// actually for the provider indicated.
+func NewManagedResourceType(providerAddr addrs.Provider, typeName string, client providers.Interface) *ManagedResourceType {
+	return &ManagedResourceType{
+		providerAddr: providerAddr,
+		typeName:     typeName,
+		client:       client,
+	}
+}
+
+// ResourceMode implements [ResourceType].
+func (rt *ManagedResourceType) ResourceMode() addrs.ResourceMode {
+	return addrs.ManagedResourceMode
+}
+
+// ResourceTypeName implements [ResourceType].
+func (rt *ManagedResourceType) ResourceTypeName() string {
+	return rt.typeName
+}
+
+// LoadSchema loads the schema for this resource type from its provider.
+//
+// This method performs no direct caching of the result, so the underlying
+// provider client (originally passed to [NewManagedResourceType]) should
+// provide its own caching.
+func (rt *ManagedResourceType) LoadSchema(ctx context.Context) (providers.Schema, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	// This is awkward because we already have higher-level objects that
+	// can answer this question given an entire provider manager, but by the
+	// time we get here we've already used the provider manager to instantiate
+	// the client and no longer have access to the manager.
+	//
+	// TODO: Find a different way to structure this so that this concern
+	// can be centralized in one place while still accessing it indirectly
+	// through a fully-encapsulated "resource type" object that we can pass
+	// around independently of the plugin library it came from. The overall
+	// idea here is to move away from the pattern of passing around
+	// the provider manager, provider address, and resource type name as
+	// three separate arguments to functions and have it all encapsulated
+	// in a single object we can pass around, similar to how exprs.Valuer
+	// encapsulates everything needed to evaluate something.
+
+	resp := rt.client.GetProviderSchema(ctx)
+	diags = diags.Append(resp.Diagnostics)
+	if resp.Diagnostics.HasErrors() {
+		return providers.Schema{}, diags
+	}
+	ret, ok := resp.ResourceTypes[rt.typeName]
+	if !ok {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Unsupported resource type",
+			fmt.Sprintf("Provider %s does not support a managed resource type named %q.", rt.providerAddr.String(), rt.typeName),
+		))
+		return providers.Schema{}, diags
+	}
+
+	return ret, diags
+}

--- a/internal/resources/managed_plan.go
+++ b/internal/resources/managed_plan.go
@@ -1,0 +1,325 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/plans/objchange"
+	"github.com/opentofu/opentofu/internal/providers"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+)
+
+// PlanChanges encapsulates the logic for deciding what changes, if any, to make
+// to a managed resource instance object by comparing its current and desired
+// states.
+//
+// The caller must ensure that all of the provided values conform to the schema
+// of the named resource type in the given provider, or the results are
+// unspecified. [ManagedResourceType.LoadSchema] returns the expected schema.
+//
+// The dispAddr argument is used only to name the corresponding resource
+// instance object when generating diagnostics. If no diagnostics are returned
+// then that argument is completely ignored. Some of the returned diagnostics
+// can be config-contextual diagnostics expecting to be elaborated by calling
+// [tfdiags.Diagnostics.InConfigBody] with the configuration body that the
+// desired value was built from, if any.
+//
+// If the returned diagnostics contains errors then the response object might
+// either be nil or be a partial description of the invalid plan, depending on
+// the nature of the failure. Callers should use defensive programming
+// techniques if interacting with a partial response associated with an error.
+func (rt *ManagedResourceType) PlanChanges(ctx context.Context, req *ManagedResourcePlanRequest, dispAddr addrs.AbsResourceInstanceObject) (*ManagedResourcePlanResponse, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	schema, moreDiags := rt.LoadSchema(ctx)
+	diags = diags.Append(moreDiags)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	ty := schema.Block.ImpliedType().WithoutOptionalAttributesDeep()
+
+	var currentVal, desiredVal cty.Value
+	var currentPrivate []byte
+	if req.Current.Value != cty.NilVal {
+		currentVal = req.Current.Value
+		currentPrivate = req.Current.Private
+	} else {
+		currentVal = cty.NullVal(ty)
+	}
+	if req.DesiredValue != cty.NilVal {
+		desiredVal = req.DesiredValue
+	} else {
+		desiredVal = cty.NullVal(ty)
+	}
+	var providerMetaVal cty.Value
+	if req.ProviderMetaValue != cty.NilVal {
+		providerMetaVal = req.ProviderMetaValue
+	} else {
+		// Leaving the ProviderMeta field unpopulated in the provider
+		// request makes some provider clients crash, so we'll substitute an
+		// untyped null just to avoid that.
+		providerMetaVal = cty.NullVal(cty.DynamicPseudoType)
+	}
+
+	// proposedVal is essentially a default answer for how to merge currentVal
+	// and desiredVal, which providers are allowed to use as a shortcut in
+	// their planning logic for simple cases where no special planning behavior
+	// is needed. Providers are allowed to ignore this value completely and
+	// implement their own merging logic though, as long as the result conforms
+	// to the rules that [objchange.AssertPlanValid] enforces.
+	var proposedVal cty.Value
+	if !desiredVal.IsNull() {
+		proposedVal = objchange.ProposedNew(schema.Block, currentVal, desiredVal)
+	} else {
+		proposedVal = cty.NullVal(ty)
+	}
+
+	currentValUnmarked, currentMarks := currentVal.UnmarkDeepWithPaths()
+	desiredValUnmarked, desiredMarks := desiredVal.UnmarkDeepWithPaths()
+	proposedValUnmarked, _ := proposedVal.UnmarkDeep()
+	providerMetaValUnmarked, _ := providerMetaVal.UnmarkDeep()
+
+	var resp providers.PlanResourceChangeResponse
+	if !desiredValUnmarked.IsNull() || rt.providerCanPlanDestroy(ctx) {
+		resp = rt.client.PlanResourceChange(ctx, providers.PlanResourceChangeRequest{
+			TypeName:         rt.typeName,
+			PriorState:       currentValUnmarked,
+			PriorPrivate:     currentPrivate,
+			Config:           desiredValUnmarked,
+			ProposedNewState: proposedValUnmarked,
+			ProviderMeta:     providerMetaValUnmarked,
+		})
+		diags = diags.Append(resp.Diagnostics)
+		if resp.Diagnostics.HasErrors() {
+			return nil, diags
+		}
+	} else {
+		// For older providers that are not capable of generating destroy plans
+		// themselves, we generate a synthetic destroy plan.
+		resp = rt.fakeDestroyPlan(ty)
+	}
+
+	plannedValUnmarked := resp.PlannedState
+	plannedPrivate := resp.PlannedPrivate
+	if errs := objchange.AssertPlanValid(schema.Block, currentValUnmarked, desiredValUnmarked, plannedValUnmarked); len(errs) > 0 {
+		if resp.LegacyTypeSystem {
+			// The shimming of the old type system in the legacy SDK is not precise
+			// enough to pass this consistency check, so we'll give it a pass here,
+			// but we will generate a warning about it so that we are more likely
+			// to notice in the logs if an inconsistency beyond the type system
+			// leads to a downstream provider failure.
+			var buf strings.Builder
+			fmt.Fprintf(&buf,
+				"[WARN] Provider %q produced an invalid plan for %s, but we are tolerating it because it is using the legacy plugin SDK.\n    The following problems may be the cause of any confusing errors from downstream operations:",
+				rt.providerAddr, dispAddr,
+			)
+			for _, err := range errs {
+				fmt.Fprintf(&buf, "\n      - %s", tfdiags.FormatError(err))
+			}
+			log.Print(buf.String())
+		} else {
+			for _, err := range errs {
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Provider produced invalid plan",
+					fmt.Sprintf(
+						"Provider %q planned an invalid value for %s.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
+						rt.providerAddr, tfdiags.FormatErrorPrefixed(err, dispAddr.String()),
+					),
+				))
+			}
+			return nil, diags
+		}
+	}
+	// FIXME: plannedVal also needs sensitive marks added to it based on the
+	// static attribute flags in the resource type schema.
+	plannedVal := plannedValUnmarked.MarkWithPaths(currentMarks).MarkWithPaths(desiredMarks)
+
+	return &ManagedResourcePlanResponse{
+		Current: ValueWithPrivate{
+			Value:   currentVal,
+			Private: currentPrivate,
+		},
+		DesiredValue: desiredVal,
+		Planned: ValueWithPrivate{
+			Value:   plannedVal,
+			Private: plannedPrivate,
+		},
+		RequiresReplace: resp.RequiresReplace,
+	}, diags
+}
+
+// ValidateFinalPlan compares two planned values returned by calls to
+// [ManagedResourceType.PlanChanges] -- typically comparing the initial plan
+// found during the planning phase with the final plan decided during the apply
+// phase -- and returns diagnostics if the two differ in any way that is not
+// allowed by the resource instance object lifecycle rules.
+//
+// dispAddr is used only as part of any returned diagnostic messages, to explain
+// which object had an invalid final plan.
+func (rt *ManagedResourceType) ValidateFinalPlan(ctx context.Context, initialPlannedValue, finalPlannedValue cty.Value, dispAddr addrs.AbsResourceInstanceObject) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+
+	schema, moreDiags := rt.LoadSchema(ctx)
+	diags = diags.Append(moreDiags)
+	if diags.HasErrors() {
+		return diags
+	}
+
+	initialValueUnmarked, _ := initialPlannedValue.UnmarkDeep()
+	finalValueUnmarked, _ := finalPlannedValue.UnmarkDeep()
+	for _, err := range objchange.AssertObjectCompatible(schema.Block, initialValueUnmarked, finalValueUnmarked) {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Provider produced inconsistent final plan",
+			fmt.Sprintf(
+				"When expanding the plan for %s to include new values learned so far during apply, provider %q produced an invalid new value for %s.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
+				dispAddr, rt.providerAddr, tfdiags.FormatError(err),
+			),
+		))
+	}
+	return diags
+}
+
+// fakeDestroyPlan is used instead of [providers.Interface.PlanResourceChange]
+// if planning to destroy an existing object and the provider has not announced
+// that it is capable of producing such a plan itself.
+//
+// This situation exists because the original provider protocol only expected
+// providers to participate in planning "create" or "update" changes, with
+// "delete" ones always generated synthetically inside the runtime. That was
+// later generalized, but existing providers would crash if asked to plan with
+// a null desired state and so providers are expected to opt-in using the
+// capabilities system.
+func (rt *ManagedResourceType) fakeDestroyPlan(ty cty.Type) providers.PlanResourceChangeResponse {
+	return providers.PlanResourceChangeResponse{
+		PlannedState: cty.NullVal(ty),
+	}
+}
+
+// ManagedResourcePlanRequest is the request type for [ManagedResourceType.PlanChanges].
+type ManagedResourcePlanRequest struct {
+	// Current is a value representing the current state of the object, bundled
+	// with an arbitrary byte array that was associated with that value by
+	// the provider that previously generated it.
+	//
+	// Providers sometimes use the "private" blob to track additional metadata
+	// that is not exposed as part of the value but is still needed to track
+	// the object between plan/apply rounds.
+	//
+	// This field is typically set to the result of "refreshing" the object
+	// that was saved at the end of the previous apply phase, in which case
+	// the Private field must also match the blob returned from that refresh
+	// operation.
+	//
+	// When planning to create a new object, this should be set to the zero
+	// value of [ValueWithPrivate].
+	Current ValueWithPrivate
+
+	// DesiredValue is a value representing the desired state for the
+	// object, which is typically the result of evaluating the arguments
+	// in a block in the configuration.
+	//
+	// There is no "private" counterpart to this one because it is evaluated
+	// fresh from the configuration each time, rather than being generated
+	// by a provider.
+	//
+	// This field is typically set to a value obtained by evaluating a resource
+	// block in the configuration. When planning to destroy an existing object,
+	// this should be set to the zero value of [cty.Value], which is
+	// [cty.NilVal].
+	DesiredValue cty.Value
+
+	// ProviderMetaValue is an optional value declared in the same module
+	// where the associated resource was declared, which should be sent
+	// to the provider as part of any planning request.
+	//
+	// This is a rarely-used feature that only really makes sense when a
+	// module is written by the same entity that owns a provider it uses,
+	// in which case the module author might want to use the provider as
+	// a covert channel for collecting usage statistics about the module.
+	//
+	// When no metadata was provided for this provider in the current module,
+	// this should be set to the zero value of [cty.Value], which is
+	// [cty.NilVal].
+	ProviderMetaValue cty.Value
+}
+
+// ManagedResourcePlanResponse is the response type for [ManagedResourceType.PlanChanges].
+type ManagedResourcePlanResponse struct {
+	// TODO: Include some representation of a provider's "deferred" signal
+	// in here, once we've updated our provider clients to support that,
+	// and then update callers to handle responses with that set.
+
+	// Current echoes back the value given in the corresponding request field,
+	// possibly with some normalization such as transforming an absent value
+	// into null.
+	Current ValueWithPrivate
+
+	// DesiredValue echoes back the value  given in the corresponding request
+	// field, possibly with some normalization such as transforming an absent
+	// value into null.
+	DesiredValue cty.Value
+
+	// Planned has a prediction for what value will be associated with
+	// this resource instance object after applying the planned change, along
+	// with an optional opaque byte array that must be sent back to the
+	// provider verbatim if this planned change is applied.
+	//
+	// The value typically includes unknown values as placeholders for specific
+	// values that the provider cannot predict, such as opaque unique
+	// identifiers selected by the remote system only once an object has
+	// been created.
+	//
+	// Any part of the value that is not unknown is required to be identical
+	// in the final object returned after applying the planned change, and so
+	// it's reasonable to use this value when evaluating downstream expressions
+	// that refer to a symbol representing this resource instance object.
+	//
+	// If the plan is to destroy the object, this is set to the zero value of
+	// [ValueWithPrivate]. Otherwise, the caller must compare the value with
+	// the request's "Current" value to determine whether any changes are
+	// actually needed, taking no action at all if this value equals the
+	// current value.
+	Planned ValueWithPrivate
+
+	// RequiresReplace describes paths within the planned value whose changes
+	// require this change to be handled as a "replace" rather than as an
+	// in-place update.
+	//
+	// If this collection is not empty then this change must be applied across
+	// two separate [ApplyManagedResourceChange] calls, where one destroys the
+	// prior object and the other creates a new object using the value from the
+	// Planned field.
+	//
+	// If this collection is zero-length then this change should instead be
+	// applied with only a single call to [ApplyManagedResourceChange].
+	RequiresReplace []cty.Path
+}
+
+func (rt *ManagedResourceType) providerCanPlanDestroy(ctx context.Context) bool {
+	// FIXME: Can we capture this somewhere else so that we don't need to
+	// pull the whole schema again here? It's not a huge deal in practice
+	// because the main implementations of [providers.Interface] do caching
+	// of the schema result anyway, but the current factoring of this code
+	// makes it hard to encapsulate this behavior nicely.
+
+	resp := rt.client.GetProviderSchema(ctx)
+	if resp.Diagnostics.HasErrors() {
+		// If the provider can't return schema at all then something else is
+		// going to go wrong soon enough anyway, and so we'll just return a
+		// conservative default.
+		return false
+	}
+	return resp.ServerCapabilities.PlanDestroy
+}

--- a/internal/resources/managed_validate.go
+++ b/internal/resources/managed_validate.go
@@ -1,0 +1,27 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resources
+
+import (
+	"context"
+
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/opentofu/opentofu/internal/providers"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+)
+
+// ValidateConfig asks the provider whether the given value is valid.
+//
+// The given value should already conform to the schema of the resource type.
+func (rt *ManagedResourceType) ValidateConfig(ctx context.Context, configVal cty.Value) tfdiags.Diagnostics {
+	configValUnmarked, _ := configVal.UnmarkDeep()
+	resp := rt.client.ValidateResourceConfig(ctx, providers.ValidateResourceConfigRequest{
+		TypeName: rt.typeName,
+		Config:   configValUnmarked,
+	})
+	return resp.Diagnostics
+}

--- a/internal/resources/resource_type.go
+++ b/internal/resources/resource_type.go
@@ -1,0 +1,26 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resources
+
+import (
+	"context"
+
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/providers"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+)
+
+// ResourceType represents a resource type belonging to a specific provider
+// client.
+//
+// This interface represents the general operations that are relevant to all
+// resource types regardless of mode, but most callers will want to use a
+// specific implementation of this interface, such as [ManagedResourceType].
+type ResourceType interface {
+	ResourceMode() addrs.ResourceMode
+	ResourceTypeName() string
+	LoadSchema(ctx context.Context) (providers.Schema, tfdiags.Diagnostics)
+}

--- a/internal/resources/values.go
+++ b/internal/resources/values.go
@@ -1,0 +1,23 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resources
+
+import (
+	"github.com/zclconf/go-cty/cty"
+)
+
+// ValueWithPrivate is a [cty.Value] associated with an arbitrary "private"
+// byte array that is somehow related to it.
+//
+// Refer to the documentation of any field or argument using this type to
+// learn how the value and the byte array are related. Typically this is used
+// to allow a provider to transfer some additional out-of-band information
+// alongside a value that it will use when the same value is resubmitted to
+// the same provider later.
+type ValueWithPrivate struct {
+	Value   cty.Value
+	Private []byte
+}


### PR DESCRIPTION
(This is for https://github.com/opentofu/opentofu/issues/3414.)

The original motivation here was to implement the special case of making a synthetic plan without calling into the provider when the desired state is absent and the provider hasn't opted in to planning to destroy objects. This case needs to be opted in because older providers will crash if asked to plan with the config value or proposed value set to null. Resolving this deals with one of the current problems in how the new runtime deals with deleting existing objects, getting us a little closer to the "walking skeleton" milestone.

However, there was already far too much code duplicated across both the planning engine and the apply engine's "final plan" operation, and so this seemed like a good prompt to finally resolve the existing TODO comments by factoring out the shared planning logic into a separate place that both can depend on.

The new package "resources" is intended to grow into the home for all of these resource-related operations that each wrap a lower-level provider call but also perform preparation or followup actions such as making sure the provider's response is valid according to the requirements of the plugin protocol.

For now it only includes config validation and planning for managed resources, but is designed to grow to include other similar operations in future. The most likely next step is to add a method for applying a previously-created plan, which would replace a bunch of the code in the apply engine's implementation of the "ManagedApply" operation.

Currently the way this integrates with the rest of the provider-related infrastructure is a little awkward. We can hopefully improve on that in future, but for now the priority was to avoid this becoming yet another sprawling architecture change that would be hard to review. Once we feel like we've achieved the "walking skeleton" milestone for the new runtime we can think about how we want to tidy up the rough edges between the different components of this new design.

As has become tradition for these new codepaths, this is designed to be independently testable but not yet actually tested because we want to wait and see how all of this code settles before we start writing tests that would then make it harder to refactor as we learn more.
