### PR TITLE
[Backport][v1.12] Update the documentation of enabled to reflect the actual behavior with ephemeral values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ BUG FIXES:
 
 - Properly handle `TF_ENCRYPTION` with only blank spaces. ([#4265](https://github.com/opentofu/opentofu/pull/4265))
 - The value resulted from the `lifecycle.enabled` evaluation now has its deprecation marks processed correctly ([#4162](https://github.com/opentofu/opentofu/pull/4162))
+- Update documentation to clarify the usage restriction of ephemeral values in `lifecycle.enabled`. ([#4220](https://github.com/opentofu/opentofu/pull/4220))
 
 
 ## 1.12.2

--- a/website/docs/language/ephemerality/ephemeral-resources.mdx
+++ b/website/docs/language/ephemerality/ephemeral-resources.mdx
@@ -59,21 +59,13 @@ ephemeral "example" "example" {
 The following arguments and nested block types are supported in the `lifecycle`
 block for an ephemeral resource:
 
-* `enabled` (bool) - Controls whether the ephemeral resource will be used by
-  OpenTofu. When set to `false`, the resource is excluded from the configuration
-  as if it didn't exist. When set to `true` (the default), the resource operates
-  normally.
-
-  For ephemeral resources in particular, you can use the boolean
-  `terraform.applying` value with `enabled` to specify that a particular
-  ephemeral resource should be active only during the apply phase, which can
-  be useful for values used only by managed resource provisioners because
-  provisioners are active only during the apply phase.
-
-  For more information, refer to [the `enabled` meta-argument](../../language/meta-arguments/enabled.mdx).
-
 * `precondition` and `postcondition` blocks, as described in
   [Custom Conditions](../../language/expressions/custom-conditions.mdx#preconditions-and-postconditions).
+
+Following the same rule of not allowing ephemeral values in repetition meta arguments (`count`, `for_each`),
+`lifecycle.enabled` disallows usage of such values too, including the usage of [`tofu.applying`](../expressions/references.mdx#filesystem-and-workspace-info).
+
+For more information, refer to [the `enabled` meta-argument](../../language/meta-arguments/enabled.mdx).
 
 ## Deferred opening
 By design, the ephemeral resources cannot be opened if the configuration is not fully known.


### PR DESCRIPTION
This backports #4220 (part of #4085) to v1.12.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
