### PR TITLE
[v1.12 backport] tofu: Don't panic if provider startup fails during validate

### DIFF
--- a/internal/tofu/node_provider.go
+++ b/internal/tofu/node_provider.go
@@ -103,9 +103,11 @@ func (n *NodeApplyableProvider) Execute(ctx context.Context, evalCtx EvalContext
 	if op == walkValidate {
 		log.Printf("[TRACE] NodeApplyableProvider: validating configuration for %s", n.Addr)
 		instance, newDiags := evalCtx.Providers().NewProvider(ctx, n.Addr.Provider)
-		n.instances[addrs.NoKey] = instance
-		for key, data := range instanceData {
-			diags = diags.Append(n.ValidateProvider(ctx, evalCtx, instance, key, data))
+		if !newDiags.HasErrors() { // We can't validate if we didn't successfully start the provider plugin
+			n.instances[addrs.NoKey] = instance
+			for key, data := range instanceData {
+				diags = diags.Append(n.ValidateProvider(ctx, evalCtx, instance, key, data))
+			}
 		}
 		return diags.Append(newDiags)
 	}


### PR DESCRIPTION
This is a backport of https://github.com/opentofu/opentofu/pull/4110 to the `v1.12` branch for inclusion in the v1.12.1 release.

As mentioned in the other PR, this intentionally doesn't have a changelog entry yet because this is an interim step toward fixing what seems like a bug but we can't actually properly debug it yet because this panic is hiding the error message. We'll add a changelog entry once we've fixed the problem that's causing the error message to appear, but we need to know what the error actually is before we can fix it.