### PR TITLE
Fix statefile roundtrip testdata

### DIFF
--- a/internal/states/statefile/testdata/roundtrip/v4-foreach.in.tfstate
+++ b/internal/states/statefile/testdata/roundtrip/v4-foreach.in.tfstate
@@ -26,7 +26,7 @@
             }
           },
           "private": "bnVsbA==",
-          "depends_on": [
+          "dependencies": [
             "var.input"
           ]
         }

--- a/internal/states/statefile/testdata/roundtrip/v4-future.in.tfstate
+++ b/internal/states/statefile/testdata/roundtrip/v4-future.in.tfstate
@@ -23,7 +23,7 @@
                         "triggers.%": "1",
                         "triggers.whaaat": "0,1"
                     },
-                    "depends_on": [
+                    "dependencies": [
                         "null_resource.foo"
                     ]
                 }

--- a/internal/states/statefile/testdata/roundtrip/v4-legacy-foreach.in.tfstate
+++ b/internal/states/statefile/testdata/roundtrip/v4-legacy-foreach.in.tfstate
@@ -26,7 +26,7 @@
             }
           },
           "private": "bnVsbA==",
-          "depends_on": [
+          "dependencies": [
             "var.input"
           ]
         }

--- a/internal/states/statefile/testdata/roundtrip/v4-legacy-foreach.out.tfstate
+++ b/internal/states/statefile/testdata/roundtrip/v4-legacy-foreach.out.tfstate
@@ -26,7 +26,7 @@
             }
           },
           "private": "bnVsbA==",
-          "depends_on": [
+          "dependencies": [
             "var.input"
           ]
         }

--- a/internal/states/statefile/testdata/roundtrip/v4-legacy-modules.in.tfstate
+++ b/internal/states/statefile/testdata/roundtrip/v4-legacy-modules.in.tfstate
@@ -23,7 +23,7 @@
             "triggers.%": "1",
             "triggers.whaaat": "0,1"
           },
-          "depends_on": [
+          "dependencies": [
             "null_resource.foo"
           ]
         }
@@ -78,7 +78,7 @@
           "dependencies": [
             "null_resource.bar"
           ],
-          "depends_on": [
+          "dependencies": [
             "var.input"
           ]
         }

--- a/internal/states/statefile/testdata/roundtrip/v4-legacy-modules.out.tfstate
+++ b/internal/states/statefile/testdata/roundtrip/v4-legacy-modules.out.tfstate
@@ -23,7 +23,7 @@
             "triggers.%": "1",
             "triggers.whaaat": "0,1"
           },
-          "depends_on": [
+          "dependencies": [
             "null_resource.foo"
           ]
         }
@@ -78,7 +78,7 @@
           "dependencies": [
             "null_resource.bar"
           ],
-          "depends_on": [
+          "dependencies": [
             "var.input"
           ]
         }

--- a/internal/states/statefile/testdata/roundtrip/v4-legacy-simple.in.tfstate
+++ b/internal/states/statefile/testdata/roundtrip/v4-legacy-simple.in.tfstate
@@ -37,7 +37,7 @@
                         "triggers.%": "1",
                         "triggers.whaaat": "0,1"
                     },
-                    "depends_on": [
+                    "dependencies": [
                         "null_resource.foo"
                     ]
                 }

--- a/internal/states/statefile/testdata/roundtrip/v4-legacy-simple.out.tfstate
+++ b/internal/states/statefile/testdata/roundtrip/v4-legacy-simple.out.tfstate
@@ -37,7 +37,7 @@
                         "triggers.%": "1",
                         "triggers.whaaat": "0,1"
                     },
-                    "depends_on": [
+                    "dependencies": [
                         "null_resource.foo"
                     ]
                 }

--- a/internal/states/statefile/testdata/roundtrip/v4-modules.in.tfstate
+++ b/internal/states/statefile/testdata/roundtrip/v4-modules.in.tfstate
@@ -23,7 +23,7 @@
             "triggers.%": "1",
             "triggers.whaaat": "0,1"
           },
-          "depends_on": [
+          "dependencies": [
             "null_resource.foo"
           ]
         }
@@ -78,7 +78,7 @@
           "dependencies": [
             "null_resource.bar"
           ],
-          "depends_on": [
+          "dependencies": [
             "var.input"
           ]
         }

--- a/internal/states/statefile/testdata/roundtrip/v4-simple.in.tfstate
+++ b/internal/states/statefile/testdata/roundtrip/v4-simple.in.tfstate
@@ -23,7 +23,7 @@
                         "triggers.%": "1",
                         "triggers.whaaat": "0,1"
                     },
-                    "depends_on": [
+                    "dependencies": [
                         "null_resource.foo"
                     ]
                 }


### PR DESCRIPTION
After TF0.12, the "depends_on" field in statev4 was replaced with "dependencies". 9fe87fe520760c7139436dd4f7b059086ce0ba23 removed the old "depends_on" field, but failed to update the corresponding tests.

Depends on #4222

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
