### PR TITLE
Fix flakey TestS3LockingWritingHeaders test

### DIFF
--- a/internal/backend/remote-state/s3/client_test.go
+++ b/internal/backend/remote-state/s3/client_test.go
@@ -921,7 +921,7 @@ func TestS3ChecksumsHeaders(t *testing.T) {
 // TestS3LockingWritingHeaders is double-checking that the configuration for writing the lock object is the same
 // with the state writing configuration
 func TestS3LockingWritingHeaders(t *testing.T) {
-	ignoredValues := []string{"Amz-Sdk-Invocation-Id", "Authorization", "X-Amz-Checksum-Sha256"}
+	ignoredValues := []string{"Amz-Sdk-Invocation-Id", "Authorization", "X-Amz-Checksum-Sha256", "X-Amz-Date"}
 	// Configured the aws config the same way it is done for the backend to ensure a similar setup as the actual main logic.
 	_, awsCfg, _ := awsbase.GetAwsConfig(context.Background(), &awsbase.Config{Region: "us-east-1", AccessKey: "test", SecretKey: "key"})
 	httpCl := &mockHttpClient{resp: &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(""))}}


### PR DESCRIPTION
This mitigates a flakey test issue with the TestS3LockingWritingHeaders test by ignoring the X-Amz-Date field along with other already ignored fields.

Broken action:
https://github.com/opentofu/opentofu/actions/runs/22724580214/job/65895929190?pr=3838#step:5:25

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.