### PR TITLE
addrs: SyncMap, and various other refactors

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -104,7 +104,7 @@ jobs:
       # it for select packages.
       - name: "Race detector"
         run: |
-          go test -race ./internal/tofu ./internal/command ./internal/states ./internal/providercache
+          go test -race ./internal/tofu ./internal/command ./internal/states ./internal/providercache ./internal/addrs
 
   e2e-tests:
     # This is an intentionally-limited form of our E2E test run which only

--- a/internal/addrs/module_call.go
+++ b/internal/addrs/module_call.go
@@ -91,6 +91,14 @@ func (c AbsModuleCall) UniqueKey() UniqueKey {
 
 func (mk absModuleCallInstanceKey) uniqueKeySigil() {}
 
+func (c AbsModuleCall) Noun() string {
+	return "module call"
+}
+
+func (c AbsModuleCall) ShortNoun() string {
+	return "call"
+}
+
 // ModuleCallInstance is the address of one instance of a module created from
 // a module call, which might create multiple instances using "count" or
 // "for_each" arguments.

--- a/internal/addrs/module_instance.go
+++ b/internal/addrs/module_instance.go
@@ -293,6 +293,14 @@ func (m ModuleInstance) UniqueKey() UniqueKey {
 
 func (mk moduleInstanceKey) uniqueKeySigil() {}
 
+func (m ModuleInstance) Noun() string {
+	return "module instance"
+}
+
+func (m ModuleInstance) ShortNoun() string {
+	return "instance"
+}
+
 // Equal returns true if the receiver and the given other value
 // contains the exact same parts.
 func (m ModuleInstance) Equal(o ModuleInstance) bool {

--- a/internal/addrs/moveable.go
+++ b/internal/addrs/moveable.go
@@ -19,6 +19,8 @@ type AbsMoveable interface {
 	UniqueKeyer
 
 	String() string
+	Noun() string
+	ShortNoun() string
 }
 
 // The following are all of the possible AbsMoveable address types:

--- a/internal/addrs/resource.go
+++ b/internal/addrs/resource.go
@@ -278,6 +278,14 @@ func (r AbsResource) UniqueKey() UniqueKey {
 	return absResourceKey(r.String())
 }
 
+func (r AbsResource) Noun() string {
+	return "resource"
+}
+
+func (r AbsResource) ShortNoun() string {
+	return "resource"
+}
+
 // AbsResourceInstance is an absolute address for a resource instance under a
 // given module path.
 type AbsResourceInstance struct {
@@ -418,6 +426,14 @@ func (r absResourceInstanceKey) uniqueKeySigil() {}
 
 func (r AbsResourceInstance) absMoveableSigil() {
 	// AbsResourceInstance is moveable
+}
+
+func (r AbsResourceInstance) Noun() string {
+	return "resource instance"
+}
+
+func (r AbsResourceInstance) ShortNoun() string {
+	return "instance"
 }
 
 // ConfigResource is an address for a resource within a configuration.

--- a/internal/addrs/sync_map.go
+++ b/internal/addrs/sync_map.go
@@ -1,0 +1,107 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package addrs
+
+import "sync"
+
+// SyncMap represents a concurrent mapping whose keys are address types that implement
+// UniqueKeyer.
+//
+// Since not all address types are comparable in the Go language sense, this
+// type cannot work with the typical Go map access syntax, and so instead has
+// a method-based syntax. Use this type only for situations where the key
+// type isn't guaranteed to always be a valid key for a standard Go map.
+//
+// This implementation is safe for concurrent use; however, we recommend
+// you use the Map[K,V] type in this package instead for any workload
+// that does not require concurrent safety when accessing the underlying
+// map data structure.
+type SyncMap[K UniqueKeyer, V any] struct {
+	// elems is the internal data structure of the map.
+	elems *sync.Map
+}
+
+func MakeSyncMap[K UniqueKeyer, V any](initialElems ...MapElem[K, V]) SyncMap[K, V] {
+	ret := SyncMap[K, V]{elems: &sync.Map{}}
+	for _, elem := range initialElems {
+		ret.Put(elem.Key, elem.Value)
+	}
+	return ret
+}
+
+// Put inserts a new element into the map, or replaces an existing element
+// which has an equivalent key.
+func (m SyncMap[K, V]) Put(key K, value V) {
+	realKey := key.UniqueKey()
+	m.elems.Store(realKey, MapElem[K, V]{key, value})
+}
+
+// PutElement is like Put but takes the key and value from the given MapElement
+// structure instead of as individual arguments.
+func (m SyncMap[K, V]) PutElement(elem MapElem[K, V]) {
+	m.Put(elem.Key, elem.Value)
+}
+
+// Remove deletes the element with the given key from the map, or does nothing
+// if there is no such element.
+func (m SyncMap[K, V]) Remove(key K) {
+	realKey := key.UniqueKey()
+	m.elems.Delete(realKey)
+}
+
+// Get returns the value of the element with the given key, or the zero value
+// of V if there is no such element.
+func (m SyncMap[K, V]) Get(key K) V {
+	realKey := key.UniqueKey()
+	elem, ok := m.elems.Load(realKey)
+	if !ok {
+		var ret V
+		return ret
+	}
+	return elem.(MapElem[K, V]).Value
+}
+
+// GetOk is like Get but additionally returns a flag for whether there was an
+// element with the given key present in the map.
+func (m SyncMap[K, V]) GetOk(key K) (V, bool) {
+	realKey := key.UniqueKey()
+	elem, ok := m.elems.Load(realKey)
+	if !ok {
+		var ret V
+		return ret, ok
+	}
+	return elem.(MapElem[K, V]).Value, ok
+}
+
+// Has returns true if and only if there is an element in the map which has the
+// given key.
+func (m SyncMap[K, V]) Has(key K) bool {
+	realKey := key.UniqueKey()
+	_, ok := m.elems.Load(realKey)
+	return ok
+}
+
+// Range calls f sequentially for each key and value present in the map.
+// If f returns false, range stops the iteration. Elements in the map
+// are visited in an unpredictable order.
+func (m SyncMap[K, V]) Range(f func(key K, value V) bool) {
+	m.elems.Range(func(_, v any) bool {
+		elem := v.(MapElem[K, V])
+		return f(elem.Key, elem.Value)
+	})
+}
+
+// keys returns a Set[K] containing a snapshot of the current keys of elements
+// of the map. Do not use this outside of tests...
+func (m SyncMap[K, V]) keys() Set[K] {
+	ret := make(Set[K])
+	m.Range(func(k K, _ V) bool {
+		realKey := k.UniqueKey()
+		ret[realKey] = k
+		return true
+	})
+	return ret
+}

--- a/internal/addrs/sync_map_test.go
+++ b/internal/addrs/sync_map_test.go
@@ -1,0 +1,124 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package addrs
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// Note: this is mostly identical to the Map test in
+// map_test.go
+func TestSyncMap(t *testing.T) {
+	variableName := InputVariable{Name: "name"}
+	localHello := LocalValue{Name: "hello"}
+	pathModule := PathAttr{Name: "module"}
+	moduleBeep := ModuleCall{Name: "beep"}
+	eachKey := ForEachAttr{Name: "key"} // intentionally not in the map
+
+	m := MakeSyncMap(
+		MakeMapElem[Referenceable](variableName, "Aisling"),
+	)
+
+	m.Put(localHello, "hello")
+	m.Put(pathModule, "boop")
+	m.Put(moduleBeep, "unrealistic")
+
+	keySet := m.keys()
+	if want := variableName; !m.Has(want) {
+		t.Errorf("map does not include %s", want)
+	}
+	if want := variableName; !keySet.Has(want) {
+		t.Errorf("key set does not include %s", want)
+	}
+	if want := localHello; !m.Has(want) {
+		t.Errorf("map does not include %s", want)
+	}
+	if want := localHello; !keySet.Has(want) {
+		t.Errorf("key set does not include %s", want)
+	}
+	if want := pathModule; !keySet.Has(want) {
+		t.Errorf("key set does not include %s", want)
+	}
+	if want := moduleBeep; !keySet.Has(want) {
+		t.Errorf("key set does not include %s", want)
+	}
+	if doNotWant := eachKey; m.Has(doNotWant) {
+		t.Errorf("map includes rogue element %s", doNotWant)
+	}
+	if doNotWant := eachKey; keySet.Has(doNotWant) {
+		t.Errorf("key set includes rogue element %s", doNotWant)
+	}
+
+	if got, want := m.Get(variableName), "Aisling"; got != want {
+		t.Errorf("unexpected value %q for %s; want %q", got, variableName, want)
+	}
+	if got, want := m.Get(localHello), "hello"; got != want {
+		t.Errorf("unexpected value %q for %s; want %q", got, localHello, want)
+	}
+	if got, want := m.Get(pathModule), "boop"; got != want {
+		t.Errorf("unexpected value %q for %s; want %q", got, pathModule, want)
+	}
+	if got, want := m.Get(moduleBeep), "unrealistic"; got != want {
+		t.Errorf("unexpected value %q for %s; want %q", got, moduleBeep, want)
+	}
+	if got, want := m.Get(eachKey), ""; got != want {
+		// eachKey isn't in the map, so Get returns the zero value of string
+		t.Errorf("unexpected value %q for %s; want %q", got, eachKey, want)
+	}
+
+	if v, ok := m.GetOk(variableName); v != "Aisling" || !ok {
+		t.Errorf("GetOk for %q returned incorrect result (%q, %#v)", variableName, v, ok)
+	}
+	if v, ok := m.GetOk(eachKey); v != "" || ok {
+		t.Errorf("GetOk for %q returned incorrect result (%q, %#v)", eachKey, v, ok)
+	}
+
+	m.Remove(moduleBeep)
+	if doNotWant := moduleBeep; m.Has(doNotWant) {
+		t.Errorf("map still includes %s after removing it", doNotWant)
+	}
+	if want := moduleBeep; !keySet.Has(want) {
+		t.Errorf("key set no longer includes %s after removing it from the map; key set is supposed to be a snapshot at the time of call", want)
+	}
+	keySet = m.keys()
+	if doNotWant := moduleBeep; keySet.Has(doNotWant) {
+		t.Errorf("key set still includes %s after a second call after removing it from the map", doNotWant)
+	}
+}
+
+func TestSyncMapConcurrency(t *testing.T) {
+	m := MakeSyncMap[AbsResourceInstance, int]()
+
+	// Spawn, like, 500 different abs addrs with different values
+	// and make sure they all end up having the right value each.
+	// We don't actually care that much about the value itself,
+	// more that no race condition or concurrent map error occurs
+	var wg sync.WaitGroup
+	for i := range 500 {
+		wg.Go(func() {
+			// spawn an abs addr here
+			m.Put(mustParseAbsResourceInstanceStr(fmt.Sprintf("test_resource.my_res[%d]", i)), i*i-i+1)
+		})
+	}
+	wg.Wait()
+
+	m.Range(func(addr AbsResourceInstance, x int) bool {
+		keyVal, ok := addr.Resource.Key.(IntKey)
+		if !ok {
+			t.Errorf("the address %s did not have an integer key", addr)
+			return false
+		}
+
+		y := int(keyVal)
+		if y*y-y+1 != x {
+			t.Errorf("wrong value in map: expected %d, got %d", y*y-y+1, x)
+			return false
+		}
+		return true
+	})
+}

--- a/internal/refactoring/move_statement_test.go
+++ b/internal/refactoring/move_statement_test.go
@@ -3,7 +3,7 @@
 // Copyright (c) 2023 HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package refactoring
+package refactoring_test
 
 import (
 	"bytes"
@@ -17,6 +17,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/refactoring"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
@@ -193,9 +194,9 @@ func TestImpliedMoveStatements(t *testing.T) {
 		)
 	})
 
-	explicitStmts := FindMoveStatements(rootCfg)
-	got := ImpliedMoveStatements(rootCfg, prevRunState, explicitStmts)
-	want := []MoveStatement{
+	explicitStmts := refactoring.FindMoveStatements(rootCfg)
+	got := refactoring.ImpliedMoveStatements(rootCfg, prevRunState, explicitStmts)
+	want := []refactoring.MoveStatement{
 		{
 			From:    addrs.ImpliedMoveStatementEndpoint(resourceAddr("formerly_count").Instance(addrs.IntKey(0)), tfdiags.SourceRange{}),
 			To:      addrs.ImpliedMoveStatementEndpoint(resourceAddr("formerly_count").Instance(addrs.NoKey), tfdiags.SourceRange{}),

--- a/internal/refactoring/move_validate.go
+++ b/internal/refactoring/move_validate.go
@@ -76,25 +76,8 @@ func ValidateMoves(stmts []MoveStatement, rootCfg *configs.Config, declaredInsts
 				continue
 			}
 
-			var noun string
-			var shortNoun string
-			switch absFrom.(type) {
-			case addrs.ModuleInstance:
-				noun = "module instance"
-				shortNoun = "instance"
-			case addrs.AbsModuleCall:
-				noun = "module call"
-				shortNoun = "call"
-			case addrs.AbsResourceInstance:
-				noun = "resource instance"
-				shortNoun = "instance"
-			case addrs.AbsResource:
-				noun = "resource"
-				shortNoun = "resource"
-			default:
-				// The above cases should cover all of the AbsMoveable types
-				panic("unsupported AbsMoveable address type")
-			}
+			noun := absFrom.Noun()
+			shortNoun := absFrom.ShortNoun()
 
 			// It's invalid to have a move statement whose "from" address
 			// refers to something that is still declared in the configuration.

--- a/internal/refactoring/move_validate_test.go
+++ b/internal/refactoring/move_validate_test.go
@@ -3,7 +3,7 @@
 // Copyright (c) 2023 HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package refactoring
+package refactoring_test
 
 import (
 	"context"
@@ -20,6 +20,7 @@ import (
 	"github.com/opentofu/opentofu/internal/configs/configload"
 	"github.com/opentofu/opentofu/internal/initwd"
 	"github.com/opentofu/opentofu/internal/instances"
+	"github.com/opentofu/opentofu/internal/refactoring"
 	"github.com/opentofu/opentofu/internal/registry"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
@@ -28,7 +29,7 @@ func TestValidateMoves(t *testing.T) {
 	rootCfg, instances := loadRefactoringFixture(t, "testdata/move-validate-zoo")
 
 	tests := map[string]struct {
-		Statements []MoveStatement
+		Statements []refactoring.MoveStatement
 		WantError  string
 	}{
 		"no move statements": {
@@ -36,7 +37,7 @@ func TestValidateMoves(t *testing.T) {
 			WantError:  ``,
 		},
 		"some valid statements": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				// This is just a grab bag of various valid cases that don't
 				// generate any errors at all.
 				makeTestMoveStmt(t,
@@ -113,7 +114,7 @@ func TestValidateMoves(t *testing.T) {
 			WantError: ``,
 		},
 		"two statements with the same endpoints": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestMoveStmt(t,
 					``,
 					`module.a`,
@@ -128,7 +129,7 @@ func TestValidateMoves(t *testing.T) {
 			WantError: ``,
 		},
 		"moving nowhere": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestMoveStmt(t,
 					``,
 					`module.a`,
@@ -138,7 +139,7 @@ func TestValidateMoves(t *testing.T) {
 			WantError: `Redundant move statement: This statement declares a move from module.a to the same address, which is the same as not declaring this move at all.`,
 		},
 		"cyclic chain": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestMoveStmt(t,
 					``,
 					`module.a`,
@@ -163,7 +164,7 @@ func TestValidateMoves(t *testing.T) {
 A chain of move statements must end with an address that doesn't appear in any other statements, and which typically also refers to an object still declared in the configuration.`,
 		},
 		"module.single as a call still exists in configuration": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestMoveStmt(t,
 					``,
 					`module.single`,
@@ -175,7 +176,7 @@ A chain of move statements must end with an address that doesn't appear in any o
 Change your configuration so that this call will be declared as module.other instead.`,
 		},
 		"module.single as an instance still exists in configuration": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestMoveStmt(t,
 					``,
 					`module.single`,
@@ -187,7 +188,7 @@ Change your configuration so that this call will be declared as module.other ins
 Change your configuration so that this instance will be declared as module.other[0] instead.`,
 		},
 		"module.count[0] still exists in configuration": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestMoveStmt(t,
 					``,
 					`module.count[0]`,
@@ -199,7 +200,7 @@ Change your configuration so that this instance will be declared as module.other
 Change your configuration so that this instance will be declared as module.other instead.`,
 		},
 		`module.for_each["a"] still exists in configuration`: {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestMoveStmt(t,
 					``,
 					`module.for_each["a"]`,
@@ -211,7 +212,7 @@ Change your configuration so that this instance will be declared as module.other
 Change your configuration so that this instance will be declared as module.other instead.`,
 		},
 		"test.single as a resource still exists in configuration": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestMoveStmt(t,
 					``,
 					`test.single`,
@@ -223,7 +224,7 @@ Change your configuration so that this instance will be declared as module.other
 Change your configuration so that this resource will be declared as test.other instead.`,
 		},
 		"test.single as an instance still exists in configuration": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestMoveStmt(t,
 					``,
 					`test.single`,
@@ -235,7 +236,7 @@ Change your configuration so that this resource will be declared as test.other i
 Change your configuration so that this instance will be declared as test.other[0] instead.`,
 		},
 		"module.single.test.single as a resource still exists in configuration": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestMoveStmt(t,
 					``,
 					`module.single.test.single`,
@@ -247,7 +248,7 @@ Change your configuration so that this instance will be declared as test.other[0
 Change your configuration so that this resource will be declared as test.other instead.`,
 		},
 		"module.single.test.single as a resource declared in module.single still exists in configuration": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestMoveStmt(t,
 					`single`,
 					`test.single`,
@@ -259,7 +260,7 @@ Change your configuration so that this resource will be declared as test.other i
 Change your configuration so that this resource will be declared as module.single.test.other instead.`,
 		},
 		"module.single.test.single as an instance still exists in configuration": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestMoveStmt(t,
 					``,
 					`module.single.test.single`,
@@ -271,7 +272,7 @@ Change your configuration so that this resource will be declared as module.singl
 Change your configuration so that this instance will be declared as test.other[0] instead.`,
 		},
 		"module.count[0].test.single still exists in configuration": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestMoveStmt(t,
 					``,
 					`module.count[0].test.single`,
@@ -283,7 +284,7 @@ Change your configuration so that this instance will be declared as test.other[0
 Change your configuration so that this resource will be declared as test.other instead.`,
 		},
 		"two different moves from test.nonexist": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestMoveStmt(t,
 					``,
 					`test.nonexist`,
@@ -300,7 +301,7 @@ Change your configuration so that this resource will be declared as test.other i
 Each resource can move to only one destination resource.`,
 		},
 		"two different moves to test.single": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestMoveStmt(t,
 					``,
 					`test.other1`,
@@ -317,7 +318,7 @@ Each resource can move to only one destination resource.`,
 Each resource can have moved from only one source resource.`,
 		},
 		"two different moves to module.count[0].test.single across two modules": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestMoveStmt(t,
 					``,
 					`test.other1`,
@@ -334,7 +335,7 @@ Each resource can have moved from only one source resource.`,
 Each resource can have moved from only one source resource.`,
 		},
 		"move from resource in another module package": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestMoveStmt(t,
 					``,
 					`module.fake_external.test.thing`,
@@ -344,7 +345,7 @@ Each resource can have moved from only one source resource.`,
 			WantError: ``,
 		},
 		"move to resource in another module package": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestMoveStmt(t,
 					``,
 					`test.thing`,
@@ -354,7 +355,7 @@ Each resource can have moved from only one source resource.`,
 			WantError: ``,
 		},
 		"move from module call in another module package": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestMoveStmt(t,
 					``,
 					`module.fake_external.module.a`,
@@ -364,7 +365,7 @@ Each resource can have moved from only one source resource.`,
 			WantError: ``,
 		},
 		"move to module call in another module package": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestMoveStmt(t,
 					``,
 					`module.a`,
@@ -374,7 +375,7 @@ Each resource can have moved from only one source resource.`,
 			WantError: ``,
 		},
 		"implied move from resource in another module package": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestImpliedMoveStmt(t,
 					``,
 					`module.fake_external.test.thing`,
@@ -385,7 +386,7 @@ Each resource can have moved from only one source resource.`,
 			WantError: ``,
 		},
 		"implied move to resource in another module package": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestImpliedMoveStmt(t,
 					``,
 					`test.thing`,
@@ -396,7 +397,7 @@ Each resource can have moved from only one source resource.`,
 			WantError: ``,
 		},
 		"implied move from module call in another module package": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestImpliedMoveStmt(t,
 					``,
 					`module.fake_external.module.a`,
@@ -407,7 +408,7 @@ Each resource can have moved from only one source resource.`,
 			WantError: ``,
 		},
 		"implied move to module call in another module package": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestImpliedMoveStmt(t,
 					``,
 					`module.a`,
@@ -418,7 +419,7 @@ Each resource can have moved from only one source resource.`,
 			WantError: ``,
 		},
 		"move to a call that refers to another module package": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestMoveStmt(t,
 					``,
 					`module.nonexist`,
@@ -428,7 +429,7 @@ Each resource can have moved from only one source resource.`,
 			WantError: ``, // This is okay because the call itself is not considered to be inside the package it refers to
 		},
 		"move to instance of a call that refers to another module package": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestMoveStmt(t,
 					``,
 					`module.nonexist`,
@@ -438,7 +439,7 @@ Each resource can have moved from only one source resource.`,
 			WantError: ``, // This is okay because the call itself is not considered to be inside the package it refers to
 		},
 		"resource type mismatch": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestMoveStmt(t, ``,
 					`test.nonexist1`,
 					`other.single`,
@@ -447,7 +448,7 @@ Each resource can have moved from only one source resource.`,
 			WantError: ``,
 		},
 		"resource instance type mismatch": {
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestMoveStmt(t, ``,
 					`test.nonexist1[0]`,
 					`other.single`,
@@ -457,7 +458,7 @@ Each resource can have moved from only one source resource.`,
 		},
 		"crossing nested statements": {
 			// overlapping nested moves will result in a cycle.
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestMoveStmt(t, ``,
 					`module.nonexist.test.single`,
 					`module.count[0].test.count[0]`,
@@ -477,7 +478,7 @@ A chain of move statements must end with an address that doesn't appear in any o
 			// we have to avoid a cycle because the nested moves appear in both
 			// the from and to address of the parent when only the module index
 			// is changing.
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestMoveStmt(t, `count`,
 					`test.count`,
 					`test.count[0]`,
@@ -492,7 +493,7 @@ A chain of move statements must end with an address that doesn't appear in any o
 			// we have to avoid a cycle because the nested moves appear in both
 			// the from and to address of the parent when only the module index
 			// is changing.
-			Statements: []MoveStatement{
+			Statements: []refactoring.MoveStatement{
 				makeTestMoveStmt(t, `count`,
 					`module.count`,
 					`module.count[0]`,
@@ -511,7 +512,7 @@ A chain of move statements must end with an address that doesn't appear in any o
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			gotDiags := ValidateMoves(test.Statements, rootCfg, instances)
+			gotDiags := refactoring.ValidateMoves(test.Statements, rootCfg, instances)
 
 			switch {
 			case test.WantError != "":
@@ -658,7 +659,7 @@ func staticPopulateExpanderResource(t *testing.T, moduleAddr addrs.ModuleInstanc
 	}
 }
 
-func makeTestMoveStmt(t *testing.T, moduleStr, fromStr, toStr string) MoveStatement {
+func makeTestMoveStmt(t *testing.T, moduleStr, fromStr, toStr string) refactoring.MoveStatement {
 	t.Helper()
 
 	module := addrs.RootModule
@@ -689,7 +690,7 @@ func makeTestMoveStmt(t *testing.T, moduleStr, fromStr, toStr string) MoveStatem
 		t.Fatalf("incompatible move endpoints")
 	}
 
-	return MoveStatement{
+	return refactoring.MoveStatement{
 		From: fromInModule,
 		To:   toInModule,
 		DeclRange: tfdiags.SourceRange{
@@ -700,7 +701,7 @@ func makeTestMoveStmt(t *testing.T, moduleStr, fromStr, toStr string) MoveStatem
 	}
 }
 
-func makeTestImpliedMoveStmt(t *testing.T, moduleStr, fromStr, toStr string) MoveStatement {
+func makeTestImpliedMoveStmt(t *testing.T, moduleStr, fromStr, toStr string) refactoring.MoveStatement {
 	t.Helper()
 	ret := makeTestMoveStmt(t, moduleStr, fromStr, toStr)
 	ret.Implied = true

--- a/internal/refactoring/remove_statement_test.go
+++ b/internal/refactoring/remove_statement_test.go
@@ -3,7 +3,7 @@
 // Copyright (c) 2023 HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package refactoring
+package refactoring_test
 
 import (
 	"testing"
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/refactoring"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
@@ -19,13 +20,13 @@ func TestGetEndpointsToRemove(t *testing.T) {
 	tests := []struct {
 		name        string
 		fixtureName string
-		want        []*RemoveStatement
+		want        []*refactoring.RemoveStatement
 		wantError   string
 	}{
 		{
 			name:        "Valid cases",
 			fixtureName: "testdata/remove-statement/valid-remove-statements",
-			want: []*RemoveStatement{
+			want: []*refactoring.RemoveStatement{
 				{
 					From: mustConfigResourceAddr("foo.basic_resource"),
 					DeclRange: tfdiags.SourceRange{
@@ -88,7 +89,7 @@ func TestGetEndpointsToRemove(t *testing.T) {
 		{
 			name:        "Error - resource block still exist",
 			fixtureName: "testdata/remove-statement/not-valid-resource-block-still-exist",
-			want: []*RemoveStatement{
+			want: []*refactoring.RemoveStatement{
 				{From: mustConfigResourceAddr("foo.basic_resource")},
 			},
 			wantError: `Removed resource block still exists: This statement declares a removal of the resource foo.basic_resource, but this resource block still exists in the configuration. Please remove the resource block.`,
@@ -96,20 +97,20 @@ func TestGetEndpointsToRemove(t *testing.T) {
 		{
 			name:        "Error - module block still exist",
 			fixtureName: "testdata/remove-statement/not-valid-module-block-still-exist",
-			want:        []*RemoveStatement{},
+			want:        []*refactoring.RemoveStatement{},
 			wantError:   `Removed module block still exists: This statement declares a removal of the module module.child, but this module block still exists in the configuration. Please remove the module block.`,
 		},
 		{
 			name:        "Error - nested resource block still exist",
 			fixtureName: "testdata/remove-statement/not-valid-nested-resource-block-still-exist",
-			want:        []*RemoveStatement{},
+			want:        []*refactoring.RemoveStatement{},
 			wantError:   `Removed resource block still exists: This statement declares a removal of the resource module.child.foo.basic_resource, but this resource block still exists in the configuration. Please remove the resource block.`,
 		}}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rootCfg, _ := loadRefactoringFixture(t, tt.fixtureName)
-			got, diags := FindRemoveStatements(rootCfg)
+			got, diags := refactoring.FindRemoveStatements(rootCfg)
 
 			if tt.wantError != "" {
 				if !diags.HasErrors() {

--- a/internal/tofu/context_plan.go
+++ b/internal/tofu/context_plan.go
@@ -778,6 +778,13 @@ func (c *Context) planWalk(ctx context.Context, config *configs.Config, prevRunS
 	var diags tfdiags.Diagnostics
 	log.Printf("[DEBUG] Building and walking plan graph for %s", opts.Mode)
 
+	// TEMP: Opt-in support for testing with the new experimental language
+	// runtime. Refer to backend_temp_new_runtime.go for more information.
+	if experimentalRuntimeEnabled() {
+		plan, moreDiags := c.newEnginePlan(ctx, config, prevRunState, opts)
+		return plan, diags.Append(moreDiags)
+	}
+
 	prevRunState = prevRunState.DeepCopy() // don't modify the caller's object when we process the moves
 	moveStmts, moveResults := c.prePlanFindAndApplyMoves(config, prevRunState)
 
@@ -789,13 +796,6 @@ func (c *Context) planWalk(ctx context.Context, config *configs.Config, prevRunS
 		// instances excluded by targeting then planning is likely to encounter
 		// strange problems that may lead to confusing error messages.
 		return nil, diags
-	}
-
-	// TEMP: Opt-in support for testing with the new experimental language
-	// runtime. Refer to backend_temp_new_runtime.go for more information.
-	if experimentalRuntimeEnabled() {
-		plan, moreDiags := c.newEnginePlan(ctx, config, prevRunState, opts)
-		return plan, diags.Append(moreDiags)
 	}
 
 	providerFunctionTracker := make(ProviderFunctionMapping)


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
This is a part of #4229

I have included three independent refactor-type commits in this pull request, as well as an implementation of a concurrency-safe map for moveable addresses. Rather than bundle this together with the move block implementation for the new engine, I've opted to include these for a separate review so that there's a lower cognitive load and greater focus for moved blocks.

Here are the refactors present:

- Rather than switching on type to get the noun/short noun of a moveable address type, I've added it to the interface. This is a much cleaner approach, and in my opinion it could stand to be done more often in the codebase.
- The new engine will be handling move statements. I've moved the experimental option to above where the current engine performs state surgery.
- The tests incidentally create an import cycle if left as-is. Fortunately, these test files only use public methods; I've switched them to a different package.

The last commit contains a straightforward rewrite of the `addrs.Map` type to use a `sync.Map` backing. I had already encountered concurrent map write errors when working with `ResultsMap` in the move block implementation, as I had expected. The `sync.Map` is designed for the use case of disjoint addresses being written to the map concurrently, which is precisely what we do in the new engine. I have already made an informal manual test of this map, and it appears to work splendidly.

I've added race condition testing to the `addrs` package, so that `addrs.SyncMap` is picked up and double-checked carefully.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.