### PR TITLE
Only call provider MovedResourceState when appropriate

### DIFF
--- a/internal/refactoring/move_execute.go
+++ b/internal/refactoring/move_execute.go
@@ -72,7 +72,7 @@ func ApplyMoves(stmts []MoveStatement, state *states.State) MoveResults {
 
 	log.Printf("[TRACE] refactoring.ApplyMoves: Processing 'moved' statements in the configuration\n%s", logging.Indent(g.String()))
 
-	recordOldAddr := func(oldAddr, newAddr addrs.AbsResourceInstance) {
+	recordOldAddr := func(oldAddr, newAddr addrs.AbsResourceInstance, implied bool) {
 		if prevMove, exists := ret.Changes.GetOk(oldAddr); exists {
 			// If the old address was _already_ the result of a move then
 			// we'll replace that entry so that our results summarize a chain
@@ -81,8 +81,9 @@ func ApplyMoves(stmts []MoveStatement, state *states.State) MoveResults {
 			oldAddr = prevMove.From
 		}
 		ret.Changes.Put(newAddr, MoveSuccess{
-			From: oldAddr,
-			To:   newAddr,
+			From:    oldAddr,
+			To:      newAddr,
+			Implied: implied,
 		})
 	}
 	recordBlockage := func(newAddr, wantedAddr addrs.AbsMoveable) {
@@ -123,7 +124,7 @@ func ApplyMoves(stmts []MoveStatement, state *states.State) MoveResults {
 						for key := range rs.Instances {
 							oldInst := relAddr.Instance(key).Absolute(modAddr)
 							newInst := relAddr.Instance(key).Absolute(newAddr)
-							recordOldAddr(oldInst, newInst)
+							recordOldAddr(oldInst, newInst, stmt.Implied)
 						}
 					}
 
@@ -157,7 +158,7 @@ func ApplyMoves(stmts []MoveStatement, state *states.State) MoveResults {
 						for key := range rs.Instances {
 							oldInst := rAddr.Instance(key)
 							newInst := newAddr.Instance(key)
-							recordOldAddr(oldInst, newInst)
+							recordOldAddr(oldInst, newInst, stmt.Implied)
 						}
 						state.MoveAbsResource(rAddr, newAddr)
 						continue
@@ -176,7 +177,7 @@ func ApplyMoves(stmts []MoveStatement, state *states.State) MoveResults {
 								continue
 							}
 
-							recordOldAddr(iAddr, newAddr)
+							recordOldAddr(iAddr, newAddr, stmt.Implied)
 
 							state.MoveAbsResourceInstance(iAddr, newAddr)
 							continue
@@ -317,8 +318,9 @@ func makeMoveResults() MoveResults {
 }
 
 type MoveSuccess struct {
-	From addrs.AbsResourceInstance
-	To   addrs.AbsResourceInstance
+	From    addrs.AbsResourceInstance
+	To      addrs.AbsResourceInstance
+	Implied bool
 }
 
 type MoveBlocked struct {
@@ -333,6 +335,17 @@ type MoveBlocked struct {
 // to find its original address prior to moving.
 func (rs MoveResults) AddrMoved(newAddr addrs.AbsResourceInstance) bool {
 	return rs.Changes.Has(newAddr)
+}
+
+// AddrMovedExplicit returns true if and only if the given resource instance
+// moved to a new address in the ApplyMoves call that the receiver is describing
+// because of a "moved" block in the configuration.
+//
+// If AddrMovedExplicit returns true, you can pass the same address to method OldAddr
+// to find its original address prior to moving.
+func (rs MoveResults) AddrMovedExplicit(newAddr addrs.AbsResourceInstance) bool {
+	change, ok := rs.Changes.GetOk(newAddr)
+	return ok && !change.Implied
 }
 
 // OldAddr returns the old address of the given resource instance address, or

--- a/internal/refactoring/move_execute_test.go
+++ b/internal/refactoring/move_execute_test.go
@@ -534,10 +534,12 @@ func TestApplyMoves(t *testing.T) {
 					addrs.MakeMapElem(mustParseInstAddr("module.boo.foo.from"), MoveSuccess{
 						mustParseInstAddr("foo.from"),
 						mustParseInstAddr("module.boo.foo.from"),
+						false,
 					}),
 					addrs.MakeMapElem(mustParseInstAddr("module.boo.foo.to"), MoveSuccess{
 						mustParseInstAddr("module.bar[0].foo.to"),
 						mustParseInstAddr("module.boo.foo.to"),
+						false,
 					}),
 				),
 				Blocked: emptyResults.Blocked,
@@ -579,10 +581,12 @@ func TestApplyMoves(t *testing.T) {
 					addrs.MakeMapElem(mustParseInstAddr("module.bar[0].foo.to"), MoveSuccess{
 						mustParseInstAddr("foo.from"),
 						mustParseInstAddr("module.bar[0].foo.to"),
+						false,
 					}),
 					addrs.MakeMapElem(mustParseInstAddr("module.bar[0].bar.to"), MoveSuccess{
 						mustParseInstAddr("bar.from"),
 						mustParseInstAddr("module.bar[0].bar.to"),
+						false,
 					}),
 				),
 				Blocked: emptyResults.Blocked,
@@ -623,6 +627,7 @@ func TestApplyMoves(t *testing.T) {
 					addrs.MakeMapElem(mustParseInstAddr("module.boo.foo.from"), MoveSuccess{
 						mustParseInstAddr("module.bar[0].foo.from"),
 						mustParseInstAddr("module.boo.foo.from"),
+						false,
 					}),
 				),
 				Blocked: addrs.MakeMap(

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -1444,6 +1444,7 @@ func TestContext2Plan_movedResourceToDifferentType(t *testing.T) {
 		newSchema     providers.Schema
 		oldType       string
 		newType       string
+		newAddr       string
 		config        map[string]string
 		attrsJSON     []byte
 		wantOp        plans.Action
@@ -1732,12 +1733,122 @@ func TestContext2Plan_movedResourceToDifferentType(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "different provider addr with same schema (explicit)",
+			oldSchema: constructProviderSchemaForTesting(map[string]*configschema.Attribute{
+				"test_number": {
+					Type:     cty.Number,
+					Required: true,
+				},
+			}),
+			newSchema: constructProviderSchemaForTesting(map[string]*configschema.Attribute{
+				"test_number": {
+					Type:     cty.Number,
+					Required: true,
+				},
+			}),
+			oldType: "provider_object",
+			newType: "provider_object",
+			newAddr: "provider_object.new[0]",
+			config: map[string]string{
+				"main.tf": `
+					resource "provider_object" "new" {
+					        count = 1
+						test_number = 1
+					}
+					moved {
+						from = provider_object.old
+						to   = provider_object.new[0]
+					}
+				`,
+			},
+			attrsJSON: []byte(`{"test_number": 1}`),
+			wantOp:    plans.NoOp,
+			providerAddr1: &addrs.AbsProviderConfig{
+				Provider: addrs.NewBuiltInProvider("provider"),
+			},
+			providerAddr2: &addrs.AbsProviderConfig{
+				Provider: addrs.NewDefaultProvider("provider"),
+			},
+			mockProvider: &MockProvider{
+				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+					ResourceTypes: map[string]providers.Schema{
+						"provider_object": constructProviderSchemaForTesting(map[string]*configschema.Attribute{
+							"test_number": {
+								Type:     cty.Number,
+								Required: true,
+							},
+						}),
+					},
+				},
+				MoveResourceStateResponse: &providers.MoveResourceStateResponse{
+					TargetState: cty.ObjectVal(map[string]cty.Value{
+						"test_number": cty.NumberIntVal(1),
+					}),
+				},
+			},
+		},
+		{
+			name: "different provider addr with same schema (implicit)",
+			oldSchema: constructProviderSchemaForTesting(map[string]*configschema.Attribute{
+				"test_number": {
+					Type:     cty.Number,
+					Required: true,
+				},
+			}),
+			newSchema: constructProviderSchemaForTesting(map[string]*configschema.Attribute{
+				"test_number": {
+					Type:     cty.Number,
+					Required: true,
+				},
+			}),
+			oldType: "provider_object",
+			newType: "provider_object",
+			config: map[string]string{
+				"main.tf": `
+					resource "provider_object" "new" {
+					        count = 1
+						test_number = 1
+					}
+					// This is an *IMPLICIT* move and should not perform a MovedResource provider request
+					// This matches what is in the provider framework documentation, but differs from
+					// terraform (as far as we can tell from black box testing)
+					// See discussion in https://github.com/opentofu/opentofu/issues/4374#issuecomment-5022178852
+				`,
+			},
+			attrsJSON: []byte(`{"test_number": 1}`),
+			providerAddr1: &addrs.AbsProviderConfig{
+				Provider: addrs.NewBuiltInProvider("provider"),
+			},
+			providerAddr2: &addrs.AbsProviderConfig{
+				Provider: addrs.NewDefaultProvider("provider"),
+			},
+			wantErrStr: "Showing Upgrade instead of moved: contrived test",
+			mockProvider: &MockProvider{
+				GetProviderSchemaResponse: &providers.GetProviderSchemaResponse{
+					ResourceTypes: map[string]providers.Schema{
+						"provider_object": constructProviderSchemaForTesting(map[string]*configschema.Attribute{
+							"test_number": {
+								Type:     cty.Number,
+								Required: true,
+							},
+						}),
+					},
+				},
+				UpgradeResourceStateResponse: &providers.UpgradeResourceStateResponse{
+					Diagnostics: tfdiags.New(tfdiags.Sourceless(tfdiags.Error, "Showing Upgrade instead of moved", "contrived test")),
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			oldAddr := mustResourceInstanceAddr(tt.oldType + ".old")
 			newAddr := mustResourceInstanceAddr(tt.newType + ".new")
+			if tt.newAddr != "" {
+				newAddr = mustResourceInstanceAddr(tt.newAddr)
+			}
 			m := testModuleInline(t, tt.config)
 
 			providerAddr := addrs.AbsProviderConfig{

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -643,7 +643,7 @@ func (n *NodeAbstractResourceInstance) readResourceInstanceState(ctx context.Con
 		currentSchema:        schema.Block,
 		currentSchemaVersion: currentVersion,
 	}
-	if isResourceMovedToDifferentType(addr, prevAddr, providerAddr, prevProviderAddr) {
+	if evalCtx.MoveResults().AddrMovedExplicit(addr) && isResourceMovedToDifferentType(addr, prevAddr, providerAddr, prevProviderAddr) {
 		src, diags = moveResourceState(transformArgs)
 	} else {
 		src, diags = upgradeResourceState(transformArgs)
@@ -722,7 +722,7 @@ func (n *NodeAbstractResourceInstance) readResourceInstanceStateDeposed(ctx cont
 		currentSchema:        schema.Block,
 		currentSchemaVersion: currentVersion,
 	}
-	if isResourceMovedToDifferentType(addr, prevAddr, providerAddr, prevProviderAddr) {
+	if evalCtx.MoveResults().AddrMovedExplicit(addr) && isResourceMovedToDifferentType(addr, prevAddr, providerAddr, prevProviderAddr) {
 		src, diags = moveResourceState(transformArgs)
 	} else {
 		src, diags = upgradeResourceState(transformArgs)

--- a/internal/tofu/upgrade_resource_state.go
+++ b/internal/tofu/upgrade_resource_state.go
@@ -149,7 +149,7 @@ func moveResourceStateTransform(args stateTransformArgs) (cty.Value, []byte, tfd
 	resp := args.provider.MoveResourceState(context.TODO(), req)
 	diags := resp.Diagnostics
 	if diags.HasErrors() {
-		log.Printf("[TRACE] moveResourceStateTransform: failed - new address: %s, previous address: %s - diags: %s", args.currentAddr, args.prevAddr, diags.Err().Error())
+		log.Printf("[TRACE] moveResourceStateTransform: failed - new address: %s %s, previous address: %s %s - diags: %s", args.currentProviderAddr, args.currentAddr, args.prevProviderAddr, args.prevAddr, diags.Err().Error())
 		return cty.NilVal, nil, diags
 	}
 	return resp.TargetState, resp.TargetPrivate, diags


### PR DESCRIPTION
Previously, if the resource type (provider host/namespace/type or resourceaddr.Type) changed we would fire off a MovedResourceState request. This was a bug introduced in v1.12.4 and v1.11.12.

We should only be looking to see if the resource type changed and performing a move IFF there is an explicit "moved" block in the configuration.

NOTE: This differs from terraform v1.15 as it appears to operate on both implicit and explicit move statements (black box testing). We are intentionally implementing what the provider framework docs suggest is correct and treating the terraform behavior as a bug. This edge case is very rarely hit, which is why we assume it has not been documented and fixed.

Changelog in backport:
```
- Fixed bug where implicit moves and provider address changes would incorrectly cause providers.MovedResourceState to be used in place of providers.UpgradeResourceState (#4375)[https://github.com/opentofu/opentofu/pull/4375]
```

<!-- If your PR resolves an issue, please add it here. -->
Resolves #4374 

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

