### PR TITLE
encryption/keyprovider/*: `go fix`

### DIFF
--- a/internal/encryption/keyprovider/aws_kms/config.go
+++ b/internal/encryption/keyprovider/aws_kms/config.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
@@ -199,12 +200,13 @@ func (c Config) Build() (keyprovider.KeyProvider, keyprovider.KeyMeta, error) {
 	_, awsConfig, awsDiags := awsbase.GetAwsConfig(ctx, cfg)
 
 	if awsDiags.HasError() {
-		out := "errors were encountered in aws kms configuration"
+		var out strings.Builder
+		out.WriteString("errors were encountered in aws kms configuration")
 		for _, diag := range awsDiags.Errors() {
-			out += "\n" + diag.Summary() + " : " + diag.Detail()
+			out.WriteString("\n" + diag.Summary() + " : " + diag.Detail())
 		}
 
-		return nil, nil, fmt.Errorf("%s", out)
+		return nil, nil, fmt.Errorf("%s", out.String())
 	}
 
 	return &keyProvider{

--- a/internal/encryption/keyprovider/compliancetest/compliance.go
+++ b/internal/encryption/keyprovider/compliancetest/compliance.go
@@ -24,14 +24,14 @@ func ComplianceTest[TDescriptor keyprovider.Descriptor, TConfig keyprovider.Conf
 ) {
 	var cfg TConfig
 	cfgType := reflect.TypeOf(cfg)
-	if cfgType.Kind() != reflect.Ptr || cfgType.Elem().Kind() != reflect.Struct {
+	if cfgType.Kind() != reflect.Pointer || cfgType.Elem().Kind() != reflect.Struct {
 		compliancetest.Fail(t, "You declared the config type to be %T, but it should be a pointer to a struct. Please fix your call to ComplianceTest().", cfg)
 	}
 
 	var meta TMeta
 	metaType := reflect.TypeOf(cfg)
 	if metaType.Kind() != reflect.Interface {
-		if metaType.Kind() != reflect.Ptr || metaType.Elem().Kind() != reflect.Struct {
+		if metaType.Kind() != reflect.Pointer || metaType.Elem().Kind() != reflect.Struct {
 			compliancetest.Log(t, "You declared a metadata type as %T, but it should be a pointer to a struct. Please fix your call to ComplianceTest().", meta)
 		}
 	} else {
@@ -83,7 +83,6 @@ func ComplianceTest[TDescriptor keyprovider.Descriptor, TConfig keyprovider.Conf
 			compliancetest.Fail(t, "Please provide a map in MetadataStructTestCases.")
 		}
 		for name, tc := range config.MetadataStructTestCases {
-			tc := tc
 			t.Run(name, func(t *testing.T) {
 				complianceTestMetadataTestCase[TConfig, TKeyProvider, TMeta](t, tc)
 			})

--- a/internal/encryption/keyprovider/openbao/compliance_test.go
+++ b/internal/encryption/keyprovider/openbao/compliance_test.go
@@ -311,7 +311,7 @@ func prepareClientMockForKeyProviderTest(t *testing.T, testKeyName string) mockC
 	generateDataKeyPath := fmt.Sprintf("/transit/datakey/plaintext/%s", escapedTestKeyName)
 	decryptPath := fmt.Sprintf("/transit/decrypt/%s", escapedTestKeyName)
 
-	return func(ctx context.Context, path string, data map[string]interface{}) (*openbao.Secret, error) {
+	return func(ctx context.Context, path string, data map[string]any) (*openbao.Secret, error) {
 		switch path {
 		case generateDataKeyPath:
 			bits, ok := data["bits"].(int)
@@ -325,7 +325,7 @@ func prepareClientMockForKeyProviderTest(t *testing.T, testKeyName string) mockC
 			}
 
 			s := &openbao.Secret{
-				Data: map[string]interface{}{
+				Data: map[string]any{
 					"plaintext":  base64.StdEncoding.EncodeToString(plaintext),
 					"ciphertext": string(append([]byte(testKeyName), plaintext...)),
 				},
@@ -342,7 +342,7 @@ func prepareClientMockForKeyProviderTest(t *testing.T, testKeyName string) mockC
 			plaintext := []byte(ciphertext[len(testKeyName):])
 
 			s := &openbao.Secret{
-				Data: map[string]interface{}{
+				Data: map[string]any{
 					"plaintext": base64.StdEncoding.EncodeToString(plaintext),
 				},
 			}

--- a/internal/encryption/keyprovider/openbao/mock_test.go
+++ b/internal/encryption/keyprovider/openbao/mock_test.go
@@ -6,9 +6,9 @@ import (
 	openbao "github.com/openbao/openbao/api/v2"
 )
 
-type mockClientFunc func(ctx context.Context, path string, data map[string]interface{}) (*openbao.Secret, error)
+type mockClientFunc func(ctx context.Context, path string, data map[string]any) (*openbao.Secret, error)
 
-func (f mockClientFunc) WriteWithContext(ctx context.Context, path string, data map[string]interface{}) (*openbao.Secret, error) {
+func (f mockClientFunc) WriteWithContext(ctx context.Context, path string, data map[string]any) (*openbao.Secret, error) {
 	return f(ctx, path, data)
 }
 

--- a/internal/encryption/keyprovider/pbkdf2/config_test.go
+++ b/internal/encryption/keyprovider/pbkdf2/config_test.go
@@ -6,6 +6,7 @@
 package pbkdf2_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -49,11 +50,11 @@ func TestHashFunctionName_Validate(t *testing.T) {
 }
 
 func generateFixedStringHelper(length int) string {
-	result := ""
-	for i := 0; i < length; i++ {
-		result += "a"
+	var result strings.Builder
+	for range length {
+		result.WriteString("a")
 	}
-	return result
+	return result.String()
 }
 
 func TestConfig_Build(t *testing.T) {


### PR DESCRIPTION
This is the result of running the "go fix" modernizers on the subset of files under this prefix that were already changed during the v1.12 development period.
