### PR TITLE
Add additional panic info and buffer panic message

### DIFF
--- a/internal/logging/panic.go
+++ b/internal/logging/panic.go
@@ -6,6 +6,7 @@
 package logging
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"runtime/debug"
@@ -48,7 +49,7 @@ func PanicHandler() {
 	defer panicMutex.Unlock()
 
 	recovered := recover()
-	panicHandler(recovered, nil)
+	panicHandler(recovered, nil, "")
 }
 
 // PanicHandlerWithTraceFn returns a function similar to PanicHandler which is
@@ -69,8 +70,17 @@ func PanicHandler() {
 // is a significant step in the right direction that will dramatically improve crash
 // debugging
 func PanicHandlerWithTraceFn() func() {
-	trace := debug.Stack()
+	ret := PanicHandlerWithTraceCallerFn()
 	return func() {
+		ret("")
+	}
+}
+
+// PanicHandlerWithTraceCallerFn is an enhanced version of PanicHandlerWithTraceFn
+// that supports providing information about the caller
+func PanicHandlerWithTraceCallerFn() func(caller string) {
+	trace := debug.Stack()
+	return func(caller string) {
 		// Have all managed goroutines checkin here, and prevent them from exiting
 		// if there's a panic in progress. While this can't lock the entire runtime
 		// to block progress, we can prevent some cases where OpenTofu may return
@@ -79,25 +89,35 @@ func PanicHandlerWithTraceFn() func() {
 		defer panicMutex.Unlock()
 
 		recovered := recover()
-		panicHandler(recovered, trace)
+		panicHandler(recovered, trace, caller)
 	}
 }
 
-func panicHandler(recovered interface{}, trace []byte) {
+func panicHandler(recovered interface{}, trace []byte, caller string) {
 	if recovered == nil {
 		return
 	}
 
-	fmt.Fprint(os.Stderr, panicOutput)
-	fmt.Fprint(os.Stderr, recovered, "\n")
+	// Given that multiple routines may be spewing to stderr at the same time
+	// buffer our message to prevent it being split.
+	buffer := new(bytes.Buffer)
+
+	fmt.Fprint(buffer, panicOutput)
+	if caller != "" {
+		fmt.Fprint(buffer, caller, "\n\n")
+	}
+	fmt.Fprint(buffer, recovered, "\n")
 
 	// When called from a deferred function, debug.PrintStack will include the
 	// full stack from the point of the pending panic.
-	debug.PrintStack()
+	buffer.Write(debug.Stack())
 	if trace != nil {
-		fmt.Fprint(os.Stderr, "With go-routine called from:\n")
-		os.Stderr.Write(trace)
+		fmt.Fprint(buffer, "With go-routine called from:\n")
+		buffer.Write(trace)
 	}
+
+	// Write the complete buffer to stderr
+	os.Stderr.Write(buffer.Bytes())
 
 	// An exit code of 11 keeps us out of the way of the detailed exitcodes
 	// from plan, and also happens to be the same code as SIGSEGV which is

--- a/internal/tofu/graph.go
+++ b/internal/tofu/graph.go
@@ -47,13 +47,13 @@ func (g *Graph) walk(ctx context.Context, walker GraphWalker) tfdiags.Diagnostic
 	// spawning many go routines for vertex evaluation
 	// to minimize the performance impact of capturing
 	// the stack trace.
-	panicHandler := logging.PanicHandlerWithTraceFn()
+	panicHandler := logging.PanicHandlerWithTraceCallerFn()
 
 	// Walk the graph.
 	walkFn := func(v dag.Vertex) (diags tfdiags.Diagnostics) {
 		// the walkFn is called asynchronously, and needs to be recovered
 		// separately in the case of a panic.
-		defer panicHandler()
+		defer panicHandler(fmt.Sprintf("Walking vertex %s - %T", dag.VertexName(v), v))
 
 		log.Printf("[TRACE] vertex %q: starting visit (%T)", dag.VertexName(v), v)
 


### PR DESCRIPTION
1. Add method to provide additional context to panic handler
2. Buffer panic message to prevent interrupted logging

Would have helped in debugging #4019 

Example:
```

!!!!!!!!!!!!!!!!!!!!!!!!!!! OPENTOFU CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!

OpenTofu crashed! This is always indicative of a bug within OpenTofu.
Please report the crash with OpenTofu[1] so that we can fix this.

When reporting bugs, please include your OpenTofu version, the stack trace
shown below, and any additional information which may help replicate the issue.

[1]: https://github.com/opentofu/opentofu/issues

!!!!!!!!!!!!!!!!!!!!!!!!!!! OPENTOFU CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!

Walking vertex output.crashme - *tofu.NodeApplyableOutput

no expansion has been registered for module.pruneme
goroutine 243 [running]:
runtime/debug.Stack()
        /usr/lib/go-1.26/src/runtime/debug/stack.go:26 +0x5e
github.com/opentofu/opentofu/internal/logging.panicHandler({0x3b00860, 0x32ba71981d40}, {0x32ba70f85c00, 0x3c6, 0x400}, {0x32ba71b48800, 0x39})
        /home/cmesh/OpenTOFU/opentofu-stable/internal/logging/panic.go:113 +0x165
github.com/opentofu/opentofu/internal/tofu.(*Graph).walk.PanicHandlerWithTraceCallerFn.func2({0x32ba71b48800, 0x39})
        /home/cmesh/OpenTOFU/opentofu-stable/internal/logging/panic.go:92 +0xa9
panic({0x3b00860?, 0x32ba71981d40?})
        /usr/lib/go-1.26/src/runtime/panic.go:860 +0x13a
github.com/opentofu/opentofu/internal/instances.(*expanderModule).moduleInstances(0x32ba71a1b2d8, {0x32ba70e5cbc8, 0x1, 0x1}, {0x32ba70e5c2d0, 0x0, 0x4}, 0x0)
        /home/cmesh/OpenTOFU/opentofu-stable/internal/instances/expander.go:388 +0x285
github.com/opentofu/opentofu/internal/instances.(*Expander).expandModule(0x32ba72382f00?, {0x32ba70e5cbc8?, 0x32ba71560940?, 0x32ba710a2620?}, 0x40?)
        /home/cmesh/OpenTOFU/opentofu-stable/internal/instances/expander.go:141 +0x12a
github.com/opentofu/opentofu/internal/instances.(*Expander).ExpandModule(...)
        /home/cmesh/OpenTOFU/opentofu-stable/internal/instances/expander.go:120
github.com/opentofu/opentofu/internal/tofu.(*evaluationStateData).GetModule(0x32ba72197320, {0x48b7b3?, 0x32ba710a3090?}, {{}, {0x32ba71560940, 0x7}}, {{0x32ba71560848, 0x7}, {0xb, 0xd, ...}, ...})
        /home/cmesh/OpenTOFU/opentofu-stable/internal/tofu/evaluate.go:456 +0x2414
github.com/opentofu/opentofu/internal/lang.(*evalVarBuilder).putValueBySubject(0x32ba70e5d350, {0x477ad98?, 0x32ba718db080?}, 0x32ba70e5d3d8?)
        /home/cmesh/OpenTOFU/opentofu-stable/internal/lang/eval.go:515 +0xe88
github.com/opentofu/opentofu/internal/lang.(*Scope).evalContext(0x32ba721973b0, {0x477ad98, 0x32ba718db080}, 0x0, {0x32ba71980ce0, 0x2, 0x2}, {0x0, 0x0})
        /home/cmesh/OpenTOFU/opentofu-stable/internal/lang/eval.go:395 +0x7e6
github.com/opentofu/opentofu/internal/lang.(*Scope).EvalContext(...)
        /home/cmesh/OpenTOFU/opentofu-stable/internal/lang/eval.go:323
github.com/opentofu/opentofu/internal/lang.(*Scope).EvalExpr(0x32ba721973b0, {0x477ad98, 0x32ba718db080}, {0x477c458, 0x32ba715e46e0}, {{0x477bdd0?, 0x7188420?}})
        /home/cmesh/OpenTOFU/opentofu-stable/internal/lang/eval.go:186 +0xb7
github.com/opentofu/opentofu/internal/tofu.(*BuiltinEvalContext).EvaluateExpr(0x0?, {0x477ad98, 0x32ba718db080}, {0x477c458, 0x32ba715e46e0}, {{0x477bdd0?, 0x7188420?}}, {0x0?, 0x0?})
        /home/cmesh/OpenTOFU/opentofu-stable/internal/tofu/eval_context_builtin.go:177 +0xf2
github.com/opentofu/opentofu/internal/tofu.(*NodeApplyableOutput).Execute(0x32ba71bae7c0, {0x477ad98, 0x32ba718db080}, {0x47af720, 0x32ba715cc2d0}, 0x48?)
        /home/cmesh/OpenTOFU/opentofu-stable/internal/tofu/node_output.go:355 +0x523
github.com/opentofu/opentofu/internal/tofu.(*ContextGraphWalker).Execute(0x32ba70dcf700, {0x477ad98, 0x32ba718db080}, {0x47af720, 0x32ba715cc2d0}, {0x7f888805b840, 0x32ba71bae7c0})
        /home/cmesh/OpenTOFU/opentofu-stable/internal/tofu/graph_walk_context.go:141 +0xdc
github.com/opentofu/opentofu/internal/tofu.(*Graph).walk.func1({0x4253c60, 0x32ba71bae7c0})
        /home/cmesh/OpenTOFU/opentofu-stable/internal/tofu/graph.go:85 +0x42a
github.com/opentofu/opentofu/internal/dag.(*Walker).walkVertex(0x32ba71a561e0, {0x4253c60, 0x32ba71bae7c0}, 0x32ba71bae880)
        /home/cmesh/OpenTOFU/opentofu-stable/internal/dag/walk.go:386 +0x2a5
created by github.com/opentofu/opentofu/internal/dag.(*Walker).Update in goroutine 226
        /home/cmesh/OpenTOFU/opentofu-stable/internal/dag/walk.go:309 +0x1048
With go-routine called from:
goroutine 226 [running]:
runtime/debug.Stack()
        /usr/lib/go-1.26/src/runtime/debug/stack.go:26 +0x5e
github.com/opentofu/opentofu/internal/logging.PanicHandlerWithTraceCallerFn(...)
        /home/cmesh/OpenTOFU/opentofu-stable/internal/logging/panic.go:82
github.com/opentofu/opentofu/internal/tofu.(*Graph).walk(0x32ba71bae780, {0x477ad98, 0x32ba718db080}, {0x477c230, 0x32ba70dcf700})
        /home/cmesh/OpenTOFU/opentofu-stable/internal/tofu/graph.go:50 +0x45
github.com/opentofu/opentofu/internal/tofu.(*Graph).walk.func1({0x4143620, 0x32ba7144ef40})
        /home/cmesh/OpenTOFU/opentofu-stable/internal/tofu/graph.go:126 +0x845
github.com/opentofu/opentofu/internal/dag.(*Walker).walkVertex(0x32ba7166dda0, {0x4143620, 0x32ba7144ef40}, 0x32ba7144f9c0)
        /home/cmesh/OpenTOFU/opentofu-stable/internal/dag/walk.go:386 +0x2a5
created by github.com/opentofu/opentofu/internal/dag.(*Walker).Update in goroutine 210
        /home/cmesh/OpenTOFU/opentofu-stable/internal/dag/walk.go:309 +0x1048
```

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
