### PR TITLE
local-exec: propagate TRACEPARENT to child processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ UPGRADE NOTES:
 
     [Modern Windows versions now support OpenSSH](https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse), and so we suggest that anyone currently relying on WinRM plan to migrate to using SSH instead.
 
+ENHANCEMENTS:
+
+- The `local-exec` provisioner now automatically sets the `TRACEPARENT` environment variable in child processes when OpenTelemetry tracing is active, following the W3C Trace Context specification. ([#4014](https://github.com/opentofu/opentofu/issues/4014))
+
 BUG FIXES:
 
 - provisioner output is no longer suppressed when `-show-sensitive` is passed. ([#3927](https://github.com/opentofu/opentofu/issues/3927))

--- a/internal/builtin/provisioners/local-exec/resource_provisioner.go
+++ b/internal/builtin/provisioners/local-exec/resource_provisioner.go
@@ -17,7 +17,7 @@ import (
 	"github.com/armon/circbuf"
 	"github.com/mitchellh/go-linereader"
 	"github.com/zclconf/go-cty/cty"
-	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/propagation"
 
 	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/provisioners"
@@ -117,10 +117,12 @@ func (p *provisioner) ProvisionResource(ctx context.Context, req provisioners.Pr
 
 	envVal := req.Config.GetAttr("environment")
 	var env []string
+	var traceparentConfigured bool
 
 	if !envVal.IsNull() {
 		for k, v := range envVal.AsValueMap() {
 			if !v.IsNull() {
+				traceparentConfigured = traceparentConfigured || strings.EqualFold(k, "TRACEPARENT")
 				entry := fmt.Sprintf("%s=%s", k, v.AsString())
 				env = append(env, entry)
 			}
@@ -175,14 +177,11 @@ func (p *provisioner) ProvisionResource(ctx context.Context, req provisioners.Pr
 	// variable (per the W3C Trace Context specification), unless the user
 	// has already set TRACEPARENT explicitly in the provisioner's
 	// "environment" block.
-	if !hasEnvVar(env, "TRACEPARENT") {
-		if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
-			cmdEnv = append(cmdEnv, fmt.Sprintf(
-				"TRACEPARENT=00-%s-%s-%s",
-				sc.TraceID().String(),
-				sc.SpanID().String(),
-				sc.TraceFlags().String(),
-			))
+	if !traceparentConfigured {
+		carrier := make(propagation.MapCarrier)
+		propagation.TraceContext{}.Inject(ctx, carrier)
+		for k, v := range carrier {
+			cmdEnv = append(cmdEnv, strings.ToUpper(k)+"="+v)
 		}
 	}
 
@@ -259,15 +258,4 @@ func copyUIOutput(o provisioners.UIOutput, r io.Reader, doneCh chan<- struct{}) 
 	for line := range lr.Ch {
 		o.Output(line)
 	}
-}
-
-// hasEnvVar checks whether a slice of "KEY=VALUE" strings contains an entry
-// for the given variable name.
-func hasEnvVar(env []string, name string) bool {
-	for _, e := range env {
-		if _, ok := strings.CutPrefix(e, name+"="); ok {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/builtin/provisioners/local-exec/resource_provisioner.go
+++ b/internal/builtin/provisioners/local-exec/resource_provisioner.go
@@ -17,7 +17,7 @@ import (
 	"github.com/armon/circbuf"
 	"github.com/mitchellh/go-linereader"
 	"github.com/zclconf/go-cty/cty"
-	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/provisioners"
@@ -178,10 +178,13 @@ func (p *provisioner) ProvisionResource(ctx context.Context, req provisioners.Pr
 	// has already set TRACEPARENT explicitly in the provisioner's
 	// "environment" block.
 	if !traceparentConfigured {
-		carrier := make(propagation.MapCarrier)
-		propagation.TraceContext{}.Inject(ctx, carrier)
-		for k, v := range carrier {
-			cmdEnv = append(cmdEnv, strings.ToUpper(k)+"="+v)
+		if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
+			cmdEnv = append(cmdEnv, fmt.Sprintf(
+				"TRACEPARENT=00-%s-%s-%s",
+				sc.TraceID().String(),
+				sc.SpanID().String(),
+				sc.TraceFlags().String(),
+			))
 		}
 	}
 

--- a/internal/builtin/provisioners/local-exec/resource_provisioner.go
+++ b/internal/builtin/provisioners/local-exec/resource_provisioner.go
@@ -16,6 +16,7 @@ import (
 	"github.com/armon/circbuf"
 	"github.com/mitchellh/go-linereader"
 	"github.com/zclconf/go-cty/cty"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/provisioners"
@@ -97,7 +98,7 @@ func (p *provisioner) ValidateProvisionerConfig(req provisioners.ValidateProvisi
 	return resp
 }
 
-func (p *provisioner) ProvisionResource(_ context.Context, req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+func (p *provisioner) ProvisionResource(ctx context.Context, req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
 	commandVal := req.Config.GetAttr("command")
 	if commandVal.IsNull() || commandVal.AsString() == "" {
 		resp.Diagnostics = resp.Diagnostics.Append(tfdiags.WholeContainingBody(
@@ -163,6 +164,22 @@ func (p *provisioner) ProvisionResource(_ context.Context, req provisioners.Prov
 	var cmdEnv []string
 	cmdEnv = os.Environ()
 	cmdEnv = append(cmdEnv, env...)
+
+	// If the caller's context carries an active OpenTelemetry trace span,
+	// propagate it to the child process via the TRACEPARENT environment
+	// variable (per the W3C Trace Context specification), unless the user
+	// has already set TRACEPARENT explicitly in the provisioner's
+	// "environment" block.
+	if !hasEnvVar(env, "TRACEPARENT") {
+		if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
+			cmdEnv = append(cmdEnv, fmt.Sprintf(
+				"TRACEPARENT=00-%s-%s-%s",
+				sc.TraceID().String(),
+				sc.SpanID().String(),
+				sc.TraceFlags().String(),
+			))
+		}
+	}
 
 	// Set up the command
 	cmd := exec.CommandContext(p.ctx, cmdargs[0], cmdargs[1:]...)
@@ -237,4 +254,16 @@ func copyUIOutput(o provisioners.UIOutput, r io.Reader, doneCh chan<- struct{}) 
 	for line := range lr.Ch {
 		o.Output(line)
 	}
+}
+
+// hasEnvVar checks whether a slice of "KEY=VALUE" strings contains an entry
+// for the given variable name.
+func hasEnvVar(env []string, name string) bool {
+	prefix := name + "="
+	for _, e := range env {
+		if len(e) >= len(prefix) && e[:len(prefix)] == prefix {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/builtin/provisioners/local-exec/resource_provisioner.go
+++ b/internal/builtin/provisioners/local-exec/resource_provisioner.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 
 	"github.com/armon/circbuf"
 	"github.com/mitchellh/go-linereader"
@@ -99,6 +100,10 @@ func (p *provisioner) ValidateProvisionerConfig(req provisioners.ValidateProvisi
 }
 
 func (p *provisioner) ProvisionResource(ctx context.Context, req provisioners.ProvisionResourceRequest) (resp provisioners.ProvisionResourceResponse) {
+	// We ignore cancellation of this incoming context because provisioners
+	// currently get cancelled by calling the "Stop" method instead.
+	ctx = context.WithoutCancel(ctx)
+
 	commandVal := req.Config.GetAttr("command")
 	if commandVal.IsNull() || commandVal.AsString() == "" {
 		resp.Diagnostics = resp.Diagnostics.Append(tfdiags.WholeContainingBody(
@@ -259,9 +264,8 @@ func copyUIOutput(o provisioners.UIOutput, r io.Reader, doneCh chan<- struct{}) 
 // hasEnvVar checks whether a slice of "KEY=VALUE" strings contains an entry
 // for the given variable name.
 func hasEnvVar(env []string, name string) bool {
-	prefix := name + "="
 	for _, e := range env {
-		if len(e) >= len(prefix) && e[:len(prefix)] == prefix {
+		if _, ok := strings.CutPrefix(e, name+"="); ok {
 			return true
 		}
 	}

--- a/internal/builtin/provisioners/local-exec/resource_provisioner_test.go
+++ b/internal/builtin/provisioners/local-exec/resource_provisioner_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/mitchellh/cli"
 	"github.com/zclconf/go-cty/cty"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/opentofu/opentofu/internal/provisioners"
 )
@@ -336,5 +337,152 @@ func TestResourceProvisioner_nullsInOptionals(t *testing.T) {
 				UIOutput: output,
 			})
 		})
+	}
+}
+
+// testSpanContext returns a known-valid SpanContext for use in tests.
+func testSpanContext() trace.SpanContext {
+	traceID, _ := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+	spanID, _ := trace.SpanIDFromHex("00f067aa0ba902b7")
+	return trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
+}
+
+func TestResourceProvider_TraceparentPropagation(t *testing.T) {
+	output := cli.NewMockUi()
+	p := New()
+	schema := p.GetSchema().Provisioner
+
+	command := "echo $TRACEPARENT"
+	if runtime.GOOS == "windows" {
+		command = "echo %TRACEPARENT%"
+	}
+
+	c, err := schema.CoerceValue(cty.ObjectVal(map[string]cty.Value{
+		"command": cty.StringVal(command),
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := trace.ContextWithSpanContext(t.Context(), testSpanContext())
+
+	resp := p.ProvisionResource(ctx, provisioners.ProvisionResourceRequest{
+		Config:   c,
+		UIOutput: output,
+	})
+
+	if resp.Diagnostics.HasErrors() {
+		t.Fatal(resp.Diagnostics.Err())
+	}
+
+	got := strings.TrimSpace(output.OutputWriter.String())
+	want := "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	if !strings.Contains(got, want) {
+		t.Errorf("expected TRACEPARENT %q in output, got %q", want, got)
+	}
+}
+
+func TestResourceProvider_TraceparentNotSetWithoutSpan(t *testing.T) {
+	t.Setenv("TRACEPARENT", "")
+
+	output := cli.NewMockUi()
+	p := New()
+	schema := p.GetSchema().Provisioner
+
+	command := "echo traceparent_is_${TRACEPARENT:-unset}"
+	if runtime.GOOS == "windows" {
+		command = "echo traceparent_is_%TRACEPARENT%"
+	}
+
+	c, err := schema.CoerceValue(cty.ObjectVal(map[string]cty.Value{
+		"command": cty.StringVal(command),
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := p.ProvisionResource(t.Context(), provisioners.ProvisionResourceRequest{
+		Config:   c,
+		UIOutput: output,
+	})
+
+	if resp.Diagnostics.HasErrors() {
+		t.Fatal(resp.Diagnostics.Err())
+	}
+
+	got := strings.TrimSpace(output.OutputWriter.String())
+	if !strings.Contains(got, "traceparent_is_unset") {
+		t.Errorf("expected TRACEPARENT to be unset without span context, got %q", got)
+	}
+}
+
+func TestResourceProvider_TraceparentUserOverride(t *testing.T) {
+	output := cli.NewMockUi()
+	p := New()
+	schema := p.GetSchema().Provisioner
+
+	userTraceparent := "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01"
+	command := "echo $TRACEPARENT"
+	if runtime.GOOS == "windows" {
+		command = "echo %TRACEPARENT%"
+	}
+
+	c, err := schema.CoerceValue(cty.ObjectVal(map[string]cty.Value{
+		"command": cty.StringVal(command),
+		"environment": cty.MapVal(map[string]cty.Value{
+			"TRACEPARENT": cty.StringVal(userTraceparent),
+		}),
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := trace.ContextWithSpanContext(t.Context(), testSpanContext())
+
+	resp := p.ProvisionResource(ctx, provisioners.ProvisionResourceRequest{
+		Config:   c,
+		UIOutput: output,
+	})
+
+	if resp.Diagnostics.HasErrors() {
+		t.Fatal(resp.Diagnostics.Err())
+	}
+
+	got := strings.TrimSpace(output.OutputWriter.String())
+	if !strings.Contains(got, userTraceparent) {
+		t.Errorf("expected user-specified TRACEPARENT %q, got %q", userTraceparent, got)
+	}
+	// The span context's traceparent should NOT appear
+	autoTraceparent := "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	if strings.Contains(got, autoTraceparent) {
+		t.Errorf("expected user override to take precedence, but found auto-generated TRACEPARENT in output")
+	}
+}
+
+func TestHasEnvVar(t *testing.T) {
+	env := []string{"FOO=bar", "TRACEPARENT=00-abc-def-01", "BAZ="}
+
+	if !hasEnvVar(env, "FOO") {
+		t.Error("expected to find FOO")
+	}
+	if !hasEnvVar(env, "TRACEPARENT") {
+		t.Error("expected to find TRACEPARENT")
+	}
+	if !hasEnvVar(env, "BAZ") {
+		t.Error("expected to find BAZ (empty value)")
+	}
+	if hasEnvVar(env, "MISSING") {
+		t.Error("expected not to find MISSING")
+	}
+	if hasEnvVar(env, "FOO=bar") {
+		t.Error("expected not to match full entry as name")
+	}
+	if hasEnvVar(nil, "FOO") {
+		t.Error("expected not to find anything in nil slice")
 	}
 }

--- a/internal/builtin/provisioners/local-exec/resource_provisioner_test.go
+++ b/internal/builtin/provisioners/local-exec/resource_provisioner_test.go
@@ -395,8 +395,14 @@ func TestResourceProvider_TraceparentNotSetWithoutSpan(t *testing.T) {
 	schema := p.GetSchema().Provisioner
 
 	command := "echo traceparent_is_${TRACEPARENT:-unset}"
+	expectedOutput := "traceparent_is_unset"
 	if runtime.GOOS == "windows" {
 		command = "echo traceparent_is_%TRACEPARENT%"
+		// On Unix, the shell substitutes ${TRACEPARENT:-unset} to "unset".
+		// On Windows, cmd.exe leaves %TRACEPARENT% unexpanded when the
+		// variable is empty, so the literal marker appears in the output.
+		// Either result confirms the provisioner did not inject TRACEPARENT.
+		expectedOutput = "traceparent_is_%TRACEPARENT%"
 	}
 
 	c, err := schema.CoerceValue(cty.ObjectVal(map[string]cty.Value{
@@ -417,18 +423,8 @@ func TestResourceProvider_TraceparentNotSetWithoutSpan(t *testing.T) {
 
 	got := strings.TrimSpace(output.OutputWriter.String())
 
-	// On Unix, the shell substitutes ${TRACEPARENT:-unset} to "unset".
-	// On Windows, cmd.exe leaves %TRACEPARENT% unexpanded when the
-	// variable is empty, so the literal marker appears in the output.
-	// Either result confirms the provisioner did not inject TRACEPARENT.
-	if runtime.GOOS == "windows" {
-		if !strings.Contains(got, "traceparent_is_%TRACEPARENT%") {
-			t.Errorf("expected TRACEPARENT to be unset without span context, got %q", got)
-		}
-	} else {
-		if !strings.Contains(got, "traceparent_is_unset") {
-			t.Errorf("expected TRACEPARENT to be unset without span context, got %q", got)
-		}
+	if !strings.Contains(got, expectedOutput) {
+		t.Errorf("expected TRACEPARENT to be unset without span context, got %q", got)
 	}
 }
 
@@ -472,28 +468,5 @@ func TestResourceProvider_TraceparentUserOverride(t *testing.T) {
 	autoTraceparent := "00-0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f-0f0f0f0f0f0f0f0f-01"
 	if strings.Contains(got, autoTraceparent) {
 		t.Errorf("expected user override to take precedence, but found auto-generated TRACEPARENT in output")
-	}
-}
-
-func TestHasEnvVar(t *testing.T) {
-	env := []string{"FOO=bar", "TRACEPARENT=00-abc-def-01", "BAZ="}
-
-	if !hasEnvVar(env, "FOO") {
-		t.Error("expected to find FOO")
-	}
-	if !hasEnvVar(env, "TRACEPARENT") {
-		t.Error("expected to find TRACEPARENT")
-	}
-	if !hasEnvVar(env, "BAZ") {
-		t.Error("expected to find BAZ (empty value)")
-	}
-	if hasEnvVar(env, "MISSING") {
-		t.Error("expected not to find MISSING")
-	}
-	if hasEnvVar(env, "FOO=bar") {
-		t.Error("expected not to match full entry as name")
-	}
-	if hasEnvVar(nil, "FOO") {
-		t.Error("expected not to find anything in nil slice")
 	}
 }

--- a/internal/builtin/provisioners/local-exec/resource_provisioner_test.go
+++ b/internal/builtin/provisioners/local-exec/resource_provisioner_test.go
@@ -416,8 +416,19 @@ func TestResourceProvider_TraceparentNotSetWithoutSpan(t *testing.T) {
 	}
 
 	got := strings.TrimSpace(output.OutputWriter.String())
-	if !strings.Contains(got, "traceparent_is_unset") {
-		t.Errorf("expected TRACEPARENT to be unset without span context, got %q", got)
+
+	// On Unix, the shell substitutes ${TRACEPARENT:-unset} to "unset".
+	// On Windows, cmd.exe leaves %TRACEPARENT% unexpanded when the
+	// variable is empty, so the literal marker appears in the output.
+	// Either result confirms the provisioner did not inject TRACEPARENT.
+	if runtime.GOOS == "windows" {
+		if !strings.Contains(got, "traceparent_is_%TRACEPARENT%") {
+			t.Errorf("expected TRACEPARENT to be unset without span context, got %q", got)
+		}
+	} else {
+		if !strings.Contains(got, "traceparent_is_unset") {
+			t.Errorf("expected TRACEPARENT to be unset without span context, got %q", got)
+		}
 	}
 }
 

--- a/internal/builtin/provisioners/local-exec/resource_provisioner_test.go
+++ b/internal/builtin/provisioners/local-exec/resource_provisioner_test.go
@@ -342,8 +342,8 @@ func TestResourceProvisioner_nullsInOptionals(t *testing.T) {
 
 // testSpanContext returns a known-valid SpanContext for use in tests.
 func testSpanContext() trace.SpanContext {
-	traceID, _ := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
-	spanID, _ := trace.SpanIDFromHex("00f067aa0ba902b7")
+	traceID, _ := trace.TraceIDFromHex("0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f")
+	spanID, _ := trace.SpanIDFromHex("0f0f0f0f0f0f0f0f")
 	return trace.NewSpanContext(trace.SpanContextConfig{
 		TraceID:    traceID,
 		SpanID:     spanID,
@@ -381,7 +381,7 @@ func TestResourceProvider_TraceparentPropagation(t *testing.T) {
 	}
 
 	got := strings.TrimSpace(output.OutputWriter.String())
-	want := "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	want := "00-0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f-0f0f0f0f0f0f0f0f-01"
 	if !strings.Contains(got, want) {
 		t.Errorf("expected TRACEPARENT %q in output, got %q", want, got)
 	}
@@ -469,7 +469,7 @@ func TestResourceProvider_TraceparentUserOverride(t *testing.T) {
 		t.Errorf("expected user-specified TRACEPARENT %q, got %q", userTraceparent, got)
 	}
 	// The span context's traceparent should NOT appear
-	autoTraceparent := "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	autoTraceparent := "00-0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f-0f0f0f0f0f0f0f0f-01"
 	if strings.Contains(got, autoTraceparent) {
 		t.Errorf("expected user override to take precedence, but found auto-generated TRACEPARENT in output")
 	}

--- a/website/docs/language/resources/provisioners/local-exec.mdx
+++ b/website/docs/language/resources/provisioners/local-exec.mdx
@@ -104,3 +104,9 @@ resource "aws_instance" "web" {
   }
 }
 ```
+
+## OpenTelemetry Trace Propagation
+
+If you run OpenTofu with [OpenTelemetry Tracing](../../../internals/tracing.mdx) enabled, the `local-exec` provisioner will automatically set the `TRACEPARENT` environment variable when launching the specified program, so that it can contribute its own spans to the overall trace.
+
+Programs launched with this provisioner also inherit environment variables from the parent OpenTofu process by default, so the child program can also access any `OTEL_`-prefixed environment variables you set to enable OpenTofu's tracing functionality.


### PR DESCRIPTION
Resolves #3936

This is PR 2 of 2. PR 1 (#3997, merged) threaded `context.Context` through the provisioner interface. This PR uses that context to propagate trace information to local-exec child processes.

When tracing is active the local-exec provisioner now sets `TRACEPARENT` in the child process environment, formatted per the W3C Trace Context spec (`00-{traceID}-{spanID}-{flags}`). If the user already sets `TRACEPARENT` in the provisioner `environment` block, that value takes precedence.

Uses `trace.SpanContextFromContext(ctx)` from the existing `go.opentelemetry.io/otel/trace` dependency — no new dependencies added, inline implementation as discussed on the issue.

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.