### PR TITLE
Properly handle EDEADLK in provider install

### DIFF
--- a/internal/flock/filesystem_lock_unix.go
+++ b/internal/flock/filesystem_lock_unix.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"syscall"
 )
@@ -34,6 +35,22 @@ func Lock(f *os.File) error {
 // If the given context is cancelled then it returns early with the cancellation
 // error.
 func LockBlocking(ctx context.Context, f *os.File) error {
+	err := lockBlockingInner(ctx, f)
+
+	// On some platforms (MacOS, Linux, ...?), fcntl tries to detect deadlocks. Unfortunately with multiple
+	// processes and multiple goroutines, we may trip the detector erroniously. It thinks that
+	// because different processes are installing different providers and have a mix of goroutines
+	// (sleeping trying to lock) / (active locked), there must be a deadlock.
+	//
+	// https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fcntl.2.html
+	for err == syscall.EDEADLK {
+		log.Printf("[INFO] Locking deadlock incorrectly detected by the kernel on %s", f.Name())
+		err = lockBlockingInner(ctx, f)
+	}
+
+	return err
+}
+func lockBlockingInner(ctx context.Context, f *os.File) error {
 	flock := &syscall.Flock_t{
 		Type:   syscall.F_RDLCK | syscall.F_WRLCK,
 		Whence: int16(io.SeekStart),


### PR DESCRIPTION
```
	// On some platforms (MacOS, Linux, ...?), fcntl tries to detect deadlocks. Unfortunately with multiple
	// processes and multiple goroutines, we may trip the detector erroniously. It thinks that
	// because different processes are installing different providers and have a mix of goroutines
	// (sleeping trying to lock) / (active locked), there must be a deadlock.
	//
	// https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/fcntl.2.html
```

Reproduced with on Linux amd64 with:
```bash
# run.sh
rm -rf ./runners/
mkdir ./runners/

rm -rf ./cache/
mkdir ./cache/

export TF_PLUGIN_CACHE_DIR=$PWD/cache
for i in {0..40}; do
        mkdir ./runners/$i
        cp -r ./template/{main.tf,.terraform.lock.hcl} ./runners/$i
done
for i in {0..20}; do
        cd ./runners/$i
        ~/go/bin/tofu init &
        cd -
done

wait
```
```hcl
# template/main.tf
provider "aws" {}
provider "tfcoremock" {}
provider "azurerm" {}
```
and a correctly written lockfile at template/.terraform.lock.hcl

Changelog entry will go on the v1.12 branch.

<!-- If your PR resolves an issue, please add it here. -->
Resolves #4165

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
