### PR TITLE
Better `create_before_destroy` handling for the new language runtime

### DIFF
--- a/internal/engine/applying/operations_resource.go
+++ b/internal/engine/applying/operations_resource.go
@@ -136,8 +136,7 @@ func (ops *execOperations) resourceInstanceStateObject(
 		return nil, diags
 	}
 	return &exec.ResourceInstanceObject{
-		InstanceAddr: instAddr,
-		DeposedKey:   deposedKey,
-		State:        state,
+		Addr:  instAddr.Object(deposedKey),
+		State: state,
 	}, diags
 }

--- a/internal/engine/applying/operations_resource_managed.go
+++ b/internal/engine/applying/operations_resource_managed.go
@@ -140,15 +140,31 @@ func (ops *execOperations) ManagedApply(
 	providerConfigAddr := plan.ProviderInstance
 
 	log.Printf("[TRACE] apply phase: ManagedApply %s using %s", plan.Addr, providerConfigAddr)
-	if fallback != nil && plan.Addr.IsDeposed() {
-		// This should not happen: we can't have a fallback deposed object
-		// when the object we're applying is already deposed itself.
-		// (This is just a safety check because below we're still using the
-		// old states.SyncState API that wants to model the fallback as
-		// "maybe restore the deposed object to current" instead of just
-		// generically rewriting the fallback object's address to not be deposed.
-		diags = diags.Append(fmt.Errorf("can't apply changes to %s with fallback to deposed object %s", plan.Addr, fallback.Addr.DeposedKey))
-		return nil, diags
+	if fallback != nil {
+		if plan.Addr.IsDeposed() {
+			// This should not happen: we can't have a fallback deposed object
+			// when the object we're applying is already deposed itself.
+			// (This is just a safety check because below we're still using the
+			// old states.SyncState API that wants to model the fallback as
+			// "maybe restore the deposed object to current" instead of just
+			// generically rewriting the fallback object's address to not be deposed.
+			diags = diags.Append(fmt.Errorf("can't apply changes to %s with fallback to deposed object %s", plan.Addr, fallback.Addr.DeposedKey))
+			return nil, diags
+		}
+		if !fallback.Addr.IsDeposed() {
+			// This should also not happen: the fallback object must always
+			// be a deposed object that would become current again if we
+			// fail to create the new object.
+			diags = diags.Append(fmt.Errorf("can't apply changes to %s with fallback to non-deposed object %s", plan.Addr, fallback.Addr))
+			return nil, diags
+		}
+		if !fallback.Addr.InstanceAddr.Equal(plan.Addr.InstanceAddr) {
+			// This should also not happen: we should always be falling back
+			// to a deposed object from the same resource instance we're trying
+			// to create a new current object for here, since the fallback
+			// will become the current instead if creation fails.
+			diags = diags.Append(fmt.Errorf("can't apply changes to %s with fallback to %s: resource instance must match", plan.Addr, fallback.Addr))
+		}
 	}
 
 	// This particular operation has a broader scope than most of them because

--- a/internal/engine/applying/operations_resource_managed.go
+++ b/internal/engine/applying/operations_resource_managed.go
@@ -296,17 +296,17 @@ func (ops *execOperations) ManagedApply(
 	return ret, diags
 }
 
-// ManagedDepose implements [exec.Operations].
-func (ops *execOperations) ManagedDepose(
+// ManagedPerformDepose implements [exec.Operations].
+func (ops *execOperations) ManagedPerformDepose(
 	ctx context.Context,
 	currentObj *exec.ResourceInstanceObject,
 ) (*exec.ResourceInstanceObject, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	if currentObj == nil {
-		log.Println("[TRACE] apply phase: ManagedDepose with nil object (ignored)")
+		log.Println("[TRACE] apply phase: ManagedPerformDepose with nil object (ignored)")
 		return nil, diags
 	}
-	log.Printf("[TRACE] apply phase: ManagedDepose %s", currentObj.Addr)
+	log.Printf("[TRACE] apply phase: ManagedPerformDepose %s", currentObj.Addr)
 	if currentObj.Addr.IsDeposed() {
 		diags = diags.Append(fmt.Errorf(
 			"attempting do depose %s when it's already deposed; this is a bug in OpenTofu",

--- a/internal/engine/applying/operations_resource_managed.go
+++ b/internal/engine/applying/operations_resource_managed.go
@@ -46,8 +46,8 @@ func (ops *execOperations) ManagedFinalPlan(
 		// TODO possibly nil here
 		providerConfigAddr = *desired.ProviderInstance
 	} else if prior != nil {
-		instAddr = prior.InstanceAddr
-		deposedKey = prior.DeposedKey
+		instAddr = prior.Addr.InstanceAddr
+		deposedKey = prior.Addr.DeposedKey
 		resourceTypeName = prior.State.ResourceType
 		providerConfigAddr = prior.State.ProviderInstanceAddr
 	} else {
@@ -108,8 +108,7 @@ func (ops *execOperations) ManagedFinalPlan(
 	}
 
 	return &exec.ManagedResourceObjectFinalPlan{
-		InstanceAddr:     instAddr,
-		DeposedKey:       deposedKey,
+		Addr:             instAddr.Object(deposedKey),
 		ResourceType:     resourceTypeName,
 		PriorStateVal:    resp.Current.Value,
 		ConfigVal:        resp.DesiredValue,
@@ -140,19 +139,15 @@ func (ops *execOperations) ManagedApply(
 
 	providerConfigAddr := plan.ProviderInstance
 
-	if plan.DeposedKey == states.NotDeposed {
-		log.Printf("[TRACE] apply phase: ManagedApply %s using %s", plan.InstanceAddr, providerConfigAddr)
-	} else {
-		log.Printf("[TRACE] apply phase: ManagedApply %s deposed object %s using %s", plan.InstanceAddr, plan.DeposedKey, providerConfigAddr)
-	}
-	if fallback != nil && plan.DeposedKey != states.NotDeposed {
+	log.Printf("[TRACE] apply phase: ManagedApply %s using %s", plan.Addr, providerConfigAddr)
+	if fallback != nil && plan.Addr.IsDeposed() {
 		// This should not happen: we can't have a fallback deposed object
 		// when the object we're applying is already deposed itself.
 		// (This is just a safety check because below we're still using the
 		// old states.SyncState API that wants to model the fallback as
 		// "maybe restore the deposed object to current" instead of just
 		// generically rewriting the fallback object's address to not be deposed.
-		diags = diags.Append(fmt.Errorf("can't apply changes to %s deposed object %s with fallback to deposed object %s", plan.InstanceAddr, plan.DeposedKey, fallback.DeposedKey))
+		diags = diags.Append(fmt.Errorf("can't apply changes to %s with fallback to deposed object %s", plan.Addr, fallback.Addr.DeposedKey))
 		return nil, diags
 	}
 
@@ -222,7 +217,7 @@ func (ops *execOperations) ManagedApply(
 				"Provider produced inconsistent result after apply",
 				fmt.Sprintf(
 					"Provider %s did not return an error when applying changes for %s, but it also didn't return a new object to save.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
-					providerAddr, plan.InstanceAddr,
+					providerAddr, plan.Addr,
 				),
 			))
 		}
@@ -230,19 +225,19 @@ func (ops *execOperations) ManagedApply(
 		// back to being the current object for our resource instance before
 		// we return.
 		if fallback != nil {
-			ok := ops.workingState.MaybeRestoreResourceInstanceDeposed(fallback.InstanceAddr, fallback.DeposedKey)
+			ok := ops.workingState.MaybeRestoreResourceInstanceDeposed(fallback.Addr.InstanceAddr, fallback.Addr.DeposedKey)
 			if !ok {
 				diags = diags.Append(tfdiags.Sourceless(
 					tfdiags.Error,
 					"Failed to restore deposed object",
 					fmt.Sprintf(
 						"Failed to restore %s deposed object %s as the current object after failing to create its replacement.\n\nThe next plan will propose to destroy this deposed object. This is a bug in OpenTofu.",
-						fallback.InstanceAddr, fallback.DeposedKey,
+						fallback.Addr.InstanceAddr, fallback.Addr.DeposedKey,
 					),
 				))
 			}
 		}
-		result, moreDiags := ops.resourceInstanceStateObject(ctx, ops.workingState, plan.InstanceAddr, states.NotDeposed)
+		result, moreDiags := ops.resourceInstanceStateObject(ctx, ops.workingState, plan.Addr.InstanceAddr, states.NotDeposed)
 		diags = diags.Append(moreDiags)
 		return result, diags
 	}
@@ -251,10 +246,7 @@ func (ops *execOperations) ManagedApply(
 	// consistent with what was planned. (That'll need the provider schema
 	// we fetched above, but currently we're just discarding that schema.)
 
-	// FIXME: Change [exec.ManagedResourceObjectFinalPlan] to use
-	// [addrs.AbsResourceInstanceObject] itself, instead of separate instance
-	// address and deposed key fields.
-	objAddr := plan.InstanceAddr.Object(plan.DeposedKey)
+	objAddr := plan.Addr
 	var state *states.ResourceInstanceObjectFull
 	if !resp.NewState.IsNull() {
 		status := states.ObjectTainted
@@ -284,7 +276,7 @@ func (ops *execOperations) ManagedApply(
 			// already been decoded using the same schema if it came from a plugin,
 			// and so it should definitely conform to that schema.
 			// FIXME: A proper error message for this.
-			diags = diags.Append(fmt.Errorf("failed to encode the new state for %s: %w", plan.InstanceAddr, err))
+			diags = diags.Append(fmt.Errorf("failed to encode the new state for %s: %w", plan.Addr, err))
 			return nil, diags
 		}
 		ops.workingState.SetResourceInstanceObjectFull(objAddr, stateSrc)
@@ -298,9 +290,8 @@ func (ops *execOperations) ManagedApply(
 	}
 
 	ret := &exec.ResourceInstanceObject{
-		InstanceAddr: plan.InstanceAddr,
-		DeposedKey:   plan.DeposedKey,
-		State:        state, // nil if the object was deleted
+		Addr:  plan.Addr,
+		State: state, // nil if the object was deleted
 	}
 	return ret, diags
 }
@@ -315,16 +306,23 @@ func (ops *execOperations) ManagedDepose(
 		log.Println("[TRACE] apply phase: ManagedDepose with nil object (ignored)")
 		return nil, diags
 	}
-	log.Printf("[TRACE] apply phase: ManagedDepose %s", currentObj.InstanceAddr)
+	log.Printf("[TRACE] apply phase: ManagedDepose %s", currentObj.Addr)
+	if currentObj.Addr.IsDeposed() {
+		diags = diags.Append(fmt.Errorf(
+			"attempting do depose %s when it's already deposed; this is a bug in OpenTofu",
+			currentObj.Addr,
+		))
+		return nil, diags
+	}
 
-	deposedKey := ops.workingState.DeposeResourceInstanceObject(currentObj.InstanceAddr)
+	deposedKey := ops.workingState.DeposeResourceInstanceObject(currentObj.Addr.InstanceAddr)
 	if deposedKey == states.NotDeposed {
 		// We should not get here with a correctly-constructed execution graph
 		// because currentObj being non-nil means that there should definitely
 		// be something to depose.
 		diags = diags.Append(fmt.Errorf(
 			"failed to depose the current object for %s; this is a bug in OpenTofu",
-			currentObj.InstanceAddr,
+			currentObj.Addr.InstanceAddr,
 		))
 		return nil, diags
 	}
@@ -355,14 +353,26 @@ func (ops *execOperations) ManagedChangeAddr(
 		log.Println("[TRACE] apply phase: ManagedChangeAddr with nil object (ignored)")
 		return nil, diags
 	}
-	log.Printf("[TRACE] apply phase: ManagedChangeAddr from %s to %s", currentObj.InstanceAddr, newAddr)
-	if !ops.workingState.MaybeMoveResourceInstance(currentObj.InstanceAddr, newAddr) {
+	log.Printf("[TRACE] apply phase: ManagedChangeAddr from %s to %s", currentObj.Addr, newAddr)
+
+	// Only "current" objects are expected to move between addresses in this
+	// way, because the only reasonable thing to do with a deposed object is
+	// to destroy it.
+	if currentObj.Addr.IsDeposed() {
+		diags = diags.Append(fmt.Errorf(
+			"can't move %s to %s; this is a bug in OpenTofu",
+			currentObj.Addr, newAddr,
+		))
+		return nil, diags
+	}
+
+	if !ops.workingState.MaybeMoveResourceInstance(currentObj.Addr.InstanceAddr, newAddr) {
 		// We should not get here with a correctly-constructed execution graph
 		// because currentObj being non-nil means that there should definitely
 		// be something to move.
 		diags = diags.Append(fmt.Errorf(
 			"failed to move %s to %s; this is a bug in OpenTofu",
-			currentObj.InstanceAddr, newAddr,
+			currentObj.Addr, newAddr,
 		))
 		return nil, diags
 	}

--- a/internal/engine/applying/operations_resource_managed.go
+++ b/internal/engine/applying/operations_resource_managed.go
@@ -300,13 +300,22 @@ func (ops *execOperations) ManagedApply(
 func (ops *execOperations) ManagedPerformDepose(
 	ctx context.Context,
 	currentObj *exec.ResourceInstanceObject,
+	deletePlan *exec.ManagedResourceObjectFinalPlan,
 ) (*exec.ResourceInstanceObject, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	if currentObj == nil {
 		log.Println("[TRACE] apply phase: ManagedPerformDepose with nil object (ignored)")
 		return nil, diags
 	}
-	log.Printf("[TRACE] apply phase: ManagedPerformDepose %s", currentObj.Addr)
+	if deletePlan == nil || deletePlan.Addr.IsCurrent() || !deletePlan.PlannedVal.IsNull() || !deletePlan.Addr.InstanceAddr.Equal(currentObj.Addr.InstanceAddr) {
+		// None of these situations should arise for a correct execution graph.
+		diags = diags.Append(fmt.Errorf(
+			"invalid delete plan for %s; this is a bug in OpenTofu",
+			currentObj.Addr.InstanceAddr,
+		))
+		return nil, diags
+	}
+	log.Printf("[TRACE] apply phase: ManagedPerformDepose %s as %s", currentObj.Addr, deletePlan.Addr.DeposedKey)
 	if currentObj.Addr.IsDeposed() {
 		diags = diags.Append(fmt.Errorf(
 			"attempting do depose %s when it's already deposed; this is a bug in OpenTofu",
@@ -315,17 +324,8 @@ func (ops *execOperations) ManagedPerformDepose(
 		return nil, diags
 	}
 
-	deposedKey := ops.workingState.DeposeResourceInstanceObject(currentObj.Addr.InstanceAddr)
-	if deposedKey == states.NotDeposed {
-		// We should not get here with a correctly-constructed execution graph
-		// because currentObj being non-nil means that there should definitely
-		// be something to depose.
-		diags = diags.Append(fmt.Errorf(
-			"failed to depose the current object for %s; this is a bug in OpenTofu",
-			currentObj.Addr.InstanceAddr,
-		))
-		return nil, diags
-	}
+	deposedKey := deletePlan.Addr.DeposedKey
+	ops.workingState.DeposeResourceInstanceObjectForceKey(deletePlan.Addr.InstanceAddr, deposedKey)
 	return currentObj.IntoDeposed(deposedKey), diags
 }
 

--- a/internal/engine/internal/exec/operations.go
+++ b/internal/engine/internal/exec/operations.go
@@ -134,7 +134,7 @@ type Operations interface {
 	// occurs when performing a "create then destroy" replace operation, so
 	// that a total failure of the "create" step leaves OpenTofu still tracking
 	// the previous object (which was presumably deposed earlier in the same
-	// apply phase using ManagedDepose) as the current object.
+	// apply phase using ManagedPerformDepose) as the current object.
 	//
 	// This method must return whatever object was left as "current" in the
 	// state, including possibly returning the "current-ized" version of
@@ -154,8 +154,8 @@ type Operations interface {
 		fallback *ResourceInstanceObject,
 	) (*ResourceInstanceObject, tfdiags.Diagnostics)
 
-	// ManagedDepose takes a "current" object for some resource instance and
-	// changes it to be a "deposed" object for the same resource instance,
+	// ManagedPerformDepose takes a "current" object for some resource instance
+	// and changes it to be a "deposed" object for the same resource instance,
 	// returning a new representation of the object with its
 	// pseudorandomly-chosen unique DeposedKey.
 	//
@@ -171,7 +171,7 @@ type Operations interface {
 	// anything. In practice though the planning engine should not include
 	// this operation unless it found an existing current object that needs to
 	// be deposed as part of a create-then-destroy "replace" change.
-	ManagedDepose(
+	ManagedPerformDepose(
 		ctx context.Context,
 		object *ResourceInstanceObject,
 	) (*ResourceInstanceObject, tfdiags.Diagnostics)
@@ -189,7 +189,7 @@ type Operations interface {
 	// [Operations.ResourceInstancePrior] but returns a deposed object rather
 	// than a current object.
 	//
-	// [Operations.ManagedDepose] deals with the more common case where a
+	// [Operations.ManagedPerformDepose] deals with the more common case where a
 	// previously-"current" object becomes deposed during the apply phase as
 	// part of handling a "create then destroy' replace operation.
 	ManagedAlreadyDeposed(

--- a/internal/engine/internal/exec/operations.go
+++ b/internal/engine/internal/exec/operations.go
@@ -174,6 +174,7 @@ type Operations interface {
 	ManagedPerformDepose(
 		ctx context.Context,
 		object *ResourceInstanceObject,
+		deletePlan *ManagedResourceObjectFinalPlan,
 	) (*ResourceInstanceObject, tfdiags.Diagnostics)
 
 	// ManagedAlreadyDeposed returns a deposed object from the prior state,

--- a/internal/engine/internal/exec/resource.go
+++ b/internal/engine/internal/exec/resource.go
@@ -66,6 +66,22 @@ type ManagedResourceObjectFinalPlan struct {
 	// request to the associated provider.
 }
 
+// IntoDeposed returns a new [ManagedResourceObjectFinalPlan] that represents
+// the same change as the receiver but has DeposedKey set the given value.
+//
+// Note that the result is only a shallow copy of the reciever, so nothing
+// reachable through pointers should be modified in either object. Final plan
+// objects are immutable by convention.
+//
+// This function does not (and cannot) verify that the chosen deposed key is
+// unique for the resource instance. It's the caller's responsibility to
+// allocate a unique deposed key to use.
+func (p *ManagedResourceObjectFinalPlan) IntoDeposed(key states.DeposedKey) *ManagedResourceObjectFinalPlan {
+	ret := *p // shallow copy
+	ret.Addr.DeposedKey = key
+	return &ret
+}
+
 // ResourceInstanceObject associates a [states.ResourceInstanceObjectFull] with
 // a resource instance address and optional deposed key.
 //
@@ -101,7 +117,7 @@ func (o *ResourceInstanceObject) IntoCurrent() *ResourceInstanceObject {
 	}
 }
 
-// IntoCurrent returns a new [ResourceInstanceObject] that has the same
+// IntoDeposed returns a new [ResourceInstanceObject] that has the same
 // State as the receiver but has DeposedKey set the given value.
 //
 // This function does not (and cannot) verify that the chosen deposed key is

--- a/internal/engine/internal/exec/resource.go
+++ b/internal/engine/internal/exec/resource.go
@@ -27,18 +27,16 @@ import (
 // there should be no assumptions about e.g. there being exactly one final
 // plan per resource instance, etc.
 type ManagedResourceObjectFinalPlan struct {
-	// InstanceAddr and DeposedKey together describe which resource instance
-	// object this plan was created for.
+	// Addr describes which resource instance object this plan was created for.
 	//
-	// These are to be used only for recording the new state of the object
+	// This is to be used only for recording the new state of the object
 	// after applying this plan, and should be treated opaquely. In particular,
 	// nothing from these fields should be sent to a provider as part of
 	// applying the plan because how we track resource instance objects between
 	// rounds is an implementation detail that providers should not rely on so
 	// that we can potentially change it in future while staying compatible
 	// with existing provider plugins.
-	InstanceAddr addrs.AbsResourceInstance
-	DeposedKey   states.DeposedKey
+	Addr addrs.AbsResourceInstanceObject
 
 	ProviderInstance addrs.AbsProviderInstanceCorrect
 
@@ -88,8 +86,7 @@ type ManagedResourceObjectFinalPlan struct {
 // change of address is modelled in the data flow between operations rather than
 // as global mutable state.
 type ResourceInstanceObject struct {
-	InstanceAddr addrs.AbsResourceInstance
-	DeposedKey   states.DeposedKey
+	Addr addrs.AbsResourceInstanceObject
 
 	// State is the object currently associated with the given address.
 	State *states.ResourceInstanceObjectFull
@@ -99,9 +96,8 @@ type ResourceInstanceObject struct {
 // State as the receiver but has DeposedKey set to [states.NotDeposed].
 func (o *ResourceInstanceObject) IntoCurrent() *ResourceInstanceObject {
 	return &ResourceInstanceObject{
-		InstanceAddr: o.InstanceAddr,
-		DeposedKey:   states.NotDeposed,
-		State:        o.State,
+		Addr:  o.Addr.InstanceAddr.CurrentObject(),
+		State: o.State,
 	}
 }
 
@@ -113,9 +109,8 @@ func (o *ResourceInstanceObject) IntoCurrent() *ResourceInstanceObject {
 // allocate a unique deposed key to use.
 func (o *ResourceInstanceObject) IntoDeposed(key states.DeposedKey) *ResourceInstanceObject {
 	return &ResourceInstanceObject{
-		InstanceAddr: o.InstanceAddr,
-		DeposedKey:   key,
-		State:        o.State,
+		Addr:  o.Addr.InstanceAddr.Object(key),
+		State: o.State,
 	}
 }
 
@@ -123,9 +118,8 @@ func (o *ResourceInstanceObject) IntoDeposed(key states.DeposedKey) *ResourceIns
 // State as the receiver but has InstanceAddr set to the given address.
 func (o *ResourceInstanceObject) WithNewAddr(addr addrs.AbsResourceInstance) *ResourceInstanceObject {
 	return &ResourceInstanceObject{
-		InstanceAddr: addr,
-		DeposedKey:   o.DeposedKey,
-		State:        o.State,
+		Addr:  addr.Object(o.Addr.DeposedKey),
+		State: o.State,
 	}
 }
 
@@ -140,8 +134,7 @@ func (o *ResourceInstanceObject) WithNewState(newState *states.ResourceInstanceO
 		return nil
 	}
 	return &ResourceInstanceObject{
-		InstanceAddr: o.InstanceAddr,
-		DeposedKey:   o.DeposedKey,
-		State:        newState,
+		Addr:  o.Addr,
+		State: newState,
 	}
 }

--- a/internal/engine/internal/exec/resource.go
+++ b/internal/engine/internal/exec/resource.go
@@ -124,6 +124,9 @@ func (o *ResourceInstanceObject) IntoCurrent() *ResourceInstanceObject {
 // unique for the resource instance. It's the caller's responsibility to
 // allocate a unique deposed key to use.
 func (o *ResourceInstanceObject) IntoDeposed(key states.DeposedKey) *ResourceInstanceObject {
+	if key == states.NotDeposed {
+		panic("ResourceInstanceObject.IntoDeposed called without a deposed key")
+	}
 	return &ResourceInstanceObject{
 		Addr:  o.Addr.InstanceAddr.Object(key),
 		State: o.State,

--- a/internal/engine/internal/execgraph/builder.go
+++ b/internal/engine/internal/execgraph/builder.go
@@ -189,11 +189,12 @@ func (b *Builder) ManagedPrepareDepose(
 
 func (b *Builder) ManagedPerformDepose(
 	currentObj ResourceInstanceResultRef,
+	finalDeletePlan ResultRef[*exec.ManagedResourceObjectFinalPlan],
 	waitFor AnyResultRef,
 ) ResourceInstanceResultRef {
 	return operationRef[*exec.ResourceInstanceObject](b, operationDesc{
 		opCode:   opManagedPerformDepose,
-		operands: []AnyResultRef{currentObj, waitFor},
+		operands: []AnyResultRef{currentObj, finalDeletePlan, waitFor},
 	})
 }
 

--- a/internal/engine/internal/execgraph/builder.go
+++ b/internal/engine/internal/execgraph/builder.go
@@ -148,8 +148,9 @@ func (b *Builder) ManagedFinalPlan(
 //
 // fallbackObj is usually a [NilResultRef], but should be set for the "create"
 // leg of a "create then destroy" replace operation to be the result of a
-// call to [Builder.ManagedDepose] so that the deposed object can be restored
-// to current if the create call completely fails to create a new object.
+// call to [Builder.ManagedPerformDepose] so that the deposed object can be
+// restored to current if the create call completely fails to create a new
+// object.
 func (b *Builder) ManagedApply(
 	finalPlan ResultRef[*exec.ManagedResourceObjectFinalPlan],
 	fallbackObj ResourceInstanceResultRef,
@@ -161,12 +162,12 @@ func (b *Builder) ManagedApply(
 	})
 }
 
-func (b *Builder) ManagedDepose(
+func (b *Builder) ManagedPerformDepose(
 	currentObj ResourceInstanceResultRef,
 	waitFor AnyResultRef,
 ) ResourceInstanceResultRef {
 	return operationRef[*exec.ResourceInstanceObject](b, operationDesc{
-		opCode:   opManagedDepose,
+		opCode:   opManagedPerformDepose,
 		operands: []AnyResultRef{currentObj, waitFor},
 	})
 }

--- a/internal/engine/internal/execgraph/builder.go
+++ b/internal/engine/internal/execgraph/builder.go
@@ -162,6 +162,31 @@ func (b *Builder) ManagedApply(
 	})
 }
 
+// ManagedPrepareDepose performs the first half of the work to "depose" a
+// resource instance object as part of a create-before-destroy replace
+// operation.
+//
+// The final plan given as input must be a plan to destroy a "current" object.
+// The result is an equivalent plan whose only difference is that it's set
+// up to destroy the deposed object which has the given deposed key.
+//
+// The result of this operation should then be sent to both
+// [Builder.ManagedPerformDepose] and [Builder.ManagedApply] as part of the
+// overall subgraph handling the replace operation.
+//
+// This operation is an intrinsic, meaning that its behavior lives directly
+// in the execution graph runner rather than being delegated to an external
+// [exec.Operations] implementation.
+func (b *Builder) ManagedPrepareDepose(
+	finalPlan ResultRef[*exec.ManagedResourceObjectFinalPlan],
+	deposedKey ResultRef[addrs.DeposedKey],
+) ResultRef[*exec.ManagedResourceObjectFinalPlan] {
+	return operationRef[*exec.ManagedResourceObjectFinalPlan](b, operationDesc{
+		opCode:   opManagedPrepareDepose,
+		operands: []AnyResultRef{finalPlan, deposedKey},
+	})
+}
+
 func (b *Builder) ManagedPerformDepose(
 	currentObj ResourceInstanceResultRef,
 	waitFor AnyResultRef,

--- a/internal/engine/internal/execgraph/compiler.go
+++ b/internal/engine/internal/execgraph/compiler.go
@@ -109,6 +109,8 @@ func (c *compiler) Compile() (*CompiledGraph, tfdiags.Diagnostics) {
 			compileFunc = c.compileOpManagedFinalPlan
 		case opManagedApply:
 			compileFunc = c.compileOpManagedApply
+		case opManagedPrepareDepose:
+			compileFunc = c.compileOpManagedPrepareDepose
 		case opManagedPerformDepose:
 			compileFunc = c.compileOpManagedPerformDepose
 		case opManagedAlreadyDeposed:

--- a/internal/engine/internal/execgraph/compiler.go
+++ b/internal/engine/internal/execgraph/compiler.go
@@ -109,8 +109,8 @@ func (c *compiler) Compile() (*CompiledGraph, tfdiags.Diagnostics) {
 			compileFunc = c.compileOpManagedFinalPlan
 		case opManagedApply:
 			compileFunc = c.compileOpManagedApply
-		case opManagedDepose:
-			compileFunc = c.compileOpManagedDepose
+		case opManagedPerformDepose:
+			compileFunc = c.compileOpManagedPerformDepose
 		case opManagedAlreadyDeposed:
 			compileFunc = c.compileOpManagedAlreadyDeposed
 		case opManagedChangeAddr:

--- a/internal/engine/internal/execgraph/compiler.go
+++ b/internal/engine/internal/execgraph/compiler.go
@@ -216,6 +216,12 @@ func (c *compiler) compileResultRef(ref AnyResultRef) nodeExecuteRaw {
 		return func(_ context.Context) (any, bool, tfdiags.Diagnostics) {
 			return resourceInstAddrs[index], true, nil
 		}
+	case deposedKeyResultRef:
+		deposedKeys := c.sourceGraph.deposedKeys
+		index := ref.index
+		return func(_ context.Context) (any, bool, tfdiags.Diagnostics) {
+			return deposedKeys[index], true, nil
+		}
 	case providerInstAddrResultRef:
 		providerInstAddrs := c.sourceGraph.providerInstAddrs
 		index := ref.index

--- a/internal/engine/internal/execgraph/compiler_ops.go
+++ b/internal/engine/internal/execgraph/compiler_ops.go
@@ -225,6 +225,17 @@ func (c *compiler) compileOpManagedPerformDepose(operands *compilerOperands) nod
 
 		ret, moreDiags := ops.ManagedPerformDepose(ctx, currentObj, deletePlan)
 		diags = diags.Append(moreDiags)
+
+		if !diags.HasErrors() {
+			// Some correctness checks just to help us catch bugs in the
+			// operations implementation before they cause confusion downstream.
+			if !ret.Addr.IsDeposed() {
+				diags = diags.Append(fmt.Errorf("opManagedPerformDepose result has non-deposed object address %s; this is a bug in OpenTofu", ret.Addr))
+			}
+			if !ret.Addr.InstanceAddr.Equal(currentObj.Addr.InstanceAddr) {
+				diags = diags.Append(fmt.Errorf("opManagedPerformDepose for %s result has wrong instance address %s; this is a bug in OpenTofu", currentObj.Addr.InstanceAddr, ret.Addr.InstanceAddr))
+			}
+		}
 		return ret, !diags.HasErrors(), diags
 	}
 }
@@ -255,6 +266,17 @@ func (c *compiler) compileOpManagedAlreadyDeposed(operands *compilerOperands) no
 
 		ret, moreDiags := ops.ManagedAlreadyDeposed(ctx, instAddr, deposedKey)
 		diags = diags.Append(moreDiags)
+
+		if !diags.HasErrors() {
+			// Some correctness checks just to help us catch bugs in the
+			// operations implementation before they cause confusion downstream.
+			if !ret.Addr.IsDeposed() {
+				diags = diags.Append(fmt.Errorf("opManagedAlreadyDeposed result has non-deposed object address %s; this is a bug in OpenTofu", ret.Addr))
+			}
+			if !ret.Addr.InstanceAddr.Equal(instAddr) {
+				diags = diags.Append(fmt.Errorf("opManagedAlreadyDeposed for %s result has wrong instance address %s; this is a bug in OpenTofu", instAddr.Object(deposedKey), ret.Addr.InstanceAddr))
+			}
+		}
 		return ret, !diags.HasErrors(), diags
 	}
 }

--- a/internal/engine/internal/execgraph/compiler_ops.go
+++ b/internal/engine/internal/execgraph/compiler_ops.go
@@ -198,6 +198,7 @@ func (c *compiler) compileOpManagedPrepareDepose(operands *compilerOperands) nod
 func (c *compiler) compileOpManagedPerformDepose(operands *compilerOperands) nodeExecuteRaw {
 	ops := c.ops
 	getCurrentObj := nextOperand[*exec.ResourceInstanceObject](operands)
+	getDeletePlan := nextOperand[*exec.ManagedResourceObjectFinalPlan](operands)
 	waitForDeps := operands.OperandWaiter()
 	diags := operands.Finish()
 	c.diags = c.diags.Append(diags)
@@ -216,8 +217,13 @@ func (c *compiler) compileOpManagedPerformDepose(operands *compilerOperands) nod
 		if !ok {
 			return nil, false, diags
 		}
+		deletePlan, ok, moreDiags := getDeletePlan(ctx)
+		diags = diags.Append(moreDiags)
+		if !ok {
+			return nil, false, diags
+		}
 
-		ret, moreDiags := ops.ManagedPerformDepose(ctx, currentObj)
+		ret, moreDiags := ops.ManagedPerformDepose(ctx, currentObj, deletePlan)
 		diags = diags.Append(moreDiags)
 		return ret, !diags.HasErrors(), diags
 	}

--- a/internal/engine/internal/execgraph/compiler_ops.go
+++ b/internal/engine/internal/execgraph/compiler_ops.go
@@ -7,6 +7,7 @@ package execgraph
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/zclconf/go-cty/cty"
@@ -136,6 +137,60 @@ func (c *compiler) compileOpManagedApply(operands *compilerOperands) nodeExecute
 		// TODO: Also call ops.ResourceInstancePostconditions if we produced a non-nil result
 		log.Printf("[WARN] opManagedApply doesn't yet handle postconditions")
 
+		return ret, !diags.HasErrors(), diags
+	}
+}
+
+func (c *compiler) compileOpManagedPrepareDepose(operands *compilerOperands) nodeExecuteRaw {
+	getFinalPlan := nextOperand[*exec.ManagedResourceObjectFinalPlan](operands)
+	getDeposedKey := nextOperand[addrs.DeposedKey](operands)
+	diags := operands.Finish()
+	c.diags = c.diags.Append(diags)
+	if diags.HasErrors() {
+		return nil
+	}
+
+	// This operation is an intrinsic, which means that its behavior is
+	// fixed directly inline here rather than being delegated to the
+	// [exec.Operations] object in c.ops. We use an intrinsic here because
+	// this operation doesn't have any externally-visible side effects and so
+	// there's no need for its behavior to vary; if implemented as a real
+	// operation then every test using mock operations would need to
+	// re-implement essentially the same logic.
+	return func(ctx context.Context) (any, bool, tfdiags.Diagnostics) {
+		var diags tfdiags.Diagnostics
+		finalPlan, ok, moreDiags := getFinalPlan(ctx)
+		diags = diags.Append(moreDiags)
+		if !ok {
+			return nil, false, diags
+		}
+
+		// The following checks are just to catch situations where the execution
+		// graph was constructed incorrectly. No user input (valid or otherwise)
+		// should cause these situations to arise, so if either of these
+		// messages appear then that suggests a bug in the planning engine.
+		const errSummary = "Invalid execution graph"
+		if finalPlan.Addr.IsDeposed() {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				errSummary,
+				fmt.Sprintf("Operation ManagedPrepareDeposed was called with a plan for already-deposed object %s. This is a bug in OpenTofu.", finalPlan.Addr),
+			))
+		}
+		if !finalPlan.PlannedVal.IsNull() {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				errSummary,
+				fmt.Sprintf("Operation ManagedPrepareDeposed was called with a non-destroy plan for %s. This is a bug in OpenTofu.", finalPlan.Addr),
+			))
+		}
+
+		deposedKey, ok, moreDiags := getDeposedKey(ctx)
+		diags = diags.Append(moreDiags)
+		if !ok {
+			return nil, false, diags
+		}
+		ret := finalPlan.IntoDeposed(deposedKey)
 		return ret, !diags.HasErrors(), diags
 	}
 }

--- a/internal/engine/internal/execgraph/compiler_ops.go
+++ b/internal/engine/internal/execgraph/compiler_ops.go
@@ -140,7 +140,7 @@ func (c *compiler) compileOpManagedApply(operands *compilerOperands) nodeExecute
 	}
 }
 
-func (c *compiler) compileOpManagedDepose(operands *compilerOperands) nodeExecuteRaw {
+func (c *compiler) compileOpManagedPerformDepose(operands *compilerOperands) nodeExecuteRaw {
 	ops := c.ops
 	getCurrentObj := nextOperand[*exec.ResourceInstanceObject](operands)
 	waitForDeps := operands.OperandWaiter()
@@ -162,7 +162,7 @@ func (c *compiler) compileOpManagedDepose(operands *compilerOperands) nodeExecut
 			return nil, false, diags
 		}
 
-		ret, moreDiags := ops.ManagedDepose(ctx, currentObj)
+		ret, moreDiags := ops.ManagedPerformDepose(ctx, currentObj)
 		diags = diags.Append(moreDiags)
 		return ret, !diags.HasErrors(), diags
 	}

--- a/internal/engine/internal/execgraph/compiler_test.go
+++ b/internal/engine/internal/execgraph/compiler_test.go
@@ -96,7 +96,7 @@ func TestCompiler_resourceInstanceBasics(t *testing.T) {
 		},
 		ResourceInstancePriorFunc: func(ctx context.Context, addr addrs.AbsResourceInstance) (*exec.ResourceInstanceObject, tfdiags.Diagnostics) {
 			return &exec.ResourceInstanceObject{
-				InstanceAddr: addr,
+				Addr: addr.CurrentObject(),
 				State: &states.ResourceInstanceObjectFull{
 					Status: states.ObjectReady,
 					Value: cty.ObjectVal(map[string]cty.Value{
@@ -115,7 +115,7 @@ func TestCompiler_resourceInstanceBasics(t *testing.T) {
 		},
 		ManagedFinalPlanFunc: func(ctx context.Context, desired *eval.DesiredResourceInstance, prior *exec.ResourceInstanceObject, plannedVal cty.Value) (*exec.ManagedResourceObjectFinalPlan, tfdiags.Diagnostics) {
 			return &exec.ManagedResourceObjectFinalPlan{
-				InstanceAddr:  desired.Addr,
+				Addr:          desired.Addr.CurrentObject(),
 				ResourceType:  desired.ResourceType,
 				ConfigVal:     desired.ConfigVal,
 				PriorStateVal: prior.State.Value,
@@ -124,7 +124,7 @@ func TestCompiler_resourceInstanceBasics(t *testing.T) {
 		},
 		ManagedApplyFunc: func(ctx context.Context, plan *exec.ManagedResourceObjectFinalPlan, fallback *exec.ResourceInstanceObject) (*exec.ResourceInstanceObject, tfdiags.Diagnostics) {
 			return &exec.ResourceInstanceObject{
-				InstanceAddr: plan.InstanceAddr,
+				Addr: plan.Addr,
 				State: &states.ResourceInstanceObjectFull{
 					Status:               states.ObjectReady,
 					Value:                plan.PlannedVal,
@@ -180,7 +180,7 @@ func TestCompiler_resourceInstanceBasics(t *testing.T) {
 			MethodName: "ManagedApply",
 			Args: []any{
 				&exec.ManagedResourceObjectFinalPlan{
-					InstanceAddr: resourceInstAddr,
+					Addr:         resourceInstAddr.CurrentObject(),
 					ResourceType: resourceInstAddr.Resource.Resource.Type,
 					ConfigVal:    wantValue,
 					PlannedVal:   wantValue,
@@ -191,7 +191,7 @@ func TestCompiler_resourceInstanceBasics(t *testing.T) {
 				(*exec.ResourceInstanceObject)(nil),
 			},
 			Result: &exec.ResourceInstanceObject{
-				InstanceAddr: resourceInstAddr,
+				Addr: resourceInstAddr.CurrentObject(),
 				State: &states.ResourceInstanceObjectFull{
 					Status:               states.ObjectReady,
 					Value:                wantValue,
@@ -212,7 +212,7 @@ func TestCompiler_resourceInstanceBasics(t *testing.T) {
 					ResourceType:     resourceInstAddr.Resource.Resource.Type,
 				},
 				&exec.ResourceInstanceObject{
-					InstanceAddr: resourceInstAddr,
+					Addr: resourceInstAddr.CurrentObject(),
 					State: &states.ResourceInstanceObjectFull{
 						Status: states.ObjectReady,
 						Value: cty.ObjectVal(map[string]cty.Value{
@@ -231,7 +231,7 @@ func TestCompiler_resourceInstanceBasics(t *testing.T) {
 				wantValue,
 			},
 			Result: &exec.ManagedResourceObjectFinalPlan{
-				InstanceAddr: resourceInstAddr,
+				Addr:         resourceInstAddr.CurrentObject(),
 				ResourceType: resourceInstAddr.Resource.Resource.Type,
 				ConfigVal:    wantValue,
 				PriorStateVal: cty.ObjectVal(map[string]cty.Value{
@@ -260,7 +260,7 @@ func TestCompiler_resourceInstanceBasics(t *testing.T) {
 				resourceInstAddr,
 			},
 			Result: &exec.ResourceInstanceObject{
-				InstanceAddr: resourceInstAddr,
+				Addr: resourceInstAddr.CurrentObject(),
 				State: &states.ResourceInstanceObjectFull{
 					Status: states.ObjectReady,
 					Value: cty.ObjectVal(map[string]cty.Value{

--- a/internal/engine/internal/execgraph/graph_unmarshal.go
+++ b/internal/engine/internal/execgraph/graph_unmarshal.go
@@ -129,8 +129,8 @@ func unmarshalOperationElem(protoOp *execgraphproto.Operation, prevResults []Any
 		return unmarshalOpManagedFinalPlan(protoOp.GetOperands(), prevResults, builder)
 	case opManagedApply:
 		return unmarshalOpManagedApply(protoOp.GetOperands(), prevResults, builder)
-	case opManagedDepose:
-		return unmarshalOpManagedDepose(protoOp.GetOperands(), prevResults, builder)
+	case opManagedPerformDepose:
+		return unmarshalOpManagedPerformDepose(protoOp.GetOperands(), prevResults, builder)
 	case opManagedAlreadyDeposed:
 		return unmarshalOpManagedAlreadyDeposed(protoOp.GetOperands(), prevResults, builder)
 	case opManagedChangeAddr:
@@ -209,19 +209,19 @@ func unmarshalOpManagedApply(rawOperands []uint64, prevResults []AnyResultRef, b
 	return builder.ManagedApply(finalPlan, fallbackObj, waitFor), nil
 }
 
-func unmarshalOpManagedDepose(rawOperands []uint64, prevResults []AnyResultRef, builder *Builder) (AnyResultRef, error) {
+func unmarshalOpManagedPerformDepose(rawOperands []uint64, prevResults []AnyResultRef, builder *Builder) (AnyResultRef, error) {
 	if len(rawOperands) != 2 {
-		return nil, fmt.Errorf("wrong number of operands (%d) for opManagedDepose", len(rawOperands))
+		return nil, fmt.Errorf("wrong number of operands (%d) for opManagedPerformDepose", len(rawOperands))
 	}
 	currentObj, err := unmarshalGetPrevResultOf[*exec.ResourceInstanceObject](prevResults, rawOperands[0])
 	if err != nil {
-		return nil, fmt.Errorf("invalid opManagedDepose currentObj: %w", err)
+		return nil, fmt.Errorf("invalid opManagedPerformDepose currentObj: %w", err)
 	}
 	waitFor, err := unmarshalGetPrevResultWaiter(prevResults, rawOperands[1])
 	if err != nil {
-		return nil, fmt.Errorf("invalid opManagedDepose waitFor: %w", err)
+		return nil, fmt.Errorf("invalid opManagedPerformDepose waitFor: %w", err)
 	}
-	return builder.ManagedDepose(currentObj, waitFor), nil
+	return builder.ManagedPerformDepose(currentObj, waitFor), nil
 }
 
 func unmarshalOpManagedAlreadyDeposed(rawOperands []uint64, prevResults []AnyResultRef, builder *Builder) (AnyResultRef, error) {

--- a/internal/engine/internal/execgraph/graph_unmarshal.go
+++ b/internal/engine/internal/execgraph/graph_unmarshal.go
@@ -227,18 +227,22 @@ func unmarshalOpManagedPrepareDepose(rawOperands []uint64, prevResults []AnyResu
 }
 
 func unmarshalOpManagedPerformDepose(rawOperands []uint64, prevResults []AnyResultRef, builder *Builder) (AnyResultRef, error) {
-	if len(rawOperands) != 2 {
+	if len(rawOperands) != 3 {
 		return nil, fmt.Errorf("wrong number of operands (%d) for opManagedPerformDepose", len(rawOperands))
 	}
 	currentObj, err := unmarshalGetPrevResultOf[*exec.ResourceInstanceObject](prevResults, rawOperands[0])
 	if err != nil {
 		return nil, fmt.Errorf("invalid opManagedPerformDepose currentObj: %w", err)
 	}
-	waitFor, err := unmarshalGetPrevResultWaiter(prevResults, rawOperands[1])
+	finalDeletePlan, err := unmarshalGetPrevResultOf[*exec.ManagedResourceObjectFinalPlan](prevResults, rawOperands[1])
+	if err != nil {
+		return nil, fmt.Errorf("invalid opManagedPerformDepose finalDeletePlan: %w", err)
+	}
+	waitFor, err := unmarshalGetPrevResultWaiter(prevResults, rawOperands[2])
 	if err != nil {
 		return nil, fmt.Errorf("invalid opManagedPerformDepose waitFor: %w", err)
 	}
-	return builder.ManagedPerformDepose(currentObj, waitFor), nil
+	return builder.ManagedPerformDepose(currentObj, finalDeletePlan, waitFor), nil
 }
 
 func unmarshalOpManagedAlreadyDeposed(rawOperands []uint64, prevResults []AnyResultRef, builder *Builder) (AnyResultRef, error) {

--- a/internal/engine/internal/execgraph/graph_unmarshal.go
+++ b/internal/engine/internal/execgraph/graph_unmarshal.go
@@ -129,6 +129,8 @@ func unmarshalOperationElem(protoOp *execgraphproto.Operation, prevResults []Any
 		return unmarshalOpManagedFinalPlan(protoOp.GetOperands(), prevResults, builder)
 	case opManagedApply:
 		return unmarshalOpManagedApply(protoOp.GetOperands(), prevResults, builder)
+	case opManagedPrepareDepose:
+		return unmarshalOpManagedPrepareDepose(protoOp.GetOperands(), prevResults, builder)
 	case opManagedPerformDepose:
 		return unmarshalOpManagedPerformDepose(protoOp.GetOperands(), prevResults, builder)
 	case opManagedAlreadyDeposed:
@@ -207,6 +209,21 @@ func unmarshalOpManagedApply(rawOperands []uint64, prevResults []AnyResultRef, b
 		return nil, fmt.Errorf("invalid opManagedApplyChanges waitFor: %w", err)
 	}
 	return builder.ManagedApply(finalPlan, fallbackObj, waitFor), nil
+}
+
+func unmarshalOpManagedPrepareDepose(rawOperands []uint64, prevResults []AnyResultRef, builder *Builder) (AnyResultRef, error) {
+	if len(rawOperands) != 2 {
+		return nil, fmt.Errorf("wrong number of operands (%d) for opManagedPrepareDepose", len(rawOperands))
+	}
+	deletePlan, err := unmarshalGetPrevResultOf[*exec.ManagedResourceObjectFinalPlan](prevResults, rawOperands[0])
+	if err != nil {
+		return nil, fmt.Errorf("invalid opManagedPrepareDepose deletePlan: %w", err)
+	}
+	deposedKey, err := unmarshalGetPrevResultOf[addrs.DeposedKey](prevResults, rawOperands[1])
+	if err != nil {
+		return nil, fmt.Errorf("invalid opManagedPrepareDepose deposedKey: %w", err)
+	}
+	return builder.ManagedPrepareDepose(deletePlan, deposedKey), nil
 }
 
 func unmarshalOpManagedPerformDepose(rawOperands []uint64, prevResults []AnyResultRef, builder *Builder) (AnyResultRef, error) {

--- a/internal/engine/internal/execgraph/opcode_string.go
+++ b/internal/engine/internal/execgraph/opcode_string.go
@@ -12,15 +12,16 @@ func _() {
 	_ = x[opResourceInstancePrior-2]
 	_ = x[opManagedFinalPlan-3]
 	_ = x[opManagedApply-4]
-	_ = x[opManagedDepose-5]
-	_ = x[opManagedAlreadyDeposed-6]
-	_ = x[opManagedChangeAddr-7]
-	_ = x[opDataRead-8]
+	_ = x[opManagedPrepareDepose-5]
+	_ = x[opManagedPerformDepose-6]
+	_ = x[opManagedAlreadyDeposed-7]
+	_ = x[opManagedChangeAddr-8]
+	_ = x[opDataRead-9]
 }
 
-const _opCode_name = "opResourceInstanceDesiredopResourceInstancePrioropManagedFinalPlanopManagedApplyopManagedDeposeopManagedAlreadyDeposedopManagedChangeAddropDataRead"
+const _opCode_name = "opResourceInstanceDesiredopResourceInstancePrioropManagedFinalPlanopManagedApplyopManagedPrepareDeposeopManagedPerformDeposeopManagedAlreadyDeposedopManagedChangeAddropDataRead"
 
-var _opCode_index = [...]uint8{0, 25, 48, 66, 80, 95, 118, 137, 147}
+var _opCode_index = [...]uint8{0, 25, 48, 66, 80, 102, 124, 147, 166, 176}
 
 func (i opCode) String() string {
 	idx := int(i) - 1

--- a/internal/engine/internal/execgraph/operation.go
+++ b/internal/engine/internal/execgraph/operation.go
@@ -30,7 +30,8 @@ const (
 
 	opManagedFinalPlan
 	opManagedApply
-	opManagedDepose
+	opManagedPrepareDepose
+	opManagedPerformDepose
 	opManagedAlreadyDeposed
 	opManagedChangeAddr
 

--- a/internal/engine/internal/execgraph/operations_test.go
+++ b/internal/engine/internal/execgraph/operations_test.go
@@ -26,7 +26,7 @@ type mockOperations struct {
 	ManagedAlreadyDeposedFunc          func(ctx context.Context, instAddr addrs.AbsResourceInstance, deposedKey states.DeposedKey) (*exec.ResourceInstanceObject, tfdiags.Diagnostics)
 	ManagedApplyFunc                   func(ctx context.Context, plan *exec.ManagedResourceObjectFinalPlan, fallback *exec.ResourceInstanceObject) (*exec.ResourceInstanceObject, tfdiags.Diagnostics)
 	ManagedChangeAddrFunc              func(ctx context.Context, currentObj *exec.ResourceInstanceObject, newAddr addrs.AbsResourceInstance) (*exec.ResourceInstanceObject, tfdiags.Diagnostics)
-	ManagedDeposeFunc                  func(ctx context.Context, currentObj *exec.ResourceInstanceObject) (*exec.ResourceInstanceObject, tfdiags.Diagnostics)
+	ManagedPerformDeposeFunc           func(ctx context.Context, currentObj *exec.ResourceInstanceObject) (*exec.ResourceInstanceObject, tfdiags.Diagnostics)
 	ManagedFinalPlanFunc               func(ctx context.Context, desired *eval.DesiredResourceInstance, prior *exec.ResourceInstanceObject, plannedVal cty.Value) (*exec.ManagedResourceObjectFinalPlan, tfdiags.Diagnostics)
 	ResourceInstanceDesiredFunc        func(ctx context.Context, instAddr addrs.AbsResourceInstance) (*eval.DesiredResourceInstance, tfdiags.Diagnostics)
 	ResourceInstancePostconditionsFunc func(ctx context.Context, result *exec.ResourceInstanceObject) tfdiags.Diagnostics
@@ -81,14 +81,14 @@ func (m *mockOperations) ManagedChangeAddr(ctx context.Context, currentObj *exec
 	return result, diags
 }
 
-// ManagedDepose implements [exec.Operations].
-func (m *mockOperations) ManagedDepose(ctx context.Context, currentObj *exec.ResourceInstanceObject) (*exec.ResourceInstanceObject, tfdiags.Diagnostics) {
+// ManagedPerformDepose implements [exec.Operations].
+func (m *mockOperations) ManagedPerformDepose(ctx context.Context, currentObj *exec.ResourceInstanceObject) (*exec.ResourceInstanceObject, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	var result *exec.ResourceInstanceObject
-	if m.ManagedDeposeFunc != nil {
-		result, diags = m.ManagedDeposeFunc(ctx, currentObj)
+	if m.ManagedPerformDeposeFunc != nil {
+		result, diags = m.ManagedPerformDeposeFunc(ctx, currentObj)
 	}
-	m.appendLog("ManagedDepose", []any{currentObj}, result)
+	m.appendLog("ManagedPerformDepose", []any{currentObj}, result)
 	return result, diags
 }
 

--- a/internal/engine/internal/execgraph/operations_test.go
+++ b/internal/engine/internal/execgraph/operations_test.go
@@ -26,7 +26,7 @@ type mockOperations struct {
 	ManagedAlreadyDeposedFunc          func(ctx context.Context, instAddr addrs.AbsResourceInstance, deposedKey states.DeposedKey) (*exec.ResourceInstanceObject, tfdiags.Diagnostics)
 	ManagedApplyFunc                   func(ctx context.Context, plan *exec.ManagedResourceObjectFinalPlan, fallback *exec.ResourceInstanceObject) (*exec.ResourceInstanceObject, tfdiags.Diagnostics)
 	ManagedChangeAddrFunc              func(ctx context.Context, currentObj *exec.ResourceInstanceObject, newAddr addrs.AbsResourceInstance) (*exec.ResourceInstanceObject, tfdiags.Diagnostics)
-	ManagedPerformDeposeFunc           func(ctx context.Context, currentObj *exec.ResourceInstanceObject) (*exec.ResourceInstanceObject, tfdiags.Diagnostics)
+	ManagedPerformDeposeFunc           func(ctx context.Context, currentObj *exec.ResourceInstanceObject, deletePlan *exec.ManagedResourceObjectFinalPlan) (*exec.ResourceInstanceObject, tfdiags.Diagnostics)
 	ManagedFinalPlanFunc               func(ctx context.Context, desired *eval.DesiredResourceInstance, prior *exec.ResourceInstanceObject, plannedVal cty.Value) (*exec.ManagedResourceObjectFinalPlan, tfdiags.Diagnostics)
 	ResourceInstanceDesiredFunc        func(ctx context.Context, instAddr addrs.AbsResourceInstance) (*eval.DesiredResourceInstance, tfdiags.Diagnostics)
 	ResourceInstancePostconditionsFunc func(ctx context.Context, result *exec.ResourceInstanceObject) tfdiags.Diagnostics
@@ -82,13 +82,13 @@ func (m *mockOperations) ManagedChangeAddr(ctx context.Context, currentObj *exec
 }
 
 // ManagedPerformDepose implements [exec.Operations].
-func (m *mockOperations) ManagedPerformDepose(ctx context.Context, currentObj *exec.ResourceInstanceObject) (*exec.ResourceInstanceObject, tfdiags.Diagnostics) {
+func (m *mockOperations) ManagedPerformDepose(ctx context.Context, currentObj *exec.ResourceInstanceObject, deletePlan *exec.ManagedResourceObjectFinalPlan) (*exec.ResourceInstanceObject, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	var result *exec.ResourceInstanceObject
 	if m.ManagedPerformDeposeFunc != nil {
-		result, diags = m.ManagedPerformDeposeFunc(ctx, currentObj)
+		result, diags = m.ManagedPerformDeposeFunc(ctx, currentObj, deletePlan)
 	}
-	m.appendLog("ManagedPerformDepose", []any{currentObj}, result)
+	m.appendLog("ManagedPerformDepose", []any{currentObj, deletePlan}, result)
 	return result, diags
 }
 

--- a/internal/engine/planning/execgraph.go
+++ b/internal/engine/planning/execgraph.go
@@ -42,16 +42,27 @@ type execGraphBuilder struct {
 	// we throw these away after building is complete because the graph
 	// becomes immutable at that point.
 	resourceInstAddrRefs addrs.Map[addrs.AbsResourceInstance, execgraph.ResultRef[addrs.AbsResourceInstance]]
+
+	// makeDeposedKey is a function provided by the caller for allocating the
+	// tracking keys for objects that will become newly-deposed during the
+	// apply phase.
+	//
+	// The implementer is required to make sure that the returned key does not
+	// overlap with any already-deposed object for the given resource instance
+	// or with any other keys previously returned for the same resource instance
+	// address during the same graph-build.
+	makeDeposedKey func(addrs.AbsResourceInstance) addrs.DeposedKey
 }
 
 // NOTE: There are additional methods for [execGraphBuilder] declared in
 // the other files named execgraph_*.go , grouped by what kinds of objects they
 // primarily work with.
 
-func newExecGraphBuilder() *execGraphBuilder {
+func newExecGraphBuilder(makeDeposedKey func(addrs.AbsResourceInstance) addrs.DeposedKey) *execGraphBuilder {
 	return &execGraphBuilder{
 		lower:                execgraph.NewBuilder(),
 		resourceInstAddrRefs: addrs.MakeMap[addrs.AbsResourceInstance, execgraph.ResultRef[addrs.AbsResourceInstance]](),
+		makeDeposedKey:       makeDeposedKey,
 	}
 }
 

--- a/internal/engine/planning/execgraph_managed.go
+++ b/internal/engine/planning/execgraph_managed.go
@@ -271,9 +271,16 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphCreateThenDelete(
 			plannedChange.After.Type(),
 		)),
 	)
+	// We'll now reinterpret the destroy plan as being for the deposed key
+	// that we'll retain this object under until the new object has been
+	// created, or failed to be created.
+	deposedKey := b.lower.ConstantDeposedKey(b.makeDeposedKey(plannedChange.Addr))
+	destroyPlanRef = b.lower.ManagedPrepareDepose(destroyPlanRef, deposedKey)
+
 	deposedObjRef := b.lower.ManagedPerformDepose(
 		priorStateRef,
-		b.lower.Waiter(createPlanRef, destroyPlanRef),
+		destroyPlanRef,
+		b.lower.Waiter(createPlanRef),
 	)
 	createResultRef := b.lower.ManagedApply(
 		createPlanRef,

--- a/internal/engine/planning/execgraph_managed.go
+++ b/internal/engine/planning/execgraph_managed.go
@@ -271,7 +271,7 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphCreateThenDelete(
 			plannedChange.After.Type(),
 		)),
 	)
-	deposedObjRef := b.lower.ManagedDepose(
+	deposedObjRef := b.lower.ManagedPerformDepose(
 		priorStateRef,
 		b.lower.Waiter(createPlanRef, destroyPlanRef),
 	)

--- a/internal/engine/planning/execgraph_managed_test.go
+++ b/internal/engine/planning/execgraph_managed_test.go
@@ -6,6 +6,7 @@
 package planning
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -246,11 +247,12 @@ func TestExecGraphBuilder_ManagedResourceInstanceSubgraph(t *testing.T) {
 				r[1] = ResourceInstanceDesired(test.placeholder, await());
 				r[2] = ManagedFinalPlan(r[1], nil, v[0]);
 				r[3] = ManagedFinalPlan(nil, r[0], v[1]);
-				r[4] = ManagedPerformDepose(r[0], await(r[2], r[3]));
-				r[5] = ManagedApply(r[2], r[4], await());
-				r[6] = ManagedApply(r[3], nil, await(r[5]));
+				r[4] = ManagedPrepareDepose(r[3], "00000001");
+				r[5] = ManagedPerformDepose(r[0], r[4], await(r[2]));
+				r[6] = ManagedApply(r[2], r[5], await());
+				r[7] = ManagedApply(r[4], nil, await(r[6]));
 
-				test.placeholder = r[5];
+				test.placeholder = r[6];
 			`,
 		},
 		"create then delete with move": {
@@ -282,18 +284,26 @@ func TestExecGraphBuilder_ManagedResourceInstanceSubgraph(t *testing.T) {
 				r[2] = ResourceInstanceDesired(test.placeholder, await());
 				r[3] = ManagedFinalPlan(r[2], nil, v[0]);
 				r[4] = ManagedFinalPlan(nil, r[1], v[1]);
-				r[5] = ManagedPerformDepose(r[1], await(r[3], r[4]));
-				r[6] = ManagedApply(r[3], r[5], await());
-				r[7] = ManagedApply(r[4], nil, await(r[6]));
+				r[5] = ManagedPrepareDepose(r[4], "00000001");
+				r[6] = ManagedPerformDepose(r[1], r[5], await(r[3]));
+				r[7] = ManagedApply(r[3], r[6], await());
+				r[8] = ManagedApply(r[5], nil, await(r[7]));
 
-				test.placeholder = r[6];
+				test.placeholder = r[7];
 			`,
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			builder := newExecGraphBuilder()
+			var placeholderDeposedKey uint32
+			builder := newExecGraphBuilder(func(_ addrs.AbsResourceInstance) addrs.DeposedKey {
+				// For testing purposes we just allocate sequential integers
+				// so that we have predictable keys to include in the expected
+				// output of each test.
+				placeholderDeposedKey++
+				return addrs.DeposedKey(fmt.Sprintf("%08x", placeholderDeposedKey))
+			})
 			// FIXME: We're currently ignoring all but the first result
 			// because this test was originally written for an older variant
 			// of this function which only had one result. We should find a

--- a/internal/engine/planning/execgraph_managed_test.go
+++ b/internal/engine/planning/execgraph_managed_test.go
@@ -246,7 +246,7 @@ func TestExecGraphBuilder_ManagedResourceInstanceSubgraph(t *testing.T) {
 				r[1] = ResourceInstanceDesired(test.placeholder, await());
 				r[2] = ManagedFinalPlan(r[1], nil, v[0]);
 				r[3] = ManagedFinalPlan(nil, r[0], v[1]);
-				r[4] = ManagedDepose(r[0], await(r[2], r[3]));
+				r[4] = ManagedPerformDepose(r[0], await(r[2], r[3]));
 				r[5] = ManagedApply(r[2], r[4], await());
 				r[6] = ManagedApply(r[3], nil, await(r[5]));
 
@@ -282,7 +282,7 @@ func TestExecGraphBuilder_ManagedResourceInstanceSubgraph(t *testing.T) {
 				r[2] = ResourceInstanceDesired(test.placeholder, await());
 				r[3] = ManagedFinalPlan(r[2], nil, v[0]);
 				r[4] = ManagedFinalPlan(nil, r[1], v[1]);
-				r[5] = ManagedDepose(r[1], await(r[3], r[4]));
+				r[5] = ManagedPerformDepose(r[1], await(r[3], r[4]));
 				r[6] = ManagedApply(r[3], r[5], await());
 				r[7] = ManagedApply(r[4], nil, await(r[6]));
 

--- a/internal/engine/planning/execgraph_resource.go
+++ b/internal/engine/planning/execgraph_resource.go
@@ -112,7 +112,7 @@ func (b *execGraphBuilder) AddResourceInstanceObjectSubgraphs(
 			addDeleteDeps.Put(addr, addDeleteDep)
 		}
 
-		if addr.IsCurrent() {
+		if addr.IsCurrent() && valueRef != nil {
 			b.SetResourceInstanceFinalStateResult(addr.InstanceAddr, valueRef)
 		}
 	}

--- a/internal/engine/planning/plan.go
+++ b/internal/engine/planning/plan.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/collections"
 	"github.com/opentofu/opentofu/internal/engine/plugins"
 	"github.com/opentofu/opentofu/internal/lang/eval"
 	"github.com/opentofu/opentofu/internal/lang/grapheval"
@@ -160,7 +161,48 @@ func finalizePlan(ctx context.Context, intermediate *planContextResult, provider
 	)
 	diags = diags.Append(moreDiags)
 
-	egb := newExecGraphBuilder()
+	// newDeposedKeys tracks any new deposed keys we allocate while constructing
+	// the execution graph, so we can avoid returning the same key twice.
+	newDeposedKeys := addrs.MakeMap[addrs.AbsResourceInstance, collections.Set[addrs.DeposedKey]]()
+
+	egb := newExecGraphBuilder(func(instAddr addrs.AbsResourceInstance) addrs.DeposedKey {
+		// TODO: We should probably factor this out somewhere else, once
+		// the rest of the nearby code has settled down.
+		var existingDeposed map[addrs.DeposedKey]*states.ResourceInstanceObjectSrc
+		newDeposed := newDeposedKeys.Get(instAddr)
+		inst := intermediate.RefreshedState.ResourceInstance(instAddr)
+		if inst != nil {
+			existingDeposed = inst.Deposed
+		}
+
+		// We'll just keep trying to allocate new keys until we get a
+		// unique one. Deposed keys are effectively 32-bit unsigned integers
+		// and so with 1000 deposed objects per instance there'd only be 0.01%
+		// probability of colliding here, and that would be a ridiculous
+		// number of deposed objects.
+		i := 0
+		for {
+			i++
+			if i == 8192 {
+				// Something seems to have gone very wrong! We should not get here.
+				panic(fmt.Sprintf("failed to allocate a unique deposed key for %s", instAddr))
+			}
+
+			key := addrs.NewDeposedKey()
+			if _, exists := existingDeposed[key]; exists {
+				continue
+			}
+			if newDeposed.Has(key) {
+				continue
+			}
+			if newDeposed == nil {
+				newDeposed = make(collections.Set[addrs.DeposedKey])
+			}
+			newDeposed[key] = struct{}{}
+			return key
+		}
+
+	})
 	egb.AddResourceInstanceObjectSubgraphs(
 		intermediate.ResourceInstanceObjects,
 		effectiveReplaceOrders,

--- a/internal/engine/planning/plan_managed.go
+++ b/internal/engine/planning/plan_managed.go
@@ -216,6 +216,12 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 	if prevRoundState == nil {
 		plannedAction = plans.Create
 	} else if len(planResp.RequiresReplace) != 0 {
+		// FIXME: The mere presence of RequiresReplace items is not sufficient
+		// because existing providers often generate spurious entries in there
+		// for paths that aren't actually changing. We need to filter out
+		// any paths whose values are equal between prior and planned in order
+		// to get the expected behavior for real-world providers.
+
 		// For "replace" actions the execution graph will include two separate
 		// plan and apply operations, where one handles deletion and the other
 		// handles creation. There is therefore an implicit third intermediate

--- a/internal/engine/planning/plan_managed.go
+++ b/internal/engine/planning/plan_managed.go
@@ -116,6 +116,8 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 		return ret, diags
 	}
 
+	// FIXME: Need to "upgrade" the previous round state before we try to decode it.
+
 	var prevRoundVal cty.Value
 	var prevRoundPrivate []byte
 	prevRoundState := p.planCtx.prevRoundState.SyncWrapper().ResourceInstanceObjectFull(inst.Addr.CurrentObject())
@@ -300,6 +302,23 @@ func (p *planGlue) planOrphanManagedResourceInstance(
 	addr addrs.AbsResourceInstance,
 	stateSrc *states.ResourceInstanceObjectFullSrc,
 ) (*resourceInstanceObject, tfdiags.Diagnostics) {
+	return p.planUnwantedManagedResourceInstanceObject(ctx, addr.CurrentObject(), stateSrc)
+}
+
+func (p *planGlue) planDeposedManagedResourceInstanceObject(
+	ctx context.Context,
+	addr addrs.AbsResourceInstance,
+	deposedKey states.DeposedKey,
+	stateSrc *states.ResourceInstanceObjectFullSrc,
+) (*resourceInstanceObject, tfdiags.Diagnostics) {
+	return p.planUnwantedManagedResourceInstanceObject(ctx, addr.Object(deposedKey), stateSrc)
+}
+
+func (p *planGlue) planUnwantedManagedResourceInstanceObject(
+	ctx context.Context,
+	addr addrs.AbsResourceInstanceObject,
+	stateSrc *states.ResourceInstanceObjectFullSrc,
+) (*resourceInstanceObject, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	// TODO: This currently has a lot of inline logic that's quite similar to
@@ -309,12 +328,12 @@ func (p *planGlue) planOrphanManagedResourceInstance(
 	// so that this'll be easier to maintain in future as requirements change.
 
 	ret := &resourceInstanceObject{
-		Addr:         addr.CurrentObject(),
+		Addr:         addr,
 		Dependencies: addrs.MakeSet[addrs.AbsResourceInstanceObject](),
 		Provider:     stateSrc.ProviderInstanceAddr.Config.Config.Provider,
 
-		// Orphan objects are always planned for deletion, so we can assume
-		// the result will be always be some kind of null.
+		// Orphan and deposed objects are always planned for deletion, so we can
+		// assume the result will be always be some kind of null.
 		PlaceholderValue: cty.NullVal(cty.DynamicPseudoType),
 
 		// NOTE: PlannedChange remains nil until we actually produce a plan,
@@ -327,14 +346,17 @@ func (p *planGlue) planOrphanManagedResourceInstance(
 	// dependencies with the actual resource instance objects in the prior state
 	// to get a comprehensive set of everything we ought to depend on.
 
-	// TODO: Ask the planning oracle whether there are any "moved" blocks
-	// that begin at inst.Addr, and if so check whether the chain of moves
-	// starting there will end up at a currently-unbound resource instance
-	// address. If so, we should do nothing here because
-	// [planGlue.planOrphanManagedResourceInstance] for that target address
-	// should notice the opposite end of the same chain of moves and so
-	// handle it as an object that is in both the prior and desired state,
-	// albeit with different addresses in each.
+	if addr.IsCurrent() {
+		// TODO: Ask the planning oracle whether there are any "moved" blocks
+		// that begin at inst.Addr, and if so check whether the chain of moves
+		// starting there will end up at a currently-unbound resource instance
+		// address. If so, we should do nothing here because
+		// [planGlue.planOrphanManagedResourceInstance] for that target address
+		// should notice the opposite end of the same chain of moves and so
+		// handle it as an object that is in both the prior and desired state,
+		// albeit with different addresses in each.
+		_ = 0 // just to quiet staticcheck about this empty branch until we complete it
+	}
 
 	// FIXME: Currently this fails if the only mention of a particular provider
 	// instance is in the state, because this function relies on provider
@@ -361,7 +383,7 @@ func (p *planGlue) planOrphanManagedResourceInstance(
 		return ret, diags
 	}
 
-	resourceType := resources.NewManagedResourceType(providerAddr, addr.Resource.Resource.Type, providerClient)
+	resourceType := resources.NewManagedResourceType(providerAddr, addr.InstanceAddr.Resource.Resource.Type, providerClient)
 	schema, schemaDiags := resourceType.LoadSchema(ctx)
 	if schemaDiags.HasErrors() {
 		// We don't return the schema-loading diagnostics directly here because
@@ -373,12 +395,15 @@ func (p *planGlue) planOrphanManagedResourceInstance(
 			"Resource type schema unavailable",
 			fmt.Sprintf(
 				"Cannot plan %s because provider %s failed to return the schema for its resource type %q.",
-				addr, providerAddr, addr.Resource.Resource.Type,
+				addr, providerAddr, addr.InstanceAddr.Resource.Resource.Type,
 			),
 			nil, // this error belongs to the whole resource config
 		))
 		return ret, diags
 	}
+
+	// FIXME: Need to "upgrade" the previous run state and then refresh it
+	// before we try to decode it.
 
 	var prevRoundVal cty.Value
 	var prevRoundPrivate []byte
@@ -435,15 +460,16 @@ func (p *planGlue) planOrphanManagedResourceInstance(
 		// to keep supporting that, and if so design a way for the relevant
 		// meta value to get from the evaluator into here.
 		ProviderMetaValue: cty.NilVal,
-	}, addr.CurrentObject())
+	}, addr)
 	diags = diags.Append(planDiags)
 	if planDiags.HasErrors() {
 		return ret, diags
 	}
 
 	ret.PlannedChange = &plans.ResourceInstanceChange{
-		Addr:        addr,
-		PrevRunAddr: addr,
+		Addr:        addr.InstanceAddr,
+		PrevRunAddr: addr.InstanceAddr,
+		DeposedKey:  addr.DeposedKey,
 		ProviderAddr: addrs.AbsProviderConfig{
 			// FIXME: This is a lossy shim to the old-style provider instance
 			// address representation, since our old models aren't yet updated
@@ -471,14 +497,4 @@ func (p *planGlue) planOrphanManagedResourceInstance(
 	}
 	ret.ProviderInst = prevRoundState.ProviderInstanceAddr
 	return ret, diags
-}
-
-func (p *planGlue) planDeposedManagedResourceInstanceObject(
-	ctx context.Context,
-	addr addrs.AbsResourceInstance,
-	deposedKey states.DeposedKey,
-	state *states.ResourceInstanceObjectFullSrc,
-) (*resourceInstanceObject, tfdiags.Diagnostics) {
-	// TODO: Implement
-	panic("unimplemented")
 }

--- a/internal/lang/eval/config_plan.go
+++ b/internal/lang/eval/config_plan.go
@@ -7,14 +7,17 @@ package eval
 
 import (
 	"context"
+	"fmt"
 	"iter"
 	"sync"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/lang/eval/internal/configgraph"
 	"github.com/opentofu/opentofu/internal/lang/eval/internal/evalglue"
+	"github.com/opentofu/opentofu/internal/lang/exprs"
 	"github.com/opentofu/opentofu/internal/lang/grapheval"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
@@ -221,6 +224,8 @@ func (p *planningEvalGlue) ValidateProviderConfig(ctx context.Context, provider 
 
 // ResourceInstanceValue implements evalglue.Glue.
 func (p *planningEvalGlue) ResourceInstanceValue(ctx context.Context, ri *configgraph.ResourceInstance, configVal cty.Value, providerInst configgraph.Maybe[*configgraph.ProviderInstance], riDeps addrs.Set[addrs.AbsResourceInstance]) (cty.Value, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
 	desired := &DesiredResourceInstance{
 		Addr:                      ri.Addr,
 		ConfigVal:                 configgraph.PrepareOutgoingValue(configVal),
@@ -228,25 +233,65 @@ func (p *planningEvalGlue) ResourceInstanceValue(ctx context.Context, ri *config
 		RequiredResourceInstances: riDeps,
 		ResourceType:              ri.Addr.Resource.Resource.Type,
 		ResourceMode:              ri.Addr.Resource.Resource.Mode,
-
-		// This reflects the direct create_before_destroy setting of just
-		// this one resource instance. During the planning phase we'll
-		// propagate "create-before-destroy-ness" to anything else in the
-		// same dependency chain as an instance with this set, but we
-		// can't do that until after the plan phase has discovered the
-		// entire resource instance graph.
-		//
-		// FIXME: Actually take this setting from the config. For now we
-		// just always assume it isn't set.
-		CreateBeforeDestroy: false,
 	}
 	if providerInst, ok := configgraph.GetKnown(providerInst); ok {
 		desired.ProviderInstance = &providerInst.Addr
 	}
+
+	cbdVal, cbdRng, moreDiags := ri.CreateBeforeDestroy(ctx)
+	diags = diags.Append(moreDiags)
+	if !exprs.IsEvalError(cbdVal) {
+		const errSummary = "Invalid create_before_destroy argument"
+		unmarkedVal, _ := cbdVal.Unmark()
+		var subjRng *hcl.Range
+		if cbdRng != nil {
+			subjRng = cbdRng.ToHCL().Ptr()
+		}
+		if !unmarkedVal.IsKnown() {
+			// FIXME: Instead of being an error, this should just force deferring
+			// the planning of this resource instance. That'll take some
+			// refactoring to make it possible for us to defer at this layer,
+			// though.
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  errSummary,
+				Detail:   fmt.Sprintf("The create_before_destroy setting for %s is derived from a value that won't be decided until the apply phase, which is invalid because OpenTofu needs to decide the order of operations during the plan phase.", desired.Addr),
+				Subject:  subjRng,
+			})
+		} else if unmarkedVal == cty.True {
+			desired.CreateBeforeDestroy = true
+		} else if unmarkedVal == cty.False {
+			// We reject "false" here for now because in future it might come
+			// to represent forcing the destroy-then-create order for situations
+			// where it's simply impossible for two objects to exist for the
+			// resource instance at the same time. If we do that then we'll
+			// need to change [DesiredResourceInstance.CreateBeforeDestroy] to
+			// be a more general "replace order" field that can accept all
+			// three possibilities of "create-then-destroy", "destroy-then-create",
+			// or "don't care".
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  errSummary,
+				Detail:   fmt.Sprintf("The create_before_destroy setting for %s may not be set to false.\n\nIf this argument is present then it must be set to true. It is not currently possible to force destroy-then-create ordering.", desired.Addr),
+				Subject:  subjRng,
+			})
+		} else if !unmarkedVal.IsNull() {
+			// No other result should be possible if [CreateBeforeDestroy]
+			// was implemented correctly.
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				errSummary,
+				fmt.Sprintf("Internal processing of create_before_destroy for %s returned unexpected value %#v. This is a bug in OpenTofu.", desired.Addr, cbdVal),
+			))
+		}
+	}
+
 	// TODO: Populate everything else in [DesiredResourceInstance], once
 	// package configgraph knows how to provide those answers.
 
-	return p.planEngineGlue.PlanDesiredResourceInstance(ctx, desired)
+	ret, moreDiags := p.planEngineGlue.PlanDesiredResourceInstance(ctx, desired)
+	diags = diags.Append(moreDiags)
+	return ret, diags
 }
 
 func announcePlanOrphans(ctx context.Context, glue PlanGlue, rootModuleInstance evalglue.CompiledModuleInstance) tfdiags.Diagnostics {

--- a/internal/lang/eval/internal/configgraph/resource_instance.go
+++ b/internal/lang/eval/internal/configgraph/resource_instance.go
@@ -13,10 +13,12 @@ import (
 	"github.com/apparentlymart/go-workgraph/workgraph"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/lang/exprs"
 	"github.com/opentofu/opentofu/internal/lang/grapheval"
+	"github.com/opentofu/opentofu/internal/lang/marks"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
@@ -48,6 +50,13 @@ type ResourceInstance struct {
 	// the address from the Provider field into [ProviderInstanceRefType],
 	// or else type mismatch errors will be reported during evaluation.
 	ProviderInstanceValuer *OnceValuer
+
+	// CreateBeforeDestroyValuer is a valuer that returns the module author's
+	// direction about what "replace" order is required for this resource
+	// instance.
+	//
+	// The valuer must return something that can be converted to [cty.Bool].
+	CreateBeforeDestroyValuer *OnceValuer
 
 	// Glue is provided by the system that "compiled" this [ResourceInstance]
 	// object to allow calling back into that system to ask further questions
@@ -102,6 +111,68 @@ func (ri *ResourceInstance) ConfigValue(ctx context.Context) (v cty.Value, diags
 	}
 
 	return configVal, diags
+}
+
+// CreateBeforeDestroy returns a value-based representation of the "create
+// before destroy" setting for this resource instance.
+//
+// The result is guaranteed to be a [cty.Bool] value, but it could potentially
+// be unknown or marked and it's the caller's responsibility to handle those
+// situations.
+//
+// The different possible known boolean results have the following meaning:
+//   - [cty.True] means that this resource instance MUST use the create-then-destroy replace order.
+//   - [cty.False] means that this resource instance MUST use the destroy-then-create replace order.
+//   - A null value means that either order is acceptable for this resource instance.
+//
+// (Callers of this function may impose additional constraints on its result
+// depending on the context where the resource instance is being used. This
+// function only checks the basic validity rules.)
+func (ri *ResourceInstance) CreateBeforeDestroy(ctx context.Context) (cty.Value, *tfdiags.SourceRange, tfdiags.Diagnostics) {
+	if ri.CreateBeforeDestroyValuer == nil {
+		// Not setting this is equivalent to setting it to null.
+		return cty.NullVal(cty.Bool), nil, nil
+	}
+	rng := ri.CreateBeforeDestroyValuer.ValueSourceRange()
+
+	cbdVal, diags := ri.CreateBeforeDestroyValuer.Value(ctx)
+	const errSummary = "Invalid create_before_destroy argument"
+	if cbdVal == cty.NilVal {
+		if !diags.HasErrors() {
+			panic("CreateBeforeDestroyValuer returned cty.NilVal without errors")
+		}
+		cbdVal = exprs.AsEvalError(cty.DynamicVal) // just so the rest of this can run without crashing
+	}
+	cbdVal, err := convert.Convert(cbdVal, cty.Bool)
+	if err != nil {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  errSummary,
+			Detail:   fmt.Sprintf("Unsuitable value for create_before_destory argument: %s.", tfdiags.FormatError(err)),
+			Subject:  ri.CreateBeforeDestroyValuer.ValueSourceRange().ToHCL().Ptr(),
+		})
+		cbdVal = cty.UnknownVal(cty.Bool)
+	}
+	if cbdVal.HasMark(marks.Sensitive) {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  errSummary,
+			Detail:   "The create_before_destroy value must not be derived from a sensitive value, because otherwise OpenTofu's proposed changes could imply the sensitive value.\n\nIf you're certain that this result cannot disclose sensitive information, consider using the \"nonsensitive\" function to explicitly allow it.",
+			Subject:  ri.CreateBeforeDestroyValuer.ValueSourceRange().ToHCL().Ptr(),
+		})
+	}
+	if cbdVal.HasMark(marks.Ephemeral) {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  errSummary,
+			Detail:   "The create_before_destroy value must not be derived from an ephemeral value, because the ordering decision must be consistent between the plan and apply phases.",
+			Subject:  ri.CreateBeforeDestroyValuer.ValueSourceRange().ToHCL().Ptr(),
+		})
+	}
+	if diags.HasErrors() {
+		cbdVal = exprs.AsEvalError(cbdVal)
+	}
+	return cbdVal, rng, diags
 }
 
 // Value implements exprs.Valuer.
@@ -218,6 +289,7 @@ func (ri *ResourceInstance) ValueSourceRange() *tfdiags.SourceRange {
 func (ri *ResourceInstance) CheckAll(ctx context.Context) tfdiags.Diagnostics {
 	var cg CheckGroup
 	cg.CheckValuer(ctx, ri)
+	cg.CheckValuer(ctx, ri.CreateBeforeDestroyValuer)
 	return cg.Complete(ctx)
 }
 
@@ -226,6 +298,12 @@ func (ri *ResourceInstance) AnnounceAllGraphevalRequests(announce func(workgraph
 		Name:        fmt.Sprintf("configuration for %s", ri.Addr),
 		SourceRange: ri.ConfigValuer.ValueSourceRange(),
 	})
+	if ri.CreateBeforeDestroyValuer != nil {
+		announce(ri.CreateBeforeDestroyValuer.RequestID(), grapheval.RequestInfo{
+			Name:        fmt.Sprintf("create_before_destroy argument for %s", ri.Addr),
+			SourceRange: ri.CreateBeforeDestroyValuer.ValueSourceRange(),
+		})
+	}
 	announce(ri.valueOnce.RequestID(), grapheval.RequestInfo{
 		Name:        fmt.Sprintf("final value for %s", ri.Addr),
 		SourceRange: ri.ConfigValuer.ValueSourceRange(),

--- a/internal/lang/eval/internal/tofu2024/compile_resources.go
+++ b/internal/lang/eval/internal/tofu2024/compile_resources.go
@@ -99,13 +99,40 @@ func compileModuleInstanceResource(
 			localScope := instanceLocalScope(declScope, repData)
 			providerRef := compileProviderConfigRef(ctx, moduleProviders, config.ProviderConfigAddr(), config.ProviderConfigRef, localScope)
 
+			// For now we require a literal boolean constant in
+			// create_before_destroy to match how the old implementation treated
+			// this, but this is designed to grow to support arbitrary
+			// expressions in future once we're ready to implement this issue:
+			//    https://github.com/opentofu/opentofu/issues/2523
+			var cbdVal cty.Value
+			if config.Managed != nil {
+				if !config.Managed.CreateBeforeDestroySet {
+					cbdVal = cty.NullVal(cty.Bool)
+				} else if config.Managed.CreateBeforeDestroy {
+					cbdVal = cty.True
+				} else {
+					cbdVal = cty.False
+				}
+			}
+			var cbdValuer *configgraph.OnceValuer
+			if cbdVal != cty.NilVal {
+				// We don't currently track the source location of the
+				// create_before_destroy argument in particular, but when
+				// we make this support arbitrary expressions in future
+				// the expression's source range will be used here instead.
+				cbdValuer = configgraph.ValuerOnce(
+					exprs.ConstantValuerWithSourceRange(cbdVal, tfdiags.SourceRangeFromHCL(config.DeclRange)),
+				)
+			}
+
 			inst := &configgraph.ResourceInstance{
 				Addr:     absAddr.Instance(key),
 				Provider: config.Provider,
 				ConfigValuer: configgraph.ValuerOnce(exprs.NewClosure(
 					configEvalable, localScope,
 				)),
-				ProviderInstanceValuer: configgraph.ValuerOnce(providerRef),
+				ProviderInstanceValuer:    configgraph.ValuerOnce(providerRef),
+				CreateBeforeDestroyValuer: cbdValuer,
 			}
 			// Again the [ResourceInstance] implementation will call back
 			// through this object so we can help it interact with the

--- a/internal/tofu/context_apply_test.go
+++ b/internal/tofu/context_apply_test.go
@@ -1012,7 +1012,7 @@ func TestContext2Apply_createBeforeDestroy(t *testing.T) {
 }
 
 func TestContext2Apply_createBeforeDestroyUpdate(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureCBD)
+	SkipExperimental(t, ExperimentalBugSpuriousReplace)
 	m := testModule(t, "apply-good-create-before-update")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn

--- a/internal/tofu/context_temp_runtime_test.go
+++ b/internal/tofu/context_temp_runtime_test.go
@@ -28,7 +28,8 @@ const (
 	ExperimentalBugResourceReadNull  ExperimentalFlag = "Bug Read Resource Deleted"
 	ExperimentalBugDataResource      ExperimentalFlag = "Bug Data Resource"
 	ExperimentalBugVariableInput     ExperimentalFlag = "Bug Variable Input"
-	ExperimentalBugForEach           ExperimentalFlag = "Bug For Each" // TODO run existing evalchecks tests against new engine
+	ExperimentalBugForEach           ExperimentalFlag = "Bug For Each"         // TODO run existing evalchecks tests against new engine
+	ExperimentalBugSpuriousReplace   ExperimentalFlag = "Bug Spurious Replace" // New runtime proposes replace where old runtime would've called for update
 
 	ExperimentalChangeDiagWording ExperimentalFlag = "Change Different Diagnostic Wording"
 	ExperimentalChangeErrorEarly  ExperimentalFlag = "Change Detect Error Earlier"


### PR DESCRIPTION
(This is for https://github.com/opentofu/opentofu/issues/4057, but is not yet sufficient to close it.)

This series of commits implements a new execution subgraph shape for "create-then-destroy" replace operations, ensuring that the expected resource instance object addresses reach each of the execution graph nodes involved in the process.

This follows the new graph shape I discussed at the end of https://github.com/opentofu/opentofu/issues/4057#issuecomment-4578449311, which I'm replicating here for easier future reference:

```mermaid
graph TB

prior_state[Read old from prior state]
desired_state[Read new from config]
delete_plan[Plan to delete old]
create_plan[Plan to create new]
depose[Depose old]
create_apply[Create new]
delete_apply[Delete old]
reinterp_deposed([reinterpret as\ndeposed abc123])
style reinterp_deposed font-size:0.9em

prior_state -->|prior state| delete_plan
prior_state -->|prior state| depose
desired_state -->|desired state| create_plan

delete_plan -->|final plan| reinterp_deposed
reinterp_deposed -->|final plan| depose
reinterp_deposed -->|final plan| delete_apply
create_plan -->|final plan| create_apply
create_plan -.-> depose
depose -->|fallback| create_apply
create_apply -.-> delete_apply
```

Along the way I fixed some other assorted small problems that were blocking me from implementing and testing this. Therefore **it's probably best to [review this on a commit-by-commit basis](https://github.com/opentofu/opentofu/pull/4226/commits)**.

A small number of tests guarded with `ExperimentalFeatureCBD` are still failing, and although it seems that they are failing for reasons unrelated to `create_before_destroy` I've not completely confirmed that yet. This changeset is already too large so I'll deal with the remaining failures in a future PR.

I have one other known omission here that I'm intentionally skipping: there are various other kinds of marks that could potentially show up on a `create_before_destroy` argument once we generalize it to support arbitrary expressions, but right now in practice it can only be a constant value and so there isn't any way to test that additional complexity without writing some unit tests that are closer to `package configgraph` and `package planning`. I'll do that in a future PR.

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
