### PR TITLE
provisioners: thread context.Context through ProvisionResource interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ UPGRADE NOTES:
 
 ENHANCEMENTS:
 
+- The provisioner plugin interface now threads `context.Context` through to provisioner implementations, preparing for future observability features such as trace context propagation. ([#3936](https://github.com/opentofu/opentofu/issues/3936))
 - A `prevent_destroy` argument in the `lifecycle` block for managed resources can now refer to other symbols in the same module, such as to the module's input variables. ([#3474](https://github.com/opentofu/opentofu/issues/3474), [#3507](https://github.com/opentofu/opentofu/issues/3507))
 - New `lifecycle` meta-argument `destroy`: when set to `false` OpenTofu will plan to just remove the affected object from state without asking the provider to destroy it first, similar to `destroy = false` in `removed` blocks. ([#3409](https://github.com/opentofu/opentofu/pull/3409))
 - Comparing an object or other complex-typed value to `null` using the `==` operator now returns a sensitive boolean result only if the object as a whole is sensitive, and not when the object merely contains a sensitive value nested inside one of its attributes. This means that comparisons to null can now be used in parts of the configuration where sensitive values are not allowed, such as in the `enabled` meta-argument on resources and modules. ([#3793](https://github.com/opentofu/opentofu/pull/3793))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ UPGRADE NOTES:
 
 ENHANCEMENTS:
 
-- The provisioner plugin interface now threads `context.Context` through to provisioner implementations, preparing for future observability features such as trace context propagation. ([#3936](https://github.com/opentofu/opentofu/issues/3936))
 - A `prevent_destroy` argument in the `lifecycle` block for managed resources can now refer to other symbols in the same module, such as to the module's input variables. ([#3474](https://github.com/opentofu/opentofu/issues/3474), [#3507](https://github.com/opentofu/opentofu/issues/3507))
 - New `lifecycle` meta-argument `destroy`: when set to `false` OpenTofu will plan to just remove the affected object from state without asking the provider to destroy it first, similar to `destroy = false` in `removed` blocks. ([#3409](https://github.com/opentofu/opentofu/pull/3409))
 - Comparing an object or other complex-typed value to `null` using the `==` operator now returns a sensitive boolean result only if the object as a whole is sensitive, and not when the object merely contains a sensitive value nested inside one of its attributes. This means that comparisons to null can now be used in parts of the configuration where sensitive values are not allowed, such as in the `enabled` meta-argument on resources and modules. ([#3793](https://github.com/opentofu/opentofu/pull/3793))

--- a/internal/builtin/provisioners/file/resource_provisioner.go
+++ b/internal/builtin/provisioners/file/resource_provisioner.go
@@ -92,7 +92,7 @@ func (p *provisioner) ValidateProvisionerConfig(req provisioners.ValidateProvisi
 	return resp
 }
 
-func (p *provisioner) ProvisionResource(req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+func (p *provisioner) ProvisionResource(_ context.Context, req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
 	if req.Connection.IsNull() {
 		resp.Diagnostics = resp.Diagnostics.Append(tfdiags.WholeContainingBody(
 			tfdiags.Error,

--- a/internal/builtin/provisioners/file/resource_provisioner_test.go
+++ b/internal/builtin/provisioners/file/resource_provisioner_test.go
@@ -6,6 +6,7 @@
 package file
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -113,7 +114,7 @@ func TestResourceProvisioner_StopClose(t *testing.T) {
 
 func TestResourceProvisioner_connectionRequired(t *testing.T) {
 	p := New()
-	resp := p.ProvisionResource(provisioners.ProvisionResourceRequest{})
+	resp := p.ProvisionResource(context.Background(), provisioners.ProvisionResourceRequest{})
 	if !resp.Diagnostics.HasErrors() {
 		t.Fatal("expected error")
 	}
@@ -155,7 +156,7 @@ func TestResourceProvider_ApplyNullDestination(t *testing.T) {
 		"host": cty.StringVal("localhost"),
 	})
 
-	resp := p.ProvisionResource(provisioners.ProvisionResourceRequest{
+	resp := p.ProvisionResource(context.Background(), provisioners.ProvisionResourceRequest{
 		Config:     cfg,
 		Connection: conn,
 	})
@@ -176,7 +177,7 @@ func TestResourceProvisioner_nullSrcVars(t *testing.T) {
 		"destination": cty.StringVal("/tmp/bar"),
 	})
 	p := New()
-	resp := p.ProvisionResource(provisioners.ProvisionResourceRequest{
+	resp := p.ProvisionResource(context.Background(), provisioners.ProvisionResourceRequest{
 		Connection: conn,
 		Config:     config,
 	})

--- a/internal/builtin/provisioners/file/resource_provisioner_test.go
+++ b/internal/builtin/provisioners/file/resource_provisioner_test.go
@@ -6,7 +6,6 @@
 package file
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -114,7 +113,7 @@ func TestResourceProvisioner_StopClose(t *testing.T) {
 
 func TestResourceProvisioner_connectionRequired(t *testing.T) {
 	p := New()
-	resp := p.ProvisionResource(context.Background(), provisioners.ProvisionResourceRequest{})
+	resp := p.ProvisionResource(t.Context(), provisioners.ProvisionResourceRequest{})
 	if !resp.Diagnostics.HasErrors() {
 		t.Fatal("expected error")
 	}
@@ -156,7 +155,7 @@ func TestResourceProvider_ApplyNullDestination(t *testing.T) {
 		"host": cty.StringVal("localhost"),
 	})
 
-	resp := p.ProvisionResource(context.Background(), provisioners.ProvisionResourceRequest{
+	resp := p.ProvisionResource(t.Context(), provisioners.ProvisionResourceRequest{
 		Config:     cfg,
 		Connection: conn,
 	})
@@ -177,7 +176,7 @@ func TestResourceProvisioner_nullSrcVars(t *testing.T) {
 		"destination": cty.StringVal("/tmp/bar"),
 	})
 	p := New()
-	resp := p.ProvisionResource(context.Background(), provisioners.ProvisionResourceRequest{
+	resp := p.ProvisionResource(t.Context(), provisioners.ProvisionResourceRequest{
 		Connection: conn,
 		Config:     config,
 	})

--- a/internal/builtin/provisioners/local-exec/resource_provisioner.go
+++ b/internal/builtin/provisioners/local-exec/resource_provisioner.go
@@ -97,7 +97,7 @@ func (p *provisioner) ValidateProvisionerConfig(req provisioners.ValidateProvisi
 	return resp
 }
 
-func (p *provisioner) ProvisionResource(req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+func (p *provisioner) ProvisionResource(_ context.Context, req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
 	commandVal := req.Config.GetAttr("command")
 	if commandVal.IsNull() || commandVal.AsString() == "" {
 		resp.Diagnostics = resp.Diagnostics.Append(tfdiags.WholeContainingBody(

--- a/internal/builtin/provisioners/local-exec/resource_provisioner_test.go
+++ b/internal/builtin/provisioners/local-exec/resource_provisioner_test.go
@@ -6,6 +6,7 @@
 package localexec
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"runtime"
@@ -32,7 +33,7 @@ func TestResourceProvider_Apply(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resp := p.ProvisionResource(provisioners.ProvisionResourceRequest{
+	resp := p.ProvisionResource(context.Background(), provisioners.ProvisionResourceRequest{
 		Config:   c,
 		UIOutput: output,
 	})
@@ -79,7 +80,7 @@ func TestResourceProvider_stop(t *testing.T) {
 	var provisionerResp atomic.Pointer[provisioners.ProvisionResourceResponse]
 	go func() {
 		defer close(doneCh)
-		resp := p.ProvisionResource(provisioners.ProvisionResourceRequest{
+		resp := p.ProvisionResource(context.Background(), provisioners.ProvisionResourceRequest{
 			Config:   c,
 			UIOutput: output,
 		})
@@ -140,7 +141,7 @@ func TestResourceProvider_ApplyCustomInterpreter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resp := p.ProvisionResource(provisioners.ProvisionResourceRequest{
+	resp := p.ProvisionResource(context.Background(), provisioners.ProvisionResourceRequest{
 		Config:   c,
 		UIOutput: output,
 	})
@@ -180,7 +181,7 @@ func TestResourceProvider_ApplyCustomWorkingDirectory(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resp := p.ProvisionResource(provisioners.ProvisionResourceRequest{
+	resp := p.ProvisionResource(context.Background(), provisioners.ProvisionResourceRequest{
 		Config:   c,
 		UIOutput: output,
 	})
@@ -224,7 +225,7 @@ func TestResourceProvider_ApplyCustomEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resp := p.ProvisionResource(provisioners.ProvisionResourceRequest{
+	resp := p.ProvisionResource(context.Background(), provisioners.ProvisionResourceRequest{
 		Config:   c,
 		UIOutput: output,
 	})
@@ -284,7 +285,7 @@ func TestResourceProvider_ApplyNullCommand(t *testing.T) {
 		"quiet":       cty.NullVal(cty.Bool),
 	})
 
-	resp := p.ProvisionResource(provisioners.ProvisionResourceRequest{
+	resp := p.ProvisionResource(context.Background(), provisioners.ProvisionResourceRequest{
 		Config:   cfg,
 		UIOutput: output,
 	})
@@ -331,7 +332,7 @@ func TestResourceProvisioner_nullsInOptionals(t *testing.T) {
 			}
 
 			// verifying there are no panics
-			p.ProvisionResource(provisioners.ProvisionResourceRequest{
+			p.ProvisionResource(context.Background(), provisioners.ProvisionResourceRequest{
 				Config:   cfg,
 				UIOutput: output,
 			})

--- a/internal/builtin/provisioners/local-exec/resource_provisioner_test.go
+++ b/internal/builtin/provisioners/local-exec/resource_provisioner_test.go
@@ -6,7 +6,6 @@
 package localexec
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"runtime"
@@ -33,7 +32,7 @@ func TestResourceProvider_Apply(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resp := p.ProvisionResource(context.Background(), provisioners.ProvisionResourceRequest{
+	resp := p.ProvisionResource(t.Context(), provisioners.ProvisionResourceRequest{
 		Config:   c,
 		UIOutput: output,
 	})
@@ -80,7 +79,7 @@ func TestResourceProvider_stop(t *testing.T) {
 	var provisionerResp atomic.Pointer[provisioners.ProvisionResourceResponse]
 	go func() {
 		defer close(doneCh)
-		resp := p.ProvisionResource(context.Background(), provisioners.ProvisionResourceRequest{
+		resp := p.ProvisionResource(t.Context(), provisioners.ProvisionResourceRequest{
 			Config:   c,
 			UIOutput: output,
 		})
@@ -141,7 +140,7 @@ func TestResourceProvider_ApplyCustomInterpreter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resp := p.ProvisionResource(context.Background(), provisioners.ProvisionResourceRequest{
+	resp := p.ProvisionResource(t.Context(), provisioners.ProvisionResourceRequest{
 		Config:   c,
 		UIOutput: output,
 	})
@@ -181,7 +180,7 @@ func TestResourceProvider_ApplyCustomWorkingDirectory(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resp := p.ProvisionResource(context.Background(), provisioners.ProvisionResourceRequest{
+	resp := p.ProvisionResource(t.Context(), provisioners.ProvisionResourceRequest{
 		Config:   c,
 		UIOutput: output,
 	})
@@ -225,7 +224,7 @@ func TestResourceProvider_ApplyCustomEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resp := p.ProvisionResource(context.Background(), provisioners.ProvisionResourceRequest{
+	resp := p.ProvisionResource(t.Context(), provisioners.ProvisionResourceRequest{
 		Config:   c,
 		UIOutput: output,
 	})
@@ -285,7 +284,7 @@ func TestResourceProvider_ApplyNullCommand(t *testing.T) {
 		"quiet":       cty.NullVal(cty.Bool),
 	})
 
-	resp := p.ProvisionResource(context.Background(), provisioners.ProvisionResourceRequest{
+	resp := p.ProvisionResource(t.Context(), provisioners.ProvisionResourceRequest{
 		Config:   cfg,
 		UIOutput: output,
 	})
@@ -332,7 +331,7 @@ func TestResourceProvisioner_nullsInOptionals(t *testing.T) {
 			}
 
 			// verifying there are no panics
-			p.ProvisionResource(context.Background(), provisioners.ProvisionResourceRequest{
+			p.ProvisionResource(t.Context(), provisioners.ProvisionResourceRequest{
 				Config:   cfg,
 				UIOutput: output,
 			})

--- a/internal/builtin/provisioners/remote-exec/resource_provisioner.go
+++ b/internal/builtin/provisioners/remote-exec/resource_provisioner.go
@@ -97,7 +97,7 @@ func (p *provisioner) ValidateProvisionerConfig(req provisioners.ValidateProvisi
 	return resp
 }
 
-func (p *provisioner) ProvisionResource(req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+func (p *provisioner) ProvisionResource(_ context.Context, req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
 	if req.Connection.IsNull() {
 		resp.Diagnostics = resp.Diagnostics.Append(tfdiags.WholeContainingBody(
 			tfdiags.Error,

--- a/internal/builtin/provisioners/remote-exec/resource_provisioner_test.go
+++ b/internal/builtin/provisioners/remote-exec/resource_provisioner_test.go
@@ -276,7 +276,7 @@ func TestResourceProvisioner_StopClose(t *testing.T) {
 
 func TestResourceProvisioner_connectionRequired(t *testing.T) {
 	p := New()
-	resp := p.ProvisionResource(provisioners.ProvisionResourceRequest{})
+	resp := p.ProvisionResource(context.Background(), provisioners.ProvisionResourceRequest{})
 	if !resp.Diagnostics.HasErrors() {
 		t.Fatal("expected error")
 	}
@@ -322,7 +322,7 @@ func TestResourceProvisioner_nullsInOptionals(t *testing.T) {
 			}
 
 			// verifying there are no panics
-			p.ProvisionResource(provisioners.ProvisionResourceRequest{
+			p.ProvisionResource(context.Background(), provisioners.ProvisionResourceRequest{
 				Config:   cfg,
 				UIOutput: output,
 			})

--- a/internal/builtin/provisioners/remote-exec/resource_provisioner_test.go
+++ b/internal/builtin/provisioners/remote-exec/resource_provisioner_test.go
@@ -276,7 +276,7 @@ func TestResourceProvisioner_StopClose(t *testing.T) {
 
 func TestResourceProvisioner_connectionRequired(t *testing.T) {
 	p := New()
-	resp := p.ProvisionResource(context.Background(), provisioners.ProvisionResourceRequest{})
+	resp := p.ProvisionResource(t.Context(), provisioners.ProvisionResourceRequest{})
 	if !resp.Diagnostics.HasErrors() {
 		t.Fatal("expected error")
 	}
@@ -322,7 +322,7 @@ func TestResourceProvisioner_nullsInOptionals(t *testing.T) {
 			}
 
 			// verifying there are no panics
-			p.ProvisionResource(context.Background(), provisioners.ProvisionResourceRequest{
+			p.ProvisionResource(t.Context(), provisioners.ProvisionResourceRequest{
 				Config:   cfg,
 				UIOutput: output,
 			})

--- a/internal/grpcwrap/provisioner.go
+++ b/internal/grpcwrap/provisioner.go
@@ -85,7 +85,7 @@ func (p *provisioner) ProvisionResource(req *tfplugin5.ProvisionResource_Request
 		return srv.Send(srvResp)
 	}
 
-	resp := p.provisioner.ProvisionResource(provisioners.ProvisionResourceRequest{
+	resp := p.provisioner.ProvisionResource(srv.Context(), provisioners.ProvisionResourceRequest{
 		Config:     configVal,
 		Connection: connVal,
 		UIOutput:   uiOutput{srv},

--- a/internal/legacy/tofu/provisioner_mock.go
+++ b/internal/legacy/tofu/provisioner_mock.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"sync"
 
 	"github.com/opentofu/opentofu/internal/provisioners"
@@ -31,7 +32,7 @@ type MockProvisioner struct {
 	ProvisionResourceCalled   bool
 	ProvisionResourceRequest  provisioners.ProvisionResourceRequest
 	ProvisionResourceResponse provisioners.ProvisionResourceResponse
-	ProvisionResourceFn       func(provisioners.ProvisionResourceRequest) provisioners.ProvisionResourceResponse
+	ProvisionResourceFn       func(context.Context, provisioners.ProvisionResourceRequest) provisioners.ProvisionResourceResponse
 
 	StopCalled   bool
 	StopResponse error
@@ -68,7 +69,7 @@ func (p *MockProvisioner) ValidateProvisionerConfig(r provisioners.ValidateProvi
 	return p.ValidateProvisionerConfigResponse
 }
 
-func (p *MockProvisioner) ProvisionResource(r provisioners.ProvisionResourceRequest) provisioners.ProvisionResourceResponse {
+func (p *MockProvisioner) ProvisionResource(ctx context.Context, r provisioners.ProvisionResourceRequest) provisioners.ProvisionResourceResponse {
 	p.Lock()
 	defer p.Unlock()
 
@@ -76,7 +77,7 @@ func (p *MockProvisioner) ProvisionResource(r provisioners.ProvisionResourceRequ
 	p.ProvisionResourceRequest = r
 	if p.ProvisionResourceFn != nil {
 		fn := p.ProvisionResourceFn
-		return fn(r)
+		return fn(ctx, r)
 	}
 
 	return p.ProvisionResourceResponse

--- a/internal/plugin/grpc_provisioner.go
+++ b/internal/plugin/grpc_provisioner.go
@@ -107,7 +107,7 @@ func (p *GRPCProvisioner) ValidateProvisionerConfig(r provisioners.ValidateProvi
 	return resp
 }
 
-func (p *GRPCProvisioner) ProvisionResource(r provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+func (p *GRPCProvisioner) ProvisionResource(_ context.Context, r provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
 	schema := p.GetSchema()
 	if schema.Diagnostics.HasErrors() {
 		resp.Diagnostics = resp.Diagnostics.Append(schema.Diagnostics)

--- a/internal/plugin/grpc_provisioner_test.go
+++ b/internal/plugin/grpc_provisioner_test.go
@@ -6,6 +6,7 @@
 package plugin
 
 import (
+	"context"
 	"io"
 	"testing"
 
@@ -108,7 +109,7 @@ func TestGRPCProvisioner_ProvisionResource(t *testing.T) {
 
 	rec := &provisionRecorder{}
 
-	resp := p.ProvisionResource(provisioners.ProvisionResourceRequest{
+	resp := p.ProvisionResource(context.Background(), provisioners.ProvisionResourceRequest{
 		Config: cty.ObjectVal(map[string]cty.Value{
 			"attr": cty.StringVal("value"),
 		}),

--- a/internal/plugin/grpc_provisioner_test.go
+++ b/internal/plugin/grpc_provisioner_test.go
@@ -6,7 +6,6 @@
 package plugin
 
 import (
-	"context"
 	"io"
 	"testing"
 
@@ -109,7 +108,7 @@ func TestGRPCProvisioner_ProvisionResource(t *testing.T) {
 
 	rec := &provisionRecorder{}
 
-	resp := p.ProvisionResource(context.Background(), provisioners.ProvisionResourceRequest{
+	resp := p.ProvisionResource(t.Context(), provisioners.ProvisionResourceRequest{
 		Config: cty.ObjectVal(map[string]cty.Value{
 			"attr": cty.StringVal("value"),
 		}),

--- a/internal/plugins/provisioner.go
+++ b/internal/plugins/provisioner.go
@@ -161,7 +161,7 @@ func (p *provisionerManager) ProvisionResource(ctx context.Context, typ string, 
 	if err != nil {
 		return tfdiags.Diagnostics{}.Append(fmt.Errorf("failed to instantiate provisioner %q to provision resource: %w", typ, err))
 	}
-	return provisioner.ProvisionResource(provisioners.ProvisionResourceRequest{
+	return provisioner.ProvisionResource(ctx, provisioners.ProvisionResourceRequest{
 		Config:     config,
 		Connection: connection,
 		UIOutput:   output,

--- a/internal/provisioners/provisioner.go
+++ b/internal/provisioners/provisioner.go
@@ -6,6 +6,8 @@
 package provisioners
 
 import (
+	"context"
+
 	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
@@ -24,7 +26,7 @@ type Interface interface {
 	// ProvisionResource blocks until the execution is complete.
 	// If the returned diagnostics contain any errors, the resource will be
 	// left in a tainted state.
-	ProvisionResource(ProvisionResourceRequest) ProvisionResourceResponse
+	ProvisionResource(ctx context.Context, req ProvisionResourceRequest) ProvisionResourceResponse
 
 	// Stop is called to interrupt the provisioner.
 	//

--- a/internal/tofu/context_apply_test.go
+++ b/internal/tofu/context_apply_test.go
@@ -2100,7 +2100,7 @@ func TestContext2Apply_cancelProvisioner(t *testing.T) {
 	})
 
 	prStopped := make(chan struct{})
-	pr.ProvisionResourceFn = func(req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+	pr.ProvisionResourceFn = func(_ context.Context, req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
 		// Start the stop process
 		go ctx.Stop()
 
@@ -4340,7 +4340,7 @@ func TestContext2Apply_Provisioner_compute(t *testing.T) {
 	pr := testProvisioner()
 	p.PlanResourceChangeFn = testDiffFn
 	p.ApplyResourceChangeFn = testApplyFn
-	pr.ProvisionResourceFn = func(req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+	pr.ProvisionResourceFn = func(_ context.Context, req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
 
 		val := req.Config.GetAttr("command").AsString()
 		if val != "computed_value" {
@@ -4472,7 +4472,7 @@ func TestContext2Apply_provisionerFail(t *testing.T) {
 	p.PlanResourceChangeFn = testDiffFn
 	p.ApplyResourceChangeFn = testApplyFn
 	pr := testProvisioner()
-	pr.ProvisionResourceFn = func(req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+	pr.ProvisionResourceFn = func(_ context.Context, req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
 		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("EXPLOSION"))
 		return
 	}
@@ -4506,7 +4506,7 @@ func TestContext2Apply_provisionerFail_createBeforeDestroy(t *testing.T) {
 	pr := testProvisioner()
 	p.PlanResourceChangeFn = testDiffFn
 	p.ApplyResourceChangeFn = testApplyFn
-	pr.ProvisionResourceFn = func(req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+	pr.ProvisionResourceFn = func(_ context.Context, req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
 		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("EXPLOSION"))
 		return
 	}
@@ -4858,7 +4858,7 @@ func TestContext2Apply_provisionerFailContinue(t *testing.T) {
 	p.PlanResourceChangeFn = testDiffFn
 	p.ApplyResourceChangeFn = testApplyFn
 
-	pr.ProvisionResourceFn = func(req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+	pr.ProvisionResourceFn = func(_ context.Context, req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
 		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("provisioner error"))
 		return
 	}
@@ -4901,7 +4901,7 @@ func TestContext2Apply_provisionerFailContinueHook(t *testing.T) {
 	p := testProvider("aws")
 	pr := testProvisioner()
 	p.PlanResourceChangeFn = testDiffFn
-	pr.ProvisionResourceFn = func(req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+	pr.ProvisionResourceFn = func(_ context.Context, req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
 		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("provisioner error"))
 		return
 	}
@@ -4935,7 +4935,7 @@ func TestContext2Apply_provisionerDestroy(t *testing.T) {
 	p := testProvider("aws")
 	pr := testProvisioner()
 	p.PlanResourceChangeFn = testDiffFn
-	pr.ProvisionResourceFn = func(req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+	pr.ProvisionResourceFn = func(_ context.Context, req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
 		val := req.Config.GetAttr("command").AsString()
 		if val != "destroy a bar" {
 			t.Fatalf("bad value for foo: %q", val)
@@ -4986,7 +4986,7 @@ func TestContext2Apply_provisionerDestroyFail(t *testing.T) {
 	p := testProvider("aws")
 	pr := testProvisioner()
 	p.PlanResourceChangeFn = testDiffFn
-	pr.ProvisionResourceFn = func(req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+	pr.ProvisionResourceFn = func(_ context.Context, req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
 		resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("provisioner error"))
 		return
 	}
@@ -5042,7 +5042,7 @@ func TestContext2Apply_provisionerDestroyFailContinue(t *testing.T) {
 
 	var l sync.Mutex
 	var calls []string
-	pr.ProvisionResourceFn = func(req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+	pr.ProvisionResourceFn = func(_ context.Context, req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
 		val := req.Config.GetAttr("command")
 		if val.IsNull() {
 			t.Fatalf("bad value for foo: %#v", val)
@@ -5109,7 +5109,7 @@ func TestContext2Apply_provisionerDestroyFailContinueFail(t *testing.T) {
 
 	var l sync.Mutex
 	var calls []string
-	pr.ProvisionResourceFn = func(req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+	pr.ProvisionResourceFn = func(_ context.Context, req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
 		val := req.Config.GetAttr("command")
 		if val.IsNull() {
 			t.Fatalf("bad value for foo: %#v", val)
@@ -5178,7 +5178,7 @@ func TestContext2Apply_provisionerDestroyTainted(t *testing.T) {
 	p.ApplyResourceChangeFn = testApplyFn
 
 	destroyCalled := false
-	pr.ProvisionResourceFn = func(req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+	pr.ProvisionResourceFn = func(_ context.Context, req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
 		expected := "create a b"
 		val := req.Config.GetAttr("command")
 		if val.AsString() != expected {
@@ -5251,7 +5251,7 @@ func TestContext2Apply_provisionerResourceRef(t *testing.T) {
 	p.ApplyResourceChangeFn = testApplyFn
 
 	pr := testProvisioner()
-	pr.ProvisionResourceFn = func(req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+	pr.ProvisionResourceFn = func(_ context.Context, req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
 		val := req.Config.GetAttr("command")
 		if val.AsString() != "2" {
 			t.Fatalf("bad value for command: %#v", val)
@@ -5294,7 +5294,7 @@ func TestContext2Apply_provisionerSelfRef(t *testing.T) {
 	pr := testProvisioner()
 	p.PlanResourceChangeFn = testDiffFn
 	p.ApplyResourceChangeFn = testApplyFn
-	pr.ProvisionResourceFn = func(req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+	pr.ProvisionResourceFn = func(_ context.Context, req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
 		val := req.Config.GetAttr("command")
 		if val.AsString() != "bar" {
 			t.Fatalf("bad value for command: %#v", val)
@@ -5340,7 +5340,7 @@ func TestContext2Apply_provisionerMultiSelfRef(t *testing.T) {
 	pr := testProvisioner()
 	p.PlanResourceChangeFn = testDiffFn
 	p.ApplyResourceChangeFn = testApplyFn
-	pr.ProvisionResourceFn = func(req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+	pr.ProvisionResourceFn = func(_ context.Context, req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
 		lock.Lock()
 		defer lock.Unlock()
 
@@ -5397,7 +5397,7 @@ func TestContext2Apply_provisionerMultiSelfRefSingle(t *testing.T) {
 	pr := testProvisioner()
 	p.PlanResourceChangeFn = testDiffFn
 	p.ApplyResourceChangeFn = testApplyFn
-	pr.ProvisionResourceFn = func(req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+	pr.ProvisionResourceFn = func(_ context.Context, req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
 		lock.Lock()
 		defer lock.Unlock()
 
@@ -5450,7 +5450,7 @@ func TestContext2Apply_provisionerExplicitSelfRef(t *testing.T) {
 	p := testProvider("aws")
 	pr := testProvisioner()
 	p.PlanResourceChangeFn = testDiffFn
-	pr.ProvisionResourceFn = func(req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+	pr.ProvisionResourceFn = func(_ context.Context, req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
 		val := req.Config.GetAttr("command")
 		if val.IsNull() || val.AsString() != "bar" {
 			t.Fatalf("bad value for command: %#v", val)
@@ -5516,7 +5516,7 @@ func TestContext2Apply_provisionerForEachSelfRef(t *testing.T) {
 	pr := testProvisioner()
 	p.PlanResourceChangeFn = testDiffFn
 
-	pr.ProvisionResourceFn = func(req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+	pr.ProvisionResourceFn = func(_ context.Context, req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
 		val := req.Config.GetAttr("command")
 		if val.IsNull() {
 			t.Fatalf("bad value for command: %#v", val)
@@ -10000,7 +10000,7 @@ func TestContext2Apply_plannedConnectionRefs(t *testing.T) {
 
 	provisionerFactory := func() (provisioners.Interface, error) {
 		pr := testProvisioner()
-		pr.ProvisionResourceFn = func(req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+		pr.ProvisionResourceFn = func(_ context.Context, req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
 			host := req.Connection.GetAttr("host")
 			if host.IsNull() || !host.IsKnown() {
 				resp.Diagnostics = resp.Diagnostics.Append(fmt.Errorf("invalid host value: %#v", host))
@@ -12620,7 +12620,7 @@ func TestContext2Apply_provisionerSensitive(t *testing.T) {
 	p := testProvider("aws")
 
 	pr := testProvisioner()
-	pr.ProvisionResourceFn = func(req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+	pr.ProvisionResourceFn = func(_ context.Context, req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
 		if req.Config.ContainsMarked() {
 			t.Fatalf("unexpectedly marked config value: %#v", req.Config)
 		}

--- a/internal/tofu/provisioner_mock.go
+++ b/internal/tofu/provisioner_mock.go
@@ -6,6 +6,7 @@
 package tofu
 
 import (
+	"context"
 	"sync"
 
 	"github.com/opentofu/opentofu/internal/provisioners"
@@ -31,7 +32,7 @@ type MockProvisioner struct {
 	ProvisionResourceCalled   bool
 	ProvisionResourceRequest  provisioners.ProvisionResourceRequest
 	ProvisionResourceResponse provisioners.ProvisionResourceResponse
-	ProvisionResourceFn       func(provisioners.ProvisionResourceRequest) provisioners.ProvisionResourceResponse
+	ProvisionResourceFn       func(context.Context, provisioners.ProvisionResourceRequest) provisioners.ProvisionResourceResponse
 
 	StopCalled   bool
 	StopResponse error
@@ -68,7 +69,7 @@ func (p *MockProvisioner) ValidateProvisionerConfig(r provisioners.ValidateProvi
 	return p.ValidateProvisionerConfigResponse
 }
 
-func (p *MockProvisioner) ProvisionResource(r provisioners.ProvisionResourceRequest) provisioners.ProvisionResourceResponse {
+func (p *MockProvisioner) ProvisionResource(ctx context.Context, r provisioners.ProvisionResourceRequest) provisioners.ProvisionResourceResponse {
 	p.Lock()
 	defer p.Unlock()
 
@@ -76,7 +77,7 @@ func (p *MockProvisioner) ProvisionResource(r provisioners.ProvisionResourceRequ
 	p.ProvisionResourceRequest = r
 	if p.ProvisionResourceFn != nil {
 		fn := p.ProvisionResourceFn
-		return fn(r)
+		return fn(ctx, r)
 	}
 
 	return p.ProvisionResourceResponse


### PR DESCRIPTION
Prep work for #3936 — adds `context.Context` to the provisioner interface so a follow-up PR can extract the active OTel span and set `TRACEPARENT` in the local-exec environment.

This is the first of two PRs as suggested by @apparentlymart in #3936. This one threads the context through without changing any behavior; the second will actually populate `TRACEPARENT`.

### What changed

- `provisioners.Interface.ProvisionResource` now takes `context.Context` as its first parameter
- All 3 built-in provisioners (local-exec, remote-exec, file) accept and ignore the context for now
- `GRPCProvisioner` in `internal/plugin` updated to match
- `grpcwrap` caller passes `srv.Context()` from the gRPC stream
- `plugins/provisioner.go` forwards the existing `ctx` it already had
- Both mock provisioners updated (including their `ProvisionResourceFn` callback type)
- All tests updated to pass `context.Background()` or `_ context.Context`

I verified this locally — built the binary, ran the provisioner unit tests, and did a quick `tofu apply` with both local-exec and remote-exec (SSH to a GCP VM) to make sure nothing broke end-to-end.

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.