### PR TITLE
[Backport][v1.12] fix: prevent panic in tofu login OAuth flow due to channel race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ SECURITY ADVISORIES:
 BUG FIXES:
 
 - Properly handle EDEADLK during provider installation. On Unix systems, the kernel may erroneously detect a deadlock between tofu processes using the global plugin cache. ([#4166](https://github.com/opentofu/opentofu/pull/4166))
+- Fix race condition while handling closing signals during `tofu login`, both when the signal is sent by the user and when the browser fails to successfully connect. ([4016](https://github.com/opentofu/opentofu/pull/4016))
 
 ## 1.12.1
 

--- a/internal/command/login.go
+++ b/internal/command/login.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/mitchellh/cli"
@@ -418,8 +419,14 @@ func (c *LoginCommand) interactiveGetTokenByCode(ctx context.Context, hostname s
 	}
 
 	// codeCh will allow our temporary HTTP server to transmit the OAuth code
-	// to the main execution path that follows.
-	codeCh := make(chan string)
+	// to the main execution path that follows. It is buffered so the handler
+	// can send without blocking even if the main goroutine has already moved on.
+	// Only the main goroutine may close codeCh, after all producers have stopped.
+	codeCh := make(chan string, 1)
+	// serverErrCh carries any unexpected error from server.Serve so that the
+	// main goroutine can handle it without a shared-state race on diags.
+	serverErrCh := make(chan error, 1)
+	var wg sync.WaitGroup
 	server := &http.Server{
 		Handler: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 			log.Printf("[TRACE] login: request to callback server")
@@ -442,12 +449,17 @@ func (c *LoginCommand) interactiveGetTokenByCode(ctx context.Context, hostname s
 				return
 			}
 
-			log.Printf("[TRACE] login: request contains an authorization code")
-
-			// Send the code to our blocking wait below, so that the token
-			// fetching process can continue.
-			codeCh <- gotCode
-			close(codeCh)
+			// Non-blocking send: only the first callback request succeeds.
+			// Duplicate or concurrent requests are rejected with 400 so that
+			// the handler never blocks on the already-full buffered channel.
+			select {
+			case codeCh <- gotCode:
+				log.Printf("[TRACE] login: request contains an authorization code")
+			default:
+				log.Printf("[WARN] login: ignoring duplicate callback request")
+				resp.WriteHeader(400)
+				return
+			}
 
 			log.Printf("[TRACE] login: returning response from callback server")
 
@@ -460,21 +472,13 @@ func (c *LoginCommand) interactiveGetTokenByCode(ctx context.Context, hostname s
 		}),
 	}
 	panicHandler := logging.PanicHandlerWithTraceFn()
-	go func() {
+	wg.Go(func() {
 		defer panicHandler()
 		err := server.Serve(listener)
 		if err != nil && err != http.ErrServerClosed {
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Can't start temporary login server",
-				fmt.Sprintf(
-					"The login process uses OAuth, which requires starting a temporary HTTP server on localhost. However, no TCP port numbers between %d and %d are available to create such a server.",
-					clientConfig.MinPort, clientConfig.MaxPort,
-				),
-			))
-			close(codeCh)
+			serverErrCh <- err
 		}
-	}()
+	})
 
 	oauthConfig := &oauth2.Config{
 		ClientID:    clientConfig.ID,
@@ -509,7 +513,6 @@ func (c *LoginCommand) interactiveGetTokenByCode(ctx context.Context, hostname s
 	view.WaitingForHostSignal()
 
 	var code string
-	var ok bool
 	select {
 	case <-c.ShutdownCh:
 		diags = diags.Append(
@@ -519,22 +522,36 @@ func (c *LoginCommand) interactiveGetTokenByCode(ctx context.Context, hostname s
 				"Current command was aborted by the calling code.",
 			),
 		)
-		code, ok = "", true
+    if err := server.Shutdown(ctx); err != nil {
+		log.Printf("[WARN] login: callback server shutdown failed: %s", err)
+	}
+		wg.Wait()
 		close(codeCh)
-	case code, ok = <-codeCh:
-	}
-
-	if !ok {
-		// If we got no code at all then the server wasn't able to start
-		// up, so we'll just give up.
 		return nil, diags
+	case serveErr := <-serverErrCh:
+		// The server failed to start up, so we'll just give up.
+		// No need to call Shutdown here: the server never started accepting
+		// requests, so there are no in-flight handler goroutines to wait for.
+		log.Printf("[ERROR] login: callback server error: %s", serveErr)
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Can't start temporary login server",
+			fmt.Sprintf(
+				"The login process uses OAuth, which requires starting a temporary HTTP server on localhost. However, no TCP port numbers between %d and %d are available to create such a server.",
+				clientConfig.MinPort, clientConfig.MaxPort,
+			),
+		))
+		wg.Wait()
+		close(codeCh)
+		return nil, diags
+	case code = <-codeCh:
 	}
 
-	if err := server.Close(); err != nil {
-		// The server will close soon enough when our process exits anyway,
-		// so we won't fuss about it for right now.
+	if err := server.Shutdown(ctx); err != nil {
 		log.Printf("[WARN] login: callback server can't shut down: %s", err)
 	}
+	wg.Wait()
+	close(codeCh)
 
 	if code == "" {
 		// empty code is not possible in happy path as it is validated in the HTTP handler of our callback server

--- a/internal/command/login_test.go
+++ b/internal/command/login_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/opentofu/opentofu/internal/command/workdir"
 	"github.com/opentofu/opentofu/internal/terminal"
@@ -368,4 +369,162 @@ func TestLogin(t *testing.T) {
 			t.Fatalf("missing expected error message\nwant: %s\nfull output:\n%s", want, got)
 		}
 	}, false))
+}
+
+// TestLoginOAuthCallbackRace verifies that no panic, deadlock, or data race
+// occurs when ShutdownCh fires concurrently with the OAuth callback completing.
+//
+// Before the fix, interactiveGetTokenByCode had multiple goroutines calling
+// close(codeCh), which could panic with "close of closed channel". The fix
+// uses server.Shutdown() to wait for all in-flight handler goroutines to
+// finish before closing codeCh, ensuring the main goroutine is the sole owner
+// of the channel's lifetime.
+//
+// Run with the race detector to catch any remaining data races:
+//
+//	go test -race -run TestLoginOAuthCallbackRace ./internal/command/
+func TestLoginOAuthCallbackRace(t *testing.T) {
+	s := httptest.NewServer(oauthserver.Handler)
+	defer s.Close()
+
+	const iterations = 200
+
+	for i := range iterations {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("iteration %d: panic in LoginCommand.Run (would crash tofu login): %v", i, r)
+				}
+			}()
+
+			workDir := t.TempDir()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			loginView, done := testView(t)
+			defer done(t)
+
+			creds := cliconfig.EmptyCredentialsSourceForTests(
+				filepath.Join(workDir, "credentials.tfrc.json"),
+			)
+			svcs := disco.New(
+				disco.WithCredentials(creds),
+				disco.WithHTTPClient(httpclient.New(ctx)),
+			)
+			svcs.ForceHostServices(svchost.Hostname("example.com"), map[string]any{
+				"login.v1": map[string]any{
+					"client": "anything-goes",
+					"authz":  s.URL + "/authz",
+					"token":  s.URL + "/token",
+				},
+			})
+
+			abortCh := make(chan struct{})
+			c := &LoginCommand{
+				Meta: Meta{
+					WorkingDir:      workdir.NewDir("."),
+					View:            loginView,
+					BrowserLauncher: webbrowser.NewMockLauncher(ctx),
+					Services:        svcs,
+					ShutdownCh:      abortCh,
+				},
+			}
+
+			defer testInputMap(t, map[string]string{
+				"approve": "yes",
+			})()
+
+			statusCh := make(chan int, 1)
+			go func() {
+				statusCh <- c.Run([]string{"example.com"})
+			}()
+
+			// Fire ShutdownCh at varying delays to hit different timing windows:
+			// - delay 0: ShutdownCh fires before MockLauncher visits the callback URL
+			// - small delay: races with the HTTP callback handler
+			// - larger delay: fires after OAuth is already complete
+			go func() {
+				time.Sleep(time.Duration(i%5) * time.Millisecond)
+				close(abortCh)
+			}()
+
+			select {
+			case <-statusCh:
+				// exit status 0 (OAuth won) or 1 (ShutdownCh won) are both valid
+			case <-time.After(10 * time.Second):
+				t.Errorf("iteration %d: LoginCommand.Run did not return — possible deadlock", i)
+			}
+		}()
+	}
+}
+
+// TestLoginOAuthCallbackNoPanicOnAbort verifies that sending to ShutdownCh
+// before the OAuth callback arrives causes a clean abort without deadlock.
+func TestLoginOAuthCallbackNoPanicOnAbort(t *testing.T) {
+	s := httptest.NewServer(oauthserver.Handler)
+	defer s.Close()
+
+	for i := range 50 {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("iteration %d: unexpected panic: %v", i, r)
+				}
+			}()
+
+			workDir := t.TempDir()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			loginView, done := testView(t)
+			defer done(t)
+
+			creds := cliconfig.EmptyCredentialsSourceForTests(
+				filepath.Join(workDir, "credentials.tfrc.json"),
+			)
+			svcs := disco.New(
+				disco.WithCredentials(creds),
+				disco.WithHTTPClient(httpclient.New(ctx)),
+			)
+			svcs.ForceHostServices(svchost.Hostname("example.com"), map[string]any{
+				"login.v1": map[string]any{
+					"client": "anything-goes",
+					"authz":  s.URL + "/authz",
+					"token":  s.URL + "/token",
+				},
+			})
+
+			// No MockLauncher: the OAuth callback will never arrive, so ShutdownCh
+			// is the only way to unblock the command.
+			abortCh := make(chan struct{})
+			c := &LoginCommand{
+				Meta: Meta{
+					WorkingDir: workdir.NewDir("."),
+					View:       loginView,
+					Services:   svcs,
+					ShutdownCh: abortCh,
+				},
+			}
+
+			defer testInputMap(t, map[string]string{
+				"approve": "yes",
+			})()
+
+			statusCh := make(chan int, 1)
+			go func() {
+				statusCh <- c.Run([]string{"example.com"})
+			}()
+
+			close(abortCh)
+
+			select {
+			case status := <-statusCh:
+				if status != 1 {
+					t.Errorf("iteration %d: expected exit status 1 after abort, got %d", i, status)
+				}
+			case <-time.After(10 * time.Second):
+				t.Errorf("iteration %d: LoginCommand.Run did not return after ShutdownCh — deadlock", i)
+			}
+		}()
+	}
 }


### PR DESCRIPTION
This backports #4016 that fixed #3988 to OpenTofu v1.12.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
