### PR TITLE
plugin+plugin6: go fix grpc_provider.go and its tests

### DIFF
--- a/internal/plugin/grpc_provider.go
+++ b/internal/plugin/grpc_provider.go
@@ -43,7 +43,7 @@ var clientCapabilities = &proto.ClientCapabilities{
 	WriteOnlyAttributesAllowed: true,
 }
 
-func (p *GRPCProviderPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, c *grpc.ClientConn) (interface{}, error) {
+func (p *GRPCProviderPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, c *grpc.ClientConn) (any, error) {
 	return &GRPCProvider{
 		client: proto.NewProviderClient(c),
 		ctx:    ctx,

--- a/internal/plugin/grpc_provider_test.go
+++ b/internal/plugin/grpc_provider_test.go
@@ -501,7 +501,7 @@ func TestGRPCProvider_PrepareProviderConfig(t *testing.T) {
 		gomock.Any(),
 	).Return(&proto.PrepareProviderConfig_Response{}, nil)
 
-	cfg := hcl2shim.HCL2ValueFromConfigValue(map[string]interface{}{"attr": "value"})
+	cfg := hcl2shim.HCL2ValueFromConfigValue(map[string]any{"attr": "value"})
 	resp := p.ValidateProviderConfig(t.Context(), providers.ValidateProviderConfigRequest{Config: cfg})
 	checkDiags(t, resp.Diagnostics)
 }
@@ -515,7 +515,7 @@ func TestGRPCProvider_ValidateResourceConfig(t *testing.T) {
 		gomock.Any(),
 	).Return(&proto.ValidateResourceTypeConfig_Response{}, nil)
 
-	cfg := hcl2shim.HCL2ValueFromConfigValue(map[string]interface{}{"attr": "value"})
+	cfg := hcl2shim.HCL2ValueFromConfigValue(map[string]any{"attr": "value"})
 	resp := p.ValidateResourceConfig(t.Context(), providers.ValidateResourceConfigRequest{
 		TypeName: "resource",
 		Config:   cfg,
@@ -532,7 +532,7 @@ func TestGRPCProvider_ValidateDataSourceConfig(t *testing.T) {
 		gomock.Any(),
 	).Return(&proto.ValidateDataSourceConfig_Response{}, nil)
 
-	cfg := hcl2shim.HCL2ValueFromConfigValue(map[string]interface{}{"attr": "value"})
+	cfg := hcl2shim.HCL2ValueFromConfigValue(map[string]any{"attr": "value"})
 	resp := p.ValidateDataResourceConfig(t.Context(), providers.ValidateDataResourceConfigRequest{
 		TypeName: "data",
 		Config:   cfg,
@@ -549,7 +549,7 @@ func TestGRPCProvider_ValidateEphemeralResourceConfig(t *testing.T) {
 		gomock.Any(),
 	).Return(&proto.ValidateEphemeralResourceConfig_Response{}, nil)
 
-	cfg := hcl2shim.HCL2ValueFromConfigValue(map[string]interface{}{"attr": "value"})
+	cfg := hcl2shim.HCL2ValueFromConfigValue(map[string]any{"attr": "value"})
 	resp := p.ValidateEphemeralConfig(t.Context(), providers.ValidateEphemeralConfigRequest{
 		TypeName: "eph",
 		Config:   cfg,

--- a/internal/plugin6/grpc_provider.go
+++ b/internal/plugin6/grpc_provider.go
@@ -43,7 +43,7 @@ var clientCapabilities = &proto6.ClientCapabilities{
 	WriteOnlyAttributesAllowed: true,
 }
 
-func (p *GRPCProviderPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, c *grpc.ClientConn) (interface{}, error) {
+func (p *GRPCProviderPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, c *grpc.ClientConn) (any, error) {
 	return &GRPCProvider{
 		client: proto6.NewProviderClient(c),
 		ctx:    ctx,

--- a/internal/plugin6/grpc_provider_test.go
+++ b/internal/plugin6/grpc_provider_test.go
@@ -505,7 +505,7 @@ func TestGRPCProvider_PrepareProviderConfig(t *testing.T) {
 		gomock.Any(),
 	).Return(&proto.ValidateProviderConfig_Response{}, nil)
 
-	cfg := hcl2shim.HCL2ValueFromConfigValue(map[string]interface{}{"attr": "value"})
+	cfg := hcl2shim.HCL2ValueFromConfigValue(map[string]any{"attr": "value"})
 	resp := p.ValidateProviderConfig(t.Context(), providers.ValidateProviderConfigRequest{Config: cfg})
 	checkDiags(t, resp.Diagnostics)
 }
@@ -519,7 +519,7 @@ func TestGRPCProvider_ValidateResourceConfig(t *testing.T) {
 		gomock.Any(),
 	).Return(&proto.ValidateResourceConfig_Response{}, nil)
 
-	cfg := hcl2shim.HCL2ValueFromConfigValue(map[string]interface{}{"attr": "value"})
+	cfg := hcl2shim.HCL2ValueFromConfigValue(map[string]any{"attr": "value"})
 	resp := p.ValidateResourceConfig(t.Context(), providers.ValidateResourceConfigRequest{
 		TypeName: "resource",
 		Config:   cfg,
@@ -536,7 +536,7 @@ func TestGRPCProvider_ValidateDataResourceConfig(t *testing.T) {
 		gomock.Any(),
 	).Return(&proto.ValidateDataResourceConfig_Response{}, nil)
 
-	cfg := hcl2shim.HCL2ValueFromConfigValue(map[string]interface{}{"attr": "value"})
+	cfg := hcl2shim.HCL2ValueFromConfigValue(map[string]any{"attr": "value"})
 	resp := p.ValidateDataResourceConfig(t.Context(), providers.ValidateDataResourceConfigRequest{
 		TypeName: "data",
 		Config:   cfg,
@@ -553,7 +553,7 @@ func TestGRPCProvider_ValidateEphemeralResourceConfig(t *testing.T) {
 		gomock.Any(),
 	).Return(&proto.ValidateEphemeralResourceConfig_Response{}, nil)
 
-	cfg := hcl2shim.HCL2ValueFromConfigValue(map[string]interface{}{"attr": "value"})
+	cfg := hcl2shim.HCL2ValueFromConfigValue(map[string]any{"attr": "value"})
 	resp := p.ValidateEphemeralConfig(t.Context(), providers.ValidateEphemeralConfigRequest{
 		TypeName: "eph",
 		Config:   cfg,


### PR DESCRIPTION
We already changed these files considerably in opentofu/opentofu#3671, so we'll take this opportunity to modernize the rest of the code while the likelihood of successful clean backporting from this file is pretty low anyway, following our policy from https://github.com/opentofu/opentofu/issues/3773.

All of the changes here were performed automatically by `go fix`.