### PR TITLE
planning: Only force-propagate create_before_destroy "upwards"

### DIFF
--- a/internal/engine/planning/plan_replace_order.go
+++ b/internal/engine/planning/plan_replace_order.go
@@ -60,7 +60,7 @@ Objects:
 			continue
 		}
 
-		for otherInst := range objs.AllDependenciesAndDependents(currentInst) {
+		for otherInst := range objs.AllDependents(currentInst) {
 			if otherInst.Equal(currentInst) {
 				// We've found a self-dependency problem, so we'll record
 				// it but continue anyway because the rest of this algorithm

--- a/internal/engine/planning/plan_replace_order_test.go
+++ b/internal/engine/planning/plan_replace_order_test.go
@@ -120,11 +120,11 @@ func TestFindEffectiveReplaceOrders(t *testing.T) {
 				},
 				addrs.MapElem[addrs.AbsResourceInstanceObject, resourceInstanceReplaceOrder]{
 					Key:   objAddr("b"),
-					Value: replaceCreateThenDestroy,
+					Value: replaceDestroyThenCreate,
 				},
 				addrs.MapElem[addrs.AbsResourceInstanceObject, resourceInstanceReplaceOrder]{
 					Key:   objAddr("c"),
-					Value: replaceCreateThenDestroy,
+					Value: replaceDestroyThenCreate,
 				},
 			),
 			addrs.MakeSet[addrs.AbsResourceInstanceObject](),
@@ -157,7 +157,7 @@ func TestFindEffectiveReplaceOrders(t *testing.T) {
 				},
 				addrs.MapElem[addrs.AbsResourceInstanceObject, resourceInstanceReplaceOrder]{
 					Key:   objAddr("c"),
-					Value: replaceCreateThenDestroy,
+					Value: replaceDestroyThenCreate,
 				},
 			),
 			addrs.MakeSet[addrs.AbsResourceInstanceObject](),

--- a/internal/engine/planning/plan_resource_instance.go
+++ b/internal/engine/planning/plan_resource_instance.go
@@ -321,18 +321,18 @@ func (rios *resourceInstanceObjects) StateDependenciesAndDependents(of addrs.Abs
 	}
 }
 
-// AllDependenciesAndDependents combines the results of
-// [*resourceInstanceObjects.ConfigDependenciesAndDependents] and
-// [*resourceInstanceObjects.StateDependenciesAndDependents] into a single
+// AllDependents combines the results of
+// [*resourceInstanceObjects.ConfigDependents] and
+// [*resourceInstanceObjects.StateDependents] into a single
 // flat sequence.
-func (rios *resourceInstanceObjects) AllDependenciesAndDependents(of addrs.AbsResourceInstanceObject) iter.Seq[addrs.AbsResourceInstanceObject] {
+func (rios *resourceInstanceObjects) AllDependents(of addrs.AbsResourceInstanceObject) iter.Seq[addrs.AbsResourceInstanceObject] {
 	return func(yield func(addrs.AbsResourceInstanceObject) bool) {
-		for addr := range rios.ConfigDependenciesAndDependents(of) {
+		for addr := range rios.ConfigDependents(of) {
 			if !yield(addr) {
 				return
 			}
 		}
-		for addr := range rios.StateDependenciesAndDependents(of) {
+		for addr := range rios.StateDependents(of) {
 			if !yield(addr) {
 				return
 			}

--- a/internal/tofu/context_plan_test.go
+++ b/internal/tofu/context_plan_test.go
@@ -4769,14 +4769,6 @@ func TestContext2Plan_actionInteractions(t *testing.T) {
 				// the two resources end up mutually-dependent on each other.
 				SkipExperimental(t, ExperimentalBugCircularReference)
 			}
-			if test.WantActions[0] == plans.CreateThenDelete && test.WantActions[1] == plans.DeleteThenCreate {
-				// The experimental new runtime doesn't currently handle this
-				// interaction correctly, instead forcing the second action
-				// to also be CreateThenDelete. It currently propagates the
-				// forced "CreateBeforeDestroy" both upstream and downstream,
-				// whereas the traditional runtime only propagates it upstream.
-				SkipExperimental(t, ExperimentalBugCBDDownstream)
-			}
 
 			cfg := testModuleInline(t, map[string]string{
 				"main.tf": test.Config,

--- a/internal/tofu/context_temp_runtime_test.go
+++ b/internal/tofu/context_temp_runtime_test.go
@@ -100,7 +100,6 @@ var (
 	ExperimentalBugSpuriousReplace   = ExperimentalFlag{"Bug Spurious Replace", true} // New runtime proposes replace where old runtime would've called for update
 	ExperimentalBugProviderPrivate   = ExperimentalFlag{"Bug Provider Private Data Not Preserved", false}
 	ExperimentalBugCircularReference = ExperimentalFlag{"Bug Circular Reference", false}
-	ExperimentalBugCBDDownstream     = ExperimentalFlag{"Bug CBD Propagates Downstream", false}
 
 	ExperimentalChangeDiagWording     = ExperimentalFlag{"Change Different Diagnostic Wording", false}
 	ExperimentalChangeErrorEarly      = ExperimentalFlag{"Change Detect Error Earlier", false}


### PR DESCRIPTION
The initial implementation of replace order propagation was changing more than necessary by analyzing both dependencies and dependents of everything that has `create_before_destroy` set.

All that's actually required is that all transitive dependencies of something with `create_before_destroy` are also forced into that mode. Resource instances that are dependents can remain in destroy-then-create mode unless they are declared otherwise or forced by one of their own dependents. This implementation actually frames the problem in the opposite way, by checking for each resource instance whether any of its dependents require `create_before_destroy`, but that's functionally equivalent.

The correctness of this is confirmed by removing the experimental skip from a test which matches the relevant pattern. This test was already passing in the current runtime, and it now also passes in the new runtime. The unit tests in package planning are therefore now corrected to match the effective behavior of the original runtime.

There is still another bug https://github.com/opentofu/opentofu/issues/4346, which we'll deal with in a second PR.

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
