### PR TITLE
backend/remote-state/azure: `go fix`

### DIFF
--- a/internal/backend/remote-state/azure/backend.go
+++ b/internal/backend/remote-state/azure/backend.go
@@ -113,7 +113,7 @@ func New(enc encryption.StateEncryption) backend.Backend {
 				Optional:    true,
 				Description: "The timeout in seconds for initializing a client or retrieving a Blob or a Metadata from Azure.",
 				DefaultFunc: schema.EnvDefaultFunc("ARM_TIMEOUT_SECONDS", defaultTimeout),
-				ValidateFunc: func(v interface{}, _ string) ([]string, []error) {
+				ValidateFunc: func(v any, _ string) ([]string, []error) {
 					value, ok := v.(int)
 					if !ok || value < 0 {
 						return nil, []error{fmt.Errorf("timeout_seconds expected to be a non-negative integer")}

--- a/internal/backend/remote-state/azure/backend_test.go
+++ b/internal/backend/remote-state/azure/backend_test.go
@@ -34,7 +34,7 @@ func TestBackendConfig(t *testing.T) {
 	// This test just instantiates the client. Shouldn't make any actual
 	// requests nor incur any costs.
 
-	config := map[string]interface{}{
+	config := map[string]any{
 		"storage_account_name": "tfaccount",
 		"container_name":       "tfcontainer",
 		"key":                  "state",
@@ -226,7 +226,7 @@ func TestAccBackendAccessKeyBasic(t *testing.T) {
 	}
 
 	// The call to backend.TestBackendStates tests workspace creation, list and deletion.
-	b1 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]interface{}{
+	b1 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]any{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
 		"key":                  res.storageKeyName,
@@ -236,7 +236,7 @@ func TestAccBackendAccessKeyBasic(t *testing.T) {
 
 	backend.TestBackendStates(t, b1)
 
-	b2 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]interface{}{
+	b2 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]any{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
 		"key":                  res.storageKeyName,
@@ -285,7 +285,7 @@ func TestAccBackendSASToken(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	b1 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]interface{}{
+	b1 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]any{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
 		"key":                  res.storageKeyName,
@@ -295,7 +295,7 @@ func TestAccBackendSASToken(t *testing.T) {
 
 	backend.TestBackendStates(t, b1)
 
-	b2 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]interface{}{
+	b2 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]any{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
 		"key":                  res.storageKeyName,
@@ -344,7 +344,7 @@ Please set TF_AZURE_TEST_CLIENT_ID and TF_AZURE_TEST_CLIENT_SECRET, either manua
 		t.Fatal(err)
 	}
 
-	b1 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]interface{}{
+	b1 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]any{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
 		"key":                  res.storageKeyName,
@@ -356,7 +356,7 @@ Please set TF_AZURE_TEST_CLIENT_ID and TF_AZURE_TEST_CLIENT_SECRET, either manua
 
 	backend.TestBackendStates(t, b1)
 
-	b2 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]interface{}{
+	b2 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]any{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
 		"key":                  res.storageKeyName,
@@ -414,7 +414,7 @@ func TestAccBackendServicePrincipalClientCertificate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	b1 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]interface{}{
+	b1 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]any{
 		"storage_account_name":        res.storageAccountName,
 		"container_name":              res.storageContainerName,
 		"key":                         res.storageKeyName,
@@ -442,7 +442,7 @@ func TestAccBackendManagedServiceIdentity(t *testing.T) {
 		t.Skip("For MSI tests, all infrastructure must be set up ahead of time and passed through environment variables.")
 	}
 
-	b := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]interface{}{
+	b := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]any{
 		"storage_account_name": storageAccountName,
 		"container_name":       containerName,
 		"key":                  "testState",
@@ -487,7 +487,7 @@ func TestAccBackendAKSWorkloadIdentity(t *testing.T) {
 		t.Skip("For MSI tests, all infrastructure must be set up ahead of time and passed through environment variables.")
 	}
 
-	b := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]interface{}{
+	b := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]any{
 		"storage_account_name":      storageAccountName,
 		"container_name":            containerName,
 		"key":                       "testState",
@@ -517,7 +517,6 @@ func TestAccBackendAKSWorkloadIdentity(t *testing.T) {
 	deleteBlobsManually(t, authCred, storageAccountName, resourceGroupName, containerName)
 }
 
-
 // TestAccBackendADOWorkloadIdentity tests if the backend functions when using workload identity, on Azure DevOps (ADO).
 // Note: this test does NOT create its own resource group, storage account, or storage container. You must set up that infrastructure
 // manually, as well as the Azure DevOps Org, workload identity, and managed identity which this test depends upon.
@@ -537,7 +536,7 @@ func TestAccBackendADOWorkloadIdentity(t *testing.T) {
 		t.Skip("For ADO tests, all infrastructure must be set up ahead of time and passed through environment variables.")
 	}
 
-	b := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]interface{}{
+	b := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]any{
 		"storage_account_name":      storageAccountName,
 		"container_name":            containerName,
 		"key":                       "testState",

--- a/internal/backend/remote-state/azure/client_test.go
+++ b/internal/backend/remote-state/azure/client_test.go
@@ -117,7 +117,7 @@ func TestAccRemoteClientAccessKeyBasic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	b1 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]interface{}{
+	b1 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]any{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
 		"key":                  res.storageKeyName,
@@ -132,7 +132,7 @@ func TestAccRemoteClientAccessKeyBasic(t *testing.T) {
 
 	remote.TestClient(t, s1.(*remote.State).Client)
 
-	b2 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]interface{}{
+	b2 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]any{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
 		"key":                  res.storageKeyName,
@@ -181,7 +181,7 @@ func TestAccRemoteClientSASToken(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	b1 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]interface{}{
+	b1 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]any{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
 		"key":                  res.storageKeyName,
@@ -196,7 +196,7 @@ func TestAccRemoteClientSASToken(t *testing.T) {
 
 	remote.TestClient(t, s1.(*remote.State).Client)
 
-	b2 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]interface{}{
+	b2 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]any{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
 		"key":                  res.storageKeyName,
@@ -246,7 +246,7 @@ Please set TF_AZURE_TEST_CLIENT_ID and TF_AZURE_TEST_CLIENT_SECRET, either manua
 		t.Fatal(err)
 	}
 
-	b1 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]interface{}{
+	b1 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]any{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
 		"key":                  res.storageKeyName,
@@ -263,7 +263,7 @@ Please set TF_AZURE_TEST_CLIENT_ID and TF_AZURE_TEST_CLIENT_SECRET, either manua
 
 	remote.TestClient(t, s1.(*remote.State).Client)
 
-	b2 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]interface{}{
+	b2 := backend.TestBackendConfig(t, New(encryption.StateEncryptionDisabled()), backend.TestWrapConfig(map[string]any{
 		"storage_account_name": res.storageAccountName,
 		"container_name":       res.storageContainerName,
 		"key":                  res.storageKeyName,


### PR DESCRIPTION
This is the result of running the "go fix" modernizers on this package, with no other changes.

The two files changed here already had a bunch of changes during the v1.12 development period, so these changes are unlikely to make the automatic backporting situation significantly worse.
