### PR TITLE
Feature/include credentials in getprovider http request

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (c) 2023 HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
-version: 2
 
 project_name: tofu
 
@@ -316,10 +315,10 @@ snapcrafts:
       OpenTofu is an OSS tool for building, changing, and versioning infrastructure
       safely and efficiently. OpenTofu can manage existing and popular service
       providers as well as custom in-house solutions.
-    disable: '{{ if eq (index .Env "RELEASE_FLAG_LATEST") "false" }}true{{ else }}false{{ end }}'
+    disable: '{{ if eq .Env.RELEASE_FLAG_LATEST "false" }}true{{ else }}false{{ end }}'
     channel_templates:
-      - '{{ if eq (index .Env "RELEASE_FLAG_PRERELEASE") "true" }}latest/edge{{ else }}latest/stable{{ end }}'
-    grade: '{{ if eq (index .Env "RELEASE_FLAG_PRERELEASE") "true" }}devel{{ else }}stable{{ end }}'
+      - '{{ if eq .Env.RELEASE_FLAG_PRERELEASE "true" }}latest/edge{{ else }}latest/stable{{ end }}'
+    grade: '{{ if eq .Env.RELEASE_FLAG_PRERELEASE "true" }}devel{{ else }}stable{{ end }}'
     confinement: classic
     license: MPL-2.0
     base: core22
@@ -349,6 +348,12 @@ docker_signs:
 
 snapshot:
   name_template: "{{ .Version }}-next"
+
+# Docs are here: https://github.com/goreleaser/goreleaser/blob/v1.26.2/www/docs/customization/nightlies.md
+nightly:
+  # Version format: nightly-20250806-c5fd934
+  name_template: "nightly-{{ .Now.Format \"20060102\" }}-{{ .ShortCommit }}"
+  publish_release: false
 
 changelog:
   use: github-native

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (c) 2023 HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
+version: 2
 
 project_name: tofu
 
@@ -315,10 +316,10 @@ snapcrafts:
       OpenTofu is an OSS tool for building, changing, and versioning infrastructure
       safely and efficiently. OpenTofu can manage existing and popular service
       providers as well as custom in-house solutions.
-    disable: '{{ if eq .Env.RELEASE_FLAG_LATEST "false" }}true{{ else }}false{{ end }}'
+    disable: '{{ if eq (index .Env "RELEASE_FLAG_LATEST") "false" }}true{{ else }}false{{ end }}'
     channel_templates:
-      - '{{ if eq .Env.RELEASE_FLAG_PRERELEASE "true" }}latest/edge{{ else }}latest/stable{{ end }}'
-    grade: '{{ if eq .Env.RELEASE_FLAG_PRERELEASE "true" }}devel{{ else }}stable{{ end }}'
+      - '{{ if eq (index .Env "RELEASE_FLAG_PRERELEASE") "true" }}latest/edge{{ else }}latest/stable{{ end }}'
+    grade: '{{ if eq (index .Env "RELEASE_FLAG_PRERELEASE") "true" }}devel{{ else }}stable{{ end }}'
     confinement: classic
     license: MPL-2.0
     base: core22
@@ -348,12 +349,6 @@ docker_signs:
 
 snapshot:
   name_template: "{{ .Version }}-next"
-
-# Docs are here: https://github.com/goreleaser/goreleaser/blob/v1.26.2/www/docs/customization/nightlies.md
-nightly:
-  # Version format: nightly-20250806-c5fd934
-  name_template: "nightly-{{ .Now.Format \"20060102\" }}-{{ .ShortCommit }}"
-  publish_release: false
 
 changelog:
   use: github-native

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -315,10 +315,10 @@ snapcrafts:
       OpenTofu is an OSS tool for building, changing, and versioning infrastructure
       safely and efficiently. OpenTofu can manage existing and popular service
       providers as well as custom in-house solutions.
-    disable: '{{ if eq .Env.RELEASE_FLAG_LATEST "false" }}true{{ else }}false{{ end }}'
+    disable: '{{ if eq (index .Env "RELEASE_FLAG_LATEST") "false" }}true{{ else }}false{{ end }}'
     channel_templates:
-      - '{{ if eq .Env.RELEASE_FLAG_PRERELEASE "true" }}latest/edge{{ else }}latest/stable{{ end }}'
-    grade: '{{ if eq .Env.RELEASE_FLAG_PRERELEASE "true" }}devel{{ else }}stable{{ end }}'
+      - '{{ if eq (index .Env "RELEASE_FLAG_PRERELEASE") "true" }}latest/edge{{ else }}latest/stable{{ end }}'
+    grade: '{{ if eq (index .Env "RELEASE_FLAG_PRERELEASE") "true" }}devel{{ else }}stable{{ end }}'
     confinement: classic
     license: MPL-2.0
     base: core22

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -928,7 +928,6 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 
 		mode = providercache.InstallUpgrades
 	}
-
 	newLocks, err := inst.EnsureProviderVersions(ctx, previousLocks, reqs, mode, c.Meta.Services.CredentialsSource())
 	if ctx.Err() == context.Canceled {
 		view.Diagnostics(diags)

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mitchellh/cli"
 	"github.com/opentofu/opentofu/internal/command/flags"
 	"github.com/opentofu/svchost"
+	"github.com/opentofu/svchost/svcauth"
 	"github.com/posener/complete"
 	"github.com/zclconf/go-cty/cty"
 
@@ -928,7 +929,10 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 
 		mode = providercache.InstallUpgrades
 	}
-	creds := c.Services.CredentialsSource()
+	var creds svcauth.CredentialsSource = nil
+	if c.Services != nil {
+		creds = c.Services.CredentialsSource()
+	}
 	newLocks, err := inst.EnsureProviderVersions(ctx, previousLocks, reqs, mode, creds)
 	if ctx.Err() == context.Canceled {
 		view.Diagnostics(diags)

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -17,7 +17,6 @@ import (
 	"github.com/mitchellh/cli"
 	"github.com/opentofu/opentofu/internal/command/flags"
 	"github.com/opentofu/svchost"
-	"github.com/opentofu/svchost/svcauth"
 	"github.com/posener/complete"
 	"github.com/zclconf/go-cty/cty"
 
@@ -929,11 +928,8 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 
 		mode = providercache.InstallUpgrades
 	}
-	var creds svcauth.CredentialsSource = nil
-	if c.Services != nil {
-		creds = c.Services.CredentialsSource()
-	}
-	newLocks, err := inst.EnsureProviderVersions(ctx, previousLocks, reqs, mode, creds)
+
+	newLocks, err := inst.EnsureProviderVersions(ctx, previousLocks, reqs, mode, c.Meta.Services.CredentialsSource())
 	if ctx.Err() == context.Canceled {
 		view.Diagnostics(diags)
 		view.ProviderInstallationInterrupted()

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -928,7 +928,8 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 
 		mode = providercache.InstallUpgrades
 	}
-	newLocks, err := inst.EnsureProviderVersions(ctx, previousLocks, reqs, mode)
+	creds := c.Services.CredentialsSource()
+	newLocks, err := inst.EnsureProviderVersions(ctx, previousLocks, reqs, mode, creds)
 	if ctx.Err() == context.Canceled {
 		view.Diagnostics(diags)
 		view.ProviderInstallationInterrupted()

--- a/internal/command/providers_lock.go
+++ b/internal/command/providers_lock.go
@@ -20,6 +20,7 @@ import (
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/opentofu/opentofu/internal/tracing"
 	"github.com/opentofu/opentofu/internal/tracing/traceattrs"
+	"github.com/opentofu/svchost/svcauth"
 )
 
 type providersLockChangeType string
@@ -270,7 +271,11 @@ func (c *ProvidersLockCommand) Run(rawArgs []string) int {
 		dir := providercache.NewDirWithPlatform(tempDir, platform)
 		installer := providercache.NewInstaller(dir, source)
 
-		newLocks, err := installer.EnsureProviderVersions(ctx, oldLocks, reqs, providercache.InstallNewProvidersForce)
+		var creds svcauth.CredentialsSource = nil
+		if c.Services != nil {
+			creds = c.Services.CredentialsSource()
+		}
+		newLocks, err := installer.EnsureProviderVersions(ctx, oldLocks, reqs, providercache.InstallNewProvidersForce, creds)
 		if err != nil {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,

--- a/internal/command/providers_lock.go
+++ b/internal/command/providers_lock.go
@@ -20,7 +20,6 @@ import (
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/opentofu/opentofu/internal/tracing"
 	"github.com/opentofu/opentofu/internal/tracing/traceattrs"
-	"github.com/opentofu/svchost/svcauth"
 )
 
 type providersLockChangeType string
@@ -271,11 +270,7 @@ func (c *ProvidersLockCommand) Run(rawArgs []string) int {
 		dir := providercache.NewDirWithPlatform(tempDir, platform)
 		installer := providercache.NewInstaller(dir, source)
 
-		var creds svcauth.CredentialsSource = nil
-		if c.Services != nil {
-			creds = c.Services.CredentialsSource()
-		}
-		newLocks, err := installer.EnsureProviderVersions(ctx, oldLocks, reqs, providercache.InstallNewProvidersForce, creds)
+		newLocks, err := installer.EnsureProviderVersions(ctx, oldLocks, reqs, providercache.InstallNewProvidersForce, c.Services.CredentialsSource())
 		if err != nil {
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,

--- a/internal/getproviders/package_location_http_archive.go
+++ b/internal/getproviders/package_location_http_archive.go
@@ -79,9 +79,9 @@ func (p PackageHTTPURL) InstallProviderPackage(ctx context.Context, meta Package
 	}
 	hostname := HostFromRequest(req.Request)
 
+	// add auth tokens for host as available in credentialssource
 	if meta.CredentialsSource != nil {
 		if creds, err := meta.CredentialsSource.ForHost(ctx, host); err == nil && creds != nil {
-			// Ensure token or basic auth strings are added cleanly depending on what svcauth returns
 			creds.PrepareRequest(req.Request)
 			credentialsInfo = "Found creds for host: " + hostname
 		} else if err != nil {

--- a/internal/getproviders/package_location_http_archive.go
+++ b/internal/getproviders/package_location_http_archive.go
@@ -19,6 +19,7 @@ import (
 	"github.com/opentofu/opentofu/internal/logging"
 	"github.com/opentofu/opentofu/internal/tracing"
 	"github.com/opentofu/opentofu/internal/tracing/traceattrs"
+	"github.com/opentofu/svchost"
 )
 
 // PackageHTTPURL is a provider package location accessible via HTTP.
@@ -71,6 +72,14 @@ func (p PackageHTTPURL) InstallProviderPackage(ctx context.Context, meta Package
 	if err != nil {
 		return nil, fmt.Errorf("invalid provider download request: %w", err)
 	}
+
+	if meta.Creds != nil {
+		if creds, err := meta.Creds.ForHost(ctx, svchost.Hostname(HostFromRequest(req.Request))); err == nil && creds != nil {
+			// Ensure token or basic auth strings are added cleanly depending on what svcauth returns
+			creds.PrepareRequest(req.Request)
+		}
+	}
+
 	resp, err := retryableClient.Do(req)
 	if err != nil {
 		if ctx.Err() == context.Canceled {

--- a/internal/getproviders/package_location_http_archive.go
+++ b/internal/getproviders/package_location_http_archive.go
@@ -19,7 +19,6 @@ import (
 	"github.com/opentofu/opentofu/internal/logging"
 	"github.com/opentofu/opentofu/internal/tracing"
 	"github.com/opentofu/opentofu/internal/tracing/traceattrs"
-	"github.com/opentofu/svchost"
 )
 
 // PackageHTTPURL is a provider package location accessible via HTTP.
@@ -73,11 +72,25 @@ func (p PackageHTTPURL) InstallProviderPackage(ctx context.Context, meta Package
 		return nil, fmt.Errorf("invalid provider download request: %w", err)
 	}
 
-	if meta.Creds != nil {
-		if creds, err := meta.Creds.ForHost(ctx, svchost.Hostname(HostFromRequest(req.Request))); err == nil && creds != nil {
+	var credentialsInfo string = ""
+	host, err := svchostFromURL(req.URL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid provider download request: %w", err)
+	}
+	hostname := HostFromRequest(req.Request)
+
+	if meta.CredentialsSource != nil {
+		if creds, err := meta.CredentialsSource.ForHost(ctx, host); err == nil && creds != nil {
 			// Ensure token or basic auth strings are added cleanly depending on what svcauth returns
 			creds.PrepareRequest(req.Request)
+			credentialsInfo = "Found creds for host: " + hostname
+		} else if err != nil {
+			credentialsInfo = "Error finding creds for host: " + hostname + ", Error: " + err.Error()
+		} else {
+			credentialsInfo = "No creds found for host: " + hostname
 		}
+	} else {
+		credentialsInfo = "No creds source. Host: " + hostname
 	}
 
 	resp, err := retryableClient.Do(req)
@@ -87,12 +100,12 @@ func (p PackageHTTPURL) InstallProviderPackage(ctx context.Context, meta Package
 			// so we'll return a more appropriate one here.
 			return nil, fmt.Errorf("provider download was interrupted")
 		}
-		return nil, fmt.Errorf("%s: %w", HostFromRequest(req.Request), err)
+		return nil, fmt.Errorf("%s: %w", hostname, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unsuccessful request to %s: %s", url, resp.Status)
+		return nil, fmt.Errorf("unsuccessful request to %s: %s, %s", url, resp.Status, credentialsInfo)
 	}
 
 	f, err := os.CreateTemp("", "terraform-provider")

--- a/internal/getproviders/package_location_http_archive_test.go
+++ b/internal/getproviders/package_location_http_archive_test.go
@@ -9,67 +9,74 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"testing"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/opentofu/svchost"
+	"github.com/opentofu/svchost/svcauth"
 )
 
-// mockCredentialsSource implements the credentials source interface for testing.
-type mockCredentialsSource struct {
-	token string
-}
-
-func (m *mockCredentialsSource) ForHost(ctx context.Context, host string) (*mockCredentials, error) {
-	if m.token == "" {
-		return nil, nil
-	}
-	return &mockCredentials{token: m.token}, nil
-}
-
-// mockCredentials satisfies the expected credentials interface with a PrepareRequest method.
-type mockCredentials struct {
-	token string
-}
-
-func (c *mockCredentials) PrepareRequest(req *http.Request) {
-	req.Header.Set("Authorization", "Bearer "+c.token)
-}
-
 func TestPackageLocationHTTPArchive(t *testing.T) {
-	// Create a test server that expects an Authorization header
+	authToken := "my-secret-token"
+	wrongToken := "wrong-token"
+
+	// 1. Create a mock HTTP server that expects an Authorization header
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		auth := r.Header.Get("Authorization")
-		if auth != "Bearer valid-token-123" {
+		if auth != "Bearer "+authToken {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
 
-		// Respond with a valid minimal ZIP structure to appease the extraction stage
-		// (PK\x05\x06 followed by 18 bytes of zeros is an empty zip archive)
+		// Respond with a valid minimal ZIP archive structure to allow the extractor stage to succeed
 		w.Header().Set("Content-Type", "application/zip")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("PK\x05\x06\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"))
 	}))
 	defer ts.Close()
 
-	// Setup a temporary target directory for the extraction process
+	// 2. Parse the test server URL to know the exact Hostname the client will target
+	parsedURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("failed to parse test server URL: %v", err)
+	}
+	targetHost := svchost.Hostname(parsedURL.Host)
+
+	// 3. Setup a temporary directory for extraction
 	tmpDir, err := os.MkdirTemp("", "opentofu-test-*")
 	if err != nil {
 		t.Fatalf("failed to create temp dir: %v", err)
 	}
 	defer os.RemoveAll(tmpDir)
 
+	// 4. Define the table-driven test cases using svcauth.StaticCredentialsSource
+	// Change *svcauth.CredentialsSource to svcauth.CredentialsSource
 	tests := map[string]struct {
-		credsSource *mockCredentialsSource
+		credsSource svcauth.CredentialsSource
 		expectError bool
 	}{
-		"success_with_valid_token": {
-			credsSource: &mockCredentialsSource{token: "valid-token-123"},
+		"happy case": {
+			credsSource: svcauth.StaticCredentialsSource(map[svchost.Hostname]svcauth.HostCredentials{
+				targetHost: svcauth.HostCredentialsToken(authToken),
+			}),
 			expectError: false,
 		},
-		"failure_without_token": {
-			credsSource: &mockCredentialsSource{token: ""}, // No token set
+		"unhappy: wrong hostname": {
+			credsSource: svcauth.StaticCredentialsSource(map[svchost.Hostname]svcauth.HostCredentials{
+				"other.host": svcauth.HostCredentialsToken(authToken),
+			}),
+			expectError: true,
+		},
+		"unhappy: wrong token": {
+			credsSource: svcauth.StaticCredentialsSource(map[svchost.Hostname]svcauth.HostCredentials{
+				targetHost: svcauth.HostCredentialsToken(wrongToken),
+			}),
+			expectError: true,
+		},
+		"unhappy: empty credential store": {
+			credsSource: svcauth.StaticCredentialsSource(map[svchost.Hostname]svcauth.HostCredentials{}),
 			expectError: true,
 		},
 	}
@@ -78,12 +85,11 @@ func TestPackageLocationHTTPArchive(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
 
-			// Build the Location struct injecting a default retryable client
 			loc := PackageHTTPURL{
 				URL: ts.URL,
 				ClientBuilder: func(ctx context.Context) *retryablehttp.Client {
 					client := retryablehttp.NewClient()
-					client.Logger = nil // Suppress noise in test output
+					client.Logger = nil // Keep testing output clean
 					return client
 				},
 			}
@@ -93,16 +99,15 @@ func TestPackageLocationHTTPArchive(t *testing.T) {
 				CredentialsSource: tc.credsSource,
 			}
 
-			// We pass nil for allowedHashes here as an empty zip needs no complex verification
 			_, err := loc.InstallProviderPackage(ctx, meta, tmpDir, nil)
 
 			if tc.expectError {
 				if err == nil {
-					t.Errorf("expected an error but installation succeeded")
+					t.Errorf("expected download to fail, but it succeeded")
 				}
 			} else {
 				if err != nil {
-					t.Errorf("unexpected error: %v", err)
+					t.Errorf("expected download to succeed, but got error: %v", err)
 				}
 			}
 		})

--- a/internal/getproviders/package_location_http_archive_test.go
+++ b/internal/getproviders/package_location_http_archive_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package getproviders
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+// mockCredentialsSource implements the credentials source interface for testing.
+type mockCredentialsSource struct {
+	token string
+}
+
+func (m *mockCredentialsSource) ForHost(ctx context.Context, host string) (*mockCredentials, error) {
+	if m.token == "" {
+		return nil, nil
+	}
+	return &mockCredentials{token: m.token}, nil
+}
+
+// mockCredentials satisfies the expected credentials interface with a PrepareRequest method.
+type mockCredentials struct {
+	token string
+}
+
+func (c *mockCredentials) PrepareRequest(req *http.Request) {
+	req.Header.Set("Authorization", "Bearer "+c.token)
+}
+
+func TestPackageLocationHTTPArchive(t *testing.T) {
+	// Create a test server that expects an Authorization header
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer valid-token-123" {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		// Respond with a valid minimal ZIP structure to appease the extraction stage
+		// (PK\x05\x06 followed by 18 bytes of zeros is an empty zip archive)
+		w.Header().Set("Content-Type", "application/zip")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("PK\x05\x06\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"))
+	}))
+	defer ts.Close()
+
+	// Setup a temporary target directory for the extraction process
+	tmpDir, err := os.MkdirTemp("", "opentofu-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	tests := map[string]struct {
+		credsSource *mockCredentialsSource
+		expectError bool
+	}{
+		"success_with_valid_token": {
+			credsSource: &mockCredentialsSource{token: "valid-token-123"},
+			expectError: false,
+		},
+		"failure_without_token": {
+			credsSource: &mockCredentialsSource{token: ""}, // No token set
+			expectError: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// Build the Location struct injecting a default retryable client
+			loc := PackageHTTPURL{
+				URL: ts.URL,
+				ClientBuilder: func(ctx context.Context) *retryablehttp.Client {
+					client := retryablehttp.NewClient()
+					client.Logger = nil // Suppress noise in test output
+					return client
+				},
+			}
+
+			meta := PackageMeta{
+				Location:          loc,
+				CredentialsSource: tc.credsSource,
+			}
+
+			// We pass nil for allowedHashes here as an empty zip needs no complex verification
+			_, err := loc.InstallProviderPackage(ctx, meta, tmpDir, nil)
+
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("expected an error but installation succeeded")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/internal/getproviders/types.go
+++ b/internal/getproviders/types.go
@@ -16,6 +16,7 @@ import (
 	"github.com/apparentlymart/go-versions/versions/constraints"
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/tfdiags"
+	"github.com/opentofu/svchost/svcauth"
 )
 
 // Version represents a particular single version of a provider.
@@ -230,6 +231,8 @@ type PackageMeta struct {
 
 	Filename string
 	Location PackageLocation
+
+	Creds svcauth.CredentialsSource
 
 	// Authentication, if non-nil, is a request from the source that produced
 	// this meta for verification of the target package after it has been

--- a/internal/getproviders/types.go
+++ b/internal/getproviders/types.go
@@ -232,7 +232,7 @@ type PackageMeta struct {
 	Filename string
 	Location PackageLocation
 
-	Creds svcauth.CredentialsSource
+	CredentialsSource svcauth.CredentialsSource
 
 	// Authentication, if non-nil, is a request from the source that produced
 	// this meta for verification of the target package after it has been

--- a/internal/providercache/installer.go
+++ b/internal/providercache/installer.go
@@ -667,8 +667,8 @@ func (i *Installer) ensureProviderVersionInDirectory(
 		cb(provider, version, meta.Location, isGlobalCache)
 	}
 
-	// Step 3d: Add credentials
-	meta.Creds = creds
+	// Step 3d: Add services
+	meta.CredentialsSource = creds
 
 	allowedHashes := preferredHashes
 	if mode.forceInstallChecksums() {

--- a/internal/providercache/installer.go
+++ b/internal/providercache/installer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/opentofu/opentofu/internal/getproviders"
 	"github.com/opentofu/opentofu/internal/tracing"
 	"github.com/opentofu/opentofu/internal/tracing/traceattrs"
+	"github.com/opentofu/svchost/svcauth"
 )
 
 // Installer is the main type in this package, representing a provider installer
@@ -185,7 +186,7 @@ func (i *Installer) SetUnmanagedProviderTypes(types map[addrs.Provider]struct{})
 // failures then those notifications will be redundant with the ones included
 // in the final returned error value so callers should show either one or the
 // other, and not both.
-func (i *Installer) EnsureProviderVersions(ctx context.Context, locks *depsfile.Locks, reqs getproviders.Requirements, mode InstallMode) (*depsfile.Locks, error) {
+func (i *Installer) EnsureProviderVersions(ctx context.Context, locks *depsfile.Locks, reqs getproviders.Requirements, mode InstallMode, creds svcauth.CredentialsSource) (*depsfile.Locks, error) {
 	ctx, span := tracing.Tracer().Start(ctx, "Install Providers") // TODO: Discuss span name
 	defer span.End()
 
@@ -236,7 +237,7 @@ func (i *Installer) EnsureProviderVersions(ctx context.Context, locks *depsfile.
 	targetPlatform := i.targetDir.targetPlatform // we inherit this to behave correctly in unit tests
 	span.SetAttributes(traceattrs.OpenTofuTargetPlatform(targetPlatform.String()))
 	span.SetName("Install Providers - " + targetPlatform.String())
-	authResults, err := i.ensureProviderVersionsInstall(ctx, locks, reqs, mode, need, targetPlatform, errs)
+	authResults, err := i.ensureProviderVersionsInstall(ctx, locks, reqs, mode, creds, need, targetPlatform, errs)
 	if err != nil {
 		return nil, err
 	}
@@ -463,6 +464,7 @@ func (i *Installer) ensureProviderVersionsInstall(
 	locks *depsfile.Locks,
 	reqs getproviders.Requirements,
 	mode InstallMode,
+	creds svcauth.CredentialsSource,
 	need map[addrs.Provider]getproviders.Version,
 	targetPlatform getproviders.Platform,
 	errs map[addrs.Provider]error,
@@ -496,7 +498,7 @@ func (i *Installer) ensureProviderVersionsInstall(
 			defer span.End()
 
 			// Heavy lifting
-			authResult, newHashes, err := i.ensureProviderVersionInstalled(traceCtx, providerExistingLock(provider), mode, provider, version, targetPlatform)
+			authResult, newHashes, err := i.ensureProviderVersionInstalled(traceCtx, providerExistingLock(provider), mode, creds, provider, version, targetPlatform)
 
 			// Update results
 			updateLock.Lock()
@@ -525,6 +527,7 @@ func (i *Installer) ensureProviderVersionInstalled(
 	ctx context.Context,
 	lock *depsfile.ProviderLock,
 	mode InstallMode,
+	creds svcauth.CredentialsSource,
 	provider addrs.Provider,
 	version getproviders.Version,
 	targetPlatform getproviders.Platform,
@@ -558,7 +561,7 @@ func (i *Installer) ensureProviderVersionInstalled(
 		linkTo = nil // no linking needed
 	}
 
-	result, newHashes, err := i.ensureProviderVersionInDirectory(ctx, lock, mode, provider, version, targetPlatform, installTo)
+	result, newHashes, err := i.ensureProviderVersionInDirectory(ctx, lock, mode, creds, provider, version, targetPlatform, installTo)
 
 	if err != nil {
 		return result, newHashes, err
@@ -612,6 +615,7 @@ func (i *Installer) ensureProviderVersionInDirectory(
 	ctx context.Context,
 	lock *depsfile.ProviderLock,
 	mode InstallMode,
+	creds svcauth.CredentialsSource,
 	provider addrs.Provider,
 	version getproviders.Version,
 	targetPlatform getproviders.Platform,
@@ -662,6 +666,9 @@ func (i *Installer) ensureProviderVersionInDirectory(
 	if cb := evts.FetchPackageBegin; cb != nil {
 		cb(provider, version, meta.Location, isGlobalCache)
 	}
+
+	// Step 3d: Add credentials
+	meta.Creds = creds
 
 	allowedHashes := preferredHashes
 	if mode.forceInstallChecksums() {

--- a/internal/providercache/installer_test.go
+++ b/internal/providercache/installer_test.go
@@ -2486,7 +2486,8 @@ func TestEnsureProviderVersions(t *testing.T) {
 			go func(ch chan *testInstallerEventLogItem) {
 				events := installerLogEventsForTests(ch)
 				ctx := events.OnContext(ctx)
-				newLocks, instErr = inst.EnsureProviderVersions(ctx, locks, test.Reqs, test.Mode)
+
+				newLocks, instErr = inst.EnsureProviderVersions(ctx, locks, test.Reqs, test.Mode, nil)
 				close(eventsCh) // exits the event loop below
 			}(eventsCh)
 			for evt := range eventsCh {
@@ -2588,7 +2589,7 @@ func TestEnsureProviderVersions_local_source(t *testing.T) {
 				provider: versionConstraint,
 			}
 
-			newLocks, err := installer.EnsureProviderVersions(t.Context(), depsfile.NewLocks(), reqs, InstallNewProvidersOnly)
+			newLocks, err := installer.EnsureProviderVersions(t.Context(), depsfile.NewLocks(), reqs, InstallNewProvidersOnly, nil)
 			gotProviderlocks := newLocks.AllProviders()
 			wantProviderLocks := map[addrs.Provider]*depsfile.ProviderLock{
 				provider: depsfile.NewProviderLock(
@@ -2675,7 +2676,7 @@ func TestEnsureProviderVersions_protocol_errors(t *testing.T) {
 			reqs := getproviders.Requirements{
 				test.provider: test.inputVersion,
 			}
-			_, err := installer.EnsureProviderVersions(t.Context(), depsfile.NewLocks(), reqs, InstallNewProvidersOnly)
+			_, err := installer.EnsureProviderVersions(t.Context(), depsfile.NewLocks(), reqs, InstallNewProvidersOnly, nil)
 
 			switch err := err.(type) {
 			case nil:
@@ -2734,7 +2735,7 @@ func TestRaceConditionOnLocks(t *testing.T) {
 	mockSrc := getproviders.NewMockSource(mockedPkgs, nil)
 	installer := NewInstaller(NewDir(installerTarget), mockSrc)
 	locks := depsfile.NewLocks()
-	_, err := installer.EnsureProviderVersions(ctx, locks, reqs, InstallNewProvidersForce)
+	_, err := installer.EnsureProviderVersions(ctx, locks, reqs, InstallNewProvidersForce, nil)
 	if err != nil {
 		t.Fatalf("unexpected error from ensure provider versions")
 	}


### PR DESCRIPTION
This change adds available credentials (for example from credentials.tfrc.json) to the http request attempting to download a provider package from a registry. 

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

Website unchanged

