### PR TITLE
Fix file descriptor leaks in provisioners and commands

### DIFF
--- a/internal/builtin/provisioners/file/resource_provisioner.go
+++ b/internal/builtin/provisioners/file/resource_provisioner.go
@@ -162,9 +162,11 @@ func getSrc(v cty.Value) (string, bool, error) {
 		}
 
 		if _, err = file.WriteString(content.AsString()); err != nil {
+			file.Close()
 			return "", true, err
 		}
 
+		file.Close()
 		return file.Name(), true, nil
 
 	case !src.IsNull():

--- a/internal/builtin/provisioners/local-exec/resource_provisioner.go
+++ b/internal/builtin/provisioners/local-exec/resource_provisioner.go
@@ -167,6 +167,7 @@ func (p *provisioner) ProvisionResource(ctx context.Context, req provisioners.Pr
 		))
 		return resp
 	}
+	defer pr.Close()
 
 	var cmdEnv []string
 	cmdEnv = os.Environ()

--- a/internal/command/login.go
+++ b/internal/command/login.go
@@ -285,6 +285,7 @@ func (c *LoginCommand) Run(rawArgs []string) int {
 			view.DefaultTFCLoginSuccess()
 			return 0
 		}
+		defer resp.Body.Close()
 
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
@@ -292,8 +293,6 @@ func (c *LoginCommand) Run(rawArgs []string) int {
 			view.DefaultTFCLoginSuccess()
 			return 0
 		}
-
-		defer resp.Body.Close()
 		if err := json.Unmarshal(body, &motd); err != nil {
 			c.logMOTDError(fmt.Errorf("platform responded with invalid motd payload: %w", err))
 			view.DefaultTFCLoginSuccess()
@@ -517,9 +516,9 @@ func (c *LoginCommand) interactiveGetTokenByCode(ctx context.Context, hostname s
 				"Current command was aborted by the calling code.",
 			),
 		)
-    if err := server.Shutdown(ctx); err != nil {
-		log.Printf("[WARN] login: callback server shutdown failed: %s", err)
-	}
+		if err := server.Shutdown(ctx); err != nil {
+			log.Printf("[WARN] login: callback server shutdown failed: %s", err)
+		}
 		wg.Wait()
 		close(codeCh)
 		return nil, diags

--- a/internal/command/workspace_new.go
+++ b/internal/command/workspace_new.go
@@ -178,6 +178,7 @@ func (c *WorkspaceNewCommand) Run(rawArgs []string) int {
 		)})
 		return 1
 	}
+	defer f.Close()
 
 	stateFile, err := statefile.Read(f, encryption.StateEncryptionDisabled()) // Assume given statefile is not encrypted
 	if err != nil {


### PR DESCRIPTION
## What this PR does

Fixes four file descriptor leaks across provisioners and commands:

1. **`local-exec/resource_provisioner.go`**: `os.Pipe()` creates pr (read) and pw (write). Only pw.Close() was called; pr leaked one OS FD per local-exec invocation. Added `defer pr.Close()`.

2. **`command/login.go`**: `defer resp.Body.Close()` placed after `io.ReadAll`; early return on ReadAll error leaked the HTTP body. Moved defer immediately after the response error check.

3. **`command/workspace_new.go`**: `os.Open(statePath)` had no close; file handle leaked for the duration of the function. Added `defer f.Close()`.

4. **`provisioners/file/resource_provisioner.go`**: `os.CreateTemp` in `getSrc()` never closed the file handle. Added explicit close before returns.

These are the same class of bugs fixed in hashicorp/terraform PR #38585.

## AI Disclosure

Developed with AI assistance (Grok by xAI) in a human-in-the-loop workflow. All code reviewed and verified by the human author.

Signed-off-by: Sebastien Tardif <sebtardif@ncf.ca>