### PR TITLE
[Govulncheck][v1.12] Upgrade go version 1.26.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ SECURITY ADVISORIES:
 
   This is fixed now by ([#4177](https://github.com/opentofu/opentofu/pull/4177))
 
+* Previous releases in the v1.12 series could be affected by several vulnerabilities:
+  * When using SSH connections through OpenTofu, the errors that were returned from attempting a connection could include unescaped input bytes.
+  * If using an attacker-controlled server to run `tofu` against, it might end up in high CPU consumption.
+  
+  These are now fixed by ([#4247](https://github.com/opentofu/opentofu/pull/4247))
+
 BUG FIXES:
 
 - Properly handle EDEADLK during provider installation. On Unix systems, the kernel may erroneously detect a deadlock between tofu processes using the global plugin cache. ([#4166](https://github.com/opentofu/opentofu/pull/4166))

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opentofu/opentofu
 
-go 1.26.3
+go 1.26.4
 
 // At the time of adding this configuration, the new Go feature introduced here https://github.com/golang/go/issues/67061,
 // was having a good amount of issues linked to, affecting AWS Firewall, GCP various services and a lot more.


### PR DESCRIPTION
Backports https://github.com/opentofu/opentofu/pull/4245 to fix #4242, #4243 and #4244 in OpenTofu v1.12.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
