### PR TITLE
Rework provider references throughout new engine

### DIFF
--- a/internal/lang/eval/internal/configgraph/module_call_instance.go
+++ b/internal/lang/eval/internal/configgraph/module_call_instance.go
@@ -66,14 +66,11 @@ type ModuleCallInstance struct {
 	// are no cycles in the dependency chain within the module.
 	InputsValuer *OnceValuer
 
-	// ProvidersFromParentValuers is our representation of the weird
+	// ProvidersFromParent is our representation of the weird
 	// "side-channel" that allows providers to pass between modules, which
 	// is separate from the concept of input variables despite being
 	// conceptually similar.
-	//
-	// Each valuer in this map is expected to evaluate to a value of a type
-	// returned by [ProviderInstanceRefType].
-	ProvidersFromParentValuers map[addrs.LocalProviderConfig]*OnceValuer
+	ProvidersFromParent CompileProviderConfigRef
 
 	validatedInputs grapheval.Once[cty.Value]
 }
@@ -119,24 +116,6 @@ func (m *ModuleCallInstance) InputsValue(ctx context.Context) (cty.Value, tfdiag
 		}
 		return inputsVal, diags
 	})
-}
-
-func (m *ModuleCallInstance) ProvidersFromParent(ctx context.Context) map[addrs.LocalProviderConfig]exprs.Valuer {
-	// We want to return a map of the interface type exprs.Valuer here, to
-	// avoid exposing the implementation detail that we're using OnceValuer
-	// internally, but unfortunately that means we need to copy our source
-	// map on each call. :(
-	// In practice that doesn't hurt too much since the main caller of this
-	// method is behind a "Once" anyway, so the result of this should get
-	// memoized further up the call stack.
-	if len(m.ProvidersFromParentValuers) == 0 {
-		return nil
-	}
-	ret := make(map[addrs.LocalProviderConfig]exprs.Valuer, len(m.ProvidersFromParentValuers))
-	for addr, valuer := range m.ProvidersFromParentValuers {
-		ret[addr] = exprs.Valuer(valuer)
-	}
-	return ret
 }
 
 // Value implements exprs.Valuer.

--- a/internal/lang/eval/internal/configgraph/provider_config.go
+++ b/internal/lang/eval/internal/configgraph/provider_config.go
@@ -19,6 +19,13 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+// CompileProviderConfigRef represents the lookup of a local provider config within a given
+// "scope". This is a side channel given the legacy inheritence of providers between modules
+//
+// Each valuer returned is expected to evaluate to a value of a type
+// returned by [ProviderInstanceRefType].
+type CompileProviderConfigRef func(ctx context.Context, providerInstAddr addrs.LocalProviderConfig) exprs.Valuer
+
 type ProviderConfig struct {
 	// FIXME: The current form of AbsProviderConfig is weird and not quite
 	// right, because the "Abs" prefix is supposed to represent something

--- a/internal/lang/eval/internal/evalglue/module.go
+++ b/internal/lang/eval/internal/evalglue/module.go
@@ -11,6 +11,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/lang/eval/internal/configgraph"
 	"github.com/opentofu/opentofu/internal/lang/exprs"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
@@ -87,7 +88,7 @@ type ModuleCall struct {
 	// normal values in the surface language too, but it's not obvious how
 	// to get there from our current language without splitting the ecosystem
 	// between old-style and new-style modules.)
-	ProvidersFromParent map[addrs.LocalProviderConfig]exprs.Valuer
+	ProvidersFromParent configgraph.CompileProviderConfigRef
 
 	// AllowImpureFunctions controls whether to allow full use of a small
 	// number of functions that produce different results each time they are

--- a/internal/lang/eval/internal/tofu2024/compile.go
+++ b/internal/lang/eval/internal/tofu2024/compile.go
@@ -94,15 +94,29 @@ func CompileModuleInstance(
 	// in future but we want to keep existing modules working for now.
 	ret.providerConfigNodes = compileModuleInstanceProviderConfigs(ctx,
 		module.ProviderConfigs,
-		module.ModuleCalls,
-		allResourcesFromModule(module),
 		topScope,
 		module.ProviderRequirements.RequiredProviders,
 		call.CalleeAddr,
 		call.EvalContext.Providers,
 		call.EvaluationGlue.ValidateProviderConfig,
 	)
-	providersSidechannel := compileModuleProvidersSidechannel(ctx, call.ProvidersFromParent, ret.providerConfigNodes)
+
+	providersFromParent := call.ProvidersFromParent
+	if providersFromParent == nil {
+		if !call.CalleeAddr.IsRoot() {
+			panic("OpenTofu Compilation Bug: Missing providers from parent in non-root module")
+		}
+		// Wrap providersFromParent to handle provider config refs that make it back to the root
+		// module without an explicitly declared provider. Store the providers discovered
+		// through followed references for later use.
+		providersFromParent, ret.missingProviders = compileProviderConfigRefMissingInRoot(
+			module.ProviderRequirements.RequiredProviders,
+			call.EvalContext.Providers,
+			call.EvaluationGlue.ValidateProviderConfig,
+		)
+	}
+	// Add all of our local providerConfigNodes to the provider ref chain.
+	providersSidechannel := compileProviderConfigRefModule(providersFromParent, ret.providerConfigNodes)
 
 	ret.inputVariableNodes = compileModuleInstanceInputVariables(ctx, module.Variables, call.InputValues, topScope, call.CalleeAddr, call.DeclRange)
 	ret.localValueNodes = compileModuleInstanceLocalValues(ctx, module.Locals, topScope, call.CalleeAddr)

--- a/internal/lang/eval/internal/tofu2024/compile_module_calls.go
+++ b/internal/lang/eval/internal/tofu2024/compile_module_calls.go
@@ -24,7 +24,7 @@ func compileModuleInstanceModuleCalls(
 	ctx context.Context,
 	callConfigs map[string]*configs.ModuleCall,
 	declScope exprs.Scope,
-	providersSidechannel *moduleProvidersSideChannel,
+	parentProviders configgraph.CompileProviderConfigRef,
 	parentSourceAddr addrs.ModuleSource,
 	moduleInstanceAddr addrs.ModuleInstance,
 	externalModules evalglue.ExternalModules,
@@ -95,7 +95,7 @@ func compileModuleInstanceModuleCalls(
 						validateInputs: func(ctx context.Context, v cty.Value) tfdiags.Diagnostics {
 							return diags
 						},
-						compileChild: func(ctx context.Context, inputs cty.Value, providersFromParent map[addrs.LocalProviderConfig]exprs.Valuer) (configgraph.Maybe[evalglue.CompiledModuleInstance], tfdiags.Diagnostics) {
+						compileChild: func(ctx context.Context, inputs cty.Value, providersFromParent configgraph.CompileProviderConfigRef) (configgraph.Maybe[evalglue.CompiledModuleInstance], tfdiags.Diagnostics) {
 							return nil, nil
 						},
 					}
@@ -104,30 +104,9 @@ func compileModuleInstanceModuleCalls(
 
 				instanceScope := instanceLocalScope(declScope, repData)
 
-				providersFromParent := make(map[addrs.LocalProviderConfig]*configgraph.OnceValuer)
-
-				if config.Providers == nil {
-					// Implicit passing (legacy)
-					for addr := range providersSidechannel.instanceVals {
-						providersFromParent[addr] = configgraph.ValuerOnce(providersSidechannel.CompileProviderConfigRef(ctx, addr, &configs.ProviderConfigRef{
-							Name:  addr.LocalName,
-							Alias: addr.Alias,
-						}, instanceScope))
-					}
-				} else {
-					// Explicit passing (modern)
-					for _, p := range config.Providers {
-						parentAddr := addrs.LocalProviderConfig{
-							LocalName: p.InParent.Name,
-							Alias:     p.InParent.Alias,
-						}
-						childAddr := addrs.LocalProviderConfig{
-							LocalName: p.InChild.Name,
-							Alias:     p.InChild.Alias,
-						}
-						providersFromParent[childAddr] = configgraph.ValuerOnce(providersSidechannel.CompileProviderConfigRef(ctx, parentAddr, p.InChild, instanceScope))
-					}
-				}
+				// Apply passed providers to the provider ref chain.
+				// TODO: consider using the required_providers block to validate this further.
+				proxyProviderCompiler := compileProviderConfigRefProxy(parentProviders, config.Providers, instanceScope)
 
 				// TODO: The following is kinda tangled and messy, with a
 				// mutual dependency between the [configgraph.ModuleCallInstance]
@@ -143,20 +122,20 @@ func compileModuleInstanceModuleCalls(
 						exprs.EvalableHCLBodyJustAttributes(config.Config),
 						instanceScope,
 					)),
-					ProvidersFromParentValuers: providersFromParent,
+					ProvidersFromParent: proxyProviderCompiler,
 				}
 				inst.Glue = &moduleCallInstanceGlue{
 					callInstNode: inst,
 					validateInputs: func(ctx context.Context, v cty.Value) tfdiags.Diagnostics {
 						return mod.ValidateModuleInputs(ctx, v)
 					},
-					compileChild: func(ctx context.Context, inputs cty.Value, providersFromParent map[addrs.LocalProviderConfig]exprs.Valuer) (configgraph.Maybe[evalglue.CompiledModuleInstance], tfdiags.Diagnostics) {
+					compileChild: func(ctx context.Context, inputs cty.Value, providersFromParent configgraph.CompileProviderConfigRef) (configgraph.Maybe[evalglue.CompiledModuleInstance], tfdiags.Diagnostics) {
 						modInst, diags := mod.CompileModuleInstance(ctx, calleeAddr, &evalglue.ModuleCall{
 							InputValues:          exprs.ConstantValuer(inputs),
 							AllowImpureFunctions: parentCall.AllowImpureFunctions,
 							EvalContext:          parentCall.EvalContext,
 							EvaluationGlue:       parentCall.EvaluationGlue,
-							ProvidersFromParent:  providersFromParent,
+							ProvidersFromParent:  proxyProviderCompiler,
 						})
 						if diags.HasErrors() {
 							return nil, diags
@@ -175,7 +154,7 @@ type moduleCallInstanceGlue struct {
 	callInstNode *configgraph.ModuleCallInstance
 
 	validateInputs func(context.Context, cty.Value) tfdiags.Diagnostics
-	compileChild   func(ctx context.Context, inputs cty.Value, providersFromParent map[addrs.LocalProviderConfig]exprs.Valuer) (configgraph.Maybe[evalglue.CompiledModuleInstance], tfdiags.Diagnostics)
+	compileChild   func(ctx context.Context, inputs cty.Value, providersFromParent configgraph.CompileProviderConfigRef) (configgraph.Maybe[evalglue.CompiledModuleInstance], tfdiags.Diagnostics)
 
 	// FIXME: This isn't exposed in the tree of AnnounceAllGraphevalRequests
 	// method calls we use to collect up user-friendly names for all of our
@@ -214,7 +193,7 @@ func (g *moduleCallInstanceGlue) compiledModuleInstance(ctx context.Context) (co
 		if !configVal.IsKnown() {
 			return nil, diags
 		}
-		providersFromParent := g.callInstNode.ProvidersFromParent(ctx)
+		providersFromParent := g.callInstNode.ProvidersFromParent
 		ret, moreDiags := g.compileChild(ctx, configVal, providersFromParent)
 		diags = diags.Append(moreDiags)
 		return ret, diags

--- a/internal/lang/eval/internal/tofu2024/compile_provider_configs.go
+++ b/internal/lang/eval/internal/tofu2024/compile_provider_configs.go
@@ -7,9 +7,7 @@ package tofu2024
 
 import (
 	"context"
-	"iter"
 
-	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -24,183 +22,79 @@ import (
 func compileModuleInstanceProviderConfigs(
 	ctx context.Context,
 	configs map[string]*configs.Provider,
-	moduleCalls map[string]*configs.ModuleCall,
-	allResources iter.Seq[*configs.Resource],
 	declScope exprs.Scope,
 	reqdProviders map[string]*configs.RequiredProvider,
 	moduleInstanceAddr addrs.ModuleInstance,
 	providers evalglue.ProvidersSchema,
 	validateProviderConfig func(context.Context, addrs.Provider, cty.Value) tfdiags.Diagnostics,
 ) map[addrs.LocalProviderConfig]*configgraph.ProviderConfig {
-	// FIXME: The following is just enough to make simple examples work, but
-	// doesn't closely match the rather complicated way that OpenTofu has
-	// traditionally dealt with provider configurations inheriting between
-	// modules, etc. If we decide to move forward with this then we should
-	// study this and the old behavior carefully and make sure they achieve
-	// equivalent results. (But note that this function is only part of the
-	// process: compileModuleProvidersSidechannel also deals with part of
-	// this problem.)
-
 	ret := make(map[addrs.LocalProviderConfig]*configgraph.ProviderConfig, len(configs))
 
-	// First we'll deal with the explicitly-declared ones.
 	for _, config := range configs {
-		providerAddr := addrs.NewDefaultProvider(config.Name)
-		if reqd, ok := reqdProviders[config.Name]; ok {
-			providerAddr = reqd.Type
-		}
 		localAddr := addrs.LocalProviderConfig{
 			LocalName: config.Name,
 			Alias:     config.Alias,
 		}
-
-		var configEvalable exprs.Evalable
-		configSchema, diags := providers.ProviderConfigSchema(ctx, providerAddr)
-		if diags.HasErrors() {
-			configEvalable = exprs.ForcedErrorEvalable(diags, tfdiags.SourceRangeFromHCL(config.DeclRange))
-		} else {
-			spec := configSchema.Block.DecoderSpec()
-			configEvalable = exprs.EvalableHCLBodyWithDynamicBlocks(config.Config, spec)
-		}
-
-		ret[localAddr] = &configgraph.ProviderConfig{
-			Addr: addrs.AbsProviderConfigCorrect{
-				Module: moduleInstanceAddr,
-				Config: addrs.ProviderConfigCorrect{
-					Provider: providerAddr,
-					Alias:    config.Alias,
-				},
-			},
-			ProviderAddr:     providerAddr,
-			InstanceSelector: compileInstanceSelector(ctx, declScope, config.ForEach, nil, nil),
-			CompileProviderInstance: func(ctx context.Context, key addrs.InstanceKey, repData instances.RepetitionData) *configgraph.ProviderInstance {
-				instanceScope := instanceLocalScope(declScope, repData)
-				return &configgraph.ProviderInstance{
-					Addr: addrs.AbsProviderInstanceCorrect{
-						Config: addrs.AbsProviderConfigCorrect{
-							Module: addrs.RootModuleInstance,
-							Config: addrs.ProviderConfigCorrect{
-								Provider: providerAddr,
-								Alias:    config.Alias,
-							},
-						},
-						Key: key,
-					},
-					ProviderAddr: providerAddr,
-					ConfigValuer: configgraph.ValuerOnce(
-						exprs.NewClosure(configEvalable, instanceScope),
-					),
-					ValidateConfig: func(ctx context.Context, v cty.Value) tfdiags.Diagnostics {
-						return validateProviderConfig(ctx, providerAddr, v)
-					},
-				}
-			},
-		}
-	}
-
-	// Now we'll add the implied ones with empty configs, but only if we're
-	// in the root module because implied configs are not supposed to appear
-	// in other modules.
-	if moduleInstanceAddr.IsRoot() {
-		implicits := map[addrs.LocalProviderConfig]hcl.Range{}
-		for resourceConfig := range allResources {
-			// TODO better range when available
-			implicits[resourceConfig.ProviderConfigAddr()] = resourceConfig.DeclRange
-		}
-		for _, moduleCall := range moduleCalls {
-			for _, provider := range moduleCall.Providers {
-				localAddr := addrs.LocalProviderConfig{
-					LocalName: provider.InParent.Name,
-					Alias:     provider.InParent.Alias,
-				}
-				implicits[localAddr] = provider.InParent.NameRange
-			}
-		}
-		for localAddr, sourceRange := range implicits {
-			if _, ok := ret[localAddr]; ok {
-				continue // we already have an instance for this local address
-			}
-			providerAddr := addrs.NewDefaultProvider(localAddr.LocalName)
-			if reqd, ok := reqdProviders[localAddr.LocalName]; ok {
-				providerAddr = reqd.Type
-			}
-
-			// For these implied ones there isn't actually any real provider
-			// config and so we just pretend that there was a block with
-			// an empty body. If the provider schema includes any required
-			// arguments this will then fail due to the fake empty body not
-			// conforming to the schema.
-			var configEvalable exprs.Evalable
-			configSchema, diags := providers.ProviderConfigSchema(ctx, providerAddr)
-			if diags.HasErrors() {
-				// We don't really have any good source location to blame for
-				// problems here, so we'll just arbitrarily blame one of the
-				// resources that refers to the provider for now. The error
-				// reporting for these situations being poor has been a classic
-				// problem even in the previous implementation so hopefully we
-				// can think of a better idea for this at some point...
-				configEvalable = exprs.ForcedErrorEvalable(diags, tfdiags.SourceRangeFromHCL(sourceRange))
-			} else {
-				spec := configSchema.Block.DecoderSpec()
-				configEvalable = exprs.EvalableHCLBodyWithDynamicBlocks(hcl.EmptyBody(), spec)
-			}
-
-			ret[localAddr] = &configgraph.ProviderConfig{
-				Addr: addrs.AbsProviderConfigCorrect{
-					Module: moduleInstanceAddr,
-					Config: addrs.ProviderConfigCorrect{
-						Provider: providerAddr,
-					},
-				},
-				ProviderAddr:     providerAddr,
-				InstanceSelector: compileInstanceSelector(ctx, declScope, nil, nil, nil),
-				CompileProviderInstance: func(ctx context.Context, key addrs.InstanceKey, repData instances.RepetitionData) *configgraph.ProviderInstance {
-					instanceScope := instanceLocalScope(declScope, repData)
-					return &configgraph.ProviderInstance{
-						Addr: addrs.AbsProviderInstanceCorrect{
-							Config: addrs.AbsProviderConfigCorrect{
-								Module: addrs.RootModuleInstance,
-								Config: addrs.ProviderConfigCorrect{
-									Provider: providerAddr,
-								},
-							},
-							Key: key,
-						},
-						ProviderAddr: providerAddr,
-						ConfigValuer: configgraph.ValuerOnce(
-							exprs.NewClosure(configEvalable, instanceScope),
-						),
-						ValidateConfig: func(ctx context.Context, v cty.Value) tfdiags.Diagnostics {
-							return validateProviderConfig(ctx, providerAddr, v)
-						},
-					}
-				},
-			}
-		}
+		ret[localAddr] = compileProviderConfig(ctx, config, declScope, reqdProviders, moduleInstanceAddr, providers, validateProviderConfig)
 	}
 
 	return ret
 }
 
-// allResourcesFromModule is a helper to collect all of the resources from
-// a module configuration regardless of mode, since the underlying
-// representation uses a separate map per mode.
-func allResourcesFromModule(mod *configs.Module) iter.Seq[*configs.Resource] {
-	return func(yield func(*configs.Resource) bool) {
-		for _, r := range mod.ManagedResources {
-			if !yield(r) {
-				return
+func compileProviderConfig(
+	ctx context.Context,
+	config *configs.Provider,
+	declScope exprs.Scope,
+	reqdProviders map[string]*configs.RequiredProvider,
+	moduleInstanceAddr addrs.ModuleInstance,
+	providers evalglue.ProvidersSchema,
+	validateProviderConfig func(context.Context, addrs.Provider, cty.Value) tfdiags.Diagnostics,
+) *configgraph.ProviderConfig {
+	providerAddr := addrs.NewDefaultProvider(config.Name)
+	if reqd, ok := reqdProviders[config.Name]; ok {
+		providerAddr = reqd.Type
+	}
+
+	var configEvalable exprs.Evalable
+	configSchema, diags := providers.ProviderConfigSchema(ctx, providerAddr)
+	if diags.HasErrors() {
+		configEvalable = exprs.ForcedErrorEvalable(diags, tfdiags.SourceRangeFromHCL(config.DeclRange))
+	} else {
+		spec := configSchema.Block.DecoderSpec()
+		configEvalable = exprs.EvalableHCLBodyWithDynamicBlocks(config.Config, spec)
+	}
+
+	return &configgraph.ProviderConfig{
+		Addr: addrs.AbsProviderConfigCorrect{
+			Module: moduleInstanceAddr,
+			Config: addrs.ProviderConfigCorrect{
+				Provider: providerAddr,
+				Alias:    config.Alias,
+			},
+		},
+		ProviderAddr:     providerAddr,
+		InstanceSelector: compileInstanceSelector(ctx, declScope, config.ForEach, nil, nil),
+		CompileProviderInstance: func(ctx context.Context, key addrs.InstanceKey, repData instances.RepetitionData) *configgraph.ProviderInstance {
+			instanceScope := instanceLocalScope(declScope, repData)
+			return &configgraph.ProviderInstance{
+				Addr: addrs.AbsProviderInstanceCorrect{
+					Config: addrs.AbsProviderConfigCorrect{
+						Module: addrs.RootModuleInstance,
+						Config: addrs.ProviderConfigCorrect{
+							Provider: providerAddr,
+							Alias:    config.Alias,
+						},
+					},
+					Key: key,
+				},
+				ProviderAddr: providerAddr,
+				ConfigValuer: configgraph.ValuerOnce(
+					exprs.NewClosure(configEvalable, instanceScope),
+				),
+				ValidateConfig: func(ctx context.Context, v cty.Value) tfdiags.Diagnostics {
+					return validateProviderConfig(ctx, providerAddr, v)
+				},
 			}
-		}
-		for _, r := range mod.DataResources {
-			if !yield(r) {
-				return
-			}
-		}
-		for _, r := range mod.EphemeralResources {
-			if !yield(r) {
-				return
-			}
-		}
+		},
 	}
 }

--- a/internal/lang/eval/internal/tofu2024/compile_resources.go
+++ b/internal/lang/eval/internal/tofu2024/compile_resources.go
@@ -27,22 +27,22 @@ func compileModuleInstanceResources(
 	dataConfigs map[string]*configs.Resource,
 	ephemeralConfigs map[string]*configs.Resource,
 	declScope exprs.Scope,
-	providersSideChannel *moduleProvidersSideChannel,
+	moduleProviders configgraph.CompileProviderConfigRef,
 	moduleInstanceAddr addrs.ModuleInstance,
 	providers evalglue.ProvidersSchema,
 	getResultValue func(context.Context, *configgraph.ResourceInstance, cty.Value, configgraph.Maybe[*configgraph.ProviderInstance], addrs.Set[addrs.AbsResourceInstance]) (cty.Value, tfdiags.Diagnostics),
 ) map[addrs.Resource]*configgraph.Resource {
 	ret := make(map[addrs.Resource]*configgraph.Resource, len(managedConfigs)+len(dataConfigs)+len(ephemeralConfigs))
 	for _, rc := range managedConfigs {
-		addr, rsrc := compileModuleInstanceResource(ctx, rc, declScope, providersSideChannel, moduleInstanceAddr, providers, getResultValue)
+		addr, rsrc := compileModuleInstanceResource(ctx, rc, declScope, moduleProviders, moduleInstanceAddr, providers, getResultValue)
 		ret[addr] = rsrc
 	}
 	for _, rc := range dataConfigs {
-		addr, rsrc := compileModuleInstanceResource(ctx, rc, declScope, providersSideChannel, moduleInstanceAddr, providers, getResultValue)
+		addr, rsrc := compileModuleInstanceResource(ctx, rc, declScope, moduleProviders, moduleInstanceAddr, providers, getResultValue)
 		ret[addr] = rsrc
 	}
 	for _, rc := range ephemeralConfigs {
-		addr, rsrc := compileModuleInstanceResource(ctx, rc, declScope, providersSideChannel, moduleInstanceAddr, providers, getResultValue)
+		addr, rsrc := compileModuleInstanceResource(ctx, rc, declScope, moduleProviders, moduleInstanceAddr, providers, getResultValue)
 		ret[addr] = rsrc
 	}
 	return ret
@@ -52,7 +52,7 @@ func compileModuleInstanceResource(
 	ctx context.Context,
 	config *configs.Resource,
 	declScope exprs.Scope,
-	providersSideChannel *moduleProvidersSideChannel,
+	moduleProviders configgraph.CompileProviderConfigRef,
 	moduleInstanceAddr addrs.ModuleInstance,
 	providers evalglue.ProvidersSchema,
 	getResultValue func(context.Context, *configgraph.ResourceInstance, cty.Value, configgraph.Maybe[*configgraph.ProviderInstance], addrs.Set[addrs.AbsResourceInstance]) (cty.Value, tfdiags.Diagnostics),
@@ -97,17 +97,15 @@ func compileModuleInstanceResource(
 		// of this resource.
 		CompileResourceInstance: func(ctx context.Context, key addrs.InstanceKey, repData instances.RepetitionData) *configgraph.ResourceInstance {
 			localScope := instanceLocalScope(declScope, repData)
+			providerRef := compileProviderConfigRef(ctx, moduleProviders, config.ProviderConfigAddr(), config.ProviderConfigRef, localScope)
+
 			inst := &configgraph.ResourceInstance{
 				Addr:     absAddr.Instance(key),
 				Provider: config.Provider,
 				ConfigValuer: configgraph.ValuerOnce(exprs.NewClosure(
 					configEvalable, localScope,
 				)),
-				ProviderInstanceValuer: configgraph.ValuerOnce(
-					providersSideChannel.CompileProviderConfigRef(
-						ctx, config.ProviderConfigAddr(), config.ProviderConfigRef, localScope,
-					),
-				),
+				ProviderInstanceValuer: configgraph.ValuerOnce(providerRef),
 			}
 			// Again the [ResourceInstance] implementation will call back
 			// through this object so we can help it interact with the

--- a/internal/lang/eval/internal/tofu2024/module_instance.go
+++ b/internal/lang/eval/internal/tofu2024/module_instance.go
@@ -35,6 +35,8 @@ type CompiledModuleInstance struct {
 	moduleCallNodes     map[addrs.ModuleCall]*configgraph.ModuleCall
 	providerConfigNodes map[addrs.LocalProviderConfig]*configgraph.ProviderConfig
 	providerLocalNames  map[addrs.Provider]string
+
+	missingProviders *rootMissingProviders
 }
 
 var _ evalglue.CompiledModuleInstance = (*CompiledModuleInstance)(nil)
@@ -190,6 +192,10 @@ func (c *CompiledModuleInstance) ProviderInstance(ctx context.Context, addr addr
 		Alias:     addr.Config.Alias,
 	}
 	node, ok := c.providerConfigNodes[localAddr]
+	if !ok && c.missingProviders != nil {
+		// Try root fallback
+		node, ok = c.missingProviders.getOk(localAddr)
+	}
 	if !ok {
 		return nil
 	}

--- a/internal/lang/eval/internal/tofu2024/module_instance_call.go
+++ b/internal/lang/eval/internal/tofu2024/module_instance_call.go
@@ -7,6 +7,7 @@ package tofu2024
 
 import (
 	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/lang/eval/internal/configgraph"
 	"github.com/opentofu/opentofu/internal/lang/eval/internal/evalglue"
 	"github.com/opentofu/opentofu/internal/lang/exprs"
 	"github.com/opentofu/opentofu/internal/tfdiags"
@@ -52,7 +53,7 @@ type ModuleInstanceCall struct {
 	// normal values in the surface language too, but it's not obvious how
 	// to get there from our current language without splitting the ecosystem
 	// between old-style and new-style modules.)
-	ProvidersFromParent map[addrs.LocalProviderConfig]exprs.Valuer
+	ProvidersFromParent configgraph.CompileProviderConfigRef
 
 	// AllowImpureFunctions controls whether to allow full use of a small
 	// number of functions that produce different results each time they are

--- a/internal/lang/eval/internal/tofu2024/providers_sidechannel.go
+++ b/internal/lang/eval/internal/tofu2024/providers_sidechannel.go
@@ -8,14 +8,16 @@ package tofu2024
 import (
 	"context"
 	"fmt"
-	"maps"
+	"sync"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
+	"github.com/opentofu/opentofu/internal/configs/hcl2shim"
 	"github.com/opentofu/opentofu/internal/lang/eval/internal/configgraph"
+	"github.com/opentofu/opentofu/internal/lang/eval/internal/evalglue"
 	"github.com/opentofu/opentofu/internal/lang/exprs"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
@@ -31,41 +33,177 @@ import (
 // can continue to treat providers in this weird special way while [configgraph]
 // _thinks_ they are just normal values of a special type.
 
-type moduleProvidersSideChannel struct {
-	// instanceVals are [exprs.Valuers] that produce values that are either
-	// individual provider instance references or objects whose attribute
-	// values are provider instance references. This is where we look to
-	// handle the weirdo sidechannel provider reference syntax, like
-	// "aws.foo" to refer to a configuration for whatever provider has the
-	// local name "aws" that has the alias "foo".
-	//
-	// In practice this can contain a mixture of valuers that were passed
-	// in from a parent module (using the "providers" argument in a module
-	// block) and valuers that refer to provider configurations declared
-	// within this module. We don't distinguish those two cases here
-	// because both are mapped together into a single namespace per module.
-	instanceVals map[addrs.LocalProviderConfig]exprs.Valuer
+// rootMissingProviders is used to ferry the dynamically injected missing providers
+// into the root module's ProviderConfig lookup
+type rootMissingProviders struct {
+	lock            sync.Mutex
+	providerConfigs map[addrs.LocalProviderConfig]*configgraph.ProviderConfig
 }
 
-func compileModuleProvidersSidechannel(_ context.Context, fromParent map[addrs.LocalProviderConfig]exprs.Valuer, local map[addrs.LocalProviderConfig]*configgraph.ProviderConfig) *moduleProvidersSideChannel {
-	instanceVals := make(map[addrs.LocalProviderConfig]exprs.Valuer, len(fromParent)+len(local))
-	maps.Copy(instanceVals, fromParent)
-	for addr, node := range local {
-		instanceVals[addr] = node
-	}
-
-	return &moduleProvidersSideChannel{
-		instanceVals: instanceVals,
-	}
+func (r *rootMissingProviders) getOk(localAddr addrs.LocalProviderConfig) (*configgraph.ProviderConfig, bool) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	ret, ok := r.providerConfigs[localAddr]
+	return ret, ok
 }
 
-// CompileProviderConfigRef compiles the given provider config reference into
-// an [exprs.Valuer] that returns a provider instance reference value.
+// compileProviderConfigRefMissingInRoot builds the "base" provider ref compiler used by the root module
+// This specifically handles the legacy edge cases where a resource references a provider that does not
+// have a corresponding provider configuration. This path injects an implicit "fake/empty" provider config
+// in the root module.
 //
-// evalScope is the scope to be used if the reference includes a dynamic
-// instance key. It should be a scope that includes instance-specific symbols
-// like each.key for whatever object the provider config reference belongs to.
-func (psc *moduleProvidersSideChannel) CompileProviderConfigRef(ctx context.Context, providerInstAddr addrs.LocalProviderConfig, ref *configs.ProviderConfigRef, evalScope exprs.Scope) exprs.Valuer {
+// This matches some complex interdependencies of the existing [tofu.MissingProviderTransformer], combined
+// with a nice ball of spaghetti logic throughout the tofu package.
+//
+// We return both the compiler function and the map of references that will be updated dynamically. The
+// map of references should be used in the root module for ProviderConfig lookups.
+func compileProviderConfigRefMissingInRoot(
+	requiredProviders map[string]*configs.RequiredProvider,
+	providers evalglue.ProvidersSchema,
+	validateProviderConfig func(context.Context, addrs.Provider, cty.Value) tfdiags.Diagnostics,
+) (configgraph.CompileProviderConfigRef, *rootMissingProviders) {
+	missing := &rootMissingProviders{
+		providerConfigs: map[addrs.LocalProviderConfig]*configgraph.ProviderConfig{},
+	}
+
+	return func(ctx context.Context, providerInstAddr addrs.LocalProviderConfig) exprs.Valuer {
+		missing.lock.Lock()
+		defer missing.lock.Unlock()
+
+		// Check to see if we have a corresponding required_providers entry with an alias. This is
+		// explicitly to support validating a non-root module.
+		//
+		// TODO: only enable this during the validation pass and forbid for other operations
+		for _, required := range requiredProviders {
+			for _, alias := range required.Aliases {
+				if alias == providerInstAddr {
+					providerInstAddr.Alias = ""
+					break
+				}
+			}
+		}
+
+		// Aliases are not supported in the provider fallback case
+		if providerInstAddr.Alias != "" {
+			diags := tfdiags.Diagnostics{}.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Reference to undeclared provider configuration",
+				Detail:   fmt.Sprintf("There is no provider configuration %s declared in this module.", providerInstAddr.StringCompact()),
+			})
+			return exprs.ForcedErrorValuer(diags)
+		}
+
+		// Have we already seen this one before?
+		if missingConfig, ok := missing.providerConfigs[providerInstAddr]; ok {
+			return &sidechannelProviderInstanceRefValuer{
+				localAddr:  providerInstAddr,
+				mainValuer: missingConfig,
+			}
+		}
+
+		// Assume this provider is within the hashicorp namespace and construct an empty provider config
+		// TODO ensure this chain works with google vs google-beta
+		emptyConfig := &configs.Provider{
+			Name:   providerInstAddr.LocalName,
+			Config: hcl2shim.SynthBody(providerInstAddr.String(), make(map[string]cty.Value)),
+		}
+		missingConfig := compileProviderConfig(ctx, emptyConfig, nil, requiredProviders, addrs.RootModuleInstance, providers, validateProviderConfig)
+		missing.providerConfigs[providerInstAddr] = missingConfig
+
+		return &sidechannelProviderInstanceRefValuer{
+			localAddr:  providerInstAddr,
+			mainValuer: missingConfig,
+		}
+	}, missing
+}
+
+// compileProviderConfigRefModule adds the provider configs declared in the module to the ref lookup chain
+func compileProviderConfigRefModule(
+	parentCompiler configgraph.CompileProviderConfigRef,
+	local map[addrs.LocalProviderConfig]*configgraph.ProviderConfig,
+) configgraph.CompileProviderConfigRef {
+	return func(ctx context.Context, providerInstAddr addrs.LocalProviderConfig) exprs.Valuer {
+
+		if localConfig, ok := local[providerInstAddr]; ok {
+			return &sidechannelProviderInstanceRefValuer{
+				localAddr:   providerInstAddr,
+				mainValuer:  localConfig,
+				sourceRange: localConfig.DeclRange.ToHCL().Ptr(),
+			}
+		}
+
+		// Not a local config, let's look back up the tree
+		return parentCompiler(ctx, providerInstAddr)
+	}
+}
+
+// compileProviderConfigRefProxy applies the `providers = { ... }` logic to the ref lookup chain.
+// TODO consider if this should have additional validation using the required_providers block. It's currently handled in the configs package directly.
+func compileProviderConfigRefProxy(
+	parentCompiler configgraph.CompileProviderConfigRef,
+	passed []configs.PassedProviderConfig,
+	evalScope exprs.Scope,
+) configgraph.CompileProviderConfigRef {
+	if passed == nil {
+		// Legacy (implicit)
+		return parentCompiler
+	}
+
+	return func(ctx context.Context, providerInstAddr addrs.LocalProviderConfig) exprs.Valuer {
+
+		// modern (explicit)
+		for _, p := range passed {
+			// This works because InChild can't have a key expression
+			if p.InChild.Name == providerInstAddr.LocalName && p.InChild.Alias == providerInstAddr.Alias {
+				parentLocalAddr := addrs.LocalProviderConfig{
+					LocalName: p.InParent.Name,
+					Alias:     p.InParent.Alias,
+				}
+
+				return newProviderInstanceRefValuer(parentCompiler(ctx, parentLocalAddr), providerInstAddr, p.InParent, evalScope)
+			}
+		}
+		// Fallback to legacy, this seems to match the current behavior?
+		return parentCompiler(ctx, providerInstAddr)
+
+		// TODO: Make this error message better by talking about what's missing
+		// in config in terms more familiar to a module author, including the
+		// various ways provider instances can be implied or inherited, and try
+		// using "didyoumean" to see if we have something similar they might
+		// have been trying to refer to.
+		/*diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Reference to undeclared provider configuration",
+			Detail:   fmt.Sprintf("There is no provider configuration %s declared in this module.", providerInstAddr.StringCompact()),
+			Subject:  wholeRange,
+		})
+		return exprs.ForcedErrorValuer(diags)*/
+	}
+}
+
+// compileProviderConfigRef uses a resource's provider config ref to dereference the
+func compileProviderConfigRef(
+	ctx context.Context,
+	parentCompiler configgraph.CompileProviderConfigRef,
+	providerInstAddr addrs.LocalProviderConfig,
+	ref *configs.ProviderConfigRef,
+	evalScope exprs.Scope,
+) exprs.Valuer {
+	return newProviderInstanceRefValuer(
+		parentCompiler(ctx, providerInstAddr),
+		providerInstAddr,
+		ref,
+		evalScope,
+	)
+}
+
+// Helper function to turn a [configs.ProviderConfigRef] into a [sidechannelProviderInstanceRefValuer]
+func newProviderInstanceRefValuer(
+	mainValuer exprs.Valuer,
+	localAddr addrs.LocalProviderConfig,
+	ref *configs.ProviderConfigRef,
+	keyScope exprs.Scope,
+) exprs.Valuer {
 	var wholeRange *hcl.Range
 	if ref != nil {
 		wholeRange = &ref.NameRange
@@ -74,30 +212,13 @@ func (psc *moduleProvidersSideChannel) CompileProviderConfigRef(ctx context.Cont
 		}
 	}
 
-	mainValuer, ok := psc.instanceVals[providerInstAddr]
-	if !ok {
-		var diags tfdiags.Diagnostics
-		// TODO: Make this error message better by talking about what's missing
-		// in config in terms more familiar to a module author, including the
-		// various ways provider instances can be implied or inherited, and try
-		// using "didyoumean" to see if we have something similar they might
-		// have been trying to refer to.
-		diags = diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Reference to undeclared provider configuration",
-			Detail:   fmt.Sprintf("There is no provider configuration %s declared in this module.", providerInstAddr.StringCompact()),
-			Subject:  wholeRange,
-		})
-		return exprs.ForcedErrorValuer(diags)
-	}
-
 	// If we have a key expression then we'll compile it into a closure to
-	// be resolved in our "normal" scope.
+	// be resolved in our "key" scope.
 	var instanceKeyValuer exprs.Valuer
 	if ref != nil && ref.KeyExpression != nil {
 		instanceKeyValuer = exprs.NewClosure(
 			exprs.EvalableHCLExpression(ref.KeyExpression),
-			evalScope,
+			keyScope,
 		)
 	}
 
@@ -105,7 +226,7 @@ func (psc *moduleProvidersSideChannel) CompileProviderConfigRef(ctx context.Cont
 		mainValuer:        mainValuer,
 		instanceKeyValuer: instanceKeyValuer,
 		sourceRange:       wholeRange,
-		localAddr:         providerInstAddr,
+		localAddr:         localAddr,
 	}
 }
 
@@ -127,7 +248,18 @@ func (s *sidechannelProviderInstanceRefValuer) StaticCheckTraversal(traversal hc
 
 // Value implements exprs.Valuer.
 func (s *sidechannelProviderInstanceRefValuer) Value(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
-	firstVal, diags := s.mainValuer.Value(ctx)
+	return s.value(ctx, true)
+}
+
+// value allows us to only check the "last" provider in the lookup chain for missing key value expressions.
+func (s *sidechannelProviderInstanceRefValuer) value(ctx context.Context, directProviderReferenceRequired bool) (cty.Value, tfdiags.Diagnostics) {
+	var firstVal cty.Value
+	var diags tfdiags.Diagnostics
+	if sideChannelProvider, ok := s.mainValuer.(*sidechannelProviderInstanceRefValuer); ok {
+		firstVal, diags = sideChannelProvider.value(ctx, false)
+	} else {
+		firstVal, diags = s.mainValuer.Value(ctx)
+	}
 	if diags.HasErrors() {
 		return exprs.AsEvalError(cty.DynamicVal), diags
 	}
@@ -146,13 +278,17 @@ func (s *sidechannelProviderInstanceRefValuer) Value(ctx context.Context) (cty.V
 		return firstVal, diags
 	} else if firstTy.IsObjectType() {
 		if s.instanceKeyValuer == nil {
-			diags = diags.Append(&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Invalid provider instance reference",
-				Detail:   fmt.Sprintf("Provider configuration %s uses for_each, so a reference to it must specify which instance to select using syntax like %s[\"example\"].", s.localAddr, s.localAddr),
-				Subject:  s.sourceRange,
-			})
-			return exprs.AsEvalError(cty.DynamicVal), diags
+			if directProviderReferenceRequired {
+				// Configuration error, user did not specify a key expression where required
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid provider instance reference",
+					Detail:   fmt.Sprintf("Provider configuration %s uses for_each, so a reference to it must specify which instance to select using syntax like %s[\"example\"].", s.localAddr, s.localAddr),
+					Subject:  s.sourceRange,
+				})
+				return exprs.AsEvalError(cty.DynamicVal), diags
+			}
+			return firstVal, diags
 		}
 		keyVal, moreDiags := s.instanceKeyValuer.Value(ctx)
 		diags = diags.Append(moreDiags)

--- a/internal/tofu/context_apply2_test.go
+++ b/internal/tofu/context_apply2_test.go
@@ -1991,6 +1991,7 @@ resource "test_object" "x" {
 }
 
 func TestContext2Apply_missingOrphanedResource(t *testing.T) {
+	SkipExperimental(t, ExperimentalBugStateProvider)
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 # changed resource address to create a new object
@@ -5133,6 +5134,7 @@ data "test_data_source" "b" {
 
 		_, diags = destroy(t, complete, state)
 		if diags.HasErrors() {
+			SkipExperimental(t, ExperimentalFeatureDestroy)
 			t.Fatal(diags.Err())
 		}
 	})
@@ -5179,6 +5181,7 @@ data "test_data_source" "b" {
 
 		_, diags = destroy(t, partial, state)
 		if diags.HasErrors() {
+			SkipExperimental(t, ExperimentalFeatureDestroy)
 			t.Fatal(diags.Err())
 		}
 	})
@@ -5198,6 +5201,7 @@ data "test_data_source" "b" {
 				return
 			}
 		}
+		SkipExperimental(t, ExperimentalChangeDiagWording)
 		t.Fatal(diags.Err())
 	})
 
@@ -5216,7 +5220,8 @@ data "test_data_source" "b" {
 				return
 			}
 		}
-		t.Fatal(diags)
+		SkipExperimental(t, ExperimentalBugStateProvider, ExperimentalChangeDiagWording)
+		t.Fatal(diags.Err())
 	})
 }
 

--- a/internal/tofu/context_apply_test.go
+++ b/internal/tofu/context_apply_test.go
@@ -664,7 +664,7 @@ func TestContext2Apply_resourceDependsOnModuleGrandchild(t *testing.T) {
 }
 
 func TestContext2Apply_resourceDependsOnModuleInModule(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
+	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureDependsOn)
 
 	m := testModule(t, "apply-resource-depends-on-module-in-module")
 	p := testProvider("aws")
@@ -717,7 +717,7 @@ func TestContext2Apply_resourceDependsOnModuleInModule(t *testing.T) {
 }
 
 func TestContext2Apply_mapVarBetweenModules(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
+	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureRootOutput)
 
 	m := testModule(t, "apply-map-var-through-module")
 	p := testProvider("null")
@@ -2339,6 +2339,7 @@ func TestContext2Apply_countDecrease(t *testing.T) {
 }
 
 func TestContext2Apply_countDecreaseToOneX(t *testing.T) {
+	SkipExperimental(t, ExperimentalBugStateProvider)
 	m := testModule(t, "apply-count-dec-one")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -6175,7 +6176,7 @@ func TestContext2Apply_destroyDeeplyNestedModule(t *testing.T) {
 
 // https://github.com/hashicorp/terraform/issues/5440
 func TestContext2Apply_destroyModuleWithAttrsReferencingResource(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
+	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureDestroy, ExperimentalFeatureHooks)
 
 	m, snap := testModuleWithSnapshot(t, "apply-destroy-module-with-attrs")
 	p := testProvider("aws")
@@ -6255,7 +6256,7 @@ func TestContext2Apply_destroyModuleWithAttrsReferencingResource(t *testing.T) {
 }
 
 func TestContext2Apply_destroyWithModuleVariableAndCount(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
+	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureDestroy, ExperimentalFeatureHooks)
 
 	m, snap := testModuleWithSnapshot(t, "apply-destroy-mod-var-and-count")
 	p := testProvider("aws")
@@ -6329,7 +6330,7 @@ func TestContext2Apply_destroyWithModuleVariableAndCount(t *testing.T) {
 }
 
 func TestContext2Apply_destroyTargetWithModuleVariableAndCount(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
+	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureDestroy)
 
 	m := testModule(t, "apply-destroy-mod-var-and-count")
 	p := testProvider("aws")
@@ -6405,7 +6406,7 @@ func TestContext2Apply_destroyTargetWithModuleVariableAndCount(t *testing.T) {
 }
 
 func TestContext2Apply_destroyWithModuleVariableAndCountNested(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
+	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureDestroy, ExperimentalFeatureHooks)
 
 	m, snap := testModuleWithSnapshot(t, "apply-destroy-mod-var-and-count-nested")
 	p := testProvider("aws")
@@ -8897,7 +8898,7 @@ aws_instance.foo:
 
 // https://github.com/hashicorp/terraform/issues/7378
 func TestContext2Apply_destroyNestedModuleWithAttrsReferencingResource(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
+	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureDestroy)
 
 	m, snap := testModuleWithSnapshot(t, "apply-destroy-nested-module-with-attrs")
 	p := testProvider("null")
@@ -11374,7 +11375,7 @@ func TestContext2Apply_ProviderMeta_refreshdata_setInvalid(t *testing.T) {
 }
 
 func TestContext2Apply_expandModuleVariables(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
+	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureRootOutput, ExperimentalFeatureStateDependencies)
 
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
@@ -12182,6 +12183,7 @@ output "outputs" {
 }
 
 func TestContext2Apply_createBeforeDestroyWithModule(t *testing.T) {
+	SkipExperimental(t, ExperimentalFeatureCBD)
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 variable "v" {}
@@ -12331,6 +12333,7 @@ resource "test_instance" "b" {
 }
 
 func TestContext2Apply_removeReferencedResource(t *testing.T) {
+	SkipExperimental(t, ExperimentalFeatureDestroy)
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 variable "ct" {

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -428,7 +428,7 @@ resource "test_resource" "b" {
 }
 
 func TestContext2Plan_resourceChecksInExpandedModule(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
+	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureChecks)
 
 	// When a resource is in a nested module we have two levels of expansion
 	// to do: first expand the module the resource is declared in, and then
@@ -3413,7 +3413,7 @@ output "output" {
 }
 
 func TestContext2Plan_moduleImplicitMove(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
+	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureMoved)
 
 	// Modules are being moved implicitly to use the `enabled` field when nothing
 	// is declared on the block. Alternatively, they are implicitly being moved from

--- a/internal/tofu/context_plan_test.go
+++ b/internal/tofu/context_plan_test.go
@@ -796,6 +796,7 @@ func TestContext2Plan_moduleMultiVar(t *testing.T) {
 }
 
 func TestContext2Plan_moduleOrphans(t *testing.T) {
+	SkipExperimental(t, ExperimentalBugStateProvider)
 	m := testModule(t, "plan-modules-remove")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -3760,7 +3761,7 @@ func TestContext2Plan_moduleDestroy(t *testing.T) {
 
 // GH-1835
 func TestContext2Plan_moduleDestroyCycle(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
+	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureDestroy)
 
 	m := testModule(t, "plan-module-destroy-gh-1835")
 	p := testProvider("aws")
@@ -3825,7 +3826,7 @@ func TestContext2Plan_moduleDestroyCycle(t *testing.T) {
 }
 
 func TestContext2Plan_moduleDestroyMultivar(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
+	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureDestroy)
 
 	m := testModule(t, "plan-module-destroy-multivar")
 	p := testProvider("aws")
@@ -4319,7 +4320,7 @@ func TestContext2Plan_requiresReplace(t *testing.T) {
 }
 
 func TestContext2Plan_taint(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
+	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureChanges)
 
 	m := testModule(t, "plan-taint")
 	p := testProvider("aws")
@@ -6601,7 +6602,7 @@ func TestContext2Plan_variableSensitivity(t *testing.T) {
 }
 
 func TestContext2Plan_variableSensitivityModule(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
+	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureSensitivity)
 
 	m := testModule(t, "plan-variable-sensitivity-module")
 
@@ -6831,7 +6832,7 @@ func TestContext2Plan_requiredModuleObject(t *testing.T) {
 }
 
 func TestContext2Plan_expandOrphan(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
+	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureChanges)
 
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `

--- a/internal/tofu/context_refresh_test.go
+++ b/internal/tofu/context_refresh_test.go
@@ -960,7 +960,7 @@ func TestContext2Refresh_moduleInputComputedOutput(t *testing.T) {
 }
 
 func TestContext2Refresh_moduleVarModule(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
+	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalBugVariableInput)
 
 	m := testModule(t, "refresh-module-var-module")
 	p := testProvider("aws")
@@ -1450,7 +1450,7 @@ func TestContext2Refresh_vars(t *testing.T) {
 }
 
 func TestContext2Refresh_orphanModule(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
+	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalBugStateProvider)
 	p := testProvider("aws")
 	m := testModule(t, "refresh-module-orphan")
 

--- a/internal/tofu/context_temp_runtime_test.go
+++ b/internal/tofu/context_temp_runtime_test.go
@@ -78,7 +78,7 @@ func SkipExperimental(t *testing.T, features ...ExperimentalFlag) {
 		var strs []string
 		for _, feature := range features {
 			switch feature {
-			case ExperimentalBugExecGraph:
+			case ExperimentalBugExecGraph, ExperimentalBugDeclareProvider, ExperimentalFeatureProviderInstances:
 			default:
 				strs = append(strs, string(feature))
 			}

--- a/internal/tofu/context_validate_test.go
+++ b/internal/tofu/context_validate_test.go
@@ -383,6 +383,8 @@ func TestContext2Validate_moduleGood(t *testing.T) {
 }
 
 func TestContext2Validate_moduleBadResource(t *testing.T) {
+	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureValidate)
+
 	m := testModule(t, "validate-module-bad-rc")
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
@@ -412,7 +414,7 @@ func TestContext2Validate_moduleBadResource(t *testing.T) {
 }
 
 func TestContext2Validate_moduleDepsShouldNotCycle(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
+	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalBugVariableInput)
 
 	m := testModule(t, "validate-module-deps-cycle")
 	p := testProvider("aws")
@@ -1636,7 +1638,7 @@ resource "aws_instance" "foo" {
 }
 
 func TestContext2Validate_expandMultipleNestedModules(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
+	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalBugVariableInput)
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 module "modA" {

--- a/internal/tofu/skip_destroy_test.go
+++ b/internal/tofu/skip_destroy_test.go
@@ -683,6 +683,7 @@ func TestSkipDestroy_Deposed(t *testing.T) {
 // - When instances are removed/reduced state attribute protects instances even if config has destroy=true
 
 func TestSkipDestroy_Enabled_Toggle(t *testing.T) {
+	SkipExperimental(t, ExperimentalBugStateProvider)
 	tests := []skipDestroyTestCase{
 		{
 			// Resource exists in state with SkipDestroy=false, but config has enabled=false and destroy=false.


### PR DESCRIPTION
This replaces the existing sidecar data structure with a set of nested compilation functions. Each step of a compilation function either produces a reference for a provider config in scope, or refines the parent provider reference.

The only oddity is how we handle missing legacy providers. They fallback to "fake" entries injected into the root module. This mirrors the existing MissingProviderTransformer logic.

<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Alternative to #4174
Follow up to #4059

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

