### PR TITLE
feat: display module versions in tofu version output

### DIFF
--- a/internal/command/version.go
+++ b/internal/command/version.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opentofu/opentofu/internal/command/arguments"
 	"github.com/opentofu/opentofu/internal/command/views"
 	"github.com/opentofu/opentofu/internal/getproviders"
+	"github.com/opentofu/opentofu/internal/modsdir"
 )
 
 // VersionCommand is a Command implementation prints the version.
@@ -75,7 +76,20 @@ func (c *VersionCommand) Run(rawArgs []string) int {
 			providerVersions[providerAddr.String()] = lock.Version().String()
 		}
 	}
-	if !view.PrintVersion(c.Version, c.VersionPrerelease, c.Platform.String(), fips140.Enabled(), providerVersions) {
+
+	// We'll also attempt to print out installed module versions. We read
+	// these from the modules manifest file in the data directory. Only
+	// modules sourced from a registry will have a version recorded.
+	moduleVersions := map[string]string{}
+	if manifest, err := modsdir.ReadManifestSnapshotForDir(c.WorkingDir.ModulesDir()); err == nil {
+		for _, record := range manifest {
+			if record.Version != nil && record.SourceAddr != "" {
+				moduleVersions[record.SourceAddr] = record.Version.String()
+			}
+		}
+	}
+
+	if !view.PrintVersion(c.Version, c.VersionPrerelease, c.Platform.String(), fips140.Enabled(), providerVersions, moduleVersions) {
 		return 1
 	}
 	return 0

--- a/internal/command/version_test.go
+++ b/internal/command/version_test.go
@@ -7,8 +7,12 @@ package command
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	version "github.com/hashicorp/go-version"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/mitchellh/cli"
@@ -17,6 +21,7 @@ import (
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/depsfile"
 	"github.com/opentofu/opentofu/internal/getproviders"
+	"github.com/opentofu/opentofu/internal/modsdir"
 )
 
 func TestVersionCommand_implements(t *testing.T) {
@@ -178,6 +183,140 @@ func TestVersion_json(t *testing.T) {
   "provider_selections": {
     "registry.opentofu.org/hashicorp/test1": "7.8.9-beta.2",
     "registry.opentofu.org/hashicorp/test2": "1.2.3"
+  }
+}
+`)
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Fatalf("wrong output\n%s", diff)
+	}
+}
+
+func TestVersion_withModules(t *testing.T) {
+	td := t.TempDir()
+	t.Chdir(td)
+
+	// Create a modules manifest in the data directory so the version command
+	// can find and display module versions.
+	modsDir := filepath.Join(td, ".terraform", "modules")
+	if err := os.MkdirAll(modsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := modsdir.Manifest{
+		"vpc": {
+			Key:        "vpc",
+			SourceAddr: "registry.opentofu.org/namespace/vpc/aws",
+			Version:    version.Must(version.NewVersion("3.5.0")),
+			Dir:        ".terraform/modules/vpc",
+		},
+		"": {
+			// The root module entry has no source and no version.
+			Key: "",
+			Dir: ".",
+		},
+		"local_mod": {
+			// A local module with no version.
+			Key:        "local_mod",
+			SourceAddr: "./modules/local",
+			Dir:        "modules/local",
+		},
+	}
+	if err := manifest.WriteSnapshotToDir(modsDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Also set up a provider lock file.
+	locks := depsfile.NewLocks()
+	locks.SetProvider(
+		addrs.NewDefaultProvider("test1"),
+		getproviders.MustParseVersion("1.0.0"),
+		nil,
+		nil,
+	)
+
+	view, done := testView(t)
+	c := &VersionCommand{
+		Meta: Meta{
+			WorkingDir: workdir.NewDir("."),
+			View:       view,
+		},
+		Version:  "4.5.6",
+		Platform: getproviders.Platform{OS: "linux", Arch: "amd64"},
+	}
+	if err := c.replaceLockedDependencies(context.Background(), locks); err != nil {
+		t.Fatal(err)
+	}
+
+	code := c.Run([]string{})
+	output := done(t)
+	if code != 0 {
+		t.Fatalf("bad: \n%s", output.Stderr())
+	}
+
+	actual := strings.TrimSpace(output.Stdout())
+	expected := "OpenTofu v4.5.6\non linux_amd64\n+ provider registry.opentofu.org/hashicorp/test1 v1.0.0\n+ module registry.opentofu.org/namespace/vpc/aws v3.5.0"
+	if actual != expected {
+		t.Fatalf("wrong output\ngot:\n%s\nwant:\n%s", actual, expected)
+	}
+}
+
+func TestVersion_jsonWithModules(t *testing.T) {
+	td := t.TempDir()
+	t.Chdir(td)
+
+	// Create a modules manifest in the data directory.
+	modsDir := filepath.Join(td, ".terraform", "modules")
+	if err := os.MkdirAll(modsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := modsdir.Manifest{
+		"iam": {
+			Key:        "iam",
+			SourceAddr: "registry.opentofu.org/namespace/iam/aws",
+			Version:    version.Must(version.NewVersion("1.4.2")),
+			Dir:        ".terraform/modules/iam",
+		},
+	}
+	if err := manifest.WriteSnapshotToDir(modsDir); err != nil {
+		t.Fatal(err)
+	}
+
+	locks := depsfile.NewLocks()
+	locks.SetProvider(
+		addrs.NewDefaultProvider("test1"),
+		getproviders.MustParseVersion("2.0.0"),
+		nil,
+		nil,
+	)
+
+	view, done := testView(t)
+	c := &VersionCommand{
+		Meta: Meta{
+			WorkingDir: workdir.NewDir("."),
+			View:       view,
+		},
+		Version:  "4.5.6",
+		Platform: getproviders.Platform{OS: "linux", Arch: "amd64"},
+	}
+	if err := c.replaceLockedDependencies(context.Background(), locks); err != nil {
+		t.Fatal(err)
+	}
+
+	code := c.Run([]string{"-json"})
+	output := done(t)
+	if code != 0 {
+		t.Fatalf("bad: \n%s", output.Stderr())
+	}
+
+	actual := strings.TrimSpace(output.Stdout())
+	expected := strings.TrimSpace(`
+{
+  "terraform_version": "4.5.6",
+  "platform": "linux_amd64",
+  "provider_selections": {
+    "registry.opentofu.org/hashicorp/test1": "2.0.0"
+  },
+  "module_selections": {
+    "registry.opentofu.org/namespace/iam/aws": "1.4.2"
   }
 }
 `)

--- a/internal/command/views/version.go
+++ b/internal/command/views/version.go
@@ -19,7 +19,7 @@ import (
 type Version interface {
 	Diagnostics(diags tfdiags.Diagnostics)
 	// PrintVersion returns true if the printing has been done successfully and false otherwise.
-	PrintVersion(version string, versionPrerelease string, platform string, fipsEnabled bool, providerVersions map[string]string) bool
+	PrintVersion(version string, versionPrerelease string, platform string, fipsEnabled bool, providerVersions map[string]string, moduleVersions map[string]string) bool
 }
 
 // NewVersion returns an initialized Version implementation for the given ViewType.
@@ -43,14 +43,14 @@ func (v *VersionMixed) Diagnostics(diags tfdiags.Diagnostics) {
 	v.view.Diagnostics(diags)
 }
 
-func (v *VersionMixed) PrintVersion(version string, versionPrerelease string, platform string, fipsEnabled bool, providerVersions map[string]string) bool {
+func (v *VersionMixed) PrintVersion(version string, versionPrerelease string, platform string, fipsEnabled bool, providerVersions map[string]string, moduleVersions map[string]string) bool {
 	if v.json {
-		return v.printJsonVersion(version, versionPrerelease, platform, fipsEnabled, providerVersions)
+		return v.printJsonVersion(version, versionPrerelease, platform, fipsEnabled, providerVersions, moduleVersions)
 	}
-	return v.printHumanVersion(version, versionPrerelease, platform, fipsEnabled, providerVersions)
+	return v.printHumanVersion(version, versionPrerelease, platform, fipsEnabled, providerVersions, moduleVersions)
 }
 
-func (v *VersionMixed) printJsonVersion(version string, versionPrerelease string, platform string, fipsEnabled bool, providerVersions map[string]string) bool {
+func (v *VersionMixed) printJsonVersion(version string, versionPrerelease string, platform string, fipsEnabled bool, providerVersions map[string]string, moduleVersions map[string]string) bool {
 	finalVersion := version
 	if versionPrerelease != "" {
 		finalVersion = fmt.Sprintf("%s-%s", finalVersion, versionPrerelease)
@@ -60,6 +60,7 @@ func (v *VersionMixed) printJsonVersion(version string, versionPrerelease string
 		Version:            finalVersion,
 		Platform:           platform,
 		ProviderSelections: providerVersions,
+		ModuleSelections:   moduleVersions,
 		FIPS140Enabled:     fipsEnabled,
 	}
 	jsonOutput, err := json.MarshalIndent(output, "", "  ")
@@ -71,7 +72,7 @@ func (v *VersionMixed) printJsonVersion(version string, versionPrerelease string
 	return true
 }
 
-func (v *VersionMixed) printHumanVersion(version string, versionPrerelease string, platform string, fipsEnabled bool, providerVersions map[string]string) bool {
+func (v *VersionMixed) printHumanVersion(version string, versionPrerelease string, platform string, fipsEnabled bool, providerVersions map[string]string, moduleVersions map[string]string) bool {
 	formattedVersion := fmt.Sprintf("OpenTofu v%s", version)
 	if versionPrerelease != "" {
 		formattedVersion = fmt.Sprintf("%s-%s", formattedVersion, versionPrerelease)
@@ -95,6 +96,16 @@ func (v *VersionMixed) printHumanVersion(version string, versionPrerelease strin
 			_, _ = v.view.streams.Println(fmt.Sprintf("+ provider %s v%s", provAddr, provVers))
 		}
 	}
+
+	moduleAddrs := slices.Collect(maps.Keys(moduleVersions))
+	sort.Strings(moduleAddrs)
+	for _, modAddr := range moduleAddrs {
+		modVers, ok := moduleVersions[modAddr]
+		if !ok {
+			continue
+		}
+		_, _ = v.view.streams.Println(fmt.Sprintf("+ module %s v%s", modAddr, modVers))
+	}
 	return true
 }
 
@@ -103,4 +114,5 @@ type versionOutput struct {
 	Platform           string            `json:"platform"`
 	FIPS140Enabled     bool              `json:"fips140,omitempty"`
 	ProviderSelections map[string]string `json:"provider_selections"`
+	ModuleSelections   map[string]string `json:"module_selections,omitempty"`
 }

--- a/internal/command/views/version_test.go
+++ b/internal/command/views/version_test.go
@@ -25,7 +25,7 @@ func TestVersionViews(t *testing.T) {
 			viewCall: func(v Version) {
 				v.PrintVersion("0.1.0", "dev", "darwin_arm64", false, map[string]string{
 					"registry.opentofu.org/test/test": "0.2.0",
-				})
+				}, nil)
 			},
 			wantStdout: `OpenTofu v0.1.0-dev
 on darwin_arm64
@@ -38,7 +38,7 @@ on darwin_arm64
 			viewCall: func(v Version) {
 				v.PrintVersion("0.1.0", "dev", "darwin_arm64", true, map[string]string{
 					"registry.opentofu.org/test/test": "0.2.0",
-				})
+				}, nil)
 			},
 			wantStdout: `OpenTofu v0.1.0-dev
 on darwin_arm64
@@ -52,11 +52,27 @@ running in FIPS 140-3 mode (not yet supported)
 			viewCall: func(v Version) {
 				v.PrintVersion("0.1.0", "dev", "darwin_arm64", false, map[string]string{
 					"registry.opentofu.org/test/test": "0.0.0",
-				})
+				}, nil)
 			},
 			wantStdout: `OpenTofu v0.1.0-dev
 on darwin_arm64
 + provider registry.opentofu.org/test/test (unversioned)
+`,
+			wantStderr: "",
+		},
+		"human printVersion with modules": {
+			viewType: arguments.ViewHuman,
+			viewCall: func(v Version) {
+				v.PrintVersion("0.1.0", "dev", "darwin_arm64", false, map[string]string{
+					"registry.opentofu.org/test/test": "0.2.0",
+				}, map[string]string{
+					"registry.opentofu.org/namespace/iam/aws": "1.4.2",
+				})
+			},
+			wantStdout: `OpenTofu v0.1.0-dev
+on darwin_arm64
++ provider registry.opentofu.org/test/test v0.2.0
++ module registry.opentofu.org/namespace/iam/aws v1.4.2
 `,
 			wantStderr: "",
 		},
@@ -65,7 +81,7 @@ on darwin_arm64
 			viewCall: func(v Version) {
 				v.PrintVersion("0.1.0", "dev", "darwin_arm64", false, map[string]string{
 					"registry.opentofu.org/test/test": "0.2.0",
-				})
+				}, nil)
 			},
 			wantStdout: `{
   "terraform_version": "0.1.0-dev",
@@ -82,7 +98,7 @@ on darwin_arm64
 			viewCall: func(v Version) {
 				v.PrintVersion("0.1.0", "dev", "darwin_arm64", true, map[string]string{
 					"registry.opentofu.org/test/test": "0.2.0",
-				})
+				}, nil)
 			},
 			wantStdout: `{
   "terraform_version": "0.1.0-dev",
@@ -100,13 +116,35 @@ on darwin_arm64
 			viewCall: func(v Version) {
 				v.PrintVersion("0.1.0", "dev", "darwin_arm64", false, map[string]string{
 					"registry.opentofu.org/test/test": "0.0.0",
-				})
+				}, nil)
 			},
 			wantStdout: `{
   "terraform_version": "0.1.0-dev",
   "platform": "darwin_arm64",
   "provider_selections": {
     "registry.opentofu.org/test/test": "0.0.0"
+  }
+}
+`,
+			wantStderr: "",
+		},
+		"json printVersion with modules": {
+			viewType: arguments.ViewJSON,
+			viewCall: func(v Version) {
+				v.PrintVersion("0.1.0", "dev", "darwin_arm64", false, map[string]string{
+					"registry.opentofu.org/test/test": "0.2.0",
+				}, map[string]string{
+					"registry.opentofu.org/namespace/iam/aws": "1.4.2",
+				})
+			},
+			wantStdout: `{
+  "terraform_version": "0.1.0-dev",
+  "platform": "darwin_arm64",
+  "provider_selections": {
+    "registry.opentofu.org/test/test": "0.2.0"
+  },
+  "module_selections": {
+    "registry.opentofu.org/namespace/iam/aws": "1.4.2"
   }
 }
 `,


### PR DESCRIPTION
## Summary

- Reads installed module versions from `.terraform/modules/modules.json` (the modules manifest) and displays them in `tofu version` output, alongside provider versions.
- Only registry-sourced modules with a recorded version are shown; local/unversioned modules are excluded.
- Supports both human-readable output (`+ module <source> v<version>`) and JSON output (`"module_selections": { ... }`), with `module_selections` omitted from JSON when empty.

Closes #3270

## Changes

- **`internal/command/version.go`**: Added module version collection from the modules manifest via `modsdir.ReadManifestSnapshotForDir`, filtering to only include records with a non-nil version and non-empty source address.
- **`internal/command/views/version.go`**: Extended `PrintVersion` interface and implementation to accept and render `moduleVersions`. Added `module_selections` field to JSON output struct with `omitempty`.
- **`internal/command/version_test.go`**: Added `TestVersion_withModules` and `TestVersion_jsonWithModules` covering both output formats with mixed module types (registry, local, root).
- **`internal/command/views/version_test.go`**: Added `"human printVersion with modules"` and `"json printVersion with modules"` test cases.

## Example output

Human-readable:
```
OpenTofu v1.10.6
on linux_amd64
+ provider registry.opentofu.org/hashicorp/aws v6.13.0
+ module registry.opentofu.org/namespace/iam/aws v1.4.2
```

JSON (`tofu version -json`):
```json
{
  "terraform_version": "1.10.6",
  "platform": "linux_amd64",
  "provider_selections": {
    "registry.opentofu.org/hashicorp/aws": "6.13.0"
  },
  "module_selections": {
    "registry.opentofu.org/namespace/iam/aws": "1.4.2"
  }
}
```

## Test plan

- [x] All existing version command tests pass
- [x] All existing version view tests pass
- [x] New test: human output with provider and module versions
- [x] New test: JSON output with provider and module versions
- [x] Verified local/unversioned modules are excluded from output
- [x] Verified empty module_selections is omitted from JSON output