### PR TITLE
fix(e2etest): strip state_lock messages in TestJsonIntoStream

### DIFF
--- a/internal/command/e2etest/json_dual_test.go
+++ b/internal/command/e2etest/json_dual_test.go
@@ -20,10 +20,16 @@ func TestJsonIntoStream(t *testing.T) {
 	tfInto := e2e.NewBinary(t, tofuBin, fixturePath)
 	logTimestampRe := regexp.MustCompile(`,"@timestamp":"[^"]*"`)
 	resourceIdRe := regexp.MustCompile(`[a-z0-9\-]{36}`)
+	// state_lock_acquire/release messages are emitted only when lock acquisition
+	// exceeds a timer threshold. On Windows the two runs have different latencies,
+	// causing one to emit the message and the other not to. Strip these lines so
+	// the comparison is not timing-sensitive. See: https://github.com/opentofu/opentofu/issues/3918
+	stateLockRe := regexp.MustCompile(`(?m)^[^\n]*"type":"state_lock_(?:acquire|release)"[^\n]*\n?`)
 
 	sanitize := func(s string) string {
 		s = logTimestampRe.ReplaceAllString(s, "")
 		s = resourceIdRe.ReplaceAllString(s, "<ident>")
+		s = stateLockRe.ReplaceAllString(s, "")
 		return s
 	}
 


### PR DESCRIPTION
On Windows, the two sequential plan runs in TestJsonIntoStream have different latencies — the -json-into run is consistently slower and crosses the timer threshold that emits state_lock_acquire, while the -json run does not. This causes a spurious one-line diff between the two outputs.

Strip state_lock_acquire/release lines from both outputs before comparison since these messages are timing-dependent and not relevant to the test's core assertion.

Fixes #3918

<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves # 

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [X] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [X] I have not used an AI coding assistant to create this PR.
- [X] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [X] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [X] I have run golangci-lint on my change and receive no errors relevant to my code.
- [X] I have run existing tests to ensure my code doesn't break anything.
- [X] I have added tests for all relevant use cases of my code, and those tests are passing.
- [X] I have only exported functions, variables and structs that should be used from other packages.
- [X] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
