### PR TITLE
resources: Ignore spurious RequiresReplace from PlanResourceChange

### DIFF
--- a/internal/resources/managed_plan.go
+++ b/internal/resources/managed_plan.go
@@ -144,15 +144,14 @@ func (rt *ManagedResourceType) PlanChanges(ctx context.Context, req *ManagedReso
 	if len(resp.RequiresReplace) != 0 && (currentVal.IsNull() || desiredVal.IsNull()) {
 		// RequiresReplace is only applicable when the plan request had both
 		// a current and a desired value, because it specifies attributes that
-		// cannot be updated-in-place.
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Provider produced invalid plan",
-			fmt.Sprintf(
-				"Provider %s reported that a create or delete plan for %s has changes that require replacement, but replacement is only valid as a modification of update-in-place.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
-				rt.providerAddr, dispAddr,
-			),
-		))
+		// cannot be updated-in-place, but unfortunately existing providers
+		// do generate spurious "requires replace" signals for non-update
+		// plans and so we need to just ignore them.
+		log.Printf("[WARN] Ignoring nonsensical RequiresReplace values from provider %s while planning a non-update change for %s", rt.providerAddr, dispAddr)
+		// We'll discard the meaningless extra info here just so that the
+		// rest of the system can assume that this is populated only when it
+		// actually needs to be acted on.
+		resp.RequiresReplace = nil
 	}
 
 	// FIXME: plannedVal also needs sensitive marks added to it based on the


### PR DESCRIPTION
(This is for https://github.com/opentofu/opentofu/issues/3414.)

Unfortunately some existing providers spuriously report `RequiresReplace` paths when they are planning create and/or delete changes[^1], so we'll need to just quietly ignore them rather than generating a user-facing error about it.

In practice ignoring these in these cases doesn't really do any harm, since `RequiresReplace` is only relevant in causing us to reinterpret an "update" into a "replace". But to keep the handling of this quirk centralized, we explicitly throw away spurious paths so that the rest of the system can safely assume that this field will be populated only when some action must be taken based on it.

[^1]: It seems that the SDK code is just handling this as a post-processing step by checking if any of the `ForceNew` attributes have changed. even when the "change" is representing creation or deletion of the entire surrounding object. The SDK is treating it more like a static report of everything in the schema that could need force-replace treatment, rather than as a dynamic report of what's relevant _for this specific request_. :man_shrugging: 