### PR TITLE
planning: Plans with unknown values always represent change

### DIFF
--- a/internal/engine/planning/plan_managed.go
+++ b/internal/engine/planning/plan_managed.go
@@ -197,7 +197,7 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 	// that case, but we would need to mark it as deferred and _not_ record a
 	// proposed change for it.
 
-	if eq, _ := planResp.Planned.Value.Equals(refreshedVal).Unmark(); !eq.IsKnown() || eq.True() {
+	if eq, _ := planResp.Planned.Value.Equals(refreshedVal).Unmark(); eq.IsKnown() && eq.True() {
 		// There is no change to make, so we'll return early without actually
 		// recording any change. In this case our resource instance will be
 		// included in the execution graph only if some other resource instance


### PR DESCRIPTION
This code was just a logic error: it was trying to guard calling `eq.True()` on an unknown bool, which would panic, but was testing it in the wrong direction: only a _known_ true is enough to justify a no-op plan, because when unknown values are present we need to wait until the apply phase to learn if any change is actually needed.

I found this while I was debugging a different problem, so there's no test immediately fixed by this but this problem is lurking beneath the surface of at least one test that's currently disabled due to unimplemented features in the new runtime.
