### PR TITLE
Partially revert changes for ephemeral support in new engine

### DIFF
--- a/internal/engine/applying/operations_resource.go
+++ b/internal/engine/applying/operations_resource.go
@@ -20,7 +20,7 @@ import (
 	"github.com/zclconf/go-cty/cty/ctymarks"
 )
 
-const resourceDependencyMissingDetail = `The value of resource %s was requested by %s during apply, %s.
+const resourceDependencyMissingDetail = `The value of resource %s was requested by %s during apply, but was not present in the plan.
 This may be caused by one of the following options:
   - Ephemeral values requiring different dependencies between plan and apply (unsupported)
   - An edge case of -target or -exclude
@@ -33,22 +33,11 @@ func (ops *execOperations) resourceDependenciesMissingCheck(idType string, idNam
 
 	cfgVal, marks := ops.resourceDependenciesMissingMarks(cfgVal)
 	for _, mark := range marks {
-		switch mark.Cause {
-		case execgraph.ResourceInstanceDependencyMissingCauseNotPlanned:
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				fmt.Sprintf("Invalid %s action", idType),
-				fmt.Sprintf(resourceDependencyMissingDetail, mark.Target, idName, "but was not present in the plan"),
-			))
-		case execgraph.ResourceInstanceDependencyMissingCauseNotExecuted:
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				fmt.Sprintf("Invalid %s action", idType),
-				fmt.Sprintf(resourceDependencyMissingDetail, mark.Target, idName, "but was not yet present in the planned execution order"),
-			))
-		default:
-			panic(fmt.Sprintf("BUG: unhandled ResourceInstanceDependencyMissingCause(%v) for %s", mark.Cause, idName))
-		}
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			fmt.Sprintf("Invalid %s action", idType),
+			fmt.Sprintf(resourceDependencyMissingDetail, mark.Target, idName),
+		))
 	}
 
 	return cfgVal, diags

--- a/internal/engine/internal/execgraph/compiled.go
+++ b/internal/engine/internal/execgraph/compiled.go
@@ -18,17 +18,8 @@ import (
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
-type ResourceInstanceDependencyMissingCause int
-
-const (
-	ResourceInstanceDependencyMissingCauseInvalid = iota
-	ResourceInstanceDependencyMissingCauseNotPlanned
-	ResourceInstanceDependencyMissingCauseNotExecuted
-)
-
 type ResourceInstanceDependencyMissingMark struct {
 	Target string // addrs.AbsResourceInstance
-	Cause  ResourceInstanceDependencyMissingCause
 }
 
 type CompiledGraph struct {
@@ -43,10 +34,6 @@ type CompiledGraph struct {
 	// functions have returned.
 	steps []compiledGraphStep
 
-	// resourceInstanceValuesLock protects concurrent reads/writes to
-	// resourceInstanceValues as we overwrite it's entries post resource
-	// execution
-	resourceInstanceValuesLock sync.Mutex
 	// resourceInstanceValues provides a function for each resource instance
 	// that was registered as a "sink" during graph building which blocks
 	// until the final state for that resource instance is available and then
@@ -116,17 +103,15 @@ func (c *CompiledGraph) Execute(ctx context.Context) tfdiags.Diagnostics {
 // resource graph node has already executed and recorded a value.
 //
 // Calls to this method should run concurrently with a call to [CompiledGraph.Execute]
-// because otherwise the operations that generate the final state for resource
-// instances will not have been run and had it's value recorded.
+// because otherwise the operations that generate the final state for resource instances
+// will not run and thus this will block indefinitely waiting for results that will never
+// arrive.
 //
 // If the resource's value is not available for any reason, a [cty.DynamicVal] will
 // be returned, marked with [ResourceInstanceDependencyMissingMark]. This allows
 // the "unplanned reference" mark to propogate through the rest of the system and be
 // handled in locations where it can generate a detailed error diagnostic.
 func (c *CompiledGraph) ResourceInstanceValue(ctx context.Context, addr addrs.AbsResourceInstance) cty.Value {
-	c.resourceInstanceValuesLock.Lock()
-	defer c.resourceInstanceValuesLock.Unlock()
-
 	getter, ok := c.resourceInstanceValues.GetOk(addr)
 	if !ok {
 		// If we get asked for a resource instance address that wasn't involved
@@ -138,7 +123,6 @@ func (c *CompiledGraph) ResourceInstanceValue(ctx context.Context, addr addrs.Ab
 		// error message elsewhere.
 		return cty.DynamicVal.Mark(ResourceInstanceDependencyMissingMark{
 			Target: addr.String(),
-			Cause:  ResourceInstanceDependencyMissingCauseNotPlanned,
 		})
 	}
 	return getter(ctx)

--- a/internal/engine/internal/execgraph/compiler.go
+++ b/internal/engine/internal/execgraph/compiler.go
@@ -161,12 +161,18 @@ func (c *compiler) Compile() (*CompiledGraph, tfdiags.Diagnostics) {
 	// evaluation system.
 	for _, elem := range c.sourceGraph.resourceInstanceResults.Elems {
 		instAddr := elem.Key
-		// No lock needed here as the concurrent execution has not yet been started.
+		ref := elem.Value
+		execFunc := c.compileResultRef(ref)
 		c.compiledGraph.resourceInstanceValues.Put(instAddr, func(ctx context.Context) cty.Value {
-			return cty.DynamicVal.Mark(ResourceInstanceDependencyMissingMark{
-				Target: instAddr.String(),
-				Cause:  ResourceInstanceDependencyMissingCauseNotExecuted,
-			})
+			rawResult, ok, _ := execFunc(ctx)
+			if !ok {
+				return cty.DynamicVal
+			}
+			finalStateObj := rawResult.(*exec.ResourceInstanceObject)
+			if finalStateObj == nil {
+				return cty.NullVal(cty.DynamicPseudoType)
+			}
+			return finalStateObj.State.Value
 		})
 	}
 

--- a/internal/engine/internal/execgraph/compiler_ops.go
+++ b/internal/engine/internal/execgraph/compiler_ops.go
@@ -136,15 +136,6 @@ func (c *compiler) compileOpManagedApply(operands *compilerOperands) nodeExecute
 		// TODO: Also call ops.ResourceInstancePostconditions if we produced a non-nil result
 		log.Printf("[WARN] opManagedApply doesn't yet handle postconditions")
 
-		c.compiledGraph.resourceInstanceValuesLock.Lock()
-		defer c.compiledGraph.resourceInstanceValuesLock.Unlock()
-		c.compiledGraph.resourceInstanceValues.Put(finalPlan.InstanceAddr, func(ctx context.Context) cty.Value {
-			if ret == nil {
-				return cty.NullVal(cty.DynamicPseudoType)
-			}
-			return ret.State.Value
-		})
-
 		return ret, !diags.HasErrors(), diags
 	}
 }

--- a/internal/engine/internal/execgraph/compiler_test.go
+++ b/internal/engine/internal/execgraph/compiler_test.go
@@ -139,16 +139,9 @@ func TestCompiler_resourceInstanceBasics(t *testing.T) {
 		t.Fatal("unexpected compile errors\n" + diags.Err().Error())
 	}
 
-	// Simulate asking for a resource before it's executed
-	gotValue := compiledGraph.ResourceInstanceValue(grapheval.ContextWithNewWorker(t.Context()), resourceInstAddr)
-	wantValue := cty.DynamicVal.Mark(ResourceInstanceDependencyMissingMark{Target: resourceInstAddr.String(), Cause: ResourceInstanceDependencyMissingCauseNotExecuted})
-	if diff := gcmp.Diff(wantValue, gotValue, ctydebug.CmpOptions); diff != "" {
-		t.Errorf("wrong result for %s: %s", resourceInstAddr, diff)
-	}
-
 	// Simulate asking for a resource that is not in the plan
-	gotValue = compiledGraph.ResourceInstanceValue(grapheval.ContextWithNewWorker(t.Context()), resourceInstAddrMissing)
-	wantValue = cty.DynamicVal.Mark(ResourceInstanceDependencyMissingMark{Target: resourceInstAddrMissing.String(), Cause: ResourceInstanceDependencyMissingCauseNotPlanned})
+	gotValue := compiledGraph.ResourceInstanceValue(grapheval.ContextWithNewWorker(t.Context()), resourceInstAddrMissing)
+	wantValue := cty.DynamicVal.Mark(ResourceInstanceDependencyMissingMark{Target: resourceInstAddrMissing.String()})
 	if diff := gcmp.Diff(wantValue, gotValue, ctydebug.CmpOptions); diff != "" {
 		t.Errorf("wrong result for %s: %s", resourceInstAddr, diff)
 	}

--- a/internal/tofu/context_apply_test.go
+++ b/internal/tofu/context_apply_test.go
@@ -2795,7 +2795,7 @@ func TestContext2Apply_moduleBasic(t *testing.T) {
 }
 
 func TestContext2Apply_moduleDestroyOrder(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugExecGraph)
+	SkipExperimental(t, ExperimentalBugExecGraph, ExperimentalFeatureDestroy)
 
 	m := testModule(t, "apply-module-destroy-order")
 	p := testProvider("aws")
@@ -3367,7 +3367,7 @@ func TestContext2Apply_moduleProviderCloseNested(t *testing.T) {
 // accessing "non-existent" resources (they existed, just not in the graph
 // cause they weren't in the diff).
 func TestContext2Apply_moduleVarRefExisting(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugExecGraph)
+	SkipExperimental(t, ExperimentalBugExecGraph, ExperimentalFeatureStateDependencies)
 
 	m := testModule(t, "apply-ref-existing")
 	p := testProvider("aws")
@@ -4149,7 +4149,7 @@ func TestContext2Apply_multiVarOrder(t *testing.T) {
 // Test that multi-var (splat) access is ordered by count, not by
 // value, through interpolations.
 func TestContext2Apply_multiVarOrderInterp(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugExecGraph)
+	SkipExperimental(t, ExperimentalBugExecGraph, ExperimentalFlagUnknown)
 
 	m := testModule(t, "apply-multi-var-order-interp")
 	p := testProvider("aws")
@@ -4185,7 +4185,7 @@ func TestContext2Apply_multiVarOrderInterp(t *testing.T) {
 // Based on GH-10440 where a graph edge wasn't properly being created
 // between a modified resource and a count instance being destroyed.
 func TestContext2Apply_multiVarCountDec(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugExecGraph)
+	SkipExperimental(t, ExperimentalBugExecGraph, ExperimentalFeatureDestroy)
 
 	var s *states.State
 
@@ -7340,7 +7340,7 @@ func TestContext2Apply_taintDep(t *testing.T) {
 }
 
 func TestContext2Apply_taintDepRequiresNew(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugExecGraph)
+	SkipExperimental(t, ExperimentalBugExecGraph, ExperimentalFlagUnknown)
 
 	m := testModule(t, "apply-taint-dep-requires-new")
 	p := testProvider("aws")
@@ -8533,7 +8533,7 @@ func TestContext2Apply_issue7824(t *testing.T) {
 // This deals with the situation where a splat expression is used referring
 // to another resource whose count is non-constant.
 func TestContext2Apply_issue5254(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugExecGraph)
+	SkipExperimental(t, ExperimentalBugExecGraph, ExperimentalFeatureStateDependencies)
 
 	// Create a provider. We use "template" here just to match the repro
 	// we got from the issue itself.

--- a/internal/tofu/context_temp_runtime_test.go
+++ b/internal/tofu/context_temp_runtime_test.go
@@ -29,7 +29,6 @@ const (
 	ExperimentalBugDataResource      ExperimentalFlag = "Bug Data Resource"
 	ExperimentalBugVariableInput     ExperimentalFlag = "Bug Variable Input"
 	ExperimentalBugForEach           ExperimentalFlag = "Bug For Each" // TODO run existing evalchecks tests against new engine
-	ExperimentalBugExecGraph         ExperimentalFlag = "Bug in generated Exec Graph"
 
 	ExperimentalChangeDiagWording ExperimentalFlag = "Change Different Diagnostic Wording"
 	ExperimentalChangeErrorEarly  ExperimentalFlag = "Change Detect Error Earlier"
@@ -69,14 +68,23 @@ const (
 	ExperimentalFeatureStateDependencies ExperimentalFlag = "Missing State Dependencies"
 	ExperimentalFeatureProviderFunctions ExperimentalFlag = "Missing Provider Defined Functions"
 	ExperimentalFeatureProviderInstances ExperimentalFlag = "Missing Provider Instances"
+
+	// Fixed
+	ExperimentalBugExecGraph ExperimentalFlag = "Bug in generated Exec Graph"
 )
 
 func SkipExperimental(t *testing.T, features ...ExperimentalFlag) {
 	if experimentalRuntimeEnabled() {
 		var strs []string
 		for _, feature := range features {
-			strs = append(strs, string(feature))
+			switch feature {
+			case ExperimentalBugExecGraph:
+			default:
+				strs = append(strs, string(feature))
+			}
 		}
-		t.Skip("New Engine: " + strings.Join(strs, ", "))
+		if len(strs) > 0 {
+			t.Skip("New Engine: " + strings.Join(strs, ", "))
+		}
 	}
 }


### PR DESCRIPTION
    Partially revert d76ac45887a1885a6de56a6f4ea14a62b3b0b716
    
    @apparentlymart and I were going through test failures and
    mananged to trace it back to this change.
    
    The main issue with the original PR (#4158) was a misunderstanding about
    when certain configgraph items are evaluated. configgraph is eager and
    will try to evaluate everything all at once, it depends on the strict
    ordering present in the execgraph to ensure the side effects occur in
    the correct order. I was under the impression that the configgraph
    was not eager and implemented the "error in order" detection seen
    in this PR.
    
    At the end of the day, this particular edge case does not warrant the
    headache it's caused and was out of scope of the original ephemeral
    implementation agreement.


## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
