### PR TITLE
backend/local: diagnose bad TF_STATE_PERSIST_INTERVAL, don't panic

### DIFF
--- a/internal/backend/local/backend_apply.go
+++ b/internal/backend/local/backend_apply.go
@@ -34,15 +34,23 @@ const (
 	persistIntervalEnvironmentVariableName = "TF_STATE_PERSIST_INTERVAL"
 )
 
-func getEnvAsInt(envName string, defaultValue int) int {
-	if val, exists := os.LookupEnv(envName); exists {
-		parsedVal, err := strconv.Atoi(val)
-		if err == nil {
-			return parsedVal
-		}
-		panic(fmt.Sprintf("Can't parse value '%s' of environment variable '%s'", val, envName))
+// getEnvAsInt reads the named environment variable and parses it as an
+// int, falling back to defaultValue when the variable is unset. It
+// returns an error (rather than panicking) when the value is set but
+// cannot be parsed as an int, so the caller can surface the problem to
+// the user through the normal diagnostics channel instead of tripping
+// the panicHandler and producing an alarming "OPENTOFU CRASH"
+// message for what is really just a bad user input.
+func getEnvAsInt(envName string, defaultValue int) (int, error) {
+	val, exists := os.LookupEnv(envName)
+	if !exists {
+		return defaultValue, nil
 	}
-	return defaultValue
+	parsed, err := strconv.Atoi(val)
+	if err != nil {
+		return 0, fmt.Errorf("invalid value %q for environment variable %s: %w", val, envName, err)
+	}
+	return parsed, nil
 }
 
 func (b *Local) opApply(
@@ -112,10 +120,26 @@ func (b *Local) opApply(
 	// stateHook uses schemas for when it periodically persists state to the
 	// persistent storage backend.
 	stateHook.Schemas = schemas
-	persistInterval := getEnvAsInt(persistIntervalEnvironmentVariableName, defaultPersistInterval)
+	persistInterval, err := getEnvAsInt(persistIntervalEnvironmentVariableName, defaultPersistInterval)
+	if err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			fmt.Sprintf("Invalid %s", persistIntervalEnvironmentVariableName),
+			fmt.Sprintf("%s must be an integer >= %d. %s",
+				persistIntervalEnvironmentVariableName, defaultPersistInterval, err),
+		))
+		op.ReportResult(runningOp, diags)
+		return
+	}
 	if persistInterval < defaultPersistInterval {
-		panic(fmt.Sprintf("Can't use value lower than %d for env variable %s, got %d",
-			defaultPersistInterval, persistIntervalEnvironmentVariableName, persistInterval))
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			fmt.Sprintf("Invalid %s", persistIntervalEnvironmentVariableName),
+			fmt.Sprintf("%s must be an integer >= %d (the minimum interval in seconds between state persistence checkpoints). Got %d.",
+				persistIntervalEnvironmentVariableName, defaultPersistInterval, persistInterval),
+		))
+		op.ReportResult(runningOp, diags)
+		return
 	}
 	stateHook.PersistInterval = time.Duration(persistInterval) * time.Second
 


### PR DESCRIPTION
Fixes #4024.

## Problem

A mistyped `TF_STATE_PERSIST_INTERVAL` (non-integer, or an integer below `20`) makes `tofu apply` / `tofu destroy` bail out with the full CRASH banner:

```
OPENTOFU CRASH
...
panic: Can't parse value 'abc' of environment variable 'TF_STATE_PERSIST_INTERVAL'
```

because both the parse path and the below-minimum check in `internal/backend/local/backend_apply.go` call `panic()` directly:

```go
panic(fmt.Sprintf("Can't parse value '%s' of environment variable '%s'", val, envName))
...
panic(fmt.Sprintf("Can't use value lower than %d for env variable %s, got %d", ...))
```

The `panicHandler` converts the raw Go panic into the CRASH banner, but that banner is meant for unexpected internal bugs, not ordinary user-input mistakes. It also gives the user no direct hint about how to fix the variable.

## Fix

- `getEnvAsInt` now returns `(int, error)` instead of panicking on parse failure.
- In `opApply`, both failure modes (parse error, value < `defaultPersistInterval`) surface through the regular diagnostics path:

```go
persistInterval, err := getEnvAsInt(persistIntervalEnvironmentVariableName, defaultPersistInterval)
if err != nil {
    diags = diags.Append(tfdiags.Sourceless(
        tfdiags.Error,
        "Invalid TF_STATE_PERSIST_INTERVAL",
        fmt.Sprintf("%s must be an integer >= %d. %s", ...),
    ))
    op.ReportResult(runningOp, diags)
    return
}
if persistInterval < defaultPersistInterval {
    // similar Sourceless diagnostic
}
```

The user now sees a normal

```
│ Error: Invalid TF_STATE_PERSIST_INTERVAL
│
│ TF_STATE_PERSIST_INTERVAL must be an integer >= 20 (the minimum
│ interval in seconds between state persistence checkpoints). Got 5.
```

diagnostic and a non-zero exit status, instead of the CRASH banner.

## Scope

Single file (`internal/backend/local/backend_apply.go`), the only caller of `getEnvAsInt`. No behaviour change when `TF_STATE_PERSIST_INTERVAL` is unset or valid; the only observable change is that the two previously panicking paths now emit a diagnostic and exit cleanly.

Signed off per DCO.
