### PR TITLE
fix: replace panic with error diagnostics for invalid TF_STATE_PERSIST_INTERVAL

### DIFF
--- a/internal/backend/local/backend_apply.go
+++ b/internal/backend/local/backend_apply.go
@@ -34,15 +34,21 @@ const (
 	persistIntervalEnvironmentVariableName = "TF_STATE_PERSIST_INTERVAL"
 )
 
-func getEnvAsInt(envName string, defaultValue int) int {
+func getEnvAsInt(envName string, defaultValue int) (int, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
 	if val, exists := os.LookupEnv(envName); exists {
 		parsedVal, err := strconv.Atoi(val)
-		if err == nil {
-			return parsedVal
+		if err != nil {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Invalid environment variable value",
+				fmt.Sprintf("The environment variable %s must be a valid integer, got %q.", envName, val),
+			))
+			return 0, diags
 		}
-		panic(fmt.Sprintf("Can't parse value '%s' of environment variable '%s'", val, envName))
+		return parsedVal, diags
 	}
-	return defaultValue
+	return defaultValue, diags
 }
 
 func (b *Local) opApply(
@@ -112,10 +118,20 @@ func (b *Local) opApply(
 	// stateHook uses schemas for when it periodically persists state to the
 	// persistent storage backend.
 	stateHook.Schemas = schemas
-	persistInterval := getEnvAsInt(persistIntervalEnvironmentVariableName, defaultPersistInterval)
+	persistInterval, intervalDiags := getEnvAsInt(persistIntervalEnvironmentVariableName, defaultPersistInterval)
+	diags = diags.Append(intervalDiags)
+	if intervalDiags.HasErrors() {
+		op.ReportResult(runningOp, diags)
+		return
+	}
 	if persistInterval < defaultPersistInterval {
-		panic(fmt.Sprintf("Can't use value lower than %d for env variable %s, got %d",
-			defaultPersistInterval, persistIntervalEnvironmentVariableName, persistInterval))
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Invalid environment variable value",
+			fmt.Sprintf("The environment variable %s must be at least %d, got %d.", persistIntervalEnvironmentVariableName, defaultPersistInterval, persistInterval),
+		))
+		op.ReportResult(runningOp, diags)
+		return
 	}
 	stateHook.PersistInterval = time.Duration(persistInterval) * time.Second
 

--- a/internal/backend/local/backend_apply.go
+++ b/internal/backend/local/backend_apply.go
@@ -42,7 +42,7 @@ func getEnvAsInt(envName string, defaultValue int) (int, tfdiags.Diagnostics) {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
 				"Invalid environment variable value",
-				fmt.Sprintf("The environment variable %s must be a valid integer, got %q.", envName, val),
+				fmt.Sprintf("The environment variable %q is expected to be a valid integer but got %q which cannot be converted.", envName, val),
 			))
 			return 0, diags
 		}
@@ -128,7 +128,7 @@ func (b *Local) opApply(
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Invalid environment variable value",
-			fmt.Sprintf("The environment variable %s must be at least %d, got %d.", persistIntervalEnvironmentVariableName, defaultPersistInterval, persistInterval),
+			fmt.Sprintf("The value for the environment variable %q cannot be smaller than %d but got %d.", persistIntervalEnvironmentVariableName, defaultPersistInterval, persistInterval),
 		))
 		op.ReportResult(runningOp, diags)
 		return

--- a/internal/backend/local/backend_apply_test.go
+++ b/internal/backend/local/backend_apply_test.go
@@ -478,7 +478,6 @@ func TestLocal_applyInvalidPersistInterval(t *testing.T) {
 		TestLocalProvider(t, b, "test", applyFixtureSchema())
 
 		op, done := testOperationApply(t, "./testdata/apply")
-		defer done(t)
 
 		run, err := b.Operation(context.Background(), op)
 		if err != nil {
@@ -487,6 +486,9 @@ func TestLocal_applyInvalidPersistInterval(t *testing.T) {
 		<-run.Done()
 		if run.Result == backend.OperationSuccess {
 			t.Fatalf("expected operation to fail with invalid %s=abc", persistIntervalEnvironmentVariableName)
+		}
+		if got, want := done(t).Stderr(), "Invalid environment variable value"; !strings.Contains(got, want) {
+			t.Errorf("expected stderr to contain %q, got:\n%s", want, got)
 		}
 	})
 
@@ -497,7 +499,6 @@ func TestLocal_applyInvalidPersistInterval(t *testing.T) {
 		TestLocalProvider(t, b, "test", applyFixtureSchema())
 
 		op, done := testOperationApply(t, "./testdata/apply")
-		defer done(t)
 
 		run, err := b.Operation(context.Background(), op)
 		if err != nil {
@@ -506,6 +507,9 @@ func TestLocal_applyInvalidPersistInterval(t *testing.T) {
 		<-run.Done()
 		if run.Result == backend.OperationSuccess {
 			t.Fatalf("expected operation to fail with invalid %s=5", persistIntervalEnvironmentVariableName)
+		}
+		if got, want := done(t).Stderr(), "Invalid environment variable value"; !strings.Contains(got, want) {
+			t.Errorf("expected stderr to contain %q, got:\n%s", want, got)
 		}
 	})
 }

--- a/internal/backend/local/backend_apply_test.go
+++ b/internal/backend/local/backend_apply_test.go
@@ -428,3 +428,85 @@ func TestApply_applyCanceledAutoApprove(t *testing.T) {
 	}
 
 }
+
+func TestGetEnvAsInt(t *testing.T) {
+	const testEnv = "TEST_GET_ENV_AS_INT"
+
+	t.Run("env not set returns default", func(t *testing.T) {
+		os.Unsetenv(testEnv)
+		got, diags := getEnvAsInt(testEnv, 20)
+		if diags.HasErrors() {
+			t.Fatalf("unexpected error: %s", diags.Err())
+		}
+		if got != 20 {
+			t.Errorf("got %d, want 20", got)
+		}
+	})
+
+	t.Run("valid integer is parsed", func(t *testing.T) {
+		t.Setenv(testEnv, "30")
+		got, diags := getEnvAsInt(testEnv, 20)
+		if diags.HasErrors() {
+			t.Fatalf("unexpected error: %s", diags.Err())
+		}
+		if got != 30 {
+			t.Errorf("got %d, want 30", got)
+		}
+	})
+
+	t.Run("non-integer value returns error", func(t *testing.T) {
+		t.Setenv(testEnv, "abc")
+		_, diags := getEnvAsInt(testEnv, 20)
+		if !diags.HasErrors() {
+			t.Error("expected error but got none")
+		}
+	})
+
+	t.Run("float value returns error", func(t *testing.T) {
+		t.Setenv(testEnv, "1.5")
+		_, diags := getEnvAsInt(testEnv, 20)
+		if !diags.HasErrors() {
+			t.Error("expected error but got none")
+		}
+	})
+}
+
+func TestLocal_applyInvalidPersistInterval(t *testing.T) {
+	t.Run("non-integer value causes error diagnostic", func(t *testing.T) {
+		t.Setenv(persistIntervalEnvironmentVariableName, "abc")
+
+		b := TestLocal(t)
+		TestLocalProvider(t, b, "test", applyFixtureSchema())
+
+		op, done := testOperationApply(t, "./testdata/apply")
+		defer done(t)
+
+		run, err := b.Operation(context.Background(), op)
+		if err != nil {
+			t.Fatalf("unexpected error starting operation: %v", err)
+		}
+		<-run.Done()
+		if run.Result == backend.OperationSuccess {
+			t.Fatalf("expected operation to fail with invalid %s=abc", persistIntervalEnvironmentVariableName)
+		}
+	})
+
+	t.Run("below minimum value causes error diagnostic", func(t *testing.T) {
+		t.Setenv(persistIntervalEnvironmentVariableName, "5")
+
+		b := TestLocal(t)
+		TestLocalProvider(t, b, "test", applyFixtureSchema())
+
+		op, done := testOperationApply(t, "./testdata/apply")
+		defer done(t)
+
+		run, err := b.Operation(context.Background(), op)
+		if err != nil {
+			t.Fatalf("unexpected error starting operation: %v", err)
+		}
+		<-run.Done()
+		if run.Result == backend.OperationSuccess {
+			t.Fatalf("expected operation to fail with invalid %s=5", persistIntervalEnvironmentVariableName)
+		}
+	})
+}

--- a/internal/backend/local/backend_apply_test.go
+++ b/internal/backend/local/backend_apply_test.go
@@ -432,42 +432,62 @@ func TestApply_applyCanceledAutoApprove(t *testing.T) {
 func TestGetEnvAsInt(t *testing.T) {
 	const testEnv = "TEST_GET_ENV_AS_INT"
 
-	t.Run("env not set returns default", func(t *testing.T) {
-		got, diags := getEnvAsInt(testEnv, 20)
-		if diags.HasErrors() {
-			t.Fatalf("unexpected error: %s", diags.Err())
-		}
-		if got != 20 {
-			t.Errorf("got %d, want 20", got)
-		}
-	})
+	tests := []struct {
+		name         string
+		envValue     string
+		defaultValue int
+		wantValue    int
+		wantError    bool
+	}{
+		{
+			name:         "env not set returns default",
+			envValue:     "",
+			defaultValue: 20,
+			wantValue:    20,
+			wantError:    false,
+		},
+		{
+			name:         "valid integer is parsed",
+			envValue:     "30",
+			defaultValue: 20,
+			wantValue:    30,
+			wantError:    false,
+		},
+		{
+			name:         "non-integer value returns error",
+			envValue:     "abc",
+			defaultValue: 20,
+			wantError:    true,
+		},
+		{
+			name:         "float value returns error",
+			envValue:     "1.5",
+			defaultValue: 20,
+			wantError:    true,
+		},
+	}
 
-	t.Run("valid integer is parsed", func(t *testing.T) {
-		t.Setenv(testEnv, "30")
-		got, diags := getEnvAsInt(testEnv, 20)
-		if diags.HasErrors() {
-			t.Fatalf("unexpected error: %s", diags.Err())
-		}
-		if got != 30 {
-			t.Errorf("got %d, want 30", got)
-		}
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				t.Setenv(testEnv, tt.envValue)
+			}
 
-	t.Run("non-integer value returns error", func(t *testing.T) {
-		t.Setenv(testEnv, "abc")
-		_, diags := getEnvAsInt(testEnv, 20)
-		if !diags.HasErrors() {
-			t.Error("expected error but got none")
-		}
-	})
-
-	t.Run("float value returns error", func(t *testing.T) {
-		t.Setenv(testEnv, "1.5")
-		_, diags := getEnvAsInt(testEnv, 20)
-		if !diags.HasErrors() {
-			t.Error("expected error but got none")
-		}
-	})
+			got, diags := getEnvAsInt(testEnv, tt.defaultValue)
+			if tt.wantError {
+				if !diags.HasErrors() {
+					t.Errorf("expected error but got none, value=%d", got)
+				}
+				return
+			}
+			if diags.HasErrors() {
+				t.Fatalf("unexpected error: %s", diags.Err())
+			}
+			if got != tt.wantValue {
+				t.Errorf("got %d, want %d", got, tt.wantValue)
+			}
+		})
+	}
 }
 
 func TestLocal_applyInvalidPersistInterval(t *testing.T) {

--- a/internal/backend/local/backend_apply_test.go
+++ b/internal/backend/local/backend_apply_test.go
@@ -433,7 +433,6 @@ func TestGetEnvAsInt(t *testing.T) {
 	const testEnv = "TEST_GET_ENV_AS_INT"
 
 	t.Run("env not set returns default", func(t *testing.T) {
-		os.Unsetenv(testEnv)
 		got, diags := getEnvAsInt(testEnv, 20)
 		if diags.HasErrors() {
 			t.Fatalf("unexpected error: %s", diags.Err())


### PR DESCRIPTION
Resolves #4024

## Description

When `TF_STATE_PERSIST_INTERVAL` is set to an invalid value (a non-integer string or an integer below the minimum of 20), the previous implementation called `panic()` directly. Although a `panicHandler` wraps the goroutine and prevents a raw crash, it still emits the "OPENTOFU CRASH" message — which is intended for unexpected internal bugs, not user configuration errors.

This PR replaces both `panic()` calls with `tfdiags.Sourceless` error diagnostics, consistent with how other user-facing errors are handled throughout `opApply`.

**Before:**
```
$ TF_STATE_PERSIST_INTERVAL=abc tofu apply

!!!!!!!!!!!!!!!!!!!!!!!!!!! OPENTOFU CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!
Can't parse value 'abc' of environment variable 'TF_STATE_PERSIST_INTERVAL'
...
```

**After:**
```
$ TF_STATE_PERSIST_INTERVAL=abc tofu apply

╷
│ Error: Invalid environment variable value
│
│ The environment variable TF_STATE_PERSIST_INTERVAL must be a valid integer, got "abc".
╵
```

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
