### PR TITLE
fix - apply progress reporting stalling after first heartbeat in -json output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
-- `tofu apply -json` now emits periodic `apply_progress` heartbeat messages for the full duration of a resource operation, instead of stopping after the first one. ([#4107](https://github.com/opentofu/opentofu/issues/4107))
+- `tofu apply -json` now emits periodic `apply_progress` heartbeat messages for the full duration of a resource operation, instead of stopping after the first one. ([#4107](https://github.com/opentofu/opentofu/pull/4318))
 - The built-in function `contains` now accepts `null` as its second argument, to test whether a collection contains any null values. ([#4043](https://github.com/opentofu/opentofu/issues/4043))
 - The built-in function `merge` no longer fails when its only argument is a null value of an object type. ([#4043](https://github.com/opentofu/opentofu/issues/4043))
 - The built-in function `cidrhost` no longer returns a "panic" error when called with an out-of-range host number represented in more than 64 bits. ([#4056](https://github.com/opentofu/opentofu/pull/4056))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
-- `tofu apply -json` now emits periodic `apply_progress` heartbeat messages for the full duration of a resource operation, instead of stopping after the first one.([#4107](https://github.com/opentofu/opentofu/issues/4107))
+- `tofu apply -json` now emits periodic `apply_progress` heartbeat messages for the full duration of a resource operation, instead of stopping after the first one. ([#4107](https://github.com/opentofu/opentofu/issues/4107))
 - The built-in function `contains` now accepts `null` as its second argument, to test whether a collection contains any null values. ([#4043](https://github.com/opentofu/opentofu/issues/4043))
 - The built-in function `merge` no longer fails when its only argument is a null value of an object type. ([#4043](https://github.com/opentofu/opentofu/issues/4043))
 - The built-in function `cidrhost` no longer returns a "panic" error when called with an out-of-range host number represented in more than 64 bits. ([#4056](https://github.com/opentofu/opentofu/pull/4056))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
+- `tofu apply -json` now emits periodic `apply_progress` heartbeat messages for the full duration of a resource operation, instead of stopping after the first one.([#4107](https://github.com/opentofu/opentofu/issues/4107))
 - The built-in function `contains` now accepts `null` as its second argument, to test whether a collection contains any null values. ([#4043](https://github.com/opentofu/opentofu/issues/4043))
 - The built-in function `merge` no longer fails when its only argument is a null value of an object type. ([#4043](https://github.com/opentofu/opentofu/issues/4043))
 - The built-in function `cidrhost` no longer returns a "panic" error when called with an out-of-range host number represented in more than 64 bits. ([#4056](https://github.com/opentofu/opentofu/pull/4056))

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -1250,7 +1250,7 @@ func TestVarsParsing(t *testing.T) {
 			},
 		}
 
-		args := append([]string{"-no-color"}, varArgs...)
+		args := append([]string{"-no-color", "-lock=false"}, varArgs...)
 		code := c.Run(args)
 		output := done(t)
 		if code != 0 {

--- a/internal/command/views/hook_json.go
+++ b/internal/command/views/hook_json.go
@@ -63,12 +63,12 @@ type applyProgress struct {
 	// heartbeatDone is used to allow tests to safely wait for the progress
 	// goroutine to finish
 	heartbeatDone chan struct{}
-
-	// elapsed is used to allow tests to safely check for heartbeat executions
-	elapsed chan time.Duration
 }
 
 func (h *jsonHook) PreApply(addr addrs.AbsResourceInstance, gen states.Generation, action plans.Action, priorState, plannedNewState cty.Value) (tofu.HookAction, error) {
+	return h.preApply(addr, gen, action, priorState, plannedNewState, nil)
+}
+func (h *jsonHook) preApply(addr addrs.AbsResourceInstance, gen states.Generation, action plans.Action, priorState, plannedNewState cty.Value, elapsed chan<- time.Duration) (tofu.HookAction, error) {
 	if action != plans.NoOp {
 		idKey, idValue := format.ObjectValueIDOrName(priorState)
 		h.view.Hook(json.NewApplyStart(addr, action, idKey, idValue))
@@ -78,7 +78,6 @@ func (h *jsonHook) PreApply(addr addrs.AbsResourceInstance, gen states.Generatio
 		addr:          addr,
 		action:        action,
 		start:         h.timeNow().Round(time.Second),
-		elapsed:       make(chan time.Duration),
 		done:          make(chan struct{}),
 		heartbeatDone: make(chan struct{}),
 	}
@@ -87,14 +86,16 @@ func (h *jsonHook) PreApply(addr addrs.AbsResourceInstance, gen states.Generatio
 	h.applyingLock.Unlock()
 
 	if action != plans.NoOp {
-		go h.applyingHeartbeat(progress)
+		go h.applyingHeartbeat(progress, elapsed)
 	}
 	return tofu.HookActionContinue, nil
 }
 
-func (h *jsonHook) applyingHeartbeat(progress applyProgress) {
+func (h *jsonHook) applyingHeartbeat(progress applyProgress, elapsedChan chan<- time.Duration) {
 	defer close(progress.heartbeatDone)
-	defer close(progress.elapsed)
+	if elapsedChan != nil {
+		defer close(elapsedChan)
+	}
 	for {
 		select {
 		case <-progress.done:
@@ -104,7 +105,9 @@ func (h *jsonHook) applyingHeartbeat(progress applyProgress) {
 
 		elapsed := h.timeNow().Round(time.Second).Sub(progress.start)
 		h.view.Hook(json.NewApplyProgress(progress.addr, progress.action, elapsed))
-		progress.elapsed <- elapsed
+		if elapsedChan != nil {
+			elapsedChan <- elapsed
+		}
 	}
 }
 

--- a/internal/command/views/hook_json_test.go
+++ b/internal/command/views/hook_json_test.go
@@ -53,7 +53,8 @@ func TestJSONHook_create(t *testing.T) {
 		}),
 	})
 
-	action, err := hook.PreApply(addr, states.CurrentGen, plans.Create, priorState, plannedNewState)
+	elapsedChan := make(chan time.Duration)
+	action, err := hook.preApply(addr, states.CurrentGen, plans.Create, priorState, plannedNewState, elapsedChan)
 	testHookReturnValues(t, action, err)
 
 	action, err = hook.PreProvisionInstanceStep(addr, "local-exec")
@@ -63,8 +64,6 @@ func TestJSONHook_create(t *testing.T) {
 
 	action, err = hook.PostProvisionInstanceStep(addr, "local-exec", nil)
 	testHookReturnValues(t, action, err)
-
-	elapsedChan := hook.applying[addr.String()].elapsed
 
 	// Travel 10s into the future, notify the progress goroutine, and wait
 	// for execution via 'elapsed' progress
@@ -96,7 +95,7 @@ func TestJSONHook_create(t *testing.T) {
 	hook.applyingLock.Lock()
 	for key, progress := range hook.applying {
 		close(progress.done)
-		close(progress.elapsed)
+		close(elapsedChan)
 		<-progress.heartbeatDone
 		delete(hook.applying, key)
 	}
@@ -213,7 +212,8 @@ func TestJSONHook_errors(t *testing.T) {
 		}),
 	})
 
-	action, err := hook.PreApply(addr, states.CurrentGen, plans.Delete, priorState, plannedNewState)
+	elapsedChan := make(chan time.Duration)
+	action, err := hook.preApply(addr, states.CurrentGen, plans.Delete, priorState, plannedNewState, elapsedChan)
 	testHookReturnValues(t, action, err)
 
 	provisionError := fmt.Errorf("provisioner didn't want to")
@@ -228,7 +228,7 @@ func TestJSONHook_errors(t *testing.T) {
 	hook.applyingLock.Lock()
 	for key, progress := range hook.applying {
 		close(progress.done)
-		close(progress.elapsed)
+		close(elapsedChan)
 		<-progress.heartbeatDone
 		delete(hook.applying, key)
 	}


### PR DESCRIPTION
When running apply with `-json`, progress messages stopped after the first one. The goroutine that sends progress was getting stuck on a channel that only the tests read, so in real runs it blockedforever. I changed it to pass that channel in only when needed (nil in production) as suggested under the issue by @apparentlymart , so progress keeps coming. Tests now create their own channel through a small `preApply` helper.

This PR also fixes an unrelated flaky test, TestVarsParsing/console, that was intermittently failing CI on Windows. The console command is read-only but still acquired a state lock; on slow runners the "Acquiring state lock…" message exceeded the 400ms threshold and leaked into stdout, breaking the test's exact-output assertion. Since console is read-only, the test now runs with -lock=false, making it deterministic.


<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves #4107 

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

