### PR TITLE
Unmark the value resulted from the 'enabled' expression evaluation

### DIFF
--- a/internal/lang/evalchecks/eval_lifecycle_enabled.go
+++ b/internal/lang/evalchecks/eval_lifecycle_enabled.go
@@ -61,6 +61,11 @@ func EvaluateEnabledExpression(expr hcl.Expression, hclCtxFunc ContextFunc) (boo
 		})
 	}
 
+	// At the moment of writing this, we don't care about other marks here so we strip all of them off to be able
+	// to work with the value in a safe manner.
+	// NOTE: whenever a new mark is introduce, check this function and handle the new mark properly if needed.
+	rawEnabledVal, _ = rawEnabledVal.UnmarkDeep()
+
 	if rawEnabledVal.IsNull() {
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity:    hcl.DiagError,

--- a/internal/lang/evalchecks/eval_lifecycle_enabled.go
+++ b/internal/lang/evalchecks/eval_lifecycle_enabled.go
@@ -61,10 +61,9 @@ func EvaluateEnabledExpression(expr hcl.Expression, hclCtxFunc ContextFunc) (boo
 		})
 	}
 
-	// At the moment of writing this, we don't care about other marks here so we strip all of them off to be able
-	// to work with the value in a safe manner.
-	// NOTE: whenever a new mark is introduce, check this function and handle the new mark properly if needed.
-	rawEnabledVal, _ = rawEnabledVal.UnmarkDeep()
+	var deprDiags tfdiags.Diagnostics
+	rawEnabledVal, deprDiags = marks.ExtractDeprecatedDiagnosticsWithExpr(rawEnabledVal, expr)
+	diags = diags.Append(deprDiags)
 
 	if rawEnabledVal.IsNull() {
 		diags = diags.Append(&hcl.Diagnostic{

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -9224,8 +9224,4 @@ resource "test_resource" "example" {
 	if changes := len(plan.Changes.Resources); changes != 1 {
 		t.Fatalf("expected to have exactly one resource change but got %d", changes)
 	}
-	res := plan.Changes.Resources[0]
-	if got, want := res.Addr.String(), "test_resource.example"; got != want {
-		t.Errorf("unexpected resource in the changes. Wanted %q but got %q", want, got)
-	}
 }

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -9173,3 +9173,59 @@ func TestContext2Plan_moduleDependsOnWithCheck(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 }
+
+// TestContext2Plan_enabledOnDeprecatedModuleOutput is a regression test for
+// https://github.com/opentofu/opentofu/issues/4161
+// "panic: value is marked, so must be unmarked first in EvaluateEnabledExpression during plan"
+//
+// When a module output is marked as deprecated and that output value is used in another resource
+// lifecycle.enabled, a panic was encountered due to the value being still marked.
+func TestContext2Plan_enabledOnDeprecatedModuleOutput(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"mod/main.tf": `
+output "trigger" {
+  value      = true
+  deprecated = "use other"
+}`,
+		"main.tf": `
+module "m" {
+  source = "./mod"
+}
+
+resource "test_resource" "example" {
+  lifecycle {
+    enabled = module.m.trigger
+  }
+}
+`,
+	})
+
+	p := &MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			Provider: providers.Schema{Block: &configschema.Block{}},
+			ResourceTypes: map[string]providers.Schema{
+				"test_resource": {Block: &configschema.Block{}},
+			},
+		},
+	}
+	ctx := testContext2(t, &ContextOpts{
+		Plugins: plugins.NewLibrary(map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		}, nil),
+	})
+
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
+	if diags.HasErrors() {
+		t.Errorf("unexpected errors: %s", diags.Err())
+	}
+	if plan == nil {
+		t.Fatalf("expected a plan but got nothing")
+	}
+	if changes := len(plan.Changes.Resources); changes != 1 {
+		t.Fatalf("expected to have exactly one resource change but got %d", changes)
+	}
+	res := plan.Changes.Resources[0]
+	if got, want := res.Addr.String(), "test_resource.example"; got != want {
+		t.Errorf("unexpected resource in the changes. Wanted %q but got %q", want, got)
+	}
+}


### PR DESCRIPTION
The function that evaluates the `enabled` expression takes care of the sensitive and ephemeral marks but the deprecation one was not handled and if the value is marked as such, it will panic on the `cty` methods that require the value to be unmarked.

~We remove all the marks after the sensitive and ephemeral marks handling to be sure that no other mark can end up there.~

Thanks to @Yantrio's sharp eyes, we realised that we don't handle properly the deprecation marks inside this function, which was the main issue (since sensitive and ephemeral are handled anyway).
In https://github.com/opentofu/opentofu/pull/4162/changes/d5d7bef04922996947cdf9b33307a6be5c9edc3d, changed the removal of marks with the actual handling of the deprecation marks, which fixes 2 things:
* the reported panic
* now usage in `enabled` of values sourced from deprecated marked values will raise a warning, as intended in the initial implementation

ℹ️ This needs to be backported to v1.12 and released in v1.12.2

Resolves #4161
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
