### PR TITLE
Add support for tofu.* and path.* attributes in new runtime

### DIFF
--- a/internal/command/temp_new_runtime.go
+++ b/internal/command/temp_new_runtime.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 
 	"github.com/apparentlymart/go-versions/versions"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/configs/configload"
@@ -38,6 +39,11 @@ func (m *Meta) StaticConfigInstance(ctx context.Context, root *configs.Module, m
 	diags = diags.Append(moreDiags)
 	if diags.HasErrors() {
 		return nil, diags
+	}
+
+	workspace, err := m.Workspace(ctx)
+	if err != nil {
+		return nil, diags.Append(err)
 	}
 
 	rawInput := map[string]cty.Value{}
@@ -66,6 +72,19 @@ func (m *Meta) StaticConfigInstance(ctx context.Context, root *configs.Module, m
 
 	owd := m.WorkingDir.OriginalWorkingDir()
 
+	// The current working directory should always be absolute, whether we
+	// just looked it up or whether we were relying on ContextMeta's
+	// (possibly non-normalized) path.
+	owd, err = filepath.Abs(owd)
+	if err != nil {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  `Failed to get working directory`,
+			Detail:   fmt.Sprintf(`The value for the original working directory cannot be determined due to a system error: %s`, err),
+		})
+		return nil, diags
+	}
+
 	if modules == nil {
 		modules = &newRuntimeModules{
 			loader: loader,
@@ -79,6 +98,7 @@ func (m *Meta) StaticConfigInstance(ctx context.Context, root *configs.Module, m
 		Modules:            modules,
 		Providers:          staticPlugins,
 		Provisioners:       staticPlugins,
+		Workspace:          workspace,
 	}
 
 	// The new config-loading system wants to work in terms of module source

--- a/internal/lang/eval/internal/evalglue/context.go
+++ b/internal/lang/eval/internal/evalglue/context.go
@@ -51,6 +51,21 @@ type EvalContext struct {
 	// but leaves OriginalWorkingDir unchanged.
 	RootModuleDir, OriginalWorkingDir string
 
+	// Applying currently wired in via the tofu context shims and does not
+	// represent the final state of how this information should be passed
+	// into the evaluator.
+	//
+	// TODO When we remove the shim, we should try to find a way to prevent
+	// this from disagreeing with the current operation the evaluator is
+	// being asked to perform.
+	Applying bool
+
+	// Workspace is the current tofu workspace passed in from the command
+	// layer
+	Workspace string
+
+	// PlanTimestamp is the time at which the plan was created. This is
+	// used to provide a consistent result for the plantimestamp function.
 	PlanTimestamp time.Time
 }
 

--- a/internal/lang/eval/internal/tofu2024/compile.go
+++ b/internal/lang/eval/internal/tofu2024/compile.go
@@ -83,6 +83,15 @@ func CompileModuleInstance(
 	topScope := &moduleInstanceScope{
 		inst:          ret,
 		coreFunctions: compileCoreFunctions(ctx, call.AllowImpureFunctions, call.EvalContext.RootModuleDir, call.EvalContext.PlanTimestamp),
+
+		// tofu attrs
+		applying:  call.EvalContext.Applying,
+		workspace: call.EvalContext.Workspace,
+
+		// path attrs
+		workingDir: call.EvalContext.OriginalWorkingDir,
+		rootDir:    call.EvalContext.RootModuleDir,
+		sourceDir:  module.SourceDir,
 	}
 
 	ret.providerRequirements = func(ctx context.Context) (getproviders.Requirements, *getproviders.ProvidersQualification, tfdiags.Diagnostics) {

--- a/internal/lang/eval/internal/tofu2024/module_instance_scope.go
+++ b/internal/lang/eval/internal/tofu2024/module_instance_scope.go
@@ -9,14 +9,17 @@ import (
 	"context"
 	"fmt"
 	"iter"
+	"path/filepath"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/didyoumean"
 	"github.com/opentofu/opentofu/internal/instances"
 	"github.com/opentofu/opentofu/internal/lang/eval/internal/configgraph"
 	"github.com/opentofu/opentofu/internal/lang/eval/internal/evalglue"
 	"github.com/opentofu/opentofu/internal/lang/exprs"
+	"github.com/opentofu/opentofu/internal/lang/marks"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
@@ -43,6 +46,15 @@ type moduleInstanceScope struct {
 	inst              *CompiledModuleInstance
 	coreFunctions     map[string]function.Function
 	providerFunctions func(context.Context, addrs.ProviderFunction, hcl.Range) (function.Function, tfdiags.Diagnostics)
+
+	// tofu attrs
+	applying  bool
+	workspace string
+
+	// path attrs
+	workingDir string
+	rootDir    string
+	sourceDir  string
 }
 
 var _ exprs.Scope = (*moduleInstanceScope)(nil)
@@ -108,7 +120,7 @@ func (m *moduleInstanceScope) ResolveAttr(ref hcl.TraverseAttr) (exprs.Attribute
 	var diags tfdiags.Diagnostics
 	switch ref.Name {
 
-	case "var", "local", "module":
+	case "var", "local", "module", "path", "terraform", "tofu":
 		// For various relatively-simple cases where there's just one level of
 		// nested symbol table we use a single shared [exprs.SymbolTable]
 		// implementation which then just delegates back to
@@ -233,7 +245,63 @@ func (m *moduleInstanceScope) resolveSimpleChildAttr(topSymbol string, ref hcl.T
 			return nil, diags
 		}
 		return exprs.ValueOf(v), diags
+	case "terraform", "tofu":
+		var val cty.Value
 
+		// Mostly copied from the tofu/evaluate.go
+		switch ref.Name {
+		case "applying":
+			val = cty.BoolVal(m.applying).Mark(marks.Ephemeral)
+
+		case "workspace":
+			val = cty.StringVal(m.workspace)
+
+		// case "env": intentionally removed as it has been deprecated for a *long* time.
+		default:
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  fmt.Sprintf("Invalid %q attribute", topSymbol),
+				Detail:   fmt.Sprintf(`The %q object does not have an attribute named %q. The only supported attributes are %s.workspace and %s.applying`, topSymbol, ref.Name, topSymbol, topSymbol),
+				Subject:  &ref.SrcRange,
+			})
+		}
+
+		if val == cty.NilVal {
+			return nil, diags
+		}
+		return exprs.ValueOf(exprs.ConstantValuer(val)), diags
+	case "path":
+		var val cty.Value
+
+		// Mostly copied from the tofu/evaluate.go
+		switch ref.Name {
+
+		case "cwd":
+			val = cty.StringVal(filepath.ToSlash(m.workingDir))
+
+		case "module":
+			val = cty.StringVal(filepath.ToSlash(m.sourceDir))
+
+		case "root":
+			val = cty.StringVal(filepath.ToSlash(m.rootDir))
+
+		default:
+			suggestion := didyoumean.NameSuggestion(ref.Name, []string{"cwd", "module", "root"})
+			if suggestion != "" {
+				suggestion = fmt.Sprintf(" Did you mean %q?", suggestion)
+			}
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  `Invalid "path" attribute`,
+				Detail:   fmt.Sprintf(`The "path" object does not have an attribute named %q.%s`, ref.Name, suggestion),
+				Subject:  &ref.SrcRange,
+			})
+		}
+
+		if val == cty.NilVal {
+			return nil, diags
+		}
+		return exprs.ValueOf(exprs.ConstantValuer(val)), diags
 	default:
 		// We should not get here because there should be a case above for
 		// every symbol name that [ModuleInstance.ResolveAttr] delegates
@@ -385,6 +453,12 @@ func nounForModuleInstanceGlobalSymbol(symbol string) string {
 		return "local value"
 	case "module":
 		return "module call"
+	case "terraform":
+		return "terraform"
+	case "tofu":
+		return "tofu"
+	case "path":
+		return "path"
 	default:
 		return "attribute" // generic fallback that we should avoid using by adding new names above as needed
 	}

--- a/internal/tofu/context_apply_test.go
+++ b/internal/tofu/context_apply_test.go
@@ -9169,7 +9169,7 @@ resource "null_instance" "depends" {
 }
 
 func TestContext2Apply_tfWorkspace(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeaturePathAttrs)
+	SkipExperimental(t, ExperimentalFeaturePathAttrs, ExperimentalFeatureRootOutput)
 
 	m := testModule(t, "apply-tf-workspace")
 	p := testProvider("aws")
@@ -9198,7 +9198,7 @@ func TestContext2Apply_tfWorkspace(t *testing.T) {
 }
 
 func TestContext2Apply_tofuWorkspace(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeaturePathAttrs)
+	SkipExperimental(t, ExperimentalFeaturePathAttrs, ExperimentalFeatureRootOutput)
 
 	m := testModule(t, "apply-tofu-workspace")
 	p := testProvider("aws")

--- a/internal/tofu/context_temp_runtime.go
+++ b/internal/tofu/context_temp_runtime.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/apparentlymart/go-versions/versions"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -78,7 +79,7 @@ func experimentalRuntimeWanted() bool {
 	return optIn != ""
 }
 
-func (c *Context) newEngineShim(ctx context.Context, config *configs.Config, inputValuesRaw InputValues, planTimestamp time.Time, allowImpureFunctions bool) (*eval.ConfigInstance, plugins.Plugins, func(), tfdiags.Diagnostics) {
+func (c *Context) newEngineShim(ctx context.Context, config *configs.Config, inputValuesRaw InputValues, planTimestamp time.Time, allowImpureFunctions bool, applying bool) (*eval.ConfigInstance, plugins.Plugins, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	rawInput := map[string]cty.Value{}
@@ -90,9 +91,26 @@ func (c *Context) newEngineShim(ctx context.Context, config *configs.Config, inp
 
 	inputValues := exprs.ConstantValuer(cty.ObjectVal(rawInput))
 
+	workspace := ""
+	if c.meta != nil {
+		workspace = c.meta.Env
+	}
 	owd := "."
 	if c.meta != nil && c.meta.OriginalWorkingDir != "" {
 		owd = c.meta.OriginalWorkingDir
+	}
+
+	// The current working directory should always be absolute, whether we
+	// just looked it up or whether we were relying on ContextMeta's
+	// (possibly non-normalized) path.
+	owd, err := filepath.Abs(owd)
+	if err != nil {
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  `Failed to get working directory`,
+			Detail:   fmt.Sprintf(`The value for the original working directory cannot be determined due to a system error: %s`, err),
+		})
+		return nil, nil, nil, diags
 	}
 
 	modules := c.modules
@@ -109,6 +127,8 @@ func (c *Context) newEngineShim(ctx context.Context, config *configs.Config, inp
 		Providers:          plugins,
 		Provisioners:       plugins,
 		PlanTimestamp:      planTimestamp,
+		Applying:           applying,
+		Workspace:          workspace,
 	}
 	done := func() {
 		// We'll call close with a cancel-free context because we do still
@@ -160,7 +180,7 @@ func (c *Context) newEngineValidate(ctx context.Context, config *configs.Config,
 
 	log.Println("[WARN] Using validate implementation from the experimental language runtime")
 
-	configInst, _, done, moreDiags := c.newEngineShim(ctx, config, inputValues, time.Time{}, false)
+	configInst, _, done, moreDiags := c.newEngineShim(ctx, config, inputValues, time.Time{}, false, false)
 	diags = diags.Append(moreDiags)
 
 	if diags.HasErrors() {
@@ -184,7 +204,7 @@ func (c *Context) newEnginePlan(ctx context.Context, config *configs.Config, pre
 	tracer := c.newEnginePlanTracer()
 	ctx = planning.ContextWithTracer(ctx, tracer)
 
-	configInst, plugins, done, moreDiags := c.newEngineShim(ctx, config, opts.SetVariables, timestamp, false)
+	configInst, plugins, done, moreDiags := c.newEngineShim(ctx, config, opts.SetVariables, timestamp, false, false)
 	diags = diags.Append(moreDiags)
 
 	if diags.HasErrors() {
@@ -296,7 +316,7 @@ func (c *Context) newEngineApply(ctx context.Context, config *configs.Config, pl
 	tracer := c.newEngineApplyTracer()
 	ctx = applying.ContextWithTracer(ctx, tracer)
 
-	configInst, plugins, done, moreDiags := c.newEngineShim(ctx, config, variables, plan.Timestamp, true)
+	configInst, plugins, done, moreDiags := c.newEngineShim(ctx, config, variables, plan.Timestamp, true, true)
 	diags = diags.Append(moreDiags)
 
 	if diags.HasErrors() {

--- a/internal/tofu/context_temp_runtime_test.go
+++ b/internal/tofu/context_temp_runtime_test.go
@@ -135,7 +135,7 @@ var (
 	ExperimentalFeatureDependsOn         = ExperimentalFlag{"Missing Depends On", true}
 	ExperimentalFeatureIgnoreChanges     = ExperimentalFlag{"Missing Ignore Changes", false}
 	ExperimentalFeatureVarCondition      = ExperimentalFlag{"Missing Variable Condiitions", false}
-	ExperimentalFeaturePathAttrs         = ExperimentalFlag{"Missing Path/Terraform/Tofu Attrs", false}
+	ExperimentalFeaturePathAttrs         = ExperimentalFlag{"Missing Path/Terraform/Tofu Attrs", true}
 	ExperimentalFeaturePreventDestroy    = ExperimentalFlag{"Missing Prevent Destroy", false}
 	ExperimentalFeaturePlannedState      = ExperimentalFlag{"Missing Planned State", false}
 	ExperimentalFeatureForceReplace      = ExperimentalFlag{"Missing Force Replace", false}

--- a/internal/tofu/evaluate.go
+++ b/internal/tofu/evaluate.go
@@ -1060,7 +1060,7 @@ func (d *evaluationStateData) GetTerraformAttr(_ context.Context, addr addrs.Ter
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  fmt.Sprintf("Invalid %q attribute", addr.Alias),
-			Detail:   fmt.Sprintf(`The %q object does not have an attribute named %q. The only supported attribute is %s.workspace, the name of the currently-selected workspace.`, addr.Alias, addr.Name, addr.Alias),
+			Detail:   fmt.Sprintf(`The %q object does not have an attribute named %q. The only supported attributes are %s.workspace and %s.applying`, addr.Alias, addr.Name, addr.Alias, addr.Alias),
 			Subject:  rng.ToHCL().Ptr(),
 		})
 		return cty.DynamicVal, diags


### PR DESCRIPTION
Depends on https://github.com/opentofu/opentofu/pull/4313

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
