### PR TITLE
planning: Set result for no-op resource instances

### DIFF
--- a/internal/engine/planning/execgraph_resource.go
+++ b/internal/engine/planning/execgraph_resource.go
@@ -188,6 +188,7 @@ func ensureResourceInstanceObjectResultRef(addr addrs.AbsResourceInstanceObject,
 	var resultRef execgraph.ResourceInstanceResultRef
 	if addr.IsCurrent() {
 		resultRef = b.lower.ResourceInstancePrior(b.lower.ConstantResourceInstAddr(addr.InstanceAddr))
+		b.SetResourceInstanceFinalStateResult(addr.InstanceAddr, resultRef)
 	} else {
 		resultRef = b.lower.ManagedAlreadyDeposed(b.lower.ConstantResourceInstAddr(addr.InstanceAddr), b.lower.ConstantDeposedKey(addr.DeposedKey))
 	}


### PR DESCRIPTION
(This is for https://github.com/opentofu/opentofu/issues/3414.)

For any resource instance object that doesn't need any changes of its own, we initially skip adding it to the execution graph but then add a stub "prior state" operation retroactively if we discover at least one other resource instance object that depends on it.

However, the code for that also needs to record in the execution graph which result provides the evaluation value for the upstream resource instance, if the object we've just added is the "current" object for its resource instance. Otherwise the generated execution graph is invalid, causing it to fail to provide the result to the evaluator for downstream evaluation.
