### PR TITLE
[Backport][v1.12] Unmark the value resulted from the 'enabled' expression evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The v1.12.x release series is supported until **February 1 2027**.
 BUG FIXES:
 
 - Properly handle `TF_ENCRYPTION` with only blank spaces. ([#4265](https://github.com/opentofu/opentofu/pull/4265))
+- The value resulted from the `lifecycle.enabled` evaluation now has its deprecation marks processed correctly ([#4162](https://github.com/opentofu/opentofu/pull/4162))
 
 
 ## 1.12.2

--- a/internal/lang/evalchecks/eval_lifecycle_enabled.go
+++ b/internal/lang/evalchecks/eval_lifecycle_enabled.go
@@ -61,6 +61,10 @@ func EvaluateEnabledExpression(expr hcl.Expression, hclCtxFunc ContextFunc) (boo
 		})
 	}
 
+	var deprDiags tfdiags.Diagnostics
+	rawEnabledVal, deprDiags = marks.ExtractDeprecatedDiagnosticsWithExpr(rawEnabledVal, expr)
+	diags = diags.Append(deprDiags)
+
 	if rawEnabledVal.IsNull() {
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity:    hcl.DiagError,

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -9089,3 +9089,55 @@ func TestContext2Plan_moduleDependsOnWithCheck(t *testing.T) {
 		t.Fatalf("unexpected errors: %s", diags.Err())
 	}
 }
+
+// TestContext2Plan_enabledOnDeprecatedModuleOutput is a regression test for
+// https://github.com/opentofu/opentofu/issues/4161
+// "panic: value is marked, so must be unmarked first in EvaluateEnabledExpression during plan"
+//
+// When a module output is marked as deprecated and that output value is used in another resource
+// lifecycle.enabled, a panic was encountered due to the value being still marked.
+func TestContext2Plan_enabledOnDeprecatedModuleOutput(t *testing.T) {
+	m := testModuleInline(t, map[string]string{
+		"mod/main.tf": `
+output "trigger" {
+  value      = true
+  deprecated = "use other"
+}`,
+		"main.tf": `
+module "m" {
+  source = "./mod"
+}
+
+resource "test_resource" "example" {
+  lifecycle {
+    enabled = module.m.trigger
+  }
+}
+`,
+	})
+
+	p := &MockProvider{
+		GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+			Provider: providers.Schema{Block: &configschema.Block{}},
+			ResourceTypes: map[string]providers.Schema{
+				"test_resource": {Block: &configschema.Block{}},
+			},
+		},
+	}
+	ctx := testContext2(t, &ContextOpts{
+		Plugins: plugins.NewLibrary(map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		}, nil),
+	})
+
+	plan, diags := ctx.Plan(context.Background(), m, states.NewState(), DefaultPlanOpts)
+	if diags.HasErrors() {
+		t.Errorf("unexpected errors: %s", diags.Err())
+	}
+	if plan == nil {
+		t.Fatalf("expected a plan but got nothing")
+	}
+	if changes := len(plan.Changes.Resources); changes != 1 {
+		t.Fatalf("expected to have exactly one resource change but got %d", changes)
+	}
+}


### PR DESCRIPTION
This backports #4162 (part of #4161) to v1.12.
This was meant to be included in v1.12.2 but we missed it, as reported by [this comment](https://github.com/opentofu/opentofu/pull/4162#issuecomment-4715713256).

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
