### PR TITLE
Remove the stateLock default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ BUG FIXES:
 - Properly handle `TF_ENCRYPTION` with only blank spaces. ([#4265](https://github.com/opentofu/opentofu/pull/4265))
 - The value resulted from the `lifecycle.enabled` evaluation now has its deprecation marks processed correctly ([#4162](https://github.com/opentofu/opentofu/pull/4162))
 - Update documentation to clarify the usage restriction of ephemeral values in `lifecycle.enabled`. ([#4220](https://github.com/opentofu/opentofu/pull/4220))
+- `tofu console -lock=false` now works as intended. ([#4291](https://github.com/opentofu/opentofu/pull/4291))
 
 
 ## 1.12.2

--- a/internal/command/console.go
+++ b/internal/command/console.go
@@ -60,12 +60,6 @@ func (c *ConsoleCommand) Run(rawArgs []string) int {
 	// continue to mutate the Meta object state for now.
 	c.Meta.input = args.ViewOptions.InputEnabled
 
-	// TODO meta-refactor: when the stateLock and stateLockTimeout are extracted to be configured separately, remove
-	// these and use a common way to configure this
-	// The stateLock=true is here this way because this command used before meta.extendedFlagSet which did the same
-	// and left for the command to configure flags for this if needed.
-	c.Meta.stateLock = true
-
 	c.Meta.variableArgs = args.Vars.All()
 
 	configPath := c.WorkingDir.NormalizePath(c.WorkingDir.RootModuleDir())


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves #4290

In [opentofu#3764](https://github.com/opentofu/opentofu/pull/3764/changes#diff-5c5b5ae504fabf75611915b88827dd51226a04b3c4111fc5c53995af2e1bb308R75) I accidentally added a `stateLock=true` assignment that was most probably copy-pasted from another command that I refactored during #3765.
That broke the state locking related flags introduced a week before in #3800.

This affects only v1.12 since this particular refactor was caught in this version. For the `main` branch, I did another refactor in [opentofu#4055](https://github.com/opentofu/opentofu/pull/4055/changes#diff-5c5b5ae504fabf75611915b88827dd51226a04b3c4111fc5c53995af2e1bb308R53) that unified the usage of the state related flags, accidentally fixing the bug that is fixed here.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
