### PR TITLE
chore: typo fixes

### DIFF
--- a/internal/addrs/instance_key_test.go
+++ b/internal/addrs/instance_key_test.go
@@ -73,7 +73,7 @@ func TestInstanceKeyString(t *testing.T) {
 			got := test.Key.String()
 			want := test.Want
 			if got != want {
-				t.Errorf("wrong result\nreciever: %s\ngot:      %s\nwant:     %s", testName, got, want)
+				t.Errorf("wrong result\nreceiver: %s\ngot:      %s\nwant:     %s", testName, got, want)
 			}
 		})
 	}

--- a/internal/command/cliconfig/ociauthconfig/docker_cli_credentials_config_test.go
+++ b/internal/command/cliconfig/ociauthconfig/docker_cli_credentials_config_test.go
@@ -288,7 +288,7 @@ func TestDockerCLIStyleAuthFileSearchLocations(t *testing.T) {
 				"/home/example/.dockercfg",
 			},
 		},
-		"linux with XDG basedir enviroment variables": {
+		"linux with XDG basedir environment variables": {
 			fakeConfigDiscoveryEnvironment{
 				osName:   "linux",
 				homePath: "/home/example",

--- a/internal/command/views/workspace.go
+++ b/internal/command/views/workspace.go
@@ -231,7 +231,7 @@ func (v *WorkspaceHuman) WorkspaceChanged(name string) {
 func (v *WorkspaceHuman) WorkspaceIsOverriddenSelectError() {
 	v.Diagnostics(tfdiags.Diagnostics{tfdiags.Sourceless(
 		tfdiags.Error,
-		"The selected workspace is overriden using the TF_WORKSPACE environment variable",
+		"The selected workspace is overridden using the TF_WORKSPACE environment variable",
 		`To select a new workspace, either update this environment variable or unset it and then run this command again.`,
 	)})
 }
@@ -239,7 +239,7 @@ func (v *WorkspaceHuman) WorkspaceIsOverriddenSelectError() {
 func (v *WorkspaceHuman) WorkspaceIsOverriddenNewError() {
 	v.Diagnostics(tfdiags.Diagnostics{tfdiags.Sourceless(
 		tfdiags.Error,
-		"The workspace is overriden using the TF_WORKSPACE environment variable",
+		"The workspace is overridden using the TF_WORKSPACE environment variable",
 		`To create a new workspace, either unset this environment variable or update it to match the workspace name you are trying to create, and then run this command again.`,
 	)})
 }

--- a/internal/command/views/workspace_test.go
+++ b/internal/command/views/workspace_test.go
@@ -141,7 +141,7 @@ URL safe characters, and no path separators.
 				},
 			},
 			wantStderr: `
-Error: The selected workspace is overriden using the TF_WORKSPACE environment variable
+Error: The selected workspace is overridden using the TF_WORKSPACE environment variable
 
 To select a new workspace, either update this environment variable or unset
 it and then run this command again.
@@ -159,7 +159,7 @@ it and then run this command again.
 				},
 			},
 			wantStderr: `
-Error: The workspace is overriden using the TF_WORKSPACE environment variable
+Error: The workspace is overridden using the TF_WORKSPACE environment variable
 
 To create a new workspace, either unset this environment variable or update
 it to match the workspace name you are trying to create, and then run this

--- a/internal/engine/planning/plan_replace_order.go
+++ b/internal/engine/planning/plan_replace_order.go
@@ -140,8 +140,8 @@ const (
 	replaceDestroyThenCreate
 )
 
-// ChangeAction returns the [plans.Action] corresponding to the reciever,
-// or panics if the reciever is [replaceAnyOrder] because that value represents
+// ChangeAction returns the [plans.Action] corresponding to the receiver,
+// or panics if the receiver is [replaceAnyOrder] because that value represents
 // that we haven't yet decided which action to use.
 //
 // This should typically be used only on values taken from the result of a

--- a/internal/engine/planning/plan_resource_instance.go
+++ b/internal/engine/planning/plan_resource_instance.go
@@ -336,7 +336,7 @@ func (b *resourceInstanceObjectsBuilder) Put(obj *resourceInstanceObject) {
 // This function panics if there have been multiple calls for the same provider
 // instance. The caller must not modify the given set or anything reachable
 // through it after calling this function, because it becomes part of the
-// internal state of the reciever.
+// internal state of the receiver.
 func (b *resourceInstanceObjectsBuilder) PutProviderInstanceDependencies(addr addrs.AbsProviderInstanceCorrect, deps addrs.Set[addrs.AbsResourceInstance]) {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/internal/getproviders/hash.go
+++ b/internal/getproviders/hash.go
@@ -538,7 +538,7 @@ type HashDisposition struct {
 	Platform *Platform
 }
 
-// SignedByAnyGPGKeys returns true if the reciever has at least one GPG key
+// SignedByAnyGPGKeys returns true if the receiver has at least one GPG key
 // ID that signed an assertion that the associated hash is valid for the
 // associated provider version.
 //
@@ -658,11 +658,11 @@ func (ds HashDispositions) HasAnySignedByGPGKeys() bool {
 	return false
 }
 
-// Merge modifies the receiever to also include all of the hashes and
+// Merge modifies the receiver to also include all of the hashes and
 // associated dispositions from the given other [HashDispositions] object.
 //
 // If both collections contain the same hash then their dispositions are
-// also merged, so that the reciever is left representing the union
+// also merged, so that the receiver is left representing the union
 // of the disposition information from both collections.
 func (ds HashDispositions) Merge(other HashDispositions) {
 	for hash, disp := range other {

--- a/internal/getproviders/package_authentication.go
+++ b/internal/getproviders/package_authentication.go
@@ -449,7 +449,7 @@ func (a *registryPackageAuthentication) AuthenticatePackage(localLocation Packag
 		return nil, err
 	}
 	if stat.Size() != platformData.PackageSize {
-		return nil, fmt.Errorf("registry response indicates a package of size %v, but recieved a package of size %v", platformData.PackageSize, stat.Size())
+		return nil, fmt.Errorf("registry response indicates a package of size %v, but received a package of size %v", platformData.PackageSize, stat.Size())
 	}
 
 	// Validate platform specific hash data

--- a/internal/getproviders/package_authentication_test.go
+++ b/internal/getproviders/package_authentication_test.go
@@ -538,7 +538,7 @@ func TestRegistryPackageAuthentication(t *testing.T) {
 				PackageSize: 295,
 			},
 		},
-		err: `registry response indicates a package of size 295, but recieved a package of size 294`,
+		err: `registry response indicates a package of size 295, but received a package of size 294`,
 	}, {
 		name:     "incorrect_platform_hash",
 		location: location,

--- a/internal/lang/eval/internal/configgraph/resource_instance.go
+++ b/internal/lang/eval/internal/configgraph/resource_instance.go
@@ -97,7 +97,7 @@ func (ri *ResourceInstance) ConfigValue(ctx context.Context) (v cty.Value, diags
 		// If we don't have a valid config value then we'll stop early
 		// with an unknown value placeholder so that the external process
 		// responsible for providing the result value can assume that it
-		// will only ever recieve validated configuration values.
+		// will only ever receive validated configuration values.
 		return exprs.AsEvalError(cty.DynamicVal), diags
 	}
 

--- a/internal/lang/eval/internal/configgraph/resource_instance_glue.go
+++ b/internal/lang/eval/internal/configgraph/resource_instance_glue.go
@@ -21,7 +21,7 @@ import (
 // outside of this package.
 //
 // Real implementations of these methods are likely to block until some
-// side-effects have occured elsewhere, such as asking a provider to produce a
+// side-effects have occurred elsewhere, such as asking a provider to produce a
 // planned new state. If that external work depends on information coming from
 // any other part of this package's API then the implementation of that
 // MUST use the mechanisms from package grapheval in order to cooperate

--- a/internal/lang/eval/resource_instance.go
+++ b/internal/lang/eval/resource_instance.go
@@ -23,7 +23,7 @@ import (
 // [DesiredResourceInstance.IsPlaceholder] returns true for these placeholder
 // objects.
 //
-// Prior state resouce instances are not represented in this package at all.
+// Prior state resource instances are not represented in this package at all.
 // The plan and apply mechanisms implemented elsewhere are responsible for
 // comparing desired resource instances with prior state resource instances
 // to determine what actions are needed, if any.

--- a/internal/tfdiags/override.go
+++ b/internal/tfdiags/override.go
@@ -87,7 +87,7 @@ func (o overriddenDiagnostic) ExtraInfo() interface{} {
 // delegates to its own ElaborateFromConfigBody implementation and then re-wraps
 // the result with the same overrides.
 //
-// Otherwise, the reciever is returned unchanged.
+// Otherwise, the receiver is returned unchanged.
 func (o overriddenDiagnostic) ElaborateFromConfigBody(body hcl.Body, addr string) Diagnostic {
 	innerContextual, ok := o.original.(contextualFromConfigBody)
 	if !ok {

--- a/internal/tofu/transform_diff.go
+++ b/internal/tofu/transform_diff.go
@@ -195,8 +195,8 @@ func (t *DiffTransformer) Transform(_ context.Context, g *Graph) error {
 						diags = diags.Append(tfdiags.Sourceless(
 							tfdiags.Error,
 							"Invalid planned change",
-							fmt.Sprintf("%s: wasn't able to set CBD, error occured %s", dag.VertexName(node), err.Error())))
-						log.Printf("[TRACE] DiffTransformer: %s: wasn't able to set CBD, error occured %s", addr, err.Error())
+							fmt.Sprintf("%s: wasn't able to set CBD, error occurred %s", dag.VertexName(node), err.Error())))
+						log.Printf("[TRACE] DiffTransformer: %s: wasn't able to set CBD, error occurred %s", addr, err.Error())
 						continue
 					}
 				}


### PR DESCRIPTION
## What and Why

- This consists of minor corrections to spelling and grammar in comments, error messages, and test descriptions throughout the codebase

---

* Corrected "reciever", "receiever", "recieved", "reciever", "occured", "enviroment", "resouce", "overriden" and similar misspellings to their correct forms such as "receiver", "received", "occurred", "environment", "resource", and "overridden" in comments, error messages, and test descriptions across multiple files.
* Updated error messages in workspace and package authentication logic to use correct spelling, ensuring clarity for users.
* Fixed spelling in test names and comments to maintain consistency and professionalism in documentation and test output.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [X] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [X] I have not used an AI coding assistant to create this PR.
- [X] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [X] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [X] I have run golangci-lint on my change and receive no errors relevant to my code.
- [X] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [X] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
