### PR TITLE
Update the documentation of `enabled` to reflect the actual behavior with ephemeral values

### DIFF
--- a/website/docs/language/ephemerality/ephemeral-resources.mdx
+++ b/website/docs/language/ephemerality/ephemeral-resources.mdx
@@ -62,10 +62,8 @@ block for an ephemeral resource:
 * `precondition` and `postcondition` blocks, as described in
   [Custom Conditions](../../language/expressions/custom-conditions.mdx#preconditions-and-postconditions).
 
-With the recent introduction of the `lifecycle.enabled` option, we decided to have it aligned
-with the other repetition meta-arguments (`count`, `for_each`) and disallow usage of ephemeral
-values, including `terraform.applying` too.
-This is a decision that we still pondering upon and might change change in the future.
+With the recent introduction of the `lifecycle.enabled` option, the `lifecycle.enabled` is related to repetition meta-args
+and ephemeral values are similarly disallowed here, including `terraform.applying`.
 
 For more information, refer to [the `enabled` meta-argument](../../language/meta-arguments/enabled.mdx).
 

--- a/website/docs/language/ephemerality/ephemeral-resources.mdx
+++ b/website/docs/language/ephemerality/ephemeral-resources.mdx
@@ -59,21 +59,15 @@ ephemeral "example" "example" {
 The following arguments and nested block types are supported in the `lifecycle`
 block for an ephemeral resource:
 
-* `enabled` (bool) - Controls whether the ephemeral resource will be used by
-  OpenTofu. When set to `false`, the resource is excluded from the configuration
-  as if it didn't exist. When set to `true` (the default), the resource operates
-  normally.
-
-  For ephemeral resources in particular, you can use the boolean
-  `terraform.applying` value with `enabled` to specify that a particular
-  ephemeral resource should be active only during the apply phase, which can
-  be useful for values used only by managed resource provisioners because
-  provisioners are active only during the apply phase.
-
-  For more information, refer to [the `enabled` meta-argument](../../language/meta-arguments/enabled.mdx).
-
 * `precondition` and `postcondition` blocks, as described in
   [Custom Conditions](../../language/expressions/custom-conditions.mdx#preconditions-and-postconditions).
+
+With the recent introduction of the `lifecycle.enabled` option, we decided to have it aligned
+with the other repetition meta-arguments (`count`, `for_each`) and disallow usage of ephemeral
+values, including `terraform.applying` too.
+This is a decision that we still pondering upon and might change change in the future.
+
+For more information, refer to [the `enabled` meta-argument](../../language/meta-arguments/enabled.mdx).
 
 ## Deferred opening
 By design, the ephemeral resources cannot be opened if the configuration is not fully known.

--- a/website/docs/language/ephemerality/ephemeral-resources.mdx
+++ b/website/docs/language/ephemerality/ephemeral-resources.mdx
@@ -62,8 +62,8 @@ block for an ephemeral resource:
 * `precondition` and `postcondition` blocks, as described in
   [Custom Conditions](../../language/expressions/custom-conditions.mdx#preconditions-and-postconditions).
 
-With the recent introduction of the `lifecycle.enabled` option, the `lifecycle.enabled` is related to repetition meta-args
-and ephemeral values are similarly disallowed here, including `terraform.applying`.
+Following the same rule of not allowing ephemeral values in repetition meta arguments (`count`, `for_each`),
+`lifecycle.enabled` disallows usage of such values too, including the usage of [`tofu.applying`](../expressions/references.mdx#filesystem-and-workspace-info).
 
 For more information, refer to [the `enabled` meta-argument](../../language/meta-arguments/enabled.mdx).
 


### PR DESCRIPTION
Part of #4085

As reported in #4085, the ephemeral resources cannot work with `lifecycle.enabled = terraform.applying`.
This was the initial intent, but while we worked on adding the `enabled` meta-argument we decided to have it aligned with the limitations of `count` and `for_each`, where we don't accept ephemeral values.

---

To provide a little bit more context:
In https://github.com/opentofu/opentofu/issues/3904 we had some attempts on going one way or the other:
* allow all repetition meta arguments to use ephemeral values
  #3907 was a proposal on how this can be done, but if you check this [particular comment](https://github.com/opentofu/opentofu/pull/3907#issuecomment-4090856405), we didn't like the bleeding of such ephemeral information into the instance keys.
* disallow all repetition meta arguments to use ephemeral values
  #3924 was in the end accepted, where we blocked usage of ephemeral values in `count`. That was an oversight in the initial ephemeral implementation and had to be fixed.


After multiple exchanges between maintainers, we decided that we want all repetition meta-arguments to behave similar in this regard, so because of the inconvenience found in #3907, we decided to go with #3924 which put all these meta-arguments in the same functional line.

Conceptually, ephemeral resource, in particular, are meant to be ephemeral blocks altogether, meaning that these meta-arguments might be allowed eventually to use ephemeral values, but that is a decision that we deferred for the [new execution engine](https://github.com/opentofu/opentofu/issues/3414).

Since then, we want to update the documentation to reflect the actual behavior and backport these changes all the way back to v1.11 (when ephemeral resources have been introduced).

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
