### PR TITLE
fix panic in init -from-module when module source references variables

### DIFF
--- a/internal/initwd/from_module.go
+++ b/internal/initwd/from_module.go
@@ -153,6 +153,12 @@ func DirFromModule(ctx context.Context, loader *configload.Loader, rootDir, modu
 				SourceAddr: sourceAddr,
 				Source:     hcl.StaticExpr(cty.StringVal(sourceAddrStr), rng),
 				DeclRange:  rng,
+				Variables: func(v *configs.Variable) (cty.Value, hcl.Diagnostics) {
+					if v.Default != cty.NilVal {
+						return v.Default, nil
+					}
+					return cty.DynamicVal, nil
+				},
 			},
 		},
 		ProviderRequirements: &configs.RequiredProviders{},
@@ -217,7 +223,12 @@ func DirFromModule(ctx context.Context, loader *configload.Loader, rootDir, modu
 			// and must thus be rewritten to be absolute addresses again.
 			// For now we can't do this rewriting automatically, but we'll
 			// generate an error to help the user do it manually.
-			mod, _ := loader.Parser().LoadConfigDir(rootDir, configs.NewStaticModuleCall(addrs.RootModule, nil, rootDir, "")) // ignore diagnostics since we're just doing value-add here anyway
+			mod, _ := loader.Parser().LoadConfigDir(rootDir, configs.NewStaticModuleCall(addrs.RootModule, func(v *configs.Variable) (cty.Value, hcl.Diagnostics) { // ignore diagnostics since we're just doing value-add here anyway
+				if v.Default != cty.NilVal {
+					return v.Default, nil
+				}
+				return cty.DynamicVal, nil
+			}, rootDir, ""))
 			if mod != nil {
 				for _, mc := range mod.ModuleCalls {
 					if pathTraversesUp(mc.SourceAddrRaw) {


### PR DESCRIPTION
<!-- If your PR resolves an issue, please add it here. -->
Resolves #3850

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
