### PR TITLE
Additional hash filter for registry package source

### DIFF
--- a/internal/getproviders/package_authentication.go
+++ b/internal/getproviders/package_authentication.go
@@ -448,6 +448,12 @@ func (a *registryPackageAuthentication) AuthenticatePackage(localLocation Packag
 	hashes := HashDispositions{}
 	for _, meta := range a.PackageData {
 		for _, hash := range meta.Hashes {
+			switch hash.Scheme() {
+			case HashScheme1, HashSchemeZip:
+				// Valid for this version of OpenTofu
+			default:
+				continue
+			}
 			// Some of these will overlap with entries from the other Authenticators.
 			// The dispositions will be merged. In practice the zh's will be merged
 			// with SignedByGPGKeyIDs (if provided) and one of the h1's will be


### PR DESCRIPTION
This handles the scenario for if we introduce a new hashing scheme to the registry response that old versions of OpenTofu may not recognise.

Part of #3858
Follow up to #3868 

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
