### PR TITLE
Warn about forthcoming end of official support when using OpenTofu v1.13 on a 32-bit CPU architecture

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,9 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_TOKEN }}
           RELEASE_FLAG_LATEST: ${{ inputs.latest }}
           RELEASE_FLAG_PRERELEASE: ${{ inputs.prerelease }}
+          # This causes version.IsOfficialBuild to return true when someone is
+          # running one of our official release builds.
+          BUILD_OPENTOFU_OFFICIAL: '1'
 
       - name: Remove GPG key
         if: always()

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,6 +24,12 @@ builds:
     ldflags:
       - "-s -w"
       - "-X 'github.com/opentofu/opentofu/version.dev=no'"
+      # BUILD_OPENTOFU_OFFICIAL is set by the OpenTofu project's main release
+      # process. It should typically _not_ be set for builds produced by
+      # third-parties such as Linux distribution maintainers, because in that
+      # case the resulting executable might generate irrelevant warnings that
+      # are intended only for users of the official release builds.
+      - "-X 'github.com/opentofu/opentofu/version.officialBuild={{if index .Env \"BUILD_OPENTOFU_OFFICIAL\" }}{{ .Env.BUILD_OPENTOFU_OFFICIAL }}{{end}}'"
 
     goos:
       - linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ UPGRADE NOTES:
 
     [Modern Windows versions now support OpenSSH](https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse), and so we suggest that anyone currently relying on WinRM plan to migrate to using SSH instead.
 
+- OpenTofu v1.13 is the final release series that will include official builds for 32-bit CPU architectures (`*_386` and `*_arm` platforms).
+
+    If you are currently relying on our official releases of OpenTofu on one of these platforms then we suggest that you begin planning to migrate to running OpenTofu on a 64-bit CPU architecture (`*_amd64` or `*_arm64` platforms) before the v1.13 series reaches end-of-life.
+
+    Third parties may continue to offer their own OpenTofu builds targeting platforms that we don't officially support. This only affects the official packages published directly by the OpenTofu project in this repository's release artifacts.
+
 - There are various minor changes to the robustness of file format and wire format parsers in the SSH client implementation used for remote provisioners.
 
     This may cause certain invalid input that was previously accepted to now be rejected, in an attempt to better match the expectations of other implementations of these protocols and formats.
@@ -25,6 +31,7 @@ ENHANCEMENTS:
 - The `providers lock` command now supports the argument `-oci-mirror`. The functionality mimics that of the field `repository_template` of `oci_mirror`-block in [`provider_installation`](https://opentofu.org/docs/cli/config/config-file/#provider-installation) with the exception of using a URI template instead of a HCL one.
 - The OpenBao key provider accepts a new `associated_data` (known as AAD) argument, allowing a base64-encoded value to be passed to OpenBao on every data key generation and decryption call. ([#4365](https://github.com/opentofu/opentofu/pull/4365))
 - `tofu plan` no longer prints the explanatory paragraph that followed the "No changes. Your infrastructure matches the configuration." message, since it only restated that message in more words. ([#4340](https://github.com/opentofu/opentofu/issues/4340))
+- `tofu init` in our official releases when running on a 32-bit CPU architecture now warns about our plan to stop publishing official builds for these platforms starting in OpenTofu v1.14. ([#4018](https://github.com/opentofu/opentofu/issues/4018))
 
 BUG FIXES:
 

--- a/cmd/tofu/main.go
+++ b/cmd/tofu/main.go
@@ -134,6 +134,11 @@ func realMain() int {
 	}
 
 	log.Printf("[INFO] OpenTofu version: %s %s", Version, VersionPrerelease)
+	if version.IsOfficialBuild() {
+		log.Printf("[DEBUG] This is an official build of OpenTofu")
+	} else {
+		log.Printf("[DEBUG] This is a third-party build of OpenTofu")
+	}
 	if logging.IsDebugOrHigher() {
 		for _, depMod := range version.InterestingDependencies() {
 			log.Printf("[DEBUG] using %s %s", depMod.Path, depMod.Version)

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -10,12 +10,12 @@ import (
 	"fmt"
 	"log"
 	"reflect"
+	"runtime"
 	"slices"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/mitchellh/cli"
-	"github.com/opentofu/opentofu/internal/command/flags"
 	"github.com/opentofu/svchost"
 	"github.com/posener/complete"
 	"github.com/zclconf/go-cty/cty"
@@ -25,6 +25,7 @@ import (
 	backendInit "github.com/opentofu/opentofu/internal/backend/init"
 	"github.com/opentofu/opentofu/internal/cloud"
 	"github.com/opentofu/opentofu/internal/command/arguments"
+	"github.com/opentofu/opentofu/internal/command/flags"
 	"github.com/opentofu/opentofu/internal/command/views"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
@@ -64,6 +65,14 @@ func (c *InitCommand) Run(rawArgs []string) int {
 	// Instantiate the view, even if there are flag errors, so that we render
 	// diagnostics according to the desired view
 	view := views.NewInit(args.ViewOptions, c.View)
+
+	// For "tofu init" in particular we'll warn if this is an official build
+	// for a platform which will stop getting official release packages in
+	// the near future. Generating this warning only during init is a compromise
+	// because it tends to be run less often than other commands and so is
+	// hopefully makes these warnings a little less annoying for however long it
+	// takes for a team to react to them.
+	diags = diags.Append(c.platformSupportWarnings())
 
 	if diags.HasErrors() {
 		view.Diagnostics(diags)
@@ -164,6 +173,7 @@ To initialize the configuration already in this working directory, omit the
 		return 1
 	}
 	if empty {
+		view.Diagnostics(diags) // just in case there are warnings
 		view.InitialisedFromEmptyDir()
 		return 0
 	}
@@ -1155,6 +1165,27 @@ func (c *InitCommand) configureBackendFlags(args *arguments.Backend) {
 	//  https://github.com/opentofu/opentofu/blob/db8c872defd8666618649ef7e29fa2b809adfd5e/internal/command/arguments/extended.go#L320-L321
 	c.Meta.stateLock = args.StateLock
 	c.Meta.stateLockTimeout = args.StateLockTimeout
+}
+
+func (c *InitCommand) platformSupportWarnings() tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+	if !tfversion.IsOfficialBuild() {
+		// platform support warnings are irrelevant for third-party builds,
+		// because they can produce release packages for whatever targets
+		// they are willing to maintain support for.
+		return diags
+	}
+	if runtime.GOARCH == "386" || runtime.GOARCH == "arm" {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Warning,
+			"Support for 32-bit CPU architectures is ending soon",
+			fmt.Sprintf(
+				"OpenTofu v1.13 is the last release series that will include official release packages for 32-bit CPU architectures.\n\nWe recommend planning to migrate to a 64-bit CPU architecture instead. Alternatively, you could build OpenTofu for %s from source code yourself, and we'll consider pull requests to fix any regressions for this platform as long as they wouldn't make OpenTofu considerably harder to maintain.",
+				getproviders.CurrentPlatform,
+			),
+		))
+	}
+	return diags
 }
 
 func (c *InitCommand) AutocompleteFlags() complete.Flags {

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -10,12 +10,12 @@ import (
 	"fmt"
 	"log"
 	"reflect"
+	"runtime"
 	"slices"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/mitchellh/cli"
-	"github.com/opentofu/opentofu/internal/command/flags"
 	"github.com/opentofu/svchost"
 	"github.com/posener/complete"
 	"github.com/zclconf/go-cty/cty"
@@ -25,6 +25,7 @@ import (
 	backendInit "github.com/opentofu/opentofu/internal/backend/init"
 	"github.com/opentofu/opentofu/internal/cloud"
 	"github.com/opentofu/opentofu/internal/command/arguments"
+	"github.com/opentofu/opentofu/internal/command/flags"
 	"github.com/opentofu/opentofu/internal/command/views"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
@@ -64,6 +65,14 @@ func (c *InitCommand) Run(rawArgs []string) int {
 	// Instantiate the view, even if there are flag errors, so that we render
 	// diagnostics according to the desired view
 	view := views.NewInit(args.ViewOptions, c.View)
+
+	// For "tofu init" in particular we'll warn if this is an official build
+	// for a platform which will stop getting official release packages in
+	// the near future. Generating this warning only during init is a compromise
+	// because it tends to be run less often than other commands and so is
+	// hopefully makes these warnings a little less annoying for however long it
+	// takes for a team to react to them.
+	diags = diags.Append(c.platformSupportWarnings())
 
 	if diags.HasErrors() {
 		view.Diagnostics(diags)
@@ -165,6 +174,7 @@ To initialize the configuration already in this working directory, omit the
 		return 1
 	}
 	if empty {
+		view.Diagnostics(diags) // just in case there are warnings
 		view.InitialisedFromEmptyDir()
 		return 0
 	}
@@ -1172,6 +1182,27 @@ func (c *InitCommand) backendConfigOverrideBody(flags flags.RawFlags, schema *co
 
 func (c *InitCommand) AutocompleteArgs() complete.Predictor {
 	return complete.PredictDirs("")
+}
+
+func (c *InitCommand) platformSupportWarnings() tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+	if !tfversion.IsOfficialBuild() {
+		// platform support warnings are irrelevant for third-party builds,
+		// because they can produce release packages for whatever targets
+		// they are willing to maintain support for.
+		return diags
+	}
+	if runtime.GOARCH == "386" || runtime.GOARCH == "arm" {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Warning,
+			"Support for 32-bit CPU architectures is ending soon",
+			fmt.Sprintf(
+				"OpenTofu v1.13 is the last release series that will include official release packages for 32-bit CPU architectures.\n\nWe recommend planning to migrate to a 64-bit CPU architecture instead. Alternatively, you could build OpenTofu for %s from source code yourself, and we'll consider pull requests to fix any regressions for this platform as long as they wouldn't make OpenTofu considerably harder to maintain.",
+				getproviders.CurrentPlatform,
+			),
+		))
+	}
+	return diags
 }
 
 func (c *InitCommand) AutocompleteFlags() complete.Flags {

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/states/statefile"
 	"github.com/opentofu/opentofu/internal/states/statemgr"
+	tofuVersion "github.com/opentofu/opentofu/version"
 )
 
 func TestInit_empty(t *testing.T) {
@@ -3258,6 +3259,43 @@ func TestInit_skipEncryptionBackendFalse(t *testing.T) {
 			t.Fatalf("init should not run successfully\n")
 		} else if !strings.Contains(output.Stderr(), "key_provider.aws_kms.key failed with error:") {
 			t.Fatalf("generated error should contain the string \"Error: Unable to fetch encryption key data\"\ninstead got : %s\n", output.Stderr())
+		}
+	})
+}
+
+func TestInit_platformSupportWarnings(t *testing.T) {
+	// Platform support warnings only appear in official builds, so we'll
+	// pretend to be one just for the duration of this test.
+	tofuVersion.WithFakedOfficialBuild(true, func() {
+		expectWarning := runtime.GOARCH == "386" || runtime.GOARCH == "arm"
+
+		// We use an empty directory for this test, because the warning we're
+		// testing for is produced very early on in "tofu init", regardless
+		// of what's in the configuration.
+		td := t.TempDir()
+		t.Chdir(td)
+
+		view, done := testView(t)
+		m := Meta{
+			WorkingDir: workdir.NewDir("."),
+			View:       view,
+		}
+		c := &InitCommand{
+			Meta: m,
+		}
+		code := c.Run(nil)
+		output := done(t)
+		t.Log("output from init command:\n" + output.All())
+		if code != 0 {
+			t.Fatal("unexpected failure")
+		}
+
+		gotWarning := strings.Contains(output.All(), "Support for 32-bit CPU architectures is ending soon")
+		if gotWarning && !expectWarning {
+			t.Error("unexpected warning about 32-bit CPU architectures")
+		}
+		if !gotWarning && expectWarning {
+			t.Error("missing expected warning about 32-bit CPU architectures")
 		}
 	})
 }

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/states/statefile"
 	"github.com/opentofu/opentofu/internal/states/statemgr"
+	tofuVersion "github.com/opentofu/opentofu/version"
 )
 
 func TestInit_empty(t *testing.T) {
@@ -3295,6 +3296,43 @@ func TestInit_backendFalse_skipsBackendFromStateOnPreviouslyInitializedDir(t *te
 		}
 		if stderr := output.Stderr(); stderr != "" {
 			t.Errorf("expected to have no errors but got:\n%s", stderr)
+		}
+	})
+}
+
+func TestInit_platformSupportWarnings(t *testing.T) {
+	// Platform support warnings only appear in official builds, so we'll
+	// pretend to be one just for the duration of this test.
+	tofuVersion.WithFakedOfficialBuild(true, func() {
+		expectWarning := runtime.GOARCH == "386" || runtime.GOARCH == "arm"
+
+		// We use an empty directory for this test, because the warning we're
+		// testing for is produced very early on in "tofu init", regardless
+		// of what's in the configuration.
+		td := t.TempDir()
+		t.Chdir(td)
+
+		view, done := testView(t)
+		m := Meta{
+			WorkingDir: workdir.NewDir("."),
+			View:       view,
+		}
+		c := &InitCommand{
+			Meta: m,
+		}
+		code := c.Run(nil)
+		output := done(t)
+		t.Log("output from init command:\n" + output.All())
+		if code != 0 {
+			t.Fatal("unexpected failure")
+		}
+
+		gotWarning := strings.Contains(output.All(), "Support for 32-bit CPU architectures is ending soon")
+		if gotWarning && !expectWarning {
+			t.Error("unexpected warning about 32-bit CPU architectures")
+		}
+		if !gotWarning && expectWarning {
+			t.Error("missing expected warning about 32-bit CPU architectures")
 		}
 	})
 }

--- a/version/official.go
+++ b/version/official.go
@@ -1,0 +1,28 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package version
+
+// officialBuild is set to a non-empty value when we build executables for
+// the OpenTofu project's official release packages, and we assume it'll
+// be empty for all other builds.
+var officialBuild string
+
+// IsOfficialBuild returns true if the current executable was built with
+// the following argument, which is set by the OpenTofu project's main
+// release process:
+//
+//	-X 'github.com/opentofu/opentofu/version.officialBuild=yes'
+//
+// We use this ONLY to generate warnings where we're intending to stop producing
+// official builds for a certain configuration in a future release series and
+// so want to warn about it. We generate such warnings only when this is set
+// because we want third-parties to be able to create and support their own
+// builds for platforms that are not officially supported, and it would be
+// very annoying if those builds generated irrelevant warnings about what is
+// supported in the official set of release packages.
+func IsOfficialBuild() bool {
+	return officialBuild != ""
+}

--- a/version/official.go
+++ b/version/official.go
@@ -11,10 +11,10 @@ package version
 var officialBuild string
 
 // IsOfficialBuild returns true if the current executable was built with
-// the following argument, which is set by the OpenTofu project's main
+// an argument like the following, which is set by the OpenTofu project's main
 // release process:
 //
-//	-X 'github.com/opentofu/opentofu/version.officialBuild=yes'
+//	-X 'github.com/opentofu/opentofu/version.officialBuild=1'
 //
 // We use this ONLY to generate warnings where we're intending to stop producing
 // official builds for a certain configuration in a future release series and
@@ -25,4 +25,23 @@ var officialBuild string
 // supported in the official set of release packages.
 func IsOfficialBuild() bool {
 	return officialBuild != ""
+}
+
+// WithFakedOfficialBuild runs the given function with the global "official
+// build" flag temporarily forced to the given value, so that [IsOfficialBuild]
+// will return that value for the duration of that function's runtime.
+//
+// This is intended for unit testing only. Because it affects global state, it
+// must not be used in parallel tests.
+func WithFakedOfficialBuild(official bool, f func()) {
+	oldOfficialBuild := officialBuild
+	defer func() {
+		officialBuild = oldOfficialBuild
+	}()
+	if official {
+		officialBuild = "1"
+	} else {
+		officialBuild = ""
+	}
+	f()
 }


### PR DESCRIPTION
This is a draft idea for one way we could potentially produce a more prominent announcement about ending official support for 32-bit CPU architectures, for https://github.com/opentofu/opentofu/issues/3912.

When we discussed this change of support with OpenTofu's technical steering committee they requested that there be at least one release that produces an in-band warning so that anyone currently relying on these builds is more likely to notice it.

However, we want to still make a best effort to help third-parties like Linux distribution maintainers produce their own builds for these CPU architectures if they want to, rather than actively _preventing_ OpenTofu from running on these platforms. It would be annoying if those third-party builds _also_ started producing these warnings, since it's up to those folks if and when they want to stop supporting any platform they currently support.

This PR therefore implements a compromise:

1. Introduces a new concept of "official builds", which is activated by an extra environment variable that's only set in the GitHub Actions workflow that we use to produce the official release packages.

    This is activated in the GitHub Action because it seems reasonable that a third-party distributor might try to adapt our `.goreleaser.yml` for their own use but might not notice the "official build" concept and so might accidentally mark their non-official builds as being official. It seems far less likely that a third-party distributor would reuse our GitHub Actions workflow.

2. _For official builds only_, the `tofu init` command in particular checks whether it's running in a `386` or `arm` build and generates a warning if so.

    This is included only in `tofu init` as a compromise because it's a command that developers are likely to run just once when initializing their working directory, and so it wouldn't be quite so annoying there as it would be to re-warn about it on every `tofu plan` or `tofu apply` run.

    There is some risk that someone won't run `tofu init` immediately after upgrading from an earlier release, but they probably will _eventually_ run it at some point during the life of the v1.13 series. Even if they don't, we'll be announcing this change of support in other ways too and so it's likely that most folks affected by this will see _some_ communication about it, even if not _this_ communication.

I'm opening this as a draft now just in preparation for a discussion about what we might do for https://github.com/opentofu/opentofu/issues/3912 during the v1.13 development period. The maintainers have not discussed this yet, and so we might decide to do something quite different in the end.
