### PR TITLE
lang/funcs: cidrsubnet now allows newbits up to 128 for IPv6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ UPGRADE NOTES:
 
 ENHANCEMENTS:
 
+- The `cidrsubnets` function now supports prefix extensions greater than 32 bits when the base CIDR block uses an IPv6 address. ([#4042](https://github.com/opentofu/opentofu/pull/4042))
 - The `local-exec` provisioner now automatically sets the `TRACEPARENT` environment variable in child processes when OpenTelemetry tracing is active, following the W3C Trace Context specification. ([#4014](https://github.com/opentofu/opentofu/issues/4014))
 
 BUG FIXES:

--- a/internal/lang/funcs/cidr.go
+++ b/internal/lang/funcs/cidr.go
@@ -163,13 +163,6 @@ var CidrSubnetsFunc = function.New(&function.Spec{
 			if length < 1 {
 				return cty.UnknownVal(cty.String), function.NewArgErrorf(i+1, "must extend prefix by at least one bit")
 			}
-			// For portability with 32-bit systems where the subnet number
-			// will be a 32-bit int, we only allow extension of 32 bits in
-			// one call even if we're running on a 64-bit machine.
-			// (Of course, this is significant only for IPv6.)
-			if length > 32 {
-				return cty.UnknownVal(cty.String), function.NewArgErrorf(i+1, "may not extend prefix by more than 32 bits")
-			}
 			length += startPrefixLen
 			if length > (len(network.IP) * 8) {
 				protocol := "IP"

--- a/internal/lang/funcs/cidr_test.go
+++ b/internal/lang/funcs/cidr_test.go
@@ -311,6 +311,38 @@ func TestCidrSubnets(t *testing.T) {
 			``,
 		},
 		{
+			cty.StringVal("2001:0db8:0102:0304::/64"),
+			[]cty.Value{
+				cty.NumberIntVal(32),
+				cty.NumberIntVal(56),
+				cty.NumberIntVal(63),
+				cty.NumberIntVal(64),
+			},
+			cty.ListVal([]cty.Value{
+				cty.StringVal("2001:db8:102:304::/96"),
+				cty.StringVal("2001:db8:102:304:0:1::/120"),
+				cty.StringVal("2001:db8:102:304:0:1:0:100/127"),
+				cty.StringVal("2001:db8:102:304:0:1:0:102/128"),
+			}),
+			``,
+		},
+		{
+			cty.StringVal("2001:db8:1100::/56"),
+			[]cty.Value{
+				cty.NumberIntVal(8),
+				cty.NumberIntVal(8),
+				cty.NumberIntVal(8),
+				cty.NumberIntVal(8),
+			},
+			cty.ListVal([]cty.Value{
+				cty.StringVal("2001:db8:1100::/64"),
+				cty.StringVal("2001:db8:1100:1::/64"),
+				cty.StringVal("2001:db8:1100:2::/64"),
+				cty.StringVal("2001:db8:1100:3::/64"),
+			}),
+			``,
+		},
+		{
 			// We inadvertently inherited a pre-Go1.17 standard library quirk
 			// if parsing zero-prefix parts as decimal rather than octal.
 			// Go 1.17 resolved that quirk by making zero-prefix invalid, but
@@ -337,6 +369,22 @@ func TestCidrSubnets(t *testing.T) {
 			`would extend prefix to 33 bits, which is too long for an IPv4 address`,
 		},
 		{
+			cty.StringVal("2001:db8:ffff::/127"),
+			[]cty.Value{
+				cty.NumberIntVal(2),
+			},
+			cty.UnknownVal(cty.List(cty.String)),
+			`would extend prefix to 129 bits, which is too long for an IPv6 address`,
+		},
+		{
+			cty.StringVal("::/1"),
+			[]cty.Value{
+				cty.NumberIntVal(129),
+			},
+			cty.UnknownVal(cty.List(cty.String)),
+			`would extend prefix to 130 bits, which is too long for an IPv6 address`,
+		},
+		{
 			cty.StringVal("10.0.0.0/8"),
 			[]cty.Value{
 				cty.NumberIntVal(1),
@@ -345,6 +393,18 @@ func TestCidrSubnets(t *testing.T) {
 			},
 			cty.UnknownVal(cty.List(cty.String)),
 			`not enough remaining address space for a subnet with a prefix of 9 bits after 10.128.0.0/9`,
+		},
+		{
+			cty.StringVal("2001:db8:1100::/125"),
+			[]cty.Value{
+				cty.NumberIntVal(2),
+				cty.NumberIntVal(2),
+				cty.NumberIntVal(2),
+				cty.NumberIntVal(2),
+				cty.NumberIntVal(2),
+			},
+			cty.UnknownVal(cty.List(cty.String)),
+			`not enough remaining address space for a subnet with a prefix of 127 bits after 2001:db8:1100::6/127`,
 		},
 		{
 			cty.StringVal("10.0.0.0/8"),
@@ -363,15 +423,6 @@ func TestCidrSubnets(t *testing.T) {
 			},
 			cty.UnknownVal(cty.List(cty.String)),
 			`must extend prefix by at least one bit`,
-		},
-		{
-			cty.StringVal("fe80::/48"),
-			[]cty.Value{
-				cty.NumberIntVal(1),
-				cty.NumberIntVal(33),
-			},
-			cty.UnknownVal(cty.List(cty.String)),
-			`may not extend prefix by more than 32 bits`,
 		},
 	}
 


### PR DESCRIPTION
The original design for this function seems to have mistakenly thought that the upstream library used to implement the calculations could not accept newbits>32, perhaps due to that having been true for some of its other functions in an earlier release.

However, this restriction is not needed in the current version of the upstream library: it performs its calculations on a byte-by-byte basis treating the IP address as a byte-slice, rather than using the Go "int" type.

Closes https://github.com/opentofu/opentofu/issues/4040.
