### PR TITLE
use an addrs.Map in GetImport with AbsResourceInstance as key

### DIFF
--- a/internal/tofu/context_import.go
+++ b/internal/tofu/context_import.go
@@ -101,14 +101,14 @@ func (i *ImportTarget) ResolvedAddr() *addrs.AbsResourceInstance {
 // Import targets' addresses are not fully known from the get-go, and could only be resolved later when walking
 // the graph. This struct helps keep track of the resolved imports, mostly for validation that all imports
 // have been addressed and point to an actual configuration.
-// The key of the map is a string representation of the address, and the value is an EvaluatedConfigImportTarget.
+// The key of the map is a AbsResourceInstance, and the value is an EvaluatedConfigImportTarget.
 type ImportResolver struct {
 	mu      sync.RWMutex
-	imports map[string]EvaluatedConfigImportTarget
+	imports addrs.Map[addrs.AbsResourceInstance, EvaluatedConfigImportTarget]
 }
 
 func NewImportResolver() *ImportResolver {
-	return &ImportResolver{imports: make(map[string]EvaluatedConfigImportTarget)}
+	return &ImportResolver{imports: addrs.MakeMap[addrs.AbsResourceInstance, EvaluatedConfigImportTarget]()}
 }
 
 // ValidateImportIDs is used during the validation phase to validate the import IDs/Identities of all import targets.
@@ -309,23 +309,21 @@ func (ri *ImportResolver) resolveImport(ctx context.Context, importTarget *Impor
 	ri.mu.Lock()
 	defer ri.mu.Unlock()
 
-	resolvedImportKey := importAddress.String()
-
-	if importTarget, exists := ri.imports[resolvedImportKey]; exists {
+	if existing, exists := ri.imports.GetOk(importAddress); exists {
 		return diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  fmt.Sprintf("Duplicate import configuration for %q", importAddress),
-			Detail:   fmt.Sprintf("An import block for the resource %q was already declared at %s. A resource can have only one import block.", importAddress, importTarget.Config.DeclRange),
-			Subject:  importTarget.Config.DeclRange.Ptr(),
+			Detail:   fmt.Sprintf("An import block for the resource %q was already declared at %s. A resource can have only one import block.", importAddress, existing.Config.DeclRange),
+			Subject:  existing.Config.DeclRange.Ptr(),
 		})
 	}
 
-	ri.imports[resolvedImportKey] = EvaluatedConfigImportTarget{
+	ri.imports.Put(importAddress, EvaluatedConfigImportTarget{
 		Config:   importTarget.Config,
 		Addr:     importAddress,
 		ID:       importId,
 		Identity: importIdentity,
-	}
+	})
 
 	if keyData == EvalDataForNoInstanceKey {
 		log.Printf("[TRACE] importResolver: resolved a singular import target %s", importAddress)
@@ -379,21 +377,15 @@ func (ri *ImportResolver) GetAllImports() []EvaluatedConfigImportTarget {
 	ri.mu.RLock()
 	defer ri.mu.RUnlock()
 
-	var allImports []EvaluatedConfigImportTarget
-	for _, importTarget := range ri.imports {
-		allImports = append(allImports, importTarget)
-	}
-	return allImports
+	return ri.imports.Values()
 }
 
 func (ri *ImportResolver) GetImport(address addrs.AbsResourceInstance) *EvaluatedConfigImportTarget {
 	ri.mu.RLock()
 	defer ri.mu.RUnlock()
 
-	for _, importTarget := range ri.imports {
-		if importTarget.Addr.Equal(address) {
-			return &importTarget
-		}
+	if importTarget, exists := ri.imports.GetOk(address); exists {
+		return &importTarget
 	}
 	return nil
 }
@@ -404,14 +396,14 @@ func (ri *ImportResolver) addCLIImportTarget(importTarget *ImportTarget) {
 	ri.mu.Lock()
 	defer ri.mu.Unlock()
 	importAddress := importTarget.CommandLineImportTarget.Addr
-	ri.imports[importAddress.String()] = EvaluatedConfigImportTarget{
-		// Since this import target originates from the CLI, and we have no config block for it
-		// setting nil value to Config here to reuse Context.postExpansionImportValidation,
-		// and there should be no possible paths to dereference this with a nil value during the import command
+	// Since this import target originates from the CLI, and we have no config block for it
+	// setting nil value to Config here to reuse Context.postExpansionImportValidation,
+	// and there should be no possible paths to dereference this with a nil value during the import command
+	ri.imports.Put(importAddress, EvaluatedConfigImportTarget{
 		Config: nil,
 		Addr:   importAddress,
 		ID:     importTarget.CommandLineImportTarget.ID,
-	}
+	})
 }
 
 // Import takes already-created external resources and brings them

--- a/internal/tofu/context_import.go
+++ b/internal/tofu/context_import.go
@@ -101,7 +101,7 @@ func (i *ImportTarget) ResolvedAddr() *addrs.AbsResourceInstance {
 // Import targets' addresses are not fully known from the get-go, and could only be resolved later when walking
 // the graph. This struct helps keep track of the resolved imports, mostly for validation that all imports
 // have been addressed and point to an actual configuration.
-// The key of the map is a AbsResourceInstance, and the value is an EvaluatedConfigImportTarget.
+// The key of the map is an AbsResourceInstance, and the value is an EvaluatedConfigImportTarget.
 type ImportResolver struct {
 	mu      sync.RWMutex
 	imports addrs.Map[addrs.AbsResourceInstance, EvaluatedConfigImportTarget]

--- a/internal/tofu/context_import_test.go
+++ b/internal/tofu/context_import_test.go
@@ -1574,3 +1574,94 @@ aws_instance.foo:
   provider = provider["registry.opentofu.org/hashicorp/aws"]
   foo = bar
 `
+
+func TestImportResolverGetImport(t *testing.T) {
+	makeAddr := func(module addrs.ModuleInstance, typeName, name string, key addrs.InstanceKey) addrs.AbsResourceInstance {
+		return module.ResourceInstance(addrs.ManagedResourceMode, typeName, name, key)
+	}
+
+	addrNoKey := makeAddr(addrs.RootModuleInstance, "aws_instance", "foo", addrs.NoKey)
+	addrIntKey := makeAddr(addrs.RootModuleInstance, "aws_instance", "bar", addrs.IntKey(0))
+	addrStringKey := makeAddr(addrs.RootModuleInstance, "aws_sqs_queue", "baz", addrs.StringKey("mykey"))
+	addrInModule := makeAddr(addrs.RootModuleInstance.Child("fruit", addrs.StringKey("apple")), "aws_sqs_queue", "color", addrs.StringKey("red"))
+
+	tests := []struct {
+		name    string
+		imports addrs.Map[addrs.AbsResourceInstance, EvaluatedConfigImportTarget]
+		lookup  addrs.AbsResourceInstance
+		wantID  string
+		wantNil bool
+	}{
+		{
+			name:    "found by address without key",
+			imports: addrs.MakeMap(addrs.MakeMapElem(addrNoKey, EvaluatedConfigImportTarget{Addr: addrNoKey, ID: "i-1234"})),
+			lookup:  addrNoKey,
+			wantID:  "i-1234",
+		},
+		{
+			name:    "found by address with int key",
+			imports: addrs.MakeMap(addrs.MakeMapElem(addrIntKey, EvaluatedConfigImportTarget{Addr: addrIntKey, ID: "i-5678"})),
+			lookup:  addrIntKey,
+			wantID:  "i-5678",
+		},
+		{
+			name:    "found by address with string key",
+			imports: addrs.MakeMap(addrs.MakeMapElem(addrStringKey, EvaluatedConfigImportTarget{Addr: addrStringKey, ID: "queue-url"})),
+			lookup:  addrStringKey,
+			wantID:  "queue-url",
+		},
+		{
+			name:    "found by address in module instance",
+			imports: addrs.MakeMap(addrs.MakeMapElem(addrInModule, EvaluatedConfigImportTarget{Addr: addrInModule, ID: "queue-in-module"})),
+			lookup:  addrInModule,
+			wantID:  "queue-in-module",
+		},
+		{
+			name:    "not found returns nil",
+			imports: addrs.MakeMap(addrs.MakeMapElem(addrNoKey, EvaluatedConfigImportTarget{Addr: addrNoKey, ID: "i-1234"})),
+			lookup:  addrIntKey,
+			wantNil: true,
+		},
+		{
+			name:    "empty resolver returns nil",
+			imports: addrs.MakeMap[addrs.AbsResourceInstance, EvaluatedConfigImportTarget](),
+			lookup:  addrNoKey,
+			wantNil: true,
+		},
+		{
+			name: "correct match among many entries",
+			imports: addrs.MakeMap(
+				addrs.MakeMapElem(addrNoKey, EvaluatedConfigImportTarget{Addr: addrNoKey, ID: "i-1234"}),
+				addrs.MakeMapElem(addrIntKey, EvaluatedConfigImportTarget{Addr: addrIntKey, ID: "i-5678"}),
+				addrs.MakeMapElem(addrStringKey, EvaluatedConfigImportTarget{Addr: addrStringKey, ID: "queue-url"}),
+				addrs.MakeMapElem(addrInModule, EvaluatedConfigImportTarget{Addr: addrInModule, ID: "queue-in-module"}),
+			),
+			lookup: addrStringKey,
+			wantID: "queue-url",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ri := &ImportResolver{imports: tc.imports}
+			got := ri.GetImport(tc.lookup)
+
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil, got %v", got)
+				}
+				return
+			}
+
+			if got == nil {
+				t.Fatal("expected non-nil result, got nil")
+			}
+			if got.ID != tc.wantID {
+				t.Errorf("expected ID %q, got %q", tc.wantID, got.ID)
+			}
+			if !got.Addr.Equal(tc.lookup) {
+				t.Errorf("expected Addr %s, got %s", tc.lookup, got.Addr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
While investigating and testing #4252, I noticed we use strings as keys. To make it consistent with newer code and more robust (ensuring other types are not used there while being converted to strings), I'm refactoring to use an `addrs.Map` with `AbsResourceInstance` as the key type.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
