### PR TITLE
Fix `tofu test` execution against a configuration containing `ephemeral` resource(s)

### DIFF
--- a/internal/command/e2etest/test_test.go
+++ b/internal/command/e2etest/test_test.go
@@ -120,3 +120,35 @@ func TestMockProviderComputedBlockCleanup(t *testing.T) {
 		t.Errorf("output doesn't have expected success string:\n%s", stdout)
 	}
 }
+
+func TestMockProviderWhenEphemeralInConfiguration(t *testing.T) {
+	// This test fetches providers from registry.
+	skipIfCannotAccessNetwork(t)
+
+	tf := e2e.NewBinary(t, tofuBin, filepath.Join("testdata", "mock-test-with-ephemeral-in-configuration"))
+
+	stdout, stderr, err := tf.Run("init")
+	if err != nil {
+		t.Errorf("unexpected error on 'init': %v", err)
+	}
+	if stderr != "" {
+		t.Errorf("unexpected stderr output on 'init':\n%s", stderr)
+	}
+	if stdout == "" {
+		t.Errorf("expected some output on 'init', got nothing")
+	}
+
+	stdout, stderr, err = tf.Run("test")
+	if err != nil {
+		if strings.Contains(stdout, "OpenTofu crashed! This is always indicative of a bug within OpenTofu.") {
+			t.Errorf("Bug reproduced: running `tofu test` against a configuration that has an ephemeral resource.\n"+
+				"This is the bug from https://github.com/opentofu/opentofu/issues/4251\n"+
+				"stdout:\n%s", stdout)
+			return
+		}
+		t.Errorf("unexpected error on 'tofu test': %v\nstderr:\n%s\nstdout:\n%s", err, stderr, stdout)
+	}
+	if !strings.Contains(stdout, "1 passed, 0 failed") {
+		t.Errorf("output doesn't have the expected success string:\n%s", stdout)
+	}
+}

--- a/internal/command/e2etest/testdata/mock-test-with-ephemeral-in-configuration/main.tf
+++ b/internal/command/e2etest/testdata/mock-test-with-ephemeral-in-configuration/main.tf
@@ -1,0 +1,30 @@
+# Minimal reproducer for https://github.com/opentofu/opentofu/issues/4251
+# Bug requires to run `tofu test` when the configuration contains also an `ephemeral` block
+
+terraform {
+  required_version = ">= 1.11.5"
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "3.8.1"
+    }
+    sleep = {
+      source  = "yottta/sleep"
+      version = "0.0.4"
+    }
+  }
+}
+
+resource "random_id" "test" {
+  byte_length = 2
+}
+
+ephemeral "random_password" "test" {
+  length = 10
+
+}
+
+resource "sleep_sleeper" "test" {
+  string_wo         = ephemeral.random_password.test.result
+  string_wo_version = 1
+}

--- a/internal/command/e2etest/testdata/mock-test-with-ephemeral-in-configuration/main.tftest.hcl
+++ b/internal/command/e2etest/testdata/mock-test-with-ephemeral-in-configuration/main.tftest.hcl
@@ -1,0 +1,10 @@
+mock_provider "random" {}
+
+run "happy_path" {
+  command = plan
+  assert {
+    condition     = sleep_sleeper.test.string_wo == null
+    error_message = "Incorrect content for sleep_sleeper.test.string_wo"
+
+  }
+}

--- a/internal/tofu/provider_for_test_framework.go
+++ b/internal/tofu/provider_for_test_framework.go
@@ -116,19 +116,28 @@ func (p providerForTest) ReadDataSource(_ context.Context, r providers.ReadDataS
 	return resp
 }
 
-func (p providerForTest) OpenEphemeralResource(_ context.Context, _ providers.OpenEphemeralResourceRequest) (resp providers.OpenEphemeralResourceResponse) {
-	// TODO ephemeral testing support - implement me when adding testing support
-	panic("implement me")
+func (p providerForTest) OpenEphemeralResource(_ context.Context, r providers.OpenEphemeralResourceRequest) (resp providers.OpenEphemeralResourceResponse) {
+	resSchema, _ := p.schema.SchemaForResourceType(addrs.EphemeralResourceMode, r.TypeName)
+
+	resp.Result, resp.Diagnostics = newMockValueComposer(r.TypeName).ComposeBySchema(resSchema.Block, r.Config, p.overrideValues)
+	return resp
 }
 
 func (p providerForTest) RenewEphemeralResource(_ context.Context, _ providers.RenewEphemeralResourceRequest) (resp providers.RenewEphemeralResourceResponse) {
 	// TODO ephemeral testing support - implement me when adding testing support
+
+	// In order to fix the issue reported in https://github.com/opentofu/opentofu/issues/4251, OpenEphemeralResource and CloseEphemeralResource
+	// had their `panic` call removed and implemented properly to ensure that `tofu test` can be executed against a
+	// configuration containing `ephemeral` blocks. The fix provided just fixed the panic without implementing any
+	// testing functionality for ephemeral resources. Therefore, RenewEphemeralResource has no reason to be implemented
+	// because it cannot be reached as it relies on OpenEphemeralResource to return a specific value in the RenewAt to
+	// have this called. Without any testing functionality to mock the value for RenewAt, this will never be called so
+	// we want to have the panic in place.
 	panic("implement me")
 }
 
 func (p providerForTest) CloseEphemeralResource(_ context.Context, _ providers.CloseEphemeralResourceRequest) (resp providers.CloseEphemeralResourceResponse) {
-	// TODO ephemeral testing support - implement me when adding testing support
-	panic("implement me")
+	return resp
 }
 
 // ValidateProviderConfig is irrelevant when provider is mocked or overridden.
@@ -148,7 +157,6 @@ func (p providerForTest) GetProviderSchema(ctx context.Context) providers.GetPro
 	providerSchema.ProviderMeta = providers.Schema{}
 	return providerSchema
 }
-
 
 // providerForTest doesn't configure its internal provider because it is mocked.
 func (p providerForTest) ConfigureProvider(context.Context, providers.ConfigureProviderRequest) providers.ConfigureProviderResponse {


### PR DESCRIPTION
Resolves #4251

This fix ensures that when `tofu test` is executed against a configuration containing an `ephemeral` block, the command runs successfully without panicking.
The changes added here, just fix the panic reported in #4251 but does not add any `tofu test` functionality around ephemeral resources. Therefore, the `OpenEphemeralResource` call will always return a generically mocked value without having a way to mock a specific value for it.

⚠️ This needs to be backported to v1.12, and possibly to v1.11.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
