### PR TITLE
Better integration of providers and modules installation in new runtime

### DIFF
--- a/internal/checks/state_test.go
+++ b/internal/checks/state_test.go
@@ -6,7 +6,6 @@
 package checks
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -14,24 +13,21 @@ import (
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/configs/configload"
-	"github.com/opentofu/opentofu/internal/initwd"
 )
 
 func TestChecksHappyPath(t *testing.T) {
 	const fixtureDir = "testdata/happypath"
-	loader := configload.NewLoaderForTests(t)
-	inst := initwd.NewModuleInstaller(loader.ModulesDir(), loader, nil, nil)
-	_, instDiags := inst.InstallModules(context.Background(), fixtureDir, "tests", true, false, initwd.ModuleInstallHooksImpl{}, configs.RootModuleCallForTesting())
-	if instDiags.HasErrors() {
-		t.Fatal(instDiags.Err())
-	}
-	if err := loader.RefreshModules(); err != nil {
-		t.Fatalf("failed to refresh modules after installation: %s", err)
+
+	t.Chdir(fixtureDir)
+
+	loader, err := configload.NewLoader(&configload.Config{
+		ModulesDir: ".terraform/modules/",
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	/////////////////////////////////////////////////////////////////////////
-
-	cfg, hclDiags := loader.LoadConfig(t.Context(), fixtureDir, configs.RootModuleCallForTesting())
+	cfg, hclDiags := loader.LoadConfig(t.Context(), ".", configs.RootModuleCallForTesting())
 	if hclDiags.HasErrors() {
 		t.Fatalf("invalid configuration: %s", hclDiags.Error())
 	}

--- a/internal/checks/testdata/happypath/.terraform/modules/modules.json
+++ b/internal/checks/testdata/happypath/.terraform/modules/modules.json
@@ -1,0 +1,14 @@
+{
+  "Modules": [
+    {
+      "Key": "",
+      "Source": "",
+      "Dir": "."
+    },
+    {
+      "Key": "child",
+      "Source": "./child",
+      "Dir": "child"
+    }
+  ]
+}

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -543,11 +543,30 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 
 	// First we'll collect all the provider dependencies we can see in the
 	// configuration and the state.
-	reqs, qualifs, hclDiags := config.ProviderRequirements()
-	diags = diags.Append(hclDiags)
-	if hclDiags.HasErrors() {
-		return false, true, diags
+
+	var reqs getproviders.Requirements
+	var qualifs *getproviders.ProvidersQualification
+
+	// New Engine Hacks
+	if c.NewRuntimeEnabled() {
+		configInst, moreDiags := c.StaticConfigInstance(ctx, config.Module, nil)
+		if moreDiags.HasErrors() {
+			return false, true, diags
+		}
+		reqs, qualifs, moreDiags = configInst.ProviderRequirements(ctx)
+		diags = diags.Append(moreDiags)
+		if moreDiags.HasErrors() {
+			return false, true, diags
+		}
+	} else {
+		var hclDiags hcl.Diagnostics
+		reqs, qualifs, hclDiags = config.ProviderRequirements()
+		diags = diags.Append(hclDiags)
+		if hclDiags.HasErrors() {
+			return false, true, diags
+		}
 	}
+
 	if state != nil {
 		stateReqs := state.ProviderRequirements()
 		reqs = reqs.Merge(stateReqs)

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -547,8 +547,9 @@ func (c *InitCommand) getProviders(ctx context.Context, config *configs.Config, 
 	var reqs getproviders.Requirements
 	var qualifs *getproviders.ProvidersQualification
 
-	// New Engine Hacks
 	if c.NewRuntimeEnabled() {
+		// Use new runtime to determine providers
+
 		configInst, moreDiags := c.StaticConfigInstance(ctx, config.Module, nil)
 		if moreDiags.HasErrors() {
 			return false, true, diags

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -399,6 +399,10 @@ func (m *Meta) contextOpts(ctx context.Context) (*tofu.ContextOpts, error) {
 	}
 
 	if m.NewRuntimeEnabled() {
+		// Inject runtime modules if the new runtime is enabled.
+		// This allows the shims in the tofu module to function
+		// without having to understand module installation logic.
+
 		loader, _ := m.initConfigLoader()
 
 		// This gets the current directory as full path.

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -398,6 +398,18 @@ func (m *Meta) contextOpts(ctx context.Context) (*tofu.ContextOpts, error) {
 		)
 	}
 
+	if m.NewRuntimeEnabled() {
+		loader, _ := m.initConfigLoader()
+
+		// This gets the current directory as full path.
+		path := m.WorkingDir.NormalizePath(m.WorkingDir.RootModuleDir())
+		root, _ := loader.Parser().LoadConfigDirUneval(path, configs.SelectiveLoadAll)
+		opts.Modules = &newRuntimeModules{
+			loader: loader,
+			root:   root,
+		}
+	}
+
 	opts.Meta = &tofu.ContextMeta{
 		Env:                workspace,
 		OriginalWorkingDir: m.WorkingDir.OriginalWorkingDir(),

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -172,6 +172,8 @@ func (m *Meta) Backend(ctx context.Context, opts *BackendOpts, enc encryption.St
 		}
 	}
 	if !m.NewRuntimeEnabled() {
+		// The new runtime does not need a pre-run validation pass as it is already baked in
+		// The old engine however does need the pre-run validation pass
 		cliOpts.Validation = true
 	}
 

--- a/internal/command/meta_backend.go
+++ b/internal/command/meta_backend.go
@@ -171,7 +171,9 @@ func (m *Meta) Backend(ctx context.Context, opts *BackendOpts, enc encryption.St
 			return nil, diags
 		}
 	}
-	cliOpts.Validation = true
+	if !m.NewRuntimeEnabled() {
+		cliOpts.Validation = true
+	}
 
 	// If the backend supports CLI initialization, do it.
 	if cli, ok := b.(backend.CLI); ok {

--- a/internal/command/meta_config.go
+++ b/internal/command/meta_config.go
@@ -295,6 +295,9 @@ func (m *Meta) installModules(ctx context.Context, rootDir, testsDir string, upg
 
 	inst := initwd.NewModuleInstaller(m.WorkingDir.ModulesDir(), loader, m.registryClient(ctx), m.ModulePackageFetcher)
 	if m.NewRuntimeEnabled() {
+		// Tell the module installer it should use
+		// the configuration for the new runtime instead
+		// of the legacy paths
 		inst.ConfigInstance = m.StaticConfigInstance
 	}
 

--- a/internal/command/meta_config.go
+++ b/internal/command/meta_config.go
@@ -294,6 +294,9 @@ func (m *Meta) installModules(ctx context.Context, rootDir, testsDir string, upg
 	}
 
 	inst := initwd.NewModuleInstaller(m.WorkingDir.ModulesDir(), loader, m.registryClient(ctx), m.ModulePackageFetcher)
+	if m.NewRuntimeEnabled() {
+		inst.ConfigInstance = m.StaticConfigInstance
+	}
 
 	call, vDiags := m.rootModuleCall(ctx, rootDir)
 	diags = diags.Append(vDiags)

--- a/internal/command/temp_new_runtime.go
+++ b/internal/command/temp_new_runtime.go
@@ -1,0 +1,168 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package command
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/apparentlymart/go-versions/versions"
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/configs"
+	"github.com/opentofu/opentofu/internal/configs/configload"
+	"github.com/opentofu/opentofu/internal/lang/eval"
+	"github.com/opentofu/opentofu/internal/lang/exprs"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func (m *Meta) NewRuntimeEnabled() bool {
+	if !m.SystemCfg.AllowExperimentalFeatures {
+		return false
+	}
+	optIn := os.Getenv("TOFU_X_EXPERIMENTAL_RUNTIME")
+	return optIn != ""
+}
+
+func (m *Meta) StaticConfigInstance(ctx context.Context, root *configs.Module, modules eval.ExternalModules) (*eval.ConfigInstance, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	rootCall, moreDiags := m.rootModuleCall(ctx, root.SourceDir)
+	diags = diags.Append(moreDiags)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	rawInput := map[string]cty.Value{}
+	varValue := rootCall.Variables()
+	for _, variable := range root.Variables {
+		val, hclDiags := varValue(variable)
+		diags = diags.Append(hclDiags)
+		if val == cty.NilVal {
+			val = cty.DynamicVal
+		}
+		rawInput[variable.Name] = val
+	}
+
+	inputValues := exprs.ConstantValuer(cty.ObjectVal(rawInput))
+
+	loader, err := m.initConfigLoader()
+	if err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Failed to create the config loader",
+			err.Error(),
+		))
+		diags = diags.Append(err)
+		return nil, diags
+	}
+
+	owd := m.WorkingDir.OriginalWorkingDir()
+
+	if modules == nil {
+		modules = &newRuntimeModules{
+			loader: loader,
+			root:   root,
+		}
+	}
+	staticPlugins := eval.NewStaticPlugins()
+	evalCtx := &eval.EvalContext{
+		RootModuleDir:      root.SourceDir,
+		OriginalWorkingDir: owd,
+		Modules:            modules,
+		Providers:          staticPlugins,
+		Provisioners:       staticPlugins,
+	}
+
+	// The new config-loading system wants to work in terms of module source
+	// addresses rather than raw local filenames, so we'll ask the
+	// addrs package to parse the path we were given. We need to adjust
+	// a little though, because this function was designed for parsing
+	// the "source" argument in a module block, not a plain filepath.
+	// We should add a function in package addrs that's actually intended for
+	// turning arbitrary filesystem paths in to addrs.LocalSource in the long
+	// run, but this will do for now.
+	configDir := root.SourceDir
+	if !filepath.IsAbs(configDir) {
+		configDir = "." + string(filepath.Separator) + configDir
+	}
+	rootModuleSource, err := addrs.ParseModuleSource(configDir)
+	if err != nil {
+		diags = diags.Append(fmt.Errorf("invalid root module source address: %w", err))
+		return nil, diags
+	}
+
+	configCall := &eval.ConfigCall{
+		RootModuleSource:     rootModuleSource,
+		InputValues:          inputValues,
+		AllowImpureFunctions: false,
+		EvalContext:          evalCtx,
+	}
+	configInst, moreDiags := eval.NewConfigInstance(ctx, configCall)
+	diags = diags.Append(moreDiags)
+	if moreDiags.HasErrors() {
+		return nil, diags
+	}
+	return configInst, diags
+}
+
+// newRuntimeModules is an implementation of [eval.ExternalModules] that makes
+// a best effort to shim to OpenTofu's current module loader, even though
+// it works in some slightly-different terms than this new API expects.
+type newRuntimeModules struct {
+	loader *configload.Loader
+	root   *configs.Module
+
+	// configload.Loader is not concurrency-safe because it wraps
+	// hclparse.Parser functionality that is not concurrency-safe, so we must
+	// hold this lock whenever we're interacting with the loader object.
+	mu sync.Mutex
+}
+
+var _ eval.ExternalModules = (*newRuntimeModules)(nil)
+
+// ModuleConfig implements evalglue.ExternalModules.
+func (n *newRuntimeModules) ModuleConfig(ctx context.Context, source addrs.ModuleSource, allowedVersions versions.Set, forCall *addrs.AbsModuleCall) (eval.UncompiledModule, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	if forCall == nil {
+		return eval.PrepareTofu2024Module(source, n.root), diags
+	}
+
+	record, hclDiags := n.loader.ModuleLocalPath(ctx, &configs.ModuleRequest{
+		Name:              forCall.Call.Name,
+		Path:              forCall.Module.Module().Child(forCall.Call.Name),
+		SourceAddr:        source,
+		VersionConstraint: configs.VersionConstraint{},
+		//SourceAddrRange hcl.Range
+		//CallRange hcl.Range
+		Parent: &configs.Config{
+			Path: forCall.Module.Module(),
+		},
+	})
+	diags = diags.Append(hclDiags)
+
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	sourceDir := record.Dir
+
+	log.Printf("[TRACE] backend/local: Loading module from %q from local path %q", source, sourceDir)
+
+	n.mu.Lock()
+	mod, hclDiags := n.loader.Parser().LoadConfigDirUneval(sourceDir, configs.SelectiveLoadAll)
+	n.mu.Unlock()
+	diags = diags.Append(hclDiags)
+	if hclDiags.HasErrors() {
+		return nil, diags
+	}
+
+	return eval.PrepareTofu2024Module(source, mod), diags
+}

--- a/internal/configs/configload/loader_load.go
+++ b/internal/configs/configload/loader_load.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 
 	"github.com/opentofu/opentofu/internal/configs"
+	"github.com/opentofu/opentofu/internal/modsdir"
 )
 
 // LoadConfig reads the OpenTofu module in the given directory and uses it as the
@@ -58,7 +59,7 @@ func (l *Loader) loadConfig(ctx context.Context, rootMod *configs.Module, diags 
 
 // moduleWalkerLoad is a configs.ModuleWalkerFunc for loading modules that
 // are presumed to have already been installed.
-func (l *Loader) moduleWalkerLoad(ctx context.Context, req *configs.ModuleRequest) (*configs.Module, *version.Version, hcl.Diagnostics) {
+func (l *Loader) ModuleLocalPath(ctx context.Context, req *configs.ModuleRequest) (*modsdir.Record, hcl.Diagnostics) {
 	// Since we're just loading here, we expect that all referenced modules
 	// will be already installed and described in our manifest. However, we
 	// do verify that the manifest and the configuration are in agreement
@@ -68,7 +69,7 @@ func (l *Loader) moduleWalkerLoad(ctx context.Context, req *configs.ModuleReques
 	record, exists := l.modules.manifest[key]
 
 	if !exists {
-		return nil, nil, hcl.Diagnostics{
+		return nil, hcl.Diagnostics{
 			{
 				Severity: hcl.DiagError,
 				Summary:  "Module not installed",
@@ -92,7 +93,7 @@ func (l *Loader) moduleWalkerLoad(ctx context.Context, req *configs.ModuleReques
 			Subject:  &req.SourceAddrRange,
 		})
 	}
-	if len(req.VersionConstraint.Required) > 0 && record.Version == nil {
+	if req.VersionConstraint.HasRequirements() && record.Version == nil {
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Module version requirements have changed",
@@ -100,7 +101,7 @@ func (l *Loader) moduleWalkerLoad(ctx context.Context, req *configs.ModuleReques
 			Subject:  &req.SourceAddrRange,
 		})
 	}
-	if record.Version != nil && !req.VersionConstraint.Required.Check(record.Version) {
+	if record.Version != nil && !req.VersionConstraint.Check(record.Version) {
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Module version requirements have changed",
@@ -110,6 +111,17 @@ func (l *Loader) moduleWalkerLoad(ctx context.Context, req *configs.ModuleReques
 			),
 			Subject: &req.SourceAddrRange,
 		})
+	}
+
+	return &record, diags
+}
+
+// moduleWalkerLoad is a configs.ModuleWalkerFunc for loading modules that
+// are presumed to have already been installed.
+func (l *Loader) moduleWalkerLoad(ctx context.Context, req *configs.ModuleRequest) (*configs.Module, *version.Version, hcl.Diagnostics) {
+	record, diags := l.ModuleLocalPath(ctx, req)
+	if diags.HasErrors() {
+		return nil, nil, diags
 	}
 
 	mod, mDiags := l.parser.LoadConfigDir(record.Dir, req.Call)

--- a/internal/configs/module_call_test.go
+++ b/internal/configs/module_call_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/apparentlymart/go-versions/versions"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	version "github.com/hashicorp/go-version"
@@ -171,6 +172,7 @@ func TestLoadModuleCall(t *testing.T) {
 		ctydebug.CmpOptions,
 		cmp.AllowUnexported(ProviderConfigRef{}),
 		cmpopts.IgnoreUnexported(hcl.TraverseAttr{}, hcl.TraverseIndex{}, hcl.TraverseRoot{}),
+		cmpopts.IgnoreTypes(versions.Set{}),
 		cmpopts.IgnoreTypes(StaticModuleVariables(nil)), // function pointer type is not comparable
 	}
 	if diff := cmp.Diff(wantModules, gotModules, cmpOpts); diff != "" {
@@ -346,6 +348,7 @@ func TestModuleCallWithVersion(t *testing.T) {
 		ctydebug.CmpOptions,
 		cmp.AllowUnexported(ProviderConfigRef{}),
 		cmpopts.IgnoreUnexported(hcl.TraverseAttr{}, hcl.TraverseIndex{}, hcl.TraverseRoot{}),
+		cmpopts.IgnoreTypes(versions.Set{}),
 		cmpopts.IgnoreTypes(StaticModuleVariables(nil)), // function pointer type is not comparable
 		cmp.Comparer(func(a, b *version.Constraint) bool {
 			return a.Equals(b)

--- a/internal/configs/version_constraint.go
+++ b/internal/configs/version_constraint.go
@@ -111,6 +111,9 @@ func (v VersionConstraint) HasRequirements() bool {
 
 func (v VersionConstraint) Check(ver *version.Version) bool {
 	if !isUnsetOrAllVersions(v.RequiredSet) {
+		// This conversion between version constraint types/packages is
+		// not ideal, but is a best effort for the new engine. Eventually,
+		// we should remove v.Required in a subsequent refactoring pass.
 		nver, err := versions.ParseVersion(ver.String())
 		if err != nil {
 			// This should not be possible as the two version packages have the same supported formats

--- a/internal/configs/version_constraint.go
+++ b/internal/configs/version_constraint.go
@@ -8,6 +8,7 @@ package configs
 import (
 	"fmt"
 
+	"github.com/apparentlymart/go-versions/versions"
 	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/opentofu/opentofu/internal/lang/marks"
@@ -20,8 +21,9 @@ import (
 // a source range so that a helpful diagnostic can be printed in the event
 // that a particular constraint does not match.
 type VersionConstraint struct {
-	Required  version.Constraints
-	DeclRange hcl.Range
+	Required    version.Constraints
+	RequiredSet versions.Set // New style
+	DeclRange   hcl.Range
 }
 
 func decodeVersionConstraint(attr *hcl.Attribute) (VersionConstraint, hcl.Diagnostics) {
@@ -97,4 +99,32 @@ func decodeVersionConstraintValue(attr *hcl.Attribute, val cty.Value) (VersionCo
 
 	ret.Required = constraints
 	return ret, diags
+}
+
+func isUnsetOrAllVersions(v versions.Set) bool {
+	return v == versions.All || v == versions.Set{}
+}
+
+func (v VersionConstraint) HasRequirements() bool {
+	return len(v.Required) > 0 || !isUnsetOrAllVersions(v.RequiredSet)
+}
+
+func (v VersionConstraint) Check(ver *version.Version) bool {
+	if !isUnsetOrAllVersions(v.RequiredSet) {
+		nver, err := versions.ParseVersion(ver.String())
+		if err != nil {
+			// This should not be possible as the two version packages have the same supported formats
+			panic(err)
+		}
+		return v.RequiredSet.Has(nver)
+	}
+	return v.Required.Check(ver)
+}
+
+func (v VersionConstraint) String() string {
+	if !isUnsetOrAllVersions(v.RequiredSet) {
+		// TODO this is not human consumable
+		return v.RequiredSet.GoString()
+	}
+	return v.Required.String()
 }

--- a/internal/getproviders/types.go
+++ b/internal/getproviders/types.go
@@ -110,6 +110,31 @@ func (r Requirements) Merge(other Requirements) Requirements {
 	return ret
 }
 
+func (pq *ProvidersQualification) Merge(other *ProvidersQualification) *ProvidersQualification {
+	ret := &ProvidersQualification{}
+
+	for explicit := range pq.Explicit {
+		ret.AddExplicitProvider(explicit)
+	}
+	for explicit := range other.Explicit {
+		ret.AddExplicitProvider(explicit)
+	}
+
+	for provider, refs := range pq.Implicit {
+		for _, ref := range refs {
+			ret.AddImplicitProvider(provider, ref)
+		}
+	}
+
+	for provider, refs := range other.Implicit {
+		for _, ref := range refs {
+			ret.AddImplicitProvider(provider, ref)
+		}
+	}
+
+	return ret
+}
+
 // Selections gathers together version selections for many different providers.
 //
 // This is the result of provider installation: a specific version selected

--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -25,6 +25,7 @@ import (
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/configs/configload"
 	"github.com/opentofu/opentofu/internal/getmodules"
+	"github.com/opentofu/opentofu/internal/lang/eval"
 	"github.com/opentofu/opentofu/internal/modsdir"
 	"github.com/opentofu/opentofu/internal/registry"
 	"github.com/opentofu/opentofu/internal/registry/response"
@@ -46,6 +47,8 @@ type ModuleInstaller struct {
 	// The keys in registryPackageSources are the moduleVersion struct below and
 	// the values are package locations returned by the registry client.
 	registryPackageSources map[moduleVersion]registry.PackageLocation
+
+	ConfigInstance func(ctx context.Context, root *configs.Module, modules eval.ExternalModules) (*eval.ConfigInstance, tfdiags.Diagnostics)
 }
 
 type moduleVersion struct {
@@ -161,9 +164,6 @@ func (i *ModuleInstaller) InstallModules(ctx context.Context, rootDir, testsDir 
 	log.Printf("[TRACE] ModuleInstaller: installing child modules for %s into %s", rootDir, i.modsDir)
 	var diags tfdiags.Diagnostics
 
-	rootMod, mDiags := i.loader.Parser().LoadConfigDirWithTests(rootDir, testsDir, call)
-	diags = diags.Append(mDiags)
-
 	manifest, err := modsdir.ReadManifestSnapshotForDir(i.modsDir)
 	if err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -189,10 +189,20 @@ func (i *ModuleInstaller) InstallModules(ctx context.Context, rootDir, testsDir 
 	}
 	walker := i.moduleInstallWalker(ctx, manifest, upgrade, hooks, fetcher)
 
-	cfg, instDiags := i.installDescendentModules(ctx, rootMod, manifest, walker, installErrsOnly)
-	diags = append(diags, instDiags...)
+	if i.ConfigInstance != nil {
+		cfg, instDiags := i.installDescendentModulesNewRuntime(ctx, rootDir, manifest, walker, installErrsOnly)
+		diags = append(diags, instDiags...)
 
-	return cfg, diags
+		return cfg, diags
+	} else {
+		rootMod, mDiags := i.loader.Parser().LoadConfigDirWithTests(rootDir, testsDir, call)
+		diags = diags.Append(mDiags)
+
+		cfg, instDiags := i.installDescendentModules(ctx, rootMod, manifest, walker, installErrsOnly)
+		diags = append(diags, instDiags...)
+
+		return cfg, diags
+	}
 }
 
 func (i *ModuleInstaller) moduleInstallWalker(_ context.Context, manifest modsdir.Manifest, upgrade bool, hooks ModuleInstallHooks, fetcher *getmodules.PackageFetcher) configs.ModuleWalker {
@@ -254,8 +264,8 @@ func (i *ModuleInstaller) moduleInstallWalker(_ context.Context, manifest modsdi
 					log.Printf("[TRACE] ModuleInstaller: %s source address has changed from %q to %q", key, record.SourceAddr, req.SourceAddr)
 					span.AddEvent("Module source address changed")
 					replace = true
-				case record.Version != nil && !req.VersionConstraint.Required.Check(record.Version):
-					log.Printf("[TRACE] ModuleInstaller: %s version %s no longer compatible with constraints %s", key, record.Version, req.VersionConstraint.Required)
+				case record.Version != nil && !req.VersionConstraint.Check(record.Version):
+					log.Printf("[TRACE] ModuleInstaller: %s version %s no longer compatible with constraints %s", key, record.Version, req.VersionConstraint.String())
 					span.AddEvent("Module version constraint changed")
 					replace = true
 				}
@@ -424,7 +434,7 @@ func (i *ModuleInstaller) installLocalModule(ctx context.Context, req *configs.M
 		panic(fmt.Errorf("missing manifest record for parent module %s", parentKey))
 	}
 
-	if len(req.VersionConstraint.Required) != 0 {
+	if req.VersionConstraint.HasRequirements() {
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Invalid version constraint",
@@ -491,7 +501,7 @@ func (i *ModuleInstaller) installRegistryModule(ctx context.Context, req *config
 	ctx, span := tracing.Tracer().Start(ctx, "Install Registry Module", tracing.SpanAttributes(
 		traceattrs.OpenTofuModuleCallName(req.Name),
 		traceattrs.OpenTofuModuleSource(req.SourceAddr.String()),
-		traceattrs.OpenTofuModuleVersion(req.VersionConstraint.Required.String()),
+		traceattrs.OpenTofuModuleVersion(req.VersionConstraint.String()),
 	))
 	defer span.End()
 
@@ -623,7 +633,7 @@ func (i *ModuleInstaller) installRegistryModule(ctx context.Context, req *config
 			// cause all prerelease versions to be excluded from the selection.
 			// For more information:
 			//     https://github.com/opentofu/opentofu/issues/2117
-			constraint := req.VersionConstraint.Required.String()
+			constraint := req.VersionConstraint.String()
 			acceptableVersions, err := versions.MeetingConstraintsString(constraint)
 			if err != nil {
 				// apparentlymart/go-versions purposely doesn't accept "v" prefixes.
@@ -689,7 +699,7 @@ func (i *ModuleInstaller) installRegistryModule(ctx context.Context, req *config
 			latestVersion = v
 		}
 
-		if req.VersionConstraint.Required.Check(v) {
+		if req.VersionConstraint.Check(v) {
 			if latestMatch == nil || v.GreaterThan(latestMatch) {
 				latestMatch = v
 			}
@@ -862,7 +872,7 @@ func (i *ModuleInstaller) installGoGetterModule(ctx context.Context, req *config
 	packageAddr := addr.Package
 	hooks.Download(key, packageAddr.String(), nil)
 
-	if len(req.VersionConstraint.Required) != 0 {
+	if req.VersionConstraint.HasRequirements() {
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Invalid version constraint",

--- a/internal/initwd/module_install_runtime.go
+++ b/internal/initwd/module_install_runtime.go
@@ -1,0 +1,158 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package initwd
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/apparentlymart/go-versions/versions"
+	version "github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/configs"
+	"github.com/opentofu/opentofu/internal/configs/configload"
+	"github.com/opentofu/opentofu/internal/lang/eval"
+	"github.com/opentofu/opentofu/internal/modsdir"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+)
+
+func (i *ModuleInstaller) installDescendentModulesNewRuntime(ctx context.Context, rootDir string, manifest modsdir.Manifest, installWalker configs.ModuleWalker, installErrsOnly bool) (*configs.Config, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	// When attempting to initialize the current directory with a module
+	// source, some use cases may want to ignore configuration errors from the
+	// building of the entire configuration structure, but we still need to
+	// capture installation errors. Because the actual module installation
+	// happens in the ModuleWalkFunc callback while building the config, we
+	// need to create a closure to capture the installation diagnostics
+	// separately.
+	var instDiags hcl.Diagnostics
+	walker := installWalker
+	if installErrsOnly {
+		walker = configs.ModuleWalkerFunc(func(ctx context.Context, req *configs.ModuleRequest) (*configs.Module, *version.Version, hcl.Diagnostics) {
+			mod, version, diags := installWalker.LoadModule(ctx, req)
+			instDiags = instDiags.Extend(diags)
+			return mod, version, diags
+		})
+	}
+
+	root, hclDiags := i.loader.Parser().LoadConfigDirUneval(rootDir, configs.SelectiveLoadAll)
+	diags = diags.Append(hclDiags)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	configInst, moreDiags := i.ConfigInstance(ctx, root, &newRuntimeModules{
+		loader: i.loader,
+		walker: walker,
+
+		root:    root,
+		rootDir: rootDir,
+	})
+	diags = diags.Append(moreDiags)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	moreDiags = configInst.StaticCheck(ctx)
+	diags = diags.Append(moreDiags)
+
+	if installErrsOnly {
+		// We can't continue if there was an error during installation, but
+		// return all diagnostics in case there happens to be anything else
+		// useful when debugging the problem. Any instDiags will be included in
+		// diags already.
+		if instDiags.HasErrors() {
+			return nil, diags
+		}
+
+		// If there are any errors here, they must be only from building the
+		// config structures. We don't want to block initialization at this
+		// point, so convert these into warnings. Any actual errors in the
+		// configuration will be raised as soon as the config is loaded again.
+		// We continue below because writing the manifest is required to finish
+		// module installation.
+		diags = tfdiags.OverrideAll(diags, tfdiags.Warning, nil)
+	}
+
+	err := manifest.WriteSnapshotToDir(i.modsDir)
+	if err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Failed to update module manifest",
+			fmt.Sprintf("Unable to write the module manifest file: %s", err),
+		))
+	}
+
+	return nil, diags
+}
+
+// newRuntimeModules is an implementation of [eval.ExternalModules] that makes
+// a best effort to shim to OpenTofu's current module loader, even though
+// it works in some slightly-different terms than this new API expects.
+type newRuntimeModules struct {
+	loader *configload.Loader
+	walker configs.ModuleWalker
+
+	root    *configs.Module
+	rootDir string
+
+	// configload.Loader is not concurrency-safe because it wraps
+	// hclparse.Parser functionality that is not concurrency-safe, so we must
+	// hold this lock whenever we're interacting with the loader object.
+	mu sync.Mutex
+}
+
+var _ eval.ExternalModules = (*newRuntimeModules)(nil)
+
+// ModuleConfig implements eval.ExternalModules.
+func (n *newRuntimeModules) ModuleConfig(ctx context.Context, source addrs.ModuleSource, allowedVersions versions.Set, forCall *addrs.AbsModuleCall) (eval.UncompiledModule, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	if forCall == nil {
+		// Root Module
+		return eval.PrepareTofu2024Module(source, n.root), diags
+	}
+
+	if remoteSource, ok := source.(addrs.ModuleSourceRemote); ok {
+		str := remoteSource.String()
+		if strings.HasPrefix(str, "file://") {
+			// This is truly terrible and should not ever be released...
+			abs, _ := filepath.Abs(n.rootDir)
+
+			sourceDir := strings.TrimPrefix(str, "file://")
+
+			rel, err := filepath.Rel(abs, sourceDir)
+			if err != nil {
+				panic(err)
+			}
+			source = addrs.ModuleSourceLocal(n.rootDir + string(filepath.Separator) + rel)
+		}
+	}
+
+	n.mu.Lock()
+	mod, _, modDiags := n.walker.LoadModule(ctx, &configs.ModuleRequest{
+		Name:       forCall.Call.Name,
+		Path:       forCall.Module.Module().Child(forCall.Call.Name),
+		SourceAddr: source,
+		VersionConstraint: configs.VersionConstraint{
+			RequiredSet: allowedVersions,
+		},
+		//SourceAddrRange hcl.Range
+		//CallRange hcl.Range
+		Parent: &configs.Config{
+			Path: forCall.Module.Module(),
+		},
+	})
+	n.mu.Unlock()
+	diags = diags.Append(modDiags)
+
+	return eval.PrepareTofu2024Module(source, mod), diags
+}

--- a/internal/lang/eval/config_static.go
+++ b/internal/lang/eval/config_static.go
@@ -1,0 +1,111 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package eval
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/getproviders"
+	"github.com/opentofu/opentofu/internal/lang/eval/internal/configgraph"
+	"github.com/opentofu/opentofu/internal/lang/eval/internal/evalglue"
+	"github.com/opentofu/opentofu/internal/lang/grapheval"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+var NewStaticPlugins = evalglue.NewStaticPlugins
+
+// StaticCheck performs a CheckAll, but using static glue (no providers or state)
+func (c *ConfigInstance) StaticCheck(ctx context.Context) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+
+	// All of our work will be associated with a workgraph worker that serves
+	// as the initial worker node in the work graph.
+	ctx = grapheval.ContextWithNewWorker(ctx)
+
+	internalGlue := &staticGlue{}
+	rootModuleInstance, moreDiags := c.newRootModuleInstance(ctx, internalGlue)
+	diags = diags.Append(moreDiags)
+	if moreDiags.HasErrors() {
+		// If we can't even load the root module then we'll bail out early.
+		return diags
+	}
+
+	// If the grapheval package detects a self-dependency problem during
+	// evaluation then it'll use this tracker to find human-friendly names
+	// for all of the requests involved in the error.
+	ctx = grapheval.ContextWithRequestTracker(ctx, workgraphRequestTracker{rootModuleInstance})
+
+	moreDiags = checkAll(ctx, rootModuleInstance)
+	diags = diags.Append(moreDiags)
+	return diags
+}
+
+// Fetches all of the provider requirments referred to by a given configuration tree
+func (c *ConfigInstance) ProviderRequirements(ctx context.Context) (getproviders.Requirements, *getproviders.ProvidersQualification, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	// All of our work will be associated with a workgraph worker that serves
+	// as the initial worker node in the work graph.
+	ctx = grapheval.ContextWithNewWorker(ctx)
+
+	internalGlue := &staticGlue{}
+	rootModuleInstance, moreDiags := c.newRootModuleInstance(ctx, internalGlue)
+	diags = diags.Append(moreDiags)
+	if moreDiags.HasErrors() {
+		// If we can't even load the root module then we'll bail out early.
+		return nil, nil, diags
+	}
+
+	// If the grapheval package detects a self-dependency problem during
+	// evaluation then it'll use this tracker to find human-friendly names
+	// for all of the requests involved in the error.
+	ctx = grapheval.ContextWithRequestTracker(ctx, workgraphRequestTracker{rootModuleInstance})
+
+	reqs, quals, moreDiags := rootModuleInstance.ProviderRequirements(ctx)
+	diags = diags.Append(moreDiags)
+
+	allChildren := rootModuleInstance.ChildModuleInstances(ctx)
+	for _, child := range allChildren {
+		moreReqs, moreQuals, moreDiags := child.ProviderRequirements(ctx)
+		diags = diags.Append(moreDiags)
+		reqs = reqs.Merge(moreReqs)
+		quals = quals.Merge(moreQuals)
+	}
+
+	moreDiags = checkAll(ctx, rootModuleInstance)
+	diags = diags.Append(moreDiags)
+
+	return reqs, quals, diags
+}
+
+// staticGlue is a similar construct to [configs.staticScope], but does not implement:
+// * variable `const` attr checking
+// * enhanced diagnostics to help track down usages of dynamic values in a static context
+// * tofu.applying (not sure how/where this is set)
+// It does add support for:
+// * module outputs
+type staticGlue struct{}
+
+// ProviderFunction implements evalglue.Glue.
+func (v *staticGlue) ProviderFunction(ctx context.Context, provider addrs.Provider, providerInst configgraph.Maybe[*configgraph.ProviderInstance], subject addrs.ProviderFunction, rng hcl.Range) (function.Function, tfdiags.Diagnostics) {
+	// TODO replace with a provider marked value and enhance the resource mark checking for "static" situations
+	return function.Function{}, tfdiags.New(&hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  "Provider function in static context",
+		Detail:   fmt.Sprintf("Unable to use %s in static context", subject.String()),
+		Subject:  rng.Ptr(),
+	})
+}
+
+// ResourceInstanceValue implements evaluationGlue.
+func (v *staticGlue) ResourceInstanceValue(ctx context.Context, ri *configgraph.ResourceInstance, configVal cty.Value, _ configgraph.Maybe[*configgraph.ProviderInstance], _ addrs.Set[addrs.AbsResourceInstance]) (cty.Value, tfdiags.Diagnostics) {
+	return cty.DynamicVal, nil
+}

--- a/internal/lang/eval/internal/evalglue/dependencies_static.go
+++ b/internal/lang/eval/internal/evalglue/dependencies_static.go
@@ -1,0 +1,52 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package evalglue
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/configs/configschema"
+	"github.com/opentofu/opentofu/internal/providers"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+type staticPlugins struct{}
+
+var _ Providers = staticPlugins{}
+var _ Provisioners = staticPlugins{}
+
+func NewStaticPlugins() staticPlugins {
+	return staticPlugins{}
+}
+
+func (s staticPlugins) ProviderConfigSchema(ctx context.Context, provider addrs.Provider) (*providers.Schema, tfdiags.Diagnostics) {
+	// schema.Block will be nil, signifying that this is not a complete implementation
+	return &providers.Schema{}, nil
+}
+func (s staticPlugins) ResourceTypeSchema(ctx context.Context, provider addrs.Provider, mode addrs.ResourceMode, typeName string) (*providers.Schema, tfdiags.Diagnostics) {
+	// schema.Block will be nil, signifying that this is not a complete implementation
+	return &providers.Schema{}, nil
+}
+func (s staticPlugins) ValidateProviderConfig(ctx context.Context, provider addrs.Provider, configVal cty.Value) tfdiags.Diagnostics {
+	return nil
+}
+func (s staticPlugins) ValidateResourceConfig(ctx context.Context, provider addrs.Provider, mode addrs.ResourceMode, typeName string, configVal cty.Value) tfdiags.Diagnostics {
+	return nil
+}
+func (s staticPlugins) BuildFunction(ctx context.Context, provider addrs.Provider, pf addrs.ProviderFunction, stubMissing bool, rng hcl.Range) (function.Function, tfdiags.Diagnostics) {
+	panic("not supported in a static context")
+}
+func (s staticPlugins) NewConfiguredProvider(ctx context.Context, provider addrs.Provider, configVal cty.Value) (providers.Configured, tfdiags.Diagnostics) {
+	panic("not supported in a static context")
+}
+func (s staticPlugins) ProvisionerConfigSchema(ctx context.Context, typeName string) (*configschema.Block, tfdiags.Diagnostics) {
+	// TODO provisioners!
+	panic("not implemented")
+}

--- a/internal/lang/eval/internal/evalglue/module_instance.go
+++ b/internal/lang/eval/internal/evalglue/module_instance.go
@@ -12,6 +12,7 @@ import (
 	"github.com/apparentlymart/go-workgraph/workgraph"
 
 	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/getproviders"
 	"github.com/opentofu/opentofu/internal/lang/eval/internal/configgraph"
 	"github.com/opentofu/opentofu/internal/lang/exprs"
 	"github.com/opentofu/opentofu/internal/lang/grapheval"
@@ -163,6 +164,8 @@ type CompiledModuleInstance interface {
 	// This blocks on the decision about which instances are available for the
 	// relevant provider config.
 	ProviderInstance(ctx context.Context, addr addrs.ProviderInstanceCorrect) *configgraph.ProviderInstance
+
+	ProviderRequirements(ctx context.Context) (getproviders.Requirements, *getproviders.ProvidersQualification, tfdiags.Diagnostics)
 
 	// AnnounceAllGraphevalRequests calls announce for each [grapheval.Once],
 	// [OnceValuer], or other [workgraph.RequestID] anywhere in the tree under this

--- a/internal/lang/eval/internal/tofu2024/compile.go
+++ b/internal/lang/eval/internal/tofu2024/compile.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
+	"github.com/opentofu/opentofu/internal/getproviders"
 	"github.com/opentofu/opentofu/internal/lang/eval/internal/configgraph"
 	"github.com/opentofu/opentofu/internal/lang/exprs"
 	"github.com/opentofu/opentofu/internal/tfdiags"
@@ -82,6 +83,12 @@ func CompileModuleInstance(
 	topScope := &moduleInstanceScope{
 		inst:          ret,
 		coreFunctions: compileCoreFunctions(ctx, call.AllowImpureFunctions, call.EvalContext.RootModuleDir, call.EvalContext.PlanTimestamp),
+	}
+
+	ret.providerRequirements = func(ctx context.Context) (getproviders.Requirements, *getproviders.ProvidersQualification, tfdiags.Diagnostics) {
+		fakeCfg := &configs.Config{Module: module}
+		reqs, quals, diags := fakeCfg.ProviderRequirements()
+		return reqs, quals, tfdiags.New(diags)
 	}
 
 	// We have some shims in here to deal with the unusual way the existing

--- a/internal/lang/eval/internal/tofu2024/compile_provider_configs.go
+++ b/internal/lang/eval/internal/tofu2024/compile_provider_configs.go
@@ -8,6 +8,7 @@ package tofu2024
 import (
 	"context"
 
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -55,15 +56,6 @@ func compileProviderConfig(
 		providerAddr = reqd.Type
 	}
 
-	var configEvalable exprs.Evalable
-	configSchema, diags := providers.ProviderConfigSchema(ctx, providerAddr)
-	if diags.HasErrors() {
-		configEvalable = exprs.ForcedErrorEvalable(diags, tfdiags.SourceRangeFromHCL(config.DeclRange))
-	} else {
-		spec := configSchema.Block.DecoderSpec()
-		configEvalable = exprs.EvalableHCLBodyWithDynamicBlocks(config.Config, spec)
-	}
-
 	// Provider configuration blocks don't have an explicit depends_on argument,
 	// but to make this as similar as possible to how we handle other similar
 	// block types we'll use the depends_on compiler with an always-empty
@@ -71,6 +63,20 @@ func compileProviderConfig(
 	// instance selector and then into the CompileProviderInstance callback
 	// below.
 	sharedDeps, compileInstanceDeps := compileDependsOn(nil, declScope, extraMarks)
+
+	var configEvalable exprs.Evalable
+	configSchema, diags := providers.ProviderConfigSchema(ctx, providerAddr)
+	if diags.HasErrors() {
+		configEvalable = exprs.ForcedErrorEvalable(diags, tfdiags.SourceRangeFromHCL(config.DeclRange))
+	} else if configSchema == nil {
+		panic("Is this possible, do we need a diagnostic here?")
+	} else if configSchema.Block == nil {
+		// Assumed static context, I don't love this sort of flagging though
+		configEvalable = exprs.EvalableHCLExpression(&hclsyntax.LiteralValueExpr{Val: cty.DynamicVal})
+	} else {
+		spec := configSchema.Block.DecoderSpec()
+		configEvalable = exprs.EvalableHCLBodyWithDynamicBlocks(config.Config, spec)
+	}
 
 	return &configgraph.ProviderConfig{
 		Addr: addrs.AbsProviderConfigCorrect{

--- a/internal/lang/eval/internal/tofu2024/compile_resources.go
+++ b/internal/lang/eval/internal/tofu2024/compile_resources.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -62,6 +63,14 @@ func compileModuleInstanceResource(
 	resourceAddr := config.Addr()
 	absAddr := moduleInstanceAddr.Resource(resourceAddr.Mode, resourceAddr.Type, resourceAddr.Name)
 
+	// We compile the depends_on argument here but don't evaluate it yet.
+	// It actually gets evaluated inside the "instance selector" we'll
+	// construct below, when it gets asked for its instances, and include
+	// the resulting marks on the count.index, each.key, and/or each.value
+	// results because that means it'll get evaluated only once per resource
+	// instead of separately for each resource instance.
+	sharedDeps, compileInstanceDeps := compileDependsOn(config.DependsOn, declScope, extraMarks)
+
 	var configEvalable exprs.Evalable
 	resourceTypeSchema, diags := providers.ResourceTypeSchema(ctx,
 		config.Provider,
@@ -79,18 +88,13 @@ func compileModuleInstanceResource(
 			Subject:  config.TypeRange.Ptr(),
 		})
 		configEvalable = exprs.ForcedErrorEvalable(diags, tfdiags.SourceRangeFromHCL(config.TypeRange))
+	} else if resourceTypeSchema.Block == nil {
+		// Assumed static context, I don't love this sort of flagging though
+		configEvalable = exprs.EvalableHCLExpression(&hclsyntax.LiteralValueExpr{Val: cty.DynamicVal})
 	} else {
 		spec := resourceTypeSchema.Block.DecoderSpec()
 		configEvalable = exprs.EvalableHCLBodyWithDynamicBlocks(config.Config, spec)
 	}
-
-	// We compile the depends_on argument here but don't evaluate it yet.
-	// It actually gets evaluated inside the "instance selector" we'll
-	// construct below, when it gets asked for its instances, and include
-	// the resulting marks on the count.index, each.key, and/or each.value
-	// results because that means it'll get evaluated only once per resource
-	// instead of separately for each resource instance.
-	sharedDeps, compileInstanceDeps := compileDependsOn(config.DependsOn, declScope, extraMarks)
 
 	ret := &configgraph.Resource{
 		Addr:      absAddr,

--- a/internal/lang/eval/internal/tofu2024/module_instance.go
+++ b/internal/lang/eval/internal/tofu2024/module_instance.go
@@ -13,6 +13,7 @@ import (
 	"github.com/apparentlymart/go-workgraph/workgraph"
 
 	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/getproviders"
 	"github.com/opentofu/opentofu/internal/lang/eval/internal/configgraph"
 	"github.com/opentofu/opentofu/internal/lang/eval/internal/evalglue"
 	"github.com/opentofu/opentofu/internal/lang/exprs"
@@ -37,6 +38,8 @@ type CompiledModuleInstance struct {
 	providerLocalNames  map[addrs.Provider]string
 
 	missingProviders rootMissingProviders
+
+	providerRequirements func(ctx context.Context) (getproviders.Requirements, *getproviders.ProvidersQualification, tfdiags.Diagnostics)
 }
 
 var _ evalglue.CompiledModuleInstance = (*CompiledModuleInstance)(nil)
@@ -242,6 +245,11 @@ func (c *CompiledModuleInstance) ResourceInstancesForResource(ctx context.Contex
 			}
 		}
 	}
+}
+
+// ResourceInstancesForResource implements evalglue.ProviderRequirements.
+func (c *CompiledModuleInstance) ProviderRequirements(ctx context.Context) (getproviders.Requirements, *getproviders.ProvidersQualification, tfdiags.Diagnostics) {
+	return c.providerRequirements(ctx)
 }
 
 // AnnounceAllGraphevalRequests implements evalglue.CompiledModuleInstance.

--- a/internal/tofu/context.go
+++ b/internal/tofu/context.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/encryption"
+	"github.com/opentofu/opentofu/internal/lang/eval"
 	"github.com/opentofu/opentofu/internal/logging"
 	"github.com/opentofu/opentofu/internal/plugins"
 	"github.com/opentofu/opentofu/internal/states"
@@ -43,6 +44,7 @@ type ContextOpts struct {
 	Parallelism int
 	Plugins     plugins.Library
 	Encryption  encryption.Encryption
+	Modules     eval.ExternalModules
 
 	UIInput UIInput
 }
@@ -78,6 +80,7 @@ type Context struct {
 	meta *ContextMeta
 
 	plugins *contextPlugins
+	modules eval.ExternalModules
 
 	hooks   []Hook
 	sh      *stopHook
@@ -142,6 +145,7 @@ func NewContext(opts *ContextOpts) (*Context, tfdiags.Diagnostics) {
 		uiInput: opts.UIInput,
 
 		plugins: plugins,
+		modules: opts.Modules,
 
 		parallelSem:         NewSemaphore(par),
 		providerInputConfig: make(map[string]map[string]cty.Value),

--- a/internal/tofu/context_temp_runtime.go
+++ b/internal/tofu/context_temp_runtime.go
@@ -11,15 +11,12 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/apparentlymart/go-versions/versions"
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
-	"github.com/opentofu/opentofu/internal/configs/configload"
 	"github.com/opentofu/opentofu/internal/engine/applying"
 	"github.com/opentofu/opentofu/internal/engine/planning"
 	"github.com/opentofu/opentofu/internal/engine/plugins"
@@ -87,23 +84,25 @@ func (c *Context) newEngineShim(ctx context.Context, config *configs.Config, inp
 
 	inputValues := exprs.ConstantValuer(cty.ObjectVal(rawInput))
 
-	tempLoader, _ := configload.NewLoader(&configload.Config{})
-
 	owd := "."
 	if c.meta != nil && c.meta.OriginalWorkingDir != "" {
 		owd = c.meta.OriginalWorkingDir
+	}
+
+	modules := c.modules
+	if modules == nil {
+		// testing fallback
+		modules = newRuntimeModulesForTesting{config: config}
 	}
 
 	plugins := plugins.NewRuntimePluginsTemp(c.plugins.providers, c.plugins.provisioners)
 	evalCtx := &eval.EvalContext{
 		RootModuleDir:      config.Module.SourceDir,
 		OriginalWorkingDir: owd,
-		Modules: &newRuntimeModules{
-			loader: tempLoader,
-		},
-		Providers:     plugins,
-		Provisioners:  plugins,
-		PlanTimestamp: planTimestamp,
+		Modules:            modules,
+		Providers:          plugins,
+		Provisioners:       plugins,
+		PlanTimestamp:      planTimestamp,
 	}
 	done := func() {
 		// We'll call close with a cancel-free context because we do still
@@ -221,57 +220,21 @@ func (c *Context) newEngineApply(ctx context.Context, config *configs.Config, pl
 	return newState, diags
 }
 
-// newRuntimeModules is an implementation of [eval.ExternalModules] that makes
-// a best effort to shim to OpenTofu's current module loader, even though
-// it works in some slightly-different terms than this new API expects.
-type newRuntimeModules struct {
-	loader *configload.Loader
-
-	// configload.Loader is not concurrency-safe because it wraps
-	// hclparse.Parser functionality that is not concurrency-safe, so we must
-	// hold this lock whenever we're interacting with the loader object.
-	mu sync.Mutex
+type newRuntimeModulesForTesting struct {
+	config *configs.Config
 }
 
-var _ eval.ExternalModules = (*newRuntimeModules)(nil)
-
-// ModuleConfig implements evalglue.ExternalModules.
-func (n *newRuntimeModules) ModuleConfig(ctx context.Context, source addrs.ModuleSource, allowedVersions versions.Set, forCall *addrs.AbsModuleCall) (eval.UncompiledModule, tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	var sourceDir string
-	switch source := source.(type) {
-	case addrs.ModuleSourceLocal:
-		sourceDir = filepath.Clean(filepath.FromSlash(string(source)))
-	default:
-		// Hack in support for file:// paths to allow existing tests to run
-		// This should be removed once support is added for [addrs.ModuleSourceRemote]
-		str := source.String()
-		if strings.HasPrefix(str, "file://") {
-			sourceDir = strings.TrimPrefix(str, "file://")
-			break
+func (n newRuntimeModulesForTesting) ModuleConfig(ctx context.Context, source addrs.ModuleSource, allowedVersions versions.Set, forCall *addrs.AbsModuleCall) (eval.UncompiledModule, tfdiags.Diagnostics) {
+	if forCall == nil {
+		// Root Module
+		if n.config.Module.ProviderRequirements == nil {
+			// Broken tests
+			n.config.Module.ProviderRequirements = &configs.RequiredProviders{}
 		}
-
-		// For this early stub implementation we only support local source
-		// addresses. We'll expand this later but that'll require this codepath
-		// to have access to the information about what's in the module cache
-		// directory at ".terraform/modules", which we've not arranged for yet.
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"New runtime codepath only supports local module sources",
-			fmt.Sprintf("Cannot load %q, because our temporary codepath for the new language runtime only supports local module sources for now.", source),
-		))
-		return nil, diags
+		return eval.PrepareTofu2024Module(source, n.config.Module), nil
 	}
-	log.Printf("[TRACE] backend/local: Loading module from %q from local path %q", source, sourceDir)
+	path := forCall.Module.Module().Child(forCall.Call.Name)
+	mod := n.config.Descendent(path)
 
-	n.mu.Lock()
-	mod, hclDiags := n.loader.Parser().LoadConfigDirUneval(sourceDir, configs.SelectiveLoadAll)
-	n.mu.Unlock()
-	diags = diags.Append(hclDiags)
-	if hclDiags.HasErrors() {
-		return nil, diags
-	}
-
-	return eval.PrepareTofu2024Module(source, mod), diags
+	return eval.PrepareTofu2024Module(source, mod.Module), nil
 }


### PR DESCRIPTION
This is a partial solution to #4060. It swaps out the module and provider installer, as well as wires in support for remote modules into the legacy path.

There is a lot in this PR that is not ideal, but it aims to be as close as possible to a 1-1 representation of how we init and run tofu now. In the long term, I expect much of this code will go away when we remove the "split-path" state that tofu is in currently.

<!-- If your PR resolves an issue, please add it here. -->
Resolves #4060

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
