### PR TITLE
Implement ignore_changes in the new engine

### DIFF
--- a/internal/engine/planning/plan_managed.go
+++ b/internal/engine/planning/plan_managed.go
@@ -221,6 +221,7 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 			ResourceType:         prevRoundState.ResourceType,
 			SchemaVersion:        uint64(schema.Version),
 			Dependencies:         prevRoundState.Dependencies,
+			ConfigDependencies:   prevRoundState.ConfigDependencies,
 			CreateBeforeDestroy:  prevRoundState.CreateBeforeDestroy,
 		}
 
@@ -274,11 +275,6 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 		prevRoundVal = cty.NullVal(schema.Block.ImpliedType())
 	}
 
-	// TODO: If inst.IgnoreChangesPaths has any entries then we need to
-	// transform effectiveConfigVal so that any paths specified in there are
-	// forced to match the corresponding value from prevRoundVal, if any.
-	effectiveConfigVal := unmarkedConfigVal
-
 	// TODO: Call resourceType.RefreshObject, update the "refreshed state",
 	// and reassign this refreshedVal to the refreshed result.
 	refreshCtx := ctx
@@ -303,15 +299,16 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 
 	planChangesCtx := ctx
 	if cb := tracer.StartManagedResourceInstanceObjectPlanChanges; cb != nil {
-		planChangesCtx = cb(ctx, inst.Addr.CurrentObject(), refreshedVal, effectiveConfigVal)
+		planChangesCtx = cb(ctx, inst.Addr.CurrentObject(), refreshedVal, unmarkedConfigVal)
 	}
 	planResp, planDiags := resourceType.PlanChanges(planChangesCtx, &resources.ManagedResourcePlanRequest{
 		Current: resources.ValueWithPrivate{
 			Value:   refreshedVal,
 			Private: refreshedPrivate,
 		},
-		DesiredValue:      effectiveConfigVal,
-		ProviderMetaValue: providerMetaValue,
+		DesiredValue:       unmarkedConfigVal,
+		ProviderMetaValue:  providerMetaValue,
+		IgnoreChangesPaths: inst.IgnoreChangesPaths,
 	}, ret.Addr)
 	diags = diags.Append(planDiags)
 	if planDiags.HasErrors() {
@@ -362,7 +359,7 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 		createPlanResp, planDiags := resourceType.PlanChanges(ctx, &resources.ManagedResourcePlanRequest{
 			// "Current" is intentionally not set here, because we're asking
 			// for a plan to create a new object matching the configuration.
-			DesiredValue:      effectiveConfigVal,
+			DesiredValue:      unmarkedConfigVal,
 			ProviderMetaValue: providerMetaValue,
 		}, ret.Addr)
 		diags = diags.Append(planDiags)

--- a/internal/lang/eval/config_plan.go
+++ b/internal/lang/eval/config_plan.go
@@ -269,6 +269,7 @@ func (p *planningEvalGlue) ResourceInstanceValue(ctx context.Context, ri *config
 		RequiredResourceInstances: riDeps,
 		ResourceType:              ri.Addr.Resource.Resource.Type,
 		ResourceMode:              ri.Addr.Resource.Resource.Mode,
+		IgnoreChangesPaths:        ri.IgnoreChangesPaths,
 	}
 	if providerInst, ok := configgraph.GetKnown(providerInst); ok {
 		desired.ProviderInstance = &providerInst.Addr

--- a/internal/lang/eval/internal/configgraph/resource_instance.go
+++ b/internal/lang/eval/internal/configgraph/resource_instance.go
@@ -63,6 +63,24 @@ type ResourceInstance struct {
 	// The valuer must return something that can be converted to [cty.Bool].
 	CreateBeforeDestroyValuer *OnceValuer
 
+	// IgnoreChangesPaths are paths for which the module author requested
+	// that we "ignore changes".
+	//
+	// To "ignore changes" means to disregard what is configured for anything
+	// under a matching path in ConfigVal and to instead treat the corresponding
+	// value from the prior state as the effective desired state. This is
+	// meaningful only when planning in-place updates to an object that is
+	// already tracked in the prior state; it should be ignored when planning
+	// to create or delete the object associated with a resource instance.
+	//
+	// Index steps within the path can potentially have unknown keys if the
+	// decision about what to ignore is based on a value that won't be known
+	// until the apply phase.
+	//
+	// This is meaningful only for resource modes that support the "update"
+	// change action, and so is always empty for other modes.
+	IgnoreChangesPaths []cty.Path
+
 	// Glue is provided by the system that "compiled" this [ResourceInstance]
 	// object to allow calling back into that system to ask further questions
 	// that arise dynamically during evaluation but whose results vary based

--- a/internal/lang/eval/internal/tofu2024/compile_resources.go
+++ b/internal/lang/eval/internal/tofu2024/compile_resources.go
@@ -8,6 +8,7 @@ package tofu2024
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -128,6 +129,50 @@ func compileModuleInstanceResource(
 			}
 		}
 	}
+
+	var ignoreChanges []cty.Path
+	if config.Managed != nil {
+		if config.Managed.IgnoreAllChanges {
+			// Represents ignore all
+			ignoreChanges = []cty.Path{{}}
+		} else {
+			// Copied from NodeValidatableResource
+			for _, traversal := range config.Managed.IgnoreChanges {
+				// validate the ignore_changes traversals apply.
+				moreDiags := resourceTypeSchema.Block.StaticValidateTraversal(traversal)
+				diags = diags.Append(moreDiags)
+
+				// ignore_changes cannot be used for Computed attributes,
+				// unless they are also Optional.
+				// If the traversal was valid, convert it to a cty.Path and
+				// use that to check whether the Attribute is Computed and
+				// non-Optional.
+				if !diags.HasErrors() {
+					path := traversalToPath(traversal)
+
+					attrSchema := resourceTypeSchema.Block.AttributeByPath(path)
+
+					if attrSchema != nil && !attrSchema.Optional && attrSchema.Computed {
+						// ignore_changes uses absolute traversal syntax in config despite
+						// using relative traversals, so we strip the leading "." added by
+						// FormatCtyPath for a better error message.
+						attrDisplayPath := strings.TrimPrefix(tfdiags.FormatCtyPath(path), ".")
+
+						diags = diags.Append(&hcl.Diagnostic{
+							Severity: hcl.DiagWarning,
+							Summary:  "Redundant ignore_changes element",
+							Detail:   fmt.Sprintf("Adding an attribute name to ignore_changes tells OpenTofu to ignore future changes to the argument in configuration after the object has been created, retaining the value originally configured.\n\nThe attribute %s is decided by the provider alone and therefore there can be no configured value to compare with. Including this attribute in ignore_changes has no effect. Remove the attribute from ignore_changes to quiet this warning.", attrDisplayPath),
+							Subject:  &config.TypeRange,
+						})
+					}
+				}
+			}
+			if travs := config.Managed.IgnoreChanges; len(travs) != 0 {
+				ignoreChanges = traversalsToPaths(travs)
+			}
+		}
+	}
+
 	if diags.HasErrors() {
 		configEvalable = exprs.ForcedErrorEvalable(diags, tfdiags.SourceRangeFromHCL(config.TypeRange))
 	}
@@ -227,6 +272,7 @@ func compileModuleInstanceResource(
 				ProviderInstanceValuer:    configgraph.ValuerOnce(providerRef),
 				CreateBeforeDestroyValuer: cbdValuer,
 				CreateProvisioners:        provisionerConfigs,
+				IgnoreChangesPaths:        ignoreChanges,
 			}
 			// Again the [ResourceInstance] implementation will call back
 			// through this object so we can help it interact with the
@@ -279,4 +325,40 @@ type resourceInstanceGlue struct {
 // ResultValue implements [configgraph.ResourceInstanceGlue].
 func (r *resourceInstanceGlue) ResultValue(ctx context.Context, configVal cty.Value, providerInst configgraph.Maybe[*configgraph.ProviderInstance], riDeps addrs.Set[addrs.AbsResourceInstance]) (cty.Value, tfdiags.Diagnostics) {
 	return r.getResultValue(ctx, configVal, providerInst, riDeps)
+}
+
+// From node_resource_abstract_instance.go
+
+// Convert the hcl.Traversal values we get form the configuration to the
+// cty.Path values we need to operate on the cty.Values
+func traversalsToPaths(traversals []hcl.Traversal) []cty.Path {
+	paths := make([]cty.Path, len(traversals))
+	for i, traversal := range traversals {
+		path := traversalToPath(traversal)
+		paths[i] = path
+	}
+	return paths
+}
+
+func traversalToPath(traversal hcl.Traversal) cty.Path {
+	path := make(cty.Path, len(traversal))
+	for si, step := range traversal {
+		switch ts := step.(type) {
+		case hcl.TraverseRoot:
+			path[si] = cty.GetAttrStep{
+				Name: ts.Name,
+			}
+		case hcl.TraverseAttr:
+			path[si] = cty.GetAttrStep{
+				Name: ts.Name,
+			}
+		case hcl.TraverseIndex:
+			path[si] = cty.IndexStep{
+				Key: ts.Key,
+			}
+		default:
+			panic(fmt.Sprintf("unsupported traversal step %#v", step))
+		}
+	}
+	return path
 }

--- a/internal/resources/ignore_changes.go
+++ b/internal/resources/ignore_changes.go
@@ -1,0 +1,214 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resources
+
+import (
+	"github.com/opentofu/opentofu/internal/configs/configschema"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// Copied from NodeResourceAbstractInstance
+
+func processIgnoreChanges(prior, config cty.Value, ignoreChanges []cty.Path, schema *configschema.Block) cty.Value {
+	// ignore_changes only applies when an object already exists, since we
+	// can't ignore changes to a thing we've not created yet.
+	if prior.IsNull() {
+		return config
+	}
+
+	ignoreAll := len(ignoreChanges) == 1 && len(ignoreChanges[0]) == 0 // Hacky signal
+
+	if len(ignoreChanges) == 0 && !ignoreAll {
+		return config
+	}
+
+	if ignoreAll {
+		// Legacy providers need up to clean up their invalid plans and ensure
+		// no changes are passed though, but that also means making an invalid
+		// config with computed values. In that case we just don't supply a
+		// schema and return the prior val directly.
+		if schema == nil {
+			return prior
+		}
+
+		// If we are trying to ignore all attribute changes, we must filter
+		// computed attributes out from the prior state to avoid sending them
+		// to the provider as if they were included in the configuration.
+		ret, _ := cty.Transform(prior, func(path cty.Path, v cty.Value) (cty.Value, error) {
+			attr := schema.AttributeByPath(path)
+			if attr != nil && attr.Computed && !attr.Optional {
+				return cty.NullVal(v.Type()), nil
+			}
+
+			return v, nil
+		})
+
+		return ret
+	}
+
+	if prior.IsNull() || config.IsNull() {
+		// Ignore changes doesn't apply when we're creating for the first time.
+		// Proposed should never be null here, but if it is then we'll just let it be.
+		return config
+	}
+
+	return processIgnoreChangesIndividual(prior, config, ignoreChanges)
+}
+
+func processIgnoreChangesIndividual(prior, config cty.Value, ignoreChangesPath []cty.Path) cty.Value {
+	type ignoreChange struct {
+		// Path is the full path, minus any trailing map index
+		path cty.Path
+		// Value is the value we are to retain at the above path. If there is a
+		// key value, this must be a map and the desired value will be at the
+		// key index.
+		value cty.Value
+		// Key is the index key if the ignored path ends in a map index.
+		key cty.Value
+	}
+	var ignoredValues []ignoreChange
+
+	// Find the actual changes first and store them in the ignoreChange struct.
+	// If the change was to a map value, and the key doesn't exist in the
+	// config, it would never be visited in the transform walk.
+	for _, icPath := range ignoreChangesPath {
+		key := cty.NullVal(cty.String)
+		// check for a map index, since maps are the only structure where we
+		// could have invalid path steps.
+		last, ok := icPath[len(icPath)-1].(cty.IndexStep)
+		if ok {
+			if last.Key.Type() == cty.String {
+				icPath = icPath[:len(icPath)-1]
+				key = last.Key
+			}
+		}
+
+		// The structure should have been validated already, and we already
+		// trimmed the trailing map index. Any other intermediate index error
+		// means we wouldn't be able to apply the value below, so no need to
+		// record this.
+		p, err := icPath.Apply(prior)
+		if err != nil {
+			continue
+		}
+		c, err := icPath.Apply(config)
+		if err != nil {
+			continue
+		}
+
+		// If this is a map, it is checking the entire map value for equality
+		// rather than the individual key. This means that the change is stored
+		// here even if our ignored key doesn't change. That is OK since it
+		// won't cause any changes in the transformation, but allows us to skip
+		// breaking up the maps and checking for key existence here too.
+		if !p.RawEquals(c) {
+			// there a change to ignore at this path, store the prior value
+			ignoredValues = append(ignoredValues, ignoreChange{icPath, p, key})
+		}
+	}
+
+	if len(ignoredValues) == 0 {
+		return config
+	}
+
+	ret, _ := cty.Transform(config, func(path cty.Path, v cty.Value) (cty.Value, error) {
+		// Easy path for when we are only matching the entire value. The only
+		// values we break up for inspection are maps.
+		if !v.Type().IsMapType() {
+			for _, ignored := range ignoredValues {
+				if path.Equals(ignored.path) {
+					return ignored.value, nil
+				}
+			}
+			return v, nil
+		}
+		// We now know this must be a map, so we need to accumulate the values
+		// key-by-key.
+
+		if !v.IsNull() && !v.IsKnown() {
+			// since v is not known, we cannot ignore individual keys
+			return v, nil
+		}
+
+		// The map values will remain as cty values, so we only need to store
+		// the marks from the outer map itself
+		v, vMarks := v.Unmark()
+
+		// The configMap is the current configuration value, which we will
+		// mutate based on the ignored paths and the prior map value.
+		var configMap map[string]cty.Value
+		switch {
+		case v.IsNull() || v.LengthInt() == 0:
+			configMap = map[string]cty.Value{}
+		default:
+			configMap = v.AsValueMap()
+		}
+
+		for _, ignored := range ignoredValues {
+			if !path.Equals(ignored.path) {
+				continue
+			}
+
+			if ignored.key.IsNull() {
+				// The map address is confirmed to match at this point,
+				// so if there is no key, we want the entire map and can
+				// stop accumulating values.
+				return ignored.value, nil
+			}
+			// Now we know we are ignoring a specific index of this map, so get
+			// the config map and modify, add, or remove the desired key.
+
+			// We also need to create a prior map, so we can check for
+			// existence while getting the value, because Value.Index will
+			// return null for a key with a null value and for a non-existent
+			// key.
+			var priorMap map[string]cty.Value
+
+			// We need to drop the marks from the ignored map for handling. We
+			// don't need to store these, as we now know the ignored value is
+			// only within the map, not the map itself.
+			ignoredVal, _ := ignored.value.Unmark()
+
+			switch {
+			case ignored.value.IsNull() || ignoredVal.LengthInt() == 0:
+				priorMap = map[string]cty.Value{}
+			default:
+				priorMap = ignoredVal.AsValueMap()
+			}
+
+			key := ignored.key.AsString()
+			priorElem, keep := priorMap[key]
+
+			switch {
+			case !keep:
+				// this didn't exist in the old map value, so we're keeping the
+				// "absence" of the key by removing it from the config
+				delete(configMap, key)
+			default:
+				configMap[key] = priorElem
+			}
+		}
+
+		var newVal cty.Value
+		switch {
+		case len(configMap) > 0:
+			newVal = cty.MapVal(configMap)
+		case v.IsNull():
+			// if the config value was null, and no values remain in the map,
+			// reset the value to null.
+			newVal = v
+		default:
+			newVal = cty.MapValEmpty(v.Type().ElementType())
+		}
+
+		if len(vMarks) > 0 {
+			newVal = newVal.WithMarks(vMarks)
+		}
+
+		return newVal, nil
+	})
+	return ret
+}

--- a/internal/resources/managed_plan.go
+++ b/internal/resources/managed_plan.go
@@ -73,6 +73,11 @@ func (rt *ManagedResourceType) PlanChanges(ctx context.Context, req *ManagedReso
 		providerMetaVal = cty.NullVal(cty.DynamicPseudoType)
 	}
 
+	// If inst.IgnoreChangesPaths has any entries then we need to
+	// transform desiredVal so that any paths specified in there are
+	// forced to match the corresponding value from currentVal, if any.
+	desiredVal = processIgnoreChanges(currentVal, desiredVal, req.IgnoreChangesPaths, schema.Block)
+
 	// proposedVal is essentially a default answer for how to merge currentVal
 	// and desiredVal, which providers are allowed to use as a shortcut in
 	// their planning logic for simple cases where no special planning behavior
@@ -143,6 +148,23 @@ func (rt *ManagedResourceType) PlanChanges(ctx context.Context, req *ManagedReso
 			return nil, diags
 		}
 	}
+
+	if resp.LegacyTypeSystem {
+		// Because we allow legacy providers to depart from the contract and
+		// return changes to non-computed values, the plan response may have
+		// altered values that were already suppressed with ignore_changes.
+		// A prime example of this is where providers attempt to obfuscate
+		// config data by turning the config value into a hash and storing the
+		// hash value in the state. There are enough cases of this in existing
+		// providers that we must accommodate the behavior for now, so for
+		// ignore_changes to work at all on these values, we will revert the
+		// ignored values once more.
+		// A nil schema is passed to processIgnoreChanges to indicate that we
+		// don't want to fixup a config value according to the schema when
+		// ignoring "all", rather we are reverting provider imposed changes.
+		plannedValUnmarked = processIgnoreChanges(currentValUnmarked, plannedValUnmarked, req.IgnoreChangesPaths, nil)
+	}
+
 	var requiresReplace cty.PathSet
 	if len(resp.RequiresReplace) != 0 {
 		if currentVal.IsNull() || desiredVal.IsNull() {
@@ -274,6 +296,8 @@ type ManagedResourcePlanRequest struct {
 	// this should be set to the zero value of [cty.Value], which is
 	// [cty.NilVal].
 	ProviderMetaValue cty.Value
+
+	IgnoreChangesPaths []cty.Path
 }
 
 // ManagedResourcePlanResponse is the response type for [ManagedResourceType.PlanChanges].

--- a/internal/tofu/context_plan_test.go
+++ b/internal/tofu/context_plan_test.go
@@ -4400,7 +4400,7 @@ func TestContext2Plan_taint(t *testing.T) {
 }
 
 func TestContext2Plan_taintIgnoreChanges(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureIgnoreChanges, ExperimentalBugDeclareProvider)
+	SkipExperimental(t, ExperimentalFeatureIgnoreChanges, ExperimentalBugDeclareProvider, ExperimentalFeatureTaint)
 
 	m := testModule(t, "plan-taint-ignore-changes")
 	p := testProvider("aws")
@@ -5536,6 +5536,12 @@ func TestContext2Plan_ignoreChanges(t *testing.T) {
 
 	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
+	if experimentalRuntimeEnabled() {
+		if len(plan.Changes.Resources) != 0 {
+			t.Fatal("expected 0 changes, got", len(plan.Changes.Resources))
+		}
+		return
+	}
 	if len(plan.Changes.Resources) != 1 {
 		t.Fatal("expected 1 changes, got", len(plan.Changes.Resources))
 	}
@@ -5648,7 +5654,7 @@ func TestContext2Plan_ignoreChangesInMap(t *testing.T) {
 			}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
 			&states.ResourceInstanceObjectSrc{
 				Status:    states.ObjectReady,
-				AttrsJSON: []byte(`{"id":"foo","tags":{"ignored":"from state","other":"from state"},"type":"aws_instance"}`),
+				AttrsJSON: []byte(`{"tags":{"ignored":"from state","other":"from state"}}`),
 			},
 			addrs.AbsProviderConfig{
 				Provider: addrs.NewDefaultProvider("test"),
@@ -5737,6 +5743,12 @@ func TestContext2Plan_ignoreChangesSensitive(t *testing.T) {
 
 	schema := p.GetProviderSchemaResponse.ResourceTypes["aws_instance"]
 
+	if experimentalRuntimeEnabled() {
+		if len(plan.Changes.Resources) != 0 {
+			t.Fatal("expected 0 changes, got", len(plan.Changes.Resources))
+		}
+		return
+	}
 	if len(plan.Changes.Resources) != 1 {
 		t.Fatal("expected 1 changes, got", len(plan.Changes.Resources))
 	}

--- a/internal/tofu/context_temp_runtime_test.go
+++ b/internal/tofu/context_temp_runtime_test.go
@@ -135,7 +135,7 @@ var (
 	ExperimentalFeatureReplaceTB         = ExperimentalFlag{"Missing replace_triggered_by", false}
 	ExperimentalFeatureProvisioner       = ExperimentalFlag{"Missing Provisioners", true}
 	ExperimentalFeatureDependsOn         = ExperimentalFlag{"Missing Depends On", true}
-	ExperimentalFeatureIgnoreChanges     = ExperimentalFlag{"Missing Ignore Changes", false}
+	ExperimentalFeatureIgnoreChanges     = ExperimentalFlag{"Missing Ignore Changes", true}
 	ExperimentalFeatureVarCondition      = ExperimentalFlag{"Missing Variable Condiitions", false}
 	ExperimentalFeaturePathAttrs         = ExperimentalFlag{"Missing Path/Terraform/Tofu Attrs", true}
 	ExperimentalFeaturePreventDestroy    = ExperimentalFlag{"Missing Prevent Destroy", false}


### PR DESCRIPTION
This was pretty straightforward given the skeleton that @apparentlymart laid out. The only annoying piece is the processing of the ignore changes traversals into paths. Most of that logic needed to be copy pasted between the new and old engine. I have marked all of the places this was done with a comment


## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
