### PR TITLE
Refine the validations around ephemeral marks before writing to the in-memory state and the in-file state

### DIFF
--- a/internal/addrs/provider_config.go
+++ b/internal/addrs/provider_config.go
@@ -258,6 +258,15 @@ func ParseAbsProviderConfigStr(str string) (AbsProviderConfig, tfdiags.Diagnosti
 	diags = diags.Append(addrDiags)
 	return addr, diags
 }
+
+func MustParseAbsProviderConfigStr(str string) AbsProviderConfig {
+	ret, diags := ParseAbsProviderConfigStr(str)
+	if diags.HasErrors() {
+		panic(fmt.Errorf("could not parse %q as AbsProviderConfig: %s", str, diags))
+	}
+	return ret
+}
+
 func ParseAbsProviderConfigInstanceStr(str string) (AbsProviderConfig, InstanceKey, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	traversal, parseDiags := hclsyntax.ParseTraversalAbs([]byte(str), "", hcl.Pos{Line: 1, Column: 1})

--- a/internal/states/statefile/version4.go
+++ b/internal/states/statefile/version4.go
@@ -620,7 +620,7 @@ func appendInstanceObjectStateV4(rs *states.Resource, is *states.ResourceInstanc
 				tfdiags.Sourceless(
 					tfdiags.Error,
 					"Ephemeral detected in state writing",
-					fmt.Sprintf("%q has an ephemeral value in %q. This is an OpenTofu error. Please report it", rs.Addr.String(), tfdiags.FormatCtyPath(mark.Path)),
+					fmt.Sprintf("%q has an ephemeral value in %q. This is a bug in OpenTofu. Please report it", rs.Addr.String(), tfdiags.FormatCtyPath(mark.Path)),
 				),
 			}
 		}

--- a/internal/states/statefile/version4.go
+++ b/internal/states/statefile/version4.go
@@ -607,6 +607,19 @@ func appendInstanceObjectStateV4(rs *states.Resource, is *states.ResourceInstanc
 		providerInstance = rs.ProviderConfig.InstanceString(is.ProviderKey)
 	}
 
+	for _, mark := range obj.TransientPathValueMarks {
+		_, ok := mark.Marks[marks.Ephemeral]
+		if ok {
+			return nil, tfdiags.Diagnostics{
+				tfdiags.Sourceless(
+					tfdiags.Error,
+					"Ephemeral detected in state writing",
+					fmt.Sprintf("%q has an ephemeral value in %q. This is an OpenTofu error. Please report it", rs.Addr.String(), tfdiags.FormatCtyPath(mark.Path)),
+				),
+			}
+		}
+	}
+
 	// Extract paths from path value marks
 	var paths []cty.Path
 	for _, vm := range obj.AttrSensitivePaths {

--- a/internal/states/statefile/version4.go
+++ b/internal/states/statefile/version4.go
@@ -607,6 +607,12 @@ func appendInstanceObjectStateV4(rs *states.Resource, is *states.ResourceInstanc
 		providerInstance = rs.ProviderConfig.InstanceString(is.ProviderKey)
 	}
 
+	// This is a guardrail added to ensure that no ephemeral value will ever get in this part of the system.
+	// Before, by configuring different configschema.Attribute (with WriteOnly=true) or configschema.Schema (with Ephemeral=true)
+	// we could have values ending up in here.
+	// This check was added proactively as a safety net for future development and was not added reactively to a found issue.
+	// Before this change, the only values that could have been marked as ephemeral and written into state were already
+	// nullified and unmarked (see usage of Block.RemoveEphemeralFromWriteOnly)
 	for _, mark := range obj.TransientPathValueMarks {
 		_, ok := mark.Marks[marks.Ephemeral]
 		if ok {

--- a/internal/states/statefile/version4_test.go
+++ b/internal/states/statefile/version4_test.go
@@ -10,6 +10,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/encryption"
+	"github.com/opentofu/opentofu/internal/lang/marks"
+	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -260,4 +265,104 @@ func TestVersion4_marshalPaths(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestVersion4_writeStateWithEphemeralMarks(t *testing.T) {
+	cases := map[string]struct {
+		buildState     func() *states.State
+		expectedErrMsg string
+	}{
+		"data source": {
+			buildState: func() *states.State {
+				s := states.NewState()
+				m := s.EnsureModule(addrs.RootModuleInstance)
+				m.SetResourceInstance(addrs.ResourceInstance{
+					Resource: addrs.Resource{
+						Mode: addrs.DataResourceMode,
+						Type: "test",
+						Name: "test",
+					},
+					Key: addrs.NoKey,
+				}, &states.ResourceInstance{
+					Current: &states.ResourceInstanceObjectSrc{
+						TransientPathValueMarks: []cty.PathValueMarks{
+							{
+								Path:  cty.GetAttrPath("test_attr"),
+								Marks: map[any]struct{}{marks.Ephemeral: {}},
+							},
+						},
+					},
+				}, addrs.MustParseAbsProviderConfigStr(`provider["testorg/test"]`))
+				return s
+			},
+			expectedErrMsg: `Ephemeral detected in state writing: "data.test.test" has an ephemeral value in ".test_attr". This is an OpenTofu error. Please report it`,
+		},
+		"ephemeral resource": {
+			buildState: func() *states.State {
+				s := states.NewState()
+				m := s.EnsureModule(addrs.RootModuleInstance)
+				m.SetResourceInstance(addrs.ResourceInstance{
+					Resource: addrs.Resource{
+						Mode: addrs.EphemeralResourceMode,
+						Type: "test",
+						Name: "test",
+					},
+					Key: addrs.NoKey,
+				}, &states.ResourceInstance{
+					Current: &states.ResourceInstanceObjectSrc{
+						TransientPathValueMarks: []cty.PathValueMarks{
+							{
+								Path:  cty.GetAttrPath("test_attr"),
+								Marks: map[any]struct{}{marks.Ephemeral: {}},
+							},
+						},
+					},
+				}, addrs.MustParseAbsProviderConfigStr(`provider["testorg/test"]`))
+				return s
+			},
+		},
+		"managed resource": {
+			buildState: func() *states.State {
+				s := states.NewState()
+				m := s.EnsureModule(addrs.RootModuleInstance)
+				m.SetResourceInstance(addrs.ResourceInstance{
+					Resource: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "test",
+						Name: "test",
+					},
+					Key: addrs.NoKey,
+				}, &states.ResourceInstance{
+					Current: &states.ResourceInstanceObjectSrc{
+						TransientPathValueMarks: []cty.PathValueMarks{
+							{
+								Path:  cty.GetAttrPath("test_attr"),
+								Marks: map[any]struct{}{marks.Ephemeral: {}},
+							},
+						},
+					},
+				}, addrs.MustParseAbsProviderConfigStr(`provider["testorg/test"]`))
+				return s
+			},
+			expectedErrMsg: `Ephemeral detected in state writing: "test.test" has an ephemeral value in ".test_attr". This is an OpenTofu error. Please report it`,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			f := new(File)
+			var s strings.Builder
+			f.State = tc.buildState()
+			diags := writeStateV4(f, &s, encryption.StateEncryptionDisabled())
+
+			var gotErrMsg string
+			if diags.HasErrors() {
+				gotErrMsg = diags.Err().Error()
+			}
+			if diff := cmp.Diff(tc.expectedErrMsg, gotErrMsg); diff != "" {
+				t.Fatalf("unexpected returned error (-want,+got):\n%s", diff)
+			}
+		})
+	}
+
 }

--- a/internal/states/statefile/version4_test.go
+++ b/internal/states/statefile/version4_test.go
@@ -295,7 +295,7 @@ func TestVersion4_writeStateWithEphemeralMarks(t *testing.T) {
 				}, addrs.MustParseAbsProviderConfigStr(`provider["testorg/test"]`))
 				return s
 			},
-			expectedErrMsg: `Ephemeral detected in state writing: "data.test.test" has an ephemeral value in ".test_attr". This is an OpenTofu error. Please report it`,
+			expectedErrMsg: `Ephemeral detected in state writing: "data.test.test" has an ephemeral value in ".test_attr". This is a bug in OpenTofu. Please report it`,
 		},
 		"ephemeral resource": {
 			buildState: func() *states.State {
@@ -344,7 +344,7 @@ func TestVersion4_writeStateWithEphemeralMarks(t *testing.T) {
 				}, addrs.MustParseAbsProviderConfigStr(`provider["testorg/test"]`))
 				return s
 			},
-			expectedErrMsg: `Ephemeral detected in state writing: "test.test" has an ephemeral value in ".test_attr". This is an OpenTofu error. Please report it`,
+			expectedErrMsg: `Ephemeral detected in state writing: "test.test" has an ephemeral value in ".test_attr". This is a bug in OpenTofu. Please report it`,
 		},
 	}
 

--- a/internal/states/statefile/version4_test.go
+++ b/internal/states/statefile/version4_test.go
@@ -353,7 +353,7 @@ func TestVersion4_writeStateWithEphemeralMarks(t *testing.T) {
 			f := new(File)
 			var s strings.Builder
 			f.State = tc.buildState()
-			diags := writeStateV4(f, &s, encryption.StateEncryptionDisabled())
+			diags := writeStateV4(f, &s, encryption.StateEncryptionDisabled(), false)
 
 			var gotErrMsg string
 			if diags.HasErrors() {

--- a/internal/tofu/node_resource_abstract_instance.go
+++ b/internal/tofu/node_resource_abstract_instance.go
@@ -763,6 +763,9 @@ func (n *NodeAbstractResourceInstance) writeResourceInstanceStateImpl(ctx contex
 	}
 
 	obj.Value = schema.Block.RemoveEphemeralFromWriteOnly(obj.Value)
+	if absAddr.Resource.Resource.Mode != addrs.EphemeralResourceMode && obj.Value.HasMarkDeep(marks.Ephemeral) {
+		return fmt.Errorf("non ephemeral resource (%q) found to be written with ephemeral values", absAddr.String())
+	}
 	src, err := obj.Encode(schema.Block.ImpliedType(), currentVersion, uint64(schema.IdentitySchemaVersion))
 	if err != nil {
 		return fmt.Errorf("failed to encode %s in state: %w", absAddr, err)

--- a/internal/tofu/node_resource_abstract_instance.go
+++ b/internal/tofu/node_resource_abstract_instance.go
@@ -763,6 +763,9 @@ func (n *NodeAbstractResourceInstance) writeResourceInstanceStateImpl(ctx contex
 	}
 
 	obj.Value = schema.Block.RemoveEphemeralFromWriteOnly(obj.Value)
+	// Because on the line above we remove ephemeral marks from the other place where these are allowed (write-only attributes),
+	// then the resulted value should have no ephemeral marks on any of its attributes if it's a value for a resource
+	// other than an ephemeral resource.
 	if absAddr.Resource.Resource.Mode != addrs.EphemeralResourceMode && obj.Value.HasMarkDeep(marks.Ephemeral) {
 		return fmt.Errorf("non ephemeral resource (%q) found to be written with ephemeral values", absAddr.String())
 	}

--- a/internal/tofu/node_resource_abstract_instance_test.go
+++ b/internal/tofu/node_resource_abstract_instance_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/opentofu/opentofu/internal/lang/marks"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -188,6 +189,45 @@ aws_instance.foo:
   ID = i-abc123
   provider = provider["registry.opentofu.org/hashicorp/aws"]
 	`)
+}
+
+func TestNodeAbstractResourceInstance_WriteResourceInstanceState_WithDataSourceContainingEphemeralMarks(t *testing.T) {
+	state := states.NewState()
+	evalCtx := new(MockEvalContext)
+	evalCtx.StateState = state.SyncWrapper()
+	evalCtx.PathPath = addrs.RootModuleInstance
+
+	mockProvider := mockProviderWithDataSourceTypeSchema("aws_region", &configschema.Block{
+		Attributes: map[string]*configschema.Attribute{
+			"region": {
+				Type:     cty.String,
+				Optional: true,
+			},
+		},
+	})
+
+	obj := &states.ResourceInstanceObject{
+		Value: cty.ObjectVal(map[string]cty.Value{
+			"region": cty.StringVal("us-east-1").Mark(marks.Ephemeral), // this is what is tested here
+		}),
+	}
+
+	node := &NodeAbstractResourceInstance{
+		Addr: mustResourceInstanceAddr("data.aws_region.foo"),
+		NodeAbstractResource: NodeAbstractResource{
+			ResolvedProvider: mustResolvedProviderInRoot("aws", mockProvider),
+		},
+	}
+	evalCtx.installProvider(addrs.NewDefaultProvider("aws"), mockProvider)
+
+	err := node.writeResourceInstanceState(t.Context(), evalCtx, obj, workingState)
+	if err == nil {
+		t.Fatalf("expected error but got nothing")
+	}
+	expectedErr := `non ephemeral resource ("data.aws_region.foo") found to be written with ephemeral values`
+	if diff := cmp.Diff(expectedErr, err.Error()); diff != "" {
+		t.Fatalf("expected a particular error bug got the wrong one (-want,+got):\n%s", diff)
+	}
 }
 
 func TestFilterResourceProvisioners(t *testing.T) {

--- a/internal/tofu/node_resource_abstract_instance_test.go
+++ b/internal/tofu/node_resource_abstract_instance_test.go
@@ -226,7 +226,7 @@ func TestNodeAbstractResourceInstance_WriteResourceInstanceState_WithDataSourceC
 	}
 	expectedErr := `non ephemeral resource ("data.aws_region.foo") found to be written with ephemeral values`
 	if diff := cmp.Diff(expectedErr, err.Error()); diff != "" {
-		t.Fatalf("expected a particular error bug got the wrong one (-want,+got):\n%s", diff)
+		t.Fatalf("expected a particular error but got the wrong one (-want,+got):\n%s", diff)
 	}
 }
 

--- a/internal/tofu/resource_provider_mock_test.go
+++ b/internal/tofu/resource_provider_mock_test.go
@@ -51,6 +51,36 @@ func mockProviderWithResourceTypeSchema(name string, schema *configschema.Block)
 	}
 }
 
+// mockProviderWithDataSourceTypeSchema is a test helper to concisely create a mock
+// provider with a schema containing a single data source type.
+func mockProviderWithDataSourceTypeSchema(name string, schema *configschema.Block) *MockProvider {
+	return &MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			Provider: providers.Schema{
+				Block: &configschema.Block{
+					Attributes: map[string]*configschema.Attribute{
+						"string": {
+							Type:     cty.String,
+							Optional: true,
+						},
+						"list": {
+							Type:     cty.List(cty.String),
+							Optional: true,
+						},
+						"root": {
+							Type:     cty.Map(cty.String),
+							Optional: true,
+						},
+					},
+				},
+			},
+			DataSources: map[string]providers.Schema{
+				name: providers.Schema{Block: schema},
+			},
+		},
+	}
+}
+
 // simpleMockProvider returns a MockProvider that is pre-configured
 // with schema for its own config, for a resource type called "test_object" and
 // for a data source also called "test_object".


### PR DESCRIPTION
Ensure that there are no ephemeral values written into the state file for any resource.
Do not allow ephemeral values to be stored into the temporary state for anything else than ephemeral resources.

This change is in response to the changes proposed in #3960.
Testing that, realised that we miss some guardrails when it comes to what `configschema.Attribute` is allowed or not to be marked as `WriteOnly` and what `configschema.Schema` can be marked or not as `Ephemeral`.

The general idea is that the schema for types that are meant to be written to state must not be allowed with such configuration: 
* The only `configschema.Schema` that is allowed to be marked as `Ephemeral` is the one used for ephemeral resource types and other ephemeral types (like provider) that by design are not persisted into the state or plan.
* The only `configschema.Attribute` that is allowed to be marked as `WriteOnly` is the one used for attributes inside *managed resources*, as instructed by the provider. This is really important, because the [provider write-only marked attributes value nullification is handled directly by the `terraform-plugin-framework`](https://github.com/hashicorp/terraform-plugin-framework/blob/main/internal/fwserver/write_only_nullification.go#L22). If it would be to allow data sources write-only attributes (which is suggested in #3960), that would mean that we have to implement in OpenTofu core this nullification strategy which defends the purpose of the protocol and the current design.


Therefore, as agreed with the maintainers, we intend to reject this enhancement in favor of a future [Backends as plugins](https://github.com/opentofu/opentofu/issues/382) availability. The reason for that, was loosely hinted in the above points: provider configuration is ephemeral by design. Hence, if the state will be handled through the providers protocol, then configuration that is needed to access it will go through the `provider` configuration block, which being ephemeral, will accept ephemeral values (as it already does).

Resolves #3959

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
