### PR TITLE
tofu: Tests for various combinations of replace, update, and delete

### DIFF
--- a/internal/engine/internal/execgraph/graph_marshal.go
+++ b/internal/engine/internal/execgraph/graph_marshal.go
@@ -22,8 +22,9 @@ import (
 // functionally-equivalent graph.
 func (g *Graph) Marshal() []byte {
 	m := &graphMarshaler{
-		graph:   g,
-		indices: make(map[AnyResultRef]uint64),
+		graph:         g,
+		indices:       make(map[AnyResultRef]uint64),
+		opsInProgress: make(map[operationResultRef[struct{}]]struct{}),
 	}
 
 	// The operations are the main essence of any graph, so we let those
@@ -49,6 +50,11 @@ type graphMarshaler struct {
 	elems                   []*execgraphproto.Element
 	indices                 map[AnyResultRef]uint64
 	resourceInstanceResults map[string]uint64
+
+	// opsInProgress is used by addOperationWithDependencies to notice if
+	// an operation depends on its own result (directly or indirectly) so
+	// we can avoid runaway infinite recursion.
+	opsInProgress map[operationResultRef[struct{}]]struct{}
 }
 
 func (m *graphMarshaler) EnsureOperationPresent(idx int) uint64 {
@@ -145,6 +151,17 @@ func (m *graphMarshaler) addProviderInstAddr(ref providerInstAddrResultRef, addr
 }
 
 func (m *graphMarshaler) addOperationWithDependencies(ref operationResultRef[struct{}], desc operationDesc) uint64 {
+	if _, active := m.opsInProgress[ref]; active {
+		// If this happens then it's a bug in the code that built this graph,
+		// because we should never be asked to marshal a graph containing
+		// self-reference problems.
+		panic(fmt.Sprintf("operation %d depends on its own result", ref.index))
+	}
+	m.opsInProgress[ref] = struct{}{}
+	defer func() {
+		delete(m.opsInProgress, ref)
+	}()
+
 	// During marshaling we just assume the graph was correctly constructed
 	// and save the operation items in their raw form. The unmarshal code
 	// then uses the opcode to decide which method of [Builder] to call

--- a/internal/tofu/context_plan_test.go
+++ b/internal/tofu/context_plan_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
@@ -4317,6 +4318,538 @@ func TestContext2Plan_requiresReplace(t *testing.T) {
 			default:
 				t.Fatalf("unexpected resource instance %s", i)
 			}
+		})
+	}
+}
+
+func TestContext2Plan_actionInteractions(t *testing.T) {
+	// The intention of this test is to prove that we can successfully plan
+	// various combinations of actions between two resource instances that
+	// have a dependency between them.
+	//
+	// Note that this test does not actually test the successfully-created
+	// plan beyond just simply verifying it has the expected actions, and
+	// in particular does not prove that the generated plan would actually
+	// be applyable.
+
+	tests := []struct {
+		Config          string
+		BuildPriorState func(ss *states.SyncState)
+		WantActions     [2]plans.Action
+	}{
+		{
+			Config: `
+				resource "test" "first" {
+					forces_replace = "config"
+				}
+				resource "test" "second" {
+					parent_id = test.first.id
+					forces_replace = "config"
+				}
+			`,
+			BuildPriorState: func(ss *states.SyncState) {
+				ss.SetResourceInstanceCurrent(
+					mustResourceInstanceAddr("test.first"),
+					&states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{"id":"before","forces_replace":"state"}`),
+					},
+					addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+					},
+					addrs.NoKey,
+				)
+				ss.SetResourceInstanceCurrent(
+					mustResourceInstanceAddr("test.second"),
+					&states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{"id":"...","parent_id":"before","forces_replace":"state"}`),
+						Dependencies: []addrs.ConfigResource{
+							mustConfigResourceAddr("test.first").Resource.InModule(addrs.RootModule),
+						},
+					},
+					addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+					},
+					addrs.NoKey,
+				)
+			},
+			WantActions: [2]plans.Action{plans.DeleteThenCreate, plans.DeleteThenCreate},
+		},
+		{
+			Config: `
+				resource "test" "first" {
+					forces_replace = "config"
+				}
+				resource "test" "second" {
+					parent_id = test.first.id
+				}
+			`,
+			BuildPriorState: func(ss *states.SyncState) {
+				ss.SetResourceInstanceCurrent(
+					mustResourceInstanceAddr("test.first"),
+					&states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{"id":"before","forces_replace":"state"}`),
+					},
+					addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+					},
+					addrs.NoKey,
+				)
+				ss.SetResourceInstanceCurrent(
+					mustResourceInstanceAddr("test.second"),
+					&states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{"id":"...","parent_id":"before"}`),
+						Dependencies: []addrs.ConfigResource{
+							mustConfigResourceAddr("test.first").Resource.InModule(addrs.RootModule),
+						},
+					},
+					addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+					},
+					addrs.NoKey,
+				)
+			},
+			WantActions: [2]plans.Action{plans.DeleteThenCreate, plans.Update},
+		},
+		{
+			Config: `
+				resource "test" "first" {
+					forces_replace = "config"
+
+					lifecycle {
+						create_before_destroy = true
+					}
+				}
+				resource "test" "second" {
+					parent_id = test.first.id
+				}
+			`,
+			BuildPriorState: func(ss *states.SyncState) {
+				ss.SetResourceInstanceCurrent(
+					mustResourceInstanceAddr("test.first"),
+					&states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{"id":"before","forces_replace":"state"}`),
+					},
+					addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+					},
+					addrs.NoKey,
+				)
+				ss.SetResourceInstanceCurrent(
+					mustResourceInstanceAddr("test.second"),
+					&states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{"id":"...","parent_id":"before"}`),
+						Dependencies: []addrs.ConfigResource{
+							mustConfigResourceAddr("test.first").Resource.InModule(addrs.RootModule),
+						},
+					},
+					addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+					},
+					addrs.NoKey,
+				)
+			},
+			WantActions: [2]plans.Action{plans.CreateThenDelete, plans.Update},
+		},
+		{
+			Config: `
+				resource "test" "first" {
+					forces_replace = "config"
+
+					lifecycle {
+						create_before_destroy = true
+					}
+				}
+				resource "test" "second" {
+					parent_id      = test.first.id
+					forces_replace = "config"
+				}
+			`,
+			BuildPriorState: func(ss *states.SyncState) {
+				ss.SetResourceInstanceCurrent(
+					mustResourceInstanceAddr("test.first"),
+					&states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{"id":"before","forces_replace":"state"}`),
+					},
+					addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+					},
+					addrs.NoKey,
+				)
+				ss.SetResourceInstanceCurrent(
+					mustResourceInstanceAddr("test.second"),
+					&states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{"id":"...","parent_id":"before","forces_replace":"state"}`),
+						Dependencies: []addrs.ConfigResource{
+							mustConfigResourceAddr("test.first").Resource.InModule(addrs.RootModule),
+						},
+					},
+					addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+					},
+					addrs.NoKey,
+				)
+			},
+			WantActions: [2]plans.Action{plans.CreateThenDelete, plans.DeleteThenCreate},
+		},
+		{
+			Config: `
+				resource "test" "first" {
+					forces_replace = "config"
+				}
+				resource "test" "second" {
+					parent_id      = test.first.id
+					forces_replace = "config"
+
+
+					lifecycle {
+						create_before_destroy = true
+					}
+				}
+			`,
+			BuildPriorState: func(ss *states.SyncState) {
+				ss.SetResourceInstanceCurrent(
+					mustResourceInstanceAddr("test.first"),
+					&states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{"id":"before","forces_replace":"state"}`),
+					},
+					addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+					},
+					addrs.NoKey,
+				)
+				ss.SetResourceInstanceCurrent(
+					mustResourceInstanceAddr("test.second"),
+					&states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{"id":"...","parent_id":"before","forces_replace":"state"}`),
+						Dependencies: []addrs.ConfigResource{
+							mustConfigResourceAddr("test.first").Resource.InModule(addrs.RootModule),
+						},
+					},
+					addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+					},
+					addrs.NoKey,
+				)
+			},
+			WantActions: [2]plans.Action{plans.CreateThenDelete, plans.CreateThenDelete},
+		},
+		{
+			Config: `
+				resource "test" "first" {
+					parent_id = "..."
+				}
+				resource "test" "second" {
+					parent_id = test.first.id
+					forces_replace = "config"
+				}
+			`,
+			BuildPriorState: func(ss *states.SyncState) {
+				ss.SetResourceInstanceCurrent(
+					mustResourceInstanceAddr("test.first"),
+					&states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{"id":"before"}`),
+					},
+					addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+					},
+					addrs.NoKey,
+				)
+				ss.SetResourceInstanceCurrent(
+					mustResourceInstanceAddr("test.second"),
+					&states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{"id":"...","parent_id":"before","forces_replace":"state"}`),
+						Dependencies: []addrs.ConfigResource{
+							mustConfigResourceAddr("test.first").Resource.InModule(addrs.RootModule),
+						},
+					},
+					addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+					},
+					addrs.NoKey,
+				)
+			},
+			WantActions: [2]plans.Action{plans.Update, plans.DeleteThenCreate},
+		},
+		{
+			Config: `
+				resource "test" "first" {
+					parent_id = "..."
+				}
+				resource "test" "second" {
+					parent_id = test.first.id
+					forces_replace = "config"
+
+					lifecycle {
+						create_before_destroy = true
+					}
+				}
+			`,
+			BuildPriorState: func(ss *states.SyncState) {
+				ss.SetResourceInstanceCurrent(
+					mustResourceInstanceAddr("test.first"),
+					&states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{"id":"before"}`),
+					},
+					addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+					},
+					addrs.NoKey,
+				)
+				ss.SetResourceInstanceCurrent(
+					mustResourceInstanceAddr("test.second"),
+					&states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{"id":"...","parent_id":"before","forces_replace":"state"}`),
+						Dependencies: []addrs.ConfigResource{
+							mustConfigResourceAddr("test.first").Resource.InModule(addrs.RootModule),
+						},
+					},
+					addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+					},
+					addrs.NoKey,
+				)
+			},
+			WantActions: [2]plans.Action{plans.Update, plans.CreateThenDelete},
+		},
+		{
+			Config: `
+				# test.first is in prior state but not config, so is an "orphan"
+				resource "test" "second" {
+					parent_id = "after"
+				}
+			`,
+			BuildPriorState: func(ss *states.SyncState) {
+				ss.SetResourceInstanceCurrent(
+					mustResourceInstanceAddr("test.first"),
+					&states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{"id":"before"}`),
+					},
+					addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+					},
+					addrs.NoKey,
+				)
+				ss.SetResourceInstanceCurrent(
+					mustResourceInstanceAddr("test.second"),
+					&states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{"id":"...","parent_id":"before"}`),
+						Dependencies: []addrs.ConfigResource{
+							mustConfigResourceAddr("test.first").Resource.InModule(addrs.RootModule),
+						},
+					},
+					addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+					},
+					addrs.NoKey,
+				)
+			},
+			WantActions: [2]plans.Action{plans.Delete, plans.Update},
+		},
+		{
+			Config: `
+				# test.first is in prior state but not config, so is an "orphan"
+				# note that test.first has CreateBeforeDestroy set in the prior state.
+				resource "test" "second" {
+					parent_id = "after"
+				}
+			`,
+			BuildPriorState: func(ss *states.SyncState) {
+				ss.SetResourceInstanceCurrent(
+					mustResourceInstanceAddr("test.first"),
+					&states.ResourceInstanceObjectSrc{
+						AttrsJSON:           []byte(`{"id":"before"}`),
+						CreateBeforeDestroy: true,
+					},
+					addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+					},
+					addrs.NoKey,
+				)
+				ss.SetResourceInstanceCurrent(
+					mustResourceInstanceAddr("test.second"),
+					&states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{"id":"...","parent_id":"before"}`),
+						Dependencies: []addrs.ConfigResource{
+							mustConfigResourceAddr("test.first").Resource.InModule(addrs.RootModule),
+						},
+					},
+					addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+					},
+					addrs.NoKey,
+				)
+			},
+			WantActions: [2]plans.Action{plans.Delete, plans.Update},
+		},
+		{
+			Config: `
+				resource "test" "first" {
+					parent_id = "after"
+				}
+				# test.second is in prior state but not config, so is an "orphan"
+			`,
+			BuildPriorState: func(ss *states.SyncState) {
+				ss.SetResourceInstanceCurrent(
+					mustResourceInstanceAddr("test.first"),
+					&states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{"id":"before"}`),
+					},
+					addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+					},
+					addrs.NoKey,
+				)
+				ss.SetResourceInstanceCurrent(
+					mustResourceInstanceAddr("test.second"),
+					&states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{"id":"...","parent_id":"before"}`),
+						Dependencies: []addrs.ConfigResource{
+							mustConfigResourceAddr("test.first").Resource.InModule(addrs.RootModule),
+						},
+					},
+					addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+					},
+					addrs.NoKey,
+				)
+			},
+			WantActions: [2]plans.Action{plans.Update, plans.Delete},
+		},
+		{
+			Config: `
+				resource "test" "first" {
+					parent_id = "after"
+
+					lifecycle {
+						create_before_destroy = true
+					}
+				}
+				# test.second is in prior state but not config, so is an "orphan"
+			`,
+			BuildPriorState: func(ss *states.SyncState) {
+				ss.SetResourceInstanceCurrent(
+					mustResourceInstanceAddr("test.first"),
+					&states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{"id":"before"}`),
+					},
+					addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+					},
+					addrs.NoKey,
+				)
+				ss.SetResourceInstanceCurrent(
+					mustResourceInstanceAddr("test.second"),
+					&states.ResourceInstanceObjectSrc{
+						AttrsJSON: []byte(`{"id":"...","parent_id":"before"}`),
+						Dependencies: []addrs.ConfigResource{
+							mustConfigResourceAddr("test.first").Resource.InModule(addrs.RootModule),
+						},
+					},
+					addrs.AbsProviderConfig{
+						Provider: addrs.NewDefaultProvider("test"),
+					},
+					addrs.NoKey,
+				)
+			},
+			WantActions: [2]plans.Action{plans.Update, plans.Delete},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%s then %s", test.WantActions[0], test.WantActions[1]), func(t *testing.T) {
+			if test.WantActions[0] == plans.DeleteThenCreate && test.WantActions[1] == plans.Update {
+				// The experimental new runtime doesn't currently handle this
+				// interaction correctly, producing an execution graph where
+				// the two resources end up mutually-dependent on each other.
+				SkipExperimental(t, ExperimentalBugCircularReference)
+			}
+			if test.WantActions[0] == plans.DeleteThenCreate && test.WantActions[1] == plans.DeleteThenCreate {
+				// The experimental new runtime doesn't currently handle this
+				// interaction correctly, producing an execution graph where
+				// the two resources end up mutually-dependent on each other.
+				SkipExperimental(t, ExperimentalBugCircularReference)
+			}
+			if test.WantActions[0] == plans.CreateThenDelete && test.WantActions[1] == plans.DeleteThenCreate {
+				// The experimental new runtime doesn't currently handle this
+				// interaction correctly, instead forcing the second action
+				// to also be CreateThenDelete. It currently propagates the
+				// forced "CreateBeforeDestroy" both upstream and downstream,
+				// whereas the traditional runtime only propagates it upstream.
+				SkipExperimental(t, ExperimentalBugCBDDownstream)
+			}
+
+			cfg := testModuleInline(t, map[string]string{
+				"main.tf": test.Config,
+			})
+			state := states.BuildState(test.BuildPriorState)
+
+			p := &MockProvider{}
+			p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
+				ResourceTypes: map[string]providers.Schema{
+					"test": {
+						Block: &configschema.Block{
+							Attributes: map[string]*configschema.Attribute{
+								"id": {
+									Type:     cty.String,
+									Computed: true,
+								},
+								"parent_id": {
+									Type:     cty.String,
+									Optional: true,
+								},
+								"forces_replace": {
+									Type:     cty.String,
+									Optional: true,
+								},
+							},
+						},
+					},
+				},
+			}
+			p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) providers.PlanResourceChangeResponse {
+				return providers.PlanResourceChangeResponse{
+					PlannedState: req.ProposedNewState, // "id" is unknown in this when planning the create leg of a replace
+					RequiresReplace: []cty.Path{
+						cty.GetAttrPath("forces_replace"),
+					},
+				}
+			}
+
+			fmtConfig := hclwrite.Format([]byte(test.Config))
+			t.Log("Prior State:\n" + state.String())
+			t.Log("Config:\n" + string(fmtConfig))
+
+			tofuCtx := testContext2(t, &ContextOpts{
+				Plugins: plugins.NewLibrary(map[addrs.Provider]providers.Factory{
+					addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+				}, nil),
+			})
+			plan, diags := assertNoPanic(t, func() (*plans.Plan, tfdiags.Diagnostics) {
+				return tofuCtx.Plan(t.Context(), cfg, state, DefaultPlanOpts)
+			})
+			assertNoDiagnostics(t, diags)
+
+			// This test is mainly focused on whether planning can succeed with this
+			// particular combination of actions, but we'll test to make sure we
+			// actually got the actions we expected or else we're not testing what
+			// we think we are testing.
+			firstInstChange := plan.Changes.ResourceInstance(mustResourceInstanceAddr("test.first"))
+			if firstInstChange != nil {
+				if got, want := firstInstChange.Action, test.WantActions[0]; got != want {
+					t.Errorf("wrong action %s for test.first; want %s", got, want)
+				}
+			} else {
+				t.Error("missing change for test.first")
+			}
+			secondInstChange := plan.Changes.ResourceInstance(mustResourceInstanceAddr("test.second"))
+			if secondInstChange != nil {
+				if got, want := secondInstChange.Action, test.WantActions[1]; got != want {
+					t.Errorf("wrong action %s for test.second; want %s", got, want)
+				}
+			} else {
+				t.Error("missing change for test.second")
+			}
+
 		})
 	}
 }

--- a/internal/tofu/context_temp_runtime_test.go
+++ b/internal/tofu/context_temp_runtime_test.go
@@ -100,6 +100,7 @@ var (
 	ExperimentalBugSpuriousReplace   = ExperimentalFlag{"Bug Spurious Replace", true} // New runtime proposes replace where old runtime would've called for update
 	ExperimentalBugProviderPrivate   = ExperimentalFlag{"Bug Provider Private Data Not Preserved", false}
 	ExperimentalBugCircularReference = ExperimentalFlag{"Bug Circular Reference", false}
+	ExperimentalBugCBDDownstream     = ExperimentalFlag{"Bug CBD Propagates Downstream", false}
 
 	ExperimentalChangeDiagWording     = ExperimentalFlag{"Change Different Diagnostic Wording", false}
 	ExperimentalChangeErrorEarly      = ExperimentalFlag{"Change Detect Error Earlier", false}

--- a/internal/tofu/opentf_test.go
+++ b/internal/tofu/opentf_test.go
@@ -251,6 +251,25 @@ func mustReference(s string) *addrs.Reference {
 	return p
 }
 
+// assertNoPanic runs the given function and returns whatever it returns, or
+// halts the test with an error if the function panics on the main goroutine
+// during execution.
+//
+// This is generic to support any function that returns two results regardless
+// of type, though it's mainly intended for functions where the second return
+// value is either error or diagnostics.
+//
+// Note that this does not catch panics on any other goroutine that might be
+// created during the function's execution.
+func assertNoPanic[R, E any](t testing.TB, f func() (R, E)) (R, E) {
+	defer func() {
+		if pe := recover(); pe != nil {
+			t.Fatalf("unexpected panic: %#v", pe)
+		}
+	}()
+	return f()
+}
+
 // HookRecordApplyOrder is a test hook that records the order of applies
 // by recording the PreApply event.
 type HookRecordApplyOrder struct {


### PR DESCRIPTION
The main purpose in adding this set of tests is to represent some current known bugs in the new language runtime where it doesn't handle the case where an instance being updated depends on an instance being replaced in the delete-first ordering, and it doesn't propagate CreateBeforeDestroy through the graph in exactly the same way.

But this also covers various other combinations too because we don't seem to have an existing test focused just on making sure all of these combinations are plannable, and we want to make sure that the later fix for the problems we know about doesn't then break one of the other combinations.

This also includes an extra check to make the execgraph-cycle problem fail as a regular panic instead of a stack overflow, since that means we can catch it as a test failure and continue running other tests instead of aborting the entire test suite when it occurs, and give a more specific panic message about it.

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
