### PR TITLE
tofu2024: Handle two more missed cases in `for_each` support

### DIFF
--- a/internal/lang/eval/internal/tofu2024/instance_selector.go
+++ b/internal/lang/eval/internal/tofu2024/instance_selector.go
@@ -209,7 +209,13 @@ func compileInstanceSelectorForEach(_ context.Context, forEachValuer exprs.Value
 
 			typ := rawVal.Type()
 			if typ.IsSetType() {
-				if !typ.ElementType().Equals(cty.String) {
+				// We accept only sets of string or of unknown element type.
+				// We must accept unknown element type so that it's valid to
+				// write:
+				//   for_each = toset([])
+				// ...since the toset function can't infer an element type
+				// automatically in that case, so it leaves it unspecified.
+				if !typ.ElementType().Equals(cty.String) && !typ.ElementType().Equals(cty.DynamicPseudoType) {
 					diags = diags.Append(&hcl.Diagnostic{
 						Severity: hcl.DiagError,
 						Summary:  errSummary,
@@ -220,6 +226,21 @@ func compileInstanceSelectorForEach(_ context.Context, forEachValuer exprs.Value
 				}
 				if !rawVal.IsWhollyKnown() {
 					return nil, marks, diags
+				}
+				// For sets it's also possible for an author to provide a null
+				// element, so we need to screen for that and reject it here
+				// to avoid problems below when we try to treat every element
+				// as a non-null string.
+				for k := range rawVal.Elements() {
+					if k.IsNull() {
+						diags = diags.Append(&hcl.Diagnostic{
+							Severity: hcl.DiagError,
+							Summary:  errSummary,
+							Detail:   "When using a set with for_each, a null element is not allowed because the element values will be used as instance keys.",
+							Subject:  forEachValuer.ValueSourceRange().ToHCL().Ptr(),
+						})
+						return nil, marks, diags
+					}
 				}
 			} else if typ.IsMapType() {
 				if !rawVal.IsKnown() {

--- a/internal/lang/eval/internal/tofu2024/instance_selector_test.go
+++ b/internal/lang/eval/internal/tofu2024/instance_selector_test.go
@@ -93,6 +93,16 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 				nil,
 				nil,
 			},
+			// This test covers what would be produced by:
+			//    for_each = tomap({})
+			// ...because in that case we don't have enough information to
+			// predict the element type, so we just leave it unspecified.
+			"empty map of unknown type inline": {
+				hcl.StaticExpr(cty.MapValEmpty(cty.DynamicPseudoType), rng),
+				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
+				nil,
+				nil,
+			},
 			"map with one element from scope": {
 				hcltest.MockExprTraversalSrc(`map_with_a`),
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
@@ -289,6 +299,16 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 				nil,
 				nil,
 			},
+			"empty set of unknown type inline": {
+				// This test covers what would be produced by:
+				//    for_each = toset([])
+				// ...because in that case we don't have enough information to
+				// predict the element type, so we just leave it unspecified.
+				hcl.StaticExpr(cty.SetValEmpty(cty.DynamicPseudoType), rng),
+				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
+				nil,
+				nil,
+			},
 			"set with one element from scope": {
 				hcltest.MockExprTraversalSrc(`set_with_a`),
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
@@ -311,6 +331,15 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 				nil, // instances are unknown
 				nil,
 				diagsHasError("The for_each value must not be null."),
+			},
+			"set with null in it": {
+				hcl.StaticExpr(cty.SetVal([]cty.Value{
+					cty.StringVal("not null"),
+					cty.NullVal(cty.String),
+				}), rng),
+				nil, // instances are unknown
+				nil,
+				diagsHasError("a null element is not allowed"),
 			},
 			"set of non-string values": {
 				hcl.StaticExpr(cty.SetVal([]cty.Value{cty.True}), rng),

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -7965,7 +7965,12 @@ import {
 }
 
 func TestContext2Plan_providerForEachWithOrphanResourceInstanceNotUsingForEach(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugForEach)
+	// This currently fails in the new runtime because it doesn't have the
+	// special check for the situation where prior state has a resource instance
+	// belonging to a provider instance that isn't in the latest configuration.
+	// It just treats it as a general provider initialization failure:
+	//    Cannot plan test_thing.a["orphaned"] because its associated provider instance provider["terraform.io/builtin/test"].multi cannot initialize.
+	SkipExperimental(t, ExperimentalBugMissingProvider)
 
 	// This test is to cover the bug reported in this issue:
 	//    https://github.com/opentofu/opentofu/issues/2334

--- a/internal/tofu/context_plan_test.go
+++ b/internal/tofu/context_plan_test.go
@@ -2730,7 +2730,7 @@ func TestContext2Plan_countComputed(t *testing.T) {
 }
 
 func TestContext2Plan_countComputedModule(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugForEach)
+	SkipExperimental(t, ExperimentalChangeDeferredActions)
 
 	m := testModule(t, "plan-count-computed-module")
 	p := testProvider("aws")

--- a/internal/tofu/context_temp_runtime_test.go
+++ b/internal/tofu/context_temp_runtime_test.go
@@ -35,12 +35,13 @@ var (
 	ExperimentalBugDataResource      = ExperimentalFlag{"Bug Data Resource", false}
 	ExperimentalBugVariableSensitive = ExperimentalFlag{"Bug Variables Declared as Sensitive", true}
 	ExperimentalBugResourceMarks     = ExperimentalFlag{"Bug Not Transferring Marks from Resource Instance Config Value to Final Value", false}
-	ExperimentalBugForEach           = ExperimentalFlag{"Bug For Each", false}         // TODO run existing evalchecks tests against new engine
+	ExperimentalBugForEach           = ExperimentalFlag{"Bug For Each", true}
 	ExperimentalBugSpuriousReplace   = ExperimentalFlag{"Bug Spurious Replace", false} // New runtime proposes replace where old runtime would've called for update
 
-	ExperimentalChangeDiagWording  = ExperimentalFlag{"Change Different Diagnostic Wording", false}
-	ExperimentalChangeErrorEarly   = ExperimentalFlag{"Change Detect Error Earlier", false}
-	ExperimentalChangeDependencies = ExperimentalFlag{"Change Precise Dependencies", false}
+	ExperimentalChangeDiagWording     = ExperimentalFlag{"Change Different Diagnostic Wording", false}
+	ExperimentalChangeErrorEarly      = ExperimentalFlag{"Change Detect Error Earlier", false}
+	ExperimentalChangeDependencies    = ExperimentalFlag{"Change Precise Dependencies", false}
+	ExperimentalChangeDeferredActions = ExperimentalFlag{"Change New Runtime Supports Deferred Actions", false}
 
 	ExperimentalFeatureStateDependencies = ExperimentalFlag{"Missing State Dependencies", true}
 	ExperimentalFeatureProviderInstances = ExperimentalFlag{"Missing Provider Instances", true}


### PR DESCRIPTION
(This is for https://github.com/opentofu/opentofu/issues/3414.)

When maps are used in for_each the rules for `cty`'s map type make our life relatively easy: map keys are always strings, are always known, and are never null.

But when a set is used, we need to do more explicit checks because HCL and cty allow sets of any type and allow null values in sets.

We previously weren't handling two set-related situations properly:

- `for_each = toset([])` (can't infer element type)
- `for_each = toset(["a", null])` (can't use null as an instance key)

This now handles both of those situations. The first is allowed because when there are no instances there are no instance keys and so it doesn't matter that we don't know the type. The second produces an error, because allowing null as a key would require cty to be able to represent an object type with an attribute whose name is null and that is not allowed.

This also includes a test for a map of an unknown element type to match the one added for sets, but we don't need to treat that in a special way because `for_each` allows maps of any element type already anyway.

---

While working on this I found that two existing context tests were incorrectly skipped with `ExperimentalBugForEach` guard, because the reasons they are failing are not related to `for_each` behavior. I've updated those to now each use a different skip flag that's a closer representation of the reason why they are failing.

`ExperimentalBugForEach` is now marked as fixed and so the remaining tests guarded by that can now run.

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
