### PR TITLE
backend/s3: Close response body in getLockInfoFromS3

### DIFF
--- a/internal/backend/remote-state/s3/client.go
+++ b/internal/backend/remote-state/s3/client.go
@@ -487,6 +487,7 @@ func (c *RemoteClient) getLockInfoFromS3(ctx context.Context) (*statemgr.LockInf
 
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	lockInfo := &statemgr.LockInfo{}
 	err = json.NewDecoder(resp.Body).Decode(lockInfo)


### PR DESCRIPTION
## What

`getLockInfoFromS3` calls `s3Client.GetObject` but never closes `resp.Body`,
leaking an HTTP connection on every call.

## How it leaks

```go
// internal/backend/remote-state/s3/client.go, line 481
resp, err := c.s3Client.GetObject(ctx, getParams, ...)
if err != nil {
    // ... error handling returns, no body to close (correct)
    return nil, err
}

// Body is read here but never closed
lockInfo := &statemgr.LockInfo{}
err = json.NewDecoder(resp.Body).Decode(lockInfo)
```

The AWS SDK v2 requires callers to close `GetObject` response bodies. Each
unclosed body holds an HTTP connection from the transport pool. This function
is called during `s3Lock` (when another lock exists) and `s3Unlock` (to verify
lock ownership), so the leak occurs on every contested lock operation and every
unlock.

In long-running automation with frequent state operations, leaked connections
accumulate and can exhaust the connection pool, causing subsequent S3 requests
to stall waiting for an available connection.

The sibling method `Get` in the same file already handles this correctly:

```go
// line 178 - correct pattern
defer output.Body.Close()
```

## Fix

Add `defer resp.Body.Close()` after the error check, matching the pattern
used by `Get`.

Introduced in #2521.

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code does not break anything.
- [x] I have only exported functions, variables and structs that should be used from other packages.
