### PR TITLE
rfc: Built-in Linting

### DIFF
--- a/rfc/20260406-linting.md
+++ b/rfc/20260406-linting.md
@@ -1,0 +1,269 @@
+# Built-in Linting
+
+(This RFC is primarily for GitHub [issue #2213](https://github.com/opentofu/opentofu/issues/2213).)
+
+OpenTofu does not currently have a fully-functional linting solution. Some folks successfully use the third-party tool `tflint`, but [it's not designed for use with OpenTofu](https://github.com/terraform-linters/tflint/issues/2037#issuecomment-2094738720) and so it tends to fail when used with configurations that use features that are in OpenTofu but not supported in its predecessor.
+
+Maintaining a linter outside of the OpenTofu codebase is also generally challenging, because it involves reimplementing much of the logic OpenTofu uses for analyzing the configuration. An external linter would inevitably lag behind changes to OpenTofu, generating spurious errors about newly-added language features that the linter has not yet been updated for.
+
+This document proposes that we begin adding built-in linting features. This first proposal focuses mainly on enabling linting rules that are written directly inside the OpenTofu codebase and describe concerns related to the core OpenTofu language. It's also intended to leave room for future expansion for lint rules coming from other sources, such as lint rules implemented inside provider plugins that relate to provider-specific features, and totally custom lint rules that an organization could impose on their own code without modifying OpenTofu or any mainstream provider plugins, but those extensions are intentionally not included here because we ought to get some implementation experience with built-in lint rules before we create any new public interfaces that would be subject to compatibility promises and therefore harder to change if we learn of a design problem.
+
+If the initial set of features described here is successful then this will hopefully be the first of a series of proposals that should eventually provide a full-fledged linting system that's built in to OpenTofu. This is an entirely new problem space for OpenTofu to handle though, so this proposal is intentionally just a small initial increment so we can learn from how and whether folks use these features.
+
+## What is "linting" anyway?
+
+For the sake of this document, we'll define "linting" as creating the opportunity for OpenTofu to warn about something that isn't necessarily wrong but may be a cause for concern. A linter therefore produces something similar to warning diagnostics, but with a higher-tolerance for "false positives" where the linter draws attention to something that is not actually a problem in practice.
+
+Because of the higher false-positive rate, linting would not be enabled by default but could be opted in by command line options to certain commands where it is relevant. The higher false-positive rate also means there must be a way for operators to opt-in and opt-out of specific lint rules based on their relevance to each operator's specific situation, whereas for warning diagnostics OpenTofu does not offer such fine-grain control.
+
+For example, producing a deprecation warning is not "linting" because OpenTofu has certainty that a particular feature has been deprecated. An example of a more "linter-like" rule would be to note that one of the addresses written in a `depends_on` argument is unnecessary because the same dependency was already implied by a reference elsewhere in the same block: that's not _wrong_ and so it would be annoying for it to unconditionally generate a warning, but having it be raised in linting mode might help someone who is trying to debug an ordering problem quickly notice that adding a `depends_on` argument is not changing anything about the meaning of the configuration.
+
+Another difference compared to warnings is that "linting" is exclusively used for potential problems relating to _configuration_, whereas normal warning diagnostics can potentially describe other problems such as strange behavior of a remote API, or situations caused by command-line options.
+
+## User Experience
+
+### Lint rule identifiers
+
+To make it possible to enable and disable individual linting rules, each rule would have a terse code associated with it. For our initial round of implementation, all rule identifiers would have the fixed prefix `core:`, followed by a short alphanumeric suffix that is a mnemonic for the rule. This prefix is intended to allow us to introduce other identifier namespaces for provider-defined rules, etc, in later releases. 
+
+For example, the hypothetical lint rule about redundant entries in `depends_on` might have the identifier `core:unuseddeps`. It's not a goal for these names to fully represent exactly what the lint rule does, but rather just to make it easier for someone who is already familiar with a particular lint rule to recognize that rule in a potentially-long list of enabled or disabled rules.
+
+It'd be very tedious to list out each individual rule a team wants to enable though, so we would also support certain identifiers that serve as aliases for groups of other identifiers. For example, the identifier `core:confusing` might represent all of the rules that notice when something has been written in a way that might be misleading to a future reader of the code, which would likely include the previously-mentioned `core:unuseddeps` along with any other similar situation.
+
+Finally, the special identifier `all` represents all available lint rules. When written without a prefix it specifies all lint rules across all namespaces, or it can be used after a prefix (e.g. `core:all`) to specify all of the rules in the "core" namespace. The identifier "all" is therefore reserved across all namespaces and must not be assigned any other meaning, but all other names are expected to vary based on the namespace prefix.
+
+All lint rule identifier prefixes are required to start with a letter or digit, using Unicode's definitions of those categories, but can otherwise contain any printable characters except colon. The part appearing after the colon must be a valid unicode identifier, and must only use lowercase or case-agnostic letters. (If we add provider-defined lint rules in future then their namespaces will presumably contain slashes, following our usual syntax for identifying providers.)
+
+### Enabling lint rules on the command line
+
+For our initial implementation of this feature, we'll require opting in to linting using a new command line option `-lint=...`, where the value is a comma-separated list of lint rule identifiers to include (without any prefix) or to exclude (with the prefix `!`).
+
+The simplest invocation would be `-lint='all'`, which opts in to all available lint rules. If an operator finds that a particular rule is generating only false-positives for a particular situation, they could exclude it by writing an invocation like `-lint='all,!core:unuseddeps'` or (to disable an entire group at once) `-lint='all,!core:confusing'`. Any `-lint=...` option must always include at least one non-negated rule ID.
+
+The new `-lint` option would be available for the following subcommands:
+
+- `tofu validate`
+- `tofu plan`
+- `tofu apply`, and its variants `tofu destroy` and `tofu refresh`
+
+The scope of possible lint rules varies depending on which command `-lint=...` is provided to, because (as usual) each of these commands performs a different subset of OpenTofu's work. As many rules as possible will be implemented in the validation phase so that they can appear for all three of these commands, but some rules might depend on dynamic data that OpenTofu only calculates when planning or applying.
+
+All of the items listed after `-lint=` must match the expected syntax for selecting lint rules, but any syntactically-valid identifier that doesn't match a currently-known rule is just silently ignored, creating the same effect as if an enabled rule were supported but not relevant to the current configuration. This is so that it's easier to just encode a single `-lint=...` option in some automation without having to vary it depending on which version of OpenTofu is in use or which providers the current configuration is using, since the set of rule IDs supported by each component is expected to change over time.
+
+> [!NOTE]  
+> A future extension of this proposal is likely to include a way to select and deselect lint rules for one or more modules as part of the configuration, rather than on the command line.
+>
+> That's intentionally excluded to start because we'd like to get experience with global, command-line-based selections before we design a language extension. For example, it's not clear yet whether lint rules in configuration would be a whole-configuration-level idea specified only alongside the root module and enforced for the whole configuration, if they'd instead be specified on a per-module basis, or something in between.
+>
+> The top-level `language` block is a potential home for such settings, but that would be appropriate only for settings specific to a single module because that block's meaning is to define how _just the current module_ is using the OpenTofu language.
+
+### Lint message rendering
+
+The rendering of a lint message is similar to that of a warning diagnostic, just with a slightly-modified header that includes a lint rule ID:
+
+```
+Warning: Unnecessary explicit dependency [core:unuseddeps]
+
+  on example.tf line 54, in resource "example" "foo":
+   54:   depends_on = [
+   55:     var.whatever,
+   56:   ]
+
+A dependency on var.whatever is already implied by the reference at
+example.tf:51,20, so this explicit dependency is ineffective and potentially
+confusing.
+```
+
+Treating lint messages as a special kind of warning diagnostic means that they can naturally integrate into our existing representation of machine-readable diagnostics, and so any wrapping automation that's collecting diagnostics to render in e.g. a web UI will automatically handle lint messages for any rules enabled on the command line.
+
+It's a goal of this initial proposal to minimize the amount of new integration points that would be covered by compatibility promises so that we can have more opportunity to react to feedback in future releases and so there would not initially be any machine-readable way to distinguish normal warnings from lint message warnings, but if this design is successful then in a later release we could extend the JSON representation of diagnostics to have an additional `"lint_rule_ids"` property mentions both the primary rule ID and any rule group aliases that are associated with the message.
+
+### Initial lint rules
+
+For the first implementation we'd keep this limited to a small set of situations that seem to have commonly caused confusion for those new to the OpenTofu language:
+
+| Rule ID | Rule Groups | Trigger |
+|---------|-------------|---------|
+| `core:unuseddeps` | `core:confusing` | One of the addresses written in a `depends_on` argument is redundant with a dependency implied by a reference elsewhere in the same block. |
+| `core:quotedref` | `core:confusing`, `core:mistake` | A quoted string in the configuration has content matching the address of something else declared in the same module, suggesting that it was probably intended to be a reference to that symbol but should've been written without the quotes. |
+| `core:ineffeq` | `core:mistake` | Evaluated an `==` or `!=` expression where the two operands were not of the same type, making the comparison ineffective. |
+| `core:impurefunc` | `core:noconverge` | An impure function (`timestamp`, `uuid`, or `bcrypt`) was used in a location where convergence is typically expected, such as in a resource argument. |
+
+This initial set is designed to cover just a small set of interesting categories of problem, while also including a mix of different locations in the system where the check would need to be implemented so that we can make sure it's feasible to implement lint rules in all of these locations. The set is intentionally small so that for this first proposal we can focus mainly on just getting the infrastructure into place, and then gradually grow this in future versions based on feedback.
+
+## Implementation details
+
+### Lint diagnostics
+
+To allow us to integrate the lint rules into existing codepaths without making disruptive changes to the internal API, we'll return lint messages as just a special kind of warning diagnostic, passed through the same `tfdiags.Diagnostics` return channel used for other configuration problems.
+
+The `tfdiags` package would therefore gain a new type `tfdiags.LintMessage` to represent a lint message, a type to represent a diagnostic identifier, and a new `Diagnostics` method for filtering out unwanted lint rules:
+
+```go
+package tfdiags
+
+// LintRuleID represents the identifier for an individual lint rule or for a
+// group of lint rules.
+type LintRuleID struct {
+    Namespace string
+    Name      string
+}
+
+// CoreLintRuleID returns a [LintRuleID] value whose namespace is "core" and
+// whose name is the given string.
+func CoreLintRuleID(name string) LintRuleID
+
+// LintMessage represents a message describing a linting problem.
+//
+// Pass pointers to values of this type to [Diagnostics.Append] to include
+// lint messages as part of your returned diagnostics.
+type LintMessage struct {
+    // RuleIDs is a set of all of the rule IDs this message relates to.
+    //
+    // There should always be at least one element in the given slice and
+    // the first element should be the identifier that uniquely identifies
+    // just the one condition being reported. Optional subsequent elements
+    // are the identifiers of any rule groups the main rule ID belongs to.
+    RuleIDs []LintRuleID
+
+    // Summary, Detail, and Subject have their usual meaning for diagnostic
+    // messages.
+    Summary string
+    Detail  string
+    Subject SourceRange
+
+    // Context is an optional additional source range that must enclose
+    // the range in Subject but can include additional characters that provide
+    // relevant context for understanding the problem. The human-oriented
+    // diagnostic renderer uses this to extend the source code snippet to
+    // include additional lines from the input configuration.
+    Context *SourceRange
+}
+
+// FilterLint modifies the backing array of the receiver so that any
+// [Lint] diagnostics which don't match the given include and exclude rules
+// are removed, and then returns a new slice over the valid part of the updated
+// backing array.
+//
+// UI code should call this to exclude any unrequested lint rules before
+// rendering the diagnostics.
+func (diags Diagnostics) FilterLint(include, exclude collections.Set[LintRuleID]) Diagnostics
+```
+
+A codepath that wants to return a lint message would therefore append it to the diagnostics it is going to return in the usual way:
+
+```go
+func Example(ctx context.Context, input string, rng tfdiags.SourceRange) tfdiags.Diagnostics {
+    var diags tfdiags.Diagnostics
+    // ...
+    if inputIsWobbly(input) {
+        diags = diags.Append(&tfdiags.LintMessage{
+            RuleIDs: []tfdiags.LintRuleID{
+                tfdiags.CoreLintRuleID("wobblyinput"),
+                tfdiags.CoreLintRuleID("confusing"),
+            },
+            Summary: "Input is wobbly",
+            Detail:  "The value of this expression keeps wobbling about, which may be confusing.",
+            Subject: rng,
+        })
+    }
+    // ...
+    return diags
+}
+```
+
+### Lint-enabled Hints
+
+It's expected that some codepaths will just unconditionally return whatever lint diagnostics are relevant to the input configuration and just trust that the UI layer will filter out any that aren't relevant.
+
+However, as we've seen with logging it's sometimes quite expensive to decide whether a particular lint rule applies and so it's helpful to be able to skip performing those expensive calculations if the resulting rule would just end up being filtered out anyway.
+
+Therefore `tfdiags` also offers an optional API for providing hints about what to bother trying to generate:
+
+```go
+package tfdiags
+
+// ContextWithLintFilterHints returns a new [context.Context] that's derived
+// from the given parent context but also tracks the sets of lint rule IDs that
+// will be used to filter any diagnostics returned from whatever function the
+// resulting context was passed to.
+//
+// Use the returned context with [LintRulesEnabled] elsewhere in the system to
+// skip expensive work to generate a lint diagnostic that is going to get
+// discarded eventually anyway.
+func ContextWithLintFilterHints(parent ctx.Context, include, exclude collections.Set[LintRuleID]) context.Context
+
+// LintRulesEnabled returns true if the given context has lint filter hints that
+// suggest that a [LintMessage] with the given RuleIDs would survive UI-level
+// filtering of lint messages, or false otherwise.
+//
+// If the given context is not derived from one previously returned by
+// [ContextWithLintFilterHints] then the result is always true, suggesting that
+// nothing will be filtered. This defaults to enabled because we assume that
+// any codepath that isn't calling this function also won't call
+// [Diagnostics.FilterLint]; this pair of functions should typically be used
+// together by the same subsystem, passing the same include/exclude sets to
+// both.
+func LintRulesEnabled(ctx context.Context, ruleIDs []LintRuleID) bool
+```
+
+If the hypothetical `inputIsWobbly` function from the example in the previous section were particularly expensive then that example could be rewritten like this:
+
+```go
+func Example(ctx context.Context, input string, rng tfdiags.SourceRange) tfdiags.Diagnostics {
+    var diags tfdiags.Diagnostics
+    // ...
+    lintRuleIDs := []tfdiags.LintRuleID{
+        tfdiags.CoreLintRuleID("wobblyinput"),
+        tfdiags.CoreLintRuleID("confusing"),
+    }
+    if tfdiags.LintRulesEnabled(ctx, lintRuleIDs) && inputIsWobbly(input) {
+        diags = diags.Append(&tfdiags.LintMessage{
+            RuleIDs: lintRuleIDs,
+            Summary: "Input is wobbly",
+            Detail:  "The value of this expression keeps wobbling about, which may be confusing.",
+            Subject: rng,
+        })
+    }
+    // ...
+    return diags
+}
+```
+
+### Location of lint rule implementation code
+
+The intent of using `context.Context` and `tfdiags.Diagnostics` as the vehicle for information related to linting is that then various parts of the language runtime can each handle different subsets of lint rules as part of the work they were already doing anyway, rather than running a completely separate pass over the configuration that happens independently of the main work. This is a tradeoff, of course: it means that there will not be any single central place to find all of the lint rule implementations, but it also means that we can avoid repeating potentially-expensive computations that we already need to do as part of OpenTofu's main work.
+
+In practice all of the initial lint rules will live in the call graph beneath the "validate" operation, which is common code used across all phases that perform configuration evaluation. However, some of the rules (e.g. `core:ineffeq`) will not be decidable when unknown values are present, and so certain lint messages will only appear when the validation codepath is re-run during the apply phase. This unfortunately means that if someone runs `tofu apply -lint=all`, using the interactive form of that command that includes both a plan phase and an apply phase, then some lint problems will be reported both during the plan phase and the apply phase. That'll be a known quirk of the first implementation, and then if it turns out to be problematic we can think about how to deal with it in a later version. `tofu validate -lint=all` will be the main entrypoint we'll recommend for the first phase, even though it won't necessarily produce a full set of lint messages when unknown values are present.
+
+## Possible Future Extensions
+
+### Provider-based Lint Rules
+
+In a future version of the provider plugin protocol we could potentially extend provider RPC functions like `ValidateResourceConfig` to be able to return zero or more lint messages alongside the diagnostics already supported, where each one includes a provider-specific lint identifier so that OpenTofu can filter them based on what's specified in the `-lint=` command line option.
+
+For example, a provider might choose to offer lint rules that detect violations of best-practices mentioned in their remote system's documentation, which OpenTofu itself would have no awareness of.
+
+We'd describe the full protocol for that in a future proposal, but _this_ proposal is assuming that a provider would be responsible for doing its own handling of "rule groups", so that each lint message returned from the provider would have _one or more_ identifiers and the provider's own logic would arrange for that to include the rule-specific identifier along with the identifiers of any groups that rule belongs to. OpenTofu would therefore need no awareness of which rule identifiers and groups a particular provider supports, aside from handling the special "all" group that matches all rule or group identifiers a provider might return.
+
+### In-configuration Lint Rules
+
+In a future release we might want to support custom lint rules implemented directly inside a module, or in some other sort of configuration file that can contain arbitrary expressions to run.
+
+If we do this then we'll need to think about how their namespaces should work, because unlike core and providers there isn't any single concise global addressing scheme for module packages.
+
+The namespacing problem aside, a custom lint rule would presumably have a similar shape to a "policy as code" configuration, as folks already commonly write using languages like Open Policy Agent's "Rego" language, and so we'll probably find that we need to use or design a configuration language of similar expressive power.
+
+As with provider-based lint rules, we'll need to take care with how much we allow custom lint rules to depend on the syntax details of the current OpenTofu language, so that we don't end up making it impossible to evolve the language without breaking existing lint rules. Perhaps custom lint rules would be required to work only with dynamic values from the configuration and not with its raw syntax, but that would mean that these rules could only be used to detect semantic issues and not to enforce stylistic preferences, etc.
+
+### Fix-it hints
+
+The initial scope focuses only on identifying potential problems, after which an author can choose to manually update their configuration.
+
+For a subset of problems we may be able to annotate a lint diagnostic with a "fix-it hint" that is just a `[]byte` value that could potentially replace the bytes in the source range that is the "subject" of that diagnostic. Not all lint diagnostics are required to have a fix-it hint, since some may require judgement in choosing a solution or may require making multiple changes.
+
+An operator could then run `tofu fmt -fix-lint=all` (or any other specification of lint rules to activate) to cause OpenTofu to perform the described replacements at the same time as applying the formatting rules. `tofu fmt` is a command already expected to rewrite the configuration, and so this is a reasonable extension of that functionality.
+
+It's likely that only `core:` rules could realistically have fix-it hints in this raw form, because that means that the fix-it hints can be updated whenever the language changes in a way that would invalidate them. However, we may be able to offer a higher-level mechanism for provider-based lint rules where a provider can describe replacing one attribute value with another, or similar, and then the core language runtime would figure out how to translate that into a raw, source-level fix-it hint that's suitable for whatever grammar (HCL or JSON) the source file was written in.
+
+This is excluded from the first round both because it's functionality we can reasonably add later without upsetting the initial design, and because we suspect that at least some operators would prefer to just provide the lint messages to a coding assistant to be interpreted by a large language model, which can then provide a more interactive workflow for gradually improving the configuration. We'll learn from experience with the first round of functionality whether this sort of simplistic "fix-it hint" is actually valuable in a world where coding assistants are available.

--- a/rfc/20260406-linting.md
+++ b/rfc/20260406-linting.md
@@ -341,6 +341,18 @@ I propose "an error" here because these errors will be generated only when the l
 
 As a first step, per-line-in-configuration suppression annotations should do the job. Later, if needed, we could introduce block or file scoped annotations too.
 
+### Linting configuration
+
+As proposed in [Enabling lint rules on the command line](#enabling-lint-rules-on-the-command-line), in the first iteration of the linting support, the target is to have the linting
+enabled manually by using a CLI flag.
+Though, as additional features will be added over time, the need of a configuration file might arise.
+
+Some possible options a configuration file could have:
+* Scan no/local/all modules
+  * Ignore specific modules
+* Ignore suppression annotations
+* A similar configuration with the `-json-into` flag to store the results as json into a separate file
+
 ### Provider-based Lint Rules
 
 In a future version of the provider plugin protocol we could potentially extend provider RPC functions like `ValidateResourceConfig` to be able to return zero or more lint messages alongside the diagnostics already supported, where each one includes a provider-specific lint identifier so that OpenTofu can filter them based on what's specified in the `-lint=` command line option.

--- a/rfc/20260406-linting.md
+++ b/rfc/20260406-linting.md
@@ -238,6 +238,109 @@ In practice all of the initial lint rules will live in the call graph beneath th
 
 ## Possible Future Extensions
 
+### In-configuration suppression annotations
+
+To allow users to exclude specific warnings, we want to introduce in-configuration suppression annotations.
+
+#### In-comments implementation
+One way to implement such a feature would be to make use of the comments inside the configuration where users can suppress warnings on specific blocks, attributes or even suppress the warnings for an entire file.
+
+The way this might look:
+```hcl
+variable "in_string" {
+  type    = string
+  default = "input"
+}
+
+// tflint-ignore: terraform_typed_variables
+variable "in_number" {
+  default = 42
+}
+
+resource "random_id" "test" {
+  // nolint(core:ineffeq): we know about this and the behavior matches our use case
+  prefix = var.in_string == var.in_number ? "apply this prefix" : "otherwise this one"
+  // nolint(core:impurefunc): this is ignored on purpose
+  byte_length = tonumber(core::split("-", core::timestamp())[1])
+}
+
+ephemeral "random_password" "test" {
+  length = 10
+  upper  = true
+}
+```
+
+Since the comment based suppression annotations is largely used in a lot of programming languages, this is the most straight-forward approach.
+To allow this, HCL would have to be updated but with just trivial changes. This is due to the fact that it already can parse comments, we just need to make it so to return it
+back to the caller which will allow functionality around this.
+
+Pros:
+* Does not touch the language parsing logic, allowing to integrate this with quite low risk to the other parts of OpenTofu;
+* As shown above, we could also create a simple parsing rule to support also `tflint` that have a correspondent implementation in OpenTofu built-in linting;
+* In other tools reading the HCL configuration, comments are silent from a functional point of view, which means that we avoid additional incompatibilities with the predecessor project.
+
+Cons:
+* As part of a multi-line comment, the `// nolint` annotations would have to always be on the last lines which might create issues in case the comments are updated pushing the annotation out of the last lines;
+* Being part of a comment, users could miss their existence, making harder to understand why a particular obviously wrong pattern is not flagged accordingly.
+
+#### New language annotations implementation
+Another way to implement such a feature would be to introduce a new language annotation.
+
+The way this might look:
+```hcl
+variable "in_string" {
+  type    = string
+  default = "input"
+}
+
+@nolint(untyped_variables): don't really want to add a type. It's too verbose
+variable "in_number" {
+  default = 42
+}
+
+resource "random_id" "test" {
+  @nolint(core:ineffeq): we know about this and the behavior matches our use case
+  prefix = var.in_string == var.in_number ? "apply this prefix" : "otherwise this one"
+  @nolint(core:impurefunc): this is ignored on purpose
+  byte_length = tonumber(core::split("-", core::timestamp())[1])
+}
+
+ephemeral "random_password" "test" {
+  length = 10
+  upper  = true
+}
+```
+To allow this, HCL would have to be updated quite heavily. The new syntax would require careful integration in the current HCL keywords and parsing.
+
+Pros:
+* Native support which is more integrated with the other blocks and concepts
+* This would add a new language feature that might prove useful in the future
+* More visible and discoverable compared with the comments-based annotations
+
+Cons:
+* Additional incompatibility with the predecessor project
+* No way to possibly integrate the `tflint` rules parsing
+* Implementation could prove to be quite tedious and dangerous as it could affect other parts of the HCL language
+
+#### Things to consider implementing suppression annotations
+
+Regardless of the decided implementation, there are several things to consider when this will be implemented.
+
+##### Format
+`nolint(<ruleID>): <reason>`
+
+With this format we ensure that whoever will use these annotations will provide clear target and reason for which they add the tech debt.
+
+##### Error on suppression annotation for a missing linting issue
+In cases where a suppression annotation is detected as unused, then we should return an error indicating that the annotation can be removed or
+double checked, maybe the ruleID is wrong.
+
+I propose "an error" here because these errors will be generated only when the linting is enabled. So when a user asks for linting checks, if the linting is misconfigured, we should consider that similarly with a misconfigured regular HCL configuration. 
+
+##### Scope the annotations
+
+As a first step, per-line-in-configuration suppression annotations should do the job. Later, if needed, we could introduce block or file scoped annotations too.
+
 ### Provider-based Lint Rules
 
 In a future version of the provider plugin protocol we could potentially extend provider RPC functions like `ValidateResourceConfig` to be able to return zero or more lint messages alongside the diagnostics already supported, where each one includes a provider-specific lint identifier so that OpenTofu can filter them based on what's specified in the `-lint=` command line option.


### PR DESCRIPTION
This is a proposal for extending OpenTofu with built-in linting features as requested in https://github.com/opentofu/opentofu/issues/2213, starting with just a small set of built-in lint rules so we can get experience with this entirely-new capability.

[Rendered Version](https://github.com/opentofu/opentofu/blob/a7bb6584740c91579c31a984315fcd23534d7872/rfc/20260406-linting.md)

If we accept this then I expect it would _begin_ our work for https://github.com/opentofu/opentofu/issues/2213, but that we would not close that issue until we've been through a few implementation iterations and have a level of functionality that's comparable to (but not necessarily exactly matching) what the third-party `tflint` supports. I've just started small here because this is an entirely new category of functionality for OpenTofu and so I think we should start this cautiously and then learn from feedback.
