### PR TITLE
views: TestStateViews non-hardcoded "terraform_version"

### DIFF
--- a/internal/command/views/state_test.go
+++ b/internal/command/views/state_test.go
@@ -11,6 +11,9 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	regaddr "github.com/opentofu/registry-address/v2"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/command/arguments"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
@@ -19,8 +22,7 @@ import (
 	"github.com/opentofu/opentofu/internal/states/statefile"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/opentofu/opentofu/internal/tofu"
-	regaddr "github.com/opentofu/registry-address/v2"
-	"github.com/zclconf/go-cty/cty"
+	"github.com/opentofu/opentofu/version"
 )
 
 func TestStateViews(t *testing.T) {
@@ -532,7 +534,7 @@ resource "test_resource" "foo" {
 			wantJson: []map[string]any{
 				{
 					"format_version":    "1.0",
-					"terraform_version": "1.12.0",
+					"terraform_version": version.SemVer.String(),
 					"values": map[string]any{
 						"root_module": map[string]any{
 							"resources": []any{


### PR DESCRIPTION
The `"terraform_version"` property of the JSON state format (intentionally misnamed for backward-compatibility with our predecessor) changes each time we make a new release, so we'll compare it with the currently-expected version number instead of with a hard-coded value.

This only affects an internal test, so it cannot have any externally-visible impact to the `tofu` executable and so no changelog update is needed.

(I found this while working on https://github.com/opentofu/opentofu/pull/4012, which is the first time we ran the tests since merging https://github.com/opentofu/opentofu/pull/4013. _That_ PR unfortunately didn't catch it because we only run the unit tests when there's at least one `.go` source file changed in the PR. :man_facepalming:)
