### PR TITLE
docs: clarify replace_triggered_by supports resource instances and attributes

### DIFF
--- a/website/docs/language/resources/behavior.mdx
+++ b/website/docs/language/resources/behavior.mdx
@@ -280,9 +280,9 @@ block for a managed resource:
   - If the reference is to a single attribute of a resource instance, any
     change to the attribute value will trigger replacement.
 
-  You can only refer to managed resources in `replace_triggered_by`
-  expressions. This lets you modify these expressions without forcing
-  replacement.
+  You can only refer to managed resources, their instances, and their
+  instance attributes in `replace_triggered_by` expressions. This lets you
+  modify these expressions without forcing replacement.
 
   ```hcl
   resource "aws_appautoscaling_target" "ecs_target" {


### PR DESCRIPTION
Part of #4348.

Deliberately not using `Resolves`, since #4348 also covers the data-source planning error (`no change found for data...`), which is an engine matter and still open. This PR is the docs half only.

The `replace_triggered_by` section contradicts itself: the introduction and the trigger-condition bullets describe managed resources, resource instances, and instance attributes, but a later sentence says you can only refer to managed resources. Reworded that sentence to match the rest of the section and the implementation.

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

No Go code in this PR, docs only.

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

- [x] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
