### PR TITLE
Prepare config loader to be used independently, without relying on the Meta struct

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -273,7 +273,7 @@ type Operation struct {
 
 	// ConfigLoader is a configuration loader that can be used to load
 	// configuration from ConfigDir.
-	ConfigLoader *configload.Loader
+	ConfigLoader configload.Loader
 
 	// DependencyLocks represents the locked dependencies associated with
 	// the configuration directory given in ConfigDir.

--- a/internal/checks/state_test.go
+++ b/internal/checks/state_test.go
@@ -20,12 +20,9 @@ func TestChecksHappyPath(t *testing.T) {
 
 	t.Chdir(fixtureDir)
 
-	loader, err := configload.NewLoader(&configload.Config{
+	loader := configload.NewLazy(&configload.Config{
 		ModulesDir: ".terraform/modules/",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	cfg, hclDiags := loader.LoadConfig(t.Context(), ".", configs.RootModuleCallForTesting())
 	if hclDiags.HasErrors() {

--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opentofu/opentofu/internal/backend"
 	"github.com/opentofu/opentofu/internal/command/arguments"
 	"github.com/opentofu/opentofu/internal/command/views"
+	"github.com/opentofu/opentofu/internal/configs/configload"
 	"github.com/opentofu/opentofu/internal/encryption"
 	"github.com/opentofu/opentofu/internal/plans/planfile"
 	"github.com/opentofu/opentofu/internal/tfdiags"
@@ -276,7 +277,7 @@ func (c *ApplyCommand) OperationRequest(
 	opReq.View = view.Operation()
 
 	var err error
-	opReq.ConfigLoader, err = c.initConfigLoader()
+	opReq.ConfigLoader, err = configload.Initialize(c.configLoader())
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("Failed to initialize config loader: %w", err))
 		return nil, diags

--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -277,7 +277,7 @@ func (c *ApplyCommand) OperationRequest(
 	opReq.View = view.Operation()
 
 	var err error
-	opReq.ConfigLoader, err = configload.Initialize(c.configLoader())
+	opReq.ConfigLoader, err = configload.Initialise(c.configLoader())
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("Failed to initialize config loader: %w", err))
 		return nil, diags

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -155,7 +155,7 @@ func testModuleWithSnapshot(t *testing.T, name string) (*configs.Config, *config
 	t.Helper()
 
 	dir := filepath.Join(fixtureDir, name)
-	loader := configload.NewLoaderForTests(t)
+	loader := configload.NewLoaderForTests(t, false)
 
 	// Test modules usually do not refer to remote sources, and for local
 	// sources only this ultimately just records all of the module paths

--- a/internal/command/console.go
+++ b/internal/command/console.go
@@ -16,6 +16,7 @@ import (
 	"github.com/opentofu/opentofu/internal/backend"
 	"github.com/opentofu/opentofu/internal/command/arguments"
 	"github.com/opentofu/opentofu/internal/command/views"
+	"github.com/opentofu/opentofu/internal/configs/configload"
 	"github.com/opentofu/opentofu/internal/repl"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/opentofu/opentofu/internal/tofu"
@@ -112,7 +113,7 @@ func (c *ConsoleCommand) Run(rawArgs []string) int {
 	// Build the operation
 	opReq := c.Operation(ctx, b, view.Backend(), enc)
 	opReq.ConfigDir = configPath
-	opReq.ConfigLoader, err = c.initConfigLoader()
+	opReq.ConfigLoader, err = configload.Initialize(c.configLoader())
 	opReq.AllowUnsetVariables = true // we'll just evaluate them as unknown
 	if err != nil {
 		diags = diags.Append(err)

--- a/internal/command/console.go
+++ b/internal/command/console.go
@@ -113,7 +113,7 @@ func (c *ConsoleCommand) Run(rawArgs []string) int {
 	// Build the operation
 	opReq := c.Operation(ctx, b, view.Backend(), enc)
 	opReq.ConfigDir = configPath
-	opReq.ConfigLoader, err = configload.Initialize(c.configLoader())
+	opReq.ConfigLoader, err = configload.Initialise(c.configLoader())
 	opReq.AllowUnsetVariables = true // we'll just evaluate them as unknown
 	if err != nil {
 		diags = diags.Append(err)

--- a/internal/command/fmt.go
+++ b/internal/command/fmt.go
@@ -191,7 +191,7 @@ func (c *FmtCommand) processFile(path string, r io.Reader, w io.Writer, args arg
 
 	// Register this path as a synthetic configuration source, so that any
 	// diagnostic errors can include the source code snippet
-	c.registerSynthConfigSource(path, src)
+	c.configLoader().ForceFileSource(path, src)
 
 	// File must be parseable as HCL native syntax before we'll try to format
 	// it. If not, the formatter is likely to make drastic changes that would

--- a/internal/command/graph.go
+++ b/internal/command/graph.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opentofu/opentofu/internal/backend"
 	"github.com/opentofu/opentofu/internal/command/arguments"
 	"github.com/opentofu/opentofu/internal/command/views"
+	"github.com/opentofu/opentofu/internal/configs/configload"
 	"github.com/opentofu/opentofu/internal/dag"
 	"github.com/opentofu/opentofu/internal/plans"
 	"github.com/opentofu/opentofu/internal/plans/planfile"
@@ -147,7 +148,7 @@ func (c *GraphCommand) Run(rawArgs []string) int {
 	// Build the operation
 	opReq := c.Operation(ctx, b, view.Backend(), enc)
 	opReq.ConfigDir = configPath
-	opReq.ConfigLoader, err = c.initConfigLoader()
+	opReq.ConfigLoader, err = configload.Initialize(c.configLoader())
 	opReq.PlanFile = planFile
 	opReq.AllowUnsetVariables = true
 

--- a/internal/command/graph.go
+++ b/internal/command/graph.go
@@ -148,7 +148,7 @@ func (c *GraphCommand) Run(rawArgs []string) int {
 	// Build the operation
 	opReq := c.Operation(ctx, b, view.Backend(), enc)
 	opReq.ConfigDir = configPath
-	opReq.ConfigLoader, err = configload.Initialize(c.configLoader())
+	opReq.ConfigLoader, err = configload.Initialise(c.configLoader())
 	opReq.PlanFile = planFile
 	opReq.AllowUnsetVariables = true
 

--- a/internal/command/import.go
+++ b/internal/command/import.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/mitchellh/cli"
+	"github.com/opentofu/opentofu/internal/configs/configload"
 	"github.com/opentofu/opentofu/internal/tracing"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -76,7 +77,7 @@ func (c *ImportCommand) Run(rawArgs []string) int {
 	if travDiags.HasErrors() {
 		// NOTE: The call to registerSynthConfigSource works well with the view.Diagnostics too since the view is
 		// configured in [Meta.initConfigLoader] with a callback to get the sources when it prints the diagnostics.
-		c.registerSynthConfigSource("<import-address>", traversalSrc) // so we can include a source snippet
+		c.configLoader().ForceFileSource("<import-address>", traversalSrc) // so we can include a source snippet
 		view.Diagnostics(diags)
 		view.InvalidAddressReference()
 		return 1
@@ -86,7 +87,7 @@ func (c *ImportCommand) Run(rawArgs []string) int {
 	if addrDiags.HasErrors() {
 		// NOTE: The call to registerSynthConfigSource works well with the view.Diagnostics too since the view is
 		// configured in [Meta.initConfigLoader] with a callback to get the sources when it prints the diagnostics.
-		c.registerSynthConfigSource("<import-address>", traversalSrc) // so we can include a source snippet
+		c.configLoader().ForceFileSource("<import-address>", traversalSrc) // so we can include a source snippet
 		view.Diagnostics(diags)
 		view.InvalidAddressReference()
 		return 1
@@ -111,7 +112,7 @@ func (c *ImportCommand) Run(rawArgs []string) int {
 		return 1
 	}
 
-	if !c.dirIsConfigPath(args.ConfigPath) {
+	if !c.configLoader().IsConfigDir(args.ConfigPath) {
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "No OpenTofu configuration files",
@@ -216,7 +217,7 @@ func (c *ImportCommand) Run(rawArgs []string) int {
 	// Build the operation
 	opReq := c.Operation(ctx, b, view.Backend(), enc)
 	opReq.ConfigDir = args.ConfigPath
-	opReq.ConfigLoader, err = c.initConfigLoader()
+	opReq.ConfigLoader, err = configload.Initialize(c.configLoader())
 	if err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,

--- a/internal/command/import.go
+++ b/internal/command/import.go
@@ -75,8 +75,8 @@ func (c *ImportCommand) Run(rawArgs []string) int {
 	traversal, travDiags := hclsyntax.ParseTraversalAbs(traversalSrc, "<import-address>", hcl.Pos{Line: 1, Column: 1})
 	diags = diags.Append(travDiags)
 	if travDiags.HasErrors() {
-		// NOTE: The call to registerSynthConfigSource works well with the view.Diagnostics too since the view is
-		// configured in [Meta.initConfigLoader] with a callback to get the sources when it prints the diagnostics.
+		// NOTE: The call to Loader.ForceFileSource works well with the view.Diagnostics too since the view is
+		// configured in [Meta.configLoader] with a callback to get the sources when it prints the diagnostics.
 		c.configLoader().ForceFileSource("<import-address>", traversalSrc) // so we can include a source snippet
 		view.Diagnostics(diags)
 		view.InvalidAddressReference()
@@ -85,8 +85,8 @@ func (c *ImportCommand) Run(rawArgs []string) int {
 	addr, addrDiags := addrs.ParseAbsResourceInstance(traversal)
 	diags = diags.Append(addrDiags)
 	if addrDiags.HasErrors() {
-		// NOTE: The call to registerSynthConfigSource works well with the view.Diagnostics too since the view is
-		// configured in [Meta.initConfigLoader] with a callback to get the sources when it prints the diagnostics.
+		// NOTE: The call to Loader.ForceFileSource works well with the view.Diagnostics too since the view is
+		// configured in [Meta.configLoader] with a callback to get the sources when it prints the diagnostics.
 		c.configLoader().ForceFileSource("<import-address>", traversalSrc) // so we can include a source snippet
 		view.Diagnostics(diags)
 		view.InvalidAddressReference()

--- a/internal/command/import.go
+++ b/internal/command/import.go
@@ -217,7 +217,7 @@ func (c *ImportCommand) Run(rawArgs []string) int {
 	// Build the operation
 	opReq := c.Operation(ctx, b, view.Backend(), enc)
 	opReq.ConfigDir = args.ConfigPath
-	opReq.ConfigLoader, err = configload.Initialize(c.configLoader())
+	opReq.ConfigLoader, err = configload.Initialise(c.configLoader())
 	if err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -400,8 +400,8 @@ func (c *InitCommand) getModules(ctx context.Context, path, testsDir string, ear
 
 	// Since module installer has modified the module manifest on disk, we need
 	// to refresh the cache of it in the loader.
-	if c.configLoader != nil {
-		if err := c.configLoader.RefreshModules(); err != nil {
+	if c.cfgLoader != nil {
+		if err := c.cfgLoader.RefreshModules(); err != nil {
 			// Should never happen
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -167,7 +167,7 @@ type Meta struct {
 	// configLoader is a shared configuration loader that is used by
 	// LoadConfig and other commands that access configuration files.
 	// It is initialized on first use.
-	configLoader *configload.Loader
+	configLoader configload.Loader
 
 	// backendState is the currently active backend state
 	backendState *clistate.BackendState

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -164,6 +164,13 @@ type Meta struct {
 	// Private: do not set these
 	// ----------------------------------------------------------
 
+	// TODO meta-refactor: we need to refactor the tests to provide a config loader
+	//   and not rely on the on-the-fly initialisation of it from the Meta struct.
+	//   Once we do it, the regular logic flow should rely on having it initialised before
+	//   creating the commands, like passing it to `initCommands`.
+	//   This way, the tests will provide the config loader and the main logic will
+	//   provide one before even creating the commands. We cannot initialise this in
+	//   the Run of the commands because some autocompletion methods rely on it too.
 	// cfgLoader is a shared configuration loader that is used by
 	// LoadConfig and other commands that access configuration files.
 	// It is initialized on first use.

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -412,11 +412,11 @@ func (m *Meta) contextOpts(ctx context.Context) (*tofu.ContextOpts, error) {
 		// This allows the shims in the tofu module to function
 		// without having to understand module installation logic.
 
-		loader, _ := m.initConfigLoader()
+		loader := m.configLoader()
 
 		// This gets the current directory as full path.
 		path := m.WorkingDir.NormalizePath(m.WorkingDir.RootModuleDir())
-		root, _ := loader.Parser().LoadConfigDirUneval(path, configs.SelectiveLoadAll)
+		root, _ := loader.LoadConfigDirUneval(path, configs.SelectiveLoadAll)
 		opts.Modules = &newRuntimeModules{
 			loader: loader,
 			root:   root,

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -164,10 +164,10 @@ type Meta struct {
 	// Private: do not set these
 	// ----------------------------------------------------------
 
-	// configLoader is a shared configuration loader that is used by
+	// cfgLoader is a shared configuration loader that is used by
 	// LoadConfig and other commands that access configuration files.
 	// It is initialized on first use.
-	configLoader configload.Loader
+	cfgLoader configload.Loader
 
 	// backendState is the currently active backend state
 	backendState *clistate.BackendState
@@ -515,12 +515,6 @@ func isAutoVarFile(path string) bool {
 func (m *Meta) checkRequiredVersion(ctx context.Context) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
-	loader, err := m.initConfigLoader()
-	if err != nil {
-		diags = diags.Append(err)
-		return diags
-	}
-
 	pwd, err := os.Getwd()
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("Error getting pwd: %w", err))
@@ -533,7 +527,7 @@ func (m *Meta) checkRequiredVersion(ctx context.Context) tfdiags.Diagnostics {
 		return diags
 	}
 
-	_, configDiags := loader.LoadConfig(ctx, pwd, call)
+	_, configDiags := m.configLoader().LoadConfig(ctx, pwd, call)
 	if configDiags.HasErrors() {
 		diags = diags.Append(configDiags)
 		return diags

--- a/internal/command/meta_config.go
+++ b/internal/command/meta_config.go
@@ -38,19 +38,13 @@ func (m *Meta) loadConfig(ctx context.Context, rootDir string) (*configs.Config,
 	var diags tfdiags.Diagnostics
 	rootDir = m.WorkingDir.NormalizePath(rootDir)
 
-	loader, err := m.initConfigLoader()
-	if err != nil {
-		diags = diags.Append(err)
-		return nil, diags
-	}
-
 	call, callDiags := m.rootModuleCall(ctx, rootDir)
 	diags = diags.Append(callDiags)
 	if callDiags.HasErrors() {
 		return nil, diags
 	}
 
-	config, hclDiags := loader.LoadConfig(ctx, rootDir, call)
+	config, hclDiags := m.configLoader().LoadConfig(ctx, rootDir, call)
 	diags = diags.Append(hclDiags)
 	return config, diags
 }
@@ -61,19 +55,13 @@ func (m *Meta) loadConfigWithTests(ctx context.Context, rootDir, testDir string)
 	var diags tfdiags.Diagnostics
 	rootDir = m.WorkingDir.NormalizePath(rootDir)
 
-	loader, err := m.initConfigLoader()
-	if err != nil {
-		diags = diags.Append(err)
-		return nil, diags
-	}
-
 	call, vDiags := m.rootModuleCall(ctx, rootDir)
 	diags = diags.Append(vDiags)
 	if diags.HasErrors() {
 		return nil, diags
 	}
 
-	config, hclDiags := loader.LoadConfigWithTests(ctx, rootDir, testDir, call)
+	config, hclDiags := m.configLoader().LoadConfigWithTests(ctx, rootDir, testDir, call)
 	diags = diags.Append(hclDiags)
 	return config, diags
 }
@@ -90,19 +78,13 @@ func (m *Meta) loadSingleModule(ctx context.Context, dir string, load configs.Se
 	var diags tfdiags.Diagnostics
 	dir = m.WorkingDir.NormalizePath(dir)
 
-	loader, err := m.initConfigLoader()
-	if err != nil {
-		diags = diags.Append(err)
-		return nil, diags
-	}
-
 	call, vDiags := m.rootModuleCall(ctx, dir)
 	diags = diags.Append(vDiags)
 	if diags.HasErrors() {
 		return nil, diags
 	}
 
-	module, hclDiags := loader.Parser().LoadConfigDirSelective(dir, call, load)
+	module, hclDiags := m.configLoader().LoadConfigDirSelective(dir, call, load)
 	diags = diags.Append(hclDiags)
 	return module, diags
 }
@@ -179,19 +161,13 @@ func (m *Meta) loadSingleModuleWithTests(ctx context.Context, dir string, testDi
 	var diags tfdiags.Diagnostics
 	dir = m.WorkingDir.NormalizePath(dir)
 
-	loader, err := m.initConfigLoader()
-	if err != nil {
-		diags = diags.Append(err)
-		return nil, diags
-	}
-
 	call, vDiags := m.rootModuleCall(ctx, dir)
 	diags = diags.Append(vDiags)
 	if diags.HasErrors() {
 		return nil, diags
 	}
 
-	module, hclDiags := loader.Parser().LoadConfigDirWithTests(dir, testDir, call)
+	module, hclDiags := m.configLoader().LoadConfigDirWithTests(dir, testDir, call)
 	diags = diags.Append(hclDiags)
 	return module, diags
 }
@@ -204,14 +180,6 @@ func (m *Meta) loadSingleModuleWithTests(ctx context.Context, dir string, testDi
 // this function optimistically returns true, assuming that the caller will
 // then do some other operation that requires the config loader and get an
 // error at that point.
-func (m *Meta) dirIsConfigPath(dir string) bool {
-	loader, err := m.initConfigLoader()
-	if err != nil {
-		return true
-	}
-
-	return loader.IsConfigDir(dir)
-}
 
 // loadBackendConfig reads configuration from the given directory and returns
 // the backend configuration defined by that module, if any. Nil is returned
@@ -251,13 +219,7 @@ func (m *Meta) loadHCLFile(filename string) (hcl.Body, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	filename = m.WorkingDir.NormalizePath(filename)
 
-	loader, err := m.initConfigLoader()
-	if err != nil {
-		diags = diags.Append(err)
-		return nil, diags
-	}
-
-	body, hclDiags := loader.Parser().LoadHCLFile(filename)
+	body, hclDiags := m.configLoader().LoadHCLFile(filename)
 	diags = diags.Append(hclDiags)
 	return body, diags
 }
@@ -282,7 +244,7 @@ func (m *Meta) installModules(ctx context.Context, rootDir, testsDir string, upg
 		return true, diags
 	}
 
-	loader, err := m.initConfigLoader()
+	loader, err := configload.Initialize(m.configLoader())
 	if err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
@@ -332,7 +294,7 @@ func (m *Meta) installModules(ctx context.Context, rootDir, testsDir string, upg
 // this package has a reasonable implementation for displaying notifications
 // via a provided cli.Ui.
 func (m *Meta) initDirFromModule(ctx context.Context, targetDir string, addr string, hooks initwd.ModuleInstallHooks, view views.Basic) (abort bool, diags tfdiags.Diagnostics) {
-	loader, err := m.initConfigLoader()
+	loader, err := configload.Initialize(m.configLoader())
 	if err != nil {
 		diags = diags.Append(err)
 		return true, diags
@@ -415,50 +377,31 @@ func (m *Meta) inputForSchema(given cty.Value, schema *configschema.Block, view 
 	return cty.ObjectVal(retVals), nil
 }
 
-// registerSynthConfigSource allows commands to add synthetic additional source
-// buffers to the config loader's cache of sources (as returned by
-// configSources), which is useful when a command is directly parsing something
-// from the command line that may produce diagnostics, so that diagnostic
-// snippets can still be produced.
-//
-// If this is called before a configLoader has been initialized then it will
-// try to initialize the loader but ignore any initialization failure, turning
-// the call into a no-op. (We presume that a caller will later call a different
-// function that also initializes the config loader as a side effect, at which
-// point those errors can be returned.)
-func (m *Meta) registerSynthConfigSource(filename string, src []byte) {
-	loader, err := m.initConfigLoader()
-	if err != nil || loader == nil {
-		return // treated as no-op, since this is best-effort
-	}
-	loader.Parser().ForceFileSource(filename, src)
-}
-
-// initConfigLoader initializes the shared configuration loader if it isn't
+// configLoader initializes the shared configuration loader if it isn't
 // already initialized.
 //
-// If the loader cannot be created for some reason then an error is returned
-// and no loader is created. Subsequent calls will presumably see the same
-// error. Loader initialization errors will tend to prevent any further use
-// of most OpenTofu features, so callers should report any error and safely
-// terminate.
-func (m *Meta) initConfigLoader() (configload.Loader, error) {
-	if m.configLoader == nil {
-		loader, err := configload.NewLoader(&configload.Config{
-			ModulesDir: m.WorkingDir.ModulesDir(),
+// The configload.Loader that is initialised it's a lazy one, meaning that the
+// initialisation is defered to be executed later when a method from it that returns
+// errors can return the loading error.
+//
+// In situations where the caller wants to be sure that the initialisation will succeed
+// before proceeding further in the flow, it must pass the value returned by this method
+// to the configload.Initialize. The error returned by that method will be the initialisation
+// error of the underlying config loader.
+func (m *Meta) configLoader() configload.Loader {
+	if m.cfgLoader == nil {
+		loader := configload.NewLazy(&configload.Config{
+			ModulesDir:               m.WorkingDir.ModulesDir(),
+			AllowLanguageExperiments: m.SystemCfg.AllowExperimentalFeatures,
 		})
-		if err != nil {
-			return nil, err
-		}
-		loader.AllowLanguageExperiments(m.SystemCfg.AllowExperimentalFeatures)
-		m.configLoader = loader
+		m.cfgLoader = loader
 		if m.View != nil {
 			m.View.SetConfigSources(loader.Sources)
 			m.View.SetModuleSourceAddrs(loader.ModuleSourceAddrs)
 			m.View.SetIsRemoteModuleSource(loader.IsRemoteModuleSource)
 		}
 	}
-	return m.configLoader, nil
+	return m.cfgLoader
 }
 
 // registryClient instantiates and returns a new Registry client.

--- a/internal/command/meta_config.go
+++ b/internal/command/meta_config.go
@@ -368,10 +368,10 @@ func (m *Meta) inputForSchema(given cty.Value, schema *configschema.Block, view 
 	return cty.ObjectVal(retVals), nil
 }
 
-// configLoader initializes the shared configuration loader if it isn't
-// already initialized.
+// configLoader initialises the shared configuration loader if it isn't
+// already initialised.
 //
-// The configload.Loader that is initialised it's a lazy one, meaning that the
+// The configload.Loader is lazy-initialised, meaning that the
 // initialisation is defered to be executed later when a method from it that returns
 // errors can return the loading error.
 //

--- a/internal/command/meta_config.go
+++ b/internal/command/meta_config.go
@@ -172,15 +172,6 @@ func (m *Meta) loadSingleModuleWithTests(ctx context.Context, dir string, testDi
 	return module, diags
 }
 
-// dirIsConfigPath checks if the given path is a directory that contains at
-// least one OpenTofu configuration file (.tf or .tf.json), returning true
-// if so.
-//
-// In the unlikely event that the underlying config loader cannot be initialized,
-// this function optimistically returns true, assuming that the caller will
-// then do some other operation that requires the config loader and get an
-// error at that point.
-
 // loadBackendConfig reads configuration from the given directory and returns
 // the backend configuration defined by that module, if any. Nil is returned
 // if the specified module does not have an explicit backend configuration.
@@ -244,7 +235,7 @@ func (m *Meta) installModules(ctx context.Context, rootDir, testsDir string, upg
 		return true, diags
 	}
 
-	loader, err := configload.Initialize(m.configLoader())
+	loader, err := configload.Initialise(m.configLoader())
 	if err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
@@ -294,7 +285,7 @@ func (m *Meta) installModules(ctx context.Context, rootDir, testsDir string, upg
 // this package has a reasonable implementation for displaying notifications
 // via a provided cli.Ui.
 func (m *Meta) initDirFromModule(ctx context.Context, targetDir string, addr string, hooks initwd.ModuleInstallHooks, view views.Basic) (abort bool, diags tfdiags.Diagnostics) {
-	loader, err := configload.Initialize(m.configLoader())
+	loader, err := configload.Initialise(m.configLoader())
 	if err != nil {
 		diags = diags.Append(err)
 		return true, diags
@@ -386,7 +377,7 @@ func (m *Meta) inputForSchema(given cty.Value, schema *configschema.Block, view 
 //
 // In situations where the caller wants to be sure that the initialisation will succeed
 // before proceeding further in the flow, it must pass the value returned by this method
-// to the configload.Initialize. The error returned by that method will be the initialisation
+// to the configload.Initialise. The error returned by that method will be the initialisation
 // error of the underlying config loader.
 //
 // TODO meta-refactor: because there is no one single entry point to initialise the commands, we have

--- a/internal/command/meta_config.go
+++ b/internal/command/meta_config.go
@@ -442,7 +442,7 @@ func (m *Meta) registerSynthConfigSource(filename string, src []byte) {
 // error. Loader initialization errors will tend to prevent any further use
 // of most OpenTofu features, so callers should report any error and safely
 // terminate.
-func (m *Meta) initConfigLoader() (*configload.Loader, error) {
+func (m *Meta) initConfigLoader() (configload.Loader, error) {
 	if m.configLoader == nil {
 		loader, err := configload.NewLoader(&configload.Config{
 			ModulesDir: m.WorkingDir.ModulesDir(),

--- a/internal/command/meta_config.go
+++ b/internal/command/meta_config.go
@@ -388,6 +388,14 @@ func (m *Meta) inputForSchema(given cty.Value, schema *configschema.Block, view 
 // before proceeding further in the flow, it must pass the value returned by this method
 // to the configload.Initialize. The error returned by that method will be the initialisation
 // error of the underlying config loader.
+//
+// TODO meta-refactor: because there is no one single entry point to initialise the commands, we have
+// to keep this method for the time being, maybe allowing it to outlive the whole refactoring, maybe ending
+// up in keeping Meta only for a limited set of functionality like this one.
+// The intent is to create constructor-like functions to initialise each command, with clear dependencies
+// given as arguments, and then the configload.Loader will be one of those, unifying the way commands are
+// built, also for the normal execution and for the tests too. This would remove from the reasons to keep the Meta
+// struct after the whole refactor.
 func (m *Meta) configLoader() configload.Loader {
 	if m.cfgLoader == nil {
 		loader := configload.NewLazy(&configload.Config{

--- a/internal/command/meta_vars.go
+++ b/internal/command/meta_vars.go
@@ -184,14 +184,8 @@ func (m *Meta) addVarsFromFile(filename string, sourceType tofu.ValueSourceType,
 		return diags
 	}
 
-	loader, err := m.initConfigLoader()
-	if err != nil {
-		diags = diags.Append(err)
-		return diags
-	}
-
 	// Record the file source code for snippets in diagnostic messages.
-	loader.Parser().ForceFileSource(filename, src)
+	m.configLoader().ForceFileSource(filename, src)
 
 	var f *hcl.File
 

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opentofu/opentofu/internal/backend"
 	"github.com/opentofu/opentofu/internal/command/arguments"
 	"github.com/opentofu/opentofu/internal/command/views"
+	"github.com/opentofu/opentofu/internal/configs/configload"
 	"github.com/opentofu/opentofu/internal/encryption"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
@@ -167,7 +168,7 @@ func (c *PlanCommand) OperationRequest(
 	opReq.View = view.Operation()
 
 	var err error
-	opReq.ConfigLoader, err = c.initConfigLoader()
+	opReq.ConfigLoader, err = configload.Initialize(c.configLoader())
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("Failed to initialize config loader: %w", err))
 		return nil, diags

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -168,7 +168,7 @@ func (c *PlanCommand) OperationRequest(
 	opReq.View = view.Operation()
 
 	var err error
-	opReq.ConfigLoader, err = configload.Initialize(c.configLoader())
+	opReq.ConfigLoader, err = configload.Initialise(c.configLoader())
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("Failed to initialize config loader: %w", err))
 		return nil, diags

--- a/internal/command/providers_schema.go
+++ b/internal/command/providers_schema.go
@@ -14,6 +14,7 @@ import (
 	"github.com/opentofu/opentofu/internal/command/arguments"
 	"github.com/opentofu/opentofu/internal/command/jsonprovider"
 	"github.com/opentofu/opentofu/internal/command/views"
+	"github.com/opentofu/opentofu/internal/configs/configload"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
@@ -99,7 +100,7 @@ func (c *ProvidersSchemaCommand) Run(rawArgs []string) int {
 	// Build the operation
 	opReq := c.Operation(ctx, b, view.Backend(), enc)
 	opReq.ConfigDir = cwd
-	opReq.ConfigLoader, err = c.initConfigLoader()
+	opReq.ConfigLoader, err = configload.Initialize(c.configLoader())
 	var callDiags tfdiags.Diagnostics
 	opReq.RootCall, callDiags = c.rootModuleCall(ctx, opReq.ConfigDir)
 	diags = diags.Append(callDiags)

--- a/internal/command/providers_schema.go
+++ b/internal/command/providers_schema.go
@@ -100,7 +100,7 @@ func (c *ProvidersSchemaCommand) Run(rawArgs []string) int {
 	// Build the operation
 	opReq := c.Operation(ctx, b, view.Backend(), enc)
 	opReq.ConfigDir = cwd
-	opReq.ConfigLoader, err = configload.Initialize(c.configLoader())
+	opReq.ConfigLoader, err = configload.Initialise(c.configLoader())
 	var callDiags tfdiags.Diagnostics
 	opReq.RootCall, callDiags = c.rootModuleCall(ctx, opReq.ConfigDir)
 	diags = diags.Append(callDiags)

--- a/internal/command/refresh.go
+++ b/internal/command/refresh.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opentofu/opentofu/internal/backend"
 	"github.com/opentofu/opentofu/internal/command/arguments"
 	"github.com/opentofu/opentofu/internal/command/views"
+	"github.com/opentofu/opentofu/internal/configs/configload"
 	"github.com/opentofu/opentofu/internal/encryption"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
@@ -148,7 +149,7 @@ func (c *RefreshCommand) OperationRequest(ctx context.Context, be backend.Enhanc
 	opReq.View = view.Operation()
 
 	var err error
-	opReq.ConfigLoader, err = c.initConfigLoader()
+	opReq.ConfigLoader, err = configload.Initialize(c.configLoader())
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("Failed to initialize config loader: %w", err))
 		return nil, diags

--- a/internal/command/refresh.go
+++ b/internal/command/refresh.go
@@ -149,7 +149,7 @@ func (c *RefreshCommand) OperationRequest(ctx context.Context, be backend.Enhanc
 	opReq.View = view.Operation()
 
 	var err error
-	opReq.ConfigLoader, err = configload.Initialize(c.configLoader())
+	opReq.ConfigLoader, err = configload.Initialise(c.configLoader())
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("Failed to initialize config loader: %w", err))
 		return nil, diags

--- a/internal/command/state_show.go
+++ b/internal/command/state_show.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/mitchellh/cli"
 	"github.com/opentofu/opentofu/internal/command/views"
+	"github.com/opentofu/opentofu/internal/configs/configload"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/backend"
@@ -110,7 +111,7 @@ func (c *StateShowCommand) Run(rawArgs []string) int {
 		return 1
 	}
 
-	opReq.ConfigLoader, err = c.initConfigLoader()
+	opReq.ConfigLoader, err = configload.Initialize(c.configLoader())
 	if err != nil {
 		view.Diagnostics(diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,

--- a/internal/command/state_show.go
+++ b/internal/command/state_show.go
@@ -111,7 +111,7 @@ func (c *StateShowCommand) Run(rawArgs []string) int {
 		return 1
 	}
 
-	opReq.ConfigLoader, err = configload.Initialize(c.configLoader())
+	opReq.ConfigLoader, err = configload.Initialise(c.configLoader())
 	if err != nil {
 		view.Diagnostics(diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,

--- a/internal/command/temp_new_runtime.go
+++ b/internal/command/temp_new_runtime.go
@@ -59,17 +59,6 @@ func (m *Meta) StaticConfigInstance(ctx context.Context, root *configs.Module, m
 
 	inputValues := exprs.ConstantValuer(cty.ObjectVal(rawInput))
 
-	loader, err := m.initConfigLoader()
-	if err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to create the config loader",
-			err.Error(),
-		))
-		diags = diags.Append(err)
-		return nil, diags
-	}
-
 	owd := m.WorkingDir.OriginalWorkingDir()
 
 	// The current working directory should always be absolute, whether we
@@ -87,7 +76,7 @@ func (m *Meta) StaticConfigInstance(ctx context.Context, root *configs.Module, m
 
 	if modules == nil {
 		modules = &newRuntimeModules{
-			loader: loader,
+			loader: m.configLoader(),
 			root:   root,
 		}
 	}
@@ -137,7 +126,7 @@ func (m *Meta) StaticConfigInstance(ctx context.Context, root *configs.Module, m
 // a best effort to shim to OpenTofu's current module loader, even though
 // it works in some slightly-different terms than this new API expects.
 type newRuntimeModules struct {
-	loader *configload.Loader
+	loader configload.Loader
 	root   *configs.Module
 
 	// configload.Loader is not concurrency-safe because it wraps
@@ -177,7 +166,7 @@ func (n *newRuntimeModules) ModuleConfig(ctx context.Context, source addrs.Modul
 	log.Printf("[TRACE] backend/local: Loading module from %q from local path %q", source, sourceDir)
 
 	n.mu.Lock()
-	mod, hclDiags := n.loader.Parser().LoadConfigDirUneval(sourceDir, configs.SelectiveLoadAll)
+	mod, hclDiags := n.loader.LoadConfigDirUneval(sourceDir, configs.SelectiveLoadAll)
 	n.mu.Unlock()
 	diags = diags.Append(hclDiags)
 	if hclDiags.HasErrors() {

--- a/internal/configs/configload/lazy.go
+++ b/internal/configs/configload/lazy.go
@@ -1,0 +1,222 @@
+package configload
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/opentofu/opentofu/internal/configs"
+)
+
+type initializer interface {
+	init() (Loader, hcl.Diagnostics)
+}
+
+type lazyLoader struct {
+	cached Loader
+
+	cfg *Config
+}
+
+func NewLazy(c *Config) Loader {
+	return &lazyLoader{
+		cfg: c,
+	}
+}
+
+// TODO andrei add docs
+func Initialize(l Loader) (Loader, error) {
+	ll, ok := l.(*lazyLoader)
+	if !ok {
+		return l, nil
+	}
+	return ll.init()
+}
+
+func (c *lazyLoader) init() (Loader, error) {
+	if c.cached == nil {
+		newLoader, err := NewLoader(c.cfg)
+		if err != nil {
+			return nil, err
+		}
+		c.cached = newLoader
+	}
+	return c.cached, nil
+}
+
+func (c *lazyLoader) ImportSources(sources map[string][]byte) {
+	l, err := c.init()
+	if err != nil {
+		return
+	}
+	l.ImportSources(sources)
+}
+
+func (c *lazyLoader) ImportSourcesFromSnapshot(snap *Snapshot) {
+	l, err := c.init()
+	if err != nil {
+		return
+	}
+	l.ImportSourcesFromSnapshot(snap)
+}
+
+func (c *lazyLoader) IsConfigDir(path string) bool {
+	l, err := c.init()
+	if err != nil {
+		return true // The same default with the previous version in Meta structure
+	}
+	return l.IsConfigDir(path)
+}
+
+func (c *lazyLoader) ModulesDir() string {
+	l, err := c.init()
+	if err != nil {
+		return "" // TODO andrei - maybe we should panic here? If the init does not work, then it's a problem with the underlying loader init
+	}
+	return l.ModulesDir()
+}
+
+func (c *lazyLoader) RefreshModules() error {
+	l, err := c.init()
+	if err != nil {
+		return err
+	}
+	return l.RefreshModules()
+}
+
+func (c *lazyLoader) Sources() map[string]*hcl.File {
+	l, err := c.init()
+	if err != nil {
+		return nil
+	}
+	return l.Sources()
+}
+
+func (c *lazyLoader) LoadConfig(ctx context.Context, rootDir string, call configs.StaticModuleCall) (*configs.Config, hcl.Diagnostics) {
+	l, err := c.init()
+	if err != nil {
+		return nil, hcl.Diagnostics{
+			&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Config loader init failed",
+				Detail:   fmt.Sprintf("Failed to initialise a config loader: %s", err),
+			},
+		}
+	}
+	return l.LoadConfig(ctx, rootDir, call)
+}
+
+func (c *lazyLoader) LoadConfigWithTests(ctx context.Context, rootDir string, testDir string, call configs.StaticModuleCall) (*configs.Config, hcl.Diagnostics) {
+	l, err := c.init()
+	if err != nil {
+		return nil, hcl.Diagnostics{
+			&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Config loader init failed",
+				Detail:   fmt.Sprintf("Failed to initialise a config loader: %s", err),
+			},
+		}
+	}
+	return l.LoadConfigWithTests(ctx, rootDir, testDir, call)
+}
+
+func (c *lazyLoader) LoadConfigWithSnapshot(ctx context.Context, rootDir string, call configs.StaticModuleCall) (*configs.Config, *Snapshot, hcl.Diagnostics) {
+	l, err := c.init()
+	if err != nil {
+		return nil, nil, hcl.Diagnostics{
+			&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Config loader init failed",
+				Detail:   fmt.Sprintf("Failed to initialise a config loader: %s", err),
+			},
+		}
+	}
+	return l.LoadConfigWithSnapshot(ctx, rootDir, call)
+}
+
+// configs.Parser related methods
+
+func (c *lazyLoader) LoadConfigDirUneval(path string, load configs.SelectiveLoader) (*configs.Module, hcl.Diagnostics) {
+	l, err := c.init()
+	if err != nil {
+		return nil, hcl.Diagnostics{
+			&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Config loader init failed",
+				Detail:   fmt.Sprintf("Failed to initialise a config loader: %s", err),
+			},
+		}
+	}
+	return l.LoadConfigDirUneval(path, load)
+}
+
+func (c *lazyLoader) LoadConfigDir(path string, call configs.StaticModuleCall) (*configs.Module, hcl.Diagnostics) {
+	l, err := c.init()
+	if err != nil {
+		return nil, hcl.Diagnostics{
+			&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Config loader init failed",
+				Detail:   fmt.Sprintf("Failed to initialise a config loader: %s", err),
+			},
+		}
+	}
+	return l.LoadConfigDir(path, call)
+}
+func (c *lazyLoader) LoadHCLFile(path string) (hcl.Body, hcl.Diagnostics) {
+	l, err := c.init()
+	if err != nil {
+		return nil, hcl.Diagnostics{
+			&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Config loader init failed",
+				Detail:   fmt.Sprintf("Failed to initialise a config loader: %s", err),
+			},
+		}
+	}
+	return l.LoadHCLFile(path)
+}
+func (c *lazyLoader) LoadConfigDirSelective(path string, call configs.StaticModuleCall, load configs.SelectiveLoader) (*configs.Module, hcl.Diagnostics) {
+	l, err := c.init()
+	if err != nil {
+		return nil, hcl.Diagnostics{
+			&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Config loader init failed",
+				Detail:   fmt.Sprintf("Failed to initialise a config loader: %s", err),
+			},
+		}
+	}
+	return l.LoadConfigDirSelective(path, call, load)
+}
+func (c *lazyLoader) LoadConfigDirWithTests(path string, testDirectory string, call configs.StaticModuleCall) (*configs.Module, hcl.Diagnostics) {
+	l, err := c.init()
+	if err != nil {
+		return nil, hcl.Diagnostics{
+			&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Config loader init failed",
+				Detail:   fmt.Sprintf("Failed to initialise a config loader: %s", err),
+			},
+		}
+	}
+	return l.LoadConfigDirWithTests(path, testDirectory, call)
+}
+
+// ForceFileSource allows to add synthetic additional source
+// buffers to the config loader's cache of sources (as returned by
+// configSources), which is useful when a command is directly parsing something
+// from the command line that may produce diagnostics, so that diagnostic
+// snippets can still be produced.
+//
+// This will try to load the underlying config loader but if there is an error it will turn
+// the call into a no-op. (We presume that a caller will later call a different
+// function that also initializes the config loader as a side effect, at which
+// point those errors can be returned.)
+func (c *lazyLoader) ForceFileSource(filename string, src []byte) {
+	l, err := c.init()
+	if err != nil {
+		return // treated as no-op, since this is best-effort
+	}
+	l.ForceFileSource(filename, src)
+}

--- a/internal/configs/configload/lazy.go
+++ b/internal/configs/configload/lazy.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 )
 
@@ -156,6 +157,24 @@ func (c *lazyLoader) LoadConfigWithSnapshot(ctx context.Context, rootDir string,
 		}
 	}
 	return l.LoadConfigWithSnapshot(ctx, rootDir, call)
+}
+
+// IsRemoteModuleSource implements Loader
+func (c *lazyLoader) IsRemoteModuleSource(path addrs.Module) bool {
+	l, err := c.init()
+	if err != nil {
+		return false // Default as in the loader implementation
+	}
+	return l.IsRemoteModuleSource(path)
+}
+
+// ModuleSourceAddrs implements Loader
+func (c *lazyLoader) ModuleSourceAddrs(path addrs.Module) addrs.ModuleSource {
+	l, err := c.init()
+	if err != nil {
+		return nil // Default as in the loader implementation
+	}
+	return l.ModuleSourceAddrs(path)
 }
 
 // configs.Parser related methods

--- a/internal/configs/configload/lazy.go
+++ b/internal/configs/configload/lazy.go
@@ -1,3 +1,8 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package configload
 
 import (
@@ -8,10 +13,16 @@ import (
 	"github.com/opentofu/opentofu/internal/configs"
 )
 
-type initializer interface {
-	init() (Loader, hcl.Diagnostics)
-}
-
+// lazyLoader implements Loader. When created, it does not initialise the
+// actual implementation of the loader but instead defers that to the first
+// call to its methods.
+//
+// Each Loader method that returns no error will return a sane default that the system
+// is known to work with in case the underlying loader initialisation will fail during
+// those methods' calls.
+// If the initialisation fails during the call on these methods, the underlying loader will
+// remain nil, retrying to do so on subsequent calls until a method that returns diagnostics
+// is finally called, returning the root cause error.
 type lazyLoader struct {
 	cached Loader
 
@@ -24,8 +35,11 @@ func NewLazy(c *Config) Loader {
 	}
 }
 
-// TODO andrei add docs
-func Initialize(l Loader) (Loader, error) {
+// Initialise provides a way for the users of Loader to forcefully initialise the instance
+// and not wait for the its methods to be called to do it.
+// This is useful in cases where the lazy loading of the loader (by calling member methods), could
+// create unexpected issues and unwanted errors in unwanted places.
+func Initialise(l Loader) (Loader, error) {
 	ll, ok := l.(*lazyLoader)
 	if !ok {
 		return l, nil
@@ -33,6 +47,7 @@ func Initialize(l Loader) (Loader, error) {
 	return ll.init()
 }
 
+// init initialises the underlying Loader by calling NewLoader.
 func (c *lazyLoader) init() (Loader, error) {
 	if c.cached == nil {
 		newLoader, err := NewLoader(c.cfg)
@@ -44,6 +59,7 @@ func (c *lazyLoader) init() (Loader, error) {
 	return c.cached, nil
 }
 
+// ImportSources implements Loader
 func (c *lazyLoader) ImportSources(sources map[string][]byte) {
 	l, err := c.init()
 	if err != nil {
@@ -52,6 +68,7 @@ func (c *lazyLoader) ImportSources(sources map[string][]byte) {
 	l.ImportSources(sources)
 }
 
+// ImportSourcesFromSnapshot implements Loader
 func (c *lazyLoader) ImportSourcesFromSnapshot(snap *Snapshot) {
 	l, err := c.init()
 	if err != nil {
@@ -60,6 +77,7 @@ func (c *lazyLoader) ImportSourcesFromSnapshot(snap *Snapshot) {
 	l.ImportSourcesFromSnapshot(snap)
 }
 
+// IsConfigDir implements Loader
 func (c *lazyLoader) IsConfigDir(path string) bool {
 	l, err := c.init()
 	if err != nil {
@@ -68,14 +86,16 @@ func (c *lazyLoader) IsConfigDir(path string) bool {
 	return l.IsConfigDir(path)
 }
 
+// ModulesDir implements Loader
 func (c *lazyLoader) ModulesDir() string {
 	l, err := c.init()
 	if err != nil {
-		return "" // TODO andrei - maybe we should panic here? If the init does not work, then it's a problem with the underlying loader init
+		return ""
 	}
 	return l.ModulesDir()
 }
 
+// RefreshModules implements Loader
 func (c *lazyLoader) RefreshModules() error {
 	l, err := c.init()
 	if err != nil {
@@ -84,6 +104,7 @@ func (c *lazyLoader) RefreshModules() error {
 	return l.RefreshModules()
 }
 
+// Sources implements Loader
 func (c *lazyLoader) Sources() map[string]*hcl.File {
 	l, err := c.init()
 	if err != nil {
@@ -92,6 +113,7 @@ func (c *lazyLoader) Sources() map[string]*hcl.File {
 	return l.Sources()
 }
 
+// LoadConfig implements Loader
 func (c *lazyLoader) LoadConfig(ctx context.Context, rootDir string, call configs.StaticModuleCall) (*configs.Config, hcl.Diagnostics) {
 	l, err := c.init()
 	if err != nil {
@@ -106,6 +128,7 @@ func (c *lazyLoader) LoadConfig(ctx context.Context, rootDir string, call config
 	return l.LoadConfig(ctx, rootDir, call)
 }
 
+// LoadConfigWithTests implements Loader
 func (c *lazyLoader) LoadConfigWithTests(ctx context.Context, rootDir string, testDir string, call configs.StaticModuleCall) (*configs.Config, hcl.Diagnostics) {
 	l, err := c.init()
 	if err != nil {
@@ -120,6 +143,7 @@ func (c *lazyLoader) LoadConfigWithTests(ctx context.Context, rootDir string, te
 	return l.LoadConfigWithTests(ctx, rootDir, testDir, call)
 }
 
+// LoadConfigWithSnapshot implements Loader
 func (c *lazyLoader) LoadConfigWithSnapshot(ctx context.Context, rootDir string, call configs.StaticModuleCall) (*configs.Config, *Snapshot, hcl.Diagnostics) {
 	l, err := c.init()
 	if err != nil {
@@ -136,6 +160,7 @@ func (c *lazyLoader) LoadConfigWithSnapshot(ctx context.Context, rootDir string,
 
 // configs.Parser related methods
 
+// LoadConfigDirUneval implements Loader
 func (c *lazyLoader) LoadConfigDirUneval(path string, load configs.SelectiveLoader) (*configs.Module, hcl.Diagnostics) {
 	l, err := c.init()
 	if err != nil {
@@ -150,6 +175,7 @@ func (c *lazyLoader) LoadConfigDirUneval(path string, load configs.SelectiveLoad
 	return l.LoadConfigDirUneval(path, load)
 }
 
+// LoadConfigDir implements Loader
 func (c *lazyLoader) LoadConfigDir(path string, call configs.StaticModuleCall) (*configs.Module, hcl.Diagnostics) {
 	l, err := c.init()
 	if err != nil {
@@ -163,6 +189,8 @@ func (c *lazyLoader) LoadConfigDir(path string, call configs.StaticModuleCall) (
 	}
 	return l.LoadConfigDir(path, call)
 }
+
+// LoadHCLFile implements Loader
 func (c *lazyLoader) LoadHCLFile(path string) (hcl.Body, hcl.Diagnostics) {
 	l, err := c.init()
 	if err != nil {
@@ -176,6 +204,8 @@ func (c *lazyLoader) LoadHCLFile(path string) (hcl.Body, hcl.Diagnostics) {
 	}
 	return l.LoadHCLFile(path)
 }
+
+// LoadConfigDirSelective implements Loader
 func (c *lazyLoader) LoadConfigDirSelective(path string, call configs.StaticModuleCall, load configs.SelectiveLoader) (*configs.Module, hcl.Diagnostics) {
 	l, err := c.init()
 	if err != nil {
@@ -189,6 +219,8 @@ func (c *lazyLoader) LoadConfigDirSelective(path string, call configs.StaticModu
 	}
 	return l.LoadConfigDirSelective(path, call, load)
 }
+
+// LoadConfigDirWithTests implements Loader
 func (c *lazyLoader) LoadConfigDirWithTests(path string, testDirectory string, call configs.StaticModuleCall) (*configs.Module, hcl.Diagnostics) {
 	l, err := c.init()
 	if err != nil {

--- a/internal/configs/configload/lazy.go
+++ b/internal/configs/configload/lazy.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
+	"github.com/opentofu/opentofu/internal/modsdir"
 )
 
 // lazyLoader implements Loader. When created, it does not initialise the
@@ -175,6 +176,21 @@ func (c *lazyLoader) ModuleSourceAddrs(path addrs.Module) addrs.ModuleSource {
 		return nil // Default as in the loader implementation
 	}
 	return l.ModuleSourceAddrs(path)
+}
+
+// ModuleLocalPath implements Loader
+func (c *lazyLoader) ModuleLocalPath(ctx context.Context, req *configs.ModuleRequest) (*modsdir.Record, hcl.Diagnostics) {
+	l, err := c.init()
+	if err != nil {
+		return nil, hcl.Diagnostics{
+			&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Config loader init failed",
+				Detail:   fmt.Sprintf("Failed to initialise a config loader: %s", err),
+			},
+		}
+	}
+	return l.ModuleLocalPath(ctx, req)
 }
 
 // configs.Parser related methods

--- a/internal/configs/configload/lazy.go
+++ b/internal/configs/configload/lazy.go
@@ -119,13 +119,7 @@ func (c *lazyLoader) Sources() map[string]*hcl.File {
 func (c *lazyLoader) LoadConfig(ctx context.Context, rootDir string, call configs.StaticModuleCall) (*configs.Config, hcl.Diagnostics) {
 	l, err := c.init()
 	if err != nil {
-		return nil, hcl.Diagnostics{
-			&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Config loader init failed",
-				Detail:   fmt.Sprintf("Failed to initialise a config loader: %s", err),
-			},
-		}
+		return nil, initErrorToDiagnostic(err)
 	}
 	return l.LoadConfig(ctx, rootDir, call)
 }
@@ -134,13 +128,7 @@ func (c *lazyLoader) LoadConfig(ctx context.Context, rootDir string, call config
 func (c *lazyLoader) LoadConfigWithTests(ctx context.Context, rootDir string, testDir string, call configs.StaticModuleCall) (*configs.Config, hcl.Diagnostics) {
 	l, err := c.init()
 	if err != nil {
-		return nil, hcl.Diagnostics{
-			&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Config loader init failed",
-				Detail:   fmt.Sprintf("Failed to initialise a config loader: %s", err),
-			},
-		}
+		return nil, initErrorToDiagnostic(err)
 	}
 	return l.LoadConfigWithTests(ctx, rootDir, testDir, call)
 }
@@ -149,13 +137,7 @@ func (c *lazyLoader) LoadConfigWithTests(ctx context.Context, rootDir string, te
 func (c *lazyLoader) LoadConfigWithSnapshot(ctx context.Context, rootDir string, call configs.StaticModuleCall) (*configs.Config, *Snapshot, hcl.Diagnostics) {
 	l, err := c.init()
 	if err != nil {
-		return nil, nil, hcl.Diagnostics{
-			&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Config loader init failed",
-				Detail:   fmt.Sprintf("Failed to initialise a config loader: %s", err),
-			},
-		}
+		return nil, nil, initErrorToDiagnostic(err)
 	}
 	return l.LoadConfigWithSnapshot(ctx, rootDir, call)
 }
@@ -182,13 +164,7 @@ func (c *lazyLoader) ModuleSourceAddrs(path addrs.Module) addrs.ModuleSource {
 func (c *lazyLoader) ModuleLocalPath(ctx context.Context, req *configs.ModuleRequest) (*modsdir.Record, hcl.Diagnostics) {
 	l, err := c.init()
 	if err != nil {
-		return nil, hcl.Diagnostics{
-			&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Config loader init failed",
-				Detail:   fmt.Sprintf("Failed to initialise a config loader: %s", err),
-			},
-		}
+		return nil, initErrorToDiagnostic(err)
 	}
 	return l.ModuleLocalPath(ctx, req)
 }
@@ -199,13 +175,7 @@ func (c *lazyLoader) ModuleLocalPath(ctx context.Context, req *configs.ModuleReq
 func (c *lazyLoader) LoadConfigDirUneval(path string, load configs.SelectiveLoader) (*configs.Module, hcl.Diagnostics) {
 	l, err := c.init()
 	if err != nil {
-		return nil, hcl.Diagnostics{
-			&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Config loader init failed",
-				Detail:   fmt.Sprintf("Failed to initialise a config loader: %s", err),
-			},
-		}
+		return nil, initErrorToDiagnostic(err)
 	}
 	return l.LoadConfigDirUneval(path, load)
 }
@@ -214,13 +184,7 @@ func (c *lazyLoader) LoadConfigDirUneval(path string, load configs.SelectiveLoad
 func (c *lazyLoader) LoadConfigDir(path string, call configs.StaticModuleCall) (*configs.Module, hcl.Diagnostics) {
 	l, err := c.init()
 	if err != nil {
-		return nil, hcl.Diagnostics{
-			&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Config loader init failed",
-				Detail:   fmt.Sprintf("Failed to initialise a config loader: %s", err),
-			},
-		}
+		return nil, initErrorToDiagnostic(err)
 	}
 	return l.LoadConfigDir(path, call)
 }
@@ -229,13 +193,7 @@ func (c *lazyLoader) LoadConfigDir(path string, call configs.StaticModuleCall) (
 func (c *lazyLoader) LoadHCLFile(path string) (hcl.Body, hcl.Diagnostics) {
 	l, err := c.init()
 	if err != nil {
-		return nil, hcl.Diagnostics{
-			&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Config loader init failed",
-				Detail:   fmt.Sprintf("Failed to initialise a config loader: %s", err),
-			},
-		}
+		return nil, initErrorToDiagnostic(err)
 	}
 	return l.LoadHCLFile(path)
 }
@@ -244,13 +202,7 @@ func (c *lazyLoader) LoadHCLFile(path string) (hcl.Body, hcl.Diagnostics) {
 func (c *lazyLoader) LoadConfigDirSelective(path string, call configs.StaticModuleCall, load configs.SelectiveLoader) (*configs.Module, hcl.Diagnostics) {
 	l, err := c.init()
 	if err != nil {
-		return nil, hcl.Diagnostics{
-			&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Config loader init failed",
-				Detail:   fmt.Sprintf("Failed to initialise a config loader: %s", err),
-			},
-		}
+		return nil, initErrorToDiagnostic(err)
 	}
 	return l.LoadConfigDirSelective(path, call, load)
 }
@@ -259,13 +211,7 @@ func (c *lazyLoader) LoadConfigDirSelective(path string, call configs.StaticModu
 func (c *lazyLoader) LoadConfigDirWithTests(path string, testDirectory string, call configs.StaticModuleCall) (*configs.Module, hcl.Diagnostics) {
 	l, err := c.init()
 	if err != nil {
-		return nil, hcl.Diagnostics{
-			&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Config loader init failed",
-				Detail:   fmt.Sprintf("Failed to initialise a config loader: %s", err),
-			},
-		}
+		return nil, initErrorToDiagnostic(err)
 	}
 	return l.LoadConfigDirWithTests(path, testDirectory, call)
 }
@@ -286,4 +232,17 @@ func (c *lazyLoader) ForceFileSource(filename string, src []byte) {
 		return // treated as no-op, since this is best-effort
 	}
 	l.ForceFileSource(filename, src)
+}
+
+// initErrorToDiagnostic converts an error type into hcl.Diagnostics.
+// This way, any error issued by the lazyLoader.init will be returned in the same format
+// to callers of the lazyLoader exported methods.
+func initErrorToDiagnostic(err error) hcl.Diagnostics {
+	return hcl.Diagnostics{
+		&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Config loader init failed",
+			Detail:   fmt.Sprintf("Failed to initialise a config loader: %s", err),
+		},
+	}
 }

--- a/internal/configs/configload/lazy_test.go
+++ b/internal/configs/configload/lazy_test.go
@@ -1,3 +1,8 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package configload
 
 import (
@@ -18,7 +23,7 @@ func TestLazyLoader_Initialize(t *testing.T) {
 		writeConfigFile(t, filepath.Join(d, "main.tf"), []byte(""))
 
 		ll := NewLazy(&Config{ModulesDir: d})
-		il, err := Initialize(ll)
+		il, err := Initialise(ll)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -33,7 +38,7 @@ func TestLazyLoader_Initialize(t *testing.T) {
 		writeManifestFile(t, d, []byte(`{"Modules":[]}`))
 
 		ll := NewLazy(&Config{ModulesDir: d})
-		il, err := Initialize(ll)
+		il, err := Initialise(ll)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -48,7 +53,7 @@ func TestLazyLoader_Initialize(t *testing.T) {
 		writeManifestFile(t, d, []byte("invalid content"))
 
 		ll := NewLazy(&Config{ModulesDir: d})
-		il, err := Initialize(ll)
+		il, err := Initialise(ll)
 		if err == nil {
 			t.Fatalf("expected but got nothing: %s", err)
 		}

--- a/internal/configs/configload/lazy_test.go
+++ b/internal/configs/configload/lazy_test.go
@@ -134,6 +134,68 @@ func TestLoaderInitializationDuringMethodCalls(t *testing.T) {
 				}
 			},
 		},
+		"loader ok - IsRemoteModuleSource": {
+			setup: func(t *testing.T, wd string) {
+				writeConfigFile(t, filepath.Join(wd, "main.tf"), []byte(`module "test" { source = "test1/test2/test3"}`))
+				writeConfigFile(t, filepath.Join(wd, ".terraform", "modules", "test1", "main.tf"), []byte(`variable "in" {}`))
+				writeManifestFile(t, wd, []byte(`{"Modules":[{"Key":"","Source":"","Dir":"."},{"Key":"test","Source":"registry.opentofu.org/test1/test2/test3","Dir":".terraform/modules/test1"}]}`))
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				c, diags := l.LoadConfig(t.Context(), wd, configs.StaticModuleCall{})
+				if diags.HasErrors() {
+					t.Errorf("unexpected error: %s", diags)
+				}
+				if c == nil {
+					t.Errorf("expected non-nil config but got nil back")
+				}
+				if got := l.IsRemoteModuleSource(addrs.Module{"test"}); !got {
+					t.Errorf("expected the module to be reported as remote but it was not")
+				}
+			},
+		},
+		"loader uninitializable - IsRemoteModuleSource": {
+			setup: func(t *testing.T, wd string) {
+				writeManifestFile(t, wd, []byte(`invalid content`))
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				if got := l.IsRemoteModuleSource(addrs.Module{"test"}); got {
+					t.Errorf("expected the module to be reported as not being remote but it was true")
+				}
+			},
+		},
+		"loader ok - ModuleSourceAddrs": {
+			setup: func(t *testing.T, wd string) {
+				writeConfigFile(t, filepath.Join(wd, "main.tf"), []byte(`module "test" { source = "test1/test2/test3"}`))
+				writeConfigFile(t, filepath.Join(wd, ".terraform", "modules", "test1", "main.tf"), []byte(`variable "in" {}`))
+				writeManifestFile(t, wd, []byte(`{"Modules":[{"Key":"","Source":"","Dir":"."},{"Key":"test","Source":"registry.opentofu.org/test1/test2/test3","Dir":".terraform/modules/test1"}]}`))
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				c, diags := l.LoadConfig(t.Context(), wd, configs.StaticModuleCall{})
+				if diags.HasErrors() {
+					t.Errorf("unexpected error: %s", diags)
+				}
+				if c == nil {
+					t.Errorf("expected non-nil config but got nil back")
+				}
+				want := addrs.MustParseModuleSource("test1/test2/test3")
+				got := l.ModuleSourceAddrs(addrs.Module{"test"})
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Errorf("invalid module source returned (-want,+got):\n%s", diff)
+				}
+			},
+		},
+		"loader uninitializable - ModuleSourceAddrs": {
+			setup: func(t *testing.T, wd string) {
+				writeManifestFile(t, wd, []byte(`invalid content`))
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				got := l.ModuleSourceAddrs(addrs.Module{"test"})
+				want := addrs.ModuleSource(nil)
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Errorf("invalid module source returned (-want,+got):\n%s", diff)
+				}
+			},
+		},
 		"loader ok - ForceFileSource": {
 			setup: func(t *testing.T, wd string) {
 				writeConfigFile(t, filepath.Join(wd, "main.tf"), []byte(`variable "in" {}`))
@@ -535,6 +597,10 @@ func writeManifestFile(t *testing.T, toDir string, content []byte) {
 }
 
 func writeConfigFile(t *testing.T, path string, content []byte) {
+	finalDir := filepath.Dir(path)
+	if err := os.MkdirAll(finalDir, 0766); err != nil {
+		t.Fatalf("failed to create the final target directory %q: %s", finalDir, err)
+	}
 	if err := os.WriteFile(path, content, 0666); err != nil {
 		t.Fatalf("unexpected error writing configuration file: %s", err)
 	}

--- a/internal/configs/configload/lazy_test.go
+++ b/internal/configs/configload/lazy_test.go
@@ -1,0 +1,536 @@
+package configload
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/configs"
+	"github.com/opentofu/opentofu/internal/modsdir"
+)
+
+func TestLazyLoader_Initialize(t *testing.T) {
+	t.Run("successful w/o manifest", func(t *testing.T) {
+		d := t.TempDir()
+		writeConfigFile(t, filepath.Join(d, "main.tf"), []byte(""))
+
+		ll := NewLazy(&Config{ModulesDir: d})
+		il, err := Initialize(ll)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		// do a sanity call to ensure that the returned loader works as expected
+		if ok := il.IsConfigDir(d); !ok {
+			t.Errorf("expected for the current directory to be a config directory but got %t", ok)
+		}
+	})
+	t.Run("successful with manifest", func(t *testing.T) {
+		d := t.TempDir()
+		writeConfigFile(t, filepath.Join(d, "main.tf"), []byte(""))
+		writeManifestFile(t, d, []byte(`{"Modules":[]}`))
+
+		ll := NewLazy(&Config{ModulesDir: d})
+		il, err := Initialize(ll)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		// do a sanity call to ensure that the returned loader works as expected
+		if ok := il.IsConfigDir(d); !ok {
+			t.Errorf("expected for the current directory to be a config directory but got %t", ok)
+		}
+	})
+	t.Run("fails when manifest is malformed", func(t *testing.T) {
+		d := t.TempDir()
+		writeConfigFile(t, filepath.Join(d, "main.tf"), []byte(""))
+		writeManifestFile(t, d, []byte("invalid content"))
+
+		ll := NewLazy(&Config{ModulesDir: d})
+		il, err := Initialize(ll)
+		if err == nil {
+			t.Fatalf("expected but got nothing: %s", err)
+		}
+		expectedErr := "failed to read module manifest: error unmarshalling snapshot: invalid character 'i' looking for beginning of value"
+		if err.Error() != expectedErr {
+			t.Errorf("the returned error is different from the expected one\nwanted: %s\ngot: %s\n", expectedErr, err.Error())
+		}
+		if il != nil {
+			t.Errorf("expected the returned loader to be nil because of the error in the initialisation")
+		}
+	})
+}
+
+func TestLoaderInitializationDuringMethodCalls(t *testing.T) {
+	cases := map[string]struct {
+		setup func(t *testing.T, wd string)
+		act   func(t *testing.T, wd string, l Loader)
+	}{
+		"loader ok - import sources": {
+			setup: func(t *testing.T, wd string) {},
+			act: func(t *testing.T, wd string, l Loader) {
+				l.ImportSources(map[string][]byte{"f": []byte("content")})
+				c, ok := l.Sources()["f"]
+				if !ok {
+					t.Fatalf("expected to have a file in the sources but got nothing")
+				}
+				if diff := cmp.Diff([]byte("content"), c.Bytes); diff != "" {
+					t.Errorf("invalid content returned from the loader sources (-want,+got):\n%s", diff)
+				}
+			},
+		},
+		"loader uninitializable - import sources": {
+			setup: func(t *testing.T, wd string) {
+				writeManifestFile(t, wd, []byte("invalid content")) // to break the loader initialization
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				l.ImportSources(map[string][]byte{"f": []byte("content")})
+				if len(l.Sources()) > 0 {
+					t.Fatalf("unexpected content in the loader sources. Importin sources in a broken loader should not work")
+				}
+			},
+		},
+		"loader ok - ImportSourcesFromSnapshot": {
+			setup: func(t *testing.T, wd string) {},
+			act: func(t *testing.T, wd string, l Loader) {
+				l.ImportSourcesFromSnapshot(&Snapshot{
+					Modules: map[string]*SnapshotModule{
+						"m1": {
+							Dir:   "m1",
+							Files: map[string][]byte{"f": []byte("content")},
+						},
+					},
+				})
+				c, ok := l.Sources()[filepath.Join("m1", "f")]
+				if !ok {
+					t.Fatalf("expected to have a file in the sources but got nothing. sources: %v", l.Sources())
+				}
+				if diff := cmp.Diff([]byte("content"), c.Bytes); diff != "" {
+					t.Errorf("invalid content returned from the loader sources (-want,+got):\n%s", diff)
+				}
+			},
+		},
+		"loader uninitializable - ImportSourcesFromSnapshot": {
+			setup: func(t *testing.T, wd string) {
+				writeManifestFile(t, wd, []byte("invalid content")) // to break the loader initialization
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				l.ImportSourcesFromSnapshot(&Snapshot{
+					Modules: map[string]*SnapshotModule{
+						"m1": {
+							Dir:   "m1",
+							Files: map[string][]byte{"f": []byte("content")},
+						},
+					},
+				})
+				if len(l.Sources()) > 0 {
+					t.Fatalf("unexpected content in the loader sources. Importin sources in a broken loader should not work")
+				}
+			},
+		},
+		"loader ok - ForceFileSource": {
+			setup: func(t *testing.T, wd string) {
+				writeConfigFile(t, filepath.Join(wd, "main.tf"), []byte(`variable "in" {}`))
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				l.ForceFileSource("f", []byte("content"))
+				c, ok := l.Sources()["f"]
+				if !ok {
+					t.Fatalf("expected to have a file in the sources but got nothing")
+				}
+				if diff := cmp.Diff([]byte("content"), c.Bytes); diff != "" {
+					t.Errorf("invalid content returned from the loader sources (-want,+got):\n%s", diff)
+				}
+			},
+		},
+		"loader uninitializable - ForceFileSource": {
+			setup: func(t *testing.T, wd string) {
+				writeManifestFile(t, wd, []byte("invalid content")) // to break the loader initialization
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				l.ForceFileSource("f", []byte("content"))
+				if len(l.Sources()) > 0 {
+					t.Fatalf("unexpected content in the loader sources. Forcing file sources in a broken loader should not work")
+				}
+			},
+		},
+		"loader ok - IsConfigDir - false": {
+			setup: func(t *testing.T, wd string) {
+				writeConfigFile(t, filepath.Join(wd, "main.tf"), []byte(`variable "in" {}`))
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				if ok := l.IsConfigDir("unexisting"); ok {
+					t.Errorf("expected to be false but was true")
+				}
+			},
+		},
+		"loader ok - IsConfigDir - true": {
+			setup: func(t *testing.T, wd string) {
+				writeConfigFile(t, filepath.Join(wd, "main.tf"), []byte(`variable "in" {}`))
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				if ok := l.IsConfigDir(wd); !ok {
+					t.Errorf("expected to be true but was false")
+				}
+			},
+		},
+		"loader uninitializable - IsConfigDir": {
+			setup: func(t *testing.T, wd string) {
+				writeManifestFile(t, wd, []byte("invalid content")) // to break the loader initialization
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				if ok := l.IsConfigDir(wd); !ok {
+					t.Errorf("expected to be true (as default because initialization of the loader should have failed) but was false")
+				}
+			},
+		},
+		"loader ok - ModulesDir": {
+			setup: func(t *testing.T, wd string) {
+				writeConfigFile(t, filepath.Join(wd, "main.tf"), []byte(`variable "in" {}`))
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				if dir := l.ModulesDir(); dir != wd {
+					t.Errorf("expected %q dir but got %q", wd, dir)
+				}
+			},
+		},
+		"loader uninitializable - ModulesDir": {
+			setup: func(t *testing.T, wd string) {
+				writeManifestFile(t, wd, []byte("invalid content")) // to break the loader initialization
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				if dir := l.ModulesDir(); dir != "" {
+					t.Errorf("expected %q dir but got %q", "", dir)
+				}
+			},
+		},
+		"loader ok - RefreshModules": {
+			setup: func(t *testing.T, wd string) {
+				writeConfigFile(t, filepath.Join(wd, "main.tf"), []byte(`variable "in" {}`))
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				if err := l.RefreshModules(); err != nil {
+					t.Errorf("expected no error but got %s", err)
+				}
+			},
+		},
+		"loader uninitializable - RefreshModules": {
+			setup: func(t *testing.T, wd string) {
+				writeManifestFile(t, wd, []byte("invalid content")) // to break the loader initialization
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				err := l.RefreshModules()
+				if err == nil {
+					t.Fatalf("expected error but got nothing")
+				}
+				expectedErrMsg := "failed to read module manifest: error unmarshalling snapshot: invalid character 'i' looking for beginning of value"
+				if !strings.Contains(err.Error(), expectedErrMsg) {
+					t.Errorf("expected error to contain %q but didn't: %s", expectedErrMsg, err)
+				}
+			},
+		},
+		"loader ok - LoadConfig": {
+			setup: func(t *testing.T, wd string) {
+				writeConfigFile(t, filepath.Join(wd, "main.tf"), []byte(`variable "in" {}`))
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				c, diags := l.LoadConfig(t.Context(), wd, configs.StaticModuleCall{})
+				if diags.HasErrors() {
+					t.Errorf("expected to have no diagnostics but got: %s", diags)
+				}
+				if _, ok := c.Module.Variables["in"]; !ok {
+					t.Errorf("expected to have a variable named 'in' but got nothing. variables: %v", c.Module.Variables)
+				}
+			},
+		},
+		"loader uninitializable - LoadConfig": {
+			setup: func(t *testing.T, wd string) {
+				writeManifestFile(t, wd, []byte("invalid content")) // to break the loader initialization
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				c, diags := l.LoadConfig(t.Context(), wd, configs.StaticModuleCall{})
+				if !diags.HasErrors() {
+					t.Errorf("expected to have no diagnostics but got: %s", diags)
+				}
+				expectedErrMsg := "Failed to initialise a config loader: failed to read module manifest: error unmarshalling snapshot: invalid character 'i' looking for beginning of value"
+				if !strings.Contains(diags.Error(), expectedErrMsg) {
+					t.Errorf("expected the diags to contain %q but it didn't: %s", expectedErrMsg, diags)
+				}
+				if c != nil {
+					t.Errorf("expected no config but got a non-nil one")
+				}
+			},
+		},
+		"loader ok - LoadConfigWithTests": {
+			setup: func(t *testing.T, wd string) {
+				writeConfigFile(t, filepath.Join(wd, "main.tf"), []byte(`variable "in" {}`))
+				writeConfigFile(t, filepath.Join(wd, "main.tftest.hcl"), []byte(``))
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				c, diags := l.LoadConfigWithTests(t.Context(), wd, ".", configs.StaticModuleCall{})
+				if diags.HasErrors() {
+					t.Fatalf("expected to have no diagnostics but got: %s", diags)
+				}
+				if _, ok := c.Module.Variables["in"]; !ok {
+					t.Errorf("expected to have a variable named 'in' but got nothing. variables: %v", c.Module.Variables)
+				}
+			},
+		},
+		"loader uninitializable - LoadConfigWithTests": {
+			setup: func(t *testing.T, wd string) {
+				writeManifestFile(t, wd, []byte("invalid content")) // to break the loader initialization
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				c, diags := l.LoadConfigWithTests(t.Context(), wd, wd, configs.StaticModuleCall{})
+				if !diags.HasErrors() {
+					t.Errorf("expected to have no diagnostics but got: %s", diags)
+				}
+				expectedErrMsg := "Failed to initialise a config loader: failed to read module manifest: error unmarshalling snapshot: invalid character 'i' looking for beginning of value"
+				if !strings.Contains(diags.Error(), expectedErrMsg) {
+					t.Errorf("expected the diags to contain %q but it didn't: %s", expectedErrMsg, diags)
+				}
+				if c != nil {
+					t.Errorf("expected no config but got a non-nil one")
+				}
+			},
+		},
+		"loader ok - LoadConfigWithSnapshot": {
+			setup: func(t *testing.T, wd string) {
+				writeConfigFile(t, filepath.Join(wd, "main.tf"), []byte(`variable "in" {}`))
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				c, snap, diags := l.LoadConfigWithSnapshot(t.Context(), wd, configs.StaticModuleCall{})
+				if diags.HasErrors() {
+					t.Errorf("expected to have no diagnostics but got: %s", diags)
+				}
+				if _, ok := c.Module.Variables["in"]; !ok {
+					t.Errorf("expected to have a variable named 'in' but got nothing. variables: %v", c.Module.Variables)
+				}
+				if snap == nil {
+					t.Fatalf("unexpected nil snapshot")
+				}
+				mod, ok := snap.Modules[addrs.RootModule.String()]
+				if !ok {
+					t.Fatalf("expected for the snapshot to have the root module but got nothing")
+				}
+				content, ok := mod.Files["main.tf"]
+				if !ok {
+					t.Fatalf("expected the snapshot to contain a root module with one file but the file is missing")
+				}
+				if diff := cmp.Diff([]byte(`variable "in" {}`), content); diff != "" {
+					t.Errorf("invalid content returned from the loader sources (-want,+got):\n%s", diff)
+				}
+			},
+		},
+		"loader uninitializable - LoadConfigWithSnapshot": {
+			setup: func(t *testing.T, wd string) {
+				writeManifestFile(t, wd, []byte("invalid content")) // to break the loader initialization
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				c, snap, diags := l.LoadConfigWithSnapshot(t.Context(), wd, configs.StaticModuleCall{})
+				if !diags.HasErrors() {
+					t.Errorf("expected to have no diagnostics but got: %s", diags)
+				}
+				expectedErrMsg := "Failed to initialise a config loader: failed to read module manifest: error unmarshalling snapshot: invalid character 'i' looking for beginning of value"
+				if !strings.Contains(diags.Error(), expectedErrMsg) {
+					t.Errorf("expected the diags to contain %q but it didn't: %s", expectedErrMsg, diags)
+				}
+				if c != nil {
+					t.Errorf("expected no config but got a non-nil one")
+				}
+				if snap != nil {
+					t.Errorf("expected no snapshot but got a non-nil one")
+				}
+			},
+		},
+		"loader ok - LoadConfigDirUneval": {
+			setup: func(t *testing.T, wd string) {
+				writeConfigFile(t, filepath.Join(wd, "main.tf"), []byte(`variable "in" {}`))
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				c, diags := l.LoadConfigDirUneval(wd, configs.SelectiveLoadAll)
+				if diags.HasErrors() {
+					t.Errorf("expected to have no diagnostics but got: %s", diags)
+				}
+				if _, ok := c.Variables["in"]; !ok {
+					t.Errorf("expected to have a variable named 'in' but got nothing. variables: %v", c.Variables)
+				}
+			},
+		},
+		"loader uninitializable - LoadConfigDirUneval": {
+			setup: func(t *testing.T, wd string) {
+				writeManifestFile(t, wd, []byte("invalid content")) // to break the loader initialization
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				c, diags := l.LoadConfigDirUneval(wd, configs.SelectiveLoadAll)
+				if !diags.HasErrors() {
+					t.Errorf("expected to have no diagnostics but got: %s", diags)
+				}
+				expectedErrMsg := "Failed to initialise a config loader: failed to read module manifest: error unmarshalling snapshot: invalid character 'i' looking for beginning of value"
+				if !strings.Contains(diags.Error(), expectedErrMsg) {
+					t.Errorf("expected the diags to contain %q but it didn't: %s", expectedErrMsg, diags)
+				}
+				if c != nil {
+					t.Errorf("expected no config but got a non-nil one")
+				}
+			},
+		},
+		"loader ok - LoadConfigDir": {
+			setup: func(t *testing.T, wd string) {
+				writeConfigFile(t, filepath.Join(wd, "main.tf"), []byte(`variable "in" {}`))
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				c, diags := l.LoadConfigDir(wd, configs.StaticModuleCall{})
+				if diags.HasErrors() {
+					t.Errorf("expected to have no diagnostics but got: %s", diags)
+				}
+				if _, ok := c.Variables["in"]; !ok {
+					t.Errorf("expected to have a variable named 'in' but got nothing. variables: %v", c.Variables)
+				}
+			},
+		},
+		"loader uninitializable - LoadConfigDir": {
+			setup: func(t *testing.T, wd string) {
+				writeManifestFile(t, wd, []byte("invalid content")) // to break the loader initialization
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				c, diags := l.LoadConfigDir(wd, configs.StaticModuleCall{})
+				if !diags.HasErrors() {
+					t.Errorf("expected to have no diagnostics but got: %s", diags)
+				}
+				expectedErrMsg := "Failed to initialise a config loader: failed to read module manifest: error unmarshalling snapshot: invalid character 'i' looking for beginning of value"
+				if !strings.Contains(diags.Error(), expectedErrMsg) {
+					t.Errorf("expected the diags to contain %q but it didn't: %s", expectedErrMsg, diags)
+				}
+				if c != nil {
+					t.Errorf("expected no config but got a non-nil one")
+				}
+			},
+		},
+		"loader ok - LoadHCLFile": {
+			setup: func(t *testing.T, wd string) {
+				writeConfigFile(t, filepath.Join(wd, "main.tf"), []byte(`variable "in" {}`))
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				body, diags := l.LoadHCLFile(filepath.Join(wd, "main.tf"))
+				if diags.HasErrors() {
+					t.Errorf("expected to have no diagnostics but got: %s", diags)
+				}
+				if body == nil {
+					t.Fatalf("expected for the hcl file to have an actual body but got nothing")
+				}
+			},
+		},
+		"loader uninitializable - LoadHCLFile": {
+			setup: func(t *testing.T, wd string) {
+				writeManifestFile(t, wd, []byte("invalid content")) // to break the loader initialization
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				c, diags := l.LoadHCLFile(filepath.Join(wd, "main.tf"))
+				if !diags.HasErrors() {
+					t.Errorf("expected to have no diagnostics but got: %s", diags)
+				}
+				expectedErrMsg := "Failed to initialise a config loader: failed to read module manifest: error unmarshalling snapshot: invalid character 'i' looking for beginning of value"
+				if !strings.Contains(diags.Error(), expectedErrMsg) {
+					t.Errorf("expected the diags to contain %q but it didn't: %s", expectedErrMsg, diags)
+				}
+				if c != nil {
+					t.Errorf("expected no config but got a non-nil one")
+				}
+			},
+		},
+		"loader ok - LoadConfigDirSelective": {
+			setup: func(t *testing.T, wd string) {
+				writeConfigFile(t, filepath.Join(wd, "main.tf"), []byte(`variable "in" {}`))
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				m, diags := l.LoadConfigDirSelective(wd, configs.StaticModuleCall{}, configs.SelectiveLoadAll)
+				if diags.HasErrors() {
+					t.Errorf("expected to have no diagnostics but got: %s", diags)
+				}
+				if m == nil {
+					t.Fatalf("expected for the hcl file to have an actual body but got nothing")
+				}
+				if _, ok := m.Variables["in"]; !ok {
+					t.Errorf("expected to have a variable named 'in' but got nothing. variables: %v", m.Variables)
+				}
+			},
+		},
+		"loader uninitializable - LoadConfigDirSelective": {
+			setup: func(t *testing.T, wd string) {
+				writeManifestFile(t, wd, []byte("invalid content")) // to break the loader initialization
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				m, diags := l.LoadConfigDirSelective(wd, configs.StaticModuleCall{}, configs.SelectiveLoadAll)
+				if !diags.HasErrors() {
+					t.Errorf("expected to have no diagnostics but got: %s", diags)
+				}
+				expectedErrMsg := "Failed to initialise a config loader: failed to read module manifest: error unmarshalling snapshot: invalid character 'i' looking for beginning of value"
+				if !strings.Contains(diags.Error(), expectedErrMsg) {
+					t.Errorf("expected the diags to contain %q but it didn't: %s", expectedErrMsg, diags)
+				}
+				if m != nil {
+					t.Errorf("expected no module but got a non-nil one")
+				}
+			},
+		},
+		"loader ok - LoadConfigDirWithTests": {
+			setup: func(t *testing.T, wd string) {
+				writeConfigFile(t, filepath.Join(wd, "main.tf"), []byte(`variable "in" {}`))
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				m, diags := l.LoadConfigDirWithTests(wd, ".", configs.StaticModuleCall{})
+				if diags.HasErrors() {
+					t.Errorf("expected to have no diagnostics but got: %s", diags)
+				}
+				if m == nil {
+					t.Fatalf("expected for the hcl file to have an actual body but got nothing")
+				}
+				if _, ok := m.Variables["in"]; !ok {
+					t.Errorf("expected to have a variable named 'in' but got nothing. variables: %v", m.Variables)
+				}
+			},
+		},
+		"loader uninitializable - LoadConfigDirWithTests": {
+			setup: func(t *testing.T, wd string) {
+				writeManifestFile(t, wd, []byte("invalid content")) // to break the loader initialization
+			},
+			act: func(t *testing.T, wd string, l Loader) {
+				m, diags := l.LoadConfigDirWithTests(wd, ".", configs.StaticModuleCall{})
+				if !diags.HasErrors() {
+					t.Errorf("expected to have no diagnostics but got: %s", diags)
+				}
+				expectedErrMsg := "Failed to initialise a config loader: failed to read module manifest: error unmarshalling snapshot: invalid character 'i' looking for beginning of value"
+				if !strings.Contains(diags.Error(), expectedErrMsg) {
+					t.Errorf("expected the diags to contain %q but it didn't: %s", expectedErrMsg, diags)
+				}
+				if m != nil {
+					t.Errorf("expected no module but got a non-nil one")
+				}
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			d := t.TempDir()
+			t.Chdir(d)
+			tc.setup(t, d)
+			ll := NewLazy(&Config{ModulesDir: d})
+			tc.act(t, d, ll)
+		})
+	}
+}
+
+func writeManifestFile(t *testing.T, toDir string, content []byte) {
+	if err := os.WriteFile(filepath.Join(toDir, modsdir.ManifestSnapshotFilename), content, 0666); err != nil {
+		t.Fatalf("unexpected error writing the modules manifest file: %s", err)
+	}
+}
+
+func writeConfigFile(t *testing.T, path string, content []byte) {
+	if err := os.WriteFile(path, content, 0666); err != nil {
+		t.Fatalf("unexpected error writing configuration file: %s", err)
+	}
+}

--- a/internal/configs/configload/lazy_test.go
+++ b/internal/configs/configload/lazy_test.go
@@ -55,7 +55,7 @@ func TestLazyLoader_Initialize(t *testing.T) {
 		ll := NewLazy(&Config{ModulesDir: d})
 		il, err := Initialise(ll)
 		if err == nil {
-			t.Fatalf("expected but got nothing: %s", err)
+			t.Fatalf("expected but got nil")
 		}
 		expectedErr := "failed to read module manifest: error unmarshalling snapshot: invalid character 'i' looking for beginning of value"
 		if err.Error() != expectedErr {

--- a/internal/configs/configload/loader.go
+++ b/internal/configs/configload/loader.go
@@ -8,28 +8,31 @@ package configload
 import (
 	"context"
 	"fmt"
-	"log"
 	"path/filepath"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/spf13/afero"
 
-	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 )
 
 type Loader interface {
-	AllowLanguageExperiments(allowed bool)
 	ImportSources(sources map[string][]byte)
 	ImportSourcesFromSnapshot(snap *Snapshot)
 	IsConfigDir(path string) bool
 	ModulesDir() string
-	Parser() *configs.Parser
 	RefreshModules() error
 	Sources() map[string]*hcl.File
 	LoadConfig(ctx context.Context, rootDir string, call configs.StaticModuleCall) (*configs.Config, hcl.Diagnostics)
 	LoadConfigWithTests(ctx context.Context, rootDir string, testDir string, call configs.StaticModuleCall) (*configs.Config, hcl.Diagnostics)
 	LoadConfigWithSnapshot(ctx context.Context, rootDir string, call configs.StaticModuleCall) (*configs.Config, *Snapshot, hcl.Diagnostics)
+
+	LoadConfigDirUneval(path string, load configs.SelectiveLoader) (*configs.Module, hcl.Diagnostics)
+	LoadConfigDir(path string, call configs.StaticModuleCall) (*configs.Module, hcl.Diagnostics)
+	LoadHCLFile(path string) (hcl.Body, hcl.Diagnostics)
+	LoadConfigDirSelective(path string, call configs.StaticModuleCall, load configs.SelectiveLoader) (*configs.Module, hcl.Diagnostics)
+	LoadConfigDirWithTests(path string, testDirectory string, call configs.StaticModuleCall) (*configs.Module, hcl.Diagnostics)
+	ForceFileSource(filename string, src []byte)
 }
 
 // A loader instance is the main entry-point for loading configurations via
@@ -57,6 +60,21 @@ type Config struct {
 	// .terraform/modules directory, in the common case where this package
 	// is being loaded from the main OpenTofu CLI package.)
 	ModulesDir string
+
+	// AllowLanguageExperiments specifies whether subsequent Loader.LoadConfig (and
+	// similar) calls will allow opting in to experimental language features.
+	//
+	// If this is not configured as true, any language experiments will be disallowed.
+	//
+	// Main code should set this only for alpha or development builds. Test code
+	// is responsible for deciding for itself whether and how to call this
+	// method.
+	//
+	// We don't currently have any support for language experiments. We'll
+	// add support here later if we decide to make use of language experiments
+	// in future versions of OpenTofu.
+	// This is the reason why this attribute is not used.
+	AllowLanguageExperiments bool
 }
 
 // NewLoader creates and returns a loader that reads configuration from the
@@ -110,15 +128,6 @@ func (l *loader) RefreshModules() error {
 	return l.modules.readModuleManifestSnapshot()
 }
 
-// Parser returns the underlying parser for this loader.
-//
-// This is useful for loading other sorts of files than the module directories
-// that a loader deals with, since then they will share the source code cache
-// for this loader and can thus be shown as snippets in diagnostic messages.
-func (l *loader) Parser() *configs.Parser {
-	return l.parser
-}
-
 // Sources returns the source code cache for the underlying parser of this
 // loader. This is a shorthand for l.Parser().Sources().
 func (l *loader) Sources() map[string]*hcl.File {
@@ -142,9 +151,8 @@ func (l *loader) IsConfigDir(path string) bool {
 //
 //	loader.ImportSources(otherLoader.Sources())
 func (l *loader) ImportSources(sources map[string][]byte) {
-	p := l.Parser()
 	for name, src := range sources {
-		p.ForceFileSource(name, src)
+		l.parser.ForceFileSource(name, src)
 	}
 }
 
@@ -154,67 +162,11 @@ func (l *loader) ImportSources(sources map[string][]byte) {
 // This is similar to ImportSources but knows how to unpack and flatten a
 // snapshot data structure to get the corresponding flat source file map.
 func (l *loader) ImportSourcesFromSnapshot(snap *Snapshot) {
-	p := l.Parser()
 	for _, m := range snap.Modules {
 		baseDir := m.Dir
 		for fn, src := range m.Files {
 			fullPath := filepath.Join(baseDir, fn)
-			p.ForceFileSource(fullPath, src)
+			l.parser.ForceFileSource(fullPath, src)
 		}
 	}
-}
-
-// AllowLanguageExperiments specifies whether subsequent LoadConfig (and
-// similar) calls will allow opting in to experimental language features.
-//
-// If this method is never called for a particular loader, the default behavior
-// is to disallow language experiments.
-//
-// Main code should set this only for alpha or development builds. Test code
-// is responsible for deciding for itself whether and how to call this
-// method.
-func (l *loader) AllowLanguageExperiments(allowed bool) {
-	// We don't currently have any support for language experiments. We'll
-	// add support here later if we decide to make use of language experiments
-	// in future versions of OpenTofu.
-}
-
-// IsRemoteModuleSource returns true if any of the modules in the path remote
-func (l *Loader) IsRemoteModuleSource(path addrs.Module) bool {
-	if l.lastLoadedRoot == nil {
-		log.Printf("[ERROR] Unable to determine if module source is remote due to missing config load")
-		return false
-	}
-
-	current := l.lastLoadedRoot
-	for _, part := range path {
-		child, childOk := current.Children[part]
-		if !childOk {
-			log.Printf("[ERROR] Unable to determine if module source is remote due to missing child")
-			return false
-		}
-		if child.EntersNewPackage() {
-			return true
-		}
-		current = child
-	}
-	return false
-}
-
-func (l *Loader) ModuleSourceAddrs(path addrs.Module) addrs.ModuleSource {
-	if l.lastLoadedRoot == nil {
-		log.Printf("[ERROR] Unable to determine if module source is remote due to missing config load")
-		return nil
-	}
-
-	current := l.lastLoadedRoot
-	for _, part := range path {
-		child, childOk := current.Children[part]
-		if !childOk {
-			log.Printf("[ERROR] Unable to determine if module source is remote due to missing child")
-			return nil
-		}
-		current = child
-	}
-	return current.SourceAddr
 }

--- a/internal/configs/configload/loader.go
+++ b/internal/configs/configload/loader.go
@@ -16,6 +16,11 @@ import (
 	"github.com/opentofu/opentofu/internal/configs"
 )
 
+// Loader represents all the exposed logic that it's needed by the various places of the system.
+//
+// This interface contains proxy methods for the configs.Parser and any future functionality
+// from the Parser should be accessed through a Loader instance instead of exposing the Parser
+// instance directly.
 type Loader interface {
 	ImportSources(sources map[string][]byte)
 	ImportSourcesFromSnapshot(snap *Snapshot)
@@ -26,6 +31,8 @@ type Loader interface {
 	LoadConfig(ctx context.Context, rootDir string, call configs.StaticModuleCall) (*configs.Config, hcl.Diagnostics)
 	LoadConfigWithTests(ctx context.Context, rootDir string, testDir string, call configs.StaticModuleCall) (*configs.Config, hcl.Diagnostics)
 	LoadConfigWithSnapshot(ctx context.Context, rootDir string, call configs.StaticModuleCall) (*configs.Config, *Snapshot, hcl.Diagnostics)
+
+	// configs.Parser proxy methods
 
 	LoadConfigDirUneval(path string, load configs.SelectiveLoader) (*configs.Module, hcl.Diagnostics)
 	LoadConfigDir(path string, call configs.StaticModuleCall) (*configs.Module, hcl.Diagnostics)

--- a/internal/configs/configload/loader.go
+++ b/internal/configs/configload/loader.go
@@ -6,6 +6,7 @@
 package configload
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"path/filepath"
@@ -17,13 +18,27 @@ import (
 	"github.com/opentofu/opentofu/internal/configs"
 )
 
-// A Loader instance is the main entry-point for loading configurations via
+type Loader interface {
+	AllowLanguageExperiments(allowed bool)
+	ImportSources(sources map[string][]byte)
+	ImportSourcesFromSnapshot(snap *Snapshot)
+	IsConfigDir(path string) bool
+	ModulesDir() string
+	Parser() *configs.Parser
+	RefreshModules() error
+	Sources() map[string]*hcl.File
+	LoadConfig(ctx context.Context, rootDir string, call configs.StaticModuleCall) (*configs.Config, hcl.Diagnostics)
+	LoadConfigWithTests(ctx context.Context, rootDir string, testDir string, call configs.StaticModuleCall) (*configs.Config, hcl.Diagnostics)
+	LoadConfigWithSnapshot(ctx context.Context, rootDir string, call configs.StaticModuleCall) (*configs.Config, *Snapshot, hcl.Diagnostics)
+}
+
+// A loader instance is the main entry-point for loading configurations via
 // this package.
 //
 // It extends the general config-loading functionality in the parent package
 // "configs" to support installation of modules from remote sources and
 // loading full configurations using modules that were previously installed.
-type Loader struct {
+type loader struct {
 	// parser is used to read configuration
 	parser *configs.Parser
 
@@ -50,11 +65,11 @@ type Config struct {
 // The loader has some internal state about the modules that are currently
 // installed, which is read from disk as part of this function. If that
 // manifest cannot be read then an error will be returned.
-func NewLoader(config *Config) (*Loader, error) {
+func NewLoader(config *Config) (Loader, error) {
 	fs := afero.NewOsFs()
 	parser := configs.NewParser(fs)
 
-	ret := &Loader{
+	ret := &loader{
 		parser: parser,
 		modules: moduleMgr{
 			FS:         afero.Afero{Fs: fs},
@@ -73,7 +88,7 @@ func NewLoader(config *Config) (*Loader, error) {
 
 // ModulesDir returns the path to the directory where the loader will look for
 // the local cache of remote module packages.
-func (l *Loader) ModulesDir() string {
+func (l *loader) ModulesDir() string {
 	return l.modules.Dir
 }
 
@@ -87,7 +102,7 @@ func (l *Loader) ModulesDir() string {
 // is already alive and may be used again later.
 //
 // An error is returned if the manifest file cannot be read.
-func (l *Loader) RefreshModules() error {
+func (l *loader) RefreshModules() error {
 	if l == nil {
 		// Nothing to do, then.
 		return nil
@@ -100,20 +115,20 @@ func (l *Loader) RefreshModules() error {
 // This is useful for loading other sorts of files than the module directories
 // that a loader deals with, since then they will share the source code cache
 // for this loader and can thus be shown as snippets in diagnostic messages.
-func (l *Loader) Parser() *configs.Parser {
+func (l *loader) Parser() *configs.Parser {
 	return l.parser
 }
 
 // Sources returns the source code cache for the underlying parser of this
 // loader. This is a shorthand for l.Parser().Sources().
-func (l *Loader) Sources() map[string]*hcl.File {
+func (l *loader) Sources() map[string]*hcl.File {
 	return l.parser.Sources()
 }
 
 // IsConfigDir returns true if and only if the given directory contains at
 // least one OpenTofu configuration file. This is a wrapper around calling
 // the same method name on the loader's parser.
-func (l *Loader) IsConfigDir(path string) bool {
+func (l *loader) IsConfigDir(path string) bool {
 	return l.parser.IsConfigDir(path)
 }
 
@@ -126,7 +141,7 @@ func (l *Loader) IsConfigDir(path string) bool {
 // to return source code snapshots in diagnostic messages.
 //
 //	loader.ImportSources(otherLoader.Sources())
-func (l *Loader) ImportSources(sources map[string][]byte) {
+func (l *loader) ImportSources(sources map[string][]byte) {
 	p := l.Parser()
 	for name, src := range sources {
 		p.ForceFileSource(name, src)
@@ -138,7 +153,7 @@ func (l *Loader) ImportSources(sources map[string][]byte) {
 //
 // This is similar to ImportSources but knows how to unpack and flatten a
 // snapshot data structure to get the corresponding flat source file map.
-func (l *Loader) ImportSourcesFromSnapshot(snap *Snapshot) {
+func (l *loader) ImportSourcesFromSnapshot(snap *Snapshot) {
 	p := l.Parser()
 	for _, m := range snap.Modules {
 		baseDir := m.Dir
@@ -158,7 +173,7 @@ func (l *Loader) ImportSourcesFromSnapshot(snap *Snapshot) {
 // Main code should set this only for alpha or development builds. Test code
 // is responsible for deciding for itself whether and how to call this
 // method.
-func (l *Loader) AllowLanguageExperiments(allowed bool) {
+func (l *loader) AllowLanguageExperiments(allowed bool) {
 	// We don't currently have any support for language experiments. We'll
 	// add support here later if we decide to make use of language experiments
 	// in future versions of OpenTofu.

--- a/internal/configs/configload/loader.go
+++ b/internal/configs/configload/loader.go
@@ -206,7 +206,7 @@ func (l *loader) IsRemoteModuleSource(path addrs.Module) bool {
 
 func (l *loader) ModuleSourceAddrs(path addrs.Module) addrs.ModuleSource {
 	if l.lastLoadedRoot == nil {
-		log.Printf("[ERROR] Unable to determine if module source is remote due to missing config load")
+		log.Printf("[ERROR] Unable to determine the module source due to missing config load")
 		return nil
 	}
 
@@ -214,7 +214,7 @@ func (l *loader) ModuleSourceAddrs(path addrs.Module) addrs.ModuleSource {
 	for _, part := range path {
 		child, childOk := current.Children[part]
 		if !childOk {
-			log.Printf("[ERROR] Unable to determine if module source is remote due to missing child")
+			log.Printf("[ERROR] Unable to determine the module source due to missing child")
 			return nil
 		}
 		current = child

--- a/internal/configs/configload/loader.go
+++ b/internal/configs/configload/loader.go
@@ -8,11 +8,13 @@ package configload
 import (
 	"context"
 	"fmt"
+	"log"
 	"path/filepath"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/spf13/afero"
 
+	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 )
 
@@ -31,6 +33,8 @@ type Loader interface {
 	LoadConfig(ctx context.Context, rootDir string, call configs.StaticModuleCall) (*configs.Config, hcl.Diagnostics)
 	LoadConfigWithTests(ctx context.Context, rootDir string, testDir string, call configs.StaticModuleCall) (*configs.Config, hcl.Diagnostics)
 	LoadConfigWithSnapshot(ctx context.Context, rootDir string, call configs.StaticModuleCall) (*configs.Config, *Snapshot, hcl.Diagnostics)
+	IsRemoteModuleSource(path addrs.Module) bool
+	ModuleSourceAddrs(path addrs.Module) addrs.ModuleSource
 
 	// configs.Parser proxy methods
 
@@ -176,4 +180,44 @@ func (l *loader) ImportSourcesFromSnapshot(snap *Snapshot) {
 			l.parser.ForceFileSource(fullPath, src)
 		}
 	}
+}
+
+// IsRemoteModuleSource returns true if any of the modules in the path remote
+func (l *loader) IsRemoteModuleSource(path addrs.Module) bool {
+	if l.lastLoadedRoot == nil {
+		log.Printf("[ERROR] Unable to determine if module source is remote due to missing config load")
+		return false
+	}
+
+	current := l.lastLoadedRoot
+	for _, part := range path {
+		child, childOk := current.Children[part]
+		if !childOk {
+			log.Printf("[ERROR] Unable to determine if module source is remote due to missing child")
+			return false
+		}
+		if child.EntersNewPackage() {
+			return true
+		}
+		current = child
+	}
+	return false
+}
+
+func (l *loader) ModuleSourceAddrs(path addrs.Module) addrs.ModuleSource {
+	if l.lastLoadedRoot == nil {
+		log.Printf("[ERROR] Unable to determine if module source is remote due to missing config load")
+		return nil
+	}
+
+	current := l.lastLoadedRoot
+	for _, part := range path {
+		child, childOk := current.Children[part]
+		if !childOk {
+			log.Printf("[ERROR] Unable to determine if module source is remote due to missing child")
+			return nil
+		}
+		current = child
+	}
+	return current.SourceAddr
 }

--- a/internal/configs/configload/loader.go
+++ b/internal/configs/configload/loader.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/opentofu/opentofu/internal/modsdir"
 	"github.com/spf13/afero"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -35,6 +36,7 @@ type Loader interface {
 	LoadConfigWithSnapshot(ctx context.Context, rootDir string, call configs.StaticModuleCall) (*configs.Config, *Snapshot, hcl.Diagnostics)
 	IsRemoteModuleSource(path addrs.Module) bool
 	ModuleSourceAddrs(path addrs.Module) addrs.ModuleSource
+	ModuleLocalPath(_ context.Context, req *configs.ModuleRequest) (*modsdir.Record, hcl.Diagnostics)
 
 	// configs.Parser proxy methods
 

--- a/internal/configs/configload/loader_load.go
+++ b/internal/configs/configload/loader_load.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 
+	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
 
 	"github.com/opentofu/opentofu/internal/configs"
@@ -58,7 +59,7 @@ func (l *loader) loadConfig(ctx context.Context, rootMod *configs.Module, diags 
 
 // moduleWalkerLoad is a configs.ModuleWalkerFunc for loading modules that
 // are presumed to have already been installed.
-func (l *loader) ModuleLocalPath(ctx context.Context, req *configs.ModuleRequest) (*modsdir.Record, hcl.Diagnostics) {
+func (l *loader) ModuleLocalPath(_ context.Context, req *configs.ModuleRequest) (*modsdir.Record, hcl.Diagnostics) {
 	// Since we're just loading here, we expect that all referenced modules
 	// will be already installed and described in our manifest. However, we
 	// do verify that the manifest and the configuration are in agreement

--- a/internal/configs/configload/loader_load.go
+++ b/internal/configs/configload/loader_load.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 
-	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
 
 	"github.com/opentofu/opentofu/internal/configs"
@@ -26,19 +25,19 @@ import (
 //
 // LoadConfig performs the basic syntax and uniqueness validations that are
 // required to process the individual modules
-func (l *Loader) LoadConfig(ctx context.Context, rootDir string, call configs.StaticModuleCall) (*configs.Config, hcl.Diagnostics) {
+func (l *loader) LoadConfig(ctx context.Context, rootDir string, call configs.StaticModuleCall) (*configs.Config, hcl.Diagnostics) {
 	config, diags := l.parser.LoadConfigDir(rootDir, call)
 	return l.loadConfig(ctx, config, diags)
 }
 
 // LoadConfigWithTests matches LoadConfig, except the configs.Config contains
 // any relevant .tftest.hcl files.
-func (l *Loader) LoadConfigWithTests(ctx context.Context, rootDir string, testDir string, call configs.StaticModuleCall) (*configs.Config, hcl.Diagnostics) {
+func (l *loader) LoadConfigWithTests(ctx context.Context, rootDir string, testDir string, call configs.StaticModuleCall) (*configs.Config, hcl.Diagnostics) {
 	config, diags := l.parser.LoadConfigDirWithTests(rootDir, testDir, call)
 	return l.loadConfig(ctx, config, diags)
 }
 
-func (l *Loader) loadConfig(ctx context.Context, rootMod *configs.Module, diags hcl.Diagnostics) (*configs.Config, hcl.Diagnostics) {
+func (l *loader) loadConfig(ctx context.Context, rootMod *configs.Module, diags hcl.Diagnostics) (*configs.Config, hcl.Diagnostics) {
 	if rootMod == nil || diags.HasErrors() {
 		// Ensure we return any parsed modules here so that required_version
 		// constraints can be verified even when encountering errors.
@@ -59,7 +58,7 @@ func (l *Loader) loadConfig(ctx context.Context, rootMod *configs.Module, diags 
 
 // moduleWalkerLoad is a configs.ModuleWalkerFunc for loading modules that
 // are presumed to have already been installed.
-func (l *Loader) ModuleLocalPath(ctx context.Context, req *configs.ModuleRequest) (*modsdir.Record, hcl.Diagnostics) {
+func (l *loader) ModuleLocalPath(ctx context.Context, req *configs.ModuleRequest) (*modsdir.Record, hcl.Diagnostics) {
 	// Since we're just loading here, we expect that all referenced modules
 	// will be already installed and described in our manifest. However, we
 	// do verify that the manifest and the configuration are in agreement
@@ -118,7 +117,7 @@ func (l *Loader) ModuleLocalPath(ctx context.Context, req *configs.ModuleRequest
 
 // moduleWalkerLoad is a configs.ModuleWalkerFunc for loading modules that
 // are presumed to have already been installed.
-func (l *Loader) moduleWalkerLoad(ctx context.Context, req *configs.ModuleRequest) (*configs.Module, *version.Version, hcl.Diagnostics) {
+func (l *loader) moduleWalkerLoad(ctx context.Context, req *configs.ModuleRequest) (*configs.Module, *version.Version, hcl.Diagnostics) {
 	record, diags := l.ModuleLocalPath(ctx, req)
 	if diags.HasErrors() {
 		return nil, nil, diags

--- a/internal/configs/configload/loader_parser.go
+++ b/internal/configs/configload/loader_parser.go
@@ -1,0 +1,30 @@
+package configload
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/opentofu/opentofu/internal/configs"
+)
+
+func (l *loader) LoadConfigDirUneval(path string, load configs.SelectiveLoader) (*configs.Module, hcl.Diagnostics) {
+	return l.LoadConfigDirUneval(path, load)
+}
+
+func (l *loader) LoadConfigDir(path string, call configs.StaticModuleCall) (*configs.Module, hcl.Diagnostics) {
+	return l.parser.LoadConfigDir(path, call)
+}
+
+func (l *loader) LoadHCLFile(path string) (hcl.Body, hcl.Diagnostics) {
+	return l.parser.LoadHCLFile(path)
+}
+
+func (l *loader) LoadConfigDirSelective(path string, call configs.StaticModuleCall, load configs.SelectiveLoader) (*configs.Module, hcl.Diagnostics) {
+	return l.parser.LoadConfigDirSelective(path, call, load)
+}
+
+func (l *loader) LoadConfigDirWithTests(path string, testDirectory string, call configs.StaticModuleCall) (*configs.Module, hcl.Diagnostics) {
+	return l.parser.LoadConfigDirWithTests(path, testDirectory, call)
+}
+
+func (l *loader) ForceFileSource(filename string, src []byte) {
+	l.parser.ForceFileSource(filename, src)
+}

--- a/internal/configs/configload/loader_parser.go
+++ b/internal/configs/configload/loader_parser.go
@@ -1,3 +1,12 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+// This file contains the configs.Parser wrapper methods.
+// A Loader implementation should not expose its inner components but provide
+// logic around it.
+
 package configload
 
 import (
@@ -5,26 +14,32 @@ import (
 	"github.com/opentofu/opentofu/internal/configs"
 )
 
+// LoadConfigDirUneval implements Loader
 func (l *loader) LoadConfigDirUneval(path string, load configs.SelectiveLoader) (*configs.Module, hcl.Diagnostics) {
-	return l.LoadConfigDirUneval(path, load)
+	return l.parser.LoadConfigDirUneval(path, load)
 }
 
+// LoadConfigDir implements Loader
 func (l *loader) LoadConfigDir(path string, call configs.StaticModuleCall) (*configs.Module, hcl.Diagnostics) {
 	return l.parser.LoadConfigDir(path, call)
 }
 
+// LoadHCLFile implements Loader
 func (l *loader) LoadHCLFile(path string) (hcl.Body, hcl.Diagnostics) {
 	return l.parser.LoadHCLFile(path)
 }
 
+// LoadConfigDirSelective implements Loader
 func (l *loader) LoadConfigDirSelective(path string, call configs.StaticModuleCall, load configs.SelectiveLoader) (*configs.Module, hcl.Diagnostics) {
 	return l.parser.LoadConfigDirSelective(path, call, load)
 }
 
+// LoadConfigDirWithTests implements Loader
 func (l *loader) LoadConfigDirWithTests(path string, testDirectory string, call configs.StaticModuleCall) (*configs.Module, hcl.Diagnostics) {
 	return l.parser.LoadConfigDirWithTests(path, testDirectory, call)
 }
 
+// ForceFileSource implements Loader
 func (l *loader) ForceFileSource(filename string, src []byte) {
 	l.parser.ForceFileSource(filename, src)
 }

--- a/internal/configs/configload/loader_snapshot.go
+++ b/internal/configs/configload/loader_snapshot.go
@@ -25,7 +25,7 @@ import (
 // LoadConfigWithSnapshot is a variant of LoadConfig that also simultaneously
 // creates an in-memory snapshot of the configuration files used, which can
 // be later used to create a loader that may read only from this snapshot.
-func (l *Loader) LoadConfigWithSnapshot(ctx context.Context, rootDir string, call configs.StaticModuleCall) (*configs.Config, *Snapshot, hcl.Diagnostics) {
+func (l *loader) LoadConfigWithSnapshot(ctx context.Context, rootDir string, call configs.StaticModuleCall) (*configs.Config, *Snapshot, hcl.Diagnostics) {
 	rootMod, diags := l.parser.LoadConfigDir(rootDir, call)
 	if rootMod == nil {
 		return nil, nil, diags
@@ -56,11 +56,11 @@ func (l *Loader) LoadConfigWithSnapshot(ctx context.Context, rootDir string, cal
 // underlying parser does not have access to other files in the native
 // filesystem, such as values files. For those, either use a normal loader
 // (created by NewLoader) or use the configs.Parser API directly.
-func NewLoaderFromSnapshot(snap *Snapshot) *Loader {
+func NewLoaderFromSnapshot(snap *Snapshot) Loader {
 	fs := newSnapshotFS(snap)
 	parser := configs.NewParser(fs)
 
-	ret := &Loader{
+	ret := &loader{
 		parser: parser,
 		modules: moduleMgr{
 			FS:         afero.Afero{Fs: fs},
@@ -137,7 +137,7 @@ func (s *Snapshot) moduleManifest() modsdir.Manifest {
 // makeModuleWalkerSnapshot creates a configs.ModuleWalker that will exhibit
 // the same lookup behaviors as l.moduleWalkerLoad but will additionally write
 // source files from the referenced modules into the given snapshot.
-func (l *Loader) makeModuleWalkerSnapshot(snap *Snapshot) configs.ModuleWalker {
+func (l *loader) makeModuleWalkerSnapshot(snap *Snapshot) configs.ModuleWalker {
 	return configs.ModuleWalkerFunc(
 		func(ctx context.Context, req *configs.ModuleRequest) (*configs.Module, *version.Version, hcl.Diagnostics) {
 			mod, v, diags := l.moduleWalkerLoad(ctx, req)
@@ -162,7 +162,7 @@ func (l *Loader) makeModuleWalkerSnapshot(snap *Snapshot) configs.ModuleWalker {
 	)
 }
 
-func (l *Loader) addModuleToSnapshot(snap *Snapshot, key string, dir string, sourceAddr string, v *version.Version) hcl.Diagnostics {
+func (l *loader) addModuleToSnapshot(snap *Snapshot, key string, dir string, sourceAddr string, v *version.Version) hcl.Diagnostics {
 	var diags hcl.Diagnostics
 
 	primaryFiles, overrideFiles, moreDiags := l.parser.ConfigDirFiles(dir)

--- a/internal/configs/configload/testing.go
+++ b/internal/configs/configload/testing.go
@@ -19,12 +19,13 @@ import (
 // In the case of any errors, t.Fatal (or similar) will be called to halt
 // execution of the test, so the calling test does not need to handle errors
 // itself.
-func NewLoaderForTests(t testing.TB) Loader {
+func NewLoaderForTests(t testing.TB, experimentsEnabled bool) Loader {
 	t.Helper()
 
 	modulesDir := t.TempDir()
 	loader, err := NewLoader(&Config{
-		ModulesDir: modulesDir,
+		ModulesDir:               modulesDir,
+		AllowLanguageExperiments: experimentsEnabled,
 	})
 	if err != nil {
 		t.Fatalf("failed to create config loader: %s", err)

--- a/internal/configs/configload/testing.go
+++ b/internal/configs/configload/testing.go
@@ -19,7 +19,7 @@ import (
 // In the case of any errors, t.Fatal (or similar) will be called to halt
 // execution of the test, so the calling test does not need to handle errors
 // itself.
-func NewLoaderForTests(t testing.TB) *Loader {
+func NewLoaderForTests(t testing.TB) Loader {
 	t.Helper()
 
 	modulesDir := t.TempDir()

--- a/internal/initwd/from_module.go
+++ b/internal/initwd/from_module.go
@@ -223,7 +223,7 @@ func DirFromModule(ctx context.Context, loader configload.Loader, rootDir, modul
 			// and must thus be rewritten to be absolute addresses again.
 			// For now we can't do this rewriting automatically, but we'll
 			// generate an error to help the user do it manually.
-			mod, _ := loader.Parser().LoadConfigDir(rootDir, configs.NewStaticModuleCall(addrs.RootModule, hcl.Range{}, func(v *configs.Variable) (cty.Value, hcl.Diagnostics) { // ignore diagnostics since we're just doing value-add here anyway
+			mod, _ := loader.LoadConfigDir(rootDir, configs.NewStaticModuleCall(addrs.RootModule, hcl.Range{}, func(v *configs.Variable) (cty.Value, hcl.Diagnostics) { // ignore diagnostics since we're just doing value-add here anyway
 				if v.Default != cty.NilVal {
 					return v.Default, nil
 				}

--- a/internal/initwd/from_module.go
+++ b/internal/initwd/from_module.go
@@ -52,7 +52,7 @@ const initFromModuleRootKeyPrefix = initFromModuleRootCallName + "."
 // references using ../ from that module to be unresolvable. Error diagnostics
 // are produced in that case, to prompt the user to rewrite the source strings
 // to be absolute references to the original remote module.
-func DirFromModule(ctx context.Context, loader *configload.Loader, rootDir, modulesDir, sourceAddrStr string, reg *registry.Client, remoteFetcher *getmodules.PackageFetcher, hooks ModuleInstallHooks) tfdiags.Diagnostics {
+func DirFromModule(ctx context.Context, loader configload.Loader, rootDir, modulesDir, sourceAddrStr string, reg *registry.Client, remoteFetcher *getmodules.PackageFetcher, hooks ModuleInstallHooks) tfdiags.Diagnostics {
 
 	var diags tfdiags.Diagnostics
 

--- a/internal/initwd/from_module_test.go
+++ b/internal/initwd/from_module_test.go
@@ -46,7 +46,7 @@ func TestDirFromModule_registry(t *testing.T) {
 
 	reg := registry.NewClient(t.Context(), nil, nil)
 	fetcher := getmodules.NewPackageFetcher(t.Context(), nil)
-	loader := configload.NewLoaderForTests(t)
+	loader := configload.NewLoaderForTests(t, false)
 	diags := DirFromModule(t.Context(), loader, dir, modsDir, "hashicorp/module-installer-acctest/aws//examples/main", reg, fetcher, hooks)
 	assertNoDiagnostics(t, diags)
 
@@ -159,7 +159,7 @@ func TestDirFromModule_submodules(t *testing.T) {
 
 	modInstallDir := filepath.Join(tmpDir, ".terraform/modules")
 
-	loader := configload.NewLoaderForTests(t)
+	loader := configload.NewLoaderForTests(t, false)
 	diags := DirFromModule(
 		context.Background(),
 		loader,
@@ -243,7 +243,7 @@ func TestDirFromModule_submodulesWithProvider(t *testing.T) {
 	}
 	modInstallDir := filepath.Join(dir, ".terraform/modules")
 
-	loader := configload.NewLoaderForTests(t)
+	loader := configload.NewLoaderForTests(t, false)
 	diags := DirFromModule(
 		context.Background(),
 		loader,
@@ -321,7 +321,7 @@ func TestDirFromModule_rel_submodules(t *testing.T) {
 
 	modInstallDir := ".terraform/modules"
 	sourceDir := "../local-modules"
-	loader := configload.NewLoaderForTests(t)
+	loader := configload.NewLoaderForTests(t, false)
 	diags := DirFromModule(
 		context.Background(),
 		loader, ".",

--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -195,7 +195,7 @@ func (i *ModuleInstaller) InstallModules(ctx context.Context, rootDir, testsDir 
 
 		return cfg, diags
 	} else {
-		rootMod, mDiags := i.loader.Parser().LoadConfigDirWithTests(rootDir, testsDir, call)
+		rootMod, mDiags := i.loader.LoadConfigDirWithTests(rootDir, testsDir, call)
 		diags = diags.Append(mDiags)
 
 		cfg, instDiags := i.installDescendentModules(ctx, rootMod, manifest, walker, installErrsOnly)
@@ -316,7 +316,7 @@ func (i *ModuleInstaller) moduleInstallWalker(_ context.Context, manifest modsdi
 				// keep our existing record.
 				info, err := os.Stat(record.Dir)
 				if err == nil && info.IsDir() {
-					mod, mDiags := i.loader.Parser().LoadConfigDir(record.Dir, req.Call)
+					mod, mDiags := i.loader.LoadConfigDir(record.Dir, req.Call)
 					if mod == nil {
 						// nil indicates an unreadable module, which should never happen,
 						// so we return the full loader diagnostics here.
@@ -460,7 +460,7 @@ func (i *ModuleInstaller) installLocalModule(ctx context.Context, req *configs.M
 	}
 
 	// Finally we are ready to try actually loading the module.
-	mod, mDiags := i.loader.Parser().LoadConfigDir(newDir, req.Call)
+	mod, mDiags := i.loader.LoadConfigDir(newDir, req.Call)
 	if mod == nil {
 		// nil indicates missing or unreadable directory, so we'll
 		// discard the returned diags and return a more specific
@@ -811,7 +811,7 @@ func (i *ModuleInstaller) installRegistryModule(ctx context.Context, req *config
 	log.Printf("[TRACE] ModuleInstaller: %s %q was downloaded to %s", key, packageLocation.UILabel(), modDir)
 
 	// Finally we are ready to try actually loading the module.
-	mod, mDiags := i.loader.Parser().LoadConfigDir(modDir, req.Call)
+	mod, mDiags := i.loader.LoadConfigDir(modDir, req.Call)
 	if mod == nil {
 
 		subDir := packageLocation.Subdir()
@@ -931,7 +931,7 @@ func (i *ModuleInstaller) installGoGetterModule(ctx context.Context, req *config
 	log.Printf("[TRACE] ModuleInstaller: %s %q was downloaded to %s", key, addr, modDir)
 
 	// Finally we are ready to try actually loading the module.
-	mod, mDiags := i.loader.Parser().LoadConfigDir(modDir, req.Call)
+	mod, mDiags := i.loader.LoadConfigDir(modDir, req.Call)
 	if mod == nil {
 		// nil indicates missing or unreadable directory, so we'll
 		// discard the returned diags and return a more specific

--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -36,7 +36,7 @@ import (
 
 type ModuleInstaller struct {
 	modsDir string
-	loader  *configload.Loader
+	loader  configload.Loader
 	reg     *registry.Client
 	fetcher *getmodules.PackageFetcher
 
@@ -75,7 +75,7 @@ type moduleVersion struct {
 // fetched from an OpenTofu module registry. This argument can be nil, in which
 // case no remote package sources are supported; this facility is included
 // primarily for unit testing where only local modules are needed.
-func NewModuleInstaller(modsDir string, loader *configload.Loader, registryClient *registry.Client, remotePackageFetcher *getmodules.PackageFetcher) *ModuleInstaller {
+func NewModuleInstaller(modsDir string, loader configload.Loader, registryClient *registry.Client, remotePackageFetcher *getmodules.PackageFetcher) *ModuleInstaller {
 	return &ModuleInstaller{
 		modsDir:                 modsDir,
 		loader:                  loader,

--- a/internal/initwd/module_install_runtime.go
+++ b/internal/initwd/module_install_runtime.go
@@ -43,7 +43,7 @@ func (i *ModuleInstaller) installDescendentModulesNewRuntime(ctx context.Context
 		})
 	}
 
-	root, hclDiags := i.loader.Parser().LoadConfigDirUneval(rootDir, configs.SelectiveLoadAll)
+	root, hclDiags := i.loader.LoadConfigDirUneval(rootDir, configs.SelectiveLoadAll)
 	diags = diags.Append(hclDiags)
 	if diags.HasErrors() {
 		return nil, diags
@@ -98,7 +98,7 @@ func (i *ModuleInstaller) installDescendentModulesNewRuntime(ctx context.Context
 // a best effort to shim to OpenTofu's current module loader, even though
 // it works in some slightly-different terms than this new API expects.
 type newRuntimeModules struct {
-	loader *configload.Loader
+	loader configload.Loader
 	walker configs.ModuleWalker
 
 	root    *configs.Module

--- a/internal/initwd/module_install_test.go
+++ b/internal/initwd/module_install_test.go
@@ -42,7 +42,7 @@ func TestModuleInstaller(t *testing.T) {
 	hooks := &testInstallHooks{}
 
 	modulesDir := filepath.Join(dir, ".terraform/modules")
-	loader := configload.NewLoaderForTests(t)
+	loader := configload.NewLoaderForTests(t, false)
 	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 	assertNoDiagnostics(t, diags)
@@ -103,7 +103,7 @@ func TestModuleInstaller_error(t *testing.T) {
 	hooks := &testInstallHooks{}
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 
-	loader := configload.NewLoaderForTests(t)
+	loader := configload.NewLoaderForTests(t, false)
 	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 
@@ -122,7 +122,7 @@ func TestModuleInstaller_emptyModuleName(t *testing.T) {
 
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 
-	loader := configload.NewLoaderForTests(t)
+	loader := configload.NewLoaderForTests(t, false)
 	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 
@@ -141,7 +141,7 @@ func TestModuleInstaller_invalidModuleName(t *testing.T) {
 
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 
-	loader := configload.NewLoaderForTests(t)
+	loader := configload.NewLoaderForTests(t, false)
 	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(t.Context(), nil, nil), nil)
 	_, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks, configs.RootModuleCallForTesting())
 	if !diags.HasErrors() {
@@ -176,7 +176,7 @@ func TestModuleInstaller_packageEscapeError(t *testing.T) {
 
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 
-	loader := configload.NewLoaderForTests(t)
+	loader := configload.NewLoaderForTests(t, false)
 	// This test needs a real getmodules.PackageFetcher because it makes use of
 	// the esoteric legacy support for treating an absolute filesystem path
 	// as if it were a "remote package". This should not use any of the
@@ -216,7 +216,7 @@ func TestModuleInstaller_explicitPackageBoundary(t *testing.T) {
 
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 
-	loader := configload.NewLoaderForTests(t)
+	loader := configload.NewLoaderForTests(t, false)
 	// This test needs a real getmodules.PackageFetcher because it makes use of
 	// the esoteric legacy support for treating an absolute filesystem path
 	// as if it were a "remote package". This should not use any of the
@@ -304,7 +304,7 @@ func TestModuleInstaller_Prerelease(t *testing.T) {
 
 			modulesDir := filepath.Join(dir, ".terraform/modules")
 
-			loader := configload.NewLoaderForTests(t)
+			loader := configload.NewLoaderForTests(t, false)
 			reg := registry.NewClient(t.Context(), nil, nil)
 			fetcher := getmodules.NewPackageFetcher(t.Context(), nil)
 			inst := NewModuleInstaller(modulesDir, loader, reg, fetcher)
@@ -336,7 +336,7 @@ func TestModuleInstaller_invalid_version_constraint_error(t *testing.T) {
 
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 
-	loader := configload.NewLoaderForTests(t)
+	loader := configload.NewLoaderForTests(t, false)
 	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 
@@ -360,7 +360,7 @@ func TestModuleInstaller_invalidVersionConstraintGetter(t *testing.T) {
 
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 
-	loader := configload.NewLoaderForTests(t)
+	loader := configload.NewLoaderForTests(t, false)
 	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 
@@ -384,7 +384,7 @@ func TestModuleInstaller_invalidVersionConstraintLocal(t *testing.T) {
 
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 
-	loader := configload.NewLoaderForTests(t)
+	loader := configload.NewLoaderForTests(t, false)
 	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 
@@ -408,7 +408,7 @@ func TestModuleInstaller_symlink(t *testing.T) {
 
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 
-	loader := configload.NewLoaderForTests(t)
+	loader := configload.NewLoaderForTests(t, false)
 	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 	assertNoDiagnostics(t, diags)
@@ -481,7 +481,7 @@ func TestLoaderInstallModules_registry(t *testing.T) {
 	hooks := &testInstallHooks{}
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 
-	loader := configload.NewLoaderForTests(t)
+	loader := configload.NewLoaderForTests(t, false)
 	reg := registry.NewClient(t.Context(), nil, nil)
 	fetcher := getmodules.NewPackageFetcher(t.Context(), nil)
 	inst := NewModuleInstaller(modulesDir, loader, reg, fetcher)
@@ -643,7 +643,7 @@ func TestLoaderInstallModules_goGetter(t *testing.T) {
 	hooks := &testInstallHooks{}
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 
-	loader := configload.NewLoaderForTests(t)
+	loader := configload.NewLoaderForTests(t, false)
 	reg := registry.NewClient(t.Context(), nil, nil)
 	fetcher := getmodules.NewPackageFetcher(t.Context(), nil)
 	inst := NewModuleInstaller(modulesDir, loader, reg, fetcher)
@@ -760,7 +760,7 @@ func TestModuleInstaller_fromTests(t *testing.T) {
 	hooks := &testInstallHooks{}
 
 	modulesDir := filepath.Join(dir, ".terraform/modules")
-	loader := configload.NewLoaderForTests(t)
+	loader := configload.NewLoaderForTests(t, false)
 	inst := NewModuleInstaller(modulesDir, loader, nil, nil)
 	_, diags := inst.InstallModules(context.Background(), ".", "tests", false, false, hooks, configs.RootModuleCallForTesting())
 	assertNoDiagnostics(t, diags)
@@ -814,7 +814,7 @@ func TestLoadInstallModules_registryFromTest(t *testing.T) {
 	hooks := &testInstallHooks{}
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 
-	loader := configload.NewLoaderForTests(t)
+	loader := configload.NewLoaderForTests(t, false)
 	reg := registry.NewClient(t.Context(), nil, nil)
 	fetcher := getmodules.NewPackageFetcher(t.Context(), nil)
 	inst := NewModuleInstaller(modulesDir, loader, reg, fetcher)
@@ -1002,7 +1002,7 @@ func TestModuleInstaller_nonExistentSubmodule(t *testing.T) {
 	hooks := &testInstallHooks{}
 	modulesDir := filepath.Join(dir, ".terraform/modules")
 
-	loader := configload.NewLoaderForTests(t)
+	loader := configload.NewLoaderForTests(t, false)
 	fetcher := getmodules.NewPackageFetcher(t.Context(), nil)
 	inst := NewModuleInstaller(modulesDir, loader, registry.NewClient(t.Context(), nil, nil), fetcher)
 	_, diags := inst.InstallModules(context.Background(), dir, "tests", false, false, hooks, configs.RootModuleCallForTesting())

--- a/internal/initwd/testing.go
+++ b/internal/initwd/testing.go
@@ -33,7 +33,7 @@ func LoadConfigForTests(t testing.TB, rootDir string, testsDir string) (*configs
 
 	var diags tfdiags.Diagnostics
 
-	loader := configload.NewLoaderForTests(t)
+	loader := configload.NewLoaderForTests(t, false)
 	inst := NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(t.Context(), nil, nil), nil)
 
 	call := configs.RootModuleCallForTesting()

--- a/internal/initwd/testing.go
+++ b/internal/initwd/testing.go
@@ -28,7 +28,7 @@ import (
 // possibly-incomplete config is returned along with error diagnostics. The
 // test run is not aborted in this case, so that the caller can make assertions
 // against the returned diagnostics.
-func LoadConfigForTests(t testing.TB, rootDir string, testsDir string) (*configs.Config, *configload.Loader, tfdiags.Diagnostics) {
+func LoadConfigForTests(t testing.TB, rootDir string, testsDir string) (*configs.Config, configload.Loader, tfdiags.Diagnostics) {
 	t.Helper()
 
 	var diags tfdiags.Diagnostics
@@ -62,7 +62,7 @@ func LoadConfigForTests(t testing.TB, rootDir string, testsDir string) (*configs
 // This is useful for concisely writing tests that don't expect errors at
 // all. For tests that expect errors and need to assert against them, use
 // LoadConfigForTests instead.
-func MustLoadConfigForTests(t testing.TB, rootDir, testsDir string) (*configs.Config, *configload.Loader) {
+func MustLoadConfigForTests(t testing.TB, rootDir, testsDir string) (*configs.Config, configload.Loader) {
 	t.Helper()
 
 	config, loader, diags := LoadConfigForTests(t, rootDir, testsDir)
@@ -74,7 +74,7 @@ func MustLoadConfigForTests(t testing.TB, rootDir, testsDir string) (*configs.Co
 
 // MustLoadConfigWithSnapshot is similar with MustLoadConfigForTests, but additionally it returns also the
 // snapshot of the config that is needed to create an actual plan file for tests.
-func MustLoadConfigWithSnapshot(t testing.TB, rootDir, testsDir string) (*configs.Config, *configload.Loader, *configload.Snapshot) {
+func MustLoadConfigWithSnapshot(t testing.TB, rootDir, testsDir string) (*configs.Config, configload.Loader, *configload.Snapshot) {
 	t.Helper()
 
 	_, loader, diags := LoadConfigForTests(t, rootDir, testsDir)

--- a/internal/lang/globalref/analyzer_test.go
+++ b/internal/lang/globalref/analyzer_test.go
@@ -24,7 +24,7 @@ import (
 func testAnalyzer(t *testing.T, fixtureName string) *Analyzer {
 	configDir := filepath.Join("testdata", fixtureName)
 
-	loader := configload.NewLoaderForTests(t)
+	loader := configload.NewLoaderForTests(t, false)
 	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(t.Context(), nil, nil), nil)
 	_, instDiags := inst.InstallModules(context.Background(), configDir, "tests", true, false, initwd.ModuleInstallHooksImpl{}, configs.RootModuleCallForTesting())
 	if instDiags.HasErrors() {

--- a/internal/refactoring/move_validate_test.go
+++ b/internal/refactoring/move_validate_test.go
@@ -538,7 +538,7 @@ A chain of move statements must end with an address that doesn't appear in any o
 func loadRefactoringFixture(t *testing.T, dir string) (*configs.Config, instances.Set) {
 	t.Helper()
 
-	loader := configload.NewLoaderForTests(t)
+	loader := configload.NewLoaderForTests(t, false)
 	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, registry.NewClient(t.Context(), nil, nil), nil)
 	_, instDiags := inst.InstallModules(context.Background(), dir, "tests", true, false, initwd.ModuleInstallHooksImpl{}, configs.RootModuleCallForTesting())
 	if instDiags.HasErrors() {

--- a/internal/tofu/opentf_test.go
+++ b/internal/tofu/opentf_test.go
@@ -62,10 +62,8 @@ func testModuleWithSnapshot(t testing.TB, name string) (*configs.Config, *config
 	t.Helper()
 
 	dir := filepath.Join(fixtureDir, name)
-	loader := configload.NewLoaderForTests(t)
-
 	// We need to be able to exercise experimental features in our integration tests.
-	loader.AllowLanguageExperiments(true)
+	loader := configload.NewLoaderForTests(t, true)
 
 	// Test modules usually do not refer to remote sources, and for local
 	// sources only this ultimately just records all of the module paths
@@ -118,10 +116,8 @@ func testModuleInline(t testing.TB, sources map[string]string) *configs.Config {
 		}
 	}
 
-	loader := configload.NewLoaderForTests(t)
-
 	// We need to be able to exercise experimental features in our integration tests.
-	loader.AllowLanguageExperiments(true)
+	loader := configload.NewLoaderForTests(t, true)
 
 	// Test modules usually do not refer to remote sources, and for local
 	// sources only this ultimately just records all of the module paths

--- a/internal/tofumigrate/tofumigrate_test.go
+++ b/internal/tofumigrate/tofumigrate_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestMigrateStateProviderAddresses(t *testing.T) {
-	loader := configload.NewLoaderForTests(t)
+	loader := configload.NewLoaderForTests(t, false)
 	mustParseInstAddr := func(s string) addrs.AbsResourceInstance {
 		addr, err := addrs.ParseAbsResourceInstanceStr(s)
 		if err != nil {


### PR DESCRIPTION
Part of #3595.

After several attempts on how to remove completely the config loader concern from the Meta structure I had to settle with the compromise presented in this PR.

* Since the previous config loader was created by using static data rather than dynamic, there is no obvious reason to have this created by the Meta struct.
* But to keep the logic as close as possible to the existing behavior, we want to defer the return of the loader initialisation errors to the moments when its member methods are invoked.

Considering the points above, I chose to create a new `lazyLoader` that can be **created** before creating the commands structs (because the information needed is already at hand) and initialised later when it's actually used.
The `lazyLoader` implementation will return its initialisation error whenever one of its methods that return errors is invoked. (❓ should we cache the error once and do not attempt to initialise again every time a non-returning-error-method is called?)

The reason for the compromise is due to the way current tests are configured:
* The commands are exported structs that are initialised during the tests with the bare minimul dependencies for that particular use case. The config loader is loaded and initialised by the command logic when it needs it (via the `Meta` struct).
* The config loader cannot be created in the `Run` methods because it needs to be accessible for all of the commands' methods, since some commands autocompletion rely on that too.

Therefore, for the time being (until we will have time to rework the tests with a custom config loader), the `Meta.configLoader` will be kept.
Later, I intend to create constructor-like functions for each command and those functions will have as their arguments clear dependencies that each command have.
Once we have those functions, we can migrate all the tests to that and the initialisation of the config loader (and other components) could happen there, making it a common code path for both, the normal flow and testing flow.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
