### PR TITLE
go.mod: Upgrade to Go 1.26.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opentofu/opentofu
 
-go 1.26.2
+go 1.26.3
 
 // At the time of adding this configuration, the new Go feature introduced here https://github.com/golang/go/issues/67061,
 // was having a good amount of issues linked to, affecting AWS Firewall, GCP various services and a lot more.


### PR DESCRIPTION
This is primarily to address https://github.com/opentofu/opentofu/issues/4094, but also includes some other minor fixes.

This is the version of the change for the `main` branch, although by the time we're releasing v1.13 from that branch we're expecting to be on Go 1.27 anyway, so this is mainly just for consistency/completeness.

The changelog entry for this was in https://github.com/opentofu/opentofu/pull/4098.
