### PR TITLE
states: Separate SyncState method for removing "full" objects

### DIFF
--- a/internal/engine/applying/operations_resource.go
+++ b/internal/engine/applying/operations_resource.go
@@ -54,7 +54,7 @@ func (ops *execOperations) resourceInstanceStateObject(
 	deposedKey states.DeposedKey,
 ) (*exec.ResourceInstanceObject, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	src := ops.priorState.ResourceInstanceObjectFull(instAddr, deposedKey)
+	src := ops.priorState.ResourceInstanceObjectFull(instAddr.Object(deposedKey))
 	if src == nil {
 		return nil, diags
 	}

--- a/internal/engine/applying/operations_resource_managed.go
+++ b/internal/engine/applying/operations_resource_managed.go
@@ -227,14 +227,17 @@ func (ops *execOperations) ManagedApply(
 	// consistent with what was planned. (That'll need the provider schema
 	// we fetched above, but currently we're just discarding that schema.)
 
-	status := states.ObjectTainted
-	if !diags.HasErrors() {
-		status = states.ObjectReady
-	}
-	ret := &exec.ResourceInstanceObject{
-		InstanceAddr: plan.InstanceAddr,
-		DeposedKey:   plan.DeposedKey,
-		State: &states.ResourceInstanceObjectFull{
+	// FIXME: Change [exec.ManagedResourceObjectFinalPlan] to use
+	// [addrs.AbsResourceInstanceObject] itself, instead of separate instance
+	// address and deposed key fields.
+	objAddr := plan.InstanceAddr.Object(plan.DeposedKey)
+	var state *states.ResourceInstanceObjectFull
+	if !resp.NewState.IsNull() {
+		status := states.ObjectTainted
+		if !diags.HasErrors() {
+			status = states.ObjectReady
+		}
+		state = &states.ResourceInstanceObjectFull{
 			Status:               status,
 			Value:                resp.NewState,
 			Private:              resp.Private,
@@ -247,21 +250,34 @@ func (ops *execOperations) ManagedApply(
 			// TODO: Propagate whether this resource instance has
 			// "create_before_destroy" set into the final plan and then
 			// populate CreateBeforeDestroy here.
-		},
+		}
+		stateSrc, err := states.EncodeResourceInstanceObjectFull(state, schema.Block.ImpliedType())
+		if err != nil {
+			// This is a worst-case scenario where we've successfully changed
+			// something but we can't represent what changed in the state for some
+			// reason, and so the changes just get lost. It shouldn't be possible
+			// to get here in practice though, because resp.NewState would've
+			// already been decoded using the same schema if it came from a plugin,
+			// and so it should definitely conform to that schema.
+			// FIXME: A proper error message for this.
+			diags = diags.Append(fmt.Errorf("failed to encode the new state for %s: %w", plan.InstanceAddr, err))
+			return nil, diags
+		}
+		ops.workingState.SetResourceInstanceObjectFull(objAddr, stateSrc)
+	} else {
+		// A null value for "new state" represents that the object has been
+		// deleted, so we now just need to remove it from the state.
+		// Unfortunately this API is still a little quirkly and wants us to
+		// pass the provider instance address so that it can update some
+		// resource-level and instance-level metadata as a side-effect.
+		ops.workingState.RemoveResourceInstanceObjectFull(objAddr, providerClient.InstanceAddr)
 	}
-	stateSrc, err := states.EncodeResourceInstanceObjectFull(ret.State, schema.Block.ImpliedType())
-	if err != nil {
-		// This is a worst-case scenario where we've successfully changed
-		// something but we can't represent what changed in the state for some
-		// reason, and so the changes just get lost. It shouldn't be possible
-		// to get here in practice though, because resp.NewState would've
-		// already been decoded using the same schema if it came from a plugin,
-		// and so it should definitely conform to that schema.
-		// FIXME: A proper error message for this.
-		diags = diags.Append(fmt.Errorf("failed to encode the new state for %s: %w", plan.InstanceAddr, err))
-		return ret, diags
+
+	ret := &exec.ResourceInstanceObject{
+		InstanceAddr: plan.InstanceAddr,
+		DeposedKey:   plan.DeposedKey,
+		State:        state, // nil if the object was deleted
 	}
-	ops.workingState.SetResourceInstanceObjectFull(plan.InstanceAddr, plan.DeposedKey, stateSrc)
 	return ret, diags
 }
 

--- a/internal/engine/planning/plan.go
+++ b/internal/engine/planning/plan.go
@@ -99,7 +99,7 @@ func PlanChanges(ctx context.Context, prevRoundState *states.State, configInst *
 					// a temporary situation while we're operating in a mixed
 					// world where most of the system doesn't know about the
 					// new runtime yet.
-					objState := prevRoundState.SyncWrapper().ResourceInstanceObjectFull(instAddr, dk)
+					objState := prevRoundState.SyncWrapper().ResourceInstanceObjectFull(instAddr.Object(dk))
 					if objState == nil {
 						// If we get here then there's a bug in the
 						// ResourceInstanceObjectFull function, because we

--- a/internal/engine/planning/plan_data.go
+++ b/internal/engine/planning/plan_data.go
@@ -117,7 +117,7 @@ func (p *planGlue) planOrphanDataResourceInstance(_ context.Context, addr addrs.
 	// An orphan data object is always just discarded completely, because
 	// OpenTofu retains them only for esoteric uses like the "tofu console"
 	// command: they are not actually expected to persist between rounds.
-	p.planCtx.refreshedState.SetResourceInstanceObjectFull(addr, states.NotDeposed, nil)
+	p.planCtx.refreshedState.RemoveResourceInstanceObjectFull(addr.CurrentObject(), state.ProviderInstanceAddr)
 
 	return &resourceInstanceObject{
 		Addr:             addr.CurrentObject(),

--- a/internal/engine/planning/plan_eval_glue.go
+++ b/internal/engine/planning/plan_eval_glue.go
@@ -329,7 +329,7 @@ func resourceInstancesFilter(state *states.State, want func(addrs.AbsResourceIns
 					// a temporary situation while we're operating in a mixed
 					// world where most of the system doesn't know about the
 					// new runtime yet.
-					objState := state.SyncWrapper().ResourceInstanceObjectFull(instAddr, states.NotDeposed)
+					objState := state.SyncWrapper().ResourceInstanceObjectFull(instAddr.CurrentObject())
 					if objState == nil {
 						// If we get here then there's a bug in the
 						// ResourceInstanceObjectFull function, because we

--- a/internal/engine/planning/plan_managed.go
+++ b/internal/engine/planning/plan_managed.go
@@ -110,7 +110,7 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 
 	var prevRoundVal cty.Value
 	var prevRoundPrivate []byte
-	prevRoundState := p.planCtx.prevRoundState.SyncWrapper().ResourceInstanceObjectFull(inst.Addr, states.NotDeposed)
+	prevRoundState := p.planCtx.prevRoundState.SyncWrapper().ResourceInstanceObjectFull(inst.Addr.CurrentObject())
 	if prevRoundState != nil {
 		obj, err := states.DecodeResourceInstanceObjectFull(prevRoundState, schema.Block.ImpliedType())
 		if err != nil {

--- a/internal/states/instance_object_full.go
+++ b/internal/states/instance_object_full.go
@@ -80,23 +80,23 @@ func EncodeResourceInstanceObjectFull(obj *ResourceInstanceObjectFull, ty cty.Ty
 //
 // The return value is a pointer to a copy of the object, which the caller
 // may then freely access and mutate.
-func (s *SyncState) ResourceInstanceObjectFull(addr addrs.AbsResourceInstance, deposedKey DeposedKey) *ResourceInstanceObjectFullSrc {
+func (s *SyncState) ResourceInstanceObjectFull(addr addrs.AbsResourceInstanceObject) *ResourceInstanceObjectFullSrc {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 
-	rsrc := s.state.Resource(addr.ContainingResource())
+	rsrc := s.state.Resource(addr.InstanceAddr.ContainingResource())
 	if rsrc == nil {
 		return nil
 	}
-	inst := rsrc.Instances[addr.Resource.Key]
+	inst := rsrc.Instances[addr.InstanceAddr.Resource.Key]
 	if inst == nil {
 		return nil
 	}
 	var srcObj *ResourceInstanceObjectSrc
-	if deposedKey == NotDeposed {
+	if addr.IsCurrent() {
 		srcObj = inst.Current
 	} else {
-		srcObj = inst.Deposed[deposedKey]
+		srcObj = inst.Deposed[addr.DeposedKey]
 	}
 	if srcObj == nil {
 		return nil
@@ -132,7 +132,7 @@ func (s *SyncState) ResourceInstanceObjectFull(addr addrs.AbsResourceInstance, d
 		Private:              slices.Clone(srcObj.Private),
 		Status:               srcObj.Status,
 		ProviderInstanceAddr: providerInstAddr,
-		ResourceType:         addr.Resource.Resource.Type,
+		ResourceType:         addr.InstanceAddr.Resource.Resource.Type,
 		SchemaVersion:        srcObj.SchemaVersion,
 		Dependencies:         slices.Clone(srcObj.Dependencies),
 		CreateBeforeDestroy:  srcObj.CreateBeforeDestroy,
@@ -143,8 +143,9 @@ func (s *SyncState) ResourceInstanceObjectFull(addr addrs.AbsResourceInstance, d
 // instance object, overwriting an existing object with the same identity
 // if present.
 //
-// Set deposedKey to [NotDeposed] to set the "current" object associated
-// with the given resource instance address.
+// The object must not be nil. To represent removing the record of an object
+// from the state completely, use [SyncState.RemoveResourceInstanceObjectFull]
+// instead.
 //
 // This is currently for use with the experimental new language runtime only.
 // Callers from the old runtime should use [SyncState.SetResourceInstance]
@@ -161,26 +162,21 @@ func (s *SyncState) ResourceInstanceObjectFull(addr addrs.AbsResourceInstance, d
 // so that's not a big deal, but we will probably want to update the state
 // model at some point to remove this constraint that isn't actually necessary
 // for the new language runtime.
-func (s *SyncState) SetResourceInstanceObjectFull(addr addrs.AbsResourceInstance, deposedKey DeposedKey, obj *ResourceInstanceObjectFullSrc) {
+func (s *SyncState) SetResourceInstanceObjectFull(addr addrs.AbsResourceInstanceObject, obj *ResourceInstanceObjectFullSrc) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
+	if obj == nil {
+		// If you see a panic here, the caller probably ought to have called
+		// [SyncState.RemoveResourceInstanceObjectFull] instead.
+		panic("called SetResourceInstanceObjectFull with nil object")
+	}
+
 	// Currently this is a wrapper around various other methods as we
 	// shim the new-style representation to fit the traditional representation.
-	ms := s.state.EnsureModule(addr.Module)
-	providerConfigAddr := addrs.AbsProviderConfig{
-		// NOTE: This is currently a little lossy because
-		// [addrs.AbsProviderConfig] is constrained by the limitations of our
-		// old language runtime. In particular, it loses any instance keys
-		// of modules in the module address, because the old runtime did not
-		// permit provider configurations inside multi-instanced modules.
-		// FIXME: Update our underlying model to support this more generally,
-		// once we're confident enough about the new runtime to risk changes
-		// that could impact code from the old runtime.
-		Module:   obj.ProviderInstanceAddr.Config.Module.Module(),
-		Provider: obj.ProviderInstanceAddr.Config.Config.Provider,
-		Alias:    obj.ProviderInstanceAddr.Config.Config.Alias,
-	}
+	ms := s.state.EnsureModule(addr.InstanceAddr.Module)
+
+	providerConfigAddr, providerInstanceKey := lossyProviderConfigAddrFromProviderInstanceAddr(obj.ProviderInstanceAddr)
 	smallerObj := &ResourceInstanceObjectSrc{
 		AttrsJSON:           obj.Value.ValueJSON,
 		SchemaVersion:       obj.SchemaVersion,
@@ -199,12 +195,44 @@ func (s *SyncState) SetResourceInstanceObjectFull(addr addrs.AbsResourceInstance
 			}
 		}
 	}
-	if deposedKey == NotDeposed {
-		ms.SetResourceInstanceCurrent(addr.Resource, smallerObj, providerConfigAddr, obj.ProviderInstanceAddr.Key)
+	if addr.IsCurrent() {
+		ms.SetResourceInstanceCurrent(addr.InstanceAddr.Resource, smallerObj, providerConfigAddr, providerInstanceKey)
 	} else {
-		ms.SetResourceInstanceDeposed(addr.Resource, deposedKey, smallerObj, providerConfigAddr, obj.ProviderInstanceAddr.Key)
+		ms.SetResourceInstanceDeposed(addr.InstanceAddr.Resource, addr.DeposedKey, smallerObj, providerConfigAddr, providerInstanceKey)
 	}
-	s.maybePruneModule(addr.Module)
+	s.maybePruneModule(addr.InstanceAddr.Module)
+}
+
+// RemoveResourceInstanceObjectFull removes any representation of the given
+// resource instance object from the state.
+//
+// The providerInstAddr argument should be the address of the provider instance
+// that was used to delete the corresponding remote object. This strange API
+// quirk exists because changes to resource instance objects currently also
+// implicitly update resource-level and instance-level metadata.
+func (s *SyncState) RemoveResourceInstanceObjectFull(addr addrs.AbsResourceInstanceObject, providerInstAddr addrs.AbsProviderInstanceCorrect) {
+	// FIXME: Rework this so that removing an object does _not_ also implicitly
+	// update the resource-level and instance-level provider tracking, which
+	// is only currently necessary because we're trying to use preexisting
+	// [ModuleState] methods without modifying them.
+
+	ms := s.state.Module(addr.InstanceAddr.Module)
+	if ms == nil {
+		// If the containing module instance doesn't exist in the state at all
+		// then we have nothing to remove.
+		return
+	}
+
+	providerConfigAddr, providerInstanceKey := lossyProviderConfigAddrFromProviderInstanceAddr(providerInstAddr)
+
+	// These [ModuleState] methods represent "remove" by the caller passing a
+	// nil object, rather than by having a separate "remove" method.
+	if addr.IsCurrent() {
+		ms.SetResourceInstanceCurrent(addr.InstanceAddr.Resource, nil, providerConfigAddr, providerInstanceKey)
+	} else {
+		ms.SetResourceInstanceDeposed(addr.InstanceAddr.Resource, addr.DeposedKey, nil, providerConfigAddr, providerInstanceKey)
+	}
+	s.maybePruneModule(addr.InstanceAddr.Module)
 }
 
 // ResourceInstanceObjectFullRepr is the generic type that both
@@ -391,4 +419,27 @@ func (s *State) InstancesMatchingConfigResource(addr addrs.ConfigResource) iter.
 			}
 		}
 	}
+}
+
+// lossyProviderConfigAddrFromProviderInstanceAddr is a lossy adapter for
+// converting from the "correct" representation of provider instance addresses
+// in [addrs.AbsProviderInstanceCorrect] to the incomplete, legacy
+// representation that our state models are still currently using.
+//
+// In particular, it loses any instance keys of modules in the module address,
+// because the old runtime did not permit provider configurations inside
+// multi-instanced modules.
+//
+// FIXME: Update our underlying model to support this more generally, once we're
+// confident enough about the new runtime to risk changes that could impact code
+// from the old runtime. At that point we can hopefully remove this helper
+// function altogether.
+func lossyProviderConfigAddrFromProviderInstanceAddr(addr addrs.AbsProviderInstanceCorrect) (addrs.AbsProviderConfig, addrs.InstanceKey) {
+	configAddr := addrs.AbsProviderConfig{
+		Module:   addr.Config.Module.Module(),
+		Provider: addr.Config.Config.Provider,
+		Alias:    addr.Config.Config.Alias,
+	}
+	instanceKey := addr.Key
+	return configAddr, instanceKey
 }

--- a/internal/states/instance_object_full_test.go
+++ b/internal/states/instance_object_full_test.go
@@ -80,7 +80,7 @@ func TestSyncStateResourceInstanceObjectFull(t *testing.T) {
 	ss := s.SyncWrapper()
 
 	t.Run("current object", func(t *testing.T) {
-		gotObjSrc := ss.ResourceInstanceObjectFull(instAddrAbs, NotDeposed)
+		gotObjSrc := ss.ResourceInstanceObjectFull(instAddrAbs.CurrentObject())
 		gotObj, err := DecodeResourceInstanceObjectFull(gotObjSrc, objTy)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
@@ -105,7 +105,7 @@ func TestSyncStateResourceInstanceObjectFull(t *testing.T) {
 		}
 	})
 	t.Run("deposed object", func(t *testing.T) {
-		gotObjSrc := ss.ResourceInstanceObjectFull(instAddrAbs, deposedKey)
+		gotObjSrc := ss.ResourceInstanceObjectFull(instAddrAbs.Object(deposedKey))
 		gotObj, err := DecodeResourceInstanceObjectFull(gotObjSrc, objTy)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
@@ -191,8 +191,8 @@ func TestSyncStateSetResourceInstanceObjectFull(t *testing.T) {
 	}
 
 	gotState := BuildState(func(ss *SyncState) {
-		ss.SetResourceInstanceObjectFull(instAddrAbs, deposedKey, deposedObjSrc)
-		ss.SetResourceInstanceObjectFull(instAddrAbs, NotDeposed, currentObjSrc)
+		ss.SetResourceInstanceObjectFull(instAddrAbs.Object(deposedKey), deposedObjSrc)
+		ss.SetResourceInstanceObjectFull(instAddrAbs.CurrentObject(), currentObjSrc)
 	})
 	wantState := &State{
 		Modules: map[string]*Module{


### PR DESCRIPTION
(This is for https://github.com/opentofu/opentofu/issues/3414, and is a new attempt at https://github.com/opentofu/opentofu/pull/3831.)

Our new language runtime uses a set of new methods on `SyncState` to work with its preferred "full" representation of resource instance objects, but those are implemented in terms of methods that already existed for the old runtime's benefit and so we need to deal with some quirks of those existing methods.

One such quirk is that the operations to write or remove objects also want to update some resource-level and instance-level metadata as a side-effect, and we need to carry through that metadata even when we're intending to completely remove a resource instance object.

To preserve our goal of leaving the existing codepaths untouched for now, this pushes a little complexity back up into the main caller in the apply engine, forcing it to call a different method when it knows it has deleted an object. That new method then only takes the metadata we need and not an actual resource instance object, so it gels better with the underlying `ModuleState` methods it's implemented in terms of.

Hopefully in the long run we'll rethink the state models to not rely on these hidden side-effects, but that's beyond the scope of our current phase of work on the new language runtime.

