### PR TITLE
Implement replace_triggered_by in the new runtime

### DIFF
--- a/internal/engine/planning/plan_eval_glue.go
+++ b/internal/engine/planning/plan_eval_glue.go
@@ -11,11 +11,13 @@ import (
 	"iter"
 	"log"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/collections"
 	"github.com/opentofu/opentofu/internal/lang/eval"
+	"github.com/opentofu/opentofu/internal/plans"
 	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
@@ -340,4 +342,67 @@ func resourceInstancesFilter(state *states.State, want func(addrs.AbsResourceIns
 			}
 		}
 	}
+}
+
+func (p *planGlue) evaluateReplaceTriggeredBy(ref eval.ResourceInstanceAttributePath) (*addrs.AbsResourceInstance, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	var changes []*plans.ResourceInstanceChange
+
+	instance, ok := p.planCtx.resourceInstObjs.Get(ref.ResourceInstance.CurrentObject())
+	if !ok {
+		// This should not happen!
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  `Reference to undeclared resource`,
+			Detail:   fmt.Sprintf(`A resource %s has not been declared`, ref.ResourceInstance),
+			//Subject:  expr.Range().Ptr(),
+		})
+		return nil, diags
+	}
+	currentChange := instance.PlannedChange
+	if currentChange != nil {
+		changes = append(changes, currentChange)
+	}
+
+	if len(changes) == 0 {
+		return nil, diags
+	}
+
+	// If we don't have a traversal beyond the resource, then we can just look
+	// for any change.
+	if len(ref.Path) == 0 {
+		for _, c := range changes {
+			if c.Action.CanTriggerDownstreamReplace() {
+				return &ref.ResourceInstance, diags
+			}
+		}
+
+		// no change triggered
+		return nil, diags
+	}
+
+	// This must be an instances to have a remaining traversal, which means a
+	// single change.
+	change := changes[0]
+
+	// Make sure the change is actionable. A Delete action will have a change
+	// in value, but is not valid for our purposes here.
+	if !change.Action.CanTriggerDownstreamReplace() {
+		return nil, diags
+	}
+
+	attrBefore, _ := ref.Path.Apply(change.Before)
+	attrAfter, _ := ref.Path.Apply(change.After)
+
+	replace := false
+	if attrBefore == cty.NilVal || attrAfter == cty.NilVal {
+		replace = attrBefore != attrAfter
+	} else {
+		replace = !attrBefore.RawEquals(attrAfter)
+	}
+
+	if replace {
+		return &ref.ResourceInstance, diags
+	}
+	return nil, diags
 }

--- a/internal/engine/planning/plan_eval_glue.go
+++ b/internal/engine/planning/plan_eval_glue.go
@@ -355,7 +355,6 @@ func (p *planGlue) evaluateReplaceTriggeredBy(ref eval.ResourceInstanceAttribute
 			Severity: hcl.DiagError,
 			Summary:  `Reference to undeclared resource`,
 			Detail:   fmt.Sprintf(`A resource %s has not been declared`, ref.ResourceInstance),
-			//Subject:  expr.Range().Ptr(),
 		})
 		return nil, diags
 	}

--- a/internal/engine/planning/plan_managed.go
+++ b/internal/engine/planning/plan_managed.go
@@ -8,6 +8,7 @@ package planning
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
@@ -318,6 +319,21 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 		return ret, diags
 	}
 
+	// Check for if replacement is required
+	replaceTriggered := false
+	for _, tb := range inst.ReplaceTriggeredBy {
+		replaceAddr, replaceDiags := p.evaluateReplaceTriggeredBy(tb)
+		diags = diags.Append(replaceDiags)
+		if replaceDiags.HasErrors() {
+			return ret, diags
+		}
+
+		if replaceAddr != nil {
+			log.Printf("[DEBUG] ReplaceTriggeredBy forcing replacement of %s due to change in %s", inst.Addr, replaceAddr)
+			replaceTriggered = true
+		}
+	}
+
 	// TODO: Check for resp.Deferred once we've updated package providers to
 	// include it. If that's set then the _provider_ is telling us we must
 	// defer planning any action for this resource instance. We'd still
@@ -325,7 +341,7 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 	// that case, but we would need to mark it as deferred and _not_ record a
 	// proposed change for it.
 
-	if eq, _ := planResp.Planned.Value.Equals(refreshedVal).Unmark(); eq.IsKnown() && eq.True() {
+	if eq, _ := planResp.Planned.Value.Equals(refreshedVal).Unmark(); eq.IsKnown() && eq.True() && !replaceTriggered {
 		// There is no change to make, so we'll return early without actually
 		// recording any change. In this case our resource instance will be
 		// included in the execution graph only if some other resource instance
@@ -341,10 +357,15 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 		return ret, diags
 	}
 
+	actionReason := plans.ResourceInstanceChangeNoReason
+	if replaceTriggered {
+		actionReason = plans.ResourceInstanceReplaceByTriggers
+	}
+
 	plannedAction := plans.Update
 	if prevRoundState == nil {
 		plannedAction = plans.Create
-	} else if !planResp.RequiresReplace.Empty() {
+	} else if !planResp.RequiresReplace.Empty() || replaceTriggered {
 		// For "replace" actions the execution graph will include two separate
 		// plan and apply operations, where one handles deletion and the other
 		// handles creation. There is therefore an implicit third intermediate
@@ -420,6 +441,7 @@ func (p *planGlue) planDesiredManagedResourceInstance(
 		// we'd need for that into here since most of the reasons are
 		// configuration-related and so would need to be driven by stuff in
 		// [eval.DesiredResourceInstance].
+		ActionReason: actionReason,
 	}
 	ret.ProviderInst = *inst.ProviderInstance
 

--- a/internal/engine/planning/plan_resource_instance.go
+++ b/internal/engine/planning/plan_resource_instance.go
@@ -358,6 +358,13 @@ func newResourceInstanceObjectsBuilder() *resourceInstanceObjectsBuilder {
 	}
 }
 
+func (b *resourceInstanceObjectsBuilder) Get(addr addrs.AbsResourceInstanceObject) (*resourceInstanceObject, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.result.objects.GetOk(addr)
+}
+
 // Put inserts the given resource instance object into the collection.
 //
 // Resource instance objects are uniquely identified by the addresses

--- a/internal/lang/eval/config_plan.go
+++ b/internal/lang/eval/config_plan.go
@@ -270,6 +270,7 @@ func (p *planningEvalGlue) ResourceInstanceValue(ctx context.Context, ri *config
 		ResourceType:              ri.Addr.Resource.Resource.Type,
 		ResourceMode:              ri.Addr.Resource.Resource.Mode,
 		IgnoreChangesPaths:        ri.IgnoreChangesPaths,
+		ReplaceTriggeredBy:        ri.ReplaceTriggeredBy,
 	}
 	// FIXME: DesiredResourceInstance is using a possibly-nil pointer to
 	// addrs.AbsProviderInstanceCorrect as a legacy way to represent a

--- a/internal/lang/eval/internal/configgraph/resource_instance.go
+++ b/internal/lang/eval/internal/configgraph/resource_instance.go
@@ -81,6 +81,24 @@ type ResourceInstance struct {
 	// change action, and so is always empty for other modes.
 	IgnoreChangesPaths []cty.Path
 
+	// ReplaceTriggeredBy describes zero ore more attribute prefixes within
+	// other resource instances for which the planning engine should force
+	// replacement of this resource instance if any value beneath one of
+	// the nominated paths has a change already planned for the current
+	// plan/apply round.
+	//
+	// Index steps within the paths and instance keys within the resource
+	// instance addresses can both potentially have unknown keys if the
+	// decision about what to refer to is based on a value that won't be known
+	// until the apply phase.
+	//
+	// This is meaningful only for resource modes that support the "update"
+	// change action, and so is always false for other modes.
+	//
+	// Any resource instance mentioned in this collection will always also
+	// appear in RequiredResourceInstances.
+	ReplaceTriggeredBy []ResourceInstanceAttributePath
+
 	// Glue is provided by the system that "compiled" this [ResourceInstance]
 	// object to allow calling back into that system to ask further questions
 	// that arise dynamically during evaluation but whose results vary based
@@ -93,6 +111,13 @@ type ResourceInstance struct {
 	// implementation, which might involve side-effects that could produce
 	// different results
 	valueOnce grapheval.Once[cty.Value]
+}
+
+// ResourceInstanceAttributePath describes a (possibly empty) attribute path
+// within a resource instance.
+type ResourceInstanceAttributePath struct {
+	ResourceInstance addrs.AbsResourceInstance
+	Path             cty.Path
 }
 
 var _ exprs.Valuer = (*ResourceInstance)(nil)

--- a/internal/lang/eval/internal/tofu2024/compile_resources.go
+++ b/internal/lang/eval/internal/tofu2024/compile_resources.go
@@ -31,22 +31,22 @@ func compileModuleInstanceResources(
 	declScope exprs.Scope,
 	moduleProviders configgraph.CompileProviderConfigRef,
 	moduleInstanceAddr addrs.ModuleInstance,
-	providers evalglue.ProvidersSchema,
-	provisioners evalglue.ProvisionersSchema,
+	providersSchema evalglue.ProvidersSchema,
+	provisionersSchema evalglue.ProvisionersSchema,
 	getResultValue func(context.Context, *configgraph.ResourceInstance, cty.Value, exprs.FromValue[*configgraph.ProviderInstance], addrs.Set[addrs.AbsResourceInstance]) (cty.Value, tfdiags.Diagnostics),
 	extraMarks cty.ValueMarks,
 ) map[addrs.Resource]*configgraph.Resource {
 	ret := make(map[addrs.Resource]*configgraph.Resource, len(managedConfigs)+len(dataConfigs)+len(ephemeralConfigs))
 	for _, rc := range managedConfigs {
-		addr, rsrc := compileModuleInstanceResource(ctx, rc, declScope, moduleProviders, moduleInstanceAddr, providers, provisioners, getResultValue, extraMarks)
+		addr, rsrc := compileModuleInstanceResource(ctx, rc, declScope, moduleProviders, moduleInstanceAddr, providersSchema, provisionersSchema, getResultValue, extraMarks)
 		ret[addr] = rsrc
 	}
 	for _, rc := range dataConfigs {
-		addr, rsrc := compileModuleInstanceResource(ctx, rc, declScope, moduleProviders, moduleInstanceAddr, providers, nil, getResultValue, extraMarks)
+		addr, rsrc := compileModuleInstanceResource(ctx, rc, declScope, moduleProviders, moduleInstanceAddr, providersSchema, nil, getResultValue, extraMarks)
 		ret[addr] = rsrc
 	}
 	for _, rc := range ephemeralConfigs {
-		addr, rsrc := compileModuleInstanceResource(ctx, rc, declScope, moduleProviders, moduleInstanceAddr, providers, nil, getResultValue, extraMarks)
+		addr, rsrc := compileModuleInstanceResource(ctx, rc, declScope, moduleProviders, moduleInstanceAddr, providersSchema, nil, getResultValue, extraMarks)
 		ret[addr] = rsrc
 	}
 	return ret
@@ -171,6 +171,7 @@ func compileModuleInstanceResource(
 				ignoreChanges = traversalsToPaths(travs)
 			}
 		}
+
 	}
 
 	if diags.HasErrors() {
@@ -191,6 +192,8 @@ func compileModuleInstanceResource(
 		// allowing us to finalize all of the details for a specific instance
 		// of this resource.
 		CompileResourceInstance: func(ctx context.Context, key addrs.InstanceKey, repData instances.RepetitionData) *configgraph.ResourceInstance {
+			var diags tfdiags.Diagnostics
+
 			localScope := instanceLocalScope(declScope, repData)
 			providerRef := compileProviderConfigRef(ctx, moduleProviders, config.ProviderConfigAddr(), config.ProviderConfigRef, localScope)
 			instanceDeps := compileInstanceDeps(localScope)
@@ -234,6 +237,61 @@ func compileModuleInstanceResource(
 				}
 			}
 
+			var replaceMarks cty.ValueMarks
+			var replaceTriggeredBy []configgraph.ResourceInstanceAttributePath
+			if config.Managed != nil {
+				// Validate that attribute traversals in replace_triggered_by
+				// expressions refer to attributes that exist in the schema.
+				// We use evalReplaceTriggeredByExpr to correctly handle JSON
+				// syntax and HCL expressions.
+				for _, expr := range config.TriggersReplacement {
+					// An alternative to this system would be to mark each resource attribute with it's exact path, sort of
+					// an ResourceInstanceMarkWithPath so we know exactly what resource and path an expression derives it's
+					// value from. I suspect that the performance impact of that would be quite terrible and we should probably
+					// not do that.
+					//
+					// TODO replace evalReplaceTriggeredByExpr with something more tailored to the new engine style of doing things.
+					ref, refDiags := evalReplaceTriggeredByExpr(expr, repData)
+					if refDiags.HasErrors() {
+						diags = diags.Append(refDiags)
+						continue
+					}
+
+					var refAddr addrs.Resource
+					switch rs := ref.Subject.(type) {
+					case addrs.Resource:
+						refAddr = rs
+					case addrs.ResourceInstance:
+						refAddr = rs.Resource
+					default:
+						continue
+					}
+
+					refVal, refValDiags := exprs.NewClosure(exprs.EvalableHCLExpression(expr), localScope).Value(ctx)
+					diags = diags.Append(refValDiags)
+					if refValDiags.HasErrors() {
+						// TODO are these errors good enough or should we replace them with something better?
+						continue
+					}
+
+					path := traversalToPath(ref.Remaining)
+					for ri := range configgraph.ContributingResourceInstances(refVal) {
+						if !ri.Addr.Resource.Resource.Equal(refAddr) {
+							continue
+						}
+
+						if replaceMarks == nil {
+							replaceMarks = cty.ValueMarks{}
+						}
+						replaceMarks[configgraph.NewResourceInstanceMark(ri)] = struct{}{}
+						replaceTriggeredBy = append(replaceTriggeredBy, configgraph.ResourceInstanceAttributePath{
+							ResourceInstance: ri.Addr,
+							Path:             path,
+						})
+					}
+				}
+			}
+
 			// Note that repetitionMarks also incorporates any marks from the
 			// depends_on argument, which got evaluated as part of the instance
 			// selector just as a convenient once-per-resource evaluation hook.
@@ -245,14 +303,14 @@ func compileModuleInstanceResource(
 			// the main config body.
 			configValuer := configgraph.ValuerOnce(exprs.DerivedValuerContext(
 				exprs.NewClosure(configEvalable, localScope),
-				func(ctx context.Context, v cty.Value, diags tfdiags.Diagnostics) (cty.Value, tfdiags.Diagnostics) {
+				func(ctx context.Context, v cty.Value, vDiags tfdiags.Diagnostics) (cty.Value, tfdiags.Diagnostics) {
 					// TODO more efficient marking, this does a lot of map garbarge
 					// TODO consider moving provider related marks into here, currently partially impl in configgraph.ResourceInstance.Value
 					if len(repetitionMarks) != 0 {
 						v = v.WithMarks(repetitionMarks)
 					}
 					instDepMarks, moreDiags := instanceDeps.Marks(ctx)
-					diags = diags.Append(moreDiags)
+					vDiags = vDiags.Append(moreDiags)
 					if len(instDepMarks) != 0 {
 						v = v.WithMarks(instDepMarks)
 					}
@@ -261,7 +319,14 @@ func compileModuleInstanceResource(
 						v = v.WithMarks(provisionerMarks)
 					}
 
-					return v, diags
+					if len(replaceMarks) != 0 {
+						v = v.WithMarks(replaceMarks)
+					}
+
+					// Include any additional diags during the instance setup logic
+					vDiags = vDiags.Append(diags)
+
+					return v, vDiags
 				},
 			))
 
@@ -273,6 +338,7 @@ func compileModuleInstanceResource(
 				CreateBeforeDestroyValuer: cbdValuer,
 				CreateProvisioners:        provisionerConfigs,
 				IgnoreChangesPaths:        ignoreChanges,
+				ReplaceTriggeredBy:        replaceTriggeredBy,
 			}
 			// Again the [ResourceInstance] implementation will call back
 			// through this object so we can help it interact with the

--- a/internal/lang/eval/internal/tofu2024/evaluate_triggers.go
+++ b/internal/lang/eval/internal/tofu2024/evaluate_triggers.go
@@ -1,0 +1,152 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tofu2024
+
+// Copied verbatium from the tofu package
+
+import (
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/instances"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// evalReplaceTriggeredByExpr evaluates the replace_triggered_by expression to get the reference
+// to the resource that triggers replacement, if any.
+func evalReplaceTriggeredByExpr(expr hcl.Expression, keyData instances.RepetitionData) (*addrs.Reference, tfdiags.Diagnostics) {
+	var ref *addrs.Reference
+	var diags tfdiags.Diagnostics
+
+	traversal, diags := triggersExprToTraversal(expr, keyData)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	// We now have a static traversal, so we can just turn it into an addrs.Reference.
+	ref, ds := addrs.ParseRef(traversal)
+	diags = diags.Append(ds)
+
+	return ref, diags
+}
+
+// triggersExprToTraversal takes an hcl expression limited to the syntax allowed
+// in replace_triggered_by, and converts it to a static traversal. The
+// RepetitionData contains the data necessary to evaluate the only allowed
+// variables in the expression, count.index and each.key.
+func triggersExprToTraversal(expr hcl.Expression, keyData instances.RepetitionData) (hcl.Traversal, tfdiags.Diagnostics) {
+	var trav hcl.Traversal
+	var diags tfdiags.Diagnostics
+
+	switch e := expr.(type) {
+	case *hclsyntax.RelativeTraversalExpr:
+		t, d := triggersExprToTraversal(e.Source, keyData)
+		diags = diags.Append(d)
+		trav = append(trav, t...)
+		trav = append(trav, e.Traversal...)
+
+	case *hclsyntax.ScopeTraversalExpr:
+		// a static reference, we can just append the traversal
+		trav = append(trav, e.Traversal...)
+
+	case *hclsyntax.IndexExpr:
+		// Get the collection from the index expression
+		t, d := triggersExprToTraversal(e.Collection, keyData)
+		diags = diags.Append(d)
+		if diags.HasErrors() {
+			return nil, diags
+		}
+		trav = append(trav, t...)
+
+		// The index key is the only place where we could have variables that
+		// reference count and each, so we need to parse those independently.
+		idx, hclDiags := parseIndexKeyExpr(e.Key, keyData)
+		diags = diags.Append(hclDiags)
+
+		trav = append(trav, idx)
+
+	default:
+		// Something unexpected got through config validation. We're not sure
+		// what it is, but we'll point it out in the diagnostics for the user
+		// to fix.
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid replace_triggered_by expression",
+			Detail:   "Unexpected expression found in replace_triggered_by.",
+			Subject:  e.Range().Ptr(),
+		})
+	}
+
+	return trav, diags
+}
+
+// parseIndexKeyExpr takes an hcl.Expression and parses it as an index key, while
+// evaluating any references to count.index or each.key.
+func parseIndexKeyExpr(expr hcl.Expression, keyData instances.RepetitionData) (hcl.TraverseIndex, hcl.Diagnostics) {
+	idx := hcl.TraverseIndex{
+		SrcRange: expr.Range(),
+	}
+
+	trav, diags := hcl.RelTraversalForExpr(expr)
+	if diags.HasErrors() {
+		return idx, diags
+	}
+
+	keyParts := []string{}
+
+	for _, t := range trav {
+		attr, ok := t.(hcl.TraverseAttr)
+		if !ok {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid index expression",
+				Detail:   "Only constant values, count.index or each.key are allowed in index expressions.",
+				Subject:  expr.Range().Ptr(),
+			})
+			return idx, diags
+		}
+		keyParts = append(keyParts, attr.Name)
+	}
+
+	switch strings.Join(keyParts, ".") {
+	case "count.index":
+		if keyData.CountIndex == cty.NilVal {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  `Reference to "count" in non-counted context`,
+				Detail:   `The "count" object can only be used in "resource" blocks when the "count" argument is set.`,
+				Subject:  expr.Range().Ptr(),
+			})
+		}
+		idx.Key = keyData.CountIndex
+
+	case "each.key":
+		if keyData.EachKey == cty.NilVal {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  `Reference to "each" in context without for_each`,
+				Detail:   `The "each" object can be used only in "resource" blocks when the "for_each" argument is set.`,
+				Subject:  expr.Range().Ptr(),
+			})
+		}
+		idx.Key = keyData.EachKey
+	default:
+		// Something may have slipped through validation, probably from a json
+		// configuration.
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid index expression",
+			Detail:   "Only constant values, count.index or each.key are allowed in index expressions.",
+			Subject:  expr.Range().Ptr(),
+		})
+	}
+
+	return idx, diags
+
+}

--- a/internal/lang/eval/internal/tofu2024/evaluate_triggers_test.go
+++ b/internal/lang/eval/internal/tofu2024/evaluate_triggers_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tofu2024
+
+// Copied verbatium from the tofu package
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/instances"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestEvalReplaceTriggeredBy(t *testing.T) {
+	tests := map[string]struct {
+		// Raw config expression from within replace_triggered_by list.
+		// If this does not contains any count or each references, it should
+		// directly parse into the same *addrs.Reference.
+		expr string
+
+		// If the expression contains count or each, then we need to add
+		// repetition data, and the static string to parse into the desired
+		// *addrs.Reference
+		repData   instances.RepetitionData
+		reference string
+	}{
+		"single resource": {
+			expr: "test_resource.a",
+		},
+
+		"resource instance attr": {
+			expr: "test_resource.a.attr",
+		},
+
+		"resource instance index attr": {
+			expr: "test_resource.a[0].attr",
+		},
+
+		"resource instance count": {
+			expr: "test_resource.a[count.index]",
+			repData: instances.RepetitionData{
+				CountIndex: cty.NumberIntVal(0),
+			},
+			reference: "test_resource.a[0]",
+		},
+		"resource instance for_each": {
+			expr: "test_resource.a[each.key].attr",
+			repData: instances.RepetitionData{
+				EachKey: cty.StringVal("k"),
+			},
+			reference: `test_resource.a["k"].attr`,
+		},
+		"resource instance for_each map attr": {
+			expr: "test_resource.a[each.key].attr[each.key]",
+			repData: instances.RepetitionData{
+				EachKey: cty.StringVal("k"),
+			},
+			reference: `test_resource.a["k"].attr["k"]`,
+		},
+	}
+
+	for name, tc := range tests {
+		pos := hcl.Pos{Line: 1, Column: 1}
+		t.Run(name, func(t *testing.T) {
+			expr, hclDiags := hclsyntax.ParseExpression([]byte(tc.expr), "", pos)
+			if hclDiags.HasErrors() {
+				t.Fatal(hclDiags)
+			}
+
+			got, diags := evalReplaceTriggeredByExpr(expr, tc.repData)
+			if diags.HasErrors() {
+				t.Fatal(diags.Err())
+			}
+
+			want := tc.reference
+			if want == "" {
+				want = tc.expr
+			}
+
+			// create the desired reference
+			traversal, travDiags := hclsyntax.ParseTraversalAbs([]byte(want), "", pos)
+			if travDiags.HasErrors() {
+				t.Fatal(travDiags)
+			}
+			ref, diags := addrs.ParseRef(traversal)
+			if diags.HasErrors() {
+				t.Fatal(diags.Err())
+			}
+
+			if got.DisplayString() != ref.DisplayString() {
+				t.Fatalf("expected %q: got %q", ref.DisplayString(), got.DisplayString())
+			}
+		})
+	}
+}

--- a/internal/lang/eval/internal/tofu2024/module_instance_scope.go
+++ b/internal/lang/eval/internal/tofu2024/module_instance_scope.go
@@ -159,11 +159,13 @@ func (m *moduleInstanceScope) ResolveAttr(ref hcl.TraverseAttr) (exprs.Attribute
 		return exprs.NestedSymbolTable(&moduleInstanceResourceSymbolTable{
 			mode:     addrs.DataResourceMode,
 			topScope: m,
+			startRng: ref.SrcRange,
 		}), diags
 	case "ephemeral":
 		return exprs.NestedSymbolTable(&moduleInstanceResourceSymbolTable{
 			mode:     addrs.EphemeralResourceMode,
 			topScope: m,
+			startRng: ref.SrcRange,
 		}), diags
 	default:
 		// We treat all unrecognized prefixes as a shorthand for "resource."
@@ -172,6 +174,7 @@ func (m *moduleInstanceScope) ResolveAttr(ref hcl.TraverseAttr) (exprs.Attribute
 			mode:     addrs.ManagedResourceMode,
 			typeName: ref.Name,
 			topScope: m,
+			startRng: ref.SrcRange,
 		}), diags
 	}
 }

--- a/internal/lang/eval/resource_instance.go
+++ b/internal/lang/eval/resource_instance.go
@@ -169,6 +169,7 @@ type DesiredResourceInstance struct {
 // Exposing configgraph details is not idea, but it's a very simple structure
 // that is probably not worth duplicating right now
 type Provisioner = configgraph.Provisioner
+type ResourceInstanceAttributePath = configgraph.ResourceInstanceAttributePath
 
 // IsPlaceholder returns true if this object is acting as a placeholder for
 // zero or more resource instances whose full expansion is not yet known.
@@ -189,11 +190,4 @@ type Provisioner = configgraph.Provisioner
 // scope of the configuration.
 func (ri *DesiredResourceInstance) IsPlaceholder() bool {
 	return ri.Addr.IsPlaceholder()
-}
-
-// ResourceInstanceAttributePath describes a (possibly empty) attribute path
-// within a resource instance.
-type ResourceInstanceAttributePath struct {
-	ResourceInstance addrs.AbsResourceInstance
-	Path             cty.Path
 }

--- a/internal/tofu/context_temp_runtime_test.go
+++ b/internal/tofu/context_temp_runtime_test.go
@@ -132,7 +132,7 @@ var (
 	ExperimentalFeatureUpgradeUnwanted   = ExperimentalFlag{"Missing Upgrade Orphan or Deposed Resource Instance State", false}
 	ExperimentalFeatureHooks             = ExperimentalFlag{"Missing Hooks", true}
 	ExperimentalFeatureTarget            = ExperimentalFlag{"Missing Targeting", false}
-	ExperimentalFeatureReplaceTB         = ExperimentalFlag{"Missing replace_triggered_by", false}
+	ExperimentalFeatureReplaceTB         = ExperimentalFlag{"Missing replace_triggered_by", true}
 	ExperimentalFeatureProvisioner       = ExperimentalFlag{"Missing Provisioners", true}
 	ExperimentalFeatureDependsOn         = ExperimentalFlag{"Missing Depends On", true}
 	ExperimentalFeatureIgnoreChanges     = ExperimentalFlag{"Missing Ignore Changes", true}


### PR DESCRIPTION
This functionally reproduces the logic that exists in the current engine, but could be made a lot smarter down the line.

The biggest downside of the current approach is that I had to duplicate evaluate_triggers*.go into the tofu2024 package from the tofu package.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
