### PR TITLE
fix: TRACESTATE log message prints TRACEPARENT value instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ BUG FIXES:
 - provisioner output is no longer suppressed when `-show-sensitive` is passed. ([#3927](https://github.com/opentofu/opentofu/issues/3927))
 - In the `azurerm` backend's OpenID Connect authorization method, when `audience` is provided as a query parameter in the URL, it will be passed through instead of being overwritten by a default value. ([#4037](https://github.com/opentofu/opentofu/pull/4037))
 - Fixed span error status not being set on module fetch failure path during `tofu init`, so observability tools now correctly identify failed spans. ([#4169](https://github.com/opentofu/opentofu/issues/4169))
+- Fixed TRACESTATE log message incorrectly printing the TRACEPARENT value instead. ([#4168](https://github.com/opentofu/opentofu/issues/4168))
 
 ## Previous Releases
 

--- a/internal/tracing/init.go
+++ b/internal/tracing/init.go
@@ -127,7 +127,7 @@ func OpenTelemetryInit(ctx context.Context) (context.Context, error) {
 		propCarrier.Set("traceparent", traceparent)
 
 		if tracestate := os.Getenv(traceStateEnvVar); tracestate != "" {
-			log.Printf("[TRACE] OpenTelemetry: found trace state in environment: %s", traceparent)
+			log.Printf("[TRACE] OpenTelemetry: found trace state in environment: %s", tracestate)
 			propCarrier.Set("tracestate", tracestate)
 		}
 


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves #4168 

The log message for trace state was using the wrong variable (traceparent instead of tracestate), logging the TRACEPARENT value when TRACESTATE is found in the environment.
[Before]
<img width="1026" height="36" alt="스크린샷 2026-06-01 오후 9 42 19" src="https://github.com/user-attachments/assets/43b5e4e4-6ef1-4b71-8504-66516c96f8f8" />
[After]
<img width="1019" height="46" alt="스크린샷 2026-06-01 오후 9 43 00" src="https://github.com/user-attachments/assets/3e21f8cd-48ac-4cf4-9fb0-6048d401c77e" />


## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
