### PR TITLE
Fix flaky TestJsonIntoStream by not comparing elapsed durations between runs

### DIFF
--- a/internal/command/e2etest/json_dual_test.go
+++ b/internal/command/e2etest/json_dual_test.go
@@ -25,11 +25,16 @@ func TestJsonIntoStream(t *testing.T) {
 	// causing one to emit the message and the other not to. Strip these lines so
 	// the comparison is not timing-sensitive. See: https://github.com/opentofu/opentofu/issues/3918
 	stateLockRe := regexp.MustCompile(`(?m)^[^\n]*"type":"state_lock_(?:acquire|release)"[^\n]*\n?`)
+	// Elapsed durations can be flaky due to timing differences between the two runs, so let's remove those
+	elapsedSecondsRe := regexp.MustCompile(`"elapsed_seconds":\d+`)
+	afterDurationRe := regexp.MustCompile(`after \d+s`)
 
 	sanitize := func(s string) string {
 		s = logTimestampRe.ReplaceAllString(s, "")
 		s = resourceIdRe.ReplaceAllString(s, "<ident>")
 		s = stateLockRe.ReplaceAllString(s, "")
+		s = elapsedSecondsRe.ReplaceAllString(s, `"elapsed_seconds":0`)
+		s = afterDurationRe.ReplaceAllString(s, "after 0s")
 		return s
 	}
 


### PR DESCRIPTION
Previously, this test was quite flakey because there is the possibility that one run would take 0s and another would take 1s, causing some flake in systems such as linux_arm where timings are quite different.

This just removes the elapsed time comparisons, It's slightly hacky but it should do the trick for now.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
