### PR TITLE
moved: change type with provider

### DIFF
--- a/internal/tofu/context_plan.go
+++ b/internal/tofu/context_plan.go
@@ -969,7 +969,11 @@ func (c *Context) driftedResources(ctx context.Context, config *configs.Config, 
 					prevRunAddr = move.From
 				}
 
-				if isResourceMovedToDifferentType(addr, prevRunAddr) {
+				// Note: provider addr is provided twice;
+				// we cannot compare the currently configured provider
+				// with the resource's provider from the previous state, so
+				// we'll skip the provider check
+				if isResourceMovedToDifferentType(addr, prevRunAddr, provider, provider) {
 					// We don't report drift in case of resource type change
 					continue
 				}

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -35,6 +35,8 @@ import (
 	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
+
+	regaddr "github.com/opentofu/registry-address/v2"
 )
 
 func TestContext2Plan_removedDuringRefresh(t *testing.T) {
@@ -1814,6 +1816,125 @@ func TestContext2Plan_movedResourceToDifferentType(t *testing.T) {
 			if got, want := instPlan.ActionReason, plans.ResourceInstanceChangeNoReason; got != want {
 				t.Errorf("wrong action reason\ngot:  %s\nwant: %s", got, want)
 			}
+		})
+	}
+}
+func TestContext2Plan_movedResourceToDifferentProvider(t *testing.T) {
+	// This tests a rare scenario where providers might
+	// change during a move, as brought up here:
+	// https://github.com/opentofu/opentofu/issues/4271
+	SkipExperimental(t, ExperimentalFeatureMoved)
+
+	type test struct {
+		name      string
+		schema    providers.Schema
+		resType   string
+		config    map[string]string
+		attrsJSON []byte
+	}
+
+	tests := []test{
+		{
+			name: "providers have same local name, but different namespace",
+			schema: constructProviderSchemaForTesting(map[string]*configschema.Attribute{
+				"test_number": {
+					Type:     cty.Number,
+					Optional: true,
+				},
+			}),
+			resType: "test_object",
+			config: map[string]string{
+				"main.tf": `
+					terraform {
+						required_providers {
+							test = {
+								source = "opentofu/test"
+							}
+						}
+					}
+
+					resource "test_object" "new" {
+
+					}
+					moved {
+						from = test_object.old
+						to   = test_object.new
+					}
+				`,
+			},
+			attrsJSON: []byte(`{}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldAddr := mustResourceInstanceAddr(tt.resType + ".old")
+			m := testModuleInline(t, tt.config)
+
+			providerAddr1 := addrs.AbsProviderConfig{
+				Provider: regaddr.Provider{
+					Type:      addrs.MustParseProviderPart("test"),
+					Namespace: "hashicorp",
+					Hostname:  addrs.DefaultProviderRegistryHost,
+				},
+				Module: addrs.RootModule,
+			}
+
+			providerAddr2 := addrs.AbsProviderConfig{
+				Provider: regaddr.Provider{
+					Type:      addrs.MustParseProviderPart("test"),
+					Namespace: "opentofu",
+					Hostname:  addrs.DefaultProviderRegistryHost,
+				},
+				Module: addrs.RootModule,
+			}
+
+			state := states.BuildState(
+				func(s *states.SyncState) {
+					s.SetResourceProvider(oldAddr.ContainingResource(), providerAddr1)
+					s.SetResourceInstanceCurrent(oldAddr, &states.ResourceInstanceObjectSrc{
+						Status:    states.ObjectReady,
+						AttrsJSON: tt.attrsJSON,
+					}, providerAddr1, addrs.NoKey)
+				})
+
+			provider1 := &MockProvider{
+				// Old provider, saved in state as the previous provider address
+				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+					ResourceTypes: map[string]providers.Schema{
+						tt.resType: tt.schema,
+					},
+				},
+			}
+
+			provider2 := &MockProvider{
+				// New provider has identical schema; we register it with a new address, but same provider name
+				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+					ResourceTypes: map[string]providers.Schema{
+						tt.resType: tt.schema,
+					},
+				},
+			}
+
+			providerFactory := map[addrs.Provider]providers.Factory{
+				providerAddr1.Provider: testProviderFuncFixed(provider1),
+				providerAddr2.Provider: testProviderFuncFixed(provider2),
+			}
+
+			ctx := testContext2(t, &ContextOpts{
+				Plugins: plugins.NewLibrary(providerFactory, nil),
+			})
+
+			_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
+				Mode: plans.NormalMode,
+			})
+
+			if !provider2.MoveResourceStateCalled {
+				// We want the provider to move to the other state
+				t.Fatal("expected a call to MoveResourceState, but none occurred")
+			}
+
+			assertNoErrors(t, diags)
 		})
 	}
 }

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -602,8 +602,8 @@ func (n *NodeAbstractResource) writeResourceState(ctx context.Context, evalCtx E
 	return diags
 }
 
-func isResourceMovedToDifferentType(newAddr, oldAddr addrs.AbsResourceInstance) bool {
-	return newAddr.Resource.Resource.Type != oldAddr.Resource.Resource.Type
+func isResourceMovedToDifferentType(newAddr, oldAddr addrs.AbsResourceInstance, providerAddr, oldProviderAddr addrs.Provider) bool {
+	return newAddr.Resource.Resource.Type != oldAddr.Resource.Resource.Type || !providerAddr.Equals(oldProviderAddr)
 }
 
 // readResourceInstanceState reads the current object for a specific instance in
@@ -640,7 +640,8 @@ func (n *NodeAbstractResourceInstance) readResourceInstanceState(ctx context.Con
 		currentSchema:        schema.Block,
 		currentSchemaVersion: currentVersion,
 	}
-	if isResourceMovedToDifferentType(addr, prevAddr) {
+	providerAddr, prevProviderAddr := n.getResourceProviderAddrs(evalCtx, addr)
+	if isResourceMovedToDifferentType(addr, prevAddr, providerAddr, prevProviderAddr) {
 		src, diags = moveResourceState(transformArgs)
 	} else {
 		src, diags = upgradeResourceState(transformArgs)
@@ -664,6 +665,18 @@ func (n *NodeAbstractResourceInstance) readResourceInstanceState(ctx context.Con
 	}
 
 	return obj, diags
+}
+
+func (n *NodeAbstractResourceInstance) getResourceProviderAddrs(evalCtx EvalContext, addr addrs.AbsResourceInstance) (addrs.Provider, addrs.Provider) {
+	// temporarily set prevProviderAddr to the current one,
+	// and use it if prevRunState is not set in this context
+	providerAddr := n.Provider()
+	prevProviderAddr := providerAddr
+	prevRunState := evalCtx.PrevRunState()
+	if prevRunState != nil {
+		prevProviderAddr = prevRunState.ResourceProvider(addr.AffectedAbsResource()).Provider
+	}
+	return providerAddr, prevProviderAddr
 }
 
 // readResourceInstanceStateDeposed reads the deposed object for a specific
@@ -704,7 +717,8 @@ func (n *NodeAbstractResourceInstance) readResourceInstanceStateDeposed(ctx cont
 		currentSchema:        schema.Block,
 		currentSchemaVersion: currentVersion,
 	}
-	if isResourceMovedToDifferentType(addr, prevAddr) {
+	providerAddr, prevProviderAddr := n.getResourceProviderAddrs(evalCtx, addr)
+	if isResourceMovedToDifferentType(addr, prevAddr, providerAddr, prevProviderAddr) {
 		src, diags = moveResourceState(transformArgs)
 	} else {
 		src, diags = upgradeResourceState(transformArgs)


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves #4271

This fixes the case when the provider for a resource is different by dint of namespace or hostname. It is an unusual scenario, but a sharp corner nonetheless.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
