### PR TITLE
Warn when relying on non-default GODEBUG values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ ENHANCEMENTS:
 
 - The `cidrsubnets` function now supports prefix extensions greater than 32 bits when the base CIDR block uses an IPv6 address. ([#4042](https://github.com/opentofu/opentofu/pull/4042))
 - The `local-exec` provisioner now automatically sets the `TRACEPARENT` environment variable in child processes when OpenTelemetry tracing is active, following the W3C Trace Context specification. ([#4014](https://github.com/opentofu/opentofu/issues/4014))
+- Some commands now produce warning diagnostics when execution relied on various workarounds in the Go runtime library ("GODEBUG" settings), encouraging the reader to report any situations where those workarounds are necessary so that we can identify a more sustainable solution, because these workarounds can be removed or change behavior in future versions of Go outside of our control and are not covered by OpenTofu's compatibility promises. ([#4049](https://github.com/opentofu/opentofu/pull/4049))
 
 BUG FIXES:
 

--- a/cmd/tofu/main.go
+++ b/cmd/tofu/main.go
@@ -339,12 +339,6 @@ func realMain() int {
 		return 1
 	}
 
-	// We might generate some additional log lines if OpenTofu relied on any
-	// non-default Go runtime behaviors enabled by GODEBUG settings, because
-	// they might be relevant when trying to reproduce certain problems for
-	// debugging or bug reporting purposes.
-	logGodebugUsage()
-
 	// if we are exiting with a non-zero code, check if it was caused by any
 	// plugins crashing
 	if exitCode != 0 {

--- a/cmd/tofu/version.go
+++ b/cmd/tofu/version.go
@@ -6,62 +6,9 @@
 package main
 
 import (
-	"log"
-	"runtime/metrics"
-	"strings"
-
-	"github.com/opentofu/opentofu/internal/logging"
 	"github.com/opentofu/opentofu/version"
 )
 
 var Version = version.Version
 
 var VersionPrerelease = version.Prerelease
-
-// logGodebugUsage produces extra DEBUG log lines if the Go runtime's metrics
-// suggest that code that was run so far relied on any non-default "GODEBUG"
-// settings, which could be helpful in reproducing a bug report if the
-// behavior differs based on such a setting.
-//
-// For this to be useful it must be run just before we're about to exit, after
-// we've already performed all of the requested work.
-func logGodebugUsage() {
-	// These constants reflect the documented conventions from the
-	// runtime/metrics package, so we can filter for only the metrics that
-	// are relevant to this function.
-	const godebugMetricPrefix = "/godebug/non-default-behavior/"
-	const godebugMetricSuffix = ":events"
-
-	if !logging.IsDebugOrHigher() {
-		// No point in doing any of this work if the log lines are going to
-		// be filtered out anyway.
-		return
-	}
-
-	metricDescs := metrics.All()
-	for _, metric := range metricDescs {
-		if !metric.Cumulative || metric.Kind != metrics.KindUint64 {
-			// godebug counters are always cumulative uint64, so this quickly
-			// filters some irrelevant metrics before we do any string
-			// comparisons.
-			continue
-		}
-		if !strings.HasPrefix(metric.Name, godebugMetricPrefix) {
-			continue // irrelevant metric
-		}
-		if !strings.HasSuffix(metric.Name, godebugMetricSuffix) {
-			continue // irrelevant metric
-		}
-		// The metrics API is designed for applications that want to periodically
-		// re-extract the same set of metrics in a long-running application by
-		// reusing a preallocated buffer, but we don't have that need here and so
-		// we'll just read one metric at a time into a single-element array.
-		var samples [1]metrics.Sample
-		samples[0].Name = metric.Name
-		metrics.Read(samples[:])
-		if count := samples[0].Value.Uint64(); count != 0 {
-			name := metric.Name[len(godebugMetricPrefix) : len(metric.Name)-len(godebugMetricSuffix)]
-			log.Printf("[DEBUG] Relied on GODEBUG %q %d times during this execution; behavior might change in future OpenTofu versions", name, count)
-		}
-	}
-}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.26.2
 // In go1.23 the godebug flag for this was named 'tlskyber', renamed in go1.24 to 'tlsmlkem'. https://tip.golang.org/doc/godebug#go-124
 godebug (
 	tlsmlkem=0
-	winsymlink=0 // See https://github.com/opentofu/opentofu/pull/3289
+	//winsymlink=0 // See https://github.com/opentofu/opentofu/pull/3289
 )
 
 require (

--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -122,10 +122,20 @@ func (c *ApplyCommand) Run(rawArgs []string) int {
 
 	// Run the operation
 	op, diags := c.RunOperation(ctx, be, opReq)
+
+	// Applying is one of the operations most likely to activate Go runtime
+	// behavior that's affected by GODEBUG, so we'll take this opportunity
+	// to warn about any reliance on non-default runtime behavior so that
+	// hopefully folks will report problems to us while their workaround is
+	// still available, instead of waiting until the workaround gets removed
+	// in a later Go releases.
+	diags = diags.Append(c.godebugUsageWarnings())
+
 	view.Diagnostics(diags)
 	if diags.HasErrors() {
 		return 1
 	}
+	diags = nil // avoid re-reporting any warnings below
 
 	if op.Result != backend.OperationSuccess {
 		return op.Result.ExitStatus()

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -341,6 +341,14 @@ To initialize the configuration already in this working directory, omit the
 		view.OutputNewline()
 	}
 
+	// Initialization is one of the operations most likely to activate Go
+	// runtime behavior that's affected by GODEBUG, so we'll take this
+	// opportunity to warn about any reliance on non-default runtime behavior so
+	// that hopefully folks will report problems to us while their workaround is
+	// still available, instead of waiting until the workaround gets removed
+	// in a later Go releases.
+	diags = diags.Append(c.godebugUsageWarnings())
+
 	// If we accumulated any warnings along the way that weren't accompanied
 	// by errors then we'll output them here so that the success message is
 	// still the final thing shown.

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -115,6 +115,7 @@ func TestInit_fromModule_cwdDest(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("unexpected error\n%s", output.Stderr())
 	}
+	t.Logf("output from init with %#v:\n%s", args, output.All())
 
 	if _, err := os.Stat(filepath.Join(td, "hello.tf")); err != nil {
 		t.Fatalf("err: %s", err)

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/go-retryablehttp"
-	"github.com/opentofu/opentofu/internal/command/flags"
 	"github.com/opentofu/svchost/disco"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -27,6 +26,7 @@ import (
 	"github.com/opentofu/opentofu/internal/backend/local"
 	"github.com/opentofu/opentofu/internal/command/arguments"
 	"github.com/opentofu/opentofu/internal/command/clistate"
+	"github.com/opentofu/opentofu/internal/command/flags"
 	"github.com/opentofu/opentofu/internal/command/views"
 	"github.com/opentofu/opentofu/internal/command/webbrowser"
 	"github.com/opentofu/opentofu/internal/command/workdir"
@@ -40,6 +40,7 @@ import (
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/opentofu/opentofu/internal/tofu"
+	"github.com/opentofu/opentofu/version"
 )
 
 // Meta are the meta-options that are available on all or most commands.
@@ -517,6 +518,64 @@ func (m *Meta) confirm(opts *tofu.InputOpts) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// godebugUsageWarnings returns zero or more warning diagnostics describing
+// non-default GODEBUG settings that have been previously relied on in earlier
+// execution before calling this function.
+//
+// These warnings encourage the reader to report to the OpenTofu team if they
+// find themselves relying on any GODEBUG settings, because the availability
+// and behavior of GODEBUG settings is subject to change outside our control
+// as we upgrade to newer versions of Go and so we want to deal with any
+// reliance on them early before it becomes a breaking change for the user in
+// a future version.
+//
+// Note that this can only report about the subset of GODEBUG keys for which
+// the runtime generates usage metrics. Some GODEBUG keys instead just directly
+// modify the runtime behavior without attempting the unmodified behavior first,
+// and those ones will never be mentioned here. The ones that cannot report
+// metrics are classified as "Opaque" in the table of possible godebug settings:
+//
+//	https://github.com/golang/go/blob/master/src/internal/godebugs/table.go
+func (m *Meta) godebugUsageWarnings() tfdiags.Diagnostics {
+	const summary = "Relying on unsupported Go runtime behavior"
+
+	var diags tfdiags.Diagnostics
+	for name, reportURL := range version.GodebugActivations() {
+		if reportURL != "" {
+			// This particular key name is one we had intentionally enabled
+			// to defer a breaking change from upstream Go, and so we have
+			// a dedicated place set aside to discuss reliance of it that
+			// we'll mention in the diagnostic message.
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Warning,
+				summary,
+				fmt.Sprintf(
+					"This execution of OpenTofu relied on a Go runtime workaround named %q, which is not officially supported and may be removed without notice in a future version.\n\nIf you cannot avoid relying on this workaround, please tell us more about your situation at:\n    %s",
+					name, reportURL,
+				),
+			))
+			continue
+		}
+		// This is _not_ a GODEBUG key we're expecting to encounter, and so
+		// presumably the end-user opted in to this themselves by setting
+		// the GODEBUG environment variable. Since we're never testing OpenTofu
+		// with non-default GODEBUG settings and they change outside of our
+		// control we won't be able to guarantee preserving that behavior in
+		// future releases and so we'll just make a general request for the
+		// operator to tell us what's going on for them so we can hopefully
+		// give them an officially-supported solution to their problem.
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Warning,
+			summary,
+			fmt.Sprintf(
+				"This execution of OpenTofu relied on a Go runtime workaround named %q, which is not officially supported and may be removed without notice in a future version.\n\nIf you cannot avoid relying on this workaround, please report an issue to the OpenTofu project describing your situation so we can find a more sustainable solution to this problem.",
+				name,
+			),
+		))
+	}
+	return diags
 }
 
 // WorkspaceNameEnvVar is the name of the environment variable that can be used

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -104,6 +104,15 @@ func (c *PlanCommand) Run(rawArgs []string) int {
 
 	// Perform the operation
 	op, diags := c.RunOperation(ctx, be, opReq)
+
+	// Planning is one of the operations most likely to activate Go runtime
+	// behavior that's affected by GODEBUG, so we'll take this opportunity
+	// to warn about any reliance on non-default runtime behavior so that
+	// hopefully folks will report problems to us while their workaround is
+	// still available, instead of waiting until the workaround gets removed
+	// in a later Go releases.
+	diags = diags.Append(c.godebugUsageWarnings())
+
 	view.Diagnostics(diags)
 	if diags.HasErrors() {
 		return 1

--- a/version/dependencies.go
+++ b/version/dependencies.go
@@ -5,7 +5,12 @@
 
 package version
 
-import "runtime/debug"
+import (
+	"iter"
+	"runtime/debug"
+	"runtime/metrics"
+	"strings"
+)
 
 // See the docs for InterestingDependencies to understand what "interesting" is
 // intended to mean here. We should keep this set relatively small to avoid
@@ -48,4 +53,70 @@ func InterestingDependencies() []*debug.Module {
 	}
 
 	return ret
+}
+
+var godebugPhaseoutURLs = map[string]string{
+	// We added this because Go fixed what was arguably a bug -- interpreting
+	// any NTFS reparse point as a symlink, rather than only symlink reparse
+	// points -- which we worried that existing OpenTofu users might nonetheless
+	// be relying on. However, we're not sure if anyone is actually relying
+	// on it so we'd like folks to tell us if they are.
+	"winsymlink": "https://github.com/opentofu/opentofu/issues/3415",
+
+	// "tlsmlkem" is another GODEBUG setting we've explicitly overridden in
+	// OpenTofu releases, but that one doesn't generate any usage metrics
+	// because it just reduces the set of algorithms offered to the remote
+	// party during TLS negotiation and so we don't get any signal about
+	// whether the request could've worked without that reduced algorithm set.
+}
+
+// GodebugActivations returns a sequence the keys of GODEBUG values that were
+// set to non-default values and then relied on at any point in the current
+// execution before calling this function.
+//
+// Only the subset of GODEBUG keys that have usage metrics tracked by the Go
+// runtime can be returned by this function. Each one is returned with an
+// optional string containing a URL where we'd like anyone relying on that
+// key to tell us about it so that we can work with them to no longer depend
+// on keys that we're intending to remove in a future release. Items whose
+// second result is empty are still unexpected, but are not expected unless
+// the operator has used the GODEBUG environment variable to change the Go
+// runtime behavior in ways that we don't officially support.
+func GodebugActivations() iter.Seq2[string, string] {
+	// These constants reflect the documented conventions from the
+	// runtime/metrics package, so we can filter for only the metrics that
+	// are relevant to this function.
+	const godebugMetricPrefix = "/godebug/non-default-behavior/"
+	const godebugMetricSuffix = ":events"
+
+	return func(yield func(string, string) bool) {
+		for _, metric := range metrics.All() {
+			if !metric.Cumulative || metric.Kind != metrics.KindUint64 {
+				// godebug counters are always cumulative uint64, so this quickly
+				// filters some irrelevant metrics before we do any string
+				// comparisons.
+				continue
+			}
+			if !strings.HasPrefix(metric.Name, godebugMetricPrefix) {
+				continue // irrelevant metric
+			}
+			if !strings.HasSuffix(metric.Name, godebugMetricSuffix) {
+				continue // irrelevant metric
+			}
+			// The metrics API is designed for applications that want to periodically
+			// re-extract the same set of metrics in a long-running application by
+			// reusing a preallocated buffer, but we don't have that need here and so
+			// we'll just read one metric at a time into a single-element array.
+			var samples [1]metrics.Sample
+			samples[0].Name = metric.Name
+			metrics.Read(samples[:])
+			if count := samples[0].Value.Uint64(); count != 0 {
+				name := metric.Name[len(godebugMetricPrefix) : len(metric.Name)-len(godebugMetricSuffix)]
+				phaseoutURL := godebugPhaseoutURLs[name]
+				if !yield(name, phaseoutURL) {
+					return
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
This change is primarily motivated by https://github.com/opentofu/opentofu/issues/3415, implementing something like what I proposed in https://github.com/opentofu/opentofu/issues/3415#issuecomment-3999975239, but I took a broader approach there that handles _all_ `GODEBUG` settings that might be used currently or in the future, rather than just the `winsymlink` setting.

---

"GODEBUG" is a mechanism that the Go runtime forces on OpenTofu that allows dynamic changes to various nuances of Go standard library behavior.

We cannot control when GODEBUG workarounds are added and removed from Go, so if someone chooses to rely on them then they are likely to get broken by a later release of OpenTofu that uses a newer version of Go. Therefore we'd like anyone relying on these to tell us so we can try to find a more sustainable solution to their problem early on while the workaround is still available to them. This is particularly important in light of the newer policy in https://github.com/golang/go/issues/76163 which calls for the Go runtime to panic immediately on startup (before any of OpenTofu's own code runs) once a previously-supported GODEBUG key has been removed, since by that point it would be too late for us to produce a user-friendly diagnostic.

We also occasionally force certain GODEBUG workarounds on by default in our official builds in anticipation of breakage caused by upstream Go changes. In that case we'd still like to know if anyone is relying on them so that we can remove those workarounds in a future release, but we'd prefer to get the reports about it in an issue or discussion we'd already created for that purpose.

This therefore introduces warning diagnostics any time something in the "init", "plan", or "apply" commands relies on non-default GODEBUG settings. For ones we enabled intentionally we provide a specific URL to report usage as part of the diagnostic message, but we also have a generic message for any GODEBUG settings the user chose to enable for themselves for reasons we probably don't know about yet but would like to learn more about.

This is included in only that subset of commands as a compromise because those primary workflow commands are the most likely to interact with Go library features that are affected by these workarounds -- they most commonly affect functionality related to networking, TLS, etc -- and additional diagnostics in these locations should not to cause breakage for anyone consuming the machine-readable output, but there are other commands where additional diagnostics are more likely to cause problems.

Unfortunately it isn't really possible to unit-test this because it relies directly on information reported by the Go metrics system and there's no facility to produce fake metrics for testing. However, Go 1.26 (which we're currently using) there is a GODEBUG setting `netedns0=0` which causes a warning any time OpenTofu makes a DNS request, so I've tested this manually by running `tofu init` with that workaround enabled in a configuration that depends on at least one provider (causing DNS lookups for the provider registry) and seen it generate the expected warning message referring to "netedns0". I also temporarily modified the code to add a report URL for that key to make sure the alternate form of the diagnostic message is working as expected, and temporarily forced some DNS lookups into plan and apply to verify that the warnings are also produced by those commands when relevant.

These new warnings replace our previous quieter messages about this in the TF_LOG=warn output, because those were only useful in situations where GODEBUG was causing a problem that led to someone opening a bug report, but we actually want to know of situations where GODEBUG was needed in order for OpenTofu to _succeed_ and so for that we need more prominent messages to let the operator know there's something they ought to report to us even though there wasn't an error.

---

Although this is for https://github.com/opentofu/opentofu/issues/3415, this will not close that issue. Instead, it's intended to give us more confidence to take action on that issue during the v1.14 development period.

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [ ] ~I have added tests for all relevant use cases of my code, and those tests are passing.~ (see above)
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
