### PR TITLE
communicator/ssh: Remove private key and certificate material from error messages

### DIFF
--- a/internal/communicator/ssh/provisioner.go
+++ b/internal/communicator/ssh/provisioner.go
@@ -400,7 +400,7 @@ func buildSSHClientConfig(opts sshClientConfigOpts) (*ssh.ClientConfig, error) {
 func signCertWithPrivateKey(pk string, certificate string) (ssh.AuthMethod, error) {
 	rawPk, err := ssh.ParseRawPrivateKey([]byte(pk))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse private key %q: %w", pk, err)
+		return nil, fmt.Errorf("failed to parse private key: %w", err)
 	}
 
 	// golang.org/x/crypto/ssh does not expose certificate parsing as a
@@ -409,7 +409,7 @@ func signCertWithPrivateKey(pk string, certificate string) (ssh.AuthMethod, erro
 	// guaranteed to be a certificate.
 	maybeCert, _, _, _, err := ssh.ParseAuthorizedKey([]byte(certificate))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse certificate %q: %w", certificate, err)
+		return nil, fmt.Errorf("failed to parse certificate: %w", err)
 	}
 	cert, ok := maybeCert.(*ssh.Certificate)
 	if !ok {
@@ -430,12 +430,12 @@ func signCertWithPrivateKey(pk string, certificate string) (ssh.AuthMethod, erro
 
 	usigner, err := ssh.NewSignerFromKey(rawPk)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create signer from raw private key %q: %w", rawPk, err)
+		return nil, fmt.Errorf("failed to create signer from private key: %w", err)
 	}
 
 	ucertSigner, err := ssh.NewCertSigner(cert, usigner)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create cert signer %q: %w", usigner, err)
+		return nil, fmt.Errorf("failed to create cert signer: %w", err)
 	}
 
 	return ssh.PublicKeys(ucertSigner), nil


### PR DESCRIPTION
## What

`signCertWithPrivateKey()` in the SSH communicator formats private key
content, certificate content, and parsed key/signer structs into error
messages using `%q`. These error strings propagate to terminal output,
CI/CD logs, and cloud platform UIs, exposing credential material to
anyone with log access.

## How it leaks

The four `fmt.Errorf` calls in `signCertWithPrivateKey` include sensitive
values via `%q`:

```go
// Line 403 - full PEM-encoded private key
return nil, fmt.Errorf("failed to parse private key %q: %w", pk, err)

// Line 412 - full SSH certificate content
return nil, fmt.Errorf("failed to parse certificate %q: %w", certificate, err)

// Line 433 - parsed raw private key struct (*rsa.PrivateKey, *ecdsa.PrivateKey, etc.)
// Go's %q on a struct prints all fields including private exponents and primes
return nil, fmt.Errorf("failed to create signer from raw private key %q: %w", rawPk, err)

// Line 438 - SSH signer derived from the private key
return nil, fmt.Errorf("failed to create cert signer %q: %w", usigner, err)
```

When a user provides a malformed key or certificate in their `connection`
block, the parse error propagates up through the provisioner to:
- Terminal output (visible in scrollback and screen recordings)
- CI/CD logs (GitHub Actions, Jenkins, GitLab CI, stored indefinitely)
- Cloud platform UIs (Terraform Cloud, Spacelift, env0, Scalr)

## Fix

Remove the sensitive data from all four format strings. The wrapped error
(`%w`) already contains the actionable diagnostic from `golang.org/x/crypto/ssh`
(e.g., "ssh: no key found", "ssh: invalid openssh private key format").
The key material itself adds no debugging value since the user already
knows which key they configured.

The sibling function `readPrivateKey()` was already safe (it only formats
`err`, not the key content).

## Related

Same fix on the Terraform side:
- [hashicorp/terraform#38543](https://github.com/hashicorp/terraform/pull/38543) - Redact private key material from SSH error messages

Related redaction work:
- [hashicorp/terraform#30067](https://github.com/hashicorp/terraform/pull/30067) - Redact sensitive values from function errors
- [moby/moby#33884](https://github.com/moby/moby/pull/33884) - Redact secret data on "secret create"

Introduced in #414.

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code does not break anything.
- [x] I have only exported functions, variables and structs that should be used from other packages.
