### PR TITLE
Change the way linting rules are executed

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -105,7 +105,7 @@ jobs:
       # it for select packages.
       - name: "Race detector"
         run: |
-          go test -race ./internal/tofu ./internal/command ./internal/states ./internal/providercache ./internal/addrs
+          go test -race ./internal/tofu ./internal/command ./internal/states ./internal/providercache ./internal/addrs ./internal/tfdiags
 
   e2e-tests:
     # This is an intentionally-limited form of our E2E test run which only

--- a/internal/command/views/view.go
+++ b/internal/command/views/view.go
@@ -171,14 +171,11 @@ func (v *View) Diagnostics(diags tfdiags.Diagnostics) {
 
 	var lintDiags tfdiags.Diagnostics
 	// Since linting related diagnostics use the Warning severity, we want to extract those out of the
-	// main diagnostics slice before consolidating warning diagnostics.
-	// That's because linting related diagnostics have a different logic for consolidation. For more details see
-	// ConsolidateLint.
+	// main diagnostics slice before consolidating warning diagnostics. These are merged again later.
 	diags, lintDiags = diags.SplitLint()
 	// Because of the in-context linting hints, this should not be necessary but it's just a guard in case
 	// there is any linting rule included without using the in-context linting hints.
 	lintDiags = lintDiags.FilterLint(v.lintInclude, v.lintExclude)
-	lintDiags = lintDiags.ConsolidateLint()
 
 	if v.consolidateWarnings {
 		diags = diags.Consolidate(1, tfdiags.Warning, func(diag tfdiags.Diagnostic) string {

--- a/internal/linting/core/rule_ids.go
+++ b/internal/linting/core/rule_ids.go
@@ -10,7 +10,7 @@ import "github.com/opentofu/opentofu/internal/linting"
 // This block below is meant to hold all the "core" namespaced linting **rule IDs**.
 
 var (
-	variableWithNoTypeRuleID = linting.MustParseRuleAddr("core:no-type-variable")
+	ruleIDUntypedVariable = linting.MustParseRuleAddr("core:no-type-variable")
 )
 
 // This block below is meant to hold all the "core" namespaced linting **group IDs**.

--- a/internal/linting/core/variable_with_no_type.go
+++ b/internal/linting/core/variable_with_no_type.go
@@ -18,18 +18,18 @@ import (
 // RootVariableWithNoType is a linting rule that checks any root "variable" block for a defined
 // "type". If none is present, then it issues a new linting diagnostic.
 func RootVariableWithNoType(ctx context.Context, vc *configs.Variable) tfdiags.Diagnostics {
-	exec := func() tfdiags.Diagnostics {
+	exec := func(ruleID linting.RuleAddr, groupIDs ...linting.RuleAddr) tfdiags.Diagnostics {
 		if vc.Type != cty.DynamicPseudoType {
 			return nil
 		}
 		return tfdiags.New(tfdiags.LintMessage(
-			variableWithNoTypeRuleID,
-			[]linting.RuleAddr{GroupIDConfusing},
+			ruleID,
+			groupIDs,
 			"Variable with no type",
 			fmt.Sprintf("Variable %q has no type specified.", vc.Name),
 			new(tfdiags.SourceRangeFromHCL(vc.DeclRange)),
 			nil,
 		))
 	}
-	return tfdiags.ExecuteLintRule(ctx, exec, tfdiags.SourceRangeFromHCL(vc.DeclRange), variableWithNoTypeRuleID, GroupIDConfusing)
+	return tfdiags.ExecuteLintRule(ctx, exec, tfdiags.SourceRangeFromHCL(vc.DeclRange), ruleIDUntypedVariable, GroupIDConfusing)
 }

--- a/internal/linting/core/variable_with_no_type.go
+++ b/internal/linting/core/variable_with_no_type.go
@@ -17,19 +17,19 @@ import (
 
 // RootVariableWithNoType is a linting rule that checks any root "variable" block for a defined
 // "type". If none is present, then it issues a new linting diagnostic.
-func RootVariableWithNoType(ctx context.Context, vc *configs.Variable) tfdiags.Diagnostic {
-	if !tfdiags.LintRuleEnabledOnSource(ctx, tfdiags.SourceRangeFromHCL(vc.DeclRange), variableWithNoTypeRuleID, GroupIDConfusing) {
-		return nil
-	}
-	if vc.Type == cty.DynamicPseudoType {
-		return tfdiags.LintMessage(
+func RootVariableWithNoType(ctx context.Context, vc *configs.Variable) tfdiags.Diagnostics {
+	exec := func() tfdiags.Diagnostics {
+		if vc.Type != cty.DynamicPseudoType {
+			return nil
+		}
+		return tfdiags.New(tfdiags.LintMessage(
 			variableWithNoTypeRuleID,
 			[]linting.RuleAddr{GroupIDConfusing},
 			"Variable with no type",
 			fmt.Sprintf("Variable %q has no type specified.", vc.Name),
 			new(tfdiags.SourceRangeFromHCL(vc.DeclRange)),
 			nil,
-		)
+		))
 	}
-	return nil
+	return tfdiags.ExecuteLintRule(ctx, exec, tfdiags.SourceRangeFromHCL(vc.DeclRange), variableWithNoTypeRuleID, GroupIDConfusing)
 }

--- a/internal/linting/core/variable_with_no_type.go
+++ b/internal/linting/core/variable_with_no_type.go
@@ -18,7 +18,7 @@ import (
 // RootVariableWithNoType is a linting rule that checks any root "variable" block for a defined
 // "type". If none is present, then it issues a new linting diagnostic.
 func RootVariableWithNoType(ctx context.Context, vc *configs.Variable) tfdiags.Diagnostic {
-	if !tfdiags.LintRuleEnabled(ctx, variableWithNoTypeRuleID, GroupIDConfusing) {
+	if !tfdiags.LintRuleEnabledOnSource(ctx, tfdiags.SourceRangeFromHCL(vc.DeclRange), variableWithNoTypeRuleID, GroupIDConfusing) {
 		return nil
 	}
 	if vc.Type == cty.DynamicPseudoType {

--- a/internal/tfdiags/lint.go
+++ b/internal/tfdiags/lint.go
@@ -6,11 +6,13 @@
 package tfdiags
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
-	"log"
-	"reflect"
 	"strings"
+	"sync"
 
 	"github.com/opentofu/opentofu/internal/collections"
 	"github.com/opentofu/opentofu/internal/linting"
@@ -115,9 +117,8 @@ func (diags Diagnostics) FilterLint(include, exclude collections.Set[linting.Rul
 
 // SplitLint is a method that returns two slices, first with non-linting diagnostics
 // and the second one with linting related diagnostics.
-// This is needed to be able to use ConsolidateLint on only a slice of linting
-// related diagnostics, since that method has different consolidation rules than
-// the general Consolidate method.
+// This is needed to be able to not mix linting warning diagnostics with the regular warning diagnostics while
+// the warning diagnostics are consolidated.
 func (diags Diagnostics) SplitLint() (Diagnostics, Diagnostics) {
 	if len(diags) == 0 {
 		return nil, nil
@@ -136,46 +137,14 @@ func (diags Diagnostics) SplitLint() (Diagnostics, Diagnostics) {
 	return nonLintDiags, lintDiags
 }
 
-// ConsolidateLint is meant to return only one lint diagnostic of the same type and the same source.
-// If the linting diagnostic is configured correctly (with a ruleId and a subject), then this will
-// remove duplicates of the same linting diagnostic.
-// Duplicates can be issued for the same linting rule on the same subject when multiple phases
-// are executed in one command (eg: `tofu apply` runs validate, plan, apply which will generate 3
-// duplicates of the same diagnostic).
-//
-// This particular method skips the handling of nil source on purpose because the used
-// method (eg: Consolidate), already skips consolidation for those diagnostics.
-func (diags Diagnostics) ConsolidateLint() Diagnostics {
-	return diags.Consolidate(1, Warning, func(diag Diagnostic) string {
-		defaultKey := func() string {
-			desc := diag.Description()
-			consolidationKey := desc.Summary
-			// If the diagnostic has a keyable extra info and it's not empty,
-			// use it as the consolidation key, along with the summary.
-			// Otherwise use the summary only.
-			if key, keyOk := diag.ExtraInfo().(Keyable); keyOk {
-				consolidationKey += key.ExtraInfoKey()
-			}
-			return consolidationKey
-		}
-		ld, ok := diag.(lintMessage)
-		if !ok {
-			log.Printf("[ERROR] A non-linting diagnostic reached into lint diagnostics consolidation logic: %s. Returning a default diagnostic consolidation key", reflect.TypeOf(diag))
-			return defaultKey()
-		}
-		consolidationKey := ld.ruleID.String()
-		consolidationKey += ld.subject.StartString()
-		return consolidationKey
-	}, ConsolidationOptDefault^ConsolidationOptIncludeCount)
-	// ^ This uses the default consolidation opts and excludes from that the count calculation. This means that any
-	// other future option added into the ConsolidationOptDefault will be automatically used by the consolidation call.
-}
-
 type lintingRulesCtxKey struct {
 }
 type lintingRulesCtxValue struct {
 	include collections.Set[linting.RuleAddr]
 	exclude collections.Set[linting.RuleAddr]
+
+	executedM sync.Mutex
+	executed  collections.Set[string]
 }
 
 // ContextWithLintFilterHints returns a new [context.Context] that's derived
@@ -187,15 +156,23 @@ type lintingRulesCtxValue struct {
 // skip expensive work to generate a lint diagnostic that is going to get
 // discarded eventually anyway.
 func ContextWithLintFilterHints(parent context.Context, include, exclude collections.Set[linting.RuleAddr]) context.Context {
-	return context.WithValue(parent, lintingRulesCtxKey{}, lintingRulesCtxValue{
-		include: include,
-		exclude: exclude,
+	return context.WithValue(parent, lintingRulesCtxKey{}, &lintingRulesCtxValue{
+		include:  include,
+		exclude:  exclude,
+		executed: collections.NewSet[string](),
 	})
 }
 
-// LintRuleEnabled returns true if the given context has lint filter hints that
-// suggest that a [lintMessage] with the given ruleID or at least one groupID would survive UI-level
-// filtering of lint messages, or false otherwise.
+// LintRuleEnabledOnSource checks the given context for any linting configuration and if none found will return false.
+// If the context contains a linting configuration, it will return true in the following cases:
+//   - the given lint rule on the given source is checked for the first time
+//   - the context contained linting configuration allows the rule to be executed (included and not excluded)
+//
+// Every call at this method will also register a hash of the given arguments which is intended to ensure that the
+// same lint rule on the same configuration is not executed multiple times. In other words, if a linting rule on the
+// same configuration block is executed first during validate and once during plan, only the one during validate
+// will run. This ensures that the same rule for the same configuration block is not executed multiple times which
+// would cause duplicate diagnostics for the same entry.
 //
 // TODO linting - this is from the RFC and I strongly disagree with this.
 //
@@ -213,23 +190,45 @@ func ContextWithLintFilterHints(parent context.Context, include, exclude collect
 //
 // TODO linting (end)
 //
-// The ruleID has priority, meaning that if that particular ruleID inclusion or exclusion will return
-// once it's found.
+// When it comes to how the linting configuration is applied, the ruleID has priority compared with the groupID,
+// meaning that if that particular ruleID inclusion or exclusion exists, this will return once it finds that.
 // If the ruleID is not found as being mentioned specifically, this method checks the given groupIDs
 // and applies the same logic: if the group is specifically included, that takes priority in front of its exclusion
 // existence.
 // If none of the groupIDs are specifically configured to be included/excluded, then this will return true
 // if the inclusion contains "all".
-func LintRuleEnabled(ctx context.Context, ruleID linting.RuleAddr, groupIDs ...linting.RuleAddr) bool {
+func LintRuleEnabledOnSource(ctx context.Context, src SourceRange, ruleID linting.RuleAddr, groupIDs ...linting.RuleAddr) bool {
 	v := ctx.Value(lintingRulesCtxKey{})
 	if v == nil {
 		return false
 	}
-	val, ok := v.(lintingRulesCtxValue)
+	val, ok := v.(*lintingRulesCtxValue)
 	if !ok {
 		return false
 	}
+	k := keyForLintCall(src, ruleID, groupIDs...)
+	val.executedM.Lock()
+	if val.executed.Has(k) {
+		val.executedM.Unlock()
+		return false
+	}
+	val.executed[k] = struct{}{}
+	val.executedM.Unlock()
 	return lintRuleAllowed(val.include, val.exclude, ruleID, groupIDs)
+}
+
+// keyForLintCall creates a sha256 representation of the given arguments. This is used to be stored and checked against
+// when the same linting rule on the same configuration source wants to execute multiple times.
+func keyForLintCall(src SourceRange, ruleID linting.RuleAddr, groupIDs ...linting.RuleAddr) string {
+	var s bytes.Buffer
+	_, _ = s.WriteString(src.StartString())
+	_, _ = s.WriteString(ruleID.String())
+	for _, d := range groupIDs {
+		_, _ = s.WriteString(d.String())
+	}
+	h := sha256.New()
+	_, _ = h.Write(s.Bytes())
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 func lintRuleAllowed(include, exclude collections.Set[linting.RuleAddr], ruleID linting.RuleAddr, groupIDs []linting.RuleAddr) bool {

--- a/internal/tfdiags/lint.go
+++ b/internal/tfdiags/lint.go
@@ -153,6 +153,51 @@ type lintingRulesCtxValue struct {
 	lintOnSourceExecution sync.Map
 }
 
+// executeRule gets an execution key and the execution function of a linting rule and executes it
+// if it doesn't yet have a successful execution cached.
+func (lrcv *lintingRulesCtxValue) executeRule(execKey string, f func() Diagnostics) Diagnostics {
+	type lintExecution struct {
+		m       sync.Mutex
+		success bool
+	}
+	loadExec := func(execId string) *lintExecution {
+		// create a new lint rule executin and lock it to store it into the status container
+		exec := &lintExecution{
+			m:       sync.Mutex{},
+			success: false,
+		}
+		exec.m.Lock()
+		loadedExec, loaded := lrcv.lintOnSourceExecution.LoadOrStore(execId, exec)
+		currentExec := exec
+		// another lint execution for this linting rule and source was created before so we need to work with it instead of
+		// the above created one.
+		if loaded {
+			// we unlock the previous created execution just to be sure that we don't leave that mutex locked,
+			// even if it will e discarded upon return from this function
+			exec.m.Unlock()
+			// get the existing execution, acquire lock, and use this instead of the previously created execution
+			cLoadedExec := loadedExec.(*lintExecution)
+			cLoadedExec.m.Lock()
+			currentExec = cLoadedExec
+		}
+
+		return currentExec
+	}
+
+	exec := loadExec(execKey)
+	defer exec.m.Unlock()
+	if exec.success {
+		return nil
+	}
+	diags := f()
+	if !diags.HasErrors() {
+		// safe to set this here since the lock was acquired when this was created, before being stored into the
+		// status container
+		exec.success = true
+	}
+	return diags
+}
+
 // ContextWithLintFilterHints returns a new [context.Context] that's derived
 // from the given parent context but also tracks the sets of lint rule IDs that
 // will be used to filter any diagnostics returned from whatever function the
@@ -206,46 +251,7 @@ func ExecuteLintRule(ctx context.Context, f func() Diagnostics, src SourceRange,
 	// this is executed
 	k := keyForLintCall(src, ruleID, groupIDs...)
 
-	type lintExecution struct {
-		m       sync.Mutex
-		success bool
-	}
-	loadExec := func(execId string) *lintExecution {
-		// create a new lint rule executin and lock it to store it into the status container
-		exec := &lintExecution{
-			m:       sync.Mutex{},
-			success: false,
-		}
-		exec.m.Lock()
-		loadedExec, loaded := lintCtx.lintOnSourceExecution.LoadOrStore(k, exec)
-		currentExec := exec
-		// another lint execution for this linting rule and source was created before so we need to work with it instead of
-		// the above created one.
-		if loaded {
-			// we unlock the previous created execution just to be sure that we don't leave that mutex locked,
-			// even if it will e discarded upon return from this function
-			exec.m.Unlock()
-			// get the existing execution, acquire lock, and use this instead of the previously created execution
-			cLoadedExec := loadedExec.(*lintExecution)
-			cLoadedExec.m.Lock()
-			currentExec = cLoadedExec
-		}
-
-		return currentExec
-	}
-
-	exec := loadExec(k)
-	defer exec.m.Unlock()
-	if exec.success {
-		return nil
-	}
-	diags := f()
-	if !diags.HasErrors() {
-		// safe to set this here since the lock was acquired when this was created, before being stored into the
-		// status container
-		exec.success = true
-	}
-	return diags
+	return lintCtx.executeRule(k, f)
 }
 
 // keyForLintCall creates a sha256 representation of the given arguments. This is used to be stored and avoid

--- a/internal/tfdiags/lint.go
+++ b/internal/tfdiags/lint.go
@@ -252,13 +252,13 @@ func ExecuteLintRule(ctx context.Context, f func() Diagnostics, src SourceRange,
 // having the same combination of (ruleID+groupIDs+src) executed more than once.
 func keyForLintCall(src SourceRange, ruleID linting.RuleAddr, groupIDs ...linting.RuleAddr) string {
 	var s bytes.Buffer
-	_, _ = s.WriteString(src.StartString())
-	_, _ = s.WriteString(ruleID.String())
+	s.WriteString(src.StartString())
+	s.WriteString(ruleID.String())
 	for _, d := range groupIDs {
-		_, _ = s.WriteString(d.String())
+		s.WriteString(d.String())
 	}
 	h := sha256.New()
-	_, _ = h.Write(s.Bytes())
+	h.Write(s.Bytes())
 	return hex.EncodeToString(h.Sum(nil))
 }
 

--- a/internal/tfdiags/lint.go
+++ b/internal/tfdiags/lint.go
@@ -11,6 +11,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 
@@ -192,12 +193,12 @@ func lintHintsFromContext(ctx context.Context) *lintingRulesCtxValue {
 // which can silently control when a phase has enough information and when not to determine if the rule can be
 // executed reliably.
 func ExecuteLintRule(ctx context.Context, f func() Diagnostics, src SourceRange, ruleID linting.RuleAddr, groupIDs ...linting.RuleAddr) Diagnostics {
-	val := lintHintsFromContext(ctx)
-	if val == nil {
+	lintCtx := lintHintsFromContext(ctx)
+	if lintCtx == nil {
 		return nil
 	}
 	// first, determine that the user actually asked for this
-	if !lintRuleAllowed(val.include, val.exclude, ruleID, groupIDs...) {
+	if !lintRuleAllowed(lintCtx.include, lintCtx.exclude, ruleID, groupIDs...) {
 		return nil
 	}
 
@@ -209,32 +210,40 @@ func ExecuteLintRule(ctx context.Context, f func() Diagnostics, src SourceRange,
 		m       sync.Mutex
 		success bool
 	}
-	// create a new lint rule executin and lock it to store it into the status container
-	exec := &lintExecution{
-		m:       sync.Mutex{},
-		success: false,
+	loadExec := func(execId string) *lintExecution {
+		// create a new lint rule executin and lock it to store it into the status container
+		exec := &lintExecution{
+			m:       sync.Mutex{},
+			success: false,
+		}
+		exec.m.Lock()
+		loadedExec, loaded := lintCtx.lintOnSourceExecution.LoadOrStore(k, exec)
+		currentExec := exec
+		// another lint execution for this linting rule and source was created before so we need to work with it instead of
+		// the above created one.
+		if loaded {
+			// we unlock the previous created execution just to be sure that we don't leave that mutex locked,
+			// even if it will e discarded upon return from this function
+			exec.m.Unlock()
+			// get the existing execution, acquire lock, and use this instead of the previously created execution
+			cLoadedExec := loadedExec.(*lintExecution)
+			cLoadedExec.m.Lock()
+			currentExec = cLoadedExec
+		}
+
+		return currentExec
 	}
-	exec.m.Lock()
+
+	exec := loadExec(k)
 	defer exec.m.Unlock()
-	loadedExec, loaded := val.lintOnSourceExecution.LoadOrStore(k, exec)
-	currentExec := exec
-	// another lint execution for this linting rule and source was created before so we need to work with it instead of
-	// the above created one.
-	if loaded {
-		// get the existing execution, acquire lock, and use this instead of the previously created execution
-		cLoadedExec := loadedExec.(*lintExecution)
-		cLoadedExec.m.Lock()
-		defer cLoadedExec.m.Unlock()
-		currentExec = cLoadedExec
-	}
-	if currentExec.success {
+	if exec.success {
 		return nil
 	}
 	diags := f()
 	if !diags.HasErrors() {
 		// safe to set this here since the lock was acquired when this was created, before being stored into the
 		// status container
-		currentExec.success = true
+		exec.success = true
 	}
 	return diags
 }
@@ -261,16 +270,12 @@ func lintRuleAllowed(include, exclude collections.Set[linting.RuleAddr], ruleID 
 		return false
 	}
 	// If at least one group is included, then include the rule
-	for _, d := range groupIDs {
-		if include.Has(d) {
-			return true
-		}
+	if slices.ContainsFunc(groupIDs, include.Has) {
+		return true
 	}
 	// If at least one group is exclude, then exclude the rule
-	for _, d := range groupIDs {
-		if exclude.Has(d) {
-			return false
-		}
+	if slices.ContainsFunc(groupIDs, exclude.Has) {
+		return false
 	}
 	// In the end, enable the rule only when the "all" configuration is provided
 	return include.Has(linting.AllRulesGroupID)

--- a/internal/tfdiags/lint.go
+++ b/internal/tfdiags/lint.go
@@ -107,7 +107,7 @@ func (diags Diagnostics) FilterLint(include, exclude collections.Set[linting.Rul
 			ret = append(ret, srcDiag)
 			continue
 		}
-		if lintRuleAllowed(include, exclude, ld.ruleID, ld.groupIDs) {
+		if lintRuleAllowed(include, exclude, ld.ruleID, ld.groupIDs...) {
 			ret = append(ret, srcDiag)
 		}
 	}
@@ -143,8 +143,13 @@ type lintingRulesCtxValue struct {
 	include collections.Set[linting.RuleAddr]
 	exclude collections.Set[linting.RuleAddr]
 
-	executedM sync.Mutex
-	executed  collections.Set[string]
+	// lintOnSourceExecution holds the execution container for a specific (linting rule on a specific config source).
+	// This is to ensure that even if it happens to have the same linting rule executed twice for the same configuration
+	// construct, only one will report the final status.
+	// Further, this is a way to signal for the different execution phases (validate, plan, apply) that a linting rule
+	// on a specific config construct has been executed. This way it avoids running the same logic multiple times.
+	// The future phases execution will be skipped only if the entry in this map contains a success run.
+	lintOnSourceExecution sync.Map
 }
 
 // ContextWithLintFilterHints returns a new [context.Context] that's derived
@@ -152,73 +157,90 @@ type lintingRulesCtxValue struct {
 // will be used to filter any diagnostics returned from whatever function the
 // resulting context was passed to.
 //
-// Use the returned context with [LintRuleEnabled] elsewhere in the system to
+// Use the returned context with [lintRuleEnabled] elsewhere in the system to
 // skip expensive work to generate a lint diagnostic that is going to get
 // discarded eventually anyway.
 func ContextWithLintFilterHints(parent context.Context, include, exclude collections.Set[linting.RuleAddr]) context.Context {
 	return context.WithValue(parent, lintingRulesCtxKey{}, &lintingRulesCtxValue{
-		include:  include,
-		exclude:  exclude,
-		executed: collections.NewSet[string](),
+		include:               include,
+		exclude:               exclude,
+		lintOnSourceExecution: sync.Map{},
 	})
 }
 
-// LintRuleEnabledOnSource checks the given context for any linting configuration and if none found will return false.
-// If the context contains a linting configuration, it will return true in the following cases:
-//   - the given lint rule on the given source is checked for the first time
-//   - the context contained linting configuration allows the rule to be executed (included and not excluded)
-//
-// Every call at this method will also register a hash of the given arguments which is intended to ensure that the
-// same lint rule on the same configuration is not executed multiple times. In other words, if a linting rule on the
-// same configuration block is executed first during validate and once during plan, only the one during validate
-// will run. This ensures that the same rule for the same configuration block is not executed multiple times which
-// would cause duplicate diagnostics for the same entry.
-//
-// TODO linting - this is from the RFC and I strongly disagree with this.
-//
-//	If the given context is not derived from one previously returned by
-//	[ContextWithLintFilterHints] then the result is always true, suggesting that
-//	nothing will be filtered. This defaults to enabled because we assume that
-//	any codepath that isn't calling this function also won't call
-//	[Diagnostics.FilterLint]; this pair of functions should typically be used
-//	together by the same subsystem, passing the same include/exclude sets to
-//	both.
-//
-// Instead of including any rule, instead, this disables all the rules, which can be used as a indirect way to
-// signal to the system that linting is enabled or not. In other words, the existence of lintingRulesCtxKey
-// in the ctx is the indication that the linting is enabled or not.
-//
-// TODO linting (end)
-//
-// When it comes to how the linting configuration is applied, the ruleID has priority compared with the groupID,
-// meaning that if that particular ruleID inclusion or exclusion exists, this will return once it finds that.
-// If the ruleID is not found as being mentioned specifically, this method checks the given groupIDs
-// and applies the same logic: if the group is specifically included, that takes priority in front of its exclusion
-// existence.
-// If none of the groupIDs are specifically configured to be included/excluded, then this will return true
-// if the inclusion contains "all".
-func LintRuleEnabledOnSource(ctx context.Context, src SourceRange, ruleID linting.RuleAddr, groupIDs ...linting.RuleAddr) bool {
+// lintHintsFromContext returns the *lintingRulesCtxValue from the given context.
+// If the context has no value, it returns nil.
+func lintHintsFromContext(ctx context.Context) *lintingRulesCtxValue {
 	v := ctx.Value(lintingRulesCtxKey{})
 	if v == nil {
-		return false
+		return nil
 	}
 	val, ok := v.(*lintingRulesCtxValue)
 	if !ok {
-		return false
+		return nil
 	}
-	k := keyForLintCall(src, ruleID, groupIDs...)
-	val.executedM.Lock()
-	if val.executed.Has(k) {
-		val.executedM.Unlock()
-		return false
-	}
-	val.executed[k] = struct{}{}
-	val.executedM.Unlock()
-	return lintRuleAllowed(val.include, val.exclude, ruleID, groupIDs)
+	return val
 }
 
-// keyForLintCall creates a sha256 representation of the given arguments. This is used to be stored and checked against
-// when the same linting rule on the same configuration source wants to execute multiple times.
+// ExecuteLintRule executes the given linting rule logic after it checks that it is allowed to execute or not.
+// If the context is configured for linting, it carries a container that stores the sucess status of each combination
+// of (ruleID, ruleIDs and src). If the container contains a successfull run for that combination, it doesn't execute
+// it again. This way, the same combination can be executed multiple times and it will not be executed more than
+// once.
+//
+// NOTE: later, f can be enhanced to return another bool to have the run skipped and not marked as a success execution,
+// which can silently control when a phase has enough information and when not to determine if the rule can be
+// executed reliably.
+func ExecuteLintRule(ctx context.Context, f func() Diagnostics, src SourceRange, ruleID linting.RuleAddr, groupIDs ...linting.RuleAddr) Diagnostics {
+	val := lintHintsFromContext(ctx)
+	if val == nil {
+		return nil
+	}
+	// first, determine that the user actually asked for this
+	if !lintRuleAllowed(val.include, val.exclude, ruleID, groupIDs...) {
+		return nil
+	}
+
+	// generate the identification key based on the ruleID, groupIDs and the place in the configuration for which
+	// this is executed
+	k := keyForLintCall(src, ruleID, groupIDs...)
+
+	type lintExecution struct {
+		m       sync.Mutex
+		success bool
+	}
+	// create a new lint rule executin and lock it to store it into the status container
+	exec := &lintExecution{
+		m:       sync.Mutex{},
+		success: false,
+	}
+	exec.m.Lock()
+	defer exec.m.Unlock()
+	loadedExec, loaded := val.lintOnSourceExecution.LoadOrStore(k, exec)
+	currentExec := exec
+	// another lint execution for this linting rule and source was created before so we need to work with it instead of
+	// the above created one.
+	if loaded {
+		// get the existing execution, acquire lock, and use this instead of the previously created execution
+		cLoadedExec := loadedExec.(*lintExecution)
+		cLoadedExec.m.Lock()
+		defer cLoadedExec.m.Unlock()
+		currentExec = cLoadedExec
+	}
+	if currentExec.success {
+		return nil
+	}
+	diags := f()
+	if !diags.HasErrors() {
+		// safe to set this here since the lock was acquired when this was created, before being stored into the
+		// status container
+		currentExec.success = true
+	}
+	return diags
+}
+
+// keyForLintCall creates a sha256 representation of the given arguments. This is used to be stored and avoid
+// having the same combination of (ruleID+groupIDs+src) executed more than once.
 func keyForLintCall(src SourceRange, ruleID linting.RuleAddr, groupIDs ...linting.RuleAddr) string {
 	var s bytes.Buffer
 	_, _ = s.WriteString(src.StartString())
@@ -231,7 +253,7 @@ func keyForLintCall(src SourceRange, ruleID linting.RuleAddr, groupIDs ...lintin
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-func lintRuleAllowed(include, exclude collections.Set[linting.RuleAddr], ruleID linting.RuleAddr, groupIDs []linting.RuleAddr) bool {
+func lintRuleAllowed(include, exclude collections.Set[linting.RuleAddr], ruleID linting.RuleAddr, groupIDs ...linting.RuleAddr) bool {
 	if include.Has(ruleID) {
 		return true
 	}

--- a/internal/tfdiags/lint.go
+++ b/internal/tfdiags/lint.go
@@ -161,7 +161,7 @@ func (lrcv *lintingRulesCtxValue) executeRule(execKey string, f func() Diagnosti
 		success bool
 	}
 	loadExec := func(execId string) *lintExecution {
-		// create a new lint rule executin and lock it to store it into the status container
+		// create a new lint rule execution and lock it to store it into the status container
 		exec := &lintExecution{
 			m:       sync.Mutex{},
 			success: false,

--- a/internal/tfdiags/lint.go
+++ b/internal/tfdiags/lint.go
@@ -237,7 +237,7 @@ func lintHintsFromContext(ctx context.Context) *lintingRulesCtxValue {
 // NOTE: later, f can be enhanced to return another bool to have the run skipped and not marked as a success execution,
 // which can silently control when a phase has enough information and when not to determine if the rule can be
 // executed reliably.
-func ExecuteLintRule(ctx context.Context, f func() Diagnostics, src SourceRange, ruleID linting.RuleAddr, groupIDs ...linting.RuleAddr) Diagnostics {
+func ExecuteLintRule(ctx context.Context, f func(ruleID linting.RuleAddr, groupIDs ...linting.RuleAddr) Diagnostics, src SourceRange, ruleID linting.RuleAddr, groupIDs ...linting.RuleAddr) Diagnostics {
 	lintCtx := lintHintsFromContext(ctx)
 	if lintCtx == nil {
 		return nil
@@ -251,7 +251,9 @@ func ExecuteLintRule(ctx context.Context, f func() Diagnostics, src SourceRange,
 	// this is executed
 	k := keyForLintCall(src, ruleID, groupIDs...)
 
-	return lintCtx.executeRule(k, f)
+	return lintCtx.executeRule(k, func() Diagnostics {
+		return f(ruleID, groupIDs...)
+	})
 }
 
 // keyForLintCall creates a sha256 representation of the given arguments. This is used to be stored and avoid

--- a/internal/tfdiags/lint_test.go
+++ b/internal/tfdiags/lint_test.go
@@ -8,6 +8,7 @@ package tfdiags
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -146,89 +147,70 @@ func TestExecuteLintRule(t *testing.T) {
 	t.Run("parallel calls locks when called for exactly the same source and lint rule", func(t *testing.T) {
 		ruleID := linting.MustParseRuleAddr("core:foo")
 		ctx := ContextWithLintFilterHints(t.Context(), collections.NewSet(ruleID), collections.NewSet[linting.RuleAddr]())
-		var durations [500]time.Duration
-		var calls int // not needed atomic here since its expected to be wrote into only by one goroutine, once
-		var idxCalled int
-		sleepFor := 300 * time.Millisecond
+		var called atomic.Bool
 		exec := func(i int) func() Diagnostics {
 			return func() Diagnostics {
-				calls++
-				<-time.After(sleepFor)
-				idxCalled = i
+				called.Store(true)
 				return nil
 			}
 		}
 		src := SourceRange{Filename: "test.tf", Start: SourcePos{Line: 1, Column: 2}, End: SourcePos{Line: 1, Column: 10}}
 		var wg sync.WaitGroup
-		startTime := time.Now()
 		for i := range 500 {
-			start := startTime
 			wg.Go(func() {
 				_ = ExecuteLintRule(ctx, exec(i), src, ruleID)
-				durations[i] = time.Since(start)
+				if !called.Load() {
+					t.Errorf("[%d] returned before having the rule executed by the routine that acquired the lock", i)
+				}
 			})
 		}
 		wg.Wait()
-		// because based on the architecture and the CI platform, time.After can return with slighlty different
-		// variation from the actually asked duration so we want to do the assertions on the actual time it took
-		// for the goroutine that managed to call into the linting rule. So we use that instead of a hardcoded
-		// duration
-		minDuration := durations[idxCalled]
-		for i, dur := range durations {
-			if i == idxCalled {
-				continue // we skip the one that actually called in the linting execution since we use its duration for comparison
-			}
-			if dur < minDuration {
-				t.Errorf("[%d] finished unexpectedly before the goroutine that actually called the linting rule. finished in %s (smaller than %s)", i, dur, minDuration)
-			}
-		}
-		if calls != 1 {
-			t.Errorf("expected in the end to have just 1 call but got %d", calls)
-		}
 		// execute the same rule one more time to be sure that the execution of it is not performed (because it should be already registered as executed successfully)
-		calls = 0
+		called.Store(false)
 		_ = ExecuteLintRule(ctx, exec(0), src, ruleID)
-		if calls != 0 {
+		if called.Load() {
 			t.Errorf("the linting rule unexpectedly called. This means that something is broken in the internals of ExecuteLintRule since this was meant be registered as successfully executed")
 		}
 	})
 	t.Run("parallel calls does not lock when called for different source and lint rule", func(t *testing.T) {
+		const samples = 500
 		ctx := ContextWithLintFilterHints(t.Context(), collections.NewSet(linting.MustParseRuleAddr("all")), collections.NewSet[linting.RuleAddr]())
-		var sources [500]SourceRange
-		for i := range 500 {
-			sources[i] = SourceRange{Filename: "test.tf", Start: SourcePos{Line: i, Column: 2}, End: SourcePos{Line: 1, Column: 10}}
+		var sources []SourceRange
+		for i := range samples {
+			sources = append(sources, SourceRange{Filename: "test.tf", Start: SourcePos{Line: i, Column: 2}, End: SourcePos{Line: 1, Column: 10}})
 		}
-		sleepFor := 300 * time.Millisecond
-		execBuilder := func(shouldWait bool) func() Diagnostics {
-			return func() Diagnostics {
-				if shouldWait {
-					<-time.After(sleepFor)
+		exec := func() Diagnostics {
+			return nil
+		}
+		results := make(chan struct{}, samples)
+		for i := range samples {
+			go func() {
+				_ = ExecuteLintRule(ctx, exec, sources[i], linting.MustParseRuleAddr("core:foo"))
+				results <- struct{}{}
+			}()
+		}
+		var finished int
+	done:
+		for {
+			select {
+			case _, ok := <-results:
+				if !ok {
+					break done
 				}
-				return nil
+				finished++
+				if finished == samples {
+					break done
+				}
+			case <-time.After(time.Second):
+				// This is just a sanity select case to ensure that if something goes wrong, the test actually ends
+				// with a clear error message
+				t.Error("executions locked. This highlights an issue in the linting rules execution")
+				break done
 			}
 		}
-		var wg sync.WaitGroup
-		var durations [500]time.Duration
-		startTime := time.Now()
-		for i := range 500 {
-			start := startTime
-			wg.Go(func() {
-				_ = ExecuteLintRule(ctx, execBuilder(i%5 == 0), sources[i], linting.MustParseRuleAddr("core:foo"))
-				durations[i] = time.Since(start)
-			})
-		}
-		wg.Wait()
-		for i, dur := range durations {
-			expectedToSleep := i%5 == 0
-			if expectedToSleep {
-				if dur < sleepFor {
-					t.Errorf("[%d] finished unexpectedly fast (in %s)", i, dur)
-				}
-			} else {
-				if dur > 100*time.Millisecond { // depends on how slow the CI runner is, this can be quite high at times
-					t.Errorf("[%d] finished later than expected (in %s)", i, dur)
-				}
-			}
+		defer close(results)
+		if finished != samples {
+			t.Fatalf("expected to have %d executions but got %d", samples, finished)
 		}
 	})
 }

--- a/internal/tfdiags/lint_test.go
+++ b/internal/tfdiags/lint_test.go
@@ -133,7 +133,7 @@ func TestExecuteLintRule(t *testing.T) {
 	t.Run("rule executed only once", func(t *testing.T) {
 		ctx := ContextWithLintFilterHints(t.Context(), collections.NewSet(linting.MustParseRuleAddr("core:foo")), collections.NewSet[linting.RuleAddr]())
 		var calls int
-		exec := func() Diagnostics {
+		exec := func(ruleID linting.RuleAddr, groupIDs ...linting.RuleAddr) Diagnostics {
 			calls++
 			return nil
 		}
@@ -148,8 +148,8 @@ func TestExecuteLintRule(t *testing.T) {
 		ruleID := linting.MustParseRuleAddr("core:foo")
 		ctx := ContextWithLintFilterHints(t.Context(), collections.NewSet(ruleID), collections.NewSet[linting.RuleAddr]())
 		var called atomic.Bool
-		exec := func(i int) func() Diagnostics {
-			return func() Diagnostics {
+		exec := func(i int) func(ruleID linting.RuleAddr, groupIDs ...linting.RuleAddr) Diagnostics {
+			return func(ruleID linting.RuleAddr, groupIDs ...linting.RuleAddr) Diagnostics {
 				called.Store(true)
 				return nil
 			}
@@ -179,7 +179,7 @@ func TestExecuteLintRule(t *testing.T) {
 		for i := range samples {
 			sources = append(sources, SourceRange{Filename: "test.tf", Start: SourcePos{Line: i, Column: 2}, End: SourcePos{Line: 1, Column: 10}})
 		}
-		exec := func() Diagnostics {
+		exec := func(ruleID linting.RuleAddr, groupIDs ...linting.RuleAddr) Diagnostics {
 			return nil
 		}
 		results := make(chan struct{}, samples)

--- a/internal/tfdiags/lint_test.go
+++ b/internal/tfdiags/lint_test.go
@@ -160,9 +160,10 @@ func TestExecuteLintRule(t *testing.T) {
 		}
 		src := SourceRange{Filename: "test.tf", Start: SourcePos{Line: 1, Column: 2}, End: SourcePos{Line: 1, Column: 10}}
 		var wg sync.WaitGroup
+		startTime := time.Now()
 		for i := range 500 {
+			start := startTime
 			wg.Go(func() {
-				start := time.Now()
 				_ = ExecuteLintRule(ctx, exec(i), src, ruleID)
 				durations[i] = time.Since(start)
 			})
@@ -177,7 +178,7 @@ func TestExecuteLintRule(t *testing.T) {
 			if i == idxCalled {
 				continue // we skip the one that actually called in the linting execution since we use its duration for comparison
 			}
-			if dur < minDuration-(50*time.Millisecond) { // just to give some buffer for the runners on different CI platforms
+			if dur < minDuration {
 				t.Errorf("[%d] finished unexpectedly before the goroutine that actually called the linting rule. finished in %s (smaller than %s)", i, dur, minDuration)
 			}
 		}
@@ -208,9 +209,10 @@ func TestExecuteLintRule(t *testing.T) {
 		}
 		var wg sync.WaitGroup
 		var durations [500]time.Duration
+		startTime := time.Now()
 		for i := range 500 {
+			start := startTime
 			wg.Go(func() {
-				start := time.Now()
 				_ = ExecuteLintRule(ctx, execBuilder(i%5 == 0), sources[i], linting.MustParseRuleAddr("core:foo"))
 				durations[i] = time.Since(start)
 			})
@@ -219,11 +221,11 @@ func TestExecuteLintRule(t *testing.T) {
 		for i, dur := range durations {
 			expectedToSleep := i%5 == 0
 			if expectedToSleep {
-				if dur < sleepFor-(50*time.Millisecond) { // just to give some buffer for the runners on different CI platforms
+				if dur < sleepFor {
 					t.Errorf("[%d] finished unexpectedly fast (in %s)", i, dur)
 				}
 			} else {
-				if dur > 50*time.Millisecond {
+				if dur > 100*time.Millisecond { // depends on how slow the CI runner is, this can be quite high at times
 					t.Errorf("[%d] finished later than expected (in %s)", i, dur)
 				}
 			}

--- a/internal/tfdiags/lint_test.go
+++ b/internal/tfdiags/lint_test.go
@@ -7,7 +7,9 @@ package tfdiags
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -24,20 +26,6 @@ func TestLintRuleEnabled(t *testing.T) {
 		givenSource    SourceRange
 		want           bool
 	}{
-		"context missing linting configuration": {
-			contextBuilder: func(ctx context.Context) context.Context {
-				return ctx
-			},
-			want:        false,
-			givenRuleID: linting.MustParseRuleAddr("foo"),
-		},
-		"context linting configuration is wrongly configured": {
-			contextBuilder: func(ctx context.Context) context.Context {
-				return context.WithValue(ctx, lintingRulesCtxKey{}, "definitely not the right struct here")
-			},
-			want:        false,
-			givenRuleID: linting.MustParseRuleAddr("foo"),
-		},
 		"with all included and nothing else": {
 			contextBuilder: func(ctx context.Context) context.Context {
 				include := collections.NewSet[linting.RuleAddr](
@@ -127,51 +115,117 @@ func TestLintRuleEnabled(t *testing.T) {
 			givenRuleID:   linting.MustParseRuleAddr("foo"),
 			givenGroupIDs: []linting.RuleAddr{linting.MustParseRuleAddr("group_including_foo")},
 		},
-		"with the same rule and group being already checked once": {
-			contextBuilder: func(ctx context.Context) context.Context {
-				v := lintingRulesCtxValue{
-					include:  collections.NewSet[linting.RuleAddr](linting.AllRulesGroupID),
-					exclude:  collections.NewSet[linting.RuleAddr](linting.MustParseRuleAddr("group_including_foo")),
-					executed: collections.NewSet(keyForLintCall(SourceRange{Filename: "test.tf", Start: SourcePos{Line: 1, Column: 1, Byte: 1}}, linting.MustParseRuleAddr("foo"))), // no group id provided here
-				}
-				return context.WithValue(ctx, lintingRulesCtxKey{}, &v)
-			},
-			want:          false,
-			givenRuleID:   linting.MustParseRuleAddr("foo"),
-			givenGroupIDs: nil, // no group ID provided
-			givenSource: SourceRange{
-				Filename: "test.tf",
-				Start:    SourcePos{Line: 1, Column: 1, Byte: 1},
-			},
-		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			ctx := tc.contextBuilder(t.Context())
-			got := LintRuleEnabledOnSource(ctx, tc.givenSource, tc.givenRuleID, tc.givenGroupIDs...)
+			v := lintHintsFromContext(ctx)
+			got := lintRuleAllowed(v.include, v.exclude, tc.givenRuleID, tc.givenGroupIDs...)
 			if tc.want != got {
 				t.Errorf("expected for the ruleID %+v (groupIDs %+v) to return %t but got %t", tc.givenRuleID, tc.givenGroupIDs, tc.want, got)
 			}
 		})
 	}
-	t.Run("running exactly the same rule twice returns true only the first time", func(t *testing.T) {
-		rID := linting.MustParseRuleAddr("foo")
-		gID := linting.MustParseRuleAddr("group_including_foo")
-		src := SourceRange{
-			Filename: "test.tf",
-			Start:    SourcePos{Line: 1, Column: 1, Byte: 1},
+}
+
+func TestExecuteLintRule(t *testing.T) {
+	t.Run("rule executed only once", func(t *testing.T) {
+		ctx := ContextWithLintFilterHints(t.Context(), collections.NewSet(linting.MustParseRuleAddr("core:foo")), collections.NewSet[linting.RuleAddr]())
+		var calls int
+		exec := func() Diagnostics {
+			calls++
+			return nil
 		}
-		ctx := ContextWithLintFilterHints(t.Context(), collections.NewSet[linting.RuleAddr](linting.AllRulesGroupID), collections.NewSet[linting.RuleAddr](gID))
-		for i := range 10 {
-			got := LintRuleEnabledOnSource(ctx, src, rID) // no group id provided
-			if i == 0 {
-				if !got {
-					t.Errorf("[%d] expected for the rule to be allowed but was not", i)
-				}
-				return
+		for range 3 {
+			_ = ExecuteLintRule(ctx, exec, SourceRange{Filename: "test.tf", Start: SourcePos{Line: 1, Column: 2}, End: SourcePos{Line: 1, Column: 10}}, linting.MustParseRuleAddr("core:foo"))
+		}
+		if calls != 1 {
+			t.Errorf("expected to be called only once but got %d", calls)
+		}
+	})
+	t.Run("parallel calls locks when called for exactly the same source and lint rule", func(t *testing.T) {
+		ruleID := linting.MustParseRuleAddr("core:foo")
+		ctx := ContextWithLintFilterHints(t.Context(), collections.NewSet(ruleID), collections.NewSet[linting.RuleAddr]())
+		var durations [500]time.Duration
+		var calls int // not needed atomic here since its expected to be wrote into only by one goroutine, once
+		var idxCalled int
+		sleepFor := 300 * time.Millisecond
+		exec := func(i int) func() Diagnostics {
+			return func() Diagnostics {
+				calls++
+				<-time.After(sleepFor)
+				idxCalled = i
+				return nil
 			}
-			if got {
-				t.Errorf("[%d] expected for the rule to be denied because it was executed once but it was allowed", i)
+		}
+		src := SourceRange{Filename: "test.tf", Start: SourcePos{Line: 1, Column: 2}, End: SourcePos{Line: 1, Column: 10}}
+		var wg sync.WaitGroup
+		for i := range 500 {
+			wg.Go(func() {
+				start := time.Now()
+				_ = ExecuteLintRule(ctx, exec(i), src, ruleID)
+				durations[i] = time.Since(start)
+			})
+		}
+		wg.Wait()
+		// because based on the architecture and the CI platform, time.After can return with slighlty different
+		// variation from the actually asked duration so we want to do the assertions on the actual time it took
+		// for the goroutine that managed to call into the linting rule. So we use that instead of a hardcoded
+		// duration
+		minDuration := durations[idxCalled]
+		for i, dur := range durations {
+			if i == idxCalled {
+				continue // we skip the one that actually called in the linting execution since we use its duration for comparison
+			}
+			if dur < minDuration-(50*time.Millisecond) { // just to give some buffer for the runners on different CI platforms
+				t.Errorf("[%d] finished unexpectedly before the goroutine that actually called the linting rule. finished in %s (smaller than %s)", i, dur, minDuration)
+			}
+		}
+		if calls != 1 {
+			t.Errorf("expected in the end to have just 1 call but got %d", calls)
+		}
+		// execute the same rule one more time to be sure that the execution of it is not performed (because it should be already registered as executed successfully)
+		calls = 0
+		_ = ExecuteLintRule(ctx, exec(0), src, ruleID)
+		if calls != 0 {
+			t.Errorf("the linting rule unexpectedly called. This means that something is broken in the internals of ExecuteLintRule since this was meant be registered as successfully executed")
+		}
+	})
+	t.Run("parallel calls does not lock when called for different source and lint rule", func(t *testing.T) {
+		ctx := ContextWithLintFilterHints(t.Context(), collections.NewSet(linting.MustParseRuleAddr("all")), collections.NewSet[linting.RuleAddr]())
+		var sources [500]SourceRange
+		for i := range 500 {
+			sources[i] = SourceRange{Filename: "test.tf", Start: SourcePos{Line: i, Column: 2}, End: SourcePos{Line: 1, Column: 10}}
+		}
+		sleepFor := 300 * time.Millisecond
+		execBuilder := func(shouldWait bool) func() Diagnostics {
+			return func() Diagnostics {
+				if shouldWait {
+					<-time.After(sleepFor)
+				}
+				return nil
+			}
+		}
+		var wg sync.WaitGroup
+		var durations [500]time.Duration
+		for i := range 500 {
+			wg.Go(func() {
+				start := time.Now()
+				_ = ExecuteLintRule(ctx, execBuilder(i%5 == 0), sources[i], linting.MustParseRuleAddr("core:foo"))
+				durations[i] = time.Since(start)
+			})
+		}
+		wg.Wait()
+		for i, dur := range durations {
+			expectedToSleep := i%5 == 0
+			if expectedToSleep {
+				if dur < sleepFor-(50*time.Millisecond) { // just to give some buffer for the runners on different CI platforms
+					t.Errorf("[%d] finished unexpectedly fast (in %s)", i, dur)
+				}
+			} else {
+				if dur > 50*time.Millisecond {
+					t.Errorf("[%d] finished later than expected (in %s)", i, dur)
+				}
 			}
 		}
 	})

--- a/internal/tfdiags/lint_test.go
+++ b/internal/tfdiags/lint_test.go
@@ -21,6 +21,7 @@ func TestLintRuleEnabled(t *testing.T) {
 		contextBuilder func(ctx context.Context) context.Context
 		givenRuleID    linting.RuleAddr
 		givenGroupIDs  []linting.RuleAddr
+		givenSource    SourceRange
 		want           bool
 	}{
 		"context missing linting configuration": {
@@ -126,16 +127,54 @@ func TestLintRuleEnabled(t *testing.T) {
 			givenRuleID:   linting.MustParseRuleAddr("foo"),
 			givenGroupIDs: []linting.RuleAddr{linting.MustParseRuleAddr("group_including_foo")},
 		},
+		"with the same rule and group being already checked once": {
+			contextBuilder: func(ctx context.Context) context.Context {
+				v := lintingRulesCtxValue{
+					include:  collections.NewSet[linting.RuleAddr](linting.AllRulesGroupID),
+					exclude:  collections.NewSet[linting.RuleAddr](linting.MustParseRuleAddr("group_including_foo")),
+					executed: collections.NewSet(keyForLintCall(SourceRange{Filename: "test.tf", Start: SourcePos{Line: 1, Column: 1, Byte: 1}}, linting.MustParseRuleAddr("foo"))), // no group id provided here
+				}
+				return context.WithValue(ctx, lintingRulesCtxKey{}, &v)
+			},
+			want:          false,
+			givenRuleID:   linting.MustParseRuleAddr("foo"),
+			givenGroupIDs: nil, // no group ID provided
+			givenSource: SourceRange{
+				Filename: "test.tf",
+				Start:    SourcePos{Line: 1, Column: 1, Byte: 1},
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			ctx := tc.contextBuilder(t.Context())
-			got := LintRuleEnabled(ctx, tc.givenRuleID, tc.givenGroupIDs...)
+			got := LintRuleEnabledOnSource(ctx, tc.givenSource, tc.givenRuleID, tc.givenGroupIDs...)
 			if tc.want != got {
 				t.Errorf("expected for the ruleID %+v (groupIDs %+v) to return %t but got %t", tc.givenRuleID, tc.givenGroupIDs, tc.want, got)
 			}
 		})
 	}
+	t.Run("running exactly the same rule twice returns true only the first time", func(t *testing.T) {
+		rID := linting.MustParseRuleAddr("foo")
+		gID := linting.MustParseRuleAddr("group_including_foo")
+		src := SourceRange{
+			Filename: "test.tf",
+			Start:    SourcePos{Line: 1, Column: 1, Byte: 1},
+		}
+		ctx := ContextWithLintFilterHints(t.Context(), collections.NewSet[linting.RuleAddr](linting.AllRulesGroupID), collections.NewSet[linting.RuleAddr](gID))
+		for i := range 10 {
+			got := LintRuleEnabledOnSource(ctx, src, rID) // no group id provided
+			if i == 0 {
+				if !got {
+					t.Errorf("[%d] expected for the rule to be allowed but was not", i)
+				}
+				return
+			}
+			if got {
+				t.Errorf("[%d] expected for the rule to be denied because it was executed once but it was allowed", i)
+			}
+		}
+	})
 }
 
 func TestFilterLint(t *testing.T) {
@@ -368,173 +407,6 @@ func TestFilterLint(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := tc.givenDiags.FilterLint(tc.include, tc.exclude)
-			if diff := cmp.Diff(tc.wantDiags, got, cmpopts.IgnoreUnexported(attributeDiagnostic{}, lintMessage{})); diff != "" {
-				t.Errorf("unexpected returned diagnostics (-want,+got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestConsolidateLintDiagnostics(t *testing.T) {
-	cases := map[string]struct {
-		givenDiags Diagnostics
-		wantDiags  Diagnostics
-	}{
-		"2 diagnostics and both with source": {
-			givenDiags: New(
-				LintMessage(
-					linting.MustParseRuleAddr("foo"),
-					nil,
-					"lint summary",
-					"lint details",
-					&SourceRange{
-						Filename: "testfile",
-					},
-					nil,
-				),
-				LintMessage(
-					linting.MustParseRuleAddr("foo"),
-					nil,
-					"lint summary",
-					"lint details",
-					&SourceRange{
-						Filename: "testfile",
-					},
-					nil,
-				),
-			),
-			wantDiags: New(
-				&consolidatedGroup{Consolidated: Diagnostics{LintMessage(
-					linting.MustParseRuleAddr("foo"),
-					nil,
-					"lint summary",
-					"lint details",
-					&SourceRange{
-						Filename: "testfile",
-					},
-					nil,
-				)}},
-			),
-		},
-		"2 diagnostics and one with no source": {
-			givenDiags: New(
-				LintMessage(
-					linting.MustParseRuleAddr("foo"),
-					nil,
-					"lint summary",
-					"lint details",
-					nil,
-					nil,
-				),
-				LintMessage(
-					linting.MustParseRuleAddr("foo"),
-					nil,
-					"lint summary",
-					"lint details",
-					&SourceRange{
-						Filename: "testfile",
-					},
-					nil,
-				),
-			),
-			wantDiags: New(
-				LintMessage(
-					linting.MustParseRuleAddr("foo"),
-					nil,
-					"lint summary",
-					"lint details",
-					nil,
-					nil,
-				),
-				&consolidatedGroup{Consolidated: Diagnostics{LintMessage(
-					linting.MustParseRuleAddr("foo"),
-					nil,
-					"lint summary",
-					"lint details",
-					&SourceRange{
-						Filename: "testfile",
-					},
-					nil,
-				)}},
-			),
-		},
-		"2 diagnostics and both with no source": {
-			givenDiags: New(
-				LintMessage(
-					linting.MustParseRuleAddr("foo"),
-					nil,
-					"lint summary",
-					"lint details",
-					nil,
-					nil,
-				),
-				LintMessage(
-					linting.MustParseRuleAddr("foo"),
-					nil,
-					"lint summary",
-					"lint details",
-					nil,
-					nil,
-				),
-			),
-			wantDiags: New(
-				LintMessage(
-					linting.MustParseRuleAddr("foo"),
-					nil,
-					"lint summary",
-					"lint details",
-					nil,
-					nil,
-				),
-				LintMessage(
-					linting.MustParseRuleAddr("foo"),
-					nil,
-					"lint summary",
-					"lint details",
-					nil,
-					nil,
-				),
-			),
-		},
-		"2 diagnostics with warning severity but not the right type and no extra info": {
-			givenDiags: New(
-				&attributeDiagnostic{
-					diagnosticBase: diagnosticBase{
-						severity: Warning,
-						summary:  "bad linting diagnostic",
-						detail:   "bad linting diagnostic 1",
-					},
-					subject: &SourceRange{Filename: "testfile"},
-				},
-				&attributeDiagnostic{
-					diagnosticBase: diagnosticBase{
-						severity: Warning,
-						summary:  "bad linting diagnostic",
-						detail:   "bad linting diagnostic 2",
-					},
-					subject: &SourceRange{Filename: "testfile"},
-				},
-			),
-
-			wantDiags: New(
-				&consolidatedGroup{
-					Consolidated: Diagnostics{
-						&attributeDiagnostic{
-							diagnosticBase: diagnosticBase{
-								severity: Warning,
-								summary:  "bad linting diagnostic",
-								detail:   "bad linting diagnostic 1",
-							},
-							subject: &SourceRange{Filename: "testfile"},
-						},
-					},
-				},
-			),
-		},
-	}
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			got := tc.givenDiags.ConsolidateLint()
 			if diff := cmp.Diff(tc.wantDiags, got, cmpopts.IgnoreUnexported(attributeDiagnostic{}, lintMessage{})); diff != "" {
 				t.Errorf("unexpected returned diagnostics (-want,+got):\n%s", diff)
 			}


### PR DESCRIPTION
This targets the branch in #4337.
On top of that, it changes the following by adding `ExecuteLintRule`:
* Makes it clear on how a rule should be implemented and what arguments it needs
* Now records the execution status of the linting rule which avoids running the same rule on the same configuration block multiple times. This removes also the need to consolidate the linting diagnostics and removes the possible performance penalty that could have been introduce by running multiple times a time consuming linting rule.

Part of #4310

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
