### PR TITLE
fix: consolidate per-instance forget warnings into a single plan diagnostic

### DIFF
--- a/internal/backend/local/backend_plan.go
+++ b/internal/backend/local/backend_plan.go
@@ -8,6 +8,7 @@ package local
 import (
 	"context"
 	"fmt"
+	"strings"
 	"io"
 	"log"
 
@@ -211,6 +212,10 @@ func (b *Local) opPlan(
 		return
 	}
 
+	// Generate a single consolidated warning for any "forget" actions in the plan,
+	// instead of per-instance warnings during planning (see #4201).
+	diags = diags.Append(forgetWarningForPlan(plan))
+
 	op.View.Plan(plan, schemas)
 
 	// If we've accumulated any diagnostics along the way then we'll show them
@@ -262,4 +267,40 @@ func maybeWriteGeneratedConfig(plan *plans.Plan, out string) (wroteConfig bool, 
 	}
 
 	return wroteConfig, diags
+}
+
+
+// forgetWarningForPlan inspects the plan for any "forget" actions and returns
+// a single consolidated warning listing all resource instances that will be
+// removed from state, rather than emitting one warning per instance.
+func forgetWarningForPlan(plan *plans.Plan) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+	if plan == nil || plan.Changes == nil {
+		return diags
+	}
+
+	var forgotten []string
+	for _, rc := range plan.Changes.Resources {
+		if rc.Action == plans.Forget || rc.Action == plans.ForgetThenCreate {
+			forgotten = append(forgotten, " - "+rc.Addr.String())
+		}
+	}
+
+	if len(forgotten) == 0 {
+		return diags
+	}
+
+	detail := "After this plan is applied, the objects associated with the following\n" +
+		"resource instances will no longer be managed by OpenTofu:\n" +
+		strings.Join(forgotten, "\n") + "\n\n" +
+		"These objects will continue to exist in the remote system until you delete\n" +
+		"them outside of OpenTofu. If you wish to manage any of these objects with\n" +
+		"OpenTofu again in future then you will need to re-import them."
+
+	diags = diags.Append(tfdiags.Sourceless(
+		tfdiags.Warning,
+		"Objects will be removed from state",
+		detail,
+	))
+	return diags
 }

--- a/internal/tofu/node_resource_plan_orphan.go
+++ b/internal/tofu/node_resource_plan_orphan.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/hashicorp/hcl/v2"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/plans"
@@ -215,11 +214,6 @@ func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(ctx context
 	if shouldDestroy {
 		change, planDiags = n.planDestroy(ctx, evalCtx, oldState, "")
 	} else {
-		diags = diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagWarning,
-			Summary:  "Resource will be removed from the state",
-			Detail:   fmt.Sprintf("After this plan is applied, the resource %s will not be managed anymore by OpenTofu.\n\nIn case you want to manage the resource again, you will have to import it.", n.Addr),
-		})
 		log.Printf("[DEBUG] NodePlannableResourceInstanceOrphan.managedResourceExecute: %s (orphan) planning forget instead of destroy", addr)
 		change = n.planForget(ctx, evalCtx, oldState, "")
 		if skipDestroy {


### PR DESCRIPTION
Resolves #4201

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [ ] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

**Transparency note:** An AI assistant was used to help draft this change. However, the implementation is small (one function removal + one new ~30-line function), follows the exact design specified by @apparentlymart in the pinned issue comment, and I have reviewed and understand every line. No Terraform source code was referenced. If this is not acceptable under your contribution policy, I'm happy to discuss.

### Go checklist

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

## Description

When a `removed` block with `lifecycle { destroy = false }` is used inside a module called with `for_each`, OpenTofu previously emitted one warning per resource instance being forgotten. For large `for_each` sets this produced hundreds of identical warnings, overwhelming the plan output.

## Changes

1. **`internal/tofu/node_resource_plan_orphan.go`** — Removed the per-instance `hcl.Diagnostic` warning that was appended for each forgotten resource. The "forget" action is still recorded in the plan as before.

2. **`internal/backend/local/backend_plan.go`** — Added `forgetWarningForPlan()` which inspects the completed plan for any `Forget` or `ForgetThenCreate` actions and emits a single consolidated warning listing all affected resource instance addresses.

## Output comparison

**Before (one warning per instance):**
```
Warning: Resource will be removed from the state (repeated hundreds of times)
```

**After (single consolidated warning):**
```
Warning: Objects will be removed from state

After this plan is applied, the objects associated with the following
resource instances will no longer be managed by OpenTofu:
 - module.app["a"].kubernetes_manifest.app
 - module.app["b"].kubernetes_manifest.app

These objects will continue to exist in the remote system until you delete
them outside of OpenTofu. If you wish to manage any of these objects with
OpenTofu again in future then you will need to re-import them.
```

## Testing

Happy to add a unit test for `forgetWarningForPlan` if maintainers prefer — let me know.

## Changelog

```
ENHANCEMENTS:
* Consolidated per-instance "forget" warnings into a single plan diagnostic listing all affected resources (#4201)
```
