### PR TITLE
states: Add missing lock in RemoveResourceInstanceObjectFull

### DIFF
--- a/internal/states/instance_object_full.go
+++ b/internal/states/instance_object_full.go
@@ -211,6 +211,9 @@ func (s *SyncState) SetResourceInstanceObjectFull(addr addrs.AbsResourceInstance
 // quirk exists because changes to resource instance objects currently also
 // implicitly update resource-level and instance-level metadata.
 func (s *SyncState) RemoveResourceInstanceObjectFull(addr addrs.AbsResourceInstanceObject, providerInstAddr addrs.AbsProviderInstanceCorrect) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
 	// FIXME: Rework this so that removing an object does _not_ also implicitly
 	// update the resource-level and instance-level provider tracking, which
 	// is only currently necessary because we're trying to use preexisting


### PR DESCRIPTION
## What

`SyncState.RemoveResourceInstanceObjectFull` reads and mutates `s.state` and calls `s.maybePruneModule` without holding `s.lock`. This fix adds the missing `s.lock.Lock()`/`defer s.lock.Unlock()`, matching every other mutation method on `SyncState`.

## How it crashes

`RemoveResourceInstanceObjectFull` is called from two sites that run concurrently inside the execution engine:

- `internal/engine/planning/plan_data.go:120` (orphan data resource cleanup during planning)
- `internal/engine/applying/operations_resource_managed.go:273` (resource deletion during apply)

Both callers execute inside goroutines spawned by `internal/engine/internal/execgraph/compiled.go:84`:

```go
go func() {
    opDiags := step(ctx)   // eventually calls RemoveResourceInstanceObjectFull
    // ...
}()
```

When two or more resource deletions run concurrently, the unsynchronized access to the underlying Go maps in `s.state` triggers a fatal runtime panic:

```
fatal error: concurrent map read and map write

goroutine 42 [running]:
runtime.throw({0x...})
    runtime/panic.go:1077 +0x...
runtime.mapaccess1_faststr(...)
    runtime/map_faststr.go:13 +0x...
```

This crash is non-recoverable (it bypasses `defer`/`recover`) and kills the entire `tofu plan` or `tofu apply` process.

The `maybePruneModule` helper called on line 235 explicitly documents this requirement at `internal/states/sync.go:542-543`:

```go
// This helper method is not concurrency-safe on its own, so must only be
// called while the caller is already holding the lock for writing.
```

Every other caller of `maybePruneModule` in `sync.go` (lines 119, 159, 234, 248, 276, 305, 337, 395, 409, 485) properly acquires `s.lock` before calling it.

## Fix

Add `s.lock.Lock()`/`defer s.lock.Unlock()` at the top of `RemoveResourceInstanceObjectFull`, matching the identical pattern used by its sibling method `SetResourceInstanceObjectFull` (line 166-167).

Introduced in #3840.

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code does not break anything.
- [x] I have only exported functions, variables and structs that should be used from other packages.
