### PR TITLE
Fix plan file serialization for ForgetThenCreate action (#4324)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ BUG FIXES:
 - Fix rendering of plans where a nested block's replacement is unknown. ([#4256](https://github.com/opentofu/opentofu/issues/4256))
 - `errored.tfstate` is now produced during a go runtime panic. This file will be a partial state and is intended for aiding in recovery from a hard crash. ([#4064](https://github.com/opentofu/opentofu/pull/4064))
 - `removed` blocks with an invalid `from` address and a destroy provisioner now report a configuration error instead of crashing. ([#4321](https://github.com/opentofu/opentofu/pull/4321))
+- `tofu plan -out` no longer fails when the plan includes a resource with `lifecycle { destroy = false }` that needs replacement, which previously errored with `invalid change action ForgetThenCreate`. ([#4324](https://github.com/opentofu/opentofu/issues/4324))
 
 ## Previous Releases
 

--- a/internal/plans/planfile/tfplan.go
+++ b/internal/plans/planfile/tfplan.go
@@ -433,6 +433,10 @@ func changeFromTfplan(rawChange *planproto.Change) (*plans.ChangeSrc, error) {
 		ret.Action = plans.DeleteThenCreate
 		beforeIdx = 0
 		afterIdx = 1
+	case planproto.Action_FORGET_THEN_CREATE:
+		ret.Action = plans.ForgetThenCreate
+		beforeIdx = 0
+		afterIdx = 1
 	default:
 		return nil, fmt.Errorf("invalid change action %s", rawChange.Action)
 	}
@@ -896,6 +900,9 @@ func changeToTfplan(change *plans.ChangeSrc) (*planproto.Change, error) {
 		ret.Values = []*planproto.DynamicValue{before, after}
 	case plans.CreateThenDelete:
 		ret.Action = planproto.Action_CREATE_THEN_DELETE
+		ret.Values = []*planproto.DynamicValue{before, after}
+	case plans.ForgetThenCreate:
+		ret.Action = planproto.Action_FORGET_THEN_CREATE
 		ret.Values = []*planproto.DynamicValue{before, after}
 	default:
 		return nil, fmt.Errorf("invalid change action %s", change.Action)

--- a/internal/plans/planfile/tfplan_test.go
+++ b/internal/plans/planfile/tfplan_test.go
@@ -156,6 +156,31 @@ func TestTFPlanRoundTrip(t *testing.T) {
 					Addr: addrs.Resource{
 						Mode: addrs.ManagedResourceMode,
 						Type: "test_thing",
+						Name: "forget_then_create",
+					}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance),
+					PrevRunAddr: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "test_thing",
+						Name: "forget_then_create",
+					}.Instance(addrs.IntKey(0)).Absolute(addrs.RootModuleInstance),
+					ProviderAddr: addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+						Module:   addrs.RootModule,
+					},
+					ChangeSrc: plans.ChangeSrc{
+						Action: plans.ForgetThenCreate,
+						Before: mustNewDynamicValue(cty.ObjectVal(map[string]cty.Value{
+							"id": cty.StringVal("old-id"),
+						}), objTy),
+						After: mustNewDynamicValue(cty.ObjectVal(map[string]cty.Value{
+							"id": cty.StringVal("new-id"),
+						}), objTy),
+					},
+				},
+				{
+					Addr: addrs.Resource{
+						Mode: addrs.ManagedResourceMode,
+						Type: "test_thing",
 						Name: "importing",
 					}.Instance(addrs.IntKey(1)).Absolute(addrs.RootModuleInstance),
 					PrevRunAddr: addrs.Resource{


### PR DESCRIPTION
When a resource has `lifecycle.destroy = false` and `triggers_replace` changes, the planner produces a `ForgetThenCreate` action. However, the plan file serialization (`changeToTfplan`) and deserialization (`changeFromTfplan`) in `internal/plans/planfile/tfplan.go` were missing the case mappings for `ForgetThenCreate`, causing:

```
Error: Failed to write plan file
...invalid change action ForgetThenCreate.
```

Both the protobuf enum value (`Action_FORGET_THEN_CREATE = 10`) and the Go action (`plans.ForgetThenCreate`) already existed, the bridging code was simply overlooked when the lifecycle.destroy=false feature landed in PR #3409.

Fixes #4324.

```
internal/plans/planfile/tfplan.go      | 7 +++++++
internal/plans/planfile/tfplan_test.go | 25 +++++++++++++++++++++++++
CHANGELOG.md                           | 1 +
```

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.