### PR TITLE
fix: set span error status on module fetch failure path in tofu init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ BUG FIXES:
 - The built-in function `cidrhost` no longer returns a "panic" error when called with an out-of-range host number represented in more than 64 bits. ([#4056](https://github.com/opentofu/opentofu/pull/4056))
 - provisioner output is no longer suppressed when `-show-sensitive` is passed. ([#3927](https://github.com/opentofu/opentofu/issues/3927))
 - In the `azurerm` backend's OpenID Connect authorization method, when `audience` is provided as a query parameter in the URL, it will be passed through instead of being overwritten by a default value. ([#4037](https://github.com/opentofu/opentofu/pull/4037))
+- Fixed span error status not being set on module fetch failure path during `tofu init`, so observability tools now correctly identify failed spans. ([#4169](https://github.com/opentofu/opentofu/issues/4169))
 
 ## Previous Releases
 

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -271,6 +271,7 @@ To initialize the configuration already in this working directory, omit the
 		modsOutput, modsAbort, modsDiags := c.getModules(ctx, path, args.TestsDirectory, rootModEarly, args.FlagUpgrade, view)
 		diags = diags.Append(modsDiags)
 		if modsAbort || modsDiags.HasErrors() {
+			tracing.SetSpanError(span, modsDiags)
 			view.Diagnostics(diags)
 			return 1
 		}
@@ -410,6 +411,7 @@ func (c *InitCommand) getModules(ctx context.Context, path, testsDir string, ear
 		}
 	}
 
+	tracing.SetSpanError(span, diags)
 	return true, installAbort, diags
 }
 

--- a/internal/getmodules/installer.go
+++ b/internal/getmodules/installer.go
@@ -94,7 +94,7 @@ func (f *PackageFetcher) FetchPackage(ctx context.Context, instDir string, packa
 	defer span.End()
 	err := f.getter.getWithGoGetter(ctx, instDir, packageAddr)
 	if err != nil {
-		span.RecordError(err)
+		tracing.SetSpanError(span, err)
 		return err
 	}
 	return nil

--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -233,7 +233,10 @@ func (i *ModuleInstaller) moduleInstallWalker(_ context.Context, manifest modsdi
 					traceattrs.OpenTofuModuleSource(req.SourceAddr.String()),
 				),
 			)
-			defer span.End()
+			defer func() {
+				tracing.SetSpanError(span, diags)
+				span.End()
+			}()
 
 			log.Printf("[DEBUG] Module installer: begin %s", key)
 


### PR DESCRIPTION

<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves #4169
Use tracing.SetSpanError() instead of span.RecordError() so that observability tools (Jaeger, Datadog, etc.) correctly mark failed spans with error status during module installation failures.

Affected spans: Init, Get Modules, Install Module, Fetch Package.

<img width="940" height="233" alt="스크린샷 2026-06-01 오후 9 18 28" src="https://github.com/user-attachments/assets/ac15b692-025a-47f9-9efc-6f121e3ae7f2" />

Before fix: see [issue #4169](https://github.com/opentofu/opentofu/issues/4169)

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
