### PR TITLE
planning: Additional simplification the execgraph-building code

### DIFF
--- a/internal/engine/planning/execgraph.go
+++ b/internal/engine/planning/execgraph.go
@@ -6,28 +6,17 @@
 package planning
 
 import (
-	"sync"
-
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/engine/internal/execgraph"
 )
 
-// execGraphBuilder is a higher-level wrapper around [execgraph.Builder] that
-// is tailored to the needs of the planning engine.
+// execGraphBuilder is a legacy leftover of an earlier version of this component
+// where execution graph construction ran concurrently with other planning work.
 //
-// Specifically:
-//   - Its exported methods that add to or modify the graph are all
-//     concurrency-safe, for convenient use during the concurrent planning work
-//     driven by the evaluator.
-//   - Many of its methods can potentially add multiple operations to the graph
-//     at once, to let the planning engine work at a higher level of abstraction
-//     than just the individual raw operation types. The lower-level
-//     [execgraph.Builder] instead directly matches the abstraction level of
-//     [execgraph.Operations].
+// That's no longer true and so we'll probably remove or further simplify this
+// eventually. Only [buildExecutionGraph] should instantiate objects of this
+// type, and outside callers should rely only on [buildExecutionGraph].
 type execGraphBuilder struct {
-	// mu must be locked while accessing any of the other fields.
-	mu sync.Mutex
-
 	// lower is the lower-level graph builder that this utility is built in
 	// terms of.
 	lower *execgraph.Builder
@@ -47,19 +36,34 @@ type execGraphBuilder struct {
 // the other files named execgraph_*.go , grouped by what kinds of objects they
 // primarily work with.
 
-func newExecGraphBuilder(makeDeposedKey func(addrs.AbsResourceInstance) addrs.DeposedKey) *execGraphBuilder {
-	return &execGraphBuilder{
+func buildExecutionGraph(
+	objs *resourceInstanceObjects,
+	effectiveReplaceOrders addrs.Map[addrs.AbsResourceInstanceObject, resourceInstanceReplaceOrder],
+	makeDeposedKey func(addrs.AbsResourceInstance) addrs.DeposedKey,
+) *execgraph.Graph {
+	// TODO: This was originally built around a separate [execGraphBuilder]
+	// type because we were building the execution graph concurrently with
+	// other planning work, and so it was convenient to have a central object
+	// to hold the necessary mutex and otherwise help coordinate between
+	// multiple callers.
+	//
+	// We no longer use that structure and instead just build the execution
+	// using normal sequential code after the rest of the planning work is
+	// complete, and so it's debatable whether we even need this
+	// [execGraphBuilder] type anymore, but the main functionality currently
+	// lives as methods of this type and so we'll keep it for now until the
+	// shape of this part of the system is feeling more settled and then we
+	// can decide whether to simplify further. But for now let's have the
+	// rest of this package pretend that [execGraphBuilder] doesn't exist so
+	// that we can refactor this more easily later.
+
+	egb := &execGraphBuilder{
 		lower:          execgraph.NewBuilder(),
 		makeDeposedKey: makeDeposedKey,
 	}
-}
-
-// Finish returns the graph that has been built, which is then immutable.
-//
-// After calling this function the execGraphBuilder is invalid and must not be
-// used anymore.
-func (b *execGraphBuilder) Finish() *execgraph.Graph {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.lower.Finish()
+	egb.AddResourceInstanceObjectSubgraphs(
+		objs,
+		effectiveReplaceOrders,
+	)
+	return egb.lower.Finish()
 }

--- a/internal/engine/planning/execgraph_managed.go
+++ b/internal/engine/planning/execgraph_managed.go
@@ -32,9 +32,6 @@ func (b *execGraphBuilder) ManagedResourceInstanceSubgraph(
 	plannedChange *plans.ResourceInstanceChange,
 	effectiveReplaceOrder resourceInstanceReplaceOrder,
 ) resourceInstanceObjectSubgraph {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
 	// Before we go any further we'll just make sure what we've been given
 	// is sensible, so that the remaining code can assume the following
 	// about the given change. Any panics in the following suggest that there's

--- a/internal/engine/planning/execgraph_managed.go
+++ b/internal/engine/planning/execgraph_managed.go
@@ -61,94 +61,78 @@ func (b *execGraphBuilder) ManagedResourceInstanceSubgraph(
 		changeAction = effectiveReplaceOrder.ChangeAction()
 	}
 
-	var ret resourceInstanceObjectSubgraph
-
 	// The shape of execution subgraph we generate here varies depending on
 	// which change action was planned.
 	switch changeAction {
 	case plans.Create:
-		ret.valueRef, ret.addConfigDep = b.managedResourceInstanceSubgraphCreate(plannedChange)
+		return b.managedResourceInstanceSubgraphCreate(plannedChange)
 	case plans.Update:
-		ret.valueRef, ret.addConfigDep, ret.addStateDep = b.managedResourceInstanceSubgraphUpdate(plannedChange)
+		return b.managedResourceInstanceSubgraphUpdate(plannedChange)
 	case plans.Delete:
-		ret.valueRef, ret.deletionRef, ret.addStateDep, ret.addDeleteDep = b.managedResourceInstanceSubgraphDelete(plannedChange)
+		return b.managedResourceInstanceSubgraphDelete(plannedChange)
 	case plans.Forget:
-		ret.valueRef = b.managedResourceInstanceSubgraphForget(plannedChange)
+		return b.managedResourceInstanceSubgraphForget(plannedChange)
 	case plans.DeleteThenCreate, plans.ForgetThenCreate:
-		ret.valueRef, ret.deletionRef, ret.addConfigDep, ret.addStateDep, ret.addDeleteDep = b.managedResourceInstanceSubgraphDeleteOrForgetThenCreate(plannedChange)
+		return b.managedResourceInstanceSubgraphDeleteOrForgetThenCreate(plannedChange)
 	case plans.CreateThenDelete:
-		ret.valueRef, ret.deletionRef, ret.addConfigDep, ret.addStateDep, ret.addDeleteDep = b.managedResourceInstanceSubgraphCreateThenDelete(plannedChange)
+		return b.managedResourceInstanceSubgraphCreateThenDelete(plannedChange)
+	case plans.NoOp:
+		// TODO: We need to handle this because it can occur if the
+		// configuration hasn't changed but the object will move to a new
+		// resource instance address during the apply phase.
+		panic("plans.NoOp execution graph not yet implemented")
 	default:
-		// FIXME: We need to handle plans.NoOp too because that can occur if
-		// the configuration hasn't changed but the object will move to a
-		// new resource instance address during the apply phase.
-
 		// We should not get here: the cases above should cover every action
 		// that [planGlue.planDesiredManagedResourceInstance] can possibly
 		// produce.
 		panic(fmt.Sprintf("unsupported change action %s for %s", plannedChange.Action, plannedChange.Addr))
 	}
-
-	return ret
 }
 
 func (b *execGraphBuilder) managedResourceInstanceSubgraphCreate(
 	plannedChange *plans.ResourceInstanceChange,
-) (execgraph.ResourceInstanceResultRef, func(execgraph.AnyResultRef)) {
+) resourceInstanceObjectSubgraph {
 	instAddrRef, _, _ := b.managedResourceInstanceChangeAddrAndPriorStateRefs(plannedChange)
 	// Per the conventions in the old engine, After contains a marked value
 	unmarkedAfter, _ := plannedChange.After.UnmarkDeep()
 	plannedValRef := b.lower.ConstantValue(unmarkedAfter)
 	waitFor, addConfigDep := b.lower.MutableWaiter()
 	desiredInstRef := b.lower.ResourceInstanceDesired(instAddrRef, waitFor)
-	return b.managedResourceInstanceSubgraphPlanAndApply(
+	valueRef := b.managedResourceInstanceSubgraphPlanAndApply(
 		desiredInstRef,
 		execgraph.NilResultRef[*exec.ResourceInstanceObject](),
 		plannedValRef,
-	), addConfigDep
+	)
+	return resourceInstanceObjectSubgraph{
+		valueRef:     valueRef,
+		addConfigDep: addConfigDep,
+	}
 }
 
 func (b *execGraphBuilder) managedResourceInstanceSubgraphUpdate(
 	plannedChange *plans.ResourceInstanceChange,
-) (execgraph.ResourceInstanceResultRef, func(execgraph.AnyResultRef), func(execgraph.AnyResultRef)) {
+) resourceInstanceObjectSubgraph {
 	instAddrRef, priorStateRef, addStateDep := b.managedResourceInstanceChangeAddrAndPriorStateRefs(plannedChange)
 	// Per the conventions in the old engine, After contains a marked value
 	unmarkedAfter, _ := plannedChange.After.UnmarkDeep()
 	plannedValRef := b.lower.ConstantValue(unmarkedAfter)
 	waitFor, addConfigDep := b.lower.MutableWaiter()
 	desiredInstRef := b.lower.ResourceInstanceDesired(instAddrRef, waitFor)
-	return b.managedResourceInstanceSubgraphPlanAndApply(
-		desiredInstRef,
-		priorStateRef,
-		plannedValRef,
-	), addConfigDep, addStateDep
-}
-
-// managedResourceInstanceSubgraphPlanAndApply deals with the simple case
-// of "create a final plan and then apply it" that is shared between "create"
-// and "update", but not for deleting or for the more complicated ones involving
-// multiple primitive actions that need to be carefully coordinated with each
-// other.
-func (b *execGraphBuilder) managedResourceInstanceSubgraphPlanAndApply(
-	desiredInstRef execgraph.ResultRef[*eval.DesiredResourceInstance],
-	priorStateRef execgraph.ResourceInstanceResultRef,
-	plannedValRef execgraph.ResultRef[cty.Value],
-) execgraph.ResourceInstanceResultRef {
-	finalPlanRef := b.lower.ManagedFinalPlan(
+	valueRef := b.managedResourceInstanceSubgraphPlanAndApply(
 		desiredInstRef,
 		priorStateRef,
 		plannedValRef,
 	)
-	return b.lower.ManagedApply(
-		finalPlanRef,
-		execgraph.NilResultRef[*exec.ResourceInstanceObject](),
-		b.lower.Waiter(), // nothing to wait for: desiredInstRef should have the relevant dependencies itself
-	)
+	return resourceInstanceObjectSubgraph{
+		valueRef:     valueRef,
+		addConfigDep: addConfigDep,
+		addStateDep:  addStateDep,
+	}
 }
 
 func (b *execGraphBuilder) managedResourceInstanceSubgraphDelete(
 	plannedChange *plans.ResourceInstanceChange,
-) (execgraph.ResourceInstanceResultRef, execgraph.ResourceInstanceResultRef, func(execgraph.AnyResultRef), func(execgraph.AnyResultRef)) {
+) resourceInstanceObjectSubgraph {
 	_, priorStateRef, addStateDep := b.managedResourceInstanceChangeAddrAndPriorStateRefs(plannedChange)
 	// Per the conventions in the old engine, After contains a marked value
 	unmarkedAfter, _ := plannedChange.After.UnmarkDeep()
@@ -159,30 +143,36 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphDelete(
 		priorStateRef,
 		plannedValRef,
 	)
-	// We report the prior state reference as the "valueRef" for a delete.
-	// In a normal plan that doesn't do anything because nothing is allowed
-	// to refer to a resource instance that's being deleted anyway, but
-	// it's important for destroy-mode plans because annoyingly it _is_ valid
-	// to refer to an object being deleted in that case, so that ephemeral
-	// objects like provider instances can configure themselves based on
-	// the prior state before the object is deleted.
-	return priorStateRef, b.lower.ManagedApply(
+	deletionRef := b.lower.ManagedApply(
 		finalPlanRef,
 		execgraph.NilResultRef[*exec.ResourceInstanceObject](),
 		waitFor,
-	), addStateDep, addDeleteDep
+	)
+	return resourceInstanceObjectSubgraph{
+		// We report the prior state reference as the "valueRef" for a delete.
+		// In a normal plan that doesn't do anything because nothing is allowed
+		// to refer to a resource instance that's being deleted anyway, but
+		// it's important for destroy-mode plans because annoyingly it _is_ valid
+		// to refer to an object being deleted in that case, so that ephemeral
+		// objects like provider instances can configure themselves based on
+		// the prior state before the object is deleted.
+		valueRef:     priorStateRef,
+		deletionRef:  deletionRef,
+		addStateDep:  addStateDep,
+		addDeleteDep: addDeleteDep,
+	}
 }
 
 func (b *execGraphBuilder) managedResourceInstanceSubgraphForget(
 	plannedChange *plans.ResourceInstanceChange,
-) execgraph.ResourceInstanceResultRef {
+) resourceInstanceObjectSubgraph {
 	// TODO: Add a new execgraph opcode ManagedForget and use that here.
 	panic("execgraph for Forget not yet implemented")
 }
 
 func (b *execGraphBuilder) managedResourceInstanceSubgraphDeleteOrForgetThenCreate(
 	plannedChange *plans.ResourceInstanceChange,
-) (execgraph.ResourceInstanceResultRef, execgraph.ResourceInstanceResultRef, func(execgraph.AnyResultRef), func(execgraph.AnyResultRef), func(execgraph.AnyResultRef)) {
+) resourceInstanceObjectSubgraph {
 	if plannedChange.Action == plans.ForgetThenCreate {
 		// TODO: Implement this action too, which is similar but with the
 		// "delete" let replaced with something like what
@@ -236,12 +226,18 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphDeleteOrForgetThenCrea
 		b.lower.Waiter(destroyResultRef),
 	)
 
-	return createResultRef, destroyResultRef, addConfigDep, addStateDep, addDeleteDep
+	return resourceInstanceObjectSubgraph{
+		valueRef:     createResultRef,
+		deletionRef:  destroyResultRef,
+		addConfigDep: addConfigDep,
+		addStateDep:  addStateDep,
+		addDeleteDep: addDeleteDep,
+	}
 }
 
 func (b *execGraphBuilder) managedResourceInstanceSubgraphCreateThenDelete(
 	plannedChange *plans.ResourceInstanceChange,
-) (execgraph.ResourceInstanceResultRef, execgraph.ResourceInstanceResultRef, func(execgraph.AnyResultRef), func(execgraph.AnyResultRef), func(execgraph.AnyResultRef)) {
+) resourceInstanceObjectSubgraph {
 	desiredWaitFor, addConfigDep := b.lower.MutableWaiter()
 	deleteWaitFor, addDeleteDep := b.lower.MutableWaiter()
 
@@ -305,7 +301,35 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphCreateThenDelete(
 		deleteWaitFor,
 	)
 
-	return createResultRef, deletionRef, addConfigDep, addStateDep, addDeleteDep
+	return resourceInstanceObjectSubgraph{
+		valueRef:     createResultRef,
+		deletionRef:  deletionRef,
+		addConfigDep: addConfigDep,
+		addStateDep:  addStateDep,
+		addDeleteDep: addDeleteDep,
+	}
+}
+
+// managedResourceInstanceSubgraphPlanAndApply deals with the simple case
+// of "create a final plan and then apply it" that is shared between "create"
+// and "update", but not for deleting or for the more complicated ones involving
+// multiple primitive actions that need to be carefully coordinated with each
+// other.
+func (b *execGraphBuilder) managedResourceInstanceSubgraphPlanAndApply(
+	desiredInstRef execgraph.ResultRef[*eval.DesiredResourceInstance],
+	priorStateRef execgraph.ResourceInstanceResultRef,
+	plannedValRef execgraph.ResultRef[cty.Value],
+) execgraph.ResourceInstanceResultRef {
+	finalPlanRef := b.lower.ManagedFinalPlan(
+		desiredInstRef,
+		priorStateRef,
+		plannedValRef,
+	)
+	return b.lower.ManagedApply(
+		finalPlanRef,
+		execgraph.NilResultRef[*exec.ResourceInstanceObject](),
+		b.lower.Waiter(), // nothing to wait for: desiredInstRef should have the relevant dependencies itself
+	)
 }
 
 func (b *execGraphBuilder) managedResourceInstanceChangeAddrAndPriorStateRefs(

--- a/internal/engine/planning/execgraph_managed_test.go
+++ b/internal/engine/planning/execgraph_managed_test.go
@@ -6,7 +6,6 @@
 package planning
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -293,14 +292,7 @@ func TestExecGraphBuilder_ManagedResourceInstanceSubgraph(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			var placeholderDeposedKey uint32
-			builder := newExecGraphBuilder(func(_ addrs.AbsResourceInstance) addrs.DeposedKey {
-				// For testing purposes we just allocate sequential integers
-				// so that we have predictable keys to include in the expected
-				// output of each test.
-				placeholderDeposedKey++
-				return addrs.DeposedKey(fmt.Sprintf("%08x", placeholderDeposedKey))
-			})
+			builder := newExecGraphBuilderForTesting()
 			// FIXME: We're currently ignoring all but the first result
 			// because this test was originally written for an older variant
 			// of this function which only had one result. We should find a
@@ -310,7 +302,7 @@ func TestExecGraphBuilder_ManagedResourceInstanceSubgraph(t *testing.T) {
 			resultRef := subgraph.valueRef
 			builder.lower.SetResourceInstanceFinalStateResult(instAddr, resultRef)
 
-			graph := builder.Finish()
+			graph := builder.lower.Finish()
 			gotGraphRepr := strings.TrimSpace(graph.DebugRepr())
 			wantGraphRepr := strings.TrimSpace(stripCommonLeadingTabs(test.WantRepr))
 			if diff := cmp.Diff(wantGraphRepr, gotGraphRepr); diff != "" {

--- a/internal/engine/planning/execgraph_resource.go
+++ b/internal/engine/planning/execgraph_resource.go
@@ -42,42 +42,17 @@ func (b *execGraphBuilder) AddResourceInstanceObjectSubgraphs(
 	// or do we instead need a post-hoc validate step which applies Tarjan's
 	// Strongly Connected Components algorithm to the execution graph?
 
-	// resultRefs tracks the execgraph result reference for each resource
-	// instance object, populated gradually as we build it out.
-	resultRefs := addrs.MakeMap[addrs.AbsResourceInstanceObject, execgraph.ResourceInstanceResultRef]()
-	// deletionRefs is like resultRefs except that it tracks the result of
-	// a deletion step for each object. There's only an entry in this table
-	// for objects whose subgraphs involve a deletion.
-	deletionRefs := addrs.MakeMap[addrs.AbsResourceInstanceObject, execgraph.ResourceInstanceResultRef]()
+	// subgraphs tracks the connection points for the subgraphs of each resource
+	// instance object so that we can add additional edges between these
+	// subgraphs in the second loop below.
+	subgraphs := addrs.MakeMap[addrs.AbsResourceInstanceObject, resourceInstanceObjectSubgraph]()
 
-	// addConfigDeps, addStateDeps and addDeleteDeps each track functions we can
-	// use to add additional dependencies to operations in the execution
-	// subgraphs of different resource instance objects.
-	//
-	// addConfigDeps callbacks are for operations that must complete before
-	// evaluating the configuration for an object.
-	//
-	// addStateDeps callbacks are for operations that must complete before
-	// we make use of the prior state of an object. These dependencies will
-	// often duplicate the ones registered with addConfigDeps because the
-	// state-tracked dependencies are based on the config-tracked dependencies
-	// from the previous round, but state-specific dependencies are important
-	// when objects are removed from the configuration on subsequent rounds, or
-	// during a destroy-mode plan where the configuration is not considered at
-	// all.
-	//
-	// addDeleteDeps callbacks are for operations that must complete before
-	// applying a "delete" plan for the object, and so these represent the
-	// "reverse dependencies" between deleting things so that they get destroyed
-	// in "inside out" dependency order.
-	//
-	// Not all resource instance objects will have elements in all of these
-	// maps. For example, an addDeleteDeps entry is present only if the
-	// execution subgraph for an object includes a ManagedApply operation
-	// for a "delete" plan.
-	addConfigDeps := addrs.MakeMap[addrs.AbsResourceInstanceObject, func(execgraph.AnyResultRef)]()
-	addStateDeps := addrs.MakeMap[addrs.AbsResourceInstanceObject, func(execgraph.AnyResultRef)]()
-	addDeleteDeps := addrs.MakeMap[addrs.AbsResourceInstanceObject, func(execgraph.AnyResultRef)]()
+	// resultRefs tracks the execgraph result reference for each resource
+	// instance object, populated gradually as we build it out. We track this
+	// separately from the objects in "subgraphs" because we will potentially
+	// add synthetic new entries to this map to read the prior state for
+	// anything that isn't otherwise being changed as part of this plan.
+	resultRefs := addrs.MakeMap[addrs.AbsResourceInstanceObject, execgraph.ResourceInstanceResultRef]()
 
 	// We pre-sort the keys here because that causes our execution graph
 	// operations to be in a deterministic order, for easier unit testing and
@@ -106,28 +81,7 @@ func (b *execGraphBuilder) AddResourceInstanceObjectSubgraphs(
 			plannedChange,
 			effectiveReplaceOrders.Get(addr),
 		)
-
-		// We'll use these three add*Dep functions in the second loop below as
-		// we fill in all of the explicit dependencies caused by expressions
-		// in the configuration.
-		// TODO: Now that we have a [resourceInstanceObjectSubgraph] type to
-		// capture all of the "connection points" of an resource instance
-		// subgraph we could potentially have just a single map with one of
-		// those for each resource instance. For now this preserves the original
-		// style of mantaining separate data structures so that the addition
-		// of "state dependencies" and "state result" stand out better in a
-		// diff compared to the original implementation, without causing lots of
-		// refactoring noise at the same time.
-		if subgraph.addConfigDep != nil {
-			addConfigDeps.Put(addr, subgraph.addConfigDep)
-		}
-		if subgraph.addStateDep != nil {
-			addStateDeps.Put(addr, subgraph.addStateDep)
-		}
-		if subgraph.addDeleteDep != nil {
-			deletionRefs.Put(addr, subgraph.deletionRef)
-			addDeleteDeps.Put(addr, subgraph.addDeleteDep)
-		}
+		subgraphs.Put(addr, subgraph)
 
 		if addr.IsCurrent() && subgraph.valueRef != nil {
 			resultRefs.Put(addr, subgraph.valueRef)
@@ -142,34 +96,36 @@ func (b *execGraphBuilder) AddResourceInstanceObjectSubgraphs(
 	// any object that isn't being changed but is a dependency for something
 	// that is changing.
 	for _, addr := range objAddrs {
-		if addConfigDep, ok := addConfigDeps.GetOk(addr); ok {
+		subgraph := subgraphs.Get(addr)
+		if subgraph.addConfigDep != nil {
 			for dependency := range objs.ConfigDependencies(addr) {
-				addConfigDep(ensureResourceInstanceObjectResultRef(dependency, resultRefs, b))
+				subgraph.addConfigDep(ensureResourceInstanceObjectResultRef(dependency, resultRefs, b))
 			}
 		}
-		if addStateDep, ok := addStateDeps.GetOk(addr); ok {
+		if subgraph.addStateDep != nil {
 			for dependency := range objs.StateDependencies(addr) {
-				addStateDep(ensureResourceInstanceObjectResultRef(dependency, resultRefs, b))
+				subgraph.addStateDep(ensureResourceInstanceObjectResultRef(dependency, resultRefs, b))
 			}
 		}
-		if addDeleteDep, ok := addDeleteDeps.GetOk(addr); ok {
+		if subgraph.addDeleteDep != nil {
 			for dependent := range objs.ConfigDependents(addr) {
-				if ref, ok := deletionRefs.GetOk(dependent); ok {
-					addDeleteDep(ref)
+				dependentSubgraph := subgraphs.Get(dependent)
+				if ref := dependentSubgraph.deletionRef; ref != nil {
+					subgraph.addDeleteDep(ref)
 				} else if ref, ok := resultRefs.GetOk(dependent); ok {
 					// If there's no deletion ref but the dependent still has
 					// a value ref (e.g. if the dependent is only being created
 					// or updated) then we wait until its create/update step
 					// has completed before deleting.
-					addDeleteDep(ref)
+					subgraph.addDeleteDep(ref)
 					// TODO: The old runtime's equivalent of this behavior has a
 					// hackily-implemented extra rule where it checks if
 					// adding this edge would create a cycle and skips adding
 					// it if so. Do we need to replicate that here? The
 					// commentary on the function that implements it
 					// ([DestroyEdgeTransformer.tryInterProviderDestroyEdge])
-					// explains that it's needed because when applying a
-					// destroy-mode plan provider instances are allowed to refer
+					// explains that it's needed because, when applying a
+					// destroy-mode plan, provider instances are allowed to refer
 					// to a resource instance that's being destroyed and expect
 					// that to take values from the prior state, and so we'll
 					// tackle this question when we add support for destroy-mode
@@ -184,10 +140,11 @@ func (b *execGraphBuilder) AddResourceInstanceObjectSubgraphs(
 			// together into a single set. Is that a correct thing to do, or
 			// do we need some special treatment in this direction too?
 			for dependent := range objs.StateDependents(addr) {
-				if ref, ok := deletionRefs.GetOk(dependent); ok {
-					addDeleteDep(ref)
+				dependentSubgraph := subgraphs.Get(dependent)
+				if ref := dependentSubgraph.deletionRef; ref != nil {
+					subgraph.addDeleteDep(ref)
 				} else if ref, ok := resultRefs.GetOk(dependent); ok {
-					addDeleteDep(ref)
+					subgraph.addDeleteDep(ref)
 				}
 			}
 		}

--- a/internal/engine/planning/execgraph_resource.go
+++ b/internal/engine/planning/execgraph_resource.go
@@ -131,7 +131,7 @@ func (b *execGraphBuilder) AddResourceInstanceObjectSubgraphs(
 
 		if addr.IsCurrent() && subgraph.valueRef != nil {
 			resultRefs.Put(addr, subgraph.valueRef)
-			b.SetResourceInstanceFinalStateResult(addr.InstanceAddr, subgraph.valueRef)
+			b.lower.SetResourceInstanceFinalStateResult(addr.InstanceAddr, subgraph.valueRef)
 		}
 	}
 
@@ -204,7 +204,7 @@ func ensureResourceInstanceObjectResultRef(addr addrs.AbsResourceInstanceObject,
 	var resultRef execgraph.ResourceInstanceResultRef
 	if addr.IsCurrent() {
 		resultRef = b.lower.ResourceInstancePrior(b.lower.ConstantResourceInstAddr(addr.InstanceAddr), nil)
-		b.SetResourceInstanceFinalStateResult(addr.InstanceAddr, resultRef)
+		b.lower.SetResourceInstanceFinalStateResult(addr.InstanceAddr, resultRef)
 	} else {
 		resultRef = b.lower.ManagedAlreadyDeposed(b.lower.ConstantResourceInstAddr(addr.InstanceAddr), b.lower.ConstantDeposedKey(addr.DeposedKey))
 	}
@@ -230,20 +230,6 @@ func (b *execGraphBuilder) resourceInstanceChangeSubgraph(
 		// the earlier planning pass could possibly plan changes for.
 		panic(fmt.Sprintf("can't build resource instance change subgraph for unexpected resource mode %s", resourceMode))
 	}
-}
-
-// SetResourceInstanceFinalStateResult records which result should be treated
-// as the "final state" for the given resource instance, for purposes such as
-// propagating the result value back into the evaluation system to allow
-// downstream expressions to derive from it.
-//
-// Only one call is allowed per distinct [addrs.AbsResourceInstance] value. If
-// two callers try to register for the same address then the second call will
-// panic.
-func (b *execGraphBuilder) SetResourceInstanceFinalStateResult(addr addrs.AbsResourceInstance, result execgraph.ResourceInstanceResultRef) {
-	b.mu.Lock()
-	b.lower.SetResourceInstanceFinalStateResult(addr, result)
-	b.mu.Unlock()
 }
 
 // resourceInstanceObjectSubgraph represents the external connection points of a

--- a/internal/engine/planning/execgraph_test.go
+++ b/internal/engine/planning/execgraph_test.go
@@ -7,9 +7,27 @@ package planning
 
 import (
 	"bufio"
+	"fmt"
 	"math"
 	"strings"
+
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/engine/internal/execgraph"
 )
+
+func newExecGraphBuilderForTesting() *execGraphBuilder {
+	var placeholderDeposedKey uint32
+	return &execGraphBuilder{
+		lower: execgraph.NewBuilder(),
+		makeDeposedKey: func(_ addrs.AbsResourceInstance) addrs.DeposedKey {
+			// For testing purposes we just allocate sequential integers
+			// so that we have predictable keys to include in the expected
+			// output of each test.
+			placeholderDeposedKey++
+			return addrs.DeposedKey(fmt.Sprintf("%08x", placeholderDeposedKey))
+		},
+	}
+}
 
 // stripCommonLeadingTabs is a helper for tests that include constant strings
 // for comparison with the result of a [Graph.DebugRepr] call, so that we can

--- a/internal/engine/planning/plan.go
+++ b/internal/engine/planning/plan.go
@@ -100,49 +100,48 @@ func finalizePlan(ctx context.Context, intermediate *planContextResult, provider
 	// the execution graph, so we can avoid returning the same key twice.
 	newDeposedKeys := addrs.MakeMap[addrs.AbsResourceInstance, collections.Set[addrs.DeposedKey]]()
 
-	egb := newExecGraphBuilder(func(instAddr addrs.AbsResourceInstance) addrs.DeposedKey {
-		// TODO: We should probably factor this out somewhere else, once
-		// the rest of the nearby code has settled down.
-		var existingDeposed map[addrs.DeposedKey]*states.ResourceInstanceObjectSrc
-		newDeposed := newDeposedKeys.Get(instAddr)
-		inst := intermediate.RefreshedState.ResourceInstance(instAddr)
-		if inst != nil {
-			existingDeposed = inst.Deposed
-		}
-
-		// We'll just keep trying to allocate new keys until we get a
-		// unique one. Deposed keys are effectively 32-bit unsigned integers
-		// and so with 1000 deposed objects per instance there'd only be 0.01%
-		// probability of colliding here, and that would be a ridiculous
-		// number of deposed objects.
-		i := 0
-		for {
-			i++
-			if i == 8192 {
-				// Something seems to have gone very wrong! We should not get here.
-				panic(fmt.Sprintf("failed to allocate a unique deposed key for %s", instAddr))
-			}
-
-			key := addrs.NewDeposedKey()
-			if _, exists := existingDeposed[key]; exists {
-				continue
-			}
-			if newDeposed.Has(key) {
-				continue
-			}
-			if newDeposed == nil {
-				newDeposed = make(collections.Set[addrs.DeposedKey])
-			}
-			newDeposed[key] = struct{}{}
-			return key
-		}
-
-	})
-	egb.AddResourceInstanceObjectSubgraphs(
+	execGraph := buildExecutionGraph(
 		intermediate.ResourceInstanceObjects,
 		effectiveReplaceOrders,
+		func(instAddr addrs.AbsResourceInstance) addrs.DeposedKey {
+			// TODO: We should probably factor this out somewhere else, once
+			// the rest of the nearby code has settled down.
+
+			var existingDeposed map[addrs.DeposedKey]*states.ResourceInstanceObjectSrc
+			newDeposed := newDeposedKeys.Get(instAddr)
+			inst := intermediate.RefreshedState.ResourceInstance(instAddr)
+			if inst != nil {
+				existingDeposed = inst.Deposed
+			}
+
+			// We'll just keep trying to allocate new keys until we get a
+			// unique one. Deposed keys are effectively 32-bit unsigned integers
+			// and so with 1000 deposed objects per instance there'd only be 0.01%
+			// probability of colliding here, and that would be a ridiculous
+			// number of deposed objects.
+			i := 0
+			for {
+				i++
+				if i == 8192 {
+					// Something seems to have gone very wrong! We should not get here.
+					panic(fmt.Sprintf("failed to allocate a unique deposed key for %s", instAddr))
+				}
+
+				key := addrs.NewDeposedKey()
+				if _, exists := existingDeposed[key]; exists {
+					continue
+				}
+				if newDeposed.Has(key) {
+					continue
+				}
+				if newDeposed == nil {
+					newDeposed = make(collections.Set[addrs.DeposedKey])
+				}
+				newDeposed[key] = struct{}{}
+				return key
+			}
+		},
 	)
-	execGraph := egb.Finish()
 	if logging.IsDebugOrHigher() {
 		// FIXME: This can potentially contain sensitive values from the
 		// configuration, so we should either remove this or change the


### PR DESCRIPTION
While working on https://github.com/opentofu/opentofu/pull/4316 I noticed a few different ways the execgraph-building code could potentially be simplified based on other changes we've made recently, but I intentionally deferred making those changes since they would've made the diff of that other PR harder to read.

This is a followup that is focused _only_ on those simplification-related changes, without changing any externally-visible behavior.

There are three distinct simplifications included here, and so it might be easier to [review on a commit-by-commit basis](https://github.com/opentofu/opentofu/pull/4323/commits) so you can read additional commentary in the commit messages.

(This is not yet enough to complete the associated issue https://github.com/opentofu/opentofu/issues/4297, since there's still some further work to deal with the missing functionality of not refreshing objects during destroy-mode planning and not taking into account updated metadata like a different provider instance selection for an existing resource instance, as described in the writeup of https://github.com/opentofu/opentofu/pull/4316. That work will follow later.)
