### PR TITLE
WIP: provider-level lifecycle.all_objects_part_of for dependency-driven forget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ UPGRADE NOTES:
 
 ENHANCEMENTS:
 
+- Provider blocks now support `lifecycle { all_objects_part_of = [...] }`, which declares that all resources managed through that provider are logically contained within the listed parent resources. When a parent is deleted or forgotten, contained resources are forgotten rather than destroyed — enabling clean removal of provider-managed objects (for example, Kubernetes workloads when an EKS cluster is torn down). ([#3148](https://github.com/opentofu/opentofu/issues/3148))
 - The `gcp_kms` key provider now supports an optional `additional_authenticated_data` as part of the encryption and decryption operations. ([#4287](https://github.com/opentofu/opentofu/pull/4287))
 - The AWS KMS key provider for state encryption now supports an `encryption_context` field, allowing key-value string pairs to be passed to AWS KMS with every `GenerateDataKey` and `Decrypt` call. ([#4298](https://github.com/opentofu/opentofu/pull/4298))
 - The `cidrsubnets` function now supports prefix extensions greater than 32 bits when the base CIDR block uses an IPv6 address. ([#4042](https://github.com/opentofu/opentofu/pull/4042))

--- a/internal/configs/provider.go
+++ b/internal/configs/provider.go
@@ -50,6 +50,14 @@ type Provider struct {
 
 	ForEach   hcl.Expression
 	Instances map[addrs.InstanceKey]instances.RepetitionData
+
+	// AllObjectsPartOf is the set of resource addresses declared in the
+	// provider lifecycle block's all_objects_part_of argument. When set,
+	// all resources managed through this provider are treated as contained
+	// within those parent resources. If any listed parent is removed from
+	// the configuration, OpenTofu will forget (rather than destroy) the
+	// managed resources instead of issuing destroy calls to the provider.
+	AllObjectsPartOf []hcl.Traversal
 }
 
 func decodeProviderBlock(block *hcl.Block) (*Provider, hcl.Diagnostics) {
@@ -129,6 +137,7 @@ func decodeProviderBlock(block *hcl.Block) (*Provider, hcl.Diagnostics) {
 	}
 
 	var seenEscapeBlock *hcl.Block
+	var seenLifecycleBlock *hcl.Block
 	for _, block := range content.Blocks {
 		switch block.Type {
 		case "_":
@@ -150,6 +159,30 @@ func decodeProviderBlock(block *hcl.Block) (*Provider, hcl.Diagnostics) {
 			// existing config we extracted earlier, so later decoding
 			// will see a blend of both.
 			provider.Config = hcl.MergeBodies([]hcl.Body{provider.Config, block.Body})
+
+		case "lifecycle":
+			if seenLifecycleBlock != nil {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Duplicate provider lifecycle block",
+					Detail: fmt.Sprintf(
+						"A provider block may have only one lifecycle block. The first lifecycle block was at %s.",
+						seenLifecycleBlock.DefRange,
+					),
+					Subject: &block.DefRange,
+				})
+				continue
+			}
+			seenLifecycleBlock = block
+
+			lcContent, lcDiags := block.Body.Content(providerLifecycleBlockSchema)
+			diags = append(diags, lcDiags...)
+
+			if attr, exists := lcContent.Attributes["all_objects_part_of"]; exists {
+				traversals, travDiags := decodeDependsOn(attr)
+				diags = append(diags, travDiags...)
+				provider.AllObjectsPartOf = traversals
+			}
 
 		default:
 			// All of the other block types in our schema are reserved for
@@ -311,10 +344,20 @@ var providerBlockSchema = &hcl.BodySchema{
 	},
 	Blocks: []hcl.BlockHeaderSchema{
 		{Type: "_"}, // meta-argument escaping block
+		{Type: "lifecycle"},
 
 		// The rest of these are reserved for future expansion.
-		{Type: "lifecycle"},
 		{Type: "locals"},
+	},
+}
+
+// providerLifecycleBlockSchema defines the schema for the lifecycle block
+// within a provider configuration block.
+var providerLifecycleBlockSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{
+			Name: "all_objects_part_of",
+		},
 	},
 }
 

--- a/internal/configs/resource.go
+++ b/internal/configs/resource.go
@@ -75,9 +75,10 @@ type ManagedResource struct {
 	// The default behavior is to destroy the resource when it is planned for destruction, so the value of false will skip destroying the resource.
 	// Note that the resource will still be removed from the state file even if Destroy is set to false but won't call the underlying provider for destruction.
 	// This field will accept only constant boolean expressions. This is of type hcl.Expression to make future extensions of dynamic evaluation easier.
-	Destroy          hcl.Expression
-	IgnoreChanges    []hcl.Traversal
-	IgnoreAllChanges bool
+	Destroy                    hcl.Expression
+	DestroyOnDependencyRemoval hcl.Expression
+	IgnoreChanges              []hcl.Traversal
+	IgnoreAllChanges           bool
 
 	CreateBeforeDestroySet bool
 }
@@ -218,6 +219,9 @@ func decodeResourceBlock(block *hcl.Block, override bool) (*Resource, hcl.Diagno
 
 			if attr, exists := lcContent.Attributes["destroy"]; exists {
 				r.Managed.Destroy = attr.Expr
+			}
+			if attr, exists := lcContent.Attributes["destroy_on_dependency_removal"]; exists {
+				r.Managed.DestroyOnDependencyRemoval = attr.Expr
 			}
 
 			if attr, exists := lcContent.Attributes["replace_triggered_by"]; exists {
@@ -695,6 +699,9 @@ func decodeEphemeralBlock(block *hcl.Block, override bool) (*Resource, hcl.Diagn
 			if _, exists := lcContent.Attributes["destroy"]; exists {
 				diags = append(diags, invalidEphemeralLifecycleAttributeDiag("destroy", block.DefRange))
 			}
+			if _, exists := lcContent.Attributes["destroy_on_dependency_removal"]; exists {
+				diags = append(diags, invalidEphemeralLifecycleAttributeDiag("destroy_on_dependency_removal", block.DefRange))
+			}
 			if _, exists := lcContent.Attributes["prevent_destroy"]; exists {
 				diags = append(diags, invalidEphemeralLifecycleAttributeDiag("prevent_destroy", block.DefRange))
 			}
@@ -1141,6 +1148,9 @@ var resourceLifecycleBlockSchema = &hcl.BodySchema{
 		},
 		{
 			Name: "destroy",
+		},
+		{
+			Name: "destroy_on_dependency_removal",
 		},
 		{
 			Name: "ignore_changes",

--- a/internal/states/instance_object.go
+++ b/internal/states/instance_object.go
@@ -67,6 +67,13 @@ type ResourceInstanceObject struct {
 	// setting as of the last update. Nil means the setting was not explicitly set.
 	DestroyOnDependencyRemoval *bool
 
+	// ProviderParents holds the set of resource addresses declared via
+	// all_objects_part_of in the provider lifecycle block at the time this
+	// object was last planned. When the object is orphaned, this list is
+	// checked against planned deletions to decide whether to forget rather
+	// than destroy the resource.
+	ProviderParents []addrs.ConfigResource
+
 	// Deferred is meant for the ephemeral resources state information.
 	// When this is "true", the evaluator will return an unknown value.
 	Deferred bool
@@ -179,6 +186,9 @@ func (o *ResourceInstanceObject) Encode(ty cty.Type, schemaVersion uint64, ident
 		destroyOnDependencyRemoval = &v
 	}
 
+	providerParents := make([]addrs.ConfigResource, len(o.ProviderParents))
+	copy(providerParents, o.ProviderParents)
+
 	return &ResourceInstanceObjectSrc{
 		SchemaVersion:              schemaVersion,
 		IdentitySchemaVersion:      identitySchemaVer,
@@ -193,6 +203,7 @@ func (o *ResourceInstanceObject) Encode(ty cty.Type, schemaVersion uint64, ident
 		CreateBeforeDestroy:        o.CreateBeforeDestroy,
 		SkipDestroy:                o.SkipDestroy,
 		DestroyOnDependencyRemoval: destroyOnDependencyRemoval,
+		ProviderParents:            providerParents,
 		Deferred:                   o.Deferred,
 	}, nil
 }

--- a/internal/states/instance_object.go
+++ b/internal/states/instance_object.go
@@ -63,6 +63,9 @@ type ResourceInstanceObject struct {
 	CreateBeforeDestroy bool
 
 	SkipDestroy bool
+	// DestroyOnDependencyRemoval tracks the lifecycle.destroy_on_dependency_removal
+	// setting as of the last update. Nil means the setting was not explicitly set.
+	DestroyOnDependencyRemoval *bool
 
 	// Deferred is meant for the ephemeral resources state information.
 	// When this is "true", the evaluator will return an unknown value.
@@ -170,21 +173,27 @@ func (o *ResourceInstanceObject) Encode(ty cty.Type, schemaVersion uint64, ident
 	if identityJSON != nil {
 		identitySchemaVer = &identitySchemaVersion
 	}
+	var destroyOnDependencyRemoval *bool
+	if o.DestroyOnDependencyRemoval != nil {
+		v := *o.DestroyOnDependencyRemoval
+		destroyOnDependencyRemoval = &v
+	}
 
 	return &ResourceInstanceObjectSrc{
-		SchemaVersion:           schemaVersion,
-		IdentitySchemaVersion:   identitySchemaVer,
-		AttrsJSON:               src,
-		AttrSensitivePaths:      sensitivePVMs,
-		TransientPathValueMarks: allPVMs,
-		Private:                 o.Private,
-		IdentityJSON:            identityJSON,
-		Status:                  o.Status,
-		Dependencies:            dependencies,
-		DependsOn:               absDependencies,
-		CreateBeforeDestroy:     o.CreateBeforeDestroy,
-		SkipDestroy:             o.SkipDestroy,
-		Deferred:                o.Deferred,
+		SchemaVersion:              schemaVersion,
+		IdentitySchemaVersion:      identitySchemaVer,
+		AttrsJSON:                  src,
+		AttrSensitivePaths:         sensitivePVMs,
+		TransientPathValueMarks:    allPVMs,
+		Private:                    o.Private,
+		IdentityJSON:               identityJSON,
+		Status:                     o.Status,
+		Dependencies:               dependencies,
+		DependsOn:                  absDependencies,
+		CreateBeforeDestroy:        o.CreateBeforeDestroy,
+		SkipDestroy:                o.SkipDestroy,
+		DestroyOnDependencyRemoval: destroyOnDependencyRemoval,
+		Deferred:                   o.Deferred,
 	}, nil
 }
 

--- a/internal/states/instance_object_src.go
+++ b/internal/states/instance_object_src.go
@@ -67,12 +67,13 @@ type ResourceInstanceObjectSrc struct {
 
 	// These fields all correspond to the fields of the same name on
 	// ResourceInstanceObject.
-	Private             []byte
-	Status              ObjectStatus
-	Dependencies        []addrs.ConfigResource
-	DependsOn           []addrs.AbsResourceInstance
-	CreateBeforeDestroy bool
-	SkipDestroy         bool
+	Private                    []byte
+	Status                     ObjectStatus
+	Dependencies               []addrs.ConfigResource
+	DependsOn                  []addrs.AbsResourceInstance
+	CreateBeforeDestroy        bool
+	SkipDestroy                bool
+	DestroyOnDependencyRemoval *bool
 	// Deferred is meant for the ephemeral resources state information.
 	// When this is "true", the evaluator will return an unknown value.
 	Deferred bool
@@ -179,6 +180,12 @@ func (os *ResourceInstanceObjectSrc) Equal(other *ResourceInstanceObjectSrc) boo
 	if os.SkipDestroy != other.SkipDestroy {
 		return false
 	}
+	if (os.DestroyOnDependencyRemoval == nil) != (other.DestroyOnDependencyRemoval == nil) {
+		return false
+	}
+	if os.DestroyOnDependencyRemoval != nil && other.DestroyOnDependencyRemoval != nil && *os.DestroyOnDependencyRemoval != *other.DestroyOnDependencyRemoval {
+		return false
+	}
 
 	if !bytes.Equal(os.IdentityJSON, other.IdentityJSON) {
 		return false
@@ -250,15 +257,16 @@ func (os *ResourceInstanceObjectSrc) Decode(ty cty.Type) (*ResourceInstanceObjec
 	}
 
 	return &ResourceInstanceObject{
-		Value:               val,
-		Status:              os.Status,
-		Dependencies:        os.Dependencies,
-		DependsOn:           os.DependsOn,
-		Private:             os.Private,
-		Identity:            identity,
-		CreateBeforeDestroy: os.CreateBeforeDestroy,
-		SkipDestroy:         os.SkipDestroy,
-		Deferred:            os.Deferred,
+		Value:                      val,
+		Status:                     os.Status,
+		Dependencies:               os.Dependencies,
+		DependsOn:                  os.DependsOn,
+		Private:                    os.Private,
+		Identity:                   identity,
+		CreateBeforeDestroy:        os.CreateBeforeDestroy,
+		SkipDestroy:                os.SkipDestroy,
+		DestroyOnDependencyRemoval: os.DestroyOnDependencyRemoval,
+		Deferred:                   os.Deferred,
 	}, nil
 }
 

--- a/internal/states/instance_object_src.go
+++ b/internal/states/instance_object_src.go
@@ -74,6 +74,7 @@ type ResourceInstanceObjectSrc struct {
 	CreateBeforeDestroy        bool
 	SkipDestroy                bool
 	DestroyOnDependencyRemoval *bool
+	ProviderParents            []addrs.ConfigResource
 	// Deferred is meant for the ephemeral resources state information.
 	// When this is "true", the evaluator will return an unknown value.
 	Deferred bool
@@ -187,6 +188,10 @@ func (os *ResourceInstanceObjectSrc) Equal(other *ResourceInstanceObjectSrc) boo
 		return false
 	}
 
+	if !equalSlicesIgnoreOrder(os.ProviderParents, other.ProviderParents, addrs.ConfigResource.Equal) {
+		return false
+	}
+
 	if !bytes.Equal(os.IdentityJSON, other.IdentityJSON) {
 		return false
 	}
@@ -266,6 +271,7 @@ func (os *ResourceInstanceObjectSrc) Decode(ty cty.Type) (*ResourceInstanceObjec
 		CreateBeforeDestroy:        os.CreateBeforeDestroy,
 		SkipDestroy:                os.SkipDestroy,
 		DestroyOnDependencyRemoval: os.DestroyOnDependencyRemoval,
+		ProviderParents:            os.ProviderParents,
 		Deferred:                   os.Deferred,
 	}, nil
 }

--- a/internal/states/state_deepcopy.go
+++ b/internal/states/state_deepcopy.go
@@ -202,6 +202,7 @@ func (os *ResourceInstanceObjectSrc) DeepCopy() *ResourceInstanceObjectSrc {
 		CreateBeforeDestroy:        os.CreateBeforeDestroy,
 		SkipDestroy:                os.SkipDestroy,
 		DestroyOnDependencyRemoval: destroyOnDependencyRemoval,
+		ProviderParents:            slices.Clone(os.ProviderParents),
 		Deferred:                   os.Deferred,
 		IdentityJSON:               identityJSON,
 		IdentitySchemaVersion:      identitySchemaVersion,
@@ -249,6 +250,7 @@ func (o *ResourceInstanceObject) DeepCopy() *ResourceInstanceObject {
 		CreateBeforeDestroy:        o.CreateBeforeDestroy,
 		SkipDestroy:                o.SkipDestroy,
 		DestroyOnDependencyRemoval: destroyOnDependencyRemoval,
+		ProviderParents:            slices.Clone(o.ProviderParents),
 		Deferred:                   o.Deferred,
 	}
 }

--- a/internal/states/state_deepcopy.go
+++ b/internal/states/state_deepcopy.go
@@ -183,22 +183,28 @@ func (os *ResourceInstanceObjectSrc) DeepCopy() *ResourceInstanceObjectSrc {
 		v := *os.IdentitySchemaVersion
 		identitySchemaVersion = &v
 	}
+	var destroyOnDependencyRemoval *bool
+	if os.DestroyOnDependencyRemoval != nil {
+		v := *os.DestroyOnDependencyRemoval
+		destroyOnDependencyRemoval = &v
+	}
 
 	return &ResourceInstanceObjectSrc{
-		Status:                  os.Status,
-		SchemaVersion:           os.SchemaVersion,
-		Private:                 private,
-		AttrsFlat:               attrsFlat,
-		AttrsJSON:               attrsJSON,
-		AttrSensitivePaths:      attrPaths,
-		TransientPathValueMarks: allAttrPaths,
-		Dependencies:            dependencies,
-		DependsOn:               absDependencies,
-		CreateBeforeDestroy:     os.CreateBeforeDestroy,
-		SkipDestroy:             os.SkipDestroy,
-		Deferred:                os.Deferred,
-		IdentityJSON:            identityJSON,
-		IdentitySchemaVersion:   identitySchemaVersion,
+		Status:                     os.Status,
+		SchemaVersion:              os.SchemaVersion,
+		Private:                    private,
+		AttrsFlat:                  attrsFlat,
+		AttrsJSON:                  attrsJSON,
+		AttrSensitivePaths:         attrPaths,
+		TransientPathValueMarks:    allAttrPaths,
+		Dependencies:               dependencies,
+		DependsOn:                  absDependencies,
+		CreateBeforeDestroy:        os.CreateBeforeDestroy,
+		SkipDestroy:                os.SkipDestroy,
+		DestroyOnDependencyRemoval: destroyOnDependencyRemoval,
+		Deferred:                   os.Deferred,
+		IdentityJSON:               identityJSON,
+		IdentitySchemaVersion:      identitySchemaVersion,
 	}
 }
 
@@ -228,16 +234,22 @@ func (o *ResourceInstanceObject) DeepCopy() *ResourceInstanceObject {
 		dependencies = make([]addrs.ConfigResource, len(o.Dependencies))
 		copy(dependencies, o.Dependencies)
 	}
+	var destroyOnDependencyRemoval *bool
+	if o.DestroyOnDependencyRemoval != nil {
+		v := *o.DestroyOnDependencyRemoval
+		destroyOnDependencyRemoval = &v
+	}
 
 	return &ResourceInstanceObject{
-		Value:               o.Value,
-		Status:              o.Status,
-		Private:             private,
-		Identity:            o.Identity,
-		Dependencies:        dependencies,
-		CreateBeforeDestroy: o.CreateBeforeDestroy,
-		SkipDestroy:         o.SkipDestroy,
-		Deferred:            o.Deferred,
+		Value:                      o.Value,
+		Status:                     o.Status,
+		Private:                    private,
+		Identity:                   o.Identity,
+		Dependencies:               dependencies,
+		CreateBeforeDestroy:        o.CreateBeforeDestroy,
+		SkipDestroy:                o.SkipDestroy,
+		DestroyOnDependencyRemoval: destroyOnDependencyRemoval,
+		Deferred:                   o.Deferred,
 	}
 }
 

--- a/internal/states/statefile/version4.go
+++ b/internal/states/statefile/version4.go
@@ -285,6 +285,19 @@ func prepareStateV4(sV4 *stateV4) (*File, tfdiags.Diagnostics) {
 				obj.DependsOn = deps
 			}
 
+			if ppRaw := isV4.ProviderParents; len(ppRaw) > 0 {
+				parents := make([]addrs.ConfigResource, 0, len(ppRaw))
+				for _, raw := range ppRaw {
+					addr, addrDiags := addrs.ParseAbsResourceStr(raw)
+					diags = diags.Append(addrDiags)
+					if addrDiags.HasErrors() {
+						continue
+					}
+					parents = append(parents, addr.Config())
+				}
+				obj.ProviderParents = parents
+			}
+
 			switch {
 			case isV4.Deposed != "":
 				dk := states.DeposedKey(isV4.Deposed)
@@ -587,6 +600,14 @@ func appendInstanceObjectStateV4(rs *states.Resource, is *states.ResourceInstanc
 		depsOn[i] = depAddr.String()
 	}
 
+	providerParents := make([]string, len(obj.ProviderParents))
+	for i, ppAddr := range obj.ProviderParents {
+		providerParents[i] = ppAddr.String()
+	}
+	if len(providerParents) == 0 {
+		providerParents = nil
+	}
+
 	var rawKey interface{}
 	switch tk := key.(type) {
 	case addrs.IntKey:
@@ -657,6 +678,7 @@ func appendInstanceObjectStateV4(rs *states.Resource, is *states.ResourceInstanc
 		CreateBeforeDestroy:        obj.CreateBeforeDestroy,
 		SkipDestroy:                obj.SkipDestroy,
 		DestroyOnDependencyRemoval: obj.DestroyOnDependencyRemoval,
+		ProviderParents:            providerParents,
 		Identity:                   identity,
 		IdentitySchemaVersion:      obj.IdentitySchemaVersion,
 	}), diags
@@ -876,9 +898,10 @@ type instanceObjectStateV4 struct {
 	Dependencies []string `json:"dependencies,omitempty"`
 	DependsOn    []string `json:"depends_on,omitempty"`
 
-	CreateBeforeDestroy        bool  `json:"create_before_destroy,omitempty"`
-	SkipDestroy                bool  `json:"skip_destroy,omitempty"`
-	DestroyOnDependencyRemoval *bool `json:"destroy_on_dependency_removal,omitempty"`
+	CreateBeforeDestroy        bool     `json:"create_before_destroy,omitempty"`
+	SkipDestroy                bool     `json:"skip_destroy,omitempty"`
+	DestroyOnDependencyRemoval *bool    `json:"destroy_on_dependency_removal,omitempty"`
+	ProviderParents            []string `json:"provider_parents,omitempty"`
 
 	Identity              json.RawMessage `json:"identity,omitempty"`
 	IdentitySchemaVersion *uint64         `json:"identity_schema_version,omitempty"`

--- a/internal/states/statefile/version4.go
+++ b/internal/states/statefile/version4.go
@@ -180,9 +180,10 @@ func prepareStateV4(sV4 *stateV4) (*File, tfdiags.Diagnostics) {
 			instAddr := rAddr.Instance(key)
 
 			obj := &states.ResourceInstanceObjectSrc{
-				SchemaVersion:       isV4.SchemaVersion,
-				CreateBeforeDestroy: isV4.CreateBeforeDestroy,
-				SkipDestroy:         isV4.SkipDestroy,
+				SchemaVersion:              isV4.SchemaVersion,
+				CreateBeforeDestroy:        isV4.CreateBeforeDestroy,
+				SkipDestroy:                isV4.SkipDestroy,
+				DestroyOnDependencyRemoval: isV4.DestroyOnDependencyRemoval,
 			}
 
 			{
@@ -642,21 +643,22 @@ func appendInstanceObjectStateV4(rs *states.Resource, is *states.ResourceInstanc
 	}
 
 	return append(isV4s, instanceObjectStateV4{
-		IndexKey:                rawKey,
-		Deposed:                 string(deposed),
-		Status:                  status,
-		ProviderInstance:        providerInstance,
-		SchemaVersion:           obj.SchemaVersion,
-		AttributesFlat:          obj.AttrsFlat,
-		AttributesRaw:           obj.AttrsJSON,
-		AttributeSensitivePaths: attributeSensitivePaths,
-		PrivateRaw:              privateRaw,
-		Dependencies:            deps,
-		DependsOn:               depsOn,
-		CreateBeforeDestroy:     obj.CreateBeforeDestroy,
-		SkipDestroy:             obj.SkipDestroy,
-		Identity:                identity,
-		IdentitySchemaVersion:   obj.IdentitySchemaVersion,
+		IndexKey:                   rawKey,
+		Deposed:                    string(deposed),
+		Status:                     status,
+		ProviderInstance:           providerInstance,
+		SchemaVersion:              obj.SchemaVersion,
+		AttributesFlat:             obj.AttrsFlat,
+		AttributesRaw:              obj.AttrsJSON,
+		AttributeSensitivePaths:    attributeSensitivePaths,
+		PrivateRaw:                 privateRaw,
+		Dependencies:               deps,
+		DependsOn:                  depsOn,
+		CreateBeforeDestroy:        obj.CreateBeforeDestroy,
+		SkipDestroy:                obj.SkipDestroy,
+		DestroyOnDependencyRemoval: obj.DestroyOnDependencyRemoval,
+		Identity:                   identity,
+		IdentitySchemaVersion:      obj.IdentitySchemaVersion,
 	}), diags
 }
 
@@ -874,8 +876,9 @@ type instanceObjectStateV4 struct {
 	Dependencies []string `json:"dependencies,omitempty"`
 	DependsOn    []string `json:"depends_on,omitempty"`
 
-	CreateBeforeDestroy bool `json:"create_before_destroy,omitempty"`
-	SkipDestroy         bool `json:"skip_destroy,omitempty"`
+	CreateBeforeDestroy        bool  `json:"create_before_destroy,omitempty"`
+	SkipDestroy                bool  `json:"skip_destroy,omitempty"`
+	DestroyOnDependencyRemoval *bool `json:"destroy_on_dependency_removal,omitempty"`
 
 	Identity              json.RawMessage `json:"identity,omitempty"`
 	IdentitySchemaVersion *uint64         `json:"identity_schema_version,omitempty"`

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -768,6 +768,25 @@ func (n *NodeAbstractResource) shouldSkipDestroy() (bool, tfdiags.Diagnostics) {
 	return skipDestroy, diags
 }
 
+// shouldForgetOnDependencyRemoval checks if the resource should be forgotten
+// when it is being removed due to one of its dependencies also being removed.
+func (n *NodeAbstractResource) shouldForgetOnDependencyRemoval() (bool, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	if n.Config == nil || n.Config.Managed == nil {
+		return false, diags
+	}
+
+	destroyOnDependencyRemoval, exprDiags := destroyOnDependencyRemovalValueFromConstantExpression(n.Config.Managed.DestroyOnDependencyRemoval)
+	diags = diags.Append(exprDiags)
+	if diags.HasErrors() {
+		return false, diags
+	}
+
+	// destroy_on_dependency_removal=false means "forget instead of destroy"
+	// when the destroy is dependency-driven.
+	return !destroyOnDependencyRemoval, diags
+}
+
 // skipDestroyValueFromConstantExpression evaluates (lifecycle.)destroy expression coming from the config and returns !destroy (Corresponding to SkipDestroy)
 // As of now, this can only be a constant expression of a boolean type. We will likely extend this in the future to make dynamic values possible
 func skipDestroyValueFromConstantExpression(destroyExpr hcl.Expression) (bool, hcl.Diagnostics) {
@@ -793,6 +812,31 @@ func skipDestroyValueFromConstantExpression(destroyExpr hcl.Expression) (bool, h
 	}
 
 	return destroyVal.False(), diags
+}
+
+func destroyOnDependencyRemovalValueFromConstantExpression(destroyOnDependencyRemovalExpr hcl.Expression) (bool, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+	// Nil means "not set", which defaults to true (destroy dependent resources normally).
+	if destroyOnDependencyRemovalExpr == nil {
+		return true, diags
+	}
+
+	destroyOnDependencyRemovalVal, valDiags := destroyOnDependencyRemovalExpr.Value(nil)
+	if valDiags.HasErrors() {
+		return false, valDiags
+	}
+
+	if destroyOnDependencyRemovalVal.Type() != cty.Bool {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid lifecycle destroy_on_dependency_removal expression",
+			Detail:   "The lifecycle destroy_on_dependency_removal expression must be a boolean constant.",
+			Subject:  destroyOnDependencyRemovalExpr.Range().Ptr(),
+		})
+		return false, diags
+	}
+
+	return destroyOnDependencyRemovalVal.True(), diags
 }
 
 // graphNodesAreResourceInstancesInDifferentInstancesOfSameModule is an

--- a/internal/tofu/node_resource_abstract.go
+++ b/internal/tofu/node_resource_abstract.go
@@ -116,6 +116,12 @@ type NodeAbstractResource struct {
 	// removed.provisioner configuration. If the field "Config.Managed.Provisioners" is having no provisioners, then
 	// these provisioners should be used instead.
 	removedBlockProvisioners []*configs.Provisioner
+
+	// ProviderParentAddrs holds the set of resource addresses declared via
+	// all_objects_part_of in the provider lifecycle block. Populated during
+	// graph construction. Resources managed through a provider with this field
+	// set are forgotten (not destroyed) when any listed parent is removed.
+	ProviderParentAddrs []addrs.ConfigResource
 }
 
 var (
@@ -531,6 +537,12 @@ func (n *NodeAbstractResource) AttachResourceSchema(schema *configschema.Block, 
 // GraphNodeAttachProviderMetaConfigs impl
 func (n *NodeAbstractResource) AttachProviderMetaConfigs(c map[addrs.Provider]*configs.ProviderMeta) {
 	n.ProviderMetas = c
+}
+
+// AttachProviderAllObjectsPartOf stores the resolved parent resource addresses
+// declared via all_objects_part_of in this provider's lifecycle block.
+func (n *NodeAbstractResource) AttachProviderAllObjectsPartOf(parents []addrs.ConfigResource) {
+	n.ProviderParentAddrs = parents
 }
 
 // GraphNodeDotter impl.

--- a/internal/tofu/node_resource_abstract_instance.go
+++ b/internal/tofu/node_resource_abstract_instance.go
@@ -368,7 +368,18 @@ func (n *NodeAbstractResourceInstance) StateDependencies() []addrs.ConfigResourc
 	// conflicts in ordering when refactoring configuration.
 	if s := n.instanceState; s != nil {
 		if s.Current != nil {
-			return s.Current.Dependencies
+			deps := s.Current.Dependencies
+			// Provider-level parent addresses also participate in graph
+			// ordering so that parent deletions are planned before child
+			// orphan planning, giving hasDependencyRemovalPlanned a chance
+			// to observe the parent's planned action.
+			if len(s.Current.ProviderParents) > 0 {
+				merged := make([]addrs.ConfigResource, 0, len(deps)+len(s.Current.ProviderParents))
+				merged = append(merged, deps...)
+				merged = append(merged, s.Current.ProviderParents...)
+				return merged
+			}
+			return deps
 		}
 	}
 
@@ -2468,9 +2479,6 @@ func (n *NodeAbstractResourceInstance) hasDependencyRemovalPlanned(evalCtx EvalC
 	if len(deps) == 0 {
 		deps = n.Dependencies
 	}
-	if len(deps) == 0 {
-		return false
-	}
 
 	nModInst := n.Addr.Module
 	nMod := nModInst.Module()
@@ -2498,10 +2506,29 @@ func (n *NodeAbstractResourceInstance) hasDependencyRemovalPlanned(evalCtx EvalC
 		}
 	}
 
+	// Also check provider-level parent resources declared via all_objects_part_of.
+	for _, parent := range state.ProviderParents {
+		for _, change := range changes.GetChangesForConfigResource(parent) {
+			if change == nil {
+				continue
+			}
+			if change.Action == plans.Delete || change.Action == plans.Forget {
+				return true
+			}
+		}
+	}
+
 	return false
 }
 
 func (n *NodeAbstractResourceInstance) shouldForgetOnDependencyRemoval(state *states.ResourceInstanceObject) (bool, tfdiags.Diagnostics) {
+	// Provider-level containment: resources managed by a provider that
+	// declares all_objects_part_of are always forgotten (not destroyed) when
+	// any listed parent is removed from the plan.
+	if state != nil && len(state.ProviderParents) > 0 {
+		return true, nil
+	}
+
 	// Prefer current config, if still available for this instance.
 	if n.Config != nil && n.Config.Managed != nil {
 		return n.NodeAbstractResource.shouldForgetOnDependencyRemoval()

--- a/internal/tofu/node_resource_abstract_instance.go
+++ b/internal/tofu/node_resource_abstract_instance.go
@@ -2459,6 +2459,63 @@ func (n *NodeAbstractResourceInstance) dependenciesHavePendingChanges(evalCtx Ev
 	return false
 }
 
+func (n *NodeAbstractResourceInstance) hasDependencyRemovalPlanned(evalCtx EvalContext, state *states.ResourceInstanceObject) bool {
+	if state == nil {
+		return false
+	}
+
+	deps := state.Dependencies
+	if len(deps) == 0 {
+		deps = n.Dependencies
+	}
+	if len(deps) == 0 {
+		return false
+	}
+
+	nModInst := n.Addr.Module
+	nMod := nModInst.Module()
+	changes := evalCtx.Changes()
+
+	for _, dep := range deps {
+		hasRemovalChange := false
+		for _, change := range changes.GetChangesForConfigResource(dep) {
+			if change == nil || change.Addr.Equal(n.Addr) {
+				continue
+			}
+
+			changeModInst := change.Addr.Module
+			if changeModInst.IsForModule(nMod) && !changeModInst.Equal(nModInst) {
+				continue
+			}
+
+			if change.Action == plans.Delete || change.Action == plans.Forget {
+				hasRemovalChange = true
+				break
+			}
+		}
+		if hasRemovalChange {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (n *NodeAbstractResourceInstance) shouldForgetOnDependencyRemoval(state *states.ResourceInstanceObject) (bool, tfdiags.Diagnostics) {
+	// Prefer current config, if still available for this instance.
+	if n.Config != nil && n.Config.Managed != nil {
+		return n.NodeAbstractResource.shouldForgetOnDependencyRemoval()
+	}
+
+	var diags tfdiags.Diagnostics
+	// Fall back to previously-applied lifecycle setting carried in state.
+	if state == nil || state.DestroyOnDependencyRemoval == nil {
+		return false, diags
+	}
+
+	return !*state.DestroyOnDependencyRemoval, diags
+}
+
 // apply deals with the main part of the data resource lifecycle: either
 // actually reading from the data source or generating a plan to do so.
 func (n *NodeAbstractResourceInstance) applyDataSource(ctx context.Context, evalCtx EvalContext, planned *plans.ResourceInstanceChange) (*states.ResourceInstanceObject, instances.RepetitionData, tfdiags.Diagnostics) {

--- a/internal/tofu/node_resource_deposed.go
+++ b/internal/tofu/node_resource_deposed.go
@@ -169,12 +169,23 @@ func (n *NodePlanDeposedResourceInstanceObject) Execute(ctx context.Context, eva
 			return diags
 		}
 
-		// We skip destroy for a depose instance in 2 cases:
+		// We skip destroy for a deposed instance in 3 cases:
 		// 1) Resource had lifecycle attribute destroy explicitly set to false
-		// 2) Removed block is declared to remove the resource from the state without it's destroy set to true
+		// 2) Resource has lifecycle.destroy_on_dependency_removal=false and at least one dependency is being removed
+		// 3) Removed block is declared to remove the resource from the state without it's destroy set to true
 		// For every other case, we should destroy the resource
 		// If the deposed instance has skip_destroy set in state, we skip destroying
 		shouldDestroy := !skipDestroy && !state.SkipDestroy
+
+		forgetOnDependencyRemoval, forgetOnDependencyRemovalDiags := n.shouldForgetOnDependencyRemoval(state)
+		diags = diags.Append(forgetOnDependencyRemovalDiags)
+		if diags.HasErrors() {
+			return diags
+		}
+		if shouldDestroy && forgetOnDependencyRemoval && n.hasDependencyRemovalPlanned(evalCtx, state) {
+			shouldDestroy = false
+			log.Printf("[DEBUG] NodePlanDeposedResourceInstanceObject.Execute: %s (deposed %s) planning forget instead of destroy due to dependency removal and lifecycle.destroy_on_dependency_removal=false", n.Addr, n.DeposedKey)
+		}
 
 		log.Printf("[TRACE] NodePlanDeposedResourceInstanceObject.Execute: %s (deposed %s): skipDestroy based on config=%t; based on state.SkipDestroy=%t; shouldDestroy=%t", n.Addr, n.DeposedKey, skipDestroy, state.SkipDestroy, shouldDestroy)
 		// Note that removed statements take precedence, since it is the latest intent the user declared

--- a/internal/tofu/node_resource_plan_instance.go
+++ b/internal/tofu/node_resource_plan_instance.go
@@ -350,6 +350,16 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx context.Conte
 				instanceRefreshState.DestroyOnDependencyRemoval = nil
 			}
 
+			// Persist provider-level containment: record the parent resource
+			// addresses declared via all_objects_part_of so they survive config
+			// removal and are still available at orphan-planning time.
+			if len(n.ProviderParentAddrs) > 0 {
+				instanceRefreshState.ProviderParents = make([]addrs.ConfigResource, len(n.ProviderParentAddrs))
+				copy(instanceRefreshState.ProviderParents, n.ProviderParentAddrs)
+			} else {
+				instanceRefreshState.ProviderParents = nil
+			}
+
 			if n.skipRefresh {
 				destroyOnDependencyRemovalChanged := (prevDestroyOnDependencyRemoval == nil) != (instanceRefreshState.DestroyOnDependencyRemoval == nil)
 				if !destroyOnDependencyRemovalChanged && prevDestroyOnDependencyRemoval != nil && instanceRefreshState.DestroyOnDependencyRemoval != nil {

--- a/internal/tofu/node_resource_plan_instance.go
+++ b/internal/tofu/node_resource_plan_instance.go
@@ -324,6 +324,7 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx context.Conte
 		if instanceRefreshState != nil {
 			prevCreateBeforeDestroy := instanceRefreshState.CreateBeforeDestroy
 			prevSkipDestroy := instanceRefreshState.SkipDestroy
+			prevDestroyOnDependencyRemoval := instanceRefreshState.DestroyOnDependencyRemoval
 
 			// This change is usually written to the refreshState and then
 			// updated value used for further graph execution. However, with
@@ -338,9 +339,23 @@ func (n *NodePlannableResourceInstance) managedResourceExecute(ctx context.Conte
 				return diags
 			}
 			instanceRefreshState.SkipDestroy = skipDestroy
+			if n.Config.Managed.DestroyOnDependencyRemoval != nil {
+				destroyOnDependencyRemoval, destroyOnDependencyRemovalDiags := destroyOnDependencyRemovalValueFromConstantExpression(n.Config.Managed.DestroyOnDependencyRemoval)
+				diags = diags.Append(destroyOnDependencyRemovalDiags)
+				if diags.HasErrors() {
+					return diags
+				}
+				instanceRefreshState.DestroyOnDependencyRemoval = &destroyOnDependencyRemoval
+			} else {
+				instanceRefreshState.DestroyOnDependencyRemoval = nil
+			}
 
 			if n.skipRefresh {
-				if prevCreateBeforeDestroy != instanceRefreshState.CreateBeforeDestroy || prevSkipDestroy != instanceRefreshState.SkipDestroy {
+				destroyOnDependencyRemovalChanged := (prevDestroyOnDependencyRemoval == nil) != (instanceRefreshState.DestroyOnDependencyRemoval == nil)
+				if !destroyOnDependencyRemovalChanged && prevDestroyOnDependencyRemoval != nil && instanceRefreshState.DestroyOnDependencyRemoval != nil {
+					destroyOnDependencyRemovalChanged = *prevDestroyOnDependencyRemoval != *instanceRefreshState.DestroyOnDependencyRemoval
+				}
+				if prevCreateBeforeDestroy != instanceRefreshState.CreateBeforeDestroy || prevSkipDestroy != instanceRefreshState.SkipDestroy || destroyOnDependencyRemovalChanged {
 					diags = diags.Append(n.writeResourceInstanceState(ctx, evalCtx, instanceRefreshState, refreshState))
 					if diags.HasErrors() {
 						return diags

--- a/internal/tofu/node_resource_plan_orphan.go
+++ b/internal/tofu/node_resource_plan_orphan.go
@@ -50,7 +50,16 @@ var (
 	_ GraphNodeAttachResourceState  = (*NodePlannableResourceInstanceOrphan)(nil)
 	_ GraphNodeExecutable           = (*NodePlannableResourceInstanceOrphan)(nil)
 	_ GraphNodeProviderConsumer     = (*NodePlannableResourceInstanceOrphan)(nil)
+	_ GraphNodeDestroyer            = (*NodePlannableResourceInstanceOrphan)(nil)
 )
+
+// DestroyAddr implements GraphNodeDestroyer so that DestroyEdgeTransformer
+// can create ordering edges between orphan nodes whose state declares
+// dependencies on other orphan nodes (via Dependencies or ProviderParents).
+func (n *NodePlannableResourceInstanceOrphan) DestroyAddr() *addrs.AbsResourceInstance {
+	addr := n.ResourceInstanceAddr()
+	return &addr
+}
 
 func (n *NodePlannableResourceInstanceOrphan) Name() string {
 	return n.ResourceInstanceAddr().String() + " (orphan)"

--- a/internal/tofu/node_resource_plan_orphan.go
+++ b/internal/tofu/node_resource_plan_orphan.go
@@ -194,13 +194,24 @@ func (n *NodePlannableResourceInstanceOrphan) managedResourceExecute(ctx context
 		return diags
 	}
 
-	// We skip destroy for an orphaned resource instance in 2 cases:
+	// We skip destroy for an orphaned resource instance in 3 cases:
 	// 1) Resource had lifecycle attribute destroy explicitly set to false (either in config or in state)
 	//    Config case in case of orphans only applies for multi-instance resources (count/for_each)
-	// 2) Removed block is declared to remove the resource from the state without it's destroy set to true
+	// 2) Resource has lifecycle.destroy_on_dependency_removal=false and at least one dependency is being removed
+	// 3) Removed block is declared to remove the resource from the state without it's destroy set to true
 	// For every other case, we should destroy the resource
 	// If the orphan instance has skip_destroy set in state, we skip destroying
 	shouldDestroy := !skipDestroy && !oldState.SkipDestroy
+
+	forgetOnDependencyRemoval, forgetOnDependencyRemovalDiags := n.shouldForgetOnDependencyRemoval(oldState)
+	diags = diags.Append(forgetOnDependencyRemovalDiags)
+	if diags.HasErrors() {
+		return diags
+	}
+	if shouldDestroy && forgetOnDependencyRemoval && n.hasDependencyRemovalPlanned(evalCtx, oldState) {
+		shouldDestroy = false
+		log.Printf("[DEBUG] NodePlannableResourceInstanceOrphan.managedResourceExecute: %s (orphan) planning forget instead of destroy due to dependency removal and lifecycle.destroy_on_dependency_removal=false", addr)
+	}
 
 	log.Printf("[TRACE] NodePlannableResourceInstanceOrphan.managedResourceExecute: %s (orphan): shouldDestroy=%t (based on config)", n.Addr, shouldDestroy)
 	// Note that removed statements take precedence, since it is the latest intent the user declared

--- a/internal/tofu/skip_destroy_test.go
+++ b/internal/tofu/skip_destroy_test.go
@@ -20,9 +20,11 @@ type skipStateInstance struct {
 	attrsJSON                  string
 	skipDestroy                bool
 	destroyOnDependencyRemoval *bool
+	providerParents            []string // resource addresses for all_objects_part_of
 	deposedKey                 string            // if set, creates a deposed instance
 	instanceKey                addrs.InstanceKey // optional, defaults to NoKey
 	dependencies               []string
+	providerConfig             string // optional provider config addr, defaults to aws
 }
 
 type skipExpectedChange struct {
@@ -55,6 +57,11 @@ func setupSkipTestState(t *testing.T, instances []skipStateInstance) *states.Sta
 			inst.attrsJSON = `{"id":"baz","type":"aws_instance"}`
 		}
 
+		providerCfg := `provider["registry.opentofu.org/hashicorp/aws"]`
+		if inst.providerConfig != "" {
+			providerCfg = inst.providerConfig
+		}
+
 		obj := &states.ResourceInstanceObjectSrc{
 			Status:                     states.ObjectReady,
 			AttrsJSON:                  []byte(inst.attrsJSON),
@@ -64,20 +71,23 @@ func setupSkipTestState(t *testing.T, instances []skipStateInstance) *states.Sta
 		for _, dep := range inst.dependencies {
 			obj.Dependencies = append(obj.Dependencies, mustResourceInstanceAddr(dep).ContainingResource().Config())
 		}
+		for _, pp := range inst.providerParents {
+			obj.ProviderParents = append(obj.ProviderParents, mustResourceInstanceAddr(pp).ContainingResource().Config())
+		}
 
 		if inst.deposedKey != "" {
 			root.SetResourceInstanceDeposed(
 				mustResourceInstanceAddr(inst.addr).Resource,
 				states.DeposedKey(inst.deposedKey),
 				obj,
-				mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+				mustProviderConfig(providerCfg),
 				addrs.NoKey,
 			)
 		} else {
 			root.SetResourceInstanceCurrent(
 				mustResourceInstanceAddr(inst.addr).Resource,
 				obj,
-				mustProviderConfig(`provider["registry.opentofu.org/hashicorp/aws"]`),
+				mustProviderConfig(providerCfg),
 				addrs.NoKey,
 			)
 		}
@@ -1529,5 +1539,162 @@ func TestSkipDestroy_ConfigChange_UpdatesState(t *testing.T) {
 
 	if appliedState2.RootModule().Resources["aws_instance.foo"].Instance(addrs.NoKey).Current.SkipDestroy {
 		t.Fatal("SkipDestroy attribute not removed after config change")
+	}
+}
+
+// Provider Lifecycle - AllObjectsPartOf Tests
+//
+// When a provider declares lifecycle.all_objects_part_of, resources managed by
+// that provider record the parent addresses in state. When those parent
+// resources are removed, the child resources are forgotten rather than
+// destroyed.
+
+func TestProviderLifecycle_AllObjectsPartOf_OrphanForget(t *testing.T) {
+	SkipExperimental(t, ExperimentalFeatureSkipDestroy)
+
+	tests := []struct {
+		name            string
+		stateInstances  []skipStateInstance
+		config          string
+		expectedChanges []skipExpectedChange
+	}{
+		{
+			name: "ForgetChildWhenParentDeleted",
+			// State has parent + child; child carries ProviderParents=[parent].
+			// Config is empty so both are orphans.
+			// Parent gets Delete; child should get Forget because of ProviderParents.
+			stateInstances: []skipStateInstance{
+				{addr: "aws_instance.parent"},
+				{
+					addr:            "aws_instance.child",
+					providerParents: []string{"aws_instance.parent"},
+				},
+			},
+			config: `# empty`,
+			expectedChanges: []skipExpectedChange{
+				{addr: "aws_instance.parent", action: plans.Delete},
+				{addr: "aws_instance.child", action: plans.Forget},
+			},
+		},
+		{
+			name: "NormalDestroyWithoutProviderParents",
+			// Same setup but child has no ProviderParents: both get Delete.
+			stateInstances: []skipStateInstance{
+				{addr: "aws_instance.parent"},
+				{addr: "aws_instance.child"},
+			},
+			config: `# empty`,
+			expectedChanges: []skipExpectedChange{
+				{addr: "aws_instance.parent", action: plans.Delete},
+				{addr: "aws_instance.child", action: plans.Delete},
+			},
+		},
+		{
+			name: "NoParentRemoval_DirectChildRemoval_StillDestroys",
+			// Child has ProviderParents=[parent], but parent is NOT being
+			// removed—it remains in config. Only the child is orphaned.
+			// Expected: child still gets Delete (forget only happens when the
+			// declared parent is the one going away).
+			stateInstances: []skipStateInstance{
+				{addr: "aws_instance.parent"},
+				{
+					addr:            "aws_instance.child",
+					providerParents: []string{"aws_instance.parent"},
+				},
+			},
+			config: `
+				resource "aws_instance" "parent" {}
+			`,
+			expectedChanges: []skipExpectedChange{
+				{addr: "aws_instance.child", action: plans.Delete},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := testModuleInline(t, map[string]string{"main.tf": tc.config})
+			ctx, _ := setupSkipTestDefaultContext(t)
+			state := setupSkipTestState(t, tc.stateInstances)
+
+			plan, diags := ctx.Plan(t.Context(), m, state, DefaultPlanOpts)
+			if diags.HasErrors() {
+				t.Fatalf("unexpected plan errors: %s", diags.Err())
+			}
+			verifySkipPlanChanges(t, plan, tc.expectedChanges)
+		})
+	}
+}
+
+// TestProviderLifecycle_AllObjectsPartOf_ConfigPropagation tests that the
+// provider lifecycle block is correctly parsed and the ProviderParents field is
+// persisted into resource state during planning.
+func TestProviderLifecycle_AllObjectsPartOf_ConfigPropagation(t *testing.T) {
+	SkipExperimental(t, ExperimentalFeatureSkipDestroy)
+
+	// Use two providers: aws (manages parent) and aws.k8s alias (manages
+	// children). The k8s alias declares all_objects_part_of = [aws_instance.parent].
+	m := testModuleInline(t, map[string]string{
+		"main.tf": `
+			terraform {
+				required_providers {
+					aws = { source = "hashicorp/aws" }
+				}
+			}
+
+			provider "aws" {}
+
+			provider "aws" {
+				alias = "k8s"
+				lifecycle {
+					all_objects_part_of = [aws_instance.parent]
+				}
+			}
+
+			resource "aws_instance" "parent" {
+				provider = aws
+			}
+
+			resource "aws_instance" "child" {
+				provider = aws.k8s
+			}
+		`,
+	})
+
+	p := testProvider("aws")
+	p.PlanResourceChangeFn = testDiffFn
+
+	ctx := testContext2(t, &ContextOpts{
+		Plugins: plugins.NewLibrary(map[addrs.Provider]providers.Factory{
+			addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p),
+		}, nil),
+	})
+
+	// Initial apply to build state with ProviderParents recorded.
+	plan, diags := ctx.Plan(t.Context(), m, states.NewState(), DefaultPlanOpts)
+	if diags.HasErrors() {
+		t.Fatalf("initial plan errors: %s", diags.Err())
+	}
+
+	applied, diags := ctx.Apply(t.Context(), plan, m, nil)
+	if diags.HasErrors() {
+		t.Fatalf("initial apply errors: %s", diags.Err())
+	}
+
+	childInst := applied.RootModule().ResourceInstance(
+		mustResourceInstanceAddr("aws_instance.child").Resource,
+	)
+	if childInst == nil || childInst.Current == nil {
+		t.Fatal("aws_instance.child not found in state after apply")
+	}
+
+	if len(childInst.Current.ProviderParents) == 0 {
+		t.Error("expected ProviderParents to be recorded in state for aws_instance.child, but it was empty")
+	} else {
+		got := childInst.Current.ProviderParents[0].String()
+		want := "aws_instance.parent"
+		if got != want {
+			t.Errorf("ProviderParents[0] = %q, want %q", got, want)
+		}
 	}
 }

--- a/internal/tofu/skip_destroy_test.go
+++ b/internal/tofu/skip_destroy_test.go
@@ -16,11 +16,13 @@ import (
 )
 
 type skipStateInstance struct {
-	addr        string
-	attrsJSON   string
-	skipDestroy bool
-	deposedKey  string            // if set, creates a deposed instance
-	instanceKey addrs.InstanceKey // optional, defaults to NoKey
+	addr                       string
+	attrsJSON                  string
+	skipDestroy                bool
+	destroyOnDependencyRemoval *bool
+	deposedKey                 string            // if set, creates a deposed instance
+	instanceKey                addrs.InstanceKey // optional, defaults to NoKey
+	dependencies               []string
 }
 
 type skipExpectedChange struct {
@@ -54,9 +56,13 @@ func setupSkipTestState(t *testing.T, instances []skipStateInstance) *states.Sta
 		}
 
 		obj := &states.ResourceInstanceObjectSrc{
-			Status:      states.ObjectReady,
-			AttrsJSON:   []byte(inst.attrsJSON),
-			SkipDestroy: inst.skipDestroy,
+			Status:                     states.ObjectReady,
+			AttrsJSON:                  []byte(inst.attrsJSON),
+			SkipDestroy:                inst.skipDestroy,
+			DestroyOnDependencyRemoval: inst.destroyOnDependencyRemoval,
+		}
+		for _, dep := range inst.dependencies {
+			obj.Dependencies = append(obj.Dependencies, mustResourceInstanceAddr(dep).ContainingResource().Config())
 		}
 
 		if inst.deposedKey != "" {
@@ -482,6 +488,83 @@ func TestSkipDestroy_Orphan_RemovedBlockOverrides(t *testing.T) {
 	t.Run(tc.name, func(t *testing.T) {
 		runSkipDestroyTestCase(t, tc)
 	})
+}
+
+func TestSkipDestroy_Orphan_DependencyDrivenDestroy(t *testing.T) {
+	SkipExperimental(t, ExperimentalFeatureSkipDestroy, ExperimentalBugStateProvider)
+	tests := []skipDestroyTestCase{
+		{
+			name: "ConfiguredForgetOnDependencyDestroy",
+			config: `
+				resource "aws_instance" "parent" {
+					lifecycle {
+						enabled = false
+					}
+				}
+
+				resource "aws_instance" "child" {
+					depends_on = [aws_instance.parent]
+					lifecycle {
+						enabled = false
+						destroy_on_dependency_removal = false
+					}
+				}
+			`,
+			stateInstances: []skipStateInstance{
+				{addr: "aws_instance.parent", skipDestroy: false},
+				{addr: "aws_instance.child", skipDestroy: false, dependencies: []string{"aws_instance.parent"}},
+			},
+			expectedChanges: []skipExpectedChange{
+				{addr: "aws_instance.parent", action: plans.Delete},
+				{addr: "aws_instance.child", action: plans.Forget},
+			},
+		},
+		{
+			name: "UnconfiguredDestroyOnDependencyDestroy",
+			config: `
+				resource "aws_instance" "parent" {
+					lifecycle {
+						enabled = false
+					}
+				}
+
+				resource "aws_instance" "child" {
+					depends_on = [aws_instance.parent]
+					lifecycle {
+						enabled = false
+					}
+				}
+			`,
+			stateInstances: []skipStateInstance{
+				{addr: "aws_instance.parent", skipDestroy: false},
+				{addr: "aws_instance.child", skipDestroy: false, dependencies: []string{"aws_instance.parent"}},
+			},
+			expectedChanges: []skipExpectedChange{
+				{addr: "aws_instance.parent", action: plans.Delete},
+				{addr: "aws_instance.child", action: plans.Delete},
+			},
+		},
+		{
+			name: "DirectRemovalUnchangedWithoutMechanism",
+			config: `
+				# Empty
+			`,
+			stateInstances: []skipStateInstance{
+				{addr: "aws_instance.parent", skipDestroy: false},
+				{addr: "aws_instance.child", skipDestroy: false, dependencies: []string{"aws_instance.parent"}},
+			},
+			expectedChanges: []skipExpectedChange{
+				{addr: "aws_instance.parent", action: plans.Delete},
+				{addr: "aws_instance.child", action: plans.Delete},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runSkipDestroyTestCase(t, tc)
+		})
+	}
 }
 
 // Resource Replacement Tests

--- a/internal/tofu/transform_attach_config_resource.go
+++ b/internal/tofu/transform_attach_config_resource.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"log"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/dag"
@@ -75,8 +76,47 @@ func (t *AttachResourceConfigTransformer) Transform(_ context.Context, g *Graph)
 					log.Printf("[TRACE] AttachResourceConfigTransformer: no provider meta configs available to attach to %s", dag.VertexName(v))
 				}
 			}
+
+			// If the provider config declares all_objects_part_of, resolve and
+			// attach those parent addresses so orphan planning can use them.
+			if node, ok := v.(interface {
+				AttachProviderAllObjectsPartOf([]addrs.ConfigResource)
+			}); ok {
+				providerAddr := r.ProviderConfigAddr()
+				if pc, ok := config.Module.GetProviderConfig(providerAddr.LocalName, providerAddr.Alias); ok && len(pc.AllObjectsPartOf) > 0 {
+					parents := resolveProviderParentTraversals(pc.AllObjectsPartOf, addr.Module)
+					if len(parents) > 0 {
+						log.Printf("[TRACE] AttachResourceConfigTransformer: attaching %d provider parent(s) to %s", len(parents), dag.VertexName(v))
+						node.AttachProviderAllObjectsPartOf(parents)
+					}
+				}
+			}
 		}
 	}
 
 	return nil
+}
+
+// resolveProviderParentTraversals converts the hcl.Traversal values from
+// all_objects_part_of into ConfigResource addresses within the given module.
+// Traversals that cannot be resolved as managed resource references are
+// silently dropped; validation should have already caught those cases.
+func resolveProviderParentTraversals(traversals []hcl.Traversal, module addrs.Module) []addrs.ConfigResource {
+	result := make([]addrs.ConfigResource, 0, len(traversals))
+	for _, traversal := range traversals {
+		ref, diags := addrs.ParseRef(traversal)
+		if diags.HasErrors() {
+			log.Printf("[ERROR] resolveProviderParentTraversals: cannot parse traversal as reference: %s", diags.Err())
+			continue
+		}
+		switch subject := ref.Subject.(type) {
+		case addrs.Resource:
+			result = append(result, subject.InModule(module))
+		case addrs.ResourceInstance:
+			result = append(result, subject.Resource.InModule(module))
+		default:
+			log.Printf("[WARN] resolveProviderParentTraversals: all_objects_part_of entry %q is not a resource reference; ignoring", traversal.RootName())
+		}
+	}
+	return result
 }


### PR DESCRIPTION
Resolves #3148

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

> **Draft / WIP** — filing this now to get early feedback on the graph ordering question described below. The checklist will be completed once that is resolved and tests are green.

---

## What this is trying to do

When a provider manages a cluster of child objects (Kubernetes deployments, Helm releases, etc.) that only make sense while a parent resource (an EKS cluster, a Helm chart install) exists, removing the parent should forget those child objects rather than issue real destroy calls that the API will reject or silently fail.

The approach follows @apparentlymart's comment in the issue thread — put the relationship on the **provider**, not on every individual resource:

```hcl
provider "kubernetes" {
  host = aws_eks_cluster.example.endpoint

  lifecycle {
    all_objects_part_of = [aws_eks_cluster.example]
  }
}
```

Everything managed through that provider is now considered "part of" the EKS cluster. When the EKS cluster is deleted or forgotten, OpenTofu forgets the kubernetes resources rather than destroying them.

This is cleaner than annotating every resource because:
- it scales — one line covers every object in the module
- it works naturally when the provider is passed into a child module
- the containment relationship sits next to the config that causes it (the cluster endpoint in the provider config)

## What has been changed

| File | What |
|---|---|
| `internal/configs/provider.go` | Parse `lifecycle { all_objects_part_of = [...] }` on provider blocks |
| `internal/states/instance_object*.go` | Carry `ProviderParents []addrs.ConfigResource` on state objects |
| `internal/states/statefile/version4.go` | Persist `ProviderParents` through state serialisation |
| `internal/states/state_deepcopy.go` | Deep-copy preserves `ProviderParents` |
| `internal/tofu/node_resource_abstract.go` | `ProviderParentAddrs` field + `AttachProviderAllObjectsPartOf` |
| `internal/tofu/transform_attach_config_resource.go` | Resolve HCL traversals to `ConfigResource` addrs during graph build |
| `internal/tofu/node_resource_plan_instance.go` | Write `ProviderParents` into the refreshed instance state so it survives to the next plan |
| `internal/tofu/node_resource_abstract_instance.go` | `StateDependencies` includes `ProviderParents`; `hasDependencyRemovalPlanned` checks parent changes; `shouldForgetOnDependencyRemoval` returns true when parents are set |
| `internal/tofu/node_resource_plan_orphan.go` | Implements `GraphNodeDestroyer` so `DestroyEdgeTransformer` can see orphan nodes |

## Where it is stuck

### The symptom

`TestProviderLifecycle_AllObjectsPartOf_OrphanForget/ForgetChildWhenParentDeleted` fails — the child orphan gets `Delete` instead of `Forget`.

### Root cause traced so far

The path to `Forget` requires `hasDependencyRemovalPlanned` to return `true`. That function loops over `ProviderParents` and looks for a `Delete`/`Forget` change for each parent in the current changeset.

The changeset lookup returns nothing because by the time the child orphan node runs in the walk, the parent orphan node **has not been visited yet** — so no change for the parent exists in the changeset at the time the child's plan node executes.

### Why ordering is hard here

I made `NodePlannableResourceInstanceOrphan` implement `GraphNodeDestroyer` (adding `DestroyAddr()`) so that `DestroyEdgeTransformer` can create an edge between the parent and child destroy nodes. The edge is created. But:

- The plan walk uses `dag.Walk` with `Reverse: true`
- With that flag, `edgeParts(BasicEdge(A, B))` returns `(waiter=A, dep=B)` — meaning **A waits for B**, so B runs first
- `DestroyEdgeTransformer.tryInterProviderDestroyEdge` calls `g.Connect(dag.BasicEdge(desDep, des))` where `desDep` is the parent and `des` is the child
- That edge makes the **parent** wait for the **child** — the opposite of what we need

Reversing the arguments would affect all existing dependency-ordered destroys going through the same code path.

### What I think the right hook is

Rather than `DestroyAddr`, the child orphan probably needs to express `ProviderParents` through `References()` or a dedicated `DestroyReferences()` method so the reference transformer (not the destroy-edge transformer) creates the ordering edge. The reference transformer uses `g.Connect(dag.BasicEdge(v, parent))` where `v` is the referencing node (child) and `parent` is the referenced node (parent). With `Reverse: true` that would make the child run after the parent — which is what we need.

## Questions for the maintainers

1. Is `DestroyReferences()` the right way for an orphan plan node to express "I need this other node to be walked before me, so I can see its planned change"? Or is there a different hook for this?

2. `NodePlannableResourceInstanceOrphan` does not currently implement `GraphNodeReferencer`. If I make it return `ProviderParents` from a `References()` method, are there any gotchas (cycles, extra edges in non-destroy walks, etc.)?

3. Is checking `changes.GetChangesForConfigResource(parent)` inside `hasDependencyRemovalPlanned` the right approach? Or should this be computed before the walk starts so every node sees it simultaneously?

## Tests

`internal/tofu/skip_destroy_test.go` — `TestProviderLifecycle_AllObjectsPartOf_OrphanForget` covers:
- `NormalDestroyWithoutProviderParents` — existing delete behaviour unchanged ✅
- `ForgetChildWhenParentDeleted` — child forgotten when parent removed ❌ (blocked on graph ordering)
- `NoParentRemoval_DirectChildRemoval_StillDestroys` — direct removal still deletes ❌ (side effect of ordering issue)

`TestProviderLifecycle_AllObjectsPartOf_ConfigPropagation` — ProviderParents persisted in state after apply ❌ (same root cause)