### PR TITLE
tofu: Stats about skipping tests against the new language runtime

### DIFF
--- a/.github/workflows/experimental-engine.yml
+++ b/.github/workflows/experimental-engine.yml
@@ -41,4 +41,4 @@ jobs:
 
       - name: "Unit tests"
         run: |
-          TOFU_X_EXPERIMENTAL_RUNTIME=1 go test -ldflags "-X main.experimentsAllowed=yes" ./internal/tofu
+          TOFU_X_EXPERIMENTAL_RUNTIME=1 go test -v -ldflags "-X main.experimentsAllowed=yes" ./internal/tofu

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ build-experimental:
 .PHONY: test-experimental
 test-experimental:
 # 	TOFU_X_EXPERIMENTAL_RUNTIME=1 go test -ldflags "-X main.experimentsAllowed=yes" -v ./...
-	TOFU_X_EXPERIMENTAL_RUNTIME=1 go test -ldflags "-X main.experimentsAllowed=yes" -v ./internal/tofu
+	TOFU_X_EXPERIMENTAL_RUNTIME=1 go test -v -ldflags "-X main.experimentsAllowed=yes" -v ./internal/tofu
 
 # generate runs `go generate` to build the dynamically generated
 # source files, except the protobuf stubs which are built instead with

--- a/internal/tofu/context_temp_runtime.go
+++ b/internal/tofu/context_temp_runtime.go
@@ -71,6 +71,10 @@ func experimentalRuntimeEnabled() bool {
 		return false
 	}
 
+	return experimentalRuntimeWanted()
+}
+
+func experimentalRuntimeWanted() bool {
 	optIn := os.Getenv("TOFU_X_EXPERIMENTAL_RUNTIME")
 	return optIn != ""
 }

--- a/internal/tofu/context_temp_runtime_test.go
+++ b/internal/tofu/context_temp_runtime_test.go
@@ -6,20 +6,77 @@
 package tofu
 
 import (
+	"cmp"
+	"fmt"
+	"os"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 )
 
-func init() {
-	// Allow running experimental engine tests with:
-	// TOFU_X_EXPERIMENTAL_RUNTIME=1 go test ./internal/tofu
+// maybeRunExperimentalNewRuntimeTests is called by this package's [TestMain]
+// to give us an opportunity to handle testing differently if it seems like
+// someone is trying to apply this package's tests against the new experimental
+// language runtime through our shim layer.
+//
+// To use this, run something like the following command:
+//
+//	TOFU_X_EXPERIMENTAL_RUNTIME=1 go test ./internal/tofu
+func maybeRunExperimentalNewRuntimeTests(m *testing.M) {
+	if !experimentalRuntimeWanted() {
+		return // we'll just let the normal TestMain function handle things, then
+	}
+
+	// In normal builds we require setting a special linker flag to permit
+	// opting in to the experimental runtime shim, but for tests it's always
+	// allowed and just enabled on request.
 	SetExperimentalRuntimeAllowed(true)
+
+	status := m.Run()
+
+	// Before we exit we'll print some stats about how many times each of
+	// the experimental flags caused us to skip running some part of a test.
+	if status == 0 && testing.Verbose() && len(experimentalFlagSkipCounts) != 0 {
+		// (We use stderr here just to avoid interfering with any
+		// machine-readable output on stdout if we happen to be running tests
+		// in JSON mode, or similar.)
+		fmt.Fprintf(os.Stderr, "\n---- New runtime test-skip summary ----\n\n")
+		fmt.Fprintf(os.Stderr, "-> %d tests were skipped due to one or more of the following...\n\n", experimentalFlagSkippedTests)
+		type Record struct {
+			name  string
+			count int
+		}
+		var records []Record
+		var nameLen int
+		for name, count := range experimentalFlagSkipCounts {
+			records = append(records, Record{name, count})
+			if len(name) > nameLen {
+				nameLen = len(name)
+			}
+		}
+		slices.SortFunc(records, func(a, b Record) int {
+			return cmp.Compare(b.count, a.count) // reverse sort, greatest count first
+		})
+		for _, record := range records {
+			fmt.Fprintf(os.Stderr, "  %[3]*[1]s: %[2]d\n", record.name, record.count, nameLen)
+		}
+		fmt.Fprintln(os.Stderr, "")
+	}
+
+	// We'll exit here now, to avoid [TestMain] running the test suite over
+	// again once we return.
+	os.Exit(status)
 }
 
 type ExperimentalFlag struct {
 	name    string
 	enabled bool
 }
+
+var experimentalFlagSkipCounts map[string]int
+var experimentalFlagSkippedTests int
+var experimentalFlagSkipMu sync.Mutex
 
 var (
 	ExperimentalFlagUnknown = ExperimentalFlag{"Unknown", false}
@@ -101,13 +158,20 @@ var (
 func SkipExperimental(t *testing.T, features ...ExperimentalFlag) {
 	if experimentalRuntimeEnabled() {
 		var strs []string
+		experimentalFlagSkipMu.Lock()
+		defer experimentalFlagSkipMu.Unlock()
+		if experimentalFlagSkipCounts == nil {
+			experimentalFlagSkipCounts = make(map[string]int)
+		}
 		for _, feature := range features {
 			if feature.enabled {
 				continue
 			}
 			strs = append(strs, feature.name)
+			experimentalFlagSkipCounts[feature.name]++
 		}
 		if len(strs) > 0 {
+			experimentalFlagSkippedTests++
 			t.Skip("New Engine: " + strings.Join(strs, ", "))
 		}
 	}

--- a/internal/tofu/opentf_test.go
+++ b/internal/tofu/opentf_test.go
@@ -44,6 +44,11 @@ func TestMain(m *testing.M) {
 	// abstractions.
 	spew.Config.DisableMethods = true
 
+	// TEMP: If the appropriate environment variable is set then we'll apply this
+	// package's tests to the experimental new language runtime instead, through
+	// some shims. Refer to this function's documentation for more information.
+	maybeRunExperimentalNewRuntimeTests(m)
+
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
We already have a special temporary mode which uses shimming to apply the tofu package's context tests to the experimental new language runtime (https://github.com/opentofu/opentofu/issues/3414) instead of to package tofu's own implementations of plan, apply, etc. Since the new runtime is not yet feature- and bug-compatible, we use experimental flags to disable skip that are not yet expected to pass.

Now when running in verbose mode and when the test suite runs successfully we'll end with a summary of how many examples of each skip flag we hit while running the test suite, and overall how many tests were skipped due to at least one of these flags.

The goal here is just to help us to easily see which missing functionality would be most impactful to work on next, and hopefully to see the total skipped test count drop over time as we continue with this work.

This is the extra output produced by this code with the current state of work on the tests, though of course these numbers will change as we continue implementing and fixing things:

```
---- New runtime test-skip summary ----

-> 471 tests were skipped due to one or more of the following...

                                                              Missing Targeting: 72
                                                                        Unknown: 64
                                                      Missing Lifecycle Destroy: 33
                                                           Missing Provisioners: 31
                                                                Missing Destroy: 26
                                                              Missing Importing: 26
                                                            Missing Root Output: 23
                                                                Missing Refresh: 17
                                                    Missing Pre/Post Conditions: 16
                                                                 Missing Checks: 16
                                                               Missing Validate: 13
                                                          Missing Provider Meta: 13
                                            Change Different Diagnostic Wording: 12
                                                                  Missing Hooks: 11
                                                                Missing Removed: 11
                                                         Missing Ignore Changes: 11
                                                                  Missing Moved: 10
                                                   Missing Sensitivity Handling: 8
                                                              Bug Data Resource: 7
                                                        Missing Prevent Destroy: 7
                                                    New testing strategy needed: 4
                                                    Change Detect Error Earlier: 4
                                                                  Missing Taint: 4
                                                             Missing Deprecated: 4
                                                           Missing Plan Changes: 4
                                   Bug CreateBeforeDestroy Not Tracked In State: 4
                                                   Missing replace_triggered_by: 3
                                                             Bug Context Cancel: 3
                                                                Missing Deposed: 3
                                              Missing Path/Terraform/Tofu Attrs: 3
                                                    Change Precise Dependencies: 2
                                              Bug Not Tainted When Create Fails: 2
                                                          Missing Force Replace: 2
                                                         Missing Error Handling: 2
                                                          Missing Planned State: 1
                                                  Missing Store locals in state: 1
  Bug Not Transferring Marks from Resource Instance Config Value to Final Value: 1
                                                Obsolete Flat Mapped Attributes: 1
                                             Missing Refresh-only Planning Mode: 1
      Change New Runtime Doesn't Inherit Full Pre "required_providers" Behavior: 1
                                   Change New Runtime Supports Deferred Actions: 1
                                                      Bug Read Resource Deleted: 1
                                                         Missing Self Reference: 1
                               Change New Runtime Doesn't Generate NoOp Changes: 1
                                                   Missing Variable Condiitions: 1
```

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
