### PR TITLE
[Backport][v1.10] Fix getting started guides for OTEL

### DIFF
--- a/website/docs/internals/tracing.mdx
+++ b/website/docs/internals/tracing.mdx
@@ -44,7 +44,7 @@ Enable tracing by setting these environment variables:
 export OTEL_TRACES_EXPORTER=otlp
 
 # Point to your Jaeger instance
-export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 
 # Required for local development (skip TLS verification)
 export OTEL_EXPORTER_OTLP_INSECURE=true


### PR DESCRIPTION
Backports #4214 to OpenTofu v1.10 which fixes the OTEL tracing backend port to be used in environment variables.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
