### PR TITLE
Add windows_arm64 to release builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -54,8 +54,6 @@ builds:
         goarch: arm64
       - goos: windows
         goarch: arm
-      - goos: windows
-        goarch: arm64
       - goos: darwin
         goarch: "386"
       - goos: darwin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ ENHANCEMENTS:
 - The `cidrsubnets` function now supports prefix extensions greater than 32 bits when the base CIDR block uses an IPv6 address. ([#4042](https://github.com/opentofu/opentofu/pull/4042))
 - The `local-exec` provisioner now automatically sets the `TRACEPARENT` environment variable in child processes when OpenTelemetry tracing is active, following the W3C Trace Context specification. ([#4014](https://github.com/opentofu/opentofu/issues/4014))
 - When installing provider and module packages from OCI Distribution registries, OpenTofu now tracks separate transient credentials for each repository to support registry implementations that issue repository-scoped tokens.  ([#3316](https://github.com/opentofu/opentofu/issues/3316))
+- Precompiled `windows_arm64` builds are now published as a best-effort platform (no CI coverage, similar to `solaris_amd64`). ([#798](https://github.com/opentofu/opentofu/issues/798))
 
 BUG FIXES:
 


### PR DESCRIPTION
## Summary

Enables precompiled `windows_arm64` archives by removing the single `windows/arm64` entry from the goreleaser `ignore:` list. The 32-bit `windows/arm` target is left ignored.

Fixes #798

## Context

This follows the maintainers' last updates on #798:

- Terraform v1.15 now ships the `windows_arm64` target, which removed the provider-ecosystem friction that had previously made the maintainers reluctant to add this platform.
- GitHub Actions [arm64 runners for public repos are now generally available](https://github.blog/changelog/2025-08-07-arm64-hosted-runners-for-public-repositories-are-now-generally-available/).

Per the discussion, this is intended as a **best-effort** platform (no routine CI coverage), in the same tier as `solaris_amd64`. The CHANGELOG note reflects that.

I offered to open this in the issue and can test the resulting build locally on a Snapdragon X / Windows 11 ARM64 machine. Happy to adjust scope (e.g. add a CI matrix entry now that GA arm64 runners exist) if maintainers prefer.

> Note: I don't have `help-wanted`/assignment on the issue yet — flagging in case maintainers want to formalize that before review.

## Changes

- `.goreleaser.yaml`: drop the `goos: windows` / `goarch: arm64` ignore entry.
- `CHANGELOG.md`: add a best-effort `windows_arm64` enhancement note under 1.13.0.


## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
