### PR TITLE
Enable trace logs for one flaky test

### DIFF
--- a/internal/command/e2etest/test_test.go
+++ b/internal/command/e2etest/test_test.go
@@ -138,6 +138,8 @@ func TestMockProviderWhenEphemeralInConfiguration(t *testing.T) {
 		t.Errorf("expected some output on 'init', got nothing")
 	}
 
+	// TODO andrei remove this when the root cause is fixed
+	tf.AddEnv("TF_LOG=trace")
 	stdout, stderr, err = tf.Run("test")
 	if err != nil {
 		if strings.Contains(stdout, "OpenTofu crashed! This is always indicative of a bug within OpenTofu.") {
@@ -149,6 +151,6 @@ func TestMockProviderWhenEphemeralInConfiguration(t *testing.T) {
 		t.Errorf("unexpected error on 'tofu test': %v\nstderr:\n%s\nstdout:\n%s", err, stderr, stdout)
 	}
 	if !strings.Contains(stdout, "1 passed, 0 failed") {
-		t.Errorf("output doesn't have the expected success string:\n%s", stdout)
+		t.Errorf("output doesn't have the expected success string\nstderr:\n%s\nstdout:\n%s", stdout, stderr)
 	}
 }

--- a/internal/command/e2etest/testdata/mock-test-with-ephemeral-in-configuration/main.tf
+++ b/internal/command/e2etest/testdata/mock-test-with-ephemeral-in-configuration/main.tf
@@ -15,6 +15,10 @@ terraform {
   }
 }
 
+provider "sleep" {
+  max_default = 2
+}
+
 resource "random_id" "test" {
   byte_length = 2
 }


### PR DESCRIPTION
Tried to catch when it fails but with no success.
The updated test fails from time to time:
<img width="636" height="443" alt="Screenshot 2026-07-21 at 15 10 28" src="https://github.com/user-attachments/assets/cb20fcac-ea28-4df0-91f2-0a9e77c49c27" />

These changes enable trace logs to be able to understand better what the issue is.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [ ] I have only exported functions, variables and structs that should be used from other packages.
- [ ] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
