### PR TITLE
resources: Unit tests for ManagedResourceType.PlanChanges

### DIFF
--- a/internal/resources/managed_plan_test.go
+++ b/internal/resources/managed_plan_test.go
@@ -1,0 +1,638 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/configs/configschema"
+	"github.com/opentofu/opentofu/internal/providers"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+)
+
+func TestManagedResourceTypePlanChanges(t *testing.T) {
+	emptySchema := &configschema.Block{
+		// Intentionally empty
+	}
+	nameSchema := &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"name": {
+				Type:     cty.String,
+				Optional: true,
+			},
+		},
+	}
+	nameAndIDSchema := &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"name": {
+				Type:     cty.String,
+				Optional: true,
+			},
+			"id": {
+				Type:     cty.String,
+				Computed: true,
+			},
+		},
+	}
+	passwordSchema := &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"password": {
+				Type:      cty.String,
+				Optional:  true,
+				Sensitive: true,
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		Schema                 *configschema.Block
+		ProviderCanPlanDestroy bool
+		PlanImpl               func(context.Context, providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse
+		Request                *ManagedResourcePlanRequest
+
+		WantResponse *ManagedResourcePlanResponse
+		WantDiags    tfdiags.Diagnostics
+	}{
+		"empty unchanged": {
+			Schema: emptySchema,
+			Request: &ManagedResourcePlanRequest{
+				Current: ValueWithPrivate{
+					Value: cty.EmptyObjectVal,
+				},
+				DesiredValue: cty.EmptyObjectVal,
+			},
+			WantResponse: &ManagedResourcePlanResponse{
+				Current: ValueWithPrivate{
+					Value: cty.EmptyObjectVal,
+				},
+				DesiredValue: cty.EmptyObjectVal,
+				Planned: ValueWithPrivate{
+					Value: cty.EmptyObjectVal,
+				},
+			},
+		},
+		"name unchanged": {
+			Schema: nameSchema,
+			Request: &ManagedResourcePlanRequest{
+				Current: ValueWithPrivate{
+					Value: cty.ObjectVal(map[string]cty.Value{
+						"name": cty.StringVal("rumpelstiltskin"),
+					}),
+				},
+				DesiredValue: cty.ObjectVal(map[string]cty.Value{
+					"name": cty.StringVal("rumpelstiltskin"),
+				}),
+			},
+			WantResponse: &ManagedResourcePlanResponse{
+				Current: ValueWithPrivate{
+					Value: cty.ObjectVal(map[string]cty.Value{
+						"name": cty.StringVal("rumpelstiltskin"),
+					}),
+				},
+				DesiredValue: cty.ObjectVal(map[string]cty.Value{
+					"name": cty.StringVal("rumpelstiltskin"),
+				}),
+				Planned: ValueWithPrivate{
+					Value: cty.ObjectVal(map[string]cty.Value{
+						"name": cty.StringVal("rumpelstiltskin"),
+					}),
+				},
+			},
+		},
+		"diagnostics from provider": {
+			Schema: emptySchema,
+			PlanImpl: func(_ context.Context, req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+				var diags tfdiags.Diagnostics
+				diags = diags.Append(tfdiags.SimpleWarning("It is dark. You might be eaten by a grue."))
+				return providers.PlanResourceChangeResponse{
+					PlannedState: req.ProposedNewState,
+					Diagnostics:  diags,
+				}
+			},
+			Request: &ManagedResourcePlanRequest{
+				Current: ValueWithPrivate{
+					Value: cty.EmptyObjectVal,
+				},
+				DesiredValue: cty.EmptyObjectVal,
+			},
+			WantResponse: &ManagedResourcePlanResponse{
+				Current: ValueWithPrivate{
+					Value: cty.EmptyObjectVal,
+				},
+				DesiredValue: cty.EmptyObjectVal,
+				Planned: ValueWithPrivate{
+					Value: cty.EmptyObjectVal,
+				},
+			},
+			WantDiags: (tfdiags.Diagnostics)(nil).Append(tfdiags.Sourceless(
+				tfdiags.Warning,
+				"It is dark. You might be eaten by a grue.",
+				``,
+			)),
+		},
+		"private data": {
+			Schema: nameSchema,
+			PlanImpl: func(ctx context.Context, req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+				return providers.PlanResourceChangeResponse{
+					PlannedState:   req.ProposedNewState,
+					PlannedPrivate: []byte("!!!"),
+				}
+			},
+			Request: &ManagedResourcePlanRequest{
+				Current: ValueWithPrivate{
+					Value: cty.ObjectVal(map[string]cty.Value{
+						"name": cty.StringVal("rumpelstiltskin"),
+					}),
+					Private: []byte("..."),
+				},
+				DesiredValue: cty.ObjectVal(map[string]cty.Value{
+					"name": cty.StringVal("rumpelstiltskin"),
+				}),
+			},
+			WantResponse: &ManagedResourcePlanResponse{
+				Current: ValueWithPrivate{
+					Value: cty.ObjectVal(map[string]cty.Value{
+						"name": cty.StringVal("rumpelstiltskin"),
+					}),
+					Private: []byte("..."), // preserved verbatim from the input
+				},
+				DesiredValue: cty.ObjectVal(map[string]cty.Value{
+					"name": cty.StringVal("rumpelstiltskin"),
+				}),
+				Planned: ValueWithPrivate{
+					Value: cty.ObjectVal(map[string]cty.Value{
+						"name": cty.StringVal("rumpelstiltskin"),
+					}),
+					Private: []byte("!!!"), // from the provider's planning response
+				},
+			},
+		},
+		"proposed new value": {
+			Schema: nameAndIDSchema,
+			Request: &ManagedResourcePlanRequest{
+				Current: ValueWithPrivate{
+					Value: cty.ObjectVal(map[string]cty.Value{
+						"id":   cty.StringVal("imp-ab463455"),
+						"name": cty.StringVal("rumpelstiltskin"),
+					}),
+				},
+				DesiredValue: cty.ObjectVal(map[string]cty.Value{
+					"id":   cty.NullVal(cty.String),
+					"name": cty.StringVal("rumleskaft"),
+				}),
+			},
+			WantResponse: &ManagedResourcePlanResponse{
+				Current: ValueWithPrivate{
+					Value: cty.ObjectVal(map[string]cty.Value{
+						"id":   cty.StringVal("imp-ab463455"),
+						"name": cty.StringVal("rumpelstiltskin"),
+					}),
+				},
+				DesiredValue: cty.ObjectVal(map[string]cty.Value{
+					"id":   cty.NullVal(cty.String),
+					"name": cty.StringVal("rumleskaft"),
+				}),
+				Planned: ValueWithPrivate{
+					// Because this test uses the fake provider's default
+					// implementation of planning, the planned new value is
+					// just what was proposed by our core logic. This is
+					// therefore indirectly testing that we're calling
+					// [objchange.ProposedNew] by expecting what that function
+					// should produce for the given current and desired values.
+					// This is not an exhaustive test of objchange.ProposedNew's
+					// behavior though; it has its own tests.
+					Value: cty.ObjectVal(map[string]cty.Value{
+						// The computed attribute value from "current".
+						"id": cty.StringVal("imp-ab463455"),
+						// The optional attribute value from "desired".
+						"name": cty.StringVal("rumleskaft"),
+					}),
+				},
+			},
+		},
+		"marks preserved": {
+			Schema: nameSchema,
+			Request: &ManagedResourcePlanRequest{
+				Current: ValueWithPrivate{
+					Value: cty.ObjectVal(map[string]cty.Value{
+						"name": cty.StringVal("rumpelstiltskin").Mark("imp"),
+					}),
+				},
+				DesiredValue: cty.ObjectVal(map[string]cty.Value{
+					"name": cty.StringVal("rumpelstiltskin").Mark("mischievous"),
+				}),
+			},
+			WantResponse: &ManagedResourcePlanResponse{
+				Current: ValueWithPrivate{
+					Value: cty.ObjectVal(map[string]cty.Value{
+						"name": cty.StringVal("rumpelstiltskin").Mark("imp"),
+					}),
+				},
+				DesiredValue: cty.ObjectVal(map[string]cty.Value{
+					"name": cty.StringVal("rumpelstiltskin").Mark("mischievous"),
+				}),
+				Planned: ValueWithPrivate{
+					Value: cty.ObjectVal(map[string]cty.Value{
+						"name": cty.StringVal("rumpelstiltskin").Mark("mischievous").Mark("imp"),
+					}),
+				},
+			},
+		},
+		"sensitive marks added": {
+			Schema: passwordSchema,
+			Request: &ManagedResourcePlanRequest{
+				Current: ValueWithPrivate{
+					Value: cty.ObjectVal(map[string]cty.Value{
+						"password": cty.StringVal("1234"),
+					}),
+				},
+				DesiredValue: cty.ObjectVal(map[string]cty.Value{
+					"password": cty.StringVal("12345"), // much more secure!
+				}),
+			},
+			WantResponse: &ManagedResourcePlanResponse{
+				Current: ValueWithPrivate{
+					Value: cty.ObjectVal(map[string]cty.Value{
+						"password": cty.StringVal("1234"),
+					}),
+				},
+				DesiredValue: cty.ObjectVal(map[string]cty.Value{
+					"password": cty.StringVal("12345"),
+				}),
+				Planned: ValueWithPrivate{
+					Value: cty.ObjectVal(map[string]cty.Value{
+						"password": cty.StringVal("12345"),
+						// FIXME: We've not actually implemented the schema-based marking yet,
+						// but this result should actually be:
+						// cty.StringVal("12345").Mark(marks.Sensitive),
+					}),
+				},
+			},
+		},
+		"absent ProviderMeta given as null": {
+			Schema: emptySchema,
+			PlanImpl: func(_ context.Context, req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+				var diags tfdiags.Diagnostics
+				// Real-world providers crash if given a nil ProviderMeta,
+				// so our PlanChanges implementation must automatically
+				// substitute a null value when the input is nil.
+				if req.ProviderMeta == cty.NilVal || !req.ProviderMeta.IsNull() {
+					diags = diags.Append(fmt.Errorf("provider meta is %#v; want null", req.ProviderMeta))
+				}
+				return providers.PlanResourceChangeResponse{
+					PlannedState: req.ProposedNewState,
+					Diagnostics:  diags,
+				}
+			},
+			Request: &ManagedResourcePlanRequest{
+				Current: ValueWithPrivate{
+					Value: cty.EmptyObjectVal,
+				},
+				DesiredValue:      cty.EmptyObjectVal,
+				ProviderMetaValue: cty.NilVal, // zero value of cty.Value
+			},
+			WantResponse: &ManagedResourcePlanResponse{
+				Current: ValueWithPrivate{
+					Value: cty.EmptyObjectVal,
+				},
+				DesiredValue: cty.EmptyObjectVal,
+				Planned: ValueWithPrivate{
+					Value: cty.EmptyObjectVal,
+				},
+			},
+		},
+		"requires replacement when updating": {
+			Schema: nameSchema,
+			PlanImpl: func(_ context.Context, req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+				return providers.PlanResourceChangeResponse{
+					PlannedState: req.ProposedNewState,
+					RequiresReplace: []cty.Path{
+						cty.GetAttrPath("name"),
+					},
+				}
+			},
+			Request: &ManagedResourcePlanRequest{
+				Current: ValueWithPrivate{
+					Value: cty.ObjectVal(map[string]cty.Value{
+						"name": cty.StringVal("rumpelstiltskin"),
+					}),
+				},
+				DesiredValue: cty.ObjectVal(map[string]cty.Value{
+					"name": cty.StringVal("rumleskaft"),
+				}),
+			},
+			WantResponse: &ManagedResourcePlanResponse{
+				Current: ValueWithPrivate{
+					Value: cty.ObjectVal(map[string]cty.Value{
+						"name": cty.StringVal("rumpelstiltskin"),
+					}),
+				},
+				DesiredValue: cty.ObjectVal(map[string]cty.Value{
+					"name": cty.StringVal("rumleskaft"),
+				}),
+				Planned: ValueWithPrivate{
+					Value: cty.ObjectVal(map[string]cty.Value{
+						"name": cty.StringVal("rumleskaft"),
+					}),
+				},
+				RequiresReplace: []cty.Path{
+					cty.GetAttrPath("name"),
+				},
+			},
+		},
+		"requires replacement when creating": {
+			Schema: nameSchema,
+			PlanImpl: func(_ context.Context, req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+				return providers.PlanResourceChangeResponse{
+					PlannedState: req.ProposedNewState,
+					RequiresReplace: []cty.Path{
+						cty.GetAttrPath("name"),
+					},
+				}
+			},
+			Request: &ManagedResourcePlanRequest{
+				Current: ValueWithPrivate{
+					Value: cty.NullVal(cty.Object(map[string]cty.Type{
+						"name": cty.String,
+					})),
+				},
+				DesiredValue: cty.ObjectVal(map[string]cty.Value{
+					"name": cty.StringVal("rumpelstiltskin"),
+				}),
+			},
+			WantResponse: &ManagedResourcePlanResponse{
+				Current: ValueWithPrivate{
+					Value: cty.NullVal(cty.Object(map[string]cty.Type{
+						"name": cty.String,
+					})),
+				},
+				DesiredValue: cty.ObjectVal(map[string]cty.Value{
+					"name": cty.StringVal("rumpelstiltskin"),
+				}),
+				Planned: ValueWithPrivate{
+					Value: cty.ObjectVal(map[string]cty.Value{
+						"name": cty.StringVal("rumpelstiltskin"),
+					}),
+				},
+				// Some real-world providers return a nonsensical "requires
+				// replace" even when they're describing the creation of
+				// something new. PlanChanges is responsible for discarding
+				// the paths in that case so that the rest of the system can
+				// assume that RequiresReplace is set only when a "replace"
+				// action would be appropriate.
+				RequiresReplace: nil,
+			},
+		},
+		"requires replacement when destroying": {
+			Schema: nameSchema,
+			PlanImpl: func(_ context.Context, req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+				return providers.PlanResourceChangeResponse{
+					PlannedState: req.ProposedNewState,
+					RequiresReplace: []cty.Path{
+						cty.GetAttrPath("name"),
+					},
+				}
+			},
+			Request: &ManagedResourcePlanRequest{
+				Current: ValueWithPrivate{
+					Value: cty.ObjectVal(map[string]cty.Value{
+						"name": cty.StringVal("rumpelstiltskin"),
+					}),
+				},
+				DesiredValue: cty.NullVal(cty.Object(map[string]cty.Type{
+					"name": cty.String,
+				})),
+			},
+			WantResponse: &ManagedResourcePlanResponse{
+				Current: ValueWithPrivate{
+					Value: cty.ObjectVal(map[string]cty.Value{
+						"name": cty.StringVal("rumpelstiltskin"),
+					}),
+				},
+				DesiredValue: cty.NullVal(cty.Object(map[string]cty.Type{
+					"name": cty.String,
+				})),
+				Planned: ValueWithPrivate{
+					Value: cty.NullVal(cty.Object(map[string]cty.Type{
+						"name": cty.String,
+					})),
+				},
+				// Some real-world providers return a nonsensical "requires
+				// replace" even when they're describing the creation of
+				// something new. PlanChanges is responsible for discarding
+				// the paths in that case so that the rest of the system can
+				// assume that RequiresReplace is set only when a "replace"
+				// action would be appropriate.
+				RequiresReplace: nil,
+			},
+		},
+		"invalid plan": {
+			Schema: nameSchema,
+			PlanImpl: func(_ context.Context, req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+				return providers.PlanResourceChangeResponse{
+					PlannedState: cty.ObjectVal(map[string]cty.Value{
+						// This is emulating one potential kind of misbehavior:
+						// returning a case-normalized version of the input,
+						// rather than preserving the input and then treating
+						// it as case-sensitive in future rounds.
+						"name": cty.StringVal("RUMPELSTILTSKIN"),
+
+						// This test intentionally doesn't exhaustively cover
+						// all possible ways a plan can be invalid, because
+						// the underlying function in "package objchange"
+						// already has its own unit tests covering all that.
+						// We're essentially just testing that that function
+						// gets called at all.
+					}),
+				}
+			},
+			Request: &ManagedResourcePlanRequest{
+				Current: ValueWithPrivate{
+					Value: cty.NullVal(cty.Object(map[string]cty.Type{
+						"name": cty.String,
+					})),
+				},
+				DesiredValue: cty.ObjectVal(map[string]cty.Value{
+					"name": cty.StringVal("rumpelstiltskin"),
+				}),
+			},
+			WantDiags: (tfdiags.Diagnostics)(nil).Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Provider produced invalid plan",
+				`Provider "terraform.io/builtin/test" planned an invalid value for test_thing.test.name: planned value cty.StringVal("RUMPELSTILTSKIN") does not match config value cty.StringVal("rumpelstiltskin").
+
+This is a bug in the provider, which should be reported in the provider's own issue tracker.`,
+			)),
+		},
+		"invalid plan from legacy plugin SDK": {
+			Schema: nameSchema,
+			PlanImpl: func(_ context.Context, req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+				return providers.PlanResourceChangeResponse{
+					PlannedState: cty.ObjectVal(map[string]cty.Value{
+						// This is not an acceptable plan but PlanChanges must
+						// allow it anyway because we're also going to report
+						// that we're the legacy Terraform Plugin SDK, which
+						// was originally made for Terraform v1.11 and earlier
+						// and isn't capable of implementing the modern protocol
+						// properly.
+						"name": cty.StringVal("RUMPELSTILTSKIN"),
+					}),
+					// This is how the Terraform Plugin SDK excuses itself from
+					// implementing the protocol correctly.
+					LegacyTypeSystem: true,
+				}
+			},
+			Request: &ManagedResourcePlanRequest{
+				Current: ValueWithPrivate{
+					Value: cty.NullVal(cty.Object(map[string]cty.Type{
+						"name": cty.String,
+					})),
+				},
+				DesiredValue: cty.ObjectVal(map[string]cty.Value{
+					"name": cty.StringVal("rumpelstiltskin"),
+				}),
+			},
+			WantResponse: &ManagedResourcePlanResponse{
+				Current: ValueWithPrivate{
+					Value: cty.NullVal(cty.Object(map[string]cty.Type{
+						"name": cty.String,
+					})),
+				},
+				DesiredValue: cty.ObjectVal(map[string]cty.Value{
+					"name": cty.StringVal("rumpelstiltskin"),
+				}),
+				Planned: ValueWithPrivate{
+					Value: cty.ObjectVal(map[string]cty.Value{
+						// The invalid value is allowed to leak out in this
+						// case, because the quirks that causes are less
+						// disruptive than completely refusing to interact
+						// with old provider implementations.
+						"name": cty.StringVal("RUMPELSTILTSKIN"),
+					}),
+				},
+			},
+		},
+		"provider vetoes destroy plan": {
+			Schema:                 nameSchema,
+			ProviderCanPlanDestroy: true,
+			PlanImpl: func(_ context.Context, req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+				var diags tfdiags.Diagnostics
+				diags = diags.Append(fmt.Errorf("destroy not supported"))
+				return providers.PlanResourceChangeResponse{
+					Diagnostics: diags,
+				}
+			},
+			Request: &ManagedResourcePlanRequest{
+				Current: ValueWithPrivate{
+					Value: cty.ObjectVal(map[string]cty.Value{
+						"name": cty.StringVal("rumpelstiltskin"),
+					}),
+				},
+				DesiredValue: cty.NullVal(cty.Object(map[string]cty.Type{
+					"name": cty.String,
+				})),
+			},
+			WantDiags: (tfdiags.Diagnostics)(nil).Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"destroy not supported",
+				``,
+			)),
+		},
+		"provider doesn't support destroy planning": {
+			Schema:                 nameSchema,
+			ProviderCanPlanDestroy: false,
+			PlanImpl: func(_ context.Context, req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+				// Originally providers were only asked to plan create or update
+				// actions and the core system just made a synthetic plan for
+				// destroy. Later there was a requirement to support systems
+				// where destroying either isn't possible at all or involves a
+				// warning to the operator, so support for destroy-planning was
+				// added to the protocol but only when the provider announces
+				// a capability to handle it because existing providers would
+				// crash in that case. This test is covering the situation where
+				// the provider _doesn't_ opt in, and so this function should
+				// never be called.
+				var diags tfdiags.Diagnostics
+				diags = diags.Append(fmt.Errorf("provider should not be asked to plan destroy"))
+				return providers.PlanResourceChangeResponse{
+					Diagnostics: diags,
+				}
+			},
+			Request: &ManagedResourcePlanRequest{
+				Current: ValueWithPrivate{
+					Value: cty.ObjectVal(map[string]cty.Value{
+						"name": cty.StringVal("rumpelstiltskin"),
+					}),
+				},
+				DesiredValue: cty.NullVal(cty.Object(map[string]cty.Type{
+					"name": cty.String,
+				})),
+			},
+			WantResponse: &ManagedResourcePlanResponse{
+				Current: ValueWithPrivate{
+					Value: cty.ObjectVal(map[string]cty.Value{
+						"name": cty.StringVal("rumpelstiltskin"),
+					}),
+				},
+				DesiredValue: cty.NullVal(cty.Object(map[string]cty.Type{
+					"name": cty.String,
+				})),
+				Planned: ValueWithPrivate{
+					Value: cty.NullVal(cty.Object(map[string]cty.Type{
+						"name": cty.String,
+					})),
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			providerClient := &fakeProviderClient{
+				schema: &providers.GetProviderSchemaResponse{
+					ResourceTypes: map[string]providers.Schema{
+						"test_thing": {
+							Block: test.Schema,
+						},
+					},
+					ServerCapabilities: providers.ServerCapabilities{
+						PlanDestroy: test.ProviderCanPlanDestroy,
+					},
+				},
+				planResourceChange: test.PlanImpl,
+			}
+			resourceType := NewManagedResourceType(
+				addrs.NewBuiltInProvider("test"),
+				"test_thing",
+				providerClient,
+			)
+			objAddr := addrs.Resource{
+				Mode: addrs.ManagedResourceMode,
+				Type: "test_thing",
+				Name: "test",
+			}.Absolute(addrs.RootModuleInstance).Instance(addrs.NoKey).CurrentObject()
+
+			gotResp, gotDiags := resourceType.PlanChanges(t.Context(), test.Request, objAddr)
+			if diff := cmp.Diff(test.WantResponse, gotResp, ctydebug.CmpOptions); diff != "" {
+				t.Error("wrong response\n" + diff)
+			}
+			// We'll use the "ForRPC" form of diagnostics here just because
+			// it's a form that's friendly to diffing in this way and we're
+			// interested only in the diagnostic content as end-users would
+			// experience it, rather than the internal representation details.
+			if diff := cmp.Diff(test.WantDiags.ForRPC(), gotDiags.ForRPC(), ctydebug.CmpOptions); diff != "" {
+				t.Error("wrong diagnostics\n" + diff)
+			}
+		})
+	}
+}

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -1,0 +1,209 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resources
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opentofu/opentofu/internal/providers"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+)
+
+// fakeProviderClient is an implementation of [providers.Interface] that just
+// delegates to various function pointers in its own fields, so that we can more
+// easily unit test the methods in this package that make calls to these
+// methods and then react to what they return.
+//
+// This is intentionally simpler than the mock provider implementation used
+// in "package tofu"'s context tests: there's no tracking of what was called
+// and what arguments were provided, so tests which need that will need to
+// implement it themselves e.g. by using closures that capture local variables
+// from the test function's scope.
+type fakeProviderClient struct {
+	// Schema is a pointer to a value that is to be returned from
+	// [fakeProviderClient.GetProviderSchema].
+	//
+	// If this is nil then that function just returns an empty schema.
+	schema *providers.GetProviderSchemaResponse
+
+	// validateResourceConfig is the implementation of [fakeProviderClient.ValidateResourceConfig].
+	//
+	// If this is left nil then the default implementation just considers all
+	// configurations to be valid.
+	validateResourceConfig func(context.Context, providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse
+
+	// readResource is the implementation of [fakeProviderClient.ReadResource].
+	//
+	// If this is left nil then the default implementation immediately returns
+	// an error, because there's no reasonable default behavior.
+	readResource func(context.Context, providers.ReadResourceRequest) providers.ReadResourceResponse
+
+	// planResourceChange is the implementation of [fakeProviderClient.PlanResourceChange].
+	//
+	// If this is left nil then the default implementation just echoes back
+	// the proposed new value.
+	planResourceChange func(context.Context, providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse
+
+	// applyResourceChange is the implementation of [fakeProviderClient.ApplyResourceChange].
+	//
+	// If this is left nil then the default implementation just echoes back
+	// the planned value.
+	applyResourceChange func(context.Context, providers.ApplyResourceChangeRequest) providers.ApplyResourceChangeResponse
+}
+
+var _ providers.Interface = (*fakeProviderClient)(nil)
+
+// GetProviderSchema implements [providers.Interface].
+func (f *fakeProviderClient) GetProviderSchema(context.Context) providers.GetProviderSchemaResponse {
+	if f.schema == nil {
+		return providers.GetProviderSchemaResponse{
+			// This schema intentionally left blank. If your test needs a schema
+			// then it should write a non-nil pointer into the Schema field.
+		}
+	}
+	return *f.schema
+}
+
+// ValidateResourceConfig implements [providers.Interface].
+func (f *fakeProviderClient) ValidateResourceConfig(ctx context.Context, req providers.ValidateResourceConfigRequest) providers.ValidateResourceConfigResponse {
+	if f.validateResourceConfig == nil {
+		return providers.ValidateResourceConfigResponse{
+			Diagnostics: nil,
+		}
+	}
+	return f.validateResourceConfig(ctx, req)
+}
+
+// ReadResource implements [providers.Interface].
+func (f *fakeProviderClient) ReadResource(ctx context.Context, req providers.ReadResourceRequest) providers.ReadResourceResponse {
+	if f.readResource == nil {
+		var diags tfdiags.Diagnostics
+		diags = diags.Append(fmt.Errorf("this fakeProviderClient does not support ReadResource"))
+		return providers.ReadResourceResponse{
+			Diagnostics: diags,
+		}
+	}
+	return f.readResource(ctx, req)
+}
+
+// PlanResourceChange implements [providers.Interface].
+func (f *fakeProviderClient) PlanResourceChange(ctx context.Context, req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+	if f.planResourceChange == nil {
+		return providers.PlanResourceChangeResponse{
+			PlannedState: req.ProposedNewState,
+		}
+	}
+	return f.planResourceChange(ctx, req)
+}
+
+// ApplyResourceChange implements [providers.Interface].
+func (f *fakeProviderClient) ApplyResourceChange(ctx context.Context, req providers.ApplyResourceChangeRequest) providers.ApplyResourceChangeResponse {
+	if f.applyResourceChange == nil {
+		return providers.ApplyResourceChangeResponse{
+			NewState: req.PlannedState,
+		}
+	}
+	return f.applyResourceChange(ctx, req)
+}
+
+// UpgradeResourceIdentity implements [providers.Interface].
+func (f *fakeProviderClient) UpgradeResourceIdentity(context.Context, providers.UpgradeResourceIdentityRequest) providers.UpgradeResourceIdentityResponse {
+	panic("unimplemented")
+}
+
+// UpgradeResourceState implements [providers.Interface].
+func (f *fakeProviderClient) UpgradeResourceState(context.Context, providers.UpgradeResourceStateRequest) providers.UpgradeResourceStateResponse {
+	panic("unimplemented")
+}
+
+// ImportResourceState implements [providers.Interface].
+func (f *fakeProviderClient) ImportResourceState(context.Context, providers.ImportResourceStateRequest) providers.ImportResourceStateResponse {
+	panic("unimplemented")
+}
+
+// MoveResourceState implements [providers.Interface].
+func (f *fakeProviderClient) MoveResourceState(context.Context, providers.MoveResourceStateRequest) providers.MoveResourceStateResponse {
+	panic("unimplemented")
+}
+
+// ValidateDataResourceConfig implements [providers.Interface].
+func (f *fakeProviderClient) ValidateDataResourceConfig(context.Context, providers.ValidateDataResourceConfigRequest) providers.ValidateDataResourceConfigResponse {
+	panic("unimplemented")
+}
+
+// ReadDataSource implements [providers.Interface].
+func (f *fakeProviderClient) ReadDataSource(context.Context, providers.ReadDataSourceRequest) providers.ReadDataSourceResponse {
+	panic("unimplemented")
+}
+
+// ValidateEphemeralConfig implements [providers.Interface].
+func (f *fakeProviderClient) ValidateEphemeralConfig(context.Context, providers.ValidateEphemeralConfigRequest) providers.ValidateEphemeralConfigResponse {
+	panic("unimplemented")
+}
+
+// OpenEphemeralResource implements [providers.Interface].
+func (f *fakeProviderClient) OpenEphemeralResource(context.Context, providers.OpenEphemeralResourceRequest) providers.OpenEphemeralResourceResponse {
+	panic("unimplemented")
+}
+
+// RenewEphemeralResource implements [providers.Interface].
+func (f *fakeProviderClient) RenewEphemeralResource(context.Context, providers.RenewEphemeralResourceRequest) (resp providers.RenewEphemeralResourceResponse) {
+	panic("unimplemented")
+}
+
+// CloseEphemeralResource implements [providers.Interface].
+func (f *fakeProviderClient) CloseEphemeralResource(context.Context, providers.CloseEphemeralResourceRequest) providers.CloseEphemeralResourceResponse {
+	panic("unimplemented")
+}
+
+// Close implements [providers.Interface].
+func (f *fakeProviderClient) Close(context.Context) error {
+	return nil
+}
+
+// Stop implements [providers.Interface].
+func (f *fakeProviderClient) Stop(context.Context) error {
+	return nil
+}
+
+// ValidateProviderConfig implements [providers.Interface].
+func (f *fakeProviderClient) ValidateProviderConfig(context.Context, providers.ValidateProviderConfigRequest) providers.ValidateProviderConfigResponse {
+	// We don't support [ConfigureProvider], so we have no need to validate.
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(fmt.Errorf("fakeProviderClient does not support ValidateProviderConfig"))
+	return providers.ValidateProviderConfigResponse{
+		Diagnostics: diags,
+	}
+}
+
+// ConfigureProvider implements [providers.Interface].
+func (f *fakeProviderClient) ConfigureProvider(context.Context, providers.ConfigureProviderRequest) providers.ConfigureProviderResponse {
+	// The methods in this package either work with unconfigured provider
+	// clients or provider clients that were preconfigured by the caller, so
+	// we don't expect to ever be calling ConfigureProvider ourselves in here.
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(fmt.Errorf("fakeProviderClient does not support ConfigureProvider"))
+	return providers.ConfigureProviderResponse{
+		Diagnostics: diags,
+	}
+}
+
+// GetFunctions implements [providers.Interface].
+func (f *fakeProviderClient) GetFunctions(context.Context) providers.GetFunctionsResponse {
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(fmt.Errorf("fakeProviderClient does not support GetFunctions"))
+	return providers.GetFunctionsResponse{
+		Diagnostics: diags,
+	}
+}
+
+// CallFunction implements [providers.Interface].
+func (f *fakeProviderClient) CallFunction(context.Context, providers.CallFunctionRequest) providers.CallFunctionResponse {
+	return providers.CallFunctionResponse{
+		Error: fmt.Errorf("fakeProviderClient does not support CallFunction"),
+	}
+}


### PR DESCRIPTION
While working through the "walking skeleton" phase of developing the new runtime we intentionally kept the test coverage pretty light so that it'd be easier to make substantial changes to the design if we learned new information as we went along.

Since we're now switching to a more incremental mode of development, it'll be helpful to have a little more test coverage. This is a retroactive addition of a unit test suite for the function that encapsulates the interactions with providers for planning changes to managed resource instances, since (FIXMEs and TODOs notwithstanding) this seems pretty unlikely to be refactored significantly in the near future.

This establishes a very simple fake provider client implementation that's convenient to use in the tests here. Along with just being much simpler than the one in `package tofu` (no call tracking, etc), including this here also avoids the need for `package resources` to depend on `package tofu`, which would therefore make it impossible for the old runtime to call into here. As we add new code to support other resource-related provider operations later the additional tests can hopefully share this fake provider client implementation.

This is for https://github.com/opentofu/opentofu/issues/3414, in preparation for ongoing development.