### PR TITLE
fix: skip local encrypted state read when init runs with -backend=false (#4076)

### DIFF
--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -207,6 +207,15 @@ To initialize the configuration already in this working directory, omit the
 	var backendOutput bool
 
 	switch {
+	case args.BackendFlagSet && !args.FlagBackend:
+		// The user explicitly passed -backend=false,
+		// so we must neither initialize a new backend nor load any
+		// previously-initialized one. Loading the previously-initialized
+		// backend would otherwise try to read (and, if encryption is
+		// configured, decrypt) the local state file, defeating the whole
+		// purpose of -backend=false and breaking workflows where the
+		// encryption key is intentionally unavailable.
+		back = nil
 	case args.FlagCloud && rootModEarly.CloudConfig != nil:
 		back, backendOutput, backDiags = c.initCloud(ctx, rootModEarly, args.FlagConfigExtra, enc, view.Backend())
 	case args.FlagBackend:

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -207,7 +207,7 @@ To initialize the configuration already in this working directory, omit the
 	var backendOutput bool
 
 	switch {
-	case args.BackendFlagSet && !args.FlagBackend:
+	case !args.FlagBackend && args.BackendFlagSet:
 		// The user explicitly passed -backend=false,
 		// so we must neither initialize a new backend nor load any
 		// previously-initialized one. Loading the previously-initialized

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -3262,6 +3262,44 @@ func TestInit_skipEncryptionBackendFalse(t *testing.T) {
 	})
 }
 
+t.Run("init succeeds with -backend=false even when an encrypted state file is already present", func(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("init-encryption-with-state"), td)
+	t.Chdir(td)
+
+	overrides := metaOverridesForProvider(testProvider())
+	view, done := testView(t)
+	providerSource, closeCallback := newMockProviderSource(t, map[string][]string{
+		"hashicorp/aws": {"5.0", "5.8"},
+	})
+	defer closeCallback()
+	m := Meta{
+		WorkingDir:       workdir.NewDir("."),
+		testingOverrides: overrides,
+		View:             view,
+		ProviderSource:   providerSource,
+	}
+
+	c := &InitCommand{
+		Meta: m,
+	}
+
+	args := []string{
+		"-backend=false",
+	}
+	code := c.Run(args)
+	output := done(t)
+	if code != 0 {
+		t.Fatalf("init should run successfully with -backend=false even with an encrypted state file present\nexit code: %d\nstderr:\n%s\nstdout:\n%s", code, output.Stderr(), output.Stdout())
+	}
+	if strings.Contains(output.Stderr(), "Error refreshing state") {
+		t.Fatalf("init must not attempt to read/refresh the local state when -backend=false is set\nstderr:\n%s", output.Stderr())
+	}
+	if strings.Contains(output.Stderr(), "can not be read without an encryption configuration") {
+		t.Fatalf("init must not attempt to decrypt the local state when -backend=false is set\nstderr:\n%s", output.Stderr())
+	}
+})
+
 // newMockProviderSource is a helper to succinctly construct a mock provider
 // source that contains a set of packages matching the given provider versions
 // that are available for installation (from temporary local files).

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -3260,45 +3260,45 @@ func TestInit_skipEncryptionBackendFalse(t *testing.T) {
 			t.Fatalf("generated error should contain the string \"Error: Unable to fetch encryption key data\"\ninstead got : %s\n", output.Stderr())
 		}
 	})
-}
 
-t.Run("init succeeds with -backend=false even when an encrypted state file is already present", func(t *testing.T) {
-	td := t.TempDir()
-	testCopyDir(t, testFixturePath("init-encryption-with-state"), td)
-	t.Chdir(td)
+	t.Run("init succeeds with -backend=false even when an encrypted state file is already present", func(t *testing.T) {
+		td := t.TempDir()
+		testCopyDir(t, testFixturePath("init-encryption-with-state"), td)
+		t.Chdir(td)
 
-	overrides := metaOverridesForProvider(testProvider())
-	view, done := testView(t)
-	providerSource, closeCallback := newMockProviderSource(t, map[string][]string{
-		"hashicorp/aws": {"5.0", "5.8"},
+		overrides := metaOverridesForProvider(testProvider())
+		view, done := testView(t)
+		providerSource, closeCallback := newMockProviderSource(t, map[string][]string{
+			"hashicorp/aws": {"5.0", "5.8"},
+		})
+		defer closeCallback()
+		m := Meta{
+			WorkingDir:       workdir.NewDir("."),
+			testingOverrides: overrides,
+			View:             view,
+			ProviderSource:   providerSource,
+		}
+
+		c := &InitCommand{
+			Meta: m,
+		}
+
+		args := []string{
+			"-backend=false",
+		}
+		code := c.Run(args)
+		output := done(t)
+		if code != 0 {
+			t.Fatalf("init should run successfully with -backend=false even with an encrypted state file present\nexit code: %d\nstderr:\n%s\nstdout:\n%s", code, output.Stderr(), output.Stdout())
+		}
+		if strings.Contains(output.Stderr(), "Error refreshing state") {
+			t.Fatalf("init must not attempt to read/refresh the local state when -backend=false is set\nstderr:\n%s", output.Stderr())
+		}
+		if strings.Contains(output.Stderr(), "can not be read without an encryption configuration") {
+			t.Fatalf("init must not attempt to decrypt the local state when -backend=false is set\nstderr:\n%s", output.Stderr())
+		}
 	})
-	defer closeCallback()
-	m := Meta{
-		WorkingDir:       workdir.NewDir("."),
-		testingOverrides: overrides,
-		View:             view,
-		ProviderSource:   providerSource,
-	}
-
-	c := &InitCommand{
-		Meta: m,
-	}
-
-	args := []string{
-		"-backend=false",
-	}
-	code := c.Run(args)
-	output := done(t)
-	if code != 0 {
-		t.Fatalf("init should run successfully with -backend=false even with an encrypted state file present\nexit code: %d\nstderr:\n%s\nstdout:\n%s", code, output.Stderr(), output.Stdout())
-	}
-	if strings.Contains(output.Stderr(), "Error refreshing state") {
-		t.Fatalf("init must not attempt to read/refresh the local state when -backend=false is set\nstderr:\n%s", output.Stderr())
-	}
-	if strings.Contains(output.Stderr(), "can not be read without an encryption configuration") {
-		t.Fatalf("init must not attempt to decrypt the local state when -backend=false is set\nstderr:\n%s", output.Stderr())
-	}
-})
+}
 
 // newMockProviderSource is a helper to succinctly construct a mock provider
 // source that contains a set of packages matching the given provider versions

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -3260,7 +3260,9 @@ func TestInit_skipEncryptionBackendFalse(t *testing.T) {
 			t.Fatalf("generated error should contain the string \"Error: Unable to fetch encryption key data\"\ninstead got : %s\n", output.Stderr())
 		}
 	})
+}
 
+func TestInit_backendFalse_skipsBackendFromStateOnPreviouslyInitializedDir(t *testing.T) {
 	t.Run("init succeeds with -backend=false even when an encrypted state file is already present", func(t *testing.T) {
 		td := t.TempDir()
 		testCopyDir(t, testFixturePath("init-encryption-with-state"), td)
@@ -3291,11 +3293,8 @@ func TestInit_skipEncryptionBackendFalse(t *testing.T) {
 		if code != 0 {
 			t.Fatalf("init should run successfully with -backend=false even with an encrypted state file present\nexit code: %d\nstderr:\n%s\nstdout:\n%s", code, output.Stderr(), output.Stdout())
 		}
-		if strings.Contains(output.Stderr(), "Error refreshing state") {
-			t.Fatalf("init must not attempt to read/refresh the local state when -backend=false is set\nstderr:\n%s", output.Stderr())
-		}
-		if strings.Contains(output.Stderr(), "can not be read without an encryption configuration") {
-			t.Fatalf("init must not attempt to decrypt the local state when -backend=false is set\nstderr:\n%s", output.Stderr())
+		if stderr := output.Stderr(); stderr != "" {
+			t.Errorf("expected to have no errors but got:\n%s", stderr)
 		}
 	})
 }

--- a/internal/command/testdata/init-encryption-with-state/main.tf
+++ b/internal/command/testdata/init-encryption-with-state/main.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.8"
+    }
+  }
+
+  encryption {
+    key_provider "pbkdf2" "main" {
+      passphrase = var.passphrase
+    }
+    method "aes_gcm" "main" {
+      keys = key_provider.pbkdf2.main
+    }
+    state {
+      method = method.aes_gcm.main
+    }
+  }
+}
+
+variable "passphrase" {
+  type      = string
+  sensitive = true
+  default   = ""
+}

--- a/internal/command/testdata/init-encryption-with-state/terraform.tfstate
+++ b/internal/command/testdata/init-encryption-with-state/terraform.tfstate
@@ -1,0 +1,12 @@
+{
+  "encryption_version": "v0",
+  "meta": {
+    "key_provider.pbkdf2.main": {
+      "salt": "ZmFrZXNhbHQ=",
+      "iterations": 600000,
+      "hash_function": "sha512",
+      "key_length": 32
+    }
+  },
+  "encrypted_data": "ZmFrZS1lbmNyeXB0ZWQtcGF5bG9hZA=="
+}


### PR DESCRIPTION
fix issue #4076

**Problem**

init with `-backend=false` could still fail in a directory that already contains an encrypted local state file, surfacing as an error while refreshing state.

**Cause**

init.go
```go
default:
	// load the previously-stored backend config
	back, backDiags = c.Meta.backendFromState(ctx, enc.State())
}
```

With `-backend=false`, init still fell into the default branch and call backendFromState, which reconstructs a backend from previously stored working-directory metadata and wires it with the encryption handle passed in for this run. 

A non-nil backend then led init to open the workspace state manager and refresh state, which attempts to read the on-disk state—including an encrypted terraform.tfstate—and fails in that situation.

**Fix**

```go
switch {
	case args.BackendFlagSet && !args.FlagBackend:
		// The user explicitly passed -backend=false,
		// so we must neither initialize a new backend nor load any
		// previously-initialized one. Loading the previously-initialized
		// backend would otherwise try to read (and, if encryption is
		// configured, decrypt) the local state file, defeating the whole
		// purpose of -backend=false and breaking workflows where the
		// encryption key is intentionally unavailable.
		back = nil
	case args.FlagCloud && rootModEarly.CloudConfig != nil:
		back, backendOutput, backDiags = c.initCloud(ctx, rootModEarly, args.FlagConfigExtra, enc, view.Backend())
	case args.FlagBackend:
		back, backendOutput, backDiags = c.initBackend(ctx, rootModEarly, args.FlagConfigExtra, enc, view.Backend())
	default:
		// load the previously-stored backend config
		back, backDiags = c.Meta.backendFromState(ctx, enc.State())
}
```

When `-backend=false` is explicitly set, do not take that path. skip loading a previously initialized backend so init does not refresh workspace state for provider hints in this mode. Add a regression test for this issue.

<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves # 4076

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [X] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [X] I have not used an AI coding assistant to create this PR.
- [X] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [X] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
