### PR TITLE
Reconstruct renderer output sensitivity

### DIFF
--- a/internal/backend/local/backend_plan_test.go
+++ b/internal/backend/local/backend_plan_test.go
@@ -224,6 +224,8 @@ Changes to Outputs:
   + added            = "after"
   ~ changed          = "before" -> "after"
   - removed          = "before" -> null
+  # Warning: this attribute value will be marked as sensitive and will not
+  # display in UI output after applying this change.
   ~ sensitive_after  = (sensitive value)
   ~ sensitive_before = (sensitive value)
 

--- a/internal/command/jsonformat/differ/output.go
+++ b/internal/command/jsonformat/differ/output.go
@@ -13,6 +13,13 @@ import (
 	"github.com/opentofu/opentofu/internal/command/jsonformat/structured"
 )
 
+// ComputeDiffForOutput computes the rendered diff for a single root output.
+//
+// Note: change.BeforeSensitive / change.AfterSensitive may legitimately
+// differ here (unlike the raw JSON plan) when this Change was constructed
+// from jsonplan.MarshalForRenderer's renderer-only sensitivity
+// reconstruction. checkForSensitiveType below already handles
+// before != after correctly via structured.Change.CheckForSensitive.
 func ComputeDiffForOutput(change structured.Change) computed.Diff {
 	if sensitive, ok := checkForSensitiveType(change, cty.DynamicPseudoType); ok {
 		return sensitive

--- a/internal/command/jsonformat/differ/output_test.go
+++ b/internal/command/jsonformat/differ/output_test.go
@@ -1,0 +1,95 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package differ
+
+import (
+	"testing"
+
+	"github.com/mitchellh/colorstring"
+
+	"github.com/opentofu/opentofu/internal/command/jsonformat/computed"
+	"github.com/opentofu/opentofu/internal/command/jsonformat/structured"
+	"github.com/opentofu/opentofu/internal/command/jsonformat/structured/attribute_path"
+)
+
+// noopColorize returns a colorstring.Colorize that strips color codes so that
+// test assertions can compare plain strings without ANSI escape sequences.
+func noopColorize() *colorstring.Colorize {
+	return &colorstring.Colorize{Colors: colorstring.DefaultColors, Disable: true, Reset: true}
+}
+
+// TestComputeDiffForOutput_SensitivityChange verifies that WarningsHuman fires
+// exactly when the sensitivity status actually changes between before and after.
+//
+// This tests the rendering layer fix for issue #2680: once
+// applyRendererOutputSensitivity has reconstructed distinct BeforeSensitive /
+// AfterSensitive values, ComputeDiffForOutput (via checkForSensitiveType) and
+// WarningsHuman must emit a warning if and only if the sensitivity changes.
+func TestComputeDiffForOutput_SensitivityChange(t *testing.T) {
+	tests := map[string]struct {
+		beforeSensitive interface{}
+		afterSensitive  interface{}
+		beforeValue     interface{}
+		afterValue      interface{}
+		wantWarning     bool
+	}{
+		"becomes sensitive — warning expected": {
+			beforeSensitive: false,
+			afterSensitive:  true,
+			beforeValue:     "hello",
+			afterValue:      "hello",
+			wantWarning:     true,
+		},
+		"no longer sensitive — warning expected": {
+			beforeSensitive: true,
+			afterSensitive:  false,
+			beforeValue:     "hello",
+			afterValue:      "hello",
+			wantWarning:     true,
+		},
+		"both sensitive, value unchanged — no warning": {
+			beforeSensitive: true,
+			afterSensitive:  true,
+			beforeValue:     "hello",
+			afterValue:      "hello",
+			wantWarning:     false,
+		},
+		"both not sensitive, value changes — no warning": {
+			beforeSensitive: false,
+			afterSensitive:  false,
+			beforeValue:     "old",
+			afterValue:      "new",
+			wantWarning:     false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			change := structured.Change{
+				Before:             tc.beforeValue,
+				BeforeExplicit:     true,
+				After:              tc.afterValue,
+				AfterExplicit:      true,
+				Unknown:            false,
+				BeforeSensitive:    tc.beforeSensitive,
+				AfterSensitive:     tc.afterSensitive,
+				ReplacePaths:       attribute_path.Empty(false),
+				RelevantAttributes: attribute_path.AlwaysMatcher(),
+			}
+
+			diff := ComputeDiffForOutput(change)
+
+			opts := computed.NewRenderHumanOpts(noopColorize(), false)
+			warnings := diff.WarningsHuman(0, opts)
+
+			gotWarning := len(warnings) > 0
+			if gotWarning != tc.wantWarning {
+				t.Errorf("WarningsHuman returned %d warning(s), wantWarning=%t\nwarnings: %v",
+					len(warnings), tc.wantWarning, warnings)
+			}
+		})
+	}
+}

--- a/internal/command/jsonformat/plan.go
+++ b/internal/command/jsonformat/plan.go
@@ -318,7 +318,12 @@ func renderHumanDiffOutputs(renderer Renderer, outputs map[string]computed.Diff)
 	for _, key := range keys {
 		output := outputs[key]
 		if output.Action != plans.NoOp {
-			rendered = append(rendered, fmt.Sprintf("%s %-*s = %s", renderer.Colorize.Color(renderers.DiffActionSymbol(output.Action)), escapedKeyMaxLen, escapedKeys[key], output.RenderHuman(0, computed.NewRenderHumanOpts(renderer.Colorize, renderer.ShowSensitive))))
+			opts := computed.NewRenderHumanOpts(renderer.Colorize, renderer.ShowSensitive)
+			for _, warning := range output.WarningsHuman(0, opts) {
+				rendered = append(rendered, warning)
+			}
+
+			rendered = append(rendered, fmt.Sprintf("%s %-*s = %s", renderer.Colorize.Color(renderers.DiffActionSymbol(output.Action)), escapedKeyMaxLen, escapedKeys[key], output.RenderHuman(0, opts)))
 		}
 	}
 	return strings.Join(rendered, "\n")

--- a/internal/command/jsonformat/plan.go
+++ b/internal/command/jsonformat/plan.go
@@ -319,10 +319,7 @@ func renderHumanDiffOutputs(renderer Renderer, outputs map[string]computed.Diff)
 		output := outputs[key]
 		if output.Action != plans.NoOp {
 			opts := computed.NewRenderHumanOpts(renderer.Colorize, renderer.ShowSensitive)
-			for _, warning := range output.WarningsHuman(0, opts) {
-				rendered = append(rendered, warning)
-			}
-
+			rendered = append(rendered, output.WarningsHuman(0, opts)...)
 			rendered = append(rendered, fmt.Sprintf("%s %-*s = %s", renderer.Colorize.Color(renderers.DiffActionSymbol(output.Action)), escapedKeyMaxLen, escapedKeys[key], output.RenderHuman(0, opts)))
 		}
 	}

--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -194,6 +194,12 @@ func MarshalForRenderer(
 		return nil, nil, nil, nil, err
 	}
 
+	// Reconstruct the real before/after sensitivity for root outputs on
+	// this renderer-only path. This does not affect Marshal or
+	// MarshalForLog, so the persisted/machine-readable JSON plan format
+	// is unaffected.
+	applyRendererOutputSensitivity(output.OutputChanges, p)
+
 	if output.ResourceChanges, err = MarshalResourceChanges(p.Changes.Resources, schemas); err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -309,6 +315,70 @@ func MarshalForLog(
 	}
 
 	return output, nil
+}
+
+// applyRendererOutputSensitivity reconstructs the real before/after
+// sensitivity for root outputs in the renderer-only output changes map.
+//
+// MarshalOutputChanges collapses output sensitivity to a single boolean
+// (oc.Sensitive) and writes it as both BeforeSensitive and AfterSensitive, so
+// the renderer cannot distinguish an output that is becoming sensitive from one
+// that is becoming non-sensitive. This helper corrects that by consulting
+// p.PrevRunState to obtain the sensitivity that was in effect before the plan
+// was generated.
+//
+// This function only modifies the in-memory map passed to the structured
+// renderer. Marshal and MarshalForLog are unaffected, so the
+// persisted/machine-readable JSON plan format is byte-for-byte identical to
+// what it was before.
+func applyRendererOutputSensitivity(outputChanges map[string]Change, p *plans.Plan) {
+	if p.Changes == nil || p.PrevRunState == nil {
+		return
+	}
+
+	rootModule := p.PrevRunState.RootModule()
+	if rootModule == nil {
+		return
+	}
+
+	for _, oc := range p.Changes.Outputs {
+		if !oc.Addr.Module.IsRoot() {
+			continue
+		}
+
+		name := oc.Addr.OutputValue.Name
+		change, ok := outputChanges[name]
+		if !ok {
+			continue
+		}
+
+		// The "after" sensitivity is what the plan says will be true once the
+		// change is applied — that is oc.Sensitive.
+		afterSensitive := oc.Sensitive
+
+		// The "before" sensitivity is the sensitivity that was recorded in the
+		// state snapshot taken before this plan walk began. If the output is
+		// not present in the prior state (e.g. it is being created), fall back
+		// to oc.Sensitive so that BeforeSensitive == AfterSensitive and no
+		// spurious warning is emitted.
+		beforeSensitive := oc.Sensitive
+		if prev, exists := rootModule.OutputValues[name]; exists {
+			beforeSensitive = prev.Sensitive
+		}
+
+		beforeJSON, err := ctyjson.Marshal(cty.BoolVal(beforeSensitive), cty.Bool)
+		if err != nil {
+			continue
+		}
+		afterJSON, err := ctyjson.Marshal(cty.BoolVal(afterSensitive), cty.Bool)
+		if err != nil {
+			continue
+		}
+
+		change.BeforeSensitive = json.RawMessage(beforeJSON)
+		change.AfterSensitive = json.RawMessage(afterJSON)
+		outputChanges[name] = change
+	}
 }
 
 // Marshal returns the json encoding of a tofu plan.

--- a/internal/command/jsonplan/plan_test.go
+++ b/internal/command/jsonplan/plan_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/lang/marks"
 	"github.com/opentofu/opentofu/internal/plans"
+	"github.com/opentofu/opentofu/internal/states"
 )
 
 func TestOmitUnknowns(t *testing.T) {
@@ -558,6 +559,104 @@ func TestGenerateChange(t *testing.T) {
 
 			if !cmp.Equal(change, test.expected) {
 				t.Errorf("wrong result:\n %v\n", cmp.Diff(change, test.expected))
+			}
+		})
+	}
+}
+
+// TestApplyRendererOutputSensitivity verifies that applyRendererOutputSensitivity
+// correctly reconstructs distinct before/after sensitivity for root outputs.
+//
+// This is a renderer-only code path: Marshal and MarshalForLog are not
+// affected, and the JSON plan format on disk remains byte-for-byte identical.
+func TestApplyRendererOutputSensitivity(t *testing.T) {
+	root := addrs.RootModuleInstance
+
+	// buildChanges creates a *plans.Changes with a single root output change.
+	buildChanges := func(name string, afterSensitive bool) *plans.Changes {
+		return &plans.Changes{
+			Outputs: []*plans.OutputChangeSrc{
+				{
+					Addr: root.OutputValue(name),
+					ChangeSrc: plans.ChangeSrc{
+						Action: plans.Update,
+					},
+					Sensitive: afterSensitive,
+				},
+			},
+		}
+	}
+
+	// buildPrevRunState returns a *states.State with the given output value
+	// and sensitivity already recorded.
+	buildPrevRunState := func(name string, sensitive bool) *states.State {
+		s := states.NewState()
+		ms := s.EnsureModule(root)
+		ms.SetOutputValue(name, cty.StringVal("hello"), sensitive, "")
+		return s
+	}
+
+	tests := map[string]struct {
+		name                string
+		prevSensitive       bool
+		afterSensitive      bool
+		wantBeforeSensitive json.RawMessage
+		wantAfterSensitive  json.RawMessage
+	}{
+		"becomes sensitive": {
+			name:                "myoutput",
+			prevSensitive:       false,
+			afterSensitive:      true,
+			wantBeforeSensitive: json.RawMessage("false"),
+			wantAfterSensitive:  json.RawMessage("true"),
+		},
+		"no longer sensitive": {
+			name:                "myoutput",
+			prevSensitive:       true,
+			afterSensitive:      false,
+			wantBeforeSensitive: json.RawMessage("true"),
+			wantAfterSensitive:  json.RawMessage("false"),
+		},
+		"unchanged sensitivity": {
+			name:                "myoutput",
+			prevSensitive:       true,
+			afterSensitive:      true,
+			wantBeforeSensitive: json.RawMessage("true"),
+			wantAfterSensitive:  json.RawMessage("true"),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			p := &plans.Plan{
+				Changes:      buildChanges(tc.name, tc.afterSensitive),
+				PrevRunState: buildPrevRunState(tc.name, tc.prevSensitive),
+			}
+
+			outputChanges, err := MarshalOutputChanges(p.Changes)
+			if err != nil {
+				t.Fatalf("MarshalOutputChanges: unexpected error: %s", err)
+			}
+
+			// Verify that MarshalOutputChanges itself (the machine-readable
+			// path) uses the same value for before and after — this is the
+			// existing behaviour and must not change.
+			rawChange := outputChanges[tc.name]
+			if !cmp.Equal(rawChange.BeforeSensitive, rawChange.AfterSensitive) {
+				t.Errorf("MarshalOutputChanges should produce identical BeforeSensitive and AfterSensitive, got before=%s after=%s",
+					rawChange.BeforeSensitive, rawChange.AfterSensitive)
+			}
+
+			// Now apply the renderer-only fix and verify the distinction is
+			// correctly reconstructed.
+			applyRendererOutputSensitivity(outputChanges, p)
+
+			got := outputChanges[tc.name]
+			if !cmp.Equal(got.BeforeSensitive, tc.wantBeforeSensitive) {
+				t.Errorf("BeforeSensitive: got %s, want %s", got.BeforeSensitive, tc.wantBeforeSensitive)
+			}
+			if !cmp.Equal(got.AfterSensitive, tc.wantAfterSensitive) {
+				t.Errorf("AfterSensitive:  got %s, want %s", got.AfterSensitive, tc.wantAfterSensitive)
 			}
 		})
 	}


### PR DESCRIPTION
Resolves #2680

Fix renderer-only sensitivity handling for root outputs. MarshalOutputChanges previously collapsed BeforeSensitive and AfterSensitive to the same value, preventing the renderer from detecting sensitivity changes; applyRendererOutputSensitivity restores distinct before/after values using PrevRunState so warnings are emitted when an output becomes or stops being sensitive. Also render sensitivity warnings before output lines. Adds tests for applyRendererOutputSensitivity and ComputeDiffForOutput sensitivity warnings. Machine-readable JSON plan format is unchanged.
   
  Checklist
  
  - [x] I have read the contribution guide (https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
  - [x] I have not used an AI coding assistant to create this PR.
  - [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
  - [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
  
  Go checklist
  
  - [x] I have run golangci-lint on my change and receive no errors relevant to my code.
  - [x] I have run existing tests to ensure my code doesn't break anything.
  - [x] I have added tests for all relevant use cases of my code, and those tests are passing.
  - [x] I have only exported functions, variables and structs that should be used from other packages.
  - [x] I have added meaningful comments to all exported functions, variables, and structs.
  
