### PR TITLE
go.mod: Upgrade to Go 1.27rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ UPGRADE NOTES:
 
     [Modern Windows versions now support OpenSSH](https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse), and so we suggest that anyone currently relying on WinRM plan to migrate to using SSH instead.
 
+- The `base64gzip` function now generates results that are equivalent to _but not equal to_ the results from previous releases, as a result of a new optimized DEFLATE compression implementation.
+
+    If you use this function as part of an argument to a managed resource then OpenTofu is likely to propose to update or replace the instances of that resource, depending on how the provider responds to the differing base64 data. The new compressed form should nonetheless still decompress to the same sequence of bytes.
+
+- OpenTofu on macOS now requires macOS 13 Ventura or later. Earlier versions are no longer supported.
+
 ENHANCEMENTS:
 
 - The `gcp_kms` key provider now supports an optional `additional_authenticated_data` as part of the encryption and decryption operations. ([#4287](https://github.com/opentofu/opentofu/pull/4287))

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/opentofu/opentofu
 
-go 1.26.4
+go 1.27
+
+toolchain go1.27rc1
 
 // At the time of adding this configuration, the new Go feature introduced here https://github.com/golang/go/issues/67061,
 // was having a good amount of issues linked to, affecting AWS Firewall, GCP various services and a lot more.

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -1852,7 +1852,7 @@ func TestInit_providerSource(t *testing.T) {
 			getproviders.MustParseVersionConstraints("= 1.2.4"),
 			[]getproviders.Hash{
 				getproviders.HashScheme1.New("vEthLkqAecdQimaW6JHZ0SBRNtHibLnOb31tX9ZXlcI="),
-				getproviders.HashSchemeZip.New("ec7c3fd6eb575c06f0e6957e1ee8531a588805c4eeb8abb5e4156911e080eb31"),
+				getproviders.HashSchemeZip.New("4115ba79e1745c9236f24ce18e643cfc1893140cbc963066348d2dde9c7c55c5"),
 			},
 		),
 		addrs.NewDefaultProvider("test"): depsfile.NewProviderLock(
@@ -1861,7 +1861,7 @@ func TestInit_providerSource(t *testing.T) {
 			getproviders.MustParseVersionConstraints("= 1.2.3"),
 			[]getproviders.Hash{
 				getproviders.HashScheme1.New("8CjxaUBuegKZSFnRos39Fs+CS78ax0Dyb7aIA5XBiNI="),
-				getproviders.HashSchemeZip.New("6f85a1f747dd09455cd77683c0e06da647d8240461b8b36b304b9056814d91f2"),
+				getproviders.HashSchemeZip.New("ac90a1419dd4648431af93b6695b6d6efcad87950ee608de4198df8e6debff23"),
 			},
 		),
 		addrs.NewDefaultProvider("source"): depsfile.NewProviderLock(
@@ -1870,7 +1870,7 @@ func TestInit_providerSource(t *testing.T) {
 			getproviders.MustParseVersionConstraints("= 1.2.3"),
 			[]getproviders.Hash{
 				getproviders.HashScheme1.New("ACYytVQ2Q6JfoEs7xxCqa1yGFf9HwF3SEHzJKBoJfo0="),
-				getproviders.HashSchemeZip.New("69f700dbf9eda586abef22ab08e3a3896760e01885f6cbda4460ceeca4e3c0ba"),
+				getproviders.HashSchemeZip.New("4932d637b6c33444920bf945d6ee17de83ab4b193c1707b35c84d828de880158"),
 			},
 		),
 	}
@@ -2119,7 +2119,7 @@ func TestInit_getUpgradePlugins(t *testing.T) {
 			getproviders.MustParseVersionConstraints("> 1.0.0, < 3.0.0"),
 			[]getproviders.Hash{
 				getproviders.HashScheme1.New("ntfa04OlRqIfGL/Gkd+nGMJSHGWyAgMQplFWk7WEsOk="),
-				getproviders.HashSchemeZip.New("29e1045215056680ac59fe95554f0eb1323534a3d411aae2a7a04495ac884258"),
+				getproviders.HashSchemeZip.New("cf1650d77dfe5681ebd7917a813c0c982d0d2e951ded422a83fbf22a1e0e6bc3"),
 			},
 		),
 		addrs.NewDefaultProvider("exact"): depsfile.NewProviderLock(
@@ -2128,7 +2128,7 @@ func TestInit_getUpgradePlugins(t *testing.T) {
 			getproviders.MustParseVersionConstraints("= 1.2.3"),
 			[]getproviders.Hash{
 				getproviders.HashScheme1.New("Xgk+LFrzi9Mop6+d01TCTaD3kgSrUASCAUU1aDsEsJU="),
-				getproviders.HashSchemeZip.New("9cb7a3006b9c1344b2d838a5bb03c1e0f04b8c046beb38901eaf3cc99fceb870"),
+				getproviders.HashSchemeZip.New("604a3ebf14e83ef19aab2e8e4063c4cd7d53c9c4c30ad22db0d9ce4f8f6edc83"),
 			},
 		),
 		addrs.NewDefaultProvider("greater-than"): depsfile.NewProviderLock(
@@ -2137,7 +2137,7 @@ func TestInit_getUpgradePlugins(t *testing.T) {
 			getproviders.MustParseVersionConstraints(">= 2.3.3"),
 			[]getproviders.Hash{
 				getproviders.HashScheme1.New("8M5DXICmUiVjbkxNNO0zXNsV6duCVNWzq3/Kf0mNIo4="),
-				getproviders.HashSchemeZip.New("bfb683ee94027efb191986484352ada8219cd45e856d25c2ddcb489e100a9a02"),
+				getproviders.HashSchemeZip.New("4c638927fcf2d35eb1c3a91c6745c0bef1a5365294641d4a8fca9c529cb8521f"),
 			},
 		),
 	}
@@ -2321,7 +2321,7 @@ provider "registry.opentofu.org/hashicorp/test" {
   constraints = "1.2.3"
   hashes = [
     "h1:8CjxaUBuegKZSFnRos39Fs+CS78ax0Dyb7aIA5XBiNI=",
-    "zh:6f85a1f747dd09455cd77683c0e06da647d8240461b8b36b304b9056814d91f2",
+    "zh:ac90a1419dd4648431af93b6695b6d6efcad87950ee608de4198df8e6debff23",
   ]
 }
 `)
@@ -2354,7 +2354,7 @@ provider "registry.opentofu.org/hashicorp/test" {
   version     = "1.2.3"
   constraints = "1.2.3"
   hashes = [
-    "zh:6f85a1f747dd09455cd77683c0e06da647d8240461b8b36b304b9056814d91f2",
+    "zh:ac90a1419dd4648431af93b6695b6d6efcad87950ee608de4198df8e6debff23",
   ]
 }
 `)
@@ -2381,7 +2381,7 @@ provider "registry.opentofu.org/hashicorp/test" {
   constraints = "1.2.3"
   hashes = [
     "h1:8CjxaUBuegKZSFnRos39Fs+CS78ax0Dyb7aIA5XBiNI=",
-    "zh:6f85a1f747dd09455cd77683c0e06da647d8240461b8b36b304b9056814d91f2",
+    "zh:ac90a1419dd4648431af93b6695b6d6efcad87950ee608de4198df8e6debff23",
   ]
 }
 `)
@@ -2505,6 +2505,7 @@ provider "registry.opentofu.org/hashicorp/test" {
 			}
 
 			buf, err := os.ReadFile(lockFile)
+			t.Logf("new lock file: %s", buf)
 			if err != nil {
 				t.Fatalf("failed to read dependency lock file %s: %s", lockFile, err)
 			}

--- a/internal/lang/funcs/encoding_test.go
+++ b/internal/lang/funcs/encoding_test.go
@@ -137,7 +137,7 @@ func TestBase64Gzip(t *testing.T) {
 	}{
 		{
 			cty.StringVal("test"),
-			cty.StringVal("H4sIAAAAAAAA/ypJLS4BAAAA//8BAAD//wx+f9gEAAAA"),
+			cty.StringVal("H4sIAAAAAAAA/wAEAPv/dGVzdAAAAP//AwAMfn/YBAAAAA=="),
 			false,
 		},
 	}
@@ -168,6 +168,11 @@ func TestBase64Gunzip(t *testing.T) {
 		Want   cty.Value
 		Err    string
 	}{
+		{
+			cty.StringVal("H4sIAAAAAAAA/wAEAPv/dGVzdAAAAP//AwAMfn/YBAAAAA=="),
+			cty.StringVal("test"),
+			"",
+		},
 		{
 			cty.StringVal("H4sIAAAAAAAA/ypJLS4BAAAA//8BAAD//wx+f9gEAAAA"),
 			cty.StringVal("test"),

--- a/internal/lang/functions_test.go
+++ b/internal/lang/functions_test.go
@@ -108,13 +108,13 @@ func TestFunctions(t *testing.T) {
 		"base64gzip": {
 			{
 				`base64gzip("test")`,
-				cty.StringVal("H4sIAAAAAAAA/ypJLS4BAAAA//8BAAD//wx+f9gEAAAA"),
+				cty.StringVal("H4sIAAAAAAAA/wAEAPv/dGVzdAAAAP//AwAMfn/YBAAAAA=="),
 			},
 		},
 
 		"base64gunzip": {
 			{
-				`base64gunzip("H4sIAAAAAAAA/ypJLS4BAAAA//8BAAD//wx+f9gEAAAA")`,
+				`base64gunzip("H4sIAAAAAAAA/wAEAPv/dGVzdAAAAP//AwAMfn/YBAAAAA==")`,
 				cty.StringVal("test"),
 			},
 		},


### PR DESCRIPTION
For the forthcoming OpenTofu v1.13.x series we intend to use Go 1.27. The first stable release in that series is not available yet, but in the meantime we'll adopt its first release candidate so we can get early notice if there are any unexpected changes we need to deal with.

This commit deals with the first significant upstream change: the standard library implementation of DEFLATE compression has been optimized in this release in a way that changes the exact bytes it produces, and since DEFLATE is the basis of both the gzip and zip packages this has two knock-on effects for OpenTofu:

- Our `base64gzip` function now produces equivalent but non-equal results compared to previous releases.

    This is a user-facing change that is therefore noted in the changelog.

- The helper we use to dynamically generate installable provider packages for testing now generates equivalent but non-equal .zip archives, meaning that the expected `zh:` checksums have changed but the `h1:` checksums have not.

    This is NOT a user-facing change, because OpenTofu only generates provider package archives inside its own test suite as throwaway test fixtures.

The updated changelog also confirms the change in which macOS versions are supported, which we pre-announced in the changelog for the v1.12 series.

There are other changes we will need to make before we can consider ourselves to have fully adopted Go 1.27 -- not least of which is actually using a stable release from that series, once available! -- but this deals with the immediate, mandatory changes we need to make to keep the tests working and make the change information visible to those who might try to test using our nightly prereleases.

This is the first step for https://github.com/opentofu/opentofu/issues/4308.
