### PR TITLE
website: Updates for the v1.12 release

### DIFF
--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -10,7 +10,7 @@ import DocVersionBadge from "@theme/DocVersionBadge";
 
 ### OpenTofu Documentation <DocVersionBadge />
 
-Welcome to OpenTofu 1.11! This version brings a lot of new features and improvements to OpenTofu. If you are coming from a previous OpenTofu or Terraform version you can [read the details about the new features here &raquo;](intro/whats-new.mdx)
+Welcome to OpenTofu 1.12! If you are coming from a previous version of OpenTofu you can [read the details about the new features](intro/whats-new.mdx).
 
 <DocCardList
     items={[

--- a/website/docs/intro/migration/index.mdx
+++ b/website/docs/intro/migration/index.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 4
-sidebar_label: Migrating to OpenTofu
+sidebar_position: 5
+sidebar_label: Migrating from Terraform
 description: |-
   Learn how to migrate to OpenTofu from Terraform.
 ---

--- a/website/docs/intro/upgrading.mdx
+++ b/website/docs/intro/upgrading.mdx
@@ -1,19 +1,19 @@
 ---
-sidebar_position: 5
-sidebar_label: Upgrading from OpenTofu 1.8.x/1.9.x/1.10.x
+sidebar_position: 4
+sidebar_label: Upgrading from earlier versions of OpenTofu
 description: |-
-    Learn how to upgrade OpenTofu from version 1.8.x/1.9.x/1.10.x to 1.11.0.
+    Learn how to upgrade OpenTofu to 1.12.
 ---
 
-# Upgrading from OpenTofu 1.8.x/1.9.x/1.10.x
+# Upgrading from earlier versions of OpenTofu
 
-OpenTofu 1.11.x is mostly compatible with previous OpenTofu versions. This migration guide will take you through the process of upgrading OpenTofu to version 1.11.0.
+OpenTofu 1.12.x is largely compatible with previous OpenTofu versions. This migration guide will take you through the process of upgrading to OpenTofu v1.12.
 
 ## Step 0: Prepare a disaster recovery plan
 
-Although OpenTofu 1.11 is mostly compatible with previous versions, you should take the necessary precautions to prevent accidents. Make sure you have an up to date and *tested* disaster recovery plan.
+Although OpenTofu v1.12 is mostly compatible with previous versions, you should take the necessary precautions to prevent accidents. Make sure you have an up-to-date and *tested* disaster recovery plan.
 
-## Step 1: Apply all changes with OpenTofu 1.7.x/1.8.x/1.9.x
+## Step 1: Apply all changes with your current OpenTofu version
 
 Before proceeding, make sure that you apply all changes with `tofu apply`. Running `tofu plan` should result in no planned changes. While you can switch to OpenTofu with pending changes, it is not recommended.
 
@@ -28,50 +28,44 @@ OpenTofu has compared your real infrastructure against your
 configuration and found no differences, so no changes are needed.
 ```
 
-## Step 2: Install OpenTofu 1.11.x
+## Step 2: Install OpenTofu v1.12
 
-As a first step, please [follow the installation instructions for the OpenTofu CLI tool](intro/install/index.mdx). Please test
-if you can successfully execute the `tofu` command and receive the correct version:
+As a first step, [install the latest version from the v1.12.x series](intro/install/index.mdx).
+
+Confirm that you are running the new version by running `tofu version`:
 
 ```
-$ tofu --version
-OpenTofu v1.11.0
+$ tofu version
+OpenTofu v1.12.0
 on linux_amd64
 ```
 
+Your output should reflect whichever patch release you installed and the platform where you're running OpenTofu.
+
 ## Step 3: Back up your state file
 
-Before you begin using the `tofu` binary on your Terraform code, make sure to back up your state file. If you are using
-a local state file, you can simply make a copy of your `terraform.tfstate` file in your project directory.
+Before you begin using the new OpenTofu version, take a backup of your latest state snapshot.
 
-If you are using a remote backend such as an S3 bucket, make sure that you follow the backup procedures for the
-backend and that you exercise the restore procedure at least once.
+You can take a copy of the latest state snapshot by running `tofu state pull >backup.tfstate`, which will write the latest snapshot into `backup.tfstate` in your current working directory.
+Alternatively, you can use a backup procedure tailored for the specific backend type you've chosen, such as making a copy of the state snapshot directly in the remote storage.
 
-## Step 4: Initialize OpenTofu 1.11.x
+Make sure you know how to restore the backup you have created, just in case you encounter problems in the subsequent steps that prevent downgrading back to your previous version of OpenTofu.
+
+## Step 4: Initialize OpenTofu 1.12.x
 
 :::warning
 
-Should any of the following steps fail, please do not proceed and follow the
-[rollback instructions below](#rolling-back-and-reporting-issues) instead.
-If you suspect the failure may be the result of a bug in OpenTofu,
-[please help us by opening an issue](https://github.com/opentofu/opentofu/issues).
+If any of the following steps fail, we recommend that you stop following these instructions and refer to [Rolling back and reporting issues](#rolling-back-and-reporting-issues) below.
 
 :::
 
 Now you are ready to migrate. Run `tofu init` in the directory where your code resides. OpenTofu will download
 any providers and modules referenced in your configuration from the OpenTofu registry.
 
-:::note
-
-If you are using the S3 backend - You will need to run `tofu init -reconfigure` to reinitialize the backend.
-
-:::
-
 ## Step 5: Inspect the plan
 
 Once initialized, run `tofu plan` and ensure that there are no pending changes similar to step 1 above. If there are
-unexpected changes in the plan, roll back to OpenTofu 1.8.x/1.9.x/1.10.x and troubleshoot your migration. (See the Troubleshooting
-section below.)
+unexpected changes in the plan, roll back to your previous OpenTofu version and troubleshoot your migration.
 
 ```
 $ tofu plan
@@ -86,34 +80,18 @@ configuration and found no differences, so no changes are needed.
 
 ## Step 6: Test out a small change
 
-Before you begin using OpenTofu for larger changes, test out `tofu apply` with a smaller, non-critical
-change.
+Before you begin using OpenTofu for larger changes, we recommend testing out `tofu apply` with a smaller, non-critical change.
 
 ## Rolling back and reporting issues
 
-If you have issues migrating to OpenTofu you can follow these steps to roll back to OpenTofu 1.8.x/1.9.x/1.10.x:
+If you have issues migrating to OpenTofu you can follow these steps to roll back to your previous OpenTofu version:
 
-1. Create another backup of your state file.
-2. Remove OpenTofu 1.11.x and verify that you are running OpenTofu 1.8.x/1.9.x/1.10.x.
+1. Create another separate backup of your latest state snapshot, just in case one of the upgrade steps has changed it.
+2. Remove OpenTofu 1.12.x and verify that you are running the same version of OpenTofu that was most recently working for you.
 3. Run `tofu init`.
 4. Run `tofu plan` and verify that no unexpected changes are in the plan.
 5. Test the rollback with a small, non-critical change.
 
-If you encountered a bug, [please report it on GitHub](https://github.com/opentofu/opentofu/issues).
+There are no intentional changes to the state snapshot format in this release and so it should not be necessary to restore the state snapshot backup you created earlier, but if you encounter any state-related errors when using your previous version then restoring the previous state snapshot is a good first troubleshooting step.
 
-## Troubleshooting
-
-If you encounter any issues during the migration to OpenTofu, you can join the <a href="/slack/">OpenTofu Slack</a> or ask on
-[GitHub Discussions](https://github.com/orgs/opentofu/discussions).
-
-### Error: Failed to query available provider packages
-
-This error happens when a provider you specified in your configuration is not available in the OpenTofu registry.
-Please roll back to OpenTofu 1.8.x/1.9.x/1.10.x and make sure your code works with that version. If your code works, please
-[submit an issue to include the provider in the registry](https://github.com/opentofu/registry/issues/).
-
-### Error: Module not found
-
-This error happens when a module you specified in your configuration is not available in the OpenTofu registry.
-Please roll back to OpenTofu 1.8.x/1.9.x/1.10.x and make sure your code works with that version. If your code works, please
-[submit an issue to include the module in the registry](https://github.com/opentofu/registry/issues/).
+If you are rolling back because you've encountered a bug, please [report the bug to us on GitHub](https://github.com/opentofu/opentofu/issues).

--- a/website/docs/intro/whats-new.mdx
+++ b/website/docs/intro/whats-new.mdx
@@ -1,55 +1,33 @@
 ---
 sidebar_position: 2
-sidebar_label: What's new in version 1.11?
+sidebar_label: What's new in version 1.12?
 description: |-
-  Learn all about the new features in OpenTofu 1.11.
+  Learn about the changes in OpenTofu 1.12.
 ---
 
-# What's new in OpenTofu 1.11?
+# What's new in OpenTofu 1.12?
 
-## New features
+Here are some highlights from the new features in this release:
 
-### Ephemeral Resources / Write-Only Attributes
+- **Dynamic `prevent_destroy`**: The `prevent_destroy` argument in a resource's lifecycle block can now refer to other symbols within the same module, such as input variables.
+- **Improved provider checksum handling**: `tofu init` now automatically includes a full set of checksums for all platforms using both `zh:` and `h1:` hashes, reducing the need for manually running `tofu providers lock`.
+- **Simultaneous output formats**: The new `-json-into=FILENAME` CLI option allows saving machine-readable output to a separate file while still producing human-readable output in the terminal.
+- **New `destroy` lifecycle meta-argument:** The new `destroy = false` lifecycle option for managed resources allows removing an object from the state without first destroying the remote object.
+- **Provider installer performance**: Provider installation now performs concurrent requests for faster `tofu init` completion when many providers are needed.
 
-**Ephemeral values** allow OpenTofu to work with data and resources that exist only in memory during a single OpenTofu phase, guaranteeing that those values will not be persisted in state snapshots or plan files.
+For more information, refer to [the v1.12.0 release announcement](http://opentofu.org/blog/opentofu-1-12-0/) and [the v1.12 series changelog](https://github.com/opentofu/opentofu/blob/v1.12/CHANGELOG.md).
 
-You can now declare input variables and output values as being ephemeral, and you can use provider plugins that have been updated to include ephemeral resource types (e.g. for fetching a secret) or managed resource types with write-only attributes (e.g. for setting a password without saving it in OpenTofu state).
+## Compatibility Notes
 
-For more information, refer to [Ephemerality](https://opentofu.org/docs/v1.11/language/ephemerality/).
+- **New `h1:` checksums in dependency lock file**: Due to the improved provider checksum handling in this release, the first time you run `tofu init` after upgrading you are likely to find additional `h1:` checksums have been added for any providers that were already tracked in your dependency lock file.
 
-### Enabled meta-argument
+    This behavior is an example of what's described in [New provider package checksums](../language/files/dependency-lock.mdx#new-provider-package-checksums): the newly-added checksums each match one of the `zh:` checksums previously recorded and represent the same information in a different way. In OpenTofu v1.12 this is now a one-time backfill of all of the official checksums, rather than "upgrading" them one-by-one as in earlier versions.
 
-The new **`enabled` meta-argument** offers an alternative to the existing `count` and `for_each` meta-arguments for situations where a particular resource instance or module instance has either zero or one instances.
+- **WinRM connections for provisioners are deprecated**: Provisioner connection blocks with `type = "winrm"` will now cause warnings in this release, and will no longer be supported at all in OpenTofu v1.13.
 
-The initial form of this argument is nested inside a `lifecycle` block, rather than directly inside a resource or module declaration, to avoid conflicting with existing input variables or resource type arguments named `enabled`.
+    We recommend migrating to [OpenSSH for Windows](https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse).
 
-For more information, refer to [the `enabled` meta-argument](https://opentofu.org/docs/v1.11/language/meta-arguments/enabled/).
+- **Phasing out support for 32-bit CPU architectures**: In a future release we plan to stop providing official release builds for the 32-bit `386` and `arm` CPU architectures. Support for `amd64` and `arm64` is unaffected.
 
-## Improvements to existing features
+    There is no immediate change to supported platforms in the v1.12 series, but we expect to introduce a deprecation warning in v1.13 and then stop providing official builds for these architectures completely in a future release series. If you don't expect that you'll be able to complete a migration to running on a 64-bit architecture in the next year, please tell us about your situation in [issue #3912](https://github.com/opentofu/opentofu/issues/3912)..
 
-### Tag support added to S3 backend
-
-The S3 backend now supports **object tagging** your backend, allowing you to add custom tags to your state files for better organization and cost tracking.
-
-## Deprecations
-
-- **Azure Backend (`azurerm`)**:
-
-  - The `endpoint` and `ARM_ENDPOINT` configuration options are no longer supported
-  - The `msi_endpoint` and `ARM_MSI_ENDPOINT` options are no longer supported
-  - The `environment` and `metadata_host` arguments are now mutually exclusive
-
-- **issensitive() Function**: Now correctly returns unknown results when evaluating unknown values. Code that previously relied on the incorrect behavior may need updates.
-
-- **Testing with Mocks**: Mock values generated during testing now strictly adhere to provider schemas. Test configurations with invalid mock values will need to be corrected.
-
-- **S3 Module Installation**: When installing module packages from Amazon S3 buckets using S3 source addresses OpenTofu will use the same credentials as the AWS CLI and SDK.
-
-- **TLS and SSH Security**:
-  - SHA-1 signatures are no longer accepted for TLS or SSH connections
-  - SSH certificates must comply with the `draft-miller-ssh-cert-03` specification
-
-
-## Full Changelog
-
-You can find the full changelog at https://github.com/opentofu/opentofu/blob/v1.11/CHANGELOG.md


### PR DESCRIPTION
As well as the usual mechanical replacements of any mention of the current release version number, this includes some other broader changes:

- The page about upgrading from earlier versions now just refers generally to "earlier versions", because continuing the tradition of listing every previous version of OpenTofu explicitly would make the page title and content very unwieldy now that there are four earlier releases.
- The "What's New" page is now just a short overview of the new features followed by a link to the longer-form content in the announcement blog post, since that makes the page easier to scan and keeps a single main place for the full announcement content.
- The sidebar is slightly reordered so that upgrading from previous OpenTofu versions is now sorted before migrating from Terraform. The page title is also now "Migrating from Terraform" rather than "Migrating to OpenTofu" so that it's clearer who is the audience for that set of pages.
- And finally, just some general copyediting to freshen some of this per-release content that has been with us for a long time, and to focus some of the pages a little more tightly.

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
