### PR TITLE
Fix panic during closing of the ephemeral resources

### DIFF
--- a/internal/shared/ephemeral_resource.go
+++ b/internal/shared/ephemeral_resource.go
@@ -147,6 +147,10 @@ func OpenEphemeralResourceInstance(
 	closeCh := make(chan context.Context, 1)
 	diagsCh := make(chan tfdiags.Diagnostics, 1)
 	go func() {
+		// The writer is responsible with closing the channel, not the receiver.
+		defer func() {
+			close(diagsCh)
+		}()
 		var diags tfdiags.Diagnostics
 		renewAt := openResp.RenewAt
 		privateData := openResp.Private
@@ -212,15 +216,16 @@ func OpenEphemeralResourceInstance(
 			hooks.PostClose(addr, diags)
 		}
 
-		diagsCh <- diags
+		select {
+		case diagsCh <- diags:
+		case <-time.After(500 * time.Millisecond):
+			log.Printf("[ERROR] OpenEphemeralResourceInstance: Diagnostics not sent fully after closing ephemeral %s", diags)
+		}
 	}()
 
 	closeFunc := func(ctx context.Context) tfdiags.Diagnostics {
 		closeCh <- ctx
 		close(closeCh)
-		defer func() {
-			close(diagsCh)
-		}()
 
 		timeout := 10 * time.Second
 		select {

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -9024,14 +9024,38 @@ ephemeral "test_ephemeral_resource" "a" {
 `,
 	})
 	p := testProvider("test")
-	p.OpenEphemeralResourceResponse = &providers.OpenEphemeralResourceResponse{
-		Result: cty.ObjectVal(map[string]cty.Value{
-			"id":     cty.StringVal("id val"),
-			"secret": cty.StringVal("val"),
-			"input":  cty.NullVal(cty.String),
-		}),
+
+	// To avoid race conditions, we perform the below checks only after the calls to the provider methods
+	// are performed.
+	callsCh := make(chan struct{}, 2)
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		var i int
+		for {
+			select {
+			case <-callsCh:
+				i++
+				if i == 2 {
+					return
+				}
+			case <-t.Context().Done():
+				return
+			}
+		}
+	}()
+	p.OpenEphemeralResourceFn = func(request providers.OpenEphemeralResourceRequest) providers.OpenEphemeralResourceResponse {
+		defer func() { callsCh <- struct{}{} }()
+		return providers.OpenEphemeralResourceResponse{
+			Result: cty.ObjectVal(map[string]cty.Value{
+				"id":     cty.StringVal("id val"),
+				"secret": cty.StringVal("val"),
+				"input":  cty.NullVal(cty.String),
+			}),
+		}
 	}
 	p.CloseEphemeralResourceFn = func(request providers.CloseEphemeralResourceRequest) providers.CloseEphemeralResourceResponse {
+		defer func() { callsCh <- struct{}{} }()
 		<-time.After(10 * time.Second) // exactly the same with the timeout inside internal/shared/ephemeral_resource.go
 		return providers.CloseEphemeralResourceResponse{}
 	}
@@ -9052,6 +9076,11 @@ ephemeral "test_ephemeral_resource" "a" {
 			t.Fatalf("unexpected plan error: %s", diags)
 		}
 		t.Logf("Plan failed with the expected error")
+	}
+	select {
+	case <-doneCh:
+	case <-time.After(12 * time.Second):
+		t.Fatalf("timed out while waiting for the provider calls to be performed")
 	}
 	if !p.OpenEphemeralResourceCalled {
 		t.Errorf("Provider's OpenEphemeralResource wasn't called; should've been")

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
@@ -9003,6 +9004,60 @@ variable "ephemeral_var" {
 	}
 	if dv, ok := plan.VariableValues["regular_var"]; !ok || !slices.Equal(expectedRegularVal, dv) {
 		t.Errorf("wrong value stored in the plan for regular_var. expected: %s; got: %s", expectedRegularVal, dv)
+	}
+}
+
+// This is to ensure that the panic encountered during closing ephemeral resources does not occur again.
+// panic: send on closed channel
+//
+//	github.com/opentofu/opentofu/internal/shared.OpenEphemeralResourceInstance.func2()
+//
+// Even with the current test setup, the error can be caught only intermittently, so if you want to
+// check it, you have to run it several times.
+// The assertions of this test are quite permissive, because we are not interested in that specifically,
+// but the focus is more on the panic. If the logic panics, the test will fail.
+func TestContext2Plan_ephemeralClosingTimeout(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+ephemeral "test_ephemeral_resource" "a" {
+}
+`,
+	})
+	p := testProvider("test")
+	p.OpenEphemeralResourceResponse = &providers.OpenEphemeralResourceResponse{
+		Result: cty.ObjectVal(map[string]cty.Value{
+			"id":     cty.StringVal("id val"),
+			"secret": cty.StringVal("val"),
+			"input":  cty.NullVal(cty.String),
+		}),
+	}
+	p.CloseEphemeralResourceFn = func(request providers.CloseEphemeralResourceRequest) providers.CloseEphemeralResourceResponse {
+		<-time.After(10 * time.Second) // exactly the same with the timeout inside internal/shared/ephemeral_resource.go
+		return providers.CloseEphemeralResourceResponse{}
+	}
+
+	state := states.NewState()
+
+	ctx := testContext2(t, &ContextOpts{
+		Plugins: plugins.NewLibrary(map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		}, nil),
+	})
+
+	_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{Mode: plans.NormalMode})
+	if diags.HasErrors() {
+		// Because of the setup (10 seconds to close and 10 seconds the timeout), this test can fail intermittently.
+		// Therefore, in case there is a situation where it fails, we only expect one diagnostic.
+		if len(diags) != 1 || !strings.Contains(diags.Err().Error(), "Closing ephemeral resource timed out") {
+			t.Fatalf("unexpected plan error: %s", diags)
+		}
+		t.Logf("Plan failed with the expected error")
+	}
+	if !p.OpenEphemeralResourceCalled {
+		t.Errorf("Provider's OpenEphemeralResource wasn't called; should've been")
+	}
+	if !p.CloseEphemeralResourceCalled {
+		t.Errorf("Provider's CloseEphemeralResource wasn't called; should've been")
 	}
 }
 


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves _No issue_

Discovered this during another test, and coincidentally, the closing of the ephemeral resources took exactly the amount of time that is [configured as timeout for the closing operation](https://github.com/opentofu/opentofu/blob/9e746cc2d159933d665cb8680819fccb99195531/internal/shared/ephemeral_resource.go#L225).
When that exact condition is met, the [writing of the diagnostics](https://github.com/opentofu/opentofu/blob/9e746cc2d159933d665cb8680819fccb99195531/internal/shared/ephemeral_resource.go#L215) for the `CloseEphemeralResource` fails because the close function returned and the [defer statements have been executed, closing the diagnostics channel](https://github.com/opentofu/opentofu/blob/9e746cc2d159933d665cb8680819fccb99195531/internal/shared/ephemeral_resource.go#L221-L223).

To avoid this kind of issues, as a general rule of thumb, in Go, the writer is responsible with the channel closing, and not the reader, so now the goroutine that writes to the channel it also closes it.
The fix includes also a failover, to avoid a deadlock in case the channel is full and there is no other reader of it.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
