### PR TITLE
tofu2024: Handle the various cases of "nullable" for input variables

### DIFF
--- a/internal/lang/eval/internal/tofu2024/compile_input_variables.go
+++ b/internal/lang/eval/internal/tofu2024/compile_input_variables.go
@@ -28,83 +28,7 @@ func compileModuleInstanceInputVariables(_ context.Context, configs map[string]*
 		// The valuer for an individual input variable derives from the
 		// valuer for the single object representing all of the input
 		// variables together.
-		rawValuer := exprs.DerivedValuer(values, func(v cty.Value, _ tfdiags.Diagnostics) (cty.Value, tfdiags.Diagnostics) {
-			// We intentionally avoid passing on the diagnostics from the
-			// "values" valuer here both because they will be about the
-			// entire object rather than the individual attribute we're
-			// interested in and because whatever produced the "values"
-			// valuer should've already reported its own errors when
-			// it was checked directly.
-			//
-			// We might return additional diagnostics about the individual
-			// atribute we're extracting, though.
-			var diags tfdiags.Diagnostics
-
-			defRange := missingDefRange
-			if valueRange := values.ValueSourceRange(); valueRange != nil {
-				defRange = valueRange
-			}
-
-			ty := v.Type()
-			if ty == cty.DynamicPseudoType {
-				return cty.DynamicVal.WithSameMarks(v), diags
-			}
-			if !ty.IsObjectType() {
-				// Should not get here because the caller should always pass
-				// us an object type based on the arguments in the module
-				// call, but we'll deal with it anyway for robustness.
-				diags = diags.Append(&hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  "Invalid input values",
-					Detail:   fmt.Sprintf("Input variable values for %s module must be provided as an object value, not %s.", moduleInstAddr, ty.FriendlyName()),
-					Subject:  configgraph.MaybeHCLSourceRange(defRange),
-				})
-				return cty.DynamicVal.WithSameMarks(v), diags
-			}
-			if v.IsNull() {
-				// Again this suggests a bug in the caller, but we'll handle
-				// it for robustness.
-				diags = diags.Append(&hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  "Invalid input values",
-					Detail:   fmt.Sprintf("The object describing the input values for %s must not be null.", moduleInstAddr),
-					Subject:  configgraph.MaybeHCLSourceRange(defRange),
-				})
-				return cty.DynamicVal.WithSameMarks(v), diags
-			}
-
-			if !ty.HasAttribute(name) || v.GetAttr(name).IsNull() {
-				if vc.Required() {
-					// We don't actually _need_ to handle an error here because
-					// the final evaluation of the variables must deal with the
-					// possibility of the final value being null anyway, but
-					// by handling this here we can produce a more helpful error
-					// message that talks about the definition being statically
-					// absent instead of dynamically null.
-					var diags tfdiags.Diagnostics
-					diags = diags.Append(&hcl.Diagnostic{
-						Severity: hcl.DiagError,
-						Summary:  "Missing definition for required input variable",
-						Detail:   fmt.Sprintf("Input variable %q is required, and so it must be provided as an argument to this module.", name),
-						Subject:  configgraph.MaybeHCLSourceRange(defRange),
-					})
-					return cty.DynamicVal.WithSameMarks(v), diags
-				} else if vc.Default != cty.NilVal {
-					return vc.Default, diags
-				} else {
-					// TODO handle nullable correctly
-					// For a non-required variable we'll provide a placeholder
-					// null value so that the evaluator can treat this the same
-					// as if there was an explicit definition evaluating to null.
-					return cty.NullVal(cty.DynamicPseudoType).WithSameMarks(v), diags
-				}
-			}
-			// After all of the checks above we should now be able to call
-			// GetAttr for this name without panicking. (If v is unknown
-			// or marked then cty will automatically return a derived unknown
-			// or marked value.)
-			return v.GetAttr(name), diags
-		})
+		rawValuer := compileInputVariableValuer(values, vc, moduleInstAddr, missingDefRange)
 		ret[addr] = &configgraph.InputVariable{
 			Addr:           moduleInstAddr.InputVariable(name),
 			RawValue:       configgraph.ValuerOnce(rawValuer),
@@ -128,4 +52,99 @@ func compileModuleInstanceInputVariables(_ context.Context, configs map[string]*
 		}
 	}
 	return ret
+}
+
+func compileInputVariableValuer(valuesValuer exprs.Valuer, config *configs.Variable, moduleInstAddr addrs.ModuleInstance, missingDefRange *tfdiags.SourceRange) exprs.Valuer {
+	name := config.Name
+	return exprs.DerivedValuer(valuesValuer, func(values cty.Value, _ tfdiags.Diagnostics) (cty.Value, tfdiags.Diagnostics) {
+		// We intentionally avoid passing on the diagnostics from the
+		// "values" valuer here both because they will be about the
+		// entire object rather than the individual attribute we're
+		// interested in and because whatever produced the "values"
+		// valuer should've already reported its own errors when
+		// it was checked directly.
+		//
+		// We might return additional diagnostics about the individual
+		// atribute we're extracting, though.
+		var diags tfdiags.Diagnostics
+
+		defRange := missingDefRange
+		if valueRange := valuesValuer.ValueSourceRange(); valueRange != nil {
+			defRange = valueRange
+		}
+
+		ty := values.Type()
+		if ty == cty.DynamicPseudoType {
+			return cty.DynamicVal.WithSameMarks(values), diags
+		}
+		if !ty.IsObjectType() {
+			// Should not get here because the caller should always pass
+			// us an object type based on the arguments in the module
+			// call, but we'll deal with it anyway for robustness.
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid input values",
+				Detail:   fmt.Sprintf("Input variable values for %s module must be provided as an object value, not %s.", moduleInstAddr, ty.FriendlyName()),
+				Subject:  configgraph.MaybeHCLSourceRange(defRange),
+			})
+			return cty.DynamicVal.WithSameMarks(values), diags
+		}
+		if values.IsNull() {
+			// Again this suggests a bug in the caller, but we'll handle
+			// it for robustness.
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid input values",
+				Detail:   fmt.Sprintf("The object describing the input values for %s must not be null.", moduleInstAddr),
+				Subject:  configgraph.MaybeHCLSourceRange(defRange),
+			})
+			return cty.DynamicVal.WithSameMarks(values), diags
+		}
+
+		// "Required" and "Nullable" are related but separate:
+		//
+		// "Required" means that an attribute representing the variable
+		// must be present in the object that's representing all of the
+		// input variables, but still allows the explicit definition to
+		// assign it the value "null". A non-required (i.e. optional) input
+		// variable always has a default value, which is allowed to be null
+		// if the variable is nullable.
+		//
+		// "Nullable" means that the value of the attribute may not be
+		// null, regardless of whether that null is explicitly set or
+		// implied by omission. If assigned null when a default is available
+		// then the default value is used instead of failing.
+
+		if !ty.HasAttribute(name) {
+			if config.Required() {
+				var diags tfdiags.Diagnostics
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Missing definition for required input variable",
+					Detail:   fmt.Sprintf("Input variable %q is required, and so it must be provided as an argument to this module.", name),
+					Subject:  configgraph.MaybeHCLSourceRange(defRange),
+				})
+				return cty.DynamicVal.WithSameMarks(values), diags
+			}
+			return config.Default, diags
+		}
+
+		// If we get here then the variable is definitely defined, but we don't
+		// yet know if it's null or not.
+		v := values.GetAttr(name)
+		if !config.Nullable && v.IsNull() {
+			if config.Required() {
+				var diags tfdiags.Diagnostics
+				diags = diags.Append(&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid value for input variable",
+					Detail:   fmt.Sprintf("Input variable %q is required and not nullable, and so it cannot be set to null.", name),
+					Subject:  configgraph.MaybeHCLSourceRange(defRange),
+				})
+				return cty.DynamicVal.WithSameMarks(values), diags
+			}
+			return config.Default, diags
+		}
+		return v, diags
+	})
 }

--- a/internal/lang/eval/internal/tofu2024/compile_input_variables_test.go
+++ b/internal/lang/eval/internal/tofu2024/compile_input_variables_test.go
@@ -1,0 +1,158 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tofu2024
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty-debug/ctydebug"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/configs"
+	"github.com/opentofu/opentofu/internal/lang/exprs"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+)
+
+func TestCompileInputVariableValuer(t *testing.T) {
+	missingDefRange := tfdiags.SourceRange{
+		Filename: "<missing-def-range>",
+		Start:    tfdiags.SourcePos{Line: 1, Column: 1, Byte: 1},
+		End:      tfdiags.SourcePos{Line: 1, Column: 1, Byte: 1},
+	}
+	presentDefRange := tfdiags.SourceRange{
+		Filename: "<present-def-range>",
+		Start:    tfdiags.SourcePos{Line: 1, Column: 1, Byte: 1},
+		End:      tfdiags.SourcePos{Line: 1, Column: 1, Byte: 1},
+	}
+
+	tests := map[string]struct {
+		values map[string]cty.Value
+		config *configs.Variable
+
+		wantValue cty.Value
+		wantDiags tfdiags.Diagnostics
+	}{
+		"required variable that is set": {
+			values: map[string]cty.Value{
+				"name": cty.StringVal("Timothy"),
+			},
+			config: &configs.Variable{
+				Name: "name",
+			},
+			wantValue: cty.StringVal("Timothy"),
+		},
+		"required, nullable variable that is null": {
+			values: map[string]cty.Value{
+				"name": cty.NullVal(cty.String),
+			},
+			config: &configs.Variable{
+				Name:        "name",
+				Nullable:    true,
+				NullableSet: true,
+			},
+			wantValue: cty.NullVal(cty.String),
+		},
+		"required variable that is not set": {
+			values: map[string]cty.Value{},
+			config: &configs.Variable{
+				Name: "name",
+			},
+			wantValue: cty.DynamicVal,
+			wantDiags: tfdiags.New(
+				&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Missing definition for required input variable",
+					Detail:   `Input variable "name" is required, and so it must be provided as an argument to this module.`,
+					Subject:  presentDefRange.ToHCL().Ptr(),
+				},
+			),
+		},
+		"required, non-nullable variable that is null": {
+			values: map[string]cty.Value{
+				"name": cty.NullVal(cty.String),
+			},
+			config: &configs.Variable{
+				Name:     "name",
+				Nullable: false,
+			},
+			wantValue: cty.DynamicVal,
+			wantDiags: tfdiags.New(
+				&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid value for input variable",
+					Detail:   `Input variable "name" is required and not nullable, and so it cannot be set to null.`,
+					Subject:  presentDefRange.ToHCL().Ptr(),
+				},
+			),
+		},
+
+		"optional variable that is set": {
+			values: map[string]cty.Value{
+				"name": cty.StringVal("Timothy"),
+			},
+			config: &configs.Variable{
+				Name:    "name",
+				Default: cty.StringVal("not Timothy"),
+			},
+			wantValue: cty.StringVal("Timothy"),
+		},
+		"optional variable that is not set": {
+			values: map[string]cty.Value{},
+			config: &configs.Variable{
+				Name:    "name",
+				Default: cty.StringVal("not Timothy"),
+			},
+			wantValue: cty.StringVal("not Timothy"),
+		},
+		"optional, nullable variable that is set to null": {
+			values: map[string]cty.Value{
+				"name": cty.NullVal(cty.String),
+			},
+			config: &configs.Variable{
+				Name:     "name",
+				Default:  cty.StringVal("not Timothy"),
+				Nullable: true,
+			},
+			wantValue: cty.NullVal(cty.String),
+		},
+		"optional, non-nullable variable that is set to null": {
+			values: map[string]cty.Value{
+				"name": cty.NullVal(cty.String),
+			},
+			config: &configs.Variable{
+				Name:     "name",
+				Default:  cty.StringVal("not Timothy"),
+				Nullable: false,
+			},
+			wantValue: cty.StringVal("not Timothy"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			valuesValuer := exprs.ConstantValuerWithSourceRange(cty.ObjectVal(test.values), presentDefRange)
+			resultValuer := compileInputVariableValuer(valuesValuer, test.config, addrs.RootModuleInstance, &missingDefRange)
+
+			gotValue, gotDiags := resultValuer.Value(t.Context())
+			if diff := cmp.Diff(test.wantValue, gotValue, ctydebug.CmpOptions); diff != "" {
+				t.Error("wrong result value\n" + diff)
+			}
+			// We'll use the "ForRPC" variant of diagnostics so that we're
+			// comparing by content and not by the implementation detail of
+			// what types of diagnostic are returned.
+			wantDiags := test.wantDiags.ForRPC()
+			wantDiags.Sort()
+			gotDiags = gotDiags.ForRPC()
+			gotDiags.Sort()
+			if diff := cmp.Diff(wantDiags, gotDiags, ctydebug.CmpOptions); diff != "" {
+				t.Error("wrong diagnostics\n" + diff)
+			}
+		})
+	}
+}

--- a/internal/tfdiags/diagnostics.go
+++ b/internal/tfdiags/diagnostics.go
@@ -26,6 +26,19 @@ import (
 // diagnostics to report at all.
 type Diagnostics []Diagnostic
 
+// New constructs a new [Diagnostics] that initially contains diagnostic
+// representations of all of the given values.
+//
+// This is just a shorthand for calling [Diagnostics.Append] on a nil
+// Diagnostics, and so the initial values are interpreted just as Append would
+// interpret them.
+func New(initial ...any) Diagnostics {
+	if len(initial) == 0 {
+		return nil
+	}
+	return Diagnostics(nil).Append(initial...)
+}
+
 // Append is the main interface for constructing Diagnostics lists, taking
 // an existing list (which may be nil) and appending the new objects to it
 // after normalizing them to be implementations of Diagnostic.
@@ -49,7 +62,7 @@ type Diagnostics []Diagnostic
 // a multierror.Error into separate error diagnostics. It can be passed
 // another Diagnostics to concatenate the two lists. If given something
 // it cannot handle, this function will panic.
-func (diags Diagnostics) Append(new ...interface{}) Diagnostics {
+func (diags Diagnostics) Append(new ...any) Diagnostics {
 	for _, item := range new {
 		if item == nil {
 			continue

--- a/internal/tofu/context_apply2_test.go
+++ b/internal/tofu/context_apply2_test.go
@@ -729,6 +729,8 @@ func TestContext2Apply_sensitiveInsideUnknown(t *testing.T) {
 }
 
 func TestContext2Apply_ignoreImpureFunctionChanges(t *testing.T) {
+	SkipExperimental(t, ExperimentalBugVariableSensitive)
+
 	// The impure function call should not cause a planned change with
 	// ignore_changes
 	m := testModuleInline(t, map[string]string{
@@ -782,7 +784,7 @@ resource "test_object" "y" {
 		if c.Action != plans.NoOp {
 			t.Logf("marks before: %#v", c.BeforeValMarks)
 			t.Logf("marks after:  %#v", c.AfterValMarks)
-			t.Errorf("Unexpcetd %s change for %s", c.Action, c.Addr)
+			t.Errorf("Unexpected %s change for %s", c.Action, c.Addr)
 		}
 	}
 }
@@ -893,7 +895,7 @@ resource "test_object" "x" {
 }
 
 func TestContext2Apply_nullableVariables(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugVariableInput)
+	SkipExperimental(t, ExperimentalFeatureRootOutput)
 
 	m := testModule(t, "apply-nullable-variables")
 	state := states.NewState()
@@ -1078,6 +1080,14 @@ resource "test_object" "b" {
 	if diags.HasErrors() {
 		t.Fatalf("plan: %s", diags.Err())
 	}
+
+	// This test tries to create a synthetic failure by tampering with the
+	// plan's prior state in a way that cannot occur in normal usage of
+	// OpenTofu, and then expecting the old-style apply graph builder to choke
+	// on it. That can't work for the new runtime because the equivalent of
+	// the apply graph (the execution graph) is constructed during the planning
+	// phase instead.
+	SkipExperimental(t, ExperimentalNewStrategyNeeded)
 
 	// We're going to corrupt the stored state so that the dependencies will
 	// cause a cycle when building the apply graph.

--- a/internal/tofu/context_apply_test.go
+++ b/internal/tofu/context_apply_test.go
@@ -8629,7 +8629,8 @@ template_file.parent.0:
 }
 
 func TestContext2Apply_targetedWithTaintedInState(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
+	SkipExperimental(t, ExperimentalFeatureTarget)
+
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
 	p.ApplyResourceChangeFn = testApplyFn

--- a/internal/tofu/context_plan_test.go
+++ b/internal/tofu/context_plan_test.go
@@ -6542,7 +6542,8 @@ resource "aws_instance" "foo" {
 }
 
 func TestContext2Plan_variableSensitivity(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugVariableInput) // Sensitivity
+	SkipExperimental(t, ExperimentalBugVariableSensitive)
+
 	m := testModule(t, "plan-variable-sensitivity")
 
 	p := testProvider("aws")

--- a/internal/tofu/context_temp_runtime.go
+++ b/internal/tofu/context_temp_runtime.go
@@ -198,7 +198,7 @@ func (c *Context) newEngineApply(ctx context.Context, config *configs.Config, pl
 
 	log.Println("[WARN] Using apply implementation from the experimental language runtime")
 
-	if len(plan.ExecutionGraph) == 0 {
+	if len(plan.ExecutionGraph) == 0 && !plan.Changes.Empty() {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Saved plan contains no execution graph",

--- a/internal/tofu/context_temp_runtime_test.go
+++ b/internal/tofu/context_temp_runtime_test.go
@@ -26,7 +26,7 @@ const (
 	ExperimentalBugReferenceProvider ExperimentalFlag = "Bug Reference Provider"
 	ExperimentalBugResourceReadNull  ExperimentalFlag = "Bug Read Resource Deleted"
 	ExperimentalBugDataResource      ExperimentalFlag = "Bug Data Resource"
-	ExperimentalBugVariableInput     ExperimentalFlag = "Bug Variable Input"
+	ExperimentalBugVariableSensitive ExperimentalFlag = "Bug Variables Declared as Sensitive"
 	ExperimentalBugForEach           ExperimentalFlag = "Bug For Each"         // TODO run existing evalchecks tests against new engine
 	ExperimentalBugSpuriousReplace   ExperimentalFlag = "Bug Spurious Replace" // New runtime proposes replace where old runtime would've called for update
 
@@ -67,14 +67,24 @@ const (
 	ExperimentalFeatureTaint             ExperimentalFlag = "Missing Taint"
 	ExperimentalFeatureErrorHandling     ExperimentalFlag = "Missing Error Handling"
 	ExperimentalFeatureProviderFunctions ExperimentalFlag = "Missing Provider Defined Functions"
-	ExperimentalFeatureProviderInstances ExperimentalFlag = "Missing Provider Instances"
+
+	// ExperimentalNewStrategyNeeded is a special experimental flag that
+	// represents that a test is failing not because the underlying behavior
+	// is wrong but because the test was relying on poking around in the
+	// internals of the old runtime to produce a synthetic result and that
+	// poking is ineffective with the new runtime. If you use this one,
+	// include a comment above the [SkipExperimental] call explaining what
+	// aspect of the testing strategy is flawed in the new implementation.
+	ExperimentalNewStrategyNeeded ExperimentalFlag = "New testing strategy needed"
 
 	// Fixed
 	ExperimentalBugExecGraph       ExperimentalFlag = "Bug in generated Exec Graph"
 	ExperimentalBugDeclareProvider ExperimentalFlag = "Bug Declare Provider"
+	ExperimentalBugVariableInput   ExperimentalFlag = "Bug Variable Input"
 
 	// Implemented
 	ExperimentalFeatureStateDependencies ExperimentalFlag = "Missing State Dependencies"
+	ExperimentalFeatureProviderInstances ExperimentalFlag = "Missing Provider Instances"
 )
 
 func SkipExperimental(t *testing.T, features ...ExperimentalFlag) {
@@ -82,8 +92,13 @@ func SkipExperimental(t *testing.T, features ...ExperimentalFlag) {
 		var strs []string
 		for _, feature := range features {
 			switch feature {
-			case ExperimentalBugExecGraph, ExperimentalBugDeclareProvider, ExperimentalFeatureProviderInstances, ExperimentalFeatureStateDependencies:
-				// Fixed
+			case
+				ExperimentalBugExecGraph,
+				ExperimentalBugDeclareProvider,
+				ExperimentalFeatureProviderInstances,
+				ExperimentalFeatureStateDependencies,
+				ExperimentalBugVariableInput:
+				// These ones are expected to be fixed already, so we don't skip.
 			default:
 				strs = append(strs, string(feature))
 			}


### PR DESCRIPTION
(This is for https://github.com/opentofu/opentofu/issues/3414.)

Unlike most parts of the OpenTofu language, input variables distinguish between "required" in the sense that a definition must be present at all and "nullable" in the sense of whether the definition can be a null value. This is compensating for a historical implementation mistake, but we must replicate it because existing modules depend on that mistake.

This now handles nullable as a separate concern from required, checking it only after we're sure that a definition is present. This also includes a unit test covering different combinations of nullability and requiredness, to make that specific behavior easier to maintain.

---

This PR also includes a few other supporting changes:

- I finally added a helper function `tfdiags.New` for constructing a new `tfdiags.Diagnostics` pre-populated with diagnostics. We keep writing inline versions of this function in different places, but calls to this helper are (subjectively) easier to write and read.
- I adjusted the consistency check that was intended to catch situations where someone manually running `tofu plan` and `tofu apply` in experimental mode accidentally tries to apply an old-style plan with the new apply engine: it was previously incorrectly producing an error whenever trying to apply an empty plan, because the execution graph serialization is _expectedly_ zero-length in that case.
- I fiddled with the `SkipExperimental` calls in the `package tofu` tests a bunch because marking `ExperimentalBugVariableInput` as fixed exposed some other separate problems that this PR does not address.
