### PR TITLE
tofu2024: Support for `depends_on` in the new language runtime

### DIFF
--- a/internal/instances/instance_key_data.go
+++ b/internal/instances/instance_key_data.go
@@ -6,6 +6,8 @@
 package instances
 
 import (
+	"maps"
+
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -30,4 +32,36 @@ type RepetitionData struct {
 	// For correct operation, EachKey must always be either of type cty.String
 	// or cty.Number if not nil.
 	EachKey, EachValue cty.Value
+}
+
+// AllValueMarks returns a mark set containing the full set of marks across
+// all values inside the receiver.
+//
+// Use this instead of accessing each field in turn because future changes
+// might add new fields to [RepetitionData] which will be included in this
+// function's result without having to update every caller.
+func (rd *RepetitionData) AllValueMarks() cty.ValueMarks {
+	if rd == nil {
+		return nil
+	}
+	var ret cty.ValueMarks
+	addMore := func(v cty.Value) {
+		// We make some effort here to avoid creating additional temporary
+		// cty.ValueMarks values because [cty.Value.Marks] already makes it
+		// copy itself anyway, so we'd prefer to just write into the set
+		// it returned than to make yet another copy of it.
+		marks := v.Marks()
+		if len(marks) == 0 {
+			return
+		}
+		if ret == nil {
+			ret = marks
+			return
+		}
+		maps.Copy(ret, marks)
+	}
+	addMore(rd.CountIndex)
+	addMore(rd.EachKey)
+	addMore(rd.EachValue)
+	return ret
 }

--- a/internal/instances/instance_key_data.go
+++ b/internal/instances/instance_key_data.go
@@ -32,6 +32,31 @@ type RepetitionData struct {
 	// For correct operation, EachKey must always be either of type cty.String
 	// or cty.Number if not nil.
 	EachKey, EachValue cty.Value
+
+	// DecisionMarks describes any cty marks that were present on values that
+	// were directly involved in the decision to include the instance that this
+	// RepetitionData object belongs to.
+	//
+	// For example, in the case of for_each with a map this would include any
+	// marks from the map itself but not marks from the elements inside the map.
+	// The elements' own marks would appear on EachValue instead.
+	//
+	// NOTE: The old language runtime in "package tofu" does not populate or
+	// make use of this field. It is used only by the new runtime's evaluator,
+	// in the packages under "internal/lang/eval".
+	DecisionMarks cty.ValueMarks
+}
+
+// HasSymbolValues returns true if any of the fields that correspond to
+// additional symbols that would describe the current item in a repetition
+// are set to non-nil values.
+//
+// This is a somewhat-imprecise signal for "is using repetition at all", since
+// in the singleton or conditional enabled cases none of the value fields are
+// populated, but this should only be used for debug-related information like
+// logging and not for making any real behavioral decisions.
+func (rd *RepetitionData) HasSymbolValues() bool {
+	return rd != nil && rd.CountIndex != cty.NilVal || rd.EachKey != cty.NilVal || rd.EachValue != cty.NilVal
 }
 
 // AllValueMarks returns a mark set containing the full set of marks across
@@ -40,11 +65,18 @@ type RepetitionData struct {
 // Use this instead of accessing each field in turn because future changes
 // might add new fields to [RepetitionData] which will be included in this
 // function's result without having to update every caller.
+//
+// Note that this only reports marks directly on the enclosed values and not
+// marks on values nested within them.
 func (rd *RepetitionData) AllValueMarks() cty.ValueMarks {
 	if rd == nil {
 		return nil
 	}
 	var ret cty.ValueMarks
+	if len(rd.DecisionMarks) != 0 {
+		ret = make(cty.ValueMarks)
+		maps.Copy(ret, rd.DecisionMarks)
+	}
 	addMore := func(v cty.Value) {
 		// We make some effort here to avoid creating additional temporary
 		// cty.ValueMarks values because [cty.Value.Marks] already makes it

--- a/internal/lang/eval/internal/configgraph/instances.go
+++ b/internal/lang/eval/internal/configgraph/instances.go
@@ -105,6 +105,7 @@ func compileInstances[T any](
 		ValueMarks: valueMarks,
 	}
 	for key, repData := range insts {
+		repData.DecisionMarks = valueMarks
 		// We transfer valueMarks to the each.key, each.value and count.index
 		// values because valueMarks are the marks on whatever value we used to
 		// decide which instances exist, and so any reference to those

--- a/internal/lang/eval/internal/configgraph/module_call.go
+++ b/internal/lang/eval/internal/configgraph/module_call.go
@@ -95,7 +95,17 @@ var _ exprs.Valuer = (*ModuleCall)(nil)
 func (c *ModuleCall) Instances(ctx context.Context) map[addrs.InstanceKey]*ModuleCallInstance {
 	// We ignore the diagnostics here because they will be returned by
 	// the Value method instead.
-	result, _ := c.decideInstances(ctx)
+	result, diags := c.decideInstances(ctx)
+	if diags.HasErrors() && result == nil {
+		// If decideInstances fails for grapheval-related reasons, such as a
+		// dependency cycle, then it won't produce any result at all. The
+		// errors from that would be collected by a concurrent
+		// [Resource.CheckAll] and so we just report no instances here to
+		// allow things to unwind and report that error.
+		// (If decideInstances returns nil without returning any errors then
+		// that's a bug in decideInstances that should be fixed there.)
+		return nil
+	}
 	return result.Instances
 }
 
@@ -304,6 +314,13 @@ func (c *ModuleCall) Value(ctx context.Context) (cty.Value, tfdiags.Diagnostics)
 	// we have and then collect their individual results into our overall
 	// return value.
 	selection, diags := c.decideInstances(ctx)
+	if diags.HasErrors() && selection == nil {
+		// If decideInstances fails for grapheval-related reasons, such as a
+		// dependency cycle, then it won't produce any result at all, but we
+		// still want to let the diagnostics propagate upwards so that the
+		// error gets reported.
+		return exprs.AsEvalError(cty.DynamicVal), diags
+	}
 	return valueForInstances(ctx, selection).WithMarks(sourceMarks), diags
 }
 

--- a/internal/lang/eval/internal/configgraph/provider_config.go
+++ b/internal/lang/eval/internal/configgraph/provider_config.go
@@ -75,7 +75,17 @@ var _ exprs.Valuer = (*ProviderConfig)(nil)
 func (p *ProviderConfig) Instances(ctx context.Context) map[addrs.InstanceKey]*ProviderInstance {
 	// We ignore the diagnostics here because they will be returned by
 	// the Value method instead.
-	result, _ := p.decideInstances(ctx)
+	result, diags := p.decideInstances(ctx)
+	if diags.HasErrors() && result == nil {
+		// If decideInstances fails for grapheval-related reasons, such as a
+		// dependency cycle, then it won't produce any result at all. The
+		// errors from that would be collected by a concurrent
+		// [Resource.CheckAll] and so we just report no instances here to
+		// allow things to unwind and report that error.
+		// (If decideInstances returns nil without returning any errors then
+		// that's a bug in decideInstances that should be fixed there.)
+		return nil
+	}
 	return result.Instances
 }
 
@@ -93,6 +103,13 @@ func (p *ProviderConfig) StaticCheckTraversal(traversal hcl.Traversal) tfdiags.D
 // Value implements exprs.Valuer.
 func (p *ProviderConfig) Value(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
 	selection, diags := p.decideInstances(ctx)
+	if diags.HasErrors() && selection == nil {
+		// If decideInstances fails for grapheval-related reasons, such as a
+		// dependency cycle, then it won't produce any result at all, but we
+		// still want to let the diagnostics propagate upwards so that the
+		// error gets reported.
+		return exprs.AsEvalError(cty.DynamicVal), diags
+	}
 	return valueForInstances(ctx, selection), diags
 }
 

--- a/internal/lang/eval/internal/configgraph/resource.go
+++ b/internal/lang/eval/internal/configgraph/resource.go
@@ -81,7 +81,17 @@ func (r *Resource) IsExpansionPlaceholder() bool {
 func (r *Resource) Instances(ctx context.Context) map[addrs.InstanceKey]*ResourceInstance {
 	// We ignore the diagnostics here because they will be returned by
 	// the Value method instead.
-	result, _ := r.decideInstances(ctx)
+	result, diags := r.decideInstances(ctx)
+	if diags.HasErrors() && result == nil {
+		// If decideInstances fails for grapheval-related reasons, such as a
+		// dependency cycle, then it won't produce any result at all. The
+		// errors from that would be collected by a concurrent
+		// [Resource.CheckAll] and so we just report no instances here to
+		// allow things to unwind and report that error.
+		// (If decideInstances returns nil without returning any errors then
+		// that's a bug in decideInstances that should be fixed there.)
+		return nil
+	}
 	return result.Instances
 }
 
@@ -93,6 +103,13 @@ func (r *Resource) StaticCheckTraversal(traversal hcl.Traversal) tfdiags.Diagnos
 // Value implements exprs.Valuer.
 func (r *Resource) Value(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
 	selection, diags := r.decideInstances(ctx)
+	if diags.HasErrors() && selection == nil {
+		// If decideInstances fails for grapheval-related reasons, such as a
+		// dependency cycle, then it won't produce any result at all, but we
+		// still want to let the diagnostics propagate upwards so that the
+		// error gets reported.
+		return exprs.AsEvalError(cty.DynamicVal), diags
+	}
 	return valueForInstances(ctx, selection), diags
 }
 

--- a/internal/lang/eval/internal/configgraph/resource_instance.go
+++ b/internal/lang/eval/internal/configgraph/resource_instance.go
@@ -37,9 +37,6 @@ type ResourceInstance struct {
 	// is the provider to use when asking for config validation, etc.
 	Provider addrs.Provider
 
-	// Used to ensure marks
-	AdditionalMarks cty.ValueMarks
-
 	// ConfigValuer is a valuer for producing the object value representing
 	// the configuration for this object. How the final configuration value
 	// is chosen is decided by whatever created this object, but most typically
@@ -112,9 +109,6 @@ func (ri *ResourceInstance) ConfigValue(ctx context.Context) (v cty.Value, diags
 		// will only ever receive validated configuration values.
 		return exprs.AsEvalError(cty.DynamicVal), diags
 	}
-
-	// Ensure marks from repetition data (and other sources) make it into the config value
-	configVal = configVal.WithMarks(ri.AdditionalMarks)
 
 	return configVal, diags
 }

--- a/internal/lang/eval/internal/configgraph/resource_instance_deps.go
+++ b/internal/lang/eval/internal/configgraph/resource_instance_deps.go
@@ -37,6 +37,15 @@ type ResourceInstanceMark struct {
 	instance *ResourceInstance
 }
 
+// NewResourceInstanceMark constructs a new [ResourceInstanceMark] referring
+// to the given resource instance.
+//
+// This is here so that code in other packages can describe dependencies caused
+// by language features that this package is not aware of.
+func NewResourceInstanceMark(inst *ResourceInstance) ResourceInstanceMark {
+	return ResourceInstanceMark{inst}
+}
+
 // ContributingResourceInstances returns an iterable sequence of all of the
 // resource instances whose result values may have contributed to the
 // given value.

--- a/internal/lang/eval/internal/configgraph/resource_instance_deps.go
+++ b/internal/lang/eval/internal/configgraph/resource_instance_deps.go
@@ -7,6 +7,7 @@ package configgraph
 
 import (
 	"iter"
+	"maps"
 
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/ctymarks"
@@ -129,4 +130,29 @@ func ResourceInstanceAddrs(insts iter.Seq[*ResourceInstance]) iter.Seq[addrs.Abs
 			}
 		}
 	}
+}
+
+// IsDependencyMark returns true if the given value is something that could
+// be used to mark a [cty.Value] to represent a "dependency".
+//
+// "Dependency" here means that some sort of externally-visible change must
+// be made before the associated value could be used during the apply phase.
+//
+// Currently only values of type [ResourceInstanceMark] are considered to be
+// dependency-related, but that might change in future if we begin tracking
+// other information about how values relate to changes that will happen during
+// the apply phase.
+func IsDependencyMark(mark any) bool {
+	// Currently only [ResourceInstanceMark] is considered to be
+	// "dependency-related".
+	_, ok := mark.(ResourceInstanceMark)
+	return ok
+}
+
+// RemoveNonDependencyMarks modifies the given mark set in-place to remove
+// any marks for which [IsDependencyMark] returns true.
+func RemoveNonDependencyMarks(from cty.ValueMarks) {
+	maps.DeleteFunc(from, func(mark any, _ struct{}) bool {
+		return !IsDependencyMark(mark)
+	})
 }

--- a/internal/lang/eval/internal/evalglue/module.go
+++ b/internal/lang/eval/internal/evalglue/module.go
@@ -90,6 +90,22 @@ type ModuleCall struct {
 	// between old-style and new-style modules.)
 	ProvidersFromParent configgraph.CompileProviderConfigRef
 
+	// DependencyMarks are additional marks that should be applied to the
+	// configuration values of anything that interacts with systems outside of
+	// OpenTofu (currently: resource instances and provider instances) to
+	// represent "whole-module-call" dependencies.
+	//
+	// For example, package tofu2024 uses this to deal with the "depends_on"
+	// meta-argument in a "module" block, which behaves as if it is declaring
+	// additional explicit dependencies for every resource instance or provider
+	// instance declared inside the module.
+	//
+	// Although this could in theory allow arbitrary cty marks of any type,
+	// callers should include only marks that represent dependencies that must
+	// be taken into account during the apply phase or else the results are
+	// likely to be quite confusing.
+	DependencyMarks cty.ValueMarks
+
 	// AllowImpureFunctions controls whether to allow full use of a small
 	// number of functions that produce different results each time they are
 	// called, such as "timestamp".

--- a/internal/lang/eval/internal/tofu2024/compile.go
+++ b/internal/lang/eval/internal/tofu2024/compile.go
@@ -94,6 +94,7 @@ func CompileModuleInstance(
 		module.ProviderRequirements.RequiredProviders,
 		call.CalleeAddr,
 		call.EvalContext.Providers,
+		call.DependencyMarks,
 	)
 
 	providersFromParent := call.ProvidersFromParent
@@ -107,6 +108,7 @@ func CompileModuleInstance(
 		providersFromParent, ret.missingProviders = compileProviderConfigRefMissingInRoot(
 			module.ProviderRequirements.RequiredProviders,
 			call.EvalContext.Providers,
+			call.DependencyMarks,
 		)
 	}
 	// Add all of our local providerConfigNodes to the provider ref chain.
@@ -141,6 +143,7 @@ func CompileModuleInstance(
 		call.CalleeAddr,
 		call.EvalContext.Providers,
 		call.EvaluationGlue.ResourceInstanceValue,
+		call.DependencyMarks,
 	)
 
 	// Now that we've assembled all of the innards of the module instance,

--- a/internal/lang/eval/internal/tofu2024/compile_module_calls.go
+++ b/internal/lang/eval/internal/tofu2024/compile_module_calls.go
@@ -49,7 +49,7 @@ func compileModuleInstanceModuleCalls(
 			Addr:             addr.Absolute(moduleInstanceAddr),
 			DeclRange:        tfdiags.SourceRangeFromHCL(config.DeclRange),
 			ParentSourceAddr: parentSourceAddr,
-			InstanceSelector: compileInstanceSelector(ctx, declScope, config.ForEach, config.Count, config.Enabled),
+			InstanceSelector: compileInstanceSelector(ctx, declScope, config.ForEach, config.Count, config.Enabled, parentCall.DependencyMarks),
 			SourceAddrValuer: configgraph.ValuerOnce(exprs.NewClosure(
 				exprs.EvalableHCLExpression(config.Source),
 				declScope,
@@ -133,9 +133,10 @@ func compileModuleInstanceModuleCalls(
 						modInst, diags := mod.CompileModuleInstance(ctx, calleeAddr, &evalglue.ModuleCall{
 							InputValues:          exprs.ConstantValuer(inputs),
 							AllowImpureFunctions: parentCall.AllowImpureFunctions,
-							EvalContext:          parentCall.EvalContext,
-							EvaluationGlue:       parentCall.EvaluationGlue,
-							ProvidersFromParent:  proxyProviderCompiler,
+							// TODO: DependencyMarks, combining parentCall.DependencyMarks and new marks from our own depends_on
+							EvalContext:         parentCall.EvalContext,
+							EvaluationGlue:      parentCall.EvaluationGlue,
+							ProvidersFromParent: proxyProviderCompiler,
 						})
 						if diags.HasErrors() {
 							return nil, diags

--- a/internal/lang/eval/internal/tofu2024/compile_module_calls.go
+++ b/internal/lang/eval/internal/tofu2024/compile_module_calls.go
@@ -7,6 +7,7 @@ package tofu2024
 
 import (
 	"context"
+	"maps"
 
 	"github.com/zclconf/go-cty/cty"
 
@@ -51,13 +52,13 @@ func compileModuleInstanceModuleCalls(
 		// the resulting marks on the count.index, each.key, and/or each.value
 		// results because that means it'll get evaluated only once per resource
 		// instead of separately for each resource instance.
-		deps := compileDependsOn(config.DependsOn, declScope, parentCall.DependencyMarks)
+		sharedDeps, compileInstanceDeps := compileDependsOn(config.DependsOn, declScope, parentCall.DependencyMarks)
 
 		ret[addr] = &configgraph.ModuleCall{
 			Addr:             addr.Absolute(moduleInstanceAddr),
 			DeclRange:        tfdiags.SourceRangeFromHCL(config.DeclRange),
 			ParentSourceAddr: parentSourceAddr,
-			InstanceSelector: compileInstanceSelector(ctx, declScope, config.ForEach, config.Count, config.Enabled, deps),
+			InstanceSelector: compileInstanceSelector(ctx, declScope, config.ForEach, config.Count, config.Enabled, sharedDeps),
 			SourceAddrValuer: configgraph.ValuerOnce(exprs.NewClosure(
 				exprs.EvalableHCLExpression(config.Source),
 				declScope,
@@ -111,17 +112,7 @@ func compileModuleInstanceModuleCalls(
 				}
 
 				instanceScope := instanceLocalScope(declScope, repData)
-
-				// We passed the marks from depends_on through the instance
-				// selector and so any dependency-related marks from there
-				// should be passed down to the child module as inherited
-				// dependency marks.
-				// TODO: This also includes any dependencies that come directly
-				// from expressions written in the count, for_each, or enabled
-				// argument. Is that acceptable or do we need to constrain this
-				// only what came from the depends_on argument?
-				childDependencyMarks := repData.AllValueMarks()
-				configgraph.RemoveNonDependencyMarks(childDependencyMarks)
+				instanceDeps := compileInstanceDeps(instanceScope)
 
 				// Apply passed providers to the provider ref chain.
 				// TODO: consider using the required_providers block to validate this further.
@@ -149,7 +140,26 @@ func compileModuleInstanceModuleCalls(
 						return mod.ValidateModuleInputs(ctx, v)
 					},
 					compileChild: func(ctx context.Context, inputs cty.Value, providersFromParent configgraph.CompileProviderConfigRef) (configgraph.Maybe[evalglue.CompiledModuleInstance], tfdiags.Diagnostics) {
-						modInst, diags := mod.CompileModuleInstance(ctx, calleeAddr, &evalglue.ModuleCall{
+						var diags tfdiags.Diagnostics
+
+						// We passed the marks from depends_on through the instance
+						// selector and so any dependency-related marks from there
+						// should be passed down to the child module as inherited
+						// dependency marks.
+						// TODO: This also includes any dependencies that come directly
+						// from expressions written in the count, for_each, or enabled
+						// argument. Is that acceptable or do we need to constrain this
+						// only what came from the depends_on argument?
+						childDependencyMarks := repData.AllValueMarks()
+
+						// We also need to add the per-instance marks.
+						instanceChildDependencyMarks, moreDiags := instanceDeps.Marks(ctx)
+						diags = diags.Append(moreDiags)
+						maps.Copy(childDependencyMarks, instanceChildDependencyMarks)
+
+						configgraph.RemoveNonDependencyMarks(childDependencyMarks)
+
+						modInst, moreDiags := mod.CompileModuleInstance(ctx, calleeAddr, &evalglue.ModuleCall{
 							InputValues:          exprs.ConstantValuer(inputs),
 							AllowImpureFunctions: parentCall.AllowImpureFunctions,
 							DependencyMarks:      childDependencyMarks,
@@ -157,7 +167,8 @@ func compileModuleInstanceModuleCalls(
 							EvaluationGlue:       parentCall.EvaluationGlue,
 							ProvidersFromParent:  proxyProviderCompiler,
 						})
-						if diags.HasErrors() {
+						diags = diags.Append(moreDiags)
+						if moreDiags.HasErrors() {
 							return nil, diags
 						}
 						return configgraph.Known(modInst), diags

--- a/internal/lang/eval/internal/tofu2024/compile_module_calls.go
+++ b/internal/lang/eval/internal/tofu2024/compile_module_calls.go
@@ -45,11 +45,19 @@ func compileModuleInstanceModuleCalls(
 			versionConstraintValuer = exprs.ConstantValuer(cty.NullVal(cty.String))
 		}
 
+		// We compile the depends_on argument here but don't evaluate it yet.
+		// It actually gets evaluated inside the "instance selector" we'll
+		// construct below, when it gets asked for its instances, and include
+		// the resulting marks on the count.index, each.key, and/or each.value
+		// results because that means it'll get evaluated only once per resource
+		// instead of separately for each resource instance.
+		deps := compileDependsOn(config.DependsOn, declScope, parentCall.DependencyMarks)
+
 		ret[addr] = &configgraph.ModuleCall{
 			Addr:             addr.Absolute(moduleInstanceAddr),
 			DeclRange:        tfdiags.SourceRangeFromHCL(config.DeclRange),
 			ParentSourceAddr: parentSourceAddr,
-			InstanceSelector: compileInstanceSelector(ctx, declScope, config.ForEach, config.Count, config.Enabled, parentCall.DependencyMarks),
+			InstanceSelector: compileInstanceSelector(ctx, declScope, config.ForEach, config.Count, config.Enabled, deps),
 			SourceAddrValuer: configgraph.ValuerOnce(exprs.NewClosure(
 				exprs.EvalableHCLExpression(config.Source),
 				declScope,
@@ -104,6 +112,17 @@ func compileModuleInstanceModuleCalls(
 
 				instanceScope := instanceLocalScope(declScope, repData)
 
+				// We passed the marks from depends_on through the instance
+				// selector and so any dependency-related marks from there
+				// should be passed down to the child module as inherited
+				// dependency marks.
+				// TODO: This also includes any dependencies that come directly
+				// from expressions written in the count, for_each, or enabled
+				// argument. Is that acceptable or do we need to constrain this
+				// only what came from the depends_on argument?
+				childDependencyMarks := repData.AllValueMarks()
+				configgraph.RemoveNonDependencyMarks(childDependencyMarks)
+
 				// Apply passed providers to the provider ref chain.
 				// TODO: consider using the required_providers block to validate this further.
 				proxyProviderCompiler := compileProviderConfigRefProxy(parentProviders, config.Providers, instanceScope)
@@ -133,10 +152,10 @@ func compileModuleInstanceModuleCalls(
 						modInst, diags := mod.CompileModuleInstance(ctx, calleeAddr, &evalglue.ModuleCall{
 							InputValues:          exprs.ConstantValuer(inputs),
 							AllowImpureFunctions: parentCall.AllowImpureFunctions,
-							// TODO: DependencyMarks, combining parentCall.DependencyMarks and new marks from our own depends_on
-							EvalContext:         parentCall.EvalContext,
-							EvaluationGlue:      parentCall.EvaluationGlue,
-							ProvidersFromParent: proxyProviderCompiler,
+							DependencyMarks:      childDependencyMarks,
+							EvalContext:          parentCall.EvalContext,
+							EvaluationGlue:       parentCall.EvaluationGlue,
+							ProvidersFromParent:  proxyProviderCompiler,
 						})
 						if diags.HasErrors() {
 							return nil, diags

--- a/internal/lang/eval/internal/tofu2024/compile_provider_configs.go
+++ b/internal/lang/eval/internal/tofu2024/compile_provider_configs.go
@@ -70,7 +70,7 @@ func compileProviderConfig(
 	// traversal set as our vehicle for getting the extraMarks into the
 	// instance selector and then into the CompileProviderInstance callback
 	// below.
-	deps := compileDependsOn(nil, declScope, extraMarks)
+	sharedDeps, compileInstanceDeps := compileDependsOn(nil, declScope, extraMarks)
 
 	return &configgraph.ProviderConfig{
 		Addr: addrs.AbsProviderConfigCorrect{
@@ -81,9 +81,10 @@ func compileProviderConfig(
 			},
 		},
 		ProviderAddr:     providerAddr,
-		InstanceSelector: compileInstanceSelector(ctx, declScope, config.ForEach, nil, nil, deps),
+		InstanceSelector: compileInstanceSelector(ctx, declScope, config.ForEach, nil, nil, sharedDeps),
 		CompileProviderInstance: func(ctx context.Context, key addrs.InstanceKey, repData instances.RepetitionData) *configgraph.ProviderInstance {
 			instanceScope := instanceLocalScope(declScope, repData)
+			instanceDeps := compileInstanceDeps(instanceScope)
 
 			// Note that repetitionMarks also incorporates any marks from the
 			// depends_on argument, which got evaluated as part of the instance
@@ -94,11 +95,16 @@ func compileProviderConfig(
 			// transformations of the configuration value, so we'll deal
 			// with those by transforming what we get from just evaluating
 			// the main config body.
-			configValuer := configgraph.ValuerOnce(exprs.DerivedValuer(
+			configValuer := configgraph.ValuerOnce(exprs.DerivedValuerContext(
 				exprs.NewClosure(configEvalable, instanceScope),
-				func(v cty.Value, diags tfdiags.Diagnostics) (cty.Value, tfdiags.Diagnostics) {
+				func(ctx context.Context, v cty.Value, diags tfdiags.Diagnostics) (cty.Value, tfdiags.Diagnostics) {
 					if len(repetitionMarks) != 0 {
-						return v.WithMarks(repetitionMarks), diags
+						v = v.WithMarks(repetitionMarks)
+					}
+					instDepMarks, moreDiags := instanceDeps.Marks(ctx)
+					diags = diags.Append(moreDiags)
+					if len(instDepMarks) != 0 {
+						v = v.WithMarks(instDepMarks)
 					}
 					return v, diags
 				},

--- a/internal/lang/eval/internal/tofu2024/compile_provider_configs.go
+++ b/internal/lang/eval/internal/tofu2024/compile_provider_configs.go
@@ -7,7 +7,6 @@ package tofu2024
 
 import (
 	"context"
-	"maps"
 
 	"github.com/zclconf/go-cty/cty"
 
@@ -65,6 +64,14 @@ func compileProviderConfig(
 		configEvalable = exprs.EvalableHCLBodyWithDynamicBlocks(config.Config, spec)
 	}
 
+	// Provider configuration blocks don't have an explicit depends_on argument,
+	// but to make this as similar as possible to how we handle other similar
+	// block types we'll use the depends_on compiler with an always-empty
+	// traversal set as our vehicle for getting the extraMarks into the
+	// instance selector and then into the CompileProviderInstance callback
+	// below.
+	deps := compileDependsOn(nil, declScope, extraMarks)
+
 	return &configgraph.ProviderConfig{
 		Addr: addrs.AbsProviderConfigCorrect{
 			Module: moduleInstanceAddr,
@@ -74,16 +81,14 @@ func compileProviderConfig(
 			},
 		},
 		ProviderAddr:     providerAddr,
-		InstanceSelector: compileInstanceSelector(ctx, declScope, config.ForEach, nil, nil, extraMarks),
+		InstanceSelector: compileInstanceSelector(ctx, declScope, config.ForEach, nil, nil, deps),
 		CompileProviderInstance: func(ctx context.Context, key addrs.InstanceKey, repData instances.RepetitionData) *configgraph.ProviderInstance {
 			instanceScope := instanceLocalScope(declScope, repData)
 
-			inheritedMarks := cty.ValueMarks{}
-			// This adds an implicit depends_on from marks in repetition data
-			maps.Copy(inheritedMarks, repData.CountIndex.Marks())
-			maps.Copy(inheritedMarks, repData.EachKey.Marks())
-			maps.Copy(inheritedMarks, repData.EachValue.Marks())
-			maps.Copy(inheritedMarks, extraMarks) // preserve the extra marks from our caller too
+			// Note that repetitionMarks also incorporates any marks from the
+			// depends_on argument, which got evaluated as part of the instance
+			// selector just as a convenient once-per-resource evaluation hook.
+			repetitionMarks := repData.AllValueMarks()
 
 			// Some language features related to resource blocks cause extra
 			// transformations of the configuration value, so we'll deal
@@ -92,8 +97,8 @@ func compileProviderConfig(
 			configValuer := configgraph.ValuerOnce(exprs.DerivedValuer(
 				exprs.NewClosure(configEvalable, instanceScope),
 				func(v cty.Value, diags tfdiags.Diagnostics) (cty.Value, tfdiags.Diagnostics) {
-					if len(inheritedMarks) != 0 {
-						return v.WithMarks(inheritedMarks), diags
+					if len(repetitionMarks) != 0 {
+						return v.WithMarks(repetitionMarks), diags
 					}
 					return v, diags
 				},

--- a/internal/lang/eval/internal/tofu2024/compile_provider_configs.go
+++ b/internal/lang/eval/internal/tofu2024/compile_provider_configs.go
@@ -7,6 +7,7 @@ package tofu2024
 
 import (
 	"context"
+	"maps"
 
 	"github.com/zclconf/go-cty/cty"
 
@@ -26,6 +27,7 @@ func compileModuleInstanceProviderConfigs(
 	reqdProviders map[string]*configs.RequiredProvider,
 	moduleInstanceAddr addrs.ModuleInstance,
 	providers evalglue.Providers,
+	extraMarks cty.ValueMarks,
 ) map[addrs.LocalProviderConfig]*configgraph.ProviderConfig {
 	ret := make(map[addrs.LocalProviderConfig]*configgraph.ProviderConfig, len(configs))
 
@@ -34,7 +36,7 @@ func compileModuleInstanceProviderConfigs(
 			LocalName: config.Name,
 			Alias:     config.Alias,
 		}
-		ret[localAddr] = compileProviderConfig(ctx, config, declScope, reqdProviders, moduleInstanceAddr, providers)
+		ret[localAddr] = compileProviderConfig(ctx, config, declScope, reqdProviders, moduleInstanceAddr, providers, extraMarks)
 	}
 
 	return ret
@@ -47,6 +49,7 @@ func compileProviderConfig(
 	reqdProviders map[string]*configs.RequiredProvider,
 	moduleInstanceAddr addrs.ModuleInstance,
 	providers evalglue.Providers,
+	extraMarks cty.ValueMarks,
 ) *configgraph.ProviderConfig {
 	providerAddr := addrs.NewDefaultProvider(config.Name)
 	if reqd, ok := reqdProviders[config.Name]; ok {
@@ -71,9 +74,31 @@ func compileProviderConfig(
 			},
 		},
 		ProviderAddr:     providerAddr,
-		InstanceSelector: compileInstanceSelector(ctx, declScope, config.ForEach, nil, nil),
+		InstanceSelector: compileInstanceSelector(ctx, declScope, config.ForEach, nil, nil, extraMarks),
 		CompileProviderInstance: func(ctx context.Context, key addrs.InstanceKey, repData instances.RepetitionData) *configgraph.ProviderInstance {
 			instanceScope := instanceLocalScope(declScope, repData)
+
+			inheritedMarks := cty.ValueMarks{}
+			// This adds an implicit depends_on from marks in repetition data
+			maps.Copy(inheritedMarks, repData.CountIndex.Marks())
+			maps.Copy(inheritedMarks, repData.EachKey.Marks())
+			maps.Copy(inheritedMarks, repData.EachValue.Marks())
+			maps.Copy(inheritedMarks, extraMarks) // preserve the extra marks from our caller too
+
+			// Some language features related to resource blocks cause extra
+			// transformations of the configuration value, so we'll deal
+			// with those by transforming what we get from just evaluating
+			// the main config body.
+			configValuer := configgraph.ValuerOnce(exprs.DerivedValuer(
+				exprs.NewClosure(configEvalable, instanceScope),
+				func(v cty.Value, diags tfdiags.Diagnostics) (cty.Value, tfdiags.Diagnostics) {
+					if len(inheritedMarks) != 0 {
+						return v.WithMarks(inheritedMarks), diags
+					}
+					return v, diags
+				},
+			))
+
 			return &configgraph.ProviderInstance{
 				Addr: addrs.AbsProviderInstanceCorrect{
 					Config: addrs.AbsProviderConfigCorrect{
@@ -86,9 +111,7 @@ func compileProviderConfig(
 					Key: key,
 				},
 				ProviderAddr: providerAddr,
-				ConfigValuer: configgraph.ValuerOnce(
-					exprs.NewClosure(configEvalable, instanceScope),
-				),
+				ConfigValuer: configValuer,
 				ValidateConfig: func(ctx context.Context, v cty.Value) tfdiags.Diagnostics {
 					return providers.ValidateProviderConfig(ctx, providerAddr, v)
 				},

--- a/internal/lang/eval/internal/tofu2024/compile_resources.go
+++ b/internal/lang/eval/internal/tofu2024/compile_resources.go
@@ -132,13 +132,26 @@ func compileModuleInstanceResource(
 			maps.Copy(additionalMarks, repData.EachKey.Marks())
 			maps.Copy(additionalMarks, repData.EachValue.Marks())
 
-			inst := &configgraph.ResourceInstance{
-				Addr:            absAddr.Instance(key),
-				Provider:        config.Provider,
-				AdditionalMarks: additionalMarks,
-				ConfigValuer: configgraph.ValuerOnce(exprs.NewClosure(
+			// Some language features related to resource blocks cause extra
+			// transformations of the configuration value, so we'll deal
+			// with those by transforming what we get from just evaluating
+			// the main config body.
+			configValuer := configgraph.ValuerOnce(exprs.DerivedValuer(
+				exprs.NewClosure(
 					configEvalable, localScope,
-				)),
+				),
+				func(v cty.Value, diags tfdiags.Diagnostics) (cty.Value, tfdiags.Diagnostics) {
+					if len(additionalMarks) != 0 {
+						return v.WithMarks(additionalMarks), diags
+					}
+					return v, diags
+				},
+			))
+
+			inst := &configgraph.ResourceInstance{
+				Addr:                      absAddr.Instance(key),
+				Provider:                  config.Provider,
+				ConfigValuer:              configValuer,
 				ProviderInstanceValuer:    configgraph.ValuerOnce(providerRef),
 				CreateBeforeDestroyValuer: cbdValuer,
 			}

--- a/internal/lang/eval/internal/tofu2024/compile_resources.go
+++ b/internal/lang/eval/internal/tofu2024/compile_resources.go
@@ -90,7 +90,7 @@ func compileModuleInstanceResource(
 	// the resulting marks on the count.index, each.key, and/or each.value
 	// results because that means it'll get evaluated only once per resource
 	// instead of separately for each resource instance.
-	deps := compileDependsOn(config.DependsOn, declScope, extraMarks)
+	sharedDeps, compileInstanceDeps := compileDependsOn(config.DependsOn, declScope, extraMarks)
 
 	ret := &configgraph.Resource{
 		Addr:      absAddr,
@@ -99,7 +99,7 @@ func compileModuleInstanceResource(
 		// Our instance selector depends on which of the repetition metaarguments
 		// are set, if any. We assume that package configs allows at most one
 		// of these to be set for each resource config.
-		InstanceSelector: compileInstanceSelector(ctx, declScope, config.ForEach, config.Count, config.Enabled, deps),
+		InstanceSelector: compileInstanceSelector(ctx, declScope, config.ForEach, config.Count, config.Enabled, sharedDeps),
 
 		// The [configgraph.Resource] implementation will call back to this
 		// for each child instance it discovers through [InstanceSelector],
@@ -108,6 +108,7 @@ func compileModuleInstanceResource(
 		CompileResourceInstance: func(ctx context.Context, key addrs.InstanceKey, repData instances.RepetitionData) *configgraph.ResourceInstance {
 			localScope := instanceLocalScope(declScope, repData)
 			providerRef := compileProviderConfigRef(ctx, moduleProviders, config.ProviderConfigAddr(), config.ProviderConfigRef, localScope)
+			instanceDeps := compileInstanceDeps(localScope)
 
 			// For now we require a literal boolean constant in
 			// create_before_destroy to match how the old implementation treated
@@ -144,11 +145,16 @@ func compileModuleInstanceResource(
 			// transformations of the configuration value, so we'll deal
 			// with those by transforming what we get from just evaluating
 			// the main config body.
-			configValuer := configgraph.ValuerOnce(exprs.DerivedValuer(
+			configValuer := configgraph.ValuerOnce(exprs.DerivedValuerContext(
 				exprs.NewClosure(configEvalable, localScope),
-				func(v cty.Value, diags tfdiags.Diagnostics) (cty.Value, tfdiags.Diagnostics) {
+				func(ctx context.Context, v cty.Value, diags tfdiags.Diagnostics) (cty.Value, tfdiags.Diagnostics) {
 					if len(repetitionMarks) != 0 {
-						return v.WithMarks(repetitionMarks), diags
+						v = v.WithMarks(repetitionMarks)
+					}
+					instDepMarks, moreDiags := instanceDeps.Marks(ctx)
+					diags = diags.Append(moreDiags)
+					if len(instDepMarks) != 0 {
+						v = v.WithMarks(instDepMarks)
 					}
 					return v, diags
 				},

--- a/internal/lang/eval/internal/tofu2024/compile_resources.go
+++ b/internal/lang/eval/internal/tofu2024/compile_resources.go
@@ -32,18 +32,19 @@ func compileModuleInstanceResources(
 	moduleInstanceAddr addrs.ModuleInstance,
 	providers evalglue.ProvidersSchema,
 	getResultValue func(context.Context, *configgraph.ResourceInstance, cty.Value, configgraph.Maybe[*configgraph.ProviderInstance], addrs.Set[addrs.AbsResourceInstance]) (cty.Value, tfdiags.Diagnostics),
+	extraMarks cty.ValueMarks,
 ) map[addrs.Resource]*configgraph.Resource {
 	ret := make(map[addrs.Resource]*configgraph.Resource, len(managedConfigs)+len(dataConfigs)+len(ephemeralConfigs))
 	for _, rc := range managedConfigs {
-		addr, rsrc := compileModuleInstanceResource(ctx, rc, declScope, moduleProviders, moduleInstanceAddr, providers, getResultValue)
+		addr, rsrc := compileModuleInstanceResource(ctx, rc, declScope, moduleProviders, moduleInstanceAddr, providers, getResultValue, extraMarks)
 		ret[addr] = rsrc
 	}
 	for _, rc := range dataConfigs {
-		addr, rsrc := compileModuleInstanceResource(ctx, rc, declScope, moduleProviders, moduleInstanceAddr, providers, getResultValue)
+		addr, rsrc := compileModuleInstanceResource(ctx, rc, declScope, moduleProviders, moduleInstanceAddr, providers, getResultValue, extraMarks)
 		ret[addr] = rsrc
 	}
 	for _, rc := range ephemeralConfigs {
-		addr, rsrc := compileModuleInstanceResource(ctx, rc, declScope, moduleProviders, moduleInstanceAddr, providers, getResultValue)
+		addr, rsrc := compileModuleInstanceResource(ctx, rc, declScope, moduleProviders, moduleInstanceAddr, providers, getResultValue, extraMarks)
 		ret[addr] = rsrc
 	}
 	return ret
@@ -57,6 +58,7 @@ func compileModuleInstanceResource(
 	moduleInstanceAddr addrs.ModuleInstance,
 	providers evalglue.ProvidersSchema,
 	getResultValue func(context.Context, *configgraph.ResourceInstance, cty.Value, configgraph.Maybe[*configgraph.ProviderInstance], addrs.Set[addrs.AbsResourceInstance]) (cty.Value, tfdiags.Diagnostics),
+	extraMarks cty.ValueMarks,
 ) (addrs.Resource, *configgraph.Resource) {
 	resourceAddr := config.Addr()
 	absAddr := moduleInstanceAddr.Resource(resourceAddr.Mode, resourceAddr.Type, resourceAddr.Name)
@@ -90,7 +92,7 @@ func compileModuleInstanceResource(
 		// Our instance selector depends on which of the repetition metaarguments
 		// are set, if any. We assume that package configs allows at most one
 		// of these to be set for each resource config.
-		InstanceSelector: compileInstanceSelector(ctx, declScope, config.ForEach, config.Count, config.Enabled),
+		InstanceSelector: compileInstanceSelector(ctx, declScope, config.ForEach, config.Count, config.Enabled, extraMarks),
 
 		// The [configgraph.Resource] implementation will call back to this
 		// for each child instance it discovers through [InstanceSelector],
@@ -126,23 +128,22 @@ func compileModuleInstanceResource(
 				)
 			}
 
-			additionalMarks := cty.ValueMarks{}
+			inheritedMarks := cty.ValueMarks{}
 			// This adds an implicit depends_on from marks in repetition data
-			maps.Copy(additionalMarks, repData.CountIndex.Marks())
-			maps.Copy(additionalMarks, repData.EachKey.Marks())
-			maps.Copy(additionalMarks, repData.EachValue.Marks())
+			maps.Copy(inheritedMarks, repData.CountIndex.Marks())
+			maps.Copy(inheritedMarks, repData.EachKey.Marks())
+			maps.Copy(inheritedMarks, repData.EachValue.Marks())
+			maps.Copy(inheritedMarks, extraMarks) // preserve the extra marks from our caller too
 
 			// Some language features related to resource blocks cause extra
 			// transformations of the configuration value, so we'll deal
 			// with those by transforming what we get from just evaluating
 			// the main config body.
 			configValuer := configgraph.ValuerOnce(exprs.DerivedValuer(
-				exprs.NewClosure(
-					configEvalable, localScope,
-				),
+				exprs.NewClosure(configEvalable, localScope),
 				func(v cty.Value, diags tfdiags.Diagnostics) (cty.Value, tfdiags.Diagnostics) {
-					if len(additionalMarks) != 0 {
-						return v.WithMarks(additionalMarks), diags
+					if len(inheritedMarks) != 0 {
+						return v.WithMarks(inheritedMarks), diags
 					}
 					return v, diags
 				},

--- a/internal/lang/eval/internal/tofu2024/compile_resources.go
+++ b/internal/lang/eval/internal/tofu2024/compile_resources.go
@@ -8,7 +8,6 @@ package tofu2024
 import (
 	"context"
 	"fmt"
-	"maps"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
@@ -85,6 +84,14 @@ func compileModuleInstanceResource(
 		configEvalable = exprs.EvalableHCLBodyWithDynamicBlocks(config.Config, spec)
 	}
 
+	// We compile the depends_on argument here but don't evaluate it yet.
+	// It actually gets evaluated inside the "instance selector" we'll
+	// construct below, when it gets asked for its instances, and include
+	// the resulting marks on the count.index, each.key, and/or each.value
+	// results because that means it'll get evaluated only once per resource
+	// instead of separately for each resource instance.
+	deps := compileDependsOn(config.DependsOn, declScope, extraMarks)
+
 	ret := &configgraph.Resource{
 		Addr:      absAddr,
 		DeclRange: tfdiags.SourceRangeFromHCL(config.DeclRange),
@@ -92,7 +99,7 @@ func compileModuleInstanceResource(
 		// Our instance selector depends on which of the repetition metaarguments
 		// are set, if any. We assume that package configs allows at most one
 		// of these to be set for each resource config.
-		InstanceSelector: compileInstanceSelector(ctx, declScope, config.ForEach, config.Count, config.Enabled, extraMarks),
+		InstanceSelector: compileInstanceSelector(ctx, declScope, config.ForEach, config.Count, config.Enabled, deps),
 
 		// The [configgraph.Resource] implementation will call back to this
 		// for each child instance it discovers through [InstanceSelector],
@@ -128,12 +135,10 @@ func compileModuleInstanceResource(
 				)
 			}
 
-			inheritedMarks := cty.ValueMarks{}
-			// This adds an implicit depends_on from marks in repetition data
-			maps.Copy(inheritedMarks, repData.CountIndex.Marks())
-			maps.Copy(inheritedMarks, repData.EachKey.Marks())
-			maps.Copy(inheritedMarks, repData.EachValue.Marks())
-			maps.Copy(inheritedMarks, extraMarks) // preserve the extra marks from our caller too
+			// Note that repetitionMarks also incorporates any marks from the
+			// depends_on argument, which got evaluated as part of the instance
+			// selector just as a convenient once-per-resource evaluation hook.
+			repetitionMarks := repData.AllValueMarks()
 
 			// Some language features related to resource blocks cause extra
 			// transformations of the configuration value, so we'll deal
@@ -142,8 +147,8 @@ func compileModuleInstanceResource(
 			configValuer := configgraph.ValuerOnce(exprs.DerivedValuer(
 				exprs.NewClosure(configEvalable, localScope),
 				func(v cty.Value, diags tfdiags.Diagnostics) (cty.Value, tfdiags.Diagnostics) {
-					if len(inheritedMarks) != 0 {
-						return v.WithMarks(inheritedMarks), diags
+					if len(repetitionMarks) != 0 {
+						return v.WithMarks(repetitionMarks), diags
 					}
 					return v, diags
 				},

--- a/internal/lang/eval/internal/tofu2024/depends_on.go
+++ b/internal/lang/eval/internal/tofu2024/depends_on.go
@@ -1,0 +1,216 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tofu2024
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"math"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/lang/exprs"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// compileDependsOn compiles a set of traversals decoded from a "depends_on"
+// argument into an object that can be used to obtain marks describing the
+// depends_on elements once the caller is ready to evaluate expressions.
+func compileDependsOn(
+	traversals []hcl.Traversal,
+	declScope exprs.Scope,
+	extraMarks cty.ValueMarks,
+) dependsOn {
+	if len(traversals) == 0 && len(extraMarks) == 0 {
+		return dependsOn{
+			// No marks at all, then.
+			valuer: exprs.ConstantValuer(cty.NullVal(cty.DynamicPseudoType)),
+		}
+	}
+
+	var items []exprs.Valuer
+	if len(traversals) != 0 {
+		items = make([]exprs.Valuer, len(traversals))
+		for i, traversal := range traversals {
+			items[i] = compileDependsOnItem(traversal, declScope)
+		}
+	}
+
+	return dependsOn{
+		valuer: &dependsOnValuer{
+			items:      items,
+			extraMarks: extraMarks,
+		},
+	}
+}
+
+// dependsOn is the compiled form of a "depends_on" argument, as produced by
+// [compileDependsOn].
+type dependsOn struct {
+	// We use a valuer in here just because that allows us to reuse a bunch of
+	// our existing machinery for expression evaluation, but it's encapsulated
+	// inside this [dependsOn] type so it's clearer in caller code that the
+	// result is used only for its marks and not for its actual value.
+	valuer exprs.Valuer
+}
+
+// Marks returns a cty-marks-based representation of the declared dependencies,
+// ready to be attached to a value to make it appear to have referred to
+// everything that the depends_on argument referred to.
+func (do dependsOn) Marks(ctx context.Context) (cty.ValueMarks, tfdiags.Diagnostics) {
+	if do.valuer == nil {
+		// The zero value of dependsOn is valid but has no marks.
+		return nil, nil
+	}
+
+	v, diags := do.valuer.Value(ctx)
+	var ret cty.ValueMarks
+	if v != cty.NilVal {
+		_, ret = v.UnmarkDeep()
+	}
+	return ret, diags
+}
+
+type dependsOnValuer struct {
+	items      []exprs.Valuer
+	extraMarks cty.ValueMarks
+}
+
+// Value implements [exprs.Valuer].
+func (d *dependsOnValuer) Value(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	marks := make(cty.ValueMarks)
+	maps.Copy(marks, d.extraMarks)
+
+	// We'll now ask all of our nested valuers for their value and collect up
+	// whatever marks they have to use for our overall return value.
+	for _, item := range d.items {
+		itemV, moreDiags := item.Value(ctx)
+		diags = diags.Append(moreDiags)
+		_, moreMarks := itemV.UnmarkDeep()
+		maps.Copy(marks, moreMarks)
+	}
+
+	// The caller is expected to discard everything except the marks from our
+	// result and so we'll just return a null value carrying the marks.
+	return cty.NullVal(cty.DynamicPseudoType).WithMarks(marks), diags
+}
+
+// ValueSourceRange implements [exprs.Valuer].
+func (d *dependsOnValuer) ValueSourceRange() *tfdiags.SourceRange {
+	if len(d.items) == 0 {
+		// No source range at all, then.
+		return nil
+	}
+
+	// Unfortunately the "configs" package doesn't retain the source range
+	// for the entire depends_on expression, so we'll approximate it by
+	// just finding the widest range covering all of the items. This
+	// assumes that all of the items will have come from the same source
+	// file, because there's no situation where a single depends_on argument
+	// can be split over multiple files.
+	minPos := tfdiags.SourcePos{
+		Byte: math.MaxInt,
+	}
+	maxPos := tfdiags.SourcePos{
+		Byte: math.MinInt,
+	}
+	var filename string
+	for _, item := range d.items {
+		rng := item.ValueSourceRange()
+		if rng == nil {
+			continue
+		}
+		filename = rng.Filename // we assume they're all the same anyway
+		if rng.Start.Byte < minPos.Byte {
+			minPos = rng.Start
+		}
+		if rng.End.Byte > maxPos.Byte {
+			maxPos = rng.End
+		}
+	}
+	if maxPos.Byte == math.MinInt {
+		// None of the items had source ranges, then.
+		return nil
+	}
+	return &tfdiags.SourceRange{
+		Filename: filename,
+		Start:    minPos,
+		End:      maxPos,
+	}
+}
+
+// StaticCheckTraversal implements [exprs.Valuer].
+func (d *dependsOnValuer) StaticCheckTraversal(traversal hcl.Traversal) tfdiags.Diagnostics {
+	// We don't expect to use this valuer implementation in any context where
+	// it would make sense to call this method.
+	panic("unimplemented")
+}
+
+func compileDependsOnItem(traversal hcl.Traversal, scope exprs.Scope) exprs.Valuer {
+	ref, compileDiags := addrs.ParseRef(traversal)
+	if compileDiags.HasErrors() {
+		// If parsing failed then further analysis is pointless.
+		return exprs.ForcedErrorValuerWithSourceRange(compileDiags, tfdiags.SourceRangeFromHCL(traversal.SourceRange()))
+	}
+	if len(ref.Remaining) != 0 {
+		// In the long run we're considering allowing arbitrary expressions
+		// in depends_on so it's possible to depend on only what a small part
+		// of an object depends on, but for now we're preserving the assumption
+		// from the old runtime that explicit dependencies are always on
+		// entire objects, and returning an error to reserve the more general
+		// syntax for potential use in a later version.
+		compileDiags = compileDiags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid explicit dependency",
+			Detail:   fmt.Sprintf("Explicit dependencies must be to entire declarations like %s, and not to attributes or elements inside them.", ref.Subject),
+			Subject:  ref.Remaining.SourceRange().Ptr(),
+		})
+		return exprs.ForcedErrorValuerWithSourceRange(compileDiags, tfdiags.SourceRangeFromHCL(traversal.SourceRange()))
+	}
+
+	// We'll use a synthetic scope traversal expression here just so we can
+	// reuse our existing expression evaluation machinery instead of making
+	// a special case for naked traversals.
+	evalable := exprs.EvalableHCLExpression(&hclsyntax.ScopeTraversalExpr{
+		Traversal: traversal,
+		SrcRange:  traversal.SourceRange(),
+	})
+	ret := exprs.Valuer(exprs.NewClosure(evalable, scope))
+
+	// To emulate some special behaviors from the old language runtime we will
+	// collect some additional marks for certain expression types.
+	var moreMarks cty.ValueMarks
+	switch subj := ref.Subject.(type) {
+	case addrs.ModuleCall:
+		moreMarks = dependsOnMarksForModuleCall(subj)
+	case addrs.ModuleCallOutput:
+		moreMarks = dependsOnMarksForModuleCall(subj.Call)
+	case addrs.ModuleCallInstance:
+		moreMarks = dependsOnMarksForModuleCallInstance(subj)
+	case addrs.ModuleCallInstanceOutput:
+		moreMarks = dependsOnMarksForModuleCallInstance(subj.Call)
+	}
+	if len(moreMarks) != 0 {
+		ret = exprs.DerivedValuer(ret, func(v cty.Value, diags tfdiags.Diagnostics) (cty.Value, tfdiags.Diagnostics) {
+			return v.WithMarks(moreMarks), diags
+		})
+	}
+
+	return ret
+}
+
+func dependsOnMarksForModuleCall(addr addrs.ModuleCall) cty.ValueMarks {
+	return nil // TODO: Implement
+}
+
+func dependsOnMarksForModuleCallInstance(addr addrs.ModuleCallInstance) cty.ValueMarks {
+	return nil // TODO: Implement
+}

--- a/internal/lang/eval/internal/tofu2024/depends_on.go
+++ b/internal/lang/eval/internal/tofu2024/depends_on.go
@@ -13,25 +13,39 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/lang/eval/internal/configgraph"
 	"github.com/opentofu/opentofu/internal/lang/exprs"
 	"github.com/opentofu/opentofu/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
+
+// emptyDependsOn is a predefined [dependsOn] that always reports no additional
+// marks at all, used in the common case where no depends_on argument was
+// present.
+var emptyDependsOn = dependsOn{
+	valuer: exprs.ConstantValuer(cty.NullVal(cty.DynamicPseudoType)),
+}
 
 // compileDependsOn compiles a set of traversals decoded from a "depends_on"
 // argument into an object that can be used to obtain marks describing the
 // depends_on elements once the caller is ready to evaluate expressions.
+//
+// The result is split into two parts: the direct dependsOn value represents
+// the subset of the dependencies that are immediately resolvable because
+// they don't involve per-instance symbols like "each.key", while the second
+// result is a function that should be called once the per-instance scope is
+// constructed to deal with any items that might vary on a per-instance basis.
 func compileDependsOn(
 	traversals []hcl.Traversal,
 	declScope exprs.Scope,
 	extraMarks cty.ValueMarks,
-) dependsOn {
+) (dependsOn, func(instanceScope exprs.Scope) dependsOn) {
 	if len(traversals) == 0 && len(extraMarks) == 0 {
-		return dependsOn{
-			// No marks at all, then.
-			valuer: exprs.ConstantValuer(cty.NullVal(cty.DynamicPseudoType)),
+		// No marks at all, then.
+		return emptyDependsOn, func(instanceScope exprs.Scope) dependsOn {
+			return emptyDependsOn
 		}
 	}
 
@@ -43,12 +57,25 @@ func compileDependsOn(
 		}
 	}
 
-	return dependsOn{
+	sharedDeps := dependsOn{
 		valuer: &dependsOnValuer{
 			items:      items,
 			extraMarks: extraMarks,
 		},
 	}
+	compileInstDeps := func(instanceScope exprs.Scope) dependsOn {
+		// TODO: Collect those which refer to each.key, etc into here.
+		// That's pointless right now though because for the hcl.Traversal
+		// representation only a direct reference like this would be possible:
+		//    depends_on = [each.key]
+		// ...and so compileDependsOnItem just rejects use of these altogether
+		// and we're returning this function only as a placeholder for future
+		// expansion once we change package configs to represent depends_on
+		// as a list of arbitrary expressions, instead of forcing traversals.
+		return emptyDependsOn
+	}
+
+	return sharedDeps, compileInstDeps
 }
 
 // dependsOn is the compiled form of a "depends_on" argument, as produced by
@@ -200,6 +227,22 @@ func compileDependsOnItem(traversal hcl.Traversal, scope exprs.Scope) exprs.Valu
 			addr:  subj.Call,
 			scope: scope,
 		}
+	case addrs.CountAttr, addrs.ForEachAttr:
+		// We just forbid these for now because the traversal-based depends_on
+		// could only include these if referred to directly, like this:
+		//     depends_on = [each.key]
+		// ...and that's not particularly useful. Later we do intend to
+		// generalize to treat depends_on as a set of arbitrary expressions to
+		// be evaluated instead of forcing only traversals, and so the
+		// [compiledDependsOn] API is set up to allow for referring to these
+		// symbols in future but currently it just never reports any additional
+		// per-instance marks.
+		return exprs.ForcedErrorValuerWithSourceRange(compileDiags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid explicit dependency",
+			Detail:   "The depends_on argument must not include references to the per-instance symbols each.key, each.value, or count.index.",
+			Subject:  ref.SourceRange.ToHCL().Ptr(),
+		}), ref.SourceRange)
 	default:
 		// We'll use a synthetic scope traversal expression here just so we can
 		// reuse our existing expression evaluation machinery instead of making

--- a/internal/lang/eval/internal/tofu2024/depends_on.go
+++ b/internal/lang/eval/internal/tofu2024/depends_on.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/lang/eval/internal/configgraph"
 	"github.com/opentofu/opentofu/internal/lang/exprs"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
@@ -151,7 +152,7 @@ func (d *dependsOnValuer) ValueSourceRange() *tfdiags.SourceRange {
 func (d *dependsOnValuer) StaticCheckTraversal(traversal hcl.Traversal) tfdiags.Diagnostics {
 	// We don't expect to use this valuer implementation in any context where
 	// it would make sense to call this method.
-	panic("unimplemented")
+	return nil
 }
 
 func compileDependsOnItem(traversal hcl.Traversal, scope exprs.Scope) exprs.Valuer {
@@ -176,41 +177,93 @@ func compileDependsOnItem(traversal hcl.Traversal, scope exprs.Scope) exprs.Valu
 		return exprs.ForcedErrorValuerWithSourceRange(compileDiags, tfdiags.SourceRangeFromHCL(traversal.SourceRange()))
 	}
 
-	// We'll use a synthetic scope traversal expression here just so we can
-	// reuse our existing expression evaluation machinery instead of making
-	// a special case for naked traversals.
-	evalable := exprs.EvalableHCLExpression(&hclsyntax.ScopeTraversalExpr{
-		Traversal: traversal,
-		SrcRange:  traversal.SourceRange(),
-	})
-	ret := exprs.Valuer(exprs.NewClosure(evalable, scope))
-
 	// To emulate some special behaviors from the old language runtime we will
-	// collect some additional marks for certain expression types.
-	var moreMarks cty.ValueMarks
+	// use different behavior for certain expression types.
 	switch subj := ref.Subject.(type) {
 	case addrs.ModuleCall:
-		moreMarks = dependsOnMarksForModuleCall(subj)
+		return dependsOnModuleCallItemValuer{
+			addr:  subj,
+			scope: scope,
+		}
 	case addrs.ModuleCallOutput:
-		moreMarks = dependsOnMarksForModuleCall(subj.Call)
+		return dependsOnModuleCallItemValuer{
+			addr:  subj.Call,
+			scope: scope,
+		}
 	case addrs.ModuleCallInstance:
-		moreMarks = dependsOnMarksForModuleCallInstance(subj)
+		return dependsOnModuleCallInstanceItemValuer{
+			addr:  subj,
+			scope: scope,
+		}
 	case addrs.ModuleCallInstanceOutput:
-		moreMarks = dependsOnMarksForModuleCallInstance(subj.Call)
-	}
-	if len(moreMarks) != 0 {
-		ret = exprs.DerivedValuer(ret, func(v cty.Value, diags tfdiags.Diagnostics) (cty.Value, tfdiags.Diagnostics) {
-			return v.WithMarks(moreMarks), diags
+		return dependsOnModuleCallInstanceItemValuer{
+			addr:  subj.Call,
+			scope: scope,
+		}
+	default:
+		// We'll use a synthetic scope traversal expression here just so we can
+		// reuse our existing expression evaluation machinery instead of making
+		// a special case for naked traversals.
+		evalable := exprs.EvalableHCLExpression(&hclsyntax.ScopeTraversalExpr{
+			Traversal: traversal,
+			SrcRange:  traversal.SourceRange(),
 		})
+		return exprs.NewClosure(evalable, scope)
 	}
-
-	return ret
 }
 
-func dependsOnMarksForModuleCall(addr addrs.ModuleCall) cty.ValueMarks {
-	return nil // TODO: Implement
+type dependsOnModuleCallItemValuer struct {
+	addr  addrs.ModuleCall
+	scope exprs.Scope
+	rng   tfdiags.SourceRange
 }
 
-func dependsOnMarksForModuleCallInstance(addr addrs.ModuleCallInstance) cty.ValueMarks {
-	return nil // TODO: Implement
+// Value implements [exprs.Valuer].
+func (v dependsOnModuleCallItemValuer) Value(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
+	marks := make(cty.ValueMarks)
+	for resourceInst := range moduleCallResourceInstancesDeep(ctx, v.scope, v.addr) {
+		mark := configgraph.NewResourceInstanceMark(resourceInst)
+		marks[mark] = struct{}{}
+	}
+	return cty.NullVal(cty.DynamicPseudoType).WithMarks(marks), nil
+}
+
+// ValueSourceRange implements [exprs.Valuer].
+func (v dependsOnModuleCallItemValuer) ValueSourceRange() *tfdiags.SourceRange {
+	return &v.rng
+}
+
+// StaticCheckTraversal implements [exprs.Valuer].
+func (v dependsOnModuleCallItemValuer) StaticCheckTraversal(traversal hcl.Traversal) tfdiags.Diagnostics {
+	// We don't expect to use this valuer implementation in any context where
+	// it would make sense to call this method.
+	return nil
+}
+
+type dependsOnModuleCallInstanceItemValuer struct {
+	addr  addrs.ModuleCallInstance
+	scope exprs.Scope
+	rng   tfdiags.SourceRange
+}
+
+// Value implements [exprs.Valuer].
+func (v dependsOnModuleCallInstanceItemValuer) Value(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
+	marks := make(cty.ValueMarks)
+	for resourceInst := range moduleCallInstanceResourceInstancesDeep(ctx, v.scope, v.addr) {
+		mark := configgraph.NewResourceInstanceMark(resourceInst)
+		marks[mark] = struct{}{}
+	}
+	return cty.NullVal(cty.DynamicPseudoType).WithMarks(marks), nil
+}
+
+// ValueSourceRange implements [exprs.Valuer].
+func (v dependsOnModuleCallInstanceItemValuer) ValueSourceRange() *tfdiags.SourceRange {
+	return &v.rng
+}
+
+// StaticCheckTraversal implements [exprs.Valuer].
+func (v dependsOnModuleCallInstanceItemValuer) StaticCheckTraversal(traversal hcl.Traversal) tfdiags.Diagnostics {
+	// We don't expect to use this valuer implementation in any context where
+	// it would make sense to call this method.
+	return nil
 }

--- a/internal/lang/eval/internal/tofu2024/depends_on_test.go
+++ b/internal/lang/eval/internal/tofu2024/depends_on_test.go
@@ -6,9 +6,288 @@
 package tofu2024
 
 import (
-	"github.com/opentofu/opentofu/internal/lang/exprs"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/opentofu/opentofu/internal/lang/exprs"
+	"github.com/opentofu/opentofu/internal/lang/grapheval"
+	"github.com/opentofu/opentofu/internal/tfdiags"
 )
+
+func TestCompileDependsOn(t *testing.T) {
+	tests := map[string]struct {
+		Input                    []hcl.Traversal
+		MainScope, InstanceScope exprs.Scope
+		ExtraMarks               cty.ValueMarks
+
+		// Our mechanism for representing dependencies is cty marks, so at this
+		// layer we're mainly just working generically with arbitrary marks
+		// rather than with dependency marks in particular, though some current
+		// special cases for referring to module calls violate that and end up
+		// depending on the configgraph package's types directly.
+		WantSharedMarks   cty.ValueMarks
+		WantSharedDiags   tfdiags.Diagnostics
+		WantInstanceMarks cty.ValueMarks
+		WantInstanceDiags tfdiags.Diagnostics
+	}{
+		"empty": {
+			Input:           nil,
+			MainScope:       exprs.FlatScopeForTesting(nil),
+			WantSharedMarks: nil,
+			WantSharedDiags: nil,
+		},
+		"reference to unmarked value": {
+			Input: []hcl.Traversal{
+				{
+					hcl.TraverseRoot{Name: "local"},
+					hcl.TraverseAttr{Name: "foo"},
+				},
+			},
+			MainScope: exprs.FlatScopeForTesting(map[string]cty.Value{
+				"local": cty.ObjectVal(map[string]cty.Value{
+					"foo": cty.StringVal("no marks here"),
+				}),
+			}),
+			WantSharedMarks: nil,
+			WantSharedDiags: nil,
+		},
+		"reference to marked value": {
+			Input: []hcl.Traversal{
+				{
+					hcl.TraverseRoot{Name: "local"},
+					hcl.TraverseAttr{Name: "foo"},
+				},
+			},
+			MainScope: exprs.FlatScopeForTesting(map[string]cty.Value{
+				"local": cty.ObjectVal(map[string]cty.Value{
+					"foo": cty.StringVal("marked").Mark("precious"),
+				}),
+			}),
+			WantSharedMarks: cty.NewValueMarks("precious"),
+			WantSharedDiags: nil,
+		},
+		"references to two marked values and one unmarked": {
+			Input: []hcl.Traversal{
+				{
+					hcl.TraverseRoot{Name: "local"},
+					hcl.TraverseAttr{Name: "marked1"},
+				},
+				{
+					hcl.TraverseRoot{Name: "local"},
+					hcl.TraverseAttr{Name: "unmarked"},
+				},
+				{
+					hcl.TraverseRoot{Name: "local"},
+					hcl.TraverseAttr{Name: "marked2"},
+				},
+			},
+			MainScope: exprs.FlatScopeForTesting(map[string]cty.Value{
+				"local": cty.ObjectVal(map[string]cty.Value{
+					"marked1":  cty.StringVal("...").Mark("precious"),
+					"marked2":  cty.StringVal("...").Mark("magic"),
+					"unmarked": cty.StringVal("..."),
+				}),
+			}),
+			WantSharedMarks: cty.NewValueMarks("precious", "magic"),
+			WantSharedDiags: nil,
+		},
+		"invalid reference": {
+			Input: []hcl.Traversal{
+				{
+					hcl.TraverseRoot{
+						Name: "local",
+						SrcRange: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.InitialPos,
+							End:      hcl.InitialPos,
+						},
+					},
+				},
+			},
+			MainScope: exprs.FlatScopeForTesting(nil),
+			// This is just one example of having the addrs.ParseRef diagnostics
+			// get passed through the depends_on evaluation, to make sure that's
+			// working at all. We don't exhaustively test every possible invalid
+			// reference because that's a job for the addrs.ParseRef tests.
+			WantSharedMarks: cty.NewValueMarks(exprs.EvalError),
+			WantSharedDiags: tfdiags.New(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid reference",
+				Detail:   `The "local" object cannot be accessed directly. Instead, access one of its attributes.`,
+				Subject: &hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.InitialPos,
+					End:      hcl.InitialPos,
+				},
+			}),
+		},
+
+		// For now our only tests for instance-specific symbols are to test
+		// that we refuse them completely, but this test structure is set up
+		// to allow for a planned future extension that allows them.
+		"refers to count.index": {
+			Input: []hcl.Traversal{
+				{
+					hcl.TraverseRoot{
+						Name: "count",
+						SrcRange: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+							End:      hcl.Pos{Line: 1, Column: 6, Byte: 5},
+						},
+					},
+					hcl.TraverseAttr{
+						Name: "index",
+						SrcRange: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 7, Byte: 6},
+							End:      hcl.Pos{Line: 1, Column: 12, Byte: 11},
+						},
+					},
+				},
+			},
+			MainScope: exprs.FlatScopeForTesting(nil),
+			InstanceScope: exprs.FlatScopeForTesting(map[string]cty.Value{
+				"count": cty.ObjectVal(map[string]cty.Value{
+					"index": cty.NumberIntVal(0),
+				}),
+			}),
+
+			WantSharedMarks: cty.NewValueMarks(exprs.EvalError),
+			WantSharedDiags: tfdiags.New(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid explicit dependency",
+				Detail:   `The depends_on argument must not include references to the per-instance symbols each.key, each.value, or count.index.`,
+				Subject: &hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+					End:      hcl.Pos{Line: 1, Column: 12, Byte: 11},
+				},
+			}),
+		},
+		"refers to each.key": {
+			Input: []hcl.Traversal{
+				{
+					hcl.TraverseRoot{
+						Name: "each",
+						SrcRange: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+							End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+						},
+					},
+					hcl.TraverseAttr{
+						Name: "key",
+						SrcRange: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 6, Byte: 5},
+							End:      hcl.Pos{Line: 1, Column: 9, Byte: 8},
+						},
+					},
+				},
+			},
+			MainScope: exprs.FlatScopeForTesting(nil),
+			InstanceScope: exprs.FlatScopeForTesting(map[string]cty.Value{
+				"each": cty.ObjectVal(map[string]cty.Value{
+					"key": cty.StringVal("a"),
+				}),
+			}),
+
+			WantSharedMarks: cty.NewValueMarks(exprs.EvalError),
+			WantSharedDiags: tfdiags.New(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid explicit dependency",
+				Detail:   `The depends_on argument must not include references to the per-instance symbols each.key, each.value, or count.index.`,
+				Subject: &hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+					End:      hcl.Pos{Line: 1, Column: 9, Byte: 8},
+				},
+			}),
+		},
+		"refers to each.value": {
+			Input: []hcl.Traversal{
+				{
+					hcl.TraverseRoot{
+						Name: "each",
+						SrcRange: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+							End:      hcl.Pos{Line: 1, Column: 5, Byte: 4},
+						},
+					},
+					hcl.TraverseAttr{
+						Name: "value",
+						SrcRange: hcl.Range{
+							Filename: "test.tf",
+							Start:    hcl.Pos{Line: 1, Column: 6, Byte: 5},
+							End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+						},
+					},
+				},
+			},
+			MainScope: exprs.FlatScopeForTesting(nil),
+			InstanceScope: exprs.FlatScopeForTesting(map[string]cty.Value{
+				"each": cty.ObjectVal(map[string]cty.Value{
+					"key": cty.StringVal("a"),
+				}),
+			}),
+
+			WantSharedMarks: cty.NewValueMarks(exprs.EvalError),
+			WantSharedDiags: tfdiags.New(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid explicit dependency",
+				Detail:   `The depends_on argument must not include references to the per-instance symbols each.key, each.value, or count.index.`,
+				Subject: &hcl.Range{
+					Filename: "test.tf",
+					Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+					End:      hcl.Pos{Line: 1, Column: 11, Byte: 10},
+				},
+			}),
+		},
+
+		// TODO: Unfortunately references to module calls are currently treated in
+		// a very special way so we can better match how the old runtime
+		// would've treated them, and that special behavior depends directly
+		// on concrete implementation details of this package in ways that
+		// the other behavior doesn't and so it isn't practical to write unit
+		// tests for those cases. For now we rely on the context tests in
+		// package tofu for testing the behavior of module calls in depends_on.
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := grapheval.ContextWithNewWorker(t.Context())
+
+			sharedDeps, compileInstanceDeps := compileDependsOn(test.Input, test.MainScope, test.ExtraMarks)
+			gotSharedMarks, gotSharedDiags := sharedDeps.Marks(ctx)
+			if diff := cmp.Diff(test.WantSharedMarks, gotSharedMarks); diff != "" {
+				t.Error("wrong shared marks\n" + diff)
+			}
+			if diff := cmp.Diff(test.WantSharedDiags.ForRPC(), gotSharedDiags.ForRPC()); diff != "" {
+				t.Error("wrong diagnostics for shared marks\n" + diff)
+			}
+
+			if test.InstanceScope != nil {
+				instanceDeps := compileInstanceDeps(test.InstanceScope)
+				gotInstanceMarks, gotInstanceDiags := instanceDeps.Marks(ctx)
+				if diff := cmp.Diff(test.WantInstanceMarks, gotInstanceMarks); diff != "" {
+					t.Error("wrong instance-specific marks\n" + diff)
+				}
+				if diff := cmp.Diff(test.WantInstanceDiags.ForRPC(), gotInstanceDiags.ForRPC()); diff != "" {
+					t.Error("wrong diagnostics for instance-specific marks\n" + diff)
+				}
+			} else {
+				if test.WantInstanceMarks != nil || test.WantInstanceDiags != nil {
+					t.Errorf("invalid test: must set InstanceScope in order to test instance-specific marks and diagnostics")
+				}
+			}
+		})
+	}
+}
 
 // dependsOnForTesting constructs a [dependsOn] that just returns exactly
 // the given marks, without any further processing.

--- a/internal/lang/eval/internal/tofu2024/depends_on_test.go
+++ b/internal/lang/eval/internal/tofu2024/depends_on_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tofu2024
+
+import (
+	"github.com/opentofu/opentofu/internal/lang/exprs"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// dependsOnForTesting constructs a [dependsOn] that just returns exactly
+// the given marks, without any further processing.
+func dependsOnForTesting(marks ...any) dependsOn {
+	var markSet cty.ValueMarks
+	if len(marks) != 0 {
+		markSet = make(cty.ValueMarks, len(marks))
+		for _, mark := range marks {
+			markSet[mark] = struct{}{}
+		}
+	}
+	return dependsOn{
+		valuer: exprs.ConstantValuer(cty.NullVal(cty.DynamicPseudoType).WithMarks(markSet)),
+	}
+}

--- a/internal/lang/eval/internal/tofu2024/instance_selector.go
+++ b/internal/lang/eval/internal/tofu2024/instance_selector.go
@@ -25,7 +25,7 @@ import (
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
-func compileInstanceSelector(ctx context.Context, declScope exprs.Scope, forEachExpr hcl.Expression, countExpr hcl.Expression, enabledExpr hcl.Expression, extraMarks cty.ValueMarks) configgraph.InstanceSelector {
+func compileInstanceSelector(ctx context.Context, declScope exprs.Scope, forEachExpr hcl.Expression, countExpr hcl.Expression, enabledExpr hcl.Expression, deps dependsOn) configgraph.InstanceSelector {
 	// We don't current verify that only one of the given expressions is set
 	// because we expect the configs package to check that.
 
@@ -33,49 +33,61 @@ func compileInstanceSelector(ctx context.Context, declScope exprs.Scope, forEach
 		return compileInstanceSelectorForEach(ctx, exprs.NewClosure(
 			exprs.EvalableHCLExpression(forEachExpr),
 			declScope,
-		), extraMarks)
+		), deps)
 	}
 	if countExpr != nil {
 		return compileInstanceSelectorCount(ctx, exprs.NewClosure(
 			exprs.EvalableHCLExpression(countExpr),
 			declScope,
-		), extraMarks)
+		), deps)
 	}
 	if enabledExpr != nil {
 		return compileInstanceSelectorEnabled(ctx, exprs.NewClosure(
 			exprs.EvalableHCLExpression(enabledExpr),
 			declScope,
-		), extraMarks)
+		), deps)
 	}
-	return compileInstanceSelectorSingleton(ctx, extraMarks)
+	return compileInstanceSelectorSingleton(ctx, deps)
 }
 
-func compileInstanceSelectorSingleton(_ context.Context, extraMarks cty.ValueMarks) configgraph.InstanceSelector {
+func compileInstanceSelectorSingleton(_ context.Context, deps dependsOn) configgraph.InstanceSelector {
 	return &instanceSelector{
 		keyType:     addrs.NoKeyType,
 		sourceRange: nil,
 		selectInstances: func(ctx context.Context) (configgraph.Maybe[configgraph.InstancesSeq], cty.ValueMarks, tfdiags.Diagnostics) {
+			depMarks, diags := deps.Marks(ctx)
 			seq := func(yield func(addrs.InstanceKey, instances.RepetitionData) bool) {
 				yield(addrs.NoKey, instances.RepetitionData{})
 			}
-			return configgraph.Known(seq), extraMarks, nil
+			return configgraph.Known(seq), depMarks, diags
 		},
 	}
 }
 
-func compileInstanceSelectorCount(_ context.Context, countValuer exprs.Valuer, extraMarks cty.ValueMarks) configgraph.InstanceSelector {
+func compileInstanceSelectorCount(_ context.Context, countValuer exprs.Valuer, deps dependsOn) configgraph.InstanceSelector {
 	countValuer = configgraph.ValuerOnce(countValuer)
 	return &instanceSelector{
 		keyType:     addrs.IntKeyType,
 		sourceRange: countValuer.ValueSourceRange(),
 		selectInstances: func(ctx context.Context) (configgraph.Maybe[configgraph.InstancesSeq], cty.ValueMarks, tfdiags.Diagnostics) {
 			var count int
+
 			countVal, diags := countValuer.Value(ctx)
 			if diags.HasErrors() {
 				return nil, nil, diags
 			}
+
 			countVal, marks := countVal.Unmark()
-			maps.Copy(marks, extraMarks) // incorporate the "extra marks" too
+
+			depMarks, moreDiags := deps.Marks(ctx)
+			diags = diags.Append(moreDiags)
+			if len(depMarks) != 0 {
+				if marks == nil {
+					marks = make(cty.ValueMarks)
+				}
+				maps.Copy(marks, depMarks)
+			}
+
 			countVal, err := convert.Convert(countVal, cty.Number)
 			if err == nil && !countVal.IsKnown() {
 				// We represent "unknown" by returning a nil configgraph.Maybe
@@ -135,7 +147,7 @@ func compileInstanceSelectorCount(_ context.Context, countValuer exprs.Valuer, e
 	}
 }
 
-func compileInstanceSelectorEnabled(_ context.Context, enabledValuer exprs.Valuer, extraMarks cty.ValueMarks) configgraph.InstanceSelector {
+func compileInstanceSelectorEnabled(_ context.Context, enabledValuer exprs.Valuer, deps dependsOn) configgraph.InstanceSelector {
 	enabledValuer = configgraph.ValuerOnce(enabledValuer)
 	return &instanceSelector{
 		keyType:     addrs.NoKeyType,
@@ -147,7 +159,16 @@ func compileInstanceSelectorEnabled(_ context.Context, enabledValuer exprs.Value
 				return nil, nil, diags
 			}
 			enabledVal, marks := enabledVal.Unmark()
-			maps.Copy(marks, extraMarks) // incorporate the "extra marks" too
+
+			depMarks, moreDiags := deps.Marks(ctx)
+			diags = diags.Append(moreDiags)
+			if len(depMarks) != 0 {
+				if marks == nil {
+					marks = make(cty.ValueMarks)
+				}
+				maps.Copy(marks, depMarks)
+			}
+
 			enabledVal, err := convert.Convert(enabledVal, cty.Bool)
 			if err == nil && !enabledVal.IsKnown() {
 				// We represent "unknown" by returning a nil configgraph.Maybe
@@ -182,7 +203,7 @@ func compileInstanceSelectorEnabled(_ context.Context, enabledValuer exprs.Value
 	}
 }
 
-func compileInstanceSelectorForEach(_ context.Context, forEachValuer exprs.Valuer, extraMarks cty.ValueMarks) configgraph.InstanceSelector {
+func compileInstanceSelectorForEach(_ context.Context, forEachValuer exprs.Valuer, deps dependsOn) configgraph.InstanceSelector {
 	forEachValuer = configgraph.ValuerOnce(forEachValuer)
 	return &instanceSelector{
 		keyType:     addrs.StringKeyType,
@@ -195,7 +216,16 @@ func compileInstanceSelectorForEach(_ context.Context, forEachValuer exprs.Value
 				return nil, nil, diags
 			}
 			rawVal, marks := rawVal.Unmark()
-			maps.Copy(marks, extraMarks) // incorporate the "extra marks" too
+
+			depMarks, moreDiags := deps.Marks(ctx)
+			diags = diags.Append(moreDiags)
+			if len(depMarks) != 0 {
+				if marks == nil {
+					marks = make(cty.ValueMarks)
+				}
+				maps.Copy(marks, depMarks)
+			}
+
 			if rawVal.IsNull() {
 				diags = diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,

--- a/internal/lang/eval/internal/tofu2024/instance_selector.go
+++ b/internal/lang/eval/internal/tofu2024/instance_selector.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"math/big"
 
@@ -24,7 +25,7 @@ import (
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
-func compileInstanceSelector(ctx context.Context, declScope exprs.Scope, forEachExpr hcl.Expression, countExpr hcl.Expression, enabledExpr hcl.Expression) configgraph.InstanceSelector {
+func compileInstanceSelector(ctx context.Context, declScope exprs.Scope, forEachExpr hcl.Expression, countExpr hcl.Expression, enabledExpr hcl.Expression, extraMarks cty.ValueMarks) configgraph.InstanceSelector {
 	// We don't current verify that only one of the given expressions is set
 	// because we expect the configs package to check that.
 
@@ -32,24 +33,24 @@ func compileInstanceSelector(ctx context.Context, declScope exprs.Scope, forEach
 		return compileInstanceSelectorForEach(ctx, exprs.NewClosure(
 			exprs.EvalableHCLExpression(forEachExpr),
 			declScope,
-		))
+		), extraMarks)
 	}
 	if countExpr != nil {
 		return compileInstanceSelectorCount(ctx, exprs.NewClosure(
 			exprs.EvalableHCLExpression(countExpr),
 			declScope,
-		))
+		), extraMarks)
 	}
 	if enabledExpr != nil {
 		return compileInstanceSelectorEnabled(ctx, exprs.NewClosure(
 			exprs.EvalableHCLExpression(enabledExpr),
 			declScope,
-		))
+		), extraMarks)
 	}
-	return compileInstanceSelectorSingleton(ctx)
+	return compileInstanceSelectorSingleton(ctx, extraMarks)
 }
 
-func compileInstanceSelectorSingleton(_ context.Context) configgraph.InstanceSelector {
+func compileInstanceSelectorSingleton(_ context.Context, extraMarks cty.ValueMarks) configgraph.InstanceSelector {
 	return &instanceSelector{
 		keyType:     addrs.NoKeyType,
 		sourceRange: nil,
@@ -57,12 +58,12 @@ func compileInstanceSelectorSingleton(_ context.Context) configgraph.InstanceSel
 			seq := func(yield func(addrs.InstanceKey, instances.RepetitionData) bool) {
 				yield(addrs.NoKey, instances.RepetitionData{})
 			}
-			return configgraph.Known(seq), nil, nil
+			return configgraph.Known(seq), extraMarks, nil
 		},
 	}
 }
 
-func compileInstanceSelectorCount(_ context.Context, countValuer exprs.Valuer) configgraph.InstanceSelector {
+func compileInstanceSelectorCount(_ context.Context, countValuer exprs.Valuer, extraMarks cty.ValueMarks) configgraph.InstanceSelector {
 	countValuer = configgraph.ValuerOnce(countValuer)
 	return &instanceSelector{
 		keyType:     addrs.IntKeyType,
@@ -74,6 +75,7 @@ func compileInstanceSelectorCount(_ context.Context, countValuer exprs.Valuer) c
 				return nil, nil, diags
 			}
 			countVal, marks := countVal.Unmark()
+			maps.Copy(marks, extraMarks) // incorporate the "extra marks" too
 			countVal, err := convert.Convert(countVal, cty.Number)
 			if err == nil && !countVal.IsKnown() {
 				// We represent "unknown" by returning a nil configgraph.Maybe
@@ -133,7 +135,7 @@ func compileInstanceSelectorCount(_ context.Context, countValuer exprs.Valuer) c
 	}
 }
 
-func compileInstanceSelectorEnabled(_ context.Context, enabledValuer exprs.Valuer) configgraph.InstanceSelector {
+func compileInstanceSelectorEnabled(_ context.Context, enabledValuer exprs.Valuer, extraMarks cty.ValueMarks) configgraph.InstanceSelector {
 	enabledValuer = configgraph.ValuerOnce(enabledValuer)
 	return &instanceSelector{
 		keyType:     addrs.NoKeyType,
@@ -145,6 +147,7 @@ func compileInstanceSelectorEnabled(_ context.Context, enabledValuer exprs.Value
 				return nil, nil, diags
 			}
 			enabledVal, marks := enabledVal.Unmark()
+			maps.Copy(marks, extraMarks) // incorporate the "extra marks" too
 			enabledVal, err := convert.Convert(enabledVal, cty.Bool)
 			if err == nil && !enabledVal.IsKnown() {
 				// We represent "unknown" by returning a nil configgraph.Maybe
@@ -179,7 +182,7 @@ func compileInstanceSelectorEnabled(_ context.Context, enabledValuer exprs.Value
 	}
 }
 
-func compileInstanceSelectorForEach(_ context.Context, forEachValuer exprs.Valuer) configgraph.InstanceSelector {
+func compileInstanceSelectorForEach(_ context.Context, forEachValuer exprs.Valuer, extraMarks cty.ValueMarks) configgraph.InstanceSelector {
 	forEachValuer = configgraph.ValuerOnce(forEachValuer)
 	return &instanceSelector{
 		keyType:     addrs.StringKeyType,
@@ -192,6 +195,7 @@ func compileInstanceSelectorForEach(_ context.Context, forEachValuer exprs.Value
 				return nil, nil, diags
 			}
 			rawVal, marks := rawVal.Unmark()
+			maps.Copy(marks, extraMarks) // incorporate the "extra marks" too
 			if rawVal.IsNull() {
 				diags = diags.Append(&hcl.Diagnostic{
 					Severity: hcl.DiagError,

--- a/internal/lang/eval/internal/tofu2024/instance_selector_test.go
+++ b/internal/lang/eval/internal/tofu2024/instance_selector_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestCompileInstanceSelectorSingleton(t *testing.T) {
 	ctx := grapheval.ContextWithNewWorker(t.Context())
-	selector := compileInstanceSelector(ctx, exprs.FlatScopeForTesting(nil), nil, nil, nil)
+	selector := compileInstanceSelector(ctx, exprs.FlatScopeForTesting(nil), nil, nil, nil, nil)
 	instsSeq, marks, diags := selector.Instances(ctx)
 	insts := configgraph.MapMaybe(instsSeq, func(s configgraph.InstancesSeq) map[addrs.InstanceKey]instances.RepetitionData {
 		return maps.Collect(s)
@@ -83,12 +83,14 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			// Maps
 			"empty map inline": {
 				hcl.StaticExpr(cty.MapValEmpty(cty.String), rng),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				nil,
 				nil,
 			},
 			"empty map from scope": {
 				hcltest.MockExprTraversalSrc(`empty_map`),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				nil,
 				nil,
@@ -99,12 +101,14 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			// predict the element type, so we just leave it unspecified.
 			"empty map of unknown type inline": {
 				hcl.StaticExpr(cty.MapValEmpty(cty.DynamicPseudoType), rng),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				nil,
 				nil,
 			},
 			"map with one element from scope": {
 				hcltest.MockExprTraversalSrc(`map_with_a`),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.StringKey("a"): {
 						EachKey:   cty.StringVal("a"),
@@ -119,6 +123,7 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 					"a": cty.StringVal("value of a"),
 					"b": cty.StringVal("value of b"),
 				}), rng),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.StringKey("a"): {
 						EachKey:   cty.StringVal("a"),
@@ -134,6 +139,7 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			},
 			"empty map marked": {
 				hcl.StaticExpr(cty.MapValEmpty(cty.String).Mark("!"), rng),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				// For this layer of the system we just have general-purpose
 				// preservation of whatever marks were present. It's the caller's
@@ -147,6 +153,7 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			},
 			"map that is marked with one element": {
 				hcl.StaticExpr(cty.MapVal(map[string]cty.Value{"a": cty.True}).Mark("!"), rng),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.StringKey("a"): {
 						// TODO: Should we transfer the marks onto these nested values automatically?
@@ -159,6 +166,7 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			},
 			"map that is unmarked with one marked element": {
 				hcl.StaticExpr(cty.MapVal(map[string]cty.Value{"a": cty.True.Mark("!")}), rng),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.StringKey("a"): {
 						EachKey:   cty.StringVal("a"),
@@ -170,12 +178,14 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			},
 			"unknown map": {
 				hcl.StaticExpr(cty.UnknownVal(cty.Map(cty.String)), rng),
+				nil,
 				nil, // instances are unknown
 				nil,
 				nil,
 			},
 			"null map": {
 				hcl.StaticExpr(cty.NullVal(cty.Map(cty.String)), rng),
+				nil,
 				nil, // instances are unknown
 				nil,
 				diagsHasError("The for_each value must not be null."),
@@ -184,6 +194,7 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			// Objects
 			"empty object": {
 				hcl.StaticExpr(cty.EmptyObjectVal, rng),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				nil,
 				nil,
@@ -192,6 +203,7 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 				hcl.StaticExpr(cty.ObjectVal(map[string]cty.Value{
 					"a": cty.StringVal("value of a"),
 				}), rng),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.StringKey("a"): {
 						EachKey:   cty.StringVal("a"),
@@ -206,6 +218,7 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 					"a": cty.StringVal("value of a"),
 					"b": cty.StringVal("value of b"),
 				}), rng),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.StringKey("a"): {
 						EachKey:   cty.StringVal("a"),
@@ -221,6 +234,7 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			},
 			"empty object marked": {
 				hcl.StaticExpr(cty.EmptyObjectVal.Mark("!"), rng),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				// For this layer of the system we just have general-purpose
 				// preservation of whatever marks were present. It's the caller's
@@ -234,6 +248,7 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			},
 			"object that is marked with one attribute": {
 				hcl.StaticExpr(cty.ObjectVal(map[string]cty.Value{"a": cty.True}).Mark("!"), rng),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.StringKey("a"): {
 						// TODO: Should we transfer the marks onto these nested values automatically?
@@ -246,6 +261,7 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			},
 			"object that is unmarked with one marked attribute": {
 				hcl.StaticExpr(cty.ObjectVal(map[string]cty.Value{"a": cty.True.Mark("!")}), rng),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.StringKey("a"): {
 						EachKey:   cty.StringVal("a"),
@@ -257,6 +273,7 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			},
 			"unknown empty object": {
 				hcl.StaticExpr(cty.UnknownVal(cty.EmptyObject), rng),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				nil,
 				nil,
@@ -266,6 +283,7 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 					"a": cty.String,
 					"b": cty.Bool,
 				})), rng),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.StringKey("a"): {
 						EachKey:   cty.StringVal("a"),
@@ -281,6 +299,7 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			},
 			"null object": {
 				hcl.StaticExpr(cty.NullVal(cty.EmptyObject), rng),
+				nil,
 				nil, // instances are unknown
 				nil,
 				diagsHasError("The for_each value must not be null."),
@@ -289,12 +308,14 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			// Sets
 			"empty set inline": {
 				hcl.StaticExpr(cty.SetValEmpty(cty.String), rng),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				nil,
 				nil,
 			},
 			"empty set from scope": {
 				hcltest.MockExprTraversalSrc(`empty_set`),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				nil,
 				nil,
@@ -305,12 +326,14 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 				// ...because in that case we don't have enough information to
 				// predict the element type, so we just leave it unspecified.
 				hcl.StaticExpr(cty.SetValEmpty(cty.DynamicPseudoType), rng),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				nil,
 				nil,
 			},
 			"set with one element from scope": {
 				hcltest.MockExprTraversalSrc(`set_with_a`),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.StringKey("a"): {
 						EachKey:   cty.StringVal("a"),
@@ -322,12 +345,14 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			},
 			"unknown set": {
 				hcl.StaticExpr(cty.UnknownVal(cty.Set(cty.String)), rng),
+				nil,
 				nil, // instances are unknown
 				nil,
 				nil,
 			},
 			"null set": {
 				hcl.StaticExpr(cty.NullVal(cty.Set(cty.String)), rng),
+				nil,
 				nil, // instances are unknown
 				nil,
 				diagsHasError("The for_each value must not be null."),
@@ -337,12 +362,14 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 					cty.StringVal("not null"),
 					cty.NullVal(cty.String),
 				}), rng),
+				nil,
 				nil, // instances are unknown
 				nil,
 				diagsHasError("a null element is not allowed"),
 			},
 			"set of non-string values": {
 				hcl.StaticExpr(cty.SetVal([]cty.Value{cty.True}), rng),
+				nil,
 				nil,
 				nil,
 				diagsHasError("When using a set with for_each, the element type must be string because the element values will be used as instance keys."),
@@ -353,10 +380,12 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 				hcl.StaticExpr(cty.ListValEmpty(cty.String), rng),
 				nil,
 				nil,
+				nil,
 				diagsHasError("The for_each value must be either a mapping or a set of strings."),
 			},
 			"string": {
 				hcl.StaticExpr(cty.StringVal("nope"), rng),
+				nil,
 				nil,
 				nil,
 				diagsHasError("The for_each value must be either a mapping or a set of strings."),
@@ -365,18 +394,20 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 				hcl.StaticExpr(cty.UnknownVal(cty.String), rng),
 				nil,
 				nil,
+				nil,
 				// Value should be type-checked even when it's unknown
 				diagsHasError("The for_each value must be either a mapping or a set of strings."),
 			},
 			"unknown type": {
 				hcl.StaticExpr(cty.DynamicVal, rng),
+				nil,
 				nil, // instances are unknown
 				nil,
 				nil,
 			},
 		},
-		func(ctx context.Context, e hcl.Expression) configgraph.InstanceSelector {
-			return compileInstanceSelector(ctx, scope, e, nil, nil)
+		func(ctx context.Context, e hcl.Expression, extraMarks cty.ValueMarks) configgraph.InstanceSelector {
+			return compileInstanceSelector(ctx, scope, e, nil, nil, extraMarks)
 		},
 	)
 }
@@ -410,18 +441,21 @@ func TestCompileInstanceSelectorCount(t *testing.T) {
 		map[string]compileInstanceSelectorTest{
 			"zero inline": {
 				hcl.StaticExpr(cty.Zero, rng),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				nil,
 				nil,
 			},
 			"zero from scope": {
 				hcltest.MockExprTraversalSrc(`zero`),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				nil,
 				nil,
 			},
 			"one inline": {
 				hcl.StaticExpr(cty.NumberIntVal(1), rng),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.IntKey(0): {
 						CountIndex: cty.Zero,
@@ -432,6 +466,7 @@ func TestCompileInstanceSelectorCount(t *testing.T) {
 			},
 			"one from scope": {
 				hcltest.MockExprTraversalSrc(`one`),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.IntKey(0): {
 						CountIndex: cty.Zero,
@@ -442,6 +477,7 @@ func TestCompileInstanceSelectorCount(t *testing.T) {
 			},
 			"three": {
 				hcl.StaticExpr(cty.NumberIntVal(3), rng),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.IntKey(0): {
 						CountIndex: cty.Zero,
@@ -458,6 +494,7 @@ func TestCompileInstanceSelectorCount(t *testing.T) {
 			},
 			"three marked": {
 				hcl.StaticExpr(cty.NumberIntVal(3).Mark("!"), rng),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					// TODO: Should we automatically propagate the mark to the
 					// CountIndex values in here too?
@@ -476,12 +513,14 @@ func TestCompileInstanceSelectorCount(t *testing.T) {
 			},
 			"unknown number": {
 				hcl.StaticExpr(cty.UnknownVal(cty.Number), rng),
+				nil,
 				nil, // instances are unknown
 				nil,
 				nil,
 			},
 			"unknown type": {
 				hcl.StaticExpr(cty.DynamicVal, rng),
+				nil,
 				nil, // instances are unknown
 				nil,
 				nil,
@@ -490,10 +529,12 @@ func TestCompileInstanceSelectorCount(t *testing.T) {
 				hcl.StaticExpr(cty.EmptyObjectVal, rng),
 				nil,
 				nil,
+				nil,
 				diagsHasError("number required, but have object."),
 			},
 			"unknown and not a number": {
 				hcl.StaticExpr(cty.UnknownVal(cty.Bool), rng),
+				nil,
 				nil,
 				nil,
 				diagsHasError("number required, but have bool."),
@@ -502,16 +543,19 @@ func TestCompileInstanceSelectorCount(t *testing.T) {
 				hcl.StaticExpr(cty.NullVal(cty.Number), rng),
 				nil,
 				nil,
+				nil,
 				diagsHasError("must not be null."),
 			},
 			"negative number": {
 				hcl.StaticExpr(cty.NumberIntVal(-1), rng),
 				nil,
 				nil,
+				nil,
 				diagsHasError("must not be a negative number."),
 			},
 			"fractional number": {
 				hcl.StaticExpr(cty.NumberFloatVal(0.5), rng),
+				nil,
 				nil,
 				nil,
 				diagsHasError("must be a whole number."),
@@ -522,6 +566,7 @@ func TestCompileInstanceSelectorCount(t *testing.T) {
 				hcl.StaticExpr(cty.MustParseNumberVal("99999999999999999999"), rng),
 				nil,
 				nil,
+				nil,
 				// The exact upper bound in this error message differs between
 				// 32-bit and 64-bit targets, and so we only match the constant
 				// prefix here which is enough to distinguish it from all
@@ -529,8 +574,8 @@ func TestCompileInstanceSelectorCount(t *testing.T) {
 				diagsHasError("must be between 0 and "),
 			},
 		},
-		func(ctx context.Context, e hcl.Expression) configgraph.InstanceSelector {
-			return compileInstanceSelector(ctx, scope, nil, e, nil)
+		func(ctx context.Context, e hcl.Expression, extraMarks cty.ValueMarks) configgraph.InstanceSelector {
+			return compileInstanceSelector(ctx, scope, nil, e, nil, extraMarks)
 		},
 	)
 }
@@ -564,18 +609,21 @@ func TestCompileInstanceSelectorEnabled(t *testing.T) {
 		map[string]compileInstanceSelectorTest{
 			"false inline": {
 				hcl.StaticExpr(cty.False, rng),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				nil,
 				nil,
 			},
 			"false from scope": {
 				hcltest.MockExprTraversalSrc(`f`),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				nil,
 				nil,
 			},
 			"true inline": {
 				hcl.StaticExpr(cty.True, rng),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.NoKey: {},
 				}),
@@ -584,6 +632,7 @@ func TestCompileInstanceSelectorEnabled(t *testing.T) {
 			},
 			"true from scope": {
 				hcltest.MockExprTraversalSrc(`t`),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.NoKey: {},
 				}),
@@ -592,6 +641,7 @@ func TestCompileInstanceSelectorEnabled(t *testing.T) {
 			},
 			"true marked": {
 				hcl.StaticExpr(cty.True.Mark("!"), rng),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.NoKey: {},
 				}),
@@ -600,18 +650,21 @@ func TestCompileInstanceSelectorEnabled(t *testing.T) {
 			},
 			"false marked": {
 				hcl.StaticExpr(cty.False.Mark("!"), rng),
+				nil,
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				cty.NewValueMarks("!"),
 				nil,
 			},
 			"unknown bool": {
 				hcl.StaticExpr(cty.UnknownVal(cty.Bool), rng),
+				nil,
 				nil, // instances are unknown
 				nil,
 				nil,
 			},
 			"unknown type": {
 				hcl.StaticExpr(cty.DynamicVal, rng),
+				nil,
 				nil, // instances are unknown
 				nil,
 				nil,
@@ -620,10 +673,12 @@ func TestCompileInstanceSelectorEnabled(t *testing.T) {
 				hcl.StaticExpr(cty.EmptyObjectVal, rng),
 				nil,
 				nil,
+				nil,
 				diagsHasError("bool required, but have object."),
 			},
 			"unknown and not a bool": {
 				hcl.StaticExpr(cty.UnknownVal(cty.EmptyObject), rng),
+				nil,
 				nil,
 				nil,
 				diagsHasError("bool required, but have object."),
@@ -632,17 +687,19 @@ func TestCompileInstanceSelectorEnabled(t *testing.T) {
 				hcl.StaticExpr(cty.NullVal(cty.Bool), rng),
 				nil,
 				nil,
+				nil,
 				diagsHasError("must not be null."),
 			},
 		},
-		func(ctx context.Context, e hcl.Expression) configgraph.InstanceSelector {
-			return compileInstanceSelector(ctx, scope, nil, nil, e)
+		func(ctx context.Context, e hcl.Expression, extraMarks cty.ValueMarks) configgraph.InstanceSelector {
+			return compileInstanceSelector(ctx, scope, nil, nil, e, extraMarks)
 		},
 	)
 }
 
 type compileInstanceSelectorTest struct {
 	expr       hcl.Expression
+	extraMarks cty.ValueMarks
 	wantInsts  configgraph.Maybe[map[addrs.InstanceKey]instances.RepetitionData]
 	wantMarks  cty.ValueMarks
 	checkDiags func(*testing.T, tfdiags.Diagnostics)
@@ -651,7 +708,7 @@ type compileInstanceSelectorTest struct {
 func testCompileInstanceSelector(
 	t *testing.T,
 	tests map[string]compileInstanceSelectorTest,
-	compile func(context.Context, hcl.Expression) configgraph.InstanceSelector,
+	compile func(context.Context, hcl.Expression, cty.ValueMarks) configgraph.InstanceSelector,
 ) {
 	t.Helper()
 
@@ -659,7 +716,7 @@ func testCompileInstanceSelector(
 		t.Run(name, func(t *testing.T) {
 			ctx := grapheval.ContextWithNewWorker(t.Context())
 
-			selector := compile(ctx, test.expr)
+			selector := compile(ctx, test.expr, test.extraMarks)
 			instsSeq, marks, diags := selector.Instances(ctx)
 			insts := configgraph.MapMaybe(instsSeq, func(s configgraph.InstancesSeq) map[addrs.InstanceKey]instances.RepetitionData {
 				return maps.Collect(s)

--- a/internal/lang/eval/internal/tofu2024/instance_selector_test.go
+++ b/internal/lang/eval/internal/tofu2024/instance_selector_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestCompileInstanceSelectorSingleton(t *testing.T) {
 	ctx := grapheval.ContextWithNewWorker(t.Context())
-	selector := compileInstanceSelector(ctx, exprs.FlatScopeForTesting(nil), nil, nil, nil, nil)
+	selector := compileInstanceSelector(ctx, exprs.FlatScopeForTesting(nil), nil, nil, nil, dependsOn{})
 	instsSeq, marks, diags := selector.Instances(ctx)
 	insts := configgraph.MapMaybe(instsSeq, func(s configgraph.InstancesSeq) map[addrs.InstanceKey]instances.RepetitionData {
 		return maps.Collect(s)
@@ -83,14 +83,14 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			// Maps
 			"empty map inline": {
 				hcl.StaticExpr(cty.MapValEmpty(cty.String), rng),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				nil,
 				nil,
 			},
 			"empty map from scope": {
 				hcltest.MockExprTraversalSrc(`empty_map`),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				nil,
 				nil,
@@ -101,14 +101,14 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			// predict the element type, so we just leave it unspecified.
 			"empty map of unknown type inline": {
 				hcl.StaticExpr(cty.MapValEmpty(cty.DynamicPseudoType), rng),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				nil,
 				nil,
 			},
 			"map with one element from scope": {
 				hcltest.MockExprTraversalSrc(`map_with_a`),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.StringKey("a"): {
 						EachKey:   cty.StringVal("a"),
@@ -123,7 +123,7 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 					"a": cty.StringVal("value of a"),
 					"b": cty.StringVal("value of b"),
 				}), rng),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.StringKey("a"): {
 						EachKey:   cty.StringVal("a"),
@@ -139,7 +139,7 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			},
 			"empty map marked": {
 				hcl.StaticExpr(cty.MapValEmpty(cty.String).Mark("!"), rng),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				// For this layer of the system we just have general-purpose
 				// preservation of whatever marks were present. It's the caller's
@@ -153,7 +153,7 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			},
 			"map that is marked with one element": {
 				hcl.StaticExpr(cty.MapVal(map[string]cty.Value{"a": cty.True}).Mark("!"), rng),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.StringKey("a"): {
 						// TODO: Should we transfer the marks onto these nested values automatically?
@@ -166,7 +166,7 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			},
 			"map that is unmarked with one marked element": {
 				hcl.StaticExpr(cty.MapVal(map[string]cty.Value{"a": cty.True.Mark("!")}), rng),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.StringKey("a"): {
 						EachKey:   cty.StringVal("a"),
@@ -178,14 +178,14 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			},
 			"unknown map": {
 				hcl.StaticExpr(cty.UnknownVal(cty.Map(cty.String)), rng),
-				nil,
+				dependsOn{},
 				nil, // instances are unknown
 				nil,
 				nil,
 			},
 			"null map": {
 				hcl.StaticExpr(cty.NullVal(cty.Map(cty.String)), rng),
-				nil,
+				dependsOn{},
 				nil, // instances are unknown
 				nil,
 				diagsHasError("The for_each value must not be null."),
@@ -194,7 +194,7 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			// Objects
 			"empty object": {
 				hcl.StaticExpr(cty.EmptyObjectVal, rng),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				nil,
 				nil,
@@ -203,7 +203,7 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 				hcl.StaticExpr(cty.ObjectVal(map[string]cty.Value{
 					"a": cty.StringVal("value of a"),
 				}), rng),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.StringKey("a"): {
 						EachKey:   cty.StringVal("a"),
@@ -218,7 +218,7 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 					"a": cty.StringVal("value of a"),
 					"b": cty.StringVal("value of b"),
 				}), rng),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.StringKey("a"): {
 						EachKey:   cty.StringVal("a"),
@@ -234,7 +234,7 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			},
 			"empty object marked": {
 				hcl.StaticExpr(cty.EmptyObjectVal.Mark("!"), rng),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				// For this layer of the system we just have general-purpose
 				// preservation of whatever marks were present. It's the caller's
@@ -248,7 +248,7 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			},
 			"object that is marked with one attribute": {
 				hcl.StaticExpr(cty.ObjectVal(map[string]cty.Value{"a": cty.True}).Mark("!"), rng),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.StringKey("a"): {
 						// TODO: Should we transfer the marks onto these nested values automatically?
@@ -261,7 +261,7 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			},
 			"object that is unmarked with one marked attribute": {
 				hcl.StaticExpr(cty.ObjectVal(map[string]cty.Value{"a": cty.True.Mark("!")}), rng),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.StringKey("a"): {
 						EachKey:   cty.StringVal("a"),
@@ -273,7 +273,7 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			},
 			"unknown empty object": {
 				hcl.StaticExpr(cty.UnknownVal(cty.EmptyObject), rng),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				nil,
 				nil,
@@ -283,7 +283,7 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 					"a": cty.String,
 					"b": cty.Bool,
 				})), rng),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.StringKey("a"): {
 						EachKey:   cty.StringVal("a"),
@@ -299,7 +299,7 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			},
 			"null object": {
 				hcl.StaticExpr(cty.NullVal(cty.EmptyObject), rng),
-				nil,
+				dependsOn{},
 				nil, // instances are unknown
 				nil,
 				diagsHasError("The for_each value must not be null."),
@@ -308,14 +308,14 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			// Sets
 			"empty set inline": {
 				hcl.StaticExpr(cty.SetValEmpty(cty.String), rng),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				nil,
 				nil,
 			},
 			"empty set from scope": {
 				hcltest.MockExprTraversalSrc(`empty_set`),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				nil,
 				nil,
@@ -326,14 +326,14 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 				// ...because in that case we don't have enough information to
 				// predict the element type, so we just leave it unspecified.
 				hcl.StaticExpr(cty.SetValEmpty(cty.DynamicPseudoType), rng),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				nil,
 				nil,
 			},
 			"set with one element from scope": {
 				hcltest.MockExprTraversalSrc(`set_with_a`),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.StringKey("a"): {
 						EachKey:   cty.StringVal("a"),
@@ -345,14 +345,14 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			},
 			"unknown set": {
 				hcl.StaticExpr(cty.UnknownVal(cty.Set(cty.String)), rng),
-				nil,
+				dependsOn{},
 				nil, // instances are unknown
 				nil,
 				nil,
 			},
 			"null set": {
 				hcl.StaticExpr(cty.NullVal(cty.Set(cty.String)), rng),
-				nil,
+				dependsOn{},
 				nil, // instances are unknown
 				nil,
 				diagsHasError("The for_each value must not be null."),
@@ -362,14 +362,14 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 					cty.StringVal("not null"),
 					cty.NullVal(cty.String),
 				}), rng),
-				nil,
+				dependsOn{},
 				nil, // instances are unknown
 				nil,
 				diagsHasError("a null element is not allowed"),
 			},
 			"set of non-string values": {
 				hcl.StaticExpr(cty.SetVal([]cty.Value{cty.True}), rng),
-				nil,
+				dependsOn{},
 				nil,
 				nil,
 				diagsHasError("When using a set with for_each, the element type must be string because the element values will be used as instance keys."),
@@ -378,21 +378,21 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			// Various other weird situations
 			"empty list": {
 				hcl.StaticExpr(cty.ListValEmpty(cty.String), rng),
-				nil,
+				dependsOn{},
 				nil,
 				nil,
 				diagsHasError("The for_each value must be either a mapping or a set of strings."),
 			},
 			"string": {
 				hcl.StaticExpr(cty.StringVal("nope"), rng),
-				nil,
+				dependsOn{},
 				nil,
 				nil,
 				diagsHasError("The for_each value must be either a mapping or a set of strings."),
 			},
 			"unknown string": {
 				hcl.StaticExpr(cty.UnknownVal(cty.String), rng),
-				nil,
+				dependsOn{},
 				nil,
 				nil,
 				// Value should be type-checked even when it's unknown
@@ -400,14 +400,30 @@ func TestCompileInstanceSelectorForEach(t *testing.T) {
 			},
 			"unknown type": {
 				hcl.StaticExpr(cty.DynamicVal, rng),
-				nil,
+				dependsOn{},
 				nil, // instances are unknown
 				nil,
 				nil,
 			},
+			"marks from depends_on": {
+				hcl.StaticExpr(cty.SetVal([]cty.Value{cty.StringVal("...")}), rng),
+				dependsOnForTesting("marked"),
+				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
+					addrs.StringKey("..."): {
+						// Note that neither of these is marked, but once these
+						// results pass through the configgraph instance
+						// compilation code _it_ will mark them both with the
+						// same marks as the instance expander returned.
+						EachKey:   cty.StringVal("..."),
+						EachValue: cty.StringVal("..."),
+					},
+				}),
+				cty.NewValueMarks("marked"),
+				nil,
+			},
 		},
-		func(ctx context.Context, e hcl.Expression, extraMarks cty.ValueMarks) configgraph.InstanceSelector {
-			return compileInstanceSelector(ctx, scope, e, nil, nil, extraMarks)
+		func(ctx context.Context, e hcl.Expression, deps dependsOn) configgraph.InstanceSelector {
+			return compileInstanceSelector(ctx, scope, e, nil, nil, deps)
 		},
 	)
 }
@@ -441,21 +457,21 @@ func TestCompileInstanceSelectorCount(t *testing.T) {
 		map[string]compileInstanceSelectorTest{
 			"zero inline": {
 				hcl.StaticExpr(cty.Zero, rng),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				nil,
 				nil,
 			},
 			"zero from scope": {
 				hcltest.MockExprTraversalSrc(`zero`),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				nil,
 				nil,
 			},
 			"one inline": {
 				hcl.StaticExpr(cty.NumberIntVal(1), rng),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.IntKey(0): {
 						CountIndex: cty.Zero,
@@ -466,7 +482,7 @@ func TestCompileInstanceSelectorCount(t *testing.T) {
 			},
 			"one from scope": {
 				hcltest.MockExprTraversalSrc(`one`),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.IntKey(0): {
 						CountIndex: cty.Zero,
@@ -477,7 +493,7 @@ func TestCompileInstanceSelectorCount(t *testing.T) {
 			},
 			"three": {
 				hcl.StaticExpr(cty.NumberIntVal(3), rng),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.IntKey(0): {
 						CountIndex: cty.Zero,
@@ -494,7 +510,7 @@ func TestCompileInstanceSelectorCount(t *testing.T) {
 			},
 			"three marked": {
 				hcl.StaticExpr(cty.NumberIntVal(3).Mark("!"), rng),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					// TODO: Should we automatically propagate the mark to the
 					// CountIndex values in here too?
@@ -513,49 +529,49 @@ func TestCompileInstanceSelectorCount(t *testing.T) {
 			},
 			"unknown number": {
 				hcl.StaticExpr(cty.UnknownVal(cty.Number), rng),
-				nil,
+				dependsOn{},
 				nil, // instances are unknown
 				nil,
 				nil,
 			},
 			"unknown type": {
 				hcl.StaticExpr(cty.DynamicVal, rng),
-				nil,
+				dependsOn{},
 				nil, // instances are unknown
 				nil,
 				nil,
 			},
 			"not a number": {
 				hcl.StaticExpr(cty.EmptyObjectVal, rng),
-				nil,
+				dependsOn{},
 				nil,
 				nil,
 				diagsHasError("number required, but have object."),
 			},
 			"unknown and not a number": {
 				hcl.StaticExpr(cty.UnknownVal(cty.Bool), rng),
-				nil,
+				dependsOn{},
 				nil,
 				nil,
 				diagsHasError("number required, but have bool."),
 			},
 			"null number": {
 				hcl.StaticExpr(cty.NullVal(cty.Number), rng),
-				nil,
+				dependsOn{},
 				nil,
 				nil,
 				diagsHasError("must not be null."),
 			},
 			"negative number": {
 				hcl.StaticExpr(cty.NumberIntVal(-1), rng),
-				nil,
+				dependsOn{},
 				nil,
 				nil,
 				diagsHasError("must not be a negative number."),
 			},
 			"fractional number": {
 				hcl.StaticExpr(cty.NumberFloatVal(0.5), rng),
-				nil,
+				dependsOn{},
 				nil,
 				nil,
 				diagsHasError("must be a whole number."),
@@ -564,7 +580,7 @@ func TestCompileInstanceSelectorCount(t *testing.T) {
 				// This number is definitely out of range on both 32-bit and
 				// 64-bit targets.
 				hcl.StaticExpr(cty.MustParseNumberVal("99999999999999999999"), rng),
-				nil,
+				dependsOn{},
 				nil,
 				nil,
 				// The exact upper bound in this error message differs between
@@ -573,9 +589,16 @@ func TestCompileInstanceSelectorCount(t *testing.T) {
 				// of the other errors this function could return.
 				diagsHasError("must be between 0 and "),
 			},
+			"marks from depends_on": {
+				hcl.StaticExpr(cty.NumberIntVal(0), rng),
+				dependsOnForTesting("marked"),
+				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
+				cty.NewValueMarks("marked"),
+				nil,
+			},
 		},
-		func(ctx context.Context, e hcl.Expression, extraMarks cty.ValueMarks) configgraph.InstanceSelector {
-			return compileInstanceSelector(ctx, scope, nil, e, nil, extraMarks)
+		func(ctx context.Context, e hcl.Expression, deps dependsOn) configgraph.InstanceSelector {
+			return compileInstanceSelector(ctx, scope, nil, e, nil, deps)
 		},
 	)
 }
@@ -609,21 +632,21 @@ func TestCompileInstanceSelectorEnabled(t *testing.T) {
 		map[string]compileInstanceSelectorTest{
 			"false inline": {
 				hcl.StaticExpr(cty.False, rng),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				nil,
 				nil,
 			},
 			"false from scope": {
 				hcltest.MockExprTraversalSrc(`f`),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				nil,
 				nil,
 			},
 			"true inline": {
 				hcl.StaticExpr(cty.True, rng),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.NoKey: {},
 				}),
@@ -632,7 +655,7 @@ func TestCompileInstanceSelectorEnabled(t *testing.T) {
 			},
 			"true from scope": {
 				hcltest.MockExprTraversalSrc(`t`),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.NoKey: {},
 				}),
@@ -641,7 +664,7 @@ func TestCompileInstanceSelectorEnabled(t *testing.T) {
 			},
 			"true marked": {
 				hcl.StaticExpr(cty.True.Mark("!"), rng),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{
 					addrs.NoKey: {},
 				}),
@@ -650,56 +673,63 @@ func TestCompileInstanceSelectorEnabled(t *testing.T) {
 			},
 			"false marked": {
 				hcl.StaticExpr(cty.False.Mark("!"), rng),
-				nil,
+				dependsOn{},
 				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
 				cty.NewValueMarks("!"),
 				nil,
 			},
 			"unknown bool": {
 				hcl.StaticExpr(cty.UnknownVal(cty.Bool), rng),
-				nil,
+				dependsOn{},
 				nil, // instances are unknown
 				nil,
 				nil,
 			},
 			"unknown type": {
 				hcl.StaticExpr(cty.DynamicVal, rng),
-				nil,
+				dependsOn{},
 				nil, // instances are unknown
 				nil,
 				nil,
 			},
 			"not a bool": {
 				hcl.StaticExpr(cty.EmptyObjectVal, rng),
-				nil,
+				dependsOn{},
 				nil,
 				nil,
 				diagsHasError("bool required, but have object."),
 			},
 			"unknown and not a bool": {
 				hcl.StaticExpr(cty.UnknownVal(cty.EmptyObject), rng),
-				nil,
+				dependsOn{},
 				nil,
 				nil,
 				diagsHasError("bool required, but have object."),
 			},
 			"null bool": {
 				hcl.StaticExpr(cty.NullVal(cty.Bool), rng),
-				nil,
+				dependsOn{},
 				nil,
 				nil,
 				diagsHasError("must not be null."),
 			},
+			"marks from depends_on": {
+				hcl.StaticExpr(cty.False, rng),
+				dependsOnForTesting("marked"),
+				configgraph.Known(map[addrs.InstanceKey]instances.RepetitionData{}),
+				cty.NewValueMarks("marked"),
+				nil,
+			},
 		},
-		func(ctx context.Context, e hcl.Expression, extraMarks cty.ValueMarks) configgraph.InstanceSelector {
-			return compileInstanceSelector(ctx, scope, nil, nil, e, extraMarks)
+		func(ctx context.Context, e hcl.Expression, deps dependsOn) configgraph.InstanceSelector {
+			return compileInstanceSelector(ctx, scope, nil, nil, e, deps)
 		},
 	)
 }
 
 type compileInstanceSelectorTest struct {
 	expr       hcl.Expression
-	extraMarks cty.ValueMarks
+	deps       dependsOn
 	wantInsts  configgraph.Maybe[map[addrs.InstanceKey]instances.RepetitionData]
 	wantMarks  cty.ValueMarks
 	checkDiags func(*testing.T, tfdiags.Diagnostics)
@@ -708,7 +738,7 @@ type compileInstanceSelectorTest struct {
 func testCompileInstanceSelector(
 	t *testing.T,
 	tests map[string]compileInstanceSelectorTest,
-	compile func(context.Context, hcl.Expression, cty.ValueMarks) configgraph.InstanceSelector,
+	compile func(context.Context, hcl.Expression, dependsOn) configgraph.InstanceSelector,
 ) {
 	t.Helper()
 
@@ -716,7 +746,7 @@ func testCompileInstanceSelector(
 		t.Run(name, func(t *testing.T) {
 			ctx := grapheval.ContextWithNewWorker(t.Context())
 
-			selector := compile(ctx, test.expr, test.extraMarks)
+			selector := compile(ctx, test.expr, test.deps)
 			instsSeq, marks, diags := selector.Instances(ctx)
 			insts := configgraph.MapMaybe(instsSeq, func(s configgraph.InstancesSeq) map[addrs.InstanceKey]instances.RepetitionData {
 				return maps.Collect(s)

--- a/internal/lang/eval/internal/tofu2024/module_instance_call.go
+++ b/internal/lang/eval/internal/tofu2024/module_instance_call.go
@@ -11,6 +11,7 @@ import (
 	"github.com/opentofu/opentofu/internal/lang/eval/internal/evalglue"
 	"github.com/opentofu/opentofu/internal/lang/exprs"
 	"github.com/opentofu/opentofu/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
 )
 
 type ModuleInstanceCall struct {
@@ -54,6 +55,22 @@ type ModuleInstanceCall struct {
 	// to get there from our current language without splitting the ecosystem
 	// between old-style and new-style modules.)
 	ProvidersFromParent configgraph.CompileProviderConfigRef
+
+	// DependencyMarks are additional marks that should be applied to the
+	// configuration values of anything that interacts with systems outside of
+	// OpenTofu (currently: resource instances and provider instances) to
+	// represent "whole-module-call" dependencies.
+	//
+	// For example, package tofu2024 uses this to deal with the "depends_on"
+	// meta-argument in a "module" block, which behaves as if it is declaring
+	// additional explicit dependencies for every resource instance or provider
+	// instance declared inside the module.
+	//
+	// Although this could in theory allow arbitrary cty marks of any type,
+	// callers should include only marks that represent dependencies that must
+	// be taken into account during the apply phase or else the results are
+	// likely to be quite confusing.
+	DependencyMarks cty.ValueMarks
 
 	// AllowImpureFunctions controls whether to allow full use of a small
 	// number of functions that produce different results each time they are

--- a/internal/lang/eval/internal/tofu2024/module_instance_scope.go
+++ b/internal/lang/eval/internal/tofu2024/module_instance_scope.go
@@ -8,11 +8,14 @@ package tofu2024
 import (
 	"context"
 	"fmt"
+	"iter"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/instances"
+	"github.com/opentofu/opentofu/internal/lang/eval/internal/configgraph"
+	"github.com/opentofu/opentofu/internal/lang/eval/internal/evalglue"
 	"github.com/opentofu/opentofu/internal/lang/exprs"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
@@ -584,5 +587,109 @@ func (i *instanceLocalSymbolTable) ResolveAttr(ref hcl.TraverseAttr) (exprs.Attr
 			Subject:  &ref.SrcRange,
 		})
 		return nil, diags
+	}
+}
+
+// moduleCallResourceInstances is a shim that allows a caller that is holding
+// an [exprs.Scope] whose concrete type is [*moduleInstanceScope] (or one of
+// our several wrappers of it) to enumerate all of the resource instances
+// declared beneath the given module call, using direct analysis of the compiled
+// module structure instead of using expression evaluation.
+//
+// This function needs to be able to resolve instance selection expressions
+// for any module calls and resources starting at the given call address and
+// so the given context must have a valid grapheval worker.
+//
+// This is here to help deal with the special treatment we give to module call
+// references in a depends_on argument, where we treat that as depending on
+// every resource instance declared inside the module regardless of whether
+// any of the output values depend on those resource instances. This is a quirky
+// oddity we inherited from the old language runtime that we're preserving for
+// backward-compatibility.
+//
+// If the given scope is not a known wrapper of [*moduleInstanceScope] then this
+// just returns a zero-length sequence so that tests which don't involve this
+// special behavior can safely use a testing-specific fake scope instead of the
+// full scope implementation.
+func moduleCallResourceInstancesDeep(ctx context.Context, scope exprs.Scope, callAddr addrs.ModuleCall) iter.Seq[*configgraph.ResourceInstance] {
+	thisModuleInst := compiledModuleInstanceFromScope(scope)
+	if thisModuleInst == nil {
+		return func(yield func(*configgraph.ResourceInstance) bool) {}
+	}
+
+	return func(yield func(*configgraph.ResourceInstance) bool) {
+		for _, calledModuleInst := range thisModuleInst.ChildModuleInstancesForCall(ctx, callAddr) {
+			// TODO: using evalglue.ResourceInstancesDeep here is probably not right
+			// because it immediately starts a new grapheval worker without also
+			// starting a new goroutine. We need to figure out how the non-goroutine
+			// coroutines started by for loops over iter.Seq fit in to the grapheval
+			// rules: they have some characteristics in common with goroutines but
+			// are not capable of running asynchronously with the calling goroutine.
+			for resourceInst := range evalglue.ResourceInstancesDeep(ctx, calledModuleInst) {
+				if !yield(resourceInst) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// moduleCallResourceInstances is a shim that allows a caller that is holding
+// an [exprs.Scope] whose concrete type is [*moduleInstanceScope] (or one of
+// our several wrappers of it) to enumerate all of the resource instances
+// declared beneath the given module call instance, using direct analysis of
+// the compiled module structure instead of using expression evaluation.
+//
+// This function needs to be able to resolve instance selection expressions
+// for any module calls and resources starting at the given call address and
+// so the given context must have a valid grapheval worker.
+//
+// This is here to help deal with the special treatment we give to module call
+// references in a depends_on argument, where we treat that as depending on
+// every resource instance declared inside the module regardless of whether
+// any of the output values depend on those resource instances. This is a quirky
+// oddity we inherited from the old language runtime that we're preserving for
+// backward-compatibility.
+//
+// If the given scope is not a known wrapper of [*moduleInstanceScope] then this
+// just returns a zero-length sequence so that tests which don't involve this
+// special behavior can safely use a testing-specific fake scope instead of the
+// full scope implementation.
+func moduleCallInstanceResourceInstancesDeep(ctx context.Context, scope exprs.Scope, callInstAddr addrs.ModuleCallInstance) iter.Seq[*configgraph.ResourceInstance] {
+	thisModuleInst := compiledModuleInstanceFromScope(scope)
+	if thisModuleInst == nil {
+		return func(yield func(*configgraph.ResourceInstance) bool) {}
+	}
+
+	calledModuleInst := thisModuleInst.ChildModuleInstance(ctx, callInstAddr)
+	if calledModuleInst == nil {
+		// No such instance then, and so no resource instances beneath it.
+		return func(yield func(*configgraph.ResourceInstance) bool) {}
+	}
+	// TODO: using evalglue.ResourceInstancesDeep here is probably not right
+	// because it immediately starts a new grapheval worker without also
+	// starting a new goroutine. We need to figure out how the non-goroutine
+	// coroutines started by for loops over iter.Seq fit in to the grapheval
+	// rules: they have some characteristics in common with goroutines but
+	// are not capable of running asynchronously with the calling goroutine.
+	return evalglue.ResourceInstancesDeep(ctx, calledModuleInst)
+}
+
+// compiledModuleInstanceFromScope knows how to extract a
+// *CompiledModuleInstance from the various concrete [exprs.Scope]
+// implementations in this package.
+//
+// If the given scope is not one this function knows how to handle then it
+// returns nil.
+func compiledModuleInstanceFromScope(scope exprs.Scope) *CompiledModuleInstance {
+	switch scope := scope.(type) {
+	case *moduleInstanceScope:
+		return scope.inst
+	case *instanceOverlayScope:
+		return compiledModuleInstanceFromScope(scope.parent)
+	case *inputVariableValidationScope:
+		return compiledModuleInstanceFromScope(scope.parentScope)
+	default:
+		return nil
 	}
 }

--- a/internal/lang/eval/internal/tofu2024/providers_sidechannel.go
+++ b/internal/lang/eval/internal/tofu2024/providers_sidechannel.go
@@ -60,6 +60,7 @@ func (r *rootMissingProviders) getOk(localAddr addrs.LocalProviderConfig) (*conf
 func compileProviderConfigRefMissingInRoot(
 	requiredProviders map[string]*configs.RequiredProvider,
 	providers evalglue.Providers,
+	extraMarks cty.ValueMarks,
 ) (configgraph.CompileProviderConfigRef, *rootMissingProviders) {
 	missing := &rootMissingProviders{
 		providerConfigs: map[addrs.LocalProviderConfig]*configgraph.ProviderConfig{},
@@ -106,7 +107,7 @@ func compileProviderConfigRefMissingInRoot(
 			Name:   providerInstAddr.LocalName,
 			Config: hcl2shim.SynthBody(providerInstAddr.String(), make(map[string]cty.Value)),
 		}
-		missingConfig := compileProviderConfig(ctx, emptyConfig, nil, requiredProviders, addrs.RootModuleInstance, providers)
+		missingConfig := compileProviderConfig(ctx, emptyConfig, nil, requiredProviders, addrs.RootModuleInstance, providers, extraMarks)
 		missing.providerConfigs[providerInstAddr] = missingConfig
 
 		return &sidechannelProviderInstanceRefValuer{

--- a/internal/lang/eval/internal/tofu2024/uncompiled.go
+++ b/internal/lang/eval/internal/tofu2024/uncompiled.go
@@ -103,10 +103,11 @@ func (u *uncompiledModule) CompileModuleInstance(ctx context.Context, calleeAddr
 	rootModuleCall := &ModuleInstanceCall{
 		CalleeAddr:           calleeAddr,
 		InputValues:          call.InputValues,
+		ProvidersFromParent:  call.ProvidersFromParent,
+		DependencyMarks:      call.DependencyMarks,
 		EvaluationGlue:       call.EvaluationGlue,
 		AllowImpureFunctions: call.AllowImpureFunctions,
 		EvalContext:          call.EvalContext,
-		ProvidersFromParent:  call.ProvidersFromParent,
 	}
 	rootModuleInstance := CompileModuleInstance(ctx, u.mod, u.sourceAddr, rootModuleCall)
 	return rootModuleInstance, nil

--- a/internal/lang/exprs/valuer.go
+++ b/internal/lang/exprs/valuer.go
@@ -183,12 +183,25 @@ func (f forcedErrorValuer) ResultTypeConstraint() cty.Type {
 //
 // The source range of the returned valuer is the same as the source valuer.
 func DerivedValuer(source Valuer, project func(cty.Value, tfdiags.Diagnostics) (cty.Value, tfdiags.Diagnostics)) Valuer {
+	return derivedValuer{
+		source,
+		func(_ context.Context, v cty.Value, diags tfdiags.Diagnostics) (cty.Value, tfdiags.Diagnostics) {
+			// We just discard the context argument in this case.
+			return project(v, diags)
+		},
+	}
+}
+
+// DerivedValuerContext is a variant of [DerivedValuer] for situations where
+// the projection function needs to perform additional evaluation and therefore
+// needs access to a properly-annotated [context.Context] to evaluate in.
+func DerivedValuerContext(source Valuer, project func(context.Context, cty.Value, tfdiags.Diagnostics) (cty.Value, tfdiags.Diagnostics)) Valuer {
 	return derivedValuer{source, project}
 }
 
 type derivedValuer struct {
 	source  Valuer
-	project func(cty.Value, tfdiags.Diagnostics) (cty.Value, tfdiags.Diagnostics)
+	project func(context.Context, cty.Value, tfdiags.Diagnostics) (cty.Value, tfdiags.Diagnostics)
 }
 
 // StaticCheckTraversal implements Valuer.
@@ -200,7 +213,8 @@ func (d derivedValuer) StaticCheckTraversal(traversal hcl.Traversal) tfdiags.Dia
 
 // Value implements Valuer.
 func (d derivedValuer) Value(ctx context.Context) (cty.Value, tfdiags.Diagnostics) {
-	return d.project(d.source.Value(ctx))
+	v, diags := d.source.Value(ctx)
+	return d.project(ctx, v, diags)
 }
 
 // ValueSourceRange implements Valuer.

--- a/internal/tofu/context_apply_test.go
+++ b/internal/tofu/context_apply_test.go
@@ -464,7 +464,7 @@ func TestContext2Apply_resourceDependsOnModule(t *testing.T) {
 // Test that without a config, the Dependencies in the state are enough
 // to maintain proper ordering.
 func TestContext2Apply_resourceDependsOnModuleStateOnly(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDependsOn)
+	SkipExperimental(t, ExperimentalFeatureDependsOn, ExperimentalBugStateProvider)
 
 	m := testModule(t, "apply-resource-depends-on-module-empty")
 	p := testProvider("aws")
@@ -537,7 +537,7 @@ func TestContext2Apply_resourceDependsOnModuleStateOnly(t *testing.T) {
 }
 
 func TestContext2Apply_resourceDependsOnModuleDestroy(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDependsOn)
+	SkipExperimental(t, ExperimentalFeatureDependsOn, ExperimentalFeatureDestroy)
 
 	m := testModule(t, "apply-resource-depends-on-module")
 	p := testProvider("aws")
@@ -1418,6 +1418,7 @@ func TestContext2Apply_destroyDependsOn(t *testing.T) {
 }
 
 func testContext2Apply_destroyDependsOn(t *testing.T) {
+	SkipExperimental(t, ExperimentalFeatureDestroy)
 	m := testModule(t, "apply-destroy-depends-on")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -1481,7 +1482,7 @@ func testContext2Apply_destroyDependsOn(t *testing.T) {
 // Test that destroy ordering is correct with dependencies only
 // in the state.
 func TestContext2Apply_destroyDependsOnStateOnly(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDependsOn)
+	SkipExperimental(t, ExperimentalFeatureDependsOn, ExperimentalBugStateProvider)
 
 	newState := states.NewState()
 	root := newState.EnsureModule(addrs.RootModuleInstance)
@@ -1581,7 +1582,7 @@ func testContext2Apply_destroyDependsOnStateOnly(t *testing.T, state *states.Sta
 // Test that destroy ordering is correct with dependencies only
 // in the state within a module (GH-11749)
 func TestContext2Apply_destroyDependsOnStateOnlyModule(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDependsOn)
+	SkipExperimental(t, ExperimentalFeatureDependsOn, ExperimentalBugStateProvider)
 
 	newState := states.NewState()
 	child := newState.EnsureModule(addrs.RootModuleInstance.Child("child", addrs.NoKey))
@@ -8989,7 +8990,7 @@ func TestContext2Apply_destroyNestedModuleWithAttrsReferencingResource(t *testin
 // If a data source explicitly depends on another resource, it's because we need
 // that resource to be applied first.
 func TestContext2Apply_dataDependsOn(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDependsOn)
+	SkipExperimental(t, ExperimentalFeatureDependsOn, ExperimentalBugDataResource)
 
 	p := testProvider("null")
 	m := testModuleInline(t, map[string]string{
@@ -11531,7 +11532,7 @@ resource "aws_instance" "cbd" {
 }
 
 func TestContext2Apply_moduleDependsOn(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDependsOn)
+	SkipExperimental(t, ExperimentalFeatureDependsOn, ExperimentalBugDataResource) // Requires data dependency status tracking
 
 	m := testModule(t, "apply-module-depends-on")
 
@@ -11743,6 +11744,8 @@ output "myoutput" {
 	if diags.HasErrors() {
 		t.Fatal(diags.ErrWithWarnings())
 	}
+
+	SkipExperimental(t, ExperimentalFeatureDestroy)
 
 	if !state.Empty() {
 		t.Fatal("expected empty state, got:", state)

--- a/internal/tofu/context_import.go
+++ b/internal/tofu/context_import.go
@@ -325,10 +325,14 @@ func (ri *ImportResolver) resolveImport(ctx context.Context, importTarget *Impor
 		Identity: importIdentity,
 	})
 
-	if keyData == EvalDataForNoInstanceKey {
-		log.Printf("[TRACE] importResolver: resolved a singular import target %s", importAddress)
-	} else {
+	// Just for trace logging purposes we'll generate a slightly different log
+	// message when each.key/each.value are not being set, making the assumption
+	// that this means for_each wasn't used. This is an imprecise signal that
+	// should not be used for anything other than debug logging.
+	if keyData.HasSymbolValues() {
 		log.Printf("[TRACE] importResolver: resolved an expanded import target %s", importAddress)
+	} else {
+		log.Printf("[TRACE] importResolver: resolved a singular import target %s", importAddress)
 	}
 
 	return diags

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -4761,7 +4761,15 @@ data "test_object" "a" {
 }
 
 func TestContext2Plan_applyGraphError(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDependsOn)
+	// This test is trying to exercise the old runtime's behavior where the
+	// plan phase quietly tries to run the apply graph builder against the
+	// generated plan so we can fail earlier if the plan is wrong in a way
+	// that the apply phase would reject. It's reasonable to test that
+	// but the new runtime doesn't guarantee that yet so we'll need to first
+	// figure out exactly how our new-style planning phase will catch the
+	// situation where the plan is invalid, and then figure out how to cause
+	// that to happen for testing purposes.
+	SkipExperimental(t, ExperimentalNewStrategyNeeded)
 
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `

--- a/internal/tofu/context_temp_runtime_test.go
+++ b/internal/tofu/context_temp_runtime_test.go
@@ -64,7 +64,7 @@ var (
 	ExperimentalFeatureTarget            = ExperimentalFlag{"Missing Targeting", false}
 	ExperimentalFeatureReplaceTB         = ExperimentalFlag{"Missing replace_triggered_by", false}
 	ExperimentalFeatureProvisioner       = ExperimentalFlag{"Missing Provisioners", false}
-	ExperimentalFeatureDependsOn         = ExperimentalFlag{"Missing Depends On", false}
+	ExperimentalFeatureDependsOn         = ExperimentalFlag{"Missing Depends On", true}
 	ExperimentalFeatureIgnoreChanges     = ExperimentalFlag{"Missing Ignore Changes", false}
 	ExperimentalFeatureVarCondition      = ExperimentalFlag{"Missing Variable Condiitions", false}
 	ExperimentalFeaturePathAttrs         = ExperimentalFlag{"Missing Path/Terraform/Tofu Attrs", false}

--- a/internal/tofu/context_validate_test.go
+++ b/internal/tofu/context_validate_test.go
@@ -1400,7 +1400,7 @@ output "out" {
 }
 
 func TestContext2Validate_invalidDependsOnResourceRef(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDependsOn)
+	SkipExperimental(t, ExperimentalFeatureDependsOn, ExperimentalFeatureValidate)
 	// This test is verifying that we raise an error if depends_on
 	// refers to something that doesn't exist in configuration.
 	m := testModuleInline(t, map[string]string{
@@ -1719,7 +1719,7 @@ output "out" {
 }
 
 func TestContext2Validate_invalidModuleDependsOn(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDependsOn)
+	SkipExperimental(t, ExperimentalFeatureDependsOn, ExperimentalFeatureValidate)
 
 	// validate module and output depends_on
 	m := testModuleInline(t, map[string]string{
@@ -1759,7 +1759,7 @@ output "out" {
 }
 
 func TestContext2Validate_invalidOutputDependsOn(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDependsOn)
+	SkipExperimental(t, ExperimentalFeatureDependsOn, ExperimentalFeatureValidate)
 
 	// validate module and output depends_on
 	m := testModuleInline(t, map[string]string{


### PR DESCRIPTION
This series of commits makes the explicit `depends_on` argument work in the new language runtime, for resource and module call blocks. This is based on earlier work that @cam72cam did in https://github.com/opentofu/opentofu/pull/4250, but slightly refactored so that more of the logic lives in `package tofu2024` instead of `package configgraph`.

As predicted in https://github.com/opentofu/opentofu/issues/4065, the handling of module-call-level dependencies was the trickiest part of this, in two ways:

- When a `module` block has `depends_on` in it, the current language treats that as if every resource instance declared in any descendant module depends on whatever was declared, regardless of whether any values passed into the module's input variables have dependencies or whether resource instance inside the module depend on those input variables.

    To handle that, the API that a parent module uses to compile a child module is extended to include the possibility for explicit dependency marks as another kind of input from the caller, alongside the existing input variables and "providers side-channel". The compilation process for the child module then arranges for those dependency marks to be attached to every resource instance compiled in the module, _and_ to any nested module calls.
- When a `depends_on` argument refers to a module call, as in `depends_on = [module.foo]`, the resource or module that argument appears in is considered to depend on every resource instance declared inside that module, regardless of whether the module's output values depend on those resource instances individually.

    To handle that, we have a special case in the code that compiles `depends_on` where it does a static check for whether the given traversal refers to a module call. If so, it enters a very special-cased codepath which just asks the child module call to enumerate all of the resource instances declared in it and announces dependencies on each of them, without performing any normal expression evaluation.

    This is something we intend to revisit later since it makes explicit dependencies on module calls act very inconsistently to everything else, but this is at least a starting point that approximates the (somewhat-questionable) behavior of the current language runtime.

Aside from those special cases, the strategy here is mainly to treat `depends_on` as if all of the expressions inside it were part of the main configuration of the object the dependencies are being declared for, augmenting the final object value to have additional dependency-marks so that the rest of the system will handle them in much the same way as it handles dependencies that are implied by normal references.

The way `depends_on` is "compiled" in `package tofu2024` is a little more complicated than it strictly needs to be for the current state of things, since `package configs` is currently forcing all `depends_on` items to be static traversals and so dynamic references to specific instances of other objects are not possible. However, we already identified that we want to be able to support arbitrary expressions in future, to allow for things like `depends_on = [aws_subnet.example[each.key]]` where this gets evaluated separately for each instance so they can all have a different `each.key`. The API here is overachieving to illustrate that this approach _can_ support that functionality, even though this initial implementation just has it stubbed out.



Closes https://github.com/opentofu/opentofu/issues/4065

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
