### PR TITLE
addrs: `go fix`

### DIFF
--- a/internal/addrs/check_rule_diagnostic.go
+++ b/internal/addrs/check_rule_diagnostic.go
@@ -42,7 +42,7 @@ func DiagnosticOriginatesFromCheckRule(diag tfdiags.Diagnostic) (CheckRule, bool
 type CheckRuleDiagnosticExtra struct {
 	CheckRule CheckRule
 
-	wrapped interface{}
+	wrapped any
 }
 
 var (
@@ -52,11 +52,11 @@ var (
 	_ tfdiags.DiagnosticExtraWrapper          = (*CheckRuleDiagnosticExtra)(nil)
 )
 
-func (c *CheckRuleDiagnosticExtra) UnwrapDiagnosticExtra() interface{} {
+func (c *CheckRuleDiagnosticExtra) UnwrapDiagnosticExtra() any {
 	return c.wrapped
 }
 
-func (c *CheckRuleDiagnosticExtra) WrapDiagnosticExtra(inner interface{}) {
+func (c *CheckRuleDiagnosticExtra) WrapDiagnosticExtra(inner any) {
 	if c.wrapped != nil {
 		// This is a logical inconsistency, the caller should know whether they
 		// have already wrapped an extra or not.

--- a/internal/addrs/module_test.go
+++ b/internal/addrs/module_test.go
@@ -143,7 +143,6 @@ func TestParseModule(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.Input, func(t *testing.T) {
 			t.Parallel()

--- a/internal/addrs/resource_test.go
+++ b/internal/addrs/resource_test.go
@@ -570,7 +570,6 @@ func TestParseConfigResource(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.Input, func(t *testing.T) {
 			t.Parallel()

--- a/internal/addrs/set.go
+++ b/internal/addrs/set.go
@@ -65,12 +65,8 @@ func (s Set[T]) Remove(addr T) {
 // of both the receiver and the given other set.
 func (s Set[T]) Union(other Set[T]) Set[T] {
 	ret := make(Set[T])
-	for k, addr := range s {
-		ret[k] = addr
-	}
-	for k, addr := range other {
-		ret[k] = addr
-	}
+	maps.Copy(ret, s)
+	maps.Copy(ret, other)
 	return ret
 }
 


### PR DESCRIPTION
This is the result of running the "go fix" modernizers against the `addrs` package.

This admittedly has a slightly larger scope than what https://github.com/opentofu/opentofu/issues/3773 called for: only `set.go` from this set of files was already modified during the v1.12 development period.

Nonetheless I'm making a judgment call that the two test changes here are unlikely to cause backport conflicts, and `check_rule_diagnostic.go` isn't likely to change significantly since that functionality has been stable for a few releases now. Seems less effort overall to just get all of these changes done at once.
