### PR TITLE
resources: Compensate for providers' incorrect `RequiresReplace`

### DIFF
--- a/internal/engine/planning/plan_managed.go
+++ b/internal/engine/planning/plan_managed.go
@@ -305,13 +305,7 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 	plannedAction := plans.Update
 	if prevRoundState == nil {
 		plannedAction = plans.Create
-	} else if len(planResp.RequiresReplace) != 0 {
-		// FIXME: The mere presence of RequiresReplace items is not sufficient
-		// because existing providers often generate spurious entries in there
-		// for paths that aren't actually changing. We need to filter out
-		// any paths whose values are equal between prior and planned in order
-		// to get the expected behavior for real-world providers.
-
+	} else if !planResp.RequiresReplace.Empty() {
 		// For "replace" actions the execution graph will include two separate
 		// plan and apply operations, where one handles deletion and the other
 		// handles creation. There is therefore an implicit third intermediate
@@ -375,7 +369,7 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 			Provider: (*inst.ProviderInstance).Config.Config.Provider,
 			Alias:    (*inst.ProviderInstance).Config.Config.Alias,
 		},
-		RequiredReplace: cty.NewPathSet(planResp.RequiresReplace...),
+		RequiredReplace: planResp.RequiresReplace,
 		Private:         planResp.Planned.Private,
 		Change: plans.Change{
 			Action: plannedAction,
@@ -581,7 +575,7 @@ func (p *planGlue) planUnwantedManagedResourceInstanceObject(
 			Provider: prevRoundState.ProviderInstanceAddr.Config.Config.Provider,
 			Alias:    prevRoundState.ProviderInstanceAddr.Config.Config.Alias,
 		},
-		RequiredReplace: cty.NewPathSet(planResp.RequiresReplace...),
+		RequiredReplace: planResp.RequiresReplace,
 		Private:         planResp.Planned.Private,
 		Change: plans.Change{
 			Action: plans.Delete,

--- a/internal/resources/managed_plan.go
+++ b/internal/resources/managed_plan.go
@@ -11,9 +11,11 @@ import (
 	"log"
 	"strings"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/plans/objchange"
 	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/tfdiags"
@@ -141,17 +143,23 @@ func (rt *ManagedResourceType) PlanChanges(ctx context.Context, req *ManagedReso
 			return nil, diags
 		}
 	}
-	if len(resp.RequiresReplace) != 0 && (currentVal.IsNull() || desiredVal.IsNull()) {
-		// RequiresReplace is only applicable when the plan request had both
-		// a current and a desired value, because it specifies attributes that
-		// cannot be updated-in-place, but unfortunately existing providers
-		// do generate spurious "requires replace" signals for non-update
-		// plans and so we need to just ignore them.
-		log.Printf("[WARN] Ignoring nonsensical RequiresReplace values from provider %s while planning a non-update change for %s", rt.providerAddr, dispAddr)
-		// We'll discard the meaningless extra info here just so that the
-		// rest of the system can assume that this is populated only when it
-		// actually needs to be acted on.
-		resp.RequiresReplace = nil
+	var requiresReplace cty.PathSet
+	if len(resp.RequiresReplace) != 0 {
+		if currentVal.IsNull() || desiredVal.IsNull() {
+			// RequiresReplace is only applicable when the plan request had both
+			// a current and a desired value, because it specifies attributes that
+			// cannot be updated-in-place, but unfortunately existing providers
+			// do generate spurious "requires replace" signals for non-update
+			// plans and so we need to just ignore them.
+			log.Printf("[WARN] Ignoring nonsensical RequiresReplace values from provider %s while planning a non-update change for %s", rt.providerAddr, dispAddr)
+			// We intentionally leave requiresReplace unpopulated here just so
+			// that the rest of the system can assume that this is populated
+			// only when it actually needs to be acted on.
+		} else {
+			pathSet, moreDiags := rt.filteredRequiresReplace(resp.RequiresReplace, currentVal, plannedValUnmarked, schema.Block)
+			diags = diags.Append(moreDiags)
+			requiresReplace = pathSet
+		}
 	}
 
 	// FIXME: plannedVal also needs sensitive marks added to it based on the
@@ -168,7 +176,7 @@ func (rt *ManagedResourceType) PlanChanges(ctx context.Context, req *ManagedReso
 			Value:   plannedVal,
 			Private: plannedPrivate,
 		},
-		RequiresReplace: resp.RequiresReplace,
+		RequiresReplace: requiresReplace,
 	}, diags
 }
 
@@ -317,7 +325,7 @@ type ManagedResourcePlanResponse struct {
 	//
 	// If this collection is zero-length then this change should instead be
 	// applied with only a single call to [ApplyManagedResourceChange].
-	RequiresReplace []cty.Path
+	RequiresReplace cty.PathSet
 }
 
 func (rt *ManagedResourceType) providerCanPlanDestroy(ctx context.Context) bool {
@@ -335,4 +343,97 @@ func (rt *ManagedResourceType) providerCanPlanDestroy(ctx context.Context) bool 
 		return false
 	}
 	return resp.ServerCapabilities.PlanDestroy
+}
+
+// filteredRequiresReplace filters the "requires replace" paths returned by
+// a provider to include only paths to values that are actually different
+// between the current and planned values.
+//
+// This compensates for common provider misbehavior of returning
+// "requires replace" paths even when the corresponding value isn't actually
+// changing, which unfortunately we must allow because OpenTofu and its
+// predecessor accepted it long enough that many existing providers ended up
+// inadvertently relying on it.
+func (rt *ManagedResourceType) filteredRequiresReplace(returned []cty.Path, currentVal, plannedVal cty.Value, schema *configschema.Block) (cty.PathSet, tfdiags.Diagnostics) {
+	var ret cty.PathSet
+	var diags tfdiags.Diagnostics
+	if len(returned) == 0 {
+		return ret, diags
+	}
+	addPath := func(path cty.Path) {
+		if ret.Empty() {
+			ret = cty.NewPathSet()
+		}
+		ret.Add(path)
+	}
+	for _, path := range returned {
+		if currentVal.IsNull() {
+			// If currentVal is null then we don't expect any RequiresReplace
+			// at all, because this is a Create action.
+			continue
+		}
+
+		currentChangedVal, currentPathDiags := hcl.ApplyPath(currentVal, path, nil)
+		plannedChangedVal, plannedPathDiags := hcl.ApplyPath(plannedVal, path, nil)
+		if plannedPathDiags.HasErrors() && currentPathDiags.HasErrors() {
+			// This means the path is invalid in both the current and new
+			// values, which is an error with the provider itself.
+			// (This particular thing is something that both OpenTofu and
+			// its predecessor historically enforced, so it's safe for us to
+			// continue enforcing it here.)
+			diags = diags.Append(tfdiags.AttributeValue(
+				tfdiags.Error,
+				"Provider produced invalid plan",
+				fmt.Sprintf(
+					"Provider %q has indicated \"requires replacement\" for a non-existent attribute path %#v.\n\nThis is a bug in the provider, which should be reported in the provider's own issue tracker.",
+					rt.providerAddr, path,
+				),
+				// This path evidently refers to something that doesn't exist
+				// and so this won't match exactly, but the caller can still
+				// resolve it into something approximately correct even if
+				// it's just to the overall resource instance that's affected.
+				path,
+			))
+			continue
+		}
+
+		// Make sure we have valid Values for both values.
+		// Note: if the opposing value was of the type
+		// cty.DynamicPseudoType, the type assigned here may not exactly
+		// match the schema. This is fine here, since we're only going to
+		// check for equality, but if the NullVal is to be used, we need to
+		// check the schema for the true type.
+		switch {
+		case currentChangedVal == cty.NilVal && plannedChangedVal == cty.NilVal:
+			// this should never happen without ApplyPath errors above
+			panic("requires replace path returned 2 nil values")
+		case currentChangedVal == cty.NilVal:
+			currentChangedVal = cty.NullVal(plannedChangedVal.Type())
+		case plannedChangedVal == cty.NilVal:
+			plannedChangedVal = cty.NullVal(currentChangedVal.Type())
+		}
+
+		// Unmark for this value for the equality test. Providers are not
+		// aware of marks and so a marks-only change cannot possibly require
+		// a provider to replace something.
+		unmarkedCurrentChangedVal, _ := currentChangedVal.UnmarkDeep()
+		unmarkedPlannedChangedVal, _ := plannedChangedVal.UnmarkDeep()
+		eqV := unmarkedPlannedChangedVal.Equals(unmarkedCurrentChangedVal)
+		if !eqV.IsKnown() || eqV.False() {
+			addPath(path)
+			// we continue here to avoid the lookup for the attribute on the next section
+			continue
+		}
+
+		// If a write-only requests the replacement of the resource, we add that to the
+		// reqRep just because it's write-only.
+		// Needed because there is no way to apply the path based on the equivalence
+		// of the before/after values of this, since both are meant to always be null.
+		schemaAttr := schema.AttributeByPath(path)
+		isWo := schemaAttr != nil && schemaAttr.WriteOnly
+		if isWo {
+			addPath(path)
+		}
+	}
+	return ret, diags
 }

--- a/internal/resources/managed_plan_test.go
+++ b/internal/resources/managed_plan_test.go
@@ -345,9 +345,54 @@ func TestManagedResourceTypePlanChanges(t *testing.T) {
 						"name": cty.StringVal("rumleskaft"),
 					}),
 				},
-				RequiresReplace: []cty.Path{
+				RequiresReplace: cty.NewPathSet(
 					cty.GetAttrPath("name"),
+				),
+			},
+		},
+		"requires replacement spurious when updating": {
+			Schema: nameSchema,
+			PlanImpl: func(_ context.Context, req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+				return providers.PlanResourceChangeResponse{
+					PlannedState: req.ProposedNewState,
+					// This test is modeling a common misbehavior in real
+					// providers where they return RequiresReplace entries for
+					// attributes that aren't actually changing. The current
+					// and desired values for "name" are equal and so this
+					// should be filtered out before returning to shield our
+					// callers from this buggy behavior.
+					RequiresReplace: []cty.Path{
+						cty.GetAttrPath("name"),
+					},
+				}
+			},
+			Request: &ManagedResourcePlanRequest{
+				Current: ValueWithPrivate{
+					Value: cty.ObjectVal(map[string]cty.Value{
+						"name": cty.StringVal("rumpelstiltskin"),
+					}),
 				},
+				DesiredValue: cty.ObjectVal(map[string]cty.Value{
+					"name": cty.StringVal("rumpelstiltskin"),
+				}),
+			},
+			WantResponse: &ManagedResourcePlanResponse{
+				Current: ValueWithPrivate{
+					Value: cty.ObjectVal(map[string]cty.Value{
+						"name": cty.StringVal("rumpelstiltskin"),
+					}),
+				},
+				DesiredValue: cty.ObjectVal(map[string]cty.Value{
+					"name": cty.StringVal("rumpelstiltskin"),
+				}),
+				Planned: ValueWithPrivate{
+					Value: cty.ObjectVal(map[string]cty.Value{
+						"name": cty.StringVal("rumpelstiltskin"),
+					}),
+				},
+				// "name" filtered out from RequiresReplace; more information in
+				// PlanImpl above.
+				RequiresReplace: cty.NewPathSet(),
 			},
 		},
 		"requires replacement when creating": {
@@ -390,7 +435,7 @@ func TestManagedResourceTypePlanChanges(t *testing.T) {
 				// the paths in that case so that the rest of the system can
 				// assume that RequiresReplace is set only when a "replace"
 				// action would be appropriate.
-				RequiresReplace: nil,
+				RequiresReplace: cty.NewPathSet(),
 			},
 		},
 		"requires replacement when destroying": {
@@ -433,7 +478,7 @@ func TestManagedResourceTypePlanChanges(t *testing.T) {
 				// the paths in that case so that the rest of the system can
 				// assume that RequiresReplace is set only when a "replace"
 				// action would be appropriate.
-				RequiresReplace: nil,
+				RequiresReplace: cty.NewPathSet(),
 			},
 		},
 		"invalid plan": {

--- a/internal/tofu/context_apply2_test.go
+++ b/internal/tofu/context_apply2_test.go
@@ -70,6 +70,13 @@ func TestContext2Apply_createBeforeDestroy_deposedKeyPreApply(t *testing.T) {
 		addrs.NoKey,
 	)
 
+	// This particular test can't work with the new runtime because it relies
+	// on the "hooks" mechanism that the new runtime does not use. We will
+	// eventually have _some_ mechanism for the new runtime to notify the
+	// caller of its progress, but it probably won't be exactly this hook
+	// API and so we should adapt this test to whatever the final answer is.
+	SkipExperimental(t, ExperimentalNewStrategyNeeded)
+
 	hook := new(MockHook)
 	ctx := testContext2(t, &ContextOpts{
 		Hooks: []Hook{hook},
@@ -78,7 +85,6 @@ func TestContext2Apply_createBeforeDestroy_deposedKeyPreApply(t *testing.T) {
 		}, nil),
 	})
 
-	SkipExperimental(t, ExperimentalFeatureCBD)
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
@@ -174,6 +180,7 @@ func TestContext2Apply_createBeforeDestroy_dependsNonCBDUpdate(t *testing.T) {
 		t.Log(legacyDiffComparisonString(plan.Changes))
 	}
 
+	SkipExperimental(t, ExperimentalBugMissingProvider)
 	state, diags = ctx.Apply(context.Background(), plan, m, nil)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())

--- a/internal/tofu/context_apply_test.go
+++ b/internal/tofu/context_apply_test.go
@@ -993,6 +993,7 @@ func TestContext2Apply_createBeforeDestroy(t *testing.T) {
 		t.Logf("%s", legacyDiffComparisonString(plan.Changes))
 	}
 
+	SkipExperimental(t, ExperimentalBugMissingProvider)
 	state, diags = ctx.Apply(context.Background(), plan, m, nil)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
@@ -1012,7 +1013,6 @@ func TestContext2Apply_createBeforeDestroy(t *testing.T) {
 }
 
 func TestContext2Apply_createBeforeDestroyUpdate(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugSpuriousReplace)
 	m := testModule(t, "apply-good-create-before-update")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -1069,6 +1069,7 @@ func TestContext2Apply_createBeforeDestroyUpdate(t *testing.T) {
 		}, nil),
 	})
 
+	SkipExperimental(t, ExperimentalBugMissingProvider)
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
@@ -1137,6 +1138,7 @@ func TestContext2Apply_createBeforeDestroy_dependsNonCBD(t *testing.T) {
 		t.Logf("%s", legacyDiffComparisonString(plan.Changes))
 	}
 
+	SkipExperimental(t, ExperimentalBugMissingProvider)
 	state, diags = ctx.Apply(context.Background(), plan, m, nil)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
@@ -1160,6 +1162,7 @@ aws_instance.foo:
 	`)
 
 	// Check that create_before_destroy was set on the foo resource
+	SkipExperimental(t, ExperimentalBugStateCBD)
 	foo := state.RootModule().Resources["aws_instance.foo"].Instances[addrs.NoKey].Current
 	if !foo.CreateBeforeDestroy {
 		t.Fatalf("foo resource should have create_before_destroy set")
@@ -1231,6 +1234,8 @@ func TestContext2Apply_createBeforeDestroy_hook(t *testing.T) {
 
 // Test that we can perform an apply with CBD in a count with deposed instances.
 func TestContext2Apply_createBeforeDestroy_deposedCount(t *testing.T) {
+	SkipExperimental(t, ExperimentalFeatureTaint)
+
 	m := testModule(t, "apply-cbd-count")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -1354,6 +1359,7 @@ func TestContext2Apply_createBeforeDestroy_deposedOnly(t *testing.T) {
 		t.Logf("%s", legacyDiffComparisonString(plan.Changes))
 	}
 
+	SkipExperimental(t, ExperimentalBugMissingProvider)
 	state, diags = ctx.Apply(context.Background(), plan, m, nil)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
@@ -4852,6 +4858,7 @@ func TestContext2Apply_errorDestroy_createBeforeDestroy(t *testing.T) {
 		t.Fatal("should have error")
 	}
 
+	SkipExperimental(t, ExperimentalBugTaintOnCreateFail)
 	actual := strings.TrimSpace(state.String())
 	expected := strings.TrimSpace(testTofuApplyErrorDestroyCreateBeforeDestroyStr)
 	if actual != expected {
@@ -4933,6 +4940,7 @@ func TestContext2Apply_multiDepose_createBeforeDestroy(t *testing.T) {
 		t.Fatal("should have error")
 	}
 
+	SkipExperimental(t, ExperimentalBugTaintOnCreateFail)
 	checkStateString(t, state, `
 aws_instance.web: (1 deposed)
   ID = bar
@@ -11525,6 +11533,7 @@ resource "aws_instance" "cbd" {
 		t.Fatal(diags.ErrWithWarnings())
 	}
 
+	SkipExperimental(t, ExperimentalBugStateCBD)
 	foo := state.ResourceInstance(mustResourceInstanceAddr("aws_instance.foo"))
 	if !foo.Current.CreateBeforeDestroy {
 		t.Fatal("aws_instance.foo should also be create_before_destroy")
@@ -11889,6 +11898,17 @@ locals {
 		t.Fatal(diags.ErrWithWarnings())
 	}
 	{
+		// This check is relying on the old runtime's behavior of inserting
+		// a "NoOp" change for every resource instance it considered during
+		// planning that didn't turn out to need any changes, because that
+		// NoOp change served as a way to record the planning result for
+		// downstream expression evaluation.
+		// Thew new runtime doesn't have that need because downstream evaluation
+		// is handled from the evaluator's internal tracking structures, and so
+		// it's actually expected for there to be no planned change for
+		// test_instance.a[0] here.
+		SkipExperimental(t, ExperimentalNewStrategyNeeded)
+
 		addr := mustResourceInstanceAddr("test_instance.a[0]")
 		change := plan.Changes.ResourceInstance(addr)
 		if change == nil {
@@ -12305,6 +12325,7 @@ resource "test_resource" "a" {
 	})
 	assertNoErrors(t, diags)
 
+	SkipExperimental(t, ExperimentalBugMissingProvider)
 	_, diags = ctx.Apply(context.Background(), plan, m, nil)
 	if diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -2802,7 +2802,7 @@ func TestContext2Plan_refreshOnlyMode_deposed(t *testing.T) {
 		}, nil),
 	})
 
-	SkipExperimental(t, ExperimentalFeatureCBD)
+	SkipExperimental(t, ExperimentalFeatureRefreshOnly)
 	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.RefreshOnlyMode,
 	})
@@ -4942,7 +4942,7 @@ resource "test_object" "b" {
 		}, nil),
 	})
 
-	SkipExperimental(t, ExperimentalFeatureCBD)
+	SkipExperimental(t, ExperimentalBugMissingProvider)
 	_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 	})

--- a/internal/tofu/context_plan_test.go
+++ b/internal/tofu/context_plan_test.go
@@ -163,6 +163,7 @@ func TestContext2Plan_createBefore_deposed(t *testing.T) {
 		changes[k] = change
 	}
 	if !reflect.DeepEqual(got, want) {
+		SkipExperimental(t, ExperimentalChangeNoNoOp) // new runtime intentionally omits the NoOp change for the non-deposed object
 		t.Fatalf("wrong resource instance object changes in plan\ngot: %s\nwant: %s", spew.Sdump(got), spew.Sdump(want))
 	}
 

--- a/internal/tofu/context_refresh_test.go
+++ b/internal/tofu/context_refresh_test.go
@@ -1875,6 +1875,7 @@ resource "aws_instance" "bar" {
 		t.Fatalf("plan errors: %s", diags.Err())
 	}
 
+	SkipExperimental(t, ExperimentalBugStateCBD)
 	r := state.ResourceInstance(mustResourceInstanceAddr("aws_instance.bar"))
 	if !r.Current.CreateBeforeDestroy {
 		t.Fatal("create_before_destroy not updated in instance state")

--- a/internal/tofu/context_temp_runtime_test.go
+++ b/internal/tofu/context_temp_runtime_test.go
@@ -29,23 +29,26 @@ var (
 	ExperimentalBugVariableInput     = ExperimentalFlag{"Bug Variable Input", true}
 	ExperimentalBugCancel            = ExperimentalFlag{"Bug Context Cancel", false}
 	ExperimentalBugStateProvider     = ExperimentalFlag{"Bug State Provider", false}
+	ExperimentalBugStateCBD          = ExperimentalFlag{"Bug CreateBeforeDestroy Not Tracked In State", false}
 	ExperimentalBugReferenceProvider = ExperimentalFlag{"Bug Reference Provider", false}
 	ExperimentalBugMissingProvider   = ExperimentalFlag{"Bug Missing Configuration For Provider", false}
 	ExperimentalBugResourceReadNull  = ExperimentalFlag{"Bug Read Resource Deleted", false}
 	ExperimentalBugDataResource      = ExperimentalFlag{"Bug Data Resource", false}
 	ExperimentalBugVariableSensitive = ExperimentalFlag{"Bug Variables Declared as Sensitive", true}
 	ExperimentalBugResourceMarks     = ExperimentalFlag{"Bug Not Transferring Marks from Resource Instance Config Value to Final Value", false}
+	ExperimentalBugTaintOnCreateFail = ExperimentalFlag{"Bug Not Tainted When Create Fails", false}
 	ExperimentalBugForEach           = ExperimentalFlag{"Bug For Each", true}
-	ExperimentalBugSpuriousReplace   = ExperimentalFlag{"Bug Spurious Replace", false} // New runtime proposes replace where old runtime would've called for update
+	ExperimentalBugSpuriousReplace   = ExperimentalFlag{"Bug Spurious Replace", true} // New runtime proposes replace where old runtime would've called for update
 
 	ExperimentalChangeDiagWording     = ExperimentalFlag{"Change Different Diagnostic Wording", false}
 	ExperimentalChangeErrorEarly      = ExperimentalFlag{"Change Detect Error Earlier", false}
 	ExperimentalChangeDependencies    = ExperimentalFlag{"Change Precise Dependencies", false}
 	ExperimentalChangeDeferredActions = ExperimentalFlag{"Change New Runtime Supports Deferred Actions", false}
+	ExperimentalChangeNoNoOp          = ExperimentalFlag{"Change New Runtime Doesn't Generate NoOp Changes", false}
 
 	ExperimentalFeatureStateDependencies = ExperimentalFlag{"Missing State Dependencies", true}
 	ExperimentalFeatureProviderInstances = ExperimentalFlag{"Missing Provider Instances", true}
-	ExperimentalFeatureCBD               = ExperimentalFlag{"Missing Create Before Destroy", false}
+	ExperimentalFeatureCBD               = ExperimentalFlag{"Missing Create Before Destroy", true}
 	ExperimentalFeatureDeposed           = ExperimentalFlag{"Missing Deposed", false}
 	ExperimentalFeatureCondition         = ExperimentalFlag{"Missing Pre/Post Conditions", false}
 	ExperimentalFeatureLocalState        = ExperimentalFlag{"Missing Store locals in state", false}
@@ -54,6 +57,7 @@ var (
 	ExperimentalFeatureDeprecated        = ExperimentalFlag{"Missing Deprecated", false}
 	ExperimentalFeatureImport            = ExperimentalFlag{"Missing Importing", false}
 	ExperimentalFeatureRefresh           = ExperimentalFlag{"Missing Refresh", false}
+	ExperimentalFeatureRefreshOnly       = ExperimentalFlag{"Missing Refresh-only Planning Mode", false}
 	ExperimentalFeatureValidate          = ExperimentalFlag{"Missing Validate", false}
 	ExperimentalFeatureDestroy           = ExperimentalFlag{"Missing Destroy", false}
 	ExperimentalFeatureMoved             = ExperimentalFlag{"Missing Moved", false}


### PR DESCRIPTION
OpenTofu and its predecessor did not historically raise an error when providers returned `RequiresReplace` paths referring to attributes whose values haven't actually changed and instead just silently ignored them.

We need to mimic that behavior in the new runtime too, for compatibility. This is an extension of the previously-added rule of just throwing the entire `RequiresReplace` value away if the planned action is create or delete. For "update" we can't just throw the whole set away, but we do throw away any paths that refer to something that hasn't changed and thus continue the principle that `package resources` is the one responsible for checking for and dealing with provider misbehavior.

This new logic is based directly on the equivalent logic from the old runtime in `package tofu`, implementing exactly the same filtering rules.

---

This was ultimately the cause of the remaining "CBD-related" tests that were failing after https://github.com/opentofu/opentofu/pull/4226. As I suspected at the time, the failures were not directly related to the create-before-destroy handling and were instead just overrepresented in those particular tests because `create_before_destroy` tests always involve "replace" actions in one way or another.

