### PR TITLE
#2680 - Add SensitiveBefore and SensitiveAfter for output changes

### DIFF
--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -729,15 +729,14 @@ func MarshalOutputChanges(changes *plans.Changes) (map[string]Change, error) {
 			return nil, err
 		}
 
-		// The only information we have in the plan about output sensitivity is
-		// a boolean which is true if the output was or is marked sensitive. As
-		// a result, BeforeSensitive and AfterSensitive will be identical, and
-		// either false or true.
-		outputSensitive := cty.False
-		if oc.Sensitive {
-			outputSensitive = cty.True
+		// Use the distinct before/after sensitivity values so that the renderer
+		// can detect when sensitivity has changed (e.g. NoOp value but
+		// sensitive flag toggled) and promote the action to Update.
+		beforeSens, err := ctyjson.Marshal(cty.BoolVal(oc.SensitiveBefore), cty.Bool)
+		if err != nil {
+			return nil, err
 		}
-		sensitive, err := ctyjson.Marshal(outputSensitive, outputSensitive.Type())
+		afterSens, err := ctyjson.Marshal(cty.BoolVal(oc.SensitiveAfter), cty.Bool)
 		if err != nil {
 			return nil, err
 		}
@@ -748,8 +747,8 @@ func MarshalOutputChanges(changes *plans.Changes) (map[string]Change, error) {
 		}
 
 		change.Actions = actionString(oc.Action.String())
-		change.BeforeSensitive = json.RawMessage(sensitive)
-		change.AfterSensitive = json.RawMessage(sensitive)
+		change.BeforeSensitive = json.RawMessage(beforeSens)
+		change.AfterSensitive = json.RawMessage(afterSens)
 
 		outputChanges[oc.Addr.OutputValue.Name] = *change
 	}

--- a/internal/command/jsonplan/plan_test.go
+++ b/internal/command/jsonplan/plan_test.go
@@ -445,6 +445,58 @@ func TestOutputs(t *testing.T) {
 				},
 			},
 		},
+		"sensitivity change with same value": {
+			// Regression test for https://github.com/opentofu/opentofu/issues/2680
+			// When only sensitivity changes (value stays the same), BeforeSensitive
+			// and AfterSensitive must differ, allowing the renderer to promote NoOp to Update.
+			changes: &plans.Changes{
+				Outputs: []*plans.OutputChangeSrc{
+					{
+						Addr: root.OutputValue("sensitive_output"),
+						ChangeSrc: plans.ChangeSrc{
+							Action: plans.NoOp,
+						},
+						SensitiveBefore: false,
+						SensitiveAfter:  true,
+					},
+				},
+			},
+			expected: map[string]Change{
+				"sensitive_output": {
+					Actions:         []string{"no-op"},
+					Before:          json.RawMessage("null"),
+					After:           json.RawMessage("null"),
+					AfterUnknown:    json.RawMessage("false"),
+					BeforeSensitive: json.RawMessage("false"),
+					AfterSensitive:  json.RawMessage("true"),
+				},
+			},
+		},
+		"sensitivity removed with same value": {
+			// Regression test for https://github.com/opentofu/opentofu/issues/2680
+			changes: &plans.Changes{
+				Outputs: []*plans.OutputChangeSrc{
+					{
+						Addr: root.OutputValue("was_sensitive"),
+						ChangeSrc: plans.ChangeSrc{
+							Action: plans.NoOp,
+						},
+						SensitiveBefore: true,
+						SensitiveAfter:  false,
+					},
+				},
+			},
+			expected: map[string]Change{
+				"was_sensitive": {
+					Actions:         []string{"no-op"},
+					Before:          json.RawMessage("null"),
+					After:           json.RawMessage("null"),
+					AfterUnknown:    json.RawMessage("false"),
+					BeforeSensitive: json.RawMessage("true"),
+					AfterSensitive:  json.RawMessage("false"),
+				},
+			},
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/internal/command/testdata/show-json-sensitive/output.json
+++ b/internal/command/testdata/show-json-sensitive/output.json
@@ -161,7 +161,7 @@
             "before": null,
             "after": "bar",
             "after_unknown": false,
-            "before_sensitive": true,
+            "before_sensitive": false,
             "after_sensitive": true
         }
     },

--- a/internal/command/testdata/show-json/sensitive-values/output.json
+++ b/internal/command/testdata/show-json/sensitive-values/output.json
@@ -65,7 +65,7 @@
             "before": null,
             "after": "boop",
             "after_unknown": false,
-            "before_sensitive": true,
+            "before_sensitive": false,
             "after_sensitive": true
         }
     },

--- a/internal/plans/changes.go
+++ b/internal/plans/changes.go
@@ -522,6 +522,12 @@ type OutputChange struct {
 	// should elide the actual values while still indicating the action of the
 	// change.
 	Sensitive bool
+
+	// SensitiveBefore is true if the prior state value was sensitive.
+	SensitiveBefore bool
+
+	// SensitiveAfter is true if the planned new value will be sensitive.
+	SensitiveAfter bool
 }
 
 // Encode produces a variant of the receiver that has its change values
@@ -531,10 +537,18 @@ func (oc *OutputChange) Encode() (*OutputChangeSrc, error) {
 	if err != nil {
 		return nil, err
 	}
+	sensitiveBefore := oc.SensitiveBefore
+	sensitiveAfter := oc.SensitiveAfter
+	if oc.Sensitive && !sensitiveBefore && !sensitiveAfter {
+		sensitiveBefore = true
+		sensitiveAfter = true
+	}
 	return &OutputChangeSrc{
-		Addr:      oc.Addr,
-		ChangeSrc: *cs,
-		Sensitive: oc.Sensitive,
+		Addr:            oc.Addr,
+		ChangeSrc:       *cs,
+		Sensitive:       oc.Sensitive,
+		SensitiveBefore: sensitiveBefore,
+		SensitiveAfter:  sensitiveAfter,
 	}, err
 }
 

--- a/internal/plans/changes_src.go
+++ b/internal/plans/changes_src.go
@@ -161,6 +161,12 @@ type OutputChangeSrc struct {
 	// should elide the actual values while still indicating the action of the
 	// change.
 	Sensitive bool
+
+	// SensitiveBefore is true if the prior state value was sensitive.
+	SensitiveBefore bool
+
+	// SensitiveAfter is true if the planned new value will be sensitive.
+	SensitiveAfter bool
 }
 
 // Decode unmarshals the raw representation of the output value being
@@ -170,10 +176,18 @@ func (ocs *OutputChangeSrc) Decode() (*OutputChange, error) {
 	if err != nil {
 		return nil, err
 	}
+	sensitiveBefore := ocs.SensitiveBefore
+	sensitiveAfter := ocs.SensitiveAfter
+	if ocs.Sensitive && !sensitiveBefore && !sensitiveAfter {
+		sensitiveBefore = true
+		sensitiveAfter = true
+	}
 	return &OutputChange{
-		Addr:      ocs.Addr,
-		Change:    *change,
-		Sensitive: ocs.Sensitive,
+		Addr:            ocs.Addr,
+		Change:          *change,
+		Sensitive:       ocs.Sensitive,
+		SensitiveBefore: sensitiveBefore,
+		SensitiveAfter:  sensitiveAfter,
 	}, nil
 }
 

--- a/internal/plans/changes_test.go
+++ b/internal/plans/changes_test.go
@@ -162,3 +162,75 @@ func TestChangeEncodeSensitive(t *testing.T) {
 		})
 	}
 }
+
+// TestOutputChangeSensitivityRoundTrip verifies that SensitiveBefore and
+// SensitiveAfter fields survive a round-trip through Encode() → Decode().
+//
+// Regression test for https://github.com/opentofu/opentofu/issues/2680
+// Before the fix, sensitivity changes would be lost during encoding/decoding.
+func TestOutputChangeSensitivityRoundTrip(t *testing.T) {
+	tests := []struct {
+		name             string
+		beforeSensitive bool
+		afterSensitive  bool
+	}{
+		{"no change: both not sensitive", false, false},
+		{"add sensitivity", false, true},
+		{"remove sensitivity", true, false},
+		{"no change: both sensitive", true, true},
+	}
+
+	root := addrs.RootModuleInstance
+	addr := root.OutputValue("test_output")
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create an OutputChange with the sensitivity values
+			oc := &OutputChange{
+				Addr:            addr,
+				Sensitive:       tc.beforeSensitive || tc.afterSensitive, // legacy field
+				SensitiveBefore: tc.beforeSensitive,
+				SensitiveAfter:  tc.afterSensitive,
+				Change: Change{
+					Action: NoOp,
+					Before: cty.StringVal("test_value"),
+					After:  cty.StringVal("test_value"),
+				},
+			}
+
+			// Encode to OutputChangeSrc
+			encoded, err := oc.Encode()
+			if err != nil {
+				t.Fatalf("unexpected error during encode: %s", err)
+			}
+
+			// Verify the encoded values
+			if encoded.SensitiveBefore != tc.beforeSensitive {
+				t.Errorf("encoded.SensitiveBefore = %v, want %v", encoded.SensitiveBefore, tc.beforeSensitive)
+			}
+			if encoded.SensitiveAfter != tc.afterSensitive {
+				t.Errorf("encoded.SensitiveAfter = %v, want %v", encoded.SensitiveAfter, tc.afterSensitive)
+			}
+
+			// Decode back to OutputChange
+			decoded, err := encoded.Decode()
+			if err != nil {
+				t.Fatalf("unexpected error during decode: %s", err)
+			}
+
+			// Verify the decoded values
+			if decoded.SensitiveBefore != tc.beforeSensitive {
+				t.Errorf("decoded.SensitiveBefore = %v, want %v", decoded.SensitiveBefore, tc.beforeSensitive)
+			}
+			if decoded.SensitiveAfter != tc.afterSensitive {
+				t.Errorf("decoded.SensitiveAfter = %v, want %v", decoded.SensitiveAfter, tc.afterSensitive)
+			}
+
+			// Verify the legacy Sensitive field is still populated correctly
+			expectedSensitive := tc.beforeSensitive || tc.afterSensitive
+			if decoded.Sensitive != expectedSensitive {
+				t.Errorf("decoded.Sensitive = %v, want %v", decoded.Sensitive, expectedSensitive)
+			}
+		})
+	}
+}

--- a/internal/plans/internal/planproto/planfile.pb.go
+++ b/internal/plans/internal/planproto/planfile.pb.go
@@ -915,9 +915,13 @@ type OutputChange struct {
 	// Sensitive, if true, indicates that one or more of the values given
 	// in "change" is sensitive and should not be shown directly in any
 	// rendered plan.
-	Sensitive     bool `protobuf:"varint,3,opt,name=sensitive,proto3" json:"sensitive,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Sensitive bool `protobuf:"varint,3,opt,name=sensitive,proto3" json:"sensitive,omitempty"`
+	// sensitive_before is true if the prior state value was sensitive.
+	SensitiveBefore bool `protobuf:"varint,4,opt,name=sensitive_before,json=sensitiveBefore,proto3" json:"sensitive_before,omitempty"`
+	// sensitive_after is true if the planned new value will be sensitive.
+	SensitiveAfter bool `protobuf:"varint,5,opt,name=sensitive_after,json=sensitiveAfter,proto3" json:"sensitive_after,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *OutputChange) Reset() {
@@ -967,6 +971,20 @@ func (x *OutputChange) GetChange() *Change {
 func (x *OutputChange) GetSensitive() bool {
 	if x != nil {
 		return x.Sensitive
+	}
+	return false
+}
+
+func (x *OutputChange) GetSensitiveBefore() bool {
+	if x != nil {
+		return x.SensitiveBefore
+	}
+	return false
+}
+
+func (x *OutputChange) GetSensitiveAfter() bool {
+	if x != nil {
+		return x.SensitiveAfter
 	}
 	return false
 }
@@ -1453,11 +1471,13 @@ const file_planfile_proto_rawDesc = "" +
 	"\aprivate\x18\n" +
 	" \x01(\fR\aprivate\x127\n" +
 	"\x10required_replace\x18\v \x03(\v2\f.tfplan.PathR\x0frequiredReplace\x12I\n" +
-	"\raction_reason\x18\f \x01(\x0e2$.tfplan.ResourceInstanceActionReasonR\factionReason\"h\n" +
+	"\raction_reason\x18\f \x01(\x0e2$.tfplan.ResourceInstanceActionReasonR\factionReason\"\xbc\x01\n" +
 	"\fOutputChange\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12&\n" +
 	"\x06change\x18\x02 \x01(\v2\x0e.tfplan.ChangeR\x06change\x12\x1c\n" +
-	"\tsensitive\x18\x03 \x01(\bR\tsensitive\"\xfc\x03\n" +
+	"\tsensitive\x18\x03 \x01(\bR\tsensitive\x12)\n" +
+	"\x10sensitive_before\x18\x04 \x01(\bR\x0fsensitiveBefore\x12'\n" +
+	"\x0fsensitive_after\x18\x05 \x01(\bR\x0esensitiveAfter\"\xfc\x03\n" +
 	"\fCheckResults\x123\n" +
 	"\x04kind\x18\x01 \x01(\x0e2\x1f.tfplan.CheckResults.ObjectKindR\x04kind\x12\x1f\n" +
 	"\vconfig_addr\x18\x02 \x01(\tR\n" +

--- a/internal/plans/internal/planproto/planfile.proto
+++ b/internal/plans/internal/planproto/planfile.proto
@@ -281,6 +281,12 @@ message OutputChange {
     // in "change" is sensitive and should not be shown directly in any
     // rendered plan.
     bool sensitive = 3;
+
+    // sensitive_before is true if the prior state value was sensitive.
+    bool sensitive_before = 4;
+
+    // sensitive_after is true if the planned new value will be sensitive.
+    bool sensitive_after = 5;
 }
 
 message CheckResults {

--- a/internal/plans/planfile/tfplan.go
+++ b/internal/plans/planfile/tfplan.go
@@ -90,13 +90,22 @@ func readTfplan(r io.Reader) (*plans.Plan, error) {
 			return nil, fmt.Errorf("invalid plan for output %q: %w", name, err)
 		}
 
+		sensitiveBefore := rawOC.SensitiveBefore
+		sensitiveAfter := rawOC.SensitiveAfter
+		if rawOC.Sensitive && !sensitiveBefore && !sensitiveAfter {
+			sensitiveBefore = true
+			sensitiveAfter = true
+		}
+
 		plan.Changes.Outputs = append(plan.Changes.Outputs, &plans.OutputChangeSrc{
 			// All output values saved in the plan file are root module outputs,
 			// since we don't retain others. (They can be easily recomputed
 			// during apply).
-			Addr:      addrs.OutputValue{Name: name}.Absolute(addrs.RootModuleInstance),
-			ChangeSrc: *change,
-			Sensitive: rawOC.Sensitive,
+			Addr:            addrs.OutputValue{Name: name}.Absolute(addrs.RootModuleInstance),
+			ChangeSrc:       *change,
+			Sensitive:       rawOC.Sensitive,
+			SensitiveBefore: sensitiveBefore,
+			SensitiveAfter:  sensitiveAfter,
 		})
 	}
 
@@ -575,9 +584,11 @@ func writeTfplan(plan *plans.Plan, w io.Writer) error {
 		}
 
 		rawPlan.OutputChanges = append(rawPlan.OutputChanges, &planproto.OutputChange{
-			Name:      name,
-			Change:    protoChange,
-			Sensitive: oc.Sensitive,
+			Name:            name,
+			Change:          protoChange,
+			Sensitive:       oc.Sensitive,
+			SensitiveBefore: oc.SensitiveBefore,
+			SensitiveAfter:  oc.SensitiveAfter,
 		})
 	}
 

--- a/internal/plans/planfile/tfplan_test.go
+++ b/internal/plans/planfile/tfplan_test.go
@@ -61,7 +61,20 @@ func TestTFPlanRoundTrip(t *testing.T) {
 						Before: mustDynamicOutputValue("old secret value"),
 						After:  mustDynamicOutputValue("new secret value"),
 					},
-					Sensitive: true,
+					Sensitive:       true,
+					SensitiveBefore: true,
+					SensitiveAfter:  true,
+				},
+				{
+					Addr: addrs.OutputValue{Name: "toggle"}.Absolute(addrs.RootModuleInstance),
+					ChangeSrc: plans.ChangeSrc{
+						Action: plans.Update,
+						Before: mustDynamicOutputValue("value"),
+						After:  mustDynamicOutputValue("value"),
+					},
+					Sensitive:       true,
+					SensitiveBefore: false,
+					SensitiveAfter:  true,
 				},
 			},
 			Resources: []*plans.ResourceInstanceChangeSrc{

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -9173,3 +9173,142 @@ func TestContext2Plan_moduleDependsOnWithCheck(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 }
+
+func TestContext2Plan_outputSensitivityChange(t *testing.T) {
+	// Regression test for https://github.com/opentofu/opentofu/issues/2680
+	// When only the sensitive flag on an output changes (value stays the same),
+	// tofu should detect this as an Update, not NoOp.
+
+	p := simpleMockProvider()
+
+	// First, create state with a non-sensitive output
+	addr := mustResourceInstanceAddr("test_object.a")
+	state := states.BuildState(func(s *states.SyncState) {
+		s.SetResourceInstanceCurrent(addr, &states.ResourceInstanceObjectSrc{
+			AttrsJSON: []byte(`{"test_string":"test-value"}`),
+			Status:    states.ObjectReady,
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`), addrs.NoKey)
+		// Set the output value in state as non-sensitive
+		s.SetOutputValue(addrs.OutputValue{Name: "test"}.Absolute(addrs.RootModuleInstance), cty.StringVal("test-value"), false, "")
+	})
+
+	// Now plan with the same value but sensitive=true
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_object" "a" {
+  test_string = "test-value"
+}
+
+output "test" {
+  value     = test_object.a.test_string
+  sensitive = true
+}
+`,
+	})
+
+	ctx := testContext2(t, &ContextOpts{
+		Plugins: plugins.NewLibrary(map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		}, nil),
+	})
+
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
+	assertNoErrors(t, diags)
+
+	// There should be exactly one output change
+	if len(plan.Changes.Outputs) != 1 {
+		t.Fatalf("expected 1 output change, got %d", len(plan.Changes.Outputs))
+	}
+
+	oc := plan.Changes.Outputs[0]
+	if oc.Addr.OutputValue.Name != "test" {
+		t.Fatalf("expected output 'test', got %s", oc.Addr.OutputValue.Name)
+	}
+
+	decoded, err := oc.Decode()
+	if err != nil {
+		t.Fatalf("failed to decode output change: %s", err)
+	}
+
+	// The action should be Update, not NoOp, because sensitivity changed
+	if decoded.Action != plans.Update {
+		t.Errorf("expected action to be Update for sensitivity change, got %v", decoded.Action)
+	}
+
+	// Verify sensitivity fields
+	if decoded.SensitiveBefore != false {
+		t.Errorf("expected SensitiveBefore to be false, got %v", decoded.SensitiveBefore)
+	}
+	if decoded.SensitiveAfter != true {
+		t.Errorf("expected SensitiveAfter to be true, got %v", decoded.SensitiveAfter)
+	}
+}
+
+func TestContext2Plan_outputSensitivityRemoval(t *testing.T) {
+	// Regression test for https://github.com/opentofu/opentofu/issues/2680
+	// Test the reverse: removing sensitive flag should also be detected as Update.
+
+	p := simpleMockProvider()
+
+	// First, create state with a sensitive output
+	addr := mustResourceInstanceAddr("test_object.a")
+	state := states.BuildState(func(s *states.SyncState) {
+		s.SetResourceInstanceCurrent(addr, &states.ResourceInstanceObjectSrc{
+			AttrsJSON: []byte(`{"test_string":"test-value"}`),
+			Status:    states.ObjectReady,
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`), addrs.NoKey)
+		// Set the output value in state as sensitive
+		s.SetOutputValue(addrs.OutputValue{Name: "test"}.Absolute(addrs.RootModuleInstance), cty.StringVal("test-value"), true, "")
+	})
+
+	// Now plan with the same value but sensitive=false
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_object" "a" {
+  test_string = "test-value"
+}
+
+output "test" {
+  value     = test_object.a.test_string
+  sensitive = false
+}
+`,
+	})
+
+	ctx := testContext2(t, &ContextOpts{
+		Plugins: plugins.NewLibrary(map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		}, nil),
+	})
+
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
+	assertNoErrors(t, diags)
+
+	// There should be exactly one output change
+	if len(plan.Changes.Outputs) != 1 {
+		t.Fatalf("expected 1 output change, got %d", len(plan.Changes.Outputs))
+	}
+
+	oc := plan.Changes.Outputs[0]
+	if oc.Addr.OutputValue.Name != "test" {
+		t.Fatalf("expected output 'test', got %s", oc.Addr.OutputValue.Name)
+	}
+
+	decoded, err := oc.Decode()
+	if err != nil {
+		t.Fatalf("failed to decode output change: %s", err)
+	}
+
+	// The action should be Update, not NoOp, because sensitivity changed
+	if decoded.Action != plans.Update {
+		t.Errorf("expected action to be Update for sensitivity removal, got %v", decoded.Action)
+	}
+
+	// Verify sensitivity fields
+	if decoded.SensitiveBefore != true {
+		t.Errorf("expected SensitiveBefore to be true, got %v", decoded.SensitiveBefore)
+	}
+	if decoded.SensitiveAfter != false {
+		t.Errorf("expected SensitiveAfter to be false, got %v", decoded.SensitiveAfter)
+	}
+}

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -9208,6 +9208,7 @@ resource "test_resource" "example" {
 			},
 		},
 	}
+
 	ctx := testContext2(t, &ContextOpts{
 		Plugins: plugins.NewLibrary(map[addrs.Provider]providers.Factory{
 			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
@@ -9225,3 +9226,143 @@ resource "test_resource" "example" {
 		t.Fatalf("expected to have exactly one resource change but got %d", changes)
 	}
 }
+
+func TestContext2Plan_outputSensitivityChange(t *testing.T) {
+	// Regression test for https://github.com/opentofu/opentofu/issues/2680
+	// When only the sensitive flag on an output changes (value stays the same),
+	// tofu should detect this as an Update, not NoOp.
+
+	p := simpleMockProvider()
+
+	// First, create state with a non-sensitive output
+	addr := mustResourceInstanceAddr("test_object.a")
+	state := states.BuildState(func(s *states.SyncState) {
+		s.SetResourceInstanceCurrent(addr, &states.ResourceInstanceObjectSrc{
+			AttrsJSON: []byte(`{"test_string":"test-value"}`),
+			Status:    states.ObjectReady,
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`), addrs.NoKey)
+		// Set the output value in state as non-sensitive
+		s.SetOutputValue(addrs.OutputValue{Name: "test"}.Absolute(addrs.RootModuleInstance), cty.StringVal("test-value"), false, "")
+	})
+
+	// Now plan with the same value but sensitive=true
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_object" "a" {
+  test_string = "test-value"
+}
+
+output "test" {
+  value     = test_object.a.test_string
+  sensitive = true
+}
+`,
+	})
+
+	ctx := testContext2(t, &ContextOpts{
+		Plugins: plugins.NewLibrary(map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		}, nil),
+	})
+
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
+	assertNoErrors(t, diags)
+
+	// There should be exactly one output change
+	if len(plan.Changes.Outputs) != 1 {
+		t.Fatalf("expected 1 output change, got %d", len(plan.Changes.Outputs))
+	}
+
+	oc := plan.Changes.Outputs[0]
+	if oc.Addr.OutputValue.Name != "test" {
+		t.Fatalf("expected output 'test', got %s", oc.Addr.OutputValue.Name)
+	}
+
+	decoded, err := oc.Decode()
+	if err != nil {
+		t.Fatalf("failed to decode output change: %s", err)
+	}
+
+	// The action should be Update, not NoOp, because sensitivity changed
+	if decoded.Action != plans.Update {
+		t.Errorf("expected action to be Update for sensitivity change, got %v", decoded.Action)
+	}
+
+	// Verify sensitivity fields
+	if decoded.SensitiveBefore != false {
+		t.Errorf("expected SensitiveBefore to be false, got %v", decoded.SensitiveBefore)
+	}
+	if decoded.SensitiveAfter != true {
+		t.Errorf("expected SensitiveAfter to be true, got %v", decoded.SensitiveAfter)
+	}
+}
+
+func TestContext2Plan_outputSensitivityRemoval(t *testing.T) {
+	// Regression test for https://github.com/opentofu/opentofu/issues/2680
+	// Test the reverse: removing sensitive flag should also be detected as Update.
+
+	p := simpleMockProvider()
+
+	// First, create state with a sensitive output
+	addr := mustResourceInstanceAddr("test_object.a")
+	state := states.BuildState(func(s *states.SyncState) {
+		s.SetResourceInstanceCurrent(addr, &states.ResourceInstanceObjectSrc{
+			AttrsJSON: []byte(`{"test_string":"test-value"}`),
+			Status:    states.ObjectReady,
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`), addrs.NoKey)
+		// Set the output value in state as sensitive
+		s.SetOutputValue(addrs.OutputValue{Name: "test"}.Absolute(addrs.RootModuleInstance), cty.StringVal("test-value"), true, "")
+	})
+
+	// Now plan with the same value but sensitive=false
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+resource "test_object" "a" {
+  test_string = "test-value"
+}
+
+output "test" {
+  value     = test_object.a.test_string
+  sensitive = false
+}
+`,
+	})
+
+	ctx := testContext2(t, &ContextOpts{
+		Plugins: plugins.NewLibrary(map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		}, nil),
+	})
+
+	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
+	assertNoErrors(t, diags)
+
+	// There should be exactly one output change
+	if len(plan.Changes.Outputs) != 1 {
+		t.Fatalf("expected 1 output change, got %d", len(plan.Changes.Outputs))
+	}
+
+	oc := plan.Changes.Outputs[0]
+	if oc.Addr.OutputValue.Name != "test" {
+		t.Fatalf("expected output 'test', got %s", oc.Addr.OutputValue.Name)
+	}
+
+	decoded, err := oc.Decode()
+	if err != nil {
+		t.Fatalf("failed to decode output change: %s", err)
+	}
+
+	// The action should be Update, not NoOp, because sensitivity changed
+	if decoded.Action != plans.Update {
+		t.Errorf("expected action to be Update for sensitivity removal, got %v", decoded.Action)
+	}
+
+	// Verify sensitivity fields
+	if decoded.SensitiveBefore != true {
+		t.Errorf("expected SensitiveBefore to be true, got %v", decoded.SensitiveBefore)
+	}
+	if decoded.SensitiveAfter != false {
+		t.Errorf("expected SensitiveAfter to be false, got %v", decoded.SensitiveAfter)
+	}
+}
+

--- a/internal/tofu/node_output.go
+++ b/internal/tofu/node_output.go
@@ -542,8 +542,10 @@ func (n *NodeDestroyableOutput) Execute(_ context.Context, evalCtx EvalContext, 
 	changes := evalCtx.Changes()
 	if changes != nil && n.Planning {
 		change := &plans.OutputChange{
-			Addr:      n.Addr,
-			Sensitive: sensitiveBefore,
+			Addr:            n.Addr,
+			Sensitive:       sensitiveBefore,
+			SensitiveBefore: sensitiveBefore,
+			SensitiveAfter:  false,
 			Change: plans.Change{
 				Action: plans.Delete,
 				Before: before,
@@ -635,8 +637,10 @@ func (n *NodeApplyableOutput) setValue(state *states.SyncState, changes *plans.C
 		}
 
 		change := &plans.OutputChange{
-			Addr:      n.Addr,
-			Sensitive: sensitiveChange,
+			Addr:            n.Addr,
+			Sensitive:       sensitiveChange,
+			SensitiveBefore: sensitiveBefore,
+			SensitiveAfter:  n.Config.Sensitive,
 			Change: plans.Change{
 				Action: action,
 				Before: before,


### PR DESCRIPTION

Resolves #2680

Fixes a bug where `tofu plan` reported "No changes" when only an outputs `sensitive` attribute changed, even though the state should have been updated to reflect the new sensitivity.

Output changes tracked only a single `Sensitive` boolean, which was used for both the “before” and “after” sensitivity flags in the JSON plan. As a result, the renderer could not detect when sensitivity changed **without a value change**, and it left the action as `NoOp`, hiding the change from the user.

So, `SensitiveBefore` and `SensitiveAfter` fields in the plan data model and planfile get wired through the protobuf and JSON serialization, and populates them in the output evaluation. With this, the existing logic correctly promotes a `NoOp` with sensitivity change into an `Update`, and the state can be updated accordingly.

Let me know if I have missed anything! I took my time on this but there is probably something I am overlooking. 

### Changes

- Extend `plans.OutputChange` and `plans.OutputChangeSrc` to carry `SensitiveBefore` and `SensitiveAfter` alongside the existing `Sensitive` flag.
- Update the planfile protobuf (`OutputChange`) and its generated Go code to persist the new fields in saved plans.
- Add backward-compatible encode/decode logic so older code paths that only set `Sensitive` still behave safely by treating both before/after as sensitive when `Sensitive` is true and the split fields are unset.
- Change the output evaluation in `internal/tofu/node_output.go` to treat sensitivity-only changes as updates, and populate `SensitiveBefore` from state and `SensitiveAfter` from configuration.
- Update the JSON plan marshaler so `BeforeSensitive` and `AfterSensitive` are derived from the distinct before/after fields, instead of duplicating a single value.
- Add unit, planfile round-trip, JSON marshaling, and context plan tests covering sensitivity being added, sensitivity being removed, and noop cases where sensitivity is unchanged.

### Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.