### PR TITLE
planning+execgraph: A last little bit of cleanup for recent changes

### DIFF
--- a/internal/engine/internal/execgraph/builder.go
+++ b/internal/engine/internal/execgraph/builder.go
@@ -93,25 +93,47 @@ func (b *Builder) ConstantProviderInstAddr(addr addrs.AbsProviderInstanceCorrect
 	return ret
 }
 
+// ResourceInstanceDesired asks the evaluator for the desired state of the
+// resource instance that has the given address.
+//
+// This operation automatically blocks awaiting the results of any upstream
+// resource instances that the requested instance's configuration depends on,
+// and prevents execution of anything that depends on its result if there
+// are any evaluation errors, even if those errors originate upstream in one
+// of the configuration's dependencies and thus would get reported separately
+// by another return path.
 func (b *Builder) ResourceInstanceDesired(
 	addr ResultRef[addrs.AbsResourceInstance],
-	waitFor AnyResultRef,
 ) ResultRef[*eval.DesiredResourceInstance] {
-	waiter := b.ensureWaiterRef(waitFor)
 	return operationRef[*eval.DesiredResourceInstance](b, operationDesc{
 		opCode:   opResourceInstanceDesired,
-		operands: []AnyResultRef{addr, waiter},
+		operands: []AnyResultRef{addr},
 	})
 }
 
+// ResourceInstancePrior returns the prior state of the resource instance that
+// has the given address.
+//
+// If the instance has no current object in the prior state then this returns
+// an object whose value is null, but not that such an object is not an
+// acceptable input to all operations that accept resource instance results,
+// and we expect that the planning engine would just skip including this
+// operation completely for any resource instance which is known during planning
+// to have no prior state because it's being created.
+//
+// Because this operation just reads static values directly from the state, it
+// does not automatically block for the completion of changes for other resource
+// instances recorded as dependencies in the prior state. Instead we expect that
+// the planning engine would record those as explicit dependencies on a
+// subsequent call to [Builder.ManagedApply] or [Builder.ManagedPerformDepose]
+// so that we constrain the ordering only of the externally-visible changes
+// and not of internal-only work.
 func (b *Builder) ResourceInstancePrior(
 	addr ResultRef[addrs.AbsResourceInstance],
-	waitFor AnyResultRef,
 ) ResourceInstanceResultRef {
-	waiter := b.ensureWaiterRef(waitFor)
 	return operationRef[*exec.ResourceInstanceObject](b, operationDesc{
 		opCode:   opResourceInstancePrior,
-		operands: []AnyResultRef{addr, waiter},
+		operands: []AnyResultRef{addr},
 	})
 }
 
@@ -158,9 +180,10 @@ func (b *Builder) ManagedApply(
 	fallbackObj ResourceInstanceResultRef,
 	waitFor AnyResultRef,
 ) ResourceInstanceResultRef {
+	waiter := b.ensureWaiterRef(waitFor)
 	return operationRef[*exec.ResourceInstanceObject](b, operationDesc{
 		opCode:   opManagedApply,
-		operands: []AnyResultRef{finalPlan, fallbackObj, waitFor},
+		operands: []AnyResultRef{finalPlan, fallbackObj, waiter},
 	})
 }
 
@@ -223,10 +246,12 @@ func (b *Builder) ManagedChangeAddr(
 func (b *Builder) DataRead(
 	desiredInst ResultRef[*eval.DesiredResourceInstance],
 	plannedVal ResultRef[cty.Value],
+	waitFor AnyResultRef,
 ) ResourceInstanceResultRef {
+	waiter := b.ensureWaiterRef(waitFor)
 	return operationRef[*exec.ResourceInstanceObject](b, operationDesc{
 		opCode:   opDataRead,
-		operands: []AnyResultRef{desiredInst, plannedVal},
+		operands: []AnyResultRef{desiredInst, plannedVal, waiter},
 	})
 }
 

--- a/internal/engine/internal/execgraph/compiler_ops.go
+++ b/internal/engine/internal/execgraph/compiler_ops.go
@@ -23,7 +23,6 @@ import (
 func (c *compiler) compileOpResourceInstanceDesired(operands *compilerOperands) nodeExecuteRaw {
 	ops := c.ops
 	getInstAddr := nextOperand[addrs.AbsResourceInstance](operands)
-	waitForDeps := operands.OperandWaiter()
 	diags := operands.Finish()
 	c.diags = c.diags.Append(diags)
 	if diags.HasErrors() {
@@ -33,9 +32,6 @@ func (c *compiler) compileOpResourceInstanceDesired(operands *compilerOperands) 
 	return func(ctx context.Context) (any, bool, tfdiags.Diagnostics) {
 		var diags tfdiags.Diagnostics
 
-		if !waitForDeps(ctx) {
-			return nil, false, diags
-		}
 		instAddr, ok, moreDiags := getInstAddr(ctx)
 		diags = diags.Append(moreDiags)
 		if !ok {
@@ -65,7 +61,6 @@ func (c *compiler) compileOpResourceInstanceDesired(operands *compilerOperands) 
 func (c *compiler) compileOpResourceInstancePrior(operands *compilerOperands) nodeExecuteRaw {
 	ops := c.ops
 	getInstAddr := nextOperand[addrs.AbsResourceInstance](operands)
-	waitForDeps := operands.OperandWaiter()
 	diags := operands.Finish()
 	c.diags = c.diags.Append(diags)
 	if diags.HasErrors() {
@@ -75,9 +70,6 @@ func (c *compiler) compileOpResourceInstancePrior(operands *compilerOperands) no
 	return func(ctx context.Context) (any, bool, tfdiags.Diagnostics) {
 		var diags tfdiags.Diagnostics
 
-		if !waitForDeps(ctx) {
-			return nil, false, diags
-		}
 		instAddr, ok, moreDiags := getInstAddr(ctx)
 		diags = diags.Append(moreDiags)
 		if !ok {
@@ -333,6 +325,7 @@ func (c *compiler) compileOpManagedChangeAddr(operands *compilerOperands) nodeEx
 func (c *compiler) compileOpDataRead(operands *compilerOperands) nodeExecuteRaw {
 	getDesired := nextOperand[*eval.DesiredResourceInstance](operands)
 	getInitialPlanned := nextOperand[cty.Value](operands)
+	waitForDeps := operands.OperandWaiter()
 	diags := operands.Finish()
 	c.diags = c.diags.Append(diags)
 	if diags.HasErrors() {
@@ -341,6 +334,10 @@ func (c *compiler) compileOpDataRead(operands *compilerOperands) nodeExecuteRaw 
 	ops := c.ops
 
 	return func(ctx context.Context) (any, bool, tfdiags.Diagnostics) {
+		if !waitForDeps(ctx) {
+			return nil, false, diags
+		}
+
 		desired, ok, moreDiags := getDesired(ctx)
 		diags = diags.Append(moreDiags)
 		if !ok {

--- a/internal/engine/internal/execgraph/compiler_test.go
+++ b/internal/engine/internal/execgraph/compiler_test.go
@@ -58,8 +58,8 @@ func TestCompiler_resourceInstanceBasics(t *testing.T) {
 		"name": cty.StringVal("thingy"),
 	}))
 	instAddrResult := builder.ConstantResourceInstAddr(resourceInstAddr)
-	desiredInst := builder.ResourceInstanceDesired(instAddrResult, nil)
-	priorState := builder.ResourceInstancePrior(instAddrResult, nil)
+	desiredInst := builder.ResourceInstanceDesired(instAddrResult)
+	priorState := builder.ResourceInstancePrior(instAddrResult)
 	finalPlan := builder.ManagedFinalPlan(
 		desiredInst,
 		priorState,

--- a/internal/engine/internal/execgraph/graph_test.go
+++ b/internal/engine/internal/execgraph/graph_test.go
@@ -68,8 +68,8 @@ func TestGraphMarshalUnmarshalValid(t *testing.T) {
 					Name: "example",
 				}.Absolute(addrs.RootModuleInstance).Instance(addrs.NoKey)
 				instAddrResult := builder.ConstantResourceInstAddr(instAddr)
-				desiredInst := builder.ResourceInstanceDesired(instAddrResult, nil)
-				priorState := builder.ResourceInstancePrior(instAddrResult, nil)
+				desiredInst := builder.ResourceInstanceDesired(instAddrResult)
+				priorState := builder.ResourceInstancePrior(instAddrResult)
 				plannedVal := builder.ConstantValue(cty.ObjectVal(map[string]cty.Value{
 					"name": cty.StringVal("thingy"),
 				}))
@@ -91,8 +91,8 @@ func TestGraphMarshalUnmarshalValid(t *testing.T) {
 					"name": cty.StringVal("thingy"),
 				});
 
-				r[0] = ResourceInstanceDesired(test.example, await());
-				r[1] = ResourceInstancePrior(test.example, await());
+				r[0] = ResourceInstanceDesired(test.example);
+				r[1] = ResourceInstancePrior(test.example);
 				r[2] = ManagedFinalPlan(r[0], r[1], v[0]);
 				r[3] = ManagedApply(r[2], nil, await());
 
@@ -109,18 +109,18 @@ func TestGraphMarshalUnmarshalValid(t *testing.T) {
 					Name: "example",
 				}.Absolute(addrs.RootModuleInstance).Instance(addrs.NoKey)
 				instAddrResult := builder.ConstantResourceInstAddr(instAddr)
-				desiredInst := builder.ResourceInstanceDesired(instAddrResult, nil)
+				desiredInst := builder.ResourceInstanceDesired(instAddrResult)
 
 				plannedVal := builder.ConstantValue(cty.DynamicVal)
-				newState := builder.DataRead(desiredInst, plannedVal)
+				newState := builder.DataRead(desiredInst, plannedVal, nil)
 				builder.SetResourceInstanceFinalStateResult(instAddr, newState)
 				return builder.Finish()
 			},
 			`
 				v[0] = cty.UnknownVal(cty.DynamicPseudoType);
 
-				r[0] = ResourceInstanceDesired(data.test.example, await());
-				r[1] = DataRead(r[0], v[0]);
+				r[0] = ResourceInstanceDesired(data.test.example);
+				r[1] = DataRead(r[0], v[0], await());
 
 				data.test.example = r[1];
 			`,
@@ -139,10 +139,10 @@ func TestGraphMarshalUnmarshalValid(t *testing.T) {
 				}.Absolute(addrs.RootModuleInstance).Instance(addrs.NoKey)
 
 				plannedVal := builder.ConstantValue(cty.DynamicVal)
-				desiredInst1 := builder.ResourceInstanceDesired(builder.ConstantResourceInstAddr(instAddr1), nil)
-				newState1 := builder.DataRead(desiredInst1, plannedVal)
-				desiredInst2 := builder.ResourceInstanceDesired(builder.ConstantResourceInstAddr(instAddr2), builder.Waiter(newState1))
-				newState2 := builder.DataRead(desiredInst2, plannedVal)
+				desiredInst1 := builder.ResourceInstanceDesired(builder.ConstantResourceInstAddr(instAddr1))
+				newState1 := builder.DataRead(desiredInst1, plannedVal, nil)
+				desiredInst2 := builder.ResourceInstanceDesired(builder.ConstantResourceInstAddr(instAddr2))
+				newState2 := builder.DataRead(desiredInst2, plannedVal, builder.Waiter(newState1))
 				builder.SetResourceInstanceFinalStateResult(instAddr1, newState1)
 				builder.SetResourceInstanceFinalStateResult(instAddr2, newState2)
 				return builder.Finish()
@@ -150,10 +150,10 @@ func TestGraphMarshalUnmarshalValid(t *testing.T) {
 			`
 				v[0] = cty.UnknownVal(cty.DynamicPseudoType);
 
-				r[0] = ResourceInstanceDesired(data.test.example1, await());
-				r[1] = DataRead(r[0], v[0]);
-				r[2] = ResourceInstanceDesired(data.test.example2, await(r[1]));
-				r[3] = DataRead(r[2], v[0]);
+				r[0] = ResourceInstanceDesired(data.test.example1);
+				r[1] = DataRead(r[0], v[0], await());
+				r[2] = ResourceInstanceDesired(data.test.example2);
+				r[3] = DataRead(r[2], v[0], await(r[1]));
 
 				data.test.example1 = r[1];
 				data.test.example2 = r[3];

--- a/internal/engine/internal/execgraph/graph_unmarshal.go
+++ b/internal/engine/internal/execgraph/graph_unmarshal.go
@@ -148,33 +148,25 @@ func unmarshalOperationElem(protoOp *execgraphproto.Operation, prevResults []Any
 }
 
 func unmarshalOpResourceInstanceDesired(rawOperands []uint64, prevResults []AnyResultRef, builder *Builder) (AnyResultRef, error) {
-	if len(rawOperands) != 2 {
+	if len(rawOperands) != 1 {
 		return nil, fmt.Errorf("wrong number of operands (%d) for opResourceInstanceDesired", len(rawOperands))
 	}
 	addr, err := unmarshalGetPrevResultOf[addrs.AbsResourceInstance](prevResults, rawOperands[0])
 	if err != nil {
 		return nil, fmt.Errorf("invalid opResourceInstanceDesired addr: %w", err)
 	}
-	waitFor, err := unmarshalGetPrevResultWaiter(prevResults, rawOperands[1])
-	if err != nil {
-		return nil, fmt.Errorf("invalid opResourceInstanceDesired waitFor: %w", err)
-	}
-	return builder.ResourceInstanceDesired(addr, waitFor), nil
+	return builder.ResourceInstanceDesired(addr), nil
 }
 
 func unmarshalOpResourceInstancePrior(rawOperands []uint64, prevResults []AnyResultRef, builder *Builder) (AnyResultRef, error) {
-	if len(rawOperands) != 2 {
+	if len(rawOperands) != 1 {
 		return nil, fmt.Errorf("wrong number of operands (%d) for opResourceInstancePrior", len(rawOperands))
 	}
 	addr, err := unmarshalGetPrevResultOf[addrs.AbsResourceInstance](prevResults, rawOperands[0])
 	if err != nil {
 		return nil, fmt.Errorf("invalid opResourceInstancePrior addr: %w", err)
 	}
-	waitFor, err := unmarshalGetPrevResultWaiter(prevResults, rawOperands[1])
-	if err != nil {
-		return nil, fmt.Errorf("invalid opResourceInstancePrior waitFor: %w", err)
-	}
-	return builder.ResourceInstancePrior(addr, waitFor), nil
+	return builder.ResourceInstancePrior(addr), nil
 }
 
 func unmarshalOpManagedFinalPlan(rawOperands []uint64, prevResults []AnyResultRef, builder *Builder) (AnyResultRef, error) {
@@ -280,7 +272,7 @@ func unmarshalOpManagedChangeAddr(rawOperands []uint64, prevResults []AnyResultR
 }
 
 func unmarshalOpDataRead(rawOperands []uint64, prevResults []AnyResultRef, builder *Builder) (AnyResultRef, error) {
-	if len(rawOperands) != 2 {
+	if len(rawOperands) != 3 {
 		return nil, fmt.Errorf("wrong number of operands (%d) for opDataRead", len(rawOperands))
 	}
 	desiredInst, err := unmarshalGetPrevResultOf[*eval.DesiredResourceInstance](prevResults, rawOperands[0])
@@ -291,7 +283,11 @@ func unmarshalOpDataRead(rawOperands []uint64, prevResults []AnyResultRef, build
 	if err != nil {
 		return nil, fmt.Errorf("invalid opDataRead plannedVal: %w", err)
 	}
-	return builder.DataRead(desiredInst, plannedVal), nil
+	waitFor, err := unmarshalGetPrevResultWaiter(prevResults, rawOperands[2])
+	if err != nil {
+		return nil, fmt.Errorf("invalid opDataRead waitFor: %w", err)
+	}
+	return builder.DataRead(desiredInst, plannedVal, waitFor), nil
 }
 
 func unmarshalWaiterElem(protoWaiter *execgraphproto.Waiter, prevResults []AnyResultRef, builder *Builder) (AnyResultRef, error) {

--- a/internal/engine/planning/execgraph_managed.go
+++ b/internal/engine/planning/execgraph_managed.go
@@ -93,7 +93,7 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphCreate(
 	// Per the conventions in the old engine, After contains a marked value
 	unmarkedAfter, _ := plannedChange.After.UnmarkDeep()
 	plannedValRef := b.lower.ConstantValue(unmarkedAfter)
-	desiredInstRef := b.lower.ResourceInstanceDesired(instAddrRef, b.lower.Waiter())
+	desiredInstRef := b.lower.ResourceInstanceDesired(instAddrRef)
 	valueRef, addDesiredDep := b.managedResourceInstanceSubgraphPlanAndApply(
 		desiredInstRef,
 		execgraph.NilResultRef[*exec.ResourceInstanceObject](),
@@ -112,7 +112,7 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphUpdate(
 	// Per the conventions in the old engine, After contains a marked value
 	unmarkedAfter, _ := plannedChange.After.UnmarkDeep()
 	plannedValRef := b.lower.ConstantValue(unmarkedAfter)
-	desiredInstRef := b.lower.ResourceInstanceDesired(instAddrRef, b.lower.Waiter())
+	desiredInstRef := b.lower.ResourceInstanceDesired(instAddrRef)
 	valueRef, addDesiredDep := b.managedResourceInstanceSubgraphPlanAndApply(
 		desiredInstRef,
 		priorStateRef,
@@ -184,7 +184,7 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphDeleteOrForgetThenCrea
 	// Per the conventions in the old engine, After contains a marked value
 	unmarkedAfter, _ := plannedChange.After.UnmarkDeep()
 	plannedValRef := b.lower.ConstantValue(unmarkedAfter)
-	desiredInstRef := b.lower.ResourceInstanceDesired(instAddrRef, b.lower.Waiter())
+	desiredInstRef := b.lower.ResourceInstanceDesired(instAddrRef)
 
 	// We plan both the create and destroy parts of this process before we
 	// make any real changes, to reduce the risk that we'll be left in a
@@ -243,7 +243,7 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphCreateThenDelete(
 	// Per the conventions in the old engine, After contains a marked value
 	unmarkedAfter, _ := plannedChange.After.UnmarkDeep()
 	plannedValRef := b.lower.ConstantValue(unmarkedAfter)
-	desiredInstRef := b.lower.ResourceInstanceDesired(instAddrRef, b.lower.Waiter())
+	desiredInstRef := b.lower.ResourceInstanceDesired(instAddrRef)
 
 	// We plan both the create and destroy parts of this process before we
 	// make any real changes, to reduce the risk that we'll be left in a
@@ -360,7 +360,7 @@ func (b *execGraphBuilder) managedResourceInstanceChangeAddrAndPriorStateRefs(
 		return execgraph.NilResultRef[addrs.AbsResourceInstance](), stateRef
 	}
 	prevAddrRef := b.lower.ConstantResourceInstAddr(plannedChange.PrevRunAddr)
-	priorStateRef := b.lower.ResourceInstancePrior(prevAddrRef, b.lower.Waiter())
+	priorStateRef := b.lower.ResourceInstancePrior(prevAddrRef)
 	retAddrRef := prevAddrRef
 	retStateRef := priorStateRef
 	if !plannedChange.PrevRunAddr.Equal(plannedChange.Addr) {

--- a/internal/engine/planning/execgraph_managed.go
+++ b/internal/engine/planning/execgraph_managed.go
@@ -273,15 +273,23 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphCreateThenDelete(
 	deposedKey := b.lower.ConstantDeposedKey(b.makeDeposedKey(plannedChange.Addr))
 	destroyPlanRef = b.lower.ManagedPrepareDepose(destroyPlanRef, deposedKey)
 
+	// Unlike most subgraphs where we put all of the forced dependencies
+	// directly on the ManagedApply, for create-before-destroy we place them
+	// on ManagedPerformDepose so that we'll delay deposing the previous
+	// object until we're definitely ready to attempt creating the new
+	// object, so we can avoid being left with a deposed object and no
+	// current object. The ManagedApply operation should not have any
+	// dependencies that ManagedPerformDepose does not also have.
+	addCreateDep(createPlanRef) // don't depose unless we successfully create a plan
 	deposedObjRef := b.lower.ManagedPerformDepose(
 		priorStateRef,
 		destroyPlanRef,
-		b.lower.Waiter(createPlanRef),
+		desiredWaitFor,
 	)
 	createResultRef := b.lower.ManagedApply(
 		createPlanRef,
-		deposedObjRef, // will be restored as current if creation completely fails
-		desiredWaitFor,
+		deposedObjRef,    // will be restored as current if creation completely fails
+		b.lower.Waiter(), // forced dependencies are on ManagedPerformDeposed instead; see above
 		// Note that this "create" operation indirectly depends on planning
 		// the destroy action due to the deposedObjRef argument above, so we
 		// don't need an additional direct dependency on destroyPlanRef here.

--- a/internal/engine/planning/execgraph_managed_test.go
+++ b/internal/engine/planning/execgraph_managed_test.go
@@ -57,7 +57,7 @@ func TestExecGraphBuilder_ManagedResourceInstanceSubgraph(t *testing.T) {
 			`
 				v[0] = cty.EmptyObjectVal;
 				
-				r[0] = ResourceInstanceDesired(test.placeholder, await());
+				r[0] = ResourceInstanceDesired(test.placeholder);
 				r[1] = ManagedFinalPlan(r[0], nil, v[0]);
 				r[2] = ManagedApply(r[1], nil, await());
 
@@ -82,8 +82,8 @@ func TestExecGraphBuilder_ManagedResourceInstanceSubgraph(t *testing.T) {
 			`
 				v[0] = cty.StringVal("after");
 				
-				r[0] = ResourceInstancePrior(test.placeholder, await());
-				r[1] = ResourceInstanceDesired(test.placeholder, await());
+				r[0] = ResourceInstancePrior(test.placeholder);
+				r[1] = ResourceInstanceDesired(test.placeholder);
 				r[2] = ManagedFinalPlan(r[1], r[0], v[0]);
 				r[3] = ManagedApply(r[2], nil, await());
 
@@ -113,9 +113,9 @@ func TestExecGraphBuilder_ManagedResourceInstanceSubgraph(t *testing.T) {
 			`
 				v[0] = cty.StringVal("after");
 
-				r[0] = ResourceInstancePrior(test.old, await());
+				r[0] = ResourceInstancePrior(test.old);
 				r[1] = ManagedChangeAddr(r[0], test.placeholder);
-				r[2] = ResourceInstanceDesired(test.placeholder, await());
+				r[2] = ResourceInstanceDesired(test.placeholder);
 				r[3] = ManagedFinalPlan(r[2], r[1], v[0]);
 				r[4] = ManagedApply(r[3], nil, await());
 
@@ -140,7 +140,7 @@ func TestExecGraphBuilder_ManagedResourceInstanceSubgraph(t *testing.T) {
 			`
 				v[0] = cty.NullVal(cty.EmptyObject);
 				
-				r[0] = ResourceInstancePrior(test.placeholder, await());
+				r[0] = ResourceInstancePrior(test.placeholder);
 				r[1] = ManagedFinalPlan(nil, r[0], v[0]);
 				r[2] = ManagedApply(r[1], nil, await());
 
@@ -175,8 +175,8 @@ func TestExecGraphBuilder_ManagedResourceInstanceSubgraph(t *testing.T) {
 				v[0] = cty.StringVal("after");
 				v[1] = cty.NullVal(cty.String);
 				
-				r[0] = ResourceInstancePrior(test.placeholder, await());
-				r[1] = ResourceInstanceDesired(test.placeholder, await());
+				r[0] = ResourceInstancePrior(test.placeholder);
+				r[1] = ResourceInstanceDesired(test.placeholder);
 				r[2] = ManagedFinalPlan(r[1], nil, v[0]);
 				r[3] = ManagedFinalPlan(nil, r[0], v[1]);
 				r[4] = ManagedApply(r[3], nil, await(r[2]));
@@ -209,9 +209,9 @@ func TestExecGraphBuilder_ManagedResourceInstanceSubgraph(t *testing.T) {
 				v[0] = cty.StringVal("after");
 				v[1] = cty.NullVal(cty.String);
 
-				r[0] = ResourceInstancePrior(test.old, await());
+				r[0] = ResourceInstancePrior(test.old);
 				r[1] = ManagedChangeAddr(r[0], test.placeholder);
-				r[2] = ResourceInstanceDesired(test.placeholder, await());
+				r[2] = ResourceInstanceDesired(test.placeholder);
 				r[3] = ManagedFinalPlan(r[2], nil, v[0]);
 				r[4] = ManagedFinalPlan(nil, r[1], v[1]);
 				r[5] = ManagedApply(r[4], nil, await(r[3]));
@@ -239,8 +239,8 @@ func TestExecGraphBuilder_ManagedResourceInstanceSubgraph(t *testing.T) {
 				v[0] = cty.StringVal("after");
 				v[1] = cty.NullVal(cty.String);
 
-				r[0] = ResourceInstancePrior(test.placeholder, await());
-				r[1] = ResourceInstanceDesired(test.placeholder, await());
+				r[0] = ResourceInstancePrior(test.placeholder);
+				r[1] = ResourceInstanceDesired(test.placeholder);
 				r[2] = ManagedFinalPlan(r[1], nil, v[0]);
 				r[3] = ManagedFinalPlan(nil, r[0], v[1]);
 				r[4] = ManagedPrepareDepose(r[3], "00000001");
@@ -275,9 +275,9 @@ func TestExecGraphBuilder_ManagedResourceInstanceSubgraph(t *testing.T) {
 				v[0] = cty.StringVal("after");
 				v[1] = cty.NullVal(cty.String);
 
-				r[0] = ResourceInstancePrior(test.old, await());
+				r[0] = ResourceInstancePrior(test.old);
 				r[1] = ManagedChangeAddr(r[0], test.placeholder);
-				r[2] = ResourceInstanceDesired(test.placeholder, await());
+				r[2] = ResourceInstanceDesired(test.placeholder);
 				r[3] = ManagedFinalPlan(r[2], nil, v[0]);
 				r[4] = ManagedFinalPlan(nil, r[1], v[1]);
 				r[5] = ManagedPrepareDepose(r[4], "00000001");

--- a/internal/engine/planning/execgraph_resource.go
+++ b/internal/engine/planning/execgraph_resource.go
@@ -206,7 +206,7 @@ func ensureResourceInstanceObjectSubgraph(addr addrs.AbsResourceInstanceObject, 
 	// a minimum subgraph for it that only involves reading its prior state.
 	var resultRef execgraph.ResourceInstanceResultRef
 	if addr.IsCurrent() {
-		resultRef = b.lower.ResourceInstancePrior(b.lower.ConstantResourceInstAddr(addr.InstanceAddr), nil)
+		resultRef = b.lower.ResourceInstancePrior(b.lower.ConstantResourceInstAddr(addr.InstanceAddr))
 		b.lower.SetResourceInstanceFinalStateResult(addr.InstanceAddr, resultRef)
 	} else {
 		resultRef = b.lower.ManagedAlreadyDeposed(b.lower.ConstantResourceInstAddr(addr.InstanceAddr), b.lower.ConstantDeposedKey(addr.DeposedKey))


### PR DESCRIPTION
In https://github.com/opentofu/opentofu/pull/4361 we made the decision to put explicit waiters only on the operations that either directly perform or that rely on the results of externally-visible changes, and let all other operations (which rely only on transient in-memory state) just begin running whenever their main inputs become available.

However, that PR was focused mainly on simplifying in preparation for https://github.com/opentofu/opentofu/pull/4378 and so left a few things unresolved. This PR aims to finish that work with the following followups:

- During a create-before-destroy replace we have the extra step of "deposing" the previous object before we attempt to create the new one. That operation performs an externally-visible change in the sense that if execution stopped immediately after it then the final state snapshot would record that object as now being deposed.

    We need to avoid any situation where we could end up successfully running `ManagedPerformDepose` without then attempting to run `ManagedApply` for the creation leg, so for this action in particular we'll put the incoming dependencies on the `ManagedPerformDepose` operation instead of the `ManagedApply` operation and impose a new rule that the `ManagedApply` isn't allowed to depend on anything that the `ManagedPerformDepose` doesn't also depend on, and thus any time deposing succeeds we should definitely be able to attempt to apply.

    (Applying may still fail, but `ManagedApply` already contains some logic to handle that situation by restoring the deposed object back to current again.)

- `ResourceInstanceDesired` and `ResourceInstancePrior` no longer have explicit waiter arguments at all.

- `DataRead` now has an explicit waiter argument so that it can be scheduled relative to changes whose results it may then consume.

After these changes then, the only operations that support explicit waiters are `ManagedApply`, `ManagedPerformDepose`, and `DataRead`. Everything else just gets scheduled dynamically based on the readiness of its inputs, and in particular `ResourceInstanceDesired` internally blocks until the evaluator has enough information to evaluate the configuration and so it relies on the evaluator's internal expression graph, rather than the explicit execution graph, for its ordering constraints.

None of these changes are urgent but I just wanted to get these remaining quirks cleaned up because my next step will be to make some more significant changes to the signatures of some of these operations as part of introducing resource instance metadata as an explicit concept, and it'll be easier to read that diff if it doesn't also include all of these cleanups.

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

