### PR TITLE
fix: `showSensitive` working for provisioners output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ UPGRADE NOTES:
 
     [Modern Windows versions now support OpenSSH](https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse), and so we suggest that anyone currently relying on WinRM plan to migrate to using SSH instead.
 
+BUG FIXES:
+
+- provisioner output is no longer suppressed when `-show-sensitive` is passed. ([#3927](https://github.com/opentofu/opentofu/issues/3927))
+
 ## Previous Releases
 
 For information on prior major and minor releases, refer to their changelogs:

--- a/internal/command/e2etest/primary_test.go
+++ b/internal/command/e2etest/primary_test.go
@@ -461,7 +461,24 @@ Changes to Outputs:
 					`simple_resource.test_res (local-exec): visible test value`,
 					`simple_resource.test_res (local-exec): \"visible test value\"`,
 				}, true},
-				outputCheckContains{[]string{"simple_resource.test_res (local-exec): (output suppressed due to ephemeral value in config)"}, true},
+				// https://github.com/opentofu/opentofu/pull/3931#discussion_r2983258136
+				// Ephemeral values can be shown on local provisioners, they do not need to be hidden
+				outputCheckContains{[]string{
+					`simple_resource.test_res (local-exec): Executing: ["/bin/sh" "-c" "echo \"visible plan_val-ephemeral_val-with-renew\""]`,
+					`simple_resource.test_res (local-exec): Executing: ["cmd" "/C" "echo \"visible plan_val-ephemeral_val-with-renew\""]`,
+				}, true},
+				outputCheckContains{[]string{
+					`simple_resource.test_res (local-exec): visible plan_val-ephemeral_val-with-renew`,
+					`simple_resource.test_res (local-exec): \"visible plan_val-ephemeral_val-with-renew\"`,
+				}, true},
+				outputCheckContains{[]string{
+					`simple_resource.test_res (local-exec): Executing: ["/bin/sh" "-c" "echo \"visible ephemeral_val\""]`,
+					`simple_resource.test_res (local-exec): Executing: ["cmd" "/C" "echo \"visible ephemeral_val\""]`,
+				}, true},
+				outputCheckContains{[]string{
+					`simple_resource.test_res (local-exec): visible ephemeral_val`,
+					`simple_resource.test_res (local-exec): \"visible ephemeral_val\"`,
+				}, true},
 			}
 			out := stripAnsi(stdout)
 

--- a/internal/command/e2etest/testdata/ephemeral-workflow/main.tf
+++ b/internal/command/e2etest/testdata/ephemeral-workflow/main.tf
@@ -49,10 +49,10 @@ resource "simple_resource" "test_res" {
     command = "echo \"visible ${self.value}\""
   }
   provisioner "local-exec" {
-    command = "echo \"not visible ${ephemeral.simple_resource.test_ephemeral[0].value}\""
+    command = "echo \"visible ${ephemeral.simple_resource.test_ephemeral[0].value}\""
   }
   provisioner "local-exec" {
-    command = "echo \"not visible ${var.ephemeral_input}\""
+    command = "echo \"visible ${var.ephemeral_input}\""
   }
   // NOTE: value_wo cannot be used in a provisioner because it is returned as null by the provider so the interpolation fails
 }

--- a/internal/command/views/hook_json.go
+++ b/internal/command/views/hook_json.go
@@ -17,6 +17,7 @@ import (
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/command/format"
 	"github.com/opentofu/opentofu/internal/command/views/json"
+	"github.com/opentofu/opentofu/internal/lang/marks"
 	"github.com/opentofu/opentofu/internal/plans"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tofu"
@@ -152,7 +153,13 @@ func (h *jsonHook) PostProvisionInstanceStep(addr addrs.AbsResourceInstance, typ
 	return tofu.HookActionContinue, nil
 }
 
-func (h *jsonHook) ProvisionOutput(addr addrs.AbsResourceInstance, typeName string, msg string) {
+func (h *jsonHook) ProvisionOutput(addr addrs.AbsResourceInstance, typeName string, msg string, configMarks cty.ValueMarks) {
+	// If the config has sensitive marks and showSensitive is not enabled,
+	// suppress the output.
+	if _, hasSensitive := configMarks[marks.Sensitive]; hasSensitive && !h.view.view.showSensitive {
+		msg = "(output suppressed due to sensitive value in config)"
+	}
+
 	s := bufio.NewScanner(strings.NewReader(msg))
 	s.Split(scanLines)
 	for s.Scan() {

--- a/internal/command/views/hook_json_test.go
+++ b/internal/command/views/hook_json_test.go
@@ -59,7 +59,7 @@ func TestJSONHook_create(t *testing.T) {
 	action, err = hook.PreProvisionInstanceStep(addr, "local-exec")
 	testHookReturnValues(t, action, err)
 
-	hook.ProvisionOutput(addr, "local-exec", `Executing: ["/bin/sh" "-c" "touch /etc/motd"]`)
+	hook.ProvisionOutput(addr, "local-exec", `Executing: ["/bin/sh" "-c" "touch /etc/motd"]`, nil)
 
 	action, err = hook.PostProvisionInstanceStep(addr, "local-exec", nil)
 	testHookReturnValues(t, action, err)

--- a/internal/command/views/hook_ui.go
+++ b/internal/command/views/hook_ui.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/command/format"
+	"github.com/opentofu/opentofu/internal/lang/marks"
 	"github.com/opentofu/opentofu/internal/plans"
 	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/states"
@@ -258,7 +259,13 @@ func (h *UiHook) PreProvisionInstanceStep(addr addrs.AbsResourceInstance, typeNa
 	return tofu.HookActionContinue, nil
 }
 
-func (h *UiHook) ProvisionOutput(addr addrs.AbsResourceInstance, typeName string, msg string) {
+func (h *UiHook) ProvisionOutput(addr addrs.AbsResourceInstance, typeName string, msg string, configMarks cty.ValueMarks) {
+	// If the config has sensitive marks and showSensitive is not enabled,
+	// suppress the output.
+	if _, hasSensitive := configMarks[marks.Sensitive]; hasSensitive && !h.view.showSensitive {
+		msg = "(output suppressed due to sensitive value in config)"
+	}
+
 	var buf bytes.Buffer
 
 	prefix := fmt.Sprintf(

--- a/internal/command/views/hook_ui_test.go
+++ b/internal/command/views/hook_ui_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/command/arguments"
+	"github.com/opentofu/opentofu/internal/lang/marks"
 	"github.com/opentofu/opentofu/internal/plans"
 	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/states"
@@ -433,60 +434,75 @@ func TestProvisionOutput(t *testing.T) {
 	}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance)
 
 	testCases := map[string]struct {
-		provisioner string
-		input       string
-		wantOutput  string
+		provisioner   string
+		input         string
+		configMarks   cty.ValueMarks
+		showSensitive bool
+		wantOutput    string
 	}{
 		"single line": {
-			"local-exec",
-			"foo\n",
-			"test_instance.foo (local-exec): foo\n",
+			provisioner: "local-exec",
+			input:       "foo\n",
+			wantOutput:  "test_instance.foo (local-exec): foo\n",
 		},
 		"multiple lines": {
-			"x",
-			`foo
+			provisioner: "x",
+			input: `foo
 bar
 baz
 `,
-			`test_instance.foo (x): foo
+			wantOutput: `test_instance.foo (x): foo
 test_instance.foo (x): bar
 test_instance.foo (x): baz
 `,
 		},
 		"trailing whitespace": {
-			"x",
-			"foo                  \nbar\n",
-			"test_instance.foo (x): foo\ntest_instance.foo (x): bar\n",
+			provisioner: "x",
+			input:       "foo                  \nbar\n",
+			wantOutput:  "test_instance.foo (x): foo\ntest_instance.foo (x): bar\n",
 		},
 		"blank lines": {
-			"x",
-			"foo\n\nbar\n\n\nbaz\n",
-			`test_instance.foo (x): foo
+			provisioner: "x",
+			input:       "foo\n\nbar\n\n\nbaz\n",
+			wantOutput: `test_instance.foo (x): foo
 test_instance.foo (x): bar
 test_instance.foo (x): baz
 `,
 		},
 		"no final newline": {
-			"x",
-			`foo
+			provisioner: "x",
+			input: `foo
 bar`,
-			`test_instance.foo (x): foo
+			wantOutput: `test_instance.foo (x): foo
 test_instance.foo (x): bar
 `,
 		},
 		"CR, no LF": {
-			"MacOS 9?",
-			"foo\rbar\r",
-			`test_instance.foo (MacOS 9?): foo
+			provisioner: "MacOS 9?",
+			input:       "foo\rbar\r",
+			wantOutput: `test_instance.foo (MacOS 9?): foo
 test_instance.foo (MacOS 9?): bar
 `,
 		},
 		"CRLF": {
-			"winrm",
-			"foo\r\nbar\r\n",
-			`test_instance.foo (winrm): foo
+			provisioner: "winrm",
+			input:       "foo\r\nbar\r\n",
+			wantOutput: `test_instance.foo (winrm): foo
 test_instance.foo (winrm): bar
 `,
+		},
+		"sensitive suppressed by default": {
+			provisioner: "local-exec",
+			input:       "secret-value\n",
+			configMarks: cty.NewValueMarks(marks.Sensitive),
+			wantOutput:  "test_instance.foo (local-exec): (output suppressed due to sensitive value in config)\n",
+		},
+		"sensitive shown with show-sensitive": {
+			provisioner:   "local-exec",
+			input:         "secret-value\n",
+			configMarks:   cty.NewValueMarks(marks.Sensitive),
+			showSensitive: true,
+			wantOutput:    "test_instance.foo (local-exec): secret-value\n",
 		},
 	}
 
@@ -494,9 +510,10 @@ test_instance.foo (winrm): bar
 		t.Run(name, func(t *testing.T) {
 			streams, done := terminal.StreamsForTesting(t)
 			view := NewView(streams)
+			view.SetShowSensitive(tc.showSensitive)
 			h := NewUiHook(view)
 
-			h.ProvisionOutput(addr, tc.provisioner, tc.input)
+			h.ProvisionOutput(addr, tc.provisioner, tc.input, tc.configMarks)
 			result := done(t)
 
 			if got := result.Stdout(); got != tc.wantOutput {

--- a/internal/tofu/context_apply_test.go
+++ b/internal/tofu/context_apply_test.go
@@ -12745,15 +12745,18 @@ func TestContext2Apply_provisionerSensitive(t *testing.T) {
 		t.Fatalf("provisioner was not called on apply")
 	}
 
-	// Verify output was suppressed
+	// Verify output was received by the hook
 	if !h.ProvisionOutputCalled {
 		t.Fatalf("ProvisionOutput hook not called")
 	}
-	if got, doNotWant := h.ProvisionOutputMessage, "secret"; strings.Contains(got, doNotWant) {
-		t.Errorf("sensitive value %q included in output:\n%s", doNotWant, got)
+
+	// The hook receives the raw message and the config marks.
+	// Suppression is handled by UiHook/jsonHook based on the View's showSensitive setting.
+	if _, hasSensitive := h.ProvisionOutputConfigMarks[marks.Sensitive]; !hasSensitive {
+		t.Errorf("expected config marks to have sensitive mark, but it didn't")
 	}
-	if got, want := h.ProvisionOutputMessage, "output suppressed"; !strings.Contains(got, want) {
-		t.Errorf("expected hook to be called with %q, but was:\n%s", want, got)
+	if got := h.ProvisionOutputMessage; !strings.Contains(got, "Executing:") {
+		t.Errorf("expected provisioner output to contain real message, but got: %q", got)
 	}
 }
 

--- a/internal/tofu/hook.go
+++ b/internal/tofu/hook.go
@@ -69,7 +69,7 @@ type Hook interface {
 	PostProvisionInstance(addr addrs.AbsResourceInstance, state cty.Value) (HookAction, error)
 	PreProvisionInstanceStep(addr addrs.AbsResourceInstance, typeName string) (HookAction, error)
 	PostProvisionInstanceStep(addr addrs.AbsResourceInstance, typeName string, err error) (HookAction, error)
-	ProvisionOutput(addr addrs.AbsResourceInstance, typeName string, line string)
+	ProvisionOutput(addr addrs.AbsResourceInstance, typeName string, line string, configMarks cty.ValueMarks)
 
 	// PreRefresh and PostRefresh are called before and after a single
 	// resource state is refreshed, respectively.
@@ -178,7 +178,7 @@ func (*NilHook) PostProvisionInstanceStep(addr addrs.AbsResourceInstance, typeNa
 	return HookActionContinue, nil
 }
 
-func (*NilHook) ProvisionOutput(addr addrs.AbsResourceInstance, typeName string, line string) {
+func (*NilHook) ProvisionOutput(addr addrs.AbsResourceInstance, typeName string, line string, configMarks cty.ValueMarks) {
 }
 
 func (*NilHook) PreRefresh(addr addrs.AbsResourceInstance, gen states.Generation, priorState cty.Value) (HookAction, error) {

--- a/internal/tofu/hook_mock.go
+++ b/internal/tofu/hook_mock.go
@@ -85,6 +85,7 @@ type MockHook struct {
 	ProvisionOutputAddr            addrs.AbsResourceInstance
 	ProvisionOutputProvisionerType string
 	ProvisionOutputMessage         string
+	ProvisionOutputConfigMarks     cty.ValueMarks
 
 	PreRefreshCalled     bool
 	PreRefreshAddr       addrs.AbsResourceInstance
@@ -285,7 +286,7 @@ func (h *MockHook) PostProvisionInstanceStep(addr addrs.AbsResourceInstance, typ
 	return h.PostProvisionInstanceStepReturn, h.PostProvisionInstanceStepError
 }
 
-func (h *MockHook) ProvisionOutput(addr addrs.AbsResourceInstance, typeName string, line string) {
+func (h *MockHook) ProvisionOutput(addr addrs.AbsResourceInstance, typeName string, line string, configMarks cty.ValueMarks) {
 	h.Lock()
 	defer h.Unlock()
 
@@ -293,6 +294,7 @@ func (h *MockHook) ProvisionOutput(addr addrs.AbsResourceInstance, typeName stri
 	h.ProvisionOutputAddr = addr
 	h.ProvisionOutputProvisionerType = typeName
 	h.ProvisionOutputMessage = line
+	h.ProvisionOutputConfigMarks = configMarks
 }
 
 func (h *MockHook) PreRefresh(addr addrs.AbsResourceInstance, gen states.Generation, priorState cty.Value) (HookAction, error) {

--- a/internal/tofu/hook_stop.go
+++ b/internal/tofu/hook_stop.go
@@ -57,7 +57,7 @@ func (h *stopHook) PostProvisionInstanceStep(addr addrs.AbsResourceInstance, typ
 	return h.hook()
 }
 
-func (h *stopHook) ProvisionOutput(addr addrs.AbsResourceInstance, typeName string, line string) {
+func (h *stopHook) ProvisionOutput(addr addrs.AbsResourceInstance, typeName string, line string, configMarks cty.ValueMarks) {
 }
 
 func (h *stopHook) PreRefresh(addr addrs.AbsResourceInstance, gen states.Generation, priorState cty.Value) (HookAction, error) {

--- a/internal/tofu/hook_test.go
+++ b/internal/tofu/hook_test.go
@@ -95,7 +95,7 @@ func (h *testHook) PostProvisionInstanceStep(addr addrs.AbsResourceInstance, typ
 	return HookActionContinue, nil
 }
 
-func (h *testHook) ProvisionOutput(addr addrs.AbsResourceInstance, typeName string, line string) {
+func (h *testHook) ProvisionOutput(addr addrs.AbsResourceInstance, typeName string, line string, configMarks cty.ValueMarks) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.Calls = append(h.Calls, &testHookCall{"ProvisionOutput", addr.String()})

--- a/internal/tofu/node_resource_abstract_instance.go
+++ b/internal/tofu/node_resource_abstract_instance.go
@@ -2718,15 +2718,6 @@ func (n *NodeAbstractResourceInstance) applyProvisioners(ctx context.Context, ev
 			}
 		}
 
-		// The output function
-		outputFn := func(msg string) {
-			// Given that we return nil below, this will never error
-			_ = evalCtx.Hook(func(h Hook) (HookAction, error) {
-				h.ProvisionOutput(n.Addr, prov.Type, msg)
-				return HookActionContinue, nil
-			})
-		}
-
 		// If our config or connection info contains any marked values, ensure
 		// those are stripped out before sending to the provisioner. Unlike
 		// resources, we have no need to capture the marked paths and reapply
@@ -2758,29 +2749,14 @@ func (n *NodeAbstractResourceInstance) applyProvisioners(ctx context.Context, ev
 			}
 		}
 
-		// Marks on the config might result in leaking sensitive values through
-		// provisioner logging, so we conservatively suppress all output in
-		// this case. This should not apply to connection info values, which
-		// provisioners ought not to be logging anyway.
-		if _, hasSensitive := configMarks[marks.Sensitive]; hasSensitive {
-			outputFn = func(msg string) {
-				// Given that we return nil below, this will never error
-				_ = evalCtx.Hook(func(h Hook) (HookAction, error) {
-					h.ProvisionOutput(n.Addr, prov.Type, "(output suppressed due to sensitive value in config)")
-					return HookActionContinue, nil
-				})
-			}
-		}
-		// In case the configuration of a provisioner is referencing an
-		// ephemeral value, supress the whole output of the provisioner.
-		if _, hasEphemeral := configMarks[marks.Ephemeral]; hasEphemeral {
-			outputFn = func(msg string) {
-				// Given that we return nil below, this will never error
-				_ = evalCtx.Hook(func(h Hook) (HookAction, error) {
-					h.ProvisionOutput(n.Addr, prov.Type, "(output suppressed due to ephemeral value in config)")
-					return HookActionContinue, nil
-				})
-			}
+		// The output function passes the config marks to hooks so they can
+		// inspect them (e.g. sensitive) and decide how to handle output.
+		outputFn := func(msg string) {
+			// Given that we return nil below, this will never error
+			_ = evalCtx.Hook(func(h Hook) (HookAction, error) {
+				h.ProvisionOutput(n.Addr, prov.Type, msg, configMarks)
+				return HookActionContinue, nil
+			})
 		}
 
 		output := CallbackUIOutput{OutputFn: outputFn}

--- a/internal/tofu/ui_output_provisioner.go
+++ b/internal/tofu/ui_output_provisioner.go
@@ -19,6 +19,6 @@ type ProvisionerUIOutput struct {
 
 func (o *ProvisionerUIOutput) Output(msg string) {
 	for _, h := range o.Hooks {
-		h.ProvisionOutput(o.InstanceAddr, o.ProvisionerType, msg)
+		h.ProvisionOutput(o.InstanceAddr, o.ProvisionerType, msg, nil)
 	}
 }

--- a/website/docs/language/ephemerality/index.mdx
+++ b/website/docs/language/ephemerality/index.mdx
@@ -183,8 +183,8 @@ output "secret_manager_arn" {
 The following configuration uses the module above to read the secret, configure a provider with
 the credentials retrieved and store the same credentials in a write-only attribute `value_wo`
 of the `aws_ssm_parameter` resource.
-Additionally, it adds two `local-exec` provisioners. The execution of the first one will print the `command` content but the
-second one will print `(output suppressed due to ephemeral value in config)`:
+Additionally, it adds two `local-exec` provisioners. Both will print the `command` content, since ephemeral values
+do not suppress provisioner output. If the output needs to be suppressed, the values should be marked as `sensitive`:
 ```hcl
 terraform {
   required_providers {
@@ -230,7 +230,7 @@ resource "aws_ssm_parameter" "store_ephemeral_in_write_only" {
     command = "echo non-ephemeral value: ${aws_ssm_parameter.store_ephemeral_in_write_only.arn}"
   }
 
-  # Because this provisioner uses ephemeral values, its output will be suppressed
+  # This provisioner uses ephemeral values but its output will still be visible
   provisioner "local-exec" {
     when    = create
     command = "echo ephemeral value from module: #${jsonencode(module.secret_management.secrets)}#"

--- a/website/docs/language/resources/provisioners/syntax.mdx
+++ b/website/docs/language/resources/provisioners/syntax.mdx
@@ -227,7 +227,7 @@ The configuration for a `provisioner` block may use sensitive values, such as
 In this case, all log output from the provisioner is automatically suppressed to
 prevent the sensitive values from being displayed.
 
-The same behavior will be visible also when using [ephemeral values](../../ephemerality/index.mdx).
+Note that [ephemeral values](../../ephemerality/index.mdx) alone do not suppress provisioner output. If you need to suppress output for ephemeral values, mark them as `sensitive` as well.
 ## Creation-Time Provisioners
 
 By default, provisioners run when the resource they are defined within is


### PR DESCRIPTION
Alternative implementation of #3930, as requested by @yottta. We can compare the implementations here.

<!-- If your PR resolves an issue, please add it here. -->
Resolves #3927

I checked passing showSensitive through the ui_hook.go (via [*View](https://github.com/opentofu/opentofu/blob/main/internal/command/views/hook_ui.go#L49)), but I didn't like the responsibility of the Hook using that.

It seemed more semantically correct to pass this option through the EvalContext, even with more code.

Before:
```
null_resource.demo: Creating...
2026-03-23T22:38:13.564-0300 [INFO]  Starting apply for null_resource.demo
2026-03-23T22:38:13.564-0300 [DEBUG] null_resource.demo: applying the planned Create change
null_resource.demo: Provisioning with 'local-exec'...
null_resource.demo (local-exec): (output suppressed due to sensitive value in config)
null_resource.demo (local-exec): (output suppressed due to sensitive value in config)
null_resource.demo: Creation complete after 0s [id=541969575736346590]
```


After:
```
null_resource.demo: Creating...
2026-03-23T22:37:20.430-0300 [INFO]  Starting apply for null_resource.demo
2026-03-23T22:37:20.430-0300 [DEBUG] null_resource.demo: applying the planned Create change
null_resource.demo: Provisioning with 'local-exec'...
null_resource.demo (local-exec): Executing: ["/bin/sh" "-c" "echo 'Transient Token Length: 22'"]
null_resource.demo (local-exec): Transient Token Length: 22
null_resource.demo: Creation complete after 0s [id=2658144095968671671]
```

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
