### PR TITLE
Add DNF alongside Yum in the install guide (#1205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ BUG FIXES:
 - provisioner output is no longer suppressed when `-show-sensitive` is passed. ([#3927](https://github.com/opentofu/opentofu/issues/3927))
 - In the `azurerm` backend's OpenID Connect authorization method, when `audience` is provided as a query parameter in the URL, it will be passed through instead of being overwritten by a default value. ([#4037](https://github.com/opentofu/opentofu/pull/4037))
 
+DOCUMENTATION:
+
+- Added DNF as an install option alongside Yum in the RPM-based Linux install guide. ([#1205](https://github.com/opentofu/opentofu/issues/1205))
+
 ## Previous Releases
 
 For information on prior major and minor releases, refer to their changelogs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,6 @@ BUG FIXES:
 - provisioner output is no longer suppressed when `-show-sensitive` is passed. ([#3927](https://github.com/opentofu/opentofu/issues/3927))
 - In the `azurerm` backend's OpenID Connect authorization method, when `audience` is provided as a query parameter in the URL, it will be passed through instead of being overwritten by a default value. ([#4037](https://github.com/opentofu/opentofu/pull/4037))
 
-DOCUMENTATION:
-
-- Added DNF as an install option alongside Yum in the RPM-based Linux install guide. ([#1205](https://github.com/opentofu/opentofu/issues/1205))
-
 ## Previous Releases
 
 For information on prior major and minor releases, refer to their changelogs:

--- a/website/docs/intro/install/examples/install-dnf.sh
+++ b/website/docs/intro/install/examples/install-dnf.sh
@@ -1,0 +1,1 @@
+sudo dnf install -y tofu

--- a/website/docs/intro/install/rpm.mdx
+++ b/website/docs/intro/install/rpm.mdx
@@ -35,7 +35,7 @@ The following steps explain how to set up the OpenTofu RPM repositories. These i
 ### Adding the OpenTofu repository
 
 <Tabs>
-    <TabItem value="redhat" label="Yum (RHEL/AlmaLinux/etc.)" default>
+    <TabItem value="redhat" label="Yum/DNF (RHEL/AlmaLinux/etc.)" default>
         Create the <code>/etc/yum.repos.d/opentofu.repo</code> file by running the following command:
         <CodeBlock language={"bash"}>{YumRepoScript}</CodeBlock>
     </TabItem>

--- a/website/docs/intro/install/rpm.mdx
+++ b/website/docs/intro/install/rpm.mdx
@@ -12,6 +12,7 @@ import RpmConvenienceScript from '!!raw-loader!./examples/rpm-convenience.sh'
 import YumRepoScript from '!!raw-loader!./examples/repo-yum.sh'
 import ZypperRepoScript from '!!raw-loader!./examples/repo-zypper.sh'
 import YumInstallScript from '!!raw-loader!./examples/install-yum.sh'
+import DnfInstallScript from '!!raw-loader!./examples/install-dnf.sh'
 import ZypperInstallScript from '!!raw-loader!./examples/install-zypper.sh'
 import Buildkite from "./buildkite";
 
@@ -51,6 +52,9 @@ Now you install OpenTofu by running:
 <Tabs>
     <TabItem value="redhat" label="Yum (RHEL/AlmaLinux/etc)" default>
         <CodeBlock language={"bash"}>{YumInstallScript}</CodeBlock>
+    </TabItem>
+    <TabItem value="redhat-dnf" label="DNF (Fedora/RHEL 8+/AlmaLinux 9+)">
+        <CodeBlock language={"bash"}>{DnfInstallScript}</CodeBlock>
     </TabItem>
     <TabItem value="opensuse-leap" label="Zypper (openSUSE)">
         <CodeBlock language={"bash"}>{ZypperInstallScript}</CodeBlock>


### PR DESCRIPTION
Resolves #  #1205

Adds DNF as an install option alongside Yum in the RPM-based Linux install guide (website/docs/intro/install/rpm.mdx). DNF has been the default package manager on Fedora since v22 and RHEL/AlmaLinux since v8/v9, with yum officially deprecated.

Testing

Verified via Docker on almalinux:9 using the existing repo-yum.sh repo setup followed by dnf install -y tofu:

```
#7 11.95 Installed:
#7 11.95   tofu-1.12.0-1.aarch64

#8 [4/4] RUN tofu --version
#8 0.121 OpenTofu v1.12.0
#8 0.121 on linux_arm64
```

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [ x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [ x] I have not used an AI coding assistant to create this PR.
- [ x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [ x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
