### PR TITLE
Releasing Instructions: Change the unversioned docs symlink too

### DIFF
--- a/CONTRIBUTING.RELEASE.md
+++ b/CONTRIBUTING.RELEASE.md
@@ -299,6 +299,12 @@ We do not release documentation for non-stable releases, any links should point 
    cp versioned_sidebars/version-v1.11-sidebars.json versioned_sidebars/version-vX.Y-sidebars.json
    cd versioned_docs && ln -s ../opentofu-repo/vX.Y/website/docs version-vX.Y
    ```
+8. Recreate the `docs` symlink in the root of the repository to refer to the `website` directory from the newly-added submodule, so that the new branch is used for unversioned doc URLs.
+   ```shell
+   # (make sure that your current working directory is the repository root)
+   rm docs
+   ln -s opentofu-repo/vX.Y/website/docs docs
+   ```
 
 </details>
 


### PR DESCRIPTION
These instructions previously only covered the documentation URLs that include an explicit version number. We also need to update the "docs" symlink in the root of the repository to specify which branch unversioned URLs should be served from.

This is capturing what I did for https://github.com/opentofu/opentofu.org/pull/425, to make the version-agnostic docs URLs refer to the docs from the `v1.12` branch now that one is current.
