### PR TITLE
Implement moved block statements in the new engine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,13 +31,13 @@ build:
 # Experimental engine building
 .PHONY: build-experimental
 build-experimental:
-	TOFU_X_EXPERIMENTAL_RUNTIME=1 go build -ldflags "-X main.version=$(shell git describe --tags --always --dirty) -X main.experimentsAllowed=yes" -o tofu$(EXT) ./cmd/tofu
+	TOFU_X_EXPERIMENTAL_RUNTIME=1 go build -gcflags=all="-N -l" -ldflags "-X main.version=$(shell git describe --tags --always --dirty) -X main.experimentsAllowed=yes" -o tofu$(EXT) ./cmd/tofu
 
 # Experimental engine testing
 .PHONY: test-experimental
 test-experimental:
 # 	TOFU_X_EXPERIMENTAL_RUNTIME=1 go test -ldflags "-X main.experimentsAllowed=yes" -v ./...
-	TOFU_X_EXPERIMENTAL_RUNTIME=1 go test -v -ldflags "-X main.experimentsAllowed=yes" -v ./internal/tofu
+	TOFU_X_EXPERIMENTAL_RUNTIME=1 go test -count=1 -v -ldflags "-X main.experimentsAllowed=yes" -v ./internal/tofu
 
 # generate runs `go generate` to build the dynamically generated
 # source files, except the protobuf stubs which are built instead with

--- a/internal/engine/planning/execgraph_managed.go
+++ b/internal/engine/planning/execgraph_managed.go
@@ -47,7 +47,7 @@ func (b *execGraphBuilder) ManagedResourceInstanceSubgraph(
 	if (plannedChange.Action == plans.Delete || plannedChange.Action == plans.Forget) && !plannedChange.After.IsNull() {
 		panic(fmt.Sprintf("change for %s has action %s but non-null planned new value", plannedChange.PrevRunAddr, plannedChange.Action))
 	}
-	if plannedChange.Action != plans.Create && plannedChange.Action != plans.Delete && plannedChange.Action != plans.Forget && plannedChange.Action != plans.NoOp && (plannedChange.Before.IsNull() || plannedChange.After.IsNull()) {
+	if plannedChange.Action != plans.Create && plannedChange.Action != plans.Delete && plannedChange.Action != plans.Forget && (plannedChange.Before.IsNull() || plannedChange.After.IsNull()) {
 		panic(fmt.Sprintf("change for %s has action %s but does not have both a before and after value", plannedChange.PrevRunAddr, plannedChange.Action))
 	}
 
@@ -291,13 +291,11 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphNoOp(
 	plannedChange *plans.ResourceInstanceChange,
 ) resourceInstanceObjectSubgraph {
 	_, addCreateDep := b.lower.MutableWaiter()
-	_, addDeleteDep := b.lower.MutableWaiter()
 
 	_, _, priorStateRef, _ := b.managedResourceInstanceChangeInputs(plannedChange)
 	return resourceInstanceObjectSubgraph{
 		valueRef:      priorStateRef,
 		addDesiredDep: addCreateDep,
-		addOrphanDep:  addDeleteDep,
 	}
 }
 

--- a/internal/engine/planning/execgraph_managed.go
+++ b/internal/engine/planning/execgraph_managed.go
@@ -47,7 +47,7 @@ func (b *execGraphBuilder) ManagedResourceInstanceSubgraph(
 	if (plannedChange.Action == plans.Delete || plannedChange.Action == plans.Forget) && !plannedChange.After.IsNull() {
 		panic(fmt.Sprintf("change for %s has action %s but non-null planned new value", plannedChange.PrevRunAddr, plannedChange.Action))
 	}
-	if plannedChange.Action != plans.Create && plannedChange.Action != plans.Delete && plannedChange.Action != plans.Forget && (plannedChange.Before.IsNull() || plannedChange.After.IsNull()) {
+	if plannedChange.Action != plans.Create && plannedChange.Action != plans.Delete && plannedChange.Action != plans.Forget && plannedChange.Action != plans.NoOp && (plannedChange.Before.IsNull() || plannedChange.After.IsNull()) {
 		panic(fmt.Sprintf("change for %s has action %s but does not have both a before and after value", plannedChange.PrevRunAddr, plannedChange.Action))
 	}
 
@@ -72,10 +72,7 @@ func (b *execGraphBuilder) ManagedResourceInstanceSubgraph(
 	case plans.CreateThenDelete:
 		return b.managedResourceInstanceSubgraphCreateThenDelete(plannedChange)
 	case plans.NoOp:
-		// TODO: We need to handle this because it can occur if the
-		// configuration hasn't changed but the object will move to a new
-		// resource instance address during the apply phase.
-		panic("plans.NoOp execution graph not yet implemented")
+		return b.managedResourceInstanceSubgraphNoOp(plannedChange)
 	default:
 		// We should not get here: the cases above should cover every action
 		// that [planGlue.planDesiredManagedResourceInstance] can possibly
@@ -285,6 +282,20 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphCreateThenDelete(
 	return resourceInstanceObjectSubgraph{
 		valueRef:      createResultRef,
 		deletionRef:   deletionRef,
+		addDesiredDep: addCreateDep,
+		addOrphanDep:  addDeleteDep,
+	}
+}
+
+func (b *execGraphBuilder) managedResourceInstanceSubgraphNoOp(
+	plannedChange *plans.ResourceInstanceChange,
+) resourceInstanceObjectSubgraph {
+	_, addCreateDep := b.lower.MutableWaiter()
+	_, addDeleteDep := b.lower.MutableWaiter()
+
+	_, _, priorStateRef, _ := b.managedResourceInstanceChangeInputs(plannedChange)
+	return resourceInstanceObjectSubgraph{
+		valueRef:      priorStateRef,
 		addDesiredDep: addCreateDep,
 		addOrphanDep:  addDeleteDep,
 	}

--- a/internal/engine/planning/plan_managed.go
+++ b/internal/engine/planning/plan_managed.go
@@ -133,146 +133,246 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 	var prevRoundVal cty.Value
 	var prevRoundPrivate []byte
 	prevRoundState := p.planCtx.prevRoundState.SyncWrapper().ResourceInstanceObjectFull(inst.Addr.CurrentObject())
-	if prevRoundState != nil {
-		// While we know prevRoundState is non-nil, let's upgrade state, too.
-		// Let's do a schema version comparison before upgrade
 
-		if prevRoundState.SchemaVersion > uint64(schema.Version) {
-			return nil, diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Resource instance managed by newer provider version",
-				// This is not a very good error message, but we don't retain enough
-				// information in state to give good feedback on what provider
-				// version might be required here. :(
-				// Or maybe we do. I dunno, I just copied the comment+diag from
-				// upgrade_resource_state.go:upgradeResourceStateTransform :P
-				fmt.Sprintf("The current state of %s was created by a newer provider version than is currently selected. Upgrade the %s provider to work with this state.", inst.Addr, inst.Provider.Type),
-			))
-		}
+	prevRunAddr := inst.Addr
+	diags = diags.Append(p.oracle.CheckMovesFromAddr(inst.Addr))
+	if diags.HasErrors() {
+		return ret, diags
+	}
 
-		upgradeCtx := ctx
-		if cb := tracer.StartManagedResourceInstanceObjectUpgrade; cb != nil {
-			upgradeCtx = cb(ctx, inst.Addr.CurrentObject())
-		}
-		upgradeReq := providers.UpgradeResourceStateRequest{
-			TypeName: inst.Addr.Resource.Resource.Type,
-
-			// TODO: The internal schema version representations are all using
-			// uint64 instead of int64, but unsigned integers aren't friendly
-			// to all protobuf target languages so in practice we use int64
-			// on the wire. In future we will change all of our internal
-			// representations to int64 too.
-			Version: int64(prevRoundState.SchemaVersion),
-
-			// We'll make the same assumption as [ResourceInstanceObjectFullSrc] and
-			// assume we'll never encounter a legacy state snapshot that uses AttrsFlat.
-			RawStateJSON: prevRoundState.Value.ValueJSON,
-		}
-		upgradeResp := providerClient.UpgradeResourceState(upgradeCtx, upgradeReq)
-		diags = diags.Append(upgradeResp.Diagnostics)
-		if cb := tracer.EndManagedResourceInstanceObjectUpgrade; cb != nil {
-			upgradedVal := cty.DynamicVal
-			if upgradeResp.UpgradedState != cty.NilVal {
-				// TODO: Should apply "sensitive" marks here where appropriate in
-				// case the tracer is reporting events in the UI.
-				upgradedVal = upgradeResp.UpgradedState
-			}
-			cb(upgradeCtx, inst.Addr.CurrentObject(), upgradedVal, diags)
-		}
+	impliedMove := false
+	moved := false
+	if prevRoundState == nil {
+		// check for ambiguous moves
+		_, moveDiags := p.oracle.FindAddressesMovedToHere(ctx, inst.Addr)
+		diags = diags.Append(moveDiags)
 		if diags.HasErrors() {
+			// More than one address this could move to.
+			// "Ambiguous move statements": many From, one To
 			return ret, diags
 		}
-		newState := upgradeResp.UpgradedState
-
-		// After upgrading, the new value must conform to the current schema. When
-		// going over RPC this is actually already ensured by the
-		// marshaling/unmarshaling of the new value, but we'll check it here
-		// anyway for robustness, e.g. for in-process providers.
-		if errs := newState.Type().TestConformance(schema.Block.ImpliedType()); len(errs) > 0 {
-			providerType := inst.Addr.Resource.Resource.ImpliedProvider()
-			for _, err := range errs {
-				diags = diags.Append(tfdiags.Sourceless(
-					tfdiags.Error,
-					"Invalid resource state transformation",
-					fmt.Sprintf("The %s provider changed the state for %s, but produced an invalid result: %s.", providerType, inst.Addr, tfdiags.FormatError(err)),
-				))
+		if moveInfo, ok := p.oracle.MovedAddress(inst.Addr); ok {
+			// we tracked a move in "Unwanted", manage state upgrades and plans here.
+			moved = true
+			prevRunAddr = moveInfo.From
+			prevRoundState = p.planCtx.prevRoundState.SyncWrapper().ResourceInstanceObjectFull(prevRunAddr.CurrentObject())
+			impliedMove = moveInfo.Implied
+		}
+	}
+	// only run MoveResourceState or UpgradeResourceState if prevRoundState is non-nil at this point.
+	if prevRoundState != nil {
+		if moved && !impliedMove && (resourceType.ResourceTypeName() != prevRoundState.ResourceType || !inst.Provider.Equals(prevRoundState.ProviderInstanceAddr.Config.Config.Provider)) {
+			moveCtx := ctx
+			if cb := tracer.StartManagedResourceInstanceObjectMove; cb != nil {
+				moveCtx = cb(ctx, inst.Addr.CurrentObject())
 			}
-			return nil, diags
-		}
 
-		src, err := ctyjson.Marshal(newState, schema.Block.ImpliedType())
-		if err != nil {
-			// We just checked for type conformance above, so getting into this
-			// codepath is probably a bug.
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Failed to encode result of resource state transformation",
-				fmt.Sprintf("Failed to encode state for %s after resource schema upgrade: %s.", inst.Addr, tfdiags.FormatError(err)),
-			))
-		}
+			// log.Printf("[TRACE] moveResourceStateTransform: new address: %s, previous address: %s", inst.Addr, prevRunAddr)
+			req := providers.MoveResourceStateRequest{
+				SourceProviderAddress: prevRunAddr.Resource.Resource.ImpliedProvider(),
+				SourceTypeName:        prevRunAddr.Resource.Resource.Type,
+				SourceSchemaVersion:   prevRoundState.SchemaVersion,
+				// We'll make the same assumption as [ResourceInstanceObjectFullSrc] and
+				// assume we'll never encounter a legacy state snapshot that uses AttrsFlat.
+				SourceStateJSON: prevRoundState.Value.ValueJSON,
+				// SourceStateFlatmap:    prevRoundState.AttrsFlat,
+				SourcePrivate:  prevRoundState.Private,
+				TargetTypeName: inst.Addr.Resource.Resource.Type,
+			}
+			resp := providerClient.MoveResourceState(moveCtx, req)
+			diags = diags.Append(resp.Diagnostics)
+			// TODO this tracer bit is copypasta for upgrade instance, IDK if it's actually legit...
+			if cb := tracer.EndManagedResourceInstanceObjectMove; cb != nil {
+				upgradedVal := cty.DynamicVal
+				if resp.TargetState != cty.NilVal {
+					// TODO: Should apply "sensitive" marks here where appropriate in
+					// case the tracer is reporting events in the UI.
+					upgradedVal = resp.TargetState
+				}
+				cb(moveCtx, inst.Addr.CurrentObject(), upgradedVal, diags)
+			}
+			if diags.HasErrors() {
+				return
+			}
 
-		upgradedPrevState := &states.ResourceInstanceObjectFullSrc{
-			Value: states.ValueJSONWithMetadata{
-				ValueJSON:      src,
-				SensitivePaths: prevRoundState.Value.SensitivePaths,
-			},
-			Private:              prevRoundState.Private,
-			Status:               prevRoundState.Status,
-			ProviderInstanceAddr: prevRoundState.ProviderInstanceAddr,
-			ResourceType:         prevRoundState.ResourceType,
-			SchemaVersion:        uint64(schema.Version),
-			Dependencies:         prevRoundState.Dependencies,
-			ConfigDependencies:   prevRoundState.ConfigDependencies,
-			CreateBeforeDestroy:  prevRoundState.CreateBeforeDestroy,
-		}
+			src, moreDiags := checkAndMarshalUpdatedState(resp.TargetState, schema, inst)
+			diags = diags.Append(moreDiags)
+			if diags.HasErrors() {
+				return ret, diags
+			}
 
-		p.planCtx.upgradedState.SetResourceInstanceObjectFull(inst.Addr.CurrentObject(), upgradedPrevState)
-		// Update the provider instance for the refreshed state only, not the upgraded state
-		upgradedPrevState.ProviderInstanceAddr = *inst.ProviderInstance
-		p.planCtx.refreshedState.SetResourceInstanceObjectFull(inst.Addr.CurrentObject(), upgradedPrevState)
+			// TODO this is very similar to what's below in upgraded state.
+			// Consider refactoring to de-duplicate
+			movedPrevState := &states.ResourceInstanceObjectFullSrc{
+				Value: states.ValueJSONWithMetadata{
+					ValueJSON:      src,
+					SensitivePaths: prevRoundState.Value.SensitivePaths,
+				},
+				Private:              resp.TargetPrivate,
+				Status:               prevRoundState.Status,
+				ProviderInstanceAddr: prevRoundState.ProviderInstanceAddr,
+				ResourceType:         prevRoundState.ResourceType,
+				SchemaVersion:        uint64(schema.Version),
+				Dependencies:         prevRoundState.Dependencies,
+				CreateBeforeDestroy:  prevRoundState.CreateBeforeDestroy,
+			}
+			p.planCtx.upgradedState.SetResourceInstanceObjectFull(inst.Addr.CurrentObject(), movedPrevState)
+			// Update the provider instance for the refreshed state only, not the "upgraded" state
+			movedPrevState.ProviderInstanceAddr = *inst.ProviderInstance
+			p.planCtx.refreshedState.SetResourceInstanceObjectFull(inst.Addr.CurrentObject(), movedPrevState)
 
-		obj, err := states.DecodeResourceInstanceObjectFull(upgradedPrevState, schema.Block.ImpliedType())
-		if err != nil {
-			diags = diags.Append(tfdiags.AttributeValue(
-				tfdiags.Error,
-				"Invalid prior state for resource instance",
-				fmt.Sprintf(
-					"Cannot decode the most recent state snapshot for %s: %s.\n\nIs the selected version of %s incompatible with the provider that most recently changed this object?",
-					inst.Addr, tfdiags.FormatError(err), inst.Provider,
-				),
-				nil, // this error belongs to the whole resource config
-			))
-			return ret, diags
-		}
-		prevRoundVal = obj.Value
-		prevRoundPrivate = obj.Private
+			obj, err := states.DecodeResourceInstanceObjectFull(movedPrevState, schema.Block.ImpliedType())
+			if err != nil {
+				diags = diags.Append(tfdiags.AttributeValue(
+					tfdiags.Error,
+					"Invalid prior state for resource instance",
+					fmt.Sprintf(
+						"Cannot decode the most recent state snapshot for %s: %s.\n\nIs the selected version of %s incompatible with the provider that most recently changed this object?",
+						inst.Addr, tfdiags.FormatError(err), inst.Provider,
+					),
+					nil, // this error belongs to the whole resource config
+				))
+				return ret, diags
+			}
+			prevRoundVal = obj.Value
+			prevRoundPrivate = resp.TargetPrivate
 
-		if len(prevRoundState.Dependencies) != 0 {
-			for _, instAddr := range prevRoundState.Dependencies {
-				ret.StateDependencies.Add(instAddr.CurrentObject())
+			if len(prevRoundState.Dependencies) != 0 {
+				for _, instAddr := range prevRoundState.Dependencies {
+					ret.StateDependencies.Add(instAddr.CurrentObject())
+				}
+			} else {
+				// Unfortunately our old state model represents dependencies only
+				// between static [addrs.ConfigResource] and loses specific instance
+				// information, so we must conservatively assume that all matching
+				// instances are dependencies. This only occurs during migration
+				// from a state generated by an older runtime.
+				for _, configAddr := range prevRoundState.ConfigDependencies {
+					for instAddr := range p.planCtx.prevRoundState.InstancesMatchingConfigResource(configAddr) {
+						ret.StateDependencies.Add(instAddr.CurrentObject())
+					}
+				}
 			}
 		} else {
-			// Unfortunately our old state model represents dependencies only
-			// between static [addrs.ConfigResource] and loses specific instance
-			// information, so we must conservatively assume that all matching
-			// instances are dependencies. This only occurs during migration
-			// from a state generated by an older runtime.
-			for _, configAddr := range prevRoundState.ConfigDependencies {
-				for instAddr := range p.planCtx.prevRoundState.InstancesMatchingConfigResource(configAddr) {
+			// While we know prevRoundState is non-nil, let's upgrade state, too.
+			// Let's do a schema version comparison before upgrade
+
+			if prevRoundState.SchemaVersion > uint64(schema.Version) {
+				return ret, diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Resource instance managed by newer provider version",
+					// This is not a very good error message, but we don't retain enough
+					// information in state to give good feedback on what provider
+					// version might be required here. :(
+					// Or maybe we do. I dunno, I just copied the comment+diag from
+					// upgrade_resource_state.go:upgradeResourceStateTransform :P
+					fmt.Sprintf("The current state of %s was created by a newer provider version than is currently selected. Upgrade the %s provider to work with this state.", inst.Addr, inst.Provider.Type),
+				))
+			}
+
+			upgradeCtx := ctx
+			if cb := tracer.StartManagedResourceInstanceObjectUpgrade; cb != nil {
+				upgradeCtx = cb(ctx, inst.Addr.CurrentObject())
+			}
+			upgradeReq := providers.UpgradeResourceStateRequest{
+				TypeName: inst.Addr.Resource.Resource.Type,
+
+				// TODO: The internal schema version representations are all using
+				// uint64 instead of int64, but unsigned integers aren't friendly
+				// to all protobuf target languages so in practice we use int64
+				// on the wire. In future we will change all of our internal
+				// representations to int64 too.
+				Version: int64(prevRoundState.SchemaVersion),
+
+				// We'll make the same assumption as [ResourceInstanceObjectFullSrc] and
+				// assume we'll never encounter a legacy state snapshot that uses AttrsFlat.
+				RawStateJSON: prevRoundState.Value.ValueJSON,
+			}
+			upgradeResp := providerClient.UpgradeResourceState(upgradeCtx, upgradeReq)
+			diags = diags.Append(upgradeResp.Diagnostics)
+			if cb := tracer.EndManagedResourceInstanceObjectUpgrade; cb != nil {
+				upgradedVal := cty.DynamicVal
+				if upgradeResp.UpgradedState != cty.NilVal {
+					// TODO: Should apply "sensitive" marks here where appropriate in
+					// case the tracer is reporting events in the UI.
+					upgradedVal = upgradeResp.UpgradedState
+				}
+				cb(upgradeCtx, inst.Addr.CurrentObject(), upgradedVal, diags)
+			}
+			if diags.HasErrors() {
+				return ret, diags
+			}
+			src, moreDiags := checkAndMarshalUpdatedState(upgradeResp.UpgradedState, schema, inst)
+			diags = diags.Append(moreDiags)
+			if diags.HasErrors() {
+				return ret, diags
+			}
+
+			upgradedPrevState := &states.ResourceInstanceObjectFullSrc{
+				Value: states.ValueJSONWithMetadata{
+					ValueJSON:      src,
+					SensitivePaths: prevRoundState.Value.SensitivePaths,
+				},
+				Private:              prevRoundState.Private,
+				Status:               prevRoundState.Status,
+				ProviderInstanceAddr: prevRoundState.ProviderInstanceAddr,
+				ResourceType:         prevRoundState.ResourceType,
+				SchemaVersion:        uint64(schema.Version),
+				Dependencies:         prevRoundState.Dependencies,
+				ConfigDependencies:   prevRoundState.ConfigDependencies,
+				CreateBeforeDestroy:  prevRoundState.CreateBeforeDestroy,
+			}
+
+			stateSaveObj := inst.Addr.CurrentObject()
+			if impliedMove {
+				// due to a quirk in how moves are handled,
+				// if it's an implied move, we save state
+				// in the prevAddr instead of current.
+				// TODO: is this true?
+				// TODO: is this actually a "current object"?
+				stateSaveObj = prevRunAddr.CurrentObject()
+			}
+			p.planCtx.upgradedState.SetResourceInstanceObjectFull(stateSaveObj, upgradedPrevState)
+			// Update the provider instance for the refreshed state only, not the upgraded state
+			upgradedPrevState.ProviderInstanceAddr = *inst.ProviderInstance
+			p.planCtx.refreshedState.SetResourceInstanceObjectFull(stateSaveObj, upgradedPrevState)
+
+			obj, err := states.DecodeResourceInstanceObjectFull(upgradedPrevState, schema.Block.ImpliedType())
+			if err != nil {
+				diags = diags.Append(tfdiags.AttributeValue(
+					tfdiags.Error,
+					"Invalid prior state for resource instance",
+					fmt.Sprintf(
+						"Cannot decode the most recent state snapshot for %s: %s.\n\nIs the selected version of %s incompatible with the provider that most recently changed this object?",
+						inst.Addr, tfdiags.FormatError(err), inst.Provider,
+					),
+					nil, // this error belongs to the whole resource config
+				))
+				return ret, diags
+			}
+			prevRoundVal = obj.Value
+			prevRoundPrivate = obj.Private
+
+			if len(prevRoundState.Dependencies) != 0 {
+				for _, instAddr := range prevRoundState.Dependencies {
 					ret.StateDependencies.Add(instAddr.CurrentObject())
+				}
+			} else {
+				// Unfortunately our old state model represents dependencies only
+				// between static [addrs.ConfigResource] and loses specific instance
+				// information, so we must conservatively assume that all matching
+				// instances are dependencies. This only occurs during migration
+				// from a state generated by an older runtime.
+				for _, configAddr := range prevRoundState.ConfigDependencies {
+					for instAddr := range p.planCtx.prevRoundState.InstancesMatchingConfigResource(configAddr) {
+						ret.StateDependencies.Add(instAddr.CurrentObject())
+					}
 				}
 			}
 		}
 	} else {
-		// TODO: Ask the planning oracle whether there are any "moved" blocks
-		// that ultimately end up at inst.Addr (possibly through a chain of
-		// multiple moves) and check the source instance address of each
-		// one in turn in case we find an as-yet-unclaimed resource instance
-		// that wants to be rebound to the address in inst.Addr.
-		// (Note that by handling moved blocks at _this_ point we could
-		// potentially have the eval system allow dynamic instance keys etc,
-		// which the original runtime can't do because it always deals with
-		// moved blocks as a preprocessing step before doing other work.)
+		// No move or upgrade occurred; this is just a configured address without any state
+		// It'll probably get created below
 		prevRoundVal = cty.NullVal(schema.Block.ImpliedType())
 	}
 
@@ -364,25 +464,12 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 	// that case, but we would need to mark it as deferred and _not_ record a
 	// proposed change for it.
 
-	if eq, _ := planResp.Planned.Value.Equals(refreshedVal).Unmark(); eq.IsKnown() && eq.True() && !forceReplace {
-		// There is no change to make, so we'll return early without actually
-		// recording any change. In this case our resource instance will be
-		// included in the execution graph only if some other resource instance
-		// depends on it, and even then only as a "read prior state" operation
-		// and no actual changes, so we'll set our placeholder to be the
-		// refreshed value to match what the prior state would contain during
-		// apply.
-		ret.PlaceholderValue = refreshedVal
-		ret.PlannedChange = nil
-		if cb := tracer.EndManagedResourceInstanceObjectPlanChanges; cb != nil {
-			cb(planChangesCtx, inst.Addr.CurrentObject(), plans.NoOp, refreshedVal, refreshedVal, diags)
-		}
-		return ret, diags
-	}
-
 	plannedAction := plans.Update
 	if prevRoundState == nil {
 		plannedAction = plans.Create
+	} else if eq, _ := planResp.Planned.Value.Equals(refreshedVal).Unmark(); eq.IsKnown() && eq.True() && !forceReplace {
+		ret.PlaceholderValue = refreshedVal
+		plannedAction = plans.NoOp
 	} else if !planResp.RequiresReplace.Empty() || forceReplace {
 		// For "replace" actions the execution graph will include two separate
 		// plan and apply operations, where one handles deletion and the other
@@ -437,7 +524,7 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 	// in planOrphanManagedResourceInstance and planDeposedManagedResourceInstanceObject below.)
 	ret.PlannedChange = &plans.ResourceInstanceChange{
 		Addr:        inst.Addr,
-		PrevRunAddr: inst.Addr, // TODO: If we add "moved" support above then this must record the original address
+		PrevRunAddr: prevRunAddr,
 		ProviderAddr: addrs.AbsProviderConfig{
 			// FIXME: This is a lossy shim to the old-style provider instance
 			// address representation, since our old models aren't yet updated
@@ -472,6 +559,36 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 	}
 
 	return ret, diags
+}
+
+func checkAndMarshalUpdatedState(newState cty.Value, schema providers.Schema, inst *eval.DesiredResourceInstance) (ret []byte, diags tfdiags.Diagnostics) {
+	// After upgrading, the new value must conform to the current schema. When
+	// going over RPC this is actually already ensured by the
+	// marshaling/unmarshaling of the new value, but we'll check it here
+	// anyway for robustness, e.g. for in-process providers.
+	if errs := newState.Type().TestConformance(schema.Block.ImpliedType()); len(errs) > 0 {
+		providerType := inst.Addr.Resource.Resource.ImpliedProvider()
+		for _, err := range errs {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Invalid resource state transformation",
+				fmt.Sprintf("The %s provider changed the state for %s, but produced an invalid result: %s.", providerType, inst.Addr, tfdiags.FormatError(err)),
+			))
+		}
+		return nil, diags
+	}
+
+	src, err := ctyjson.Marshal(newState, schema.Block.ImpliedType())
+	if err != nil {
+		// We just checked for type conformance above, so getting into this
+		// codepath is probably a bug.
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Failed to encode result of resource state transformation",
+			fmt.Sprintf("Failed to encode state for %s after resource schema upgrade: %s.", inst.Addr, tfdiags.FormatError(err)),
+		))
+	}
+	return src, diags
 }
 
 func (p *planGlue) planOrphanManagedResourceInstance(
@@ -523,16 +640,76 @@ func (p *planGlue) planUnwantedManagedResourceInstanceObject(
 	// dependencies with the actual resource instance objects in the prior state
 	// to get a comprehensive set of everything we ought to depend on.
 
+	currentRunAddr := addr.InstanceAddr
 	if addr.IsCurrent() {
-		// TODO: Ask the planning oracle whether there are any "moved" blocks
-		// that begin at inst.Addr, and if so check whether the chain of moves
-		// starting there will end up at a currently-unbound resource instance
-		// address. If so, we should do nothing here because
-		// [planGlue.planOrphanManagedResourceInstance] for that target address
-		// should notice the opposite end of the same chain of moves and so
-		// handle it as an object that is in both the prior and desired state,
-		// albeit with different addresses in each.
-		_ = 0 // just to quiet staticcheck about this empty branch until we complete it
+		// Ask the planning oracle whether there are any "moved" blocks
+		// starting at inst.Addr in the configuration (possibly following
+		// a chain of multiple moves).
+		moveAddrs, moveDiags := p.oracle.FindAddressesMovedFromHere(ctx, addr.InstanceAddr)
+		diags = diags.Append(moveDiags)
+		if diags.HasErrors() {
+			// More than one address this could move to.
+			// "Ambiguous move statements": one From, many To
+			return ret, diags
+		}
+		// Check the target instance address of each
+		// one in turn in case we find an as-yet-unbound resource address
+		// that wants to be rebound to the state given here.
+		// Addresses are given from start "From" to final "To"
+		foundAddr := false
+		blockedMove := false
+		for _, nextAddr := range moveAddrs {
+			if nextAddr.Equal(addr.InstanceAddr) {
+				continue
+			}
+			if p.oracle.HasAddress(ctx, nextAddr) {
+				// found state at a moveable address!
+				foundAddr = true
+				blockedMove = p.checkStateAndRecordMoveResult(currentRunAddr, nextAddr, addr, false)
+				if blockedMove {
+					// STOP THE PRESSES!
+					// We're going to handle this state with another function call
+					// (or the state is already bound to an address).
+					// As it is, this state is blocked.
+
+					// We also undo the address, but keep that we "found a move"
+					// so we correctly remove this blocked state
+					currentRunAddr = addr.InstanceAddr
+					break
+				}
+				currentRunAddr = nextAddr
+
+				// We continue the loop, although technically, we should not
+				// find any more addresses in configuration.
+			}
+		}
+		if !foundAddr && !blockedMove {
+			// no address found. Try an implicit move
+			// TODO a logical question: do we check these implicit moves for EVERY candidate address above?
+			// I'd prefer it if we didn't... but I'm afraid that might match what we're expecting...
+			// Except! Who in the world is actually combining moves like that???
+			implicitMoveAddr, pyrrhicMove := p.oracle.SearchForImplicitMoveableResourceInstance(ctx, addr.InstanceAddr)
+			if implicitMoveAddr != nil {
+				if pyrrhicMove {
+					// We set currentRunAddr to implicitMoveAddr,
+					// but we're still going to be deleting it
+					// because we didn't actually find an instance
+					// in the configuration
+					currentRunAddr = *implicitMoveAddr
+				} else {
+					foundAddr = true
+					blockedMove = p.checkStateAndRecordMoveResult(currentRunAddr, *implicitMoveAddr, addr, true)
+					if !blockedMove {
+						currentRunAddr = *implicitMoveAddr
+					}
+				}
+			}
+		}
+		if foundAddr && !blockedMove {
+			// No change planned: it's moved, and the state movement is handled in "Desired"
+			ret.PlannedChange = nil
+			return ret, diags
+		}
 	}
 
 	// FIXME: Currently this fails if the only mention of a particular provider
@@ -666,7 +843,7 @@ func (p *planGlue) planUnwantedManagedResourceInstanceObject(
 	}
 
 	ret.PlannedChange = &plans.ResourceInstanceChange{
-		Addr:        addr.InstanceAddr,
+		Addr:        currentRunAddr,
 		PrevRunAddr: addr.InstanceAddr,
 		DeposedKey:  addr.DeposedKey,
 		ProviderAddr: addrs.AbsProviderConfig{
@@ -694,4 +871,17 @@ func (p *planGlue) planUnwantedManagedResourceInstanceObject(
 	}
 	ret.ProviderInst = prevRoundState.ProviderInstanceAddr
 	return ret, diags
+}
+
+// checkStateAndRecordMoveResult returns true is a successful move and false if
+// the move is blocked by pre-existing state
+func (p *planGlue) checkStateAndRecordMoveResult(currentRunAddr addrs.AbsResourceInstance, nextAddr addrs.AbsResourceInstance, addr addrs.AbsResourceInstanceObject, impliedMove bool) bool {
+	preExistingState := p.planCtx.prevRoundState.SyncWrapper().ResourceInstanceObjectFull(nextAddr.CurrentObject())
+	if preExistingState != nil {
+		p.oracle.RecordBlockedMove(currentRunAddr, nextAddr)
+		return true
+	}
+	// Record move in the oracle, for use in "Desired" section
+	p.oracle.RecordSuccessfulMove(nextAddr, addr.InstanceAddr, impliedMove)
+	return false
 }

--- a/internal/engine/planning/plan_managed.go
+++ b/internal/engine/planning/plan_managed.go
@@ -328,8 +328,6 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 				// due to a quirk in how moves are handled,
 				// if it's an implied move, we save state
 				// in the prevAddr instead of current.
-				// TODO: is this true?
-				// TODO: is this actually a "current object"?
 				stateSaveObj = prevRunAddr.CurrentObject()
 			}
 			p.planCtx.upgradedState.SetResourceInstanceObjectFull(stateSaveObj, upgradedPrevState)
@@ -677,12 +675,13 @@ func (p *planGlue) planUnwantedManagedResourceInstanceObject(
 					// We also undo the address, but keep that we "found a move"
 					// so we correctly remove this blocked state
 					currentRunAddr = addr.InstanceAddr
-					break
+				} else {
+					currentRunAddr = nextAddr
 				}
-				currentRunAddr = nextAddr
-
-				// We continue the loop, although technically, we should not
-				// find any more addresses in configuration.
+				// If there is another address down the chain, it is an error;
+				// you cannot move from an address that exists in configuration.
+				// We'll leave the loop now.
+				break
 			}
 		}
 		if !foundAddr && !blockedMove {

--- a/internal/engine/planning/plan_managed.go
+++ b/internal/engine/planning/plan_managed.go
@@ -133,146 +133,246 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 	var prevRoundVal cty.Value
 	var prevRoundPrivate []byte
 	prevRoundState := p.planCtx.prevRoundState.SyncWrapper().ResourceInstanceObjectFull(inst.Addr.CurrentObject())
-	if prevRoundState != nil {
-		// While we know prevRoundState is non-nil, let's upgrade state, too.
-		// Let's do a schema version comparison before upgrade
 
-		if prevRoundState.SchemaVersion > uint64(schema.Version) {
-			return nil, diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Resource instance managed by newer provider version",
-				// This is not a very good error message, but we don't retain enough
-				// information in state to give good feedback on what provider
-				// version might be required here. :(
-				// Or maybe we do. I dunno, I just copied the comment+diag from
-				// upgrade_resource_state.go:upgradeResourceStateTransform :P
-				fmt.Sprintf("The current state of %s was created by a newer provider version than is currently selected. Upgrade the %s provider to work with this state.", inst.Addr, inst.Provider.Type),
-			))
-		}
+	prevRunAddr := inst.Addr
+	diags = diags.Append(p.oracle.CheckMovesFromAddr(inst.Addr))
+	if diags.HasErrors() {
+		return ret, diags
+	}
 
-		upgradeCtx := ctx
-		if cb := tracer.StartManagedResourceInstanceObjectUpgrade; cb != nil {
-			upgradeCtx = cb(ctx, inst.Addr.CurrentObject())
-		}
-		upgradeReq := providers.UpgradeResourceStateRequest{
-			TypeName: inst.Addr.Resource.Resource.Type,
-
-			// TODO: The internal schema version representations are all using
-			// uint64 instead of int64, but unsigned integers aren't friendly
-			// to all protobuf target languages so in practice we use int64
-			// on the wire. In future we will change all of our internal
-			// representations to int64 too.
-			Version: int64(prevRoundState.SchemaVersion),
-
-			// We'll make the same assumption as [ResourceInstanceObjectFullSrc] and
-			// assume we'll never encounter a legacy state snapshot that uses AttrsFlat.
-			RawStateJSON: prevRoundState.Value.ValueJSON,
-		}
-		upgradeResp := providerClient.UpgradeResourceState(upgradeCtx, upgradeReq)
-		diags = diags.Append(upgradeResp.Diagnostics)
-		if cb := tracer.EndManagedResourceInstanceObjectUpgrade; cb != nil {
-			upgradedVal := cty.DynamicVal
-			if upgradeResp.UpgradedState != cty.NilVal {
-				// TODO: Should apply "sensitive" marks here where appropriate in
-				// case the tracer is reporting events in the UI.
-				upgradedVal = upgradeResp.UpgradedState
-			}
-			cb(upgradeCtx, inst.Addr.CurrentObject(), upgradedVal, diags)
-		}
+	impliedMove := false
+	moved := false
+	if prevRoundState == nil {
+		// check for ambiguous moves
+		_, moveDiags := p.oracle.FindAddressesMovedToHere(ctx, inst.Addr)
+		diags = diags.Append(moveDiags)
 		if diags.HasErrors() {
+			// More than one address this could move to.
+			// "Ambiguous move statements": many From, one To
 			return ret, diags
 		}
-		newState := upgradeResp.UpgradedState
-
-		// After upgrading, the new value must conform to the current schema. When
-		// going over RPC this is actually already ensured by the
-		// marshaling/unmarshaling of the new value, but we'll check it here
-		// anyway for robustness, e.g. for in-process providers.
-		if errs := newState.Type().TestConformance(schema.Block.ImpliedType()); len(errs) > 0 {
-			providerType := inst.Addr.Resource.Resource.ImpliedProvider()
-			for _, err := range errs {
-				diags = diags.Append(tfdiags.Sourceless(
-					tfdiags.Error,
-					"Invalid resource state transformation",
-					fmt.Sprintf("The %s provider changed the state for %s, but produced an invalid result: %s.", providerType, inst.Addr, tfdiags.FormatError(err)),
-				))
+		if moveInfo, ok := p.oracle.MovedAddress(inst.Addr); ok {
+			// we tracked a move in "Unwanted", manage state upgrades and plans here.
+			moved = true
+			prevRunAddr = moveInfo.From
+			prevRoundState = p.planCtx.prevRoundState.SyncWrapper().ResourceInstanceObjectFull(prevRunAddr.CurrentObject())
+			impliedMove = moveInfo.Implied
+		}
+	}
+	// only run MoveResourceState or UpgradeResourceState if prevRoundState is non-nil at this point.
+	if prevRoundState != nil {
+		if moved && !impliedMove && (resourceType.ResourceTypeName() != prevRoundState.ResourceType || !inst.Provider.Equals(prevRoundState.ProviderInstanceAddr.Config.Config.Provider)) {
+			moveCtx := ctx
+			if cb := tracer.StartManagedResourceInstanceObjectMove; cb != nil {
+				moveCtx = cb(ctx, inst.Addr.CurrentObject())
 			}
-			return nil, diags
-		}
 
-		src, err := ctyjson.Marshal(newState, schema.Block.ImpliedType())
-		if err != nil {
-			// We just checked for type conformance above, so getting into this
-			// codepath is probably a bug.
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Failed to encode result of resource state transformation",
-				fmt.Sprintf("Failed to encode state for %s after resource schema upgrade: %s.", inst.Addr, tfdiags.FormatError(err)),
-			))
-		}
+			// log.Printf("[TRACE] moveResourceStateTransform: new address: %s, previous address: %s", inst.Addr, prevRunAddr)
+			req := providers.MoveResourceStateRequest{
+				SourceProviderAddress: prevRunAddr.Resource.Resource.ImpliedProvider(),
+				SourceTypeName:        prevRunAddr.Resource.Resource.Type,
+				SourceSchemaVersion:   prevRoundState.SchemaVersion,
+				// We'll make the same assumption as [ResourceInstanceObjectFullSrc] and
+				// assume we'll never encounter a legacy state snapshot that uses AttrsFlat.
+				SourceStateJSON: prevRoundState.Value.ValueJSON,
+				// SourceStateFlatmap:    prevRoundState.AttrsFlat,
+				SourcePrivate:  prevRoundState.Private,
+				TargetTypeName: inst.Addr.Resource.Resource.Type,
+			}
+			resp := providerClient.MoveResourceState(moveCtx, req)
+			diags = diags.Append(resp.Diagnostics)
+			// TODO this tracer bit is copypasta for upgrade instance, IDK if it's actually legit...
+			if cb := tracer.EndManagedResourceInstanceObjectMove; cb != nil {
+				upgradedVal := cty.DynamicVal
+				if resp.TargetState != cty.NilVal {
+					// TODO: Should apply "sensitive" marks here where appropriate in
+					// case the tracer is reporting events in the UI.
+					upgradedVal = resp.TargetState
+				}
+				cb(moveCtx, inst.Addr.CurrentObject(), upgradedVal, diags)
+			}
+			if diags.HasErrors() {
+				return
+			}
 
-		upgradedPrevState := &states.ResourceInstanceObjectFullSrc{
-			Value: states.ValueJSONWithMetadata{
-				ValueJSON:      src,
-				SensitivePaths: prevRoundState.Value.SensitivePaths,
-			},
-			Private:              prevRoundState.Private,
-			Status:               prevRoundState.Status,
-			ProviderInstanceAddr: prevRoundState.ProviderInstanceAddr,
-			ResourceType:         prevRoundState.ResourceType,
-			SchemaVersion:        uint64(schema.Version),
-			Dependencies:         prevRoundState.Dependencies,
-			ConfigDependencies:   prevRoundState.ConfigDependencies,
-			CreateBeforeDestroy:  prevRoundState.CreateBeforeDestroy,
-		}
+			src, moreDiags := checkAndMarshalUpdatedState(resp.TargetState, schema, inst)
+			diags = diags.Append(moreDiags)
+			if diags.HasErrors() {
+				return ret, diags
+			}
 
-		p.planCtx.upgradedState.SetResourceInstanceObjectFull(inst.Addr.CurrentObject(), upgradedPrevState)
-		// Update the provider instance for the refreshed state only, not the upgraded state
-		upgradedPrevState.ProviderInstanceAddr = *inst.ProviderInstance
-		p.planCtx.refreshedState.SetResourceInstanceObjectFull(inst.Addr.CurrentObject(), upgradedPrevState)
+			// TODO this is very similar to what's below in upgraded state.
+			// Consider refactoring to de-duplicate
+			movedPrevState := &states.ResourceInstanceObjectFullSrc{
+				Value: states.ValueJSONWithMetadata{
+					ValueJSON:      src,
+					SensitivePaths: prevRoundState.Value.SensitivePaths,
+				},
+				Private:              resp.TargetPrivate,
+				Status:               prevRoundState.Status,
+				ProviderInstanceAddr: prevRoundState.ProviderInstanceAddr,
+				ResourceType:         prevRoundState.ResourceType,
+				SchemaVersion:        uint64(schema.Version),
+				Dependencies:         prevRoundState.Dependencies,
+				CreateBeforeDestroy:  prevRoundState.CreateBeforeDestroy,
+			}
+			p.planCtx.upgradedState.SetResourceInstanceObjectFull(inst.Addr.CurrentObject(), movedPrevState)
+			// Update the provider instance for the refreshed state only, not the "upgraded" state
+			movedPrevState.ProviderInstanceAddr = *inst.ProviderInstance
+			p.planCtx.refreshedState.SetResourceInstanceObjectFull(inst.Addr.CurrentObject(), movedPrevState)
 
-		obj, err := states.DecodeResourceInstanceObjectFull(upgradedPrevState, schema.Block.ImpliedType())
-		if err != nil {
-			diags = diags.Append(tfdiags.AttributeValue(
-				tfdiags.Error,
-				"Invalid prior state for resource instance",
-				fmt.Sprintf(
-					"Cannot decode the most recent state snapshot for %s: %s.\n\nIs the selected version of %s incompatible with the provider that most recently changed this object?",
-					inst.Addr, tfdiags.FormatError(err), inst.Provider,
-				),
-				nil, // this error belongs to the whole resource config
-			))
-			return ret, diags
-		}
-		prevRoundVal = obj.Value
-		prevRoundPrivate = obj.Private
+			obj, err := states.DecodeResourceInstanceObjectFull(movedPrevState, schema.Block.ImpliedType())
+			if err != nil {
+				diags = diags.Append(tfdiags.AttributeValue(
+					tfdiags.Error,
+					"Invalid prior state for resource instance",
+					fmt.Sprintf(
+						"Cannot decode the most recent state snapshot for %s: %s.\n\nIs the selected version of %s incompatible with the provider that most recently changed this object?",
+						inst.Addr, tfdiags.FormatError(err), inst.Provider,
+					),
+					nil, // this error belongs to the whole resource config
+				))
+				return ret, diags
+			}
+			prevRoundVal = obj.Value
+			prevRoundPrivate = resp.TargetPrivate
 
-		if len(prevRoundState.Dependencies) != 0 {
-			for _, instAddr := range prevRoundState.Dependencies {
-				ret.StateDependencies.Add(instAddr.CurrentObject())
+			if len(prevRoundState.Dependencies) != 0 {
+				for _, instAddr := range prevRoundState.Dependencies {
+					ret.StateDependencies.Add(instAddr.CurrentObject())
+				}
+			} else {
+				// Unfortunately our old state model represents dependencies only
+				// between static [addrs.ConfigResource] and loses specific instance
+				// information, so we must conservatively assume that all matching
+				// instances are dependencies. This only occurs during migration
+				// from a state generated by an older runtime.
+				for _, configAddr := range prevRoundState.ConfigDependencies {
+					for instAddr := range p.planCtx.prevRoundState.InstancesMatchingConfigResource(configAddr) {
+						ret.StateDependencies.Add(instAddr.CurrentObject())
+					}
+				}
 			}
 		} else {
-			// Unfortunately our old state model represents dependencies only
-			// between static [addrs.ConfigResource] and loses specific instance
-			// information, so we must conservatively assume that all matching
-			// instances are dependencies. This only occurs during migration
-			// from a state generated by an older runtime.
-			for _, configAddr := range prevRoundState.ConfigDependencies {
-				for instAddr := range p.planCtx.prevRoundState.InstancesMatchingConfigResource(configAddr) {
+			// While we know prevRoundState is non-nil, let's upgrade state, too.
+			// Let's do a schema version comparison before upgrade
+
+			if prevRoundState.SchemaVersion > uint64(schema.Version) {
+				return ret, diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Resource instance managed by newer provider version",
+					// This is not a very good error message, but we don't retain enough
+					// information in state to give good feedback on what provider
+					// version might be required here. :(
+					// Or maybe we do. I dunno, I just copied the comment+diag from
+					// upgrade_resource_state.go:upgradeResourceStateTransform :P
+					fmt.Sprintf("The current state of %s was created by a newer provider version than is currently selected. Upgrade the %s provider to work with this state.", inst.Addr, inst.Provider.Type),
+				))
+			}
+
+			upgradeCtx := ctx
+			if cb := tracer.StartManagedResourceInstanceObjectUpgrade; cb != nil {
+				upgradeCtx = cb(ctx, inst.Addr.CurrentObject())
+			}
+			upgradeReq := providers.UpgradeResourceStateRequest{
+				TypeName: inst.Addr.Resource.Resource.Type,
+
+				// TODO: The internal schema version representations are all using
+				// uint64 instead of int64, but unsigned integers aren't friendly
+				// to all protobuf target languages so in practice we use int64
+				// on the wire. In future we will change all of our internal
+				// representations to int64 too.
+				Version: int64(prevRoundState.SchemaVersion),
+
+				// We'll make the same assumption as [ResourceInstanceObjectFullSrc] and
+				// assume we'll never encounter a legacy state snapshot that uses AttrsFlat.
+				RawStateJSON: prevRoundState.Value.ValueJSON,
+			}
+			upgradeResp := providerClient.UpgradeResourceState(upgradeCtx, upgradeReq)
+			diags = diags.Append(upgradeResp.Diagnostics)
+			if cb := tracer.EndManagedResourceInstanceObjectUpgrade; cb != nil {
+				upgradedVal := cty.DynamicVal
+				if upgradeResp.UpgradedState != cty.NilVal {
+					// TODO: Should apply "sensitive" marks here where appropriate in
+					// case the tracer is reporting events in the UI.
+					upgradedVal = upgradeResp.UpgradedState
+				}
+				cb(upgradeCtx, inst.Addr.CurrentObject(), upgradedVal, diags)
+			}
+			if diags.HasErrors() {
+				return ret, diags
+			}
+			src, moreDiags := checkAndMarshalUpdatedState(upgradeResp.UpgradedState, schema, inst)
+			diags = diags.Append(moreDiags)
+			if diags.HasErrors() {
+				return ret, diags
+			}
+
+			upgradedPrevState := &states.ResourceInstanceObjectFullSrc{
+				Value: states.ValueJSONWithMetadata{
+					ValueJSON:      src,
+					SensitivePaths: prevRoundState.Value.SensitivePaths,
+				},
+				Private:              prevRoundState.Private,
+				Status:               prevRoundState.Status,
+				ProviderInstanceAddr: prevRoundState.ProviderInstanceAddr,
+				ResourceType:         prevRoundState.ResourceType,
+				SchemaVersion:        uint64(schema.Version),
+				Dependencies:         prevRoundState.Dependencies,
+				ConfigDependencies:   prevRoundState.ConfigDependencies,
+				CreateBeforeDestroy:  prevRoundState.CreateBeforeDestroy,
+			}
+
+			stateSaveObj := inst.Addr.CurrentObject()
+			if impliedMove {
+				// due to a quirk in how moves are handled,
+				// if it's an implied move, we save state
+				// in the prevAddr instead of current.
+				// TODO: is this true?
+				// TODO: is this actually a "current object"?
+				stateSaveObj = prevRunAddr.CurrentObject()
+			}
+			p.planCtx.upgradedState.SetResourceInstanceObjectFull(stateSaveObj, upgradedPrevState)
+			// Update the provider instance for the refreshed state only, not the upgraded state
+			upgradedPrevState.ProviderInstanceAddr = *inst.ProviderInstance
+			p.planCtx.refreshedState.SetResourceInstanceObjectFull(stateSaveObj, upgradedPrevState)
+
+			obj, err := states.DecodeResourceInstanceObjectFull(upgradedPrevState, schema.Block.ImpliedType())
+			if err != nil {
+				diags = diags.Append(tfdiags.AttributeValue(
+					tfdiags.Error,
+					"Invalid prior state for resource instance",
+					fmt.Sprintf(
+						"Cannot decode the most recent state snapshot for %s: %s.\n\nIs the selected version of %s incompatible with the provider that most recently changed this object?",
+						inst.Addr, tfdiags.FormatError(err), inst.Provider,
+					),
+					nil, // this error belongs to the whole resource config
+				))
+				return ret, diags
+			}
+			prevRoundVal = obj.Value
+			prevRoundPrivate = obj.Private
+
+			if len(prevRoundState.Dependencies) != 0 {
+				for _, instAddr := range prevRoundState.Dependencies {
 					ret.StateDependencies.Add(instAddr.CurrentObject())
+				}
+			} else {
+				// Unfortunately our old state model represents dependencies only
+				// between static [addrs.ConfigResource] and loses specific instance
+				// information, so we must conservatively assume that all matching
+				// instances are dependencies. This only occurs during migration
+				// from a state generated by an older runtime.
+				for _, configAddr := range prevRoundState.ConfigDependencies {
+					for instAddr := range p.planCtx.prevRoundState.InstancesMatchingConfigResource(configAddr) {
+						ret.StateDependencies.Add(instAddr.CurrentObject())
+					}
 				}
 			}
 		}
 	} else {
-		// TODO: Ask the planning oracle whether there are any "moved" blocks
-		// that ultimately end up at inst.Addr (possibly through a chain of
-		// multiple moves) and check the source instance address of each
-		// one in turn in case we find an as-yet-unclaimed resource instance
-		// that wants to be rebound to the address in inst.Addr.
-		// (Note that by handling moved blocks at _this_ point we could
-		// potentially have the eval system allow dynamic instance keys etc,
-		// which the original runtime can't do because it always deals with
-		// moved blocks as a preprocessing step before doing other work.)
+		// No move or upgrade occurred; this is just a configured address without any state
+		// It'll probably get created below
 		prevRoundVal = cty.NullVal(schema.Block.ImpliedType())
 	}
 
@@ -364,25 +464,12 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 	// that case, but we would need to mark it as deferred and _not_ record a
 	// proposed change for it.
 
-	if eq, _ := planResp.Planned.Value.Equals(refreshedVal).Unmark(); eq.IsKnown() && eq.True() && !forceReplace {
-		// There is no change to make, so we'll return early without actually
-		// recording any change. In this case our resource instance will be
-		// included in the execution graph only if some other resource instance
-		// depends on it, and even then only as a "read prior state" operation
-		// and no actual changes, so we'll set our placeholder to be the
-		// refreshed value to match what the prior state would contain during
-		// apply.
-		ret.PlaceholderValue = refreshedVal
-		ret.PlannedChange = nil
-		if cb := tracer.EndManagedResourceInstanceObjectPlanChanges; cb != nil {
-			cb(planChangesCtx, inst.Addr.CurrentObject(), plans.NoOp, refreshedVal, refreshedVal, diags)
-		}
-		return ret, diags
-	}
-
 	plannedAction := plans.Update
 	if prevRoundState == nil {
 		plannedAction = plans.Create
+	} else if eq, _ := planResp.Planned.Value.Equals(refreshedVal).Unmark(); eq.IsKnown() && eq.True() && !forceReplace {
+		ret.PlaceholderValue = refreshedVal
+		plannedAction = plans.NoOp
 	} else if !planResp.RequiresReplace.Empty() || forceReplace {
 		// For "replace" actions the execution graph will include two separate
 		// plan and apply operations, where one handles deletion and the other
@@ -437,7 +524,7 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 	// in planOrphanManagedResourceInstance and planDeposedManagedResourceInstanceObject below.)
 	ret.PlannedChange = &plans.ResourceInstanceChange{
 		Addr:        inst.Addr,
-		PrevRunAddr: inst.Addr, // TODO: If we add "moved" support above then this must record the original address
+		PrevRunAddr: prevRunAddr,
 		ProviderAddr: addrs.AbsProviderConfig{
 			// FIXME: This is a lossy shim to the old-style provider instance
 			// address representation, since our old models aren't yet updated
@@ -474,6 +561,36 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 	}
 
 	return ret, diags
+}
+
+func checkAndMarshalUpdatedState(newState cty.Value, schema providers.Schema, inst *eval.DesiredResourceInstance) (ret []byte, diags tfdiags.Diagnostics) {
+	// After upgrading, the new value must conform to the current schema. When
+	// going over RPC this is actually already ensured by the
+	// marshaling/unmarshaling of the new value, but we'll check it here
+	// anyway for robustness, e.g. for in-process providers.
+	if errs := newState.Type().TestConformance(schema.Block.ImpliedType()); len(errs) > 0 {
+		providerType := inst.Addr.Resource.Resource.ImpliedProvider()
+		for _, err := range errs {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Invalid resource state transformation",
+				fmt.Sprintf("The %s provider changed the state for %s, but produced an invalid result: %s.", providerType, inst.Addr, tfdiags.FormatError(err)),
+			))
+		}
+		return nil, diags
+	}
+
+	src, err := ctyjson.Marshal(newState, schema.Block.ImpliedType())
+	if err != nil {
+		// We just checked for type conformance above, so getting into this
+		// codepath is probably a bug.
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Failed to encode result of resource state transformation",
+			fmt.Sprintf("Failed to encode state for %s after resource schema upgrade: %s.", inst.Addr, tfdiags.FormatError(err)),
+		))
+	}
+	return src, diags
 }
 
 func (p *planGlue) planOrphanManagedResourceInstance(
@@ -525,16 +642,76 @@ func (p *planGlue) planUnwantedManagedResourceInstanceObject(
 	// dependencies with the actual resource instance objects in the prior state
 	// to get a comprehensive set of everything we ought to depend on.
 
+	currentRunAddr := addr.InstanceAddr
 	if addr.IsCurrent() {
-		// TODO: Ask the planning oracle whether there are any "moved" blocks
-		// that begin at inst.Addr, and if so check whether the chain of moves
-		// starting there will end up at a currently-unbound resource instance
-		// address. If so, we should do nothing here because
-		// [planGlue.planOrphanManagedResourceInstance] for that target address
-		// should notice the opposite end of the same chain of moves and so
-		// handle it as an object that is in both the prior and desired state,
-		// albeit with different addresses in each.
-		_ = 0 // just to quiet staticcheck about this empty branch until we complete it
+		// Ask the planning oracle whether there are any "moved" blocks
+		// starting at inst.Addr in the configuration (possibly following
+		// a chain of multiple moves).
+		moveAddrs, moveDiags := p.oracle.FindAddressesMovedFromHere(ctx, addr.InstanceAddr)
+		diags = diags.Append(moveDiags)
+		if diags.HasErrors() {
+			// More than one address this could move to.
+			// "Ambiguous move statements": one From, many To
+			return ret, diags
+		}
+		// Check the target instance address of each
+		// one in turn in case we find an as-yet-unbound resource address
+		// that wants to be rebound to the state given here.
+		// Addresses are given from start "From" to final "To"
+		foundAddr := false
+		blockedMove := false
+		for _, nextAddr := range moveAddrs {
+			if nextAddr.Equal(addr.InstanceAddr) {
+				continue
+			}
+			if p.oracle.HasAddress(ctx, nextAddr) {
+				// found state at a moveable address!
+				foundAddr = true
+				blockedMove = p.checkStateAndRecordMoveResult(currentRunAddr, nextAddr, addr, false)
+				if blockedMove {
+					// STOP THE PRESSES!
+					// We're going to handle this state with another function call
+					// (or the state is already bound to an address).
+					// As it is, this state is blocked.
+
+					// We also undo the address, but keep that we "found a move"
+					// so we correctly remove this blocked state
+					currentRunAddr = addr.InstanceAddr
+					break
+				}
+				currentRunAddr = nextAddr
+
+				// We continue the loop, although technically, we should not
+				// find any more addresses in configuration.
+			}
+		}
+		if !foundAddr && !blockedMove {
+			// no address found. Try an implicit move
+			// TODO a logical question: do we check these implicit moves for EVERY candidate address above?
+			// I'd prefer it if we didn't... but I'm afraid that might match what we're expecting...
+			// Except! Who in the world is actually combining moves like that???
+			implicitMoveAddr, pyrrhicMove := p.oracle.SearchForImplicitMoveableResourceInstance(ctx, addr.InstanceAddr)
+			if implicitMoveAddr != nil {
+				if pyrrhicMove {
+					// We set currentRunAddr to implicitMoveAddr,
+					// but we're still going to be deleting it
+					// because we didn't actually find an instance
+					// in the configuration
+					currentRunAddr = *implicitMoveAddr
+				} else {
+					foundAddr = true
+					blockedMove = p.checkStateAndRecordMoveResult(currentRunAddr, *implicitMoveAddr, addr, true)
+					if !blockedMove {
+						currentRunAddr = *implicitMoveAddr
+					}
+				}
+			}
+		}
+		if foundAddr && !blockedMove {
+			// No change planned: it's moved, and the state movement is handled in "Desired"
+			ret.PlannedChange = nil
+			return ret, diags
+		}
 	}
 
 	// FIXME: Currently this fails if the only mention of a particular provider
@@ -668,7 +845,7 @@ func (p *planGlue) planUnwantedManagedResourceInstanceObject(
 	}
 
 	ret.PlannedChange = &plans.ResourceInstanceChange{
-		Addr:        addr.InstanceAddr,
+		Addr:        currentRunAddr,
 		PrevRunAddr: addr.InstanceAddr,
 		DeposedKey:  addr.DeposedKey,
 		ProviderAddr: addrs.AbsProviderConfig{
@@ -698,4 +875,17 @@ func (p *planGlue) planUnwantedManagedResourceInstanceObject(
 	}
 	ret.ProviderInst = prevRoundState.ProviderInstanceAddr
 	return ret, diags
+}
+
+// checkStateAndRecordMoveResult returns true is a successful move and false if
+// the move is blocked by pre-existing state
+func (p *planGlue) checkStateAndRecordMoveResult(currentRunAddr addrs.AbsResourceInstance, nextAddr addrs.AbsResourceInstance, addr addrs.AbsResourceInstanceObject, impliedMove bool) bool {
+	preExistingState := p.planCtx.prevRoundState.SyncWrapper().ResourceInstanceObjectFull(nextAddr.CurrentObject())
+	if preExistingState != nil {
+		p.oracle.RecordBlockedMove(currentRunAddr, nextAddr)
+		return true
+	}
+	// Record move in the oracle, for use in "Desired" section
+	p.oracle.RecordSuccessfulMove(nextAddr, addr.InstanceAddr, impliedMove)
+	return false
 }

--- a/internal/engine/planning/plan_managed.go
+++ b/internal/engine/planning/plan_managed.go
@@ -328,8 +328,6 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 				// due to a quirk in how moves are handled,
 				// if it's an implied move, we save state
 				// in the prevAddr instead of current.
-				// TODO: is this true?
-				// TODO: is this actually a "current object"?
 				stateSaveObj = prevRunAddr.CurrentObject()
 			}
 			p.planCtx.upgradedState.SetResourceInstanceObjectFull(stateSaveObj, upgradedPrevState)
@@ -675,12 +673,13 @@ func (p *planGlue) planUnwantedManagedResourceInstanceObject(
 					// We also undo the address, but keep that we "found a move"
 					// so we correctly remove this blocked state
 					currentRunAddr = addr.InstanceAddr
-					break
+				} else {
+					currentRunAddr = nextAddr
 				}
-				currentRunAddr = nextAddr
-
-				// We continue the loop, although technically, we should not
-				// find any more addresses in configuration.
+				// If there is another address down the chain, it is an error;
+				// you cannot move from an address that exists in configuration.
+				// We'll leave the loop now.
+				break
 			}
 		}
 		if !foundAddr && !blockedMove {

--- a/internal/engine/planning/plan_managed.go
+++ b/internal/engine/planning/plan_managed.go
@@ -465,9 +465,6 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 	plannedAction := plans.Update
 	if prevRoundState == nil {
 		plannedAction = plans.Create
-	} else if eq, _ := planResp.Planned.Value.Equals(refreshedVal).Unmark(); eq.IsKnown() && eq.True() && !forceReplace {
-		ret.PlaceholderValue = refreshedVal
-		plannedAction = plans.NoOp
 	} else if !planResp.RequiresReplace.Empty() || forceReplace {
 		// For "replace" actions the execution graph will include two separate
 		// plan and apply operations, where one handles deletion and the other
@@ -517,6 +514,9 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 		} else {
 			plannedAction = plans.DeleteThenCreate
 		}
+	} else if eq, _ := planResp.Planned.Value.Equals(refreshedVal).Unmark(); eq.IsKnown() && eq.True() {
+		ret.PlaceholderValue = refreshedVal
+		plannedAction = plans.NoOp
 	}
 	// (a "desired" object cannot have a Delete action; we handle those cases
 	// in planOrphanManagedResourceInstance and planDeposedManagedResourceInstanceObject below.)

--- a/internal/engine/planning/tracing.go
+++ b/internal/engine/planning/tracing.go
@@ -52,6 +52,17 @@ type Tracer struct {
 	StartManagedResourceInstanceObjectPlanning func(ctx context.Context, addr addrs.AbsResourceInstanceObject) context.Context
 	EndManagedResourceInstanceObjectPlanning   func(ctx context.Context, addr addrs.AbsResourceInstanceObject, diags tfdiags.Diagnostics)
 
+	// StartManagedResourceInstanceObjectMove and
+	// EndManagedResourceInstanceObjectMove mark the beginning and end
+	// of the "state move" step for the identified managed resource instance
+	// object.
+	//
+	// These events always occur between calls to
+	// StartManagedResourceInstanceObjectPlanning and
+	// EndManagedResourceInstanceObjectPlanning for the same object address.
+	StartManagedResourceInstanceObjectMove func(ctx context.Context, addr addrs.AbsResourceInstanceObject) context.Context
+	EndManagedResourceInstanceObjectMove   func(ctx context.Context, addr addrs.AbsResourceInstanceObject, upgradedVal cty.Value, diags tfdiags.Diagnostics)
+
 	// StartManagedResourceInstanceObjectUpgrade and
 	// EndManagedResourceInstanceObjectUpgrade mark the beginning and end
 	// of the "state upgrade" step for the identified managed resource instance

--- a/internal/lang/eval/config_plan.go
+++ b/internal/lang/eval/config_plan.go
@@ -176,30 +176,35 @@ func (c *ConfigInstance) DrivePlanning(ctx context.Context, buildGlue func(*Plan
 	oracle.providers = managedProviders
 	// Inject configured providers
 	evalGlue.providers = managedProviders
+	// Set up the move results map
+	moreDiags = oracle.SetUpMoveStatements(ctx)
+
+	diags = diags.Append(moreDiags)
+	if moreDiags.HasErrors() {
+		return nil, diags
+	}
 
 	// The plan phase is driven forward by us evaluating expressions during
 	// the "checkAll" process, and so we can just run that here and then
 	// it'll cause various calls out to the "glue" object whenever we're
-	// ready to provide configuration for a resource intance and need to
+	// ready to provide configuration for a resource instance and need to
 	// obtain its result for downstream use.
 	//
-	// We also concurrently work to call the Plan*Orphans methods on
+	// We also call the Plan*Orphans methods on
 	// PlanGlue, which does a similar tree walk but is unique only to the
 	// planning phase and doesn't directly evaluate any nodes.
-	var wg sync.WaitGroup
-	var checkDiags tfdiags.Diagnostics
-	var orphanDiags tfdiags.Diagnostics
-	wg.Go(func() {
-		ctx := grapheval.ContextWithNewWorker(ctx)
-		checkDiags = checkAll(ctx, rootModuleInstance)
-	})
-	wg.Go(func() {
-		ctx := grapheval.ContextWithNewWorker(ctx)
-		orphanDiags = announcePlanOrphans(ctx, glue, rootModuleInstance)
-	})
-	wg.Wait()
-	diags = diags.Append(checkDiags)
+	// Note that these calls are done sequentially instead of concurrently:
+	// that's because Plan*Orphans populates move results
+	// within the oracle, which are then used in CheckAll.
+	orphanDiags := announcePlanOrphans(ctx, glue, rootModuleInstance)
 	diags = diags.Append(orphanDiags)
+
+	// Check whether any moves were blocked, and provide the appropriate warnings
+	diags = diags.Append(oracle.BlockedDiags())
+
+	checkDiags := checkAll(ctx, rootModuleInstance)
+	diags = diags.Append(checkDiags)
+
 	// (We intentionally don't return here because we'll make a best effort
 	// to return a partial result even if we encountered errors, so an
 	// operator can potentially use the partial result to help debug

--- a/internal/lang/eval/config_plan_move.go
+++ b/internal/lang/eval/config_plan_move.go
@@ -1,0 +1,369 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package eval
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"iter"
+	"slices"
+	"sync"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/lang/eval/internal/evalglue"
+	"github.com/opentofu/opentofu/internal/refactoring"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+)
+
+type moveResults struct {
+	Changes addrs.SyncMap[addrs.AbsResourceInstance, refactoring.MoveSuccess]
+	Blocked addrs.SyncMap[addrs.AbsMoveable, refactoring.MoveBlocked]
+}
+
+// SetUpMoveStatements obtains the complete collection of move statements from the root module
+// and all its called sub-modules. Diagnostics from move graph validation are returned,
+// which checks for cycles in the graph.
+func (o *PlanningOracle) SetUpMoveStatements(ctx context.Context) tfdiags.Diagnostics {
+	o.moveResults = moveResults{
+		Changes: addrs.MakeSyncMap[addrs.AbsResourceInstance, refactoring.MoveSuccess](),
+		Blocked: addrs.MakeSyncMap[addrs.AbsMoveable, refactoring.MoveBlocked](),
+	}
+	o.moveStatements = o.root.GetMoveStatements(ctx)
+	return refactoring.ValidateMoveStatementGraph(o.moveStatements)
+}
+
+// FindAddressesMovedFromHere returns all of the addresses that this address will be moved to,
+// that is, it follows the move statements' in their logical way.
+//
+// Importantly, this function assumes the underlying move statement graph
+// has no cycles. Be sure to check for that before calling this method, or
+// it may take a while to return.
+//
+// A diagnostic is returned if the move was ambiguous.
+func (o *PlanningOracle) FindAddressesMovedFromHere(ctx context.Context, addr addrs.AbsResourceInstance) ([]addrs.AbsResourceInstance, tfdiags.Diagnostics) {
+	return o.findAddressesByMove(ctx, addr, false)
+}
+
+// FindAddressesMovedToHere returns all of the addresses that might be moved to this address,
+// that is, has a series of move statements with From addresses that eventually lead to
+// addr as a To address.
+//
+// Importantly, this function assumes the underlying move statement graph
+// has no cycles. Be sure to check for that before calling this method, or
+// it may take a while to return.
+//
+// A diagnostic is returned if the move was ambiguous.
+func (o *PlanningOracle) FindAddressesMovedToHere(ctx context.Context, addr addrs.AbsResourceInstance) ([]addrs.AbsResourceInstance, tfdiags.Diagnostics) {
+	return o.findAddressesByMove(ctx, addr, true)
+}
+
+type moveInfo struct {
+	addr addrs.AbsResourceInstance
+	stmt refactoring.MoveStatement
+}
+
+func mapToSlice(m map[addrs.UniqueKey]*moveInfo) iter.Seq[addrs.AbsResourceInstance] {
+	return func(yield func(addrs.AbsResourceInstance) bool) {
+		for _, mi := range m {
+			if !yield(mi.addr) {
+				return
+			}
+		}
+	}
+}
+
+func (o *PlanningOracle) findAddressesByMove(ctx context.Context, addr addrs.AbsResourceInstance, reverse bool) ([]addrs.AbsResourceInstance, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	output := make([]addrs.AbsResourceInstance, 1)
+	output[0] = addr
+	prevAddr := addr
+
+	selfCycles := make(map[addrs.UniqueKey]any)
+
+	// We're never going to "move" more times
+	// than there are move statements
+	for range len(o.moveStatements) {
+		addresses := make(map[addrs.UniqueKey]*moveInfo)
+		for _, move := range o.moveStatements {
+			from, to := move.From, move.To
+			if reverse {
+				from, to = move.To, move.From
+			}
+			if movedAddr, moved := prevAddr.MoveDestination(from, to); moved {
+				if _, alreadyFound := selfCycles[prevAddr.UniqueKey()]; !alreadyFound && addrs.Equivalent(prevAddr, movedAddr) {
+					// The previous address and current address are equivalent, meaning this statement is redundant
+					// we'll shortcut here with this error
+					absFrom := move.From.InModuleInstance(prevAddr.Module)
+
+					diags = diags.Append(&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Redundant move statement",
+						Detail: fmt.Sprintf(
+							"This statement declares a move from %s to the same address, which is the same as not declaring this move at all.",
+							absFrom,
+						),
+						Subject: move.DeclRange.ToHCL().Ptr(),
+					})
+					selfCycles[movedAddr.UniqueKey()] = struct{}{}
+					continue
+				}
+				// Note: using the movedAddr.UniqueKey() is equivalent to checking addrs.Equivalent
+				// So all addresses in this map will be uniquely determined
+				if _, ok := addresses[movedAddr.UniqueKey()]; !ok {
+					addresses[movedAddr.UniqueKey()] = &moveInfo{addr: movedAddr, stmt: move}
+				}
+			}
+		}
+		if len(addresses) == 0 {
+			break
+		}
+		if len(addresses) > 1 {
+			// more than one address means an ambiguous move
+			var first *moveInfo
+			for _, mi := range addresses {
+				if first == nil {
+					// TODO: might have to set "first" above, since the map may not be ordered the way we "expect"
+					first = mi
+					continue
+				}
+				ambiguityDiag := oneFromManyTo(first, mi)
+				if reverse {
+					ambiguityDiag = manyFromOneTo(first, mi)
+				}
+				diags = diags.Append(ambiguityDiag)
+
+			}
+			return slices.Collect(mapToSlice(addresses)), diags
+		}
+		// There is exactly one address in addresses.
+		// TODO is there a more... idk, elegant way to extract it?
+		prevAddr = slices.Collect(mapToSlice(addresses))[0]
+		output = append(output, prevAddr)
+	}
+	return output, diags
+}
+
+// oneFromManyTo formats an existing piece of movement info and a conflicting ambiguous movement statement
+// into a diagnostic error
+func oneFromManyTo(first *moveInfo, mi *moveInfo) *hcl.Diagnostic {
+	absFrom := first.stmt.From.InModuleInstance(first.addr.Module)
+	absTo := first.stmt.To.InModuleInstance(first.addr.Module)
+	absOtherTo := mi.stmt.To.InModuleInstance(mi.addr.Module)
+
+	return &hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  "Ambiguous move statements",
+		Detail: fmt.Sprintf(
+			"A statement at %s declared that %s moved to %s, but this statement instead declares that it moved to %s.\n\nEach %s can move to only one destination %s.",
+			first.stmt.DeclRange.StartString(), absFrom, absTo, absOtherTo,
+			absFrom.Noun(), absFrom.ShortNoun(),
+		),
+		Subject: mi.stmt.DeclRange.ToHCL().Ptr(),
+	}
+}
+
+// manyFromOneTo formats an existing piece of movement info and a conflicting ambiguous movement statement
+// into a diagnostic error
+// TODO: maybe we can unify the manyFromOneTo with oneFromManyTo?
+func manyFromOneTo(first *moveInfo, mi *moveInfo) *hcl.Diagnostic {
+	absFrom := first.stmt.From.InModuleInstance(first.addr.Module)
+	absTo := first.stmt.To.InModuleInstance(first.addr.Module)
+	absOtherFrom := mi.stmt.From.InModuleInstance(mi.addr.Module)
+
+	return &hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  "Ambiguous move statements",
+		Detail: fmt.Sprintf(
+			"A statement at %s declared that %s moved to %s, but this statement instead declares that %s moved there.\n\nEach %s can have moved from only one source %s.",
+			first.stmt.DeclRange.StartString(), absFrom, absTo, absOtherFrom,
+			absFrom.Noun(), absFrom.ShortNoun(),
+		),
+		Subject: mi.stmt.DeclRange.ToHCL().Ptr(),
+	}
+}
+
+func (o *PlanningOracle) RecordSuccessfulMove(newAddr, oldAddr addrs.AbsResourceInstance, implied bool) {
+	o.moveResults.Changes.Put(newAddr, refactoring.MoveSuccess{
+		From:    oldAddr,
+		To:      newAddr,
+		Implied: implied,
+	})
+}
+
+func (o *PlanningOracle) RecordBlockedMove(newAddr, wantedAddr addrs.AbsResourceInstance) {
+	o.moveResults.Blocked.Put(newAddr, refactoring.MoveBlocked{
+		Wanted: wantedAddr,
+		Actual: newAddr,
+	})
+}
+
+func (o *PlanningOracle) MovedAddress(addr addrs.AbsResourceInstance) (refactoring.MoveSuccess, bool) {
+	return o.moveResults.Changes.GetOk(addr)
+}
+
+func (o *PlanningOracle) BlockedDiags() tfdiags.Diagnostics {
+	var itemsBuf bytes.Buffer
+	// Question: Do we actually need these concurrency features?
+	// I don't think Range is actually parallel...
+	var mux sync.Mutex
+	var markNonEmptyOnce sync.Once
+	empty := true
+
+	o.moveResults.Blocked.Range(func(_ addrs.AbsMoveable, blocked refactoring.MoveBlocked) bool {
+		mux.Lock()
+		fmt.Fprintf(&itemsBuf, "\n  - %s could not move to %s", blocked.Actual, blocked.Wanted)
+		mux.Unlock()
+
+		markNonEmptyOnce.Do(func() {
+			empty = false
+		})
+
+		// always return true; we want to go thru every item in the range
+		return true
+	})
+
+	if empty {
+		return nil
+	}
+
+	return tfdiags.Diagnostics{tfdiags.Sourceless(
+		tfdiags.Warning,
+		"Unresolved resource instance address changes",
+		fmt.Sprintf(
+			"OpenTofu tried to adjust resource instance addresses in the prior state based on change information recorded in the configuration, but some adjustments did not succeed due to existing objects already at the intended addresses:%s\n\nOpenTofu has planned to destroy these objects. If OpenTofu's proposed changes aren't appropriate, you must first resolve the conflicts using the \"tofu state\" subcommands and then create a new plan.",
+			itemsBuf.String(),
+		),
+	)}
+}
+
+func (o *PlanningOracle) CheckMovesFromAddr(addr addrs.AbsResourceInstance) (diags tfdiags.Diagnostics) {
+	for _, move := range o.moveStatements {
+		// if the move statement can move our address, it matches the "From"
+		if _, moved := addr.MoveDestination(move.From, move.To); moved {
+			absFrom := move.From.InModuleInstance(addr.Module)
+			absTo := move.To.InModuleInstance(addr.Module)
+			noun := absFrom.Noun()
+			shortNoun := absFrom.ShortNoun()
+
+			// TODO determine DeclRange, probably by adding some config information from the caller
+			declaredAt := ""
+
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Moved object still exists",
+				Detail: fmt.Sprintf(
+					"This statement declares a move from %s, but that %s is still declared%s.\n\nChange your configuration so that this %s will be declared as %s instead.",
+					absFrom, noun, declaredAt, shortNoun, absTo,
+				),
+				Subject: move.DeclRange.ToHCL().Ptr(),
+			})
+		}
+	}
+	return diags
+}
+
+func reciprocalKey(a, b addrs.InstanceKey) bool {
+	return a == addrs.NoKey && b == addrs.IntKey(0) ||
+		a == addrs.IntKey(0) && b == addrs.NoKey
+}
+
+// SearchForImplicitMoveableResourceInstance looks through the configuration for a resource instance address
+// which is reciprocal, by which we mean one of the keys changes from IntKey(0) to NoKey or vice versa.
+// A flag is also returned for whether this is a "pyrrhic move": we may make a move to a non-nil resource
+// instance address with a IntKey(0), but the instance does not actually exist. This is a quirk implemented
+// for compatibility with the previous runtime.
+func (o *PlanningOracle) SearchForImplicitMoveableResourceInstance(ctx context.Context, addr addrs.AbsResourceInstance) (*addrs.AbsResourceInstance, bool) {
+	// Note: the config graph should already be expanded at this point,
+	// so looking through it again to obtain resource instance information
+	// should be just fine. But I'm also gonna add this, because it's
+	// everywhere else that this function is used:
+	// TODO: using evalglue.ResourceInstancesDeep here is probably not right
+	// because it immediately starts a new grapheval worker without also
+	// starting a new goroutine. We need to figure out how the non-goroutine
+	// coroutines started by for loops over iter.Seq fit in to the grapheval
+	// rules: they have some characteristics in common with goroutines but
+	// are not capable of running asynchronously with the calling goroutine.
+	// PS: I know it's evalglue.ModuleInstancesDeep, not evalglue.ResourceInstancesDeep,
+	// but that's what the TODO says everywhere soooo......
+	for mAddr, mi := range evalglue.ModuleInstancesDeep(ctx, o.root) {
+		// Four easy steps!
+		// 1. Check the module keys
+		modA, modB := mAddr, addr.Module
+		if len(modA) != len(modB) {
+			continue
+		}
+		reciprocalModule := false
+		incompatibleModule := false
+		for i := range len(modA) {
+			if modA[i].Name != modB[i].Name {
+				incompatibleModule = true
+				break
+			}
+			if reciprocalKey(modA[i].InstanceKey, modB[i].InstanceKey) {
+				reciprocalModule = true
+				// Do not break:
+				// we want to check whether or not these are incompatible.
+			} else if modA[i].InstanceKey != modB[i].InstanceKey {
+				// these instances are incompatible
+				incompatibleModule = true
+				break
+			}
+		}
+		if incompatibleModule {
+			continue
+		}
+
+		// 2. Find the resource
+		res := mi.Resource(ctx, addr.Resource.Resource)
+		if res == nil {
+			continue
+		}
+		instanceMap := res.Instances(ctx)
+		instanceKeyType := res.InstanceSelector.InstanceKeyType()
+
+		// 3. Check the resource instance key
+		// Note: resource names are the same due to how we found res
+		keyA, keyB := addr.Resource.Key, addr.Resource.Key
+		ri := instanceMap[keyA]
+		nonPyrrhicMove := true
+		reciprocalResourceInstance := false
+		switch instanceKeyType {
+		case addrs.NoKeyType:
+			if keyB == addrs.IntKey(0) {
+				keyA = addrs.NoKey
+				ri = instanceMap[keyA]
+				reciprocalResourceInstance = true
+			}
+		case addrs.IntKeyType:
+			if keyB == addrs.NoKey {
+				keyA = addrs.IntKey(0)
+				ri, nonPyrrhicMove = instanceMap[keyA]
+				reciprocalResourceInstance = true
+			}
+		}
+
+		// check if the resource instances are incompatible, provided
+		// they aren't also reciprocals
+		if !reciprocalResourceInstance && keyA != keyB {
+			continue
+		}
+
+		// 4. If the module and resource keys are compatible, but at least one of them is reciprocal
+		// this is a candidate for an implicit move.
+		if ri != nil && (reciprocalModule || reciprocalResourceInstance) {
+			return &ri.Addr, false
+		}
+		// If we're moving from NoKey to count = 0,
+		// we're making a pyrrhic move and we handle that specially
+		if !nonPyrrhicMove {
+			fakeAddr := res.Addr.Instance(keyA)
+			return &fakeAddr, true
+		}
+	}
+	return nil, false
+}

--- a/internal/lang/eval/config_plan_move.go
+++ b/internal/lang/eval/config_plan_move.go
@@ -33,7 +33,7 @@ func (o *PlanningOracle) SetUpMoveStatements(ctx context.Context) tfdiags.Diagno
 		Changes: addrs.MakeSyncMap[addrs.AbsResourceInstance, refactoring.MoveSuccess](),
 		Blocked: addrs.MakeSyncMap[addrs.AbsMoveable, refactoring.MoveBlocked](),
 	}
-	o.moveStatements = o.root.GetMoveStatements(ctx)
+	o.moveStatements = slices.Collect(o.root.GetMoveStatements(ctx))
 	return refactoring.ValidateMoveStatementGraph(o.moveStatements)
 }
 

--- a/internal/lang/eval/config_plan_oracle.go
+++ b/internal/lang/eval/config_plan_oracle.go
@@ -11,6 +11,7 @@ import (
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/lang/eval/internal/evalglue"
 	"github.com/opentofu/opentofu/internal/providers"
+	"github.com/opentofu/opentofu/internal/refactoring"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -18,8 +19,16 @@ import (
 // A PlanningOracle provides information from the configuration that is needed
 // by the planning engine to help orchestrate the planning process.
 type PlanningOracle struct {
-	root      evalglue.CompiledModuleInstance
-	providers *managedProviders
+	root           evalglue.CompiledModuleInstance
+	providers      *managedProviders
+	moveStatements []refactoring.MoveStatement
+	moveResults    moveResults
+}
+
+// HasAddress queries the root module instance to determine if the address is
+// present in the configuration.
+func (o *PlanningOracle) HasAddress(ctx context.Context, addr addrs.AbsResourceInstance) bool {
+	return evalglue.ResourceInstance(ctx, o.root, addr) != nil
 }
 
 // ProviderInstanceConfig returns a value representing the configuration to

--- a/internal/lang/eval/config_plan_oracle.go
+++ b/internal/lang/eval/config_plan_oracle.go
@@ -26,7 +26,8 @@ type PlanningOracle struct {
 }
 
 // HasAddress queries the root module instance to determine if the address is
-// present in the configuration.
+// present in the configuration. Note: if instances for the address's underlying
+// resource cannot be resolved, this will return false.
 func (o *PlanningOracle) HasAddress(ctx context.Context, addr addrs.AbsResourceInstance) bool {
 	return evalglue.ResourceInstance(ctx, o.root, addr) != nil
 }

--- a/internal/lang/eval/internal/evalglue/module_instance.go
+++ b/internal/lang/eval/internal/evalglue/module_instance.go
@@ -16,6 +16,7 @@ import (
 	"github.com/opentofu/opentofu/internal/lang/eval/internal/configgraph"
 	"github.com/opentofu/opentofu/internal/lang/exprs"
 	"github.com/opentofu/opentofu/internal/lang/grapheval"
+	"github.com/opentofu/opentofu/internal/refactoring"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
@@ -213,6 +214,10 @@ type CompiledModuleInstance interface {
 	// range to use to describe each of the requests that were involved in the
 	// problem.
 	AnnounceAllGraphevalRequests(announce func(workgraph.RequestID, grapheval.RequestInfo))
+
+	// GetMoveStatements obtains the move statements for this module and all of its module calls,
+	// with all move statements returned relative to this module instance.
+	GetMoveStatements(ctx context.Context) []refactoring.MoveStatement
 }
 
 // ModuleInstance finds the [CompiledModuleInstance] representation of the

--- a/internal/lang/eval/internal/evalglue/module_instance.go
+++ b/internal/lang/eval/internal/evalglue/module_instance.go
@@ -217,7 +217,7 @@ type CompiledModuleInstance interface {
 
 	// GetMoveStatements obtains the move statements for this module and all of its module calls,
 	// with all move statements returned relative to this module instance.
-	GetMoveStatements(ctx context.Context) []refactoring.MoveStatement
+	GetMoveStatements(ctx context.Context) iter.Seq[refactoring.MoveStatement]
 }
 
 // ModuleInstance finds the [CompiledModuleInstance] representation of the

--- a/internal/lang/eval/internal/tofu2024/compile.go
+++ b/internal/lang/eval/internal/tofu2024/compile.go
@@ -14,6 +14,7 @@ import (
 	"github.com/opentofu/opentofu/internal/getproviders"
 	"github.com/opentofu/opentofu/internal/lang/eval/internal/configgraph"
 	"github.com/opentofu/opentofu/internal/lang/exprs"
+	"github.com/opentofu/opentofu/internal/refactoring"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
@@ -162,6 +163,10 @@ func CompileModuleInstance(
 		call.EvaluationGlue.ResourceInstanceValue,
 		call.DependencyMarks,
 	)
+	ret.moveStatements = compileMoveStatements(
+		module,
+		call.CalleeAddr,
+	)
 
 	// Now that we've assembled all of the innards of the module instance,
 	// we'll wire the output values up to the top-level module instance
@@ -173,6 +178,17 @@ func CompileModuleInstance(
 	}
 
 	return ret
+}
+
+func compileMoveStatements(module *configs.Module, moduleInstanceAddr addrs.ModuleInstance) []refactoring.MoveStatement {
+	// TODO add implicit move statements
+	// implicitMoveStmts := refactoring.ImpliedMoveStatements(config, prevRunState, explicitMoveStmts)
+	// Hmmm, do we do that here or do we do that "implicitly" at move-time during the plan phase?
+
+	// Note: this will have the same move statements for each instance of a given module.
+	// When collecting all move statements from the root module, be sure to
+	// only collect from one instance per module call made.
+	return refactoring.FindMoveStatementsShallow(module, moduleInstanceAddr.Module())
 }
 
 func compileCheckRules(configs []*configs.CheckRule, evalScope exprs.Scope) iter.Seq[*configgraph.CheckRule] {

--- a/internal/lang/eval/internal/tofu2024/module_instance.go
+++ b/internal/lang/eval/internal/tofu2024/module_instance.go
@@ -381,16 +381,25 @@ func (c *CompiledModuleInstance) AnnounceAllGraphevalRequests(announce func(work
 }
 
 // GetMoveStatements implements evalglue.GetMoveStatements.
-func (c *CompiledModuleInstance) GetMoveStatements(ctx context.Context) []refactoring.MoveStatement {
-	myMoveStatements := c.moveStatements
-	for callAddr := range c.ChildModuleCalls(ctx) {
-		for _, compiled := range c.ChildModuleInstancesForCall(ctx, callAddr) {
-			// Note: move statement addresses are already "unified" with their module address relative to the root
-			subModuleMoveStatements := compiled.GetMoveStatements(ctx)
-			myMoveStatements = append(myMoveStatements, subModuleMoveStatements...)
-			// We only need move statements from one module instance, so we break immediately.
-			break
+func (c *CompiledModuleInstance) GetMoveStatements(ctx context.Context) iter.Seq[refactoring.MoveStatement] {
+	return func(yield func(refactoring.MoveStatement) bool) {
+		for _, moveStatement := range c.moveStatements {
+			if !yield(moveStatement) {
+				return
+			}
+		}
+		for callAddr := range c.ChildModuleCalls(ctx) {
+			for _, compiled := range c.ChildModuleInstancesForCall(ctx, callAddr) {
+				// Note: move statement addresses are already "unified" with their module address relative to the root
+				subModuleMoveStatements := compiled.GetMoveStatements(ctx)
+				for subModuleMoveStatement := range subModuleMoveStatements {
+					if !yield(subModuleMoveStatement) {
+						return
+					}
+				}
+				// We only need move statements from one module instance, so we break immediately.
+				break
+			}
 		}
 	}
-	return myMoveStatements
 }

--- a/internal/lang/eval/internal/tofu2024/module_instance.go
+++ b/internal/lang/eval/internal/tofu2024/module_instance.go
@@ -21,6 +21,7 @@ import (
 	"github.com/opentofu/opentofu/internal/lang/eval/internal/evalglue"
 	"github.com/opentofu/opentofu/internal/lang/exprs"
 	"github.com/opentofu/opentofu/internal/lang/grapheval"
+	"github.com/opentofu/opentofu/internal/refactoring"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
@@ -39,6 +40,8 @@ type CompiledModuleInstance struct {
 	moduleCallNodes     map[addrs.ModuleCall]*configgraph.ModuleCall
 	providerConfigNodes map[addrs.LocalProviderConfig]*configgraph.ProviderConfig
 	providerLocalNames  map[addrs.Provider]string
+
+	moveStatements []refactoring.MoveStatement
 
 	missingProviders rootMissingProviders
 
@@ -375,4 +378,19 @@ func (c *CompiledModuleInstance) AnnounceAllGraphevalRequests(announce func(work
 	for _, n := range c.providerConfigNodes {
 		n.AnnounceAllGraphevalRequests(announce)
 	}
+}
+
+// GetMoveStatements implements evalglue.GetMoveStatements.
+func (c *CompiledModuleInstance) GetMoveStatements(ctx context.Context) []refactoring.MoveStatement {
+	myMoveStatements := c.moveStatements
+	for callAddr := range c.ChildModuleCalls(ctx) {
+		for _, compiled := range c.ChildModuleInstancesForCall(ctx, callAddr) {
+			// Note: move statement addresses are already "unified" with their module address relative to the root
+			subModuleMoveStatements := compiled.GetMoveStatements(ctx)
+			myMoveStatements = append(myMoveStatements, subModuleMoveStatements...)
+			// We only need move statements from one module instance, so we break immediately.
+			break
+		}
+	}
+	return myMoveStatements
 }

--- a/internal/refactoring/move_statement.go
+++ b/internal/refactoring/move_statement.go
@@ -64,6 +64,30 @@ func findMoveStatements(cfg *configs.Config, into []MoveStatement) []MoveStateme
 	return into
 }
 
+// FindMoveStatementsShallow gets only the move statements declared within a
+// single module call. It explicitly does not obtain move statements in child modules.
+// The modAddr should be the address of this module relative to the root module.
+func FindMoveStatementsShallow(module *configs.Module, modAddr addrs.Module) []MoveStatement {
+	output := make([]MoveStatement, len(module.Moved))
+	for i, mc := range module.Moved {
+		fromAddr, toAddr := addrs.UnifyMoveEndpoints(modAddr, mc.From, mc.To)
+		if fromAddr == nil || toAddr == nil {
+			// Invalid combination should've been caught during original
+			// configuration decoding, in the configs package.
+			panic(fmt.Sprintf("incompatible move endpoints in %s", mc.DeclRange))
+		}
+
+		output[i] = MoveStatement{
+			From:      fromAddr,
+			To:        toAddr,
+			DeclRange: tfdiags.SourceRangeFromHCL(mc.DeclRange),
+			Implied:   false,
+		}
+	}
+
+	return output
+}
+
 // ImpliedMoveStatements compares addresses in the given state with addresses
 // in the given configuration and potentially returns additional MoveStatement
 // objects representing moves we infer automatically, even though they aren't
@@ -230,6 +254,9 @@ func impliedMoveStatementsForModuleResources(cfg *configs.Config, modState *stat
 			// wrote an explicit statement referring to this resource,
 			// because they may wish to select an instance key other than
 			// zero as the one to retain.
+			// Fun fact! Since implicit moves require that no explicit
+			// move statement involve the AbsAddress of the resource,
+			// they can never create a cycle.
 			if !haveMoveStatementForResource(rAddr, explicitStmts) {
 				into = append(into, MoveStatement{
 					From:      addrs.ImpliedMoveStatementEndpoint(rAddr.Instance(fromKey), approxSrcRange),

--- a/internal/refactoring/move_validate.go
+++ b/internal/refactoring/move_validate.go
@@ -19,6 +19,21 @@ import (
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
+// ValidateMoveStatementGraph takes a set of move statements and validates that there
+// are no cycles in it. This is a strict subset of validations done by
+// ValidateMoves, which was written for the runtime defined in the `tofu` package.
+// Local checks for ambiguous moves and moving from a resource which
+// is still defined in the configuration are done on a per-resource
+// basis in the 2026 engine.
+func ValidateMoveStatementGraph(stmts []MoveStatement) tfdiags.Diagnostics {
+	if len(stmts) == 0 {
+		return nil
+	}
+
+	g := buildMoveStatementGraph(stmts)
+	return validateMoveStatementGraph(g)
+}
+
 // ValidateMoves tests whether all of the given move statements comply with
 // both the single-statement validation rules and the "big picture" rules
 // that constrain statements in relation to one another.

--- a/internal/tofu/context_apply_test.go
+++ b/internal/tofu/context_apply_test.go
@@ -9784,6 +9784,8 @@ func TestContext2Apply_scaleInMultivarRef(t *testing.T) {
 		if got, want := change.Action, plans.Delete; got != want {
 			t.Errorf("wrong action for %s %s; want %s", addr, got, want)
 		}
+		// Note: by skipping here, we still check for the errors and failures above!
+		SkipExperimental(t, ExperimentalFeatureActionReason)
 		if got, want := change.ActionReason, plans.ResourceInstanceDeleteBecauseCountIndex; got != want {
 			t.Errorf("wrong action reason for %s %s; want %s", addr, got, want)
 		}

--- a/internal/tofu/context_apply_test.go
+++ b/internal/tofu/context_apply_test.go
@@ -12378,6 +12378,7 @@ resource "test_resource" "a" {
 }
 
 func TestContext2Apply_forcedCBD(t *testing.T) {
+	SkipExperimental(t, ExperimentalBugCircularReference)
 	// Unfortunately in experimental mode this test is currently flaking with
 	// errors like this, but not consistently on every run:
 	//
@@ -12454,7 +12455,7 @@ resource "test_instance" "b" {
 }
 
 func TestContext2Apply_removeReferencedResource(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDestroy)
+	SkipExperimental(t, ExperimentalFeatureDestroy, ExperimentalBugCircularReference)
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 variable "ct" {

--- a/internal/tofu/context_apply_test.go
+++ b/internal/tofu/context_apply_test.go
@@ -9583,6 +9583,8 @@ func TestContext2Apply_scaleInMultivarRef(t *testing.T) {
 		if got, want := change.Action, plans.Delete; got != want {
 			t.Errorf("wrong action for %s %s; want %s", addr, got, want)
 		}
+		// Note: by skipping here, we still check for the errors and failures above!
+		SkipExperimental(t, ExperimentalFeatureActionReason)
 		if got, want := change.ActionReason, plans.ResourceInstanceDeleteBecauseCountIndex; got != want {
 			t.Errorf("wrong action reason for %s %s; want %s", addr, got, want)
 		}

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -1804,9 +1804,10 @@ func TestContext2Plan_movedResourceToDifferentType(t *testing.T) {
 			}),
 			oldType: "provider_object",
 			newType: "provider_object",
+			newAddr: "provider_object.old",
 			config: map[string]string{
 				"main.tf": `
-					resource "provider_object" "new" {
+					resource "provider_object" "old" {
 					        count = 1
 						test_number = 1
 					}
@@ -2147,6 +2148,9 @@ OpenTofu has planned to destroy these objects. If OpenTofu's proposed changes ar
 		if got, want := instPlan.Action, plans.Delete; got != want {
 			t.Errorf("wrong planned action\ngot:  %s\nwant: %s", got, want)
 		}
+
+		// Note: by skipping here, we still check for the errors and failures above!
+		SkipExperimental(t, ExperimentalFeatureActionReason)
 		if got, want := instPlan.ActionReason, plans.ResourceInstanceDeleteBecauseWrongRepetition; got != want {
 			t.Errorf("wrong action reason\ngot:  %s\nwant: %s", got, want)
 		}
@@ -2274,7 +2278,8 @@ OpenTofu has planned to destroy these objects. If OpenTofu's proposed changes ar
 }
 
 func TestContext2Plan_movedResourceUntargeted(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureMoved)
+	// I did not see the "excludes" flag in experimental features, but that's used here, too.
+	SkipExperimental(t, ExperimentalFeatureMoved, ExperimentalFeatureTarget)
 	addrA := mustResourceInstanceAddr("test_object.a")
 	addrB := mustResourceInstanceAddr("test_object.b")
 	m := testModuleInline(t, map[string]string{
@@ -2624,6 +2629,156 @@ The -target and -exclude options are not for routine use, and are provided only 
 	})
 }
 
+func TestContext2Plan_movedResourceErrors(t *testing.T) {
+	SkipExperimental(t, ExperimentalFeatureMoved)
+
+	type testChange struct {
+		addr        addrs.AbsResourceInstance
+		prevRunAddr addrs.AbsResourceInstance
+		action      plans.Action
+	}
+
+	type test struct {
+		configFolder string
+		state        *states.State
+		planChanges  []testChange
+		wantDiag     map[string]string
+	}
+
+	// state building functions
+	makeState := func(s *states.SyncState, addr string) {
+		s.SetResourceInstanceCurrent(mustResourceInstanceAddr(addr), &states.ResourceInstanceObjectSrc{
+			AttrsJSON: []byte(`{}`),
+			Status:    states.ObjectReady,
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`), addrs.NoKey)
+	}
+
+	tests := map[string]test{
+		"ambiguous move from two addresses": {
+			configFolder: "move-ambig-from",
+			state: states.BuildState(func(s *states.SyncState) {
+				makeState(s, "test_object.a")
+				makeState(s, "test_object.b")
+			}),
+			wantDiag: map[string]string{
+				// TODO: there's a race condition where it sometimes swaps a and b
+				"Ambiguous move statements": "test_object.a moved to test_object.c, but this statement instead declares that test_object.b moved there.",
+			},
+		},
+		"ambiguous move to two addresses": {
+			configFolder: "move-ambig-to",
+			state: states.BuildState(func(s *states.SyncState) {
+				makeState(s, "test_object.a")
+			}),
+			wantDiag: map[string]string{
+				// TODO: there's a race condition where it sometimes swaps b and c
+				"Ambiguous move statements": "test_object.a moved to test_object.b, but this statement instead declares that it moved to test_object.c.",
+			},
+		},
+		"redundant move statements": {
+			configFolder: "move-double",
+			state: states.BuildState(func(s *states.SyncState) {
+				makeState(s, "test_object.a")
+			}),
+			planChanges: []testChange{
+				{
+					addr:        mustResourceInstanceAddr("test_object.b"),
+					prevRunAddr: mustResourceInstanceAddr("test_object.a"),
+					action:      plans.NoOp,
+				},
+			},
+		},
+		"cycle in several move statements": {
+			configFolder: "move-cycle",
+			state:        states.NewState(),
+			wantDiag: map[string]string{
+				"Cyclic dependency in move statements": "The following chained move statements form a cycle, and so there is no final location",
+			},
+		},
+		"self-cycle in a move statements": {
+			configFolder: "move-self-cycle",
+			state: states.BuildState(func(s *states.SyncState) {
+				makeState(s, "test_object.a")
+			}),
+			wantDiag: map[string]string{
+				"Redundant move statement": "",
+			},
+		},
+		"move blocked by already-present state": {
+			configFolder: "move-blocked",
+			state: states.BuildState(func(s *states.SyncState) {
+				makeState(s, "test_object.a")
+				makeState(s, "test_object.b")
+			}),
+			wantDiag: map[string]string{
+				"Unresolved resource instance address changes": "OpenTofu has planned to destroy these objects.",
+			},
+		},
+		"object to move still in configuration": {
+			configFolder: "move-exist-obj",
+			state: states.BuildState(func(s *states.SyncState) {
+				makeState(s, "test_object.a")
+			}),
+			wantDiag: map[string]string{
+				"Moved object still exists": "This statement declares a move from test_object.a, but that resource is still declared",
+			},
+		},
+	}
+	for testName, tc := range tests {
+		t.Run(testName, func(t *testing.T) {
+			m := testModule(t, tc.configFolder)
+			state := tc.state
+
+			p := simpleMockProvider()
+			ctx := testContext2(t, &ContextOpts{
+				Plugins: plugins.NewLibrary(map[addrs.Provider]providers.Factory{
+					addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+				}, nil),
+			})
+			plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
+			if diags != nil {
+				if len(tc.wantDiag) == 0 {
+					t.Fatalf("unexpected errors: %v", diags.Err())
+				}
+				// check for expected errs
+				for _, diag := range diags {
+					wantedDetailSubstr, ok := tc.wantDiag[diag.Description().Summary]
+					if !ok {
+						t.Errorf("diagnostic with summary \"%s\" occurred, but did not expect this one", diag.Description().Summary)
+						continue
+					}
+					if !strings.Contains(diag.Description().Detail, wantedDetailSubstr) {
+						t.Errorf("expected diagnostic to contain substring: \"%s\"\nActual diagnostic:\n%s", wantedDetailSubstr, diag.Description().Detail)
+					}
+				}
+				return
+			} else {
+				if plan == nil || plan.Changes == nil {
+					t.Fatal("nil plan with nil diags, this should never happen!")
+				}
+				if len(tc.wantDiag) != 0 && !diags.HasErrors() {
+					t.Fatalf("expected errors, but got none")
+				}
+				// plan.Changes is non-nil, check the plan looks right.
+				for _, planChange := range tc.planChanges {
+					change := plan.Changes.ResourceInstance(planChange.addr)
+					if change == nil {
+						t.Errorf("tried to find address %s in plan changes, but did not find it", planChange.addr)
+						continue
+					}
+					if change.Action != planChange.action {
+						t.Errorf("expected action %s, got %s", planChange.action, change.Action)
+					}
+					if !change.PrevRunAddr.Equal(planChange.prevRunAddr) {
+						t.Errorf("expected move from %s, got %s", planChange.prevRunAddr, change.PrevRunAddr)
+					}
+				}
+
+			}
+		})
+	}
+}
+
 func TestContext2Plan_untargetedResourceSchemaChange(t *testing.T) {
 	SkipExperimental(t, ExperimentalFeatureTarget)
 
@@ -2756,7 +2911,7 @@ resource "test_object" "b" {
 }
 
 func TestContext2Plan_movedResourceRefreshOnly(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureMoved)
+	SkipExperimental(t, ExperimentalFeatureMoved, ExperimentalFeatureRefreshOnly)
 	addrA := mustResourceInstanceAddr("test_object.a")
 	addrB := mustResourceInstanceAddr("test_object.b")
 	m := testModuleInline(t, map[string]string{
@@ -3446,13 +3601,6 @@ func TestContext2Plan_forceReplace(t *testing.T) {
 	})
 	t.Run(addrB.String(), func(t *testing.T) {
 		instPlan := plan.Changes.ResourceInstance(addrB)
-		if experimentalRuntimeEnabled() {
-			if instPlan != nil {
-				t.Fatalf("expected no plan for %s at all", addrB)
-			}
-			// New engine does not generate NoOps
-			return
-		}
 		if instPlan == nil {
 			t.Fatalf("no plan for %s at all", addrB)
 		}
@@ -3517,13 +3665,6 @@ func TestContext2Plan_forceReplaceIncompleteAddr(t *testing.T) {
 
 	t.Run(addr0.String(), func(t *testing.T) {
 		instPlan := plan.Changes.ResourceInstance(addr0)
-		if experimentalRuntimeEnabled() {
-			if instPlan != nil {
-				t.Fatalf("expected no plan for %s at all", addr0)
-			}
-			// New engine does not generate NoOps
-			return
-		}
 
 		if instPlan == nil {
 			t.Fatalf("no plan for %s at all", addr0)
@@ -3538,13 +3679,6 @@ func TestContext2Plan_forceReplaceIncompleteAddr(t *testing.T) {
 	})
 	t.Run(addr1.String(), func(t *testing.T) {
 		instPlan := plan.Changes.ResourceInstance(addr1)
-		if experimentalRuntimeEnabled() {
-			if instPlan != nil {
-				t.Fatalf("expected no plan for %s at all", addr1)
-			}
-			// New engine does not generate NoOps
-			return
-		}
 		if instPlan == nil {
 			t.Fatalf("no plan for %s at all", addr1)
 		}
@@ -3760,6 +3894,7 @@ func TestContext2Plan_moduleImplicitMove(t *testing.T) {
 		prevAddr     addrs.AbsResourceInstance
 		config       *configs.Config
 		prevState    *states.State
+		skipFlags    []ExperimentalFlag
 	}{
 		"from count-module single-resource to enabled-module single-resource": {
 			config: testModuleInline(t, map[string]string{
@@ -3960,6 +4095,7 @@ func TestContext2Plan_moduleImplicitMove(t *testing.T) {
 					Status:    states.ObjectReady,
 				}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`), addrs.NoKey)
 			}),
+			skipFlags: []ExperimentalFlag{ExperimentalFeatureModuleEnabled},
 		},
 	}
 
@@ -3972,6 +4108,7 @@ func TestContext2Plan_moduleImplicitMove(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
+			SkipExperimental(t, test.skipFlags...)
 			plan, diags := ctx.Plan(context.Background(), test.config, test.prevState, DefaultPlanOpts)
 			if diags.HasErrors() {
 				t.Fatalf("unexpected errors\n%s", diags.Err().Error())

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -2640,7 +2640,7 @@ func TestContext2Plan_movedResourceErrors(t *testing.T) {
 		configFolder string
 		state        *states.State
 		planChanges  []testChange
-		wantDiag     map[string]string
+		wantDiag     map[string][]string
 	}
 
 	// state building functions
@@ -2658,9 +2658,11 @@ func TestContext2Plan_movedResourceErrors(t *testing.T) {
 				makeState(s, "test_object.a")
 				makeState(s, "test_object.b")
 			}),
-			wantDiag: map[string]string{
-				// TODO: there's a race condition where it sometimes swaps a and b
-				"Ambiguous move statements": "test_object.a moved to test_object.c, but this statement instead declares that test_object.b moved there.",
+			wantDiag: map[string][]string{
+				"Ambiguous move statements": {
+					"test_object.a moved to test_object.c, but this statement instead declares that test_object.b moved there.",
+					"test_object.b moved to test_object.c, but this statement instead declares that test_object.a moved there.",
+				},
 			},
 		},
 		"ambiguous move to two addresses": {
@@ -2668,9 +2670,11 @@ func TestContext2Plan_movedResourceErrors(t *testing.T) {
 			state: states.BuildState(func(s *states.SyncState) {
 				makeState(s, "test_object.a")
 			}),
-			wantDiag: map[string]string{
-				// TODO: there's a race condition where it sometimes swaps b and c
-				"Ambiguous move statements": "test_object.a moved to test_object.b, but this statement instead declares that it moved to test_object.c.",
+			wantDiag: map[string][]string{
+				"Ambiguous move statements": {
+					"test_object.a moved to test_object.b, but this statement instead declares that it moved to test_object.c.",
+					"test_object.a moved to test_object.c, but this statement instead declares that it moved to test_object.b.",
+				},
 			},
 		},
 		"redundant move statements": {
@@ -2689,8 +2693,8 @@ func TestContext2Plan_movedResourceErrors(t *testing.T) {
 		"cycle in several move statements": {
 			configFolder: "move-cycle",
 			state:        states.NewState(),
-			wantDiag: map[string]string{
-				"Cyclic dependency in move statements": "The following chained move statements form a cycle, and so there is no final location",
+			wantDiag: map[string][]string{
+				"Cyclic dependency in move statements": {"The following chained move statements form a cycle, and so there is no final location"},
 			},
 		},
 		"self-cycle in a move statements": {
@@ -2698,8 +2702,8 @@ func TestContext2Plan_movedResourceErrors(t *testing.T) {
 			state: states.BuildState(func(s *states.SyncState) {
 				makeState(s, "test_object.a")
 			}),
-			wantDiag: map[string]string{
-				"Redundant move statement": "",
+			wantDiag: map[string][]string{
+				"Redundant move statement": {""},
 			},
 		},
 		"move blocked by already-present state": {
@@ -2708,8 +2712,8 @@ func TestContext2Plan_movedResourceErrors(t *testing.T) {
 				makeState(s, "test_object.a")
 				makeState(s, "test_object.b")
 			}),
-			wantDiag: map[string]string{
-				"Unresolved resource instance address changes": "OpenTofu has planned to destroy these objects.",
+			wantDiag: map[string][]string{
+				"Unresolved resource instance address changes": {"OpenTofu has planned to destroy these objects."},
 			},
 		},
 		"object to move still in configuration": {
@@ -2717,8 +2721,8 @@ func TestContext2Plan_movedResourceErrors(t *testing.T) {
 			state: states.BuildState(func(s *states.SyncState) {
 				makeState(s, "test_object.a")
 			}),
-			wantDiag: map[string]string{
-				"Moved object still exists": "This statement declares a move from test_object.a, but that resource is still declared",
+			wantDiag: map[string][]string{
+				"Moved object still exists": {"This statement declares a move from test_object.a, but that resource is still declared"},
 			},
 		},
 	}
@@ -2740,13 +2744,20 @@ func TestContext2Plan_movedResourceErrors(t *testing.T) {
 				}
 				// check for expected errs
 				for _, diag := range diags {
-					wantedDetailSubstr, ok := tc.wantDiag[diag.Description().Summary]
+					wantedDetailSubstrs, ok := tc.wantDiag[diag.Description().Summary]
 					if !ok {
 						t.Errorf("diagnostic with summary \"%s\" occurred, but did not expect this one", diag.Description().Summary)
 						continue
 					}
-					if !strings.Contains(diag.Description().Detail, wantedDetailSubstr) {
-						t.Errorf("expected diagnostic to contain substring: \"%s\"\nActual diagnostic:\n%s", wantedDetailSubstr, diag.Description().Detail)
+					found := false
+					for _, possibleSubstr := range wantedDetailSubstrs {
+						if strings.Contains(diag.Description().Detail, possibleSubstr) {
+							found = true
+							break
+						}
+					}
+					if !found {
+						t.Errorf("expected diagnostic to contain substring: \"%s\"\nActual diagnostic:\n%s", wantedDetailSubstrs, diag.Description().Detail)
 					}
 				}
 				return

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -1802,9 +1802,10 @@ func TestContext2Plan_movedResourceToDifferentType(t *testing.T) {
 			}),
 			oldType: "provider_object",
 			newType: "provider_object",
+			newAddr: "provider_object.old",
 			config: map[string]string{
 				"main.tf": `
-					resource "provider_object" "new" {
+					resource "provider_object" "old" {
 					        count = 1
 						test_number = 1
 					}
@@ -2145,6 +2146,9 @@ OpenTofu has planned to destroy these objects. If OpenTofu's proposed changes ar
 		if got, want := instPlan.Action, plans.Delete; got != want {
 			t.Errorf("wrong planned action\ngot:  %s\nwant: %s", got, want)
 		}
+
+		// Note: by skipping here, we still check for the errors and failures above!
+		SkipExperimental(t, ExperimentalFeatureActionReason)
 		if got, want := instPlan.ActionReason, plans.ResourceInstanceDeleteBecauseWrongRepetition; got != want {
 			t.Errorf("wrong action reason\ngot:  %s\nwant: %s", got, want)
 		}
@@ -2272,7 +2276,8 @@ OpenTofu has planned to destroy these objects. If OpenTofu's proposed changes ar
 }
 
 func TestContext2Plan_movedResourceUntargeted(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureMoved)
+	// I did not see the "excludes" flag in experimental features, but that's used here, too.
+	SkipExperimental(t, ExperimentalFeatureMoved, ExperimentalFeatureTarget)
 	addrA := mustResourceInstanceAddr("test_object.a")
 	addrB := mustResourceInstanceAddr("test_object.b")
 	m := testModuleInline(t, map[string]string{
@@ -2622,6 +2627,156 @@ The -target and -exclude options are not for routine use, and are provided only 
 	})
 }
 
+func TestContext2Plan_movedResourceErrors(t *testing.T) {
+	SkipExperimental(t, ExperimentalFeatureMoved)
+
+	type testChange struct {
+		addr        addrs.AbsResourceInstance
+		prevRunAddr addrs.AbsResourceInstance
+		action      plans.Action
+	}
+
+	type test struct {
+		configFolder string
+		state        *states.State
+		planChanges  []testChange
+		wantDiag     map[string]string
+	}
+
+	// state building functions
+	makeState := func(s *states.SyncState, addr string) {
+		s.SetResourceInstanceCurrent(mustResourceInstanceAddr(addr), &states.ResourceInstanceObjectSrc{
+			AttrsJSON: []byte(`{}`),
+			Status:    states.ObjectReady,
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`), addrs.NoKey)
+	}
+
+	tests := map[string]test{
+		"ambiguous move from two addresses": {
+			configFolder: "move-ambig-from",
+			state: states.BuildState(func(s *states.SyncState) {
+				makeState(s, "test_object.a")
+				makeState(s, "test_object.b")
+			}),
+			wantDiag: map[string]string{
+				// TODO: there's a race condition where it sometimes swaps a and b
+				"Ambiguous move statements": "test_object.a moved to test_object.c, but this statement instead declares that test_object.b moved there.",
+			},
+		},
+		"ambiguous move to two addresses": {
+			configFolder: "move-ambig-to",
+			state: states.BuildState(func(s *states.SyncState) {
+				makeState(s, "test_object.a")
+			}),
+			wantDiag: map[string]string{
+				// TODO: there's a race condition where it sometimes swaps b and c
+				"Ambiguous move statements": "test_object.a moved to test_object.b, but this statement instead declares that it moved to test_object.c.",
+			},
+		},
+		"redundant move statements": {
+			configFolder: "move-double",
+			state: states.BuildState(func(s *states.SyncState) {
+				makeState(s, "test_object.a")
+			}),
+			planChanges: []testChange{
+				{
+					addr:        mustResourceInstanceAddr("test_object.b"),
+					prevRunAddr: mustResourceInstanceAddr("test_object.a"),
+					action:      plans.NoOp,
+				},
+			},
+		},
+		"cycle in several move statements": {
+			configFolder: "move-cycle",
+			state:        states.NewState(),
+			wantDiag: map[string]string{
+				"Cyclic dependency in move statements": "The following chained move statements form a cycle, and so there is no final location",
+			},
+		},
+		"self-cycle in a move statements": {
+			configFolder: "move-self-cycle",
+			state: states.BuildState(func(s *states.SyncState) {
+				makeState(s, "test_object.a")
+			}),
+			wantDiag: map[string]string{
+				"Redundant move statement": "",
+			},
+		},
+		"move blocked by already-present state": {
+			configFolder: "move-blocked",
+			state: states.BuildState(func(s *states.SyncState) {
+				makeState(s, "test_object.a")
+				makeState(s, "test_object.b")
+			}),
+			wantDiag: map[string]string{
+				"Unresolved resource instance address changes": "OpenTofu has planned to destroy these objects.",
+			},
+		},
+		"object to move still in configuration": {
+			configFolder: "move-exist-obj",
+			state: states.BuildState(func(s *states.SyncState) {
+				makeState(s, "test_object.a")
+			}),
+			wantDiag: map[string]string{
+				"Moved object still exists": "This statement declares a move from test_object.a, but that resource is still declared",
+			},
+		},
+	}
+	for testName, tc := range tests {
+		t.Run(testName, func(t *testing.T) {
+			m := testModule(t, tc.configFolder)
+			state := tc.state
+
+			p := simpleMockProvider()
+			ctx := testContext2(t, &ContextOpts{
+				Plugins: plugins.NewLibrary(map[addrs.Provider]providers.Factory{
+					addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+				}, nil),
+			})
+			plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
+			if diags != nil {
+				if len(tc.wantDiag) == 0 {
+					t.Fatalf("unexpected errors: %v", diags.Err())
+				}
+				// check for expected errs
+				for _, diag := range diags {
+					wantedDetailSubstr, ok := tc.wantDiag[diag.Description().Summary]
+					if !ok {
+						t.Errorf("diagnostic with summary \"%s\" occurred, but did not expect this one", diag.Description().Summary)
+						continue
+					}
+					if !strings.Contains(diag.Description().Detail, wantedDetailSubstr) {
+						t.Errorf("expected diagnostic to contain substring: \"%s\"\nActual diagnostic:\n%s", wantedDetailSubstr, diag.Description().Detail)
+					}
+				}
+				return
+			} else {
+				if plan == nil || plan.Changes == nil {
+					t.Fatal("nil plan with nil diags, this should never happen!")
+				}
+				if len(tc.wantDiag) != 0 && !diags.HasErrors() {
+					t.Fatalf("expected errors, but got none")
+				}
+				// plan.Changes is non-nil, check the plan looks right.
+				for _, planChange := range tc.planChanges {
+					change := plan.Changes.ResourceInstance(planChange.addr)
+					if change == nil {
+						t.Errorf("tried to find address %s in plan changes, but did not find it", planChange.addr)
+						continue
+					}
+					if change.Action != planChange.action {
+						t.Errorf("expected action %s, got %s", planChange.action, change.Action)
+					}
+					if !change.PrevRunAddr.Equal(planChange.prevRunAddr) {
+						t.Errorf("expected move from %s, got %s", planChange.prevRunAddr, change.PrevRunAddr)
+					}
+				}
+
+			}
+		})
+	}
+}
+
 func TestContext2Plan_untargetedResourceSchemaChange(t *testing.T) {
 	SkipExperimental(t, ExperimentalFeatureTarget)
 
@@ -2754,7 +2909,7 @@ resource "test_object" "b" {
 }
 
 func TestContext2Plan_movedResourceRefreshOnly(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureMoved)
+	SkipExperimental(t, ExperimentalFeatureMoved, ExperimentalFeatureRefreshOnly)
 	addrA := mustResourceInstanceAddr("test_object.a")
 	addrB := mustResourceInstanceAddr("test_object.b")
 	m := testModuleInline(t, map[string]string{
@@ -3442,13 +3597,6 @@ func TestContext2Plan_forceReplace(t *testing.T) {
 	})
 	t.Run(addrB.String(), func(t *testing.T) {
 		instPlan := plan.Changes.ResourceInstance(addrB)
-		if experimentalRuntimeEnabled() {
-			if instPlan != nil {
-				t.Fatalf("expected no plan for %s at all", addrB)
-			}
-			// New engine does not generate NoOps
-			return
-		}
 		if instPlan == nil {
 			t.Fatalf("no plan for %s at all", addrB)
 		}
@@ -3511,13 +3659,6 @@ func TestContext2Plan_forceReplaceIncompleteAddr(t *testing.T) {
 
 	t.Run(addr0.String(), func(t *testing.T) {
 		instPlan := plan.Changes.ResourceInstance(addr0)
-		if experimentalRuntimeEnabled() {
-			if instPlan != nil {
-				t.Fatalf("expected no plan for %s at all", addr0)
-			}
-			// New engine does not generate NoOps
-			return
-		}
 
 		if instPlan == nil {
 			t.Fatalf("no plan for %s at all", addr0)
@@ -3532,13 +3673,6 @@ func TestContext2Plan_forceReplaceIncompleteAddr(t *testing.T) {
 	})
 	t.Run(addr1.String(), func(t *testing.T) {
 		instPlan := plan.Changes.ResourceInstance(addr1)
-		if experimentalRuntimeEnabled() {
-			if instPlan != nil {
-				t.Fatalf("expected no plan for %s at all", addr1)
-			}
-			// New engine does not generate NoOps
-			return
-		}
 		if instPlan == nil {
 			t.Fatalf("no plan for %s at all", addr1)
 		}
@@ -3751,6 +3885,7 @@ func TestContext2Plan_moduleImplicitMove(t *testing.T) {
 		prevAddr     addrs.AbsResourceInstance
 		config       *configs.Config
 		prevState    *states.State
+		skipFlags    []ExperimentalFlag
 	}{
 		"from count-module single-resource to enabled-module single-resource": {
 			config: testModuleInline(t, map[string]string{
@@ -3951,6 +4086,7 @@ func TestContext2Plan_moduleImplicitMove(t *testing.T) {
 					Status:    states.ObjectReady,
 				}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`), addrs.NoKey)
 			}),
+			skipFlags: []ExperimentalFlag{ExperimentalFeatureModuleEnabled},
 		},
 	}
 
@@ -3963,6 +4099,7 @@ func TestContext2Plan_moduleImplicitMove(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
+			SkipExperimental(t, test.skipFlags...)
 			plan, diags := ctx.Plan(context.Background(), test.config, test.prevState, DefaultPlanOpts)
 			if diags.HasErrors() {
 				t.Fatalf("unexpected errors\n%s", diags.Err().Error())

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -2642,7 +2642,7 @@ func TestContext2Plan_movedResourceErrors(t *testing.T) {
 		configFolder string
 		state        *states.State
 		planChanges  []testChange
-		wantDiag     map[string]string
+		wantDiag     map[string][]string
 	}
 
 	// state building functions
@@ -2660,9 +2660,11 @@ func TestContext2Plan_movedResourceErrors(t *testing.T) {
 				makeState(s, "test_object.a")
 				makeState(s, "test_object.b")
 			}),
-			wantDiag: map[string]string{
-				// TODO: there's a race condition where it sometimes swaps a and b
-				"Ambiguous move statements": "test_object.a moved to test_object.c, but this statement instead declares that test_object.b moved there.",
+			wantDiag: map[string][]string{
+				"Ambiguous move statements": {
+					"test_object.a moved to test_object.c, but this statement instead declares that test_object.b moved there.",
+					"test_object.b moved to test_object.c, but this statement instead declares that test_object.a moved there.",
+				},
 			},
 		},
 		"ambiguous move to two addresses": {
@@ -2670,9 +2672,11 @@ func TestContext2Plan_movedResourceErrors(t *testing.T) {
 			state: states.BuildState(func(s *states.SyncState) {
 				makeState(s, "test_object.a")
 			}),
-			wantDiag: map[string]string{
-				// TODO: there's a race condition where it sometimes swaps b and c
-				"Ambiguous move statements": "test_object.a moved to test_object.b, but this statement instead declares that it moved to test_object.c.",
+			wantDiag: map[string][]string{
+				"Ambiguous move statements": {
+					"test_object.a moved to test_object.b, but this statement instead declares that it moved to test_object.c.",
+					"test_object.a moved to test_object.c, but this statement instead declares that it moved to test_object.b.",
+				},
 			},
 		},
 		"redundant move statements": {
@@ -2691,8 +2695,8 @@ func TestContext2Plan_movedResourceErrors(t *testing.T) {
 		"cycle in several move statements": {
 			configFolder: "move-cycle",
 			state:        states.NewState(),
-			wantDiag: map[string]string{
-				"Cyclic dependency in move statements": "The following chained move statements form a cycle, and so there is no final location",
+			wantDiag: map[string][]string{
+				"Cyclic dependency in move statements": {"The following chained move statements form a cycle, and so there is no final location"},
 			},
 		},
 		"self-cycle in a move statements": {
@@ -2700,8 +2704,8 @@ func TestContext2Plan_movedResourceErrors(t *testing.T) {
 			state: states.BuildState(func(s *states.SyncState) {
 				makeState(s, "test_object.a")
 			}),
-			wantDiag: map[string]string{
-				"Redundant move statement": "",
+			wantDiag: map[string][]string{
+				"Redundant move statement": {""},
 			},
 		},
 		"move blocked by already-present state": {
@@ -2710,8 +2714,8 @@ func TestContext2Plan_movedResourceErrors(t *testing.T) {
 				makeState(s, "test_object.a")
 				makeState(s, "test_object.b")
 			}),
-			wantDiag: map[string]string{
-				"Unresolved resource instance address changes": "OpenTofu has planned to destroy these objects.",
+			wantDiag: map[string][]string{
+				"Unresolved resource instance address changes": {"OpenTofu has planned to destroy these objects."},
 			},
 		},
 		"object to move still in configuration": {
@@ -2719,8 +2723,8 @@ func TestContext2Plan_movedResourceErrors(t *testing.T) {
 			state: states.BuildState(func(s *states.SyncState) {
 				makeState(s, "test_object.a")
 			}),
-			wantDiag: map[string]string{
-				"Moved object still exists": "This statement declares a move from test_object.a, but that resource is still declared",
+			wantDiag: map[string][]string{
+				"Moved object still exists": {"This statement declares a move from test_object.a, but that resource is still declared"},
 			},
 		},
 	}
@@ -2742,13 +2746,20 @@ func TestContext2Plan_movedResourceErrors(t *testing.T) {
 				}
 				// check for expected errs
 				for _, diag := range diags {
-					wantedDetailSubstr, ok := tc.wantDiag[diag.Description().Summary]
+					wantedDetailSubstrs, ok := tc.wantDiag[diag.Description().Summary]
 					if !ok {
 						t.Errorf("diagnostic with summary \"%s\" occurred, but did not expect this one", diag.Description().Summary)
 						continue
 					}
-					if !strings.Contains(diag.Description().Detail, wantedDetailSubstr) {
-						t.Errorf("expected diagnostic to contain substring: \"%s\"\nActual diagnostic:\n%s", wantedDetailSubstr, diag.Description().Detail)
+					found := false
+					for _, possibleSubstr := range wantedDetailSubstrs {
+						if strings.Contains(diag.Description().Detail, possibleSubstr) {
+							found = true
+							break
+						}
+					}
+					if !found {
+						t.Errorf("expected diagnostic to contain substring: \"%s\"\nActual diagnostic:\n%s", wantedDetailSubstrs, diag.Description().Detail)
 					}
 				}
 				return

--- a/internal/tofu/context_plan_test.go
+++ b/internal/tofu/context_plan_test.go
@@ -6006,12 +6006,6 @@ func TestContext2Plan_ignoreChanges(t *testing.T) {
 
 	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
-	if experimentalRuntimeEnabled() {
-		if len(plan.Changes.Resources) != 0 {
-			t.Fatal("expected 0 changes, got", len(plan.Changes.Resources))
-		}
-		return
-	}
 	if len(plan.Changes.Resources) != 1 {
 		t.Fatal("expected 1 changes, got", len(plan.Changes.Resources))
 	}
@@ -6207,12 +6201,6 @@ func TestContext2Plan_ignoreChangesSensitive(t *testing.T) {
 
 	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
-	if experimentalRuntimeEnabled() {
-		if len(plan.Changes.Resources) != 0 {
-			t.Fatal("expected 0 changes, got", len(plan.Changes.Resources))
-		}
-		return
-	}
 	if len(plan.Changes.Resources) != 1 {
 		t.Fatal("expected 1 changes, got", len(plan.Changes.Resources))
 	}

--- a/internal/tofu/context_plan_test.go
+++ b/internal/tofu/context_plan_test.go
@@ -6051,12 +6051,6 @@ func TestContext2Plan_ignoreChanges(t *testing.T) {
 
 	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
-	if experimentalRuntimeEnabled() {
-		if len(plan.Changes.Resources) != 0 {
-			t.Fatal("expected 0 changes, got", len(plan.Changes.Resources))
-		}
-		return
-	}
 	if len(plan.Changes.Resources) != 1 {
 		t.Fatal("expected 1 changes, got", len(plan.Changes.Resources))
 	}
@@ -6258,12 +6252,6 @@ func TestContext2Plan_ignoreChangesSensitive(t *testing.T) {
 
 	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
-	if experimentalRuntimeEnabled() {
-		if len(plan.Changes.Resources) != 0 {
-			t.Fatal("expected 0 changes, got", len(plan.Changes.Resources))
-		}
-		return
-	}
 	if len(plan.Changes.Resources) != 1 {
 		t.Fatal("expected 1 changes, got", len(plan.Changes.Resources))
 	}

--- a/internal/tofu/context_temp_runtime_test.go
+++ b/internal/tofu/context_temp_runtime_test.go
@@ -107,7 +107,7 @@ var (
 	ExperimentalFeatureLinting         = ExperimentalFlag{"Missing Linting", false}
 	ExperimentalFeatureRefresh         = ExperimentalFlag{"Missing Refresh", false}
 	ExperimentalFeatureRefreshOnly     = ExperimentalFlag{"Missing Refresh-only Planning Mode", false}
-	ExperimentalFeatureMoved           = ExperimentalFlag{"Missing Moved", false}
+	ExperimentalFeatureMoved           = ExperimentalFlag{"Missing Moved", true}
 	ExperimentalFeatureRemoved         = ExperimentalFlag{"Missing Removed", false}
 	ExperimentalFeatureSkipDestroy     = ExperimentalFlag{"Missing Lifecycle Destroy", false}
 	ExperimentalFeatureUpgradeUnwanted = ExperimentalFlag{"Missing Upgrade Orphan or Deposed Resource Instance State", false}
@@ -121,6 +121,7 @@ var (
 	ExperimentalFeatureErrorHandling   = ExperimentalFlag{"Missing Error Handling", false}
 	ExperimentalFeatureProviderInput   = ExperimentalFlag{"Missing Provider Input Prompting", false}
 	ExperimentalFeatureModuleEnabled   = ExperimentalFlag{"Missing Module Lifecycle Enabled", false}
+	ExperimentalFeatureActionReason    = ExperimentalFlag{"Missing ActionReason", false}
 
 	// Obsolete flags indicate a test which depends on a feature we do not
 	// intend to carry forward into the new engine

--- a/internal/tofu/context_temp_runtime_test.go
+++ b/internal/tofu/context_temp_runtime_test.go
@@ -125,7 +125,7 @@ var (
 	ExperimentalFeatureRefreshOnly       = ExperimentalFlag{"Missing Refresh-only Planning Mode", false}
 	ExperimentalFeatureValidate          = ExperimentalFlag{"Missing Validate", true}
 	ExperimentalFeatureDestroy           = ExperimentalFlag{"Missing Destroy-mode Planning", true}
-	ExperimentalFeatureMoved             = ExperimentalFlag{"Missing Moved", false}
+	ExperimentalFeatureMoved             = ExperimentalFlag{"Missing Moved", true}
 	ExperimentalFeatureRemoved           = ExperimentalFlag{"Missing Removed", false}
 	ExperimentalFeatureSkipDestroy       = ExperimentalFlag{"Missing Lifecycle Destroy", false}
 	ExperimentalFeatureUpgradeState      = ExperimentalFlag{"Missing Upgrade Resource State", true}
@@ -150,6 +150,7 @@ var (
 	ExperimentalFeatureProviderFunctions = ExperimentalFlag{"Missing Provider Defined Functions", true}
 	ExperimentalFeatureProviderInput     = ExperimentalFlag{"Missing Provider Input Prompting", false}
 	ExperimentalFeatureModuleEnabled     = ExperimentalFlag{"Missing Module Lifecycle Enabled", false}
+	ExperimentalFeatureActionReason      = ExperimentalFlag{"Missing ActionReason", false}
 
 	// Obsolete flags indicate a test which depends on a feature we do not
 	// intend to carry forward into the new engine

--- a/internal/tofu/testdata/move-ambig-from/main.tf
+++ b/internal/tofu/testdata/move-ambig-from/main.tf
@@ -1,0 +1,11 @@
+moved {
+    from = test_object.a
+    to = test_object.c
+}
+
+moved {
+    from = test_object.b
+    to = test_object.c
+}
+
+resource "test_object" "c" {}

--- a/internal/tofu/testdata/move-ambig-to/main.tf
+++ b/internal/tofu/testdata/move-ambig-to/main.tf
@@ -1,0 +1,13 @@
+moved {
+    from = test_object.a
+    to = test_object.b
+}
+
+moved {
+    from = test_object.a
+    to = test_object.c
+}
+
+resource "test_object" "b" {}
+
+resource "test_object" "c" {}

--- a/internal/tofu/testdata/move-blocked/main.tf
+++ b/internal/tofu/testdata/move-blocked/main.tf
@@ -1,0 +1,6 @@
+moved {
+    from = test_object.a
+    to = test_object.b
+}
+
+resource "test_object" "b" {}

--- a/internal/tofu/testdata/move-cycle/main.tf
+++ b/internal/tofu/testdata/move-cycle/main.tf
@@ -1,0 +1,14 @@
+moved {
+    from = test_object.a
+    to = test_object.b
+}
+
+moved {
+    from = test_object.b
+    to = test_object.c
+}
+
+moved {
+    from = test_object.c
+    to = test_object.a
+}

--- a/internal/tofu/testdata/move-double/main.tf
+++ b/internal/tofu/testdata/move-double/main.tf
@@ -1,0 +1,11 @@
+moved {
+    from = test_object.a
+    to = test_object.b
+}
+
+moved {
+    from = test_object.a
+    to = test_object.b
+}
+
+resource "test_object" "b" {}

--- a/internal/tofu/testdata/move-exist-obj/main.tf
+++ b/internal/tofu/testdata/move-exist-obj/main.tf
@@ -1,0 +1,7 @@
+moved {
+    from = test_object.a
+    to = test_object.b
+}
+
+resource "test_object" "a" {}
+resource "test_object" "b" {}

--- a/internal/tofu/testdata/move-self-cycle/main.tf
+++ b/internal/tofu/testdata/move-self-cycle/main.tf
@@ -1,0 +1,4 @@
+moved {
+    from = test_object.a
+    to = test_object.a
+}


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves #4229 

This PR implements move statements for the experimental runtime. The main two files of this change are `config_plan_move.go`, which lets the plan oracle handle move statement and move results, and `plan_managed.go`, which uses those methods to implement moves for managed resources. There's a lot to say about this implementation, and I hope this description helps with reviewing the code!

In short: the oracle has been updated to have move statements and record moves. Moves are detected in "unwanted" resources, which are not deleted but instead ignored and handled in "desired." In addition to picking up the previously-orphaned state, "desired" also handles provider requests for state upgrades.

There's a subtle aspect of moves that bears mentioning: a move only occurs when there is state for an address, but no configuration at that address; if there's no state, there's nothing to move, and if there's configuration, any move statement that might occur would error given that configuration matches some `from` address. Because we're looking for state without configuration, it's most logical to have move logic in `planUnwantedManagedResourceInstanceObject`, and I recommend reviewers start from that function. This is also the reason I put `announcePlanOrphans` and `checkAll` in sequence in `config_plan.go`; the moves made in "unwanted" are subsequently picked up in "desired"[^1].

[^1]: I suppose a future version might have concurrent "adoption of orphaned state", but it would have to be some fancy footwork to manage blocking between candidate state and configuration.

I found it interesting how there are similarities between the current runtime and the experimental runtime. With `NoOp`, the current set of circumstances determining which action to take resembles [a switch statement in `NodeAbstractResourceInstance.plan`](https://github.com/opentofu/opentofu/blob/2ea7fa46c78ab9ba0c5e888234b8db07445359dc/internal/tofu/node_resource_abstract_instance.go#L1505-L1518). You may find it helpful to also compare the decision of whether to run a `MoveResourceState` or `UpgradeResourceState` to its corresponding decision point [in the current runtime](https://github.com/opentofu/opentofu/blob/2ea7fa46c78ab9ba0c5e888234b8db07445359dc/internal/tofu/node_resource_abstract.go#L646-L650). The diff is somewhat inscrutable because of the changed control structure, but the `Upgrade` part of the code has not changed much. Actually, the only change made to the `Upgrade` part of the code involves implicit moves: if it's an implied move, we change the place we save state over to the previous address. This prevents a [panic](https://github.com/opentofu/opentofu/blob/2ea7fa46c78ab9ba0c5e888234b8db07445359dc/internal/states/state.go#L545) later in the [exec operations](https://github.com/opentofu/opentofu/blob/2ea7fa46c78ab9ba0c5e888234b8db07445359dc/internal/engine/applying/operations_resource_managed.go#L478). I'm... not entirely sure about that part of the PR...

That diff in `planDesiredManagedResourceInstance` is so difficult to understand... let me try to simplify. If the state is non-nil, we'll try to upgrade it. Using the same decision logic, we choose which branch to go down. Note that implied moves are always upgraded and moves are only upgraded if the resource type hasn't changed. Also note that both upgrades are very similar; we may want to do a refactor equivalent to what it looks like in the current runtime.

Speaking of implicit moves: their handling is somewhat different than what happens in the current runtime. Rather than creating ersatz statements if no such statement exists, we look in the configuration for a "reciprocal address", that is, one that is equivalent to the given address in state, with the exception of swapping `NoKey` and `IntKey(0)` in one location[^3]. Another difference is that implicit moves only occur if there are no explicit moves for that address in state. I think it might technically be possible to mix implicit and explicit moves, but it seems a bit difficult or wasteful resource-wise[^2].

[^3]: I've also done an investigation about nested implicit moves, where multiple counts are changed in both modules and resource. It doesn't look like our current engine does more than one implicit move at a time; I do not believe the experimental engine's implicit moves do more than one implicit move, either, however, I was not able to test this as I encountered a strange bug when I tried!

[^2]: The wasteful part is the address lookup. I wish there were some sort of tree to look up absolute resource addresses, and also a "trie" data structure that we could access all the instance keys for a given absolute resource address... although see "pyrrhic move" for why that still isn't sufficient. As it stands, looping through instances to find the right one every time seems like a bad idea, and we might want a (non-sync, read-only) map to cache said results once expansion is complete.

I'll quickly mention the "pyrrhic move." Occasionally, a resource changes from `NoKey` to `count = 0`. The current runtime records this as an implicit move, but then deletes it anyway because there's no corresponding instance. The pyrrhic move exists to match this quirk in functionality. See the `TestContext2Apply_scaleInMultivarRef` test, which gave me no small amount of grief.

Part of this PR involved implementing the `NoOp` operation. This simplified a bit of logic in `planDesiredManagedResourceInstance`. You'll also notice that some tests have been readjusted to put them back in line with how the current runtime operates.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
