### PR TITLE
go.mod: Upgrade to Go 1.25.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 The v1.11.x release series is supported until **August 1 2026**.
 
 ## 1.11.8 (Unreleased)
+
+SECURITY ADVISORIES:
+
+* Previous releases in the v1.11 series could potentially take an excessive amount of time and send extraneous data to an HTTP2 server that specifies a maximum frame size of zero. This is now fixed. ([#4094](https://github.com/opentofu/opentofu/issues/4094))
+
+    An attacker that can coerce an operator to install a dependency from an attacker-controlled server could use this to cause unexpected resource consumption during `tofu init`.
+
 ## 1.11.7
 
 BUG FIXES:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opentofu/opentofu
 
-go 1.25.9
+go 1.25.10
 
 // At the time of adding this configuration, the new Go feature introduced here https://github.com/golang/go/issues/67061,
 // was having a good amount of issues linked to, affecting AWS Firewall, GCP various services and a lot more.


### PR DESCRIPTION
This is primarily to fix https://github.com/opentofu/opentofu/issues/4094, although there are various other small improvements in this minor release too.

This also closes https://github.com/opentofu/opentofu/issues/4095, which came in through the "govulncheck" path but from OpenTofu's perspective is just a hypothetical crasher bug, and we don't know of any specific way to cause that bug to be triggered through OpenTofu's functionality so there won't be a changelog entry for it.
