### PR TITLE
Just enough new-runtime tracing to shim the `tofu.Hook` API

### DIFF
--- a/internal/engine/applying/apply.go
+++ b/internal/engine/applying/apply.go
@@ -16,6 +16,7 @@ import (
 	"github.com/opentofu/opentofu/internal/lang/eval"
 	"github.com/opentofu/opentofu/internal/lang/grapheval"
 	"github.com/opentofu/opentofu/internal/plans"
+	"github.com/opentofu/opentofu/internal/shared"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
@@ -30,6 +31,10 @@ import (
 // we have a stronger understanding of what those needs are.
 func ApplyPlannedChanges(ctx context.Context, plan *plans.Plan, configInst *eval.ConfigInstance, plugins plugins.Plugins) (*states.State, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
+
+	// We'll make the "shared" tracer also available to everything we call.
+	tracer := contextTracer(ctx)
+	ctx = shared.ContextWithTracer(ctx, &tracer.Tracer)
 
 	glue := &evalGlue{
 		plugins: plugins,

--- a/internal/engine/applying/operations_resource_managed.go
+++ b/internal/engine/applying/operations_resource_managed.go
@@ -65,12 +65,24 @@ func (ops *execOperations) ManagedFinalPlan(
 
 	tracer := contextTracer(ctx)
 	if cb := tracer.StartManagedResourceInstanceObjectFinalPlan; cb != nil {
-		ctx = cb(ctx, objAddr)
+		priorVal := cty.NullVal(cty.DynamicPseudoType)
+		if prior != nil && prior.State != nil {
+			priorVal = prior.State.Value
+		}
+		configVal := cty.NullVal(cty.DynamicPseudoType)
+		if desired != nil {
+			configVal = desired.ConfigVal
+		}
+		ctx = cb(ctx, objAddr, priorVal, configVal, initialPlannedVal)
 	}
 	plannedVal := cty.DynamicVal // reassigned once we have a final value to return
 	if cb := tracer.EndManagedResourceInstanceObjectFinalPlan; cb != nil {
+		priorVal := cty.NullVal(cty.DynamicPseudoType)
+		if prior != nil && prior.State != nil {
+			priorVal = prior.State.Value
+		}
 		defer func() { // Extra closure to delay evaluating plannedVal and diags until we actually return
-			cb(ctx, objAddr, plannedVal, diags)
+			cb(ctx, objAddr, priorVal, plannedVal, diags)
 		}()
 	}
 
@@ -194,7 +206,7 @@ func (ops *execOperations) ManagedApply(
 
 	tracer := contextTracer(ctx)
 	if cb := tracer.StartManagedResourceInstanceObjectApply; cb != nil {
-		ctx = cb(ctx, plan.Addr)
+		ctx = cb(ctx, plan.Addr, plan.PriorStateVal, plan.PlannedVal)
 	}
 	resultVal := cty.DynamicVal // reassigned once we have a final value to return
 	if cb := tracer.EndManagedResourceInstanceObjectApply; cb != nil {

--- a/internal/engine/applying/operations_resource_managed.go
+++ b/internal/engine/applying/operations_resource_managed.go
@@ -63,6 +63,17 @@ func (ops *execOperations) ManagedFinalPlan(
 	objAddr := instAddr.Object(deposedKey)
 	log.Printf("[TRACE] apply phase: ManagedFinalPlan %s using %s", objAddr, providerConfigAddr)
 
+	tracer := contextTracer(ctx)
+	if cb := tracer.StartManagedResourceInstanceObjectFinalPlan; cb != nil {
+		ctx = cb(ctx, objAddr)
+	}
+	plannedVal := cty.DynamicVal // reassigned once we have a final value to return
+	if cb := tracer.EndManagedResourceInstanceObjectFinalPlan; cb != nil {
+		defer func() { // Extra closure to delay evaluating plannedVal and diags until we actually return
+			cb(ctx, objAddr, plannedVal, diags)
+		}()
+	}
+
 	providerClient, moreDiags := ops.configOracle.ProviderInstance(ctx, providerConfigAddr)
 	diags = diags.Append(moreDiags)
 	if diags.HasErrors() {
@@ -110,6 +121,7 @@ func (ops *execOperations) ManagedFinalPlan(
 		return nil, diags
 	}
 
+	plannedVal = resp.Planned.Value // for our deferred call to tracer.EndManagedResourceInstanceObjectFinalPlan
 	return &exec.ManagedResourceObjectFinalPlan{
 		Addr:                      instAddr.Object(deposedKey),
 		ResourceType:              resourceTypeName,
@@ -179,6 +191,17 @@ func (ops *execOperations) ManagedApply(
 	// through as normal, linear code without any special control flow, but
 	// that comes at the expense of this function doing considerably more
 	// work than most other operation methods do.
+
+	tracer := contextTracer(ctx)
+	if cb := tracer.StartManagedResourceInstanceObjectApply; cb != nil {
+		ctx = cb(ctx, plan.Addr)
+	}
+	resultVal := cty.DynamicVal // reassigned once we have a final value to return
+	if cb := tracer.EndManagedResourceInstanceObjectApply; cb != nil {
+		defer func() { // Extra closure to delay evaluating resultVal and diags until we actually return
+			cb(ctx, plan.Addr, resultVal, diags)
+		}()
+	}
 
 	providerAddr := providerConfigAddr.Config.Config.Provider
 	schema, moreDiags := ops.plugins.ResourceTypeSchema(
@@ -320,6 +343,11 @@ func (ops *execOperations) ManagedApply(
 		ops.workingState.RemoveResourceInstanceObjectFull(objAddr, providerConfigAddr)
 	}
 
+	if state != nil {
+		resultVal = state.Value // for our deferred call to tracer.EndManagedResourceInstanceObjectApply
+	} else {
+		resultVal = cty.NullVal(schema.Block.ImpliedType())
+	}
 	ret := &exec.ResourceInstanceObject{
 		Addr:  plan.Addr,
 		State: state, // nil if the object was deleted

--- a/internal/engine/applying/tracing.go
+++ b/internal/engine/applying/tracing.go
@@ -1,0 +1,118 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package applying
+
+import (
+	"context"
+
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// Tracer is a container for various callbacks used to report various
+// events that can occur during a call to [ApplyPlannedChanges].
+//
+// Pass a pointer to an object of this type to [ContextWithTracer] to
+// get an annotated [context.Context], and then pass it to [ApplyPlannedChanges].
+//
+// Any fields left as nil will be ignored. Non-nil callbacks will be called
+// whenever the associated event (mentioned in the field's documentation comment)
+// occurs.
+//
+// Some callback functions come in "Start" and "End" pairs that share a common
+// suffix. In those cases, the Start function is expected to return a context
+// is a child of the one passed to the callback function, possibly annotated
+// with additional information such as OpenTelemetry trace metadata. The
+// returned context is then used for all of the requests that occur between
+// the Start and End calls, and finally the same context is passed to the
+// corresponding End function so that e.g. an OpenTelemetry trace can be
+// closed. Implementations that don't need to preserve additional context can
+// just directly return the provided context without modification.
+type Tracer struct {
+
+	////////// Managed Resource Applying Events
+
+	// StartManagedResourceInstanceObjectFinalPlan and
+	// EndManagedResourceInstanceObjectFinalPlan mark the beginning and end of
+	// the work to produce the final plan for the identified managed resource
+	// instance object.
+	StartManagedResourceInstanceObjectFinalPlan func(ctx context.Context, addr addrs.AbsResourceInstanceObject) context.Context
+	EndManagedResourceInstanceObjectFinalPlan   func(ctx context.Context, addr addrs.AbsResourceInstanceObject, plannedVal cty.Value, diags tfdiags.Diagnostics)
+
+	// StartManagedResourceInstanceObjectApply and
+	// EndManagedResourceInstanceObjectApply mark the beginning and end of
+	// the work to apply the final plan for the identified managed resource
+	// instance object.
+	StartManagedResourceInstanceObjectApply func(ctx context.Context, addr addrs.AbsResourceInstanceObject) context.Context
+	EndManagedResourceInstanceObjectApply   func(ctx context.Context, addr addrs.AbsResourceInstanceObject, resultVal cty.Value, diags tfdiags.Diagnostics)
+
+	////////// Data Resource Applying Events
+
+	// StartDataResourceInstanceRead and EndDataResourceInstanceRead mark the
+	// beginning and end of the work to read data for the identified data
+	// resource instance.
+	//
+	// These events occur only when the data resource instance read was delayed
+	// due to there not being enough information to read it during the planning
+	// phase.
+	StartDataResourceInstanceRead func(ctx context.Context, addr addrs.AbsResourceInstance) context.Context
+	EndDataResourceInstanceRead   func(ctx context.Context, addr addrs.AbsResourceInstance, resultVal cty.Value, diags tfdiags.Diagnostics)
+
+	////////// Ephemeral Resource Lifecycle Events
+	// TODO: StartEphemeralResourceInstanceOpen, EndEphemeralResourceInstanceOpen,
+	// StartEphemeralResourceInstanceRenew, EndEphemeralResourceInstanceRenew,
+	// StartEphemeralResourceInstanceClose, and EndEphemeralResourceInstanceClose,
+	// but these are trickier because the evaluator manages them so we will
+	// probably need some additional indirection in this case. Maybe we'll
+	// define a shared "Tracer" object in package eval and just embed that
+	// here so we can reuse it during both plan and apply in a way that allows
+	// our caller to share the same set of tracing hooks between the plan and
+	// apply phases.
+
+	////////// Provider Instance Lifecycle Events
+	// TODO: Similar to ephemeral resource lifecycle events above, probably
+	// want to embed something we can share between the plan and apply tracer
+	// types.
+}
+
+// ContextWithTracer returns a new context derived from parent that carries
+// a [Tracer].
+//
+// Use the resulting context when calling [ApplyPlannedChanges], to get event
+// notification callbacks throughout the planning process.
+func ContextWithTracer(parent context.Context, tracer *Tracer) context.Context {
+	if tracer == nil {
+		return parent
+	}
+	return context.WithValue(parent, ctxTracerKey{}, tracer)
+}
+
+// contextTracer returns the [Tracer] associated with the given context,
+// or a pointer to [noopPlanTracer] if there is no associated tracer.
+//
+// The result is therefore guaranteed to never be nil, although the caller
+// must still check to see if each specific field it intends to use is nil or
+// not.
+func contextTracer(ctx context.Context) *Tracer {
+	ret, _ := ctx.Value(ctxTracerKey{}).(*Tracer)
+	if ret == nil {
+		return &noopTracer
+	}
+	return ret
+}
+
+type ctxTracerKey struct{}
+
+// noopTracer is an all-nil [Tracer] we return from [contextTracer]
+// when the given context has no tracer, so that calling code only needs to
+// worry about the individual fields being nil and not the overall object
+// being nil.
+//
+// A pointer to this object must never be exposed outside of this package
+// because that would risk such a caller acceidentally modifying the shared
+// noop tracer.
+var noopTracer Tracer

--- a/internal/engine/applying/tracing.go
+++ b/internal/engine/applying/tracing.go
@@ -8,9 +8,11 @@ package applying
 import (
 	"context"
 
-	"github.com/opentofu/opentofu/internal/addrs"
-	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/shared"
+	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
 // Tracer is a container for various callbacks used to report various
@@ -62,21 +64,10 @@ type Tracer struct {
 	StartDataResourceInstanceRead func(ctx context.Context, addr addrs.AbsResourceInstance) context.Context
 	EndDataResourceInstanceRead   func(ctx context.Context, addr addrs.AbsResourceInstance, resultVal cty.Value, diags tfdiags.Diagnostics)
 
-	////////// Ephemeral Resource Lifecycle Events
-	// TODO: StartEphemeralResourceInstanceOpen, EndEphemeralResourceInstanceOpen,
-	// StartEphemeralResourceInstanceRenew, EndEphemeralResourceInstanceRenew,
-	// StartEphemeralResourceInstanceClose, and EndEphemeralResourceInstanceClose,
-	// but these are trickier because the evaluator manages them so we will
-	// probably need some additional indirection in this case. Maybe we'll
-	// define a shared "Tracer" object in package eval and just embed that
-	// here so we can reuse it during both plan and apply in a way that allows
-	// our caller to share the same set of tracing hooks between the plan and
-	// apply phases.
-
-	////////// Provider Instance Lifecycle Events
-	// TODO: Similar to ephemeral resource lifecycle events above, probably
-	// want to embed something we can share between the plan and apply tracer
-	// types.
+	// We also embed [shared.Tracer] for some events that are common across
+	// plan and apply. [ApplyPlannedChanges] automatically ensures that this
+	// nested tracer reaches the shared codepaths that rely on it.
+	shared.Tracer
 }
 
 // ContextWithTracer returns a new context derived from parent that carries

--- a/internal/engine/applying/tracing.go
+++ b/internal/engine/applying/tracing.go
@@ -42,14 +42,14 @@ type Tracer struct {
 	// EndManagedResourceInstanceObjectFinalPlan mark the beginning and end of
 	// the work to produce the final plan for the identified managed resource
 	// instance object.
-	StartManagedResourceInstanceObjectFinalPlan func(ctx context.Context, addr addrs.AbsResourceInstanceObject) context.Context
-	EndManagedResourceInstanceObjectFinalPlan   func(ctx context.Context, addr addrs.AbsResourceInstanceObject, plannedVal cty.Value, diags tfdiags.Diagnostics)
+	StartManagedResourceInstanceObjectFinalPlan func(ctx context.Context, addr addrs.AbsResourceInstanceObject, priorVal, configVal, expectedVal cty.Value) context.Context
+	EndManagedResourceInstanceObjectFinalPlan   func(ctx context.Context, addr addrs.AbsResourceInstanceObject, priorVal, plannedVal cty.Value, diags tfdiags.Diagnostics)
 
 	// StartManagedResourceInstanceObjectApply and
 	// EndManagedResourceInstanceObjectApply mark the beginning and end of
 	// the work to apply the final plan for the identified managed resource
 	// instance object.
-	StartManagedResourceInstanceObjectApply func(ctx context.Context, addr addrs.AbsResourceInstanceObject) context.Context
+	StartManagedResourceInstanceObjectApply func(ctx context.Context, addr addrs.AbsResourceInstanceObject, priorVal, plannedVal cty.Value) context.Context
 	EndManagedResourceInstanceObjectApply   func(ctx context.Context, addr addrs.AbsResourceInstanceObject, resultVal cty.Value, diags tfdiags.Diagnostics)
 
 	////////// Data Resource Applying Events

--- a/internal/engine/planning/plan.go
+++ b/internal/engine/planning/plan.go
@@ -17,6 +17,7 @@ import (
 	"github.com/opentofu/opentofu/internal/lang/eval"
 	"github.com/opentofu/opentofu/internal/logging"
 	"github.com/opentofu/opentofu/internal/plans"
+	"github.com/opentofu/opentofu/internal/shared"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
@@ -42,6 +43,11 @@ func PlanChanges(ctx context.Context, opts *PlanOpts, prevRoundState *states.Sta
 	if opts == nil {
 		panic("PlanChanges with nil PlanOpts") // caller must always provide valid PlanOpts
 	}
+
+	// We'll make the "shared" tracer also available to everything we call.
+	tracer := contextTracer(ctx)
+	ctx = shared.ContextWithTracer(ctx, &tracer.Tracer)
+
 	switch opts.Mode {
 	case plans.NormalMode:
 		return normalPlan(ctx, opts, prevRoundState, configInst, providers)

--- a/internal/engine/planning/plan_data.go
+++ b/internal/engine/planning/plan_data.go
@@ -21,6 +21,16 @@ import (
 func (p *planGlue) planDesiredDataResourceInstance(ctx context.Context, inst *eval.DesiredResourceInstance) (*resourceInstanceObject, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
+	tracer := contextTracer(ctx)
+	if cb := tracer.StartDataResourceInstancePlanning; cb != nil {
+		ctx = cb(ctx, inst.Addr)
+	}
+	if cb := tracer.EndDataResourceInstancePlanning; cb != nil {
+		defer func() { // closure to delay evaluating diags until we return
+			cb(ctx, inst.Addr, diags)
+		}()
+	}
+
 	ret := &resourceInstanceObject{
 		Addr:               inst.Addr.CurrentObject(),
 		ConfigDependencies: addrs.MakeSet[addrs.AbsResourceInstanceObject](),
@@ -85,7 +95,11 @@ func (p *planGlue) planDesiredDataResourceInstance(ctx context.Context, inst *ev
 		return ret, diags
 	}
 
-	resp := providerClient.ReadDataSource(ctx, providers.ReadDataSourceRequest{
+	readCtx := ctx
+	if cb := tracer.StartDataResourceInstanceRead; cb != nil {
+		readCtx = cb(ctx, inst.Addr)
+	}
+	resp := providerClient.ReadDataSource(readCtx, providers.ReadDataSourceRequest{
 		TypeName: inst.ResourceType,
 		Config:   unmarkedConfigVal,
 
@@ -98,6 +112,15 @@ func (p *planGlue) planDesiredDataResourceInstance(ctx context.Context, inst *ev
 		ProviderMeta: cty.NullVal(cty.DynamicPseudoType),
 	})
 	diags = diags.Append(resp.Diagnostics)
+	if cb := tracer.EndDataResourceInstanceRead; cb != nil {
+		resultVal := cty.DynamicVal
+		if resp.State != cty.NilVal {
+			// TODO: Should apply "sensitive" marks here where appropriate in
+			// case the tracer is reporting events in the UI.
+			resultVal = resp.State
+		}
+		cb(readCtx, inst.Addr, resultVal, diags)
+	}
 	if resp.Diagnostics.HasErrors() {
 		return ret, diags
 	}

--- a/internal/engine/planning/plan_managed.go
+++ b/internal/engine/planning/plan_managed.go
@@ -283,14 +283,14 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 	// and reassign this refreshedVal to the refreshed result.
 	refreshCtx := ctx
 	if cb := tracer.StartManagedResourceInstanceObjectRefresh; cb != nil {
-		refreshCtx = cb(ctx, inst.Addr.CurrentObject())
+		refreshCtx = cb(ctx, inst.Addr.CurrentObject(), prevRoundVal)
 	}
 	refreshedVal := prevRoundVal
 	refreshedPrivate := prevRoundPrivate
 	if cb := tracer.EndManagedResourceInstanceObjectRefresh; cb != nil {
 		// TODO: Should apply "sensitive" marks here where appropriate in
 		// case the tracer is reporting events in the UI.
-		cb(refreshCtx, inst.Addr.CurrentObject(), refreshedVal, diags)
+		cb(refreshCtx, inst.Addr.CurrentObject(), prevRoundVal, refreshedVal, diags)
 	}
 
 	// TODO: ProviderMeta is a rarely-used feature that only really makes
@@ -303,7 +303,7 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 
 	planChangesCtx := ctx
 	if cb := tracer.StartManagedResourceInstanceObjectPlanChanges; cb != nil {
-		planChangesCtx = cb(ctx, inst.Addr.CurrentObject())
+		planChangesCtx = cb(ctx, inst.Addr.CurrentObject(), refreshedVal, effectiveConfigVal)
 	}
 	planResp, planDiags := resourceType.PlanChanges(planChangesCtx, &resources.ManagedResourcePlanRequest{
 		Current: resources.ValueWithPrivate{
@@ -313,17 +313,11 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 		DesiredValue:      effectiveConfigVal,
 		ProviderMetaValue: providerMetaValue,
 	}, ret.Addr)
-	if cb := tracer.EndManagedResourceInstanceObjectUpgrade; cb != nil {
-		plannedVal := cty.DynamicVal
-		if planResp.Planned.Value != cty.NilVal {
-			// TODO: Should apply "sensitive" marks here where appropriate in
-			// case the tracer is reporting events in the UI.
-			plannedVal = planResp.Planned.Value
-		}
-		cb(planChangesCtx, inst.Addr.CurrentObject(), plannedVal, diags)
-	}
 	diags = diags.Append(planDiags)
 	if planDiags.HasErrors() {
+		if cb := tracer.EndManagedResourceInstanceObjectPlanChanges; cb != nil {
+			cb(planChangesCtx, inst.Addr.CurrentObject(), plans.NoOp, refreshedVal, cty.DynamicVal, diags)
+		}
 		return ret, diags
 	}
 
@@ -344,6 +338,9 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 		// apply.
 		ret.PlaceholderValue = refreshedVal
 		ret.PlannedChange = nil
+		if cb := tracer.EndManagedResourceInstanceObjectPlanChanges; cb != nil {
+			cb(planChangesCtx, inst.Addr.CurrentObject(), plans.NoOp, refreshedVal, refreshedVal, diags)
+		}
 		return ret, diags
 	}
 
@@ -428,6 +425,16 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 		// [eval.DesiredResourceInstance].
 	}
 	ret.ProviderInst = *inst.ProviderInstance
+
+	if cb := tracer.EndManagedResourceInstanceObjectPlanChanges; cb != nil {
+		plannedVal := cty.DynamicVal
+		if planResp.Planned.Value != cty.NilVal {
+			// TODO: Should apply "sensitive" marks here where appropriate in
+			// case the tracer is reporting events in the UI.
+			plannedVal = planResp.Planned.Value
+		}
+		cb(planChangesCtx, inst.Addr.CurrentObject(), plannedAction, refreshedVal, plannedVal, diags)
+	}
 
 	return ret, diags
 }

--- a/internal/engine/planning/plan_managed.go
+++ b/internal/engine/planning/plan_managed.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/lang/eval"
@@ -18,7 +19,6 @@ import (
 	"github.com/opentofu/opentofu/internal/resources"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
-	ctyjson "github.com/zclconf/go-cty/cty/json"
 )
 
 func (p *planGlue) planDesiredManagedResourceInstance(
@@ -43,6 +43,16 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 		// in case that allows us to detect a problem sooner. The important
 		// thing is that in the deferred case we won't actually propose any
 		// planned changes for this resource instance.
+	}
+
+	tracer := contextTracer(ctx)
+	if cb := tracer.StartManagedResourceInstanceObjectPlanning; cb != nil {
+		ctx = cb(ctx, inst.Addr.CurrentObject())
+	}
+	if cb := tracer.EndManagedResourceInstanceObjectPlanning; cb != nil {
+		defer func() { // closure to delay evaluating diags until we return
+			cb(ctx, inst.Addr.CurrentObject(), diags)
+		}()
 	}
 
 	ret = &resourceInstanceObject{
@@ -139,6 +149,10 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 			))
 		}
 
+		upgradeCtx := ctx
+		if cb := tracer.StartManagedResourceInstanceObjectUpgrade; cb != nil {
+			upgradeCtx = cb(ctx, inst.Addr.CurrentObject())
+		}
 		upgradeReq := providers.UpgradeResourceStateRequest{
 			TypeName: inst.Addr.Resource.Resource.Type,
 
@@ -153,9 +167,17 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 			// assume we'll never encounter a legacy state snapshot that uses AttrsFlat.
 			RawStateJSON: prevRoundState.Value.ValueJSON,
 		}
-
-		upgradeResp := providerClient.UpgradeResourceState(ctx, upgradeReq)
+		upgradeResp := providerClient.UpgradeResourceState(upgradeCtx, upgradeReq)
 		diags = diags.Append(upgradeResp.Diagnostics)
+		if cb := tracer.EndManagedResourceInstanceObjectUpgrade; cb != nil {
+			upgradedVal := cty.DynamicVal
+			if upgradeResp.UpgradedState != cty.NilVal {
+				// TODO: Should apply "sensitive" marks here where appropriate in
+				// case the tracer is reporting events in the UI.
+				upgradedVal = upgradeResp.UpgradedState
+			}
+			cb(upgradeCtx, inst.Addr.CurrentObject(), upgradedVal, diags)
+		}
 		if diags.HasErrors() {
 			return ret, diags
 		}
@@ -259,8 +281,17 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 
 	// TODO: Call resourceType.RefreshObject, update the "refreshed state",
 	// and reassign this refreshedVal to the refreshed result.
+	refreshCtx := ctx
+	if cb := tracer.StartManagedResourceInstanceObjectRefresh; cb != nil {
+		refreshCtx = cb(ctx, inst.Addr.CurrentObject())
+	}
 	refreshedVal := prevRoundVal
 	refreshedPrivate := prevRoundPrivate
+	if cb := tracer.EndManagedResourceInstanceObjectRefresh; cb != nil {
+		// TODO: Should apply "sensitive" marks here where appropriate in
+		// case the tracer is reporting events in the UI.
+		cb(refreshCtx, inst.Addr.CurrentObject(), refreshedVal, diags)
+	}
 
 	// TODO: ProviderMeta is a rarely-used feature that only really makes
 	// sense when the module and provider are both written by the same
@@ -270,7 +301,11 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 	// meta value to get from the evaluator into here.
 	providerMetaValue := cty.NilVal
 
-	planResp, planDiags := resourceType.PlanChanges(ctx, &resources.ManagedResourcePlanRequest{
+	planChangesCtx := ctx
+	if cb := tracer.StartManagedResourceInstanceObjectPlanChanges; cb != nil {
+		planChangesCtx = cb(ctx, inst.Addr.CurrentObject())
+	}
+	planResp, planDiags := resourceType.PlanChanges(planChangesCtx, &resources.ManagedResourcePlanRequest{
 		Current: resources.ValueWithPrivate{
 			Value:   refreshedVal,
 			Private: refreshedPrivate,
@@ -278,6 +313,15 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 		DesiredValue:      effectiveConfigVal,
 		ProviderMetaValue: providerMetaValue,
 	}, ret.Addr)
+	if cb := tracer.EndManagedResourceInstanceObjectUpgrade; cb != nil {
+		plannedVal := cty.DynamicVal
+		if planResp.Planned.Value != cty.NilVal {
+			// TODO: Should apply "sensitive" marks here where appropriate in
+			// case the tracer is reporting events in the UI.
+			plannedVal = planResp.Planned.Value
+		}
+		cb(planChangesCtx, inst.Addr.CurrentObject(), plannedVal, diags)
+	}
 	diags = diags.Append(planDiags)
 	if planDiags.HasErrors() {
 		return ret, diags

--- a/internal/engine/planning/tracing.go
+++ b/internal/engine/planning/tracing.go
@@ -11,6 +11,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/plans"
 	"github.com/opentofu/opentofu/internal/shared"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
@@ -70,8 +71,8 @@ type Tracer struct {
 	// These events always occur between calls to
 	// StartManagedResourceInstanceObjectPlanning and
 	// EndManagedResourceInstanceObjectPlanning for the same object address.
-	StartManagedResourceInstanceObjectRefresh func(ctx context.Context, addr addrs.AbsResourceInstanceObject) context.Context
-	EndManagedResourceInstanceObjectRefresh   func(ctx context.Context, addr addrs.AbsResourceInstanceObject, refreshedVal cty.Value, diags tfdiags.Diagnostics)
+	StartManagedResourceInstanceObjectRefresh func(ctx context.Context, addr addrs.AbsResourceInstanceObject, prevRoundVal cty.Value) context.Context
+	EndManagedResourceInstanceObjectRefresh   func(ctx context.Context, addr addrs.AbsResourceInstanceObject, prevRoundVal, refreshedVal cty.Value, diags tfdiags.Diagnostics)
 
 	// StartManagedResourceInstanceObjectPlanChanges and
 	// EndManagedResourceInstanceObjectPlanChanges mark the beginning and end
@@ -83,8 +84,8 @@ type Tracer struct {
 	// EndManagedResourceInstanceObjectPlanning for the same object address,
 	// which act as a container for the upgrade, refresh, and change-planning
 	// sequence.
-	StartManagedResourceInstanceObjectPlanChanges func(ctx context.Context, addr addrs.AbsResourceInstanceObject) context.Context
-	EndManagedResourceInstanceObjectPlanChanges   func(ctx context.Context, addr addrs.AbsResourceInstanceObject, plannedVal cty.Value, diags tfdiags.Diagnostics)
+	StartManagedResourceInstanceObjectPlanChanges func(ctx context.Context, addr addrs.AbsResourceInstanceObject, priorVal, configVal cty.Value) context.Context
+	EndManagedResourceInstanceObjectPlanChanges   func(ctx context.Context, addr addrs.AbsResourceInstanceObject, action plans.Action, priorVal, plannedVal cty.Value, diags tfdiags.Diagnostics)
 
 	////////// Data Resource Planning Events
 

--- a/internal/engine/planning/tracing.go
+++ b/internal/engine/planning/tracing.go
@@ -1,0 +1,168 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package planning
+
+import (
+	"context"
+
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+)
+
+// Tracer is a container for various callbacks used to report various
+// events that can occur during a call to [PlanChanges].
+//
+// Pass a pointer to an object of this type to [ContextWithTracer] to
+// get an annotated [context.Context], and then pass it to [PlanChanges].
+//
+// Any fields left as nil will be ignored. Non-nil callbacks will be called
+// whenever the associated event (mentioned in the field's documentation comment)
+// occurs.
+//
+// Some callback functions come in "Start" and "End" pairs that share a common
+// suffix. In those cases, the Start function is expected to return a context
+// is a child of the one passed to the callback function, possibly annotated
+// with additional information such as OpenTelemetry trace metadata. The
+// returned context is then used for all of the requests that occur between
+// the Start and End calls, and finally the same context is passed to the
+// corresponding End function so that e.g. an OpenTelemetry trace can be
+// closed. Implementations that don't need to preserve additional context can
+// just directly return the provided context without modification.
+type Tracer struct {
+
+	////////// Managed Resource Planning Events
+
+	// StartManagedResourceInstanceObjectPlanning and
+	// EndManagedResourceInstanceObjectPlanning mark the beginning and end of
+	// the overall planning work for the identified managed resource instance
+	// object.
+	//
+	// These events cover the whole planning process for the given resource
+	// instance object, including the state upgrade and refresh steps alongside
+	// the actual call to ask the provider to determine if any changes are
+	// needed. There are other more specific events below, which nest inside
+	// this pair of events.
+	StartManagedResourceInstanceObjectPlanning func(ctx context.Context, addr addrs.AbsResourceInstanceObject) context.Context
+	EndManagedResourceInstanceObjectPlanning   func(ctx context.Context, addr addrs.AbsResourceInstanceObject, diags tfdiags.Diagnostics)
+
+	// StartManagedResourceInstanceObjectUpgrade and
+	// EndManagedResourceInstanceObjectUpgrade mark the beginning and end
+	// of the "state upgrade" step for the identified managed resource instance
+	// object.
+	//
+	// These events always occur between calls to
+	// StartManagedResourceInstanceObjectPlanning and
+	// EndManagedResourceInstanceObjectPlanning for the same object address.
+	StartManagedResourceInstanceObjectUpgrade func(ctx context.Context, addr addrs.AbsResourceInstanceObject) context.Context
+	EndManagedResourceInstanceObjectUpgrade   func(ctx context.Context, addr addrs.AbsResourceInstanceObject, upgradedVal cty.Value, diags tfdiags.Diagnostics)
+
+	// StartManagedResourceInstanceObjectRefresh and
+	// EndManagedResourceInstanceObjectRefresh mark the beginning and end
+	// of the "refresh" step for the identified managed resource instance
+	// object.
+	//
+	// These events always occur between calls to
+	// StartManagedResourceInstanceObjectPlanning and
+	// EndManagedResourceInstanceObjectPlanning for the same object address.
+	StartManagedResourceInstanceObjectRefresh func(ctx context.Context, addr addrs.AbsResourceInstanceObject) context.Context
+	EndManagedResourceInstanceObjectRefresh   func(ctx context.Context, addr addrs.AbsResourceInstanceObject, refreshedVal cty.Value, diags tfdiags.Diagnostics)
+
+	// StartManagedResourceInstanceObjectPlanChanges and
+	// EndManagedResourceInstanceObjectPlanChanges mark the beginning and end
+	// of the step where we actually ask the provider to plan changes for
+	// the identified resource instance object.
+	//
+	// These events always occur between calls to
+	// StartManagedResourceInstanceObjectPlanning and
+	// EndManagedResourceInstanceObjectPlanning for the same object address,
+	// which act as a container for the upgrade, refresh, and change-planning
+	// sequence.
+	StartManagedResourceInstanceObjectPlanChanges func(ctx context.Context, addr addrs.AbsResourceInstanceObject) context.Context
+	EndManagedResourceInstanceObjectPlanChanges   func(ctx context.Context, addr addrs.AbsResourceInstanceObject, plannedVal cty.Value, diags tfdiags.Diagnostics)
+
+	////////// Data Resource Planning Events
+
+	// StartDataResourceInstancePlanning and EndDataResourceInstancePlanning
+	// mark the beginning and end of the overall planning work for the
+	// identified data resource instance.
+	//
+	// These events cover the whole planning process for the given resource
+	// instance. There are other more specific events below, which nest inside
+	// this pair of events.
+	StartDataResourceInstancePlanning func(ctx context.Context, addr addrs.AbsResourceInstance) context.Context
+	EndDataResourceInstancePlanning   func(ctx context.Context, addr addrs.AbsResourceInstance, diags tfdiags.Diagnostics)
+
+	// StartDataResourceInstanceRead and EndDataResourceInstanceRead mark the
+	// beginning and end of the work to read data for the identified data
+	// resource instance.
+	//
+	// These events occur only when the data resource instance is readable
+	// during the planning phase. Some data resource instances get delayed until
+	// the apply phase because there isn't enough information to read them
+	// during the planning phase.
+	//
+	// These events always occur between calls to
+	// StartDataResourceInstancePlanning and EndDataResourceInstancePlanning for
+	// the same instance address.
+	StartDataResourceInstanceRead func(ctx context.Context, addr addrs.AbsResourceInstance) context.Context
+	EndDataResourceInstanceRead   func(ctx context.Context, addr addrs.AbsResourceInstance, resultVal cty.Value, diags tfdiags.Diagnostics)
+
+	////////// Ephemeral Resource Lifecycle Events
+	// TODO: StartEphemeralResourceInstanceOpen, EndEphemeralResourceInstanceOpen,
+	// StartEphemeralResourceInstanceRenew, EndEphemeralResourceInstanceRenew,
+	// StartEphemeralResourceInstanceClose, and EndEphemeralResourceInstanceClose,
+	// but these are trickier because the evaluator manages them so we will
+	// probably need some additional indirection in this case. Maybe we'll
+	// define a shared "Tracer" object in package eval and just embed that
+	// here so we can reuse it during both plan and apply in a way that allows
+	// our caller to share the same set of tracing hooks between the plan and
+	// apply phases.
+
+	////////// Provider Instance Lifecycle Events
+	// TODO: Similar to ephemeral resource lifecycle events above, probably
+	// want to embed something we can share between the plan and apply tracer
+	// types.
+}
+
+// ContextWithTracer returns a new context derived from parent that carries
+// a [Tracer].
+//
+// Use the resulting context when calling [PlanChanges], to get event
+// notification callbacks throughout the planning process.
+func ContextWithTracer(parent context.Context, tracer *Tracer) context.Context {
+	if tracer == nil {
+		return parent
+	}
+	return context.WithValue(parent, ctxTracerKey{}, tracer)
+}
+
+// contextTracer returns the [Tracer] associated with the given context,
+// or a pointer to [noopPlanTracer] if there is no associated tracer.
+//
+// The result is therefore guaranteed to never be nil, although the caller
+// must still check to see if each specific field it intends to use is nil or
+// not.
+func contextTracer(ctx context.Context) *Tracer {
+	ret, _ := ctx.Value(ctxTracerKey{}).(*Tracer)
+	if ret == nil {
+		return &noopTracer
+	}
+	return ret
+}
+
+type ctxTracerKey struct{}
+
+// noopTracer is an all-nil [Tracer] we return from [contextTracer]
+// when the given context has no tracer, so that calling code only needs to
+// worry about the individual fields being nil and not the overall object
+// being nil.
+//
+// A pointer to this object must never be exposed outside of this package
+// because that would risk such a caller acceidentally modifying the shared
+// noop tracer.
+var noopTracer Tracer

--- a/internal/engine/planning/tracing.go
+++ b/internal/engine/planning/tracing.go
@@ -11,6 +11,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/shared"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
@@ -112,21 +113,10 @@ type Tracer struct {
 	StartDataResourceInstanceRead func(ctx context.Context, addr addrs.AbsResourceInstance) context.Context
 	EndDataResourceInstanceRead   func(ctx context.Context, addr addrs.AbsResourceInstance, resultVal cty.Value, diags tfdiags.Diagnostics)
 
-	////////// Ephemeral Resource Lifecycle Events
-	// TODO: StartEphemeralResourceInstanceOpen, EndEphemeralResourceInstanceOpen,
-	// StartEphemeralResourceInstanceRenew, EndEphemeralResourceInstanceRenew,
-	// StartEphemeralResourceInstanceClose, and EndEphemeralResourceInstanceClose,
-	// but these are trickier because the evaluator manages them so we will
-	// probably need some additional indirection in this case. Maybe we'll
-	// define a shared "Tracer" object in package eval and just embed that
-	// here so we can reuse it during both plan and apply in a way that allows
-	// our caller to share the same set of tracing hooks between the plan and
-	// apply phases.
-
-	////////// Provider Instance Lifecycle Events
-	// TODO: Similar to ephemeral resource lifecycle events above, probably
-	// want to embed something we can share between the plan and apply tracer
-	// types.
+	// We also embed [shared.Tracer] for some events that are common across
+	// plan and apply. [PlanChanges] automatically ensures that this nested
+	// tracer reaches the shared codepaths that rely on it.
+	shared.Tracer
 }
 
 // ContextWithTracer returns a new context derived from parent that carries

--- a/internal/lang/eval/providers.go
+++ b/internal/lang/eval/providers.go
@@ -13,13 +13,14 @@ import (
 	"sync"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/lang/grapheval"
 	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/shared"
 	"github.com/opentofu/opentofu/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
-	"github.com/zclconf/go-cty/cty/function"
 )
 
 type providerConfigSupplier func(ctx context.Context, addr addrs.AbsProviderInstanceCorrect) (cty.Value, tfdiags.Diagnostics)
@@ -180,7 +181,6 @@ func (p *managedProviders) OpenEphemeralResourceInstance(ctx context.Context, ad
 		*providerInstance,
 		providerClient,
 		cfgVal,
-		shared.EphemeralResourceHooks{},
 	)
 	diags = diags.Append(openDiags)
 	if openDiags.HasErrors() {

--- a/internal/shared/ephemeral_resource.go
+++ b/internal/shared/ephemeral_resource.go
@@ -22,15 +22,6 @@ import (
 // This may be modified to expedite tests
 var EphemeralResourceCloseTimeout = 10 * time.Second
 
-type EphemeralResourceHooks struct {
-	PreOpen   func(addrs.AbsResourceInstance)
-	PostOpen  func(addrs.AbsResourceInstance, tfdiags.Diagnostics)
-	PreRenew  func(addrs.AbsResourceInstance)
-	PostRenew func(addrs.AbsResourceInstance, tfdiags.Diagnostics)
-	PreClose  func(addrs.AbsResourceInstance)
-	PostClose func(addrs.AbsResourceInstance, tfdiags.Diagnostics)
-}
-
 type EphemeralCloseFunc func(context.Context) tfdiags.Diagnostics
 
 func OpenEphemeralResourceInstance(
@@ -41,10 +32,11 @@ func OpenEphemeralResourceInstance(
 	providerAddr addrs.AbsProviderInstanceCorrect,
 	provider providers.Interface,
 	configVal cty.Value,
-	hooks EphemeralResourceHooks,
 ) (cty.Value, EphemeralCloseFunc, tfdiags.Diagnostics) {
 	var newVal cty.Value
 	var diags tfdiags.Diagnostics
+
+	tracer := contextTracer(ctx)
 
 	// Unmark before sending to provider, will re-mark before returning
 	configVal, pvm := configVal.UnmarkDeepWithPaths()
@@ -66,17 +58,21 @@ func OpenEphemeralResourceInstance(
 	// to actually call the provider to open the ephemeral resource.
 	log.Printf("[TRACE] OpenEphemeralResourceInstance: %s configuration is complete, so calling the provider", addr)
 
-	if hooks.PreOpen != nil {
-		hooks.PreOpen(addr)
+	openCtx := ctx
+	if cb := tracer.StartEphemeralResourceInstanceOpen; cb != nil {
+		openCtx = cb(ctx, addr)
 	}
 
 	openReq := providers.OpenEphemeralResourceRequest{
 		TypeName: addr.ContainingResource().Resource.Type,
 		Config:   configVal,
 	}
-	openResp := provider.OpenEphemeralResource(ctx, openReq)
+	openResp := provider.OpenEphemeralResource(openCtx, openReq)
 	diags = diags.Append(openResp.Diagnostics)
 	if diags.HasErrors() {
+		if cb := tracer.EndEphemeralResourceInstanceOpen; cb != nil {
+			cb(openCtx, addr, diags)
+		}
 		return newVal, nil, diags
 	}
 
@@ -123,9 +119,16 @@ func OpenEphemeralResourceInstance(
 		}
 	}()
 
+	if cb := tracer.EndEphemeralResourceInstanceOpen; cb != nil {
+		cb(openCtx, addr, diags)
+	}
+
 	if diags.HasErrors() {
 		// We have an open ephemeral resource, but don't plan to use it due to validation errors
 		// It needs to be closed before we can return
+		// TODO: We should probably call
+		// tracer.StartEphemeralResourceInstanceClose and
+		// tracer.EndEphemeralResourceInstanceClose around this early close.
 
 		closReq := providers.CloseEphemeralResourceRequest{
 			TypeName: addr.Resource.Resource.Type,
@@ -140,10 +143,6 @@ func OpenEphemeralResourceInstance(
 	// TODO see if this conflicts with anything in the new engine?
 	if len(pvm) > 0 {
 		newVal = newVal.MarkWithPaths(pvm)
-	}
-
-	if hooks.PostOpen != nil {
-		hooks.PostOpen(addr, diags)
 	}
 
 	// Initialize the closing channel and the channel that sends diagnostics back to the close caller.
@@ -177,23 +176,24 @@ func OpenEphemeralResourceInstance(
 				}
 				select {
 				case <-waitForRenewal():
-					if hooks.PreRenew != nil {
-						hooks.PreRenew(addr)
+					renewCtx := ctx
+					if cb := tracer.StartEphemeralResourceInstanceRenew; cb != nil {
+						renewCtx = cb(ctx, addr)
 					}
 
 					renewReq := providers.RenewEphemeralResourceRequest{
 						TypeName: addr.Resource.Resource.Type,
 						Private:  privateData,
 					}
-					renewResp := provider.RenewEphemeralResource(ctx, renewReq)
+					renewResp := provider.RenewEphemeralResource(renewCtx, renewReq)
 					diags = diags.Append(renewResp.Diagnostics)
 
 					// TODO consider what happens if renew fails, do we still want to update private?
 					renewAt = renewResp.RenewAt
-					if hooks.PostRenew != nil {
-						hooks.PostRenew(addr, diags)
-					}
 					privateData = renewResp.Private
+					if cb := tracer.EndEphemeralResourceInstanceRenew; cb != nil {
+						cb(renewCtx, addr, diags)
+					}
 				case closeCtx = <-closeCh:
 					return
 				case <-ctx.Done():
@@ -204,8 +204,8 @@ func OpenEphemeralResourceInstance(
 			}
 		}()
 
-		if hooks.PreClose != nil {
-			hooks.PreClose(addr)
+		if cb := tracer.StartEphemeralResourceInstanceClose; cb != nil {
+			closeCtx = cb(closeCtx, addr)
 		}
 
 		closReq := providers.CloseEphemeralResourceRequest{
@@ -215,8 +215,8 @@ func OpenEphemeralResourceInstance(
 		closeResp := provider.CloseEphemeralResource(closeCtx, closReq)
 		diags = diags.Append(closeResp.Diagnostics)
 
-		if hooks.PostClose != nil {
-			hooks.PostClose(addr, diags)
+		if cb := tracer.EndEphemeralResourceInstanceClose; cb != nil {
+			cb(closeCtx, addr, diags)
 		}
 
 		select {

--- a/internal/shared/tracing.go
+++ b/internal/shared/tracing.go
@@ -1,0 +1,75 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package shared
+
+import (
+	"context"
+
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+)
+
+// Tracer represents a set of tracing event handlers for events that are common
+// across the planning and applying phases.
+type Tracer struct {
+	////////// Ephemeral Resource Events
+
+	// StartEphemeralResourceInstanceOpen and EndEphemeralResourceInstanceOpen
+	// mark the beginning and end of the work to open the identified ephemeral
+	// resource instance.
+	StartEphemeralResourceInstanceOpen func(ctx context.Context, addr addrs.AbsResourceInstance) context.Context
+	EndEphemeralResourceInstanceOpen   func(ctx context.Context, addr addrs.AbsResourceInstance, diags tfdiags.Diagnostics)
+
+	// StartEphemeralResourceInstanceRenew and EndEphemeralResourceInstanceRenew
+	// mark the beginning and end of the work to renew the identified ephemeral
+	// resource instance.
+	StartEphemeralResourceInstanceRenew func(ctx context.Context, addr addrs.AbsResourceInstance) context.Context
+	EndEphemeralResourceInstanceRenew   func(ctx context.Context, addr addrs.AbsResourceInstance, diags tfdiags.Diagnostics)
+
+	// StartEphemeralResourceInstanceClose and EndEphemeralResourceInstanceClose
+	// mark the beginning and end of the work to close the identified ephemeral
+	// resource instance.
+	StartEphemeralResourceInstanceClose func(ctx context.Context, addr addrs.AbsResourceInstance) context.Context
+	EndEphemeralResourceInstanceClose   func(ctx context.Context, addr addrs.AbsResourceInstance, diags tfdiags.Diagnostics)
+}
+
+// ContextWithTracer returns a new context derived from parent that carries
+// a [Tracer].
+//
+// Use the resulting context when calling [ApplyPlannedChanges], to get event
+// notification callbacks throughout the planning process.
+func ContextWithTracer(parent context.Context, tracer *Tracer) context.Context {
+	if tracer == nil {
+		return parent
+	}
+	return context.WithValue(parent, ctxTracerKey{}, tracer)
+}
+
+// contextTracer returns the [Tracer] associated with the given context,
+// or a pointer to [noopPlanTracer] if there is no associated tracer.
+//
+// The result is therefore guaranteed to never be nil, although the caller
+// must still check to see if each specific field it intends to use is nil or
+// not.
+func contextTracer(ctx context.Context) *Tracer {
+	ret, _ := ctx.Value(ctxTracerKey{}).(*Tracer)
+	if ret == nil {
+		return &noopTracer
+	}
+	return ret
+}
+
+type ctxTracerKey struct{}
+
+// noopTracer is an all-nil [Tracer] we return from [contextTracer]
+// when the given context has no tracer, so that calling code only needs to
+// worry about the individual fields being nil and not the overall object
+// being nil.
+//
+// A pointer to this object must never be exposed outside of this package
+// because that would risk such a caller acceidentally modifying the shared
+// noop tracer.
+var noopTracer Tracer

--- a/internal/tofu/context_apply2_test.go
+++ b/internal/tofu/context_apply2_test.go
@@ -6083,8 +6083,6 @@ check "http_check" {
 // TestContext2Apply_ephemeralResourcesLifecycleCheck is checking the hook calls
 // and the state to be sure that the expected information is there.
 func TestContext2Apply_ephemeralResourcesLifecycleCheck(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureHooks)
-
 	addr := mustAbsResourceAddr("ephemeral.test_ephemeral_resource.a")
 	cases := map[string]struct {
 		cfg               *configs.Config
@@ -6204,9 +6202,16 @@ resource "test_instance" "a" {
 
 			gotRes := newState.Resource(addr)
 			if diff := cmp.Diff(tc.expectedState, gotRes); diff != "" {
+				// The new runtime intentionally excludes ephemeral resource
+				// instances from the plan and state because it no longer needs
+				// to rely on those artifacts for obtaining values during
+				// expression evaluation: they just propagate ephemerally
+				// through the evaluator instead.
+				SkipExperimental(t, ExperimentalObsoleteEphemeralInState)
 				t.Errorf("unexpected ephemeral resource content in the state (-want,+got):\n%s", diff)
 			}
 			if diff := cmp.Diff(tc.expectedHookCalls, h.Calls); diff != "" {
+				SkipExperimental(t, ExperimentalBugStateUpdateHook)
 				t.Errorf("unexpected hook calls (-want,+got):\n%s", diff)
 			}
 		})

--- a/internal/tofu/context_apply_test.go
+++ b/internal/tofu/context_apply_test.go
@@ -8411,6 +8411,13 @@ func TestContext2Apply_createBefore_depends(t *testing.T) {
 		t.Fatalf("wrong final state\ngot:\n%s\n\nwant:\n%s", got, want)
 	}
 
+	if got, want := len(h.Diffs), 3; got < want {
+		t.Fatalf("wrong number of tracked diffs %d; need at least %d", got, want)
+	}
+	if got, want := len(h.States), 3; got < want {
+		t.Fatalf("wrong number of tracked states %d; need at least %d", got, want)
+	}
+
 	// Test that things were managed _in the right order_
 	order := h.States
 

--- a/internal/tofu/context_apply_test.go
+++ b/internal/tofu/context_apply_test.go
@@ -1732,7 +1732,14 @@ func TestContext2Apply_dataBasic(t *testing.T) {
 }
 
 func TestContext2Apply_destroyData(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDestroy)
+	// The concept of "destroying" a data resource instance is a nonsense that
+	// the original runtime invented to compensate for some
+	// managed-resource-specific lifecycle assumptions, but the new runtime
+	// has no need for this since its planning engine should just quietly drop
+	// any no-longer-needed data resource instances at the same time it would've
+	// tried to read a data resource instance that's still desired, without any
+	// special handling in the apply phase at all.
+	SkipExperimental(t, ExperimentalObsoleteDestroyData)
 
 	m := testModule(t, "apply-destroy-data-resource")
 	p := testProvider("null")
@@ -7004,8 +7011,6 @@ func TestContext2Apply_errorPartial(t *testing.T) {
 }
 
 func TestContext2Apply_hook(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureHooks)
-
 	m := testModule(t, "apply-good")
 	h := new(MockHook)
 	p := testProvider("aws")
@@ -7030,14 +7035,13 @@ func TestContext2Apply_hook(t *testing.T) {
 	if !h.PostApplyCalled {
 		t.Fatal("should be called")
 	}
+	SkipExperimental(t, ExperimentalBugStateUpdateHook)
 	if !h.PostStateUpdateCalled {
 		t.Fatalf("should call post state update")
 	}
 }
 
 func TestContext2Apply_hookOrphan(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureHooks)
-
 	m := testModule(t, "apply-blank")
 	h := new(MockHook)
 	p := testProvider("aws")
@@ -7075,6 +7079,7 @@ func TestContext2Apply_hookOrphan(t *testing.T) {
 	if !h.PostApplyCalled {
 		t.Fatal("should be called")
 	}
+	SkipExperimental(t, ExperimentalBugStateUpdateHook)
 	if !h.PostStateUpdateCalled {
 		t.Fatalf("should call post state update")
 	}

--- a/internal/tofu/context_temp_runtime.go
+++ b/internal/tofu/context_temp_runtime.go
@@ -15,6 +15,8 @@ import (
 	"time"
 
 	"github.com/apparentlymart/go-versions/versions"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/engine/applying"
@@ -25,7 +27,6 @@ import (
 	"github.com/opentofu/opentofu/internal/plans"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
 /////////////////////////
@@ -297,6 +298,9 @@ func (c *Context) newEngineApply(ctx context.Context, config *configs.Config, pl
 		return nil, diags
 	}
 
+	tracer := c.newEngineApplyTracer()
+	ctx = applying.ContextWithTracer(ctx, tracer)
+
 	configInst, plugins, done, moreDiags := c.newEngineShim(ctx, config, variables, plan.Timestamp, true)
 	diags = diags.Append(moreDiags)
 
@@ -309,6 +313,95 @@ func (c *Context) newEngineApply(ctx context.Context, config *configs.Config, pl
 	newState, moreDiags := applying.ApplyPlannedChanges(ctx, plan, configInst, plugins)
 	diags = diags.Append(moreDiags)
 	return newState, diags
+}
+
+func (c *Context) newEngineApplyTracer() *applying.Tracer {
+	// TODO: For now this just shims to our old Hook API as best we can. Once we
+	// start using the new runtime directly instead of shimming it through
+	// the old runtime's API we should let the CLI layer be responsible for
+	// providing its own planning.PlanTracer directly, which it can then
+	// use both to drive its own UI and to centralize our OpenTelemetry tracing
+	// logic instead of having it spread all over the codebase.
+	eachHook := func(fn func(Hook) (HookAction, error)) {
+		for _, h := range c.hooks {
+			action, err := fn(h)
+			if err != nil {
+				// The new runtime intentionally doesn't allow tracers to
+				// force failure: this API is purely for passive tracing and
+				// UI reporting. Therefore we'll just log the error and return.
+				log.Printf("[ERROR] %T: %s", h, err)
+				return
+			}
+			switch action {
+			case HookActionContinue:
+				continue
+			case HookActionHalt:
+				return
+			}
+		}
+	}
+
+	return &applying.Tracer{
+		StartManagedResourceInstanceObjectFinalPlan: func(ctx context.Context, addr addrs.AbsResourceInstanceObject) context.Context {
+			inst := addr.InstanceAddr
+			gen := addr.DeposedKey.Generation()
+			eachHook(func(h Hook) (HookAction, error) {
+				return h.PreDiff(inst, gen, cty.DynamicVal, cty.DynamicVal)
+			})
+			return ctx
+		},
+		EndManagedResourceInstanceObjectFinalPlan: func(ctx context.Context, addr addrs.AbsResourceInstanceObject, plannedVal cty.Value, diags tfdiags.Diagnostics) {
+			inst := addr.InstanceAddr
+			gen := addr.DeposedKey.Generation()
+			eachHook(func(h Hook) (HookAction, error) {
+				// TODO: For now we're just always reporting plans.Update here
+				// as a placeholder, since we're shimming hooks here primarily
+				// for the benefit of the context tests and so we'll wait to
+				// see if any of those tests need more than this before we add
+				// that complexity.
+				return h.PostDiff(inst, gen, plans.Update, cty.DynamicVal, plannedVal)
+			})
+		},
+		StartManagedResourceInstanceObjectApply: func(ctx context.Context, addr addrs.AbsResourceInstanceObject) context.Context {
+			inst := addr.InstanceAddr
+			gen := addr.DeposedKey.Generation()
+			eachHook(func(h Hook) (HookAction, error) {
+				// TODO: For now we're just always reporting plans.Update here
+				// as a placeholder, since we're shimming hooks here primarily
+				// for the benefit of the context tests and so we'll wait to
+				// see if any of those tests need more than this before we add
+				// that complexity.
+				return h.PreApply(inst, gen, plans.Update, cty.DynamicVal, cty.DynamicVal)
+			})
+			return ctx
+		},
+		EndManagedResourceInstanceObjectApply: func(ctx context.Context, addr addrs.AbsResourceInstanceObject, resultVal cty.Value, diags tfdiags.Diagnostics) {
+			inst := addr.InstanceAddr
+			gen := addr.DeposedKey.Generation()
+			eachHook(func(h Hook) (HookAction, error) {
+				return h.PostApply(inst, gen, resultVal, diags.Err())
+			})
+			// TODO: the CLI layer and some of our tests also expect to get a
+			// PostStateUpdate call each time the state might have changed,
+			// but supporting that here would require us to either expose the
+			// apply engine's internal working state or to copy it each time
+			// we apply something, and we're trying to move away from there
+			// being a single big state object that everything is interacting
+			// with so we'll need to think about what compromise is best to
+			// make here.
+		},
+		StartDataResourceInstanceRead: func(ctx context.Context, addr addrs.AbsResourceInstance) context.Context {
+			eachHook(func(h Hook) (HookAction, error) {
+				return h.PreRefresh(addr, addrs.CurrentResourceInstanceObjectGeneration, cty.DynamicVal)
+			})
+			return ctx
+		},
+		EndDataResourceInstanceRead: func(ctx context.Context, addr addrs.AbsResourceInstance, resultVal cty.Value, diags tfdiags.Diagnostics) {
+			eachHook(func(h Hook) (HookAction, error) {
+				return h.PostRefresh(addr, addrs.CurrentResourceInstanceObjectGeneration, cty.DynamicVal, resultVal)
+			})
+		},
+	}
 }
 
 type newRuntimeModulesForTesting struct {

--- a/internal/tofu/context_temp_runtime.go
+++ b/internal/tofu/context_temp_runtime.go
@@ -25,6 +25,7 @@ import (
 	"github.com/opentofu/opentofu/internal/lang/eval"
 	"github.com/opentofu/opentofu/internal/lang/exprs"
 	"github.com/opentofu/opentofu/internal/plans"
+	"github.com/opentofu/opentofu/internal/shared"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
@@ -215,30 +216,12 @@ func (c *Context) newEnginePlanTracer() *planning.Tracer {
 	// providing its own planning.PlanTracer directly, which it can then
 	// use both to drive its own UI and to centralize our OpenTelemetry tracing
 	// logic instead of having it spread all over the codebase.
-	eachHook := func(fn func(Hook) (HookAction, error)) {
-		for _, h := range c.hooks {
-			action, err := fn(h)
-			if err != nil {
-				// The new runtime intentionally doesn't allow tracers to
-				// force failure: this API is purely for passive tracing and
-				// UI reporting. Therefore we'll just log the error and return.
-				log.Printf("[ERROR] %T: %s", h, err)
-				return
-			}
-			switch action {
-			case HookActionContinue:
-				continue
-			case HookActionHalt:
-				return
-			}
-		}
-	}
 
 	return &planning.Tracer{
 		StartManagedResourceInstanceObjectRefresh: func(ctx context.Context, addr addrs.AbsResourceInstanceObject) context.Context {
 			inst := addr.InstanceAddr
 			gen := addr.DeposedKey.Generation()
-			eachHook(func(h Hook) (HookAction, error) {
+			c.eachHook(func(h Hook) (HookAction, error) {
 				return h.PreRefresh(inst, gen, cty.DynamicVal)
 			})
 			return ctx
@@ -246,14 +229,14 @@ func (c *Context) newEnginePlanTracer() *planning.Tracer {
 		EndManagedResourceInstanceObjectRefresh: func(ctx context.Context, addr addrs.AbsResourceInstanceObject, refreshedVal cty.Value, diags tfdiags.Diagnostics) {
 			inst := addr.InstanceAddr
 			gen := addr.DeposedKey.Generation()
-			eachHook(func(h Hook) (HookAction, error) {
+			c.eachHook(func(h Hook) (HookAction, error) {
 				return h.PostRefresh(inst, gen, cty.DynamicVal, refreshedVal)
 			})
 		},
 		StartManagedResourceInstanceObjectPlanChanges: func(ctx context.Context, addr addrs.AbsResourceInstanceObject) context.Context {
 			inst := addr.InstanceAddr
 			gen := addr.DeposedKey.Generation()
-			eachHook(func(h Hook) (HookAction, error) {
+			c.eachHook(func(h Hook) (HookAction, error) {
 				return h.PreDiff(inst, gen, cty.DynamicVal, cty.DynamicVal)
 			})
 			return ctx
@@ -261,7 +244,7 @@ func (c *Context) newEnginePlanTracer() *planning.Tracer {
 		EndManagedResourceInstanceObjectPlanChanges: func(ctx context.Context, addr addrs.AbsResourceInstanceObject, plannedVal cty.Value, diags tfdiags.Diagnostics) {
 			inst := addr.InstanceAddr
 			gen := addr.DeposedKey.Generation()
-			eachHook(func(h Hook) (HookAction, error) {
+			c.eachHook(func(h Hook) (HookAction, error) {
 				// TODO: For now we're just always reporting plans.Update here
 				// as a placeholder, since we're shimming hooks here primarily
 				// for the benefit of the context tests and so we'll wait to
@@ -271,16 +254,19 @@ func (c *Context) newEnginePlanTracer() *planning.Tracer {
 			})
 		},
 		StartDataResourceInstanceRead: func(ctx context.Context, addr addrs.AbsResourceInstance) context.Context {
-			eachHook(func(h Hook) (HookAction, error) {
+			c.eachHook(func(h Hook) (HookAction, error) {
 				return h.PreRefresh(addr, addrs.CurrentResourceInstanceObjectGeneration, cty.DynamicVal)
 			})
 			return ctx
 		},
 		EndDataResourceInstanceRead: func(ctx context.Context, addr addrs.AbsResourceInstance, resultVal cty.Value, diags tfdiags.Diagnostics) {
-			eachHook(func(h Hook) (HookAction, error) {
+			c.eachHook(func(h Hook) (HookAction, error) {
 				return h.PostRefresh(addr, addrs.CurrentResourceInstanceObjectGeneration, cty.DynamicVal, resultVal)
 			})
 		},
+
+		// We'll also include the [shared.Tracer] we use for both plan and apply.
+		Tracer: c.newEngineSharedTracer(),
 	}
 }
 
@@ -322,30 +308,12 @@ func (c *Context) newEngineApplyTracer() *applying.Tracer {
 	// providing its own planning.PlanTracer directly, which it can then
 	// use both to drive its own UI and to centralize our OpenTelemetry tracing
 	// logic instead of having it spread all over the codebase.
-	eachHook := func(fn func(Hook) (HookAction, error)) {
-		for _, h := range c.hooks {
-			action, err := fn(h)
-			if err != nil {
-				// The new runtime intentionally doesn't allow tracers to
-				// force failure: this API is purely for passive tracing and
-				// UI reporting. Therefore we'll just log the error and return.
-				log.Printf("[ERROR] %T: %s", h, err)
-				return
-			}
-			switch action {
-			case HookActionContinue:
-				continue
-			case HookActionHalt:
-				return
-			}
-		}
-	}
 
 	return &applying.Tracer{
 		StartManagedResourceInstanceObjectFinalPlan: func(ctx context.Context, addr addrs.AbsResourceInstanceObject) context.Context {
 			inst := addr.InstanceAddr
 			gen := addr.DeposedKey.Generation()
-			eachHook(func(h Hook) (HookAction, error) {
+			c.eachHook(func(h Hook) (HookAction, error) {
 				return h.PreDiff(inst, gen, cty.DynamicVal, cty.DynamicVal)
 			})
 			return ctx
@@ -353,7 +321,7 @@ func (c *Context) newEngineApplyTracer() *applying.Tracer {
 		EndManagedResourceInstanceObjectFinalPlan: func(ctx context.Context, addr addrs.AbsResourceInstanceObject, plannedVal cty.Value, diags tfdiags.Diagnostics) {
 			inst := addr.InstanceAddr
 			gen := addr.DeposedKey.Generation()
-			eachHook(func(h Hook) (HookAction, error) {
+			c.eachHook(func(h Hook) (HookAction, error) {
 				// TODO: For now we're just always reporting plans.Update here
 				// as a placeholder, since we're shimming hooks here primarily
 				// for the benefit of the context tests and so we'll wait to
@@ -365,7 +333,7 @@ func (c *Context) newEngineApplyTracer() *applying.Tracer {
 		StartManagedResourceInstanceObjectApply: func(ctx context.Context, addr addrs.AbsResourceInstanceObject) context.Context {
 			inst := addr.InstanceAddr
 			gen := addr.DeposedKey.Generation()
-			eachHook(func(h Hook) (HookAction, error) {
+			c.eachHook(func(h Hook) (HookAction, error) {
 				// TODO: For now we're just always reporting plans.Update here
 				// as a placeholder, since we're shimming hooks here primarily
 				// for the benefit of the context tests and so we'll wait to
@@ -378,7 +346,7 @@ func (c *Context) newEngineApplyTracer() *applying.Tracer {
 		EndManagedResourceInstanceObjectApply: func(ctx context.Context, addr addrs.AbsResourceInstanceObject, resultVal cty.Value, diags tfdiags.Diagnostics) {
 			inst := addr.InstanceAddr
 			gen := addr.DeposedKey.Generation()
-			eachHook(func(h Hook) (HookAction, error) {
+			c.eachHook(func(h Hook) (HookAction, error) {
 				return h.PostApply(inst, gen, resultVal, diags.Err())
 			})
 			// TODO: the CLI layer and some of our tests also expect to get a
@@ -391,16 +359,83 @@ func (c *Context) newEngineApplyTracer() *applying.Tracer {
 			// make here.
 		},
 		StartDataResourceInstanceRead: func(ctx context.Context, addr addrs.AbsResourceInstance) context.Context {
-			eachHook(func(h Hook) (HookAction, error) {
+			c.eachHook(func(h Hook) (HookAction, error) {
 				return h.PreRefresh(addr, addrs.CurrentResourceInstanceObjectGeneration, cty.DynamicVal)
 			})
 			return ctx
 		},
 		EndDataResourceInstanceRead: func(ctx context.Context, addr addrs.AbsResourceInstance, resultVal cty.Value, diags tfdiags.Diagnostics) {
-			eachHook(func(h Hook) (HookAction, error) {
+			c.eachHook(func(h Hook) (HookAction, error) {
 				return h.PostRefresh(addr, addrs.CurrentResourceInstanceObjectGeneration, cty.DynamicVal, resultVal)
 			})
 		},
+
+		// We'll also include the [shared.Tracer] we use for both plan and apply.
+		Tracer: c.newEngineSharedTracer(),
+	}
+}
+
+func (c *Context) newEngineSharedTracer() shared.Tracer {
+	// TODO: For now this just shims to our old Hook API as best we can. Once we
+	// start using the new runtime directly instead of shimming it through
+	// the old runtime's API we should let the CLI layer be responsible for
+	// providing its own planning.PlanTracer directly, which it can then
+	// use both to drive its own UI and to centralize our OpenTelemetry tracing
+	// logic instead of having it spread all over the codebase.
+
+	return shared.Tracer{
+		StartEphemeralResourceInstanceOpen: func(ctx context.Context, addr addrs.AbsResourceInstance) context.Context {
+			c.eachHook(func(h Hook) (HookAction, error) {
+				return h.PreOpen(addr)
+			})
+			return ctx
+		},
+		EndEphemeralResourceInstanceOpen: func(ctx context.Context, addr addrs.AbsResourceInstance, diags tfdiags.Diagnostics) {
+			c.eachHook(func(h Hook) (HookAction, error) {
+				return h.PostOpen(addr, diags.Err())
+			})
+		},
+		StartEphemeralResourceInstanceRenew: func(ctx context.Context, addr addrs.AbsResourceInstance) context.Context {
+			c.eachHook(func(h Hook) (HookAction, error) {
+				return h.PreRenew(addr)
+			})
+			return ctx
+		},
+		EndEphemeralResourceInstanceRenew: func(ctx context.Context, addr addrs.AbsResourceInstance, diags tfdiags.Diagnostics) {
+			c.eachHook(func(h Hook) (HookAction, error) {
+				return h.PostRenew(addr, diags.Err())
+			})
+		},
+		StartEphemeralResourceInstanceClose: func(ctx context.Context, addr addrs.AbsResourceInstance) context.Context {
+			c.eachHook(func(h Hook) (HookAction, error) {
+				return h.PreClose(addr)
+			})
+			return ctx
+		},
+		EndEphemeralResourceInstanceClose: func(ctx context.Context, addr addrs.AbsResourceInstance, diags tfdiags.Diagnostics) {
+			c.eachHook(func(h Hook) (HookAction, error) {
+				return h.PostClose(addr, diags.Err())
+			})
+		},
+	}
+}
+
+func (c *Context) eachHook(fn func(Hook) (HookAction, error)) {
+	for _, h := range c.hooks {
+		action, err := fn(h)
+		if err != nil {
+			// The new runtime intentionally doesn't allow tracers to
+			// force failure: this API is purely for passive tracing and
+			// UI reporting. Therefore we'll just log the error and return.
+			log.Printf("[ERROR] %T: %s", h, err)
+			return
+		}
+		switch action {
+		case HookActionContinue:
+			continue
+		case HookActionHalt:
+			return
+		}
 	}
 }
 

--- a/internal/tofu/context_temp_runtime.go
+++ b/internal/tofu/context_temp_runtime.go
@@ -318,37 +318,59 @@ func (c *Context) newEngineApplyTracer() *applying.Tracer {
 	// use both to drive its own UI and to centralize our OpenTelemetry tracing
 	// logic instead of having it spread all over the codebase.
 
+	// TODO: shimPlanAction is a very rough approximation of deciding a
+	// [plans.Action] based on the prior and planned value, dealing with the
+	// fact that in the new runtime the "planned action" is primarily a UI
+	// thing used by the planning engine to describe to the user what it is
+	// proposing to change. The applying engine has no need for this because
+	// "planned action" is not represented anywhere in the provider protocol.
+	// This is a temporary shim until we decide whose job it should be to decide
+	// the planned action under the new runtime... hopefully it becomes purely
+	// a UI concern that even the planning engine doesn't need to care about,
+	// but that remains to be seen once we design new plan models matching how
+	// the new runtime prefers to think about changes.
+	shimPlanAction := func(priorVal, plannedVal cty.Value) plans.Action {
+		// Note that we don't need to handle the "replace" actions here because
+		// by the time we're in the apply phase they've already been decomposed
+		// into their separate Create and Destroy legs.
+		if priorVal.IsNull() {
+			return plans.Create
+		}
+		if plannedVal.IsNull() {
+			return plans.Delete
+		}
+		return plans.Update
+	}
+
 	return &applying.Tracer{
-		StartManagedResourceInstanceObjectFinalPlan: func(ctx context.Context, addr addrs.AbsResourceInstanceObject) context.Context {
+		StartManagedResourceInstanceObjectFinalPlan: func(ctx context.Context, addr addrs.AbsResourceInstanceObject, priorVal, configVal, expectedVal cty.Value) context.Context {
 			inst := addr.InstanceAddr
 			gen := addr.DeposedKey.Generation()
 			c.eachHook(func(h Hook) (HookAction, error) {
-				return h.PreDiff(inst, gen, cty.DynamicVal, cty.DynamicVal)
+				// TODO: We're sending the expectedVal in the slot where the
+				// Hook API expects the "proposed new value", and that isn't
+				// quite right. Does that matter for the current real-world
+				// use of the hook API?
+				// The new runtime intentionally buries the "proposed new value"
+				// in the implementation details of the provider call since
+				// it's a quirky part of the protocol that we preserve only
+				// for compatibility.
+				return h.PreDiff(inst, gen, priorVal, expectedVal)
 			})
 			return ctx
 		},
-		EndManagedResourceInstanceObjectFinalPlan: func(ctx context.Context, addr addrs.AbsResourceInstanceObject, plannedVal cty.Value, diags tfdiags.Diagnostics) {
+		EndManagedResourceInstanceObjectFinalPlan: func(ctx context.Context, addr addrs.AbsResourceInstanceObject, priorVal, plannedVal cty.Value, diags tfdiags.Diagnostics) {
 			inst := addr.InstanceAddr
 			gen := addr.DeposedKey.Generation()
 			c.eachHook(func(h Hook) (HookAction, error) {
-				// TODO: For now we're just always reporting plans.Update here
-				// as a placeholder, since we're shimming hooks here primarily
-				// for the benefit of the context tests and so we'll wait to
-				// see if any of those tests need more than this before we add
-				// that complexity.
-				return h.PostDiff(inst, gen, plans.Update, cty.DynamicVal, plannedVal)
+				return h.PostDiff(inst, gen, shimPlanAction(priorVal, plannedVal), priorVal, plannedVal)
 			})
 		},
-		StartManagedResourceInstanceObjectApply: func(ctx context.Context, addr addrs.AbsResourceInstanceObject) context.Context {
+		StartManagedResourceInstanceObjectApply: func(ctx context.Context, addr addrs.AbsResourceInstanceObject, priorVal, plannedVal cty.Value) context.Context {
 			inst := addr.InstanceAddr
 			gen := addr.DeposedKey.Generation()
 			c.eachHook(func(h Hook) (HookAction, error) {
-				// TODO: For now we're just always reporting plans.Update here
-				// as a placeholder, since we're shimming hooks here primarily
-				// for the benefit of the context tests and so we'll wait to
-				// see if any of those tests need more than this before we add
-				// that complexity.
-				return h.PreApply(inst, gen, plans.Update, cty.DynamicVal, cty.DynamicVal)
+				return h.PreApply(inst, gen, shimPlanAction(priorVal, plannedVal), priorVal, plannedVal)
 			})
 			return ctx
 		},
@@ -369,13 +391,19 @@ func (c *Context) newEngineApplyTracer() *applying.Tracer {
 		},
 		StartDataResourceInstanceRead: func(ctx context.Context, addr addrs.AbsResourceInstance) context.Context {
 			c.eachHook(func(h Hook) (HookAction, error) {
-				return h.PreRefresh(addr, addrs.CurrentResourceInstanceObjectGeneration, cty.DynamicVal)
+				// The prior value for a data resource instance is always null
+				// because conceptually it is always read anew for each round.
+				// (It's retained in the state as a convenience for unusual
+				// situations like "tofu console", but the prior state value
+				// cannot be used in the main codepath because the protocol
+				// includes no way to "upgrade" when the provider schema changes.)
+				return h.PreRefresh(addr, addrs.CurrentResourceInstanceObjectGeneration, cty.NullVal(cty.DynamicPseudoType))
 			})
 			return ctx
 		},
 		EndDataResourceInstanceRead: func(ctx context.Context, addr addrs.AbsResourceInstance, resultVal cty.Value, diags tfdiags.Diagnostics) {
 			c.eachHook(func(h Hook) (HookAction, error) {
-				return h.PostRefresh(addr, addrs.CurrentResourceInstanceObjectGeneration, cty.DynamicVal, resultVal)
+				return h.PostRefresh(addr, addrs.CurrentResourceInstanceObjectGeneration, cty.NullVal(cty.DynamicPseudoType), resultVal)
 			})
 		},
 

--- a/internal/tofu/context_temp_runtime.go
+++ b/internal/tofu/context_temp_runtime.go
@@ -179,6 +179,9 @@ func (c *Context) newEnginePlan(ctx context.Context, config *configs.Config, pre
 
 	timestamp := time.Now().UTC()
 
+	tracer := c.newEnginePlanTracer()
+	ctx = planning.ContextWithTracer(ctx, tracer)
+
 	configInst, plugins, done, moreDiags := c.newEngineShim(ctx, config, opts.SetVariables, timestamp, false)
 	diags = diags.Append(moreDiags)
 
@@ -202,6 +205,82 @@ func (c *Context) newEnginePlan(ctx context.Context, config *configs.Config, pre
 	}
 	diags = diags.Append(moreDiags)
 	return plan, diags
+}
+
+func (c *Context) newEnginePlanTracer() *planning.Tracer {
+	// TODO: For now this just shims to our old Hook API as best we can. Once we
+	// start using the new runtime directly instead of shimming it through
+	// the old runtime's API we should let the CLI layer be responsible for
+	// providing its own planning.PlanTracer directly, which it can then
+	// use both to drive its own UI and to centralize our OpenTelemetry tracing
+	// logic instead of having it spread all over the codebase.
+	eachHook := func(fn func(Hook) (HookAction, error)) {
+		for _, h := range c.hooks {
+			action, err := fn(h)
+			if err != nil {
+				// The new runtime intentionally doesn't allow tracers to
+				// force failure: this API is purely for passive tracing and
+				// UI reporting. Therefore we'll just log the error and return.
+				log.Printf("[ERROR] %T: %s", h, err)
+				return
+			}
+			switch action {
+			case HookActionContinue:
+				continue
+			case HookActionHalt:
+				return
+			}
+		}
+	}
+
+	return &planning.Tracer{
+		StartManagedResourceInstanceObjectRefresh: func(ctx context.Context, addr addrs.AbsResourceInstanceObject) context.Context {
+			inst := addr.InstanceAddr
+			gen := addr.DeposedKey.Generation()
+			eachHook(func(h Hook) (HookAction, error) {
+				return h.PreRefresh(inst, gen, cty.DynamicVal)
+			})
+			return ctx
+		},
+		EndManagedResourceInstanceObjectRefresh: func(ctx context.Context, addr addrs.AbsResourceInstanceObject, refreshedVal cty.Value, diags tfdiags.Diagnostics) {
+			inst := addr.InstanceAddr
+			gen := addr.DeposedKey.Generation()
+			eachHook(func(h Hook) (HookAction, error) {
+				return h.PostRefresh(inst, gen, cty.DynamicVal, refreshedVal)
+			})
+		},
+		StartManagedResourceInstanceObjectPlanChanges: func(ctx context.Context, addr addrs.AbsResourceInstanceObject) context.Context {
+			inst := addr.InstanceAddr
+			gen := addr.DeposedKey.Generation()
+			eachHook(func(h Hook) (HookAction, error) {
+				return h.PreDiff(inst, gen, cty.DynamicVal, cty.DynamicVal)
+			})
+			return ctx
+		},
+		EndManagedResourceInstanceObjectPlanChanges: func(ctx context.Context, addr addrs.AbsResourceInstanceObject, plannedVal cty.Value, diags tfdiags.Diagnostics) {
+			inst := addr.InstanceAddr
+			gen := addr.DeposedKey.Generation()
+			eachHook(func(h Hook) (HookAction, error) {
+				// TODO: For now we're just always reporting plans.Update here
+				// as a placeholder, since we're shimming hooks here primarily
+				// for the benefit of the context tests and so we'll wait to
+				// see if any of those tests need more than this before we add
+				// that complexity.
+				return h.PostDiff(inst, gen, plans.Update, cty.DynamicVal, plannedVal)
+			})
+		},
+		StartDataResourceInstanceRead: func(ctx context.Context, addr addrs.AbsResourceInstance) context.Context {
+			eachHook(func(h Hook) (HookAction, error) {
+				return h.PreRefresh(addr, addrs.CurrentResourceInstanceObjectGeneration, cty.DynamicVal)
+			})
+			return ctx
+		},
+		EndDataResourceInstanceRead: func(ctx context.Context, addr addrs.AbsResourceInstance, resultVal cty.Value, diags tfdiags.Diagnostics) {
+			eachHook(func(h Hook) (HookAction, error) {
+				return h.PostRefresh(addr, addrs.CurrentResourceInstanceObjectGeneration, cty.DynamicVal, resultVal)
+			})
+		},
+	}
 }
 
 func (c *Context) newEngineApply(ctx context.Context, config *configs.Config, plan *plans.Plan, variables InputValues) (*states.State, tfdiags.Diagnostics) {

--- a/internal/tofu/context_temp_runtime.go
+++ b/internal/tofu/context_temp_runtime.go
@@ -218,50 +218,59 @@ func (c *Context) newEnginePlanTracer() *planning.Tracer {
 	// logic instead of having it spread all over the codebase.
 
 	return &planning.Tracer{
-		StartManagedResourceInstanceObjectRefresh: func(ctx context.Context, addr addrs.AbsResourceInstanceObject) context.Context {
+		StartManagedResourceInstanceObjectRefresh: func(ctx context.Context, addr addrs.AbsResourceInstanceObject, prevRoundVal cty.Value) context.Context {
 			inst := addr.InstanceAddr
 			gen := addr.DeposedKey.Generation()
 			c.eachHook(func(h Hook) (HookAction, error) {
-				return h.PreRefresh(inst, gen, cty.DynamicVal)
+				return h.PreRefresh(inst, gen, prevRoundVal)
 			})
 			return ctx
 		},
-		EndManagedResourceInstanceObjectRefresh: func(ctx context.Context, addr addrs.AbsResourceInstanceObject, refreshedVal cty.Value, diags tfdiags.Diagnostics) {
+		EndManagedResourceInstanceObjectRefresh: func(ctx context.Context, addr addrs.AbsResourceInstanceObject, prevRoundVal, refreshedVal cty.Value, diags tfdiags.Diagnostics) {
 			inst := addr.InstanceAddr
 			gen := addr.DeposedKey.Generation()
 			c.eachHook(func(h Hook) (HookAction, error) {
-				return h.PostRefresh(inst, gen, cty.DynamicVal, refreshedVal)
+				return h.PostRefresh(inst, gen, prevRoundVal, refreshedVal)
 			})
 		},
-		StartManagedResourceInstanceObjectPlanChanges: func(ctx context.Context, addr addrs.AbsResourceInstanceObject) context.Context {
+		StartManagedResourceInstanceObjectPlanChanges: func(ctx context.Context, addr addrs.AbsResourceInstanceObject, priorVal, configVal cty.Value) context.Context {
 			inst := addr.InstanceAddr
 			gen := addr.DeposedKey.Generation()
 			c.eachHook(func(h Hook) (HookAction, error) {
-				return h.PreDiff(inst, gen, cty.DynamicVal, cty.DynamicVal)
+				// TODO: We're sending the configVal in the slot where the
+				// Hook API expects the "proposed new value", and that isn't
+				// quite right. Does that matter for the current real-world
+				// use of the hook API?
+				// The new runtime intentionally buries the "proposed new value"
+				// in the implementation details of the provider call since
+				// it's a quirky part of the protocol that we preserve only
+				// for compatibility.
+				return h.PreDiff(inst, gen, priorVal, configVal)
 			})
 			return ctx
 		},
-		EndManagedResourceInstanceObjectPlanChanges: func(ctx context.Context, addr addrs.AbsResourceInstanceObject, plannedVal cty.Value, diags tfdiags.Diagnostics) {
+		EndManagedResourceInstanceObjectPlanChanges: func(ctx context.Context, addr addrs.AbsResourceInstanceObject, action plans.Action, priorVal, plannedVal cty.Value, diags tfdiags.Diagnostics) {
 			inst := addr.InstanceAddr
 			gen := addr.DeposedKey.Generation()
 			c.eachHook(func(h Hook) (HookAction, error) {
-				// TODO: For now we're just always reporting plans.Update here
-				// as a placeholder, since we're shimming hooks here primarily
-				// for the benefit of the context tests and so we'll wait to
-				// see if any of those tests need more than this before we add
-				// that complexity.
-				return h.PostDiff(inst, gen, plans.Update, cty.DynamicVal, plannedVal)
+				return h.PostDiff(inst, gen, action, priorVal, plannedVal)
 			})
 		},
 		StartDataResourceInstanceRead: func(ctx context.Context, addr addrs.AbsResourceInstance) context.Context {
 			c.eachHook(func(h Hook) (HookAction, error) {
-				return h.PreRefresh(addr, addrs.CurrentResourceInstanceObjectGeneration, cty.DynamicVal)
+				// The prior value for a data resource instance is always null
+				// because conceptually it is always read anew for each round.
+				// (It's retained in the state as a convenience for unusual
+				// situations like "tofu console", but the prior state value
+				// cannot be used in the main codepath because the protocol
+				// includes no way to "upgrade" when the provider schema changes.)
+				return h.PreRefresh(addr, addrs.CurrentResourceInstanceObjectGeneration, cty.NullVal(cty.DynamicPseudoType))
 			})
 			return ctx
 		},
 		EndDataResourceInstanceRead: func(ctx context.Context, addr addrs.AbsResourceInstance, resultVal cty.Value, diags tfdiags.Diagnostics) {
 			c.eachHook(func(h Hook) (HookAction, error) {
-				return h.PostRefresh(addr, addrs.CurrentResourceInstanceObjectGeneration, cty.DynamicVal, resultVal)
+				return h.PostRefresh(addr, addrs.CurrentResourceInstanceObjectGeneration, cty.NullVal(cty.DynamicPseudoType), resultVal)
 			})
 		},
 

--- a/internal/tofu/context_temp_runtime_test.go
+++ b/internal/tofu/context_temp_runtime_test.go
@@ -87,6 +87,7 @@ var (
 	ExperimentalBugCancel            = ExperimentalFlag{"Bug Context Cancel", false}
 	ExperimentalBugStateProvider     = ExperimentalFlag{"Bug State Provider", true}
 	ExperimentalBugStateCBD          = ExperimentalFlag{"Bug CreateBeforeDestroy Not Tracked In State", false}
+	ExperimentalBugStateUpdateHook   = ExperimentalFlag{"Bug State Update Hook", false}
 	ExperimentalBugReferenceProvider = ExperimentalFlag{"Bug Reference Provider", true}
 	ExperimentalBugMissingProvider   = ExperimentalFlag{"Bug Missing Configuration For Provider", true}
 	ExperimentalBugMissingResource   = ExperimentalFlag{"Bug Missing Configuration For Resource Instance", false}
@@ -127,7 +128,7 @@ var (
 	ExperimentalFeatureSkipDestroy       = ExperimentalFlag{"Missing Lifecycle Destroy", false}
 	ExperimentalFeatureUpgradeState      = ExperimentalFlag{"Missing Upgrade Resource State", true}
 	ExperimentalFeatureUpgradeUnwanted   = ExperimentalFlag{"Missing Upgrade Orphan or Deposed Resource Instance State", false}
-	ExperimentalFeatureHooks             = ExperimentalFlag{"Missing Hooks", false}
+	ExperimentalFeatureHooks             = ExperimentalFlag{"Missing Hooks", true}
 	ExperimentalFeatureTarget            = ExperimentalFlag{"Missing Targeting", false}
 	ExperimentalFeatureReplaceTB         = ExperimentalFlag{"Missing replace_triggered_by", false}
 	ExperimentalFeatureProvisioner       = ExperimentalFlag{"Missing Provisioners", false}
@@ -150,7 +151,9 @@ var (
 
 	// Obsolete flags indicate a test which depends on a feature we do not
 	// intend to carry forward into the new engine
-	ExperimentalObsoleteFlatAttrs = ExperimentalFlag{"Obsolete Flat Mapped Attributes", false}
+	ExperimentalObsoleteFlatAttrs        = ExperimentalFlag{"Obsolete Flat Mapped Attributes", false}
+	ExperimentalObsoleteDestroyData      = ExperimentalFlag{"Obsolete Explicit Destroy of Data Resource Instances", false}
+	ExperimentalObsoleteEphemeralInState = ExperimentalFlag{"Obsolete Ephemeral Resource Instances in State", false}
 
 	// ExperimentalNewStrategyNeeded is a special experimental flag that
 	// represents that a test is failing not because the underlying behavior

--- a/internal/tofu/node_resource_abstract_instance.go
+++ b/internal/tofu/node_resource_abstract_instance.go
@@ -2103,6 +2103,41 @@ func (n *NodeAbstractResourceInstance) openEphemeralResource(ctx context.Context
 		return cty.NilVal, diags
 	}
 
+	ctx = shared.ContextWithTracer(ctx, &shared.Tracer{
+		StartEphemeralResourceInstanceOpen: func(ctx context.Context, addr addrs.AbsResourceInstance) context.Context {
+			_ = evalCtx.Hook(func(h Hook) (HookAction, error) {
+				return h.PreOpen(addr)
+			})
+			return ctx
+		},
+		EndEphemeralResourceInstanceOpen: func(ctx context.Context, addr addrs.AbsResourceInstance, diags tfdiags.Diagnostics) {
+			_ = evalCtx.Hook(func(h Hook) (HookAction, error) {
+				return h.PostOpen(addr, diags.Err())
+			})
+		},
+		StartEphemeralResourceInstanceRenew: func(ctx context.Context, addr addrs.AbsResourceInstance) context.Context {
+			_ = evalCtx.Hook(func(h Hook) (HookAction, error) {
+				return h.PreRenew(addr)
+			})
+			return ctx
+		},
+		EndEphemeralResourceInstanceRenew: func(ctx context.Context, addr addrs.AbsResourceInstance, diags tfdiags.Diagnostics) {
+			_ = evalCtx.Hook(func(h Hook) (HookAction, error) {
+				return h.PostRenew(addr, diags.Err())
+			})
+		},
+		StartEphemeralResourceInstanceClose: func(ctx context.Context, addr addrs.AbsResourceInstance) context.Context {
+			_ = evalCtx.Hook(func(h Hook) (HookAction, error) {
+				return h.PreClose(addr)
+			})
+			return ctx
+		},
+		EndEphemeralResourceInstanceClose: func(ctx context.Context, addr addrs.AbsResourceInstance, diags tfdiags.Diagnostics) {
+			_ = evalCtx.Hook(func(h Hook) (HookAction, error) {
+				return h.PostClose(addr, diags.Err())
+			})
+		},
+	})
 	newVal, closeFn, openDiags := shared.OpenEphemeralResourceInstance(
 		ctx,
 		n.Addr,
@@ -2110,38 +2145,6 @@ func (n *NodeAbstractResourceInstance) openEphemeralResource(ctx context.Context
 		n.ResolvedProvider.ProviderConfig.Correct().Instance(n.ResolvedProviderKey),
 		provider,
 		configVal,
-		shared.EphemeralResourceHooks{
-			PreOpen: func(addr addrs.AbsResourceInstance) {
-				_ = evalCtx.Hook(func(h Hook) (HookAction, error) {
-					return h.PreOpen(addr)
-				})
-			},
-			PostOpen: func(addr addrs.AbsResourceInstance, diags tfdiags.Diagnostics) {
-				_ = evalCtx.Hook(func(h Hook) (HookAction, error) {
-					return h.PostOpen(addr, diags.Err())
-				})
-			},
-			PreRenew: func(addr addrs.AbsResourceInstance) {
-				_ = evalCtx.Hook(func(h Hook) (HookAction, error) {
-					return h.PreRenew(addr)
-				})
-			},
-			PostRenew: func(addr addrs.AbsResourceInstance, diags tfdiags.Diagnostics) {
-				_ = evalCtx.Hook(func(h Hook) (HookAction, error) {
-					return h.PostRenew(addr, diags.Err())
-				})
-			},
-			PreClose: func(addr addrs.AbsResourceInstance) {
-				_ = evalCtx.Hook(func(h Hook) (HookAction, error) {
-					return h.PreClose(addr)
-				})
-			},
-			PostClose: func(addr addrs.AbsResourceInstance, diags tfdiags.Diagnostics) {
-				_ = evalCtx.Hook(func(h Hook) (HookAction, error) {
-					return h.PostClose(addr, diags.Err())
-				})
-			},
-		},
 	)
 
 	diags = diags.Append(openDiags.InConfigBody(config.Config, n.Addr.String()))


### PR DESCRIPTION
(This is for https://github.com/opentofu/opentofu/issues/3414.)

This PR introduces a new general-purpose API for tracing events in the new planning and applying engines, and then uses that API to shim the `tofu.Hook` API just enough to get a bunch of new context tests running and passing.

The tracing API here is designed in the same modern-ish shape we've used for other tracers recently while we were implementing OpenTelemetry support, where the "Start" event is allowed to return a new `context.Context` annotated with tracing-related metadata and then that context is used for all operations related to that Start/End pair, including the eventual call to "End" that can then terminate the trace. In the long run I expect us to use this to implement OpenTelemetry tracing as a more centralized concern, living in the CLI layer instead of spread awkwardly over the entire runtime.

However, the `tofu.Hook` API long predates OpenTelemetry tracing or `context.Context` and so that particular aspect of the tracing API is unused for now. Instead, this adds some partial stubs of the hook API that _approximate_ how the original language runtime would've called those hooks.

I prioritized this now because there are several tests which use the `tofu.Hook` API as a side concern for testing the behavior of something else, and so having this minimal implementation in place unblocks us for working on the various other problems those tests are representing. This is not yet intended to be complete enough to fully drive the CLI layer's UI hooks and so I expect we'll do another pass for that in a later PR but we have more fundamental concerns to deal with first.

There are a few tests that continue to fail even with these changes in place, and so I've added some more granular flags to represent those. Note that only one of them is classified as a bug to be fixed, because the other two are from tests of behaviors that are intentionally different in the new runtime and we have no current intention of changing that.

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
