### PR TITLE
Fix the simple-provider schema for data-source

### DIFF
--- a/internal/command/e2etest/primary_test.go
+++ b/internal/command/e2etest/primary_test.go
@@ -281,9 +281,8 @@ OpenTofu will perform the following actions:
   # data.simple_resource.test_data2 will be read during apply
   # (depends on a resource or a module with changes pending)
  <= data "simple_resource" "test_data2" {
-      + id       = (known after apply)
-      + value    = "test"
-      + value_wo = (write-only attribute)
+      + id    = (known after apply)
+      + value = "test"
     }
 
   # simple_resource.test_res will be created

--- a/internal/provider-simple-v6/provider.go
+++ b/internal/provider-simple-v6/provider.go
@@ -24,44 +24,43 @@ type simple struct {
 }
 
 func Provider() providers.Interface {
-	simpleResource := providers.Schema{
-		Block: &configschema.Block{
-			Attributes: map[string]*configschema.Attribute{
-				"id": {
-					Computed: true,
-					Type:     cty.String,
-				},
-				"value": {
-					Optional: true,
-					Type:     cty.String,
-				},
-			},
-		},
-	}
-	// Only managed resource should have write-only arguments.
-	withWriteOnlyBlocks := func(s providers.Schema) providers.Schema {
-		b := *s.Block
-
-		b.Attributes["value_wo"] = &configschema.Attribute{
-			Optional:  true,
-			Type:      cty.String,
-			WriteOnly: true,
-		}
-		b.BlockTypes = map[string]*configschema.NestedBlock{
-			"nested_block": {
-				Nesting: configschema.NestingSingle,
-				Block: configschema.Block{
-					Attributes: map[string]*configschema.Attribute{
-						"nested_block_attr": {
-							Type:      cty.String,
-							Optional:  true,
-							WriteOnly: true,
-						},
+	schema := func(withWoField bool) providers.Schema {
+		ret := providers.Schema{
+			Block: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"id": {
+						Computed: true,
+						Type:     cty.String,
+					},
+					"value": {
+						Optional: true,
+						Type:     cty.String,
 					},
 				},
 			},
 		}
-		return providers.Schema{Block: &b}
+		if withWoField {
+			ret.Block.Attributes["value_wo"] = &configschema.Attribute{
+				Optional:  true,
+				Type:      cty.String,
+				WriteOnly: true,
+			}
+			ret.Block.BlockTypes = map[string]*configschema.NestedBlock{
+				"nested_block": {
+					Nesting: configschema.NestingSingle,
+					Block: configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"nested_block_attr": {
+								Type:      cty.String,
+								Optional:  true,
+								WriteOnly: true,
+							},
+						},
+					},
+				},
+			}
+		}
+		return ret
 	}
 
 	return simple{
@@ -84,13 +83,13 @@ func Provider() providers.Interface {
 				},
 			},
 			ResourceTypes: map[string]providers.Schema{
-				"simple_resource": withWriteOnlyBlocks(simpleResource),
+				"simple_resource": schema(true),
 			},
 			DataSources: map[string]providers.Schema{
-				"simple_resource": simpleResource,
+				"simple_resource": schema(false),
 			},
 			EphemeralResources: map[string]providers.Schema{
-				"simple_resource": simpleResource,
+				"simple_resource": schema(false),
 			},
 			ServerCapabilities: providers.ServerCapabilities{
 				PlanDestroy: true,

--- a/internal/provider-simple/provider.go
+++ b/internal/provider-simple/provider.go
@@ -23,44 +23,43 @@ type simple struct {
 }
 
 func Provider() providers.Interface {
-	simpleResource := providers.Schema{
-		Block: &configschema.Block{
-			Attributes: map[string]*configschema.Attribute{
-				"id": {
-					Computed: true,
-					Type:     cty.String,
-				},
-				"value": {
-					Optional: true,
-					Type:     cty.String,
-				},
-			},
-		},
-	}
-	// Only managed resource should have write-only arguments.
-	withWriteOnlyBlocks := func(s providers.Schema) providers.Schema {
-		b := *s.Block
-
-		b.BlockTypes = map[string]*configschema.NestedBlock{
-			"nested_block": {
-				Nesting: configschema.NestingSingle,
-				Block: configschema.Block{
-					Attributes: map[string]*configschema.Attribute{
-						"nested_block_attr": {
-							Type:      cty.String,
-							Optional:  true,
-							WriteOnly: true,
-						},
+	schema := func(withWoField bool) providers.Schema {
+		ret := providers.Schema{
+			Block: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"id": {
+						Computed: true,
+						Type:     cty.String,
+					},
+					"value": {
+						Optional: true,
+						Type:     cty.String,
 					},
 				},
 			},
 		}
-		b.Attributes["value_wo"] = &configschema.Attribute{
-			Optional:  true,
-			Type:      cty.String,
-			WriteOnly: true,
+		if withWoField {
+			ret.Block.Attributes["value_wo"] = &configschema.Attribute{
+				Optional:  true,
+				Type:      cty.String,
+				WriteOnly: true,
+			}
+			ret.Block.BlockTypes = map[string]*configschema.NestedBlock{
+				"nested_block": {
+					Nesting: configschema.NestingSingle,
+					Block: configschema.Block{
+						Attributes: map[string]*configschema.Attribute{
+							"nested_block_attr": {
+								Type:      cty.String,
+								Optional:  true,
+								WriteOnly: true,
+							},
+						},
+					},
+				},
+			}
 		}
-		return providers.Schema{Block: &b}
+		return ret
 	}
 
 	return simple{
@@ -83,13 +82,13 @@ func Provider() providers.Interface {
 				},
 			},
 			ResourceTypes: map[string]providers.Schema{
-				"simple_resource": withWriteOnlyBlocks(simpleResource),
+				"simple_resource": schema(true),
 			},
 			DataSources: map[string]providers.Schema{
-				"simple_resource": simpleResource,
+				"simple_resource": schema(false),
 			},
 			EphemeralResources: map[string]providers.Schema{
-				"simple_resource": simpleResource,
+				"simple_resource": schema(false),
 			},
 			ServerCapabilities: providers.ServerCapabilities{
 				PlanDestroy: true,


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
This fixes a mistake that was added in [#3049](https://github.com/opentofu/opentofu/pull/3049/changes#diff-a51054efb8b9ef8ee3f43425fdaf3189812b0bd69db4a6da2a24fd075f0267c5R43) where the write-only attribute have been used for the data-source schemas for our testing simple-provider implementations.

The `withWriteOnlyAttribute` was poorly written and changed an attribute of a pointer which meant that the whole main "schema" object was changed, propagating that write-only attribute to any resource type schema.
## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
