### PR TITLE
Fix `internal/cloud` tests that were missed from being updated when the changes that broke these were added

### DIFF
--- a/internal/cloud/backend_apply_test.go
+++ b/internal/cloud/backend_apply_test.go
@@ -166,9 +166,11 @@ func TestCloud_applyJSONBasic(t *testing.T) {
 	outp := close(t)
 	gotOut := outp.Stdout()
 
-	if !strings.Contains(gotOut, "1 to add, 0 to change, 0 to destroy") {
-		t.Fatalf("expected plan summary in output: %s", gotOut)
-	}
+	// This has been added in terraform#32504 but seems that this test was not executed, because in the same PR
+	// it was added the logic to skip logs of type jsonformat.LogChangeSummary (see Cloud.renderPlanLogs).
+	//if !strings.Contains(gotOut, "1 to add, 0 to change, 0 to destroy") {
+	//	t.Fatalf("expected plan summary in output: %s", gotOut)
+	//}
 	if !strings.Contains(gotOut, "1 added, 0 changed, 0 destroyed") {
 		t.Fatalf("expected apply summary in output: %s", gotOut)
 	}
@@ -242,9 +244,11 @@ func TestCloud_applyJSONWithOutputs(t *testing.T) {
         }
     }`
 
-	if !strings.Contains(gotOut, "1 to add, 0 to change, 0 to destroy") {
-		t.Fatalf("expected plan summary in output: %s", gotOut)
-	}
+	// This has been added in terraform#32504 but seems that this test was not executed, because in the same PR
+	// it was added the logic to skip logs of type jsonformat.LogChangeSummary (see Cloud.renderPlanLogs).
+	//if !strings.Contains(gotOut, "1 to add, 0 to change, 0 to destroy") {
+	//	t.Fatalf("expected plan summary in output: %s", gotOut)
+	//}
 	if !strings.Contains(gotOut, "1 added, 0 changed, 0 destroyed") {
 		t.Fatalf("expected apply summary in output: %s", gotOut)
 	}

--- a/internal/cloud/backend_plan_test.go
+++ b/internal/cloud/backend_plan_test.go
@@ -111,6 +111,7 @@ func TestCloud_planJSONBasic(t *testing.T) {
 	defer bCleanup()
 
 	stream, close := terminal.StreamsForTesting(t)
+	defer close(t)
 
 	b.renderer = &jsonformat.Renderer{
 		Streams:  stream,
@@ -137,12 +138,11 @@ func TestCloud_planJSONBasic(t *testing.T) {
 		t.Fatal("expected a non-empty plan")
 	}
 
-	outp := close(t)
-	gotOut := outp.Stdout()
-
-	if !strings.Contains(gotOut, "1 to add, 0 to change, 0 to destroy") {
-		t.Fatalf("expected plan summary in output: %s", gotOut)
-	}
+	// This has been added in terraform#32504 but seems that this test was not executed, because in the same PR
+	// it was added the logic to skip logs of type jsonformat.LogChangeSummary (see Cloud.renderPlanLogs).
+	//if !strings.Contains(gotOut, "1 to add, 0 to change, 0 to destroy") {
+	//	t.Fatalf("expected plan summary in output: %s", gotOut)
+	//}
 
 	stateMgr, _ := b.StateMgr(t.Context(), testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after the operation finished
@@ -249,9 +249,11 @@ func TestCloud_planJSONFull(t *testing.T) {
 		t.Fatalf("expected plan log: %s", gotOut)
 	}
 
-	if !strings.Contains(gotOut, "2 to add, 0 to change, 0 to destroy") {
-		t.Fatalf("expected plan summary in output: %s", gotOut)
-	}
+	// This has been added in terraform#32504 but seems that this test was not executed, because in the same PR
+	// it was added the logic to skip logs of type jsonformat.LogChangeSummary (see Cloud.renderPlanLogs).
+	//if !strings.Contains(gotOut, "2 to add, 0 to change, 0 to destroy") {
+	//	t.Fatalf("expected plan summary in output: %s", gotOut)
+	//}
 
 	stateMgr, _ := b.StateMgr(t.Context(), testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after the operation finished
@@ -1315,11 +1317,13 @@ func TestCloud_planImportConfigGeneration(t *testing.T) {
 		t.Fatal("expected a non-empty plan")
 	}
 	outp := close(t)
-	gotOut := outp.Stdout()
+	_ = outp.Stdout()
 
-	if !strings.Contains(gotOut, "1 to import, 0 to add, 0 to change, 0 to destroy") {
-		t.Fatalf("expected plan summary in output: %s", gotOut)
-	}
+	// This has been added in terraform#32504 but seems that this test was not executed, because in the same PR
+	// it was added the logic to skip logs of type jsonformat.LogChangeSummary (see Cloud.renderPlanLogs).
+	//if !strings.Contains(gotOut, "1 to import, 0 to add, 0 to change, 0 to destroy") {
+	//	t.Fatalf("expected plan summary in output: %s", gotOut)
+	//}
 
 	stateMgr, _ := b.StateMgr(t.Context(), testBackendSingleWorkspaceName)
 	// An error suggests that the state was not unlocked after the operation finished
@@ -1422,7 +1426,11 @@ func TestCloud_planShouldRenderSRO(t *testing.T) {
 					StructuredRunOutputEnabled: true,
 				},
 			}
-			assertSRORendered(t, b, r, true)
+			// Because the /ping handler above does not add the "X-TFE-Version" header, there is no way for the
+			// SRO rendering to be true.
+			// Added in terraform#33018 with initial "true" assertion, but most probably it was a mistake and
+			// nobody caught it.
+			assertSRORendered(t, b, r, false)
 		})
 
 		t.Run("and SRO is not enabled", func(t *testing.T) {
@@ -1433,7 +1441,6 @@ func TestCloud_planShouldRenderSRO(t *testing.T) {
 			}
 			assertSRORendered(t, b, r, false)
 		})
-
 	})
 
 	t.Run("when instance is TFE and version supports CLI SRO", func(t *testing.T) {

--- a/internal/cloud/backend_test.go
+++ b/internal/cloud/backend_test.go
@@ -292,21 +292,25 @@ func TestCloud_PrepareConfigWithEnvVars(t *testing.T) {
 				"TF_WORKSPACE": "qux",
 			},
 		},
-		"with TF_WORKSPACE value outside of the tags set": {
-			// see https://github.com/opentofu/opentofu/issues/814 for context
+		"with TF_WORKSPACE value different than the workspace name in config": {
+			// This test case has been introduced initially in
+			// https://github.com/opentofu/opentofu/pull/867.
+			// Later, during investigations done for https://github.com/opentofu/opentofu/issues/1787,
+			// the implementation and the error message was changed but this test case was never updated as part
+			// of the work in https://github.com/opentofu/opentofu/pull/1930
 			config: cty.ObjectVal(map[string]cty.Value{
 				"hostname":     cty.StringVal("foo"),
 				"organization": cty.StringVal("bar"),
 				"workspaces": cty.ObjectVal(map[string]cty.Value{
-					"name":    cty.NullVal(cty.String),
+					"name":    cty.StringVal("not-quxx"),
 					"project": cty.NullVal(cty.String),
-					"tags":    cty.SetVal([]cty.Value{cty.StringVal("baz"), cty.StringVal("qux")}),
+					"tags":    cty.NullVal(cty.Set(cty.String)),
 				}),
 			}),
 			vars: map[string]string{
 				"TF_WORKSPACE": "quxx",
 			},
-			expectedErr: `Invalid workspaces configuration: The workspace defined using the environment variable "TF_WORKSPACE" does not belong to "tags".`,
+			expectedErr: `Invalid workspaces configuration: The workspace defined using the environment variable "TF_WORKSPACE" is not consistent with the workspace "name" in the configuration.`,
 		},
 		"with workspace block w/o attributes, TF_WORKSPACE defined": {
 			config: cty.ObjectVal(map[string]cty.Value{
@@ -348,10 +352,11 @@ func TestCloud_PrepareConfigWithEnvVars(t *testing.T) {
 
 func TestCloud_config(t *testing.T) {
 	cases := map[string]struct {
-		config  cty.Value
-		confErr string
-		valErr  string
-		envVars map[string]string
+		config            cty.Value
+		confErr           string
+		valErr            string
+		envVars           map[string]string
+		workspaceToCreate string
 	}{
 		"with_a_non_tfe_host": {
 			config: cty.ObjectVal(map[string]cty.Value{
@@ -442,11 +447,13 @@ func TestCloud_config(t *testing.T) {
 			config: cty.NullVal(cty.EmptyObject),
 		},
 		"with_tags_and_TF_WORKSPACE_env_var_not_matching_tags": { //TODO: once we have proper e2e backend testing we should also add the opposite test - with_tags_and_TF_WORKSPACE_env_var_matching_tags
+			workspaceToCreate: "my-workspace",
 			config: cty.ObjectVal(map[string]cty.Value{
-				"hostname":     cty.NullVal(cty.String),
+				"hostname":     cty.StringVal("localhost"),
 				"organization": cty.StringVal("opentofu"),
-				"token":        cty.NullVal(cty.String),
+				"token":        cty.StringVal("token"),
 				"workspaces": cty.ObjectVal(map[string]cty.Value{
+					"name": cty.NullVal(cty.String),
 					"tags": cty.SetVal(
 						[]cty.Value{
 							cty.StringVal("billing"),
@@ -458,7 +465,7 @@ func TestCloud_config(t *testing.T) {
 			envVars: map[string]string{
 				"TF_WORKSPACE": "my-workspace",
 			},
-			confErr: `OpenTofu failed to find workspace my-workspace with the tags specified in your configuration`,
+			confErr: `OpenTofu failed to find workspace "my-workspace" with the tags specified in your configuration`,
 		},
 	}
 
@@ -471,6 +478,15 @@ func TestCloud_config(t *testing.T) {
 			b, cleanup := testUnconfiguredBackend(t)
 			t.Cleanup(cleanup)
 
+			// workspaceToCreate is a hack that helps with "mocking" existing organization workspaces.
+			if tc.workspaceToCreate != "" {
+				_, err := b.client.Workspaces.Create(t.Context(), b.organization, tfe.WorkspaceCreateOptions{
+					Name: new(tc.workspaceToCreate),
+				})
+				if err != nil {
+					t.Fatalf("failed to create the requested workspace: %s", err)
+				}
+			}
 			// Validate
 			_, valDiags := b.PrepareConfig(tc.config)
 			if (valDiags.Err() != nil || tc.valErr != "") &&


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
While working on the last item in #3765, I realized that several tests in the cloud implementation were failing. 

This PR fixes those tests based on git archaeology used to determine when the failures began and what functionality should have been tested. 

Further details are provided in the comments on each change.

---

### Tests results
On the `main` branch:
```shell
%> TF_TFC_TEST=1 go test github.com/opentofu/opentofu/internal/cloud -count=1 -ldflags=-linkmode=internal | grep FAIL:
--- FAIL: TestCloud_applyJSONBasic (0.01s)
--- FAIL: TestCloud_applyJSONWithOutputs (0.01s)
--- FAIL: TestCloud_planJSONBasic (0.01s)
--- FAIL: TestCloud_planJSONFull (0.01s)
--- FAIL: TestCloud_planImportConfigGeneration (0.01s)
--- FAIL: TestCloud_planShouldRenderSRO (0.00s)
    --- FAIL: TestCloud_planShouldRenderSRO/when_instance_is_TFC (0.00s)
        --- FAIL: TestCloud_planShouldRenderSRO/when_instance_is_TFC/and_SRO_is_enabled (0.00s)
--- FAIL: TestCloud_PrepareConfigWithEnvVars (0.00s)
    --- FAIL: TestCloud_PrepareConfigWithEnvVars/with_TF_WORKSPACE_value_outside_of_the_tags_set (0.00s)
--- FAIL: TestCloud_config (2.66s)
    --- FAIL: TestCloud_config/with_tags_and_TF_WORKSPACE_env_var_not_matching_tags (0.38s)
```

On this branch:
```shell
TF_TFC_TEST=1 go test github.com/opentofu/opentofu/internal/cloud -count=1 -ldflags=-linkmode=internal
ok      github.com/opentofu/opentofu/internal/cloud     7.644s
```

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
