### PR TITLE
Add support for instances in test resource overrides

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -305,7 +305,7 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/hashicorp/hcl/v2 v2.20.1 => github.com/opentofu/hcl/v2 v2.20.2-0.20251021132045-587d123c2828
+replace github.com/hashicorp/hcl/v2 v2.20.1 => github.com/opentofu/hcl/v2 v2.20.2-0.20260420161427-789bd2dd659c
 
 tool (
 	github.com/hashicorp/copywrite

--- a/go.mod
+++ b/go.mod
@@ -274,7 +274,7 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/hashicorp/hcl/v2 v2.20.1 => github.com/opentofu/hcl/v2 v2.20.2-0.20251021132045-587d123c2828
+replace github.com/hashicorp/hcl/v2 v2.20.1 => github.com/opentofu/hcl/v2 v2.20.2-0.20260420161427-789bd2dd659c
 
 tool (
 	github.com/mitchellh/gox

--- a/go.mod
+++ b/go.mod
@@ -274,7 +274,7 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/hashicorp/hcl/v2 v2.20.1 => github.com/opentofu/hcl/v2 v2.20.2-0.20260420161427-789bd2dd659c
+replace github.com/hashicorp/hcl/v2 v2.20.1 => github.com/opentofu/hcl/v2 v2.20.2-0.20260626151130-6cce96c532a5
 
 tool (
 	github.com/mitchellh/gox

--- a/go.sum
+++ b/go.sum
@@ -652,8 +652,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/opentofu/hcl/v2 v2.20.2-0.20251021132045-587d123c2828 h1:r2WiJxljn/Cxwpq9zMZ5HomJcNwmGNjKmeZnFsxkpBg=
-github.com/opentofu/hcl/v2 v2.20.2-0.20251021132045-587d123c2828/go.mod h1:k+HgkLpoWu9OS81sy4j1XKDXaWm/rLysG33v5ibdDnc=
+github.com/opentofu/hcl/v2 v2.20.2-0.20260420161427-789bd2dd659c h1:A/ryDETkpuVk7G2Q7l/6Dv6Bnh6glixq6PJXmefs2NY=
+github.com/opentofu/hcl/v2 v2.20.2-0.20260420161427-789bd2dd659c/go.mod h1:WS1ymNdBhhwYKDVlGnUb9fmqB2hw1djJva6S8Bj/WfI=
 github.com/opentofu/registry-address/v2 v2.0.0-20260307135325-45f3562374e4 h1:k5ODrqBcfHzccrsiiKKRcqvtMgDw1yo1W53K7LYFBlA=
 github.com/opentofu/registry-address/v2 v2.0.0-20260307135325-45f3562374e4/go.mod h1:7M92SvuJm1WBriIpa4j0XmruU9pxkgPXmRdc6FfAvAk=
 github.com/opentofu/svchost v0.0.0-20250610175836-86c9e5e3d8c8 h1:J3pmsVB+nGdfNp5HWdEAC96asYgc7S6J724ICrYDCTk=

--- a/go.sum
+++ b/go.sum
@@ -489,8 +489,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/opentofu/hcl/v2 v2.20.2-0.20260420161427-789bd2dd659c h1:A/ryDETkpuVk7G2Q7l/6Dv6Bnh6glixq6PJXmefs2NY=
-github.com/opentofu/hcl/v2 v2.20.2-0.20260420161427-789bd2dd659c/go.mod h1:WS1ymNdBhhwYKDVlGnUb9fmqB2hw1djJva6S8Bj/WfI=
+github.com/opentofu/hcl/v2 v2.20.2-0.20260626151130-6cce96c532a5 h1:amymCSm6rg5mkqDU45+JqsHpF+rKSHNm5v/5zwZjCG0=
+github.com/opentofu/hcl/v2 v2.20.2-0.20260626151130-6cce96c532a5/go.mod h1:WS1ymNdBhhwYKDVlGnUb9fmqB2hw1djJva6S8Bj/WfI=
 github.com/opentofu/registry-address/v2 v2.0.0-20260307135325-45f3562374e4 h1:k5ODrqBcfHzccrsiiKKRcqvtMgDw1yo1W53K7LYFBlA=
 github.com/opentofu/registry-address/v2 v2.0.0-20260307135325-45f3562374e4/go.mod h1:7M92SvuJm1WBriIpa4j0XmruU9pxkgPXmRdc6FfAvAk=
 github.com/opentofu/svchost v0.0.0-20260410171206-1a42986aa3f4 h1:BhB8EYO7kGYQS64iSAsCrz5t1ZILAmQBCxlAI4iXK2c=

--- a/go.sum
+++ b/go.sum
@@ -489,8 +489,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/opentofu/hcl/v2 v2.20.2-0.20251021132045-587d123c2828 h1:r2WiJxljn/Cxwpq9zMZ5HomJcNwmGNjKmeZnFsxkpBg=
-github.com/opentofu/hcl/v2 v2.20.2-0.20251021132045-587d123c2828/go.mod h1:k+HgkLpoWu9OS81sy4j1XKDXaWm/rLysG33v5ibdDnc=
+github.com/opentofu/hcl/v2 v2.20.2-0.20260420161427-789bd2dd659c h1:A/ryDETkpuVk7G2Q7l/6Dv6Bnh6glixq6PJXmefs2NY=
+github.com/opentofu/hcl/v2 v2.20.2-0.20260420161427-789bd2dd659c/go.mod h1:WS1ymNdBhhwYKDVlGnUb9fmqB2hw1djJva6S8Bj/WfI=
 github.com/opentofu/registry-address/v2 v2.0.0-20260307135325-45f3562374e4 h1:k5ODrqBcfHzccrsiiKKRcqvtMgDw1yo1W53K7LYFBlA=
 github.com/opentofu/registry-address/v2 v2.0.0-20260307135325-45f3562374e4/go.mod h1:7M92SvuJm1WBriIpa4j0XmruU9pxkgPXmRdc6FfAvAk=
 github.com/opentofu/svchost v0.0.0-20260410171206-1a42986aa3f4 h1:BhB8EYO7kGYQS64iSAsCrz5t1ZILAmQBCxlAI4iXK2c=

--- a/internal/addrs/checkable.go
+++ b/internal/addrs/checkable.go
@@ -159,7 +159,7 @@ func ParseCheckableStr(kind CheckableKind, src string) (Checkable, tfdiags.Diagn
 	// might be a resource whose type is literally "output".
 	switch kind {
 	case CheckableResource:
-		riAddr, moreDiags := parseResourceInstanceUnderModule(path, remain)
+		riAddr, moreDiags := parseResourceInstanceUnderModule(path, remain, false)
 		diags = diags.Append(moreDiags)
 		if diags.HasErrors() {
 			return nil, diags

--- a/internal/addrs/module_instance.go
+++ b/internal/addrs/module_instance.go
@@ -98,6 +98,10 @@ func MustParseModuleInstanceStr(str string) ModuleInstance {
 // traversal.
 // This function supports module addresses with and without instance keys.
 func parseModuleInstancePrefix(traversal hcl.Traversal) (ModuleInstance, hcl.Traversal, tfdiags.Diagnostics) {
+	return parseModuleInstancePrefixWithOptionalRanges(traversal, false)
+}
+
+func parseModuleInstancePrefixWithOptionalRanges(traversal hcl.Traversal, allowRanges bool) (ModuleInstance, hcl.Traversal, tfdiags.Diagnostics) {
 	remain := traversal
 	var mi ModuleInstance
 	var diags tfdiags.Diagnostics
@@ -147,6 +151,9 @@ func parseModuleInstancePrefix(traversal hcl.Traversal) (ModuleInstance, hcl.Tra
 						Subject:  idx.SourceRange().Ptr(),
 					})
 				}
+			} else if _, ok := remain[0].(hcl.TraverseSplat); allowRanges && ok {
+				remain = remain[1:]
+				step.InstanceKey = WildcardKey{UnknownKeyType}
 			}
 		}
 

--- a/internal/addrs/move_endpoint.go
+++ b/internal/addrs/move_endpoint.go
@@ -142,7 +142,7 @@ func ParseMoveEndpoint(traversal hcl.Traversal) (*MoveEndpoint, tfdiags.Diagnost
 		}, diags
 	}
 
-	riAddr, moreDiags := parseResourceInstanceUnderModule(path, remain)
+	riAddr, moreDiags := parseResourceInstanceUnderModule(path, remain, false)
 	diags = diags.Append(moreDiags)
 	if diags.HasErrors() {
 		return nil, diags

--- a/internal/addrs/override_trie.go
+++ b/internal/addrs/override_trie.go
@@ -59,7 +59,7 @@ func NewOverrideTrie[T any]() *OverrideTrie[T] {
 // containing the value for the address.
 //
 // The "NoKey" key is treated specially and made equivalent to WildCard. This is
-// to provide backwards compatibility; before this was implemented, a non-instanced
+// to provide backwards compatibility; before this was implemented, an unkeyed
 // resource address was used to refer to every instance associated with the address.
 //
 // val is expected to be non-nil; it might complicate overrides if no value
@@ -72,29 +72,29 @@ func (ot *OverrideTrie[T]) Set(addr *AbsResourceInstance, val T, src *hcl.Range)
 	for i, mod := range addr.Module {
 		next, usesNoKey := ot.subSet(current, mod.InstanceKey)
 		if usesNoKey {
-			ot.SetNoKeyEvidence(i, addr, src)
+			ot.setNoKeyEvidence(i, addr, src)
 		}
-		ot.TrackModernAddressing(mod.InstanceKey)
+		ot.trackModernAddressing(mod.InstanceKey)
 		current = next
 	}
 	last, usesNoKey := ot.subSet(current, addr.Resource.Key)
 	if usesNoKey {
-		ot.SetNoKeyEvidence(len(addr.Module), addr, src)
+		ot.setNoKeyEvidence(len(addr.Module), addr, src)
 	}
-	ot.TrackModernAddressing(addr.Resource.Key)
+	ot.trackModernAddressing(addr.Resource.Key)
 	last.value = new(val)
 }
 
-func (ot *OverrideTrie[T]) TrackModernAddressing(key InstanceKey) {
+func (ot *OverrideTrie[T]) trackModernAddressing(key InstanceKey) {
 	_, usesWildcard := key.(WildcardKey)
 	ot.usesModernAddresses = ot.usesModernAddresses || usesWildcard
 }
 
-// SetNoKeyEvidence provides evidence that the NoKey instance key was used in a
+// setNoKeyEvidence provides evidence that the NoKey instance key was used in a
 // particular resource override. This is later used when getting a key; if
 // this trie uses modern address syntax, but no key is used when a key is
 // called for, this is how we obtain that evidence.
-func (ot *OverrideTrie[T]) SetNoKeyEvidence(i int, addr *AbsResourceInstance, src *hcl.Range) {
+func (ot *OverrideTrie[T]) setNoKeyEvidence(i int, addr *AbsResourceInstance, src *hcl.Range) {
 	if ot.noKeyEvidenceMap == nil {
 		ot.noKeyEvidenceMap = make([][]*hcl.Range, len(addr.Module)+1)
 		for i := range len(addr.Module) + 1 {
@@ -118,8 +118,8 @@ func (ot *OverrideTrie[T]) subSet(current *OverrideTrie[T], key InstanceKey) (*O
 	}
 	next, ok := current.trie[key]
 	if !ok {
-		current.trie[key] = NewOverrideTrie[T]()
-		next = current.trie[key]
+		next = NewOverrideTrie[T]()
+		current.trie[key] = next
 		next.root = ot
 	}
 	return next, usesNoKey
@@ -199,8 +199,8 @@ func (ot *OverrideTrie[T]) checkKey(i int, key InstanceKey, addrString string) t
 		for _, noKeyRange := range ot.noKeyEvidenceMap[i] {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
-				Summary:  "Please switch overrides to wildcard syntax (i.e. \"[*]\") to refer to for-each resources",
-				Detail:   fmt.Sprintf("When trying to override %s", addrString),
+				Summary:  "Invalid resource override usage",
+				Detail:   fmt.Sprintf("The mixed usage of un-keyed and wildcard references in an override is not allowed, but detected in %q. Switch overrides to wildcard syntax (i.e. \"[*]\" to refer to for-each or count resources.)", addrString),
 				Subject:  noKeyRange,
 			})
 		}

--- a/internal/addrs/override_trie.go
+++ b/internal/addrs/override_trie.go
@@ -1,0 +1,196 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+package addrs
+
+import (
+	"fmt"
+
+	"github.com/opentofu/opentofu/internal/tfdiags"
+)
+
+// OverrideTrie provides a step-wise method to obtain values
+// for overridden resource. Each instance of the OverrideTrie
+// represents one "hop" in the resource address, traversing
+// through modules.
+//
+// A resource without a key, which is expected to have a key, may use
+// either the Wildcard key "[*]" or no key at all, but not both. See Set
+// and Get for more specific information on how that is handled.
+type OverrideTrie[T any] struct {
+	trie  map[InstanceKey]*OverrideTrie[T]
+	value *T
+
+	// usesModernAddresses is used in the root trie to track
+	// whether a wildcard literal was ever used for the
+	// index of an override
+	usesModernAddresses bool
+
+	// noKeyEvidenceMap, for each step, provides a list of address ranges used in overrides
+	// where, at that step of the process, the instance key was NoKey. This is used
+	// for error handling to provide user feedback on which addresses to fix.
+	noKeyEvidenceMap [][]*AbsResourceInstance
+
+	root *OverrideTrie[T]
+}
+
+// NewOverrideTrie creates a new trie for mapping override values to addresses.
+//
+// A default value is provided in this constructor.
+// This is used when the address is not found in the trie, that is,
+// it is not set as an override.
+func NewOverrideTrie[T any]() *OverrideTrie[T] {
+	return &OverrideTrie[T]{
+		trie:  make(map[InstanceKey]*OverrideTrie[T]),
+		value: nil,
+	}
+}
+
+// Set takes an address and value and loads it into the OverrideTrie. Each
+// instance key, for a module or resource, creates a trie, with the "leaf" trie
+// containing the value for the address.
+//
+// The "NoKey" key is treated specially and made equivalent to WildCard. This is
+// to provide backwards compatibility; before this was implemented, a non-instanced
+// resource address was used to refer to every instance associated with the address.
+//
+// val is expected to be non-nil; it might complicate overrides if no value
+// is provided but the resource is still considered "overridden"
+func (ot *OverrideTrie[T]) Set(addr *AbsResourceInstance, val T) {
+	current := ot
+	for i, mod := range addr.Module {
+		next, usesNoKey := ot.subSet(current, mod.InstanceKey)
+		if usesNoKey {
+			ot.SetNoKeyEvidence(i, addr)
+		}
+		ot.TrackModernAddressing(mod.InstanceKey)
+		current = next
+	}
+	last, usesNoKey := ot.subSet(current, addr.Resource.Key)
+	if usesNoKey {
+		ot.SetNoKeyEvidence(len(addr.Module), addr)
+	}
+	ot.TrackModernAddressing(addr.Resource.Key)
+	last.value = new(val)
+}
+
+func (ot *OverrideTrie[T]) TrackModernAddressing(key InstanceKey) {
+	_, usesWildcard := key.(WildcardKey)
+	ot.usesModernAddresses = ot.usesModernAddresses || usesWildcard
+}
+
+// SetNoKeyEvidence provides evidence that the NoKey instance key was used in a
+// particular resource override. This is later used when getting a key; if
+// this trie uses modern address syntax, but no key is used when a key is
+// called for, this is how we obtain that evidence.
+func (ot *OverrideTrie[T]) SetNoKeyEvidence(i int, addr *AbsResourceInstance) {
+	if ot.noKeyEvidenceMap == nil {
+		ot.noKeyEvidenceMap = make([][]*AbsResourceInstance, len(addr.Module)+1)
+		for i := range len(addr.Module) + 1 {
+			ot.noKeyEvidenceMap[i] = make([]*AbsResourceInstance, 0)
+		}
+	}
+	ot.noKeyEvidenceMap[i] = append(ot.noKeyEvidenceMap[i], addr)
+}
+
+// subSet prepares one step in the module or resource chain
+// as a trie of instance keys. It also provides evidence that a NoKey
+// was used in one step of the override; if, during Get, a key is used,
+// and the OverrideTrie is using "Modern Addresses Ranges" (i.e.
+// override addresses with wildcards), we can return an error and call
+// out the particular address.
+func (ot *OverrideTrie[T]) subSet(current *OverrideTrie[T], key InstanceKey) (*OverrideTrie[T], bool) {
+	usesNoKey := false
+	if key == NoKey {
+		key = WildcardKey{UnknownKeyType}
+		usesNoKey = true
+	}
+	next, ok := current.trie[key]
+	if !ok {
+		current.trie[key] = NewOverrideTrie[T]()
+		next = current.trie[key]
+		next.root = ot
+	}
+	return next, usesNoKey
+}
+
+// Get returns the value in the OverrideTrie associated with the address. If part of the
+// address is not found, but a WildCard address is set in the trie, that sub-trie is
+// recursively searched against the query.
+//
+// If the address could not be found in the OverrideTrie as an override, Get returns nil.
+//
+// A wildcard instance key anywhere in the provided address will produce an error; it
+// make sense to use this to obtain a single value when referencing a wildcard. Additionally,
+// if the override addresses had no key in a module or resource where a key was expected,
+// this method will also produce an error for that.
+func (ot *OverrideTrie[T]) Get(addr *AbsResourceInstance) (*T, tfdiags.Diagnostics) {
+	n := len(addr.Module) + 1
+	keyList := make([]InstanceKey, n)
+	for i, mod := range addr.Module {
+		keyList[i] = mod.InstanceKey
+	}
+	keyList[n-1] = addr.Resource.Key
+
+	value, diags := ot.recursiveGet(0, n, keyList, addr.String())
+	return value, diags
+}
+func (ot *OverrideTrie[T]) recursiveGet(i, n int, keyList []InstanceKey, addrString string) (*T, tfdiags.Diagnostics) {
+	if ot == nil {
+		return nil, nil
+	}
+	if i == n {
+		return ot.value, nil
+	}
+	keyCheckDiags := ot.checkKey(i, keyList[i], addrString)
+	if keyCheckDiags.HasErrors() {
+		return nil, keyCheckDiags
+	}
+	value, diags := ot.trie[keyList[i]].recursiveGet(i+1, n, keyList, addrString)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	if value != nil {
+		return value, diags
+	}
+
+	// Could not find against concrete instance key, try on Wildcard key
+	return ot.trie[WildcardKey{UnknownKeyType}].recursiveGet(i+1, n, keyList, addrString)
+}
+
+func (ot *OverrideTrie[T]) checkKey(i int, key InstanceKey, addrString string) tfdiags.Diagnostics {
+	if ot.root != nil && ot.root != ot {
+		return ot.root.checkKey(i, key, addrString)
+	}
+	if _, usesWildcard := key.(WildcardKey); usesWildcard {
+		return tfdiags.Diagnostics{
+			tfdiags.Sourceless(
+				tfdiags.Error,
+				"Wildcard key not expected in when retrieving override values",
+				fmt.Sprintf("In the provided resource address \"%s\", a wildcard accessor is used for the instance key. A specific key should always be used, where applicable.", addrString),
+			),
+		}
+	}
+	if ot.noKeyEvidenceMap == nil || !ot.usesModernAddresses {
+		return nil
+	}
+	// check if NoKey is being used in a place it shouldn't
+	// i.e. this key isn't NoKey, but the override was NoKey
+	// at this step
+	var diags tfdiags.Diagnostics
+	if key != NoKey && len(ot.noKeyEvidenceMap[i]) > 0 {
+		for _, noKeyAddr := range ot.noKeyEvidenceMap[i] {
+			// TODO this results in a crazy amount of diagnostics...
+			// Like, for every instance of every instance of every instance, and every override therein,
+			// has an error output example. How do I avoid this? Hash on AbsResource or something?
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				// TODO I'm open to a less-verbose version of this summary
+				"The override address cannot contain unkeyed for-each resources if it is also using the wildcard syntax (i.e. \"[*]\"). Please switch entirely to wildcard syntax for test overrides.",
+				fmt.Sprintf("Using %s to override %s", noKeyAddr.String(), addrString),
+			))
+		}
+	}
+	return diags
+}

--- a/internal/addrs/override_trie.go
+++ b/internal/addrs/override_trie.go
@@ -7,6 +7,7 @@ package addrs
 import (
 	"fmt"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
@@ -30,7 +31,12 @@ type OverrideTrie[T any] struct {
 	// noKeyEvidenceMap, for each step, provides a list of address ranges used in overrides
 	// where, at that step of the process, the instance key was NoKey. This is used
 	// for error handling to provide user feedback on which addresses to fix.
-	noKeyEvidenceMap [][]*AbsResourceInstance
+	noKeyEvidenceMap [][]*hcl.Range
+	// refuse is a boolean that, when set to true, refuses further queries.
+	// This flag is set when there's a diagnostic is returned from
+	// a Get request. This is to ensure only one diagnostic message is returned,
+	// rather than one for each resource instance (which is pretty spammy).
+	refuse bool
 
 	root *OverrideTrie[T]
 }
@@ -57,19 +63,22 @@ func NewOverrideTrie[T any]() *OverrideTrie[T] {
 //
 // val is expected to be non-nil; it might complicate overrides if no value
 // is provided but the resource is still considered "overridden"
-func (ot *OverrideTrie[T]) Set(addr *AbsResourceInstance, val T) {
+//
+// src is only used for diagnostic purposes, in the case that an override does not
+// use a key where it ought to have a key set.
+func (ot *OverrideTrie[T]) Set(addr *AbsResourceInstance, val T, src *hcl.Range) {
 	current := ot
 	for i, mod := range addr.Module {
 		next, usesNoKey := ot.subSet(current, mod.InstanceKey)
 		if usesNoKey {
-			ot.SetNoKeyEvidence(i, addr)
+			ot.SetNoKeyEvidence(i, addr, src)
 		}
 		ot.TrackModernAddressing(mod.InstanceKey)
 		current = next
 	}
 	last, usesNoKey := ot.subSet(current, addr.Resource.Key)
 	if usesNoKey {
-		ot.SetNoKeyEvidence(len(addr.Module), addr)
+		ot.SetNoKeyEvidence(len(addr.Module), addr, src)
 	}
 	ot.TrackModernAddressing(addr.Resource.Key)
 	last.value = new(val)
@@ -84,14 +93,14 @@ func (ot *OverrideTrie[T]) TrackModernAddressing(key InstanceKey) {
 // particular resource override. This is later used when getting a key; if
 // this trie uses modern address syntax, but no key is used when a key is
 // called for, this is how we obtain that evidence.
-func (ot *OverrideTrie[T]) SetNoKeyEvidence(i int, addr *AbsResourceInstance) {
+func (ot *OverrideTrie[T]) SetNoKeyEvidence(i int, addr *AbsResourceInstance, src *hcl.Range) {
 	if ot.noKeyEvidenceMap == nil {
-		ot.noKeyEvidenceMap = make([][]*AbsResourceInstance, len(addr.Module)+1)
+		ot.noKeyEvidenceMap = make([][]*hcl.Range, len(addr.Module)+1)
 		for i := range len(addr.Module) + 1 {
-			ot.noKeyEvidenceMap[i] = make([]*AbsResourceInstance, 0)
+			ot.noKeyEvidenceMap[i] = make([]*hcl.Range, 0)
 		}
 	}
-	ot.noKeyEvidenceMap[i] = append(ot.noKeyEvidenceMap[i], addr)
+	ot.noKeyEvidenceMap[i] = append(ot.noKeyEvidenceMap[i], src)
 }
 
 // subSet prepares one step in the module or resource chain
@@ -126,6 +135,9 @@ func (ot *OverrideTrie[T]) subSet(current *OverrideTrie[T], key InstanceKey) (*O
 // if the override addresses had no key in a module or resource where a key was expected,
 // this method will also produce an error for that.
 func (ot *OverrideTrie[T]) Get(addr *AbsResourceInstance) (*T, tfdiags.Diagnostics) {
+	if ot.refuse {
+		return nil, nil
+	}
 	n := len(addr.Module) + 1
 	keyList := make([]InstanceKey, n)
 	for i, mod := range addr.Module {
@@ -164,6 +176,7 @@ func (ot *OverrideTrie[T]) checkKey(i int, key InstanceKey, addrString string) t
 		return ot.root.checkKey(i, key, addrString)
 	}
 	if _, usesWildcard := key.(WildcardKey); usesWildcard {
+		ot.refuse = true
 		return tfdiags.Diagnostics{
 			tfdiags.Sourceless(
 				tfdiags.Error,
@@ -180,17 +193,15 @@ func (ot *OverrideTrie[T]) checkKey(i int, key InstanceKey, addrString string) t
 	// at this step
 	var diags tfdiags.Diagnostics
 	if key != NoKey && len(ot.noKeyEvidenceMap[i]) > 0 {
-		for _, noKeyAddr := range ot.noKeyEvidenceMap[i] {
-			// TODO this results in a crazy amount of diagnostics...
-			// Like, for every instance of every instance of every instance, and every override therein,
-			// has an error output example. How do I avoid this? Hash on AbsResource or something?
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				// TODO I'm open to a less-verbose version of this summary
-				"The override address cannot contain unkeyed for-each resources if it is also using the wildcard syntax (i.e. \"[*]\"). Please switch entirely to wildcard syntax for test overrides.",
-				fmt.Sprintf("Using %s to override %s", noKeyAddr.String(), addrString),
-			))
+		for _, noKeyRange := range ot.noKeyEvidenceMap[i] {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Please switch overrides to wildcard syntax (i.e. \"[*]\") to refer to for-each resources",
+				Detail:   fmt.Sprintf("When trying to override %s", addrString),
+				Subject:  noKeyRange,
+			})
 		}
 	}
+	ot.refuse = true
 	return diags
 }

--- a/internal/addrs/override_trie.go
+++ b/internal/addrs/override_trie.go
@@ -97,8 +97,8 @@ func (ot *OverrideTrie[T]) trackModernAddressing(key InstanceKey) {
 func (ot *OverrideTrie[T]) setNoKeyEvidence(i int, addr *AbsResourceInstance, src *hcl.Range) {
 	if ot.noKeyEvidenceMap == nil {
 		ot.noKeyEvidenceMap = make([][]*hcl.Range, len(addr.Module)+1)
-		for i := range len(addr.Module) + 1 {
-			ot.noKeyEvidenceMap[i] = make([]*hcl.Range, 0)
+		for j := range len(addr.Module) + 1 {
+			ot.noKeyEvidenceMap[j] = make([]*hcl.Range, 0)
 		}
 	}
 	ot.noKeyEvidenceMap[i] = append(ot.noKeyEvidenceMap[i], src)

--- a/internal/addrs/override_trie.go
+++ b/internal/addrs/override_trie.go
@@ -6,6 +6,7 @@ package addrs
 
 import (
 	"fmt"
+	"sync/atomic"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/opentofu/opentofu/internal/tfdiags"
@@ -36,7 +37,7 @@ type OverrideTrie[T any] struct {
 	// This flag is set when there's a diagnostic is returned from
 	// a Get request. This is to ensure only one diagnostic message is returned,
 	// rather than one for each resource instance (which is pretty spammy).
-	refuse bool
+	refuse atomic.Bool
 
 	root *OverrideTrie[T]
 }
@@ -135,7 +136,7 @@ func (ot *OverrideTrie[T]) subSet(current *OverrideTrie[T], key InstanceKey) (*O
 // if the override addresses had no key in a module or resource where a key was expected,
 // this method will also produce an error for that.
 func (ot *OverrideTrie[T]) Get(addr *AbsResourceInstance) (*T, tfdiags.Diagnostics) {
-	if ot.refuse {
+	if ot.refuse.Load() {
 		return nil, nil
 	}
 	n := len(addr.Module) + 1
@@ -176,7 +177,6 @@ func (ot *OverrideTrie[T]) checkKey(i int, key InstanceKey, addrString string) t
 		return ot.root.checkKey(i, key, addrString)
 	}
 	if _, usesWildcard := key.(WildcardKey); usesWildcard {
-		ot.refuse = true
 		return tfdiags.Diagnostics{
 			tfdiags.Sourceless(
 				tfdiags.Error,
@@ -191,8 +191,11 @@ func (ot *OverrideTrie[T]) checkKey(i int, key InstanceKey, addrString string) t
 	// check if NoKey is being used in a place it shouldn't
 	// i.e. this key isn't NoKey, but the override was NoKey
 	// at this step
+	// Note: the Swap at the end prevents this error from being returned
+	// more than once per resource. We rely on logic shortcutting for it
+	// to not be executed when the first two conditions are not met.
 	var diags tfdiags.Diagnostics
-	if key != NoKey && len(ot.noKeyEvidenceMap[i]) > 0 {
+	if key != NoKey && len(ot.noKeyEvidenceMap[i]) > 0 && !ot.refuse.Swap(true) {
 		for _, noKeyRange := range ot.noKeyEvidenceMap[i] {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
@@ -202,6 +205,5 @@ func (ot *OverrideTrie[T]) checkKey(i int, key InstanceKey, addrString string) t
 			})
 		}
 	}
-	ot.refuse = true
 	return diags
 }

--- a/internal/addrs/override_trie_test.go
+++ b/internal/addrs/override_trie_test.go
@@ -1,0 +1,153 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+package addrs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+)
+
+// parseAbsResourceRangeStr is copied from ParseAbsResourceInstanceStr (more or less),
+// but with functions edited to refer to ranges instead.
+// TODO should this be outside of the test file?
+func parseAbsResourceRangeStr(str string) (AbsResourceInstance, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	expr, parseDiags := hclsyntax.ParseExpression([]byte(str), "", hcl.InitialPos)
+	diags = diags.Append(parseDiags)
+	if parseDiags.HasErrors() {
+		return AbsResourceInstance{}, diags
+	}
+
+	traversal, parseDiags := hcl.AbsTraversalPatternForExpr(expr)
+	diags = diags.Append(parseDiags)
+	if parseDiags.HasErrors() {
+		return AbsResourceInstance{}, diags
+	}
+
+	addr, addrDiags := ParseAbsResourceRange(traversal)
+	diags = diags.Append(addrDiags)
+	return addr, diags
+}
+
+// shorthand function to obtain known good strings.
+// Please please please do not use this outside of tests!!!
+func getAbsResourceRangeOrPanic(str string) AbsResourceInstance {
+	out, diags := parseAbsResourceRangeStr(str)
+	if diags.HasErrors() {
+		panic(diags)
+	}
+	return out
+}
+
+type override struct {
+	Address *AbsResourceInstance
+	Values  string
+}
+
+func TestOverrideTrie(t *testing.T) {
+	tests := []struct {
+		TestName    string
+		Default     string
+		Overrides   []override
+		Query       *AbsResourceInstance
+		WantMissing bool
+		WantError   bool
+		Want        *string
+	}{
+		{
+			TestName: "basic input",
+			Overrides: []override{
+				{
+					Address: new(getAbsResourceRangeOrPanic(`module.vps["us-central1"].tofu_network.spiderweb`)),
+					Values:  "usa",
+				},
+			},
+			Query: new(getAbsResourceRangeOrPanic(`module.vps["us-central1"].tofu_network.spiderweb`)),
+			Want:  new("usa"),
+		},
+		{
+			TestName: "wildcard override",
+			Overrides: []override{
+				{
+					Address: new(getAbsResourceRangeOrPanic(`module.vps[*].tofu_network.spiderweb`)),
+					Values:  "global",
+				},
+			},
+			Query: new(getAbsResourceRangeOrPanic(`module.vps["us-central1"].tofu_network.spiderweb`)),
+			Want:  new("global"),
+		},
+		{
+			TestName: "use default",
+			Overrides: []override{
+				{
+					Address: new(getAbsResourceRangeOrPanic(`module.vps["apac"].tofu_network.spiderweb`)),
+					Values:  "australia",
+				},
+			},
+			Query:       new(getAbsResourceRangeOrPanic(`module.vps["us-central1"].tofu_network.spiderweb`)),
+			WantMissing: true,
+			Want:        new("somewhere"),
+		},
+		{
+			TestName: "error on wildcard",
+			Overrides: []override{
+				{
+					Address: new(getAbsResourceRangeOrPanic(`module.vps["apac"].tofu_network.spiderweb`)),
+					Values:  "australia",
+				},
+			},
+			Query:     new(getAbsResourceRangeOrPanic(`module.vps[*].tofu_network.spiderweb`)),
+			WantError: true,
+		},
+		{
+			TestName: "wildcard fallback",
+			Overrides: []override{
+				{
+					Address: new(getAbsResourceRangeOrPanic(`module.vps[*].module.subnet[*].tofu_network.spiderweb["a"]`)),
+					Values:  "australia",
+				},
+				{
+					Address: new(getAbsResourceRangeOrPanic(`module.vps["a"].module.subnet["a"].tofu_network.spiderweb["b"]`)),
+					Values:  "burkina faso",
+				},
+			},
+			Query: new(getAbsResourceRangeOrPanic(`module.vps["a"].module.subnet["a"].tofu_network.spiderweb["a"]`)),
+			Want:  new("australia"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.TestName, func(t *testing.T) {
+			trie := NewOverrideTrie[string]()
+			for _, override := range test.Overrides {
+				trie.Set(override.Address, override.Values)
+			}
+
+			got, diags := trie.Get(test.Query)
+			if diags.HasErrors() {
+				if !test.WantError {
+					// unexpectedly encountered an error
+					t.Errorf("got an error from trie override retrieval: %s", diags.Err().Error())
+				}
+				return
+			} else {
+				if test.WantError {
+					t.Fatal("expected an error, but did not get one")
+				}
+			}
+
+			if test.WantMissing && got != nil {
+				t.Error("expected to get nothing, but found something")
+			}
+			if !test.WantMissing && got == nil {
+				t.Error("expected something, but didn't find anything")
+			} else if !test.WantMissing && *test.Want != *got {
+				t.Errorf("wrong result: expected %s, got %s\n", *test.Want, *got)
+			}
+		})
+	}
+}

--- a/internal/addrs/override_trie_test.go
+++ b/internal/addrs/override_trie_test.go
@@ -7,10 +7,12 @@ package addrs
 import (
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
-// shorthand function to obtain known good strings.
-// Please please please do not use this outside of tests!!!
+// mustAbsResourceRange parses the given string into an AbsResourceInstance.
+// If the given string is not parsable, it panics.
 func mustAbsResourceRange(str string) AbsResourceInstance {
 	out, diags := parseAbsResourceRangeStr(str)
 	if diags.HasErrors() {
@@ -30,7 +32,6 @@ func TestOverrideTrie(t *testing.T) {
 		Default     string
 		Overrides   []override
 		Query       *AbsResourceInstance
-		WantMissing bool
 		ErrorSubstr string
 		Want        *string
 	}{
@@ -64,9 +65,7 @@ func TestOverrideTrie(t *testing.T) {
 					Value:   "australia",
 				},
 			},
-			Query:       new(mustAbsResourceRange(`module.vps["us-central1"].tofu_network.spiderweb`)),
-			WantMissing: true,
-			Want:        new("somewhere"),
+			Query: new(mustAbsResourceRange(`module.vps["us-central1"].tofu_network.spiderweb`)),
 		},
 		{
 			TestName: "error on wildcard",
@@ -103,30 +102,24 @@ func TestOverrideTrie(t *testing.T) {
 			}
 
 			got, diags := trie.Get(test.Query)
+			var gotErr string
 			if diags.HasErrors() {
-				if test.ErrorSubstr == "" {
-					// unexpectedly encountered an error
-					t.Errorf("got an error from trie override retrieval: %s", diags.Err().Error())
-				} else if got != nil {
-					// we always expect a nil return when there's an error
-					t.Errorf("got an error and expected no return value, but got: %s", *got)
-				} else if !strings.Contains(diags.Err().Error(), test.ErrorSubstr) {
-					t.Errorf("expected error to contain %s, but it did not: %s", test.ErrorSubstr, diags.Err().Error())
-				}
-				return
-			} else {
-				if test.ErrorSubstr != "" {
-					t.Fatal("expected an error, but did not get one")
-				}
+				gotErr = diags.Err().Error()
 			}
 
-			if test.WantMissing && got != nil {
-				t.Error("expected to get nothing, but found something")
+			// if ErrorSubstr is empty, this checks that there were no errors
+			if !strings.Contains(gotErr, test.ErrorSubstr) {
+				// this is incorrect:
+				if test.ErrorSubstr == "" {
+					// we either got an error when we didn't expect...
+					t.Errorf("unexpected error encountered: %s", gotErr)
+				} else {
+					// or got no error when we *were* expecting one
+					t.Errorf("expected error containing \"%s\", but no error was returned", test.ErrorSubstr)
+				}
 			}
-			if !test.WantMissing && got == nil {
-				t.Error("expected something, but didn't find anything")
-			} else if !test.WantMissing && *test.Want != *got {
-				t.Errorf("wrong result: expected %s, got %s\n", *test.Want, *got)
+			if diff := cmp.Diff(test.Want, got); diff != "" {
+				t.Errorf("unexpected returned value (-want,+got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/addrs/override_trie_test.go
+++ b/internal/addrs/override_trie_test.go
@@ -5,12 +5,13 @@
 package addrs
 
 import (
+	"strings"
 	"testing"
 )
 
 // shorthand function to obtain known good strings.
 // Please please please do not use this outside of tests!!!
-func getAbsResourceRangeOrPanic(str string) AbsResourceInstance {
+func mustAbsResourceRange(str string) AbsResourceInstance {
 	out, diags := parseAbsResourceRangeStr(str)
 	if diags.HasErrors() {
 		panic(diags)
@@ -20,7 +21,7 @@ func getAbsResourceRangeOrPanic(str string) AbsResourceInstance {
 
 type override struct {
 	Address *AbsResourceInstance
-	Values  string
+	Value   string
 }
 
 func TestOverrideTrie(t *testing.T) {
@@ -30,40 +31,40 @@ func TestOverrideTrie(t *testing.T) {
 		Overrides   []override
 		Query       *AbsResourceInstance
 		WantMissing bool
-		WantError   bool
+		ErrorSubstr string
 		Want        *string
 	}{
 		{
 			TestName: "basic input",
 			Overrides: []override{
 				{
-					Address: new(getAbsResourceRangeOrPanic(`module.vps["us-central1"].tofu_network.spiderweb`)),
-					Values:  "usa",
+					Address: new(mustAbsResourceRange(`module.vps["us-central1"].tofu_network.spiderweb`)),
+					Value:   "usa",
 				},
 			},
-			Query: new(getAbsResourceRangeOrPanic(`module.vps["us-central1"].tofu_network.spiderweb`)),
+			Query: new(mustAbsResourceRange(`module.vps["us-central1"].tofu_network.spiderweb`)),
 			Want:  new("usa"),
 		},
 		{
 			TestName: "wildcard override",
 			Overrides: []override{
 				{
-					Address: new(getAbsResourceRangeOrPanic(`module.vps[*].tofu_network.spiderweb`)),
-					Values:  "global",
+					Address: new(mustAbsResourceRange(`module.vps[*].tofu_network.spiderweb`)),
+					Value:   "global",
 				},
 			},
-			Query: new(getAbsResourceRangeOrPanic(`module.vps["us-central1"].tofu_network.spiderweb`)),
+			Query: new(mustAbsResourceRange(`module.vps["us-central1"].tofu_network.spiderweb`)),
 			Want:  new("global"),
 		},
 		{
 			TestName: "use default",
 			Overrides: []override{
 				{
-					Address: new(getAbsResourceRangeOrPanic(`module.vps["apac"].tofu_network.spiderweb`)),
-					Values:  "australia",
+					Address: new(mustAbsResourceRange(`module.vps["apac"].tofu_network.spiderweb`)),
+					Value:   "australia",
 				},
 			},
-			Query:       new(getAbsResourceRangeOrPanic(`module.vps["us-central1"].tofu_network.spiderweb`)),
+			Query:       new(mustAbsResourceRange(`module.vps["us-central1"].tofu_network.spiderweb`)),
 			WantMissing: true,
 			Want:        new("somewhere"),
 		},
@@ -71,26 +72,26 @@ func TestOverrideTrie(t *testing.T) {
 			TestName: "error on wildcard",
 			Overrides: []override{
 				{
-					Address: new(getAbsResourceRangeOrPanic(`module.vps["apac"].tofu_network.spiderweb`)),
-					Values:  "australia",
+					Address: new(mustAbsResourceRange(`module.vps["apac"].tofu_network.spiderweb`)),
+					Value:   "australia",
 				},
 			},
-			Query:     new(getAbsResourceRangeOrPanic(`module.vps[*].tofu_network.spiderweb`)),
-			WantError: true,
+			Query:       new(mustAbsResourceRange(`module.vps[*].tofu_network.spiderweb`)),
+			ErrorSubstr: "Wildcard key not expected",
 		},
 		{
 			TestName: "wildcard fallback",
 			Overrides: []override{
 				{
-					Address: new(getAbsResourceRangeOrPanic(`module.vps[*].module.subnet[*].tofu_network.spiderweb["a"]`)),
-					Values:  "australia",
+					Address: new(mustAbsResourceRange(`module.vps[*].module.subnet[*].tofu_network.spiderweb["a"]`)),
+					Value:   "australia",
 				},
 				{
-					Address: new(getAbsResourceRangeOrPanic(`module.vps["a"].module.subnet["a"].tofu_network.spiderweb["b"]`)),
-					Values:  "burkina faso",
+					Address: new(mustAbsResourceRange(`module.vps["a"].module.subnet["a"].tofu_network.spiderweb["b"]`)),
+					Value:   "burkina faso",
 				},
 			},
-			Query: new(getAbsResourceRangeOrPanic(`module.vps["a"].module.subnet["a"].tofu_network.spiderweb["a"]`)),
+			Query: new(mustAbsResourceRange(`module.vps["a"].module.subnet["a"].tofu_network.spiderweb["a"]`)),
 			Want:  new("australia"),
 		},
 	}
@@ -98,18 +99,23 @@ func TestOverrideTrie(t *testing.T) {
 		t.Run(test.TestName, func(t *testing.T) {
 			trie := NewOverrideTrie[string]()
 			for _, override := range test.Overrides {
-				trie.Set(override.Address, override.Values, nil)
+				trie.Set(override.Address, override.Value, nil)
 			}
 
 			got, diags := trie.Get(test.Query)
 			if diags.HasErrors() {
-				if !test.WantError {
+				if test.ErrorSubstr == "" {
 					// unexpectedly encountered an error
 					t.Errorf("got an error from trie override retrieval: %s", diags.Err().Error())
+				} else if got != nil {
+					// we always expect a nil return when there's an error
+					t.Errorf("got an error and expected no return value, but got: %s", *got)
+				} else if !strings.Contains(diags.Err().Error(), test.ErrorSubstr) {
+					t.Errorf("expected error to contain %s, but it did not: %s", test.ErrorSubstr, diags.Err().Error())
 				}
 				return
 			} else {
-				if test.WantError {
+				if test.ErrorSubstr != "" {
 					t.Fatal("expected an error, but did not get one")
 				}
 			}

--- a/internal/addrs/override_trie_test.go
+++ b/internal/addrs/override_trie_test.go
@@ -6,33 +6,7 @@ package addrs
 
 import (
 	"testing"
-
-	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/hclsyntax"
-	"github.com/opentofu/opentofu/internal/tfdiags"
 )
-
-// parseAbsResourceRangeStr is copied from ParseAbsResourceInstanceStr (more or less),
-// but with functions edited to refer to ranges instead.
-// TODO should this be outside of the test file?
-func parseAbsResourceRangeStr(str string) (AbsResourceInstance, tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-	expr, parseDiags := hclsyntax.ParseExpression([]byte(str), "", hcl.InitialPos)
-	diags = diags.Append(parseDiags)
-	if parseDiags.HasErrors() {
-		return AbsResourceInstance{}, diags
-	}
-
-	traversal, parseDiags := hcl.AbsTraversalPatternForExpr(expr)
-	diags = diags.Append(parseDiags)
-	if parseDiags.HasErrors() {
-		return AbsResourceInstance{}, diags
-	}
-
-	addr, addrDiags := ParseAbsResourceRange(traversal)
-	diags = diags.Append(addrDiags)
-	return addr, diags
-}
 
 // shorthand function to obtain known good strings.
 // Please please please do not use this outside of tests!!!
@@ -124,7 +98,7 @@ func TestOverrideTrie(t *testing.T) {
 		t.Run(test.TestName, func(t *testing.T) {
 			trie := NewOverrideTrie[string]()
 			for _, override := range test.Overrides {
-				trie.Set(override.Address, override.Values)
+				trie.Set(override.Address, override.Values, nil)
 			}
 
 			got, diags := trie.Get(test.Query)

--- a/internal/addrs/parse_target.go
+++ b/internal/addrs/parse_target.go
@@ -361,6 +361,27 @@ func ParseAbsResourceRange(traversal hcl.Traversal) (AbsResourceInstance, tfdiag
 	return parseAbsResourceInstance(traversal, true)
 }
 
+// parseAbsResourceRangeStr is copied from ParseAbsResourceInstanceStr (more or less),
+// but with functions edited to refer to ranges instead.
+func parseAbsResourceRangeStr(str string) (AbsResourceInstance, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	expr, parseDiags := hclsyntax.ParseExpression([]byte(str), "", hcl.InitialPos)
+	diags = diags.Append(parseDiags)
+	if parseDiags.HasErrors() {
+		return AbsResourceInstance{}, diags
+	}
+
+	traversal, parseDiags := hcl.AbsTraversalPatternForExpr(expr)
+	diags = diags.Append(parseDiags)
+	if parseDiags.HasErrors() {
+		return AbsResourceInstance{}, diags
+	}
+
+	addr, addrDiags := ParseAbsResourceRange(traversal)
+	diags = diags.Append(addrDiags)
+	return addr, diags
+}
+
 // ParseAbsResourceInstance attempts to interpret the given traversal as an
 // absolute resource instance address, using the same syntax as expected by
 // ParseTarget.

--- a/internal/addrs/parse_target.go
+++ b/internal/addrs/parse_target.go
@@ -30,7 +30,11 @@ type Target struct {
 // If error diagnostics are returned then the Target value is invalid and
 // must not be used.
 func ParseTarget(traversal hcl.Traversal) (*Target, tfdiags.Diagnostics) {
-	path, remain, diags := parseModuleInstancePrefix(traversal)
+	return parseTarget(traversal, false)
+}
+
+func parseTarget(traversal hcl.Traversal, allowRanges bool) (*Target, tfdiags.Diagnostics) {
+	path, remain, diags := parseModuleInstancePrefixWithOptionalRanges(traversal, allowRanges)
 	if diags.HasErrors() {
 		return nil, diags
 	}
@@ -44,7 +48,7 @@ func ParseTarget(traversal hcl.Traversal) (*Target, tfdiags.Diagnostics) {
 		}, diags
 	}
 
-	riAddr, moreDiags := parseResourceInstanceUnderModule(path, remain)
+	riAddr, moreDiags := parseResourceInstanceUnderModule(path, remain, allowRanges)
 	diags = diags.Append(moreDiags)
 	if diags.HasErrors() {
 		return nil, diags
@@ -67,7 +71,7 @@ func ParseTarget(traversal hcl.Traversal) (*Target, tfdiags.Diagnostics) {
 	}, diags
 }
 
-func parseResourceInstanceUnderModule(moduleAddr ModuleInstance, remain hcl.Traversal) (AbsResourceInstance, tfdiags.Diagnostics) {
+func parseResourceInstanceUnderModule(moduleAddr ModuleInstance, remain hcl.Traversal, allowRanges bool) (AbsResourceInstance, tfdiags.Diagnostics) {
 	// Note that this helper is used as part of multiple public functions
 	// so its error messages should be generic enough to suit all the situations.
 
@@ -106,6 +110,9 @@ func parseResourceInstanceUnderModule(moduleAddr ModuleInstance, remain hcl.Trav
 			}
 
 			return moduleAddr.ResourceInstance(mode, typeName, name, key), diags
+
+		} else if _, ok := remain[0].(hcl.TraverseSplat); allowRanges && ok {
+			return moduleAddr.ResourceInstance(mode, typeName, name, WildcardKey{UnknownKeyType}), diags
 		} else {
 			diags = diags.Append(&hcl.Diagnostic{
 				Severity: hcl.DiagError,
@@ -350,6 +357,10 @@ func ParseAbsResourceStr(str string) (AbsResource, tfdiags.Diagnostics) {
 	return addr, diags
 }
 
+func ParseAbsResourceRange(traversal hcl.Traversal) (AbsResourceInstance, tfdiags.Diagnostics) {
+	return parseAbsResourceInstance(traversal, true)
+}
+
 // ParseAbsResourceInstance attempts to interpret the given traversal as an
 // absolute resource instance address, using the same syntax as expected by
 // ParseTarget.
@@ -360,7 +371,11 @@ func ParseAbsResourceStr(str string) (AbsResource, tfdiags.Diagnostics) {
 // If error diagnostics are returned then the AbsResource value is invalid and
 // must not be used.
 func ParseAbsResourceInstance(traversal hcl.Traversal) (AbsResourceInstance, tfdiags.Diagnostics) {
-	addr, diags := ParseTarget(traversal)
+	return parseAbsResourceInstance(traversal, false)
+}
+
+func parseAbsResourceInstance(traversal hcl.Traversal, allowRanges bool) (AbsResourceInstance, tfdiags.Diagnostics) {
+	addr, diags := parseTarget(traversal, allowRanges)
 	if diags.HasErrors() {
 		return AbsResourceInstance{}, diags
 	}

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -1654,3 +1654,139 @@ func TestTest_DeprecatedOutputs(t *testing.T) {
 		t.Fatalf("expected status code 0 but got %d: %s", code, output.All())
 	}
 }
+
+func TestTest_InstanceOverride(t *testing.T) {
+	tcs := map[string]struct {
+		expected    string
+		expectedErr string
+		code        int
+	}{
+		"default": {
+			expected: "2 passed, 0 failed.",
+			code:     0,
+		},
+		"default_provider": {
+			expected: "2 passed, 0 failed.",
+			code:     0,
+		},
+		"instance": {
+			expected: "1 passed, 1 failed.",
+			code:     1,
+		},
+		"instance_provider": {
+			expected: "1 passed, 1 failed.",
+			code:     1,
+		},
+		"default_instance_mixed": {
+			expected: "3 passed, 0 failed.",
+			code:     0,
+		},
+		"default_instance_wildcard": {
+			expected: "3 passed, 0 failed.",
+			code:     0,
+		},
+		"default_instance_mixed_provider": {
+			expected: "3 passed, 0 failed.",
+			code:     0,
+		},
+		"resource_and_provider": {
+			expected: "2 passed, 0 failed.",
+			code:     0,
+		},
+		"resource_precedes_provider": {
+			expected: "2 passed, 0 failed.",
+			code:     0,
+		},
+		"module_1": {
+			expected: "3 passed, 0 failed.",
+			code:     0,
+		},
+		"module_2": {
+			expected: "3 passed, 0 failed.",
+			code:     0,
+		},
+		"mixed_syntax": {
+			expectedErr: "override address cannot contain unkeyed for-each resources if it is also using the wildcard syntax",
+			code:        1,
+		},
+		"uninstanced_module": {
+			expected: "1 passed, 1 failed.",
+			code:     1,
+		},
+		"module_data": {
+			expected: "2 passed, 0 failed.",
+			code:     0,
+		},
+		"module_json": {
+			expected: "3 passed, 0 failed.",
+			code:     0,
+		},
+	}
+
+	providerSource, close := newMockProviderSource(t, map[string][]string{
+		"test": {"1.0.0"},
+	})
+	defer close()
+	for name, tc := range tcs {
+		t.Run(name, func(t *testing.T) {
+			tftestHCLDir := fmt.Sprintf("override_instance_%s", name)
+			td := t.TempDir()
+			testCopyDir(t, testFixturePath(path.Join("test", "override_instance_base")), td)
+			testCopyDir(t, testFixturePath(path.Join("test", tftestHCLDir)), td)
+			t.Chdir(td)
+
+			provider := testing_command.NewProvider(nil)
+			view, done := testView(t)
+
+			// HACK:
+			// When using overrides, a test framework provider is used, which ignores
+			// calls to the ConfigureProvider method. However, the underlying
+			// MockProvider expects its ConfigureProvider to be called, and returns
+			// an error if its internal ConfigureProviderCalled flag is false. So,
+			// we are setting it to true here, as that configuration isn't what we're
+			// testing.
+			provider.Provider.ConfigureProviderCalled = true
+
+			meta := Meta{
+				WorkingDir:       workdir.NewDir("."),
+				testingOverrides: metaOverridesForProvider(provider.Provider),
+				View:             view,
+				ProviderSource:   providerSource,
+			}
+
+			init := &InitCommand{
+				Meta: meta,
+			}
+
+			initCode := init.Run(nil)
+
+			if initCode != 0 {
+				initOutput := done(t)
+				t.Fatalf("expected status code 0 but got %d: %s", initCode, initOutput.Stderr())
+			}
+
+			c := &TestCommand{
+				Meta: meta,
+			}
+
+			code := c.Run(nil)
+			output := done(t)
+
+			if code != tc.code {
+				t.Errorf("expected status code %d but got %d\n", tc.code, code)
+			}
+
+			if !strings.Contains(output.Stdout(), tc.expected) {
+				t.Errorf("output didn't contain expected string \"%s\":\n\n%s\n", tc.expected, output.All())
+			}
+
+			if !strings.Contains(output.Stderr(), tc.expectedErr) {
+				t.Errorf("errors didn't contain expected string \"%s\":\n\n%s\n", tc.expectedErr, output.All())
+			}
+
+			if provider.ResourceCount() > 0 {
+				t.Errorf("should have deleted all resources on completion but left %v\n", provider.ResourceString())
+			}
+		})
+	}
+}

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -1706,7 +1706,7 @@ func TestTest_InstanceOverride(t *testing.T) {
 			code:     0,
 		},
 		"mixed_syntax": {
-			expectedErr: "Please switch overrides to wildcard syntax",
+			expectedErr: "Invalid resource override usage",
 			code:        1,
 		},
 		"uninstanced_module": {

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -1706,7 +1706,7 @@ func TestTest_InstanceOverride(t *testing.T) {
 			code:     0,
 		},
 		"mixed_syntax": {
-			expectedErr: "override address cannot contain unkeyed for-each resources if it is also using the wildcard syntax",
+			expectedErr: "Please switch overrides to wildcard syntax",
 			code:        1,
 		},
 		"uninstanced_module": {

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -1703,7 +1703,7 @@ func TestTest_InstanceOverride(t *testing.T) {
 			code:     0,
 		},
 		"mixed_syntax": {
-			expectedErr: "Please switch overrides to wildcard syntax",
+			expectedErr: "Invalid resource override usage",
 			code:        1,
 		},
 		"uninstanced_module": {

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -1703,7 +1703,7 @@ func TestTest_InstanceOverride(t *testing.T) {
 			code:     0,
 		},
 		"mixed_syntax": {
-			expectedErr: "override address cannot contain unkeyed for-each resources if it is also using the wildcard syntax",
+			expectedErr: "Please switch overrides to wildcard syntax",
 			code:        1,
 		},
 		"uninstanced_module": {

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -1651,3 +1651,139 @@ func TestTest_DeprecatedOutputs(t *testing.T) {
 		t.Fatalf("expected status code 0 but got %d: %s", code, output.All())
 	}
 }
+
+func TestTest_InstanceOverride(t *testing.T) {
+	tcs := map[string]struct {
+		expected    string
+		expectedErr string
+		code        int
+	}{
+		"default": {
+			expected: "2 passed, 0 failed.",
+			code:     0,
+		},
+		"default_provider": {
+			expected: "2 passed, 0 failed.",
+			code:     0,
+		},
+		"instance": {
+			expected: "1 passed, 1 failed.",
+			code:     1,
+		},
+		"instance_provider": {
+			expected: "1 passed, 1 failed.",
+			code:     1,
+		},
+		"default_instance_mixed": {
+			expected: "3 passed, 0 failed.",
+			code:     0,
+		},
+		"default_instance_wildcard": {
+			expected: "3 passed, 0 failed.",
+			code:     0,
+		},
+		"default_instance_mixed_provider": {
+			expected: "3 passed, 0 failed.",
+			code:     0,
+		},
+		"resource_and_provider": {
+			expected: "2 passed, 0 failed.",
+			code:     0,
+		},
+		"resource_precedes_provider": {
+			expected: "2 passed, 0 failed.",
+			code:     0,
+		},
+		"module_1": {
+			expected: "3 passed, 0 failed.",
+			code:     0,
+		},
+		"module_2": {
+			expected: "3 passed, 0 failed.",
+			code:     0,
+		},
+		"mixed_syntax": {
+			expectedErr: "override address cannot contain unkeyed for-each resources if it is also using the wildcard syntax",
+			code:        1,
+		},
+		"uninstanced_module": {
+			expected: "1 passed, 1 failed.",
+			code:     1,
+		},
+		"module_data": {
+			expected: "2 passed, 0 failed.",
+			code:     0,
+		},
+		"module_json": {
+			expected: "3 passed, 0 failed.",
+			code:     0,
+		},
+	}
+
+	providerSource, close := newMockProviderSource(t, map[string][]string{
+		"test": {"1.0.0"},
+	})
+	defer close()
+	for name, tc := range tcs {
+		t.Run(name, func(t *testing.T) {
+			tftestHCLDir := fmt.Sprintf("override_instance_%s", name)
+			td := t.TempDir()
+			testCopyDir(t, testFixturePath(path.Join("test", "override_instance_base")), td)
+			testCopyDir(t, testFixturePath(path.Join("test", tftestHCLDir)), td)
+			t.Chdir(td)
+
+			provider := testing_command.NewProvider(nil)
+			view, done := testView(t)
+
+			// HACK:
+			// When using overrides, a test framework provider is used, which ignores
+			// calls to the ConfigureProvider method. However, the underlying
+			// MockProvider expects its ConfigureProvider to be called, and returns
+			// an error if its internal ConfigureProviderCalled flag is false. So,
+			// we are setting it to true here, as that configuration isn't what we're
+			// testing.
+			provider.Provider.ConfigureProviderCalled = true
+
+			meta := Meta{
+				WorkingDir:       workdir.NewDir("."),
+				testingOverrides: metaOverridesForProvider(provider.Provider),
+				View:             view,
+				ProviderSource:   providerSource,
+			}
+
+			init := &InitCommand{
+				Meta: meta,
+			}
+
+			initCode := init.Run(nil)
+
+			if initCode != 0 {
+				initOutput := done(t)
+				t.Fatalf("expected status code 0 but got %d: %s", initCode, initOutput.Stderr())
+			}
+
+			c := &TestCommand{
+				Meta: meta,
+			}
+
+			code := c.Run(nil)
+			output := done(t)
+
+			if code != tc.code {
+				t.Errorf("expected status code %d but got %d\n", tc.code, code)
+			}
+
+			if !strings.Contains(output.Stdout(), tc.expected) {
+				t.Errorf("output didn't contain expected string \"%s\":\n\n%s\n", tc.expected, output.All())
+			}
+
+			if !strings.Contains(output.Stderr(), tc.expectedErr) {
+				t.Errorf("errors didn't contain expected string \"%s\":\n\n%s\n", tc.expectedErr, output.All())
+			}
+
+			if provider.ResourceCount() > 0 {
+				t.Errorf("should have deleted all resources on completion but left %v\n", provider.ResourceString())
+			}
+		})
+	}
+}

--- a/internal/command/testdata/test/override_instance_base/dog_house/main.tf
+++ b/internal/command/testdata/test/override_instance_base/dog_house/main.tf
@@ -1,0 +1,36 @@
+locals {
+    my_pets = toset(["dino", "astro", "scoob"])
+}
+
+resource "test_resource" "dogs" {
+    for_each = local.my_pets
+}
+
+data "test_data_source" "water_bowl" {
+    for_each = local.my_pets
+    id = "whatever"
+}
+
+output "flintstones" {
+    value = test_resource.dogs["dino"].id 
+}
+
+output "jetsons" {
+    value = test_resource.dogs["astro"].id 
+}
+
+output "shaggy" {
+    value = test_resource.dogs["scoob"].id 
+}
+
+output "stone_bowl" {
+    value = "${test_resource.dogs["dino"].id} drinks from a ${data.test_data_source.water_bowl["dino"].value}"
+}
+
+output "space_bowl" {
+    value = "${test_resource.dogs["astro"].id} drinks from a ${data.test_data_source.water_bowl["astro"].value}"
+}
+
+output "spooky_bowl" {
+    value = "${test_resource.dogs["scoob"].id} drinks from a ${data.test_data_source.water_bowl["scoob"].value}"
+}

--- a/internal/command/testdata/test/override_instance_base/main.tf
+++ b/internal/command/testdata/test/override_instance_base/main.tf
@@ -1,0 +1,84 @@
+locals {
+    my_pets = toset(["pet_a", "pet_b", "pet_c"])
+    universes = toset(["a", "b", "c"])
+}
+
+resource "test_resource" "cats" {
+    for_each = local.my_pets
+}
+
+output "pet_a_greeting" {
+    value = "Hi ${test_resource.cats["pet_a"].id}"
+}
+output "pet_b_greeting" {
+    value = "Hello ${test_resource.cats["pet_b"].id}"
+}
+output "pet_c_greeting" {
+    value = "Sup ${test_resource.cats["pet_c"].id}"
+}
+
+module dog_houses {
+    source = "./dog_house"
+    for_each = local.universes
+}
+
+module concrete_dog_house {
+    source = "./dog_house"
+}
+
+output "dino_a_greeting" {
+    value = "Hey there, ${module.dog_houses["a"].flintstones}"
+}
+
+output "dino_b_greeting" {
+    value = "Ooga Booga, ${module.dog_houses["b"].flintstones}"
+}
+
+output "dino_c_greeting" {
+    value = "*random grunts*, ${module.dog_houses["c"].flintstones}"
+}
+
+output "astro_a_greeting" {
+    value = "Greetings, ${module.dog_houses["a"].jetsons}"
+}
+
+output "astro_b_greeting" {
+    value = "Avast, ${module.dog_houses["b"].jetsons}"
+}
+
+output "astro_c_greeting" {
+    value = "*random beeps*, ${module.dog_houses["c"].jetsons}"
+}
+
+output "scoob_a_greeting" {
+    value = "Zoinks, ${module.dog_houses["a"].shaggy}"
+}
+
+output "scoob_b_greeting" {
+    value = "Jeepers, ${module.dog_houses["b"].shaggy}"
+}
+
+output "scoob_c_greeting" {
+    value = "Jinkies, ${module.dog_houses["c"].shaggy}"
+}
+
+output "dino_concrete_greeting" {
+    value = "Hello, ${module.concrete_dog_house.flintstones}"
+}
+
+output "astro_concrete_greeting" {
+    value = "Hello, ${module.concrete_dog_house.jetsons}"
+}
+
+output "scoob_concrete_greeting" {
+    value = "Hello, ${module.concrete_dog_house.shaggy}"
+}
+
+output "scoob_a_bowl" {
+    value = module.dog_houses["a"].spooky_bowl
+}
+
+output "astro_c_bowl" {
+    value = module.dog_houses["c"].space_bowl
+}
+

--- a/internal/command/testdata/test/override_instance_default/main_provider.tftest.hcl
+++ b/internal/command/testdata/test/override_instance_default/main_provider.tftest.hcl
@@ -1,0 +1,23 @@
+mock_provider "test" {
+}
+
+override_resource {
+    target = test_resource.cats
+    values = {
+        id = "Lassie"
+    }
+}
+
+run "test_a" {
+    assert {
+        condition = strcontains(output.pet_a_greeting, "Hi Lassie")
+        error_message = "Woops thats not what that output should be"
+    }
+}
+
+run "test_b" {
+    assert {
+        condition = strcontains(output.pet_b_greeting, "Hello Lassie")
+        error_message = "Woops thats not what that output should be"
+    }
+}

--- a/internal/command/testdata/test/override_instance_default_instance_mixed/main_provider.tftest.hcl
+++ b/internal/command/testdata/test/override_instance_default_instance_mixed/main_provider.tftest.hcl
@@ -1,0 +1,45 @@
+
+mock_provider "test" {
+}
+
+override_resource {
+    target = test_resource.cats["pet_a"]
+    values = {
+        id = "Lassie"
+    }
+}
+
+override_resource {
+    target = test_resource.cats
+    values = {
+        id = "Baby"
+    }
+}
+
+override_resource {
+    target = test_resource.cats["pet_c"]
+    values = {
+        id = "Babby"
+    }
+}
+
+run "test_a" {
+    assert {
+        condition = strcontains(output.pet_a_greeting, "Hi Lassie")
+        error_message = "Woops thats not what that output should be"
+    }
+}
+
+run "test_b" {
+    assert {
+        condition = strcontains(output.pet_b_greeting, "Hello Baby")
+        error_message = "Woops thats not what that output should be"
+    }
+}
+
+run "test_c" {
+    assert {
+        condition = strcontains(output.pet_c_greeting, "Sup Babby")
+        error_message = "Woops thats not what that output should be"
+    }
+}

--- a/internal/command/testdata/test/override_instance_default_instance_mixed_provider/main_provider.tftest.hcl
+++ b/internal/command/testdata/test/override_instance_default_instance_mixed_provider/main_provider.tftest.hcl
@@ -1,0 +1,44 @@
+
+mock_provider "test" {
+    override_resource {
+        target = test_resource.cats["pet_a"]
+        values = {
+            id = "Lassie"
+        }
+    }
+
+    override_resource {
+        target = test_resource.cats
+        values = {
+            id = "Baby"
+        }
+    }
+
+    override_resource {
+        target = test_resource.cats["pet_c"]
+        values = {
+            id = "Babby"
+        }
+    }
+}
+
+run "test_a" {
+    assert {
+        condition = strcontains(output.pet_a_greeting, "Hi Lassie")
+        error_message = "Woops thats not what that output should be"
+    }
+}
+
+run "test_b" {
+    assert {
+        condition = strcontains(output.pet_b_greeting, "Hello Baby")
+        error_message = "Woops thats not what that output should be"
+    }
+}
+
+run "test_c" {
+    assert {
+        condition = strcontains(output.pet_c_greeting, "Sup Babby")
+        error_message = "Woops thats not what that output should be"
+    }
+}

--- a/internal/command/testdata/test/override_instance_default_instance_wildcard/main_provider.tftest.hcl
+++ b/internal/command/testdata/test/override_instance_default_instance_wildcard/main_provider.tftest.hcl
@@ -1,0 +1,45 @@
+
+mock_provider "test" {
+}
+
+override_resource {
+    target = test_resource.cats["pet_a"]
+    values = {
+        id = "Lassie"
+    }
+}
+
+override_resource {
+    target = test_resource.cats[*]
+    values = {
+        id = "Baby"
+    }
+}
+
+override_resource {
+    target = test_resource.cats["pet_c"]
+    values = {
+        id = "Babby"
+    }
+}
+
+run "test_a" {
+    assert {
+        condition = strcontains(output.pet_a_greeting, "Hi Lassie")
+        error_message = "Woops thats not what that output should be"
+    }
+}
+
+run "test_b" {
+    assert {
+        condition = strcontains(output.pet_b_greeting, "Hello Baby")
+        error_message = "Woops thats not what that output should be"
+    }
+}
+
+run "test_c" {
+    assert {
+        condition = strcontains(output.pet_c_greeting, "Sup Babby")
+        error_message = "Woops thats not what that output should be"
+    }
+}

--- a/internal/command/testdata/test/override_instance_default_provider/main_provider.tftest.hcl
+++ b/internal/command/testdata/test/override_instance_default_provider/main_provider.tftest.hcl
@@ -1,0 +1,22 @@
+mock_provider "test" {
+    override_resource {
+        target = test_resource.cats
+        values = {
+            id = "Lassie"
+        }
+    }
+}
+
+run "test_a" {
+    assert {
+        condition = strcontains(output.pet_a_greeting, "Hi Lassie")
+        error_message = "Woops thats not what that output should be"
+    }
+}
+
+run "test_b" {
+    assert {
+        condition = strcontains(output.pet_b_greeting, "Hello Lassie")
+        error_message = "Woops thats not what that output should be"
+    }
+}

--- a/internal/command/testdata/test/override_instance_instance/main_provider.tftest.hcl
+++ b/internal/command/testdata/test/override_instance_instance/main_provider.tftest.hcl
@@ -1,0 +1,23 @@
+mock_provider "test" {
+}
+
+override_resource {
+    target = test_resource.cats["pet_a"]
+    values = {
+        id = "Lassie"
+    }
+}
+
+run "test_a" {
+    assert {
+        condition = strcontains(output.pet_a_greeting, "Hi Lassie")
+        error_message = "Woops thats not what that output should be"
+    }
+}
+
+run "test_b" {
+    assert {
+        condition = strcontains(output.pet_b_greeting, "Hello Lassie")
+        error_message = "Woops thats not what that output should be"
+    }
+}

--- a/internal/command/testdata/test/override_instance_instance_provider/main_provider.tftest.hcl
+++ b/internal/command/testdata/test/override_instance_instance_provider/main_provider.tftest.hcl
@@ -1,0 +1,22 @@
+mock_provider "test" {
+    override_resource {
+        target = test_resource.cats["pet_a"]
+        values = {
+            id = "Lassie"
+        }
+    }
+}
+
+run "test_a" {
+    assert {
+        condition = strcontains(output.pet_a_greeting, "Hi Lassie")
+        error_message = "Woops thats not what that output should be"
+    }
+}
+
+run "test_b" {
+    assert {
+        condition = strcontains(output.pet_b_greeting, "Hello Lassie")
+        error_message = "Woops thats not what that output should be"
+    }
+}

--- a/internal/command/testdata/test/override_instance_mixed_syntax/main_provider.tftest.hcl
+++ b/internal/command/testdata/test/override_instance_mixed_syntax/main_provider.tftest.hcl
@@ -1,0 +1,16 @@
+mock_provider "test" {
+}
+
+override_resource {
+    target = module.dog_houses.test_resource.dogs[*]
+    values = {
+        id = "Woofer"
+    }
+}
+
+run "test_a" {
+    assert {
+        condition = strcontains(output.scoob_b_greeting, "Jeepers, Woofer")
+        error_message = "Woops thats not what that output should be"
+    }
+}

--- a/internal/command/testdata/test/override_instance_module_1/main_provider.tftest.hcl
+++ b/internal/command/testdata/test/override_instance_module_1/main_provider.tftest.hcl
@@ -1,0 +1,30 @@
+mock_provider "test" {
+}
+
+override_resource {
+    target = module.dog_houses.test_resource.dogs
+    values = {
+        id = "Puppy"
+    }
+}
+
+run "test_a" {
+    assert {
+        condition = strcontains(output.dino_a_greeting, "Hey there, Puppy")
+        error_message = "Woops thats not what that output should be"
+    }
+}
+
+run "test_b" {
+    assert {
+        condition = strcontains(output.astro_b_greeting, "Avast, Puppy")
+        error_message = "Woops thats not what that output should be"
+    }
+}
+
+run "test_c" {
+    assert {
+        condition = strcontains(output.scoob_c_greeting, "Jinkies, Puppy")
+        error_message = "Woops thats not what that output should be"
+    }
+}

--- a/internal/command/testdata/test/override_instance_module_2/main_provider.tftest.hcl
+++ b/internal/command/testdata/test/override_instance_module_2/main_provider.tftest.hcl
@@ -1,0 +1,45 @@
+mock_provider "test" {
+}
+
+override_resource {
+    target = module.dog_houses[*].test_resource.dogs["scoob"]
+    values = {
+        id = "Scooby Doo"
+    }
+}
+
+override_resource {
+    target = module.dog_houses["c"].test_resource.dogs["astro"]
+    values = {
+        id = "Krypto"
+    }
+}
+
+override_resource {
+    target = module.dog_houses["b"].test_resource.dogs[*]
+    values = {
+        id = "Snoopy"
+    }
+}
+
+# Prefer overrides due to earlier module instance key over resource instance keys across general modules 
+run "test_a" {
+    assert {
+        condition = strcontains(output.scoob_b_greeting, "Jeepers, Snoopy")
+        error_message = "Woops thats not what that output should be"
+    }
+}
+
+run "test_b" {
+    assert {
+        condition = strcontains(output.astro_b_greeting, "Avast, Snoopy")
+        error_message = "Woops thats not what that output should be"
+    }
+}
+
+run "test_c" {
+    assert {
+        condition = strcontains(output.scoob_c_greeting, "Jinkies, Scooby Doo")
+        error_message = "Woops thats not what that output should be"
+    }
+}

--- a/internal/command/testdata/test/override_instance_module_data/main_provider.tftest.hcl
+++ b/internal/command/testdata/test/override_instance_module_data/main_provider.tftest.hcl
@@ -1,0 +1,37 @@
+mock_provider "test" {
+}
+
+override_resource {
+    target = module.dog_houses[*].test_resource.dogs["scoob"]
+    values = {
+        id = "Scooby Doo"
+    }
+}
+
+override_resource {
+    target = module.dog_houses["c"].test_resource.dogs[*]
+    values = {
+        id = "Snoopy"
+    }
+}
+
+override_data {
+    target = module.dog_houses[*].data.test_data_source.water_bowl[*]
+    values = {
+        value = "hose"
+    }
+}
+
+run "test_a" {
+    assert {
+        condition = strcontains(output.scoob_a_bowl, "Scooby Doo drinks from a hose")
+        error_message = "Woops thats not what that output should be"
+    }
+}
+
+run "test_b" {
+    assert {
+        condition = strcontains(output.astro_c_bowl, "Snoopy drinks from a hose")
+        error_message = "Woops thats not what that output should be"
+    }
+}

--- a/internal/command/testdata/test/override_instance_module_json/main_provider.tftest.json
+++ b/internal/command/testdata/test/override_instance_module_json/main_provider.tftest.json
@@ -1,0 +1,51 @@
+{
+  "mock_provider": {
+    "test": {}
+  },
+  "override_resource": [
+    {
+        "target": "module.dog_houses[*].test_resource.dogs[\"scoob\"]",
+        "values": {
+            "id": "Scooby Doo"
+        }
+    },
+    {
+        "target": "module.dog_houses[\"c\"].test_resource.dogs[\"astro\"]",
+        "values": {
+            "id": "Krypto"
+        }
+    },
+    {
+        "target": "module.dog_houses[\"b\"].test_resource.dogs[*]",
+        "values": {
+            "id": "Snoopy"
+        }
+    }
+  ],
+  "run": {
+    "test_a": {
+      "assert": [
+        {
+          "condition": "${output.scoob_b_greeting == \"Jeepers, Snoopy\"}",
+          "error_message": "Woops thats not what that output should be"
+        }
+      ]
+    },
+    "test_b": {
+      "assert": [
+        {
+          "condition": "${output.astro_b_greeting == \"Avast, Snoopy\"}",
+          "error_message": "Woops thats not what that output should be"
+        }
+      ]
+    },
+    "test_c": {
+      "assert": [
+        {
+          "condition": "${output.scoob_c_greeting == \"Jinkies, Scooby Doo\"}",
+          "error_message": "Woops thats not what that output should be"
+        }
+      ]
+    }
+  }
+}

--- a/internal/command/testdata/test/override_instance_resource_and_provider/main_provider.tftest.hcl
+++ b/internal/command/testdata/test/override_instance_resource_and_provider/main_provider.tftest.hcl
@@ -1,0 +1,28 @@
+mock_provider "test" {
+    override_resource {
+        target = test_resource.cats["pet_a"]
+        values = {
+            id = "Lassie"
+        }
+    }
+}
+override_resource {
+    target = test_resource.cats["pet_b"]
+    values = {
+        id = "Nemo"
+    }
+}
+
+run "test_a" {
+    assert {
+        condition = strcontains(output.pet_a_greeting, "Hi Lassie")
+        error_message = "Woops thats not what that output should be"
+    }
+}
+
+run "test_b" {
+    assert {
+        condition = strcontains(output.pet_b_greeting, "Hello Nemo")
+        error_message = "Woops thats not what that output should be"
+    }
+}

--- a/internal/command/testdata/test/override_instance_resource_precedes_provider/main_provider.tftest.hcl
+++ b/internal/command/testdata/test/override_instance_resource_precedes_provider/main_provider.tftest.hcl
@@ -1,0 +1,31 @@
+mock_provider "test" {
+    override_resource {
+        target = test_resource.cats["pet_a"]
+        values = {
+            id = "Lassie"
+        }
+    }
+}
+
+override_resource {
+    target = test_resource.cats
+    values = {
+        id = "Bartholomew"
+    }
+}
+# Even though this override is less specific, it's done at the root level.
+# All root-level test resource overrides are given precedence over any override in the mock provider
+
+run "test_a" {
+    assert {
+        condition = strcontains(output.pet_a_greeting, "Hi Bartholomew")
+        error_message = "Woops thats not what that output should be"
+    }
+}
+
+run "test_b" {
+    assert {
+        condition = strcontains(output.pet_b_greeting, "Hello Bartholomew")
+        error_message = "Woops thats not what that output should be"
+    }
+}

--- a/internal/command/testdata/test/override_instance_uninstanced_module/main_provider.tftest.hcl
+++ b/internal/command/testdata/test/override_instance_uninstanced_module/main_provider.tftest.hcl
@@ -1,0 +1,23 @@
+mock_provider "test" {
+}
+
+override_resource {
+    target = module.concrete_dog_house.test_resource.dogs["dino"]
+    values = {
+        id = "Lizard"
+    }
+}
+
+run "test_a" {
+    assert {
+        condition = strcontains(output.dino_concrete_greeting, "Hello, Lizard")
+        error_message = "Woops thats not what that output should be"
+    }
+}
+
+run "test_b" {
+    assert {
+        condition = strcontains(output.scoob_concrete_greeting, "Hello, Lizard")
+        error_message = "Woops thats not what that output should be"
+    }
+}

--- a/internal/configs/config.go
+++ b/internal/configs/config.go
@@ -1060,18 +1060,18 @@ func (c *Config) transformOverriddenResourcesForTest(run *TestRun, file *TestFil
 
 	// We want to pass override values to resources being overridden.
 	for _, overrideRes := range resources {
-		targetConfig := c.Root.Descendent(overrideRes.TargetParsed.Module)
+		targetConfig := c.Root.Descendent(overrideRes.TargetParsed.Module.Module())
 		if targetConfig == nil {
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
-				Summary:  fmt.Sprintf("Module not found: %v", overrideRes.TargetParsed.Module),
+				Summary:  fmt.Sprintf("Module not found: %v", overrideRes.TargetParsed.Module.Module()),
 				Detail:   "Target points to resource in undefined module. Please, ensure module exists.",
 				Subject:  overrideRes.Target.SourceRange().Ptr(),
 			})
 			continue
 		}
 
-		res := targetConfig.Module.ResourceByAddr(overrideRes.TargetParsed.Resource)
+		res := targetConfig.Module.ResourceByAddr(overrideRes.TargetParsed.Resource.Resource)
 		if res == nil {
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
@@ -1099,24 +1099,27 @@ func (c *Config) transformOverriddenResourcesForTest(run *TestRun, file *TestFil
 		}
 
 		res.IsOverridden = true
-		res.OverrideValues = overrideRes.Values
+		if res.Overrides == nil {
+			res.Overrides = addrs.NewOverrideTrie[map[string]cty.Value]()
+		}
+		res.Overrides.Set(overrideRes.TargetParsed, overrideRes.Values)
 	}
 
 	return func() {
 		// Reset all the overridden resources.
 		for _, o := range run.OverrideResources {
-			m := c.Root.Descendent(o.TargetParsed.Module)
+			m := c.Root.Descendent(o.TargetParsed.Module.Module())
 			if m == nil {
 				continue
 			}
 
-			res := m.Module.ResourceByAddr(o.TargetParsed.Resource)
+			res := m.Module.ResourceByAddr(o.TargetParsed.Resource.Resource)
 			if res == nil {
 				continue
 			}
 
 			res.IsOverridden = false
-			res.OverrideValues = nil
+			res.Overrides = addrs.NewOverrideTrie[map[string]cty.Value]()
 		}
 	}, diags
 }

--- a/internal/configs/config.go
+++ b/internal/configs/config.go
@@ -1102,7 +1102,7 @@ func (c *Config) transformOverriddenResourcesForTest(run *TestRun, file *TestFil
 		if res.Overrides == nil {
 			res.Overrides = addrs.NewOverrideTrie[map[string]cty.Value]()
 		}
-		res.Overrides.Set(overrideRes.TargetParsed, overrideRes.Values)
+		res.Overrides.Set(overrideRes.TargetParsed, overrideRes.Values, overrideRes.Target.SourceRange().Ptr())
 	}
 
 	return func() {

--- a/internal/configs/resource.go
+++ b/internal/configs/resource.go
@@ -55,10 +55,12 @@ type Resource struct {
 	// IsOverridden indicates if the resource is being overridden. It's used in
 	// testing framework to not call the underlying provider.
 	IsOverridden bool
-	// OverrideValues are only valid if IsOverridden is set to true. The values
+	// Overrides are only valid if IsOverridden is set to true. The resources
 	// should be used to compose mock provider response. It is possible to have
-	// zero-length OverrideValues even if IsOverridden is set to true.
-	OverrideValues map[string]cty.Value
+	// an empty Overrides even if IsOverridden is set to true. This map
+	// is keyed for particular instances, with addrs.NoKey being the default, and all
+	// associated modules being added to the list.
+	Overrides *addrs.OverrideTrie[map[string]cty.Value]
 
 	DeclRange hcl.Range
 	TypeRange hcl.Range

--- a/internal/configs/test_file.go
+++ b/internal/configs/test_file.go
@@ -271,7 +271,7 @@ const (
 type OverrideResource struct {
 	// Target references resource or data block to override.
 	Target       hcl.Traversal
-	TargetParsed *addrs.ConfigResource
+	TargetParsed *addrs.AbsResourceInstance
 
 	// Mode indicates if the Target is resource or data block.
 	Mode addrs.ResourceMode
@@ -799,14 +799,14 @@ func decodeTestRunOptionsBlock(block *hcl.Block) (*TestRunOptions, hcl.Diagnosti
 }
 
 func decodeOverrideResourceBlock(block *hcl.Block) (*OverrideResource, hcl.Diagnostics) {
-	parseTarget := func(attr *hcl.Attribute) (hcl.Traversal, *addrs.ConfigResource, hcl.Diagnostics) {
-		traversal, traversalDiags := hcl.AbsTraversalForExpr(attr.Expr)
+	parseTarget := func(attr *hcl.Attribute) (hcl.Traversal, *addrs.AbsResourceInstance, hcl.Diagnostics) {
+		traversal, traversalDiags := hcl.AbsTraversalPatternForExpr(attr.Expr)
 		diags := traversalDiags
 		if traversalDiags.HasErrors() {
 			return nil, nil, diags
 		}
 
-		configRes, configResDiags := addrs.ParseConfigResource(traversal)
+		configRes, configResDiags := addrs.ParseAbsResourceRange(traversal)
 		diags = append(diags, configResDiags.ToHCL()...)
 		if configResDiags.HasErrors() {
 			return nil, nil, diags

--- a/internal/tofu/node_resource_abstract_instance.go
+++ b/internal/tofu/node_resource_abstract_instance.go
@@ -3222,7 +3222,7 @@ func (n *NodeAbstractResourceInstance) getProvider(ctx context.Context, evalCtx 
 		// Overridden by the provider (overrides mocks)
 		for _, res := range n.ResolvedProvider.OverrideResources {
 			if res.TargetParsed.AffectedAbsResource().Equal(n.Addr.AffectedAbsResource()) && res.Mode == n.Addr.AffectedAbsResource().Resource.Mode {
-				trie.Set(res.TargetParsed, res.Values)
+				trie.Set(res.TargetParsed, res.Values, res.Target.SourceRange().Ptr())
 			}
 		}
 

--- a/internal/tofu/node_resource_abstract_instance.go
+++ b/internal/tofu/node_resource_abstract_instance.go
@@ -3218,19 +3218,36 @@ func (n *NodeAbstractResourceInstance) getProvider(ctx context.Context, evalCtx 
 			}
 		}
 
+		trie := addrs.NewOverrideTrie[map[string]cty.Value]()
 		// Overridden by the provider (overrides mocks)
 		for _, res := range n.ResolvedProvider.OverrideResources {
-			if res.TargetParsed.Equal(n.Addr.ConfigResource()) && res.Mode == n.Addr.Resource.Resource.Mode {
-				overrideValues = res.Values
-				break
+			if res.TargetParsed.AffectedAbsResource().Equal(n.Addr.AffectedAbsResource()) && res.Mode == n.Addr.AffectedAbsResource().Resource.Mode {
+				trie.Set(res.TargetParsed, res.Values)
 			}
+		}
+
+		overrideValuesP, providerOverrideDiags := trie.Get(&n.Addr)
+		if overrideValuesP != nil {
+			overrideValues = *overrideValuesP
+		}
+
+		if providerOverrideDiags.HasErrors() {
+			return nil, providers.ProviderSchema{}, providerOverrideDiags.Err()
 		}
 	}
 
-	if n.Config != nil && n.Config.IsOverridden {
+	if n.Config != nil && n.Config.IsOverridden && n.Config.Overrides != nil {
 		// Overridden in the currently running test (overrides any provider settings)
-		isOverridden = n.Config.IsOverridden
-		overrideValues = n.Config.OverrideValues
+		isOverridden = true
+
+		newOverrideValues, resourceOverrideDiags := n.Config.Overrides.Get(&n.Addr)
+		if resourceOverrideDiags.HasErrors() {
+			return nil, providers.ProviderSchema{}, resourceOverrideDiags.Err()
+		}
+		// set resource override, if it exists
+		if newOverrideValues != nil {
+			overrideValues = *newOverrideValues
+		}
 	}
 
 	if isOverridden {

--- a/internal/tofu/node_resource_abstract_instance.go
+++ b/internal/tofu/node_resource_abstract_instance.go
@@ -3227,19 +3227,36 @@ func (n *NodeAbstractResourceInstance) getProvider(ctx context.Context, evalCtx 
 			}
 		}
 
+		trie := addrs.NewOverrideTrie[map[string]cty.Value]()
 		// Overridden by the provider (overrides mocks)
 		for _, res := range n.ResolvedProvider.OverrideResources {
-			if res.TargetParsed.Equal(n.Addr.ConfigResource()) && res.Mode == n.Addr.Resource.Resource.Mode {
-				overrideValues = res.Values
-				break
+			if res.TargetParsed.AffectedAbsResource().Equal(n.Addr.AffectedAbsResource()) && res.Mode == n.Addr.AffectedAbsResource().Resource.Mode {
+				trie.Set(res.TargetParsed, res.Values)
 			}
+		}
+
+		overrideValuesP, providerOverrideDiags := trie.Get(&n.Addr)
+		if overrideValuesP != nil {
+			overrideValues = *overrideValuesP
+		}
+
+		if providerOverrideDiags.HasErrors() {
+			return nil, providers.ProviderSchema{}, providerOverrideDiags.Err()
 		}
 	}
 
-	if n.Config != nil && n.Config.IsOverridden {
+	if n.Config != nil && n.Config.IsOverridden && n.Config.Overrides != nil {
 		// Overridden in the currently running test (overrides any provider settings)
-		isOverridden = n.Config.IsOverridden
-		overrideValues = n.Config.OverrideValues
+		isOverridden = true
+
+		newOverrideValues, resourceOverrideDiags := n.Config.Overrides.Get(&n.Addr)
+		if resourceOverrideDiags.HasErrors() {
+			return nil, providers.ProviderSchema{}, resourceOverrideDiags.Err()
+		}
+		// set resource override, if it exists
+		if newOverrideValues != nil {
+			overrideValues = *newOverrideValues
+		}
 	}
 
 	if isOverridden {

--- a/internal/tofu/node_resource_abstract_instance.go
+++ b/internal/tofu/node_resource_abstract_instance.go
@@ -3231,7 +3231,7 @@ func (n *NodeAbstractResourceInstance) getProvider(ctx context.Context, evalCtx 
 		// Overridden by the provider (overrides mocks)
 		for _, res := range n.ResolvedProvider.OverrideResources {
 			if res.TargetParsed.AffectedAbsResource().Equal(n.Addr.AffectedAbsResource()) && res.Mode == n.Addr.AffectedAbsResource().Resource.Mode {
-				trie.Set(res.TargetParsed, res.Values)
+				trie.Set(res.TargetParsed, res.Values, res.Target.SourceRange().Ptr())
 			}
 		}
 

--- a/website/docs/cli/commands/test/examples/override_resource_instance/main.tf
+++ b/website/docs/cli/commands/test/examples/override_resource_instance/main.tf
@@ -1,0 +1,19 @@
+locals {
+    my_files = toset(["file_a", "file_b", "file_c"])
+}
+
+data "local_file" "greeting" {
+    for_each = local.my_files
+
+    filename = each.value
+}
+
+output "greeting_a" {
+    value = "${data.local_file.greeting["file_a"].content} World"
+}
+output "greeting_b" {
+    value = "${data.local_file.greeting["file_b"].content} World"
+}
+output "greeting_c" {
+    value = "${data.local_file.greeting["file_c"].content} World"
+}

--- a/website/docs/cli/commands/test/examples/override_resource_instance/main.tftest.hcl
+++ b/website/docs/cli/commands/test/examples/override_resource_instance/main.tftest.hcl
@@ -1,0 +1,28 @@
+
+override_data {
+  target = data.local_file.greeting["file_a"]
+  values = {
+    content = "Howdy"
+  }
+}
+override_data {
+  target = data.local_file.greeting[*]
+  values = {
+    content = "Hello"
+  }
+}
+
+run "test" {
+  assert {
+    condition     = output.greeting_a == "Howdy World"
+    error_message = "Incorrect greeting: ${output.greeting_a}"
+  }
+  assert {
+    condition     = output.greeting_b == "Hello World"
+    error_message = "Incorrect greeting: ${output.greeting_a}"
+  }
+  assert {
+    condition     = output.greeting_c == "Hello World"
+    error_message = "Incorrect greeting: ${output.greeting_a}"
+  }
+}

--- a/website/docs/cli/commands/test/examples/override_resource_provider/main.tf
+++ b/website/docs/cli/commands/test/examples/override_resource_provider/main.tf
@@ -1,0 +1,19 @@
+locals {
+    my_files = toset(["file_a", "file_b", "file_c"])
+}
+
+data "local_file" "greeting" {
+    for_each = local.my_files
+
+    filename = each.value
+}
+
+output "greeting_a" {
+    value = "${data.local_file.greeting["file_a"].content} World"
+}
+output "greeting_b" {
+    value = "${data.local_file.greeting["file_b"].content} World"
+}
+output "greeting_c" {
+    value = "${data.local_file.greeting["file_c"].content} World"
+}

--- a/website/docs/cli/commands/test/examples/override_resource_provider/main.tftest.hcl
+++ b/website/docs/cli/commands/test/examples/override_resource_provider/main.tftest.hcl
@@ -1,0 +1,48 @@
+mock_provider "local" {
+  override_data {
+    target = data.local_file.greeting["file_a"]
+    values = {
+      content = "Howdy"
+    }
+  }
+  override_data {
+    target = data.local_file.greeting["file_b"]
+    values = {
+      content = "Salutations"
+    }
+  }
+  override_data {
+    target = data.local_file.greeting[*]
+    values = {
+      content = "Hey"
+    }
+  }
+}
+
+override_data {
+  target = data.local_file.greeting["file_a"]
+  values = {
+    content = "Aloha"
+  }
+}
+override_data {
+  target = data.local_file.greeting[*]
+  values = {
+    content = "Hello"
+  }
+}
+
+run "test" {
+  assert {
+    condition     = output.greeting_a == "Aloha World"
+    error_message = "Incorrect greeting: ${output.greeting_a}"
+  }
+  assert {
+    condition     = output.greeting_b == "Hello World"
+    error_message = "Incorrect greeting: ${output.greeting_a}"
+  }
+  assert {
+    condition     = output.greeting_c == "Hello World"
+    error_message = "Incorrect greeting: ${output.greeting_a}"
+  }
+}

--- a/website/docs/cli/commands/test/index.mdx
+++ b/website/docs/cli/commands/test/index.mdx
@@ -31,6 +31,10 @@ import ExpectFailureResourcesMain from '!!raw-loader!./examples/expect_failures_
 import ExpectFailureResourcesTest from '!!raw-loader!./examples/expect_failures_resources/main.tftest.hcl'
 import OverrideResourceMain from '!!raw-loader!./examples/override_resource/main.tf'
 import OverrideResourceTest from '!!raw-loader!./examples/override_resource/main.tftest.hcl'
+import OverrideResourceInstanceMain from '!!raw-loader!./examples/override_resource_instance/main.tf'
+import OverrideResourceInstanceTest from '!!raw-loader!./examples/override_resource_instance/main.tftest.hcl'
+import OverrideResourceProviderMain from '!!raw-loader!./examples/override_resource_provider/main.tf'
+import OverrideResourceProviderTest from '!!raw-loader!./examples/override_resource_provider/main.tftest.hcl'
 import MockProviderMain from '!!raw-loader!./examples/mock_provider/main.tf'
 import MockProviderTest from '!!raw-loader!./examples/mock_provider/main.tftest.hcl'
 import OverrideModuleMain from '!!raw-loader!./examples/override_module/main.tf'
@@ -536,12 +540,27 @@ In the example below, we test if the bucket name is correctly passed to the reso
     </TabItem>
 </Tabs>
 
-:::warning Limitation
+As of OpenTofu 1.12, you can also specify instances of a resource or data source which use a `for_each` or `count`. You can even specify all of them, using a wildcard instance key.
 
-You cannot use `override_resource` or `override_data` with a single instance of a resource or data source.
-Each instance of a resource or data source must be overridden.
+<Tabs>
+    <TabItem value={"test"} label={"main.tftest.hcl"} default>
+        <CodeBlock language={"hcl"}>{OverrideResourceInstanceTest}</CodeBlock>
+    </TabItem>
+    <TabItem value={"main"} label={"main.tf"}>
+        <CodeBlock language={"hcl"}>{OverrideResourceInstanceMain}</CodeBlock>
+    </TabItem>
+</Tabs>
 
-:::
+As mentioned before, you can specify an override in either the `mock_provider` block or at the root level of a test file. Root-level overrides always take precedence over anything specified in the `mock_provider` regardless of specificity, as you can see in this example.
+
+<Tabs>
+    <TabItem value={"test"} label={"main.tftest.hcl"} default>
+        <CodeBlock language={"hcl"}>{OverrideResourceProviderTest}</CodeBlock>
+    </TabItem>
+    <TabItem value={"main"} label={"main.tf"}>
+        <CodeBlock language={"hcl"}>{OverrideResourceProviderMain}</CodeBlock>
+    </TabItem>
+</Tabs>
 
 ### Automatically generated values
 

--- a/website/docs/cli/commands/test/index.mdx
+++ b/website/docs/cli/commands/test/index.mdx
@@ -31,6 +31,10 @@ import ExpectFailureResourcesMain from '!!raw-loader!./examples/expect_failures_
 import ExpectFailureResourcesTest from '!!raw-loader!./examples/expect_failures_resources/main.tftest.hcl'
 import OverrideResourceMain from '!!raw-loader!./examples/override_resource/main.tf'
 import OverrideResourceTest from '!!raw-loader!./examples/override_resource/main.tftest.hcl'
+import OverrideResourceInstanceMain from '!!raw-loader!./examples/override_resource_instance/main.tf'
+import OverrideResourceInstanceTest from '!!raw-loader!./examples/override_resource_instance/main.tftest.hcl'
+import OverrideResourceProviderMain from '!!raw-loader!./examples/override_resource_provider/main.tf'
+import OverrideResourceProviderTest from '!!raw-loader!./examples/override_resource_provider/main.tftest.hcl'
 import MockProviderMain from '!!raw-loader!./examples/mock_provider/main.tf'
 import MockProviderTest from '!!raw-loader!./examples/mock_provider/main.tftest.hcl'
 import OverrideModuleMain from '!!raw-loader!./examples/override_module/main.tf'
@@ -577,12 +581,27 @@ In the example below, we test if the bucket name is correctly passed to the reso
     </TabItem>
 </Tabs>
 
-:::warning Limitation
+As of OpenTofu 1.12, you can also specify instances of a resource or data source which use a `for_each` or `count`. You can even specify all of them, using a wildcard instance key.
 
-You cannot use `override_resource` or `override_data` with a single instance of a resource or data source.
-Each instance of a resource or data source must be overridden.
+<Tabs>
+    <TabItem value={"test"} label={"main.tftest.hcl"} default>
+        <CodeBlock language={"hcl"}>{OverrideResourceInstanceTest}</CodeBlock>
+    </TabItem>
+    <TabItem value={"main"} label={"main.tf"}>
+        <CodeBlock language={"hcl"}>{OverrideResourceInstanceMain}</CodeBlock>
+    </TabItem>
+</Tabs>
 
-:::
+As mentioned before, you can specify an override in either the `mock_provider` block or at the root level of a test file. Root-level overrides always take precedence over anything specified in the `mock_provider` regardless of specificity, as you can see in this example.
+
+<Tabs>
+    <TabItem value={"test"} label={"main.tftest.hcl"} default>
+        <CodeBlock language={"hcl"}>{OverrideResourceProviderTest}</CodeBlock>
+    </TabItem>
+    <TabItem value={"main"} label={"main.tf"}>
+        <CodeBlock language={"hcl"}>{OverrideResourceProviderMain}</CodeBlock>
+    </TabItem>
+</Tabs>
 
 ### Automatically generated values
 


### PR DESCRIPTION
<!-- If your PR resolves an issue, please add it here. -->
Resolves #3264 

This change introduces an `OverrideTrie` concept which is used to either identify individual resource instances or a coarse ranges of resource instances relevant to a particular set of value overrides. It also introduces a novel use of the splat expression: you can "select" against all instances of a targeted resource and have that instance key be respected. This might be relevant to imports and moves; I've kept OverrideTrie generic in case it's useful elsewhere, and I'm open to renaming it should the need arise.

A couple of notes that may make this easier to review:

- I've split this PR into a couple of commits to make it easier to review.
  - The actual override logic is mostly implemented in `node_resource_abstract_instance.go`. This is where the magic happens.
- This uses an [unmerged version of HCL](https://github.com/opentofu/hcl/compare/opentofu...f-splat-as-traversal). It has `AbsTraversalPatternForExpr`, which enables using wildcard expression in resource and module indexes. Big, big thanks to Martin for implementing this; I might know where to begin, but certainly not how it ought to work.
- A good chunk of the override trie code is written specifically to test for a backwards-compatibility feature. Currently, overrides can be like `module.a.resource.element` and that overrides `module.a["x"].resource.element["iron"]` and `module.a.["y"].resource.element["copper"], etc. However, we don't want to mix syntax: if someone's using a wildcard, they should know better, and they ought to specify every range using a wildcard rather than relying on the "old" (i.e. current) way of managing all resources.

Additionally, there are a couple `TODO`s still in there. Those are relevant, and they are open questions I'm hoping to hash out through the review process. Another question: should I engineer the `OverrideTrie` to be safe for concurrent usage? I'm not totally sure what the execution model looks like when it enters the `getProvider` function of `node_resource_abstract_instance.go`. I'm hoping to learn a little more through this PR!

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
