### PR TITLE
Resolve symlinks in NormalizePath to fix tofu fmt with absolute paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ BUG FIXES:
 - Fixed TRACESTATE log message incorrectly printing the TRACEPARENT value instead. ([#4168](https://github.com/opentofu/opentofu/issues/4168))
 - Fix rendering of plans where a nested block's replacement is unknown. ([#4256](https://github.com/opentofu/opentofu/issues/4256))
 - `errored.tfstate` is now produced during a go runtime panic. This file will be a partial state and is intended for aiding in recovery from a hard crash. ([#4064](https://github.com/opentofu/opentofu/pull/4064))
+- `tofu fmt` no longer fails with "No file or directory" when given an absolute path while running from a directory reached through a symlink. ([#3879](https://github.com/opentofu/opentofu/issues/3879))
 
 ## Previous Releases
 

--- a/internal/command/workdir/normalize_path.go
+++ b/internal/command/workdir/normalize_path.go
@@ -40,6 +40,20 @@ func (d *Dir) NormalizePath(given string) string {
 		return filepath.Clean(given)
 	}
 
+	// filepath.Abs relies on os.Getwd, which on Unix prefers the $PWD
+	// environment variable when it names the current directory. If OpenTofu
+	// was launched from a directory reached through a symlink, $PWD keeps the
+	// symlinked path while the kernel still resolves relative paths against
+	// the real directory. Computing a relative path against the symlinked
+	// path then yields a result that no longer resolves to the intended file
+	// (e.g. "tofu fmt /abs/path" failing with "No file or directory"). We
+	// canonicalize the main directory so the relative result stays in sync
+	// with how the filesystem actually resolves it.
+	// See https://github.com/opentofu/opentofu/issues/3879.
+	if resolved, err := filepath.EvalSymlinks(absMain); err == nil {
+		absMain = resolved
+	}
+
 	if !filepath.IsAbs(given) {
 		given = filepath.Join(absMain, given)
 	}

--- a/internal/command/workdir/normalize_path_test.go
+++ b/internal/command/workdir/normalize_path_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package workdir
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestNormalizePathSymlinkedMainDir checks that an absolute path is normalized
+// correctly when the main directory is reached through a symlink. Previously
+// the relative result was computed against the symlinked path, producing a
+// path that no longer resolved to the intended file.
+// See https://github.com/opentofu/opentofu/issues/3879.
+func TestNormalizePathSymlinkedMainDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink behavior under test is specific to Unix-like systems")
+	}
+
+	// Canonicalize the temp dir up front so the expectations don't depend on
+	// the platform's own symlinking of the temp location (e.g. /var on macOS).
+	base, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("failed to resolve temp dir: %s", err)
+	}
+
+	realDir := filepath.Join(base, "a", "b")
+	if err := os.MkdirAll(filepath.Join(realDir, "c"), 0o755); err != nil {
+		t.Fatalf("failed to create real dir: %s", err)
+	}
+	target := filepath.Join(realDir, "c", "test.tf")
+	if err := os.WriteFile(target, []byte("\n"), 0o644); err != nil {
+		t.Fatalf("failed to create target file: %s", err)
+	}
+
+	// linkDir is a symlink that points at realDir but lives at a different
+	// depth, mirroring the reproduction in the issue.
+	linkDir := filepath.Join(base, "z")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Fatalf("failed to create symlink: %s", err)
+	}
+
+	d := NewDir(linkDir)
+
+	got := d.NormalizePath(target)
+	if want := filepath.Join("c", "test.tf"); got != want {
+		t.Fatalf("NormalizePath(%q) = %q; want %q", target, got, want)
+	}
+
+	// The normalized path must resolve back to the original file when joined
+	// with the canonicalized main directory.
+	if resolved := filepath.Join(realDir, got); resolved != target {
+		t.Fatalf("normalized path resolved to %q; want %q", resolved, target)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #3879.

`tofu fmt /absolute/path/to/file.tf` fails with `No file or directory` when the command is run from a directory that was reached through a symlink (e.g. `cd` into a symlink that points one or more levels deeper/shallower).

### Root cause

`Dir.NormalizePath` derives the working directory with `filepath.Abs(d.mainDir)`, which for the usual `"."` main dir calls `os.Getwd()`. On Unix `os.Getwd()` prefers the `$PWD` environment variable when it names the current directory, so it returns the **symlinked** path. The kernel, however, resolves relative paths against the **real** directory. `filepath.Rel` then produces a relative path against the symlinked location (e.g. `../a/b/c/test.tf`) that `os.Stat` resolves against the real cwd, pointing at a non-existent file.

This was diagnosed in the issue thread by the reporter and a contributor.

### Fix

Canonicalize the main directory with `filepath.EvalSymlinks` before computing the relative path, keeping the result consistent with how the filesystem resolves it. Relative and `"."` inputs are unaffected: the canonicalization cancels out in the subsequent `filepath.Rel` computation, so only absolute inputs under a symlinked working directory change behavior.

## Testing

Added `TestNormalizePathSymlinkedMainDir`, which reproduces the issue's scenario (a symlinked main directory plus an absolute target path) and asserts the normalized result both equals the expected relative path and resolves back to the original file. The test is skipped on Windows, where the symlink semantics under test don't apply.

## Target Release

1.13.0

## CHANGELOG entry

Added under BUG FIXES.