### PR TITLE
Support Provisioners in the new runtime

### DIFF
--- a/internal/engine/applying/operations_provisioners.go
+++ b/internal/engine/applying/operations_provisioners.go
@@ -1,0 +1,84 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package applying
+
+import (
+	"context"
+	"log"
+
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/configs"
+	"github.com/opentofu/opentofu/internal/lang/eval"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func (ops *execOperations) runProvisioner(ctx context.Context, objAddr addrs.AbsResourceInstanceObject, prov eval.Provisioner, selfVal cty.Value) (bool, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	tracer := contextTracer(ctx)
+
+	provConfig, moreDiags := prov.Config(ctx, selfVal)
+	diags = diags.Append(moreDiags)
+	if moreDiags.HasErrors() {
+		return false, diags
+	}
+
+	// Based on NodeAbstractInstance.applyProvisioners
+
+	// Call pre hook
+	if cb := tracer.StartProvisionInstanceStep; cb != nil {
+		ctx = cb(ctx, objAddr.InstanceAddr, prov.Type)
+	}
+
+	// If our config or connection info contains any marked values, ensure
+	// those are stripped out before sending to the provisioner. Unlike
+	// resources, we have no need to capture the marked paths and reapply
+	// later.
+	unmarkedConfig, configMarks := provConfig.Value.UnmarkDeep()
+	unmarkedConnInfo, _ := provConfig.Connection.UnmarkDeep()
+
+	// The output function passes the config marks to hooks so they can
+	// inspect them (e.g. sensitive) and decide how to handle output.
+	outputFn := func(string) {}
+	if cb := tracer.ProvisionOutput; cb != nil {
+		outputFn = func(msg string) {
+			cb(ctx, objAddr.InstanceAddr, prov.Type, msg, configMarks)
+		}
+	}
+
+	resp := ops.plugins.ProvisionResource(
+		ctx,
+		prov.Type,
+		unmarkedConfig,
+		unmarkedConnInfo,
+		outputFn,
+	)
+	applyDiags := resp //.InConfigBody(prov.Config, n.Addr.String())
+
+	// Call post hook
+	if cb := tracer.StopProvisionInstanceStep; cb != nil {
+		cb(ctx, objAddr.InstanceAddr, prov.Type, applyDiags)
+	}
+
+	switch prov.OnFailure {
+	case configs.ProvisionerOnFailureContinue:
+		if applyDiags.HasErrors() {
+			log.Printf("[WARN] Errors while provisioning %s with %q, but continuing as requested in configuration", objAddr, prov.Type)
+		} else {
+			// Maybe there are warnings that we still want to see
+			diags = diags.Append(applyDiags)
+		}
+	default:
+		diags = diags.Append(applyDiags)
+		if applyDiags.HasErrors() {
+			log.Printf("[WARN] Errors while provisioning %s with %q, so aborting", objAddr, prov.Type)
+			return false, diags
+		}
+	}
+
+	return true, diags
+}

--- a/internal/engine/applying/operations_resource_managed.go
+++ b/internal/engine/applying/operations_resource_managed.go
@@ -33,6 +33,8 @@ func (ops *execOperations) ManagedFinalPlan(
 
 	var instAddr addrs.AbsResourceInstance
 	var providerConfigAddr addrs.AbsProviderInstanceCorrect
+	var createProvisioners []eval.Provisioner
+	var destroyProvisioners []eval.Provisioner
 	var resourceTypeName string
 	var requiredConfigResources addrs.Set[addrs.AbsResourceInstance]
 	deposedKey := states.NotDeposed
@@ -48,11 +50,21 @@ func (ops *execOperations) ManagedFinalPlan(
 		// TODO possibly nil here
 		providerConfigAddr = *desired.ProviderInstance
 		requiredConfigResources = desired.RequiredResourceInstances
+
+		createProvisioners = desired.CreateProvisioners
 	} else if prior != nil {
 		instAddr = prior.Addr.InstanceAddr
 		deposedKey = prior.Addr.DeposedKey
 		resourceTypeName = prior.State.ResourceType
 		providerConfigAddr = prior.State.ProviderInstanceAddr
+
+		if prior.State.Status == states.ObjectTainted {
+			// No point in provisioning an object that is already tainted, since
+			// it's going to get recreated on the next apply anyway.
+			log.Printf("[TRACE] %s is tainted, so skipping provisioning", instAddr)
+		} else {
+			destroyProvisioners = ops.configOracle.DestroyProvisioners(ctx, instAddr)
+		}
 	} else {
 		// Both should not be nil but if they are then we'll treat it the same
 		// way as if we dynamically discover that no change is actually
@@ -141,6 +153,8 @@ func (ops *execOperations) ManagedFinalPlan(
 		PriorStateVal:             resp.Current.Value,
 		ConfigVal:                 resp.DesiredValue,
 		PlannedVal:                resp.Planned.Value,
+		CreateProvisioners:        createProvisioners,
+		DestroyProvisioners:       destroyProvisioners,
 		ProviderInstance:          providerConfigAddr,
 		ProviderPrivate:           resp.Planned.Private,
 	}, diags
@@ -227,6 +241,8 @@ func (ops *execOperations) ManagedApply(
 		return nil, diags
 	}
 
+	objAddr := plan.Addr
+
 	// TODO: Encapsulate most of the following logic into a method of
 	// [resources.ManagedResourceType].
 
@@ -252,6 +268,17 @@ func (ops *execOperations) ManagedApply(
 	diags = diags.Append(moreDiags)
 	if diags.HasErrors() {
 		return nil, diags
+	}
+
+	// Destroy Provisioners
+	if plannedValUnmarked.IsNull() {
+		for _, prov := range plan.DestroyProvisioners {
+			cont, provDiags := ops.runProvisioner(ctx, objAddr, prov, priorValUnmarked)
+			diags = diags.Append(provDiags)
+			if !cont {
+				return nil, diags
+			}
+		}
 	}
 
 	resp := providerClient.ApplyResourceChange(ctx, providers.ApplyResourceChangeRequest{
@@ -297,11 +324,21 @@ func (ops *execOperations) ManagedApply(
 		return result, diags
 	}
 
+	// Create Provisioners
+	if !plannedValUnmarked.IsNull() && priorValUnmarked.IsNull() {
+		for _, prov := range plan.CreateProvisioners {
+			cont, provDiags := ops.runProvisioner(ctx, objAddr, prov, resp.NewState)
+			diags = diags.Append(provDiags)
+			if !cont {
+				break
+			}
+		}
+	}
+
 	// TODO: objchange.AssertObjectCompatible to verify that the result is
 	// consistent with what was planned. (That'll need the provider schema
 	// we fetched above, but currently we're just discarding that schema.)
 
-	objAddr := plan.Addr
 	var state *states.ResourceInstanceObjectFull
 	if !resp.NewState.IsNull() {
 		status := states.ObjectTainted
@@ -360,6 +397,7 @@ func (ops *execOperations) ManagedApply(
 	} else {
 		resultVal = cty.NullVal(schema.Block.ImpliedType())
 	}
+
 	ret := &exec.ResourceInstanceObject{
 		Addr:  plan.Addr,
 		State: state, // nil if the object was deleted

--- a/internal/engine/applying/tracing.go
+++ b/internal/engine/applying/tracing.go
@@ -52,6 +52,11 @@ type Tracer struct {
 	StartManagedResourceInstanceObjectApply func(ctx context.Context, addr addrs.AbsResourceInstanceObject, priorVal, plannedVal cty.Value) context.Context
 	EndManagedResourceInstanceObjectApply   func(ctx context.Context, addr addrs.AbsResourceInstanceObject, resultVal cty.Value, diags tfdiags.Diagnostics)
 
+	// Provisioner Hooks for Managed Resources
+	StartProvisionInstanceStep func(ctx context.Context, addr addrs.AbsResourceInstance, typeName string) context.Context
+	ProvisionOutput            func(ctx context.Context, addr addrs.AbsResourceInstance, typeName string, line string, configMarks cty.ValueMarks)
+	StopProvisionInstanceStep  func(ctx context.Context, addr addrs.AbsResourceInstance, typeName string, diags tfdiags.Diagnostics)
+
 	////////// Data Resource Applying Events
 
 	// StartDataResourceInstanceRead and EndDataResourceInstanceRead mark the

--- a/internal/engine/internal/exec/resource.go
+++ b/internal/engine/internal/exec/resource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/lang/eval"
 	"github.com/opentofu/opentofu/internal/states"
 )
 
@@ -74,6 +75,13 @@ type ManagedResourceObjectFinalPlan struct {
 	ProviderPrivate []byte
 	// TODO: Anything else we'd need to populate an "ApplyResourceChanges"
 	// request to the associated provider.
+
+	// CreateProvisioners are the provisioners to execute if the resource
+	// instance is being created.
+	CreateProvisioners []eval.Provisioner
+	// DestroyProvisioners are the provisioners to execute if the resource
+	// instance is being destroyed.
+	DestroyProvisioners []eval.Provisioner
 }
 
 // IntoDeposed returns a new [ManagedResourceObjectFinalPlan] that represents

--- a/internal/engine/planning/plan_managed.go
+++ b/internal/engine/planning/plan_managed.go
@@ -567,7 +567,7 @@ func (p *planGlue) planUnwantedManagedResourceInstanceObject(
 
 	if len(prevRoundState.Dependencies) != 0 {
 		for _, instAddr := range prevRoundState.Dependencies {
-			ret.StateDependencies.Add(instAddr.Object(addrs.NotDeposed))
+			ret.StateDependencies.Add(instAddr.CurrentObject())
 		}
 	} else {
 		// Unfortunately our old state model represents dependencies only
@@ -579,6 +579,13 @@ func (p *planGlue) planUnwantedManagedResourceInstanceObject(
 			for instAddr := range p.planCtx.prevRoundState.InstancesMatchingConfigResource(configAddr) {
 				ret.StateDependencies.Add(instAddr.CurrentObject())
 			}
+		}
+	}
+
+	// Include destroy provisioner dependencies
+	for _, prov := range p.oracle.DestroyProvisioners(ctx, addr.InstanceAddr) {
+		for ri := range prov.Dependencies {
+			ret.ConfigDependencies.Add(ri.Addr.CurrentObject())
 		}
 	}
 

--- a/internal/engine/plugins/plugins.go
+++ b/internal/engine/plugins/plugins.go
@@ -36,7 +36,10 @@ type Providers interface {
 }
 
 type Provisioners interface {
-	eval.ProvisionersSchema
+	eval.Provisioners
+
+	// [provisioners.Interface.ProvisionResource]
+	ProvisionResource(ctx context.Context, typ string, config cty.Value, connection cty.Value, output ProvisionerOutput) tfdiags.Diagnostics
 }
 
 type newRuntimePlugins struct {
@@ -200,16 +203,22 @@ func (n *newRuntimePlugins) unconfiguredProviderInst(ctx context.Context, provid
 
 // ProvisionerConfigSchema implements evalglue.Provisioners.
 func (n *newRuntimePlugins) ProvisionerConfigSchema(ctx context.Context, typeName string) (*configschema.Block, tfdiags.Diagnostics) {
-	// TODO: Implement this in terms of [newRuntimePlugins.provisioners].
-	// But provisioners aren't in scope for our "walking skeleton" phase of
-	// development, so we'll skip this for now.
-	var diags tfdiags.Diagnostics
-	diags = diags.Append(tfdiags.Sourceless(
-		tfdiags.Error,
-		"Cannot use providers in new runtime codepath",
-		fmt.Sprintf("Can't use provisioner %q: new runtime codepath doesn't know how to instantiate provisioners yet", typeName),
-	))
-	return nil, diags
+	schema, err := n.provisioners.ProvisionerSchema(typeName)
+	return schema, tfdiags.New(err)
+}
+
+func (n *newRuntimePlugins) ValidateProvisionerConfig(ctx context.Context, typ string, config cty.Value) tfdiags.Diagnostics {
+	return n.provisioners.ValidateProvisionerConfig(ctx, typ, config)
+}
+
+type ProvisionerOutput func(string)
+
+func (fn ProvisionerOutput) Output(str string) {
+	fn(str)
+}
+
+func (n *newRuntimePlugins) ProvisionResource(ctx context.Context, typ string, config cty.Value, connection cty.Value, output ProvisionerOutput) tfdiags.Diagnostics {
+	return n.provisioners.ProvisionResource(ctx, typ, config, connection, output)
 }
 
 // Close terminates any plugins that are managed by this object and are still

--- a/internal/lang/eval/config_apply.go
+++ b/internal/lang/eval/config_apply.go
@@ -120,8 +120,8 @@ func (g *applyingEvalGlue) ResourceInstanceValue(ctx context.Context, ri *config
 		return cty.UnknownVal(cty.DynamicPseudoType), nil
 	}
 
-	finalValue := g.applyEngineGlue.ResourceInstanceFinalState(ctx, ri.Addr)
-	return finalValue, nil
+	finalVal := g.applyEngineGlue.ResourceInstanceFinalState(ctx, ri.Addr)
+	return finalVal, nil
 }
 
 // ProviderFunction implements [evalglue.Glue]
@@ -203,8 +203,13 @@ func (o *ApplyOracle) DesiredResourceInstance(ctx context.Context, addr addrs.Ab
 		ResourceMode:              addr.Resource.Resource.Mode,
 		ResourceType:              addr.Resource.Resource.Type,
 		RequiredResourceInstances: riDeps,
+		CreateProvisioners:        inst.CreateProvisioners,
 	}
 	return ret, diags
+}
+
+func (o *ApplyOracle) DestroyProvisioners(ctx context.Context, addr addrs.AbsResourceInstance) []Provisioner {
+	return evalglue.DestroyProvisioners(ctx, o.root, addr)
 }
 
 // ProviderInstanceConfig returns the configuration value for the given

--- a/internal/lang/eval/config_plan_oracle.go
+++ b/internal/lang/eval/config_plan_oracle.go
@@ -43,6 +43,10 @@ func (o *PlanningOracle) ProviderInstance(ctx context.Context, addr addrs.AbsPro
 	return o.providers.ProviderInstance(ctx, addr)
 }
 
+func (o *PlanningOracle) DestroyProvisioners(ctx context.Context, addr addrs.AbsResourceInstance) []Provisioner {
+	return evalglue.DestroyProvisioners(ctx, o.root, addr)
+}
+
 func (o *PlanningOracle) Close(ctx context.Context) tfdiags.Diagnostics {
 	return o.providers.Close(ctx)
 }

--- a/internal/lang/eval/config_prepare.go
+++ b/internal/lang/eval/config_prepare.go
@@ -31,7 +31,8 @@ func (c *ConfigInstance) precheckedModuleInstance(ctx context.Context) (evalglue
 	var diags tfdiags.Diagnostics
 
 	internalGlue := &preparationGlue{
-		providers: c.evalContext.Providers,
+		providers:    c.evalContext.Providers,
+		provisioners: c.evalContext.Provisioners,
 	}
 	rootModuleInstance, moreDiags := c.newRootModuleInstance(ctx, internalGlue)
 	diags = diags.Append(moreDiags)
@@ -54,7 +55,8 @@ type preparationGlue struct {
 	// preparationGlue uses provider schema information to prepare placeholder
 	// "final state" values for resource instances because validation does
 	// not use information from the state.
-	providers evalglue.Providers
+	providers    evalglue.Providers
+	provisioners evalglue.Provisioners
 }
 
 // ProviderFunction implements evalglue.Glue.
@@ -100,7 +102,27 @@ func (v *preparationGlue) ResourceInstanceValue(ctx context.Context, ri *configg
 	// it's not competing with other expensive work like performing transitive
 	// reduction on a dag, etc. The main problem seems to be that it allocates
 	// a _lot_ of temporary objects, and so there's lots of GC pressure.
-	return objchange.ProposedNew(
+	proposed := objchange.ProposedNew(
 		schema.Block, cty.NullVal(schema.Block.ImpliedType()), configVal,
-	), diags
+	)
+
+	// Handle provisioners validate
+	for _, prov := range ri.CreateProvisioners {
+		cfg, cfgDiags := prov.Config(ctx, proposed)
+		diags = diags.Append(cfgDiags)
+		if cfgDiags.HasErrors() {
+			continue
+		}
+
+		cfgUnmarked, _ := cfg.Value.UnmarkDeep()
+
+		valDiags := v.provisioners.ValidateProvisionerConfig(ctx, prov.Type, cfgUnmarked)
+		diags = diags.Append(valDiags)
+		if valDiags.HasErrors() {
+			continue
+		}
+	}
+	// TODO validate destroy provisioners
+
+	return proposed, diags
 }

--- a/internal/lang/eval/internal/configgraph/provisioner.go
+++ b/internal/lang/eval/internal/configgraph/provisioner.go
@@ -1,0 +1,34 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package configgraph
+
+import (
+	"context"
+	"iter"
+
+	"github.com/opentofu/opentofu/internal/configs"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type Provisioner struct {
+	// Fields from configuration
+
+	Type      string
+	When      configs.ProvisionerWhen
+	OnFailure configs.ProvisionerOnFailure
+
+	// Config is the current instance value specific configuration function
+	Config func(context.Context, cty.Value) (ProvisionerConfig, tfdiags.Diagnostics)
+
+	// Dependencies of the configuration (excluding the self value)
+	Dependencies iter.Seq[*ResourceInstance]
+}
+
+type ProvisionerConfig struct {
+	Value      cty.Value
+	Connection cty.Value
+}

--- a/internal/lang/eval/internal/configgraph/resource.go
+++ b/internal/lang/eval/internal/configgraph/resource.go
@@ -45,6 +45,8 @@ type Resource struct {
 	// incorporating the new information about this specific instance.
 	CompileResourceInstance func(ctx context.Context, key addrs.InstanceKey, repData instances.RepetitionData) *ResourceInstance
 
+	DestroyProvisioners func(ctx context.Context, addr addrs.ResourceInstance) []Provisioner
+
 	DeclRange tfdiags.SourceRange
 
 	// instancesResult tracks the process of deciding which instances are

--- a/internal/lang/eval/internal/configgraph/resource_instance.go
+++ b/internal/lang/eval/internal/configgraph/resource_instance.go
@@ -51,6 +51,11 @@ type ResourceInstance struct {
 	// or else type mismatch errors will be reported during evaluation.
 	ProviderInstanceValuer *OnceValuer
 
+	// CreateProvisioners are the provisioners to run if the resource instance
+	// is being created. These are distinct from Destroy provisioners, which
+	// are handled in a different code path.
+	CreateProvisioners []Provisioner
+
 	// CreateBeforeDestroyValuer is a valuer that returns the module author's
 	// direction about what "replace" order is required for this resource
 	// instance.

--- a/internal/lang/eval/internal/configgraph/resource_instance_deps.go
+++ b/internal/lang/eval/internal/configgraph/resource_instance_deps.go
@@ -129,6 +129,21 @@ func WithoutResourceInstanceMarks(v cty.Value) cty.Value {
 	return v
 }
 
+// WithoutResourceInstanceDependency returns a copy of the given value with
+// any [ResourceInstanceMark] marks removed which match the given [addrs.AbsResourceInstance],
+// but with all other marks left intact.
+//
+// This is primarilly used when dealing with "self" dependencies
+func WithoutResourceInstanceDependency(v cty.Value, addr addrs.AbsResourceInstance) cty.Value {
+	v, _ = v.WrangleMarksDeep(func(mark any, path cty.Path) (ctymarks.WrangleAction, error) {
+		if mark, isOurMark := mark.(ResourceInstanceMark); isOurMark && mark.instance.Addr.Equal(addr) {
+			return ctymarks.WrangleDrop, nil
+		}
+		return nil, nil // leave all other marks alone
+	})
+	return v
+}
+
 // ResourceInstanceAddrs maps a sequence of [ResourceInstance] pointers into
 // a sequence of their [addrs.AbsResourceInstance] addresses.
 func ResourceInstanceAddrs(insts iter.Seq[*ResourceInstance]) iter.Seq[addrs.AbsResourceInstance] {

--- a/internal/lang/eval/internal/evalglue/dependencies.go
+++ b/internal/lang/eval/internal/evalglue/dependencies.go
@@ -128,6 +128,9 @@ type ProvisionersSchema interface {
 // or whether plugins are even being used.
 type Provisioners interface {
 	ProvisionersSchema
+
+	// [provisioners.Interface.ValidateProvisionerConfig]
+	ValidateProvisionerConfig(ctx context.Context, typ string, config cty.Value) tfdiags.Diagnostics
 }
 
 // emptyDependencies is an implementation of all of our dependency-related
@@ -250,4 +253,15 @@ func (e emptyDependencies) ProvisionerConfigSchema(ctx context.Context, typeName
 		"There are no provisioners available for use in this context.",
 	))
 	return nil, diags
+}
+
+// ValidateProvisionerConfig implements Provisioners.
+func (e emptyDependencies) ValidateProvisionerConfig(ctx context.Context, typ string, config cty.Value) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+	diags = diags.Append(tfdiags.Sourceless(
+		tfdiags.Error,
+		"No provisioners are available",
+		"There are no provisioners available for use in this context.",
+	))
+	return diags
 }

--- a/internal/lang/eval/internal/evalglue/dependencies_static.go
+++ b/internal/lang/eval/internal/evalglue/dependencies_static.go
@@ -26,13 +26,14 @@ func NewStaticPlugins() staticPlugins {
 	return staticPlugins{}
 }
 
+var StaticProviderSchema = &providers.Schema{}
+var StaticProvisionerSchema = &configschema.Block{}
+
 func (s staticPlugins) ProviderConfigSchema(ctx context.Context, provider addrs.Provider) (*providers.Schema, tfdiags.Diagnostics) {
-	// schema.Block will be nil, signifying that this is not a complete implementation
-	return &providers.Schema{}, nil
+	return StaticProviderSchema, nil
 }
 func (s staticPlugins) ResourceTypeSchema(ctx context.Context, provider addrs.Provider, mode addrs.ResourceMode, typeName string) (*providers.Schema, tfdiags.Diagnostics) {
-	// schema.Block will be nil, signifying that this is not a complete implementation
-	return &providers.Schema{}, nil
+	return StaticProviderSchema, nil
 }
 func (s staticPlugins) ValidateProviderConfig(ctx context.Context, provider addrs.Provider, configVal cty.Value) tfdiags.Diagnostics {
 	return nil
@@ -47,6 +48,8 @@ func (s staticPlugins) NewConfiguredProvider(ctx context.Context, provider addrs
 	panic("not supported in a static context")
 }
 func (s staticPlugins) ProvisionerConfigSchema(ctx context.Context, typeName string) (*configschema.Block, tfdiags.Diagnostics) {
-	// TODO provisioners!
-	panic("not implemented")
+	return StaticProvisionerSchema, nil
+}
+func (s staticPlugins) ValidateProvisionerConfig(ctx context.Context, typ string, config cty.Value) tfdiags.Diagnostics {
+	return nil
 }

--- a/internal/lang/eval/internal/evalglue/module_instance.go
+++ b/internal/lang/eval/internal/evalglue/module_instance.go
@@ -123,6 +123,8 @@ type CompiledModuleInstance interface {
 	// dynamically-decided resource instances for each resource.
 	Resources(ctx context.Context) iter.Seq[addrs.Resource]
 
+	Resource(ctx context.Context, addr addrs.Resource) *configgraph.Resource
+
 	// ResourceInstances returns a sequence of all of the resource instances
 	// declared in the module.
 	//
@@ -332,4 +334,17 @@ func ProviderInstance(ctx context.Context, root CompiledModuleInstance, addr add
 		return nil
 	}
 	return moduleInst.ProviderInstance(ctx, addr.LocalConfig())
+}
+
+func DestroyProvisioners(ctx context.Context, root CompiledModuleInstance, addr addrs.AbsResourceInstance) []configgraph.Provisioner {
+	// TODO removed block provisioners
+	mod := ModuleInstance(ctx, root, addr.Module)
+	if mod == nil {
+		return nil
+	}
+	resource := mod.Resource(ctx, addr.Resource.Resource)
+	if resource == nil {
+		return nil
+	}
+	return resource.DestroyProvisioners(ctx, addr.Resource)
 }

--- a/internal/lang/eval/internal/tofu2024/compile.go
+++ b/internal/lang/eval/internal/tofu2024/compile.go
@@ -158,6 +158,7 @@ func CompileModuleInstance(
 		providersSidechannel,
 		call.CalleeAddr,
 		call.EvalContext.Providers,
+		call.EvalContext.Provisioners,
 		call.EvaluationGlue.ResourceInstanceValue,
 		call.DependencyMarks,
 	)

--- a/internal/lang/eval/internal/tofu2024/compile_provider_configs.go
+++ b/internal/lang/eval/internal/tofu2024/compile_provider_configs.go
@@ -70,7 +70,7 @@ func compileProviderConfig(
 		configEvalable = exprs.ForcedErrorEvalable(diags, tfdiags.SourceRangeFromHCL(config.DeclRange))
 	} else if configSchema == nil {
 		panic("Is this possible, do we need a diagnostic here?")
-	} else if configSchema.Block == nil {
+	} else if configSchema == evalglue.StaticProviderSchema {
 		// Assumed static context, I don't love this sort of flagging though
 		configEvalable = exprs.EvalableHCLExpression(&hclsyntax.LiteralValueExpr{Val: cty.DynamicVal})
 	} else {

--- a/internal/lang/eval/internal/tofu2024/compile_provisioners.go
+++ b/internal/lang/eval/internal/tofu2024/compile_provisioners.go
@@ -1,0 +1,123 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tofu2024
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/opentofu/opentofu/internal/addrs"
+	commShared "github.com/opentofu/opentofu/internal/communicator/shared"
+	"github.com/opentofu/opentofu/internal/configs"
+	"github.com/opentofu/opentofu/internal/lang/eval/internal/configgraph"
+	"github.com/opentofu/opentofu/internal/lang/eval/internal/evalglue"
+	"github.com/opentofu/opentofu/internal/lang/exprs"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// Based on NodeValidatableResource.validateProvisioner and NodeAbstractInstance.applyProvisioners
+
+type compiledProvisioner func(ctx context.Context, localScope exprs.Scope, addr addrs.AbsResourceInstance) configgraph.Provisioner
+
+func compileProvisioner(ctx context.Context,
+	prov *configs.Provisioner,
+	baseConn hcl.Body,
+	provisioners evalglue.ProvisionersSchema,
+) (compiledProvisioner, tfdiags.Diagnostics) {
+	specConn := commShared.ConnectionBlockSupersetSchema.DecoderSpec()
+
+	schema, err := provisioners.ProvisionerConfigSchema(ctx, prov.Type)
+	if err != nil {
+		// TODO This error probably won't be a great diagnostic
+		return nil, tfdiags.New(err)
+	}
+
+	if schema == evalglue.StaticProvisionerSchema {
+		// Not available in a static context
+		return nil, nil
+	}
+
+	spec := schema.DecoderSpec()
+
+	// If the provisioner block contains a connection block of its own then
+	// it can override the base connection configuration, if any.
+	var localConn hcl.Body
+	if prov.Connection != nil {
+		localConn = prov.Connection.Config
+	}
+
+	var connBody hcl.Body
+	switch {
+	case baseConn != nil && localConn != nil:
+		// Our standard merging logic applies here, similar to what we do
+		// with _override.tf configuration files: arguments from the
+		// base connection block will be masked by any arguments of the
+		// same name in the local connection block.
+		connBody = configs.MergeBodies(baseConn, localConn)
+	case baseConn != nil:
+		connBody = baseConn
+	case localConn != nil:
+		connBody = localConn
+	}
+
+	return func(ctx context.Context, localScope exprs.Scope, addr addrs.AbsResourceInstance) configgraph.Provisioner {
+		configFn := func(ctx context.Context, self cty.Value) (configgraph.ProvisionerConfig, tfdiags.Diagnostics) {
+			var diags tfdiags.Diagnostics
+
+			var selfIdent, selfName string
+			if addr.Resource.Key == nil {
+				// type.name syntax only allowed when no keys present
+				// This is an intentional difference between the new engine and the original.
+				selfIdent, selfName = addr.Resource.Resource.Type, addr.Resource.Resource.Name
+			}
+
+			provScope := selfScope(
+				localScope,
+				configgraph.WithoutResourceInstanceDependency(self, addr),
+				selfIdent, selfName,
+			)
+
+			config, configDiags := exprs.NewClosure(exprs.EvalableHCLBody(prov.Config, spec), provScope).Value(ctx)
+			diags = diags.Append(configDiags)
+
+			// start with an empty connInfo
+			connInfo := cty.NullVal(commShared.ConnectionBlockSupersetSchema.ImpliedType())
+
+			if connBody != nil {
+				var connInfoDiags tfdiags.Diagnostics
+				connInfo, connInfoDiags = exprs.NewClosure(exprs.EvalableHCLBody(connBody, specConn), provScope).Value(ctx)
+				diags = diags.Append(connInfoDiags)
+			}
+			return configgraph.ProvisionerConfig{
+				Value:      config,
+				Connection: connInfo,
+			}, diags
+		}
+
+		dummyCfg, _ := configFn(ctx, cty.DynamicVal)
+
+		return configgraph.Provisioner{
+			Type:      prov.Type,
+			When:      prov.When,
+			OnFailure: prov.OnFailure,
+			Config:    configFn,
+
+			Dependencies: func(yield func(*configgraph.ResourceInstance) bool) {
+				for ri := range configgraph.ContributingResourceInstances(dummyCfg.Value) {
+					if !yield(ri) {
+						return
+					}
+				}
+				for ri := range configgraph.ContributingResourceInstances(dummyCfg.Connection) {
+					if !yield(ri) {
+						return
+					}
+				}
+			},
+		}
+	}, nil
+}

--- a/internal/lang/eval/internal/tofu2024/compile_resources.go
+++ b/internal/lang/eval/internal/tofu2024/compile_resources.go
@@ -31,20 +31,21 @@ func compileModuleInstanceResources(
 	moduleProviders configgraph.CompileProviderConfigRef,
 	moduleInstanceAddr addrs.ModuleInstance,
 	providers evalglue.ProvidersSchema,
+	provisioners evalglue.ProvisionersSchema,
 	getResultValue func(context.Context, *configgraph.ResourceInstance, cty.Value, configgraph.Maybe[*configgraph.ProviderInstance], addrs.Set[addrs.AbsResourceInstance]) (cty.Value, tfdiags.Diagnostics),
 	extraMarks cty.ValueMarks,
 ) map[addrs.Resource]*configgraph.Resource {
 	ret := make(map[addrs.Resource]*configgraph.Resource, len(managedConfigs)+len(dataConfigs)+len(ephemeralConfigs))
 	for _, rc := range managedConfigs {
-		addr, rsrc := compileModuleInstanceResource(ctx, rc, declScope, moduleProviders, moduleInstanceAddr, providers, getResultValue, extraMarks)
+		addr, rsrc := compileModuleInstanceResource(ctx, rc, declScope, moduleProviders, moduleInstanceAddr, providers, provisioners, getResultValue, extraMarks)
 		ret[addr] = rsrc
 	}
 	for _, rc := range dataConfigs {
-		addr, rsrc := compileModuleInstanceResource(ctx, rc, declScope, moduleProviders, moduleInstanceAddr, providers, getResultValue, extraMarks)
+		addr, rsrc := compileModuleInstanceResource(ctx, rc, declScope, moduleProviders, moduleInstanceAddr, providers, nil, getResultValue, extraMarks)
 		ret[addr] = rsrc
 	}
 	for _, rc := range ephemeralConfigs {
-		addr, rsrc := compileModuleInstanceResource(ctx, rc, declScope, moduleProviders, moduleInstanceAddr, providers, getResultValue, extraMarks)
+		addr, rsrc := compileModuleInstanceResource(ctx, rc, declScope, moduleProviders, moduleInstanceAddr, providers, nil, getResultValue, extraMarks)
 		ret[addr] = rsrc
 	}
 	return ret
@@ -57,6 +58,7 @@ func compileModuleInstanceResource(
 	moduleProviders configgraph.CompileProviderConfigRef,
 	moduleInstanceAddr addrs.ModuleInstance,
 	providers evalglue.ProvidersSchema,
+	provisioners evalglue.ProvisionersSchema,
 	getResultValue func(context.Context, *configgraph.ResourceInstance, cty.Value, configgraph.Maybe[*configgraph.ProviderInstance], addrs.Set[addrs.AbsResourceInstance]) (cty.Value, tfdiags.Diagnostics),
 	extraMarks cty.ValueMarks,
 ) (addrs.Resource, *configgraph.Resource) {
@@ -88,12 +90,46 @@ func compileModuleInstanceResource(
 			Subject:  config.TypeRange.Ptr(),
 		})
 		configEvalable = exprs.ForcedErrorEvalable(diags, tfdiags.SourceRangeFromHCL(config.TypeRange))
-	} else if resourceTypeSchema.Block == nil {
+	} else if resourceTypeSchema == evalglue.StaticProviderSchema {
 		// Assumed static context, I don't love this sort of flagging though
 		configEvalable = exprs.EvalableHCLExpression(&hclsyntax.LiteralValueExpr{Val: cty.DynamicVal})
 	} else {
 		spec := resourceTypeSchema.Block.DecoderSpec()
 		configEvalable = exprs.EvalableHCLBodyWithDynamicBlocks(config.Config, spec)
+	}
+
+	// Compile Provisioners
+	var createProvisioners []compiledProvisioner
+	var destroyProvisioners []compiledProvisioner
+	if config.Managed != nil {
+		var baseConn hcl.Body
+		if config.Managed.Connection != nil {
+			baseConn = config.Managed.Connection.Config
+		}
+
+		for _, prov := range config.Managed.Provisioners {
+			provComp, provDiags := compileProvisioner(ctx, prov, baseConn, provisioners)
+			diags = diags.Append(provDiags)
+			if provDiags.HasErrors() {
+				continue
+			}
+
+			if provComp == nil {
+				continue
+			}
+
+			switch prov.When {
+			case configs.ProvisionerWhenCreate:
+				createProvisioners = append(createProvisioners, provComp)
+			case configs.ProvisionerWhenDestroy:
+				destroyProvisioners = append(destroyProvisioners, provComp)
+			default:
+				panic("Unreachable")
+			}
+		}
+	}
+	if diags.HasErrors() {
+		configEvalable = exprs.ForcedErrorEvalable(diags, tfdiags.SourceRangeFromHCL(config.TypeRange))
 	}
 
 	ret := &configgraph.Resource{
@@ -140,6 +176,19 @@ func compileModuleInstanceResource(
 				)
 			}
 
+			var provisionerConfigs []configgraph.Provisioner
+			var provisionerMarks cty.ValueMarks
+			for _, provFn := range createProvisioners {
+				provCfg := provFn(ctx, localScope, absAddr.Instance(key))
+				provisionerConfigs = append(provisionerConfigs, provCfg)
+				for dep := range provCfg.Dependencies {
+					if provisionerMarks == nil {
+						provisionerMarks = cty.ValueMarks{}
+					}
+					provisionerMarks[configgraph.NewResourceInstanceMark(dep)] = struct{}{}
+				}
+			}
+
 			// Note that repetitionMarks also incorporates any marks from the
 			// depends_on argument, which got evaluated as part of the instance
 			// selector just as a convenient once-per-resource evaluation hook.
@@ -152,6 +201,8 @@ func compileModuleInstanceResource(
 			configValuer := configgraph.ValuerOnce(exprs.DerivedValuerContext(
 				exprs.NewClosure(configEvalable, localScope),
 				func(ctx context.Context, v cty.Value, diags tfdiags.Diagnostics) (cty.Value, tfdiags.Diagnostics) {
+					// TODO more efficient marking, this does a lot of map garbarge
+					// TODO consider moving provider related marks into here, currently partially impl in configgraph.ResourceInstance.Value
 					if len(repetitionMarks) != 0 {
 						v = v.WithMarks(repetitionMarks)
 					}
@@ -160,6 +211,11 @@ func compileModuleInstanceResource(
 					if len(instDepMarks) != 0 {
 						v = v.WithMarks(instDepMarks)
 					}
+
+					if len(provisionerMarks) != 0 {
+						v = v.WithMarks(provisionerMarks)
+					}
+
 					return v, diags
 				},
 			))
@@ -170,6 +226,7 @@ func compileModuleInstanceResource(
 				ConfigValuer:              configValuer,
 				ProviderInstanceValuer:    configgraph.ValuerOnce(providerRef),
 				CreateBeforeDestroyValuer: cbdValuer,
+				CreateProvisioners:        provisionerConfigs,
 			}
 			// Again the [ResourceInstance] implementation will call back
 			// through this object so we can help it interact with the
@@ -183,6 +240,29 @@ func compileModuleInstanceResource(
 				},
 			}
 			return inst
+		},
+
+		DestroyProvisioners: func(ctx context.Context, addr addrs.ResourceInstance) []configgraph.Provisioner {
+			var repData instances.RepetitionData
+			if addr.Key != nil {
+				keyValue := addr.Key.Value()
+				switch keyValue.Type() {
+				case cty.String:
+					repData.EachKey = keyValue
+					// For a destroy-time provisioner EachValue is intentionally nil here,
+					// that's okay because each.value is prohibited for destroy-time provisioners.
+				case cty.Number:
+					repData.CountIndex = keyValue
+				}
+			}
+
+			localScope := instanceLocalScope(declScope, repData)
+
+			var provisionerConfigs []configgraph.Provisioner
+			for _, provFn := range destroyProvisioners {
+				provisionerConfigs = append(provisionerConfigs, provFn(ctx, localScope, addr.Absolute(moduleInstanceAddr)))
+			}
+			return provisionerConfigs
 		},
 	}
 	return resourceAddr, ret

--- a/internal/lang/eval/internal/tofu2024/module_instance.go
+++ b/internal/lang/eval/internal/tofu2024/module_instance.go
@@ -216,6 +216,11 @@ func (c *CompiledModuleInstance) Resources(_ context.Context) iter.Seq[addrs.Res
 	return maps.Keys(c.resourceNodes)
 }
 
+// Resource implements evalglue.CompiledModuleInstance.
+func (c *CompiledModuleInstance) Resource(ctx context.Context, addr addrs.Resource) *configgraph.Resource {
+	return c.resourceNodes[addr]
+}
+
 // ResourceInstances implements evalglue.CompiledModuleInstance.
 func (c *CompiledModuleInstance) ResourceInstances(ctx context.Context) iter.Seq[*configgraph.ResourceInstance] {
 	return func(yield func(*configgraph.ResourceInstance) bool) {

--- a/internal/lang/eval/internal/tofu2024/module_instance_scope.go
+++ b/internal/lang/eval/internal/tofu2024/module_instance_scope.go
@@ -473,6 +473,7 @@ func nounForModuleInstanceGlobalSymbol(symbol string) string {
 // we need to be able to evaluate an expression referring to the variable
 // as part of deciding the final value of the variable and so if we didn't
 // handle it directly then there would be a self-reference error.
+// TODO consider merging this with selfScope
 type inputVariableValidationScope struct {
 	varTable    exprs.SymbolTable
 	wantName    string

--- a/internal/lang/eval/internal/tofu2024/self_scope.go
+++ b/internal/lang/eval/internal/tofu2024/self_scope.go
@@ -1,0 +1,85 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tofu2024
+
+import (
+	"context"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/opentofu/opentofu/internal/lang/exprs"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+func selfScope(parentScope exprs.Scope, self cty.Value, ident string, name string) exprs.Scope {
+	return &selfOverlayScope{
+		ident:  ident,
+		name:   name,
+		self:   self,
+		parent: parentScope,
+	}
+}
+
+type selfOverlayScope struct {
+	ident  string
+	name   string
+	self   cty.Value
+	parent exprs.Scope
+}
+
+// HandleInvalidStep implements exprs.Scope.
+func (i *selfOverlayScope) HandleInvalidStep(rng tfdiags.SourceRange) tfdiags.Diagnostics {
+	return i.parent.HandleInvalidStep(rng)
+}
+
+// ResolveAttr implements exprs.Scope.
+func (i *selfOverlayScope) ResolveAttr(ref hcl.TraverseAttr) (exprs.Attribute, tfdiags.Diagnostics) {
+	if ref.Name == "self" {
+		return exprs.ValueOf(exprs.ConstantValuer(i.self)), nil
+	}
+
+	parentRef, diags := i.parent.ResolveAttr(ref)
+	if ref.Name == i.ident && !diags.HasErrors() {
+		nestedTable := exprs.NestedSymbolTableFromAttribute(parentRef)
+		if nestedTable != nil {
+			return exprs.NestedSymbolTable(&selfOverlaySymbolTable{
+				name:        i.name,
+				self:        i.self,
+				nestedTable: nestedTable,
+			}), diags
+		}
+	}
+
+	// Everything else is delegated to the parent scope.
+	return parentRef, diags
+
+}
+
+// ResolveFunc implements exprs.Scope.
+func (i *selfOverlayScope) ResolveFunc(ctx context.Context, call *hcl.StaticCall) (function.Function, tfdiags.Diagnostics) {
+	// no extra functions in this local scope
+	return i.parent.ResolveFunc(ctx, call)
+}
+
+type selfOverlaySymbolTable struct {
+	name        string
+	self        cty.Value
+	nestedTable exprs.SymbolTable
+}
+
+// ResolveAttr implements exprs.SymbolTable.
+func (s *selfOverlaySymbolTable) ResolveAttr(ref hcl.TraverseAttr) (exprs.Attribute, tfdiags.Diagnostics) {
+	if ref.Name == s.name {
+		return exprs.ValueOf(exprs.ConstantValuer(s.self)), nil
+	}
+	return s.nestedTable.ResolveAttr(ref)
+}
+
+// HandleInvalidStep implements exprs.SymbolTable.
+func (s *selfOverlaySymbolTable) HandleInvalidStep(rng tfdiags.SourceRange) tfdiags.Diagnostics {
+	return s.nestedTable.HandleInvalidStep(rng)
+}

--- a/internal/lang/eval/resource_instance.go
+++ b/internal/lang/eval/resource_instance.go
@@ -9,6 +9,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/lang/eval/internal/configgraph"
 )
 
 // DesiredResourceInstance describes a resource instance that is part of
@@ -159,7 +160,15 @@ type DesiredResourceInstance struct {
 	// Any resource instance mentioned in this collection will always also
 	// appear in RequiredResourceInstances.
 	ReplaceTriggeredBy []ResourceInstanceAttributePath
+
+	// CreateProvisioners are the provisioners that will be run if the resource
+	// is created
+	CreateProvisioners []Provisioner
 }
+
+// Exposing configgraph details is not idea, but it's a very simple structure
+// that is probably not worth duplicating right now
+type Provisioner = configgraph.Provisioner
 
 // IsPlaceholder returns true if this object is acting as a placeholder for
 // zero or more resource instances whose full expansion is not yet known.

--- a/internal/tofu/context_apply_test.go
+++ b/internal/tofu/context_apply_test.go
@@ -2146,7 +2146,7 @@ aws_instance.foo:
 }
 
 func TestContext2Apply_cancelProvisioner(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
+	SkipExperimental(t, ExperimentalFeatureProvisioner, ExperimentalBugCancel)
 
 	m := testModule(t, "apply-cancel-provisioner")
 	p := testProvider("aws")
@@ -2678,7 +2678,7 @@ func TestContext2Apply_provisionerInterpCount(t *testing.T) {
 }
 
 func TestContext2Apply_winrmConnectionMigrationMessage(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
+	SkipExperimental(t, ExperimentalFeatureProvisioner, ExperimentalChangeDiagWording)
 
 	// This is testing for an error diagnostic we've added temporarily
 	// for the v1.13 series to help folks migrate from the no-longer-supported
@@ -5453,7 +5453,7 @@ aws_instance.foo:
 
 // Verify destroy provisioners are not run for tainted instances.
 func TestContext2Apply_provisionerDestroyTainted(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
+	SkipExperimental(t, ExperimentalFeatureProvisioner, ExperimentalFeatureTaint)
 
 	m := testModule(t, "apply-provisioner-destroy")
 	p := testProvider("aws")
@@ -5679,7 +5679,7 @@ func TestContext2Apply_provisionerMultiSelfRef(t *testing.T) {
 }
 
 func TestContext2Apply_provisionerMultiSelfRefSingle(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
+	SkipExperimental(t, ExperimentalFeatureProvisioner, ExperimentalChangeCursedSelfRef)
 
 	var lock sync.Mutex
 	order := make([]string, 0, 5)
@@ -12054,7 +12054,7 @@ locals {
 // Ensure that we can destroy when a provider references a resource that will
 // also be destroyed
 func TestContext2Apply_destroyProviderReference(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
+	SkipExperimental(t, ExperimentalBugDataResource)
 
 	m, snap := testModuleWithSnapshot(t, "apply-destroy-provider-refs")
 

--- a/internal/tofu/context_plan_test.go
+++ b/internal/tofu/context_plan_test.go
@@ -869,7 +869,7 @@ module.child:
 
 // https://github.com/hashicorp/terraform/issues/3114
 func TestContext2Plan_moduleOrphansWithProvisioner(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
+	SkipExperimental(t, ExperimentalFlagUnknown)
 
 	m := testModule(t, "plan-modules-remove-provisioners")
 	p := testProvider("aws")

--- a/internal/tofu/context_temp_runtime.go
+++ b/internal/tofu/context_temp_runtime.go
@@ -427,6 +427,24 @@ func (c *Context) newEngineApplyTracer() *applying.Tracer {
 			})
 		},
 
+		StartProvisionInstanceStep: func(ctx context.Context, addr addrs.AbsResourceInstance, typeName string) context.Context {
+			c.eachHook(func(h Hook) (HookAction, error) {
+				return h.PreProvisionInstanceStep(addr, typeName)
+			})
+			return ctx
+		},
+		StopProvisionInstanceStep: func(ctx context.Context, addr addrs.AbsResourceInstance, typeName string, diags tfdiags.Diagnostics) {
+			c.eachHook(func(h Hook) (HookAction, error) {
+				return h.PostProvisionInstanceStep(addr, typeName, diags.Err())
+			})
+		},
+		ProvisionOutput: func(ctx context.Context, addr addrs.AbsResourceInstance, typeName string, line string, configMarks cty.ValueMarks) {
+			c.eachHook(func(h Hook) (HookAction, error) {
+				h.ProvisionOutput(addr, typeName, line, configMarks)
+				return HookActionContinue, nil
+			})
+		},
+
 		// We'll also include the [shared.Tracer] we use for both plan and apply.
 		Tracer: c.newEngineSharedTracer(),
 	}

--- a/internal/tofu/context_temp_runtime_test.go
+++ b/internal/tofu/context_temp_runtime_test.go
@@ -109,6 +109,7 @@ var (
 	ExperimentalChangePreReqdProvider = ExperimentalFlag{"Change New Runtime Doesn't Inherit Full Pre \"required_providers\" Behavior", false}
 	ExperimentalChangeDestroyOrder    = ExperimentalFlag{"Change Destroy Order", false}
 	ExperimentalChangeModuleOutput    = ExperimentalFlag{"Change Module Outputs (test only)", false}
+	ExperimentalChangeCursedSelfRef   = ExperimentalFlag{"Change Cursed Self Reference (legacy race condition)", false}
 
 	ExperimentalFeatureStateDependencies = ExperimentalFlag{"Missing State Dependencies", true}
 	ExperimentalFeatureProviderInstances = ExperimentalFlag{"Missing Provider Instances", true}
@@ -132,7 +133,7 @@ var (
 	ExperimentalFeatureHooks             = ExperimentalFlag{"Missing Hooks", true}
 	ExperimentalFeatureTarget            = ExperimentalFlag{"Missing Targeting", false}
 	ExperimentalFeatureReplaceTB         = ExperimentalFlag{"Missing replace_triggered_by", false}
-	ExperimentalFeatureProvisioner       = ExperimentalFlag{"Missing Provisioners", false}
+	ExperimentalFeatureProvisioner       = ExperimentalFlag{"Missing Provisioners", true}
 	ExperimentalFeatureDependsOn         = ExperimentalFlag{"Missing Depends On", true}
 	ExperimentalFeatureIgnoreChanges     = ExperimentalFlag{"Missing Ignore Changes", false}
 	ExperimentalFeatureVarCondition      = ExperimentalFlag{"Missing Variable Condiitions", false}


### PR DESCRIPTION
Provisioners are a very old concept and therefore do not integrate well into the new engine. I've done what I can to keep the changes here as unintrusive as possible.

The difference in this implementation path (when compared to the rest of the new engine) is that we need to interact with resources directly, not resource instances for the destroy path. Only resource instances that exist within the configuration will have create provisioners, there is no current "config entity" to attach destroy resource instance provisioners to. Therefore we expose configgraph.Resource and the corresponding destroy provisioners.

This exposes a gap in the new engine, where we don't have a good or consistent mechanism for orphaned instances to have configuration attributes attached. This is a larger item to consider that is outside the scope of what is intended to be addressed in this PR.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
