### PR TITLE
applying: Update state correctly after deleting an object

### DIFF
--- a/internal/engine/applying/operations_resource_managed.go
+++ b/internal/engine/applying/operations_resource_managed.go
@@ -245,10 +245,12 @@ func (ops *execOperations) ManagedApply(
 	if !diags.HasErrors() {
 		status = states.ObjectReady
 	}
-	ret := &exec.ResourceInstanceObject{
-		InstanceAddr: plan.InstanceAddr,
-		DeposedKey:   plan.DeposedKey,
-		State: &states.ResourceInstanceObjectFull{
+	// We include a "state" object only for an object that actually exists,
+	// because the [states.SyncState] API expects us to pass nil to represent
+	// that an object ought to be completely removed from the state.
+	var state *states.ResourceInstanceObjectFull
+	if resp.NewState != cty.NilVal && !resp.NewState.IsNull() {
+		state = &states.ResourceInstanceObjectFull{
 			Status:               status,
 			Value:                resp.NewState,
 			Private:              resp.Private,
@@ -261,7 +263,12 @@ func (ops *execOperations) ManagedApply(
 			// TODO: Propagate whether this resource instance has
 			// "create_before_destroy" set into the final plan and then
 			// populate CreateBeforeDestroy here.
-		},
+		}
+	}
+	ret := &exec.ResourceInstanceObject{
+		InstanceAddr: plan.InstanceAddr,
+		DeposedKey:   plan.DeposedKey,
+		State:        state,
 	}
 	stateSrc, err := states.EncodeResourceInstanceObjectFull(ret.State, schema.Block.ImpliedType())
 	if err != nil {

--- a/internal/states/instance_object_full.go
+++ b/internal/states/instance_object_full.go
@@ -48,6 +48,9 @@ type ResourceInstanceObjectFull = resourceInstanceObjectRepr[cty.Value]
 type ResourceInstanceObjectFullSrc = resourceInstanceObjectRepr[ValueJSONWithMetadata]
 
 func DecodeResourceInstanceObjectFull(src *ResourceInstanceObjectFullSrc, ty cty.Type) (*ResourceInstanceObjectFull, error) {
+	if src == nil {
+		return nil, nil
+	}
 	v, err := src.Value.Decode(ty)
 	if err != nil {
 		return nil, err
@@ -56,6 +59,9 @@ func DecodeResourceInstanceObjectFull(src *ResourceInstanceObjectFullSrc, ty cty
 }
 
 func EncodeResourceInstanceObjectFull(obj *ResourceInstanceObjectFull, ty cty.Type) (*ResourceInstanceObjectFullSrc, error) {
+	if obj == nil {
+		return nil, nil
+	}
 	vSrc, err := EncodeValueJSONWithMetadata(obj.Value, ty)
 	if err != nil {
 		return nil, err
@@ -167,41 +173,55 @@ func (s *SyncState) SetResourceInstanceObjectFull(addr addrs.AbsResourceInstance
 	// Currently this is a wrapper around various other methods as we
 	// shim the new-style representation to fit the traditional representation.
 	ms := s.state.EnsureModule(addr.Module)
-	providerConfigAddr := addrs.AbsProviderConfig{
-		// NOTE: This is currently a little lossy because
-		// [addrs.AbsProviderConfig] is constrained by the limitations of our
-		// old language runtime. In particular, it loses any instance keys
-		// of modules in the module address, because the old runtime did not
-		// permit provider configurations inside multi-instanced modules.
-		// FIXME: Update our underlying model to support this more generally,
-		// once we're confident enough about the new runtime to risk changes
-		// that could impact code from the old runtime.
-		Module:   obj.ProviderInstanceAddr.Config.Module.Module(),
-		Provider: obj.ProviderInstanceAddr.Config.Config.Provider,
-		Alias:    obj.ProviderInstanceAddr.Config.Config.Alias,
-	}
-	smallerObj := &ResourceInstanceObjectSrc{
-		AttrsJSON:           obj.Value.ValueJSON,
-		SchemaVersion:       obj.SchemaVersion,
-		Status:              obj.Status,
-		Private:             obj.Private,
-		Dependencies:        obj.Dependencies,
-		CreateBeforeDestroy: obj.CreateBeforeDestroy,
-	}
-	if len(obj.Value.SensitivePaths) != 0 {
-		smallerObj.AttrSensitivePaths = make([]cty.PathValueMarks, len(obj.Value.SensitivePaths))
-		marks := cty.NewValueMarks(marks.Sensitive)
-		for i, path := range obj.Value.SensitivePaths {
-			smallerObj.AttrSensitivePaths[i] = cty.PathValueMarks{
-				Path:  path,
-				Marks: marks,
+
+	// The underlying [ModuleState] method that this method is based on have
+	// an awkward signature where some metadata that is either resource-scoped
+	// or instance-scoped gets passed alongside the object in additional
+	// arguments. However, those other arguments are ignored whenever the
+	// given object is nil to represent "remove from state", so it's intentional
+	// that we leave all of the following variables at their zero value when
+	// the given obj is nil.
+	var smallerObj *ResourceInstanceObjectSrc
+	var providerConfigAddr addrs.AbsProviderConfig
+	var providerInstanceKey addrs.InstanceKey
+	if obj != nil {
+		providerConfigAddr = addrs.AbsProviderConfig{
+			// NOTE: This is currently a little lossy because
+			// [addrs.AbsProviderConfig] is constrained by the limitations of our
+			// old language runtime. In particular, it loses any instance keys
+			// of modules in the module address, because the old runtime did not
+			// permit provider configurations inside multi-instanced modules.
+			// FIXME: Update our underlying model to support this more generally,
+			// once we're confident enough about the new runtime to risk changes
+			// that could impact code from the old runtime.
+			Module:   obj.ProviderInstanceAddr.Config.Module.Module(),
+			Provider: obj.ProviderInstanceAddr.Config.Config.Provider,
+			Alias:    obj.ProviderInstanceAddr.Config.Config.Alias,
+		}
+		providerInstanceKey = obj.ProviderInstanceAddr.Key
+		smallerObj = &ResourceInstanceObjectSrc{
+			AttrsJSON:           obj.Value.ValueJSON,
+			SchemaVersion:       obj.SchemaVersion,
+			Status:              obj.Status,
+			Private:             obj.Private,
+			Dependencies:        obj.Dependencies,
+			CreateBeforeDestroy: obj.CreateBeforeDestroy,
+		}
+		if len(obj.Value.SensitivePaths) != 0 {
+			smallerObj.AttrSensitivePaths = make([]cty.PathValueMarks, len(obj.Value.SensitivePaths))
+			marks := cty.NewValueMarks(marks.Sensitive)
+			for i, path := range obj.Value.SensitivePaths {
+				smallerObj.AttrSensitivePaths[i] = cty.PathValueMarks{
+					Path:  path,
+					Marks: marks,
+				}
 			}
 		}
 	}
 	if deposedKey == NotDeposed {
-		ms.SetResourceInstanceCurrent(addr.Resource, smallerObj, providerConfigAddr, obj.ProviderInstanceAddr.Key)
+		ms.SetResourceInstanceCurrent(addr.Resource, smallerObj, providerConfigAddr, providerInstanceKey)
 	} else {
-		ms.SetResourceInstanceDeposed(addr.Resource, deposedKey, smallerObj, providerConfigAddr, obj.ProviderInstanceAddr.Key)
+		ms.SetResourceInstanceDeposed(addr.Resource, deposedKey, smallerObj, providerConfigAddr, providerInstanceKey)
 	}
 	s.maybePruneModule(addr.Module)
 }

--- a/internal/states/module.go
+++ b/internal/states/module.go
@@ -115,6 +115,11 @@ func (ms *Module) SetResourceInstanceCurrent(addr addrs.ResourceInstance, obj *R
 		return
 	}
 	if obj == nil && rs != nil {
+		// NOTE: [SyncState.SetResourceInstanceObjectFull] is assuming that
+		// this function completely ignores the "provider" argument whenever
+		// "obj" is nil, so we must not interact with provider anywhere in
+		// this block.
+
 		// does the resource have any other objects?
 		// if not then delete the whole resource
 		if len(rs.Instances) == 0 {


### PR DESCRIPTION
(This is for https://github.com/opentofu/opentofu/issues/3414.)

The methods of `states.State` and `states.SyncState` related to saving resource instance objects have some quirky API design where some resource-level and resource-instance-level properties also get passed in as some additional arguments and then it opportunistically updates those higher-level fields in the state structure at the same time as updating the specific resource instance object.

That quirky design caused me to originally try to write this in a way where we always pass in a state object but sometimes the actual value is null to represent that the object has been deleted, but that doesn't actually work properly: it causes there to be a broken object in the state which still has partial metadata but is incomplete and cannot be properly decoded again later.

Ideally we'd fix this at the root by making the main methods more robust and have a less confusing API design, but at our current phase of work on the new runtime we have a preference for leaving existing codepaths unchanged and compensating in our new experimental callers instead, so that's the strategy I followed here: the experimental method for writing a "full" object into the state relies on the underlying method's implementation detail of ignoring the metadata fields whenever the main object is `nil`, just passing zero-values for those to get the needed behavior.

With this change in place, deletion of resource instance objects now causes them to get properly removed from the state, without corrupting the state in a way that makes it unusable for future plan/apply rounds.
