### PR TITLE
tofu: Don't panic if provider startup fails during validate

### DIFF
--- a/internal/tofu/node_provider.go
+++ b/internal/tofu/node_provider.go
@@ -103,9 +103,11 @@ func (n *NodeApplyableProvider) Execute(ctx context.Context, evalCtx EvalContext
 	if op == walkValidate {
 		log.Printf("[TRACE] NodeApplyableProvider: validating configuration for %s", n.Addr)
 		instance, newDiags := evalCtx.Providers().NewProvider(ctx, n.Addr.Provider)
-		n.instances[addrs.NoKey] = instance
-		for key, data := range instanceData {
-			diags = diags.Append(n.ValidateProvider(ctx, evalCtx, instance, key, data))
+		if !newDiags.HasErrors() { // We can't validate if we didn't successfully start the provider plugin
+			n.instances[addrs.NoKey] = instance
+			for key, data := range instanceData {
+				diags = diags.Append(n.ValidateProvider(ctx, evalCtx, instance, key, data))
+			}
 		}
 		return diags.Append(newDiags)
 	}


### PR DESCRIPTION
If a `ProviderManager` returns error diagnostics when asked to start up a provider then the providers.Interface it returns is likely to be uninitialized, so we mustn't try to use it to validate the provider configuration in that case.

(I'm fixing this because somebody reported seeing a panic caused by this, and the panic is obscuring whatever the real error is. Once this is fixed it'll presumably reveal another problem by returning an error diagnostic.)

