### PR TITLE
planning: Delete steps fall back to depending on create/update steps

### DIFF
--- a/internal/engine/planning/execgraph_resource.go
+++ b/internal/engine/planning/execgraph_resource.go
@@ -77,9 +77,7 @@ func (b *execGraphBuilder) AddResourceInstanceObjectSubgraphs(
 
 	// First we'll insert separate subgraphs for each resource instance object
 	// that has a planned action, without putting any explicit dependency
-	// edges between them yet. This loop also ensures that we have the
-	// operations needed for any provider instance at least one object
-	// belongs to.
+	// edges between them yet.
 	//
 	// We'll insert the explicit dependency edges between the subgraphs in a
 	// separate loop afterwards, along with any needed prior state operations
@@ -133,6 +131,26 @@ func (b *execGraphBuilder) AddResourceInstanceObjectSubgraphs(
 			for dependent := range objs.Dependendents(addr) {
 				if ref, ok := deletionRefs.GetOk(dependent); ok {
 					addDeleteDep(ref)
+				} else if ref, ok := resultRefs.GetOk(dependent); ok {
+					// If there's no deletion ref but the dependent still has
+					// a value ref (e.g. if the dependent is only being created
+					// or updated) then we wait until its create/update step
+					// has completed before deleting.
+					addDeleteDep(ref)
+					// TODO: The old runtime's equivalent of this behavior has a
+					// hackily-implemented extra rule where it checks if
+					// adding this edge would create a cycle and skips adding
+					// it if so. Do we need to replicate that here? The
+					// commentary on the function that implements it
+					// ([DestroyEdgeTransformer.tryInterProviderDestroyEdge])
+					// explains that it's needed because when applying a
+					// destroy-mode plan provider instances are allowed to refer
+					// to a resource instance that's being destroyed and expect
+					// that to take values from the prior state, and so we'll
+					// tackle this question when we add support for destroy-mode
+					// planning (which seems likely to have its own separate
+					// execgraph-building logic just because the rules are quite
+					// different for that planning mode).
 				}
 			}
 		}

--- a/internal/tofu/context_apply_test.go
+++ b/internal/tofu/context_apply_test.go
@@ -1069,7 +1069,7 @@ func TestContext2Apply_createBeforeDestroyUpdate(t *testing.T) {
 		}, nil),
 	})
 
-	SkipExperimental(t, ExperimentalBugMissingProvider, ExperimentalBugExecGraph2)
+	SkipExperimental(t, ExperimentalBugMissingProvider)
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())

--- a/internal/tofu/context_temp_runtime_test.go
+++ b/internal/tofu/context_temp_runtime_test.go
@@ -39,7 +39,6 @@ var (
 	ExperimentalBugTaintOnCreateFail = ExperimentalFlag{"Bug Not Tainted When Create Fails", false}
 	ExperimentalBugForEach           = ExperimentalFlag{"Bug For Each", true}
 	ExperimentalBugSpuriousReplace   = ExperimentalFlag{"Bug Spurious Replace", true} // New runtime proposes replace where old runtime would've called for update
-	ExperimentalBugExecGraph2        = ExperimentalFlag{"Bug in generated Exec Graph (2)", false}
 
 	ExperimentalChangeDiagWording     = ExperimentalFlag{"Change Different Diagnostic Wording", false}
 	ExperimentalChangeErrorEarly      = ExperimentalFlag{"Change Detect Error Earlier", false}


### PR DESCRIPTION
This logic was previously missing an important rule for handling dependencies for a "delete" action: if something that's being deleted depends on something that is only being created or updated (not deleted or replaced) then that delete action is expected to wait until the create or update has completed.

This extra rule is subtle but helps deal with the rare bothersome situations where it's necessary to update one thing before another thing can be deleted, due to constraints enforced in a remote API. For example, it might be necessary to update a container to disable remote-enforced deletion protection before it's possible to delete anything nested inside that container.

This fixes a bug that we noticed earlier while preparing https://github.com/opentofu/opentofu/pull/4284.

---

The TODO comment added here is foreshadowing something we're going to need to deal with when we implement destroy-mode planning later: while it's tempting to think of destroy-mode planning as equivalent to planning with a prior state and an empty configuration, in practice it's treated quite differently because in that case all references from ephemeral objects to managed resource instances are expected to be resolved from the prior state before the dependencies are destroyed. (In normal-mode planning, a reference to an "orphan" resource instance would be forbidden.)

Therefore I'm anticipating that destroy-mode planning will be different enough to have its own logic for constructing the execution graph, but we'll wait until we get to implementing that to make a final decision about how to handle this case.

(The context tests covering that gap are already guarded by `ExperimentalFeatureDestroy`, so we're currently skipping them.)

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
