### PR TITLE
tofu2024: Apply Sensitive and Ephemeral marks to the values of variables declared as such

### DIFF
--- a/internal/lang/eval/internal/configgraph/input_variable.go
+++ b/internal/lang/eval/internal/configgraph/input_variable.go
@@ -37,8 +37,21 @@ type InputVariable struct {
 	TargetType     cty.Type
 	TargetDefaults *typeexpr.Defaults
 
-	// TODO: Default value
-	// TODO: ForceEphemeral, ForceSensitive
+	// FinalizeValue is an optional callback which, if provided, is called
+	// during [InputVariable.Value] returns to allow
+	// language-edition-specific code to apply any final checks or
+	// transformations to the value. The provided value has already been
+	// subjected to type conversion, but has not yet had the validation
+	// rules applied to it. The result of this function is passed to the
+	// validation checks.
+	//
+	// For example, this is used by package tofu2024 to deal with the various
+	// arguments in a variable declaration that affect the interpretation of
+	// the value, such as marking it as sensitive.
+	//
+	// The given context has the values needed to support potentially evaluating
+	// other expressions inside the callback.
+	FinalizeValue func(context.Context, cty.Value) (cty.Value, tfdiags.Diagnostics)
 
 	// Validation rules are user-defined checks that must succeed for the
 	// final value to be considered valid for use in downstream expressions.
@@ -83,7 +96,24 @@ func (i *InputVariable) Value(ctx context.Context) (cty.Value, tfdiags.Diagnosti
 			Detail:   fmt.Sprintf("Unsuitable value for variable %q: %s.", i.Addr.Variable.Name, tfdiags.FormatError(err)),
 			Subject:  MaybeHCLSourceRange(i.ValueSourceRange()),
 		})
-		finalV = cty.UnknownVal(i.TargetType.WithoutOptionalAttributesDeep())
+		finalV = exprs.AsEvalError(cty.UnknownVal(i.TargetType.WithoutOptionalAttributesDeep()))
+	}
+
+	// Apply any language-edition-specific transforms or checks to the value
+	// before we handle the author-provided validation rules, so that they
+	// are always validating the final form of the value.
+	if i.FinalizeValue != nil {
+		finalV, moreDiags = i.FinalizeValue(ctx, finalV)
+		diags = diags.Append(moreDiags)
+		if moreDiags.HasErrors() {
+			// If finalization failed then the result is likely to be something
+			// surprising to any author-provided validation rules, and so we'll
+			// proceed with an unknown value of the expected type meaning we
+			// can still catch static-type-related problems in the validation
+			// rules but won't trigger confusing additional responses to
+			// whatever was wrong with finalV.
+			finalV = exprs.AsEvalError(cty.UnknownVal(i.TargetType.WithoutOptionalAttributesDeep()))
+		}
 	}
 
 	// Once we have our converted and prepared value we can finally compile

--- a/internal/lang/eval/internal/tofu2024/compile_input_variables.go
+++ b/internal/lang/eval/internal/tofu2024/compile_input_variables.go
@@ -17,6 +17,7 @@ import (
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/lang/eval/internal/configgraph"
 	"github.com/opentofu/opentofu/internal/lang/exprs"
+	"github.com/opentofu/opentofu/internal/lang/marks"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
@@ -34,6 +35,38 @@ func compileModuleInstanceInputVariables(_ context.Context, configs map[string]*
 			RawValue:       configgraph.ValuerOnce(rawValuer),
 			TargetType:     vc.ConstraintType,
 			TargetDefaults: vc.TypeDefaults,
+			FinalizeValue: func(_ context.Context, v cty.Value) (cty.Value, tfdiags.Diagnostics) {
+				var diags tfdiags.Diagnostics
+				if vc.Sensitive {
+					v = v.Mark(marks.Sensitive)
+				}
+				if vc.Ephemeral {
+					v = v.Mark(marks.Ephemeral)
+				} else {
+					// At the boundary between modules we treat ephemerality
+					// as a static concern, so that module authors don't need to
+					// defensively handle ephemeral values in all input
+					// variables. An input variable is either entirely ephemeral
+					// or not ephemeral at all.
+					if v.HasMarkDeep(marks.Ephemeral) {
+						diags = diags.Append(&hcl.Diagnostic{
+							Severity: hcl.DiagError,
+							Summary:  "Invalid value for input variable",
+							Detail:   fmt.Sprintf("The given value is derived from an ephemeral object, but %s is not declared as ephemeral.", addr),
+							Subject:  configgraph.MaybeHCLSourceRange(rawValuer.ValueSourceRange()),
+						})
+					}
+				}
+				// TODO: Do we want to do something with "const" here too?
+				// In our new runtime we don't have an explicit concept of
+				// "early evaluation" and so if we want to support this we'll
+				// need to find a more nuanced definition of what it means for
+				// a variable to be "constant", such as disallowing it being
+				// derived from any resource instances, having any unknown
+				// values inside it and/or having ephemeral values anywhere.
+				// TODO: Handle "Deprecated" in here too.
+				return v, diags
+			},
 			CompileValidationRules: func(ctx context.Context, value cty.Value) iter.Seq[*configgraph.CheckRule] {
 				// For variable validation we need to use a special overlay
 				// scope that resolves the single variable we are validating

--- a/internal/lang/eval/internal/tofu2024/compile_input_variables_test.go
+++ b/internal/lang/eval/internal/tofu2024/compile_input_variables_test.go
@@ -10,16 +10,18 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/ext/typeexpr"
 	"github.com/zclconf/go-cty-debug/ctydebug"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/lang/exprs"
+	"github.com/opentofu/opentofu/internal/lang/grapheval"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
-func TestCompileInputVariableValuer(t *testing.T) {
+func TestCompileInputVariable(t *testing.T) {
 	missingDefRange := tfdiags.SourceRange{
 		Filename: "<missing-def-range>",
 		Start:    tfdiags.SourcePos{Line: 1, Column: 1, Byte: 1},
@@ -44,6 +46,7 @@ func TestCompileInputVariableValuer(t *testing.T) {
 			},
 			config: &configs.Variable{
 				Name: "name",
+				Type: cty.String,
 			},
 			wantValue: cty.StringVal("Timothy"),
 		},
@@ -53,6 +56,7 @@ func TestCompileInputVariableValuer(t *testing.T) {
 			},
 			config: &configs.Variable{
 				Name:        "name",
+				Type:        cty.String,
 				Nullable:    true,
 				NullableSet: true,
 			},
@@ -62,8 +66,9 @@ func TestCompileInputVariableValuer(t *testing.T) {
 			values: map[string]cty.Value{},
 			config: &configs.Variable{
 				Name: "name",
+				Type: cty.String,
 			},
-			wantValue: cty.DynamicVal,
+			wantValue: exprs.AsEvalError(cty.UnknownVal(cty.String)),
 			wantDiags: tfdiags.New(
 				&hcl.Diagnostic{
 					Severity: hcl.DiagError,
@@ -79,9 +84,10 @@ func TestCompileInputVariableValuer(t *testing.T) {
 			},
 			config: &configs.Variable{
 				Name:     "name",
+				Type:     cty.String,
 				Nullable: false,
 			},
-			wantValue: cty.DynamicVal,
+			wantValue: exprs.AsEvalError(cty.UnknownVal(cty.String)),
 			wantDiags: tfdiags.New(
 				&hcl.Diagnostic{
 					Severity: hcl.DiagError,
@@ -98,6 +104,7 @@ func TestCompileInputVariableValuer(t *testing.T) {
 			},
 			config: &configs.Variable{
 				Name:    "name",
+				Type:    cty.String,
 				Default: cty.StringVal("not Timothy"),
 			},
 			wantValue: cty.StringVal("Timothy"),
@@ -106,6 +113,7 @@ func TestCompileInputVariableValuer(t *testing.T) {
 			values: map[string]cty.Value{},
 			config: &configs.Variable{
 				Name:    "name",
+				Type:    cty.String,
 				Default: cty.StringVal("not Timothy"),
 			},
 			wantValue: cty.StringVal("not Timothy"),
@@ -116,6 +124,7 @@ func TestCompileInputVariableValuer(t *testing.T) {
 			},
 			config: &configs.Variable{
 				Name:     "name",
+				Type:     cty.String,
 				Default:  cty.StringVal("not Timothy"),
 				Nullable: true,
 			},
@@ -127,6 +136,7 @@ func TestCompileInputVariableValuer(t *testing.T) {
 			},
 			config: &configs.Variable{
 				Name:     "name",
+				Type:     cty.String,
 				Default:  cty.StringVal("not Timothy"),
 				Nullable: false,
 			},
@@ -136,10 +146,40 @@ func TestCompileInputVariableValuer(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			valuesValuer := exprs.ConstantValuerWithSourceRange(cty.ObjectVal(test.values), presentDefRange)
-			resultValuer := compileInputVariableValuer(valuesValuer, test.config, addrs.RootModuleInstance, &missingDefRange)
+			if test.config.Type == cty.NilType {
+				t.Fatal("input variable declaration has no type") // omitting this causes confusing downstream errors, and never occurs in practice
+			}
+			if test.config.ConstraintType == cty.NilType {
+				// This emulates some fixup that the config loader would normally do
+				// in the simple case where no optional attributes are present,
+				// since we're not actually running the config loader here.
+				test.config.ConstraintType = test.config.Type
+				test.config.TypeDefaults = &typeexpr.Defaults{
+					Type: test.config.Type,
+				}
+			}
 
-			gotValue, gotDiags := resultValuer.Value(t.Context())
+			// This test is oriented around testing one variable at a time,
+			// but it uses the function that compiles all of the variables
+			// in a module at once so we'll pretend like we're compiling
+			// a module that only has this one variable declaration.
+			configs := map[string]*configs.Variable{
+				test.config.Name: test.config,
+			}
+			valuesValuer := exprs.ConstantValuerWithSourceRange(cty.ObjectVal(test.values), presentDefRange)
+			emptyScope := exprs.FlatScopeForTesting(nil)
+
+			compiled := compileModuleInstanceInputVariables(t.Context(), configs, valuesValuer, emptyScope, addrs.RootModuleInstance, &missingDefRange)
+			if compiled == nil {
+				t.Fatal("compileModuleInstanceInputVariables returned nil")
+			}
+			vn, ok := compiled[test.config.Addr()]
+			if !ok {
+				t.Fatalf("compileModuleInstanceInputVariables result does not include entry for %s", test.config.Addr())
+			}
+
+			ctx := grapheval.ContextWithNewWorker(t.Context())
+			gotValue, gotDiags := vn.Value(ctx)
 			if diff := cmp.Diff(test.wantValue, gotValue, ctydebug.CmpOptions); diff != "" {
 				t.Error("wrong result value\n" + diff)
 			}

--- a/internal/lang/eval/internal/tofu2024/compile_input_variables_test.go
+++ b/internal/lang/eval/internal/tofu2024/compile_input_variables_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/lang/exprs"
 	"github.com/opentofu/opentofu/internal/lang/grapheval"
+	"github.com/opentofu/opentofu/internal/lang/marks"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
@@ -141,6 +142,69 @@ func TestCompileInputVariable(t *testing.T) {
 				Nullable: false,
 			},
 			wantValue: cty.StringVal("not Timothy"),
+		},
+
+		"sensitive": {
+			values: map[string]cty.Value{
+				"name": cty.StringVal("Rumpelstiltskin"),
+			},
+			config: &configs.Variable{
+				Name:      "name",
+				Type:      cty.String,
+				Sensitive: true,
+			},
+			wantValue: cty.StringVal("Rumpelstiltskin").Mark(marks.Sensitive),
+		},
+		"sensitive undeclared": {
+			values: map[string]cty.Value{
+				"name": cty.StringVal("Rumpelstiltskin").Mark(marks.Sensitive),
+			},
+			config: &configs.Variable{
+				Name: "name",
+				Type: cty.String,
+			},
+			wantValue: cty.StringVal("Rumpelstiltskin").Mark(marks.Sensitive),
+		},
+		"ephemeral": {
+			values: map[string]cty.Value{
+				"name": cty.StringVal("Lavender Gooms"),
+			},
+			config: &configs.Variable{
+				Name:      "name",
+				Type:      cty.String,
+				Ephemeral: true,
+			},
+			wantValue: cty.StringVal("Lavender Gooms").Mark(marks.Ephemeral),
+		},
+		"sensitive and ephemeral together": {
+			values: map[string]cty.Value{
+				"name": cty.StringVal("Burton Guster"),
+			},
+			config: &configs.Variable{
+				Name:      "name",
+				Type:      cty.String,
+				Ephemeral: true,
+				Sensitive: true,
+			},
+			wantValue: cty.StringVal("Burton Guster").Mark(marks.Sensitive).Mark(marks.Ephemeral),
+		},
+		"ephemeral unwanted": {
+			values: map[string]cty.Value{
+				"name": cty.StringVal("Gus T.T. Showbiz").Mark(marks.Ephemeral),
+			},
+			config: &configs.Variable{
+				Name: "name",
+				Type: cty.String,
+			},
+			wantValue: exprs.AsEvalError(cty.UnknownVal(cty.String)),
+			wantDiags: tfdiags.New(
+				&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid value for input variable",
+					Detail:   `The given value is derived from an ephemeral object, but var.name is not declared as ephemeral.`,
+					Subject:  presentDefRange.ToHCL().Ptr(),
+				},
+			),
 		},
 	}
 

--- a/internal/tofu/context_apply2_test.go
+++ b/internal/tofu/context_apply2_test.go
@@ -729,7 +729,7 @@ func TestContext2Apply_sensitiveInsideUnknown(t *testing.T) {
 }
 
 func TestContext2Apply_ignoreImpureFunctionChanges(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugVariableSensitive)
+	SkipExperimental(t, ExperimentalFeatureIgnoreChanges)
 
 	// The impure function call should not cause a planned change with
 	// ignore_changes

--- a/internal/tofu/context_plan_test.go
+++ b/internal/tofu/context_plan_test.go
@@ -6542,7 +6542,11 @@ resource "aws_instance" "foo" {
 }
 
 func TestContext2Plan_variableSensitivity(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugVariableSensitive)
+	// This test relies on marks like "sensitive" being transferred from the
+	// configuration of a resource instance into the final value returned by
+	// the provider when planning it, which the new implementation is not
+	// currently doing.
+	SkipExperimental(t, ExperimentalBugResourceMarks)
 
 	m := testModule(t, "plan-variable-sensitivity")
 

--- a/internal/tofu/context_temp_runtime_test.go
+++ b/internal/tofu/context_temp_runtime_test.go
@@ -32,7 +32,8 @@ var (
 	ExperimentalBugReferenceProvider = ExperimentalFlag{"Bug Reference Provider", false}
 	ExperimentalBugResourceReadNull  = ExperimentalFlag{"Bug Read Resource Deleted", false}
 	ExperimentalBugDataResource      = ExperimentalFlag{"Bug Data Resource", false}
-	ExperimentalBugVariableSensitive = ExperimentalFlag{"Bug Variables Declared as Sensitive", false}
+	ExperimentalBugVariableSensitive = ExperimentalFlag{"Bug Variables Declared as Sensitive", true}
+	ExperimentalBugResourceMarks     = ExperimentalFlag{"Bug Not Transferring Marks from Resource Instance Config Value to Final Value", false}
 	ExperimentalBugForEach           = ExperimentalFlag{"Bug For Each", false}         // TODO run existing evalchecks tests against new engine
 	ExperimentalBugSpuriousReplace   = ExperimentalFlag{"Bug Spurious Replace", false} // New runtime proposes replace where old runtime would've called for update
 


### PR DESCRIPTION
(This is for https://github.com/opentofu/opentofu/issues/3414.)

In the current edition of the OpenTofu language there are some arguments in `variable` blocks that act like additional transformations or checks of the final value of the input variable, including `sensitive = true` and `ephemeral = true` that are handled here.

To keep the `configgraph` code focused on "core" functionality that is unlikely to change in future language editions, this works by having `configgraph.InputVariable` call back into the `tofu2024` ("compiler") code after type conversion has succeeded but before input variable validation has been applied.

As before having input variable validation considered "core functionality" while the others are not feels quite arbitrary in retrospect but I previously justified it because the `tofu test` harness relies on being able to get individual results for each "checkable object" and so all future language editions will presumably have _something_ that maps to `configgraph.CheckRule` in order to provide the signal that the test harness expects, even if the surface syntax for it ends up quite different.

This enables all of the `package tofu` tests that had been guarded by `ExperimentalBugVariableSensitive`, but introduces new guards to two tests that were revealed to have other problems beyond the missing handling of sensitive input variables.

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
