### PR TITLE
Escape the script_path on the communicator and remote-exec provisioner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ BUG FIXES:
 - `errored.tfstate` is now produced during a go runtime panic. This file will be a partial state and is intended for aiding in recovery from a hard crash. ([#4064](https://github.com/opentofu/opentofu/pull/4064))
 - `removed` blocks with an invalid `from` address and a destroy provisioner now report a configuration error instead of crashing. ([#4321](https://github.com/opentofu/opentofu/pull/4321))
 - `tofu plan -out` no longer fails when the plan includes a resource with `lifecycle { destroy = false }` that needs replacement, which previously errored with `invalid change action ForgetThenCreate`. ([#4324](https://github.com/opentofu/opentofu/issues/4324))
+- `connection.script_path` is escaped correctly not allowing anymore additional commands to be executed on the remote host together with the script path indicated by the argument. ([#4330](https://github.com/opentofu/opentofu/pull/4330))
 
 ## Previous Releases
 

--- a/internal/builtin/provisioners/remote-exec/resource_provisioner.go
+++ b/internal/builtin/provisioners/remote-exec/resource_provisioner.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/apparentlymart/go-shquot/shquot"
 	"github.com/mitchellh/go-linereader"
 	"github.com/opentofu/opentofu/internal/communicator"
 	"github.com/opentofu/opentofu/internal/communicator/remote"
@@ -269,7 +270,7 @@ func runScripts(ctx context.Context, o provisioners.UIOutput, comm communicator.
 		}
 
 		cmd = &remote.Cmd{
-			Command: remotePath,
+			Command: shquot.POSIXShell([]string{remotePath}),
 			Stdout:  outW,
 			Stderr:  errW,
 		}

--- a/internal/communicator/ssh/communicator.go
+++ b/internal/communicator/ssh/communicator.go
@@ -466,7 +466,7 @@ func (c *Communicator) UploadScript(path string, input io.Reader) error {
 	if c.connInfo.TargetPlatform != TargetPlatformWindows {
 		var stdout, stderr bytes.Buffer
 		cmd := &remote.Cmd{
-			Command: fmt.Sprintf("chmod 0777 %s", path),
+			Command: shquot.POSIXShell([]string{"chmod", "0777", path}),
 			Stdout:  &stdout,
 			Stderr:  &stderr,
 		}


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
This fixes a bug in the `remote-exec` provisioner that allowed the `script_path` field to include also additional commands to be executed together (or after) running the script that OpenTofu builds, uploads and execute on the remote host.

ℹ️ Tried to add an e2e test but there is not really a way to do so since this requires an ssh connection to a remote host. If any of the reviewers have a good idea on how to do it, please let me know down below.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
