### PR TITLE
[v1.12 backport] go.mod: Upgrade to Go 1.26.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opentofu/opentofu
 
-go 1.26.2
+go 1.26.3
 
 // At the time of adding this configuration, the new Go feature introduced here https://github.com/golang/go/issues/67061,
 // was having a good amount of issues linked to, affecting AWS Firewall, GCP various services and a lot more.


### PR DESCRIPTION
This is primarily to address https://github.com/opentofu/opentofu/issues/4094, but also includes some other minor fixes.

This is the v1.12 backport, intended for inclusion in the forthcoming v1.12.0 release.

The changelog entry for this was in https://github.com/opentofu/opentofu/pull/4098.
