### PR TITLE
website: New compatibility promises for "Supported Platforms"

### DIFF
--- a/website/docs/language/v1-compatibility-promises.mdx
+++ b/website/docs/language/v1-compatibility-promises.mdx
@@ -322,23 +322,35 @@ be updated in case of any breaking changes to the services they integrate with.
 
 ## Supported Platforms
 
-Throughout the v1.x series we will continue to produce official releases for
-the following platforms, and make changes as necessary to support new
-releases of these operating systems:
+The set of platforms (operating systems and CPU architectures) commonly used
+in our community is constantly evolving in ways that are outside of our direct
+control and so we cannot guarantee to support any specific platforms for
+the entirety of the v1.x series.
 
-* macOS on x64 CPUs (`darwin_amd64`)
+However, we do intend to retain support for platforms that are in broad use
+by our community and which remain well-supported by their vendors and by the
+other software (libraries and programming languages) that OpenTofu is built and
+tested with. We intend to provide at least two minor release series of advance
+notice before ending support for any currently-supported platform, unless a more
+rapid change is forced on us by sudden changes in vendor support policies
+outside of our control.
+
+We currently consider the following platforms to be officially supported, to
+the extent that the maintainers frequently test OpenTofu on these platforms and
+aim to prioritize fixing any regressions that are reported:
+
+* macOS on Apple Silicon (`darwin_arm64`)
 * Windows on x64 CPUs (`windows_amd64`)
-* Linux on x64, 32-bit ARMv6, and 64-bit ARMv8 (`linux_amd64`, `linux_arm`, and `linux_arm64` respectively)
+* Linux on x64 and 64-bit ARM (`linux_amd64` and `linux_arm64` respectively)
 
 Over time we may require newer versions of these operating systems. For
 example, subsequent OpenTofu releases in the v1.x series might end support
 for earlier versions of macOS or Windows, or earlier Linux kernel releases.
 
 We have historically produced official releases for a number of other platforms
-as a convenience to users of those platforms, and we have no current plans to
-stop publishing them but we cannot promise ongoing releases or bug fixes for
-the other platforms throughout the v1.x series. We do not routinely test
-OpenTofu on any platforms other than those listed above.
+as a convenience to users of those platforms, but we cannot promise ongoing
+releases or bug fixes for the other platforms throughout the v1.x series. We do
+not routinely test OpenTofu on any platforms other than those listed above.
 
 We might add support for new platforms in later v1.x releases. If so, earlier
 OpenTofu releases prior to that support will not be available on those
@@ -348,6 +360,21 @@ All OpenTofu plugins, including provider plugins, are separate programs that
 have their own policies for which platforms they support. We cannot guarantee
 that all providers currently support or will continue to support the platforms
 listed above, even though OpenTofu CLI itself will support them.
+
+:::note
+An earlier version of these compatibility promises _did_ promise ongoing support
+for a specific set of platforms, including some that are no longer listed above.
+
+The original commitments had been made for OpenTofu's predecessor, adopted by
+our project as part of the fork, and represented a snapshot of platforms that
+were in wide use at the time their version of this document was drafted. The
+trends of platform usage and support then inevitably changed in the meantime,
+making those original promises seem dated.
+
+We've now relaxed the promises in this section under the "External Dependencies"
+item in [Pragmatic Exceptions](#pragmatic-exceptions) below, based on changes
+in usage we've recognized through package download metrics.
+:::
 
 ## Later Revisions to These Promises
 


### PR DESCRIPTION
We inherited this "compatibility promises" document from our predecessor as part of the fork, but have now come to realize that the specific set of platforms it committed to support had become quite stale over time: macOS support for x64 is phasing out in favor of Apple Silicon, and 32-bit CPU architectures are no longer commonly used.

In preparation for some anticipated future changes to platform support, this revises the "Supported Platforms" section of our compatibility promises so that it no longer commits to any specific platforms and instead documents that we intend to provide two minor release period's worth of advance notice for removing support for any platform that is currently supported. This is a more sustainable compromise that will allow us to respond to ongoing changes in which platforms are commonly used in our community, and which platforms are supported well by the dependencies that OpenTofu relies on.

This also proactively switches from listing `darwin_amd64` to `darwin_arm64` and removes the commitment to support `linux_arm`. We do not intend to immediately stop testing on and building for those two platforms, but we do expect to phasing them out under the revised version of this policy in future releases and so this update serves as part of our initial communication about that future change.

This change is part of the initial communication about https://github.com/opentofu/opentofu/issues/3278, though we expect to also mention this change in the changelog and in other announcements related to the OpenTofu v1.12 release, which will be added in later PRs.
