### PR TITLE
tofu: fixed Incorrect warnings produced during plan -replace #4368

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ BUG FIXES:
 - `removed` blocks with an invalid `from` address and a destroy provisioner now report a configuration error instead of crashing. ([#4321](https://github.com/opentofu/opentofu/pull/4321))
 - `tofu plan -out` no longer fails when the plan includes a resource with `lifecycle { destroy = false }` that needs replacement, which previously errored with `invalid change action ForgetThenCreate`. ([#4324](https://github.com/opentofu/opentofu/issues/4324))
 - `connection.script_path` is escaped correctly not allowing anymore additional commands to be executed on the remote host together with the script path indicated by the argument. ([#4330](https://github.com/opentofu/opentofu/pull/4330))
+- `tofu plan`: Fixed Incorrect warnings produced during plan -replace ([#4368](https://github.com/opentofu/opentofu/issues/4368))
 
 ## Previous Releases
 

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -3557,6 +3557,159 @@ func TestContext2Plan_forceReplaceIncompleteAddr(t *testing.T) {
 	})
 }
 
+// This TestContext2Plan_forceReplaceIncompleteAddr_multipleResources is a test case for
+// https://github.com/opentofu/opentofu/issues/4368
+// I've added all the required test cases that are needed to verify the fix for the issue.
+func TestContext2Plan_forceReplaceIncompleteAddr_multipleResources(t *testing.T) {
+	SkipExperimental(t, ExperimentalFeatureForceReplace)
+	rootAddr0 := mustResourceInstanceAddr("test_object.foo[0]")
+	rootAddr1 := mustResourceInstanceAddr("test_object.foo[1]")
+	childAddr0 := mustResourceInstanceAddr("module.child.test_object.foo[0]")
+	childAddr1 := mustResourceInstanceAddr("module.child.test_object.foo[1]")
+	childBare := mustResourceInstanceAddr("module.child.test_object.foo")
+
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+		resource "test_object" "foo" {
+			count = 2
+		}
+		module "child" {
+			source = "./child"
+		}
+	`,
+		"child/child.tf": `
+			resource "test_object" "foo" {
+				count = 2
+			}
+		`,
+	})
+
+	state := states.BuildState(func(s *states.SyncState) {
+		s.SetResourceInstanceCurrent(rootAddr0, &states.ResourceInstanceObjectSrc{
+			AttrsJSON: []byte(`{}`),
+			Status:    states.ObjectReady,
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`), addrs.NoKey)
+		s.SetResourceInstanceCurrent(rootAddr1, &states.ResourceInstanceObjectSrc{
+			AttrsJSON: []byte(`{}`),
+			Status:    states.ObjectReady,
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`), addrs.NoKey)
+		s.SetResourceInstanceCurrent(childAddr0, &states.ResourceInstanceObjectSrc{
+			AttrsJSON: []byte(`{}`),
+			Status:    states.ObjectReady,
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`), addrs.NoKey)
+		s.SetResourceInstanceCurrent(childAddr1, &states.ResourceInstanceObjectSrc{
+			AttrsJSON: []byte(`{}`),
+			Status:    states.ObjectReady,
+		}, mustProviderConfig(`provider["registry.opentofu.org/hashicorp/test"]`), addrs.NoKey)
+	})
+	p := simpleMockProvider()
+	ctx := testContext2(t, &ContextOpts{
+		Plugins: plugins.NewLibrary(map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
+		}, nil),
+	})
+	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
+		Mode: plans.NormalMode,
+		ForceReplace: []addrs.AbsResourceInstance{
+			childBare,
+		},
+	})
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors\n%s", diags.Err().Error())
+	}
+	diagsErr := diags.ErrWithWarnings()
+	if diagsErr == nil {
+		t.Fatalf("no warnings were returned")
+	}
+	if got, want := diagsErr.Error(), "Incompletely-matched force-replace resource instance"; !strings.Contains(got, want) {
+		t.Errorf("missing expected warning\ngot:\n%s\n\nwant substring: %s", got, want)
+	}
+
+	t.Run(rootAddr0.String(), func(t *testing.T) {
+		instPlan := plan.Changes.ResourceInstance(rootAddr0)
+		if experimentalRuntimeEnabled() {
+			if instPlan != nil {
+				t.Fatalf("expected no plan for %s at all", rootAddr0)
+			}
+			// New engine does not generate NoOps
+			return
+		}
+		if instPlan == nil {
+			t.Fatalf("no plan for %s at all", rootAddr0)
+		}
+
+		if got, want := instPlan.Action, plans.NoOp; got != want {
+			t.Errorf("wrong planned action\ngot:  %s\nwant: %s", got, want)
+		}
+		if got, want := instPlan.ActionReason, plans.ResourceInstanceChangeNoReason; got != want {
+			t.Errorf("wrong action reason\ngot:  %s\nwant: %s", got, want)
+		}
+	})
+
+	t.Run(rootAddr1.String(), func(t *testing.T) {
+		instPlan := plan.Changes.ResourceInstance(rootAddr1)
+		if experimentalRuntimeEnabled() {
+			if instPlan != nil {
+				t.Fatalf("expected no plan for %s at all", rootAddr1)
+			}
+			// New engine does not generate NoOps
+			return
+		}
+		if instPlan == nil {
+			t.Fatalf("no plan for %s at all", rootAddr1)
+		}
+
+		if got, want := instPlan.Action, plans.NoOp; got != want {
+			t.Errorf("wrong planned action\ngot:  %s\nwant: %s", got, want)
+		}
+		if got, want := instPlan.ActionReason, plans.ResourceInstanceChangeNoReason; got != want {
+			t.Errorf("wrong action reason\ngot:  %s\nwant: %s", got, want)
+		}
+	})
+
+	t.Run(childAddr0.String(), func(t *testing.T) {
+		instPlan := plan.Changes.ResourceInstance(childAddr0)
+		if experimentalRuntimeEnabled() {
+			if instPlan != nil {
+				t.Fatalf("expected no plan for %s at all", childAddr0)
+			}
+			// New engine does not generate NoOps
+			return
+		}
+		if instPlan == nil {
+			t.Fatalf("no plan for %s at all", childAddr0)
+		}
+
+		if got, want := instPlan.Action, plans.NoOp; got != want {
+			t.Errorf("wrong planned action\ngot:  %s\nwant: %s", got, want)
+		}
+		if got, want := instPlan.ActionReason, plans.ResourceInstanceChangeNoReason; got != want {
+			t.Errorf("wrong action reason\ngot:  %s\nwant: %s", got, want)
+		}
+	})
+
+	t.Run(childAddr1.String(), func(t *testing.T) {
+		instPlan := plan.Changes.ResourceInstance(childAddr1)
+		if experimentalRuntimeEnabled() {
+			if instPlan != nil {
+				t.Fatalf("expected no plan for %s at all", childAddr1)
+			}
+			// New engine does not generate NoOps
+			return
+		}
+		if instPlan == nil {
+			t.Fatalf("no plan for %s at all", childAddr1)
+		}
+
+		if got, want := instPlan.Action, plans.NoOp; got != want {
+			t.Errorf("wrong planned action\ngot:  %s\nwant: %s", got, want)
+		}
+		if got, want := instPlan.ActionReason, plans.ResourceInstanceChangeNoReason; got != want {
+			t.Errorf("wrong action reason\ngot:  %s\nwant: %s", got, want)
+		}
+	})
+}
+
 // Verify that adding a module instance does force existing module data sources
 // to be deferred
 func TestContext2Plan_noChangeDataSourceAddingModuleInstance(t *testing.T) {

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -3560,6 +3560,7 @@ func TestContext2Plan_forceReplaceIncompleteAddr(t *testing.T) {
 // This TestContext2Plan_forceReplaceIncompleteAddr_multipleResources is a test case for
 // https://github.com/opentofu/opentofu/issues/4368
 // I've added all the required test cases that are needed to verify the fix for the issue.
+// This will cover the scope of issue #4368
 func TestContext2Plan_forceReplaceIncompleteAddr_multipleResources(t *testing.T) {
 	SkipExperimental(t, ExperimentalFeatureForceReplace)
 	rootAddr0 := mustResourceInstanceAddr("test_object.foo[0]")

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -3608,7 +3608,7 @@ func TestContext2Plan_forceReplaceIncompleteAddr_multipleResources(t *testing.T)
 			addrs.NewDefaultProvider("test"): testProviderFuncFixed(p),
 		}, nil),
 	})
-	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
+	_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 		ForceReplace: []addrs.AbsResourceInstance{
 			childBare,
@@ -3622,92 +3622,14 @@ func TestContext2Plan_forceReplaceIncompleteAddr_multipleResources(t *testing.T)
 		t.Fatalf("no warnings were returned")
 	}
 	if got, want := diagsErr.Error(), "Incompletely-matched force-replace resource instance"; !strings.Contains(got, want) {
-		t.Errorf("missing expected warning\ngot:\n%s\n\nwant substring: %s", got, want)
+		t.Errorf("missing expected warning summary\ngot:\n%s\n\nwant substring: %s", got, want)
 	}
-
-	t.Run(rootAddr0.String(), func(t *testing.T) {
-		instPlan := plan.Changes.ResourceInstance(rootAddr0)
-		if experimentalRuntimeEnabled() {
-			if instPlan != nil {
-				t.Fatalf("expected no plan for %s at all", rootAddr0)
-			}
-			// New engine does not generate NoOps
-			return
-		}
-		if instPlan == nil {
-			t.Fatalf("no plan for %s at all", rootAddr0)
-		}
-
-		if got, want := instPlan.Action, plans.NoOp; got != want {
-			t.Errorf("wrong planned action\ngot:  %s\nwant: %s", got, want)
-		}
-		if got, want := instPlan.ActionReason, plans.ResourceInstanceChangeNoReason; got != want {
-			t.Errorf("wrong action reason\ngot:  %s\nwant: %s", got, want)
-		}
-	})
-
-	t.Run(rootAddr1.String(), func(t *testing.T) {
-		instPlan := plan.Changes.ResourceInstance(rootAddr1)
-		if experimentalRuntimeEnabled() {
-			if instPlan != nil {
-				t.Fatalf("expected no plan for %s at all", rootAddr1)
-			}
-			// New engine does not generate NoOps
-			return
-		}
-		if instPlan == nil {
-			t.Fatalf("no plan for %s at all", rootAddr1)
-		}
-
-		if got, want := instPlan.Action, plans.NoOp; got != want {
-			t.Errorf("wrong planned action\ngot:  %s\nwant: %s", got, want)
-		}
-		if got, want := instPlan.ActionReason, plans.ResourceInstanceChangeNoReason; got != want {
-			t.Errorf("wrong action reason\ngot:  %s\nwant: %s", got, want)
-		}
-	})
-
-	t.Run(childAddr0.String(), func(t *testing.T) {
-		instPlan := plan.Changes.ResourceInstance(childAddr0)
-		if experimentalRuntimeEnabled() {
-			if instPlan != nil {
-				t.Fatalf("expected no plan for %s at all", childAddr0)
-			}
-			// New engine does not generate NoOps
-			return
-		}
-		if instPlan == nil {
-			t.Fatalf("no plan for %s at all", childAddr0)
-		}
-
-		if got, want := instPlan.Action, plans.NoOp; got != want {
-			t.Errorf("wrong planned action\ngot:  %s\nwant: %s", got, want)
-		}
-		if got, want := instPlan.ActionReason, plans.ResourceInstanceChangeNoReason; got != want {
-			t.Errorf("wrong action reason\ngot:  %s\nwant: %s", got, want)
-		}
-	})
-
-	t.Run(childAddr1.String(), func(t *testing.T) {
-		instPlan := plan.Changes.ResourceInstance(childAddr1)
-		if experimentalRuntimeEnabled() {
-			if instPlan != nil {
-				t.Fatalf("expected no plan for %s at all", childAddr1)
-			}
-			// New engine does not generate NoOps
-			return
-		}
-		if instPlan == nil {
-			t.Fatalf("no plan for %s at all", childAddr1)
-		}
-
-		if got, want := instPlan.Action, plans.NoOp; got != want {
-			t.Errorf("wrong planned action\ngot:  %s\nwant: %s", got, want)
-		}
-		if got, want := instPlan.ActionReason, plans.ResourceInstanceChangeNoReason; got != want {
-			t.Errorf("wrong action reason\ngot:  %s\nwant: %s", got, want)
-		}
-	})
+	if got, want := diagsErr.Error(), "Your force-replace request for module.child.test_object.foo doesn't match"; !strings.Contains(got, want) {
+		t.Errorf("missing expected warning detail for module.child.test_object.foo\ngot:\n%s\n\nwant substring: %s", got, want)
+	}
+	if got, want := diagsErr.Error(), "Your force-replace request for test_object.foo doesn't match"; strings.Contains(got, want) {
+		t.Errorf("unexpected warning detail for test_object.foo\ngot:\n%s\n\nunexpected substring: %s", got, want)
+	}
 }
 
 // Verify that adding a module instance does force existing module data sources

--- a/internal/tofu/node_resource_plan.go
+++ b/internal/tofu/node_resource_plan.go
@@ -261,7 +261,7 @@ func (n *nodeExpandPlannableResource) expandResourceInstances(ctx context.Contex
 	if mustHaveIndex {
 		for _, candidateAddr := range n.forceReplace {
 			if candidateAddr.Resource.Key == addrs.NoKey {
-				if n.Addr.Resource.Equal(candidateAddr.Resource.Resource) {
+				if n.Addr.Equal(candidateAddr.ConfigResource()) {
 					switch {
 					case len(instanceAddrs) == 0:
 						// In this case there _are_ no instances to replace, so


### PR DESCRIPTION
<!-- If your PR resolves an issue, please add it here. -->
Resolves #4368
This PR fixes an issue where tofu plan -replace would emit duplicate warnings for resources with identical names in different modules by ensuring module paths are included when evaluating candidate replace targets. 

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.