### PR TITLE
rfc: "Miscellaneous Configuration Settings in Modules" simpler interaction between new- and old-style version requirements

### DIFF
--- a/rfc/20250730-module-misc-settings.md
+++ b/rfc/20250730-module-misc-settings.md
@@ -98,10 +98,9 @@ Modules that use a `language` block should choose carefully where to place it:
   block which OpenTofu will then use _in preference to_ the settings in
   the `versions.tf` file.
 
-For any module that contains a `language` block, OpenTofu will completely
-ignore any of the corresponding arguments within `terraform` blocks assuming
-that they are intended only for Terraform's use. We'd recommend, but not
-_require_, that `language` blocks be placed in `.tofu` configuration files.
+OpenTofu will allow `language` blocks to appear in `.tf` files, but our
+documentation will recommend placing them in `.tofu` files to increase the
+chances of an OpenTofu module being cross-compatible with Terraform.
 
 ### The existing `required_version` argument in `terraform` blocks
 
@@ -135,6 +134,20 @@ until all currently-supported OpenTofu minor release series support it, so that
 anyone trying to use the module with older versions of OpenTofu will recieve
 an error message about an incorrect OpenTofu version, rather than a generic
 syntax error about the unsupported `language` block.
+
+To draw attention to that consideration, OpenTofu v1.12 will include a heuristic
+which checks whether a version constraint given in the new-style
+`compatible_with` block would allow OpenTofu v1.11.0. If so, it will emit a
+warning recommending to use the old-style `required_version` approach instead
+for that version constraint. Authors may also quiet the warning by including
+a lower bound of `1.12` in their configured version constriant. We may choose to
+remove that warning in a later version of OpenTofu once the v1.11 series reaches
+end-of-life.
+
+Although there is no useful reason to include both a `language` block and an
+old-style `required_version` declaration in the same module, OpenTofu will
+allow that and will check and enforce each one separately as long as the
+`required_version` argument is in a `.tofu`-suffixed file.
 
 ## Provider Dependencies
 


### PR DESCRIPTION
This is an amendment to the RFC tracked in https://github.com/opentofu/opentofu/issues/3300, and is a successor of earlier writing in https://github.com/opentofu/opentofu/pull/3085 and https://github.com/opentofu/opentofu/pull/3408.

---

The earlier drafts of this RFC included a special rule for ignoring `required_version` declarations across all files in any module that includes a `language` block. That special case was an adaptation of some complexity from earlier proposals in this area that was intended for gradual adoption of the new syntax.

However, with the current form of this proposal that exception doesn't really serve any useful purpose: any module with a `language` block in it will be immediately incompatible with OpenTofu v1.11, but we already proposed a gradual adoption strategy by suggesting authors should continue to use the old-style `required_version` pattern until they are ready to require OpenTofu v1.12 or later.

Therefore we'll now amend the RFC to say that the old and new strategies are allowed to coexist in the same module and that OpenTofu will check and enforce them separately, which is an easier rule to explain in documentation and also considerably easier to implement because it allows checking each declaration independently rather than having to wait until the full module has loaded to decide which declarations are relevant.

This also proposes a small heuristic warning to hopefully help authors notice that they must continue using `required_version` for any module that is explicitly intended to support the OpenTofu v1.11 series. This will complement our documentation to reinforce the recommendation to continue using the old-style approach until the v1.11 series is no longer supported. I have already prototyped that heuristic in my implementation branch, finding that it doesn't cause significant extra complexity and should be easy to remove in a later release.

[Rendered Version](https://github.com/opentofu/opentofu/blob/cba3902c0bf20531ee27d6c76e907fa7348b74e6/rfc/20250730-module-misc-settings.md)