### PR TITLE
configs: add source attribute to mock_provider for .tfmock.hcl files

### DIFF
--- a/internal/configs/parser_config.go
+++ b/internal/configs/parser_config.go
@@ -6,6 +6,8 @@
 package configs
 
 import (
+	"path/filepath"
+
 	"github.com/hashicorp/hcl/v2"
 
 	"github.com/opentofu/opentofu/internal/encryption/config"
@@ -50,7 +52,39 @@ func (p *Parser) LoadTestFile(path string) (*TestFile, hcl.Diagnostics) {
 
 	test, testDiags := loadTestFile(body)
 	diags = append(diags, testDiags...)
+
+	if test != nil {
+		baseDir := filepath.Dir(path)
+		for _, mockProvider := range test.MockProviders {
+			if mockProvider.Source == "" {
+				continue
+			}
+			sourceDir := filepath.Join(baseDir, mockProvider.Source)
+			fromFiles, fileDiags := p.loadMockFilesFromDir(sourceDir, mockProvider.SourceRange)
+			diags = append(diags, fileDiags...)
+			if fromFiles != nil {
+				mockProvider.MockResources = mergeMockResources(mockProvider.MockResources, fromFiles.MockResources)
+				mockProvider.OverrideResources = mergeOverrideResources(mockProvider.OverrideResources, fromFiles.OverrideResources)
+			}
+		}
+	}
+
 	return test, diags
+}
+
+// LoadMockFile reads the file at the given path and parses it as a mock data
+// file (.tfmock.hcl or .tofumock.hcl). Mock files contain mock_resource,
+// mock_data, override_resource, and override_data blocks used to populate a
+// mock_provider that specifies a source directory.
+func (p *Parser) LoadMockFile(path string) (*MockProvider, hcl.Diagnostics) {
+	body, diags := p.LoadHCLFile(path)
+	if body == nil {
+		return nil, diags
+	}
+
+	mock, mockDiags := loadMockFileBody(body)
+	diags = append(diags, mockDiags...)
+	return mock, diags
 }
 
 func (p *Parser) loadConfigFile(path string, override bool) (*File, hcl.Diagnostics) {

--- a/internal/configs/parser_config_dir.go
+++ b/internal/configs/parser_config_dir.go
@@ -30,6 +30,8 @@ const (
 	tofuTestExt     = ".tofutest.hcl"
 	tfTestJSONExt   = ".tftest.json"
 	tofuTestJSONExt = ".tofutest.json"
+	tfMockExt       = ".tfmock.hcl"
+	tofuMockExt     = ".tofumock.hcl"
 )
 
 // LoadConfigDir reads the .tf and .tf.json files in the given directory
@@ -330,6 +332,71 @@ func (p *Parser) loadTestFiles(basePath string, paths []string) (map[string]*Tes
 	}
 
 	return tfs, diags
+}
+
+// loadMockFilesFromDir reads all .tfmock.hcl and .tofumock.hcl files from dir,
+// parses them, and returns a merged MockProvider containing all discovered blocks.
+// When both a .tfmock.hcl and a .tofumock.hcl file share the same base name,
+// the .tofumock.hcl file takes precedence and the .tfmock.hcl file is skipped.
+func (p *Parser) loadMockFilesFromDir(dir string, sourceRange hcl.Range) (*MockProvider, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+
+	infos, err := p.fs.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, hcl.Diagnostics{{
+				Severity: hcl.DiagError,
+				Summary:  "Mock source directory not found",
+				Detail:   fmt.Sprintf("The mock source directory %q does not exist.", dir),
+				Subject:  sourceRange.Ptr(),
+			}}
+		}
+		return nil, hcl.Diagnostics{{
+			Severity: hcl.DiagError,
+			Summary:  "Failed to read mock source directory",
+			Detail:   fmt.Sprintf("Could not read mock source directory %q: %s.", dir, err),
+			Subject:  sourceRange.Ptr(),
+		}}
+	}
+
+	// Pre-collect .tofumock.hcl base names so we can skip .tfmock.hcl duplicates.
+	tofuMockNames := make(map[string]bool)
+	for _, info := range infos {
+		name := info.Name()
+		if strings.HasSuffix(name, tofuMockExt) {
+			tofuMockNames[strings.TrimSuffix(name, tofuMockExt)] = true
+		}
+	}
+
+	result := &MockProvider{}
+
+	for _, info := range infos {
+		if info.IsDir() || IsIgnoredFile(info.Name()) {
+			continue
+		}
+
+		name := info.Name()
+		switch {
+		case strings.HasSuffix(name, tofuMockExt):
+			// always load .tofumock.hcl files
+		case strings.HasSuffix(name, tfMockExt):
+			// skip if a .tofumock.hcl alternative with the same base name exists
+			if tofuMockNames[strings.TrimSuffix(name, tfMockExt)] {
+				continue
+			}
+		default:
+			continue
+		}
+
+		mock, mockDiags := p.LoadMockFile(filepath.Join(dir, name))
+		diags = append(diags, mockDiags...)
+		if mock != nil {
+			result.MockResources = append(result.MockResources, mock.MockResources...)
+			result.OverrideResources = append(result.OverrideResources, mock.OverrideResources...)
+		}
+	}
+
+	return result, diags
 }
 
 // fileExt returns the OpenTofu configuration extension of the given

--- a/internal/configs/test_file.go
+++ b/internal/configs/test_file.go
@@ -329,6 +329,12 @@ type MockProvider struct {
 
 	MockResources     []*MockResource
 	OverrideResources []*OverrideResource
+
+	// Source is the path to a directory containing .tfmock.hcl or .tofumock.hcl
+	// files. Blocks from those files are merged into this provider after parsing,
+	// with any inline mock_resource / override_resource blocks taking precedence.
+	Source      string
+	SourceRange hcl.Range
 }
 
 // moduleUniqueKey is copied from Provider.moduleUniqueKey
@@ -921,6 +927,12 @@ func decodeMockProviderBlock(block *hcl.Block) (*MockProvider, hcl.Diagnostics) 
 		provider.ForEach = attr.Expr
 	}
 
+	if attr, exists := content.Attributes["source"]; exists {
+		valDiags := gohcl.DecodeExpression(attr.Expr, nil, &provider.Source)
+		diags = append(diags, valDiags...)
+		provider.SourceRange = attr.Range
+	}
+
 	if len(provider.Alias) == 0 && provider.ForEach != nil {
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
@@ -1180,6 +1192,10 @@ var mockProviderBlockSchema = &hcl.BodySchema{
 			Name:     "for_each",
 			Required: false,
 		},
+		{
+			Name:     "source",
+			Required: false,
+		},
 	},
 	Blocks: []hcl.BlockHeaderSchema{
 		{
@@ -1205,4 +1221,99 @@ var mockResourceBlockSchema = &hcl.BodySchema{
 			Name: "defaults",
 		},
 	},
+}
+
+// mockFileSchema defines the structure of a .tfmock.hcl / .tofumock.hcl file.
+// These files may only contain mock_resource, mock_data, override_resource, and
+// override_data blocks — the same blocks that can appear inside a mock_provider,
+// but without the provider wrapper.
+var mockFileSchema = &hcl.BodySchema{
+	Blocks: []hcl.BlockHeaderSchema{
+		{
+			Type:       blockNameMockResource,
+			LabelNames: []string{"type"},
+		},
+		{
+			Type:       blockNameMockData,
+			LabelNames: []string{"type"},
+		},
+		{
+			Type: blockNameOverrideResource,
+		},
+		{
+			Type: blockNameOverrideData,
+		},
+	},
+}
+
+func loadMockFileBody(body hcl.Body) (*MockProvider, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+
+	content, contentDiags := body.Content(mockFileSchema)
+	diags = append(diags, contentDiags...)
+
+	mp := &MockProvider{}
+
+	for _, block := range content.Blocks {
+		switch block.Type {
+		case blockNameMockData, blockNameMockResource:
+			res, resDiags := decodeMockResourceBlock(block)
+			diags = append(diags, resDiags...)
+			if !resDiags.HasErrors() {
+				mp.MockResources = append(mp.MockResources, res)
+			}
+		case blockNameOverrideData, blockNameOverrideResource:
+			res, resDiags := decodeOverrideResourceBlock(block)
+			diags = append(diags, resDiags...)
+			if !resDiags.HasErrors() {
+				mp.OverrideResources = append(mp.OverrideResources, res)
+			}
+		}
+	}
+
+	return mp, diags
+}
+
+// mergeMockResources returns inline mock resources plus any file-sourced
+// resources whose type is not already defined inline. Inline takes precedence.
+func mergeMockResources(inline, fromFiles []*MockResource) []*MockResource {
+	if len(fromFiles) == 0 {
+		return inline
+	}
+
+	inlineKeys := make(map[string]struct{}, len(inline))
+	for _, r := range inline {
+		inlineKeys[r.Mode.String()+"."+r.Type] = struct{}{}
+	}
+
+	result := make([]*MockResource, len(inline), len(inline)+len(fromFiles))
+	copy(result, inline)
+	for _, r := range fromFiles {
+		if _, exists := inlineKeys[r.Mode.String()+"."+r.Type]; !exists {
+			result = append(result, r)
+		}
+	}
+	return result
+}
+
+// mergeOverrideResources returns inline override resources plus any file-sourced
+// override resources whose target is not already defined inline. Inline takes precedence.
+func mergeOverrideResources(inline, fromFiles []*OverrideResource) []*OverrideResource {
+	if len(fromFiles) == 0 {
+		return inline
+	}
+
+	inlineKeys := make(map[string]struct{}, len(inline))
+	for _, r := range inline {
+		inlineKeys[r.TargetParsed.String()] = struct{}{}
+	}
+
+	result := make([]*OverrideResource, len(inline), len(inline)+len(fromFiles))
+	copy(result, inline)
+	for _, r := range fromFiles {
+		if _, exists := inlineKeys[r.TargetParsed.String()]; !exists {
+			result = append(result, r)
+		}
+	}
+	return result
 }

--- a/internal/configs/test_file_test.go
+++ b/internal/configs/test_file_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hcltest"
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestTestRun_Validate(t *testing.T) {
@@ -176,5 +178,162 @@ func TestDecodeTestRunModuleBlock(t *testing.T) {
 				t.Fatalf("got %#v; want %#v", trcm.Source.String(), tc.wantModuleSource)
 			}
 		})
+	}
+}
+
+func TestLoadMockFile_ValidBlocks(t *testing.T) {
+	parser := NewParser(nil)
+
+	mp, diags := parser.LoadMockFile("testdata/mock-source-valid/mocks/resources.tfmock.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Error())
+	}
+
+	if len(mp.MockResources) != 2 {
+		t.Fatalf("expected 2 mock resources, got %d", len(mp.MockResources))
+	}
+
+	var managed, data *MockResource
+	for _, r := range mp.MockResources {
+		switch r.Mode {
+		case addrs.ManagedResourceMode:
+			managed = r
+		case addrs.DataResourceMode:
+			data = r
+		}
+	}
+
+	if managed == nil || managed.Type != "aws_instance" {
+		t.Fatalf("expected mock_resource aws_instance, got %v", managed)
+	}
+	if data == nil || data.Type != "aws_ami" {
+		t.Fatalf("expected mock_data aws_ami, got %v", data)
+	}
+}
+
+func TestLoadTestFile_MockSourceLoadsFromDir(t *testing.T) {
+	parser := NewParser(nil)
+
+	tf, diags := parser.LoadTestFile("testdata/mock-source-valid/main.tftest.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Error())
+	}
+
+	mp, ok := tf.MockProviders["aws"]
+	if !ok {
+		t.Fatal("expected mock_provider aws")
+	}
+
+	if len(mp.MockResources) != 2 {
+		t.Fatalf("expected 2 mock resources loaded from source dir, got %d", len(mp.MockResources))
+	}
+}
+
+func TestLoadTestFile_MockSourceTofuPrecedence(t *testing.T) {
+	parser := NewParser(nil)
+
+	tf, diags := parser.LoadTestFile("testdata/mock-source-tofuprecedence/main.tftest.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Error())
+	}
+
+	mp, ok := tf.MockProviders["aws"]
+	if !ok {
+		t.Fatal("expected mock_provider aws")
+	}
+
+	if len(mp.MockResources) != 1 {
+		t.Fatalf("expected exactly 1 mock resource (tofumock wins), got %d", len(mp.MockResources))
+	}
+
+	r := mp.MockResources[0]
+	if r.Type != "aws_instance" {
+		t.Fatalf("expected aws_instance, got %s", r.Type)
+	}
+
+	val, ok := r.Defaults["ami"]
+	if !ok {
+		t.Fatal("expected ami default value")
+	}
+	if val.AsString() != "ami-from-tofumock" {
+		t.Fatalf("expected ami-from-tofumock (tofumock wins), got %s", val.AsString())
+	}
+}
+
+func TestLoadTestFile_MockSourceInlinePrecedence(t *testing.T) {
+	parser := NewParser(nil)
+
+	tf, diags := parser.LoadTestFile("testdata/mock-source-inline-precedence/main.tftest.hcl")
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Error())
+	}
+
+	mp, ok := tf.MockProviders["aws"]
+	if !ok {
+		t.Fatal("expected mock_provider aws")
+	}
+
+	// Should have 2 resources: aws_instance (inline) + aws_vpc (from file)
+	if len(mp.MockResources) != 2 {
+		t.Fatalf("expected 2 mock resources (1 inline + 1 from file), got %d", len(mp.MockResources))
+	}
+
+	resourcesByType := make(map[string]*MockResource)
+	for _, r := range mp.MockResources {
+		resourcesByType[r.Type] = r
+	}
+
+	instance, ok := resourcesByType["aws_instance"]
+	if !ok {
+		t.Fatal("expected aws_instance")
+	}
+	if instance.Defaults["ami"].AsString() != "ami-inline" {
+		t.Fatalf("inline aws_instance should win, got %s", instance.Defaults["ami"].AsString())
+	}
+
+	if _, ok := resourcesByType["aws_vpc"]; !ok {
+		t.Fatal("expected aws_vpc loaded from mock file")
+	}
+}
+
+func TestLoadTestFile_MockSourceMissingDir(t *testing.T) {
+	parser := NewParser(nil)
+
+	_, diags := parser.LoadTestFile("testdata/mock-source-missing-dir/main.tftest.hcl")
+	if !diags.HasErrors() {
+		t.Fatal("expected error for missing source directory")
+	}
+
+	found := false
+	for _, d := range diags {
+		if d.Summary == "Mock source directory not found" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected 'Mock source directory not found' diagnostic, got: %s", diags.Error())
+	}
+}
+
+func TestMergeMockResources_InlinePrecedence(t *testing.T) {
+	inline := []*MockResource{
+		{Mode: addrs.ManagedResourceMode, Type: "aws_instance", Defaults: map[string]cty.Value{}},
+	}
+	fromFiles := []*MockResource{
+		{Mode: addrs.ManagedResourceMode, Type: "aws_instance", Defaults: map[string]cty.Value{}},
+		{Mode: addrs.ManagedResourceMode, Type: "aws_vpc", Defaults: map[string]cty.Value{}},
+	}
+
+	result := mergeMockResources(inline, fromFiles)
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 resources (inline aws_instance + file aws_vpc), got %d", len(result))
+	}
+	if result[0].Type != "aws_instance" {
+		t.Fatalf("first resource should be the inline aws_instance")
+	}
+	if result[1].Type != "aws_vpc" {
+		t.Fatalf("second resource should be aws_vpc from file")
 	}
 }

--- a/internal/configs/testdata/mock-source-inline-precedence/main.tftest.hcl
+++ b/internal/configs/testdata/mock-source-inline-precedence/main.tftest.hcl
@@ -1,0 +1,11 @@
+mock_provider "aws" {
+  source = "./mocks"
+
+  # This inline block should take precedence over the one in the mock file.
+  mock_resource "aws_instance" {
+    defaults = {
+      ami = "ami-inline"
+    }
+  }
+}
+

--- a/internal/configs/testdata/mock-source-inline-precedence/mocks/resources.tfmock.hcl
+++ b/internal/configs/testdata/mock-source-inline-precedence/mocks/resources.tfmock.hcl
@@ -1,0 +1,13 @@
+# aws_instance is already defined inline in the test file; this should be skipped.
+mock_resource "aws_instance" {
+  defaults = {
+    ami = "ami-from-file"
+  }
+}
+
+# aws_vpc is not defined inline, so it should be loaded from this file.
+mock_resource "aws_vpc" {
+  defaults = {
+    cidr_block = "10.0.0.0/16"
+  }
+}

--- a/internal/configs/testdata/mock-source-missing-dir/main.tftest.hcl
+++ b/internal/configs/testdata/mock-source-missing-dir/main.tftest.hcl
@@ -1,0 +1,4 @@
+mock_provider "aws" {
+  source = "./does-not-exist"
+}
+

--- a/internal/configs/testdata/mock-source-tofuprecedence/main.tftest.hcl
+++ b/internal/configs/testdata/mock-source-tofuprecedence/main.tftest.hcl
@@ -1,0 +1,4 @@
+mock_provider "aws" {
+  source = "./mocks"
+}
+

--- a/internal/configs/testdata/mock-source-tofuprecedence/mocks/resources.tfmock.hcl
+++ b/internal/configs/testdata/mock-source-tofuprecedence/mocks/resources.tfmock.hcl
@@ -1,0 +1,6 @@
+# This file should be ignored because a .tofumock.hcl alternative exists.
+mock_resource "aws_instance" {
+  defaults = {
+    ami = "ami-from-tfmock"
+  }
+}

--- a/internal/configs/testdata/mock-source-tofuprecedence/mocks/resources.tofumock.hcl
+++ b/internal/configs/testdata/mock-source-tofuprecedence/mocks/resources.tofumock.hcl
@@ -1,0 +1,5 @@
+mock_resource "aws_instance" {
+  defaults = {
+    ami = "ami-from-tofumock"
+  }
+}

--- a/internal/configs/testdata/mock-source-valid/main.tftest.hcl
+++ b/internal/configs/testdata/mock-source-valid/main.tftest.hcl
@@ -1,0 +1,4 @@
+mock_provider "aws" {
+  source = "./mocks"
+}
+

--- a/internal/configs/testdata/mock-source-valid/mocks/resources.tfmock.hcl
+++ b/internal/configs/testdata/mock-source-valid/mocks/resources.tfmock.hcl
@@ -1,0 +1,12 @@
+mock_resource "aws_instance" {
+  defaults = {
+    ami           = "ami-12345678"
+    instance_type = "t2.micro"
+  }
+}
+
+mock_data "aws_ami" {
+  defaults = {
+    id = "ami-12345678"
+  }
+}


### PR DESCRIPTION
## Description

Implements the `source` attribute on `mock_provider` blocks in `.tftest.hcl` files, resolving #1778.

Users can now point a `mock_provider` to a directory of `.tfmock.hcl` or `.tofumock.hcl` files instead of duplicating `mock_resource` / `mock_data` blocks across every test file:

```hcl
mock_provider "aws" {
  source = "./mocks"
}
```

Any `.tfmock.hcl` / `.tofumock.hcl` files in that directory are parsed and their `mock_resource`, `mock_data`, `override_resource`, and `override_data` blocks are merged into the provider.

## Behaviour

- **Inline takes precedence**: blocks defined directly inside `mock_provider` override any file-sourced blocks of the same type/target.
- **`.tofumock.hcl` takes precedence over `.tfmock.hcl`**: when both share the same base name, the `.tofumock.hcl` file is used and the `.tfmock.hcl` file is skipped — consistent with how `.tofu` files supersede `.tf` files.
- **Missing directory**: a clear error diagnostic is returned if the `source` directory does not exist.

## Changes

- `internal/configs/test_file.go` — `MockProvider.Source` + `SourceRange` fields; `source` added to `mockProviderBlockSchema`; `decodeMockProviderBlock` parses the attribute; new `mockFileSchema`, `loadMockFileBody`, `mergeMockResources`, `mergeOverrideResources`
- `internal/configs/parser_config_dir.go` — `.tfmock.hcl` / `.tofumock.hcl` extension constants; `loadMockFilesFromDir` with `.tofumock` precedence logic
- `internal/configs/parser_config.go` — `LoadMockFile` public method; `LoadTestFile` resolves `source` and merges after initial parse

## Tests

Six new tests covering:
- Basic loading from a source directory
- `.tofumock.hcl` takes precedence over `.tfmock.hcl` with same base name
- Inline blocks take precedence over file-sourced blocks of the same resource type
- Error diagnostic for a missing source directory
- Unit test for `mergeMockResources` precedence logic

All existing tests in `./internal/configs/...` continue to pass.

Fixes #1778