### PR TITLE
Fix provider schema caching broken in v1.12

### DIFF
--- a/internal/command/meta_providers.go
+++ b/internal/command/meta_providers.go
@@ -307,6 +307,11 @@ func (m *Meta) providerFactories() (map[addrs.Provider]providers.Factory, error)
 		checkedProvider := false
 		var checkErr error
 
+		// This should only ever be called once per provider type.
+		// It creates the schema cache to be re-used in all of the subsequent
+		// provider instances.
+		factory := providerFactory(cached)
+
 		factories[provider] = func() (providers.Interface, error) {
 			checkLock.Lock()
 			if !checkedProvider {
@@ -319,7 +324,7 @@ func (m *Meta) providerFactories() (map[addrs.Provider]providers.Factory, error)
 				return nil, checkErr
 			}
 
-			return providerFactory(cached)()
+			return factory()
 		}
 	}
 	for provider, localDir := range devOverrideProviders {


### PR DESCRIPTION
Changelog will be added in the backport.

This was traced down to two PRs that were modifying the same section of the provider initialization process in command/meta_providers.go.  Notably, the code changes didn't conflict directly, but produced a unintended side effect.

In https://github.com/opentofu/opentofu/pull/2730/changes#diff-0604af16e484c13bcb4a729aa4baf5feac2ee4fe450ee0974e5a7f3d50af9f25R327-R339, I deferred the checking of provider hashes until the provider is actually needed.  With parallelism elsewhere in the application, this can lead to a performance boost. It also prevented these checks in commands that didn't need to start providers (ideally done elsewhere, but the command package is a mess).

At the same time, I was working on https://github.com/opentofu/opentofu/pull/3589/changes#diff-0604af16e484c13bcb4a729aa4baf5feac2ee4fe450ee0974e5a7f3d50af9f25R367-R368, which cleaned up a few places where we were duplicating schema caching logic and validation. This PR *was supposed to* reduce the number of times getProviderSchema was called on the provider. The initialization of `tofu.Schemas` early on in validate/plan/apply would fill up the grpc provider caches and then shut down the "bloated" providers that had been asked for their schema. For the rest of the command execution, provider instances would not be asked for their schemas and keep total system memory usage down.

Unfortunately, the way these two changes interacted was a broken provider level schema cache.

I used the "Mixed" case from #4123 with the following commands to validate this change:
```bash
# Run before every test:
echo 3 > /proc/sys/vm/drop_caches

# Run at the same time:
for i in {0..10}; do /usr/bin/time -v ./tofu_main validate >> main.log 2>&1; sleep 1; done
for i in {0..10000}; do free -m | grep Mem | awk '{print $3}' >> rss_main; sleep 0.1; done
```


System Memory usage in MB offset to the starting value.
<img width="1714" height="964" alt="image" src="https://github.com/user-attachments/assets/5a1c35ea-95c7-4865-9da1-e37a82efd358" />


As you can see, with the patch in this PR, the intended effect occurs.  The initial memory peak is roughly the same between v1.11 and this branch, but the subsequent peaks are noticeably lower.  You can also clearly see the regression introduced by asking every instance of every provider to produce it's schema on first use.

<!-- If your PR resolves an issue, please add it here. -->
Resolves #4123
Related to #4118

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
  - In full transparency, I believe that @joe-a-dbt used AI in creating the issue and suggesting what the root cause was. I did my best to ignore the root cause posted (and actively thought it was incorrect for most of the triage). Although the fix is related to what was suggested in the root cause, it was derived independently and for a very different effect.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
