### PR TITLE
Unify the state related flags in one struct

### DIFF
--- a/internal/backend/cli.go
+++ b/internal/backend/cli.go
@@ -55,7 +55,7 @@ type CLIOpts struct {
 	// StateArgs carries the state related configurations. Refer to the
 	// arguments.State for more details.
 	// In this particular case, an empty arguments.State#BackupPath will result
-	// in skipping the backup entirely and the new state will just ovewrite the old
+	// in skipping the backup entirely and the new state will just overwrite the old
 	// one.
 	StateArgs arguments.State
 

--- a/internal/backend/cli.go
+++ b/internal/backend/cli.go
@@ -6,6 +6,7 @@
 package backend
 
 import (
+	"github.com/opentofu/opentofu/internal/command/arguments"
 	"github.com/opentofu/opentofu/internal/command/views"
 	"github.com/opentofu/opentofu/internal/tofu"
 )
@@ -51,16 +52,12 @@ type CLIOpts struct {
 	// of their actions.
 	View views.BackendRemote
 
-	// StatePath is the local path where state is read from.
-	//
-	// StateOutPath is the local path where the state will be written.
-	// If this is empty, it will default to StatePath.
-	//
-	// StateBackupPath is the local path where a backup file will be written.
-	// If this is empty, no backup will be taken.
-	StatePath       string
-	StateOutPath    string
-	StateBackupPath string
+	// StateArgs carries the state related configurations. Refer to the
+	// arguments.State for more details.
+	// In this particular case, an empty arguments.State#BackupPath will result
+	// in skipping the backup entirely and the new state will just ovewrite the old
+	// one.
+	StateArgs arguments.State
 
 	// ContextOpts are the base context options to set when initializing a
 	// OpenTofu context. Many of these will be overridden or merged by

--- a/internal/backend/local/cli.go
+++ b/internal/backend/local/cli.go
@@ -18,19 +18,19 @@ func (b *Local) CLIInit(opts *backend.CLIOpts) error {
 	b.OpValidation = opts.Validation
 
 	// configure any new cli options
-	if opts.StatePath != "" {
-		log.Printf("[TRACE] backend/local: CLI option -state is overriding state path to %s", opts.StatePath)
-		b.OverrideStatePath = opts.StatePath
+	if opts.StateArgs.StatePath != "" {
+		log.Printf("[TRACE] backend/local: CLI option -state is overriding state path to %s", opts.StateArgs.StatePath)
+		b.OverrideStatePath = opts.StateArgs.StatePath
 	}
 
-	if opts.StateOutPath != "" {
-		log.Printf("[TRACE] backend/local: CLI option -state-out is overriding state output path to %s", opts.StateOutPath)
-		b.OverrideStateOutPath = opts.StateOutPath
+	if opts.StateArgs.StateOutPath != "" {
+		log.Printf("[TRACE] backend/local: CLI option -state-out is overriding state output path to %s", opts.StateArgs.StateOutPath)
+		b.OverrideStateOutPath = opts.StateArgs.StateOutPath
 	}
 
-	if opts.StateBackupPath != "" {
-		log.Printf("[TRACE] backend/local: CLI option -backup is overriding state backup path to %s", opts.StateBackupPath)
-		b.OverrideStateBackupPath = opts.StateBackupPath
+	if opts.StateArgs.BackupPath != "" {
+		log.Printf("[TRACE] backend/local: CLI option -backup is overriding state backup path to %s", opts.StateArgs.BackupPath)
+		b.OverrideStateBackupPath = opts.StateArgs.BackupPath
 	}
 
 	return nil

--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -196,11 +196,7 @@ func (c *ApplyCommand) LoadPlanFile(path string, enc encryption.Encryption) (*pl
 func (c *ApplyCommand) PrepareBackend(ctx context.Context, planFile *planfile.WrappedPlanFile, args *arguments.State, backendView views.Backend, enc encryption.StateEncryption) (backend.Enhanced, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	// FIXME: we need to apply the state arguments to the meta object here
-	// because they are later used when initializing the backend. Carving a
-	// path to pass these arguments to the functions that need them is
-	// difficult but would make their use easier to understand.
-	c.Meta.applyStateArguments(args)
+	c.stateArgs = *args
 
 	// Load the backend
 	var be backend.Enhanced

--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -196,7 +196,7 @@ func (c *ApplyCommand) LoadPlanFile(path string, enc encryption.Encryption) (*pl
 func (c *ApplyCommand) PrepareBackend(ctx context.Context, planFile *planfile.WrappedPlanFile, args *arguments.State, backendView views.Backend, enc encryption.StateEncryption) (backend.Enhanced, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	c.stateArgs = *args
+	c.Meta.stateArgs = *args
 
 	// Load the backend
 	var be backend.Enhanced

--- a/internal/command/arguments/apply.go
+++ b/internal/command/arguments/apply.go
@@ -42,16 +42,17 @@ type Apply struct {
 func ParseApply(args []string) (*Apply, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	apply := &Apply{
-		State:     &State{},
+		State:     NewStateFlags(),
 		Operation: &Operation{},
 		Vars:      &Vars{},
 	}
 
-	cmdFlags := extendedFlagSet("apply", apply.State, apply.Operation, apply.Vars)
+	cmdFlags := extendedFlagSet("apply", apply.Operation, apply.Vars)
 	cmdFlags.BoolVar(&apply.AutoApprove, "auto-approve", false, "auto-approve")
 	cmdFlags.BoolVar(&apply.ShowSensitive, "show-sensitive", false, "displays sensitive values")
 	cmdFlags.BoolVar(&apply.SuppressForgetErrorsDuringDestroy, "suppress-forget-errors", false, "suppress errors in destroy mode due to resources being forgotten")
 
+	apply.State.AddFlags(cmdFlags, true, true, true, true)
 	apply.ViewOptions.AddFlags(cmdFlags, true)
 
 	if err := cmdFlags.Parse(args); err != nil {

--- a/internal/command/arguments/apply.go
+++ b/internal/command/arguments/apply.go
@@ -42,7 +42,7 @@ type Apply struct {
 func ParseApply(args []string) (*Apply, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	apply := &Apply{
-		State:     NewStateFlags(),
+		State:     &State{},
 		Operation: &Operation{},
 		Vars:      &Vars{},
 	}

--- a/internal/command/arguments/apply.go
+++ b/internal/command/arguments/apply.go
@@ -52,7 +52,7 @@ func ParseApply(args []string) (*Apply, func(), tfdiags.Diagnostics) {
 	cmdFlags.BoolVar(&apply.ShowSensitive, "show-sensitive", false, "displays sensitive values")
 	cmdFlags.BoolVar(&apply.SuppressForgetErrorsDuringDestroy, "suppress-forget-errors", false, "suppress errors in destroy mode due to resources being forgotten")
 
-	apply.State.AddFlags(cmdFlags, true, true, true, true)
+	apply.State.addFlags(cmdFlags, stateFlagAll)
 	apply.ViewOptions.AddFlags(cmdFlags, true)
 
 	if err := cmdFlags.Parse(args); err != nil {

--- a/internal/command/arguments/apply_test.go
+++ b/internal/command/arguments/apply_test.go
@@ -33,7 +33,7 @@ func TestParseApply_basicValid(t *testing.T) {
 					ViewType:     ViewHuman,
 				},
 				PlanPath: "",
-				State:    &State{Lock: true},
+				State:    NewStateFlags(),
 				Vars:     &Vars{},
 				Operation: &Operation{
 					PlanMode:    plans.NormalMode,
@@ -51,7 +51,7 @@ func TestParseApply_basicValid(t *testing.T) {
 					ViewType:     ViewHuman,
 				},
 				PlanPath: "saved.tfplan",
-				State:    &State{Lock: true},
+				State:    NewStateFlags(),
 				Vars:     &Vars{},
 				Operation: &Operation{
 					PlanMode:    plans.NormalMode,
@@ -69,7 +69,7 @@ func TestParseApply_basicValid(t *testing.T) {
 					ViewType:     ViewHuman,
 				},
 				PlanPath: "",
-				State:    &State{Lock: true},
+				State:    NewStateFlags(),
 				Vars:     &Vars{},
 				Operation: &Operation{
 					PlanMode:    plans.DestroyMode,
@@ -87,7 +87,7 @@ func TestParseApply_basicValid(t *testing.T) {
 					ViewType:     ViewJSON,
 				},
 				PlanPath: "",
-				State:    &State{Lock: true},
+				State:    NewStateFlags(),
 				Vars:     &Vars{},
 				Operation: &Operation{
 					PlanMode:    plans.NormalMode,
@@ -774,7 +774,7 @@ func TestParseApplyDestroy_basicValid(t *testing.T) {
 					InputEnabled: true,
 					ViewType:     ViewHuman,
 				},
-				State: &State{Lock: true},
+				State: NewStateFlags(),
 				Vars:  &Vars{},
 				Operation: &Operation{
 					PlanMode:    plans.DestroyMode,
@@ -791,7 +791,7 @@ func TestParseApplyDestroy_basicValid(t *testing.T) {
 					InputEnabled: false,
 					ViewType:     ViewHuman,
 				},
-				State: &State{Lock: true},
+				State: NewStateFlags(),
 				Vars:  &Vars{},
 				Operation: &Operation{
 					PlanMode:    plans.DestroyMode,

--- a/internal/command/arguments/apply_test.go
+++ b/internal/command/arguments/apply_test.go
@@ -33,7 +33,7 @@ func TestParseApply_basicValid(t *testing.T) {
 					ViewType:     ViewHuman,
 				},
 				PlanPath: "",
-				State:    NewStateFlags(),
+				State:    &State{Lock: true},
 				Vars:     &Vars{},
 				Operation: &Operation{
 					PlanMode:    plans.NormalMode,
@@ -51,7 +51,7 @@ func TestParseApply_basicValid(t *testing.T) {
 					ViewType:     ViewHuman,
 				},
 				PlanPath: "saved.tfplan",
-				State:    NewStateFlags(),
+				State:    &State{Lock: true},
 				Vars:     &Vars{},
 				Operation: &Operation{
 					PlanMode:    plans.NormalMode,
@@ -69,7 +69,7 @@ func TestParseApply_basicValid(t *testing.T) {
 					ViewType:     ViewHuman,
 				},
 				PlanPath: "",
-				State:    NewStateFlags(),
+				State:    &State{Lock: true},
 				Vars:     &Vars{},
 				Operation: &Operation{
 					PlanMode:    plans.DestroyMode,
@@ -87,7 +87,7 @@ func TestParseApply_basicValid(t *testing.T) {
 					ViewType:     ViewJSON,
 				},
 				PlanPath: "",
-				State:    NewStateFlags(),
+				State:    &State{Lock: true},
 				Vars:     &Vars{},
 				Operation: &Operation{
 					PlanMode:    plans.NormalMode,
@@ -774,7 +774,7 @@ func TestParseApplyDestroy_basicValid(t *testing.T) {
 					InputEnabled: true,
 					ViewType:     ViewHuman,
 				},
-				State: NewStateFlags(),
+				State: &State{Lock: true},
 				Vars:  &Vars{},
 				Operation: &Operation{
 					PlanMode:    plans.DestroyMode,
@@ -791,7 +791,7 @@ func TestParseApplyDestroy_basicValid(t *testing.T) {
 					InputEnabled: false,
 					ViewType:     ViewHuman,
 				},
-				State: NewStateFlags(),
+				State: &State{Lock: true},
 				Vars:  &Vars{},
 				Operation: &Operation{
 					PlanMode:    plans.DestroyMode,

--- a/internal/command/arguments/backend.go
+++ b/internal/command/arguments/backend.go
@@ -7,17 +7,12 @@ package arguments
 
 import (
 	"flag"
-	"time"
 
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
 type Backend struct {
 	IgnoreRemoteVersion bool
-	// StateLock indicates if the state should be locked or not.
-	StateLock bool
-	// StateLockTimeout configures the duration that it waits for the state lock to be acquired.
-	StateLockTimeout time.Duration
 	// ForceInitCopy controls if the prompts for state migration should be skipped or not.
 	ForceInitCopy bool
 	// Reconfigure controls if the reconfiguration of the backend should happen with discarding the old configurations.
@@ -28,12 +23,6 @@ type Backend struct {
 
 func (b *Backend) AddIgnoreRemoteVersionFlag(f *flag.FlagSet) {
 	f.BoolVar(&b.IgnoreRemoteVersion, "ignore-remote-version", false, "continue even if remote and local OpenTofu versions are incompatible")
-}
-
-// TODO meta-refactor: replace this with the State.AddFlags instead.
-func (b *Backend) AddStateFlags(f *flag.FlagSet) {
-	f.BoolVar(&b.StateLock, "lock", true, "lock state")
-	f.DurationVar(&b.StateLockTimeout, "lock-timeout", 0, "lock timeout")
 }
 
 func (b *Backend) AddMigrationFlags(f *flag.FlagSet) {

--- a/internal/command/arguments/backend.go
+++ b/internal/command/arguments/backend.go
@@ -30,6 +30,7 @@ func (b *Backend) AddIgnoreRemoteVersionFlag(f *flag.FlagSet) {
 	f.BoolVar(&b.IgnoreRemoteVersion, "ignore-remote-version", false, "continue even if remote and local OpenTofu versions are incompatible")
 }
 
+// TODO meta-refactor: replace this with the State.AddFlags instead.
 func (b *Backend) AddStateFlags(f *flag.FlagSet) {
 	f.BoolVar(&b.StateLock, "lock", true, "lock state")
 	f.DurationVar(&b.StateLockTimeout, "lock-timeout", 0, "lock timeout")

--- a/internal/command/arguments/backend_test.go
+++ b/internal/command/arguments/backend_test.go
@@ -8,7 +8,6 @@ package arguments
 import (
 	"flag"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/opentofu/opentofu/internal/tfdiags"
@@ -53,65 +52,6 @@ func TestBackend_AddIgnoreRemoteVersionFlag(t *testing.T) {
 
 			if got := backend.IgnoreRemoteVersion; got != tc.want {
 				t.Errorf("IgnoreRemoteVersion = %v, want %v", got, tc.want)
-			}
-		})
-	}
-}
-
-func TestBackend_AddStateFlags(t *testing.T) {
-	testCases := map[string]struct {
-		args            []string
-		wantLock        bool
-		wantLockTimeout time.Duration
-	}{
-		"default values": {
-			args:            nil,
-			wantLock:        true,
-			wantLockTimeout: 0,
-		},
-		"lock set to false": {
-			args:            []string{"-lock=false"},
-			wantLock:        false,
-			wantLockTimeout: 0,
-		},
-		"lock set to true explicitly": {
-			args:            []string{"-lock=true"},
-			wantLock:        true,
-			wantLockTimeout: 0,
-		},
-		"lock-timeout set": {
-			args:            []string{"-lock-timeout=10s"},
-			wantLock:        true,
-			wantLockTimeout: 10 * time.Second,
-		},
-		"lock-timeout set in minutes": {
-			args:            []string{"-lock-timeout=5m"},
-			wantLock:        true,
-			wantLockTimeout: 5 * time.Minute,
-		},
-		"both flags set": {
-			args:            []string{"-lock=false", "-lock-timeout=30s"},
-			wantLock:        false,
-			wantLockTimeout: 30 * time.Second,
-		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			backend := &Backend{}
-			fs := flag.NewFlagSet("test", flag.ContinueOnError)
-			backend.AddStateFlags(fs)
-
-			if err := fs.Parse(tc.args); err != nil {
-				t.Fatalf("unexpected error parsing flags: %v", err)
-			}
-
-			if got := backend.StateLock; got != tc.wantLock {
-				t.Errorf("StateLock = %v, want %v", got, tc.wantLock)
-			}
-
-			if got := backend.StateLockTimeout; got != tc.wantLockTimeout {
-				t.Errorf("StateLockTimeout = %v, want %v", got, tc.wantLockTimeout)
 			}
 		})
 	}
@@ -350,8 +290,6 @@ func TestBackend_AllFlags(t *testing.T) {
 			args: nil,
 			want: Backend{
 				IgnoreRemoteVersion: false,
-				StateLock:           true,
-				StateLockTimeout:    0,
 				ForceInitCopy:       false,
 				Reconfigure:         false,
 				MigrateState:        false,
@@ -360,16 +298,12 @@ func TestBackend_AllFlags(t *testing.T) {
 		"all flags set": {
 			args: []string{
 				"-ignore-remote-version",
-				"-lock=false",
-				"-lock-timeout=1m",
 				"-force-copy",
 				"-reconfigure",
 				"-migrate-state",
 			},
 			want: Backend{
 				IgnoreRemoteVersion: true,
-				StateLock:           false,
-				StateLockTimeout:    time.Minute,
 				ForceInitCopy:       true,
 				Reconfigure:         true,
 				MigrateState:        true,
@@ -378,13 +312,10 @@ func TestBackend_AllFlags(t *testing.T) {
 		"mixed flags": {
 			args: []string{
 				"-ignore-remote-version=true",
-				"-lock-timeout=30s",
 				"-migrate-state",
 			},
 			want: Backend{
 				IgnoreRemoteVersion: true,
-				StateLock:           true,
-				StateLockTimeout:    30 * time.Second,
 				ForceInitCopy:       false,
 				Reconfigure:         false,
 				MigrateState:        true,
@@ -397,7 +328,6 @@ func TestBackend_AllFlags(t *testing.T) {
 			backend := &Backend{}
 			fs := flag.NewFlagSet("test", flag.ContinueOnError)
 			backend.AddIgnoreRemoteVersionFlag(fs)
-			backend.AddStateFlags(fs)
 			backend.AddMigrationFlags(fs)
 
 			if err := fs.Parse(tc.args); err != nil {

--- a/internal/command/arguments/console.go
+++ b/internal/command/arguments/console.go
@@ -27,7 +27,7 @@ func ParseConsole(args []string) (*Console, func(), tfdiags.Diagnostics) {
 
 	console := &Console{
 		Vars:  &Vars{},
-		State: NewStateFlags(),
+		State: &State{},
 	}
 
 	cmdFlags := extendedFlagSet("console", nil, console.Vars)

--- a/internal/command/arguments/console.go
+++ b/internal/command/arguments/console.go
@@ -18,8 +18,8 @@ type Console struct {
 	ViewOptions ViewOptions
 	// Vars holds and provides information for the flags related to variables that a user can give into the process
 	Vars *Vars
-	// Backend is used here to register and parse the flags for state locking
-	Backend Backend
+	// State is used for the state related flags
+	State *State
 }
 
 // ParseConsole processes CLI arguments, returning a Console value, a closer function, and errors.
@@ -29,11 +29,12 @@ func ParseConsole(args []string) (*Console, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	console := &Console{
-		Vars: &Vars{},
+		Vars:  &Vars{},
+		State: NewStateFlags(),
 	}
 
 	cmdFlags := extendedFlagSet("console", nil, console.Vars)
-	console.Backend.AddStateFlags(cmdFlags)
+	console.State.AddFlags(cmdFlags, true, false, false, false)
 	cmdFlags.StringVar(&console.StatePath, "state", DefaultStateFilename, "path")
 
 	console.ViewOptions.AddFlags(cmdFlags, true)

--- a/internal/command/arguments/console.go
+++ b/internal/command/arguments/console.go
@@ -11,9 +11,6 @@ import (
 
 // Console represents the command-line arguments for the console command.
 type Console struct {
-	// StatePath is the path to the state file to use for the console session.
-	StatePath string
-
 	// ViewOptions specifies which view options to use
 	ViewOptions ViewOptions
 	// Vars holds and provides information for the flags related to variables that a user can give into the process
@@ -35,7 +32,7 @@ func ParseConsole(args []string) (*Console, func(), tfdiags.Diagnostics) {
 
 	cmdFlags := extendedFlagSet("console", nil, console.Vars)
 	console.State.AddFlags(cmdFlags, true, false, false, false)
-	cmdFlags.StringVar(&console.StatePath, "state", DefaultStateFilename, "path")
+	console.State.AddStateInFlag(cmdFlags, DefaultStateFilename)
 
 	console.ViewOptions.AddFlags(cmdFlags, true)
 

--- a/internal/command/arguments/console.go
+++ b/internal/command/arguments/console.go
@@ -31,7 +31,7 @@ func ParseConsole(args []string) (*Console, func(), tfdiags.Diagnostics) {
 	}
 
 	cmdFlags := extendedFlagSet("console", nil, console.Vars)
-	console.State.AddFlags(cmdFlags, true, false, false, false)
+	console.State.addFlags(cmdFlags, stateFlagLock)
 	console.State.AddStateInFlag(cmdFlags, DefaultStateFilename)
 
 	console.ViewOptions.AddFlags(cmdFlags, true)

--- a/internal/command/arguments/console.go
+++ b/internal/command/arguments/console.go
@@ -32,7 +32,7 @@ func ParseConsole(args []string) (*Console, func(), tfdiags.Diagnostics) {
 		Vars: &Vars{},
 	}
 
-	cmdFlags := extendedFlagSet("console", nil, nil, console.Vars)
+	cmdFlags := extendedFlagSet("console", nil, console.Vars)
 	console.Backend.AddStateFlags(cmdFlags)
 	cmdFlags.StringVar(&console.StatePath, "state", DefaultStateFilename, "path")
 

--- a/internal/command/arguments/console_test.go
+++ b/internal/command/arguments/console_test.go
@@ -102,8 +102,10 @@ func consoleArgsWithDefaults(mutate func(console *Console)) *Console {
 			ViewType:     ViewHuman,
 			InputEnabled: true,
 		},
-		Vars:  &Vars{},
-		State: NewStateFlags(),
+		Vars: &Vars{},
+		State: &State{
+			Lock: true,
+		},
 	}
 	// Because the state flag is registered with a different default value
 	ret.State.StatePath = DefaultStateFilename

--- a/internal/command/arguments/console_test.go
+++ b/internal/command/arguments/console_test.go
@@ -65,13 +65,13 @@ func TestParseConsole_basicValidation(t *testing.T) {
 			args: []string{"-lock-timeout=10s"},
 			want: consoleArgsWithDefaults(func(console *Console) {
 				// do not set `console.Backend.StateLock = true` since it's meant to be true already
-				console.Backend.StateLockTimeout = 10 * time.Second
+				console.State.LockTimeout = 10 * time.Second
 			}),
 		},
 		"disable locking": {
 			args: []string{"-lock=false"},
 			want: consoleArgsWithDefaults(func(console *Console) {
-				console.Backend.StateLock = false
+				console.State.Lock = false
 			}),
 		},
 	}
@@ -103,10 +103,8 @@ func consoleArgsWithDefaults(mutate func(console *Console)) *Console {
 			ViewType:     ViewHuman,
 			InputEnabled: true,
 		},
-		Vars: &Vars{},
-		Backend: Backend{
-			StateLock: true,
-		},
+		Vars:  &Vars{},
+		State: NewStateFlags(),
 	}
 	if mutate != nil {
 		mutate(ret)

--- a/internal/command/arguments/console_test.go
+++ b/internal/command/arguments/console_test.go
@@ -105,10 +105,10 @@ func consoleArgsWithDefaults(mutate func(console *Console)) *Console {
 		Vars: &Vars{},
 		State: &State{
 			Lock: true,
+			// Because the state flag is registered with a different default value
+			StatePath: DefaultStateFilename,
 		},
 	}
-	// Because the state flag is registered with a different default value
-	ret.State.StatePath = DefaultStateFilename
 	if mutate != nil {
 		mutate(ret)
 	}

--- a/internal/command/arguments/console_test.go
+++ b/internal/command/arguments/console_test.go
@@ -28,7 +28,7 @@ func TestParseConsole_basicValidation(t *testing.T) {
 		"custom state path": {
 			args: []string{"-state=/path/to/state.tfstate"},
 			want: consoleArgsWithDefaults(func(console *Console) {
-				console.StatePath = "/path/to/state.tfstate"
+				console.State.StatePath = "/path/to/state.tfstate"
 			}),
 		},
 		"json-into with input enabled": {
@@ -98,7 +98,6 @@ func TestParseConsole_basicValidation(t *testing.T) {
 
 func consoleArgsWithDefaults(mutate func(console *Console)) *Console {
 	ret := &Console{
-		StatePath: DefaultStateFilename,
 		ViewOptions: ViewOptions{
 			ViewType:     ViewHuman,
 			InputEnabled: true,
@@ -106,6 +105,8 @@ func consoleArgsWithDefaults(mutate func(console *Console)) *Console {
 		Vars:  &Vars{},
 		State: NewStateFlags(),
 	}
+	// Because the state flag is registered with a different default value
+	ret.State.StatePath = DefaultStateFilename
 	if mutate != nil {
 		mutate(ret)
 	}

--- a/internal/command/arguments/extended.go
+++ b/internal/command/arguments/extended.go
@@ -39,6 +39,7 @@ type State struct {
 
 	// StatePath specifies a non-default location for the state file. The
 	// default value is blank, which is interpreted as "terraform.tfstate".
+	// Represents the local path where state is read from.
 	StatePath string
 
 	// StateOutPath specifies a different path to write the final state file.
@@ -48,8 +49,8 @@ type State struct {
 
 	// BackupPath specifies the path where a backup copy of the state file will
 	// be stored before the new state is written. The default value is blank,
-	// which is interpreted as StateOutPath +
-	// ".backup".
+	// which is interpreted as StateOutPath + ".backup" or, in some cases, the backup
+	// is skipped altogether.
 	BackupPath string
 }
 

--- a/internal/command/arguments/extended.go
+++ b/internal/command/arguments/extended.go
@@ -54,16 +54,6 @@ type State struct {
 	BackupPath string
 }
 
-// NewStateFlags can be used to create the [State] instance with [State.Lock] initialised as "true", instead of creating
-// a new object inline.
-// It's not needed to be used if the lock related flags are registered, since that provides the same default value
-// for the lock flag.
-func NewStateFlags() *State {
-	return &State{
-		Lock: true,
-	}
-}
-
 // AddFlags is the sole logic of registering the state related flags in OpenTofu.
 func (s *State) AddFlags(f *flag.FlagSet, lockFlags bool, stateInPath bool, stateOutPath bool, backupPath bool) {
 	if lockFlags {

--- a/internal/command/arguments/extended.go
+++ b/internal/command/arguments/extended.go
@@ -54,8 +54,10 @@ type State struct {
 	BackupPath string
 }
 
-// NewStateFlags must be used when creating a new [State] instance, instead of creating a new object inline.
-// This is because it provides the default value for [State.Lock] even if the flags are not registered.
+// NewStateFlags can be used to create the [State] instance with [State.Lock] initialised as "true", instead of creating
+// a new object inline.
+// It's not needed to be used if the lock related flags are registered, since that provides the same default value
+// for the lock flag.
 func NewStateFlags() *State {
 	return &State{
 		Lock: true,

--- a/internal/command/arguments/extended.go
+++ b/internal/command/arguments/extended.go
@@ -74,8 +74,13 @@ func (s *State) AddFlags(f *flag.FlagSet, lockFlags bool, stateInPath bool, stat
 		f.StringVar(&s.StateOutPath, "state-out", "", "state-path")
 	}
 	if backupPath {
-		f.StringVar(&s.BackupPath, "backup", "", "backup-path")
+		s.AddBackupFlag(f, "")
 	}
+}
+
+// AddBackupFlag exists strictly because the default value can get a different value in some commands.
+func (s *State) AddBackupFlag(f *flag.FlagSet, defVal string) {
+	f.StringVar(&s.BackupPath, "backup", defVal, "backup-path")
 }
 
 // Operation describes arguments which are used to configure how a OpenTofu

--- a/internal/command/arguments/extended.go
+++ b/internal/command/arguments/extended.go
@@ -26,6 +26,17 @@ import (
 // operations as it walks the dependency graph.
 const DefaultParallelism = 10
 
+type stateFlag uint8
+
+const (
+	stateFlagLock stateFlag = 1 << iota
+	stateFlagStateIn
+	stateFlagStateOut
+	stateFlagBackup
+
+	stateFlagAll = stateFlagLock | stateFlagStateIn | stateFlagStateOut | stateFlagBackup
+)
+
 // State describes arguments which are used to define how OpenTofu interacts
 // with state.
 type State struct {
@@ -54,19 +65,19 @@ type State struct {
 	BackupPath string
 }
 
-// AddFlags is the sole logic of registering the state related flags in OpenTofu.
-func (s *State) AddFlags(f *flag.FlagSet, lockFlags bool, stateInPath bool, stateOutPath bool, backupPath bool) {
-	if lockFlags {
+// addFlags is the sole logic of registering the state related flags in OpenTofu.
+func (s *State) addFlags(f *flag.FlagSet, mask stateFlag) {
+	if mask&stateFlagLock != 0 {
 		f.BoolVar(&s.Lock, "lock", true, "lock")
 		f.DurationVar(&s.LockTimeout, "lock-timeout", 0, "lock-timeout")
 	}
-	if stateInPath {
+	if mask&stateFlagStateIn != 0 {
 		s.AddStateInFlag(f, "")
 	}
-	if stateOutPath {
+	if mask&stateFlagStateOut != 0 {
 		f.StringVar(&s.StateOutPath, "state-out", "", "state-path")
 	}
-	if backupPath {
+	if mask&stateFlagBackup != 0 {
 		s.AddBackupFlag(f, "")
 	}
 }

--- a/internal/command/arguments/extended.go
+++ b/internal/command/arguments/extended.go
@@ -53,6 +53,31 @@ type State struct {
 	BackupPath string
 }
 
+// NewStateFlags must be used when creating a new [State] instance, instead of creating a new object inline.
+// This is because it provides the default value for [State.Lock] even if the flags are not registered.
+func NewStateFlags() *State {
+	return &State{
+		Lock: true,
+	}
+}
+
+// AddFlags is the sole logic of registering the state related flags in OpenTofu.
+func (s *State) AddFlags(f *flag.FlagSet, lockFlags bool, stateInPath bool, stateOutPath bool, backupPath bool) {
+	if lockFlags {
+		f.BoolVar(&s.Lock, "lock", true, "lock")
+		f.DurationVar(&s.LockTimeout, "lock-timeout", 0, "lock-timeout")
+	}
+	if stateInPath {
+		f.StringVar(&s.StatePath, "state", "", "state-path")
+	}
+	if stateOutPath {
+		f.StringVar(&s.StateOutPath, "state-out", "", "state-path")
+	}
+	if backupPath {
+		f.StringVar(&s.BackupPath, "backup", "", "backup-path")
+	}
+}
+
 // Operation describes arguments which are used to configure how a OpenTofu
 // operation such as a plan or apply executes.
 type Operation struct {
@@ -310,19 +335,11 @@ func (v *Vars) Empty() bool {
 // extendedFlagSet creates a FlagSet with common backend, operation, and vars
 // flags used in many commands. Target structs for each subset of flags must be
 // provided in order to support those flags.
-func extendedFlagSet(name string, state *State, operation *Operation, vars *Vars) *flag.FlagSet {
+func extendedFlagSet(name string, operation *Operation, vars *Vars) *flag.FlagSet {
 	f := defaultFlagSet(name)
 
-	if state == nil && operation == nil && vars == nil {
+	if operation == nil && vars == nil {
 		panic("use defaultFlagSet")
-	}
-
-	if state != nil {
-		f.BoolVar(&state.Lock, "lock", true, "lock")
-		f.DurationVar(&state.LockTimeout, "lock-timeout", 0, "lock-timeout")
-		f.StringVar(&state.StatePath, "state", "", "state-path")
-		f.StringVar(&state.StateOutPath, "state-out", "", "state-path")
-		f.StringVar(&state.BackupPath, "backup", "", "backup-path")
 	}
 
 	if operation != nil {

--- a/internal/command/arguments/extended.go
+++ b/internal/command/arguments/extended.go
@@ -69,7 +69,7 @@ func (s *State) AddFlags(f *flag.FlagSet, lockFlags bool, stateInPath bool, stat
 		f.DurationVar(&s.LockTimeout, "lock-timeout", 0, "lock-timeout")
 	}
 	if stateInPath {
-		f.StringVar(&s.StatePath, "state", "", "state-path")
+		s.AddStateInFlag(f, "")
 	}
 	if stateOutPath {
 		f.StringVar(&s.StateOutPath, "state-out", "", "state-path")
@@ -77,6 +77,11 @@ func (s *State) AddFlags(f *flag.FlagSet, lockFlags bool, stateInPath bool, stat
 	if backupPath {
 		s.AddBackupFlag(f, "")
 	}
+}
+
+// AddStateInFlag exists strictly because the default value can get a different value in some commands.
+func (s *State) AddStateInFlag(f *flag.FlagSet, defVal string) {
+	f.StringVar(&s.StatePath, "state", defVal, "state-path")
 }
 
 // AddBackupFlag exists strictly because the default value can get a different value in some commands.

--- a/internal/command/arguments/extended_test.go
+++ b/internal/command/arguments/extended_test.go
@@ -1,3 +1,8 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package arguments
 
 import (

--- a/internal/command/arguments/extended_test.go
+++ b/internal/command/arguments/extended_test.go
@@ -1,0 +1,253 @@
+package arguments
+
+import (
+	"flag"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestStateFlagsParsing(t *testing.T) {
+	testCases := map[string]struct {
+		args     []string
+		register func(s *State, f *flag.FlagSet)
+		want     *State
+		wantErr  error
+	}{
+		"defaults": {
+			args: nil,
+			register: func(s *State, f *flag.FlagSet) {
+				s.AddFlags(f, true, true, true, true)
+			},
+			want: stateArgsWithDefaults(nil),
+		},
+		"lock": {
+			args: []string{"-lock=false"},
+			register: func(s *State, f *flag.FlagSet) {
+				s.AddFlags(f, true, true, true, true)
+			},
+			want: stateArgsWithDefaults(func(v *State) {
+				v.Lock = false
+			}),
+		},
+		"lockTimeout": {
+			args: []string{"-lock-timeout=2s"},
+			register: func(s *State, f *flag.FlagSet) {
+				s.AddFlags(f, true, true, true, true)
+			},
+			want: stateArgsWithDefaults(func(v *State) {
+				v.LockTimeout = 2 * time.Second
+			}),
+		},
+		"state": {
+			args: []string{"-state=/path/to/state"},
+			register: func(s *State, f *flag.FlagSet) {
+				s.AddFlags(f, true, true, true, true)
+			},
+			want: stateArgsWithDefaults(func(v *State) {
+				v.StatePath = "/path/to/state"
+			}),
+		},
+		"stateOut": {
+			args: []string{"-state-out=/path/to/output/state"},
+			register: func(s *State, f *flag.FlagSet) {
+				s.AddFlags(f, true, true, true, true)
+			},
+			want: stateArgsWithDefaults(func(v *State) {
+				v.StateOutPath = "/path/to/output/state"
+			}),
+		},
+		"backup": {
+			args: []string{"-backup=/path/to/state/backup"},
+			register: func(s *State, f *flag.FlagSet) {
+				s.AddFlags(f, true, true, true, true)
+			},
+			want: stateArgsWithDefaults(func(v *State) {
+				v.BackupPath = "/path/to/state/backup"
+			}),
+		},
+		"all flags": {
+			args: []string{
+				"-backup=/path/to/state/backup",
+				"-state-out=/path/to/output/state",
+				"-state=/path/to/state",
+				"-lock-timeout=2s",
+				"-lock=false",
+			},
+			register: func(s *State, f *flag.FlagSet) {
+				s.AddFlags(f, true, true, true, true)
+			},
+			want: stateArgsWithDefaults(func(v *State) {
+				v.BackupPath = "/path/to/state/backup"
+				v.StateOutPath = "/path/to/output/state"
+				v.StatePath = "/path/to/state"
+				v.LockTimeout = 2 * time.Second
+				v.Lock = false
+			}),
+		},
+		"unknown flags provided": {
+			args: []string{
+				"-backup=/path/to/state/backup",
+				"-unknown=foo",
+			},
+			register: func(s *State, f *flag.FlagSet) {
+				s.AddFlags(f, true, true, true, true)
+			},
+			want: stateArgsWithDefaults(func(v *State) {
+				v.BackupPath = "/path/to/state/backup"
+			}),
+			wantErr: fmt.Errorf("flag provided but not defined: -unknown"),
+		},
+		"register only backup flag - no flags provided": {
+			args: []string{},
+			register: func(s *State, f *flag.FlagSet) {
+				s.AddBackupFlag(f, "-")
+			},
+			want: stateArgsWithDefaults(func(v *State) {
+				v.BackupPath = "-" // the provided different default
+			}),
+		},
+		"register only backup flag - with backup flag": {
+			args: []string{"-backup=/path/to/backup"},
+			register: func(s *State, f *flag.FlagSet) {
+				s.AddBackupFlag(f, "-")
+			},
+			want: stateArgsWithDefaults(func(v *State) {
+				v.BackupPath = "/path/to/backup"
+			}),
+		},
+		"register only backup flag - unregistered flag": {
+			args: []string{"-backup=/path/to/backup", "-lock=false"},
+			register: func(s *State, f *flag.FlagSet) {
+				s.AddBackupFlag(f, "-")
+			},
+			want: stateArgsWithDefaults(func(v *State) {
+				v.BackupPath = "/path/to/backup"
+			}),
+			wantErr: fmt.Errorf("flag provided but not defined: -lock"),
+		},
+	}
+
+	cmpOpts := cmpopts.IgnoreUnexported()
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			s := NewStateFlags()
+			f := defaultFlagSet("test")
+			tc.register(s, f)
+			err := f.Parse(tc.args)
+			if diff := cmp.Diff(fmt.Sprintf("%s", tc.wantErr), fmt.Sprintf("%s", err)); diff != "" {
+				t.Errorf("unexpected error (-want,+got)\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want, s, cmpOpts); diff != "" {
+				t.Errorf("unexpected result (-want,+got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestStateFlagsRegistering(t *testing.T) {
+	testCases := map[string]struct {
+		register func(s *State, f *flag.FlagSet)
+		want     *State
+		wantErr  error
+	}{
+		"no flag registered": {
+			register: func(s *State, f *flag.FlagSet) {
+			},
+			want:    stateArgsWithDefaults(func(v *State) {}),
+			wantErr: fmt.Errorf("flag provided but not defined: -lock"),
+		},
+		"only lock flags registered": {
+			register: func(s *State, f *flag.FlagSet) {
+				s.AddFlags(f, true, false, false, false)
+			},
+			want: stateArgsWithDefaults(func(v *State) {
+				v.Lock = false
+				v.LockTimeout = 2 * time.Second
+			}),
+			wantErr: fmt.Errorf("flag provided but not defined: -state"),
+		},
+		"lock and state in": {
+			register: func(s *State, f *flag.FlagSet) {
+				s.AddFlags(f, true, true, false, false)
+			},
+			want: stateArgsWithDefaults(func(v *State) {
+				v.Lock = false
+				v.LockTimeout = 2 * time.Second
+				v.StatePath = "/path/to/state"
+			}),
+			wantErr: fmt.Errorf("flag provided but not defined: -state-out"),
+		},
+		"lock, state in and state out": {
+			register: func(s *State, f *flag.FlagSet) {
+				s.AddFlags(f, true, true, true, false)
+			},
+			want: stateArgsWithDefaults(func(v *State) {
+				v.Lock = false
+				v.LockTimeout = 2 * time.Second
+				v.StatePath = "/path/to/state"
+				v.StateOutPath = "/path/to/output/state"
+			}),
+			wantErr: fmt.Errorf("flag provided but not defined: -backup"),
+		},
+		"lock, state in, state out and backup": {
+			register: func(s *State, f *flag.FlagSet) {
+				s.AddFlags(f, true, true, true, true)
+			},
+			want: stateArgsWithDefaults(func(v *State) {
+				v.Lock = false
+				v.LockTimeout = 2 * time.Second
+				v.StatePath = "/path/to/state"
+				v.StateOutPath = "/path/to/output/state"
+				v.BackupPath = "/path/to/state/backup"
+			}),
+		},
+		"lock, state in, state out and backup with a different default": {
+			register: func(s *State, f *flag.FlagSet) {
+				s.AddFlags(f, true, true, true, false)
+				s.AddBackupFlag(f, "-")
+			},
+			want: stateArgsWithDefaults(func(v *State) {
+				v.Lock = false
+				v.LockTimeout = 2 * time.Second
+				v.StatePath = "/path/to/state"
+				v.StateOutPath = "/path/to/output/state"
+				v.BackupPath = "/path/to/state/backup"
+			}),
+		},
+	}
+	cmpOpts := cmpopts.IgnoreUnexported()
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			s := NewStateFlags()
+			f := defaultFlagSet("test")
+			tc.register(s, f)
+			err := f.Parse([]string{
+				"-lock=false",
+				"-lock-timeout=2s",
+				"-state=/path/to/state",
+				"-state-out=/path/to/output/state",
+				"-backup=/path/to/state/backup",
+			})
+			if diff := cmp.Diff(fmt.Sprintf("%s", tc.wantErr), fmt.Sprintf("%s", err)); diff != "" {
+				t.Errorf("unexpected error (-want,+got)\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want, s, cmpOpts); diff != "" {
+				t.Errorf("unexpected result (-want,+got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func stateArgsWithDefaults(mutate func(v *State)) *State {
+	ret := NewStateFlags()
+	if mutate != nil {
+		mutate(ret)
+	}
+	return ret
+}

--- a/internal/command/arguments/extended_test.go
+++ b/internal/command/arguments/extended_test.go
@@ -192,12 +192,14 @@ func TestStateFlagsParsing(t *testing.T) {
 func TestStateFlagsRegistering(t *testing.T) {
 	testCases := map[string]struct {
 		register func(s *State, f *flag.FlagSet)
+		args     []string
 		want     *State
 		wantErr  error
 	}{
 		"no flag registered": {
 			register: func(s *State, f *flag.FlagSet) {
 			},
+			args:    []string{"-lock=false"},
 			want:    stateArgsWithDefaults(func(v *State) {}),
 			wantErr: fmt.Errorf("flag provided but not defined: -lock"),
 		},
@@ -205,42 +207,61 @@ func TestStateFlagsRegistering(t *testing.T) {
 			register: func(s *State, f *flag.FlagSet) {
 				s.addFlags(f, stateFlagLock)
 			},
+			args: []string{
+				"-lock=false",
+				"-lock-timeout=42ns",
+			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.Lock = false
-				v.LockTimeout = 2 * time.Second
+				v.LockTimeout = 42 * time.Nanosecond
 			}),
-			wantErr: fmt.Errorf("flag provided but not defined: -state"),
 		},
 		"lock and state in": {
 			register: func(s *State, f *flag.FlagSet) {
 				s.addFlags(f, stateFlagLock|stateFlagStateIn)
 			},
+			args: []string{
+				"-lock=false",
+				"-lock-timeout=42µs",
+				"-state=/path/to/state",
+			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.Lock = false
-				v.LockTimeout = 2 * time.Second
+				v.LockTimeout = 42 * time.Microsecond
 				v.StatePath = "/path/to/state"
 			}),
-			wantErr: fmt.Errorf("flag provided but not defined: -state-out"),
 		},
 		"lock, state in and state out": {
 			register: func(s *State, f *flag.FlagSet) {
 				s.addFlags(f, stateFlagLock|stateFlagStateIn|stateFlagStateOut)
 			},
+			args: []string{
+				"-lock=false",
+				"-lock-timeout=42ms",
+				"-state=/path/to/state",
+				"-state-out=/path/to/output/state",
+			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.Lock = false
-				v.LockTimeout = 2 * time.Second
+				v.LockTimeout = 42 * time.Millisecond
 				v.StatePath = "/path/to/state"
 				v.StateOutPath = "/path/to/output/state"
 			}),
-			wantErr: fmt.Errorf("flag provided but not defined: -backup"),
 		},
 		"lock, state in, state out and backup": {
 			register: func(s *State, f *flag.FlagSet) {
 				s.addFlags(f, stateFlagAll)
 			},
+			args: []string{
+				"-lock=false",
+				"-lock-timeout=42s",
+				"-state=/path/to/state",
+				"-state-out=/path/to/output/state",
+				"-backup=/path/to/state/backup",
+			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.Lock = false
-				v.LockTimeout = 2 * time.Second
+				v.LockTimeout = 42 * time.Second
 				v.StatePath = "/path/to/state"
 				v.StateOutPath = "/path/to/output/state"
 				v.BackupPath = "/path/to/state/backup"
@@ -252,9 +273,16 @@ func TestStateFlagsRegistering(t *testing.T) {
 				s.addFlags(f, stateFlagLock|stateFlagStateIn|stateFlagStateOut)
 				s.AddBackupFlag(f, "-")
 			},
+			args: []string{
+				"-lock=false",
+				"-lock-timeout=42m",
+				"-state=/path/to/state",
+				"-state-out=/path/to/output/state",
+				"-backup=/path/to/state/backup",
+			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.Lock = false
-				v.LockTimeout = 2 * time.Second
+				v.LockTimeout = 42 * time.Minute
 				v.StatePath = "/path/to/state"
 				v.StateOutPath = "/path/to/output/state"
 				v.BackupPath = "/path/to/state/backup"
@@ -268,13 +296,7 @@ func TestStateFlagsRegistering(t *testing.T) {
 			s := &State{}
 			f := defaultFlagSet("test")
 			tc.register(s, f)
-			err := f.Parse([]string{
-				"-lock=false",
-				"-lock-timeout=2s",
-				"-state=/path/to/state",
-				"-state-out=/path/to/output/state",
-				"-backup=/path/to/state/backup",
-			})
+			err := f.Parse(tc.args)
 			if diff := cmp.Diff(fmt.Sprintf("%s", tc.wantErr), fmt.Sprintf("%s", err)); diff != "" {
 				t.Errorf("unexpected error (-want,+got)\n%s", diff)
 			}

--- a/internal/command/arguments/extended_test.go
+++ b/internal/command/arguments/extended_test.go
@@ -25,7 +25,7 @@ func TestStateFlagsParsing(t *testing.T) {
 		"defaults": {
 			args: nil,
 			register: func(s *State, f *flag.FlagSet) {
-				s.AddFlags(f, true, true, true, true)
+				s.addFlags(f, stateFlagAll)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.Lock = true
@@ -34,7 +34,7 @@ func TestStateFlagsParsing(t *testing.T) {
 		"lock": {
 			args: []string{"-lock=false"},
 			register: func(s *State, f *flag.FlagSet) {
-				s.AddFlags(f, true, true, true, true)
+				s.addFlags(f, stateFlagAll)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.Lock = false
@@ -43,7 +43,7 @@ func TestStateFlagsParsing(t *testing.T) {
 		"lockTimeout": {
 			args: []string{"-lock-timeout=2s"},
 			register: func(s *State, f *flag.FlagSet) {
-				s.AddFlags(f, true, true, true, true)
+				s.addFlags(f, stateFlagAll)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.LockTimeout = 2 * time.Second
@@ -53,7 +53,7 @@ func TestStateFlagsParsing(t *testing.T) {
 		"state": {
 			args: []string{"-state=/path/to/state"},
 			register: func(s *State, f *flag.FlagSet) {
-				s.AddFlags(f, true, true, true, true)
+				s.addFlags(f, stateFlagAll)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.StatePath = "/path/to/state"
@@ -63,7 +63,7 @@ func TestStateFlagsParsing(t *testing.T) {
 		"stateOut": {
 			args: []string{"-state-out=/path/to/output/state"},
 			register: func(s *State, f *flag.FlagSet) {
-				s.AddFlags(f, true, true, true, true)
+				s.addFlags(f, stateFlagAll)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.StateOutPath = "/path/to/output/state"
@@ -73,7 +73,7 @@ func TestStateFlagsParsing(t *testing.T) {
 		"backup": {
 			args: []string{"-backup=/path/to/state/backup"},
 			register: func(s *State, f *flag.FlagSet) {
-				s.AddFlags(f, true, true, true, true)
+				s.addFlags(f, stateFlagAll)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.BackupPath = "/path/to/state/backup"
@@ -89,7 +89,7 @@ func TestStateFlagsParsing(t *testing.T) {
 				"-lock=false",
 			},
 			register: func(s *State, f *flag.FlagSet) {
-				s.AddFlags(f, true, true, true, true)
+				s.addFlags(f, stateFlagAll)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.BackupPath = "/path/to/state/backup"
@@ -105,7 +105,7 @@ func TestStateFlagsParsing(t *testing.T) {
 				"-unknown=foo",
 			},
 			register: func(s *State, f *flag.FlagSet) {
-				s.AddFlags(f, true, true, true, true)
+				s.addFlags(f, stateFlagAll)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.BackupPath = "/path/to/state/backup"
@@ -203,7 +203,7 @@ func TestStateFlagsRegistering(t *testing.T) {
 		},
 		"only lock flags registered": {
 			register: func(s *State, f *flag.FlagSet) {
-				s.AddFlags(f, true, false, false, false)
+				s.addFlags(f, stateFlagLock)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.Lock = false
@@ -213,7 +213,7 @@ func TestStateFlagsRegistering(t *testing.T) {
 		},
 		"lock and state in": {
 			register: func(s *State, f *flag.FlagSet) {
-				s.AddFlags(f, true, true, false, false)
+				s.addFlags(f, stateFlagLock|stateFlagStateIn)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.Lock = false
@@ -224,7 +224,7 @@ func TestStateFlagsRegistering(t *testing.T) {
 		},
 		"lock, state in and state out": {
 			register: func(s *State, f *flag.FlagSet) {
-				s.AddFlags(f, true, true, true, false)
+				s.addFlags(f, stateFlagLock|stateFlagStateIn|stateFlagStateOut)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.Lock = false
@@ -236,7 +236,7 @@ func TestStateFlagsRegistering(t *testing.T) {
 		},
 		"lock, state in, state out and backup": {
 			register: func(s *State, f *flag.FlagSet) {
-				s.AddFlags(f, true, true, true, true)
+				s.addFlags(f, stateFlagAll)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.Lock = false
@@ -248,7 +248,8 @@ func TestStateFlagsRegistering(t *testing.T) {
 		},
 		"lock, state in, state out and backup with a different default": {
 			register: func(s *State, f *flag.FlagSet) {
-				s.AddFlags(f, true, true, true, false)
+				// StateFlagBackup omitted here to be added later with a different default value
+				s.addFlags(f, stateFlagLock|stateFlagStateIn|stateFlagStateOut)
 				s.AddBackupFlag(f, "-")
 			},
 			want: stateArgsWithDefaults(func(v *State) {

--- a/internal/command/arguments/extended_test.go
+++ b/internal/command/arguments/extended_test.go
@@ -27,7 +27,9 @@ func TestStateFlagsParsing(t *testing.T) {
 			register: func(s *State, f *flag.FlagSet) {
 				s.AddFlags(f, true, true, true, true)
 			},
-			want: stateArgsWithDefaults(nil),
+			want: stateArgsWithDefaults(func(v *State) {
+				v.Lock = true
+			}),
 		},
 		"lock": {
 			args: []string{"-lock=false"},
@@ -45,6 +47,7 @@ func TestStateFlagsParsing(t *testing.T) {
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.LockTimeout = 2 * time.Second
+				v.Lock = true
 			}),
 		},
 		"state": {
@@ -54,6 +57,7 @@ func TestStateFlagsParsing(t *testing.T) {
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.StatePath = "/path/to/state"
+				v.Lock = true
 			}),
 		},
 		"stateOut": {
@@ -63,6 +67,7 @@ func TestStateFlagsParsing(t *testing.T) {
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.StateOutPath = "/path/to/output/state"
+				v.Lock = true
 			}),
 		},
 		"backup": {
@@ -72,6 +77,7 @@ func TestStateFlagsParsing(t *testing.T) {
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.BackupPath = "/path/to/state/backup"
+				v.Lock = true
 			}),
 		},
 		"all flags": {
@@ -103,6 +109,7 @@ func TestStateFlagsParsing(t *testing.T) {
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.BackupPath = "/path/to/state/backup"
+				v.Lock = true
 			}),
 			wantErr: fmt.Errorf("flag provided but not defined: -unknown"),
 		},
@@ -168,7 +175,7 @@ func TestStateFlagsParsing(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			s := NewStateFlags()
+			s := &State{}
 			f := defaultFlagSet("test")
 			tc.register(s, f)
 			err := f.Parse(tc.args)
@@ -257,7 +264,7 @@ func TestStateFlagsRegistering(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			s := NewStateFlags()
+			s := &State{}
 			f := defaultFlagSet("test")
 			tc.register(s, f)
 			err := f.Parse([]string{
@@ -278,7 +285,7 @@ func TestStateFlagsRegistering(t *testing.T) {
 }
 
 func stateArgsWithDefaults(mutate func(v *State)) *State {
-	ret := NewStateFlags()
+	ret := &State{}
 	if mutate != nil {
 		mutate(ret)
 	}

--- a/internal/command/arguments/extended_test.go
+++ b/internal/command/arguments/extended_test.go
@@ -129,6 +129,34 @@ func TestStateFlagsParsing(t *testing.T) {
 			}),
 			wantErr: fmt.Errorf("flag provided but not defined: -lock"),
 		},
+		"register only stateIn flag - no flags provided": {
+			args: []string{},
+			register: func(s *State, f *flag.FlagSet) {
+				s.AddStateInFlag(f, "default.tfstate")
+			},
+			want: stateArgsWithDefaults(func(v *State) {
+				v.StatePath = "default.tfstate" // the provided different default
+			}),
+		},
+		"register only stateIn flag - with state flag": {
+			args: []string{"-state=/path/to/state"},
+			register: func(s *State, f *flag.FlagSet) {
+				s.AddStateInFlag(f, "default.tfstate")
+			},
+			want: stateArgsWithDefaults(func(v *State) {
+				v.StatePath = "/path/to/state"
+			}),
+		},
+		"register only stateIn flag - unregistered flag": {
+			args: []string{"-state=/path/to/state", "-lock=false"},
+			register: func(s *State, f *flag.FlagSet) {
+				s.AddStateInFlag(f, "-")
+			},
+			want: stateArgsWithDefaults(func(v *State) {
+				v.StatePath = "/path/to/state"
+			}),
+			wantErr: fmt.Errorf("flag provided but not defined: -lock"),
+		},
 	}
 
 	cmpOpts := cmpopts.IgnoreUnexported()

--- a/internal/command/arguments/get.go
+++ b/internal/command/arguments/get.go
@@ -31,7 +31,7 @@ func ParseGet(args []string) (*Get, func(), tfdiags.Diagnostics) {
 		Vars: &Vars{},
 	}
 
-	cmdFlags := extendedFlagSet("get", nil, nil, arguments.Vars)
+	cmdFlags := extendedFlagSet("get", nil, arguments.Vars)
 	cmdFlags.BoolVar(&arguments.Update, "update", false, "update")
 	cmdFlags.StringVar(&arguments.TestsDirectory, "test-directory", "tests", "test-directory")
 	arguments.ViewOptions.AddFlags(cmdFlags, false)

--- a/internal/command/arguments/graph.go
+++ b/internal/command/arguments/graph.go
@@ -38,7 +38,7 @@ func ParseGraph(args []string) (*Graph, func(), tfdiags.Diagnostics) {
 		Vars: &Vars{},
 	}
 
-	cmdFlags := extendedFlagSet("graph", nil, nil, arguments.Vars)
+	cmdFlags := extendedFlagSet("graph", nil, arguments.Vars)
 	cmdFlags.BoolVar(&arguments.DrawCycles, "draw-cycles", false, "draw-cycles")
 	cmdFlags.StringVar(&arguments.GraphType, "type", "", "type")
 	cmdFlags.IntVar(&arguments.ModuleDepth, "module-depth", -1, "module-depth")

--- a/internal/command/arguments/import.go
+++ b/internal/command/arguments/import.go
@@ -38,7 +38,7 @@ func ParseImport(args []string, wd *workdir.Dir) (*Import, func(), tfdiags.Diagn
 	var diags tfdiags.Diagnostics
 	ret := &Import{
 		Vars:    &Vars{},
-		State:   NewStateFlags(),
+		State:   &State{},
 		Backend: &Backend{},
 	}
 	// Get the pwd since its our default -config flag value

--- a/internal/command/arguments/import.go
+++ b/internal/command/arguments/import.go
@@ -48,7 +48,7 @@ func ParseImport(args []string, wd *workdir.Dir) (*Import, func(), tfdiags.Diagn
 	cmdFlags.IntVar(&ret.Parallelism, "parallelism", DefaultParallelism, "parallelism")
 	cmdFlags.StringVar(&ret.ConfigPath, "config", pwd, "path")
 	ret.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
-	ret.State.AddFlags(cmdFlags, true, true, true, true)
+	ret.State.addFlags(cmdFlags, stateFlagAll)
 	ret.ViewOptions.AddFlags(cmdFlags, true)
 
 	if err := cmdFlags.Parse(args); err != nil {

--- a/internal/command/arguments/import.go
+++ b/internal/command/arguments/import.go
@@ -38,16 +38,17 @@ func ParseImport(args []string, wd *workdir.Dir) (*Import, func(), tfdiags.Diagn
 	var diags tfdiags.Diagnostics
 	ret := &Import{
 		Vars:    &Vars{},
-		State:   &State{},
+		State:   NewStateFlags(),
 		Backend: &Backend{},
 	}
 	// Get the pwd since its our default -config flag value
 	pwd := wd.NormalizePath(wd.RootModuleDir())
 
-	cmdFlags := extendedFlagSet("import", ret.State, nil, ret.Vars)
-	ret.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
+	cmdFlags := extendedFlagSet("import", nil, ret.Vars)
 	cmdFlags.IntVar(&ret.Parallelism, "parallelism", DefaultParallelism, "parallelism")
 	cmdFlags.StringVar(&ret.ConfigPath, "config", pwd, "path")
+	ret.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
+	ret.State.AddFlags(cmdFlags, true, true, true, true)
 	ret.ViewOptions.AddFlags(cmdFlags, true)
 
 	if err := cmdFlags.Parse(args); err != nil {

--- a/internal/command/arguments/import_test.go
+++ b/internal/command/arguments/import_test.go
@@ -202,7 +202,10 @@ func importArgsWithDefaults(mutate func(imp *Import)) *Import {
 			vars:     &v,
 			varFiles: &vf,
 		},
-		State:   NewStateFlags(),
+		State: &State{
+			Lock:      true,
+			StatePath: "",
+		},
 		Backend: &Backend{},
 	}
 	if mutate != nil {

--- a/internal/command/arguments/import_test.go
+++ b/internal/command/arguments/import_test.go
@@ -202,10 +202,7 @@ func importArgsWithDefaults(mutate func(imp *Import)) *Import {
 			vars:     &v,
 			varFiles: &vf,
 		},
-		State: &State{
-			Lock:      true,
-			StatePath: "",
-		},
+		State:   NewStateFlags(),
 		Backend: &Backend{},
 	}
 	if mutate != nil {

--- a/internal/command/arguments/init.go
+++ b/internal/command/arguments/init.go
@@ -50,6 +50,8 @@ type Init struct {
 	// Backend holds and providers information for the flags related to the backend operations, like locking
 	// locking timeout, force migration, etc.
 	Backend *Backend
+	// State is used for the state related flags
+	State *State
 }
 
 // ParseInit processes CLI arguments, returning an Init value, a closer function, and errors.
@@ -60,12 +62,13 @@ func ParseInit(args []string) (*Init, func(), tfdiags.Diagnostics) {
 	init := &Init{
 		Vars:            &Vars{},
 		Backend:         &Backend{},
+		State:           NewStateFlags(),
 		FlagConfigExtra: flags.NewRawFlags("-backend-config"),
 	}
 
-	cmdFlags := extendedFlagSet("init", nil, nil, init.Vars)
+	cmdFlags := extendedFlagSet("init", nil, init.Vars)
 	init.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
-	init.Backend.AddStateFlags(cmdFlags)
+	init.State.AddFlags(cmdFlags, true, false, false, false)
 	init.Backend.AddMigrationFlags(cmdFlags)
 	cmdFlags.BoolVar(&init.FlagBackend, "backend", true, "")
 	cmdFlags.BoolVar(&init.FlagCloud, "cloud", true, "")

--- a/internal/command/arguments/init.go
+++ b/internal/command/arguments/init.go
@@ -68,8 +68,8 @@ func ParseInit(args []string) (*Init, func(), tfdiags.Diagnostics) {
 
 	cmdFlags := extendedFlagSet("init", nil, init.Vars)
 	init.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
-	init.State.AddFlags(cmdFlags, true, false, false, false)
 	init.Backend.AddMigrationFlags(cmdFlags)
+	init.State.AddFlags(cmdFlags, true, false, false, false)
 	cmdFlags.BoolVar(&init.FlagBackend, "backend", true, "")
 	cmdFlags.BoolVar(&init.FlagCloud, "cloud", true, "")
 	cmdFlags.Var(init.FlagConfigExtra, "backend-config", "")

--- a/internal/command/arguments/init.go
+++ b/internal/command/arguments/init.go
@@ -69,7 +69,7 @@ func ParseInit(args []string) (*Init, func(), tfdiags.Diagnostics) {
 	cmdFlags := extendedFlagSet("init", nil, init.Vars)
 	init.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
 	init.Backend.AddMigrationFlags(cmdFlags)
-	init.State.AddFlags(cmdFlags, true, false, false, false)
+	init.State.addFlags(cmdFlags, stateFlagLock)
 	cmdFlags.BoolVar(&init.FlagBackend, "backend", true, "")
 	cmdFlags.BoolVar(&init.FlagCloud, "cloud", true, "")
 	cmdFlags.Var(init.FlagConfigExtra, "backend-config", "")

--- a/internal/command/arguments/init.go
+++ b/internal/command/arguments/init.go
@@ -62,7 +62,7 @@ func ParseInit(args []string) (*Init, func(), tfdiags.Diagnostics) {
 	init := &Init{
 		Vars:            &Vars{},
 		Backend:         &Backend{},
-		State:           NewStateFlags(),
+		State:           &State{},
 		FlagConfigExtra: flags.NewRawFlags("-backend-config"),
 	}
 

--- a/internal/command/arguments/init_test.go
+++ b/internal/command/arguments/init_test.go
@@ -442,18 +442,3 @@ func initArgsWithDefaults(mutate func(init *Init)) *Init {
 	}
 	return ret
 }
-
-func backendWithDefaults(mutate func(backend *Backend)) Backend {
-	ret := Backend{
-		IgnoreRemoteVersion: false,
-		StateLock:           false,
-		StateLockTimeout:    0,
-		ForceInitCopy:       false,
-		Reconfigure:         false,
-		MigrateState:        false,
-	}
-	if mutate != nil {
-		mutate(&ret)
-	}
-	return ret
-}

--- a/internal/command/arguments/init_test.go
+++ b/internal/command/arguments/init_test.go
@@ -434,7 +434,7 @@ func initArgsWithDefaults(mutate func(init *Init)) *Init {
 			InputEnabled: true,
 		},
 		Vars:    &Vars{},
-		State:   NewStateFlags(),
+		State:   &State{Lock: true},
 		Backend: &Backend{},
 	}
 	if mutate != nil {

--- a/internal/command/arguments/init_test.go
+++ b/internal/command/arguments/init_test.go
@@ -92,6 +92,18 @@ func TestParseInit_basicValidation(t *testing.T) {
 				_ = init.FlagPluginPath.Set("/test2")
 			}),
 		},
+		"lock disabled": {
+			args: []string{"-lock=false"},
+			want: initArgsWithDefaults(func(init *Init) {
+				init.State.Lock = false
+			}),
+		},
+		"lock-timeout": {
+			args: []string{"-lock-timeout=30s"},
+			want: initArgsWithDefaults(func(init *Init) {
+				init.State.LockTimeout = 30 * time.Second
+			}),
+		},
 	}
 
 	cmpOpts := cmpopts.IgnoreUnexported(Vars{}, ViewOptions{})
@@ -213,65 +225,6 @@ func TestParseInit_backendCloudSynchronization(t *testing.T) {
 			}
 			if got.FlagBackend != got.FlagCloud {
 				t.Errorf("wrong FlagBackend. expected to be in sync with FlagCloud, instead got FlagBackend=%t and FlagCloud=%t", got.FlagCloud, got.FlagBackend)
-			}
-		})
-	}
-}
-
-func TestParseInit_backendFlags(t *testing.T) {
-	testCases := map[string]struct {
-		args        []string
-		wantBackend Backend
-	}{
-		"ignore-remote-version": {
-			args: []string{"-ignore-remote-version"},
-			wantBackend: backendWithDefaults(func(backend *Backend) {
-				backend.IgnoreRemoteVersion = true
-			}),
-		},
-		"lock disabled": {
-			args: []string{"-lock=false"},
-			wantBackend: backendWithDefaults(func(backend *Backend) {
-				backend.StateLock = false
-			}),
-		},
-		"lock-timeout": {
-			args: []string{"-lock-timeout=30s"},
-			wantBackend: backendWithDefaults(func(backend *Backend) {
-				backend.StateLockTimeout = 30 * time.Second
-			}),
-		},
-		"migrate-state": {
-			args: []string{"-migrate-state"},
-			wantBackend: backendWithDefaults(func(backend *Backend) {
-				backend.MigrateState = true
-			}),
-		},
-		"reconfigure": {
-			args: []string{"-reconfigure"},
-			wantBackend: backendWithDefaults(func(backend *Backend) {
-				backend.Reconfigure = true
-			}),
-		},
-		"force-copy": {
-			args: []string{"-force-copy"},
-			wantBackend: backendWithDefaults(func(backend *Backend) {
-				backend.ForceInitCopy = true
-				backend.MigrateState = true
-			}),
-		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			got, closer, diags := ParseInit(tc.args)
-			defer closer()
-
-			if len(diags) > 0 {
-				t.Fatalf("unexpected diags: %v", diags)
-			}
-			if diff := cmp.Diff(tc.wantBackend, *got.Backend); diff != "" {
-				t.Errorf("unexpected Backend result (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -481,7 +434,8 @@ func initArgsWithDefaults(mutate func(init *Init)) *Init {
 			InputEnabled: true,
 		},
 		Vars:    &Vars{},
-		Backend: &Backend{StateLock: true},
+		State:   NewStateFlags(),
+		Backend: &Backend{},
 	}
 	if mutate != nil {
 		mutate(ret)
@@ -492,7 +446,7 @@ func initArgsWithDefaults(mutate func(init *Init)) *Init {
 func backendWithDefaults(mutate func(backend *Backend)) Backend {
 	ret := Backend{
 		IgnoreRemoteVersion: false,
-		StateLock:           true,
+		StateLock:           false,
 		StateLockTimeout:    0,
 		ForceInitCopy:       false,
 		Reconfigure:         false,

--- a/internal/command/arguments/login.go
+++ b/internal/command/arguments/login.go
@@ -31,7 +31,7 @@ func ParseLogin(args []string) (*Login, func(), tfdiags.Diagnostics) {
 		// just to keep backwards compatibility for users (in case any of them are using these flags with this command)
 		Vars: &Vars{},
 		// State is only initialised and no flags are registered since the login command needs to lock the
-		// state by default, which is ensured by NewStateFlags.
+		// state by default, with no user input on that.
 		State: &State{Lock: true},
 	}
 

--- a/internal/command/arguments/login.go
+++ b/internal/command/arguments/login.go
@@ -32,7 +32,7 @@ func ParseLogin(args []string) (*Login, func(), tfdiags.Diagnostics) {
 		Vars: &Vars{},
 		// State is only initialised and no flags are registered since the login command needs to lock the
 		// state by default, which is ensured by NewStateFlags.
-		State: NewStateFlags(),
+		State: &State{Lock: true},
 	}
 
 	cmdFlags := extendedFlagSet("login", nil, arguments.Vars)

--- a/internal/command/arguments/login.go
+++ b/internal/command/arguments/login.go
@@ -16,7 +16,7 @@ type Login struct {
 
 	// ViewOptions specifies which view options to use
 	ViewOptions ViewOptions
-	// Vars holds and provides information for the flags related to variables that a user can give into the process
+	// Vars and State are the common extended flags
 	Vars  *Vars
 	State *State
 }
@@ -29,7 +29,9 @@ func ParseLogin(args []string) (*Login, func(), tfdiags.Diagnostics) {
 	arguments := &Login{
 		// Even though the command does not use the -var/-var-file content, we will keep this for the moment
 		// just to keep backwards compatibility for users (in case any of them are using these flags with this command)
-		Vars:  &Vars{},
+		Vars: &Vars{},
+		// State is only initialised and no flags are registered since the login command needs to lock the
+		// state by default, which is ensured by NewStateFlags.
 		State: NewStateFlags(),
 	}
 

--- a/internal/command/arguments/login.go
+++ b/internal/command/arguments/login.go
@@ -13,7 +13,7 @@ import (
 type Login struct {
 	// Host represents the host that OpenTofu will try to login to
 	Host string
-	
+
 	// ViewOptions specifies which view options to use
 	ViewOptions ViewOptions
 	// Vars holds and provides information for the flags related to variables that a user can give into the process
@@ -31,7 +31,7 @@ func ParseLogin(args []string) (*Login, func(), tfdiags.Diagnostics) {
 		Vars: &Vars{},
 	}
 
-	cmdFlags := extendedFlagSet("login", nil, nil, arguments.Vars)
+	cmdFlags := extendedFlagSet("login", nil, arguments.Vars)
 	arguments.ViewOptions.AddFlags(cmdFlags, true)
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(

--- a/internal/command/arguments/login.go
+++ b/internal/command/arguments/login.go
@@ -17,7 +17,8 @@ type Login struct {
 	// ViewOptions specifies which view options to use
 	ViewOptions ViewOptions
 	// Vars holds and provides information for the flags related to variables that a user can give into the process
-	Vars *Vars
+	Vars  *Vars
+	State *State
 }
 
 // ParseLogin processes CLI arguments, returning a Login value, a closer function, and errors.
@@ -28,7 +29,8 @@ func ParseLogin(args []string) (*Login, func(), tfdiags.Diagnostics) {
 	arguments := &Login{
 		// Even though the command does not use the -var/-var-file content, we will keep this for the moment
 		// just to keep backwards compatibility for users (in case any of them are using these flags with this command)
-		Vars: &Vars{},
+		Vars:  &Vars{},
+		State: NewStateFlags(),
 	}
 
 	cmdFlags := extendedFlagSet("login", nil, arguments.Vars)

--- a/internal/command/arguments/login_test.go
+++ b/internal/command/arguments/login_test.go
@@ -157,3 +157,18 @@ func TestParseLogin_viewOptions(t *testing.T) {
 		})
 	}
 }
+
+func TestParseLogin_StateLock(t *testing.T) {
+	// NOTE: the command needs to have the state lock flag set as true all the time.
+	args, closer, diags := ParseLogin([]string{"host"})
+	defer closer()
+	if len(diags) > 0 {
+		t.Errorf("unexpected diagnostics: %s", diags)
+	}
+	if args.State == nil {
+		t.Fatalf("expected to have a state arguments object but got nil")
+	}
+	if !args.State.Lock {
+		t.Errorf("the state.lock should be true. This is a bug in the parsing of the arguments")
+	}
+}

--- a/internal/command/arguments/output.go
+++ b/internal/command/arguments/output.go
@@ -14,18 +14,14 @@ type Output struct {
 	// Name identifies which root module output to show.  If empty, show all
 	// outputs.
 	Name string
-
-	// StatePath is an optional path to a state file, from which outputs will
-	// be loaded.
-	StatePath string
+	// ShowSensitive is used to display the value of variables marked as sensitive.
+	ShowSensitive bool
 
 	// ViewOptions specifies which view options to use
 	ViewOptions ViewOptions
-
-	Vars *Vars
-
-	// ShowSensitive is used to display the value of variables marked as sensitive.
-	ShowSensitive bool
+	// Vars and State are the common extended flags
+	Vars  *Vars
+	State *State
 }
 
 // ParseOutput processes CLI arguments, returning an Output value, a closer function, and errors.
@@ -34,14 +30,14 @@ type Output struct {
 func ParseOutput(args []string) (*Output, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	output := &Output{
-		Vars: &Vars{},
+		Vars:  &Vars{},
+		State: NewStateFlags(),
 	}
 
 	var rawOutput bool
-	var statePath string
 	cmdFlags := extendedFlagSet("output", nil, output.Vars)
 	cmdFlags.BoolVar(&rawOutput, "raw", false, "raw")
-	cmdFlags.StringVar(&statePath, "state", "", "path")
+	output.State.AddFlags(cmdFlags, false, true, false, false)
 	cmdFlags.BoolVar(&output.ShowSensitive, "show-sensitive", false, "displays sensitive values")
 
 	output.ViewOptions.AddFlags(cmdFlags, false)
@@ -79,8 +75,6 @@ func ParseOutput(args []string) (*Output, func(), tfdiags.Diagnostics) {
 			rawOutput = false
 		}
 	}
-
-	output.StatePath = statePath
 
 	if len(args) > 0 {
 		output.Name = args[0]

--- a/internal/command/arguments/output.go
+++ b/internal/command/arguments/output.go
@@ -39,7 +39,7 @@ func ParseOutput(args []string) (*Output, func(), tfdiags.Diagnostics) {
 
 	var rawOutput bool
 	var statePath string
-	cmdFlags := extendedFlagSet("output", nil, nil, output.Vars)
+	cmdFlags := extendedFlagSet("output", nil, output.Vars)
 	cmdFlags.BoolVar(&rawOutput, "raw", false, "raw")
 	cmdFlags.StringVar(&statePath, "state", "", "path")
 	cmdFlags.BoolVar(&output.ShowSensitive, "show-sensitive", false, "displays sensitive values")

--- a/internal/command/arguments/output.go
+++ b/internal/command/arguments/output.go
@@ -31,7 +31,7 @@ func ParseOutput(args []string) (*Output, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	output := &Output{
 		Vars:  &Vars{},
-		State: NewStateFlags(),
+		State: &State{},
 	}
 
 	var rawOutput bool

--- a/internal/command/arguments/output.go
+++ b/internal/command/arguments/output.go
@@ -37,7 +37,7 @@ func ParseOutput(args []string) (*Output, func(), tfdiags.Diagnostics) {
 	var rawOutput bool
 	cmdFlags := extendedFlagSet("output", nil, output.Vars)
 	cmdFlags.BoolVar(&rawOutput, "raw", false, "raw")
-	output.State.AddFlags(cmdFlags, false, true, false, false)
+	output.State.addFlags(cmdFlags, stateFlagStateIn)
 	cmdFlags.BoolVar(&output.ShowSensitive, "show-sensitive", false, "displays sensitive values")
 
 	output.ViewOptions.AddFlags(cmdFlags, false)

--- a/internal/command/arguments/output_test.go
+++ b/internal/command/arguments/output_test.go
@@ -102,7 +102,7 @@ func outputArgsWithDefaults(mutate func(a *Output)) *Output {
 			ViewType: ViewHuman,
 		},
 		Vars:  &Vars{},
-		State: NewStateFlags(),
+		State: &State{},
 	}
 	if mutate != nil {
 		mutate(ret)

--- a/internal/command/arguments/output_test.go
+++ b/internal/command/arguments/output_test.go
@@ -6,146 +6,106 @@
 package arguments
 
 import (
-	"reflect"
+	"strings"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
-	"github.com/opentofu/opentofu/internal/tfdiags"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
-func TestParseOutput_valid(t *testing.T) {
+func TestParseOutput_basicValidation(t *testing.T) {
 	testCases := map[string]struct {
-		args []string
-		want *Output
+		args        []string
+		want        *Output
+		wantErrText string
 	}{
 		"defaults": {
-			nil,
-			&Output{
-				Name:        "",
-				ViewOptions: ViewOptions{ViewType: ViewHuman},
-				StatePath:   "",
-			},
+			args: nil,
+			want: outputArgsWithDefaults(func(a *Output) {
+			}),
 		},
 		"json": {
-			[]string{"-json"},
-			&Output{
-				Name:        "",
-				ViewOptions: ViewOptions{ViewType: ViewJSON},
-				StatePath:   "",
-			},
+			args: []string{"-json"},
+			want: outputArgsWithDefaults(func(a *Output) {
+				a.ViewOptions.ViewType = ViewJSON
+			}),
 		},
 		"raw": {
-			[]string{"-raw", "foo"},
-			&Output{
-				Name:        "foo",
-				ViewOptions: ViewOptions{ViewType: ViewRaw},
-				StatePath:   "",
-			},
+			args: []string{"-raw", "foo"},
+			want: outputArgsWithDefaults(func(a *Output) {
+				a.Name = "foo"
+				a.ViewOptions.ViewType = ViewRaw
+			}),
 		},
 		"state": {
-			[]string{"-state=foobar.tfstate", "-raw", "foo"},
-			&Output{
-				Name:        "foo",
-				ViewOptions: ViewOptions{ViewType: ViewRaw},
-				StatePath:   "foobar.tfstate",
-			},
+			args: []string{"-state=foobar.tfstate", "-raw", "foo"},
+			want: outputArgsWithDefaults(func(a *Output) {
+				a.Name = "foo"
+				a.ViewOptions.ViewType = ViewRaw
+				a.State.StatePath = "foobar.tfstate"
+			}),
+		},
+		"unknown flag": {
+			args:        []string{"-boop"},
+			want:        outputArgsWithDefaults(func(a *Output) {}),
+			wantErrText: "Failed to parse command-line flags: flag provided but not defined: -boop",
+		},
+		"json and raw specified": {
+			args:        []string{"-json", "-raw"},
+			want:        outputArgsWithDefaults(func(a *Output) {}),
+			wantErrText: "Invalid output format: The -raw and -json options are mutually-exclusive.",
+		},
+		"raw with no name": {
+			args: []string{"-raw"},
+			want: outputArgsWithDefaults(func(a *Output) {
+				a.ViewOptions.ViewType = ViewRaw
+			}),
+			wantErrText: "Output name required: You must give the name of a single output value when using the -raw option.",
+		},
+		"too many arguments": {
+			args: []string{"-raw", "-state=foo.tfstate", "bar", "baz"},
+			want: outputArgsWithDefaults(func(a *Output) {
+				a.ViewOptions.ViewType = ViewRaw
+				a.Name = "bar"
+				a.State.StatePath = "foo.tfstate"
+			}),
+			wantErrText: "Unexpected argument: The output command expects exactly one argument with the name of an output variable or no arguments to show all outputs.",
 		},
 	}
-
+	cmpOpts := cmpopts.IgnoreUnexported(ViewOptions{}, Vars{})
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			got, _, diags := ParseOutput(tc.args)
-			if len(diags) > 0 {
-				t.Fatalf("unexpected diags: %v", diags)
+			got, closer, diags := ParseOutput(tc.args)
+			defer closer()
+			if tc.wantErrText != "" && len(diags) == 0 {
+				t.Errorf("test wanted error but got nothing")
+			} else if tc.wantErrText == "" && len(diags) > 0 {
+				t.Errorf("test didn't expect errors but got some: %s", diags.ErrWithWarnings())
+			} else if tc.wantErrText != "" && len(diags) > 0 {
+				errStr := diags.ErrWithWarnings().Error()
+				if !strings.Contains(errStr, tc.wantErrText) {
+					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n%s\nwanted: %s\n", errStr, tc.wantErrText)
+				}
 			}
-			got.Vars = nil
-			got.ViewOptions.jsonFlag = tc.want.ViewOptions.jsonFlag
-			if *got != *tc.want {
-				t.Fatalf("unexpected result\n got: %#v\nwant: %#v", got, tc.want)
+			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+				t.Errorf("unexpected result\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestParseOutput_invalid(t *testing.T) {
-	testCases := map[string]struct {
-		args      []string
-		want      *Output
-		wantDiags tfdiags.Diagnostics
-	}{
-		"unknown flag": {
-			[]string{"-boop"},
-			&Output{
-				Name:        "",
-				ViewOptions: ViewOptions{ViewType: ViewHuman},
-				StatePath:   "",
-			},
-			tfdiags.Diagnostics{
-				tfdiags.Sourceless(
-					tfdiags.Error,
-					"Failed to parse command-line flags",
-					"flag provided but not defined: -boop",
-				),
-			},
+func outputArgsWithDefaults(mutate func(a *Output)) *Output {
+	ret := &Output{
+		Name:          "",
+		ShowSensitive: false,
+		ViewOptions: ViewOptions{
+			ViewType: ViewHuman,
 		},
-		"json and raw specified": {
-			[]string{"-json", "-raw"},
-			&Output{
-				Name:        "",
-				ViewOptions: ViewOptions{ViewType: ViewHuman},
-				StatePath:   "",
-			},
-			tfdiags.Diagnostics{
-				tfdiags.Sourceless(
-					tfdiags.Error,
-					"Invalid output format",
-					"The -raw and -json options are mutually-exclusive.",
-				),
-			},
-		},
-		"raw with no name": {
-			[]string{"-raw"},
-			&Output{
-				Name:        "",
-				ViewOptions: ViewOptions{ViewType: ViewRaw},
-				StatePath:   "",
-			},
-			tfdiags.Diagnostics{
-				tfdiags.Sourceless(
-					tfdiags.Error,
-					"Output name required",
-					"You must give the name of a single output value when using the -raw option.",
-				),
-			},
-		},
-		"too many arguments": {
-			[]string{"-raw", "-state=foo.tfstate", "bar", "baz"},
-			&Output{
-				Name:        "bar",
-				ViewOptions: ViewOptions{ViewType: ViewRaw},
-				StatePath:   "foo.tfstate",
-			},
-			tfdiags.Diagnostics{
-				tfdiags.Sourceless(
-					tfdiags.Error,
-					"Unexpected argument",
-					"The output command expects exactly one argument with the name of an output variable or no arguments to show all outputs.",
-				),
-			},
-		},
+		Vars:  &Vars{},
+		State: NewStateFlags(),
 	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			got, _, gotDiags := ParseOutput(tc.args)
-			got.Vars = nil
-			got.ViewOptions.jsonFlag = tc.want.ViewOptions.jsonFlag
-			if *got != *tc.want {
-				t.Fatalf("unexpected result\n got: %#v\nwant: %#v", got, tc.want)
-			}
-			if !reflect.DeepEqual(gotDiags, tc.wantDiags) {
-				t.Errorf("wrong result\ngot: %s\nwant: %s", spew.Sdump(gotDiags), spew.Sdump(tc.wantDiags))
-			}
-		})
+	if mutate != nil {
+		mutate(ret)
 	}
+	return ret
 }

--- a/internal/command/arguments/plan.go
+++ b/internal/command/arguments/plan.go
@@ -47,7 +47,7 @@ func ParsePlan(args []string) (*Plan, func(), tfdiags.Diagnostics) {
 	}
 
 	cmdFlags := extendedFlagSet("plan", plan.Operation, plan.Vars)
-	plan.State.AddFlags(cmdFlags, true, true, true, true)
+	plan.State.addFlags(cmdFlags, stateFlagAll)
 	cmdFlags.BoolVar(&plan.DetailedExitCode, "detailed-exitcode", false, "detailed-exitcode")
 	cmdFlags.StringVar(&plan.OutPath, "out", "", "out")
 	cmdFlags.StringVar(&plan.GenerateConfigPath, "generate-config-out", "", "generate-config-out")

--- a/internal/command/arguments/plan.go
+++ b/internal/command/arguments/plan.go
@@ -41,7 +41,7 @@ type Plan struct {
 func ParsePlan(args []string) (*Plan, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	plan := &Plan{
-		State:     NewStateFlags(),
+		State:     &State{},
 		Operation: &Operation{},
 		Vars:      &Vars{},
 	}

--- a/internal/command/arguments/plan.go
+++ b/internal/command/arguments/plan.go
@@ -41,12 +41,13 @@ type Plan struct {
 func ParsePlan(args []string) (*Plan, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	plan := &Plan{
-		State:     &State{},
+		State:     NewStateFlags(),
 		Operation: &Operation{},
 		Vars:      &Vars{},
 	}
 
-	cmdFlags := extendedFlagSet("plan", plan.State, plan.Operation, plan.Vars)
+	cmdFlags := extendedFlagSet("plan", plan.Operation, plan.Vars)
+	plan.State.AddFlags(cmdFlags, true, true, true, true)
 	cmdFlags.BoolVar(&plan.DetailedExitCode, "detailed-exitcode", false, "detailed-exitcode")
 	cmdFlags.StringVar(&plan.OutPath, "out", "", "out")
 	cmdFlags.StringVar(&plan.GenerateConfigPath, "generate-config-out", "", "generate-config-out")

--- a/internal/command/arguments/plan_test.go
+++ b/internal/command/arguments/plan_test.go
@@ -33,7 +33,7 @@ func TestParsePlan_basicValid(t *testing.T) {
 					ViewType:     ViewHuman,
 				},
 				OutPath: "",
-				State:   &State{Lock: true},
+				State:   NewStateFlags(),
 				Vars:    &Vars{},
 				Operation: &Operation{
 					PlanMode:    plans.NormalMode,
@@ -51,7 +51,7 @@ func TestParsePlan_basicValid(t *testing.T) {
 					ViewType:     ViewHuman,
 				},
 				OutPath: "saved.tfplan",
-				State:   &State{Lock: true},
+				State:   NewStateFlags(),
 				Vars:    &Vars{},
 				Operation: &Operation{
 					PlanMode:    plans.DestroyMode,
@@ -69,7 +69,7 @@ func TestParsePlan_basicValid(t *testing.T) {
 					ViewType:     ViewJSON,
 				},
 				OutPath: "",
-				State:   &State{Lock: true},
+				State:   NewStateFlags(),
 				Vars:    &Vars{},
 				Operation: &Operation{
 					PlanMode:    plans.NormalMode,

--- a/internal/command/arguments/plan_test.go
+++ b/internal/command/arguments/plan_test.go
@@ -33,7 +33,7 @@ func TestParsePlan_basicValid(t *testing.T) {
 					ViewType:     ViewHuman,
 				},
 				OutPath: "",
-				State:   NewStateFlags(),
+				State:   &State{Lock: true},
 				Vars:    &Vars{},
 				Operation: &Operation{
 					PlanMode:    plans.NormalMode,
@@ -51,7 +51,7 @@ func TestParsePlan_basicValid(t *testing.T) {
 					ViewType:     ViewHuman,
 				},
 				OutPath: "saved.tfplan",
-				State:   NewStateFlags(),
+				State:   &State{Lock: true},
 				Vars:    &Vars{},
 				Operation: &Operation{
 					PlanMode:    plans.DestroyMode,
@@ -69,7 +69,7 @@ func TestParsePlan_basicValid(t *testing.T) {
 					ViewType:     ViewJSON,
 				},
 				OutPath: "",
-				State:   NewStateFlags(),
+				State:   &State{Lock: true},
 				Vars:    &Vars{},
 				Operation: &Operation{
 					PlanMode:    plans.NormalMode,

--- a/internal/command/arguments/providers.go
+++ b/internal/command/arguments/providers.go
@@ -29,7 +29,7 @@ func ParseProviders(args []string) (*Providers, func(), tfdiags.Diagnostics) {
 		Vars: &Vars{},
 	}
 
-	cmdFlags := extendedFlagSet("providers", nil, nil, arguments.Vars)
+	cmdFlags := extendedFlagSet("providers", nil, arguments.Vars)
 	cmdFlags.StringVar(&arguments.TestsDirectory, "test-directory", "tests", "test-directory")
 
 	if err := cmdFlags.Parse(args); err != nil {

--- a/internal/command/arguments/providers_lock.go
+++ b/internal/command/arguments/providers_lock.go
@@ -40,7 +40,7 @@ func ParseProvidersLock(args []string) (*ProvidersLock, func(), tfdiags.Diagnost
 		Vars: &Vars{},
 	}
 
-	cmdFlags := extendedFlagSet("providers lock", nil, nil, arguments.Vars)
+	cmdFlags := extendedFlagSet("providers lock", nil, arguments.Vars)
 	cmdFlags.Var(&arguments.OptPlatforms, "platform", "target platform")
 	cmdFlags.StringVar(&arguments.FsMirrorDir, "fs-mirror", "", "filesystem mirror directory")
 	cmdFlags.StringVar(&arguments.NetMirrorURL, "net-mirror", "", "network mirror base URL")

--- a/internal/command/arguments/providers_mirror.go
+++ b/internal/command/arguments/providers_mirror.go
@@ -33,7 +33,7 @@ func ParseProvidersMirror(args []string) (*ProvidersMirror, func(), tfdiags.Diag
 		Vars: &Vars{},
 	}
 
-	cmdFlags := extendedFlagSet("providers mirror", nil, nil, arguments.Vars)
+	cmdFlags := extendedFlagSet("providers mirror", nil, arguments.Vars)
 	cmdFlags.Var(&arguments.OptPlatforms, "platform", "target platform")
 	arguments.ViewOptions.AddFlags(cmdFlags, false)
 	if err := cmdFlags.Parse(args); err != nil {

--- a/internal/command/arguments/providers_schema.go
+++ b/internal/command/arguments/providers_schema.go
@@ -28,7 +28,7 @@ func ParseProvidersSchema(args []string) (*ProvidersSchema, func(), tfdiags.Diag
 		Vars: &Vars{},
 	}
 
-	cmdFlags := extendedFlagSet("providers schema", nil, nil, schema.Vars)
+	cmdFlags := extendedFlagSet("providers schema", nil, schema.Vars)
 
 	schema.ViewOptions.AddGranularFlags(cmdFlags, false, false)
 

--- a/internal/command/arguments/refresh.go
+++ b/internal/command/arguments/refresh.go
@@ -26,7 +26,7 @@ type Refresh struct {
 func ParseRefresh(args []string) (*Refresh, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	refresh := &Refresh{
-		State:     NewStateFlags(),
+		State:     &State{},
 		Operation: &Operation{},
 		Vars:      &Vars{},
 	}

--- a/internal/command/arguments/refresh.go
+++ b/internal/command/arguments/refresh.go
@@ -26,12 +26,13 @@ type Refresh struct {
 func ParseRefresh(args []string) (*Refresh, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	refresh := &Refresh{
-		State:     &State{},
+		State:     NewStateFlags(),
 		Operation: &Operation{},
 		Vars:      &Vars{},
 	}
 
-	cmdFlags := extendedFlagSet("refresh", refresh.State, refresh.Operation, refresh.Vars)
+	cmdFlags := extendedFlagSet("refresh", refresh.Operation, refresh.Vars)
+	refresh.State.AddFlags(cmdFlags, true, true, true, true)
 	refresh.ViewOptions.AddFlags(cmdFlags, true)
 
 	if err := cmdFlags.Parse(args); err != nil {

--- a/internal/command/arguments/refresh.go
+++ b/internal/command/arguments/refresh.go
@@ -32,7 +32,7 @@ func ParseRefresh(args []string) (*Refresh, func(), tfdiags.Diagnostics) {
 	}
 
 	cmdFlags := extendedFlagSet("refresh", refresh.Operation, refresh.Vars)
-	refresh.State.AddFlags(cmdFlags, true, true, true, true)
+	refresh.State.addFlags(cmdFlags, stateFlagAll)
 	refresh.ViewOptions.AddFlags(cmdFlags, true)
 
 	if err := cmdFlags.Parse(args); err != nil {

--- a/internal/command/arguments/show.go
+++ b/internal/command/arguments/show.go
@@ -76,7 +76,7 @@ func ParseShow(args []string) (*Show, func(), tfdiags.Diagnostics) {
 	var planTarget string
 	var configTarget bool
 	var moduleTarget string
-	cmdFlags := extendedFlagSet("show", nil, nil, show.Vars)
+	cmdFlags := extendedFlagSet("show", nil, show.Vars)
 	cmdFlags.BoolVar(&show.ShowSensitive, "show-sensitive", false, "displays sensitive values")
 	cmdFlags.BoolVar(&stateTarget, "state", false, "show the latest state snapshot")
 	cmdFlags.StringVar(&planTarget, "plan", "", "show the plan from a saved plan file")

--- a/internal/command/arguments/state_list.go
+++ b/internal/command/arguments/state_list.go
@@ -38,7 +38,7 @@ func ParseStateList(args []string) (*StateList, func(), tfdiags.Diagnostics) {
 
 	cmdFlags := extendedFlagSet("state list", nil, ret.Vars)
 	cmdFlags.StringVar(&ret.LookupId, "id", "", "Restrict output to paths with a resource having the specified ID.")
-	ret.State.AddFlags(cmdFlags, false, true, false, false)
+	ret.State.addFlags(cmdFlags, stateFlagStateIn)
 	ret.ViewOptions.AddFlags(cmdFlags, false)
 
 	if err := cmdFlags.Parse(args); err != nil {

--- a/internal/command/arguments/state_list.go
+++ b/internal/command/arguments/state_list.go
@@ -11,8 +11,6 @@ import (
 
 // StateList represents the command-line arguments for the 'state list' command.
 type StateList struct {
-	// StatePath is the path to the state file to be used to list the information from.
-	StatePath string
 	// LookupId restricts output to paths with a resource having the specified ID.
 	LookupId string
 	// InstancesRawAddr is a list of raw addresses of the resources that are requested
@@ -22,8 +20,9 @@ type StateList struct {
 	// ViewOptions specifies which view options to use
 	ViewOptions ViewOptions
 
-	// Vars holds and provides information for the flags related to variables that a user can give into the process
-	Vars *Vars
+	// Vars and State are the common extended flags
+	Vars  *Vars
+	State *State
 }
 
 // ParseStateList processes CLI arguments, returning a StateList value, a closer function, and errors.
@@ -33,12 +32,13 @@ func ParseStateList(args []string) (*StateList, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	ret := &StateList{
-		Vars: &Vars{},
+		Vars:  &Vars{},
+		State: &State{}, // Initialised like this because we don't want to have the lock enabled by default
 	}
 
 	cmdFlags := extendedFlagSet("state list", nil, ret.Vars)
-	cmdFlags.StringVar(&ret.StatePath, "state", "", "path")
 	cmdFlags.StringVar(&ret.LookupId, "id", "", "Restrict output to paths with a resource having the specified ID.")
+	ret.State.AddFlags(cmdFlags, false, true, false, false)
 	ret.ViewOptions.AddFlags(cmdFlags, false)
 
 	if err := cmdFlags.Parse(args); err != nil {

--- a/internal/command/arguments/state_list.go
+++ b/internal/command/arguments/state_list.go
@@ -36,7 +36,7 @@ func ParseStateList(args []string) (*StateList, func(), tfdiags.Diagnostics) {
 		Vars: &Vars{},
 	}
 
-	cmdFlags := extendedFlagSet("state list", nil, nil, ret.Vars)
+	cmdFlags := extendedFlagSet("state list", nil, ret.Vars)
 	cmdFlags.StringVar(&ret.StatePath, "state", "", "path")
 	cmdFlags.StringVar(&ret.LookupId, "id", "", "Restrict output to paths with a resource having the specified ID.")
 	ret.ViewOptions.AddFlags(cmdFlags, false)

--- a/internal/command/arguments/state_list.go
+++ b/internal/command/arguments/state_list.go
@@ -33,7 +33,7 @@ func ParseStateList(args []string) (*StateList, func(), tfdiags.Diagnostics) {
 
 	ret := &StateList{
 		Vars:  &Vars{},
-		State: &State{}, // Initialised like this because we don't want to have the lock enabled by default
+		State: &State{},
 	}
 
 	cmdFlags := extendedFlagSet("state list", nil, ret.Vars)

--- a/internal/command/arguments/state_list_test.go
+++ b/internal/command/arguments/state_list_test.go
@@ -26,7 +26,7 @@ func TestParseStateList_basicValidation(t *testing.T) {
 		"custom state path": {
 			args: []string{"-state=/path/to/state.tfstate"},
 			want: stateListArgsWithDefaults(func(stateList *StateList) {
-				stateList.StatePath = "/path/to/state.tfstate"
+				stateList.State.StatePath = "/path/to/state.tfstate"
 			}),
 		},
 		"lookup by id": {
@@ -50,7 +50,7 @@ func TestParseStateList_basicValidation(t *testing.T) {
 		"combined flags and addresses": {
 			args: []string{"-state=/path/to/state.tfstate", "-id=i-123", "aws_instance.example", "aws_instance.example2"},
 			want: stateListArgsWithDefaults(func(stateList *StateList) {
-				stateList.StatePath = "/path/to/state.tfstate"
+				stateList.State.StatePath = "/path/to/state.tfstate"
 				stateList.LookupId = "i-123"
 				stateList.InstancesRawAddr = []string{"aws_instance.example", "aws_instance.example2"}
 			}),
@@ -137,7 +137,7 @@ func TestParseStateList_vars(t *testing.T) {
 
 func stateListArgsWithDefaults(mutate func(stateList *StateList)) *StateList {
 	ret := &StateList{
-		StatePath:        "",
+		State:            &State{},
 		LookupId:         "",
 		InstancesRawAddr: []string{},
 		ViewOptions: ViewOptions{

--- a/internal/command/arguments/state_mv.go
+++ b/internal/command/arguments/state_mv.go
@@ -19,20 +19,16 @@ type StateMv struct {
 	// DryRun just validates that the arguments provided are valid and will output the possible outcome.
 	// When running in this mode, the state will suffer no change.
 	DryRun bool
-	// BackupPathOut and BackupPath can be used by the user to configure where to save the backup file of the state file.
+	// BackupPathOut can be used by the user to configure where to save the backup file of the state file.
 	BackupPathOut string
-	BackupPath    string
-	// StatePath represents the path of the state to be used for the moving operation.
-	StatePath string
-	// StateOutPath represents the path where OpenTofu should save the new state.
-	StateOutPath string
 
 	// ViewOptions specifies which view options to use
 	ViewOptions ViewOptions
 
-	// Vars and Backend are the common extended flags
+	// Vars, Backend and State are the common extended flags
 	Vars    *Vars
 	Backend Backend
+	State   *State
 }
 
 // ParseStateMv processes CLI arguments, returning a StateMv value, a closer function, and errors.
@@ -42,23 +38,16 @@ func ParseStateMv(args []string) (*StateMv, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	ret := &StateMv{
-		Vars: &Vars{},
+		Vars:  &Vars{},
+		State: NewStateFlags(),
 	}
 
 	cmdFlags := extendedFlagSet("state mv", nil, ret.Vars)
 	ret.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
-	ret.Backend.AddStateFlags(cmdFlags)
+	ret.State.AddFlags(cmdFlags, true, true, true, false)
+	ret.State.AddBackupFlag(cmdFlags, "-")
 	cmdFlags.BoolVar(&ret.DryRun, "dry-run", false, "dry run")
-	// NOTE: because the `-backup` and `-backup-out` flags need a different default value than usual,
-	// we cannot use the [State] flags extension to register and parse these.
-	// Therefore, we need to have these redefined here.
-	// TODO meta-refactor: we might want to have a separate function on the [arguments.State] to register flags,
-	//  where default value can be provided by the caller. This way we could still use those flags instead of redefining
-	//  everything again.
-	cmdFlags.StringVar(&ret.BackupPath, "backup", "-", "backup-path")
 	cmdFlags.StringVar(&ret.BackupPathOut, "backup-out", "-", "backup")
-	cmdFlags.StringVar(&ret.StatePath, "state", "", "state-path")
-	cmdFlags.StringVar(&ret.StateOutPath, "state-out", "", "state-path")
 
 	ret.ViewOptions.AddFlags(cmdFlags, false)
 

--- a/internal/command/arguments/state_mv.go
+++ b/internal/command/arguments/state_mv.go
@@ -44,7 +44,8 @@ func ParseStateMv(args []string) (*StateMv, func(), tfdiags.Diagnostics) {
 
 	cmdFlags := extendedFlagSet("state mv", nil, ret.Vars)
 	ret.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
-	ret.State.AddFlags(cmdFlags, true, true, true, false)
+	// StateFlagBackup omitted here to be added later with a different default value
+	ret.State.addFlags(cmdFlags, stateFlagLock|stateFlagStateIn|stateFlagStateOut)
 	ret.State.AddBackupFlag(cmdFlags, "-")
 	cmdFlags.BoolVar(&ret.DryRun, "dry-run", false, "dry run")
 	cmdFlags.StringVar(&ret.BackupPathOut, "backup-out", "-", "backup")

--- a/internal/command/arguments/state_mv.go
+++ b/internal/command/arguments/state_mv.go
@@ -45,7 +45,7 @@ func ParseStateMv(args []string) (*StateMv, func(), tfdiags.Diagnostics) {
 		Vars: &Vars{},
 	}
 
-	cmdFlags := extendedFlagSet("state mv", nil, nil, ret.Vars)
+	cmdFlags := extendedFlagSet("state mv", nil, ret.Vars)
 	ret.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
 	ret.Backend.AddStateFlags(cmdFlags)
 	cmdFlags.BoolVar(&ret.DryRun, "dry-run", false, "dry run")

--- a/internal/command/arguments/state_mv.go
+++ b/internal/command/arguments/state_mv.go
@@ -39,7 +39,7 @@ func ParseStateMv(args []string) (*StateMv, func(), tfdiags.Diagnostics) {
 
 	ret := &StateMv{
 		Vars:  &Vars{},
-		State: NewStateFlags(),
+		State: &State{},
 	}
 
 	cmdFlags := extendedFlagSet("state mv", nil, ret.Vars)

--- a/internal/command/arguments/state_mv_test.go
+++ b/internal/command/arguments/state_mv_test.go
@@ -167,8 +167,10 @@ func stateMvArgsWithDefaults(mutate func(stateMv *StateMv)) *StateMv {
 		Backend: Backend{
 			IgnoreRemoteVersion: false,
 		},
-		State: NewStateFlags(),
-		Vars:  &Vars{},
+		State: &State{
+			Lock: true,
+		},
+		Vars: &Vars{},
 	}
 	// Because the default value is different on this command
 	ret.State.BackupPath = "-"

--- a/internal/command/arguments/state_mv_test.go
+++ b/internal/command/arguments/state_mv_test.go
@@ -46,7 +46,7 @@ func TestParseStateMv_basicValidation(t *testing.T) {
 		"custom state path": {
 			args: []string{"-state=/path/to/state.tfstate", "source", "dest"},
 			want: stateMvArgsWithDefaults(func(stateMv *StateMv) {
-				stateMv.StatePath = "/path/to/state.tfstate"
+				stateMv.State.StatePath = "/path/to/state.tfstate"
 				stateMv.RawSrcAddr = "source"
 				stateMv.RawDestAddr = "dest"
 			}),
@@ -54,7 +54,7 @@ func TestParseStateMv_basicValidation(t *testing.T) {
 		"custom state-out path": {
 			args: []string{"-state-out=/path/to/state-out.tfstate", "source", "dest"},
 			want: stateMvArgsWithDefaults(func(stateMv *StateMv) {
-				stateMv.StateOutPath = "/path/to/state-out.tfstate"
+				stateMv.State.StateOutPath = "/path/to/state-out.tfstate"
 				stateMv.RawSrcAddr = "source"
 				stateMv.RawDestAddr = "dest"
 			}),
@@ -62,7 +62,7 @@ func TestParseStateMv_basicValidation(t *testing.T) {
 		"custom backup path": {
 			args: []string{"-backup=/path/to/backup.tfstate", "source", "dest"},
 			want: stateMvArgsWithDefaults(func(stateMv *StateMv) {
-				stateMv.BackupPath = "/path/to/backup.tfstate"
+				stateMv.State.BackupPath = "/path/to/backup.tfstate"
 				stateMv.RawSrcAddr = "source"
 				stateMv.RawDestAddr = "dest"
 			}),
@@ -71,7 +71,7 @@ func TestParseStateMv_basicValidation(t *testing.T) {
 			args: []string{"-lock-timeout=10s", "source", "dest"},
 			want: stateMvArgsWithDefaults(func(stateMv *StateMv) {
 				// do not set `stateMv.State.Lock = true` since it's meant to be true already
-				stateMv.Backend.StateLockTimeout = 10 * time.Second
+				stateMv.State.LockTimeout = 10 * time.Second
 				stateMv.RawSrcAddr = "source"
 				stateMv.RawDestAddr = "dest"
 			}),
@@ -79,7 +79,7 @@ func TestParseStateMv_basicValidation(t *testing.T) {
 		"disable locking": {
 			args: []string{"-lock=false", "source", "dest"},
 			want: stateMvArgsWithDefaults(func(stateMv *StateMv) {
-				stateMv.Backend.StateLock = false
+				stateMv.State.Lock = false
 				stateMv.RawSrcAddr = "source"
 				stateMv.RawDestAddr = "dest"
 			}),
@@ -94,19 +94,21 @@ func TestParseStateMv_basicValidation(t *testing.T) {
 				"-lock-timeout=15s",
 				"-lock=true",
 				"-var=key=value",
+				"-ignore-remote-version=true",
 				"source",
 				"dest",
 			},
 			want: stateMvArgsWithDefaults(func(stateMv *StateMv) {
 				stateMv.DryRun = true
 				stateMv.BackupPathOut = "/path/to/backup-out.tfstate"
-				stateMv.StatePath = "/path/to/state.tfstate"
-				stateMv.StateOutPath = "/path/to/state-out.tfstate"
-				stateMv.BackupPath = "/path/to/backup.tfstate"
-				stateMv.Backend.StateLockTimeout = 15 * time.Second
-				stateMv.Backend.StateLock = true
+				stateMv.State.StatePath = "/path/to/state.tfstate"
+				stateMv.State.StateOutPath = "/path/to/state-out.tfstate"
+				stateMv.State.BackupPath = "/path/to/backup.tfstate"
+				stateMv.State.LockTimeout = 15 * time.Second
+				stateMv.State.Lock = true
 				stateMv.RawSrcAddr = "source"
 				stateMv.RawDestAddr = "dest"
+				stateMv.Backend.IgnoreRemoteVersion = true
 				// Vars would be updated, but we ignore it in cmp
 			}),
 		},
@@ -157,7 +159,6 @@ func TestParseStateMv_basicValidation(t *testing.T) {
 func stateMvArgsWithDefaults(mutate func(stateMv *StateMv)) *StateMv {
 	ret := &StateMv{
 		DryRun:        false,
-		BackupPath:    "-",
 		BackupPathOut: "-",
 		ViewOptions: ViewOptions{
 			ViewType:     ViewHuman,
@@ -165,11 +166,12 @@ func stateMvArgsWithDefaults(mutate func(stateMv *StateMv)) *StateMv {
 		},
 		Backend: Backend{
 			IgnoreRemoteVersion: false,
-			StateLock:           true,
-			StateLockTimeout:    0,
 		},
-		Vars: &Vars{},
+		State: NewStateFlags(),
+		Vars:  &Vars{},
 	}
+	// Because the default value is different on this command
+	ret.State.BackupPath = "-"
 	if mutate != nil {
 		mutate(ret)
 	}

--- a/internal/command/arguments/state_pull.go
+++ b/internal/command/arguments/state_pull.go
@@ -27,7 +27,7 @@ func ParseStatePull(args []string) (*StatePull, func(), tfdiags.Diagnostics) {
 	ret := &StatePull{
 		Vars: &Vars{},
 	}
-	cmdFlags := extendedFlagSet("state pull", nil, nil, ret.Vars)
+	cmdFlags := extendedFlagSet("state pull", nil, ret.Vars)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(

--- a/internal/command/arguments/state_push.go
+++ b/internal/command/arguments/state_push.go
@@ -19,9 +19,10 @@ type StatePush struct {
 	// ViewOptions specifies which view options to use
 	ViewOptions ViewOptions
 
-	// Vars and Backend are the common extended flags
+	// Vars, Backend and State are the common extended flags
 	Vars    *Vars
 	Backend Backend
+	State   *State
 }
 
 // ParseStatePush processes CLI arguments, returning a StatePush value, a closer function, and errors.
@@ -31,11 +32,12 @@ func ParseStatePush(args []string) (*StatePush, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	ret := &StatePush{
-		Vars: &Vars{},
+		Vars:  &Vars{},
+		State: NewStateFlags(),
 	}
 	cmdFlags := extendedFlagSet("state push", nil, ret.Vars)
 	ret.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
-	ret.Backend.AddStateFlags(cmdFlags)
+	ret.State.AddFlags(cmdFlags, true, false, false, false)
 	cmdFlags.BoolVar(&ret.Force, "force", false, "")
 	ret.ViewOptions.AddFlags(cmdFlags, false)
 

--- a/internal/command/arguments/state_push.go
+++ b/internal/command/arguments/state_push.go
@@ -37,7 +37,7 @@ func ParseStatePush(args []string) (*StatePush, func(), tfdiags.Diagnostics) {
 	}
 	cmdFlags := extendedFlagSet("state push", nil, ret.Vars)
 	ret.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
-	ret.State.AddFlags(cmdFlags, true, false, false, false)
+	ret.State.addFlags(cmdFlags, stateFlagLock)
 	cmdFlags.BoolVar(&ret.Force, "force", false, "")
 	ret.ViewOptions.AddFlags(cmdFlags, false)
 

--- a/internal/command/arguments/state_push.go
+++ b/internal/command/arguments/state_push.go
@@ -33,7 +33,7 @@ func ParseStatePush(args []string) (*StatePush, func(), tfdiags.Diagnostics) {
 
 	ret := &StatePush{
 		Vars:  &Vars{},
-		State: NewStateFlags(),
+		State: &State{},
 	}
 	cmdFlags := extendedFlagSet("state push", nil, ret.Vars)
 	ret.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)

--- a/internal/command/arguments/state_push.go
+++ b/internal/command/arguments/state_push.go
@@ -33,7 +33,7 @@ func ParseStatePush(args []string) (*StatePush, func(), tfdiags.Diagnostics) {
 	ret := &StatePush{
 		Vars: &Vars{},
 	}
-	cmdFlags := extendedFlagSet("state push", nil, nil, ret.Vars)
+	cmdFlags := extendedFlagSet("state push", nil, ret.Vars)
 	ret.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
 	ret.Backend.AddStateFlags(cmdFlags)
 	cmdFlags.BoolVar(&ret.Force, "force", false, "")

--- a/internal/command/arguments/state_push_test.go
+++ b/internal/command/arguments/state_push_test.go
@@ -172,7 +172,9 @@ func statePushArgsWithDefaults(mutate func(v *StatePush)) *StatePush {
 			MigrateState:        false,
 			ForceInitCopy:       false,
 		},
-		State: NewStateFlags(),
+		State: &State{
+			Lock: true,
+		},
 	}
 	if mutate != nil {
 		mutate(ret)

--- a/internal/command/arguments/state_push_test.go
+++ b/internal/command/arguments/state_push_test.go
@@ -51,14 +51,14 @@ func TestParseStatePush_basicValidation(t *testing.T) {
 		"lock flag": {
 			args: []string{"-lock=false", "terraform.tfstate"},
 			want: statePushArgsWithDefaults(func(v *StatePush) {
-				v.Backend.StateLock = false
+				v.State.Lock = false
 				v.StateSrc = "terraform.tfstate"
 			}),
 		},
 		"lock-timeout flag": {
 			args: []string{"-lock-timeout=30s", "terraform.tfstate"},
 			want: statePushArgsWithDefaults(func(v *StatePush) {
-				v.Backend.StateLockTimeout = 30000000000 // 30s in nanoseconds
+				v.State.LockTimeout = 30000000000 // 30s in nanoseconds
 				v.StateSrc = "terraform.tfstate"
 			}),
 		},
@@ -73,7 +73,7 @@ func TestParseStatePush_basicValidation(t *testing.T) {
 			args: []string{"-force", "-lock=false", "-ignore-remote-version", "terraform.tfstate"},
 			want: statePushArgsWithDefaults(func(v *StatePush) {
 				v.Force = true
-				v.Backend.StateLock = false
+				v.State.Lock = false
 				v.Backend.IgnoreRemoteVersion = true
 				v.StateSrc = "terraform.tfstate"
 			}),
@@ -167,13 +167,12 @@ func statePushArgsWithDefaults(mutate func(v *StatePush)) *StatePush {
 		},
 		Vars: &Vars{},
 		Backend: Backend{
-			StateLock:           true,
-			StateLockTimeout:    0,
 			IgnoreRemoteVersion: false,
 			Reconfigure:         false,
 			MigrateState:        false,
 			ForceInitCopy:       false,
 		},
+		State: NewStateFlags(),
 	}
 	if mutate != nil {
 		mutate(ret)

--- a/internal/command/arguments/state_replace_provider.go
+++ b/internal/command/arguments/state_replace_provider.go
@@ -37,7 +37,7 @@ func ParseReplaceProvider(args []string) (*StateReplaceProvider, func(), tfdiags
 
 	ret := &StateReplaceProvider{
 		Vars:  &Vars{},
-		State: NewStateFlags(),
+		State: &State{},
 	}
 
 	cmdFlags := extendedFlagSet("state replace-provider", nil, ret.Vars)

--- a/internal/command/arguments/state_replace_provider.go
+++ b/internal/command/arguments/state_replace_provider.go
@@ -43,7 +43,8 @@ func ParseReplaceProvider(args []string) (*StateReplaceProvider, func(), tfdiags
 	cmdFlags := extendedFlagSet("state replace-provider", nil, ret.Vars)
 	cmdFlags.BoolVar(&ret.AutoApprove, "auto-approve", false, "skip interactive approval of replacements")
 	ret.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
-	ret.State.AddFlags(cmdFlags, true, true, false, false)
+	// StateFlagBackup omitted here to be added later with a different default value
+	ret.State.addFlags(cmdFlags, stateFlagLock|stateFlagStateIn)
 	ret.State.AddBackupFlag(cmdFlags, "-")
 	ret.ViewOptions.AddFlags(cmdFlags, false)
 

--- a/internal/command/arguments/state_replace_provider.go
+++ b/internal/command/arguments/state_replace_provider.go
@@ -43,7 +43,7 @@ func ParseReplaceProvider(args []string) (*StateReplaceProvider, func(), tfdiags
 		Vars: &Vars{},
 	}
 
-	cmdFlags := extendedFlagSet("state replace-provider", nil, nil, ret.Vars)
+	cmdFlags := extendedFlagSet("state replace-provider", nil, ret.Vars)
 	ret.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
 	ret.Backend.AddStateFlags(cmdFlags)
 	cmdFlags.BoolVar(&ret.AutoApprove, "auto-approve", false, "skip interactive approval of replacements")

--- a/internal/command/arguments/state_replace_provider.go
+++ b/internal/command/arguments/state_replace_provider.go
@@ -19,18 +19,14 @@ type StateReplaceProvider struct {
 	// AutoApprove is an option that the user can configure to skip the confirmation step of the replacement
 	// process.
 	AutoApprove bool
-	// BackupPath can be used by the user to configure where to save the backup file of the state file
-	// before replacing the provider
-	BackupPath string
-	// StatePath represents the path of the state to be used for the replace operation.
-	StatePath string
 
 	// ViewOptions specifies which view options to use
 	ViewOptions ViewOptions
 
-	// Vars and Backend are the common extended flags
+	// Vars, Backend and State are the common extended flags
 	Vars    *Vars
 	Backend Backend
+	State   *State
 }
 
 // ParseReplaceProvider processes CLI arguments, returning a StateReplaceProvider value, a closer function, and errors.
@@ -40,21 +36,15 @@ func ParseReplaceProvider(args []string) (*StateReplaceProvider, func(), tfdiags
 	var diags tfdiags.Diagnostics
 
 	ret := &StateReplaceProvider{
-		Vars: &Vars{},
+		Vars:  &Vars{},
+		State: NewStateFlags(),
 	}
 
 	cmdFlags := extendedFlagSet("state replace-provider", nil, ret.Vars)
-	ret.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
-	ret.Backend.AddStateFlags(cmdFlags)
 	cmdFlags.BoolVar(&ret.AutoApprove, "auto-approve", false, "skip interactive approval of replacements")
-	// NOTE: because the `-backup` flag needs a different default value than usual,
-	// we cannot use the [State] flags extension to register and parse these.
-	// Therefore, we need to have those flags redefined here.
-	// TODO meta-refactor: we might want to have a separate function on the [arguments.State] to register flags,
-	//  where default value can be provided by the caller. This way we could still use those flags instead of redefining
-	//  everything again.
-	cmdFlags.StringVar(&ret.BackupPath, "backup", "-", "backup-path")
-	cmdFlags.StringVar(&ret.StatePath, "state", "", "state-path")
+	ret.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
+	ret.State.AddFlags(cmdFlags, true, true, false, false)
+	ret.State.AddBackupFlag(cmdFlags, "-")
 	ret.ViewOptions.AddFlags(cmdFlags, false)
 
 	if err := cmdFlags.Parse(args); err != nil {

--- a/internal/command/arguments/state_replace_provider_test.go
+++ b/internal/command/arguments/state_replace_provider_test.go
@@ -162,8 +162,10 @@ func stateReplaceProviderArgsWithDefaults(mutate func(srp *StateReplaceProvider)
 		Backend: Backend{
 			IgnoreRemoteVersion: false,
 		},
-		Vars:  &Vars{},
-		State: NewStateFlags(),
+		Vars: &Vars{},
+		State: &State{
+			Lock: true,
+		},
 	}
 	// Because the default value is different on this command
 	ret.State.BackupPath = "-"

--- a/internal/command/arguments/state_replace_provider_test.go
+++ b/internal/command/arguments/state_replace_provider_test.go
@@ -165,10 +165,11 @@ func stateReplaceProviderArgsWithDefaults(mutate func(srp *StateReplaceProvider)
 		Vars: &Vars{},
 		State: &State{
 			Lock: true,
+			// Because the backup flag is registered with a different default value
+			BackupPath: "-",
 		},
 	}
 	// Because the default value is different on this command
-	ret.State.BackupPath = "-"
 	if mutate != nil {
 		mutate(ret)
 	}

--- a/internal/command/arguments/state_replace_provider_test.go
+++ b/internal/command/arguments/state_replace_provider_test.go
@@ -38,7 +38,7 @@ func TestParseReplaceProvider_basicValidation(t *testing.T) {
 		"custom backup path": {
 			args: []string{"-backup=/path/to/backup.tfstate", "source", "dest"},
 			want: stateReplaceProviderArgsWithDefaults(func(srp *StateReplaceProvider) {
-				srp.BackupPath = "/path/to/backup.tfstate"
+				srp.State.BackupPath = "/path/to/backup.tfstate"
 				srp.RawSrcAddr = "source"
 				srp.RawDestAddr = "dest"
 			}),
@@ -46,7 +46,7 @@ func TestParseReplaceProvider_basicValidation(t *testing.T) {
 		"custom state path": {
 			args: []string{"-state=/path/to/state.tfstate", "source", "dest"},
 			want: stateReplaceProviderArgsWithDefaults(func(srp *StateReplaceProvider) {
-				srp.StatePath = "/path/to/state.tfstate"
+				srp.State.StatePath = "/path/to/state.tfstate"
 				srp.RawSrcAddr = "source"
 				srp.RawDestAddr = "dest"
 			}),
@@ -54,8 +54,8 @@ func TestParseReplaceProvider_basicValidation(t *testing.T) {
 		"only lock-timeout": {
 			args: []string{"-lock-timeout=10s", "source", "dest"},
 			want: stateReplaceProviderArgsWithDefaults(func(srp *StateReplaceProvider) {
-				srp.Backend.StateLock = true
-				srp.Backend.StateLockTimeout = 10 * time.Second
+				srp.State.Lock = true
+				srp.State.LockTimeout = 10 * time.Second
 				srp.RawSrcAddr = "source"
 				srp.RawDestAddr = "dest"
 			}),
@@ -63,7 +63,7 @@ func TestParseReplaceProvider_basicValidation(t *testing.T) {
 		"disable locking": {
 			args: []string{"-lock=false", "source", "dest"},
 			want: stateReplaceProviderArgsWithDefaults(func(srp *StateReplaceProvider) {
-				srp.Backend.StateLock = false
+				srp.State.Lock = false
 				srp.RawSrcAddr = "source"
 				srp.RawDestAddr = "dest"
 			}),
@@ -81,10 +81,10 @@ func TestParseReplaceProvider_basicValidation(t *testing.T) {
 			},
 			want: stateReplaceProviderArgsWithDefaults(func(srp *StateReplaceProvider) {
 				srp.AutoApprove = true
-				srp.BackupPath = "/path/to/backup.tfstate"
-				srp.StatePath = "/path/to/state.tfstate"
-				srp.Backend.StateLockTimeout = 15 * time.Second
-				srp.Backend.StateLock = true
+				srp.State.BackupPath = "/path/to/backup.tfstate"
+				srp.State.StatePath = "/path/to/state.tfstate"
+				srp.State.LockTimeout = 15 * time.Second
+				srp.State.Lock = true
 				srp.RawSrcAddr = "source"
 				srp.RawDestAddr = "dest"
 				// Vars would be updated, but we ignore it in cmp
@@ -155,18 +155,18 @@ func TestParseReplaceProvider_basicValidation(t *testing.T) {
 func stateReplaceProviderArgsWithDefaults(mutate func(srp *StateReplaceProvider)) *StateReplaceProvider {
 	ret := &StateReplaceProvider{
 		AutoApprove: false,
-		BackupPath:  "-",
 		ViewOptions: ViewOptions{
 			ViewType:     ViewHuman,
 			InputEnabled: false,
 		},
 		Backend: Backend{
 			IgnoreRemoteVersion: false,
-			StateLock:           true,
-			StateLockTimeout:    0,
 		},
-		Vars: &Vars{},
+		Vars:  &Vars{},
+		State: NewStateFlags(),
 	}
+	// Because the default value is different on this command
+	ret.State.BackupPath = "-"
 	if mutate != nil {
 		mutate(ret)
 	}

--- a/internal/command/arguments/state_rm.go
+++ b/internal/command/arguments/state_rm.go
@@ -34,7 +34,7 @@ func ParseStateRm(args []string) (*StateRm, func(), tfdiags.Diagnostics) {
 
 	ret := &StateRm{
 		Vars:  &Vars{},
-		State: NewStateFlags(),
+		State: &State{},
 	}
 	cmdFlags := extendedFlagSet("state rm", nil, ret.Vars)
 	ret.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)

--- a/internal/command/arguments/state_rm.go
+++ b/internal/command/arguments/state_rm.go
@@ -38,7 +38,7 @@ func ParseStateRm(args []string) (*StateRm, func(), tfdiags.Diagnostics) {
 	ret := &StateRm{
 		Vars: &Vars{},
 	}
-	cmdFlags := extendedFlagSet("state rm", nil, nil, ret.Vars)
+	cmdFlags := extendedFlagSet("state rm", nil, ret.Vars)
 	ret.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
 	ret.Backend.AddStateFlags(cmdFlags)
 	cmdFlags.BoolVar(&ret.DryRun, "dry-run", false, "dry run")

--- a/internal/command/arguments/state_rm.go
+++ b/internal/command/arguments/state_rm.go
@@ -38,7 +38,8 @@ func ParseStateRm(args []string) (*StateRm, func(), tfdiags.Diagnostics) {
 	}
 	cmdFlags := extendedFlagSet("state rm", nil, ret.Vars)
 	ret.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
-	ret.State.AddFlags(cmdFlags, true, true, false, false)
+	// StateFlagBackup omitted here to be added later with a different default value
+	ret.State.addFlags(cmdFlags, stateFlagLock|stateFlagStateIn)
 	ret.State.AddBackupFlag(cmdFlags, "-")
 	cmdFlags.BoolVar(&ret.DryRun, "dry-run", false, "dry run")
 

--- a/internal/command/arguments/state_rm.go
+++ b/internal/command/arguments/state_rm.go
@@ -16,17 +16,14 @@ type StateRm struct {
 	// DryRun just validates that the arguments provided are valid and will output the possible outcome.
 	// When running in this mode, the state will suffer no change.
 	DryRun bool
-	//  BackupPath can be used by the user to configure where to save the backup file of the state file.
-	BackupPath string
-	// StatePath represents the path of the state to be used for the remove operation.
-	StatePath string
 
 	// ViewOptions specifies which view options to use
 	ViewOptions ViewOptions
 
-	// Vars and Backend are the common extended flags
+	// Vars, Backend and State are the common extended flags
 	Vars    *Vars
 	Backend Backend
+	State   *State
 }
 
 // ParseStateRm processes CLI arguments, returning a StateRm value, a closer function, and errors.
@@ -36,20 +33,14 @@ func ParseStateRm(args []string) (*StateRm, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	ret := &StateRm{
-		Vars: &Vars{},
+		Vars:  &Vars{},
+		State: NewStateFlags(),
 	}
 	cmdFlags := extendedFlagSet("state rm", nil, ret.Vars)
 	ret.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
-	ret.Backend.AddStateFlags(cmdFlags)
+	ret.State.AddFlags(cmdFlags, true, true, false, false)
+	ret.State.AddBackupFlag(cmdFlags, "-")
 	cmdFlags.BoolVar(&ret.DryRun, "dry-run", false, "dry run")
-	// NOTE: because the `-backup` flag needs a different default value than usual,
-	// we cannot use the [State] flags extension to register and parse these.
-	// Therefore, we need to have these redefined here.
-	// TODO meta-refactor: we might want to have a separate function on the [arguments.State] to register flags,
-	//  where default value can be provided by the caller. This way we could still use those flags instead of redefining
-	//  everything again.
-	cmdFlags.StringVar(&ret.BackupPath, "backup", "-", "backup-path")
-	cmdFlags.StringVar(&ret.StatePath, "state", "", "state-path")
 
 	ret.ViewOptions.AddFlags(cmdFlags, false)
 

--- a/internal/command/arguments/state_rm_test.go
+++ b/internal/command/arguments/state_rm_test.go
@@ -132,8 +132,10 @@ func stateRmArgsWithDefaults(mutate func(stateRm *StateRm)) *StateRm {
 		Backend: Backend{
 			IgnoreRemoteVersion: false,
 		},
-		Vars:  &Vars{},
-		State: NewStateFlags(),
+		Vars: &Vars{},
+		State: &State{
+			Lock: true,
+		},
 	}
 	// Because the default value is different on this command
 	ret.State.BackupPath = "-"

--- a/internal/command/arguments/state_rm_test.go
+++ b/internal/command/arguments/state_rm_test.go
@@ -135,10 +135,10 @@ func stateRmArgsWithDefaults(mutate func(stateRm *StateRm)) *StateRm {
 		Vars: &Vars{},
 		State: &State{
 			Lock: true,
+			// Because the default value is different on this command
+			BackupPath: "-",
 		},
 	}
-	// Because the default value is different on this command
-	ret.State.BackupPath = "-"
 	if mutate != nil {
 		mutate(ret)
 	}

--- a/internal/command/arguments/state_rm_test.go
+++ b/internal/command/arguments/state_rm_test.go
@@ -42,28 +42,28 @@ func TestParseStateRm_basicValidation(t *testing.T) {
 		"custom backup path": {
 			args: []string{"-backup=/path/to/backup.tfstate", "resource.foo"},
 			want: stateRmArgsWithDefaults(func(stateRm *StateRm) {
-				stateRm.BackupPath = "/path/to/backup.tfstate"
+				stateRm.State.BackupPath = "/path/to/backup.tfstate"
 				stateRm.TargetAddrs = []string{"resource.foo"}
 			}),
 		},
 		"custom state path": {
 			args: []string{"-state=/path/to/state.tfstate", "resource.foo"},
 			want: stateRmArgsWithDefaults(func(stateRm *StateRm) {
-				stateRm.StatePath = "/path/to/state.tfstate"
+				stateRm.State.StatePath = "/path/to/state.tfstate"
 				stateRm.TargetAddrs = []string{"resource.foo"}
 			}),
 		},
 		"only lock-timeout": {
 			args: []string{"-lock-timeout=10s", "resource.foo"},
 			want: stateRmArgsWithDefaults(func(stateRm *StateRm) {
-				stateRm.Backend.StateLockTimeout = 10 * time.Second
+				stateRm.State.LockTimeout = 10 * time.Second
 				stateRm.TargetAddrs = []string{"resource.foo"}
 			}),
 		},
 		"disable locking": {
 			args: []string{"-lock=false", "resource.foo"},
 			want: stateRmArgsWithDefaults(func(stateRm *StateRm) {
-				stateRm.Backend.StateLock = false
+				stateRm.State.Lock = false
 				stateRm.TargetAddrs = []string{"resource.foo"}
 			}),
 		},
@@ -80,10 +80,10 @@ func TestParseStateRm_basicValidation(t *testing.T) {
 			},
 			want: stateRmArgsWithDefaults(func(stateRm *StateRm) {
 				stateRm.DryRun = true
-				stateRm.BackupPath = "/path/to/backup.tfstate"
-				stateRm.StatePath = "/path/to/state.tfstate"
-				stateRm.Backend.StateLockTimeout = 15 * time.Second
-				stateRm.Backend.StateLock = true
+				stateRm.State.BackupPath = "/path/to/backup.tfstate"
+				stateRm.State.StatePath = "/path/to/state.tfstate"
+				stateRm.State.LockTimeout = 15 * time.Second
+				stateRm.State.Lock = true
 				stateRm.TargetAddrs = []string{"resource.foo", "resource.bar"}
 				// Vars would be updated, but we ignore it in cmp
 			}),
@@ -124,19 +124,19 @@ func TestParseStateRm_basicValidation(t *testing.T) {
 
 func stateRmArgsWithDefaults(mutate func(stateRm *StateRm)) *StateRm {
 	ret := &StateRm{
-		DryRun:     false,
-		BackupPath: "-",
+		DryRun: false,
 		ViewOptions: ViewOptions{
 			ViewType:     ViewHuman,
 			InputEnabled: false,
 		},
 		Backend: Backend{
 			IgnoreRemoteVersion: false,
-			StateLock:           true,
-			StateLockTimeout:    0,
 		},
-		Vars: &Vars{},
+		Vars:  &Vars{},
+		State: NewStateFlags(),
 	}
+	// Because the default value is different on this command
+	ret.State.BackupPath = "-"
 	if mutate != nil {
 		mutate(ret)
 	}

--- a/internal/command/arguments/state_show.go
+++ b/internal/command/arguments/state_show.go
@@ -34,7 +34,7 @@ func ParseStateShow(args []string) (*StateShow, func(), tfdiags.Diagnostics) {
 
 	ret := &StateShow{
 		Vars:  &Vars{},
-		State: &State{}, // Initialised like this because we don't want to have the lock enabled by default
+		State: &State{},
 	}
 	cmdFlags := extendedFlagSet("state show", nil, ret.Vars)
 	cmdFlags.BoolVar(&ret.ShowSensitive, "show-sensitive", false, "displays sensitive values")

--- a/internal/command/arguments/state_show.go
+++ b/internal/command/arguments/state_show.go
@@ -34,7 +34,7 @@ func ParseStateShow(args []string) (*StateShow, func(), tfdiags.Diagnostics) {
 
 	ret := &StateShow{
 		Vars:  &Vars{},
-		State: NewStateFlags(),
+		State: &State{}, // Initialised like this because we don't want to have the lock enabled by default
 	}
 	cmdFlags := extendedFlagSet("state show", nil, ret.Vars)
 	cmdFlags.BoolVar(&ret.ShowSensitive, "show-sensitive", false, "displays sensitive values")

--- a/internal/command/arguments/state_show.go
+++ b/internal/command/arguments/state_show.go
@@ -36,7 +36,7 @@ func ParseStateShow(args []string) (*StateShow, func(), tfdiags.Diagnostics) {
 	ret := &StateShow{
 		Vars: &Vars{},
 	}
-	cmdFlags := extendedFlagSet("state show", nil, nil, ret.Vars)
+	cmdFlags := extendedFlagSet("state show", nil, ret.Vars)
 	cmdFlags.BoolVar(&ret.ShowSensitive, "show-sensitive", false, "displays sensitive values")
 	// TODO meta-refactor: we should use directly the [State] struct here but we cannot use it in the `extendedFlagSet`
 	//  since that registers more flags than desired by this command.

--- a/internal/command/arguments/state_show.go
+++ b/internal/command/arguments/state_show.go
@@ -17,14 +17,13 @@ type StateShow struct {
 	// This applies only to the [views.StateHuman] since the [views.StateJSON] shows the sensitive values
 	// all the time.
 	ShowSensitive bool
-	// StatePath represents the path of the state where the [TargetRawAddr] resource information is stored in.
-	StatePath string
 
 	// ViewOptions specifies which view options to use
 	ViewOptions ViewOptions
 
-	// Vars are the common extended flags
-	Vars *Vars
+	// Vars and State are the common extended flags
+	Vars  *Vars
+	State *State
 }
 
 // ParseStateShow processes CLI arguments, returning a StateShow value, a closer function, and errors.
@@ -34,13 +33,12 @@ func ParseStateShow(args []string) (*StateShow, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	ret := &StateShow{
-		Vars: &Vars{},
+		Vars:  &Vars{},
+		State: NewStateFlags(),
 	}
 	cmdFlags := extendedFlagSet("state show", nil, ret.Vars)
 	cmdFlags.BoolVar(&ret.ShowSensitive, "show-sensitive", false, "displays sensitive values")
-	// TODO meta-refactor: we should use directly the [State] struct here but we cannot use it in the `extendedFlagSet`
-	//  since that registers more flags than desired by this command.
-	cmdFlags.StringVar(&ret.StatePath, "state", "", "state-path")
+	ret.State.AddFlags(cmdFlags, false, true, false, false)
 
 	ret.ViewOptions.AddFlags(cmdFlags, false)
 

--- a/internal/command/arguments/state_show.go
+++ b/internal/command/arguments/state_show.go
@@ -38,7 +38,7 @@ func ParseStateShow(args []string) (*StateShow, func(), tfdiags.Diagnostics) {
 	}
 	cmdFlags := extendedFlagSet("state show", nil, ret.Vars)
 	cmdFlags.BoolVar(&ret.ShowSensitive, "show-sensitive", false, "displays sensitive values")
-	ret.State.AddFlags(cmdFlags, false, true, false, false)
+	ret.State.addFlags(cmdFlags, stateFlagStateIn)
 
 	ret.ViewOptions.AddFlags(cmdFlags, false)
 

--- a/internal/command/arguments/state_show_test.go
+++ b/internal/command/arguments/state_show_test.go
@@ -35,7 +35,7 @@ func TestParseStateShow_basicValidation(t *testing.T) {
 		"custom state path": {
 			args: []string{"-state=/path/to/state.tfstate", "resource_address"},
 			want: stateShowArgsWithDefaults(func(stateShow *StateShow) {
-				stateShow.StatePath = "/path/to/state.tfstate"
+				stateShow.State.StatePath = "/path/to/state.tfstate"
 				stateShow.TargetRawAddr = "resource_address"
 			}),
 		},
@@ -48,7 +48,7 @@ func TestParseStateShow_basicValidation(t *testing.T) {
 			},
 			want: stateShowArgsWithDefaults(func(stateShow *StateShow) {
 				stateShow.ShowSensitive = true
-				stateShow.StatePath = "/path/to/state.tfstate"
+				stateShow.State.StatePath = "/path/to/state.tfstate"
 				stateShow.TargetRawAddr = "resource_address"
 				// Vars would be updated, but we ignore it in cmp
 			}),
@@ -104,7 +104,8 @@ func stateShowArgsWithDefaults(mutate func(stateShow *StateShow)) *StateShow {
 			ViewType:     ViewHuman,
 			InputEnabled: false,
 		},
-		Vars: &Vars{},
+		Vars:  &Vars{},
+		State: NewStateFlags(),
 	}
 	if mutate != nil {
 		mutate(ret)

--- a/internal/command/arguments/state_show_test.go
+++ b/internal/command/arguments/state_show_test.go
@@ -105,7 +105,7 @@ func stateShowArgsWithDefaults(mutate func(stateShow *StateShow)) *StateShow {
 			InputEnabled: false,
 		},
 		Vars:  &Vars{},
-		State: &State{}, // Initialised like this because we don't want to have the lock enabled by default
+		State: &State{},
 	}
 	if mutate != nil {
 		mutate(ret)

--- a/internal/command/arguments/state_show_test.go
+++ b/internal/command/arguments/state_show_test.go
@@ -105,7 +105,7 @@ func stateShowArgsWithDefaults(mutate func(stateShow *StateShow)) *StateShow {
 			InputEnabled: false,
 		},
 		Vars:  &Vars{},
-		State: NewStateFlags(),
+		State: &State{}, // Initialised like this because we don't want to have the lock enabled by default
 	}
 	if mutate != nil {
 		mutate(ret)

--- a/internal/command/arguments/taint.go
+++ b/internal/command/arguments/taint.go
@@ -42,14 +42,15 @@ func ParseTaint(isTaint bool, args []string) (*Taint, func(), tfdiags.Diagnostic
 	var diags tfdiags.Diagnostics
 	arguments := &Taint{
 		Vars:    &Vars{},
-		State:   &State{},
+		State:   NewStateFlags(),
 		Backend: &Backend{},
 	}
 	cmd := "taint"
 	if !isTaint {
 		cmd = "untaint"
 	}
-	cmdFlags := extendedFlagSet(cmd, arguments.State, nil, arguments.Vars)
+	cmdFlags := extendedFlagSet(cmd, nil, arguments.Vars)
+	arguments.State.AddFlags(cmdFlags, true, true, true, true)
 	cmdFlags.BoolVar(&arguments.AllowMissing, "allow-missing", false, "allow missing")
 	arguments.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
 	arguments.ViewOptions.AddFlags(cmdFlags, false)

--- a/internal/command/arguments/taint.go
+++ b/internal/command/arguments/taint.go
@@ -26,9 +26,6 @@ type Taint struct {
 	// Vars holds and provides information for the flags related to variables that a user can give into the process
 	Vars *Vars
 
-	// TODO meta-refactor: Backend and State have overlapping flags. Those need to be unified and
-	//  have a single point of registration of those flags
-
 	// State is used for the state related flags
 	State *State
 	// Backend is used strictly for the ignore remote version flag

--- a/internal/command/arguments/taint.go
+++ b/internal/command/arguments/taint.go
@@ -39,7 +39,7 @@ func ParseTaint(isTaint bool, args []string) (*Taint, func(), tfdiags.Diagnostic
 	var diags tfdiags.Diagnostics
 	arguments := &Taint{
 		Vars:    &Vars{},
-		State:   NewStateFlags(),
+		State:   &State{},
 		Backend: &Backend{},
 	}
 	cmd := "taint"

--- a/internal/command/arguments/taint.go
+++ b/internal/command/arguments/taint.go
@@ -47,7 +47,7 @@ func ParseTaint(isTaint bool, args []string) (*Taint, func(), tfdiags.Diagnostic
 		cmd = "untaint"
 	}
 	cmdFlags := extendedFlagSet(cmd, nil, arguments.Vars)
-	arguments.State.AddFlags(cmdFlags, true, true, true, true)
+	arguments.State.addFlags(cmdFlags, stateFlagAll)
 	cmdFlags.BoolVar(&arguments.AllowMissing, "allow-missing", false, "allow missing")
 	arguments.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
 	arguments.ViewOptions.AddFlags(cmdFlags, false)

--- a/internal/command/arguments/taint_test.go
+++ b/internal/command/arguments/taint_test.go
@@ -184,8 +184,10 @@ func taintArgsWithDefaults(mutate func(v *Taint)) *Taint {
 			ViewType:     ViewHuman,
 			InputEnabled: false,
 		},
-		Vars:    &Vars{},
-		State:   NewStateFlags(),
+		Vars: &Vars{},
+		State: &State{
+			Lock: true,
+		},
 		Backend: &Backend{},
 	}
 	if mutate != nil {

--- a/internal/command/arguments/taint_test.go
+++ b/internal/command/arguments/taint_test.go
@@ -184,10 +184,8 @@ func taintArgsWithDefaults(mutate func(v *Taint)) *Taint {
 			ViewType:     ViewHuman,
 			InputEnabled: false,
 		},
-		Vars: &Vars{},
-		State: &State{
-			Lock: true,
-		},
+		Vars:    &Vars{},
+		State:   NewStateFlags(),
 		Backend: &Backend{},
 	}
 	if mutate != nil {

--- a/internal/command/arguments/test.go
+++ b/internal/command/arguments/test.go
@@ -42,7 +42,7 @@ func ParseTest(args []string) (*Test, func(), tfdiags.Diagnostics) {
 		Vars: new(Vars),
 	}
 
-	cmdFlags := extendedFlagSet("test", nil, nil, test.Vars)
+	cmdFlags := extendedFlagSet("test", nil, test.Vars)
 	cmdFlags.Var((*flags.FlagStringSlice)(&test.Filter), "filter", "filter")
 	cmdFlags.StringVar(&test.TestDirectory, "test-directory", configs.DefaultTestDirectory, "test-directory")
 	cmdFlags.BoolVar(&test.Verbose, "verbose", false, "verbose")

--- a/internal/command/arguments/unlock.go
+++ b/internal/command/arguments/unlock.go
@@ -31,7 +31,7 @@ func ParseUnlock(args []string) (*Unlock, func(), tfdiags.Diagnostics) {
 		Vars: &Vars{},
 	}
 
-	cmdFlags := extendedFlagSet("force-unlock", nil, nil, arguments.Vars)
+	cmdFlags := extendedFlagSet("force-unlock", nil, arguments.Vars)
 	cmdFlags.BoolVar(&arguments.Force, "force", false, "force")
 	arguments.ViewOptions.AddFlags(cmdFlags, false)
 

--- a/internal/command/arguments/validate.go
+++ b/internal/command/arguments/validate.go
@@ -41,7 +41,7 @@ func ParseValidate(args []string) (*Validate, func(), tfdiags.Diagnostics) {
 		Vars: &Vars{},
 	}
 
-	cmdFlags := extendedFlagSet("validate", nil, nil, validate.Vars)
+	cmdFlags := extendedFlagSet("validate", nil, validate.Vars)
 	cmdFlags.StringVar(&validate.TestDirectory, "test-directory", "tests", "test-directory")
 	cmdFlags.BoolVar(&validate.NoTests, "no-tests", false, "no-tests")
 

--- a/internal/command/arguments/workspace_delete.go
+++ b/internal/command/arguments/workspace_delete.go
@@ -38,7 +38,7 @@ func ParseWorkspaceDelete(args []string) (*WorkspaceDelete, func(), tfdiags.Diag
 		Vars: &Vars{},
 	}
 
-	cmdFlags := extendedFlagSet("workspace delete", nil, nil, ret.Vars)
+	cmdFlags := extendedFlagSet("workspace delete", nil, ret.Vars)
 	cmdFlags.BoolVar(&ret.Force, "force", false, "force removal of a non-empty workspace")
 	cmdFlags.BoolVar(&ret.StateLock, "lock", true, "lock state")
 	cmdFlags.DurationVar(&ret.StateLockTimeout, "lock-timeout", 0, "lock timeout")

--- a/internal/command/arguments/workspace_delete.go
+++ b/internal/command/arguments/workspace_delete.go
@@ -36,7 +36,7 @@ func ParseWorkspaceDelete(args []string) (*WorkspaceDelete, func(), tfdiags.Diag
 
 	cmdFlags := extendedFlagSet("workspace delete", nil, ret.Vars)
 	cmdFlags.BoolVar(&ret.Force, "force", false, "force removal of a non-empty workspace")
-	ret.State.AddFlags(cmdFlags, true, false, false, false)
+	ret.State.addFlags(cmdFlags, stateFlagLock)
 	ret.ViewOptions.AddFlags(cmdFlags, false)
 
 	if err := cmdFlags.Parse(args); err != nil {

--- a/internal/command/arguments/workspace_delete.go
+++ b/internal/command/arguments/workspace_delete.go
@@ -31,7 +31,7 @@ func ParseWorkspaceDelete(args []string) (*WorkspaceDelete, func(), tfdiags.Diag
 
 	ret := &WorkspaceDelete{
 		Vars:  &Vars{},
-		State: NewStateFlags(),
+		State: &State{},
 	}
 
 	cmdFlags := extendedFlagSet("workspace delete", nil, ret.Vars)

--- a/internal/command/arguments/workspace_delete.go
+++ b/internal/command/arguments/workspace_delete.go
@@ -6,8 +6,6 @@
 package arguments
 
 import (
-	"time"
-
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
@@ -18,30 +16,27 @@ type WorkspaceDelete struct {
 	// Force allows the user to forcefully delete a workspace removing the still existing resources
 	// from the OpenTofu's management.
 	Force bool
-	// StateLock allows the user to disable, the default enabled, state locking.
-	StateLock bool
-	// StateLockTimeout allows the user to configure the timeout for the locking of the state.
-	StateLockTimeout time.Duration
 
 	// ViewOptions contains the options that allows the user to configure different types of outputs
 	// from the current command.
 	ViewOptions ViewOptions
 
-	// Vars holds the information that might be needed to be given through `-var`/`-var-file`.
-	Vars *Vars
+	// Vars and State are the common extended flags
+	Vars  *Vars
+	State *State
 }
 
 func ParseWorkspaceDelete(args []string) (*WorkspaceDelete, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	ret := &WorkspaceDelete{
-		Vars: &Vars{},
+		Vars:  &Vars{},
+		State: NewStateFlags(),
 	}
 
 	cmdFlags := extendedFlagSet("workspace delete", nil, ret.Vars)
 	cmdFlags.BoolVar(&ret.Force, "force", false, "force removal of a non-empty workspace")
-	cmdFlags.BoolVar(&ret.StateLock, "lock", true, "lock state")
-	cmdFlags.DurationVar(&ret.StateLockTimeout, "lock-timeout", 0, "lock timeout")
+	ret.State.AddFlags(cmdFlags, true, false, false, false)
 	ret.ViewOptions.AddFlags(cmdFlags, false)
 
 	if err := cmdFlags.Parse(args); err != nil {

--- a/internal/command/arguments/workspace_delete_test.go
+++ b/internal/command/arguments/workspace_delete_test.go
@@ -73,14 +73,14 @@ func TestParseWorkspaceDelete_basicValidation(t *testing.T) {
 			[]string{"-lock=false", "target-ws"},
 			workspaceDeleteArgsWithDefaults(func(in *WorkspaceDelete) {
 				in.WorkspaceName = "target-ws"
-				in.StateLock = false
+				in.State.Lock = false
 			}),
 		},
 		"lock timeout flag": {
 			[]string{"-lock-timeout=2s", "target-ws"},
 			workspaceDeleteArgsWithDefaults(func(in *WorkspaceDelete) {
 				in.WorkspaceName = "target-ws"
-				in.StateLockTimeout = 2 * time.Second
+				in.State.LockTimeout = 2 * time.Second
 			}),
 		},
 	}
@@ -163,13 +163,12 @@ func TestParseWorkspaceDelete_vars(t *testing.T) {
 
 func workspaceDeleteArgsWithDefaults(mutate func(in *WorkspaceDelete)) *WorkspaceDelete {
 	ret := &WorkspaceDelete{
-		Force:            false,
-		StateLock:        true,
-		StateLockTimeout: 0,
-		Vars:             &Vars{},
+		Force: false,
+		Vars:  &Vars{},
 		ViewOptions: ViewOptions{
 			ViewType: ViewHuman,
 		},
+		State: NewStateFlags(),
 	}
 	if mutate != nil {
 		mutate(ret)

--- a/internal/command/arguments/workspace_delete_test.go
+++ b/internal/command/arguments/workspace_delete_test.go
@@ -168,7 +168,9 @@ func workspaceDeleteArgsWithDefaults(mutate func(in *WorkspaceDelete)) *Workspac
 		ViewOptions: ViewOptions{
 			ViewType: ViewHuman,
 		},
-		State: NewStateFlags(),
+		State: &State{
+			Lock: true,
+		},
 	}
 	if mutate != nil {
 		mutate(ret)

--- a/internal/command/arguments/workspace_list.go
+++ b/internal/command/arguments/workspace_list.go
@@ -25,7 +25,7 @@ func ParseWorkspaceList(args []string) (*WorkspaceList, func(), tfdiags.Diagnost
 		Vars: &Vars{},
 	}
 
-	cmdFlags := extendedFlagSet("workspace list", nil, nil, ret.Vars)
+	cmdFlags := extendedFlagSet("workspace list", nil, ret.Vars)
 	ret.ViewOptions.AddFlags(cmdFlags, false)
 
 	if err := cmdFlags.Parse(args); err != nil {

--- a/internal/command/arguments/workspace_new.go
+++ b/internal/command/arguments/workspace_new.go
@@ -17,9 +17,8 @@ type WorkspaceNew struct {
 	// from the current command.
 	ViewOptions ViewOptions
 
-	// Vars holds the information that might be needed to be given through `-var`/`-var-file`.
-	Vars *Vars
-	// State is used for the state related flags
+	// Vars and State are the common extended flags
+	Vars  *Vars
 	State *State
 }
 

--- a/internal/command/arguments/workspace_new.go
+++ b/internal/command/arguments/workspace_new.go
@@ -27,7 +27,7 @@ func ParseWorkspaceNew(args []string) (*WorkspaceNew, func(), tfdiags.Diagnostic
 
 	ret := &WorkspaceNew{
 		Vars:  &Vars{},
-		State: NewStateFlags(),
+		State: &State{},
 	}
 
 	cmdFlags := extendedFlagSet("workspace new", nil, ret.Vars)

--- a/internal/command/arguments/workspace_new.go
+++ b/internal/command/arguments/workspace_new.go
@@ -31,7 +31,7 @@ func ParseWorkspaceNew(args []string) (*WorkspaceNew, func(), tfdiags.Diagnostic
 	}
 
 	cmdFlags := extendedFlagSet("workspace new", nil, ret.Vars)
-	ret.State.AddFlags(cmdFlags, true, true, false, false)
+	ret.State.addFlags(cmdFlags, stateFlagLock|stateFlagStateIn)
 	ret.ViewOptions.AddFlags(cmdFlags, false)
 
 	if err := cmdFlags.Parse(args); err != nil {

--- a/internal/command/arguments/workspace_new.go
+++ b/internal/command/arguments/workspace_new.go
@@ -6,8 +6,6 @@
 package arguments
 
 import (
-	"time"
-
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
@@ -15,32 +13,26 @@ type WorkspaceNew struct {
 	// Workspace represents the name of the workspace that the user wants to be selected.
 	WorkspaceName string
 
-	// StatePath allows the user to give a specific state file into the command.
-	StatePath string
-	// StateLock allows the user to disable, the default enabled, state locking.
-	StateLock bool
-	// StateLockTimeout allows the user to configure the timeout for the locking of the state..
-	StateLockTimeout time.Duration
-
 	// ViewOptions contains the options that allows the user to configure different types of outputs
 	// from the current command.
 	ViewOptions ViewOptions
 
 	// Vars holds the information that might be needed to be given through `-var`/`-var-file`.
 	Vars *Vars
+	// State is used for the state related flags
+	State *State
 }
 
 func ParseWorkspaceNew(args []string) (*WorkspaceNew, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	ret := &WorkspaceNew{
-		Vars: &Vars{},
+		Vars:  &Vars{},
+		State: NewStateFlags(),
 	}
 
-	cmdFlags := extendedFlagSet("workspace new", nil, nil, ret.Vars)
-	cmdFlags.StringVar(&ret.StatePath, "state", "", "tofu state file")
-	cmdFlags.BoolVar(&ret.StateLock, "lock", true, "lock state")
-	cmdFlags.DurationVar(&ret.StateLockTimeout, "lock-timeout", 0, "lock timeout")
+	cmdFlags := extendedFlagSet("workspace new", nil, ret.Vars)
+	ret.State.AddFlags(cmdFlags, true, true, false, false)
 	ret.ViewOptions.AddFlags(cmdFlags, false)
 
 	if err := cmdFlags.Parse(args); err != nil {

--- a/internal/command/arguments/workspace_new_test.go
+++ b/internal/command/arguments/workspace_new_test.go
@@ -163,8 +163,10 @@ func TestParseWorkspaceNew_vars(t *testing.T) {
 
 func workspaceNewArgsWithDefaults(mutate func(in *WorkspaceNew)) *WorkspaceNew {
 	ret := &WorkspaceNew{
-		State: NewStateFlags(),
-		Vars:  &Vars{},
+		State: &State{
+			Lock: true,
+		},
+		Vars: &Vars{},
 		ViewOptions: ViewOptions{
 			ViewType: ViewHuman,
 		},

--- a/internal/command/arguments/workspace_new_test.go
+++ b/internal/command/arguments/workspace_new_test.go
@@ -108,21 +108,21 @@ func TestParseWorkspaceNew_basicValidation(t *testing.T) {
 			[]string{"-state=/path/to/state.tfstate", "target-ws"},
 			workspaceNewArgsWithDefaults(func(in *WorkspaceNew) {
 				in.WorkspaceName = "target-ws"
-				in.StatePath = "/path/to/state.tfstate"
+				in.State.StatePath = "/path/to/state.tfstate"
 			}),
 		},
 		"lock flag": {
 			[]string{"-lock=false", "target-ws"},
 			workspaceNewArgsWithDefaults(func(in *WorkspaceNew) {
 				in.WorkspaceName = "target-ws"
-				in.StateLock = false
+				in.State.Lock = false
 			}),
 		},
 		"lock timeout flag": {
 			[]string{"-lock-timeout=2s", "target-ws"},
 			workspaceNewArgsWithDefaults(func(in *WorkspaceNew) {
 				in.WorkspaceName = "target-ws"
-				in.StateLockTimeout = 2 * time.Second
+				in.State.LockTimeout = 2 * time.Second
 			}),
 		},
 	}
@@ -163,10 +163,8 @@ func TestParseWorkspaceNew_vars(t *testing.T) {
 
 func workspaceNewArgsWithDefaults(mutate func(in *WorkspaceNew)) *WorkspaceNew {
 	ret := &WorkspaceNew{
-		StatePath:        "",
-		StateLock:        true,
-		StateLockTimeout: 0,
-		Vars:             &Vars{},
+		State: NewStateFlags(),
+		Vars:  &Vars{},
 		ViewOptions: ViewOptions{
 			ViewType: ViewHuman,
 		},

--- a/internal/command/arguments/workspace_select.go
+++ b/internal/command/arguments/workspace_select.go
@@ -31,7 +31,7 @@ func ParseWorkspaceSelect(args []string) (*WorkspaceSelect, func(), tfdiags.Diag
 		Vars: &Vars{},
 	}
 
-	cmdFlags := extendedFlagSet("workspace select", nil, nil, ret.Vars)
+	cmdFlags := extendedFlagSet("workspace select", nil, ret.Vars)
 	cmdFlags.BoolVar(&ret.CreateIfMissing, "or-create", false, "create workspace if it does not exist")
 	ret.ViewOptions.AddFlags(cmdFlags, false)
 

--- a/internal/command/arguments/workspace_show.go
+++ b/internal/command/arguments/workspace_show.go
@@ -25,7 +25,7 @@ func ParseWorkspaceShow(args []string) (*WorkspaceShow, func(), tfdiags.Diagnost
 		Vars: &Vars{},
 	}
 
-	cmdFlags := extendedFlagSet("workspace show", nil, nil, ret.Vars)
+	cmdFlags := extendedFlagSet("workspace show", nil, ret.Vars)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(

--- a/internal/command/console.go
+++ b/internal/command/console.go
@@ -50,7 +50,7 @@ func (c *ConsoleCommand) Run(rawArgs []string) int {
 		}
 		return cli.RunResultHelp
 	}
-	c.stateArgs = *args.State
+	c.Meta.stateArgs = *args.State
 
 	// FIXME: the -input flag value is needed to initialize the backend and the
 	// operation, but there is no clear path to pass this value down, so we

--- a/internal/command/console.go
+++ b/internal/command/console.go
@@ -52,8 +52,8 @@ func (c *ConsoleCommand) Run(rawArgs []string) int {
 	}
 	// TODO meta-refactor: get rid of this assignment once the statePath from Meta is removed
 	c.Meta.statePath = args.StatePath
-	c.Meta.stateLock = args.Backend.StateLock
-	c.Meta.stateLockTimeout = args.Backend.StateLockTimeout
+	c.Meta.stateLock = args.State.Lock
+	c.Meta.stateLockTimeout = args.State.LockTimeout
 
 	// FIXME: the -input flag value is needed to initialize the backend and the
 	// operation, but there is no clear path to pass this value down, so we

--- a/internal/command/console.go
+++ b/internal/command/console.go
@@ -50,21 +50,12 @@ func (c *ConsoleCommand) Run(rawArgs []string) int {
 		}
 		return cli.RunResultHelp
 	}
-	// TODO meta-refactor: get rid of this assignment once the statePath from Meta is removed
-	c.Meta.statePath = args.StatePath
-	c.Meta.stateLock = args.State.Lock
-	c.Meta.stateLockTimeout = args.State.LockTimeout
+	c.stateArgs = *args.State
 
 	// FIXME: the -input flag value is needed to initialize the backend and the
 	// operation, but there is no clear path to pass this value down, so we
 	// continue to mutate the Meta object state for now.
 	c.Meta.input = args.ViewOptions.InputEnabled
-
-	// TODO meta-refactor: when the stateLock and stateLockTimeout are extracted to be configured separately, remove
-	// these and use a common way to configure this
-	// The stateLock=true is here this way because this command used before meta.extendedFlagSet which did the same
-	// and left for the command to configure flags for this if needed.
-	c.Meta.stateLock = true
 
 	c.Meta.variableArgs = args.Vars.All()
 

--- a/internal/command/console_interactive_test.go
+++ b/internal/command/console_interactive_test.go
@@ -116,7 +116,7 @@ func TestConsole_multiline_interactive(t *testing.T) {
 			}
 
 			// TODO meta-refactor: remove this assertion once the stateLock from Meta is removed
-			if !c.Meta.stateLock {
+			if !c.Meta.stateArgs.Lock {
 				t.Errorf("stateLock should always be nil for this command")
 			}
 		})

--- a/internal/command/console_interactive_test.go
+++ b/internal/command/console_interactive_test.go
@@ -115,9 +115,9 @@ func TestConsole_multiline_interactive(t *testing.T) {
 				t.Fatalf("unexpected output. For input: %s\n%s", tc.input, diff)
 			}
 
-			// TODO meta-refactor: remove this assertion once the stateLock from Meta is removed
+			// TODO meta-refactor: remove this assertion once the stateArgs from Meta is removed
 			if !c.Meta.stateArgs.Lock {
-				t.Errorf("stateLock should always be nil for this command")
+				t.Errorf("stateLock should always be false for this command")
 			}
 		})
 	}

--- a/internal/command/import.go
+++ b/internal/command/import.go
@@ -330,7 +330,7 @@ func (c *ImportCommand) configureBackendFlags(args *arguments.Import) {
 	c.Meta.input = args.ViewOptions.InputEnabled
 
 	c.Meta.variableArgs = args.Vars.All()
-	c.stateArgs = *args.State
+	c.Meta.stateArgs = *args.State
 }
 
 func (c *ImportCommand) Help() string {

--- a/internal/command/import.go
+++ b/internal/command/import.go
@@ -319,17 +319,10 @@ func (c *ImportCommand) Run(rawArgs []string) int {
 // with proper arguments for the backend.
 func (c *ImportCommand) configureBackendFlags(args *arguments.Import) {
 	c.Meta.ignoreRemoteVersion = args.Backend.IgnoreRemoteVersion
-	// TODO meta-refactor: unify these 2 args attributes with the state flags in arguments.extendedFlagSet
-	//  https://github.com/opentofu/opentofu/blob/db8c872defd8666618649ef7e29fa2b809adfd5e/internal/command/arguments/extended.go#L320-L321
-	c.Meta.stateLock = args.State.Lock
-	c.Meta.stateLockTimeout = args.State.LockTimeout
 
 	// TODO meta-refactor: remove this only when there is clear path of passing these from the "arguments" package to
 	// the place where these needs to be used
 	c.Meta.parallelism = args.Parallelism
-	c.Meta.statePath = args.State.StatePath
-	c.Meta.stateOutPath = args.State.StateOutPath
-	c.Meta.backupPath = args.State.BackupPath
 
 	// FIXME: the -input flag value is needed to initialize the backend and the
 	// operation, but there is no clear path to pass this value down, so we
@@ -337,6 +330,7 @@ func (c *ImportCommand) configureBackendFlags(args *arguments.Import) {
 	c.Meta.input = args.ViewOptions.InputEnabled
 
 	c.Meta.variableArgs = args.Vars.All()
+	c.stateArgs = *args.State
 }
 
 func (c *ImportCommand) Help() string {

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -83,7 +83,7 @@ func (c *InitCommand) Run(rawArgs []string) int {
 		c.pluginPath = args.FlagPluginPath
 	}
 	c.Meta.variableArgs = args.Vars.All()
-	c.stateArgs = *args.State
+	c.Meta.stateArgs = *args.State
 
 	// This gets the current directory as full path.
 	path := c.WorkingDir.NormalizePath(c.WorkingDir.RootModuleDir())

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -77,7 +77,7 @@ func (c *InitCommand) Run(rawArgs []string) int {
 	// operation, but there is no clear path to pass this value down, so we
 	// continue to mutate the Meta object state for now.
 	c.Meta.input = args.ViewOptions.InputEnabled
-	c.configureBackendFlags(args.Backend)
+	c.configureBackendFlags(args.Backend, args.State)
 
 	if len(args.FlagPluginPath) > 0 {
 		c.pluginPath = args.FlagPluginPath
@@ -1146,15 +1146,15 @@ func (c *InitCommand) AutocompleteArgs() complete.Predictor {
 //
 // TODO meta-refactor: remove this when the Meta fields configured here will be removed and replaced
 // with proper arguments for the backend.
-func (c *InitCommand) configureBackendFlags(args *arguments.Backend) {
+func (c *InitCommand) configureBackendFlags(args *arguments.Backend, state *arguments.State) {
 	c.forceInitCopy = args.ForceInitCopy
 	c.reconfigure = args.Reconfigure
 	c.migrateState = args.MigrateState
 	c.Meta.ignoreRemoteVersion = args.IgnoreRemoteVersion
 	// TODO meta-refactor: unify these 2 args attributes with the state flags in arguments.extendedFlagSet
 	//  https://github.com/opentofu/opentofu/blob/db8c872defd8666618649ef7e29fa2b809adfd5e/internal/command/arguments/extended.go#L320-L321
-	c.Meta.stateLock = args.StateLock
-	c.Meta.stateLockTimeout = args.StateLockTimeout
+	c.Meta.stateLock = state.Lock
+	c.Meta.stateLockTimeout = state.LockTimeout
 }
 
 func (c *InitCommand) AutocompleteFlags() complete.Flags {

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -77,12 +77,13 @@ func (c *InitCommand) Run(rawArgs []string) int {
 	// operation, but there is no clear path to pass this value down, so we
 	// continue to mutate the Meta object state for now.
 	c.Meta.input = args.ViewOptions.InputEnabled
-	c.configureBackendFlags(args.Backend, args.State)
+	c.configureBackendFlags(args.Backend)
 
 	if len(args.FlagPluginPath) > 0 {
 		c.pluginPath = args.FlagPluginPath
 	}
 	c.Meta.variableArgs = args.Vars.All()
+	c.stateArgs = *args.State
 
 	// This gets the current directory as full path.
 	path := c.WorkingDir.NormalizePath(c.WorkingDir.RootModuleDir())
@@ -1146,15 +1147,11 @@ func (c *InitCommand) AutocompleteArgs() complete.Predictor {
 //
 // TODO meta-refactor: remove this when the Meta fields configured here will be removed and replaced
 // with proper arguments for the backend.
-func (c *InitCommand) configureBackendFlags(args *arguments.Backend, state *arguments.State) {
+func (c *InitCommand) configureBackendFlags(args *arguments.Backend) {
 	c.forceInitCopy = args.ForceInitCopy
 	c.reconfigure = args.Reconfigure
 	c.migrateState = args.MigrateState
 	c.Meta.ignoreRemoteVersion = args.IgnoreRemoteVersion
-	// TODO meta-refactor: unify these 2 args attributes with the state flags in arguments.extendedFlagSet
-	//  https://github.com/opentofu/opentofu/blob/db8c872defd8666618649ef7e29fa2b809adfd5e/internal/command/arguments/extended.go#L320-L321
-	c.Meta.stateLock = state.Lock
-	c.Meta.stateLockTimeout = state.LockTimeout
 }
 
 func (c *InitCommand) AutocompleteFlags() complete.Flags {

--- a/internal/command/login.go
+++ b/internal/command/login.go
@@ -78,7 +78,7 @@ func (c *LoginCommand) Run(rawArgs []string) int {
 		}
 		return cli.RunResultHelp
 	}
-	c.stateArgs = *args.State
+	c.Meta.stateArgs = *args.State
 
 	// FIXME: the -input flag value is needed to initialize the backend and the
 	// operation, but there is no clear path to pass this value down, so we

--- a/internal/command/login.go
+++ b/internal/command/login.go
@@ -78,17 +78,12 @@ func (c *LoginCommand) Run(rawArgs []string) int {
 		}
 		return cli.RunResultHelp
 	}
+	c.stateArgs = *args.State
 
 	// FIXME: the -input flag value is needed to initialize the backend and the
 	// operation, but there is no clear path to pass this value down, so we
 	// continue to mutate the Meta object state for now.
 	c.Meta.input = args.ViewOptions.InputEnabled
-
-	// TODO meta-refactor: when the stateLock and stateLockTimeout are extracted to be configured separately, remove
-	// these and use a common way to configure this
-	// The stateLock=true is here this way because this command used before meta.extendedFlagSet which did the same
-	// and left for the command to configure flags for this if needed.
-	c.Meta.stateLock = true
 
 	if !c.input {
 		diags = diags.Append(tfdiags.Sourceless(

--- a/internal/command/login_test.go
+++ b/internal/command/login_test.go
@@ -159,7 +159,7 @@ func TestLogin(t *testing.T) {
 		if got, want := loginOutput.Stdout(), "Welcome to the cloud backend!␀"; !strings.Contains(got, want) {
 			t.Errorf("expected output to contain %q, but was:\n%s", want, got)
 		}
-		if !c.Meta.stateLock {
+		if !c.Meta.stateArgs.Lock {
 			t.Errorf("stateLock always expected to be true for the login command")
 		}
 	}, true))

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -217,27 +217,8 @@ type Meta struct {
 	// The fields below are expected to be set by the command via
 	// command line flags. See the Apply command for an example.
 	//
-	// statePath is the path to the state file. If this is empty, then
-	// no state will be loaded. It is also okay for this to be a path to
-	// a file that doesn't exist; it is assumed that this means that there
-	// is simply no state.
-	//
-	// stateOutPath is used to override the output path for the state.
-	// If not provided, the StatePath is used causing the old state to
-	// be overridden.
-	//
-	// backupPath is used to backup the state file before writing a modified
-	// version. It defaults to stateOutPath + DefaultBackupExtension
-	//
 	// parallelism is used to control the number of concurrent operations
 	// allowed when walking the graph
-	//
-	// provider is to specify specific resource providers
-	//
-	// stateLock is set to false to disable state locking
-	//
-	// stateLockTimeout is the optional duration to retry a state locks locks
-	// when it is already locked by another process.
 	//
 	// forceInitCopy suppresses confirmation for copying state data during
 	// init.
@@ -246,15 +227,11 @@ type Meta struct {
 	//
 	// migrateState confirms the user wishes to migrate from the prior backend
 	// configuration to a new configuration.
-	statePath        string
-	stateOutPath     string
-	backupPath       string
-	parallelism      int
-	stateLock        bool
-	stateLockTimeout time.Duration
-	forceInitCopy    bool
-	reconfigure      bool
-	migrateState     bool
+	stateArgs     arguments.State
+	parallelism   int
+	forceInitCopy bool
+	reconfigure   bool
+	migrateState  bool
 
 	// Used with commands which write state to allow users to write remote
 	// state even if the remote and local OpenTofu versions don't match.
@@ -279,22 +256,22 @@ type testingOverrides struct {
 }
 
 // initStatePaths is used to initialize the default values for
-// statePath, stateOutPath, and backupPath
+// arguments.State#StatePath, arguments.State#stateOutPath, and arguments.State#backupPath
 func (m *Meta) initStatePaths() {
-	if m.statePath == "" {
-		m.statePath = arguments.DefaultStateFilename
+	if m.stateArgs.StatePath == "" {
+		m.stateArgs.StatePath = arguments.DefaultStateFilename
 	}
-	if m.stateOutPath == "" {
-		m.stateOutPath = m.statePath
+	if m.stateArgs.StateOutPath == "" {
+		m.stateArgs.StateOutPath = m.stateArgs.StatePath
 	}
-	if m.backupPath == "" {
-		m.backupPath = m.stateOutPath + DefaultBackupExtension
+	if m.stateArgs.BackupPath == "" {
+		m.stateArgs.BackupPath = m.stateArgs.StateOutPath + DefaultBackupExtension
 	}
 }
 
 // StateOutPath returns the true output path for the state file
 func (m *Meta) StateOutPath() string {
-	return m.stateOutPath
+	return m.stateArgs.StateOutPath
 }
 
 const (
@@ -580,17 +557,6 @@ func (m *Meta) SetWorkspace(name string) error {
 func isAutoVarFile(path string) bool {
 	return strings.HasSuffix(path, ".auto.tfvars") ||
 		strings.HasSuffix(path, ".auto.tfvars.json")
-}
-
-// FIXME: as an interim refactoring step, we apply the contents of the state
-// arguments directly to the Meta object. Future work would ideally update the
-// code paths which use these arguments to be passed them directly for clarity.
-func (m *Meta) applyStateArguments(args *arguments.State) {
-	m.stateLock = args.Lock
-	m.stateLockTimeout = args.LockTimeout
-	m.statePath = args.StatePath
-	m.stateOutPath = args.StateOutPath
-	m.backupPath = args.BackupPath
 }
 
 // checkRequiredVersion loads the config and check if the

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -255,20 +255,6 @@ type testingOverrides struct {
 	Provisioners map[string]provisioners.Factory
 }
 
-// initStatePaths is used to initialize the default values for
-// arguments.State#StatePath, arguments.State#stateOutPath, and arguments.State#backupPath
-func (m *Meta) initStatePaths() {
-	if m.stateArgs.StatePath == "" {
-		m.stateArgs.StatePath = arguments.DefaultStateFilename
-	}
-	if m.stateArgs.StateOutPath == "" {
-		m.stateArgs.StateOutPath = m.stateArgs.StatePath
-	}
-	if m.stateArgs.BackupPath == "" {
-		m.stateArgs.BackupPath = m.stateArgs.StateOutPath + DefaultBackupExtension
-	}
-}
-
 // StateOutPath returns the true output path for the state file
 func (m *Meta) StateOutPath() string {
 	return m.stateArgs.StateOutPath

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -425,11 +425,8 @@ func (m *Meta) backendCLIOpts(ctx context.Context) (*backend.CLIOpts, error) {
 		return nil, err
 	}
 	return &backend.CLIOpts{
-		View: views.NewBackendRemote(m.View),
-		// TODO andrei: pass the arguments.State here instead of individual properties
-		StatePath:           m.stateArgs.StatePath,
-		StateOutPath:        m.stateArgs.StateOutPath,
-		StateBackupPath:     m.stateArgs.BackupPath,
+		View:                views.NewBackendRemote(m.View),
+		StateArgs:           m.stateArgs,
 		ContextOpts:         contextOpts,
 		Input:               m.Input(),
 		RunningInAutomation: m.RunningInAutomation,

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -425,10 +425,11 @@ func (m *Meta) backendCLIOpts(ctx context.Context) (*backend.CLIOpts, error) {
 		return nil, err
 	}
 	return &backend.CLIOpts{
-		View:                views.NewBackendRemote(m.View),
-		StatePath:           m.statePath,
-		StateOutPath:        m.stateOutPath,
-		StateBackupPath:     m.backupPath,
+		View: views.NewBackendRemote(m.View),
+		// TODO meta-refactor: pass the arguments.State here instead of individual properties
+		StatePath:           m.stateArgs.StatePath,
+		StateOutPath:        m.stateArgs.StateOutPath,
+		StateBackupPath:     m.stateArgs.BackupPath,
 		ContextOpts:         contextOpts,
 		Input:               m.Input(),
 		RunningInAutomation: m.RunningInAutomation,
@@ -459,8 +460,8 @@ func (m *Meta) Operation(ctx context.Context, b backend.Backend, view views.Back
 	}
 
 	stateLocker := clistate.NewNoopLocker()
-	if m.stateLock {
-		stateLocker = clistate.NewLocker(m.stateLockTimeout, view.StateLocker())
+	if m.stateArgs.Lock {
+		stateLocker = clistate.NewLocker(m.stateArgs.LockTimeout, view.StateLocker())
 	}
 
 	depLocks, diags := m.lockedDependencies()
@@ -1072,8 +1073,8 @@ func (m *Meta) backend_C_r_s(ctx context.Context, c *configs.Backend, cHash int,
 		}
 	}
 
-	if m.stateLock {
-		stateLocker := clistate.NewLocker(m.stateLockTimeout, view.StateLocker())
+	if m.stateArgs.Lock {
+		stateLocker := clistate.NewLocker(m.stateArgs.LockTimeout, view.StateLocker())
 		if d := stateLocker.Lock(sMgr, "backend from plan"); d != nil {
 			diags = diags.Append(fmt.Errorf("Error locking state: %s", d))
 			return nil, diags
@@ -1204,8 +1205,8 @@ func (m *Meta) backend_C_r_S_changed(ctx context.Context, c *configs.Backend, cH
 			return nil, diags
 		}
 
-		if m.stateLock {
-			stateLocker := clistate.NewLocker(m.stateLockTimeout, view.StateLocker())
+		if m.stateArgs.Lock {
+			stateLocker := clistate.NewLocker(m.stateArgs.LockTimeout, view.StateLocker())
 			if d := stateLocker.Lock(sMgr, "backend from plan"); d != nil {
 				diags = diags.Append(fmt.Errorf("Error locking state: %s", d))
 				return nil, diags

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -426,7 +426,7 @@ func (m *Meta) backendCLIOpts(ctx context.Context) (*backend.CLIOpts, error) {
 	}
 	return &backend.CLIOpts{
 		View: views.NewBackendRemote(m.View),
-		// TODO meta-refactor: pass the arguments.State here instead of individual properties
+		// TODO andrei: pass the arguments.State here instead of individual properties
 		StatePath:           m.stateArgs.StatePath,
 		StateOutPath:        m.stateArgs.StateOutPath,
 		StateBackupPath:     m.stateArgs.BackupPath,

--- a/internal/command/meta_backend_migrate.go
+++ b/internal/command/meta_backend_migrate.go
@@ -350,10 +350,10 @@ func (m *Meta) backendMigrateState_s_s(ctx context.Context, opts *backendMigrate
 		}
 	}
 
-	if m.stateLock {
+	if m.stateArgs.Lock {
 		lockCtx := context.Background()
 		view := opts.backendView(m.View).StateLocker()
-		locker := clistate.NewLocker(m.stateLockTimeout, view)
+		locker := clistate.NewLocker(m.stateArgs.LockTimeout, view)
 
 		lockerSource := locker.WithContext(lockCtx)
 		if diags := lockerSource.Lock(sourceState, "migration source state"); diags.HasErrors() {

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -2126,11 +2126,11 @@ func testMetaBackend(t *testing.T) *Meta {
 	var m Meta
 	view, _ := testView(t)
 	m.View = view
+	m.stateArgs = *arguments.NewStateFlags()
 
 	// TODO meta-refactor: these assignments are needed because the extendedFlagSet was used here before,
 	//   which had these with defaults as "true". In a future iteration, once these are not needed, we need to remove them.
 	m.input = true
-	m.stateArgs.Lock = true
 
 	// metaBackend tests are verifying migrate actions
 	m.migrateState = true

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -183,7 +183,7 @@ func TestMetaBackend_emptyWithExplicitState(t *testing.T) {
 
 	// Setup the meta
 	m := testMetaBackend(t)
-	m.statePath = statePath
+	m.stateArgs.StatePath = statePath
 
 	// Get the backend
 	b, diags := m.Backend(t.Context(), &BackendOpts{Init: true}, encryption.StateEncryptionDisabled())
@@ -1816,7 +1816,7 @@ func TestMetaBackend_planLocalStatePath(t *testing.T) {
 
 	// Setup the meta
 	m := testMetaBackend(t)
-	m.stateOutPath = statePath
+	m.stateArgs.StateOutPath = statePath
 
 	// Get the backend
 	b, diags := m.BackendForLocalPlan(t.Context(), plannedBackend, encryption.StateEncryptionDisabled())
@@ -2130,7 +2130,7 @@ func testMetaBackend(t *testing.T) *Meta {
 	// TODO meta-refactor: these assignments are needed because the extendedFlagSet was used here before,
 	//   which had these with defaults as "true". In a future iteration, once these are not needed, we need to remove them.
 	m.input = true
-	m.stateLock = true
+	m.stateArgs.Lock = true
 
 	// metaBackend tests are verifying migrate actions
 	m.migrateState = true

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -2126,7 +2126,7 @@ func testMetaBackend(t *testing.T) *Meta {
 	var m Meta
 	view, _ := testView(t)
 	m.View = view
-	m.stateArgs = *arguments.NewStateFlags()
+	m.stateArgs = arguments.State{}
 
 	// TODO meta-refactor: these assignments are needed because the extendedFlagSet was used here before,
 	//   which had these with defaults as "true". In a future iteration, once these are not needed, we need to remove them.

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -2126,7 +2126,7 @@ func testMetaBackend(t *testing.T) *Meta {
 	var m Meta
 	view, _ := testView(t)
 	m.View = view
-	m.stateArgs = arguments.State{}
+	m.stateArgs = arguments.State{Lock: true}
 
 	// TODO meta-refactor: these assignments are needed because the extendedFlagSet was used here before,
 	//   which had these with defaults as "true". In a future iteration, once these are not needed, we need to remove them.

--- a/internal/command/meta_test.go
+++ b/internal/command/meta_test.go
@@ -30,7 +30,7 @@ func TestMetaInputMode(t *testing.T) {
 	// TODO meta-refactor: these assignments are needed because the extendedFlagSet was used here before,
 	//   which had these with defaults as "true". In a future iteration, once these are not needed, we need to remove them.
 	m.input = true
-	m.stateLock = true
+	m.stateArgs.Lock = true
 
 	args := []string{}
 
@@ -54,7 +54,7 @@ func TestMetaInputMode_envVar(t *testing.T) {
 	// TODO meta-refactor: these assignments are needed because the extendedFlagSet was used here before,
 	//   which had these with defaults as "true". In a future iteration, once these are not needed, we need to remove them.
 	m.input = true
-	m.stateLock = true
+	m.stateArgs.Lock = true
 
 	args := []string{}
 
@@ -93,7 +93,7 @@ func TestMetaInputMode_disable(t *testing.T) {
 	// TODO meta-refactor: these assignments are needed because the extendedFlagSet was used here before,
 	//   which had these with defaults as "true". In a future iteration, once these are not needed, we need to remove them.
 	m.input = true
-	m.stateLock = true
+	m.stateArgs.Lock = true
 	args := []string{"-input=false"}
 
 	fs := flag.NewFlagSet("foo", flag.ContinueOnError)
@@ -118,39 +118,39 @@ func TestMeta_initStatePaths(t *testing.T) {
 	}
 	m.initStatePaths()
 
-	if m.statePath != arguments.DefaultStateFilename {
+	if m.stateArgs.StatePath != arguments.DefaultStateFilename {
 		t.Fatalf("bad: %#v", m)
 	}
-	if m.stateOutPath != arguments.DefaultStateFilename {
+	if m.stateArgs.StateOutPath != arguments.DefaultStateFilename {
 		t.Fatalf("bad: %#v", m)
 	}
-	if m.backupPath != arguments.DefaultStateFilename+DefaultBackupExtension {
-		t.Fatalf("bad: %#v", m)
-	}
-
-	m = &Meta{
-		WorkingDir: workdir.NewDir("."),
-	}
-	m.statePath = "foo"
-	m.initStatePaths()
-
-	if m.stateOutPath != "foo" {
-		t.Fatalf("bad: %#v", m)
-	}
-	if m.backupPath != "foo"+DefaultBackupExtension {
+	if m.stateArgs.BackupPath != arguments.DefaultStateFilename+DefaultBackupExtension {
 		t.Fatalf("bad: %#v", m)
 	}
 
 	m = &Meta{
 		WorkingDir: workdir.NewDir("."),
 	}
-	m.stateOutPath = "foo"
+	m.stateArgs.StatePath = "foo"
 	m.initStatePaths()
 
-	if m.statePath != arguments.DefaultStateFilename {
+	if m.stateArgs.StateOutPath != "foo" {
 		t.Fatalf("bad: %#v", m)
 	}
-	if m.backupPath != "foo"+DefaultBackupExtension {
+	if m.stateArgs.BackupPath != "foo"+DefaultBackupExtension {
+		t.Fatalf("bad: %#v", m)
+	}
+
+	m = &Meta{
+		WorkingDir: workdir.NewDir("."),
+	}
+	m.stateArgs.StateOutPath = "foo"
+	m.initStatePaths()
+
+	if m.stateArgs.StatePath != arguments.DefaultStateFilename {
+		t.Fatalf("bad: %#v", m)
+	}
+	if m.stateArgs.BackupPath != "foo"+DefaultBackupExtension {
 		t.Fatalf("bad: %#v", m)
 	}
 }

--- a/internal/command/meta_test.go
+++ b/internal/command/meta_test.go
@@ -26,7 +26,7 @@ func TestMetaInputMode(t *testing.T) {
 
 	m := &Meta{
 		WorkingDir: workdir.NewDir("."),
-		stateArgs:  *arguments.NewStateFlags(),
+		stateArgs:  arguments.State{},
 	}
 	// TODO meta-refactor: these assignments are needed because the extendedFlagSet was used here before,
 	//   which had these with defaults as "true". In a future iteration, once these are not needed, we need to remove them.
@@ -50,7 +50,7 @@ func TestMetaInputMode_envVar(t *testing.T) {
 
 	m := &Meta{
 		WorkingDir: workdir.NewDir("."),
-		stateArgs:  *arguments.NewStateFlags(),
+		stateArgs:  arguments.State{},
 	}
 	// TODO meta-refactor: these assignments are needed because the extendedFlagSet was used here before,
 	//   which had these with defaults as "true". In a future iteration, once these are not needed, we need to remove them.
@@ -89,7 +89,7 @@ func TestMetaInputMode_disable(t *testing.T) {
 
 	m := &Meta{
 		WorkingDir: workdir.NewDir("."),
-		stateArgs:  *arguments.NewStateFlags(),
+		stateArgs:  arguments.State{},
 	}
 	// TODO meta-refactor: these assignments are needed because the extendedFlagSet was used here before,
 	//   which had these with defaults as "true". In a future iteration, once these are not needed, we need to remove them.

--- a/internal/command/meta_test.go
+++ b/internal/command/meta_test.go
@@ -112,49 +112,6 @@ func TestMetaInputMode_disable(t *testing.T) {
 	}
 }
 
-func TestMeta_initStatePaths(t *testing.T) {
-	m := &Meta{
-		WorkingDir: workdir.NewDir("."),
-	}
-	m.initStatePaths()
-
-	if m.stateArgs.StatePath != arguments.DefaultStateFilename {
-		t.Fatalf("bad: %#v", m)
-	}
-	if m.stateArgs.StateOutPath != arguments.DefaultStateFilename {
-		t.Fatalf("bad: %#v", m)
-	}
-	if m.stateArgs.BackupPath != arguments.DefaultStateFilename+DefaultBackupExtension {
-		t.Fatalf("bad: %#v", m)
-	}
-
-	m = &Meta{
-		WorkingDir: workdir.NewDir("."),
-	}
-	m.stateArgs.StatePath = "foo"
-	m.initStatePaths()
-
-	if m.stateArgs.StateOutPath != "foo" {
-		t.Fatalf("bad: %#v", m)
-	}
-	if m.stateArgs.BackupPath != "foo"+DefaultBackupExtension {
-		t.Fatalf("bad: %#v", m)
-	}
-
-	m = &Meta{
-		WorkingDir: workdir.NewDir("."),
-	}
-	m.stateArgs.StateOutPath = "foo"
-	m.initStatePaths()
-
-	if m.stateArgs.StatePath != arguments.DefaultStateFilename {
-		t.Fatalf("bad: %#v", m)
-	}
-	if m.stateArgs.BackupPath != "foo"+DefaultBackupExtension {
-		t.Fatalf("bad: %#v", m)
-	}
-}
-
 func TestMeta_Env(t *testing.T) {
 	td := t.TempDir()
 	t.Chdir(td)

--- a/internal/command/meta_test.go
+++ b/internal/command/meta_test.go
@@ -26,7 +26,7 @@ func TestMetaInputMode(t *testing.T) {
 
 	m := &Meta{
 		WorkingDir: workdir.NewDir("."),
-		stateArgs:  arguments.State{},
+		stateArgs:  arguments.State{Lock: true},
 	}
 	// TODO meta-refactor: these assignments are needed because the extendedFlagSet was used here before,
 	//   which had these with defaults as "true". In a future iteration, once these are not needed, we need to remove them.
@@ -50,7 +50,7 @@ func TestMetaInputMode_envVar(t *testing.T) {
 
 	m := &Meta{
 		WorkingDir: workdir.NewDir("."),
-		stateArgs:  arguments.State{},
+		stateArgs:  arguments.State{Lock: true},
 	}
 	// TODO meta-refactor: these assignments are needed because the extendedFlagSet was used here before,
 	//   which had these with defaults as "true". In a future iteration, once these are not needed, we need to remove them.
@@ -89,7 +89,7 @@ func TestMetaInputMode_disable(t *testing.T) {
 
 	m := &Meta{
 		WorkingDir: workdir.NewDir("."),
-		stateArgs:  arguments.State{},
+		stateArgs:  arguments.State{Lock: true},
 	}
 	// TODO meta-refactor: these assignments are needed because the extendedFlagSet was used here before,
 	//   which had these with defaults as "true". In a future iteration, once these are not needed, we need to remove them.

--- a/internal/command/meta_test.go
+++ b/internal/command/meta_test.go
@@ -26,11 +26,11 @@ func TestMetaInputMode(t *testing.T) {
 
 	m := &Meta{
 		WorkingDir: workdir.NewDir("."),
+		stateArgs:  *arguments.NewStateFlags(),
 	}
 	// TODO meta-refactor: these assignments are needed because the extendedFlagSet was used here before,
 	//   which had these with defaults as "true". In a future iteration, once these are not needed, we need to remove them.
 	m.input = true
-	m.stateArgs.Lock = true
 
 	args := []string{}
 
@@ -50,11 +50,11 @@ func TestMetaInputMode_envVar(t *testing.T) {
 
 	m := &Meta{
 		WorkingDir: workdir.NewDir("."),
+		stateArgs:  *arguments.NewStateFlags(),
 	}
 	// TODO meta-refactor: these assignments are needed because the extendedFlagSet was used here before,
 	//   which had these with defaults as "true". In a future iteration, once these are not needed, we need to remove them.
 	m.input = true
-	m.stateArgs.Lock = true
 
 	args := []string{}
 
@@ -89,11 +89,11 @@ func TestMetaInputMode_disable(t *testing.T) {
 
 	m := &Meta{
 		WorkingDir: workdir.NewDir("."),
+		stateArgs:  *arguments.NewStateFlags(),
 	}
 	// TODO meta-refactor: these assignments are needed because the extendedFlagSet was used here before,
 	//   which had these with defaults as "true". In a future iteration, once these are not needed, we need to remove them.
 	m.input = true
-	m.stateArgs.Lock = true
 	args := []string{"-input=false"}
 
 	fs := flag.NewFlagSet("foo", flag.ContinueOnError)

--- a/internal/command/output.go
+++ b/internal/command/output.go
@@ -44,6 +44,7 @@ func (c *OutputCommand) Run(rawArgs []string) int {
 
 	// Inject variables from args into meta for static evaluation
 	c.Meta.variableArgs = args.Vars.All()
+	c.stateArgs = *args.State
 
 	// Load the encryption configuration
 	enc, encDiags := c.Encryption(ctx)
@@ -54,7 +55,7 @@ func (c *OutputCommand) Run(rawArgs []string) int {
 	}
 
 	// Fetch data from state
-	outputs, diags := c.Outputs(ctx, args.StatePath, enc)
+	outputs, diags := c.Outputs(ctx, args.State.StatePath, enc)
 	if diags.HasErrors() {
 		view.Diagnostics(diags)
 		return 1
@@ -78,7 +79,8 @@ func (c *OutputCommand) Outputs(ctx context.Context, statePath string, enc encry
 
 	// Allow state path override
 	if statePath != "" {
-		c.Meta.statePath = statePath
+		// TODO andrei - double check this, since this might be redundant
+		c.Meta.stateArgs.StatePath = statePath
 	}
 
 	// Load the backend

--- a/internal/command/output.go
+++ b/internal/command/output.go
@@ -44,7 +44,6 @@ func (c *OutputCommand) Run(rawArgs []string) int {
 
 	// Inject variables from args into meta for static evaluation
 	c.Meta.variableArgs = args.Vars.All()
-	c.stateArgs = *args.State
 
 	// Load the encryption configuration
 	enc, encDiags := c.Encryption(ctx)
@@ -79,7 +78,6 @@ func (c *OutputCommand) Outputs(ctx context.Context, statePath string, enc encry
 
 	// Allow state path override
 	if statePath != "" {
-		// TODO andrei - double check this, since this might be redundant
 		c.Meta.stateArgs.StatePath = statePath
 	}
 

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -120,11 +120,7 @@ func (c *PlanCommand) Run(rawArgs []string) int {
 }
 
 func (c *PlanCommand) PrepareBackend(ctx context.Context, args *arguments.State, view views.Plan, enc encryption.Encryption) (backend.Enhanced, tfdiags.Diagnostics) {
-	// FIXME: we need to apply the state arguments to the meta object here
-	// because they are later used when initializing the backend. Carving a
-	// path to pass these arguments to the functions that need them is
-	// difficult but would make their use easier to understand.
-	c.Meta.applyStateArguments(args)
+	c.stateArgs = *args
 
 	backendConfig, diags := c.loadBackendConfig(ctx, ".")
 	if diags.HasErrors() {

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -120,7 +120,7 @@ func (c *PlanCommand) Run(rawArgs []string) int {
 }
 
 func (c *PlanCommand) PrepareBackend(ctx context.Context, args *arguments.State, view views.Plan, enc encryption.Encryption) (backend.Enhanced, tfdiags.Diagnostics) {
-	c.stateArgs = *args
+	c.Meta.stateArgs = *args
 
 	backendConfig, diags := c.loadBackendConfig(ctx, ".")
 	if diags.HasErrors() {

--- a/internal/command/refresh.go
+++ b/internal/command/refresh.go
@@ -114,11 +114,7 @@ func (c *RefreshCommand) Run(rawArgs []string) int {
 }
 
 func (c *RefreshCommand) PrepareBackend(ctx context.Context, args *arguments.State, view views.Refresh, enc encryption.Encryption) (backend.Enhanced, tfdiags.Diagnostics) {
-	// FIXME: we need to apply the state arguments to the meta object here
-	// because they are later used when initializing the backend. Carving a
-	// path to pass these arguments to the functions that need them is
-	// difficult but would make their use easier to understand.
-	c.Meta.applyStateArguments(args)
+	c.stateArgs = *args
 
 	backendConfig, diags := c.loadBackendConfig(ctx, ".")
 	if diags.HasErrors() {

--- a/internal/command/refresh.go
+++ b/internal/command/refresh.go
@@ -114,7 +114,7 @@ func (c *RefreshCommand) Run(rawArgs []string) int {
 }
 
 func (c *RefreshCommand) PrepareBackend(ctx context.Context, args *arguments.State, view views.Refresh, enc encryption.Encryption) (backend.Enhanced, tfdiags.Diagnostics) {
-	c.stateArgs = *args
+	c.Meta.stateArgs = *args
 
 	backendConfig, diags := c.loadBackendConfig(ctx, ".")
 	if diags.HasErrors() {

--- a/internal/command/state_list.go
+++ b/internal/command/state_list.go
@@ -48,8 +48,9 @@ func (c *StateListCommand) Run(rawArgs []string) int {
 	}
 	c.Meta.variableArgs = args.Vars.All()
 
+	// TODO meta-refactor: migrate this command's arguments to use the arguments.State
 	if args.StatePath != "" {
-		c.Meta.statePath = args.StatePath
+		c.Meta.stateArgs.StatePath = args.StatePath
 	}
 
 	// Load the encryption configuration

--- a/internal/command/state_list.go
+++ b/internal/command/state_list.go
@@ -48,9 +48,8 @@ func (c *StateListCommand) Run(rawArgs []string) int {
 	}
 	c.Meta.variableArgs = args.Vars.All()
 
-	// TODO meta-refactor: migrate this command's arguments to use the arguments.State
-	if args.StatePath != "" {
-		c.Meta.stateArgs.StatePath = args.StatePath
+	if args.State.StatePath != "" {
+		c.Meta.stateArgs.StatePath = args.State.StatePath
 	}
 
 	// Load the encryption configuration

--- a/internal/command/state_meta.go
+++ b/internal/command/state_meta.go
@@ -32,12 +32,12 @@ type StateMeta struct {
 // backup path.
 func (c *StateMeta) State(ctx context.Context, enc encryption.Encryption, view views.State) (statemgr.Full, error) {
 	var realState statemgr.Full
-	backupPath := c.stateArgs.BackupPath
-	stateOutPath := c.stateArgs.StatePath
+	backupPath := c.Meta.stateArgs.BackupPath
+	stateOutPath := c.Meta.stateArgs.StatePath
 
 	// use the specified state
-	if c.stateArgs.StatePath != "" {
-		realState = statemgr.NewFilesystem(c.stateArgs.StatePath, encryption.StateEncryptionDisabled()) // User specified state file should not be encrypted
+	if c.Meta.stateArgs.StatePath != "" {
+		realState = statemgr.NewFilesystem(c.Meta.stateArgs.StatePath, encryption.StateEncryptionDisabled()) // User specified state file should not be encrypted
 	} else {
 		// Load the backend
 		b, backendDiags := c.Backend(ctx, nil, enc.State())

--- a/internal/command/state_meta.go
+++ b/internal/command/state_meta.go
@@ -32,12 +32,12 @@ type StateMeta struct {
 // backup path.
 func (c *StateMeta) State(ctx context.Context, enc encryption.Encryption, view views.State) (statemgr.Full, error) {
 	var realState statemgr.Full
-	backupPath := c.backupPath
-	stateOutPath := c.statePath
+	backupPath := c.stateArgs.BackupPath
+	stateOutPath := c.stateArgs.StatePath
 
 	// use the specified state
-	if c.statePath != "" {
-		realState = statemgr.NewFilesystem(c.statePath, encryption.StateEncryptionDisabled()) // User specified state file should not be encrypted
+	if c.stateArgs.StatePath != "" {
+		realState = statemgr.NewFilesystem(c.stateArgs.StatePath, encryption.StateEncryptionDisabled()) // User specified state file should not be encrypted
 	} else {
 		// Load the backend
 		b, backendDiags := c.Backend(ctx, nil, enc.State())

--- a/internal/command/state_mv.go
+++ b/internal/command/state_mv.go
@@ -54,7 +54,17 @@ func (c *StateMvCommand) Run(rawArgs []string) int {
 	c.ignoreRemoteVersion = args.Backend.IgnoreRemoteVersion
 
 	c.Meta.variableArgs = args.Vars.All()
-	c.stateArgs = *args.State
+	// NOTE: We intentionally configure the stateArgs here like this, ignoring the stateOutPath, because the c.stateArgs
+	// are used for loading the state which stores internally the output path which in the context of this command
+	// will have unwanted side effects.
+	// TODO meta-refactor: when we move the backend logic to its own component, maybe there is a way to change the
+	//  arguments.State in such way to be reused with/without the stateOut.
+	c.stateArgs = arguments.State{
+		Lock:        args.State.Lock,
+		LockTimeout: args.State.LockTimeout,
+		StatePath:   args.State.StatePath,
+		BackupPath:  args.State.BackupPath,
+	}
 
 	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {
 		view.Diagnostics(diags)

--- a/internal/command/state_mv.go
+++ b/internal/command/state_mv.go
@@ -59,7 +59,7 @@ func (c *StateMvCommand) Run(rawArgs []string) int {
 	// will have unwanted side effects, ending in writing the source state in the target state.
 	// TODO meta-refactor: when we move the backend logic to its own component, maybe there is a way to change the
 	//  arguments.State in such way to be reused with/without the stateOut.
-	c.stateArgs = arguments.State{
+	c.Meta.stateArgs = arguments.State{
 		Lock:        args.State.Lock,
 		LockTimeout: args.State.LockTimeout,
 		StatePath:   args.State.StatePath,

--- a/internal/command/state_mv.go
+++ b/internal/command/state_mv.go
@@ -51,10 +51,10 @@ func (c *StateMvCommand) Run(rawArgs []string) int {
 	}
 	// TODO meta-refactor: remove these assignments once there is a clear way to propagate these to the place
 	//   where are used
-	c.backupPath = args.BackupPath
-	c.statePath = args.StatePath
-	c.stateLock = args.Backend.StateLock
-	c.stateLockTimeout = args.Backend.StateLockTimeout
+	c.backupPath = args.State.BackupPath
+	c.statePath = args.State.StatePath
+	c.stateLock = args.State.Lock
+	c.stateLockTimeout = args.State.LockTimeout
 	c.ignoreRemoteVersion = args.Backend.IgnoreRemoteVersion
 	c.Meta.variableArgs = args.Vars.All()
 
@@ -66,8 +66,8 @@ func (c *StateMvCommand) Run(rawArgs []string) int {
 	// If backup or backup-out options are set
 	// and the state option is not set, make sure
 	// the backend is local
-	backupOptionSetWithoutStateOption := args.BackupPath != "-" && args.StatePath == ""
-	backupOutOptionSetWithoutStateOption := args.BackupPathOut != "-" && args.StatePath == ""
+	backupOptionSetWithoutStateOption := args.State.BackupPath != "-" && args.State.StatePath == ""
+	backupOutOptionSetWithoutStateOption := args.BackupPathOut != "-" && args.State.StatePath == ""
 
 	var setLegacyLocalBackendOptions []string
 	if backupOptionSetWithoutStateOption {
@@ -146,8 +146,8 @@ func (c *StateMvCommand) Run(rawArgs []string) int {
 	stateToMgr := stateFromMgr
 	stateTo := stateFrom
 
-	if args.StateOutPath != "" {
-		c.statePath = args.StateOutPath
+	if args.State.StateOutPath != "" {
+		c.statePath = args.State.StateOutPath
 		c.backupPath = args.BackupPathOut
 
 		stateToMgr, err = c.State(ctx, enc, view)

--- a/internal/command/state_mv.go
+++ b/internal/command/state_mv.go
@@ -56,7 +56,7 @@ func (c *StateMvCommand) Run(rawArgs []string) int {
 	c.Meta.variableArgs = args.Vars.All()
 	// NOTE: We intentionally configure the stateArgs here like this, ignoring the stateOutPath, because the c.stateArgs
 	// are used for loading the state which stores internally the output path which in the context of this command
-	// will have unwanted side effects.
+	// will have unwanted side effects, ending in writing the source state in the target state.
 	// TODO meta-refactor: when we move the backend logic to its own component, maybe there is a way to change the
 	//  arguments.State in such way to be reused with/without the stateOut.
 	c.stateArgs = arguments.State{

--- a/internal/command/state_mv.go
+++ b/internal/command/state_mv.go
@@ -49,14 +49,12 @@ func (c *StateMvCommand) Run(rawArgs []string) int {
 		}
 		return cli.RunResultHelp
 	}
-	// TODO meta-refactor: remove these assignments once there is a clear way to propagate these to the place
-	//   where are used
-	c.backupPath = args.State.BackupPath
-	c.statePath = args.State.StatePath
-	c.stateLock = args.State.Lock
-	c.stateLockTimeout = args.State.LockTimeout
+	// TODO meta-refactor: remove this assignment once there is a clear way to propagate this to the place
+	//   where is used
 	c.ignoreRemoteVersion = args.Backend.IgnoreRemoteVersion
+
 	c.Meta.variableArgs = args.Vars.All()
+	c.stateArgs = *args.State
 
 	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {
 		view.Diagnostics(diags)
@@ -114,8 +112,8 @@ func (c *StateMvCommand) Run(rawArgs []string) int {
 		return 1
 	}
 
-	if c.stateLock {
-		stateLocker := clistate.NewLocker(c.stateLockTimeout, view.Backend().StateLocker())
+	if c.stateArgs.Lock {
+		stateLocker := clistate.NewLocker(c.stateArgs.LockTimeout, view.Backend().StateLocker())
 		if diags := stateLocker.Lock(stateFromMgr, "state-mv"); diags.HasErrors() {
 			view.Diagnostics(diags)
 			return 1
@@ -147,8 +145,8 @@ func (c *StateMvCommand) Run(rawArgs []string) int {
 	stateTo := stateFrom
 
 	if args.State.StateOutPath != "" {
-		c.statePath = args.State.StateOutPath
-		c.backupPath = args.BackupPathOut
+		c.stateArgs.StatePath = args.State.StateOutPath
+		c.stateArgs.BackupPath = args.BackupPathOut
 
 		stateToMgr, err = c.State(ctx, enc, view)
 		if err != nil {
@@ -156,8 +154,8 @@ func (c *StateMvCommand) Run(rawArgs []string) int {
 			return 1
 		}
 
-		if c.stateLock {
-			stateLocker := clistate.NewLocker(c.stateLockTimeout, view.Backend().StateLocker())
+		if c.stateArgs.Lock {
+			stateLocker := clistate.NewLocker(c.stateArgs.LockTimeout, view.Backend().StateLocker())
 			if diags := stateLocker.Lock(stateToMgr, "state-mv"); diags.HasErrors() {
 				view.Diagnostics(diags)
 				return 1

--- a/internal/command/state_push.go
+++ b/internal/command/state_push.go
@@ -58,7 +58,7 @@ func (c *StatePushCommand) Run(rawArgs []string) int {
 	c.ignoreRemoteVersion = args.Backend.IgnoreRemoteVersion
 
 	c.Meta.variableArgs = args.Vars.All()
-	c.stateArgs = *args.State
+	c.Meta.stateArgs = *args.State
 
 	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {
 		view.Diagnostics(diags)

--- a/internal/command/state_push.go
+++ b/internal/command/state_push.go
@@ -55,10 +55,10 @@ func (c *StatePushCommand) Run(rawArgs []string) int {
 	}
 	// TODO meta-refactor: remove these assignments once we have a clear way to propagate these to the logic
 	//  that uses them
-	c.Meta.variableArgs = args.Vars.All()
-	c.stateLock = args.State.Lock
-	c.stateLockTimeout = args.State.LockTimeout
 	c.ignoreRemoteVersion = args.Backend.IgnoreRemoteVersion
+
+	c.Meta.variableArgs = args.Vars.All()
+	c.stateArgs = *args.State
 
 	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {
 		view.Diagnostics(diags)
@@ -141,8 +141,8 @@ func (c *StatePushCommand) Run(rawArgs []string) int {
 		return 1
 	}
 
-	if c.stateLock {
-		stateLocker := clistate.NewLocker(c.stateLockTimeout, view.Backend().StateLocker())
+	if c.stateArgs.Lock {
+		stateLocker := clistate.NewLocker(c.stateArgs.LockTimeout, view.Backend().StateLocker())
 		if diags := stateLocker.Lock(stateMgr, "state-push"); diags.HasErrors() {
 			view.Diagnostics(diags)
 			return 1

--- a/internal/command/state_push.go
+++ b/internal/command/state_push.go
@@ -56,8 +56,8 @@ func (c *StatePushCommand) Run(rawArgs []string) int {
 	// TODO meta-refactor: remove these assignments once we have a clear way to propagate these to the logic
 	//  that uses them
 	c.Meta.variableArgs = args.Vars.All()
-	c.stateLock = args.Backend.StateLock
-	c.stateLockTimeout = args.Backend.StateLockTimeout
+	c.stateLock = args.State.Lock
+	c.stateLockTimeout = args.State.LockTimeout
 	c.ignoreRemoteVersion = args.Backend.IgnoreRemoteVersion
 
 	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {

--- a/internal/command/state_replace_provider.go
+++ b/internal/command/state_replace_provider.go
@@ -53,10 +53,10 @@ func (c *StateReplaceProviderCommand) Run(rawArgs []string) int {
 	}
 	// TODO meta-refactor: remove these assignments once there is a clear way to propagate these to the place
 	//   where are used
-	c.backupPath = args.BackupPath
-	c.statePath = args.StatePath
-	c.stateLock = args.Backend.StateLock
-	c.stateLockTimeout = args.Backend.StateLockTimeout
+	c.backupPath = args.State.BackupPath
+	c.statePath = args.State.StatePath
+	c.stateLock = args.State.Lock
+	c.stateLockTimeout = args.State.LockTimeout
 	c.ignoreRemoteVersion = args.Backend.IgnoreRemoteVersion
 	c.Meta.variableArgs = args.Vars.All()
 

--- a/internal/command/state_replace_provider.go
+++ b/internal/command/state_replace_provider.go
@@ -53,9 +53,9 @@ func (c *StateReplaceProviderCommand) Run(rawArgs []string) int {
 	}
 	// TODO meta-refactor: remove these assignments once there is a clear way to propagate these to the place
 	//   where are used
-	c.ignoreRemoteVersion = args.Backend.IgnoreRemoteVersion
+	c.Meta.ignoreRemoteVersion = args.Backend.IgnoreRemoteVersion
 
-	c.stateArgs = *args.State
+	c.Meta.stateArgs = *args.State
 	c.Meta.variableArgs = args.Vars.All()
 
 	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {

--- a/internal/command/state_replace_provider.go
+++ b/internal/command/state_replace_provider.go
@@ -53,11 +53,9 @@ func (c *StateReplaceProviderCommand) Run(rawArgs []string) int {
 	}
 	// TODO meta-refactor: remove these assignments once there is a clear way to propagate these to the place
 	//   where are used
-	c.backupPath = args.State.BackupPath
-	c.statePath = args.State.StatePath
-	c.stateLock = args.State.Lock
-	c.stateLockTimeout = args.State.LockTimeout
 	c.ignoreRemoteVersion = args.Backend.IgnoreRemoteVersion
+
+	c.stateArgs = *args.State
 	c.Meta.variableArgs = args.Vars.All()
 
 	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {
@@ -103,8 +101,8 @@ func (c *StateReplaceProviderCommand) Run(rawArgs []string) int {
 	}
 
 	// Acquire lock if requested
-	if c.stateLock {
-		stateLocker := clistate.NewLocker(c.stateLockTimeout, view.Backend().StateLocker())
+	if c.stateArgs.Lock {
+		stateLocker := clistate.NewLocker(c.stateArgs.LockTimeout, view.Backend().StateLocker())
 		if diags := stateLocker.Lock(stateMgr, "state-replace-provider"); diags.HasErrors() {
 			view.Diagnostics(diags)
 			return 1

--- a/internal/command/state_rm.go
+++ b/internal/command/state_rm.go
@@ -48,10 +48,10 @@ func (c *StateRmCommand) Run(rawArgs []string) int {
 	}
 	// TODO meta-refactor: remove these assignments once we have a clear way to propagate these to the logic
 	//  that uses them
-	c.ignoreRemoteVersion = args.Backend.IgnoreRemoteVersion
+	c.Meta.ignoreRemoteVersion = args.Backend.IgnoreRemoteVersion
 
 	c.Meta.variableArgs = args.Vars.All()
-	c.stateArgs = *args.State
+	c.Meta.stateArgs = *args.State
 
 	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {
 		view.Diagnostics(diags)

--- a/internal/command/state_rm.go
+++ b/internal/command/state_rm.go
@@ -50,10 +50,10 @@ func (c *StateRmCommand) Run(rawArgs []string) int {
 	//  that uses them
 	c.Meta.variableArgs = args.Vars.All()
 	c.ignoreRemoteVersion = args.Backend.IgnoreRemoteVersion
-	c.backupPath = args.BackupPath
-	c.stateLock = args.Backend.StateLock
-	c.stateLockTimeout = args.Backend.StateLockTimeout
-	c.statePath = args.StatePath
+	c.backupPath = args.State.BackupPath
+	c.stateLock = args.State.Lock
+	c.stateLockTimeout = args.State.LockTimeout
+	c.statePath = args.State.StatePath
 
 	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {
 		view.Diagnostics(diags)

--- a/internal/command/state_rm.go
+++ b/internal/command/state_rm.go
@@ -48,12 +48,10 @@ func (c *StateRmCommand) Run(rawArgs []string) int {
 	}
 	// TODO meta-refactor: remove these assignments once we have a clear way to propagate these to the logic
 	//  that uses them
-	c.Meta.variableArgs = args.Vars.All()
 	c.ignoreRemoteVersion = args.Backend.IgnoreRemoteVersion
-	c.backupPath = args.State.BackupPath
-	c.stateLock = args.State.Lock
-	c.stateLockTimeout = args.State.LockTimeout
-	c.statePath = args.State.StatePath
+
+	c.Meta.variableArgs = args.Vars.All()
+	c.stateArgs = *args.State
 
 	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {
 		view.Diagnostics(diags)
@@ -74,8 +72,8 @@ func (c *StateRmCommand) Run(rawArgs []string) int {
 		return 1
 	}
 
-	if c.stateLock {
-		stateLocker := clistate.NewLocker(c.stateLockTimeout, view.Backend().StateLocker())
+	if c.stateArgs.Lock {
+		stateLocker := clistate.NewLocker(c.stateArgs.LockTimeout, view.Backend().StateLocker())
 		if diags := stateLocker.Lock(stateMgr, "state-rm"); diags.HasErrors() {
 			view.Diagnostics(diags)
 			return 1

--- a/internal/command/state_show.go
+++ b/internal/command/state_show.go
@@ -52,7 +52,7 @@ func (c *StateShowCommand) Run(rawArgs []string) int {
 	}
 	c.View.SetShowSensitive(args.ShowSensitive)
 	c.Meta.variableArgs = args.Vars.All()
-	c.stateArgs = *args.State
+	c.Meta.stateArgs = *args.State
 
 	// Check for user-supplied plugin path
 	var err error

--- a/internal/command/state_show.go
+++ b/internal/command/state_show.go
@@ -51,10 +51,8 @@ func (c *StateShowCommand) Run(rawArgs []string) int {
 		return cli.RunResultHelp
 	}
 	c.View.SetShowSensitive(args.ShowSensitive)
-	// TODO meta-refactor: remove these assignments once we have a clear way to propagate these to the logic
-	//  that uses them
 	c.Meta.variableArgs = args.Vars.All()
-	c.statePath = args.StatePath
+	c.stateArgs = *args.State
 
 	// Check for user-supplied plugin path
 	var err error

--- a/internal/command/taint.go
+++ b/internal/command/taint.go
@@ -39,13 +39,6 @@ func (c *TaintCommand) Run(rawArgs []string) int {
 	// Parse and validate flags
 	args, closer, diags := arguments.ParseTaint(true, rawArgs)
 	defer closer()
-	// TODO meta-refactor: move these values to their right place once it's clear how to propagate their values to
-	//   the functionality that is using these.
-	c.Meta.backupPath = args.State.BackupPath
-	c.Meta.stateLock = args.State.Lock
-	c.Meta.stateLockTimeout = args.State.LockTimeout
-	c.Meta.statePath = args.State.StatePath
-	c.Meta.stateOutPath = args.State.StateOutPath
 
 	// Instantiate the view, even if there are flag errors, so that we render
 	// diagnostics according to the desired view
@@ -59,6 +52,8 @@ func (c *TaintCommand) Run(rawArgs []string) int {
 		return cli.RunResultHelp
 	}
 	c.Meta.variableArgs = args.Vars.All()
+	c.stateArgs = *args.State
+
 	addr := args.TargetAddress
 
 	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {
@@ -113,8 +108,8 @@ func (c *TaintCommand) Run(rawArgs []string) int {
 		return 1
 	}
 
-	if c.stateLock {
-		stateLocker := clistate.NewLocker(c.stateLockTimeout, view.Backend().StateLocker())
+	if c.stateArgs.Lock {
+		stateLocker := clistate.NewLocker(c.stateArgs.LockTimeout, view.Backend().StateLocker())
 		if diags := stateLocker.Lock(stateMgr, "taint"); diags.HasErrors() {
 			view.Diagnostics(diags)
 			return 1

--- a/internal/command/taint.go
+++ b/internal/command/taint.go
@@ -52,7 +52,7 @@ func (c *TaintCommand) Run(rawArgs []string) int {
 		return cli.RunResultHelp
 	}
 	c.Meta.variableArgs = args.Vars.All()
-	c.stateArgs = *args.State
+	c.Meta.stateArgs = *args.State
 
 	addr := args.TargetAddress
 

--- a/internal/command/untaint.go
+++ b/internal/command/untaint.go
@@ -39,13 +39,6 @@ func (c *UntaintCommand) Run(rawArgs []string) int {
 	// Parse and validate flags
 	args, closer, diags := arguments.ParseTaint(false, rawArgs)
 	defer closer()
-	// TODO meta-refactor: move these values to their right place once it's clear how to propagate their values to
-	//   the functionality that is using these.
-	c.Meta.backupPath = args.State.BackupPath
-	c.Meta.stateLock = args.State.Lock
-	c.Meta.stateLockTimeout = args.State.LockTimeout
-	c.Meta.statePath = args.State.StatePath
-	c.Meta.stateOutPath = args.State.StateOutPath
 
 	// Instantiate the view, even if there are flag errors, so that we render
 	// diagnostics according to the desired view
@@ -58,6 +51,8 @@ func (c *UntaintCommand) Run(rawArgs []string) int {
 		return cli.RunResultHelp
 	}
 	c.Meta.variableArgs = args.Vars.All()
+	c.stateArgs = *args.State
+
 	addr := args.TargetAddress
 
 	// Load the encryption configuration
@@ -108,8 +103,8 @@ func (c *UntaintCommand) Run(rawArgs []string) int {
 		return 1
 	}
 
-	if c.stateLock {
-		stateLocker := clistate.NewLocker(c.stateLockTimeout, view.Backend().StateLocker())
+	if c.stateArgs.Lock {
+		stateLocker := clistate.NewLocker(c.stateArgs.LockTimeout, view.Backend().StateLocker())
 		if diags := stateLocker.Lock(stateMgr, "untaint"); diags.HasErrors() {
 			view.Diagnostics(diags)
 			return 1

--- a/internal/command/untaint.go
+++ b/internal/command/untaint.go
@@ -51,7 +51,7 @@ func (c *UntaintCommand) Run(rawArgs []string) int {
 		return cli.RunResultHelp
 	}
 	c.Meta.variableArgs = args.Vars.All()
-	c.stateArgs = *args.State
+	c.Meta.stateArgs = *args.State
 
 	addr := args.TargetAddress
 

--- a/internal/command/workspace_delete.go
+++ b/internal/command/workspace_delete.go
@@ -50,13 +50,9 @@ func (c *WorkspaceDeleteCommand) Run(rawArgs []string) int {
 		return cli.RunResultHelp
 	}
 	c.Meta.variableArgs = args.Vars.All()
+	c.stateArgs = *args.State
 
 	view.WarnWhenUsedAsEnvCmd(c.LegacyName)
-
-	// TODO meta-refactor: remove these when meta state locking related fields are removed and pass the
-	//  arguments to the backend component instead
-	c.stateLock = args.StateLock
-	c.stateLockTimeout = args.StateLockTimeout
 
 	configPath := c.WorkingDir.NormalizePath(c.WorkingDir.RootModuleDir())
 
@@ -134,8 +130,8 @@ func (c *WorkspaceDeleteCommand) Run(rawArgs []string) int {
 	}
 
 	var stateLocker clistate.Locker
-	if args.StateLock {
-		stateLocker = clistate.NewLocker(args.StateLockTimeout, backendView.StateLocker())
+	if args.State.Lock {
+		stateLocker = clistate.NewLocker(args.State.LockTimeout, backendView.StateLocker())
 		if diags := stateLocker.Lock(stateMgr, "state-replace-provider"); diags.HasErrors() {
 			view.Diagnostics(diags)
 			return 1

--- a/internal/command/workspace_delete.go
+++ b/internal/command/workspace_delete.go
@@ -50,7 +50,7 @@ func (c *WorkspaceDeleteCommand) Run(rawArgs []string) int {
 		return cli.RunResultHelp
 	}
 	c.Meta.variableArgs = args.Vars.All()
-	c.stateArgs = *args.State
+	c.Meta.stateArgs = *args.State
 
 	view.WarnWhenUsedAsEnvCmd(c.LegacyName)
 

--- a/internal/command/workspace_new.go
+++ b/internal/command/workspace_new.go
@@ -57,9 +57,9 @@ func (c *WorkspaceNewCommand) Run(rawArgs []string) int {
 
 	// TODO meta-refactor: remove these when meta state locking related fields are removed and pass the
 	//  arguments to the backend component instead
-	c.stateLock = args.StateLock
-	c.stateLockTimeout = args.StateLockTimeout
-	c.statePath = args.StatePath
+	c.stateLock = args.State.Lock
+	c.stateLockTimeout = args.State.LockTimeout
+	c.statePath = args.State.StatePath
 
 	configPath := c.WorkingDir.NormalizePath(c.WorkingDir.RootModuleDir())
 
@@ -143,7 +143,7 @@ func (c *WorkspaceNewCommand) Run(rawArgs []string) int {
 
 	view.WorkspaceCreated(workspace)
 
-	statePath := args.StatePath
+	statePath := args.State.StatePath
 	if statePath == "" {
 		// if we're not loading a state, then we're done
 		return 0
@@ -160,8 +160,8 @@ func (c *WorkspaceNewCommand) Run(rawArgs []string) int {
 		return 1
 	}
 
-	if args.StateLock {
-		stateLocker := clistate.NewLocker(args.StateLockTimeout, backendView.StateLocker())
+	if args.State.Lock {
+		stateLocker := clistate.NewLocker(args.State.LockTimeout, backendView.StateLocker())
 		if diags := stateLocker.Lock(stateMgr, "workspace-new"); diags.HasErrors() {
 			view.Diagnostics(diags)
 			return 1

--- a/internal/command/workspace_new.go
+++ b/internal/command/workspace_new.go
@@ -52,14 +52,9 @@ func (c *WorkspaceNewCommand) Run(rawArgs []string) int {
 		return cli.RunResultHelp
 	}
 	c.Meta.variableArgs = args.Vars.All()
+	c.stateArgs = *args.State
 
 	view.WarnWhenUsedAsEnvCmd(c.LegacyName)
-
-	// TODO meta-refactor: remove these when meta state locking related fields are removed and pass the
-	//  arguments to the backend component instead
-	c.stateLock = args.State.Lock
-	c.stateLockTimeout = args.State.LockTimeout
-	c.statePath = args.State.StatePath
 
 	configPath := c.WorkingDir.NormalizePath(c.WorkingDir.RootModuleDir())
 

--- a/internal/command/workspace_new.go
+++ b/internal/command/workspace_new.go
@@ -52,7 +52,7 @@ func (c *WorkspaceNewCommand) Run(rawArgs []string) int {
 		return cli.RunResultHelp
 	}
 	c.Meta.variableArgs = args.Vars.All()
-	c.stateArgs = *args.State
+	c.Meta.stateArgs = *args.State
 
 	view.WarnWhenUsedAsEnvCmd(c.LegacyName)
 


### PR DESCRIPTION
OpenTofu has several flags that control how the state is handled:
* `-state`: indicates the input file containing the state
* `-state-out`: indicates the output file where the newly updated state should be written
* `-lock`: enables or disables the locking of the state
* `-lock-timeout`: specifies the timeout duration when the lock of the state is triggered
* `-backup`: when specified, it backups the previous state into it, before writing the new one

Before this PR, all these flags were mostly registered via `extendedFlagSet`, but that implementation lacked granularity. But most of the commands don't use all of those flags, but only a subset, and some commands use a subset with different default values. 
Even more, the `Meta` structure contained individual attributes to store and pass these values to the concerned logic in the system.
Another thing, some commands, even if they didn't register the `-lock` flag (which provides a default value as `true`), still wanted to have the lock enabled but without a way for the user to control its value. Before this, that `Meta` attributes was configured specifically by the commands that required that.

As can be seen in the list of inconveniences listed above, the handling of these was pretty much scattered and hard to follow. 
Now, all of these are unified under one struct, with a constructor that ensures that lock is enabled and methods to granularly register flags as are needed.

Some things that needs to be known before jumping into the review:
* Any command that passed a non-nil value in the `extendedFlagSet` should register all the flags from the `arguments.State`.
* Some commands register the flags in 2 steps since some flags are registered with their general default values but some are registered with a different default value.
* Previously, I added in the `arguments.Backend` also the flags for `-lock`/`-lock-timeout`, but since now I managed to unify everything, I removed those too.
* Check the `NOTE:` from `commands/state.mv.go` since that's the part that gets a little bit out of the way of doing things around. Maybe you have other suggestions ❓ 

<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Part of #3595

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
