### PR TITLE
planning: Inter-resource-instance dependencies only on `ManagedApply` operations

### DIFF
--- a/internal/engine/internal/execgraph/compiler.go
+++ b/internal/engine/internal/execgraph/compiler.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/engine/internal/exec"
+	"github.com/opentofu/opentofu/internal/lang/exprs"
 	"github.com/opentofu/opentofu/internal/lang/grapheval"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
@@ -168,7 +169,7 @@ func (c *compiler) Compile() (*CompiledGraph, tfdiags.Diagnostics) {
 		c.compiledGraph.resourceInstanceValues.Put(instAddr, func(ctx context.Context) cty.Value {
 			rawResult, ok, _ := execFunc(ctx)
 			if !ok {
-				return cty.DynamicVal
+				return exprs.AsEvalError(cty.DynamicVal)
 			}
 			finalStateObj := rawResult.(*exec.ResourceInstanceObject)
 			if finalStateObj == nil {

--- a/internal/engine/internal/execgraph/compiler_ops.go
+++ b/internal/engine/internal/execgraph/compiler_ops.go
@@ -15,6 +15,7 @@ import (
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/engine/internal/exec"
 	"github.com/opentofu/opentofu/internal/lang/eval"
+	"github.com/opentofu/opentofu/internal/lang/exprs"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
@@ -43,6 +44,20 @@ func (c *compiler) compileOpResourceInstanceDesired(operands *compilerOperands) 
 
 		ret, moreDiags := ops.ResourceInstanceDesired(ctx, instAddr)
 		diags = diags.Append(moreDiags)
+
+		if ret != nil && ret.ConfigVal.HasMarkDeep(exprs.EvalError) {
+			// The execution graph compiler arranges for the final value for
+			// a resource instance to be marked in this way if the operation
+			// that produces it indicates that execution must halt, even
+			// when no diagnostics are directly returned due to them being
+			// reported via a different return path. The reason for this is
+			// expected to be clear from other diagnostics reported upstream,
+			// but just in case that isn't true due to a bug we'll include
+			// a log line to note why we're intentionally halting here.
+			log.Printf("[DEBUG] Cannot finalize desired object for %s because something it depends on encountered an error.", instAddr)
+			return ret, false, diags
+		}
+
 		return ret, !diags.HasErrors(), diags
 	}
 }

--- a/internal/engine/planning/execgraph_managed.go
+++ b/internal/engine/planning/execgraph_managed.go
@@ -93,9 +93,8 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphCreate(
 	// Per the conventions in the old engine, After contains a marked value
 	unmarkedAfter, _ := plannedChange.After.UnmarkDeep()
 	plannedValRef := b.lower.ConstantValue(unmarkedAfter)
-	waitFor, addConfigDep := b.lower.MutableWaiter()
-	desiredInstRef := b.lower.ResourceInstanceDesired(instAddrRef, waitFor)
-	valueRef := b.managedResourceInstanceSubgraphPlanAndApply(
+	desiredInstRef := b.lower.ResourceInstanceDesired(instAddrRef, b.lower.Waiter())
+	valueRef, addConfigDep := b.managedResourceInstanceSubgraphPlanAndApply(
 		desiredInstRef,
 		execgraph.NilResultRef[*exec.ResourceInstanceObject](),
 		plannedValRef,
@@ -109,13 +108,12 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphCreate(
 func (b *execGraphBuilder) managedResourceInstanceSubgraphUpdate(
 	plannedChange *plans.ResourceInstanceChange,
 ) resourceInstanceObjectSubgraph {
-	instAddrRef, priorStateRef, addStateDep := b.managedResourceInstanceChangeAddrAndPriorStateRefs(plannedChange)
+	instAddrRef, priorStateRef, _ := b.managedResourceInstanceChangeAddrAndPriorStateRefs(plannedChange)
 	// Per the conventions in the old engine, After contains a marked value
 	unmarkedAfter, _ := plannedChange.After.UnmarkDeep()
 	plannedValRef := b.lower.ConstantValue(unmarkedAfter)
-	waitFor, addConfigDep := b.lower.MutableWaiter()
-	desiredInstRef := b.lower.ResourceInstanceDesired(instAddrRef, waitFor)
-	valueRef := b.managedResourceInstanceSubgraphPlanAndApply(
+	desiredInstRef := b.lower.ResourceInstanceDesired(instAddrRef, b.lower.Waiter())
+	valueRef, addConfigDep := b.managedResourceInstanceSubgraphPlanAndApply(
 		desiredInstRef,
 		priorStateRef,
 		plannedValRef,
@@ -123,14 +121,14 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphUpdate(
 	return resourceInstanceObjectSubgraph{
 		valueRef:     valueRef,
 		addConfigDep: addConfigDep,
-		addStateDep:  addStateDep,
+		addStateDep:  addConfigDep,
 	}
 }
 
 func (b *execGraphBuilder) managedResourceInstanceSubgraphDelete(
 	plannedChange *plans.ResourceInstanceChange,
 ) resourceInstanceObjectSubgraph {
-	_, priorStateRef, addStateDep := b.managedResourceInstanceChangeAddrAndPriorStateRefs(plannedChange)
+	_, priorStateRef, _ := b.managedResourceInstanceChangeAddrAndPriorStateRefs(plannedChange)
 	// Per the conventions in the old engine, After contains a marked value
 	unmarkedAfter, _ := plannedChange.After.UnmarkDeep()
 	plannedValRef := b.lower.ConstantValue(unmarkedAfter)
@@ -155,7 +153,6 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphDelete(
 		// the prior state before the object is deleted.
 		valueRef:     priorStateRef,
 		deletionRef:  deletionRef,
-		addStateDep:  addStateDep,
 		addDeleteDep: addDeleteDep,
 	}
 }
@@ -184,11 +181,11 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphDeleteOrForgetThenCrea
 	// actions chained together, but we arrange the operations in such a
 	// way that the delete leg can't start unless the desired state is
 	// successfully evaluated.
-	instAddrRef, priorStateRef, addStateDep := b.managedResourceInstanceChangeAddrAndPriorStateRefs(plannedChange)
+	instAddrRef, priorStateRef, _ := b.managedResourceInstanceChangeAddrAndPriorStateRefs(plannedChange)
 	// Per the conventions in the old engine, After contains a marked value
 	unmarkedAfter, _ := plannedChange.After.UnmarkDeep()
 	plannedValRef := b.lower.ConstantValue(unmarkedAfter)
-	desiredInstRef := b.lower.ResourceInstanceDesired(instAddrRef, desiredWaitFor)
+	desiredInstRef := b.lower.ResourceInstanceDesired(instAddrRef, b.lower.Waiter())
 
 	// We plan both the create and destroy parts of this process before we
 	// make any real changes, to reduce the risk that we'll be left in a
@@ -217,17 +214,18 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphDeleteOrForgetThenCrea
 		execgraph.NilResultRef[*exec.ResourceInstanceObject](),
 		deleteWaitFor,
 	)
+	addConfigDep(destroyResultRef) // must finish deleting before creating
 	createResultRef := b.lower.ManagedApply(
 		createPlanRef,
 		execgraph.NilResultRef[*exec.ResourceInstanceObject](),
-		b.lower.Waiter(destroyResultRef),
+		desiredWaitFor,
 	)
 
 	return resourceInstanceObjectSubgraph{
 		valueRef:     createResultRef,
 		deletionRef:  destroyResultRef,
 		addConfigDep: addConfigDep,
-		addStateDep:  addStateDep,
+		addStateDep:  addConfigDep,
 		addDeleteDep: addDeleteDep,
 	}
 }
@@ -242,11 +240,11 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphCreateThenDelete(
 	// actions chained together, but we arrange the operations in such a
 	// way that we don't make any changes unless we can produce valid final
 	// plans for both changes.
-	instAddrRef, priorStateRef, addStateDep := b.managedResourceInstanceChangeAddrAndPriorStateRefs(plannedChange)
+	instAddrRef, priorStateRef, _ := b.managedResourceInstanceChangeAddrAndPriorStateRefs(plannedChange)
 	// Per the conventions in the old engine, After contains a marked value
 	unmarkedAfter, _ := plannedChange.After.UnmarkDeep()
 	plannedValRef := b.lower.ConstantValue(unmarkedAfter)
-	desiredInstRef := b.lower.ResourceInstanceDesired(instAddrRef, desiredWaitFor)
+	desiredInstRef := b.lower.ResourceInstanceDesired(instAddrRef, b.lower.Waiter())
 
 	// We plan both the create and destroy parts of this process before we
 	// make any real changes, to reduce the risk that we'll be left in a
@@ -284,7 +282,7 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphCreateThenDelete(
 	createResultRef := b.lower.ManagedApply(
 		createPlanRef,
 		deposedObjRef, // will be restored as current if creation completely fails
-		b.lower.Waiter(),
+		desiredWaitFor,
 	)
 	// No other resource instances can depend on the value from the destroy
 	// result, so if the destroy fails after the create succeeded then we can
@@ -302,7 +300,7 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphCreateThenDelete(
 		valueRef:     createResultRef,
 		deletionRef:  deletionRef,
 		addConfigDep: addConfigDep,
-		addStateDep:  addStateDep,
+		addStateDep:  addConfigDep,
 		addDeleteDep: addDeleteDep,
 	}
 }
@@ -316,17 +314,21 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphPlanAndApply(
 	desiredInstRef execgraph.ResultRef[*eval.DesiredResourceInstance],
 	priorStateRef execgraph.ResourceInstanceResultRef,
 	plannedValRef execgraph.ResultRef[cty.Value],
-) execgraph.ResourceInstanceResultRef {
+) (
+	resultRef execgraph.ResourceInstanceResultRef,
+	addConfigDep func(execgraph.AnyResultRef),
+) {
 	finalPlanRef := b.lower.ManagedFinalPlan(
 		desiredInstRef,
 		priorStateRef,
 		plannedValRef,
 	)
+	waitFor, addConfigDep := b.lower.MutableWaiter()
 	return b.lower.ManagedApply(
 		finalPlanRef,
 		execgraph.NilResultRef[*exec.ResourceInstanceObject](),
-		b.lower.Waiter(), // nothing to wait for: desiredInstRef should have the relevant dependencies itself
-	)
+		waitFor,
+	), addConfigDep
 }
 
 func (b *execGraphBuilder) managedResourceInstanceChangeAddrAndPriorStateRefs(

--- a/internal/engine/planning/execgraph_managed.go
+++ b/internal/engine/planning/execgraph_managed.go
@@ -89,7 +89,7 @@ func (b *execGraphBuilder) ManagedResourceInstanceSubgraph(
 func (b *execGraphBuilder) managedResourceInstanceSubgraphCreate(
 	plannedChange *plans.ResourceInstanceChange,
 ) resourceInstanceObjectSubgraph {
-	instAddrRef, _, _ := b.managedResourceInstanceChangeAddrAndPriorStateRefs(plannedChange)
+	instAddrRef, _ := b.managedResourceInstanceChangeAddrAndPriorStateRefs(plannedChange)
 	// Per the conventions in the old engine, After contains a marked value
 	unmarkedAfter, _ := plannedChange.After.UnmarkDeep()
 	plannedValRef := b.lower.ConstantValue(unmarkedAfter)
@@ -100,15 +100,15 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphCreate(
 		plannedValRef,
 	)
 	return resourceInstanceObjectSubgraph{
-		valueRef:     valueRef,
-		addConfigDep: addConfigDep,
+		valueRef:      valueRef,
+		addDesiredDep: addConfigDep,
 	}
 }
 
 func (b *execGraphBuilder) managedResourceInstanceSubgraphUpdate(
 	plannedChange *plans.ResourceInstanceChange,
 ) resourceInstanceObjectSubgraph {
-	instAddrRef, priorStateRef, _ := b.managedResourceInstanceChangeAddrAndPriorStateRefs(plannedChange)
+	instAddrRef, priorStateRef := b.managedResourceInstanceChangeAddrAndPriorStateRefs(plannedChange)
 	// Per the conventions in the old engine, After contains a marked value
 	unmarkedAfter, _ := plannedChange.After.UnmarkDeep()
 	plannedValRef := b.lower.ConstantValue(unmarkedAfter)
@@ -119,16 +119,15 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphUpdate(
 		plannedValRef,
 	)
 	return resourceInstanceObjectSubgraph{
-		valueRef:     valueRef,
-		addConfigDep: addConfigDep,
-		addStateDep:  addConfigDep,
+		valueRef:      valueRef,
+		addDesiredDep: addConfigDep,
 	}
 }
 
 func (b *execGraphBuilder) managedResourceInstanceSubgraphDelete(
 	plannedChange *plans.ResourceInstanceChange,
 ) resourceInstanceObjectSubgraph {
-	_, priorStateRef, _ := b.managedResourceInstanceChangeAddrAndPriorStateRefs(plannedChange)
+	_, priorStateRef := b.managedResourceInstanceChangeAddrAndPriorStateRefs(plannedChange)
 	// Per the conventions in the old engine, After contains a marked value
 	unmarkedAfter, _ := plannedChange.After.UnmarkDeep()
 	plannedValRef := b.lower.ConstantValue(unmarkedAfter)
@@ -153,7 +152,7 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphDelete(
 		// the prior state before the object is deleted.
 		valueRef:     priorStateRef,
 		deletionRef:  deletionRef,
-		addDeleteDep: addDeleteDep,
+		addOrphanDep: addDeleteDep,
 	}
 }
 
@@ -181,7 +180,7 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphDeleteOrForgetThenCrea
 	// actions chained together, but we arrange the operations in such a
 	// way that the delete leg can't start unless the desired state is
 	// successfully evaluated.
-	instAddrRef, priorStateRef, _ := b.managedResourceInstanceChangeAddrAndPriorStateRefs(plannedChange)
+	instAddrRef, priorStateRef := b.managedResourceInstanceChangeAddrAndPriorStateRefs(plannedChange)
 	// Per the conventions in the old engine, After contains a marked value
 	unmarkedAfter, _ := plannedChange.After.UnmarkDeep()
 	plannedValRef := b.lower.ConstantValue(unmarkedAfter)
@@ -222,11 +221,10 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphDeleteOrForgetThenCrea
 	)
 
 	return resourceInstanceObjectSubgraph{
-		valueRef:     createResultRef,
-		deletionRef:  destroyResultRef,
-		addConfigDep: addConfigDep,
-		addStateDep:  addConfigDep,
-		addDeleteDep: addDeleteDep,
+		valueRef:      createResultRef,
+		deletionRef:   destroyResultRef,
+		addDesiredDep: addConfigDep,
+		addOrphanDep:  addDeleteDep,
 	}
 }
 
@@ -240,7 +238,7 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphCreateThenDelete(
 	// actions chained together, but we arrange the operations in such a
 	// way that we don't make any changes unless we can produce valid final
 	// plans for both changes.
-	instAddrRef, priorStateRef, _ := b.managedResourceInstanceChangeAddrAndPriorStateRefs(plannedChange)
+	instAddrRef, priorStateRef := b.managedResourceInstanceChangeAddrAndPriorStateRefs(plannedChange)
 	// Per the conventions in the old engine, After contains a marked value
 	unmarkedAfter, _ := plannedChange.After.UnmarkDeep()
 	plannedValRef := b.lower.ConstantValue(unmarkedAfter)
@@ -297,11 +295,10 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphCreateThenDelete(
 	)
 
 	return resourceInstanceObjectSubgraph{
-		valueRef:     createResultRef,
-		deletionRef:  deletionRef,
-		addConfigDep: addConfigDep,
-		addStateDep:  addConfigDep,
-		addDeleteDep: addDeleteDep,
+		valueRef:      createResultRef,
+		deletionRef:   deletionRef,
+		addDesiredDep: addConfigDep,
+		addOrphanDep:  addDeleteDep,
 	}
 }
 
@@ -336,29 +333,22 @@ func (b *execGraphBuilder) managedResourceInstanceChangeAddrAndPriorStateRefs(
 ) (
 	newAddr execgraph.ResultRef[addrs.AbsResourceInstance],
 	priorState execgraph.ResourceInstanceResultRef,
-	addStateDep func(execgraph.AnyResultRef),
 ) {
-	var stateWaitFor execgraph.AnyResultRef
-	stateWaitFor, addStateDep = b.lower.MutableWaiter()
-
 	if plannedChange.Action == plans.Create {
 		// For a create change there is no prior state at all, but we still
 		// need the new instance address.
 		newAddrRef := b.lower.ConstantResourceInstAddr(plannedChange.Addr)
-		return newAddrRef, execgraph.NilResultRef[*exec.ResourceInstanceObject](), nil
+		return newAddrRef, execgraph.NilResultRef[*exec.ResourceInstanceObject]()
 	}
 	if plannedChange.DeposedKey != states.NotDeposed {
 		// We need to use a different operation to access deposed objects.
 		prevAddrRef := b.lower.ConstantResourceInstAddr(plannedChange.PrevRunAddr)
 		dkRef := b.lower.ConstantDeposedKey(plannedChange.DeposedKey)
-		// FIXME: ManagedAlreadyDeposed should have a waitFor argument, just
-		// like ResourceInstancePrior does, and we should put stateWaitFor
-		// into it so that addStateDep calls will add to it.
 		stateRef := b.lower.ManagedAlreadyDeposed(prevAddrRef, dkRef)
-		return execgraph.NilResultRef[addrs.AbsResourceInstance](), stateRef, addStateDep
+		return execgraph.NilResultRef[addrs.AbsResourceInstance](), stateRef
 	}
 	prevAddrRef := b.lower.ConstantResourceInstAddr(plannedChange.PrevRunAddr)
-	priorStateRef := b.lower.ResourceInstancePrior(prevAddrRef, stateWaitFor)
+	priorStateRef := b.lower.ResourceInstancePrior(prevAddrRef, b.lower.Waiter())
 	retAddrRef := prevAddrRef
 	retStateRef := priorStateRef
 	if !plannedChange.PrevRunAddr.Equal(plannedChange.Addr) {
@@ -368,5 +358,5 @@ func (b *execGraphBuilder) managedResourceInstanceChangeAddrAndPriorStateRefs(
 		retAddrRef = b.lower.ConstantResourceInstAddr(plannedChange.Addr)
 		retStateRef = b.lower.ManagedChangeAddr(retStateRef, retAddrRef)
 	}
-	return retAddrRef, retStateRef, addStateDep
+	return retAddrRef, retStateRef
 }

--- a/internal/engine/planning/execgraph_resource.go
+++ b/internal/engine/planning/execgraph_resource.go
@@ -98,27 +98,25 @@ func (b *execGraphBuilder) AddResourceInstanceObjectSubgraphs(
 	// that is changing.
 	for _, addr := range objAddrs {
 		subgraph := subgraphs.Get(addr)
-		if subgraph.addConfigDep != nil {
+		if subgraph.addDesiredDep != nil {
 			for dependency := range objs.ConfigDependencies(addr) {
-				subgraph.addConfigDep(ensureResourceInstanceObjectResultRef(dependency, resultRefs, b))
+				subgraph.addDesiredDep(ensureResourceInstanceObjectResultRef(dependency, resultRefs, b))
 			}
-		}
-		if subgraph.addStateDep != nil {
 			for dependency := range objs.StateDependencies(addr) {
-				subgraph.addStateDep(ensureResourceInstanceObjectResultRef(dependency, resultRefs, b))
+				subgraph.addDesiredDep(ensureResourceInstanceObjectResultRef(dependency, resultRefs, b))
 			}
 		}
-		if subgraph.addDeleteDep != nil {
+		if subgraph.addOrphanDep != nil {
 			for dependent := range objs.ConfigDependents(addr) {
 				dependentSubgraph := subgraphs.Get(dependent)
 				if ref := dependentSubgraph.deletionRef; ref != nil {
-					subgraph.addDeleteDep(ref)
+					subgraph.addOrphanDep(ref)
 				} else if ref, ok := resultRefs.GetOk(dependent); ok {
 					// If there's no deletion ref but the dependent still has
 					// a value ref (e.g. if the dependent is only being created
 					// or updated) then we wait until its create/update step
 					// has completed before deleting.
-					subgraph.addDeleteDep(ref)
+					subgraph.addOrphanDep(ref)
 					// TODO: The old runtime's equivalent of this behavior has a
 					// hackily-implemented extra rule where it checks if
 					// adding this edge would create a cycle and skips adding
@@ -135,17 +133,12 @@ func (b *execGraphBuilder) AddResourceInstanceObjectSubgraphs(
 					// different for that planning mode).
 				}
 			}
-			// TODO: There's an asymmetry here where for forward dependencies
-			// we track config and state dependencies separately but for
-			// the reverse dependencies during destroy we just meld them
-			// together into a single set. Is that a correct thing to do, or
-			// do we need some special treatment in this direction too?
 			for dependent := range objs.StateDependents(addr) {
 				dependentSubgraph := subgraphs.Get(dependent)
 				if ref := dependentSubgraph.deletionRef; ref != nil {
-					subgraph.addDeleteDep(ref)
+					subgraph.addOrphanDep(ref)
 				} else if ref, ok := resultRefs.GetOk(dependent); ok {
-					subgraph.addDeleteDep(ref)
+					subgraph.addOrphanDep(ref)
 				}
 			}
 		}
@@ -201,28 +194,40 @@ func (b *execGraphBuilder) resourceInstanceChangeSubgraph(
 // previously-built resource instance object subgraph so that we can
 // subsequently create dependency edges between the subgraphs.
 type resourceInstanceObjectSubgraph struct {
-	// valueRef and deletionRef are the result references for whatever
-	// operations in the subgraph represent the result of creating/updating
-	// and of deleting the resource instance respectively.
+	// valueRef is the result reference for the final state for this resource
+	// instance object that should be used to satisfy expressions that refer
+	// to this resource instance object.
 	//
-	// These are nil for subgraphs that don't include a relevant result.
-	valueRef, deletionRef execgraph.ResourceInstanceResultRef
+	// For objects that are just being deleted (i.e. "orphan" or "deposed"
+	// objects for managed resource instances), this actually refers to the
+	// prior state. This is a quirky but important special case to make
+	// it possible to apply a "destroy-mode" plan where an ephemeral object
+	// such as a provider instance depends on a resource instance, in which
+	// case the ephemeral object gets configured based on the (refreshed)
+	// prior state rather than the configured object that is expected to be
+	// deleted during the apply phase.
+	valueRef execgraph.ResourceInstanceResultRef
 
-	// addConfigDep, addStateDep and addDeleteDep each add an additional
-	// dependency to one of the operations in the subgraph.
+	// deletionRef is a result reference which resolves once any existing
+	// remote object has been deleted.
 	//
-	// addConfigDep adds a dependency of whatever operation accesses the
-	// configuration for the resource instance object, and so delays the
-	// evaluation of the configuration.
+	// This is nil for objects whose planned actions don't include deletion
+	// at all.
+	deletionRef execgraph.AnyResultRef
+
+	// addDesiredDep and addOrphanDep each add an additional dependency to
+	// one of the operations in the subgraph.
 	//
-	// addStateDep adds a dependency of whatever operation accesses the
-	// prior state for the resource instance object, and so delays some
-	// analysis of the prior state information.
+	// addDesiredDep adds a dependency of whatever operation causes there
+	// to be an object matching the desired state, whether that be creating
+	// or updating. It is nil for resource instance objects that have no
+	// desired state, i.e. when they are just being deleted.
 	//
-	// addDeleteDep adds a dependency of whatever operation deletes the
-	// associated object.
-	//
-	// Each of these is nil when there is no corresponding operation to add
-	// dependencies to.
-	addConfigDep, addStateDep, addDeleteDep func(execgraph.AnyResultRef)
+	// addOrphanDep adds a dependency of whatever operation causes an object
+	// to be deleted because it's no longer desired, which could either be
+	// the solitary operation to delete something that is "orphaned" (present
+	// in prior state but not desired state) or could be the delete leg of
+	// a replace operation. It is nil for resource instance objects where no
+	// deletion is needed, i.e. when they are only being created or updated.
+	addDesiredDep, addOrphanDep func(execgraph.AnyResultRef)
 }

--- a/internal/tofu/context_plan_test.go
+++ b/internal/tofu/context_plan_test.go
@@ -4763,12 +4763,6 @@ func TestContext2Plan_actionInteractions(t *testing.T) {
 				// the two resources end up mutually-dependent on each other.
 				SkipExperimental(t, ExperimentalBugCircularReference)
 			}
-			if test.WantActions[0] == plans.DeleteThenCreate && test.WantActions[1] == plans.DeleteThenCreate {
-				// The experimental new runtime doesn't currently handle this
-				// interaction correctly, producing an execution graph where
-				// the two resources end up mutually-dependent on each other.
-				SkipExperimental(t, ExperimentalBugCircularReference)
-			}
 
 			cfg := testModuleInline(t, map[string]string{
 				"main.tf": test.Config,


### PR DESCRIPTION
(This is for https://github.com/opentofu/opentofu/issues/3414.)

The original concept for the execution graph was that it existed primarily to control the order of externally-visible side effects involving providers, like what we do in `ManagedFinalPlan`, `ManagedApply`, and `DataRead`.

The execution graph _does not_ need to constrain expression evaluation order: whereas the traditional runtime just silently returns the wrong answer if you ask it to evaluate an expression too early, the new architecture's evaluator is built to block until the necessary information is available and so it already ensures that expression evaluation happens in a reasonable order, and so the execution graph can focus only on capturing what the expression graph doesn't: the ordering of separate create/destroy steps when replacing, and change ordering information that might've been more conservative during the planning phase due to unknown values.

Old habits die hard though, and so in recent evolution of the execution graph builder (e.g. in https://github.com/opentofu/opentofu/pull/4316) I started to forget about that distinction and started trying to build the execution graph around expression evaluation instead of focusing only on provider-based side effects. That's caused things to get pretty complicated and caused some bugs where the execution graphs are not correct for various interactions between resource instance subgraphs for different actions (https://github.com/opentofu/opentofu/pull/4342).

This PR is an initial step back toward the original focus, and in fact takes an even stronger position than the original design: it'll be primarily focused on forcing the ordering of `ManagedApply` and `DataRead` in particular, with `ManagedFinalPlan` instead running as soon as expression evaluation provides the data needed to do it. We already treat planning in that way during the planning phase, so it ought to be acceptable to do the same during the apply phase as long as we take care to apply the generated plans in the correct sequence. This simplification will give us the flexibility to wait until we've planned both the create and delete legs of a replace before applying either of them, although this PR doesn't go all the way to that outcome yet.

Already this is enough to make chained `DeleteThenCreate` actions plannable again, but there's still some more work to do for interactions between "replace" subgraphs and update-only subgraphs, which are still not quite right as of this PR but I don't want to change too much at once.

---

There is a small side-quest here to fill a gap that previously existed in the interaction between execgraph and the evaluator, which the old execgraph shape was hiding:

The main execution graph machinery has explicit support for an operation to report that it hasn't completed enough for its dependents to be executed, causing execution to end early. However, resource instance final values travel indirectly through the evaluator and the evaluator can't directly propagate that signal, so we were previously just returning a
generic `cty.DynamicVal` and losing the "stop executing downstream" signal and thus attempting to execute more execgraph operations than we ought to have.

Now we'll approximate that "stop executing downstream" signal by marking the dynamic value as an evaluation error, and then having the `ResourceInstanceDesired` operation at the other end check for that. This therefore propagates the "stop" signal across into the subgraph of any resource instance whose configuration is derived from a failed result, translating it back into the explicit `ok` flag that the execution graph machinery is expecting so that we can halt execution as expected, instead of failing in a confusing way.

This uses the general-purpose `exprs.EvalError` mark instead of a specialized mark intentionally because that means we'll also stop if the downstream config is derived from something whose evaluation failed in some other way too. `exprs.EvalError` is our general way to say "this value is just a placeholder for something that failed", used for other similar purposes inside the evaluator.

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

