### PR TITLE
Fix duplicated word in S3 backend key validation error

### DIFF
--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -509,7 +509,7 @@ func (b *Backend) PrepareConfig(obj cty.Value) (cty.Value, tfdiags.Diagnostics) 
 		diags = diags.Append(tfdiags.AttributeValue(
 			tfdiags.Error,
 			"Invalid key value",
-			`The "key" attribute value must not start or end with with "/".`,
+			`The "key" attribute value must not start or end with "/".`,
 			cty.Path{cty.GetAttrStep{Name: "key"}},
 		))
 	}

--- a/internal/backend/remote-state/s3/backend_test.go
+++ b/internal/backend/remote-state/s3/backend_test.go
@@ -649,7 +649,7 @@ func TestBackendConfig_PrepareConfigValidation(t *testing.T) {
 				"key":    cty.StringVal("/leading-slash"),
 				"region": cty.StringVal("us-west-2"),
 			}),
-			expectedErr: `The "key" attribute value must not start or end with with "/".`,
+			expectedErr: `The "key" attribute value must not start or end with "/".`,
 		},
 		"key with trailing slash": {
 			config: cty.ObjectVal(map[string]cty.Value{
@@ -657,7 +657,7 @@ func TestBackendConfig_PrepareConfigValidation(t *testing.T) {
 				"key":    cty.StringVal("trailing-slash/"),
 				"region": cty.StringVal("us-west-2"),
 			}),
-			expectedErr: `The "key" attribute value must not start or end with with "/".`,
+			expectedErr: `The "key" attribute value must not start or end with "/".`,
 		},
 		"null region": {
 			config: cty.ObjectVal(map[string]cty.Value{


### PR DESCRIPTION
The S3 backend key validation error read "must not start or end with with \"/\"" — removed the duplicated "with". User-facing diagnostic.
