### PR TITLE
[Backport][v1.12] Ignore blank spaces from TF_ENCRYPTION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ The v1.12.x release series is supported until **February 1 2027**.
 
 ## 1.12.3 (Unreleased)
 
+BUG FIXES:
+
+- Properly handle `TF_ENCRYPTION` with only blank spaces. ([#4265](https://github.com/opentofu/opentofu/pull/4265))
+
+
 ## 1.12.2
 
 SECURITY ADVISORIES:

--- a/internal/command/e2etest/encryption_test.go
+++ b/internal/command/e2etest/encryption_test.go
@@ -265,3 +265,27 @@ func TestEncryptionFlow(t *testing.T) {
 		requireUnencryptedState()
 	}
 }
+
+func TestEncryptionEnvironmentVariable(t *testing.T) {
+	// This test reaches out to registry.opentofu.org to download the
+	// mock provider, so it can only run if network access is allowed
+	skipIfCannotAccessNetwork(t)
+
+	// There is a lot of setup / helpers defined.  Actual test logic is below.
+
+	fixturePath := filepath.Join("testdata", "encryption-flow")
+	tf := e2e.NewBinary(t, tofuBin, fixturePath)
+
+	// This test reproduces the situation reported in https://github.com/opentofu/opentofu/issues/4262
+	t.Run("with TF_ENCRYPTION containing only a simple space", func(t *testing.T) {
+		// Setting this env var at the test level will force `tf.Run` to pick this up
+		t.Setenv("TF_ENCRYPTION", " ")
+		_, stderr, err := tf.Run("init")
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+		if stderr != "" {
+			t.Errorf("unexpected stderr output:\n%s", stderr)
+		}
+	})
+}

--- a/internal/command/meta_encryption.go
+++ b/internal/command/meta_encryption.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/encryption"
@@ -43,7 +44,7 @@ func (m *Meta) EncryptionFromModule(ctx context.Context, module *configs.Module)
 	cfg := module.Encryption
 	var diags tfdiags.Diagnostics
 
-	env := os.Getenv(encryptionConfigEnvName)
+	env := strings.TrimSpace(os.Getenv(encryptionConfigEnvName))
 	if len(env) != 0 {
 		envCfg, envDiags := config.LoadConfigFromString(encryptionConfigEnvName, env)
 		diags = diags.Append(envDiags)


### PR DESCRIPTION
This backports #4265 (fixing #4262) to v1.12.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
