### PR TITLE
go.mod: Upgrade to Go 1.25.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opentofu/opentofu
 
-go 1.25.8
+go 1.25.9
 
 // At the time of adding this configuration, the new Go feature introduced here https://github.com/golang/go/issues/67061,
 // was having a good amount of issues linked to, affecting AWS Firewall, GCP various services and a lot more.


### PR DESCRIPTION
The Go team has preannounced that they intend to release Go 1.25.9 on April 7 2026, and that it will contain changes to address the following security advisories that are not yet public:

- CVE-2026-32282
- CVE-2026-32289
- CVE-2026-33810
- CVE-2026-27144
- CVE-2026-27143
- CVE-2026-32288
- CVE-2026-32283
- CVE-2026-27140

We don't know yet if any of these advisories is significant for OpenTofu. I'm opening this PR early so that we can hopefully preapprove it so that we can act quickly on April 7 if at least one of the advisories turns out to be highly-sensitive for OpenTofu.

**Update:** These advisories were not announced as part of this release after all. More information in https://github.com/opentofu/opentofu/pull/3966#issuecomment-4201975382.

---

The checks will, of course, fail until the Go 1.25.9 release is actually published. Once that release is out we should use the GitHub Actions "re-run failed jobs" feature to verify that the checks begin passing.

If we _do_ find that one of these advisories is relevant to OpenTofu then we will also need to add a CHANGELOG entry here about it before merging and releasing. I'm going to add an unresolved comment inline to remind us to think about whether we need to do that.

If we find that none of these advisories are significant for OpenTofu then we would still merge this PR so it would be included in the next patch release for the v1.11 series, but we would not _immediately_ produce that patch release and would instead wait until there's something more significant to release. This is consistent with our policy for upstream security advisories where we only produce patch releases for problems that actually affect OpenTofu's behavior.

