### PR TITLE
planning: Respect state-based dependencies in the execution graph

### DIFF
--- a/internal/engine/planning/plan_managed.go
+++ b/internal/engine/planning/plan_managed.go
@@ -127,6 +127,17 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 		}
 		prevRoundVal = obj.Value
 		prevRoundPrivate = obj.Private
+		// Unfortunately our current state model represents dependencies only
+		// between static [addrs.ConfigResource] and loses specific instance
+		// information, so we must conservatively assume that all matching
+		// instances are dependencies. This loses the precision we get from
+		// dynamic analysis of the configuration, but it's the best we can
+		// do without switching to an updated model of state.
+		for _, configAddr := range prevRoundState.Dependencies {
+			for instAddr := range p.planCtx.prevRoundState.InstancesMatchingConfigResource(configAddr) {
+				ret.Dependencies.Add(instAddr.CurrentObject())
+			}
+		}
 	} else {
 		// TODO: Ask the planning oracle whether there are any "moved" blocks
 		// that ultimately end up at inst.Addr (possibly through a chain of
@@ -378,6 +389,17 @@ func (p *planGlue) planOrphanManagedResourceInstance(
 	}
 	prevRoundVal = prevRoundState.Value
 	prevRoundPrivate = prevRoundState.Private
+	// Unfortunately our current state model represents dependencies only
+	// between static [addrs.ConfigResource] and loses specific instance
+	// information, so we must conservatively assume that all matching
+	// instances are dependencies. This loses the precision we get from
+	// dynamic analysis of the configuration, but it's the best we can
+	// do without switching to an updated model of state.
+	for _, configAddr := range prevRoundState.Dependencies {
+		for instAddr := range p.planCtx.prevRoundState.InstancesMatchingConfigResource(configAddr) {
+			ret.Dependencies.Add(instAddr.CurrentObject())
+		}
+	}
 
 	// TODO: Call providerClient.ReadResource and update the "refreshed state"
 	// and reassign this refreshedVal to the refreshed result.

--- a/internal/states/instance_object_full.go
+++ b/internal/states/instance_object_full.go
@@ -6,6 +6,7 @@
 package states
 
 import (
+	"iter"
 	"slices"
 
 	"github.com/zclconf/go-cty/cty"
@@ -259,6 +260,12 @@ type resourceInstanceObjectRepr[V interface {
 	// just because that needs less shimming from the current underlying
 	// representation, and so we can wait until we better understand what the
 	// caller needs before we spend time implementing that.
+	//
+	// Use [State.InstancesMatchingConfigResource] to find all of the
+	// instances that match an address in this slice, which should include
+	// _at least_ the same instances that ought to have been recorded here,
+	// along with some spurious extras that we match due to the lossiness
+	// of this representation.
 	Dependencies []addrs.ConfigResource
 
 	// CreateBeforeDestroy reflects the status of the lifecycle
@@ -341,4 +348,47 @@ func EncodeValueJSONWithMetadata(v cty.Value, ty cty.Type) (ValueJSONWithMetadat
 		}
 	}
 	return ret, nil
+}
+
+// InstancesMatchingConfigResource is an adapter to help deal with the fact
+// that our state model current represents dependencies between whole resources
+// using their unexpanded addresses, but in the new experimental language
+// runtime we want to work in relationships between individual resource
+// instances instead.
+//
+// Given an [addrs.ConfigResource] address, the result is every
+// [addrs.AbsResourceInstance] that matches the given address and has a current
+// object in the state.
+//
+// TODO: Consider changing the state model so that we track relationships
+// between resource instances as the _main_ representation, rather than throwing
+// that information away and then trying to recover it lossily later.
+func (s *State) InstancesMatchingConfigResource(addr addrs.ConfigResource) iter.Seq[addrs.AbsResourceInstance] {
+	// (This function is lurking in here just because it's exclusively for
+	// the new experimental langauge runtime and this is the file where we're
+	// gathering all of its state model extensions. It's not actually
+	// particularly related to "full" state object representations except that
+	// it's helping to compensate for a current concession we're making in
+	// _not_ representing dependencies properly in the "full" representations.)
+
+	return func(yield func(addrs.AbsResourceInstance) bool) {
+		for _, ms := range s.Modules {
+			if !ms.Addr.IsForModule(addr.Module) {
+				continue
+			}
+			for _, rs := range ms.Resources {
+				if !rs.Addr.Resource.Equal(addr.Resource) {
+					continue
+				}
+				for key, is := range rs.Instances {
+					if is.Current == nil {
+						continue // instances that only have deposed objects are not eligible
+					}
+					if !yield(rs.Addr.Instance(key)) {
+						return
+					}
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
(This is for https://github.com/opentofu/opentofu/issues/3414.)

This is the first half of solving the current problem that we're not always properly respecting the reverse dependency edges while destroying objects: we need to consider both the config-derived dependencies and the dependencies recorded in the the previous run state together when building the resource instance graph.

The "orphan" case is the most obvious way this manifests right now, but this needs handling in the desired case too because the desired case is what handles "replace" actions, which include a delete component that also needs to respect these prior dependencies.

The other half of this problem is that we're not actually currently propagating the dependency information to the apply phase, and so it's not saving that information in the new state objects it creates. That's not solved in this commit, and instead I just tested this by manually modifying the prior state to include the dependencies that ought to have been recorded in it and then verified that caused a correct execution graph to be constructed. I intend to deal with the apply-time part of this problem in a separate commit later.
