### PR TITLE
Release process: introduce manual step to sync get.opentofu.org

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,8 +1,9 @@
 name: Post-release
 
 on:
+  workflow_dispatch:
   release:
-    types: [published]
+    types: [created, published, edited, prereleased, released]
 
 jobs:
   redeploy:

--- a/CONTRIBUTING.RELEASE.md
+++ b/CONTRIBUTING.RELEASE.md
@@ -226,6 +226,25 @@ For point releases, simply copy the section from the [CHANGELOG.md](CHANGELOG.md
 
 ---
 
+## Redeploying get.opentofu.org
+
+After the release is published, `get.opentofu.org` needs to be redeployed so that the
+installer picks up the new version.
+
+> [!IMPORTANT]
+> This step must be done **after** clicking `Publish release` above. It does not happen
+> automatically: releases are created as drafts by `github-actions[bot]`, so the
+> `release` event does not reliably trigger the redeploy workflow on its own.
+
+1. Head to the [Actions tab](https://github.com/opentofu/opentofu/actions) on the main repository.
+2. Select the `Post-release` workflow on the left side.
+3. Click the `Run workflow` button and run it against the `main` branch.
+
+This invokes the Cloudflare deploy hook that redeploys `get.opentofu.org`. You no longer
+need to log into Cloudflare manually for this step.
+
+---
+
 ## Updating the website/documentation
 
 Depending on the release type, you will need to update the [opentofu.org](https://github.com/opentofu/opentofu.org) repository.


### PR DESCRIPTION
For some undocumented reason GitHub does not want to fire events for this workflow in the way we intended. Therefore we're going for a shotgun approach, and a manual backup.

This also re-instates some documentation into the release process about manually fixing get.opentofu.org but instead its now to trigger this workflow using workflow_dispatch instead.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.