### PR TITLE
planning: Handle more weird `create_before_destroy` edges for execgraph construction

### DIFF
--- a/internal/engine/planning/execgraph_managed.go
+++ b/internal/engine/planning/execgraph_managed.go
@@ -94,14 +94,14 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphCreate(
 	unmarkedAfter, _ := plannedChange.After.UnmarkDeep()
 	plannedValRef := b.lower.ConstantValue(unmarkedAfter)
 	desiredInstRef := b.lower.ResourceInstanceDesired(instAddrRef, b.lower.Waiter())
-	valueRef, addConfigDep := b.managedResourceInstanceSubgraphPlanAndApply(
+	valueRef, addDesiredDep := b.managedResourceInstanceSubgraphPlanAndApply(
 		desiredInstRef,
 		execgraph.NilResultRef[*exec.ResourceInstanceObject](),
 		plannedValRef,
 	)
 	return resourceInstanceObjectSubgraph{
 		valueRef:      valueRef,
-		addDesiredDep: addConfigDep,
+		addDesiredDep: addDesiredDep,
 	}
 }
 
@@ -113,14 +113,14 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphUpdate(
 	unmarkedAfter, _ := plannedChange.After.UnmarkDeep()
 	plannedValRef := b.lower.ConstantValue(unmarkedAfter)
 	desiredInstRef := b.lower.ResourceInstanceDesired(instAddrRef, b.lower.Waiter())
-	valueRef, addConfigDep := b.managedResourceInstanceSubgraphPlanAndApply(
+	valueRef, addDesiredDep := b.managedResourceInstanceSubgraphPlanAndApply(
 		desiredInstRef,
 		priorStateRef,
 		plannedValRef,
 	)
 	return resourceInstanceObjectSubgraph{
 		valueRef:      valueRef,
-		addDesiredDep: addConfigDep,
+		addDesiredDep: addDesiredDep,
 	}
 }
 
@@ -173,7 +173,7 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphDeleteOrForgetThenCrea
 		panic("execgraph for ForgetThenCreate not yet implemented")
 	}
 
-	desiredWaitFor, addConfigDep := b.lower.MutableWaiter()
+	desiredWaitFor, addCreateDep := b.lower.MutableWaiter()
 	deleteWaitFor, addDeleteDep := b.lower.MutableWaiter()
 
 	// This has much the same _effect_ as the separate delete and create
@@ -208,12 +208,13 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphDeleteOrForgetThenCrea
 			plannedChange.After.Type(),
 		)),
 	)
+	addDeleteDep(createPlanRef) // must successfully plan for creation before applying deletion
 	destroyResultRef := b.lower.ManagedApply(
 		destroyPlanRef,
 		execgraph.NilResultRef[*exec.ResourceInstanceObject](),
 		deleteWaitFor,
 	)
-	addConfigDep(destroyResultRef) // must finish deleting before creating
+	addCreateDep(destroyResultRef) // must finish deleting before creating
 	createResultRef := b.lower.ManagedApply(
 		createPlanRef,
 		execgraph.NilResultRef[*exec.ResourceInstanceObject](),
@@ -223,7 +224,7 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphDeleteOrForgetThenCrea
 	return resourceInstanceObjectSubgraph{
 		valueRef:      createResultRef,
 		deletionRef:   destroyResultRef,
-		addDesiredDep: addConfigDep,
+		addDesiredDep: addCreateDep,
 		addOrphanDep:  addDeleteDep,
 	}
 }
@@ -231,7 +232,7 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphDeleteOrForgetThenCrea
 func (b *execGraphBuilder) managedResourceInstanceSubgraphCreateThenDelete(
 	plannedChange *plans.ResourceInstanceChange,
 ) resourceInstanceObjectSubgraph {
-	desiredWaitFor, addConfigDep := b.lower.MutableWaiter()
+	desiredWaitFor, addCreateDep := b.lower.MutableWaiter()
 	deleteWaitFor, addDeleteDep := b.lower.MutableWaiter()
 
 	// This has much the same effect as the separate delete and create
@@ -281,6 +282,9 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphCreateThenDelete(
 		createPlanRef,
 		deposedObjRef, // will be restored as current if creation completely fails
 		desiredWaitFor,
+		// Note that this "create" operation indirectly depends on planning
+		// the destroy action due to the deposedObjRef argument above, so we
+		// don't need an additional direct dependency on destroyPlanRef here.
 	)
 	// No other resource instances can depend on the value from the destroy
 	// result, so if the destroy fails after the create succeeded then we can
@@ -297,7 +301,7 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphCreateThenDelete(
 	return resourceInstanceObjectSubgraph{
 		valueRef:      createResultRef,
 		deletionRef:   deletionRef,
-		addDesiredDep: addConfigDep,
+		addDesiredDep: addCreateDep,
 		addOrphanDep:  addDeleteDep,
 	}
 }
@@ -313,19 +317,19 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphPlanAndApply(
 	plannedValRef execgraph.ResultRef[cty.Value],
 ) (
 	resultRef execgraph.ResourceInstanceResultRef,
-	addConfigDep func(execgraph.AnyResultRef),
+	addApplyDep func(execgraph.AnyResultRef),
 ) {
 	finalPlanRef := b.lower.ManagedFinalPlan(
 		desiredInstRef,
 		priorStateRef,
 		plannedValRef,
 	)
-	waitFor, addConfigDep := b.lower.MutableWaiter()
+	waitFor, addApplyDep := b.lower.MutableWaiter()
 	return b.lower.ManagedApply(
 		finalPlanRef,
 		execgraph.NilResultRef[*exec.ResourceInstanceObject](),
 		waitFor,
-	), addConfigDep
+	), addApplyDep
 }
 
 func (b *execGraphBuilder) managedResourceInstanceChangeAddrAndPriorStateRefs(

--- a/internal/engine/planning/execgraph_managed_test.go
+++ b/internal/engine/planning/execgraph_managed_test.go
@@ -179,7 +179,7 @@ func TestExecGraphBuilder_ManagedResourceInstanceSubgraph(t *testing.T) {
 				r[1] = ResourceInstanceDesired(test.placeholder, await());
 				r[2] = ManagedFinalPlan(r[1], nil, v[0]);
 				r[3] = ManagedFinalPlan(nil, r[0], v[1]);
-				r[4] = ManagedApply(r[3], nil, await());
+				r[4] = ManagedApply(r[3], nil, await(r[2]));
 				r[5] = ManagedApply(r[2], nil, await(r[4]));
 
 				test.placeholder = r[5];
@@ -214,7 +214,7 @@ func TestExecGraphBuilder_ManagedResourceInstanceSubgraph(t *testing.T) {
 				r[2] = ResourceInstanceDesired(test.placeholder, await());
 				r[3] = ManagedFinalPlan(r[2], nil, v[0]);
 				r[4] = ManagedFinalPlan(nil, r[1], v[1]);
-				r[5] = ManagedApply(r[4], nil, await());
+				r[5] = ManagedApply(r[4], nil, await(r[3]));
 				r[6] = ManagedApply(r[3], nil, await(r[5]));
 
 				test.placeholder = r[6];

--- a/internal/engine/planning/execgraph_resource.go
+++ b/internal/engine/planning/execgraph_resource.go
@@ -48,13 +48,6 @@ func (b *execGraphBuilder) AddResourceInstanceObjectSubgraphs(
 	// subgraphs in the second loop below.
 	subgraphs := addrs.MakeMap[addrs.AbsResourceInstanceObject, resourceInstanceObjectSubgraph]()
 
-	// resultRefs tracks the execgraph result reference for each resource
-	// instance object, populated gradually as we build it out. We track this
-	// separately from the objects in "subgraphs" because we will potentially
-	// add synthetic new entries to this map to read the prior state for
-	// anything that isn't otherwise being changed as part of this plan.
-	resultRefs := addrs.MakeMap[addrs.AbsResourceInstanceObject, execgraph.ResourceInstanceResultRef]()
-
 	// We pre-sort the keys here because that causes our execution graph
 	// operations to be in a deterministic order, for easier unit testing and
 	// easier reading of debug output.
@@ -85,61 +78,113 @@ func (b *execGraphBuilder) AddResourceInstanceObjectSubgraphs(
 		subgraphs.Put(addr, subgraph)
 
 		if addr.IsCurrent() && subgraph.valueRef != nil {
-			resultRefs.Put(addr, subgraph.valueRef)
 			b.lower.SetResourceInstanceFinalStateResult(addr.InstanceAddr, subgraph.valueRef)
 		}
 	}
 
 	// Now we'll add explicit dependencies between the subgraphs we just created
 	// for the resource instance object changes. Any object that has a planned
-	// change should already have entries in addConfigDeps/addDeleteDeps where
-	// appropriate, but we will need to add prior-state-reading stubs for
-	// any object that isn't being changed but is a dependency for something
-	// that is changing.
-	for _, addr := range objAddrs {
-		subgraph := subgraphs.Get(addr)
-		if subgraph.addDesiredDep != nil {
-			for dependency := range objs.ConfigDependencies(addr) {
-				subgraph.addDesiredDep(ensureResourceInstanceObjectResultRef(dependency, resultRefs, b))
-			}
-			for dependency := range objs.StateDependencies(addr) {
-				subgraph.addDesiredDep(ensureResourceInstanceObjectResultRef(dependency, resultRefs, b))
+	// change should already have an entry in "subgraphs", but we will need to
+	// add prior-state-reading stubs for any object that isn't being changed but
+	// is a dependency for something that is changing.
+	//
+	// In the following we follow the convention of describing edges between
+	// operations for objects A and B, where B depends on A. Exactly how we
+	// wire together the subgraphs of these objects depends on whether they
+	// each have create/update and delete legs in their subgraphs and whether
+	// they use the "create before destroy" ordering for replacing.
+	for _, addrB := range objAddrs {
+		objB := subgraphs.Get(addrB)
+
+		for addrA := range objs.ConfigDependencies(addrB) {
+			objA := ensureResourceInstanceObjectSubgraph(addrA, subgraphs, b)
+
+			// Config-based dependencies are relatively straightforward because
+			// they can only possibly constrain ordering of creation-related
+			// operations.
+			if objA.HasCreateOrUpdateLeg() && objB.HasCreateOrUpdateLeg() {
+				objB.CreateOrUpdateDependsOn(objA.CreateOrUpdateCompletionRef())
 			}
 		}
-		if subgraph.addOrphanDep != nil {
-			for dependent := range objs.ConfigDependents(addr) {
-				dependentSubgraph := subgraphs.Get(dependent)
-				if ref := dependentSubgraph.deletionRef; ref != nil {
-					subgraph.addOrphanDep(ref)
-				} else if ref, ok := resultRefs.GetOk(dependent); ok {
-					// If there's no deletion ref but the dependent still has
-					// a value ref (e.g. if the dependent is only being created
-					// or updated) then we wait until its create/update step
-					// has completed before deleting.
-					subgraph.addOrphanDep(ref)
-					// TODO: The old runtime's equivalent of this behavior has a
-					// hackily-implemented extra rule where it checks if
-					// adding this edge would create a cycle and skips adding
-					// it if so. Do we need to replicate that here? The
-					// commentary on the function that implements it
-					// ([DestroyEdgeTransformer.tryInterProviderDestroyEdge])
-					// explains that it's needed because, when applying a
-					// destroy-mode plan, provider instances are allowed to refer
-					// to a resource instance that's being destroyed and expect
-					// that to take values from the prior state, and so we'll
-					// tackle this question when we add support for destroy-mode
-					// planning (which seems likely to have its own separate
-					// execgraph-building logic just because the rules are quite
-					// different for that planning mode).
-				}
+
+		for addrA := range objs.StateDependencies(addrB) {
+			objA := ensureResourceInstanceObjectSubgraph(addrA, subgraphs, b)
+
+			// The creation-related operations still just get connected in
+			// the intuitive order where A would be created before B, as
+			// with the config-based dependencies.
+			if objA.HasCreateOrUpdateLeg() && objB.HasCreateOrUpdateLeg() {
+				// (Note that this can potentially duplicate connections we
+				// already made in the ConfigDependencies loop above. We just
+				// ignore those redundant dependencies for now, since their
+				// overhead is minimal.)
+				objB.CreateOrUpdateDependsOn(objA.CreateOrUpdateCompletionRef())
 			}
-			for dependent := range objs.StateDependents(addr) {
-				dependentSubgraph := subgraphs.Get(dependent)
-				if ref := dependentSubgraph.deletionRef; ref != nil {
-					subgraph.addOrphanDep(ref)
-				} else if ref, ok := resultRefs.GetOk(dependent); ok {
-					subgraph.addOrphanDep(ref)
+			// If object A is not being deleted then there's nothing else for us
+			// to do here.
+			if !objA.HasDeleteLeg() {
+				continue
+			}
+
+			// Unfortunately the rules for the ordering of deletion operations
+			// are more complicated because we need to handle various awkward
+			// situations, including:
+			// - Making sure we connect the subgraphs in a way that respects
+			//   the replace order of each object, if either is being replaced.
+			// - Dealing with situations where create-only or delete-only
+			//   objects interact with those that are being replaced, and so
+			//   we might need to e.g. use a create/update result as a
+			//   placeholder for an absent delete result.
+			//
+			// Regardless of the above we can assume that the individual
+			// create/delete operations inside each subgraph are already ordered
+			// correctly for the selected replace order, and so we only need
+			// to worry about the connections _between_ the subgraphs.
+			cbdA := effectiveReplaceOrders.Get(addrA) == replaceCreateThenDestroy
+			cbdB := effectiveReplaceOrders.Get(addrB) == replaceCreateThenDestroy
+			if cbdA {
+				// If A is create_before_destroy then we're aiming for an
+				// ordering like this:
+				//   - Create A
+				//   - Create B
+				//   - Delete B
+				//   - Delete A
+				if objB.HasCreateOrUpdateLeg() {
+					objA.DeleteDependsOn(objB.CreateOrUpdateCompletionRef())
 				}
+				if objB.HasDeleteLeg() {
+					// In this case we need to connect differently depending
+					// on the replace order being used by B, so that we can
+					// avoid creating a cycle.
+					if cbdB {
+						objA.DeleteDependsOn(objB.DeletionRef())
+					} else {
+						// If A is cbd but B is not then we need to connect
+						// this the other way around, to achieve this unusual
+						// ordering where A and B's operations are interleaved:
+						//   - Delete B
+						//   - Create A
+						//   - Create B
+						//   - Delete A
+						if objA.HasCreateOrUpdateLeg() {
+							objA.CreateOrUpdateDependsOn(objB.DeletionRef())
+						}
+					}
+				}
+			} else if objB.HasDeleteLeg() {
+				// For all other combinations, we just use the intuitive
+				// rule that B must be deleted before A, because a
+				// dependency must outlive objects that depend on it.
+				//
+				// If both objects also have creation legs (i.e. they are both
+				// being replaced) then this combines with the dependency
+				// between the two create legs that we added above to produce
+				// the following effective order:
+				//   - Delete B
+				//   - Delete A
+				//   - Create A
+				//   - Create B
+				objA.DeleteDependsOn(objB.DeletionRef())
 			}
 		}
 	}
@@ -148,15 +193,15 @@ func (b *execGraphBuilder) AddResourceInstanceObjectSubgraphs(
 	// Here we ensure that they make it into the execution graph and don't hit the "missing resource instance"
 	// ephemeral detection logic.
 	for _, dependency := range additionalStateDependencies {
-		ensureResourceInstanceObjectResultRef(dependency.CurrentObject(), resultRefs, b)
+		ensureResourceInstanceObjectSubgraph(dependency.CurrentObject(), subgraphs, b)
 	}
 }
 
-func ensureResourceInstanceObjectResultRef(addr addrs.AbsResourceInstanceObject, knownResults addrs.Map[addrs.AbsResourceInstanceObject, execgraph.ResourceInstanceResultRef], b *execGraphBuilder) execgraph.ResourceInstanceResultRef {
-	if existing, ok := knownResults.GetOk(addr); ok {
+func ensureResourceInstanceObjectSubgraph(addr addrs.AbsResourceInstanceObject, subgraphs addrs.Map[addrs.AbsResourceInstanceObject, resourceInstanceObjectSubgraph], b *execGraphBuilder) resourceInstanceObjectSubgraph {
+	if existing, ok := subgraphs.GetOk(addr); ok {
 		return existing
 	}
-	// If we don't already have an existing result then this is an object
+	// If we don't already have an existing subgraph then this is an object
 	// that doesn't have any planned changes, so and we'll just provide
 	// a minimum subgraph for it that only involves reading its prior state.
 	var resultRef execgraph.ResourceInstanceResultRef
@@ -166,8 +211,22 @@ func ensureResourceInstanceObjectResultRef(addr addrs.AbsResourceInstanceObject,
 	} else {
 		resultRef = b.lower.ManagedAlreadyDeposed(b.lower.ConstantResourceInstAddr(addr.InstanceAddr), b.lower.ConstantDeposedKey(addr.DeposedKey))
 	}
-	knownResults.Put(addr, resultRef)
-	return resultRef
+	subgraph := resourceInstanceObjectSubgraph{
+		valueRef: resultRef,
+
+		// We intentionally don't populate addDesiredDep here, because we're
+		// only reading an object from the prior state and so there's never
+		// any need for that to have any dependencies. This also means that
+		// [resourceInstanceObjectSubgraph.HasCreateOrUpdateLeg] will return
+		// false, so the graph builder will know that there's no need to
+		// treat this as an explicit dependency of whatever is depending on
+		// it since the evaluator will naturally block until this result
+		// is available anyway (in ResourceInstanceDesired for any dependency),
+		// so an explicit dependency would be redundant and distracting for
+		// humans trying to diagnose misbehavior using the debug repr.
+	}
+	subgraphs.Put(addr, subgraph)
+	return subgraph
 }
 
 func (b *execGraphBuilder) resourceInstanceChangeSubgraph(
@@ -230,4 +289,45 @@ type resourceInstanceObjectSubgraph struct {
 	// a replace operation. It is nil for resource instance objects where no
 	// deletion is needed, i.e. when they are only being created or updated.
 	addDesiredDep, addOrphanDep func(execgraph.AnyResultRef)
+}
+
+// The following methods of resourceInstanceObjectSubgraph are just here to help
+// make the graph-connecting algorithm in [AddResourceInstanceObjectSubgraphs]
+// a little easier to read by hiding some of the details in favor of descriptive
+// method names.
+
+func (s *resourceInstanceObjectSubgraph) HasCreateOrUpdateLeg() bool {
+	return s.addDesiredDep != nil
+}
+
+func (s *resourceInstanceObjectSubgraph) HasDeleteLeg() bool {
+	return s.addOrphanDep != nil
+}
+
+func (s *resourceInstanceObjectSubgraph) CreateOrUpdateCompletionRef() execgraph.AnyResultRef {
+	if !s.HasCreateOrUpdateLeg() {
+		// In this case valueRef is sometimes set to the prior state value as
+		// a way to resolve some awkward situations in a destroy-mode plan, but
+		// it doesn't represent completion in that case.
+		return nil
+	}
+	return s.valueRef
+}
+
+func (s *resourceInstanceObjectSubgraph) DeletionRef() execgraph.AnyResultRef {
+	return s.deletionRef
+}
+
+func (s *resourceInstanceObjectSubgraph) CreateOrUpdateDependsOn(r execgraph.AnyResultRef) {
+	if s.addDesiredDep == nil {
+		panic("attempt to add creation or updating dependency for object that has no create/update leg")
+	}
+	s.addDesiredDep(r)
+}
+
+func (s *resourceInstanceObjectSubgraph) DeleteDependsOn(r execgraph.AnyResultRef) {
+	if s.addOrphanDep == nil {
+		panic("attempt to add deletion dependency for object that has no deletion leg")
+	}
+	s.addOrphanDep(r)
 }

--- a/internal/tofu/context_apply2_test.go
+++ b/internal/tofu/context_apply2_test.go
@@ -194,7 +194,7 @@ func TestContext2Apply_createBeforeDestroy_dependsNonCBDUpdate(t *testing.T) {
 }
 
 func TestContext2Apply_destroyWithDataSourceExpansion(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDestroy, ExperimentalBugStateProvider)
+	SkipExperimental(t, ExperimentalBugDataResource)
 
 	// While managed resources store their destroy-time dependencies, data
 	// sources do not. This means that if a provider were only included in a

--- a/internal/tofu/context_plan_test.go
+++ b/internal/tofu/context_plan_test.go
@@ -4760,13 +4760,6 @@ func TestContext2Plan_actionInteractions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%s then %s", test.WantActions[0], test.WantActions[1]), func(t *testing.T) {
-			if test.WantActions[0] == plans.DeleteThenCreate && test.WantActions[1] == plans.Update {
-				// The experimental new runtime doesn't currently handle this
-				// interaction correctly, producing an execution graph where
-				// the two resources end up mutually-dependent on each other.
-				SkipExperimental(t, ExperimentalBugCircularReference)
-			}
-
 			cfg := testModuleInline(t, map[string]string{
 				"main.tf": test.Config,
 			})


### PR DESCRIPTION
The `create_before_destroy` feature unfortunately requires some additional complexity in execgraph construction to make sure we can create all of the necessary supporting edges between resource instance subgraphs for different combinations of replace orders and in situations where replace and non-replace actions interact between dependencies.

I believe that the logic here is a faithful translation of the ultimate effect of the traditional runtime's logic that was spread across both `DestroyEdgeTransformer` and `CBDEdgeTransformer`, but instead of the confusing old approach where it first constructs an incorrect graph and then tries to fix it up after the fact, here we check for all of the relevant interactions up front to create only the actually-needed edges in the first place.

This set of rules was historically pretty hard to follow and maintain, but for this new implementation I've tried to make it as easy as possible to follow when reading it linearly, including use of descriptively-named methods added to the `resourceInstanceObjectSubgraph` type so that hopefully a future maintainer can use this also as a sort of "executable pseudocode" to understand the logic without getting distracted by all of the internal mechanics.

For now the correctness of this is being confirmed only by the existing context tests in `package tofu`. In a future commit I intend to also add some unit tests to `package planning` to cover this, but for now our focus is on making more of the existing test suite pass, before we finalize how exactly to arrange the new code and then how to directly test it.

This fixes https://github.com/opentofu/opentofu/issues/4346, which is part of https://github.com/opentofu/opentofu/issues/3414.

---

This also includes a little renaming I did as a followup to the earlier work in https://github.com/opentofu/opentofu/pull/4361, improving the consistency of naming a little more, and introduces a previously-absent constraint in the execgraph to force successful planning of both the create and destroy legs of a replace before attempting to apply either of them. This constraint on ordering was already present for `CreateThenDelete` as a side-effect of how the deposing step works, but it's now also introduced to `DeleteThenCreate` for consistency across both.

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
