### PR TITLE
configs: fix panic on invalid removed.from with destroy provisioner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ BUG FIXES:
 - Fixed TRACESTATE log message incorrectly printing the TRACEPARENT value instead. ([#4168](https://github.com/opentofu/opentofu/issues/4168))
 - Fix rendering of plans where a nested block's replacement is unknown. ([#4256](https://github.com/opentofu/opentofu/issues/4256))
 - `errored.tfstate` is now produced during a go runtime panic. This file will be a partial state and is intended for aiding in recovery from a hard crash. ([#4064](https://github.com/opentofu/opentofu/pull/4064))
-- `removed` blocks with an invalid `from` address and a destroy provisioner now report a configuration error instead of crashing. ([#4319](https://github.com/opentofu/opentofu/issues/4319))
+- `removed` blocks with an invalid `from` address and a destroy provisioner now report a configuration error instead of crashing. ([#4321](https://github.com/opentofu/opentofu/pull/4321))
 
 ## Previous Releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ BUG FIXES:
 - Fixed TRACESTATE log message incorrectly printing the TRACEPARENT value instead. ([#4168](https://github.com/opentofu/opentofu/issues/4168))
 - Fix rendering of plans where a nested block's replacement is unknown. ([#4256](https://github.com/opentofu/opentofu/issues/4256))
 - `errored.tfstate` is now produced during a go runtime panic. This file will be a partial state and is intended for aiding in recovery from a hard crash. ([#4064](https://github.com/opentofu/opentofu/pull/4064))
+- `removed` blocks with an invalid `from` address and a destroy provisioner now report a configuration error instead of crashing. ([#4319](https://github.com/opentofu/opentofu/issues/4319))
 
 ## Previous Releases
 

--- a/internal/configs/removed.go
+++ b/internal/configs/removed.go
@@ -81,6 +81,10 @@ func decodeRemovedBlock(removedBlock *hcl.Block) (*Removed, hcl.Diagnostics) {
 					})
 					continue
 				}
+				// Skip nil address from decode error to avoid panic; config load will halt anyway.
+				if removed.From == nil {
+					continue
+				}
 				if removed.From.RelSubject.AddrType() == addrs.ModuleAddrType {
 					diags = append(diags, &hcl.Diagnostic{
 						Severity: hcl.DiagError,

--- a/internal/configs/removed_test.go
+++ b/internal/configs/removed_test.go
@@ -29,6 +29,7 @@ func TestRemovedBlock_decode(t *testing.T) {
 	foo_index_expr := hcltest.MockExprTraversalSrc("test_instance.foo[1]")
 	mod_boop_index_foo_expr := hcltest.MockExprTraversalSrc("module.boop[1].test_instance.foo")
 	data_foo_expr := hcltest.MockExprTraversalSrc("data.test_instance.foo")
+	invalid_from_expr := hcltest.MockExprLiteral(cty.StringVal("not-a-traversal"))
 
 	tests := map[string]struct {
 		input         *hcl.Block
@@ -213,14 +214,14 @@ func TestRemovedBlock_decode(t *testing.T) {
 				Subject:  &blockRange,
 			}),
 		},
-		"error-data-source-from-with-provisioner": {
+		"error-invalid-from-with-provisioner": {
 			&hcl.Block{
 				Type: "removed",
 				Body: hcltest.MockBody(&hcl.BodyContent{
 					Attributes: hcl.Attributes{
 						"from": {
 							Name: "from",
-							Expr: data_foo_expr,
+							Expr: invalid_from_expr,
 						},
 					},
 					Blocks: hcl.Blocks{
@@ -246,7 +247,7 @@ func TestRemovedBlock_decode(t *testing.T) {
 			&Removed{
 				DeclRange: blockRange,
 			},
-			"Data source address is not allowed",
+			"Invalid expression",
 			hcl.Diagnostics{},
 		},
 		"error-removed-module-with-provisioner": {

--- a/internal/configs/removed_test.go
+++ b/internal/configs/removed_test.go
@@ -29,7 +29,6 @@ func TestRemovedBlock_decode(t *testing.T) {
 	foo_index_expr := hcltest.MockExprTraversalSrc("test_instance.foo[1]")
 	mod_boop_index_foo_expr := hcltest.MockExprTraversalSrc("module.boop[1].test_instance.foo")
 	data_foo_expr := hcltest.MockExprTraversalSrc("data.test_instance.foo")
-	invalid_from_expr := hcltest.MockExprLiteral(cty.StringVal("not-a-traversal"))
 
 	tests := map[string]struct {
 		input         *hcl.Block
@@ -213,42 +212,6 @@ func TestRemovedBlock_decode(t *testing.T) {
 				Detail:   "It is recommended for each 'removed' block configured to have also the 'lifecycle' block defined. By not specifying if the resource should be destroyed or not, could lead to unwanted behavior.",
 				Subject:  &blockRange,
 			}),
-		},
-		"error-invalid-from-with-provisioner": {
-			&hcl.Block{
-				Type: "removed",
-				Body: hcltest.MockBody(&hcl.BodyContent{
-					Attributes: hcl.Attributes{
-						"from": {
-							Name: "from",
-							Expr: invalid_from_expr,
-						},
-					},
-					Blocks: hcl.Blocks{
-						{
-							Type:   "provisioner",
-							Labels: []string{"local-exec"},
-							LabelRanges: []hcl.Range{
-								{
-									Filename: "file",
-								},
-							},
-							Body: hcltest.MockBody(&hcl.BodyContent{
-								Attributes: hcl.Attributes{
-									"command": &hcl.Attribute{Expr: &hclsyntax.LiteralValueExpr{Val: cty.StringVal("echo 'test'")}},
-									"when":    &hcl.Attribute{Expr: hcltest.MockExprTraversalSrc("destroy")},
-								},
-							}),
-						},
-					},
-				}),
-				DefRange: blockRange,
-			},
-			&Removed{
-				DeclRange: blockRange,
-			},
-			"Invalid expression",
-			hcl.Diagnostics{},
 		},
 		"error-data-source-from-with-provisioner": {
 			&hcl.Block{

--- a/internal/configs/removed_test.go
+++ b/internal/configs/removed_test.go
@@ -29,6 +29,7 @@ func TestRemovedBlock_decode(t *testing.T) {
 	foo_index_expr := hcltest.MockExprTraversalSrc("test_instance.foo[1]")
 	mod_boop_index_foo_expr := hcltest.MockExprTraversalSrc("module.boop[1].test_instance.foo")
 	data_foo_expr := hcltest.MockExprTraversalSrc("data.test_instance.foo")
+	invalid_from_expr := hcltest.MockExprLiteral(cty.StringVal("not-a-traversal"))
 
 	tests := map[string]struct {
 		input         *hcl.Block
@@ -214,6 +215,42 @@ func TestRemovedBlock_decode(t *testing.T) {
 			}),
 		},
 		"error-invalid-from-with-provisioner": {
+			&hcl.Block{
+				Type: "removed",
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"from": {
+							Name: "from",
+							Expr: invalid_from_expr,
+						},
+					},
+					Blocks: hcl.Blocks{
+						{
+							Type:   "provisioner",
+							Labels: []string{"local-exec"},
+							LabelRanges: []hcl.Range{
+								{
+									Filename: "file",
+								},
+							},
+							Body: hcltest.MockBody(&hcl.BodyContent{
+								Attributes: hcl.Attributes{
+									"command": &hcl.Attribute{Expr: &hclsyntax.LiteralValueExpr{Val: cty.StringVal("echo 'test'")}},
+									"when":    &hcl.Attribute{Expr: hcltest.MockExprTraversalSrc("destroy")},
+								},
+							}),
+						},
+					},
+				}),
+				DefRange: blockRange,
+			},
+			&Removed{
+				DeclRange: blockRange,
+			},
+			"Invalid expression",
+			hcl.Diagnostics{},
+		},
+		"error-data-source-from-with-provisioner": {
 			&hcl.Block{
 				Type: "removed",
 				Body: hcltest.MockBody(&hcl.BodyContent{

--- a/internal/configs/removed_test.go
+++ b/internal/configs/removed_test.go
@@ -213,6 +213,42 @@ func TestRemovedBlock_decode(t *testing.T) {
 				Subject:  &blockRange,
 			}),
 		},
+		"error-invalid-from-with-provisioner": {
+			&hcl.Block{
+				Type: "removed",
+				Body: hcltest.MockBody(&hcl.BodyContent{
+					Attributes: hcl.Attributes{
+						"from": {
+							Name: "from",
+							Expr: data_foo_expr,
+						},
+					},
+					Blocks: hcl.Blocks{
+						{
+							Type:   "provisioner",
+							Labels: []string{"local-exec"},
+							LabelRanges: []hcl.Range{
+								{
+									Filename: "file",
+								},
+							},
+							Body: hcltest.MockBody(&hcl.BodyContent{
+								Attributes: hcl.Attributes{
+									"command": &hcl.Attribute{Expr: &hclsyntax.LiteralValueExpr{Val: cty.StringVal("echo 'test'")}},
+									"when":    &hcl.Attribute{Expr: hcltest.MockExprTraversalSrc("destroy")},
+								},
+							}),
+						},
+					},
+				}),
+				DefRange: blockRange,
+			},
+			&Removed{
+				DeclRange: blockRange,
+			},
+			"Data source address is not allowed",
+			hcl.Diagnostics{},
+		},
 		"error-removed-module-with-provisioner": {
 			&hcl.Block{
 				Type: "removed",


### PR DESCRIPTION
## Description

A `removed` block with an invalid `from` address and a destroy provisioner could panic during configuration loading instead of reporting the invalid address.

The invalid `from` address leaves `removed.From` nil after address parsing returns diagnostics, but the provisioner branch still dereferenced it while checking the target address type.

This change guards the nil address path so configuration loading can return the existing configuration error instead of crashing.

## Testing

* Added a regression test for an invalid `removed.from` address with a destroy provisioner.
* Kept the existing module-target provisioner case to continue covering the module validation path.
* Verified the regression test fails before the fix and passes after the nil guard.


Fixes #4319

<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves #4319

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
