### PR TITLE
Refactor CLI arguments package to allow different backing implementations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -83,6 +83,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/posener/complete v1.2.3
 	github.com/spf13/afero v1.15.0
+	github.com/spf13/pflag v1.0.9
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.1.41
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sts v1.1.11
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.1.0
@@ -224,7 +225,6 @@ require (
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
-	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.7.0 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect

--- a/internal/command/arguments/apply.go
+++ b/internal/command/arguments/apply.go
@@ -48,8 +48,7 @@ func BindApply(cli *CommandLine) *Apply {
 	apply.Vars = &Vars{}
 	apply.Vars.bind(cli)
 
-	apply.State = &State{}
-	apply.State.bind(cli, stateFlagAll)
+	apply.State = BindState(cli, stateFlagAll)
 
 	cli.BoolVar(&apply.AutoApprove, "auto-approve", false, "Skip interactive approval of plan before applying.")
 	cli.BoolVar(&apply.ShowSensitive, "show-sensitive", false, "If specified, sensitive values will be displayed.")

--- a/internal/command/arguments/apply.go
+++ b/internal/command/arguments/apply.go
@@ -37,30 +37,27 @@ type Apply struct {
 }
 
 // BindApply registers CLI arguments, returning a Apply value and it's corresponding hooks.
-func BindApply(flags Flags) (*Apply, Hooks) {
+func BindApply(cli *CommandLine) *Apply {
 	var apply Apply
-	var hooks Hooks
 
-	apply.ViewOptions.bind(flags, true)
-	hooks = append(hooks, apply.ViewOptions.ParseHook())
+	apply.ViewOptions.bind(cli, true)
 
 	apply.Operation = &Operation{}
-	apply.Operation.bind(flags)
-	hooks = append(hooks, Hook{Pre: apply.Operation.Parse})
+	apply.Operation.bind(cli)
 
 	apply.Vars = &Vars{}
-	apply.Vars.bind(flags)
+	apply.Vars.bind(cli)
 
 	apply.State = &State{}
-	apply.State.bind(flags, stateFlagAll)
+	apply.State.bind(cli, stateFlagAll)
 
-	flags.BoolVar(&apply.AutoApprove, "auto-approve", false, "Skip interactive approval of plan before applying.")
-	flags.BoolVar(&apply.ShowSensitive, "show-sensitive", false, "If specified, sensitive values will be displayed.")
-	flags.BoolVar(&apply.SuppressForgetErrorsDuringDestroy, "suppress-forget-errors", false, "Suppress the error that occurs when a destroy operation completes successfully but leaves forgotten instances behind.")
+	cli.BoolVar(&apply.AutoApprove, "auto-approve", false, "Skip interactive approval of plan before applying.")
+	cli.BoolVar(&apply.ShowSensitive, "show-sensitive", false, "If specified, sensitive values will be displayed.")
+	cli.BoolVar(&apply.SuppressForgetErrorsDuringDestroy, "suppress-forget-errors", false, "Suppress the error that occurs when a destroy operation completes successfully but leaves forgotten instances behind.")
 
-	// TODO better handling of positional arguments
+	cli.PositionalArg(&apply.PlanPath, "plan path", true)
 
-	hooks = append(hooks, Hook{Pre: func() tfdiags.Diagnostics {
+	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
 		// JSON view cannot confirm apply, so we require either a plan file or
 		// auto-approve to be specified. We intentionally fail here rather than
 		// override auto-approve, which would be dangerous.
@@ -74,43 +71,17 @@ func BindApply(flags Flags) (*Apply, Hooks) {
 		return nil
 	}})
 
-	return &apply, hooks
+	return &apply
 }
 
 // ParseApply processes CLI arguments, returning an Apply value, a closer function, and errors.
 // If errors are encountered, an Apply value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseApply(args []string) (*Apply, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	apply, hooks := BindApply(flags)
-
-	cmdFlags := defaultFlagSet("apply", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	args = cmdFlags.Args()
-	if len(args) > 0 {
-		apply.PlanPath = args[0]
-		args = args[1:]
-	}
-
-	if len(args) > 0 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Too many command line arguments",
-			"Expected at most one positional argument.",
-		))
-	}
-
-	return apply, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	apply := BindApply(cli)
+	closer, diags := cli.Stdlib("apply", args)
+	return apply, closer, diags
 }
 
 // ParseApplyDestroy is a special case of ParseApply that deals with the

--- a/internal/command/arguments/apply.go
+++ b/internal/command/arguments/apply.go
@@ -42,12 +42,8 @@ func BindApply(cli *CommandLine) *Apply {
 
 	apply.ViewOptions.bind(cli, true)
 
-	apply.Operation = &Operation{}
-	apply.Operation.bind(cli)
-
-	apply.Vars = &Vars{}
-	apply.Vars.bind(cli)
-
+	apply.Operation = BindOperation(cli)
+	apply.Vars = BindVars(cli)
 	apply.State = BindState(cli, stateFlagAll)
 
 	cli.BoolVar(&apply.AutoApprove, "auto-approve", false, "Skip interactive approval of plan before applying.")

--- a/internal/command/arguments/apply.go
+++ b/internal/command/arguments/apply.go
@@ -55,7 +55,7 @@ func BindApply(cli *CommandLine) *Apply {
 	cli.BoolVar(&apply.ShowSensitive, "show-sensitive", false, "If specified, sensitive values will be displayed.")
 	cli.BoolVar(&apply.SuppressForgetErrorsDuringDestroy, "suppress-forget-errors", false, "Suppress the error that occurs when a destroy operation completes successfully but leaves forgotten instances behind.")
 
-	cli.PositionalArg(&apply.PlanPath, "plan path", true)
+	cli.PositionalArg(&apply.PlanPath, "PLAN", true)
 
 	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
 		// JSON view cannot confirm apply, so we require either a plan file or
@@ -74,6 +74,57 @@ func BindApply(cli *CommandLine) *Apply {
 	return &apply
 }
 
+// BindApplyDestroy registers CLI arguments, returning a Apply value and it's corresponding hooks.
+func BindApplyDestroy(cli *CommandLine) *Apply {
+	apply := BindApply(cli)
+
+	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+		// So far ParseApply was using the command line options like -destroy
+		// and -refresh-only to determine the plan mode. For "tofu destroy"
+		// we expect neither of those arguments to be set, and so the plan mode
+		// should currently be set to NormalMode, which we'll replace with
+		// DestroyMode here. If it's already set to something else then that
+		// suggests incorrect usage.
+		switch apply.Operation.PlanMode {
+		case plans.NormalMode:
+			// This indicates that the user didn't specify any mode options at
+			// all, which is correct, although we know from the command that
+			// they actually intended to use DestroyMode here.
+			apply.Operation.PlanMode = plans.DestroyMode
+		case plans.DestroyMode:
+			return tfdiags.New(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Invalid mode option",
+				"The -destroy option is not valid for \"tofu destroy\", because this command always runs in destroy mode.",
+			))
+		case plans.RefreshOnlyMode:
+			return tfdiags.New(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Invalid mode option",
+				"The -refresh-only option is not valid for \"tofu destroy\".",
+			))
+		default:
+			// This is a non-ideal error message for if we forget to handle a
+			// newly-handled plan mode in Operation.Parse. Ideally they should all
+			// have cases above so we can produce better error messages.
+			return tfdiags.New(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Invalid mode option",
+				fmt.Sprintf("The \"tofu destroy\" command doesn't support %s.", apply.Operation.PlanMode),
+			))
+		}
+
+		// NOTE: It's also invalid to have apply.PlanPath set in this codepath,
+		// but we don't check that in here because we'll return a different error
+		// message depending on whether the given path seems to refer to a saved
+		// plan file or to a configuration directory. The apply command
+		// implementation itself therefore handles this situation.
+		return nil
+	}})
+
+	return apply
+}
+
 // ParseApply processes CLI arguments, returning an Apply value, a closer function, and errors.
 // If errors are encountered, an Apply value is still returned representing
 // the best effort interpretation of the arguments.
@@ -88,48 +139,8 @@ func ParseApply(args []string) (*Apply, func(), tfdiags.Diagnostics) {
 // "tofu destroy" command, which is effectively an alias for
 // "tofu apply -destroy".
 func ParseApplyDestroy(args []string) (*Apply, func(), tfdiags.Diagnostics) {
-	apply, closer, diags := ParseApply(args)
-
-	// So far ParseApply was using the command line options like -destroy
-	// and -refresh-only to determine the plan mode. For "tofu destroy"
-	// we expect neither of those arguments to be set, and so the plan mode
-	// should currently be set to NormalMode, which we'll replace with
-	// DestroyMode here. If it's already set to something else then that
-	// suggests incorrect usage.
-	switch apply.Operation.PlanMode {
-	case plans.NormalMode:
-		// This indicates that the user didn't specify any mode options at
-		// all, which is correct, although we know from the command that
-		// they actually intended to use DestroyMode here.
-		apply.Operation.PlanMode = plans.DestroyMode
-	case plans.DestroyMode:
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Invalid mode option",
-			"The -destroy option is not valid for \"tofu destroy\", because this command always runs in destroy mode.",
-		))
-	case plans.RefreshOnlyMode:
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Invalid mode option",
-			"The -refresh-only option is not valid for \"tofu destroy\".",
-		))
-	default:
-		// This is a non-ideal error message for if we forget to handle a
-		// newly-handled plan mode in Operation.Parse. Ideally they should all
-		// have cases above so we can produce better error messages.
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Invalid mode option",
-			fmt.Sprintf("The \"tofu destroy\" command doesn't support %s.", apply.Operation.PlanMode),
-		))
-	}
-
-	// NOTE: It's also invalid to have apply.PlanPath set in this codepath,
-	// but we don't check that in here because we'll return a different error
-	// message depending on whether the given path seems to refer to a saved
-	// plan file or to a configuration directory. The apply command
-	// implementation itself therefore handles this situation.
-
+	cli := new(CommandLine)
+	apply := BindApplyDestroy(cli)
+	closer, diags := cli.Stdlib("destroy", args)
 	return apply, closer, diags
 }

--- a/internal/command/arguments/apply.go
+++ b/internal/command/arguments/apply.go
@@ -36,24 +36,57 @@ type Apply struct {
 	SuppressForgetErrorsDuringDestroy bool
 }
 
+// BindApply registers CLI arguments, returning a Apply value and it's corresponding hooks.
+func BindApply(flags Flags) (*Apply, Hooks) {
+	var apply Apply
+	var hooks Hooks
+
+	apply.ViewOptions.bind(flags, true)
+	hooks = append(hooks, apply.ViewOptions.ParseHook())
+
+	apply.Operation = &Operation{}
+	apply.Operation.bind(flags)
+	hooks = append(hooks, Hook{Pre: apply.Operation.Parse})
+
+	apply.Vars = &Vars{}
+	apply.Vars.bind(flags)
+
+	apply.State = &State{}
+	apply.State.bind(flags, stateFlagAll)
+
+	flags.BoolVar(&apply.AutoApprove, "auto-approve", false, "Skip interactive approval of plan before applying.")
+	flags.BoolVar(&apply.ShowSensitive, "show-sensitive", false, "If specified, sensitive values will be displayed.")
+	flags.BoolVar(&apply.SuppressForgetErrorsDuringDestroy, "suppress-forget-errors", false, "Suppress the error that occurs when a destroy operation completes successfully but leaves forgotten instances behind.")
+
+	// TODO better handling of positional arguments
+
+	hooks = append(hooks, Hook{Pre: func() tfdiags.Diagnostics {
+		// JSON view cannot confirm apply, so we require either a plan file or
+		// auto-approve to be specified. We intentionally fail here rather than
+		// override auto-approve, which would be dangerous.
+		if apply.ViewOptions.jsonFlag && apply.PlanPath == "" && !apply.AutoApprove {
+			return tfdiags.New(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Plan file or auto-approve required",
+				"OpenTofu cannot ask for interactive approval when -json is set. You can either apply a saved plan file, or enable the -auto-approve option.",
+			))
+		}
+		return nil
+	}})
+
+	return &apply, hooks
+}
+
 // ParseApply processes CLI arguments, returning an Apply value, a closer function, and errors.
 // If errors are encountered, an Apply value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseApply(args []string) (*Apply, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	apply := &Apply{
-		State:     &State{},
-		Operation: &Operation{},
-		Vars:      &Vars{},
-	}
 
-	cmdFlags := extendedFlagSet("apply", apply.Operation, apply.Vars)
-	cmdFlags.BoolVar(&apply.AutoApprove, "auto-approve", false, "auto-approve")
-	cmdFlags.BoolVar(&apply.ShowSensitive, "show-sensitive", false, "displays sensitive values")
-	cmdFlags.BoolVar(&apply.SuppressForgetErrorsDuringDestroy, "suppress-forget-errors", false, "suppress errors in destroy mode due to resources being forgotten")
+	flags := Flags{}
+	apply, hooks := BindApply(flags)
 
-	apply.State.addFlags(cmdFlags, stateFlagAll)
-	apply.ViewOptions.AddFlags(cmdFlags, true)
+	cmdFlags := defaultFlagSet("apply", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -77,22 +110,7 @@ func ParseApply(args []string) (*Apply, func(), tfdiags.Diagnostics) {
 		))
 	}
 
-	// JSON view cannot confirm apply, so we require either a plan file or
-	// auto-approve to be specified. We intentionally fail here rather than
-	// override auto-approve, which would be dangerous.
-	if apply.ViewOptions.jsonFlag && apply.PlanPath == "" && !apply.AutoApprove {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Plan file or auto-approve required",
-			"OpenTofu cannot ask for interactive approval when -json is set. You can either apply a saved plan file, or enable the -auto-approve option.",
-		))
-	}
-
-	diags = diags.Append(apply.Operation.Parse())
-	closer, moreDiags := apply.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-
-	return apply, closer, diags
+	return apply, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }
 
 // ParseApplyDestroy is a special case of ParseApply that deals with the

--- a/internal/command/arguments/apply.go
+++ b/internal/command/arguments/apply.go
@@ -52,7 +52,7 @@ func BindApply(cli *CommandLine) *Apply {
 
 	cli.PositionalArg(&apply.PlanPath, "PLAN", true)
 
-	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+	cli.PreHook(func() tfdiags.Diagnostics {
 		// JSON view cannot confirm apply, so we require either a plan file or
 		// auto-approve to be specified. We intentionally fail here rather than
 		// override auto-approve, which would be dangerous.
@@ -64,7 +64,7 @@ func BindApply(cli *CommandLine) *Apply {
 			))
 		}
 		return nil
-	}})
+	})
 
 	return &apply
 }
@@ -73,7 +73,7 @@ func BindApply(cli *CommandLine) *Apply {
 func BindApplyDestroy(cli *CommandLine) *Apply {
 	apply := BindApply(cli)
 
-	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+	cli.PreHook(func() tfdiags.Diagnostics {
 		// So far ParseApply was using the command line options like -destroy
 		// and -refresh-only to determine the plan mode. For "tofu destroy"
 		// we expect neither of those arguments to be set, and so the plan mode
@@ -115,7 +115,7 @@ func BindApplyDestroy(cli *CommandLine) *Apply {
 		// plan file or to a configuration directory. The apply command
 		// implementation itself therefore handles this situation.
 		return nil
-	}})
+	})
 
 	return apply
 }

--- a/internal/command/arguments/backend.go
+++ b/internal/command/arguments/backend.go
@@ -21,29 +21,35 @@ type Backend struct {
 	MigrateState bool
 }
 
-func (b *Backend) bindIgnoreRemoteVersionFlag(f *CommandLine) {
-	f.BoolVar(&b.IgnoreRemoteVersion, "ignore-remote-version", false, "A rare option used for the remote backend only. See the remote backend documentation for more information.")
+func BindBackend(cli *CommandLine) *Backend {
+	var b Backend
+	cli.BoolVar(&b.IgnoreRemoteVersion, "ignore-remote-version", false, "A rare option used for the remote backend only. See the remote backend documentation for more information.")
+	return &b
 }
 
-func (b *Backend) bindMigrationFlags(f *CommandLine) {
-	f.BoolVar(&b.ForceInitCopy, "force-copy", false, `Suppress prompts about copying state data when initializing a new state backend. This is equivalent to providing a "yes" to all confirmation prompts.`)
-	f.BoolVar(&b.Reconfigure, "reconfigure", false, `Reconfigure a backend, ignoring any saved configuration.`)
-	f.BoolVar(&b.MigrateState, "migrate-state", false, `Reconfigure a backend, and attempt to migrate any existing state.`)
-}
+func BindBackendWithMigration(cli *CommandLine) *Backend {
+	b := BindBackend(cli)
 
-func (b *Backend) migrationFlagsCheck() (diags tfdiags.Diagnostics) {
-	if b.MigrateState && b.Reconfigure {
-		return diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Wrong combination of options",
-			"The -migrate-state and -reconfigure options are mutually-exclusive",
-		))
-	}
+	cli.BoolVar(&b.ForceInitCopy, "force-copy", false, `Suppress prompts about copying state data when initializing a new state backend. This is equivalent to providing a "yes" to all confirmation prompts.`)
+	cli.BoolVar(&b.Reconfigure, "reconfigure", false, `Reconfigure a backend, ignoring any saved configuration.`)
+	cli.BoolVar(&b.MigrateState, "migrate-state", false, `Reconfigure a backend, and attempt to migrate any existing state.`)
 
-	// Copying the state only happens during backend migration, so setting
-	// -force-copy implies -migrate-state
-	if b.ForceInitCopy {
-		b.MigrateState = true
-	}
-	return diags
+	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+		if b.MigrateState && b.Reconfigure {
+			return tfdiags.New(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Wrong combination of options",
+				"The -migrate-state and -reconfigure options are mutually-exclusive",
+			))
+		}
+
+		// Copying the state only happens during backend migration, so setting
+		// -force-copy implies -migrate-state
+		if b.ForceInitCopy {
+			b.MigrateState = true
+		}
+		return nil
+	}})
+
+	return b
 }

--- a/internal/command/arguments/backend.go
+++ b/internal/command/arguments/backend.go
@@ -26,9 +26,9 @@ func (b *Backend) bindIgnoreRemoteVersionFlag(f *CommandLine) {
 }
 
 func (b *Backend) bindMigrationFlags(f *CommandLine) {
-	f.BoolVar(&b.ForceInitCopy, "force-copy", false, "suppress prompts about copying state data")
-	f.BoolVar(&b.Reconfigure, "reconfigure", false, "reconfigure")
-	f.BoolVar(&b.MigrateState, "migrate-state", false, "migrate state")
+	f.BoolVar(&b.ForceInitCopy, "force-copy", false, `Suppress prompts about copying state data when initializing a new state backend. This is equivalent to providing a "yes" to all confirmation prompts.`)
+	f.BoolVar(&b.Reconfigure, "reconfigure", false, `Reconfigure a backend, ignoring any saved configuration.`)
+	f.BoolVar(&b.MigrateState, "migrate-state", false, `Reconfigure a backend, and attempt to migrate any existing state.`)
 }
 
 func (b *Backend) migrationFlagsCheck() (diags tfdiags.Diagnostics) {

--- a/internal/command/arguments/backend.go
+++ b/internal/command/arguments/backend.go
@@ -34,7 +34,7 @@ func BindBackendWithMigration(cli *CommandLine) *Backend {
 	cli.BoolVar(&b.Reconfigure, "reconfigure", false, `Reconfigure a backend, ignoring any saved configuration.`)
 	cli.BoolVar(&b.MigrateState, "migrate-state", false, `Reconfigure a backend, and attempt to migrate any existing state.`)
 
-	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+	cli.PreHook(func() tfdiags.Diagnostics {
 		if b.MigrateState && b.Reconfigure {
 			return tfdiags.New(tfdiags.Sourceless(
 				tfdiags.Error,
@@ -49,7 +49,7 @@ func BindBackendWithMigration(cli *CommandLine) *Backend {
 			b.MigrateState = true
 		}
 		return nil
-	}})
+	})
 
 	return b
 }

--- a/internal/command/arguments/backend.go
+++ b/internal/command/arguments/backend.go
@@ -6,8 +6,6 @@
 package arguments
 
 import (
-	"flag"
-
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
@@ -23,11 +21,11 @@ type Backend struct {
 	MigrateState bool
 }
 
-func (b *Backend) AddIgnoreRemoteVersionFlag(f *flag.FlagSet) {
-	f.BoolVar(&b.IgnoreRemoteVersion, "ignore-remote-version", false, "continue even if remote and local OpenTofu versions are incompatible")
+func (b *Backend) bindIgnoreRemoteVersionFlag(f Flags) {
+	f.BoolVar(&b.IgnoreRemoteVersion, "ignore-remote-version", false, "A rare option used for the remote backend only. See the remote backend documentation for more information.")
 }
 
-func (b *Backend) AddMigrationFlags(f *flag.FlagSet) {
+func (b *Backend) bindMigrationFlags(f Flags) {
 	f.BoolVar(&b.ForceInitCopy, "force-copy", false, "suppress prompts about copying state data")
 	f.BoolVar(&b.Reconfigure, "reconfigure", false, "reconfigure")
 	f.BoolVar(&b.MigrateState, "migrate-state", false, "migrate state")

--- a/internal/command/arguments/backend.go
+++ b/internal/command/arguments/backend.go
@@ -21,11 +21,11 @@ type Backend struct {
 	MigrateState bool
 }
 
-func (b *Backend) bindIgnoreRemoteVersionFlag(f Flags) {
+func (b *Backend) bindIgnoreRemoteVersionFlag(f *CommandLine) {
 	f.BoolVar(&b.IgnoreRemoteVersion, "ignore-remote-version", false, "A rare option used for the remote backend only. See the remote backend documentation for more information.")
 }
 
-func (b *Backend) bindMigrationFlags(f Flags) {
+func (b *Backend) bindMigrationFlags(f *CommandLine) {
 	f.BoolVar(&b.ForceInitCopy, "force-copy", false, "suppress prompts about copying state data")
 	f.BoolVar(&b.Reconfigure, "reconfigure", false, "reconfigure")
 	f.BoolVar(&b.MigrateState, "migrate-state", false, "migrate state")

--- a/internal/command/arguments/backend_test.go
+++ b/internal/command/arguments/backend_test.go
@@ -42,8 +42,7 @@ func TestBackend_AddIgnoreRemoteVersionFlag(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			var cli CommandLine
-			backend := &Backend{}
-			backend.bindIgnoreRemoteVersionFlag(&cli)
+			backend := BindBackend(&cli)
 			if _, diags := cli.Stdlib("test", tc.args); diags.HasErrors() {
 				t.Fatalf("unexpected error parsing flags: %v", diags.Err().Error())
 			}
@@ -61,6 +60,8 @@ func TestBackend_AddMigrationFlags(t *testing.T) {
 		wantForceInitCopy bool
 		wantReconfigure   bool
 		wantMigrateState  bool
+		wantDiags         bool
+		diagsSummary      string
 	}{
 		"default values": {
 			args:              nil,
@@ -72,13 +73,13 @@ func TestBackend_AddMigrationFlags(t *testing.T) {
 			args:              []string{"-force-copy"},
 			wantForceInitCopy: true,
 			wantReconfigure:   false,
-			wantMigrateState:  false,
+			wantMigrateState:  true,
 		},
 		"force-copy explicitly true": {
 			args:              []string{"-force-copy=true"},
 			wantForceInitCopy: true,
 			wantReconfigure:   false,
-			wantMigrateState:  false,
+			wantMigrateState:  true,
 		},
 		"force-copy explicitly false": {
 			args:              []string{"-force-copy=false"},
@@ -133,120 +134,16 @@ func TestBackend_AddMigrationFlags(t *testing.T) {
 			wantForceInitCopy: true,
 			wantReconfigure:   true,
 			wantMigrateState:  true,
+			wantDiags:         true,
+			diagsSummary:      "Wrong combination of options",
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			var cli CommandLine
-			backend := &Backend{}
-			backend.bindMigrationFlags(&cli)
-			if _, diags := cli.Stdlib("test", tc.args); diags.HasErrors() {
-				t.Fatalf("unexpected error parsing flags: %v", diags.Err().Error())
-			}
-
-			if got := backend.ForceInitCopy; got != tc.wantForceInitCopy {
-				t.Errorf("ForceInitCopy = %v, want %v", got, tc.wantForceInitCopy)
-			}
-
-			if got := backend.Reconfigure; got != tc.wantReconfigure {
-				t.Errorf("Reconfigure = %v, want %v", got, tc.wantReconfigure)
-			}
-
-			if got := backend.MigrateState; got != tc.wantMigrateState {
-				t.Errorf("MigrateState = %v, want %v", got, tc.wantMigrateState)
-			}
-		})
-	}
-}
-
-func TestBackend_migrationFlagsCheck(t *testing.T) {
-	testCases := map[string]struct {
-		backend          Backend
-		wantDiags        bool
-		wantMigrateState bool
-		diagsSummary     string
-	}{
-		"no flags set": {
-			backend: Backend{
-				ForceInitCopy: false,
-				Reconfigure:   false,
-				MigrateState:  false,
-			},
-			wantDiags:        false,
-			wantMigrateState: false,
-		},
-		"only migrate-state set": {
-			backend: Backend{
-				ForceInitCopy: false,
-				Reconfigure:   false,
-				MigrateState:  true,
-			},
-			wantDiags:        false,
-			wantMigrateState: true,
-		},
-		"only reconfigure set": {
-			backend: Backend{
-				ForceInitCopy: false,
-				Reconfigure:   true,
-				MigrateState:  false,
-			},
-			wantDiags:        false,
-			wantMigrateState: false,
-		},
-		"only force-copy set": {
-			backend: Backend{
-				ForceInitCopy: true,
-				Reconfigure:   false,
-				MigrateState:  false,
-			},
-			wantDiags:        false,
-			wantMigrateState: true, // force-copy implies migrate-state
-		},
-		"force-copy and migrate-state set": {
-			backend: Backend{
-				ForceInitCopy: true,
-				Reconfigure:   false,
-				MigrateState:  true,
-			},
-			wantDiags:        false,
-			wantMigrateState: true,
-		},
-		"migrate-state and reconfigure set (mutually exclusive)": {
-			backend: Backend{
-				ForceInitCopy: false,
-				Reconfigure:   true,
-				MigrateState:  true,
-			},
-			wantDiags:        true,
-			wantMigrateState: true,
-			diagsSummary:     "Wrong combination of options",
-		},
-		"all flags set (error due to reconfigure + migrate-state)": {
-			backend: Backend{
-				ForceInitCopy: true,
-				Reconfigure:   true,
-				MigrateState:  true,
-			},
-			wantDiags:        true,
-			wantMigrateState: true,
-			diagsSummary:     "Wrong combination of options",
-		},
-		"force-copy and reconfigure set (no error - check happens before force-copy sets migrate-state)": {
-			backend: Backend{
-				ForceInitCopy: true,
-				Reconfigure:   true,
-				MigrateState:  false,
-			},
-			wantDiags:        false, // No error because MigrateState is false when check happens
-			wantMigrateState: true,  // force-copy sets this to true after the check
-		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			backend := tc.backend
-			diags := backend.migrationFlagsCheck()
+			backend := BindBackendWithMigration(&cli)
+			_, diags := cli.Stdlib("test", tc.args)
 
 			if tc.wantDiags && len(diags) == 0 {
 				t.Fatal("expected diagnostics but got none")
@@ -270,9 +167,16 @@ func TestBackend_migrationFlagsCheck(t *testing.T) {
 				}
 			}
 
-			// Verify that MigrateState is set correctly
+			if got := backend.ForceInitCopy; got != tc.wantForceInitCopy {
+				t.Errorf("ForceInitCopy = %v, want %v", got, tc.wantForceInitCopy)
+			}
+
+			if got := backend.Reconfigure; got != tc.wantReconfigure {
+				t.Errorf("Reconfigure = %v, want %v", got, tc.wantReconfigure)
+			}
+
 			if got := backend.MigrateState; got != tc.wantMigrateState {
-				t.Errorf("MigrateState after check = %v, want %v", got, tc.wantMigrateState)
+				t.Errorf("MigrateState = %v, want %v", got, tc.wantMigrateState)
 			}
 		})
 	}
@@ -280,8 +184,9 @@ func TestBackend_migrationFlagsCheck(t *testing.T) {
 
 func TestBackend_AllFlags(t *testing.T) {
 	testCases := map[string]struct {
-		args []string
-		want Backend
+		args      []string
+		want      Backend
+		wantDiags bool
 	}{
 		"all defaults": {
 			args: nil,
@@ -305,6 +210,7 @@ func TestBackend_AllFlags(t *testing.T) {
 				Reconfigure:         true,
 				MigrateState:        true,
 			},
+			wantDiags: true,
 		},
 		"mixed flags": {
 			args: []string{
@@ -323,11 +229,9 @@ func TestBackend_AllFlags(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			var cli CommandLine
-			backend := &Backend{}
-			backend.bindIgnoreRemoteVersionFlag(&cli)
-			backend.bindMigrationFlags(&cli)
+			backend := BindBackendWithMigration(&cli)
 
-			if _, diags := cli.Stdlib("test", tc.args); diags.HasErrors() {
+			if _, diags := cli.Stdlib("test", tc.args); diags.HasErrors() != tc.wantDiags {
 				t.Fatalf("unexpected error parsing flags: %v", diags.Err().Error())
 			}
 

--- a/internal/command/arguments/backend_test.go
+++ b/internal/command/arguments/backend_test.go
@@ -6,7 +6,6 @@
 package arguments
 
 import (
-	"flag"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -42,12 +41,11 @@ func TestBackend_AddIgnoreRemoteVersionFlag(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			var cli CommandLine
 			backend := &Backend{}
-			fs := flag.NewFlagSet("test", flag.ContinueOnError)
-			backend.AddIgnoreRemoteVersionFlag(fs)
-
-			if err := fs.Parse(tc.args); err != nil {
-				t.Fatalf("unexpected error parsing flags: %v", err)
+			backend.bindIgnoreRemoteVersionFlag(&cli)
+			if _, diags := cli.Stdlib("test", tc.args); diags.HasErrors() {
+				t.Fatalf("unexpected error parsing flags: %v", diags.Err().Error())
 			}
 
 			if got := backend.IgnoreRemoteVersion; got != tc.want {
@@ -140,12 +138,11 @@ func TestBackend_AddMigrationFlags(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			var cli CommandLine
 			backend := &Backend{}
-			fs := flag.NewFlagSet("test", flag.ContinueOnError)
-			backend.AddMigrationFlags(fs)
-
-			if err := fs.Parse(tc.args); err != nil {
-				t.Fatalf("unexpected error parsing flags: %v", err)
+			backend.bindMigrationFlags(&cli)
+			if _, diags := cli.Stdlib("test", tc.args); diags.HasErrors() {
+				t.Fatalf("unexpected error parsing flags: %v", diags.Err().Error())
 			}
 
 			if got := backend.ForceInitCopy; got != tc.wantForceInitCopy {
@@ -325,13 +322,13 @@ func TestBackend_AllFlags(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			var cli CommandLine
 			backend := &Backend{}
-			fs := flag.NewFlagSet("test", flag.ContinueOnError)
-			backend.AddIgnoreRemoteVersionFlag(fs)
-			backend.AddMigrationFlags(fs)
+			backend.bindIgnoreRemoteVersionFlag(&cli)
+			backend.bindMigrationFlags(&cli)
 
-			if err := fs.Parse(tc.args); err != nil {
-				t.Fatalf("unexpected error parsing flags: %v", err)
+			if _, diags := cli.Stdlib("test", tc.args); diags.HasErrors() {
+				t.Fatalf("unexpected error parsing flags: %v", diags.Err().Error())
 			}
 
 			if diff := cmp.Diff(tc.want, *backend); diff != "" {

--- a/internal/command/arguments/common.go
+++ b/internal/command/arguments/common.go
@@ -43,40 +43,59 @@ func (c CommandLine) Stdlib(name string, args []string) (func(), tfdiags.Diagnos
 	}
 
 	remaining := cmdFlags.Args()
+	argsErrored := false
+	nRequired := 0
+	nOptional := 0
 	for _, arg := range c.Args {
+		if arg.Optional {
+			nOptional += 1
+		} else {
+			nRequired += 1
+		}
+
 		var err error
 		remaining, err = arg.Process(remaining)
 		if err != nil {
-			detail := err.Error()
-			if c.ArgHelp != "" {
-				detail = c.ArgHelp
-			}
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Invalid arguments list",
-				detail,
-			))
+			// For now, we don't care about the more specific error text
+			argsErrored = true
 		}
 	}
-	if len(remaining) > 0 {
+	if len(remaining) > 0 || argsErrored {
+		summary := "Unexpected argument"
+		if argsErrored {
+			summary = "Invalid arguments list"
+		}
+
 		detail := c.ArgHelp
 		if detail == "" {
-			switch len(c.Args) {
-			case 0:
-				detail = "Too many command line arguments. Did you mean to use -chdir?"
-			case 1:
-				detail = "Expected at most one positional argument."
-			case 2:
-				detail = "Expected at most two positional arguments."
-			case 3:
-				detail = "Expected at most three positional arguments."
-			default:
-				detail = fmt.Sprintf("Expected at most %s positional arguments.", len(c.Args))
+			numText := func(i int) string {
+				switch i {
+				case 0:
+					return "two positional arguments."
+				case 1:
+					return "one positional argument."
+				case 2:
+					return "two positional arguments."
+				case 3:
+					return "three positional arguments."
+				default:
+					return fmt.Sprintf("%v positional arguments.", len(c.Args))
+				}
 			}
+			if nRequired == 0 {
+				if nOptional == 0 {
+					detail = "Did you mean to use -chdir?"
+				} else {
+					detail = "Expected at most " + numText(nOptional)
+				}
+			} else {
+				detail = "Expected exactly " + numText(nRequired)
+			}
+			detail = "Too many command line arguments. " + detail
 		}
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
-			"Too many command line arguments",
+			summary,
 			detail,
 		))
 	}
@@ -90,12 +109,13 @@ func (c *CommandLine) Hook(h Hook) {
 }
 
 type Argument struct {
-	Name    string
-	Process func([]string) ([]string, error)
+	Name     string
+	Optional bool
+	Process  func([]string) ([]string, error)
 }
 
 func (c *CommandLine) PositionalArg(p *string, name string, optional bool) {
-	c.Args = append(c.Args, Argument{Name: name, Process: func(args []string) ([]string, error) {
+	c.Args = append(c.Args, Argument{Name: name, Optional: optional, Process: func(args []string) ([]string, error) {
 		if len(args) == 0 {
 			if !optional {
 				return args, fmt.Errorf("Missing positional argument %s", name)

--- a/internal/command/arguments/common.go
+++ b/internal/command/arguments/common.go
@@ -34,11 +34,13 @@ type CommandLine struct {
 	// This is a legacy option and should not be used for any new commands.
 	ArgHelp string
 
-	// Hooks defines the pre/post command logic. Hooks.Pre should be run
-	// between os.Arg handling and the actual command logic. Hooks.Post
-	// should be run after the command has completed and before os.Exit is
-	// called.
-	Hooks Hooks
+	// PreHooks contain the logic that should be run between os.Args
+	// handling and the actual command logic.
+	PreHooks Hooks
+	// PostHooks contain the logic that should be run after the command
+	// has completed and before os.Exit is called.
+	// This is typically only used for the --json-into special case.
+	PostHooks Hooks
 }
 
 // PositionalArgs processes the input as a set of positional arguments. This
@@ -172,12 +174,17 @@ func (c CommandLine) Stdlib(name string, args []string) (func(), tfdiags.Diagnos
 	diags := c.StdlibArgs(args)
 
 	// Process hooks
-	return func() { c.Hooks.Post() }, diags.Append(c.Hooks.Pre())
+	return func() { c.PostHooks.Run() }, diags.Append(c.PreHooks.Run())
 }
 
-// Hook is a helper function to add a hook to the command line processing.
-func (c *CommandLine) Hook(h Hook) {
-	c.Hooks = append(c.Hooks, h)
+// PreHook is a helper function to add a hook to the command line processing.
+func (c *CommandLine) PreHook(h func() tfdiags.Diagnostics) {
+	c.PreHooks = append(c.PreHooks, h)
+}
+
+// PostHook is a helper function to add a hook to the command line processing.
+func (c *CommandLine) PostHook(h func() tfdiags.Diagnostics) {
+	c.PostHooks = append(c.PostHooks, h)
 }
 
 // Argument represents a positional argument.
@@ -360,27 +367,19 @@ type FlagGroup struct {
 	Suffix string
 }
 
-type Hook struct {
-	Pre, Post func() tfdiags.Diagnostics
-}
+// Hook is a function that will be executed
+// pre or post command execution
+type Hook func() tfdiags.Diagnostics
+
+// Hooks is a list of hooks with a helper method
 type Hooks []Hook
 
-func (h Hooks) Pre() tfdiags.Diagnostics {
+// Run executes all hooks sequentially and
+// returns any diagnostics encountered.
+func (h Hooks) Run() tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 	for _, hook := range h {
-		if hook.Pre != nil {
-			diags = diags.Append(hook.Pre())
-		}
-	}
-	return diags
-}
-
-func (h Hooks) Post() tfdiags.Diagnostics {
-	var diags tfdiags.Diagnostics
-	for _, hook := range h {
-		if hook.Post != nil {
-			diags = diags.Append(hook.Post())
-		}
+		diags = diags.Append(hook())
 	}
 	return diags
 }

--- a/internal/command/arguments/common.go
+++ b/internal/command/arguments/common.go
@@ -8,6 +8,7 @@ package arguments
 import (
 	"flag"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/opentofu/opentofu/internal/command/flags"
@@ -16,33 +17,18 @@ import (
 )
 
 type CommandLine struct {
-	Flags   map[string]*Flag
+	Flags      map[string]*Flag
+	FlagGroups []FlagGroup
+
 	Args    []Argument
 	ArgHelp string
-	Hooks   Hooks
+
+	Hooks Hooks
 }
 
-func (c CommandLine) Stdlib(name string, args []string) (func(), tfdiags.Diagnostics) {
+func (c CommandLine) PositionalArgs(remaining []string) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
-	cmdFlags := defaultFlagSet(name)
-	for _, flag := range c.Flags {
-		flag.Stdlib(cmdFlags)
-	}
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line options",
-			err.Error(),
-		))
-	}
-
-	// Record flag set state (init hack)
-	for _, flag := range c.Flags {
-		flag.IsSet = flags.FlagIsSet(cmdFlags, flag.Name)
-	}
-
-	remaining := cmdFlags.Args()
 	argsErrored := false
 	nRequired := 0
 	nOptional := 0
@@ -100,6 +86,66 @@ func (c CommandLine) Stdlib(name string, args []string) (func(), tfdiags.Diagnos
 		))
 	}
 
+	return diags
+}
+
+func (c CommandLine) Attach(flags *pflag.FlagSet) {
+	for _, flag := range c.Flags {
+		flag.Cobra(flags)
+	}
+}
+
+func (c CommandLine) StdlibArgs(args []string) tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+
+	// Special re-ordering of arguments for "global" options
+	var globalFlags []string
+	var rest []string
+	for _, arg := range args {
+		isGlobal := false
+		for _, flag := range c.Flags {
+			if flag.Global {
+				if strings.HasPrefix(arg, "-"+flag.Name) || strings.HasPrefix(arg, "--"+flag.Name) {
+					isGlobal = true
+				}
+			}
+		}
+		if isGlobal {
+			globalFlags = append(globalFlags, arg)
+		} else {
+			rest = append(rest, arg)
+		}
+	}
+	if len(globalFlags) > 0 {
+		args = append(globalFlags, rest...)
+	}
+
+	cmdFlags := defaultFlagSet("")
+	for _, flag := range c.Flags {
+		flag.Stdlib(cmdFlags)
+	}
+	if err := cmdFlags.Parse(args); err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Failed to parse command-line options",
+			err.Error(),
+		))
+	}
+
+	// Record flag set state (init hack)
+	for _, flag := range c.Flags {
+		flag.IsSet = flags.FlagIsSet(cmdFlags, flag.Name)
+	}
+
+	remaining := cmdFlags.Args()
+
+	diags = diags.Append(c.PositionalArgs(remaining))
+
+	return diags
+}
+
+func (c CommandLine) Stdlib(name string, args []string) (func(), tfdiags.Diagnostics) {
+	diags := c.StdlibArgs(args)
 	// Process hooks
 	return func() { c.Hooks.Post() }, diags.Append(c.Hooks.Pre())
 }
@@ -198,6 +244,7 @@ type Flag struct {
 	GroupID string
 	Display string
 	Hidden  bool
+	Global  bool
 
 	Cobra  func(*pflag.FlagSet)
 	Stdlib func(*flag.FlagSet)
@@ -218,11 +265,16 @@ func (f *Flag) SetHidden(hidden bool) *Flag {
 	f.Hidden = hidden
 	return f
 }
+func (f *Flag) SetGlobal(mixed bool) *Flag {
+	f.Global = mixed
+	return f
+}
 
 type FlagGroup struct {
 	ID          string
 	Title       string
 	Description string
+	Suffix      string
 }
 
 type Hook struct {

--- a/internal/command/arguments/common.go
+++ b/internal/command/arguments/common.go
@@ -16,16 +16,33 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// CommandLine represents the information need to represent the cli options
+// available to a given OpenTofu command. It is used for both argument
+// handling and help text construction.
 type CommandLine struct {
-	Flags      map[string]*Flag
+	// Flags represents all flags available to the command line.
+	Flags map[string]*Flag
+	// FlagGroups defines the group headers for the Flags. These are
+	// only used in a few specific commands for now and are typically
+	// left empty.
 	FlagGroups []FlagGroup
 
-	Args    []Argument
+	// Args contains the positional arguments defined for a given command.
+	// These are only allowed after all of the flag parsing is complete.
+	Args []Argument
+	// ArgsHelp is a field used to customize the argument error help text.
+	// This is a legacy option and should not be used for any new commands.
 	ArgHelp string
 
+	// Hooks defines the pre/post command logic. Hooks.Pre should be run
+	// between os.Arg handling and the actual command logic. Hooks.Post
+	// should be run after the command has completed and before os.Exit is
+	// called.
 	Hooks Hooks
 }
 
+// PositionalArgs processes the input as a set of positional arguments. This
+// should be the entries remaining after Flag parsing.
 func (c CommandLine) PositionalArgs(remaining []string) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
@@ -89,12 +106,17 @@ func (c CommandLine) PositionalArgs(remaining []string) tfdiags.Diagnostics {
 	return diags
 }
 
+// Attach iterates through all of the flags and adds them
+// to the given flagset.
 func (c CommandLine) Attach(flags *pflag.FlagSet) {
 	for _, flag := range c.Flags {
 		flag.Cobra(flags)
 	}
 }
 
+// StdlibArgs uses the old command line stdargs processing method. This currently exists
+// as a fallback and is primarily used for testing. Once we have completely switched to a
+// new CLI library, the tests can be updated and this function removed.
 func (c CommandLine) StdlibArgs(args []string) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
@@ -144,23 +166,31 @@ func (c CommandLine) StdlibArgs(args []string) tfdiags.Diagnostics {
 	return diags
 }
 
+// Stdlib is a wrapper around StdlibArgs that handles hooks. This is used by the
+// legacy Parse methods and should be removed when they are retired.
 func (c CommandLine) Stdlib(name string, args []string) (func(), tfdiags.Diagnostics) {
 	diags := c.StdlibArgs(args)
+
 	// Process hooks
 	return func() { c.Hooks.Post() }, diags.Append(c.Hooks.Pre())
 }
 
+// Hook is a helper function to add a hook to the command line processing.
 func (c *CommandLine) Hook(h Hook) {
 	c.Hooks = append(c.Hooks, h)
 }
 
+// Argument represents a positional argument.
 type Argument struct {
 	Name     string
 	Optional bool
 	Variadic bool
-	Process  func([]string) ([]string, error)
+	// Process takes the current remaining os.Args entries and returns
+	// the remainder after the given argument has been processed.
+	Process func([]string) ([]string, error)
 }
 
+// PositionalArg registers a positional argument.
 func (c *CommandLine) PositionalArg(p *string, name string, optional bool) {
 	for _, arg := range c.Args {
 		if arg.Variadic {
@@ -179,6 +209,8 @@ func (c *CommandLine) PositionalArg(p *string, name string, optional bool) {
 		return args[1:], nil
 	}})
 }
+
+// VariadicArg registers a variadic argument.
 func (c *CommandLine) VariadicArg(p *[]string, name string) {
 	for _, arg := range c.Args {
 		if arg.Variadic {
@@ -192,6 +224,7 @@ func (c *CommandLine) VariadicArg(p *[]string, name string) {
 	}})
 }
 
+// Flag registers the given flag to the CommandLine.
 func (c *CommandLine) Flag(flag *Flag) *Flag {
 	if c.Flags == nil {
 		c.Flags = map[string]*Flag{}
@@ -200,6 +233,7 @@ func (c *CommandLine) Flag(flag *Flag) *Flag {
 	return flag
 }
 
+// BoolVar attaches a bool flag to the CommandLine.
 func (c *CommandLine) BoolVar(p *bool, name string, value bool, usage string) *Flag {
 	return c.Flag(&Flag{
 		Name:   name,
@@ -208,6 +242,8 @@ func (c *CommandLine) BoolVar(p *bool, name string, value bool, usage string) *F
 		Stdlib: func(f *flag.FlagSet) { f.BoolVar(p, name, value, usage) },
 	})
 }
+
+// IntVar attaches a int flag to the CommandLine.
 func (c *CommandLine) IntVar(p *int, name string, value int, usage string) *Flag {
 	return c.Flag(&Flag{
 		Name:   name,
@@ -216,6 +252,8 @@ func (c *CommandLine) IntVar(p *int, name string, value int, usage string) *Flag
 		Stdlib: func(f *flag.FlagSet) { f.IntVar(p, name, value, usage) },
 	})
 }
+
+// StringVar attaches a string flag to the CommandLine.
 func (c *CommandLine) StringVar(p *string, name string, value string, usage string) *Flag {
 	return c.Flag(&Flag{
 		Name:   name,
@@ -224,6 +262,8 @@ func (c *CommandLine) StringVar(p *string, name string, value string, usage stri
 		Stdlib: func(f *flag.FlagSet) { f.StringVar(p, name, value, usage) },
 	})
 }
+
+// DurationVar attaches a time.Duration flag to the CommandLine.
 func (c *CommandLine) DurationVar(p *time.Duration, name string, value time.Duration, usage string) *Flag {
 	return c.Flag(&Flag{
 		Name:   name,
@@ -233,6 +273,8 @@ func (c *CommandLine) DurationVar(p *time.Duration, name string, value time.Dura
 	})
 }
 
+// StringArrayVar attaches a StringArray flag to the CommandLine.
+// This treats every instance of -name is a new entry and does not perform any ',' splitting.
 func (c *CommandLine) StringArrayVar(p *[]string, name string, value []string, usage string) *Flag {
 	return c.Flag(&Flag{
 		Name:   name,
@@ -242,6 +284,9 @@ func (c *CommandLine) StringArrayVar(p *[]string, name string, value []string, u
 	})
 }
 
+// RawFlags attaches a flags.RawFlags to the CommandLine.
+// This is a deprecated function and should be removed once var and var-file
+// processing is improved. This will correspond with the removal of the flags package.
 func (c *CommandLine) RawFlags(p flags.RawFlags, name string, usage string) *Flag {
 	return c.Flag(&Flag{
 		Name:   name,
@@ -251,18 +296,36 @@ func (c *CommandLine) RawFlags(p flags.RawFlags, name string, usage string) *Fla
 	})
 }
 
+// Flag is our representation of a command line flag and the implementation
+// details of interfacing it with a given command line library.
 type Flag struct {
-	Name    string
-	Usage   string
+	// Name is the name of the flag.
+	Name string
+	// Usage is the usage text that will be formatted.  It may include
+	// newlines, but it is discouraged.
+	Usage string
+	// GroupID is the group that this flag is nested under. This is
+	// for formatting in the help/usage text.
 	GroupID string
+	// Display is a suffix for the Name during help text formatting. For example:
+	// Display: "=value", would render as
+	//   --flag-name=value
 	Display string
-	Hidden  bool
-	Global  bool
+	// Hidden determines if this flag be visible in help text.
+	Hidden bool
+	// Global determines if this flag is allowed to intermix with positional
+	// arguments. This is a view holdover and should be considered for removal
+	// at some future date.
+	Global bool
 
-	Cobra  func(*pflag.FlagSet)
+	// Cobra implementation of this flag
+	Cobra func(*pflag.FlagSet)
+	// Stdlib implementation of this flag. Will be removed once the new
+	// CLI adoption is complete.
 	Stdlib func(*flag.FlagSet)
 
-	// Hack for -backend and -cloud
+	// IsSet is a workaround for -backend and -cloud. TODO consider
+	// proper argument aliases as supported by the cli implementation.
 	IsSet bool
 }
 
@@ -283,11 +346,18 @@ func (f *Flag) SetGlobal(mixed bool) *Flag {
 	return f
 }
 
+// FlagGroup is the information needed to define a flag
+// grouping for help text display.
 type FlagGroup struct {
-	ID          string
-	Title       string
+	// ID corresponds to flag's GroupID
+	ID string
+	// Title of the group
+	Title string
+	// Description present below the title
 	Description string
-	Suffix      string
+	// Suffix text for after the group flags have
+	// been rendered
+	Suffix string
 }
 
 type Hook struct {

--- a/internal/command/arguments/common.go
+++ b/internal/command/arguments/common.go
@@ -1,0 +1,152 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package arguments
+
+import (
+	"flag"
+	"time"
+
+	"github.com/opentofu/opentofu/internal/command/flags"
+	"github.com/opentofu/opentofu/internal/tfdiags"
+	"github.com/spf13/pflag"
+)
+
+type Flags map[string]*Flag
+
+func (f Flags) Stdlib(stdlib *flag.FlagSet) {
+	for _, flag := range f {
+		flag.Stdlib(stdlib)
+	}
+}
+
+func (f Flags) BoolVar(p *bool, name string, value bool, usage string) *Flag {
+	flag := &Flag{
+		Name:   name,
+		Usage:  usage,
+		Cobra:  func(f *pflag.FlagSet) { f.BoolVar(p, name, value, usage) },
+		Stdlib: func(f *flag.FlagSet) { f.BoolVar(p, name, value, usage) },
+	}
+	f[name] = flag
+	return flag
+}
+func (f Flags) IntVar(p *int, name string, value int, usage string) *Flag {
+	flag := &Flag{
+		Name:   name,
+		Usage:  usage,
+		Cobra:  func(f *pflag.FlagSet) { f.IntVar(p, name, value, usage) },
+		Stdlib: func(f *flag.FlagSet) { f.IntVar(p, name, value, usage) },
+	}
+	f[name] = flag
+	return flag
+}
+func (f Flags) StringVar(p *string, name string, value string, usage string) *Flag {
+	flag := &Flag{
+		Name:   name,
+		Usage:  usage,
+		Cobra:  func(f *pflag.FlagSet) { f.StringVar(p, name, value, usage) },
+		Stdlib: func(f *flag.FlagSet) { f.StringVar(p, name, value, usage) },
+	}
+	f[name] = flag
+	return flag
+}
+func (f Flags) DurationVar(p *time.Duration, name string, value time.Duration, usage string) *Flag {
+	flag := &Flag{
+		Name:   name,
+		Usage:  usage,
+		Cobra:  func(f *pflag.FlagSet) { f.DurationVar(p, name, value, usage) },
+		Stdlib: func(f *flag.FlagSet) { f.DurationVar(p, name, value, usage) },
+	}
+	f[name] = flag
+	return flag
+}
+
+func (f Flags) StringArrayVar(p *[]string, name string, value []string, usage string) *Flag {
+	flag := &Flag{
+		Name:   name,
+		Usage:  usage,
+		Cobra:  func(f *pflag.FlagSet) { f.StringArrayVar(p, name, value, usage) },
+		Stdlib: func(f *flag.FlagSet) { f.Var((*flags.FlagStringSlice)(p), name, usage) },
+	}
+	f[name] = flag
+	return flag
+}
+
+func (f Flags) RawFlags(p flags.RawFlags, name string, usage string) *Flag {
+	flag := &Flag{
+		Name:   name,
+		Usage:  usage,
+		Cobra:  func(f *pflag.FlagSet) { f.Func(name, usage, func(s string) error { return p.Set(s) }) },
+		Stdlib: func(f *flag.FlagSet) { f.Var(p, name, usage) },
+	}
+	f[name] = flag
+	return flag
+}
+
+func (f Flags) Func(name string, usage string, fn func(string) error) *Flag {
+	flag := &Flag{
+		Name:   name,
+		Usage:  usage,
+		Cobra:  func(f *pflag.FlagSet) { f.Func(name, usage, fn) },
+		Stdlib: func(f *flag.FlagSet) { panic("not implemented") },
+	}
+	f[name] = flag
+	return flag
+}
+
+type Flag struct {
+	Name    string
+	Usage   string
+	GroupID string
+	Display string
+	Hidden  bool
+
+	Cobra  func(*pflag.FlagSet)
+	Stdlib func(*flag.FlagSet)
+}
+
+func (f *Flag) SetGroup(id string) *Flag {
+	f.GroupID = id
+	return f
+}
+func (f *Flag) SetDisplay(display string) *Flag {
+	f.Display = display
+	return f
+}
+func (f *Flag) SetHidden(hidden bool) *Flag {
+	f.Hidden = hidden
+	return f
+}
+
+type FlagGroup struct {
+	ID          string
+	Title       string
+	Description string
+}
+
+type Hook struct {
+	Pre, Post func() tfdiags.Diagnostics
+}
+type Hooks []Hook
+
+func (h Hooks) Pre() tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+	for _, hook := range h {
+		if hook.Pre != nil {
+			diags = diags.Append(hook.Pre())
+		}
+	}
+	return diags
+}
+
+func (h Hooks) Post() tfdiags.Diagnostics {
+	var diags tfdiags.Diagnostics
+	for _, hook := range h {
+		if hook.Post != nil {
+			diags = diags.Append(hook.Post())
+		}
+	}
+	return diags
+}

--- a/internal/command/arguments/common.go
+++ b/internal/command/arguments/common.go
@@ -157,10 +157,17 @@ func (c *CommandLine) Hook(h Hook) {
 type Argument struct {
 	Name     string
 	Optional bool
+	Variadic bool
 	Process  func([]string) ([]string, error)
 }
 
 func (c *CommandLine) PositionalArg(p *string, name string, optional bool) {
+	for _, arg := range c.Args {
+		if arg.Variadic {
+			// In practice, this will be caught in testing as it's run before we even get to executing any commands
+			panic("BUG: Can not register a positional argument after a variadic argument!")
+		}
+	}
 	c.Args = append(c.Args, Argument{Name: name, Optional: optional, Process: func(args []string) ([]string, error) {
 		if len(args) == 0 {
 			if !optional {
@@ -173,7 +180,13 @@ func (c *CommandLine) PositionalArg(p *string, name string, optional bool) {
 	}})
 }
 func (c *CommandLine) VariadicArg(p *[]string, name string) {
-	c.Args = append(c.Args, Argument{Name: name, Process: func(args []string) ([]string, error) {
+	for _, arg := range c.Args {
+		if arg.Variadic {
+			// In practice, this will be caught in testing as it's run before we even get to executing any commands
+			panic("BUG: Can not register multiple variadic arguments!")
+		}
+	}
+	c.Args = append(c.Args, Argument{Name: name, Variadic: true, Process: func(args []string) ([]string, error) {
 		*p = args
 		return nil, nil
 	}})

--- a/internal/command/arguments/common.go
+++ b/internal/command/arguments/common.go
@@ -7,6 +7,7 @@ package arguments
 
 import (
 	"flag"
+	"fmt"
 	"time"
 
 	"github.com/opentofu/opentofu/internal/command/flags"
@@ -14,86 +15,161 @@ import (
 	"github.com/spf13/pflag"
 )
 
-type Flags map[string]*Flag
-
-func (f Flags) Stdlib(stdlib *flag.FlagSet) {
-	for _, flag := range f {
-		flag.Stdlib(stdlib)
-	}
+type CommandLine struct {
+	Flags   map[string]*Flag
+	Args    []Argument
+	ArgHelp string
+	Hooks   Hooks
 }
 
-func (f Flags) BoolVar(p *bool, name string, value bool, usage string) *Flag {
-	flag := &Flag{
+func (c CommandLine) Stdlib(name string, args []string) (func(), tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+
+	cmdFlags := defaultFlagSet(name)
+	for _, flag := range c.Flags {
+		flag.Stdlib(cmdFlags)
+	}
+	if err := cmdFlags.Parse(args); err != nil {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Failed to parse command-line options",
+			err.Error(),
+		))
+	}
+
+	// Record flag set state (init hack)
+	for _, flag := range c.Flags {
+		flag.IsSet = flags.FlagIsSet(cmdFlags, flag.Name)
+	}
+
+	remaining := cmdFlags.Args()
+	for _, arg := range c.Args {
+		var err error
+		remaining, err = arg.Process(remaining)
+		if err != nil {
+			detail := err.Error()
+			if c.ArgHelp != "" {
+				detail = c.ArgHelp
+			}
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Invalid arguments list",
+				detail,
+			))
+		}
+	}
+	if len(remaining) > 0 {
+		detail := c.ArgHelp
+		if detail == "" {
+			switch len(c.Args) {
+			case 0:
+				detail = "Too many command line arguments. Did you mean to use -chdir?"
+			case 1:
+				detail = "Expected at most one positional argument."
+			case 2:
+				detail = "Expected at most two positional arguments."
+			case 3:
+				detail = "Expected at most three positional arguments."
+			default:
+				detail = fmt.Sprintf("Expected at most %s positional arguments.", len(c.Args))
+			}
+		}
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Too many command line arguments",
+			detail,
+		))
+	}
+
+	// Process hooks
+	return func() { c.Hooks.Post() }, diags.Append(c.Hooks.Pre())
+}
+
+func (c *CommandLine) Hook(h Hook) {
+	c.Hooks = append(c.Hooks, h)
+}
+
+type Argument struct {
+	Name    string
+	Process func([]string) ([]string, error)
+}
+
+func (c *CommandLine) PositionalArg(p *string, name string, optional bool) {
+	c.Args = append(c.Args, Argument{Name: name, Process: func(args []string) ([]string, error) {
+		if len(args) == 0 {
+			if !optional {
+				return args, fmt.Errorf("Missing positional argument %s", name)
+			}
+			return args, nil
+		}
+		*p = args[0]
+		return args[1:], nil
+	}})
+}
+func (c *CommandLine) VariadicArg(p *[]string, name string) {
+	c.Args = append(c.Args, Argument{Name: name, Process: func(args []string) ([]string, error) {
+		*p = args
+		return nil, nil
+	}})
+}
+
+func (c *CommandLine) Flag(flag *Flag) *Flag {
+	if c.Flags == nil {
+		c.Flags = map[string]*Flag{}
+	}
+	c.Flags[flag.Name] = flag
+	return flag
+}
+
+func (c *CommandLine) BoolVar(p *bool, name string, value bool, usage string) *Flag {
+	return c.Flag(&Flag{
 		Name:   name,
 		Usage:  usage,
 		Cobra:  func(f *pflag.FlagSet) { f.BoolVar(p, name, value, usage) },
 		Stdlib: func(f *flag.FlagSet) { f.BoolVar(p, name, value, usage) },
-	}
-	f[name] = flag
-	return flag
+	})
 }
-func (f Flags) IntVar(p *int, name string, value int, usage string) *Flag {
-	flag := &Flag{
+func (c *CommandLine) IntVar(p *int, name string, value int, usage string) *Flag {
+	return c.Flag(&Flag{
 		Name:   name,
 		Usage:  usage,
 		Cobra:  func(f *pflag.FlagSet) { f.IntVar(p, name, value, usage) },
 		Stdlib: func(f *flag.FlagSet) { f.IntVar(p, name, value, usage) },
-	}
-	f[name] = flag
-	return flag
+	})
 }
-func (f Flags) StringVar(p *string, name string, value string, usage string) *Flag {
-	flag := &Flag{
+func (c *CommandLine) StringVar(p *string, name string, value string, usage string) *Flag {
+	return c.Flag(&Flag{
 		Name:   name,
 		Usage:  usage,
 		Cobra:  func(f *pflag.FlagSet) { f.StringVar(p, name, value, usage) },
 		Stdlib: func(f *flag.FlagSet) { f.StringVar(p, name, value, usage) },
-	}
-	f[name] = flag
-	return flag
+	})
 }
-func (f Flags) DurationVar(p *time.Duration, name string, value time.Duration, usage string) *Flag {
-	flag := &Flag{
+func (c *CommandLine) DurationVar(p *time.Duration, name string, value time.Duration, usage string) *Flag {
+	return c.Flag(&Flag{
 		Name:   name,
 		Usage:  usage,
 		Cobra:  func(f *pflag.FlagSet) { f.DurationVar(p, name, value, usage) },
 		Stdlib: func(f *flag.FlagSet) { f.DurationVar(p, name, value, usage) },
-	}
-	f[name] = flag
-	return flag
+	})
 }
 
-func (f Flags) StringArrayVar(p *[]string, name string, value []string, usage string) *Flag {
-	flag := &Flag{
+func (c *CommandLine) StringArrayVar(p *[]string, name string, value []string, usage string) *Flag {
+	return c.Flag(&Flag{
 		Name:   name,
 		Usage:  usage,
 		Cobra:  func(f *pflag.FlagSet) { f.StringArrayVar(p, name, value, usage) },
 		Stdlib: func(f *flag.FlagSet) { f.Var((*flags.FlagStringSlice)(p), name, usage) },
-	}
-	f[name] = flag
-	return flag
+	})
 }
 
-func (f Flags) RawFlags(p flags.RawFlags, name string, usage string) *Flag {
-	flag := &Flag{
+func (c *CommandLine) RawFlags(p flags.RawFlags, name string, usage string) *Flag {
+	return c.Flag(&Flag{
 		Name:   name,
 		Usage:  usage,
 		Cobra:  func(f *pflag.FlagSet) { f.Func(name, usage, func(s string) error { return p.Set(s) }) },
 		Stdlib: func(f *flag.FlagSet) { f.Var(p, name, usage) },
-	}
-	f[name] = flag
-	return flag
-}
-
-func (f Flags) Func(name string, usage string, fn func(string) error) *Flag {
-	flag := &Flag{
-		Name:   name,
-		Usage:  usage,
-		Cobra:  func(f *pflag.FlagSet) { f.Func(name, usage, fn) },
-		Stdlib: func(f *flag.FlagSet) { panic("not implemented") },
-	}
-	f[name] = flag
-	return flag
+	})
 }
 
 type Flag struct {
@@ -105,6 +181,9 @@ type Flag struct {
 
 	Cobra  func(*pflag.FlagSet)
 	Stdlib func(*flag.FlagSet)
+
+	// Hack for -backend and -cloud
+	IsSet bool
 }
 
 func (f *Flag) SetGroup(id string) *Flag {

--- a/internal/command/arguments/console.go
+++ b/internal/command/arguments/console.go
@@ -26,13 +26,14 @@ func BindConsole(cli *CommandLine) *Console {
 	console.Vars = &Vars{}
 	console.Vars.bind(cli)
 
-	console.State = &State{}
-	console.State.bind(cli, stateFlagLock)
-	console.State.bindStateInFlag(cli, DefaultStateFilename)
+	console.State = BindState(cli, stateFlagLock|stateFlagStateIn)
 
 	console.ViewOptions.bind(cli, true)
 
 	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+		if console.State.StatePath == "" {
+			console.State.StatePath = DefaultStateFilename
+		}
 		// If the user provided the -json flag, we don't allow it since the UX is just poor in this case.
 		// We allow only the streaming of the evaluated values in a json file, by using the `-json-into` flag.
 		if console.ViewOptions.ViewType == ViewJSON {

--- a/internal/command/arguments/console.go
+++ b/internal/command/arguments/console.go
@@ -23,9 +23,7 @@ type Console struct {
 func BindConsole(cli *CommandLine) *Console {
 	var console Console
 
-	console.Vars = &Vars{}
-	console.Vars.bind(cli)
-
+	console.Vars = BindVars(cli)
 	console.State = BindState(cli, stateFlagLock|stateFlagStateIn)
 
 	console.ViewOptions.bind(cli, true)

--- a/internal/command/arguments/console.go
+++ b/internal/command/arguments/console.go
@@ -35,13 +35,13 @@ func BindConsole(cli *CommandLine) *Console {
 		// If the user provided the -json flag, we don't allow it since the UX is just poor in this case.
 		// We allow only the streaming of the evaluated values in a json file, by using the `-json-into` flag.
 		if console.ViewOptions.ViewType == ViewJSON {
+			// Revert the view type to be able to print the diagnostic properly
+			console.ViewOptions.ViewType = ViewHuman
 			return tfdiags.New(tfdiags.Sourceless(
 				tfdiags.Error,
 				"Output only in json is not allowed",
 				"In case you want to stream the output of the console into json, use the \"-json-into\" instead.",
 			))
-			// Revert the view type to be able to print the diagnostic properly
-			console.ViewOptions.ViewType = ViewHuman
 		}
 		return nil
 	}})

--- a/internal/command/arguments/console.go
+++ b/internal/command/arguments/console.go
@@ -19,22 +19,49 @@ type Console struct {
 	State *State
 }
 
+// BindConsole registers CLI arguments, returning a Console value and it's corresponding hooks.
+func BindConsole(flags Flags) (*Console, Hooks) {
+	var console Console
+	var hooks Hooks
+
+	console.Vars = &Vars{}
+	console.Vars.bind(flags)
+
+	console.State = &State{}
+	console.State.bind(flags, stateFlagLock)
+	console.State.bindStateInFlag(flags, DefaultStateFilename)
+
+	console.ViewOptions.bind(flags, true)
+
+	hooks = append(hooks, console.ViewOptions.ParseHook())
+	hooks = append(hooks, Hook{Pre: func() tfdiags.Diagnostics {
+		// If the user provided the -json flag, we don't allow it since the UX is just poor in this case.
+		// We allow only the streaming of the evaluated values in a json file, by using the `-json-into` flag.
+		if console.ViewOptions.ViewType == ViewJSON {
+			return tfdiags.New(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Output only in json is not allowed",
+				"In case you want to stream the output of the console into json, use the \"-json-into\" instead.",
+			))
+			// Revert the view type to be able to print the diagnostic properly
+			console.ViewOptions.ViewType = ViewHuman
+		}
+		return nil
+	}})
+
+	return &console, hooks
+}
+
 // ParseConsole processes CLI arguments, returning a Console value, a closer function, and errors.
 // If errors are encountered, a Console value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseConsole(args []string) (*Console, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	console := &Console{
-		Vars:  &Vars{},
-		State: &State{},
-	}
+	flags := Flags{}
+	console, hooks := BindConsole(flags)
 
-	cmdFlags := extendedFlagSet("console", nil, console.Vars)
-	console.State.addFlags(cmdFlags, stateFlagLock)
-	console.State.AddStateInFlag(cmdFlags, DefaultStateFilename)
-
-	console.ViewOptions.AddFlags(cmdFlags, true)
+	cmdFlags := defaultFlagSet("console", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -53,19 +80,6 @@ func ParseConsole(args []string) (*Console, func(), tfdiags.Diagnostics) {
 		))
 	}
 
-	closer, moreDiags := console.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-	// If the user provided the -json flag, we don't allow it since the UX is just poor in this case.
-	// We allow only the streaming of the evaluated values in a json file, by using the `-json-into` flag.
-	if console.ViewOptions.ViewType == ViewJSON {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Output only in json is not allowed",
-			"In case you want to stream the output of the console into json, use the \"-json-into\" instead.",
-		))
-		// Revert the view type to be able to print the diagnostic properly
-		console.ViewOptions.ViewType = ViewHuman
-	}
-
-	return console, closer, diags
+	diags = diags.Append(hooks.Pre())
+	return console, func() { hooks.Post() }, diags
 }

--- a/internal/command/arguments/console.go
+++ b/internal/command/arguments/console.go
@@ -20,21 +20,19 @@ type Console struct {
 }
 
 // BindConsole registers CLI arguments, returning a Console value and it's corresponding hooks.
-func BindConsole(flags Flags) (*Console, Hooks) {
+func BindConsole(cli *CommandLine) *Console {
 	var console Console
-	var hooks Hooks
 
 	console.Vars = &Vars{}
-	console.Vars.bind(flags)
+	console.Vars.bind(cli)
 
 	console.State = &State{}
-	console.State.bind(flags, stateFlagLock)
-	console.State.bindStateInFlag(flags, DefaultStateFilename)
+	console.State.bind(cli, stateFlagLock)
+	console.State.bindStateInFlag(cli, DefaultStateFilename)
 
-	console.ViewOptions.bind(flags, true)
+	console.ViewOptions.bind(cli, true)
 
-	hooks = append(hooks, console.ViewOptions.ParseHook())
-	hooks = append(hooks, Hook{Pre: func() tfdiags.Diagnostics {
+	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
 		// If the user provided the -json flag, we don't allow it since the UX is just poor in this case.
 		// We allow only the streaming of the evaluated values in a json file, by using the `-json-into` flag.
 		if console.ViewOptions.ViewType == ViewJSON {
@@ -49,37 +47,15 @@ func BindConsole(flags Flags) (*Console, Hooks) {
 		return nil
 	}})
 
-	return &console, hooks
+	return &console
 }
 
 // ParseConsole processes CLI arguments, returning a Console value, a closer function, and errors.
 // If errors are encountered, a Console value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseConsole(args []string) (*Console, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	console, hooks := BindConsole(flags)
-
-	cmdFlags := defaultFlagSet("console", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	args = cmdFlags.Args()
-	if len(args) > 0 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Too many command line arguments",
-			"Expected at most one positional argument.",
-		))
-	}
-
-	diags = diags.Append(hooks.Pre())
-	return console, func() { hooks.Post() }, diags
+	cli := new(CommandLine)
+	console := BindConsole(cli)
+	closer, diags := cli.Stdlib("console", args)
+	return console, closer, diags
 }

--- a/internal/command/arguments/console.go
+++ b/internal/command/arguments/console.go
@@ -28,7 +28,7 @@ func BindConsole(cli *CommandLine) *Console {
 
 	console.ViewOptions.bind(cli, true)
 
-	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+	cli.PreHook(func() tfdiags.Diagnostics {
 		if console.State.StatePath == "" {
 			console.State.StatePath = DefaultStateFilename
 		}
@@ -44,7 +44,7 @@ func BindConsole(cli *CommandLine) *Console {
 			))
 		}
 		return nil
-	}})
+	})
 
 	return &console
 }

--- a/internal/command/arguments/default.go
+++ b/internal/command/arguments/default.go
@@ -12,10 +12,12 @@ import (
 
 // defaultFlagSet creates a FlagSet with the common settings to override
 // the flag package's noisy defaults.
-func defaultFlagSet(name string) *flag.FlagSet {
+func defaultFlagSet(name string, flags Flags) *flag.FlagSet {
 	f := flag.NewFlagSet(name, flag.ContinueOnError)
 	f.SetOutput(io.Discard)
 	f.Usage = func() {}
+
+	flags.Stdlib(f)
 
 	return f
 }

--- a/internal/command/arguments/default.go
+++ b/internal/command/arguments/default.go
@@ -12,12 +12,10 @@ import (
 
 // defaultFlagSet creates a FlagSet with the common settings to override
 // the flag package's noisy defaults.
-func defaultFlagSet(name string, flags Flags) *flag.FlagSet {
+func defaultFlagSet(name string) *flag.FlagSet {
 	f := flag.NewFlagSet(name, flag.ContinueOnError)
 	f.SetOutput(io.Discard)
 	f.Usage = func() {}
-
-	flags.Stdlib(f)
 
 	return f
 }

--- a/internal/command/arguments/extended.go
+++ b/internal/command/arguments/extended.go
@@ -91,7 +91,7 @@ func (s *State) bind(cli *CommandLine, mask stateFlag) {
 func (s *State) bindStateInFlag(cli *CommandLine, defVal string) {
 	cli.StringVar(&s.StatePath, "state", defVal,
 		`A legacy option used for the local backend only. Refer to the local backend's documentation for more information.`,
-	).SetDisplay("=statefile")
+	).SetDisplay("=statefile").SetHidden(true)
 }
 
 // bindBackupFlag exists strictly because the default value can get a different value in some commands.

--- a/internal/command/arguments/extended.go
+++ b/internal/command/arguments/extended.go
@@ -348,7 +348,8 @@ func (v *Vars) Empty() bool {
 }
 
 // bind registers all Operation flags
-func (operation *Operation) bind(cli *CommandLine) {
+func BindOperation(cli *CommandLine) *Operation {
+	var operation Operation
 	cli.IntVar(&operation.Parallelism, "parallelism", DefaultParallelism,
 		`Limit the number of parallel resource operations. Defaults to 10.`,
 	).SetDisplay("=n")
@@ -376,10 +377,13 @@ func (operation *Operation) bind(cli *CommandLine) {
 	).SetDisplay("=resource")
 
 	cli.Hook(Hook{Pre: operation.Parse})
+
+	return &operation
 }
 
 // bind registers all Vars flags
-func (vars *Vars) bind(cli *CommandLine) {
+func BindVars(cli *CommandLine) *Vars {
+	var vars Vars
 	varsFlags := flags.NewRawFlags("-var")
 	varFilesFlags := varsFlags.Alias("-var-file")
 	vars.vars = &varsFlags
@@ -390,4 +394,5 @@ func (vars *Vars) bind(cli *CommandLine) {
 	cli.RawFlags(varFilesFlags, "var-file",
 		`Load variable values from the given file, in addition to the default files terraform.tfvars and *.auto.tfvars. Use this option more than once to include more than one variables file.`,
 	).SetDisplay("=filename")
+	return &vars
 }

--- a/internal/command/arguments/extended.go
+++ b/internal/command/arguments/extended.go
@@ -65,38 +65,38 @@ type State struct {
 }
 
 // bind is the sole logic of registering the state related flags in OpenTofu.
-func (s *State) bind(flags Flags, mask stateFlag) {
+func (s *State) bind(cli *CommandLine, mask stateFlag) {
 	if mask&stateFlagLock != 0 {
-		flags.BoolVar(&s.Lock, "lock", true,
+		cli.BoolVar(&s.Lock, "lock", true,
 			`Don't hold a state lock during the operation. This is dangerous if others might concurrently run commands against the same workspace.`,
 		).SetDisplay("=false")
-		flags.DurationVar(&s.LockTimeout, "lock-timeout", 0,
+		cli.DurationVar(&s.LockTimeout, "lock-timeout", 0,
 			`Duration to retry a state lock, such as "5s" to represent five seconds.`,
 		).SetDisplay("=duration")
 	}
 	if mask&stateFlagStateIn != 0 {
-		s.bindStateInFlag(flags, "")
+		s.bindStateInFlag(cli, "")
 	}
 	if mask&stateFlagStateOut != 0 {
-		flags.StringVar(&s.StateOutPath, "state-out", "",
+		cli.StringVar(&s.StateOutPath, "state-out", "",
 			`Path to write state to that is different than "-state". This can be used to preserve the old state.`,
 		).SetHidden(true)
 	}
 	if mask&stateFlagBackup != 0 {
-		s.bindBackupFlag(flags, "")
+		s.bindBackupFlag(cli, "")
 	}
 }
 
 // bindtateInFlag exists strictly because the default value can get a different value in some commands.
-func (s *State) bindStateInFlag(flags Flags, defVal string) {
-	flags.StringVar(&s.StatePath, "state", defVal,
+func (s *State) bindStateInFlag(cli *CommandLine, defVal string) {
+	cli.StringVar(&s.StatePath, "state", defVal,
 		`A legacy option used for the local backend only. Refer to the local backend's documentation for more information.`,
 	).SetDisplay("=statefile")
 }
 
 // bindBackupFlag exists strictly because the default value can get a different value in some commands.
-func (s *State) bindBackupFlag(flags Flags, defVal string) {
-	flags.StringVar(&s.BackupPath, "backup", defVal,
+func (s *State) bindBackupFlag(cli *CommandLine, defVal string) {
+	cli.StringVar(&s.BackupPath, "backup", defVal,
 		`Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.`,
 	).SetHidden(true)
 }
@@ -356,44 +356,46 @@ func (v *Vars) Empty() bool {
 }
 
 // bind registers all Operation flags
-func (operation *Operation) bind(flags Flags) {
-	flags.IntVar(&operation.Parallelism, "parallelism", DefaultParallelism,
+func (operation *Operation) bind(cli *CommandLine) {
+	cli.IntVar(&operation.Parallelism, "parallelism", DefaultParallelism,
 		`Limit the number of parallel resource operations. Defaults to 10.`,
 	).SetDisplay("=n")
-	flags.BoolVar(&operation.Refresh, "refresh", true,
+	cli.BoolVar(&operation.Refresh, "refresh", true,
 		`Skip checking for external changes to remote objects while creating the plan. This can potentially make planning faster, but at the expense of possibly planning against a stale record of the remote system state.`,
 	).SetDisplay("=false")
-	flags.BoolVar(&operation.destroyRaw, "destroy", false,
+	cli.BoolVar(&operation.destroyRaw, "destroy", false,
 		`Select the "destroy" planning mode, which creates a plan to destroy all objects currently managed by this OpenTofu configuration instead of the usual behavior.`)
-	flags.BoolVar(&operation.refreshOnlyRaw, "refresh-only", false,
+	cli.BoolVar(&operation.refreshOnlyRaw, "refresh-only", false,
 		`Select the "refresh only" planning mode, which checks whether remote objects still match the outcome of the most recent OpenTofu apply but does not propose any actions to undo any changes made outside of OpenTofu.`)
-	flags.StringArrayVar(&operation.targetsRaw, "target", nil,
+	cli.StringArrayVar(&operation.targetsRaw, "target", nil,
 		`Limit the planning operation to only the given module, resource, or resource instance and all of its dependencies. You can use this option multiple times to include more than one object. This is for exceptional use only. Cannot be used alongside the -exclude option.`,
 	).SetDisplay("=resource")
-	flags.StringArrayVar(&operation.targetsFilesRaw, "target-file", nil,
+	cli.StringArrayVar(&operation.targetsFilesRaw, "target-file", nil,
 		`Similar to -target, but specifies zero or more resource addresses from a file.`,
 	).SetDisplay("=filename")
-	flags.StringArrayVar(&operation.excludesRaw, "exclude", nil,
+	cli.StringArrayVar(&operation.excludesRaw, "exclude", nil,
 		`Limit the planning operation to not operate on the given module, resource, or resource instance and all of the resources and modules that depend on it. You can use this option multiple times to exclude more than one object. This is for exceptional use only. Cannot be used together with the -target option.`,
 	).SetDisplay("=resource")
-	flags.StringArrayVar(&operation.excludesFilesRaw, "exclude-file", nil,
+	cli.StringArrayVar(&operation.excludesFilesRaw, "exclude-file", nil,
 		`Similar to -exclude, but specifies zero or more resource addresses from a file.`,
 	).SetDisplay("=filename")
-	flags.StringArrayVar(&operation.forceReplaceRaw, "replace", nil,
+	cli.StringArrayVar(&operation.forceReplaceRaw, "replace", nil,
 		`Force replacement of a particular resource instance using its resource address. If the plan would've otherwise produced an update or no-op action for this instance, OpenTofu will plan to replace it instead. You can use this option multiple times to replace more than one object.`,
 	).SetDisplay("=resource")
+
+	cli.Hook(Hook{Pre: operation.Parse})
 }
 
 // bind registers all Vars flags
-func (vars *Vars) bind(f Flags) {
+func (vars *Vars) bind(cli *CommandLine) {
 	varsFlags := flags.NewRawFlags("-var")
 	varFilesFlags := varsFlags.Alias("-var-file")
 	vars.vars = &varsFlags
 	vars.varFiles = &varFilesFlags
-	f.RawFlags(varsFlags, "var",
+	cli.RawFlags(varsFlags, "var",
 		`Set a value for one of the input variables in the root module of the configuration. Use this option more than once to set more than one variable.`,
 	).SetDisplay(" 'foo=bar'")
-	f.RawFlags(varFilesFlags, "var-file",
+	cli.RawFlags(varFilesFlags, "var-file",
 		`Load variable values from the given file, in addition to the default files terraform.tfvars and *.auto.tfvars. Use this option more than once to include more than one variables file.`,
 	).SetDisplay("=filename")
 }

--- a/internal/command/arguments/extended.go
+++ b/internal/command/arguments/extended.go
@@ -65,7 +65,8 @@ type State struct {
 }
 
 // bind is the sole logic of registering the state related flags in OpenTofu.
-func (s *State) bind(cli *CommandLine, mask stateFlag) {
+func BindState(cli *CommandLine, mask stateFlag) *State {
+	var s State
 	if mask&stateFlagLock != 0 {
 		cli.BoolVar(&s.Lock, "lock", true,
 			`Don't hold a state lock during the operation. This is dangerous if others might concurrently run commands against the same workspace.`,
@@ -75,7 +76,9 @@ func (s *State) bind(cli *CommandLine, mask stateFlag) {
 		).SetDisplay("=duration")
 	}
 	if mask&stateFlagStateIn != 0 {
-		s.bindStateInFlag(cli, "")
+		cli.StringVar(&s.StatePath, "state", "",
+			`A legacy option used for the local backend only. Refer to the local backend's documentation for more information.`,
+		).SetDisplay("=statefile").SetHidden(true)
 	}
 	if mask&stateFlagStateOut != 0 {
 		cli.StringVar(&s.StateOutPath, "state-out", "",
@@ -83,22 +86,11 @@ func (s *State) bind(cli *CommandLine, mask stateFlag) {
 		).SetHidden(true)
 	}
 	if mask&stateFlagBackup != 0 {
-		s.bindBackupFlag(cli, "")
+		cli.StringVar(&s.BackupPath, "backup", "",
+			`Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.`,
+		).SetHidden(true)
 	}
-}
-
-// bindtateInFlag exists strictly because the default value can get a different value in some commands.
-func (s *State) bindStateInFlag(cli *CommandLine, defVal string) {
-	cli.StringVar(&s.StatePath, "state", defVal,
-		`A legacy option used for the local backend only. Refer to the local backend's documentation for more information.`,
-	).SetDisplay("=statefile").SetHidden(true)
-}
-
-// bindBackupFlag exists strictly because the default value can get a different value in some commands.
-func (s *State) bindBackupFlag(cli *CommandLine, defVal string) {
-	cli.StringVar(&s.BackupPath, "backup", defVal,
-		`Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.`,
-	).SetHidden(true)
+	return &s
 }
 
 // Operation describes arguments which are used to configure how a OpenTofu

--- a/internal/command/arguments/extended.go
+++ b/internal/command/arguments/extended.go
@@ -8,7 +8,6 @@ package arguments
 import (
 	"bufio"
 	"bytes"
-	"flag"
 	"fmt"
 	"os"
 	"time"
@@ -65,31 +64,41 @@ type State struct {
 	BackupPath string
 }
 
-// addFlags is the sole logic of registering the state related flags in OpenTofu.
-func (s *State) addFlags(f *flag.FlagSet, mask stateFlag) {
+// bind is the sole logic of registering the state related flags in OpenTofu.
+func (s *State) bind(flags Flags, mask stateFlag) {
 	if mask&stateFlagLock != 0 {
-		f.BoolVar(&s.Lock, "lock", true, "lock")
-		f.DurationVar(&s.LockTimeout, "lock-timeout", 0, "lock-timeout")
+		flags.BoolVar(&s.Lock, "lock", true,
+			`Don't hold a state lock during the operation. This is dangerous if others might concurrently run commands against the same workspace.`,
+		).SetDisplay("=false")
+		flags.DurationVar(&s.LockTimeout, "lock-timeout", 0,
+			`Duration to retry a state lock, such as "5s" to represent five seconds.`,
+		).SetDisplay("=duration")
 	}
 	if mask&stateFlagStateIn != 0 {
-		s.AddStateInFlag(f, "")
+		s.bindStateInFlag(flags, "")
 	}
 	if mask&stateFlagStateOut != 0 {
-		f.StringVar(&s.StateOutPath, "state-out", "", "state-path")
+		flags.StringVar(&s.StateOutPath, "state-out", "",
+			`Path to write state to that is different than "-state". This can be used to preserve the old state.`,
+		).SetHidden(true)
 	}
 	if mask&stateFlagBackup != 0 {
-		s.AddBackupFlag(f, "")
+		s.bindBackupFlag(flags, "")
 	}
 }
 
-// AddStateInFlag exists strictly because the default value can get a different value in some commands.
-func (s *State) AddStateInFlag(f *flag.FlagSet, defVal string) {
-	f.StringVar(&s.StatePath, "state", defVal, "state-path")
+// bindtateInFlag exists strictly because the default value can get a different value in some commands.
+func (s *State) bindStateInFlag(flags Flags, defVal string) {
+	flags.StringVar(&s.StatePath, "state", defVal,
+		`A legacy option used for the local backend only. Refer to the local backend's documentation for more information.`,
+	).SetDisplay("=statefile")
 }
 
-// AddBackupFlag exists strictly because the default value can get a different value in some commands.
-func (s *State) AddBackupFlag(f *flag.FlagSet, defVal string) {
-	f.StringVar(&s.BackupPath, "backup", defVal, "backup-path")
+// bindBackupFlag exists strictly because the default value can get a different value in some commands.
+func (s *State) bindBackupFlag(flags Flags, defVal string) {
+	flags.StringVar(&s.BackupPath, "backup", defVal,
+		`Path to backup the existing state file before modifying. Defaults to the "-state-out" path with ".backup" extension. Set to "-" to disable backup.`,
+	).SetHidden(true)
 }
 
 // Operation describes arguments which are used to configure how a OpenTofu
@@ -346,38 +355,45 @@ func (v *Vars) Empty() bool {
 	return v.vars.Empty()
 }
 
-// extendedFlagSet creates a FlagSet with common backend, operation, and vars
-// flags used in many commands. Target structs for each subset of flags must be
-// provided in order to support those flags.
-func extendedFlagSet(name string, operation *Operation, vars *Vars) *flag.FlagSet {
-	f := defaultFlagSet(name)
+// bind registers all Operation flags
+func (operation *Operation) bind(flags Flags) {
+	flags.IntVar(&operation.Parallelism, "parallelism", DefaultParallelism,
+		`Limit the number of parallel resource operations. Defaults to 10.`,
+	).SetDisplay("=n")
+	flags.BoolVar(&operation.Refresh, "refresh", true,
+		`Skip checking for external changes to remote objects while creating the plan. This can potentially make planning faster, but at the expense of possibly planning against a stale record of the remote system state.`,
+	).SetDisplay("=false")
+	flags.BoolVar(&operation.destroyRaw, "destroy", false,
+		`Select the "destroy" planning mode, which creates a plan to destroy all objects currently managed by this OpenTofu configuration instead of the usual behavior.`)
+	flags.BoolVar(&operation.refreshOnlyRaw, "refresh-only", false,
+		`Select the "refresh only" planning mode, which checks whether remote objects still match the outcome of the most recent OpenTofu apply but does not propose any actions to undo any changes made outside of OpenTofu.`)
+	flags.StringArrayVar(&operation.targetsRaw, "target", nil,
+		`Limit the planning operation to only the given module, resource, or resource instance and all of its dependencies. You can use this option multiple times to include more than one object. This is for exceptional use only. Cannot be used alongside the -exclude option.`,
+	).SetDisplay("=resource")
+	flags.StringArrayVar(&operation.targetsFilesRaw, "target-file", nil,
+		`Similar to -target, but specifies zero or more resource addresses from a file.`,
+	).SetDisplay("=filename")
+	flags.StringArrayVar(&operation.excludesRaw, "exclude", nil,
+		`Limit the planning operation to not operate on the given module, resource, or resource instance and all of the resources and modules that depend on it. You can use this option multiple times to exclude more than one object. This is for exceptional use only. Cannot be used together with the -target option.`,
+	).SetDisplay("=resource")
+	flags.StringArrayVar(&operation.excludesFilesRaw, "exclude-file", nil,
+		`Similar to -exclude, but specifies zero or more resource addresses from a file.`,
+	).SetDisplay("=filename")
+	flags.StringArrayVar(&operation.forceReplaceRaw, "replace", nil,
+		`Force replacement of a particular resource instance using its resource address. If the plan would've otherwise produced an update or no-op action for this instance, OpenTofu will plan to replace it instead. You can use this option multiple times to replace more than one object.`,
+	).SetDisplay("=resource")
+}
 
-	if operation == nil && vars == nil {
-		panic("use defaultFlagSet")
-	}
-
-	if operation != nil {
-		f.IntVar(&operation.Parallelism, "parallelism", DefaultParallelism, "parallelism")
-		f.BoolVar(&operation.Refresh, "refresh", true, "refresh")
-		f.BoolVar(&operation.destroyRaw, "destroy", false, "destroy")
-		f.BoolVar(&operation.refreshOnlyRaw, "refresh-only", false, "refresh-only")
-		f.Var((*flags.FlagStringSlice)(&operation.targetsRaw), "target", "target")
-		f.Var((*flags.FlagStringSlice)(&operation.targetsFilesRaw), "target-file", "target-file")
-		f.Var((*flags.FlagStringSlice)(&operation.excludesRaw), "exclude", "exclude")
-		f.Var((*flags.FlagStringSlice)(&operation.excludesFilesRaw), "exclude-file", "exclude-file")
-		f.Var((*flags.FlagStringSlice)(&operation.forceReplaceRaw), "replace", "replace")
-	}
-
-	// Gather all -var and -var-file arguments into one heterogeneous structure
-	// to preserve the overall order.
-	if vars != nil {
-		varsFlags := flags.NewRawFlags("-var")
-		varFilesFlags := varsFlags.Alias("-var-file")
-		vars.vars = &varsFlags
-		vars.varFiles = &varFilesFlags
-		f.Var(vars.vars, "var", "var")
-		f.Var(vars.varFiles, "var-file", "var-file")
-	}
-
-	return f
+// bind registers all Vars flags
+func (vars *Vars) bind(f Flags) {
+	varsFlags := flags.NewRawFlags("-var")
+	varFilesFlags := varsFlags.Alias("-var-file")
+	vars.vars = &varsFlags
+	vars.varFiles = &varFilesFlags
+	f.RawFlags(varsFlags, "var",
+		`Set a value for one of the input variables in the root module of the configuration. Use this option more than once to set more than one variable.`,
+	).SetDisplay(" 'foo=bar'")
+	f.RawFlags(varFilesFlags, "var-file",
+		`Load variable values from the given file, in addition to the default files terraform.tfvars and *.auto.tfvars. Use this option more than once to include more than one variables file.`,
+	).SetDisplay("=filename")
 }

--- a/internal/command/arguments/extended.go
+++ b/internal/command/arguments/extended.go
@@ -376,7 +376,7 @@ func BindOperation(cli *CommandLine) *Operation {
 		`Force replacement of a particular resource instance using its resource address. If the plan would've otherwise produced an update or no-op action for this instance, OpenTofu will plan to replace it instead. You can use this option multiple times to replace more than one object.`,
 	).SetDisplay("=resource")
 
-	cli.Hook(Hook{Pre: operation.Parse})
+	cli.PreHook(operation.Parse)
 
 	return &operation
 }

--- a/internal/command/arguments/extended_test.go
+++ b/internal/command/arguments/extended_test.go
@@ -19,22 +19,22 @@ import (
 // Legacy helpers
 func BindStateBackupFlag(cli *CommandLine, def string) *State {
 	s := BindState(cli, stateFlagBackup)
-	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+	cli.PreHook(func() tfdiags.Diagnostics {
 		if s.BackupPath == "" {
 			s.BackupPath = def
 		}
 		return nil
-	}})
+	})
 	return s
 }
 func BindStateInFlag(cli *CommandLine, def string) *State {
 	s := BindState(cli, stateFlagStateIn)
-	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+	cli.PreHook(func() tfdiags.Diagnostics {
 		if s.StatePath == "" {
 			s.StatePath = def
 		}
 		return nil
-	}})
+	})
 	return s
 }
 
@@ -296,12 +296,12 @@ func TestStateFlagsRegistering(t *testing.T) {
 		"lock, state in, state out and backup with a different default": {
 			register: func(cli *CommandLine) *State {
 				s := BindState(cli, stateFlagLock|stateFlagStateIn|stateFlagStateOut|stateFlagBackup)
-				cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+				cli.PreHook(func() tfdiags.Diagnostics {
 					if s.BackupPath == "" {
 						s.BackupPath = "-"
 					}
 					return nil
-				}})
+				})
 				return s
 			},
 			args: []string{

--- a/internal/command/arguments/extended_test.go
+++ b/internal/command/arguments/extended_test.go
@@ -13,19 +13,43 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
+// Legacy helpers
+func BindStateBackupFlag(cli *CommandLine, def string) *State {
+	s := BindState(cli, stateFlagBackup)
+	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+		if s.BackupPath == "" {
+			s.BackupPath = def
+		}
+		return nil
+	}})
+	return s
+}
+func BindStateInFlag(cli *CommandLine, def string) *State {
+	s := BindState(cli, stateFlagStateIn)
+	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+		if s.StatePath == "" {
+			s.StatePath = def
+		}
+		return nil
+	}})
+	return s
+}
+
 func TestStateFlagsParsing(t *testing.T) {
+
 	testCases := map[string]struct {
 		args     []string
-		register func(s *State, cli *CommandLine)
+		register func(cli *CommandLine) *State
 		want     *State
 		wantErr  error
 	}{
 		"defaults": {
 			args: nil,
-			register: func(s *State, cli *CommandLine) {
-				s.bind(cli, stateFlagAll)
+			register: func(cli *CommandLine) *State {
+				return BindState(cli, stateFlagAll)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.Lock = true
@@ -33,8 +57,8 @@ func TestStateFlagsParsing(t *testing.T) {
 		},
 		"lock": {
 			args: []string{"-lock=false"},
-			register: func(s *State, cli *CommandLine) {
-				s.bind(cli, stateFlagAll)
+			register: func(cli *CommandLine) *State {
+				return BindState(cli, stateFlagAll)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.Lock = false
@@ -42,8 +66,8 @@ func TestStateFlagsParsing(t *testing.T) {
 		},
 		"lockTimeout": {
 			args: []string{"-lock-timeout=2s"},
-			register: func(s *State, cli *CommandLine) {
-				s.bind(cli, stateFlagAll)
+			register: func(cli *CommandLine) *State {
+				return BindState(cli, stateFlagAll)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.LockTimeout = 2 * time.Second
@@ -52,8 +76,8 @@ func TestStateFlagsParsing(t *testing.T) {
 		},
 		"state": {
 			args: []string{"-state=/path/to/state"},
-			register: func(s *State, cli *CommandLine) {
-				s.bind(cli, stateFlagAll)
+			register: func(cli *CommandLine) *State {
+				return BindState(cli, stateFlagAll)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.StatePath = "/path/to/state"
@@ -62,8 +86,8 @@ func TestStateFlagsParsing(t *testing.T) {
 		},
 		"stateOut": {
 			args: []string{"-state-out=/path/to/output/state"},
-			register: func(s *State, cli *CommandLine) {
-				s.bind(cli, stateFlagAll)
+			register: func(cli *CommandLine) *State {
+				return BindState(cli, stateFlagAll)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.StateOutPath = "/path/to/output/state"
@@ -72,8 +96,8 @@ func TestStateFlagsParsing(t *testing.T) {
 		},
 		"backup": {
 			args: []string{"-backup=/path/to/state/backup"},
-			register: func(s *State, cli *CommandLine) {
-				s.bind(cli, stateFlagAll)
+			register: func(cli *CommandLine) *State {
+				return BindState(cli, stateFlagAll)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.BackupPath = "/path/to/state/backup"
@@ -88,8 +112,8 @@ func TestStateFlagsParsing(t *testing.T) {
 				"-lock-timeout=2s",
 				"-lock=false",
 			},
-			register: func(s *State, cli *CommandLine) {
-				s.bind(cli, stateFlagAll)
+			register: func(cli *CommandLine) *State {
+				return BindState(cli, stateFlagAll)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.BackupPath = "/path/to/state/backup"
@@ -104,8 +128,8 @@ func TestStateFlagsParsing(t *testing.T) {
 				"-backup=/path/to/state/backup",
 				"-unknown=foo",
 			},
-			register: func(s *State, cli *CommandLine) {
-				s.bind(cli, stateFlagAll)
+			register: func(cli *CommandLine) *State {
+				return BindState(cli, stateFlagAll)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.BackupPath = "/path/to/state/backup"
@@ -115,8 +139,8 @@ func TestStateFlagsParsing(t *testing.T) {
 		},
 		"register only backup flag - no flags provided": {
 			args: []string{},
-			register: func(s *State, cli *CommandLine) {
-				s.bindBackupFlag(cli, "-")
+			register: func(cli *CommandLine) *State {
+				return BindStateBackupFlag(cli, "-")
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.BackupPath = "-" // the provided different default
@@ -124,8 +148,8 @@ func TestStateFlagsParsing(t *testing.T) {
 		},
 		"register only backup flag - with backup flag": {
 			args: []string{"-backup=/path/to/backup"},
-			register: func(s *State, cli *CommandLine) {
-				s.bindBackupFlag(cli, "-")
+			register: func(cli *CommandLine) *State {
+				return BindStateBackupFlag(cli, "-")
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.BackupPath = "/path/to/backup"
@@ -133,8 +157,8 @@ func TestStateFlagsParsing(t *testing.T) {
 		},
 		"register only backup flag - unregistered flag": {
 			args: []string{"-backup=/path/to/backup", "-lock=false"},
-			register: func(s *State, cli *CommandLine) {
-				s.bindBackupFlag(cli, "-")
+			register: func(cli *CommandLine) *State {
+				return BindStateBackupFlag(cli, "-")
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.BackupPath = "/path/to/backup"
@@ -143,8 +167,8 @@ func TestStateFlagsParsing(t *testing.T) {
 		},
 		"register only stateIn flag - no flags provided": {
 			args: []string{},
-			register: func(s *State, cli *CommandLine) {
-				s.bindStateInFlag(cli, "default.tfstate")
+			register: func(cli *CommandLine) *State {
+				return BindStateInFlag(cli, "default.tfstate")
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.StatePath = "default.tfstate" // the provided different default
@@ -152,8 +176,8 @@ func TestStateFlagsParsing(t *testing.T) {
 		},
 		"register only stateIn flag - with state flag": {
 			args: []string{"-state=/path/to/state"},
-			register: func(s *State, cli *CommandLine) {
-				s.bindStateInFlag(cli, "default.tfstate")
+			register: func(cli *CommandLine) *State {
+				return BindStateInFlag(cli, "default.tfstate")
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.StatePath = "/path/to/state"
@@ -161,8 +185,8 @@ func TestStateFlagsParsing(t *testing.T) {
 		},
 		"register only stateIn flag - unregistered flag": {
 			args: []string{"-state=/path/to/state", "-lock=false"},
-			register: func(s *State, cli *CommandLine) {
-				s.bindStateInFlag(cli, "-")
+			register: func(cli *CommandLine) *State {
+				return BindStateInFlag(cli, "-")
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.StatePath = "/path/to/state"
@@ -176,8 +200,7 @@ func TestStateFlagsParsing(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			var cli CommandLine
-			s := &State{}
-			tc.register(s, &cli)
+			s := tc.register(&cli)
 
 			_, diags := cli.Stdlib("test", tc.args)
 
@@ -193,21 +216,22 @@ func TestStateFlagsParsing(t *testing.T) {
 
 func TestStateFlagsRegistering(t *testing.T) {
 	testCases := map[string]struct {
-		register func(s *State, cli *CommandLine)
+		register func(cli *CommandLine) *State
 		args     []string
 		want     *State
 		wantErr  error
 	}{
 		"no flag registered": {
-			register: func(s *State, cli *CommandLine) {
+			register: func(cli *CommandLine) *State {
+				return new(State)
 			},
 			args:    []string{"-lock=false"},
 			want:    stateArgsWithDefaults(func(v *State) {}),
 			wantErr: fmt.Errorf("flag provided but not defined: -lock"),
 		},
 		"only lock flags registered": {
-			register: func(s *State, cli *CommandLine) {
-				s.bind(cli, stateFlagLock)
+			register: func(cli *CommandLine) *State {
+				return BindState(cli, stateFlagLock)
 			},
 			args: []string{
 				"-lock=false",
@@ -219,8 +243,8 @@ func TestStateFlagsRegistering(t *testing.T) {
 			}),
 		},
 		"lock and state in": {
-			register: func(s *State, cli *CommandLine) {
-				s.bind(cli, stateFlagLock|stateFlagStateIn)
+			register: func(cli *CommandLine) *State {
+				return BindState(cli, stateFlagLock|stateFlagStateIn)
 			},
 			args: []string{
 				"-lock=false",
@@ -234,8 +258,8 @@ func TestStateFlagsRegistering(t *testing.T) {
 			}),
 		},
 		"lock, state in and state out": {
-			register: func(s *State, cli *CommandLine) {
-				s.bind(cli, stateFlagLock|stateFlagStateIn|stateFlagStateOut)
+			register: func(cli *CommandLine) *State {
+				return BindState(cli, stateFlagLock|stateFlagStateIn|stateFlagStateOut)
 			},
 			args: []string{
 				"-lock=false",
@@ -251,8 +275,8 @@ func TestStateFlagsRegistering(t *testing.T) {
 			}),
 		},
 		"lock, state in, state out and backup": {
-			register: func(s *State, cli *CommandLine) {
-				s.bind(cli, stateFlagAll)
+			register: func(cli *CommandLine) *State {
+				return BindState(cli, stateFlagAll)
 			},
 			args: []string{
 				"-lock=false",
@@ -270,10 +294,15 @@ func TestStateFlagsRegistering(t *testing.T) {
 			}),
 		},
 		"lock, state in, state out and backup with a different default": {
-			register: func(s *State, cli *CommandLine) {
-				// StateFlagBackup omitted here to be added later with a different default value
-				s.bind(cli, stateFlagLock|stateFlagStateIn|stateFlagStateOut)
-				s.bindBackupFlag(cli, "-")
+			register: func(cli *CommandLine) *State {
+				s := BindState(cli, stateFlagLock|stateFlagStateIn|stateFlagStateOut|stateFlagBackup)
+				cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+					if s.BackupPath == "" {
+						s.BackupPath = "-"
+					}
+					return nil
+				}})
+				return s
 			},
 			args: []string{
 				"-lock=false",
@@ -296,8 +325,7 @@ func TestStateFlagsRegistering(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			var cli CommandLine
-			s := &State{}
-			tc.register(s, &cli)
+			s := tc.register(&cli)
 			_, diags := cli.Stdlib("test", tc.args)
 			if want, got := fmt.Sprintf("%s", tc.wantErr), fmt.Sprintf("%s", diags.Err()); !strings.Contains(got, want) {
 				t.Errorf("wanted error: %q, got error %q", want, got)

--- a/internal/command/arguments/extended_test.go
+++ b/internal/command/arguments/extended_test.go
@@ -6,8 +6,8 @@
 package arguments
 
 import (
-	"flag"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -18,14 +18,14 @@ import (
 func TestStateFlagsParsing(t *testing.T) {
 	testCases := map[string]struct {
 		args     []string
-		register func(s *State, f *flag.FlagSet)
+		register func(s *State, cli *CommandLine)
 		want     *State
 		wantErr  error
 	}{
 		"defaults": {
 			args: nil,
-			register: func(s *State, f *flag.FlagSet) {
-				s.addFlags(f, stateFlagAll)
+			register: func(s *State, cli *CommandLine) {
+				s.bind(cli, stateFlagAll)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.Lock = true
@@ -33,8 +33,8 @@ func TestStateFlagsParsing(t *testing.T) {
 		},
 		"lock": {
 			args: []string{"-lock=false"},
-			register: func(s *State, f *flag.FlagSet) {
-				s.addFlags(f, stateFlagAll)
+			register: func(s *State, cli *CommandLine) {
+				s.bind(cli, stateFlagAll)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.Lock = false
@@ -42,8 +42,8 @@ func TestStateFlagsParsing(t *testing.T) {
 		},
 		"lockTimeout": {
 			args: []string{"-lock-timeout=2s"},
-			register: func(s *State, f *flag.FlagSet) {
-				s.addFlags(f, stateFlagAll)
+			register: func(s *State, cli *CommandLine) {
+				s.bind(cli, stateFlagAll)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.LockTimeout = 2 * time.Second
@@ -52,8 +52,8 @@ func TestStateFlagsParsing(t *testing.T) {
 		},
 		"state": {
 			args: []string{"-state=/path/to/state"},
-			register: func(s *State, f *flag.FlagSet) {
-				s.addFlags(f, stateFlagAll)
+			register: func(s *State, cli *CommandLine) {
+				s.bind(cli, stateFlagAll)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.StatePath = "/path/to/state"
@@ -62,8 +62,8 @@ func TestStateFlagsParsing(t *testing.T) {
 		},
 		"stateOut": {
 			args: []string{"-state-out=/path/to/output/state"},
-			register: func(s *State, f *flag.FlagSet) {
-				s.addFlags(f, stateFlagAll)
+			register: func(s *State, cli *CommandLine) {
+				s.bind(cli, stateFlagAll)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.StateOutPath = "/path/to/output/state"
@@ -72,8 +72,8 @@ func TestStateFlagsParsing(t *testing.T) {
 		},
 		"backup": {
 			args: []string{"-backup=/path/to/state/backup"},
-			register: func(s *State, f *flag.FlagSet) {
-				s.addFlags(f, stateFlagAll)
+			register: func(s *State, cli *CommandLine) {
+				s.bind(cli, stateFlagAll)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.BackupPath = "/path/to/state/backup"
@@ -88,8 +88,8 @@ func TestStateFlagsParsing(t *testing.T) {
 				"-lock-timeout=2s",
 				"-lock=false",
 			},
-			register: func(s *State, f *flag.FlagSet) {
-				s.addFlags(f, stateFlagAll)
+			register: func(s *State, cli *CommandLine) {
+				s.bind(cli, stateFlagAll)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.BackupPath = "/path/to/state/backup"
@@ -104,8 +104,8 @@ func TestStateFlagsParsing(t *testing.T) {
 				"-backup=/path/to/state/backup",
 				"-unknown=foo",
 			},
-			register: func(s *State, f *flag.FlagSet) {
-				s.addFlags(f, stateFlagAll)
+			register: func(s *State, cli *CommandLine) {
+				s.bind(cli, stateFlagAll)
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.BackupPath = "/path/to/state/backup"
@@ -115,8 +115,8 @@ func TestStateFlagsParsing(t *testing.T) {
 		},
 		"register only backup flag - no flags provided": {
 			args: []string{},
-			register: func(s *State, f *flag.FlagSet) {
-				s.AddBackupFlag(f, "-")
+			register: func(s *State, cli *CommandLine) {
+				s.bindBackupFlag(cli, "-")
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.BackupPath = "-" // the provided different default
@@ -124,8 +124,8 @@ func TestStateFlagsParsing(t *testing.T) {
 		},
 		"register only backup flag - with backup flag": {
 			args: []string{"-backup=/path/to/backup"},
-			register: func(s *State, f *flag.FlagSet) {
-				s.AddBackupFlag(f, "-")
+			register: func(s *State, cli *CommandLine) {
+				s.bindBackupFlag(cli, "-")
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.BackupPath = "/path/to/backup"
@@ -133,8 +133,8 @@ func TestStateFlagsParsing(t *testing.T) {
 		},
 		"register only backup flag - unregistered flag": {
 			args: []string{"-backup=/path/to/backup", "-lock=false"},
-			register: func(s *State, f *flag.FlagSet) {
-				s.AddBackupFlag(f, "-")
+			register: func(s *State, cli *CommandLine) {
+				s.bindBackupFlag(cli, "-")
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.BackupPath = "/path/to/backup"
@@ -143,8 +143,8 @@ func TestStateFlagsParsing(t *testing.T) {
 		},
 		"register only stateIn flag - no flags provided": {
 			args: []string{},
-			register: func(s *State, f *flag.FlagSet) {
-				s.AddStateInFlag(f, "default.tfstate")
+			register: func(s *State, cli *CommandLine) {
+				s.bindStateInFlag(cli, "default.tfstate")
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.StatePath = "default.tfstate" // the provided different default
@@ -152,8 +152,8 @@ func TestStateFlagsParsing(t *testing.T) {
 		},
 		"register only stateIn flag - with state flag": {
 			args: []string{"-state=/path/to/state"},
-			register: func(s *State, f *flag.FlagSet) {
-				s.AddStateInFlag(f, "default.tfstate")
+			register: func(s *State, cli *CommandLine) {
+				s.bindStateInFlag(cli, "default.tfstate")
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.StatePath = "/path/to/state"
@@ -161,8 +161,8 @@ func TestStateFlagsParsing(t *testing.T) {
 		},
 		"register only stateIn flag - unregistered flag": {
 			args: []string{"-state=/path/to/state", "-lock=false"},
-			register: func(s *State, f *flag.FlagSet) {
-				s.AddStateInFlag(f, "-")
+			register: func(s *State, cli *CommandLine) {
+				s.bindStateInFlag(cli, "-")
 			},
 			want: stateArgsWithDefaults(func(v *State) {
 				v.StatePath = "/path/to/state"
@@ -175,12 +175,14 @@ func TestStateFlagsParsing(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			var cli CommandLine
 			s := &State{}
-			f := defaultFlagSet("test")
-			tc.register(s, f)
-			err := f.Parse(tc.args)
-			if diff := cmp.Diff(fmt.Sprintf("%s", tc.wantErr), fmt.Sprintf("%s", err)); diff != "" {
-				t.Errorf("unexpected error (-want,+got)\n%s", diff)
+			tc.register(s, &cli)
+
+			_, diags := cli.Stdlib("test", tc.args)
+
+			if want, got := fmt.Sprintf("%s", tc.wantErr), fmt.Sprintf("%s", diags.Err()); !strings.Contains(got, want) {
+				t.Errorf("wanted error: %q, got error %q", want, got)
 			}
 			if diff := cmp.Diff(tc.want, s, cmpOpts); diff != "" {
 				t.Errorf("unexpected result (-want,+got)\n%s", diff)
@@ -191,21 +193,21 @@ func TestStateFlagsParsing(t *testing.T) {
 
 func TestStateFlagsRegistering(t *testing.T) {
 	testCases := map[string]struct {
-		register func(s *State, f *flag.FlagSet)
+		register func(s *State, cli *CommandLine)
 		args     []string
 		want     *State
 		wantErr  error
 	}{
 		"no flag registered": {
-			register: func(s *State, f *flag.FlagSet) {
+			register: func(s *State, cli *CommandLine) {
 			},
 			args:    []string{"-lock=false"},
 			want:    stateArgsWithDefaults(func(v *State) {}),
 			wantErr: fmt.Errorf("flag provided but not defined: -lock"),
 		},
 		"only lock flags registered": {
-			register: func(s *State, f *flag.FlagSet) {
-				s.addFlags(f, stateFlagLock)
+			register: func(s *State, cli *CommandLine) {
+				s.bind(cli, stateFlagLock)
 			},
 			args: []string{
 				"-lock=false",
@@ -217,8 +219,8 @@ func TestStateFlagsRegistering(t *testing.T) {
 			}),
 		},
 		"lock and state in": {
-			register: func(s *State, f *flag.FlagSet) {
-				s.addFlags(f, stateFlagLock|stateFlagStateIn)
+			register: func(s *State, cli *CommandLine) {
+				s.bind(cli, stateFlagLock|stateFlagStateIn)
 			},
 			args: []string{
 				"-lock=false",
@@ -232,8 +234,8 @@ func TestStateFlagsRegistering(t *testing.T) {
 			}),
 		},
 		"lock, state in and state out": {
-			register: func(s *State, f *flag.FlagSet) {
-				s.addFlags(f, stateFlagLock|stateFlagStateIn|stateFlagStateOut)
+			register: func(s *State, cli *CommandLine) {
+				s.bind(cli, stateFlagLock|stateFlagStateIn|stateFlagStateOut)
 			},
 			args: []string{
 				"-lock=false",
@@ -249,8 +251,8 @@ func TestStateFlagsRegistering(t *testing.T) {
 			}),
 		},
 		"lock, state in, state out and backup": {
-			register: func(s *State, f *flag.FlagSet) {
-				s.addFlags(f, stateFlagAll)
+			register: func(s *State, cli *CommandLine) {
+				s.bind(cli, stateFlagAll)
 			},
 			args: []string{
 				"-lock=false",
@@ -268,10 +270,10 @@ func TestStateFlagsRegistering(t *testing.T) {
 			}),
 		},
 		"lock, state in, state out and backup with a different default": {
-			register: func(s *State, f *flag.FlagSet) {
+			register: func(s *State, cli *CommandLine) {
 				// StateFlagBackup omitted here to be added later with a different default value
-				s.addFlags(f, stateFlagLock|stateFlagStateIn|stateFlagStateOut)
-				s.AddBackupFlag(f, "-")
+				s.bind(cli, stateFlagLock|stateFlagStateIn|stateFlagStateOut)
+				s.bindBackupFlag(cli, "-")
 			},
 			args: []string{
 				"-lock=false",
@@ -293,12 +295,12 @@ func TestStateFlagsRegistering(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			var cli CommandLine
 			s := &State{}
-			f := defaultFlagSet("test")
-			tc.register(s, f)
-			err := f.Parse(tc.args)
-			if diff := cmp.Diff(fmt.Sprintf("%s", tc.wantErr), fmt.Sprintf("%s", err)); diff != "" {
-				t.Errorf("unexpected error (-want,+got)\n%s", diff)
+			tc.register(s, &cli)
+			_, diags := cli.Stdlib("test", tc.args)
+			if want, got := fmt.Sprintf("%s", tc.wantErr), fmt.Sprintf("%s", diags.Err()); !strings.Contains(got, want) {
+				t.Errorf("wanted error: %q, got error %q", want, got)
 			}
 			if diff := cmp.Diff(tc.want, s, cmpOpts); diff != "" {
 				t.Errorf("unexpected result (-want,+got)\n%s", diff)

--- a/internal/command/arguments/fmt.go
+++ b/internal/command/arguments/fmt.go
@@ -53,7 +53,7 @@ func BindFmt(cli *CommandLine) *Fmt {
 	cli.BoolVar(&ret.Recursive, "recursive", false, "Also process files in subdirectories. By default, only the given directory (or current directory) is processed.")
 
 	cli.VariadicArg(&ret.Paths, "paths")
-	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+	cli.PreHook(func() tfdiags.Diagnostics {
 		if len(ret.Paths) == 0 {
 			ret.Paths = []string{"."}
 		} else if ret.Paths[0] == stdinArg {
@@ -62,7 +62,7 @@ func BindFmt(cli *CommandLine) *Fmt {
 			ret.Write = false
 		}
 		return nil
-	}})
+	})
 
 	return &ret
 }

--- a/internal/command/arguments/fmt.go
+++ b/internal/command/arguments/fmt.go
@@ -40,51 +40,39 @@ type Fmt struct {
 }
 
 // BindFmt registers CLI arguments, returning a Fmt value and it's corresponding hooks.
-func BindFmt(flags Flags) (*Fmt, Hooks) {
+func BindFmt(cli *CommandLine) *Fmt {
 	var ret Fmt
-	var hooks Hooks
 
 	// we only parse but do not register the views flags since this command does not need it
-	hooks = append(hooks, ret.ViewOptions.ParseHook())
+	ret.ViewOptions.ParseHook(cli)
 
-	flags.BoolVar(&ret.List, "list", true, "Don't list files whose formatting differs (always disabled if using STDIN)").SetDisplay("=false")
-	flags.BoolVar(&ret.Write, "write", true, "Don't write to source files (always disabled if using STDIN or -check)").SetDisplay("=false")
-	flags.BoolVar(&ret.Diff, "diff", false, "Display diffs of formatting changes")
-	flags.BoolVar(&ret.Check, "check", false, "Check if the input is formatted. Exit status will be 0 if all input is properly formatted and non-zero otherwise.")
-	flags.BoolVar(&ret.Recursive, "recursive", false, "Also process files in subdirectories. By default, only the given directory (or current directory) is processed.")
+	cli.BoolVar(&ret.List, "list", true, "Don't list files whose formatting differs (always disabled if using STDIN)").SetDisplay("=false")
+	cli.BoolVar(&ret.Write, "write", true, "Don't write to source files (always disabled if using STDIN or -check)").SetDisplay("=false")
+	cli.BoolVar(&ret.Diff, "diff", false, "Display diffs of formatting changes")
+	cli.BoolVar(&ret.Check, "check", false, "Check if the input is formatted. Exit status will be 0 if all input is properly formatted and non-zero otherwise.")
+	cli.BoolVar(&ret.Recursive, "recursive", false, "Also process files in subdirectories. By default, only the given directory (or current directory) is processed.")
 
-	return &ret, hooks
+	cli.VariadicArg(&ret.Paths, "paths")
+	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+		if len(ret.Paths) == 0 {
+			ret.Paths = []string{"."}
+		} else if ret.Paths[0] == stdinArg {
+			ret.Paths = nil
+			ret.List = false
+			ret.Write = false
+		}
+		return nil
+	}})
+
+	return &ret
 }
 
 // ParseFmt processes CLI arguments, returning a Fmt value, a closer function, and errors.
 // If errors are encountered, a Fmt value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseFmt(args []string) (*Fmt, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	ret, hooks := BindFmt(flags)
-
-	cmdFlags := defaultFlagSet("fmt", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	// TODO positional args
-	args = cmdFlags.Args()
-	if len(args) == 0 {
-		ret.Paths = []string{"."}
-	} else if args[0] == stdinArg {
-		ret.List = false
-		ret.Write = false
-	} else {
-		ret.Paths = args
-	}
-
-	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	ret := BindFmt(cli)
+	closer, diags := cli.Stdlib("fmt", args)
+	return ret, closer, diags
 }

--- a/internal/command/arguments/fmt.go
+++ b/internal/command/arguments/fmt.go
@@ -39,20 +39,33 @@ type Fmt struct {
 	ViewOptions ViewOptions
 }
 
+// BindFmt registers CLI arguments, returning a Fmt value and it's corresponding hooks.
+func BindFmt(flags Flags) (*Fmt, Hooks) {
+	var ret Fmt
+	var hooks Hooks
+
+	// we only parse but do not register the views flags since this command does not need it
+	hooks = append(hooks, ret.ViewOptions.ParseHook())
+
+	flags.BoolVar(&ret.List, "list", true, "Don't list files whose formatting differs (always disabled if using STDIN)").SetDisplay("=false")
+	flags.BoolVar(&ret.Write, "write", true, "Don't write to source files (always disabled if using STDIN or -check)").SetDisplay("=false")
+	flags.BoolVar(&ret.Diff, "diff", false, "Display diffs of formatting changes")
+	flags.BoolVar(&ret.Check, "check", false, "Check if the input is formatted. Exit status will be 0 if all input is properly formatted and non-zero otherwise.")
+	flags.BoolVar(&ret.Recursive, "recursive", false, "Also process files in subdirectories. By default, only the given directory (or current directory) is processed.")
+
+	return &ret, hooks
+}
+
 // ParseFmt processes CLI arguments, returning a Fmt value, a closer function, and errors.
 // If errors are encountered, a Fmt value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseFmt(args []string) (*Fmt, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	ret := &Fmt{}
+	flags := Flags{}
+	ret, hooks := BindFmt(flags)
 
-	cmdFlags := defaultFlagSet("fmt")
-	cmdFlags.BoolVar(&ret.List, "list", true, "list")
-	cmdFlags.BoolVar(&ret.Write, "write", true, "write")
-	cmdFlags.BoolVar(&ret.Diff, "diff", false, "diff")
-	cmdFlags.BoolVar(&ret.Check, "check", false, "check")
-	cmdFlags.BoolVar(&ret.Recursive, "recursive", false, "recursive")
+	cmdFlags := defaultFlagSet("fmt", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -62,6 +75,7 @@ func ParseFmt(args []string) (*Fmt, func(), tfdiags.Diagnostics) {
 		))
 	}
 
+	// TODO positional args
 	args = cmdFlags.Args()
 	if len(args) == 0 {
 		ret.Paths = []string{"."}
@@ -72,9 +86,5 @@ func ParseFmt(args []string) (*Fmt, func(), tfdiags.Diagnostics) {
 		ret.Paths = args
 	}
 
-	// we only parse but do not register the views flags since this command does not need it
-	closer, moreDiags := ret.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-
-	return ret, closer, diags
+	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/get.go
+++ b/internal/command/arguments/get.go
@@ -22,19 +22,33 @@ type Get struct {
 	ViewOptions ViewOptions
 }
 
+// BindGet registers CLI arguments, returning a Get value and it's corresponding hooks.
+func BindGet(flags Flags) (*Get, Hooks) {
+	var arguments Get
+	var hooks Hooks
+
+	arguments.ViewOptions.bind(flags, true)
+	hooks = append(hooks, arguments.ViewOptions.ParseHook())
+
+	arguments.Vars = &Vars{}
+	arguments.Vars.bind(flags)
+
+	flags.BoolVar(&arguments.Update, "update", false, "Check already-downloaded modules for available updates and install the newest versions available.")
+	flags.StringVar(&arguments.TestsDirectory, "test-directory", "tests", `Set the OpenTofu test directory, defaults to "tests". When set, the test command will search for test files in the current directory and in the one specified by the flag.`).SetDisplay("=path")
+
+	return &arguments, hooks
+}
+
 // ParseGet processes CLI arguments, returning a Get value, a closer function, and errors.
 // If errors are encountered, a Get value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseGet(args []string) (*Get, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	arguments := &Get{
-		Vars: &Vars{},
-	}
 
-	cmdFlags := extendedFlagSet("get", nil, arguments.Vars)
-	cmdFlags.BoolVar(&arguments.Update, "update", false, "update")
-	cmdFlags.StringVar(&arguments.TestsDirectory, "test-directory", "tests", "test-directory")
-	arguments.ViewOptions.AddFlags(cmdFlags, false)
+	flags := Flags{}
+	arguments, hooks := BindGet(flags)
+
+	cmdFlags := defaultFlagSet("get", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -44,11 +58,6 @@ func ParseGet(args []string) (*Get, func(), tfdiags.Diagnostics) {
 		))
 	}
 
-	closer, moreDiags := arguments.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-	if diags.HasErrors() {
-		return arguments, closer, diags
-	}
 	if len(cmdFlags.Args()) > 0 {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
@@ -57,5 +66,5 @@ func ParseGet(args []string) (*Get, func(), tfdiags.Diagnostics) {
 		))
 	}
 
-	return arguments, closer, diags
+	return arguments, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/get.go
+++ b/internal/command/arguments/get.go
@@ -28,8 +28,7 @@ func BindGet(cli *CommandLine) *Get {
 
 	arguments.ViewOptions.bind(cli, false)
 
-	arguments.Vars = &Vars{}
-	arguments.Vars.bind(cli)
+	arguments.Vars = BindVars(cli)
 
 	cli.BoolVar(&arguments.Update, "update", false, "Check already-downloaded modules for available updates and install the newest versions available.")
 	cli.StringVar(&arguments.TestsDirectory, "test-directory", "tests", `Set the OpenTofu test directory, defaults to "tests". When set, the test command will search for test files in the current directory and in the one specified by the flag.`).SetDisplay("=path")

--- a/internal/command/arguments/get.go
+++ b/internal/command/arguments/get.go
@@ -26,7 +26,7 @@ type Get struct {
 func BindGet(cli *CommandLine) *Get {
 	var arguments Get
 
-	arguments.ViewOptions.bind(cli, true)
+	arguments.ViewOptions.bind(cli, false)
 
 	arguments.Vars = &Vars{}
 	arguments.Vars.bind(cli)

--- a/internal/command/arguments/get.go
+++ b/internal/command/arguments/get.go
@@ -23,48 +23,26 @@ type Get struct {
 }
 
 // BindGet registers CLI arguments, returning a Get value and it's corresponding hooks.
-func BindGet(flags Flags) (*Get, Hooks) {
+func BindGet(cli *CommandLine) *Get {
 	var arguments Get
-	var hooks Hooks
 
-	arguments.ViewOptions.bind(flags, true)
-	hooks = append(hooks, arguments.ViewOptions.ParseHook())
+	arguments.ViewOptions.bind(cli, true)
 
 	arguments.Vars = &Vars{}
-	arguments.Vars.bind(flags)
+	arguments.Vars.bind(cli)
 
-	flags.BoolVar(&arguments.Update, "update", false, "Check already-downloaded modules for available updates and install the newest versions available.")
-	flags.StringVar(&arguments.TestsDirectory, "test-directory", "tests", `Set the OpenTofu test directory, defaults to "tests". When set, the test command will search for test files in the current directory and in the one specified by the flag.`).SetDisplay("=path")
+	cli.BoolVar(&arguments.Update, "update", false, "Check already-downloaded modules for available updates and install the newest versions available.")
+	cli.StringVar(&arguments.TestsDirectory, "test-directory", "tests", `Set the OpenTofu test directory, defaults to "tests". When set, the test command will search for test files in the current directory and in the one specified by the flag.`).SetDisplay("=path")
 
-	return &arguments, hooks
+	return &arguments
 }
 
 // ParseGet processes CLI arguments, returning a Get value, a closer function, and errors.
 // If errors are encountered, a Get value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseGet(args []string) (*Get, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	arguments, hooks := BindGet(flags)
-
-	cmdFlags := defaultFlagSet("get", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	if len(cmdFlags.Args()) > 0 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Unexpected argument",
-			"Too many command line arguments. Did you mean to use -chdir?",
-		))
-	}
-
-	return arguments, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	arguments := BindGet(cli)
+	closer, diags := cli.Stdlib("get", args)
+	return arguments, closer, diags
 }

--- a/internal/command/arguments/graph.go
+++ b/internal/command/arguments/graph.go
@@ -29,21 +29,36 @@ type Graph struct {
 	Vars *Vars
 }
 
+// BindGraph registers CLI arguments, returning a Graph value and it's corresponding hooks.
+func BindGraph(flags Flags) (*Graph, Hooks) {
+	var graph Graph
+	var hooks Hooks
+
+	// we only parse but do not register the views flags since this command does not need it
+	hooks = append(hooks, graph.ViewOptions.ParseHook())
+
+	graph.Vars = &Vars{}
+	graph.Vars.bind(flags)
+
+	flags.BoolVar(&graph.DrawCycles, "draw-cycles", false, "Highlight any cycles in the graph with colored edges. This helps when diagnosing cycle errors.")
+	flags.StringVar(&graph.GraphType, "type", "", `Type of graph to output. Can be: plan, plan-refresh-only, plan-destroy, or apply. By default OpenTofu chooses "plan", or "apply" if you also set the -plan=... option.`)
+	flags.IntVar(&graph.ModuleDepth, "module-depth", -1, "(deprecated) In prior versions of OpenTofu, specified the depth of modules to show in the output.")
+	flags.BoolVar(&graph.Verbose, "verbose", false, "verbose").SetHidden(true)
+	flags.StringVar(&graph.PlanPath, "plan", "", "Render graph using the specified plan file instead of the configuration in the current directory.")
+
+	return &graph, hooks
+}
+
 // ParseGraph processes CLI arguments, returning a Graph value, a closer function, and errors.
 // If errors are encountered, a Graph value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseGraph(args []string) (*Graph, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	arguments := &Graph{
-		Vars: &Vars{},
-	}
 
-	cmdFlags := extendedFlagSet("graph", nil, arguments.Vars)
-	cmdFlags.BoolVar(&arguments.DrawCycles, "draw-cycles", false, "draw-cycles")
-	cmdFlags.StringVar(&arguments.GraphType, "type", "", "type")
-	cmdFlags.IntVar(&arguments.ModuleDepth, "module-depth", -1, "module-depth")
-	cmdFlags.BoolVar(&arguments.Verbose, "verbose", false, "verbose")
-	cmdFlags.StringVar(&arguments.PlanPath, "plan", "", "plan")
+	flags := Flags{}
+	arguments, hooks := BindGraph(flags)
+
+	cmdFlags := defaultFlagSet("graph", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -51,13 +66,6 @@ func ParseGraph(args []string) (*Graph, func(), tfdiags.Diagnostics) {
 			"Failed to parse command-line flags",
 			err.Error(),
 		))
-	}
-
-	// we only parse but do not register the views flags since this command does not need it
-	closer, moreDiags := arguments.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-	if diags.HasErrors() {
-		return arguments, closer, diags
 	}
 
 	if len(cmdFlags.Args()) > 0 {
@@ -68,5 +76,5 @@ func ParseGraph(args []string) (*Graph, func(), tfdiags.Diagnostics) {
 		))
 	}
 
-	return arguments, closer, diags
+	return arguments, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/graph.go
+++ b/internal/command/arguments/graph.go
@@ -40,10 +40,10 @@ func BindGraph(cli *CommandLine) *Graph {
 	graph.Vars.bind(cli)
 
 	cli.BoolVar(&graph.DrawCycles, "draw-cycles", false, "Highlight any cycles in the graph with colored edges. This helps when diagnosing cycle errors.")
-	cli.StringVar(&graph.GraphType, "type", "", `Type of graph to output. Can be: plan, plan-refresh-only, plan-destroy, or apply. By default OpenTofu chooses "plan", or "apply" if you also set the -plan=... option.`)
+	cli.StringVar(&graph.GraphType, "type", "", `Type of graph to output. Can be: plan, plan-refresh-only, plan-destroy, or apply. By default OpenTofu chooses "plan", or "apply" if you also set the -plan=... option.`).SetDisplay("=plan")
 	cli.IntVar(&graph.ModuleDepth, "module-depth", -1, "(deprecated) In prior versions of OpenTofu, specified the depth of modules to show in the output.")
 	cli.BoolVar(&graph.Verbose, "verbose", false, "verbose").SetHidden(true)
-	cli.StringVar(&graph.PlanPath, "plan", "", "Render graph using the specified plan file instead of the configuration in the current directory.")
+	cli.StringVar(&graph.PlanPath, "plan", "", "Render graph using the specified plan file instead of the configuration in the current directory.").SetDisplay("=tfplan")
 
 	return &graph
 }

--- a/internal/command/arguments/graph.go
+++ b/internal/command/arguments/graph.go
@@ -30,51 +30,30 @@ type Graph struct {
 }
 
 // BindGraph registers CLI arguments, returning a Graph value and it's corresponding hooks.
-func BindGraph(flags Flags) (*Graph, Hooks) {
+func BindGraph(cli *CommandLine) *Graph {
 	var graph Graph
-	var hooks Hooks
 
 	// we only parse but do not register the views flags since this command does not need it
-	hooks = append(hooks, graph.ViewOptions.ParseHook())
+	graph.ViewOptions.ParseHook(cli)
 
 	graph.Vars = &Vars{}
-	graph.Vars.bind(flags)
+	graph.Vars.bind(cli)
 
-	flags.BoolVar(&graph.DrawCycles, "draw-cycles", false, "Highlight any cycles in the graph with colored edges. This helps when diagnosing cycle errors.")
-	flags.StringVar(&graph.GraphType, "type", "", `Type of graph to output. Can be: plan, plan-refresh-only, plan-destroy, or apply. By default OpenTofu chooses "plan", or "apply" if you also set the -plan=... option.`)
-	flags.IntVar(&graph.ModuleDepth, "module-depth", -1, "(deprecated) In prior versions of OpenTofu, specified the depth of modules to show in the output.")
-	flags.BoolVar(&graph.Verbose, "verbose", false, "verbose").SetHidden(true)
-	flags.StringVar(&graph.PlanPath, "plan", "", "Render graph using the specified plan file instead of the configuration in the current directory.")
+	cli.BoolVar(&graph.DrawCycles, "draw-cycles", false, "Highlight any cycles in the graph with colored edges. This helps when diagnosing cycle errors.")
+	cli.StringVar(&graph.GraphType, "type", "", `Type of graph to output. Can be: plan, plan-refresh-only, plan-destroy, or apply. By default OpenTofu chooses "plan", or "apply" if you also set the -plan=... option.`)
+	cli.IntVar(&graph.ModuleDepth, "module-depth", -1, "(deprecated) In prior versions of OpenTofu, specified the depth of modules to show in the output.")
+	cli.BoolVar(&graph.Verbose, "verbose", false, "verbose").SetHidden(true)
+	cli.StringVar(&graph.PlanPath, "plan", "", "Render graph using the specified plan file instead of the configuration in the current directory.")
 
-	return &graph, hooks
+	return &graph
 }
 
 // ParseGraph processes CLI arguments, returning a Graph value, a closer function, and errors.
 // If errors are encountered, a Graph value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseGraph(args []string) (*Graph, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	arguments, hooks := BindGraph(flags)
-
-	cmdFlags := defaultFlagSet("graph", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	if len(cmdFlags.Args()) > 0 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Unexpected argument",
-			"Too many command line arguments. Did you mean to use -chdir?",
-		))
-	}
-
-	return arguments, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	arguments := BindGraph(cli)
+	closer, diags := cli.Stdlib("graph", args)
+	return arguments, closer, diags
 }

--- a/internal/command/arguments/graph.go
+++ b/internal/command/arguments/graph.go
@@ -36,8 +36,7 @@ func BindGraph(cli *CommandLine) *Graph {
 	// we only parse but do not register the views flags since this command does not need it
 	graph.ViewOptions.ParseHook(cli)
 
-	graph.Vars = &Vars{}
-	graph.Vars.bind(cli)
+	graph.Vars = BindVars(cli)
 
 	cli.BoolVar(&graph.DrawCycles, "draw-cycles", false, "Highlight any cycles in the graph with colored edges. This helps when diagnosing cycle errors.")
 	cli.StringVar(&graph.GraphType, "type", "", `Type of graph to output. Can be: plan, plan-refresh-only, plan-destroy, or apply. By default OpenTofu chooses "plan", or "apply" if you also set the -plan=... option.`).SetDisplay("=plan")

--- a/internal/command/arguments/import.go
+++ b/internal/command/arguments/import.go
@@ -31,25 +31,44 @@ type Import struct {
 	Vars    *Vars
 }
 
+// BindImport registers CLI arguments, returning a Import value and it's corresponding hooks.
+func BindImport(flags Flags, wd *workdir.Dir) (*Import, Hooks) {
+	var imp Import
+	var hooks Hooks
+
+	imp.ViewOptions.bind(flags, true)
+	hooks = append(hooks, imp.ViewOptions.ParseHook())
+
+	imp.Vars = &Vars{}
+	imp.Vars.bind(flags)
+
+	imp.Backend = &Backend{}
+	imp.Backend.bindIgnoreRemoteVersionFlag(flags)
+
+	imp.State = &State{}
+	imp.State.bind(flags, stateFlagAll)
+
+	// Get the pwd since its our default -config flag value
+	pwd := wd.NormalizePath(wd.RootModuleDir())
+
+	flags.IntVar(&imp.Parallelism, "parallelism", DefaultParallelism, "parallelism")
+	flags.StringVar(&imp.ConfigPath, "config", pwd, "path")
+
+	// TODO positional args
+
+	return &imp, hooks
+}
+
 // ParseImport processes CLI arguments, returning an Import value, a closer function, and errors.
 // If errors are encountered, an Import value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseImport(args []string, wd *workdir.Dir) (*Import, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	ret := &Import{
-		Vars:    &Vars{},
-		State:   &State{},
-		Backend: &Backend{},
-	}
-	// Get the pwd since its our default -config flag value
-	pwd := wd.NormalizePath(wd.RootModuleDir())
 
-	cmdFlags := extendedFlagSet("import", nil, ret.Vars)
-	cmdFlags.IntVar(&ret.Parallelism, "parallelism", DefaultParallelism, "parallelism")
-	cmdFlags.StringVar(&ret.ConfigPath, "config", pwd, "path")
-	ret.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
-	ret.State.addFlags(cmdFlags, stateFlagAll)
-	ret.ViewOptions.AddFlags(cmdFlags, true)
+	flags := Flags{}
+	ret, hooks := BindImport(flags, wd)
+
+	cmdFlags := defaultFlagSet("import", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -59,12 +78,6 @@ func ParseImport(args []string, wd *workdir.Dir) (*Import, func(), tfdiags.Diagn
 		))
 	}
 
-	closer, moreDiags := ret.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-	if diags.HasErrors() {
-		return ret, closer, diags
-	}
-
 	args = cmdFlags.Args()
 	if len(args) != 2 {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -72,9 +85,9 @@ func ParseImport(args []string, wd *workdir.Dir) (*Import, func(), tfdiags.Diagn
 			"Invalid number of arguments",
 			"The import command expects two arguments",
 		))
-		return ret, closer, diags
+	} else {
+		ret.ResourceAddress = args[0]
+		ret.ResourceID = args[1]
 	}
-	ret.ResourceAddress = args[0]
-	ret.ResourceID = args[1]
-	return ret, closer, diags
+	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/import.go
+++ b/internal/command/arguments/import.go
@@ -37,10 +37,7 @@ func BindImport(cli *CommandLine) *Import {
 	ret.ViewOptions.bind(cli, true)
 
 	ret.Vars = BindVars(cli)
-
-	ret.Backend = &Backend{}
-	ret.Backend.bindIgnoreRemoteVersionFlag(cli)
-
+	ret.Backend = BindBackend(cli)
 	ret.State = BindState(cli, stateFlagAll)
 
 	cli.IntVar(&ret.Parallelism, "parallelism", DefaultParallelism, `Limit the number of parallel resource operations. Defaults to 10.`).SetDisplay("=n")

--- a/internal/command/arguments/import.go
+++ b/internal/command/arguments/import.go
@@ -52,8 +52,9 @@ func BindImport(cli *CommandLine, wd *workdir.Dir) *Import {
 	cli.IntVar(&ret.Parallelism, "parallelism", DefaultParallelism, "parallelism")
 	cli.StringVar(&ret.ConfigPath, "config", pwd, "path")
 
-	cli.PositionalArg(&ret.ResourceAddress, "resource address", false)
-	cli.PositionalArg(&ret.ResourceID, "resource id", false)
+	cli.ArgHelp = "The import command expects two arguments"
+	cli.PositionalArg(&ret.ResourceAddress, "ADDR", false)
+	cli.PositionalArg(&ret.ResourceID, "ID", false)
 
 	return &ret
 }

--- a/internal/command/arguments/import.go
+++ b/internal/command/arguments/import.go
@@ -6,7 +6,6 @@
 package arguments
 
 import (
-	"github.com/opentofu/opentofu/internal/command/workdir"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
@@ -32,7 +31,7 @@ type Import struct {
 }
 
 // BindImport registers CLI arguments, returning a Import value and it's corresponding hooks.
-func BindImport(cli *CommandLine, wd *workdir.Dir) *Import {
+func BindImport(cli *CommandLine) *Import {
 	var ret Import
 
 	ret.ViewOptions.bind(cli, true)
@@ -46,11 +45,8 @@ func BindImport(cli *CommandLine, wd *workdir.Dir) *Import {
 	ret.State = &State{}
 	ret.State.bind(cli, stateFlagAll)
 
-	// Get the pwd since its our default -config flag value
-	pwd := wd.NormalizePath(wd.RootModuleDir())
-
-	cli.IntVar(&ret.Parallelism, "parallelism", DefaultParallelism, "parallelism")
-	cli.StringVar(&ret.ConfigPath, "config", pwd, "path")
+	cli.IntVar(&ret.Parallelism, "parallelism", DefaultParallelism, `Limit the number of parallel resource operations. Defaults to 10.`).SetDisplay("=n")
+	cli.StringVar(&ret.ConfigPath, "config", "", "Path to a directory of OpenTofu configuration files to use to configure the provider. Defaults to pwd. If no config files are present, they must be provided via the input prompts or env vars.").SetDisplay("=path")
 
 	cli.ArgHelp = "The import command expects two arguments"
 	cli.PositionalArg(&ret.ResourceAddress, "ADDR", false)
@@ -62,9 +58,9 @@ func BindImport(cli *CommandLine, wd *workdir.Dir) *Import {
 // ParseImport processes CLI arguments, returning an Import value, a closer function, and errors.
 // If errors are encountered, an Import value is still returned representing
 // the best effort interpretation of the arguments.
-func ParseImport(args []string, wd *workdir.Dir) (*Import, func(), tfdiags.Diagnostics) {
+func ParseImport(args []string) (*Import, func(), tfdiags.Diagnostics) {
 	cli := new(CommandLine)
-	ret := BindImport(cli, wd)
+	ret := BindImport(cli)
 	closer, diags := cli.Stdlib("import", args)
 	return ret, closer, diags
 }

--- a/internal/command/arguments/import.go
+++ b/internal/command/arguments/import.go
@@ -32,62 +32,38 @@ type Import struct {
 }
 
 // BindImport registers CLI arguments, returning a Import value and it's corresponding hooks.
-func BindImport(flags Flags, wd *workdir.Dir) (*Import, Hooks) {
-	var imp Import
-	var hooks Hooks
+func BindImport(cli *CommandLine, wd *workdir.Dir) *Import {
+	var ret Import
 
-	imp.ViewOptions.bind(flags, true)
-	hooks = append(hooks, imp.ViewOptions.ParseHook())
+	ret.ViewOptions.bind(cli, true)
 
-	imp.Vars = &Vars{}
-	imp.Vars.bind(flags)
+	ret.Vars = &Vars{}
+	ret.Vars.bind(cli)
 
-	imp.Backend = &Backend{}
-	imp.Backend.bindIgnoreRemoteVersionFlag(flags)
+	ret.Backend = &Backend{}
+	ret.Backend.bindIgnoreRemoteVersionFlag(cli)
 
-	imp.State = &State{}
-	imp.State.bind(flags, stateFlagAll)
+	ret.State = &State{}
+	ret.State.bind(cli, stateFlagAll)
 
 	// Get the pwd since its our default -config flag value
 	pwd := wd.NormalizePath(wd.RootModuleDir())
 
-	flags.IntVar(&imp.Parallelism, "parallelism", DefaultParallelism, "parallelism")
-	flags.StringVar(&imp.ConfigPath, "config", pwd, "path")
+	cli.IntVar(&ret.Parallelism, "parallelism", DefaultParallelism, "parallelism")
+	cli.StringVar(&ret.ConfigPath, "config", pwd, "path")
 
-	// TODO positional args
+	cli.PositionalArg(&ret.ResourceAddress, "resource address", false)
+	cli.PositionalArg(&ret.ResourceID, "resource id", false)
 
-	return &imp, hooks
+	return &ret
 }
 
 // ParseImport processes CLI arguments, returning an Import value, a closer function, and errors.
 // If errors are encountered, an Import value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseImport(args []string, wd *workdir.Dir) (*Import, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	ret, hooks := BindImport(flags, wd)
-
-	cmdFlags := defaultFlagSet("import", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	args = cmdFlags.Args()
-	if len(args) != 2 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Invalid number of arguments",
-			"The import command expects two arguments",
-		))
-	} else {
-		ret.ResourceAddress = args[0]
-		ret.ResourceID = args[1]
-	}
-	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	ret := BindImport(cli, wd)
+	closer, diags := cli.Stdlib("import", args)
+	return ret, closer, diags
 }

--- a/internal/command/arguments/import.go
+++ b/internal/command/arguments/import.go
@@ -36,8 +36,7 @@ func BindImport(cli *CommandLine) *Import {
 
 	ret.ViewOptions.bind(cli, true)
 
-	ret.Vars = &Vars{}
-	ret.Vars.bind(cli)
+	ret.Vars = BindVars(cli)
 
 	ret.Backend = &Backend{}
 	ret.Backend.bindIgnoreRemoteVersionFlag(cli)

--- a/internal/command/arguments/import.go
+++ b/internal/command/arguments/import.go
@@ -42,8 +42,7 @@ func BindImport(cli *CommandLine) *Import {
 	ret.Backend = &Backend{}
 	ret.Backend.bindIgnoreRemoteVersionFlag(cli)
 
-	ret.State = &State{}
-	ret.State.bind(cli, stateFlagAll)
+	ret.State = BindState(cli, stateFlagAll)
 
 	cli.IntVar(&ret.Parallelism, "parallelism", DefaultParallelism, `Limit the number of parallel resource operations. Defaults to 10.`).SetDisplay("=n")
 	cli.StringVar(&ret.ConfigPath, "config", "", "Path to a directory of OpenTofu configuration files to use to configure the provider. Defaults to pwd. If no config files are present, they must be provided via the input prompts or env vars.").SetDisplay("=path")

--- a/internal/command/arguments/import_test.go
+++ b/internal/command/arguments/import_test.go
@@ -13,11 +13,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/opentofu/opentofu/internal/command/flags"
-	"github.com/opentofu/opentofu/internal/command/workdir"
 )
 
 func TestParseImport_basicValidation(t *testing.T) {
-	wd := workdir.NewDir(".")
 	testCases := map[string]struct {
 		args        []string
 		want        *Import
@@ -119,7 +117,7 @@ func TestParseImport_basicValidation(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			got, closer, diags := ParseImport(tc.args, wd)
+			got, closer, diags := ParseImport(tc.args)
 			defer closer()
 
 			if tc.wantErrText != "" && len(diags) == 0 {
@@ -142,7 +140,6 @@ func TestParseImport_basicValidation(t *testing.T) {
 }
 
 func TestParseImport_vars(t *testing.T) {
-	wd := workdir.NewDir(".")
 	testCases := map[string]struct {
 		args      []string
 		wantCount int
@@ -172,7 +169,7 @@ func TestParseImport_vars(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			got, closer, diags := ParseImport(tc.args, wd)
+			got, closer, diags := ParseImport(tc.args)
 			defer closer()
 
 			if len(diags) > 0 {
@@ -194,7 +191,7 @@ func importArgsWithDefaults(mutate func(imp *Import)) *Import {
 	ret := &Import{
 		ResourceAddress: "",
 		ResourceID:      "",
-		ConfigPath:      ".",
+		ConfigPath:      "",
 		Parallelism:     DefaultParallelism,
 		ViewOptions: ViewOptions{
 			ViewType:     ViewHuman,

--- a/internal/command/arguments/import_test.go
+++ b/internal/command/arguments/import_test.go
@@ -101,17 +101,17 @@ func TestParseImport_basicValidation(t *testing.T) {
 		"no arguments": {
 			args:        []string{},
 			want:        importArgsWithDefaults(nil),
-			wantErrText: "Invalid number of arguments: The import command expects two arguments",
+			wantErrText: "The import command expects two arguments",
 		},
 		"one argument": {
 			args:        []string{"addr"},
 			want:        importArgsWithDefaults(nil),
-			wantErrText: "Invalid number of arguments: The import command expects two arguments",
+			wantErrText: "The import command expects two arguments",
 		},
 		"too many arguments": {
 			args:        []string{"addr", "id", "extra"},
 			want:        importArgsWithDefaults(nil),
-			wantErrText: "Invalid number of arguments: The import command expects two arguments",
+			wantErrText: "The import command expects two arguments",
 		},
 	}
 
@@ -132,8 +132,10 @@ func TestParseImport_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n%s\nwanted: %s\n", errStr, tc.wantErrText)
 				}
 			}
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
-				t.Errorf("unexpected result\n%s", diff)
+			if !diags.HasErrors() {
+				if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+					t.Errorf("unexpected result\n%s", diff)
+				}
 			}
 		})
 	}

--- a/internal/command/arguments/import_test.go
+++ b/internal/command/arguments/import_test.go
@@ -102,13 +102,18 @@ func TestParseImport_basicValidation(t *testing.T) {
 			wantErrText: "The import command expects two arguments",
 		},
 		"one argument": {
-			args:        []string{"addr"},
-			want:        importArgsWithDefaults(nil),
+			args: []string{"addr"},
+			want: importArgsWithDefaults(func(imp *Import) {
+				imp.ResourceAddress = "addr"
+			}),
 			wantErrText: "The import command expects two arguments",
 		},
 		"too many arguments": {
-			args:        []string{"addr", "id", "extra"},
-			want:        importArgsWithDefaults(nil),
+			args: []string{"addr", "id", "extra"},
+			want: importArgsWithDefaults(func(imp *Import) {
+				imp.ResourceAddress = "addr"
+				imp.ResourceID = "id"
+			}),
 			wantErrText: "The import command expects two arguments",
 		},
 	}
@@ -130,10 +135,8 @@ func TestParseImport_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n%s\nwanted: %s\n", errStr, tc.wantErrText)
 				}
 			}
-			if !diags.HasErrors() {
-				if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
-					t.Errorf("unexpected result\n%s", diff)
-				}
+			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+				t.Errorf("unexpected result\n%s", diff)
 			}
 		})
 	}

--- a/internal/command/arguments/init.go
+++ b/internal/command/arguments/init.go
@@ -63,8 +63,7 @@ func BindInit(cli *CommandLine) *Init {
 	init.Vars = &Vars{}
 	init.Vars.bind(cli)
 
-	init.State = &State{}
-	init.State.bind(cli, stateFlagLock)
+	init.State = BindState(cli, stateFlagLock)
 
 	init.Backend = &Backend{}
 	init.Backend.bindIgnoreRemoteVersionFlag(cli)

--- a/internal/command/arguments/init.go
+++ b/internal/command/arguments/init.go
@@ -60,9 +60,7 @@ func BindInit(cli *CommandLine) *Init {
 
 	init.ViewOptions.bind(cli, true)
 
-	init.Vars = &Vars{}
-	init.Vars.bind(cli)
-
+	init.Vars = BindVars(cli)
 	init.State = BindState(cli, stateFlagLock)
 
 	init.Backend = &Backend{}

--- a/internal/command/arguments/init.go
+++ b/internal/command/arguments/init.go
@@ -55,86 +55,61 @@ type Init struct {
 }
 
 // BindInit registers CLI arguments, returning a Init value and it's corresponding hooks.
-func BindInit(flags Flags) (*Init, Hooks) {
+func BindInit(cli *CommandLine) *Init {
 	var init Init
-	var hooks Hooks
 
-	init.ViewOptions.bind(flags, true)
-	hooks = append(hooks, init.ViewOptions.ParseHook())
+	init.ViewOptions.bind(cli, true)
 
 	init.Vars = &Vars{}
-	init.Vars.bind(flags)
+	init.Vars.bind(cli)
 
 	init.State = &State{}
-	init.State.bind(flags, stateFlagLock)
+	init.State.bind(cli, stateFlagLock)
 
 	init.Backend = &Backend{}
-	init.Backend.bindIgnoreRemoteVersionFlag(flags)
-	init.Backend.bindMigrationFlags(flags)
+	init.Backend.bindIgnoreRemoteVersionFlag(cli)
+	init.Backend.bindMigrationFlags(cli)
 
 	init.FlagConfigExtra = flagspkg.NewRawFlags("-backend-config")
 
-	flags.BoolVar(&init.FlagBackend, "backend", true, "Disable backend or cloud backend initialization for this configuration and use what was previously initialized instead.").SetDisplay("=false")
-	flags.BoolVar(&init.FlagCloud, "cloud", true, "") // TODO alias of -backend
-	flags.RawFlags(init.FlagConfigExtra, "backend-config", "Configuration to be merged with what is in the configuration file's 'backend' block. This can be either a path to an HCL file with key/value assignments (same format as terraform.tfvars) or a 'key=value' format, and can be specified multiple times. The backend type must be in the configuration itself.").SetDisplay("=path")
-	flags.StringVar(&init.FlagFromModule, "from-module", "", "Copy the contents of the given module into the target directory before initialization.").SetDisplay("=SOURCE")
-	flags.BoolVar(&init.FlagGet, "get", true, "Disable downloading modules for this configuration.").SetDisplay("=false")
-	flags.BoolVar(&init.FlagUpgrade, "upgrade", false, "Install the latest module and provider versions allowed within configured constraints, overriding the default behavior of selecting exactly the version recorded in the dependency lockfile.")
-	flags.StringArrayVar(&init.FlagPluginPath, "plugin-dir", nil, "Directory containing plugin binaries. This overrides all default search paths for plugins, and prevents the automatic installation of plugins. This flag can be used multiple times.")
-	flags.StringVar(&init.FlagLockfile, "lockfile", "", `Set a dependency lockfile mode. Currently only "readonly" is valid.`).SetDisplay("=MODE")
-	flags.StringVar(&init.TestsDirectory, "test-directory", "tests", `Set the OpenTofu test directory, defaults to "tests". When set, the test command will search for test files in the current directory and in the one specified by the flag.`).SetDisplay("=path")
+	backend := cli.BoolVar(&init.FlagBackend, "backend", true, "Disable backend or cloud backend initialization for this configuration and use what was previously initialized instead.").SetDisplay("=false")
+	cloud := cli.BoolVar(&init.FlagCloud, "cloud", true, "").SetHidden(true)
+	cli.RawFlags(init.FlagConfigExtra, "backend-config", "Configuration to be merged with what is in the configuration file's 'backend' block. This can be either a path to an HCL file with key/value assignments (same format as terraform.tfvars) or a 'key=value' format, and can be specified multiple times. The backend type must be in the configuration itself.").SetDisplay("=path")
+	cli.StringVar(&init.FlagFromModule, "from-module", "", "Copy the contents of the given module into the target directory before initialization.").SetDisplay("=SOURCE")
+	cli.BoolVar(&init.FlagGet, "get", true, "Disable downloading modules for this configuration.").SetDisplay("=false")
+	cli.BoolVar(&init.FlagUpgrade, "upgrade", false, "Install the latest module and provider versions allowed within configured constraints, overriding the default behavior of selecting exactly the version recorded in the dependency lockfile.")
+	cli.StringArrayVar(&init.FlagPluginPath, "plugin-dir", nil, "Directory containing plugin binaries. This overrides all default search paths for plugins, and prevents the automatic installation of plugins. This flag can be used multiple times.")
+	cli.StringVar(&init.FlagLockfile, "lockfile", "", `Set a dependency lockfile mode. Currently only "readonly" is valid.`).SetDisplay("=MODE")
+	cli.StringVar(&init.TestsDirectory, "test-directory", "tests", `Set the OpenTofu test directory, defaults to "tests". When set, the test command will search for test files in the current directory and in the one specified by the flag.`).SetDisplay("=path")
 
-	// TODO complex cloud and backend hook alias/logic
+	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+		init.BackendFlagSet = backend.IsSet
+		init.CloudFlagSet = cloud.IsSet
 
-	return &init, hooks
+		switch {
+		case init.BackendFlagSet && init.CloudFlagSet:
+			return tfdiags.New(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Wrong combination of options",
+				"The -backend and -cloud options are aliases of one another and mutually-exclusive in their use",
+			))
+		case init.BackendFlagSet:
+			init.FlagCloud = init.FlagBackend
+		case init.CloudFlagSet:
+			init.FlagBackend = init.FlagCloud
+		}
+		return init.Backend.migrationFlagsCheck()
+	}})
+
+	return &init
 }
 
 // ParseInit processes CLI arguments, returning an Init value, a closer function, and errors.
 // If errors are encountered, an Init value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseInit(args []string) (*Init, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	init, hooks := BindInit(flags)
-
-	cmdFlags := defaultFlagSet("init", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	if len(cmdFlags.Args()) > 0 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Unexpected argument",
-			"Too many command line arguments. Did you mean to use -chdir?",
-		))
-	}
-
-	init.BackendFlagSet = flagspkg.FlagIsSet(cmdFlags, "backend")
-	init.CloudFlagSet = flagspkg.FlagIsSet(cmdFlags, "cloud")
-
-	diags = diags.Append(hooks.Pre())
-	closer := func() { hooks.Post() }
-
-	switch {
-	case init.BackendFlagSet && init.CloudFlagSet:
-		return init, closer, diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Wrong combination of options",
-			"The -backend and -cloud options are aliases of one another and mutually-exclusive in their use",
-		))
-	case init.BackendFlagSet:
-		init.FlagCloud = init.FlagBackend
-	case init.CloudFlagSet:
-		init.FlagBackend = init.FlagCloud
-	}
-	diags = diags.Append(init.Backend.migrationFlagsCheck())
-
+	cli := new(CommandLine)
+	init := BindInit(cli)
+	closer, diags := cli.Stdlib("init", args)
 	return init, closer, diags
 }

--- a/internal/command/arguments/init.go
+++ b/internal/command/arguments/init.go
@@ -6,7 +6,7 @@
 package arguments
 
 import (
-	"github.com/opentofu/opentofu/internal/command/flags"
+	flagspkg "github.com/opentofu/opentofu/internal/command/flags"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
@@ -27,11 +27,11 @@ type Init struct {
 	FlagUpgrade bool
 	// Directory containing plugin binaries. This overrides all default search paths for plugins, and prevents the
 	// automatic installation of plugins. This flag can be used multiple times.
-	FlagPluginPath flags.FlagStringSlice
+	FlagPluginPath []string
 	// Configuration to be merged with what is in the configuration file's 'backend' block. This can be
 	// either a path to an HCL file with key/value assignments (same format as terraform.tfvars) or a
 	// 'key=value' format, and can be specified multiple times. The backend type must be in the configuration itself.
-	FlagConfigExtra flags.RawFlags
+	FlagConfigExtra flagspkg.RawFlags
 	// Disable backend or cloud backend initialization for this configuration and use what was previously
 	// initialized instead. This and the FlagCloud cannot be toggled in the same time.
 	FlagBackend bool
@@ -54,33 +54,51 @@ type Init struct {
 	State *State
 }
 
+// BindInit registers CLI arguments, returning a Init value and it's corresponding hooks.
+func BindInit(flags Flags) (*Init, Hooks) {
+	var init Init
+	var hooks Hooks
+
+	init.ViewOptions.bind(flags, true)
+	hooks = append(hooks, init.ViewOptions.ParseHook())
+
+	init.Vars = &Vars{}
+	init.Vars.bind(flags)
+
+	init.State = &State{}
+	init.State.bind(flags, stateFlagLock)
+
+	init.Backend = &Backend{}
+	init.Backend.bindIgnoreRemoteVersionFlag(flags)
+	init.Backend.bindMigrationFlags(flags)
+
+	init.FlagConfigExtra = flagspkg.NewRawFlags("-backend-config")
+
+	flags.BoolVar(&init.FlagBackend, "backend", true, "Disable backend or cloud backend initialization for this configuration and use what was previously initialized instead.").SetDisplay("=false")
+	flags.BoolVar(&init.FlagCloud, "cloud", true, "") // TODO alias of -backend
+	flags.RawFlags(init.FlagConfigExtra, "backend-config", "Configuration to be merged with what is in the configuration file's 'backend' block. This can be either a path to an HCL file with key/value assignments (same format as terraform.tfvars) or a 'key=value' format, and can be specified multiple times. The backend type must be in the configuration itself.").SetDisplay("=path")
+	flags.StringVar(&init.FlagFromModule, "from-module", "", "Copy the contents of the given module into the target directory before initialization.").SetDisplay("=SOURCE")
+	flags.BoolVar(&init.FlagGet, "get", true, "Disable downloading modules for this configuration.").SetDisplay("=false")
+	flags.BoolVar(&init.FlagUpgrade, "upgrade", false, "Install the latest module and provider versions allowed within configured constraints, overriding the default behavior of selecting exactly the version recorded in the dependency lockfile.")
+	flags.StringArrayVar(&init.FlagPluginPath, "plugin-dir", nil, "Directory containing plugin binaries. This overrides all default search paths for plugins, and prevents the automatic installation of plugins. This flag can be used multiple times.")
+	flags.StringVar(&init.FlagLockfile, "lockfile", "", `Set a dependency lockfile mode. Currently only "readonly" is valid.`).SetDisplay("=MODE")
+	flags.StringVar(&init.TestsDirectory, "test-directory", "tests", `Set the OpenTofu test directory, defaults to "tests". When set, the test command will search for test files in the current directory and in the one specified by the flag.`).SetDisplay("=path")
+
+	// TODO complex cloud and backend hook alias/logic
+
+	return &init, hooks
+}
+
 // ParseInit processes CLI arguments, returning an Init value, a closer function, and errors.
 // If errors are encountered, an Init value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseInit(args []string) (*Init, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	init := &Init{
-		Vars:            &Vars{},
-		Backend:         &Backend{},
-		State:           &State{},
-		FlagConfigExtra: flags.NewRawFlags("-backend-config"),
-	}
 
-	cmdFlags := extendedFlagSet("init", nil, init.Vars)
-	init.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
-	init.Backend.AddMigrationFlags(cmdFlags)
-	init.State.addFlags(cmdFlags, stateFlagLock)
-	cmdFlags.BoolVar(&init.FlagBackend, "backend", true, "")
-	cmdFlags.BoolVar(&init.FlagCloud, "cloud", true, "")
-	cmdFlags.Var(init.FlagConfigExtra, "backend-config", "")
-	cmdFlags.StringVar(&init.FlagFromModule, "from-module", "", "copy the source of the given module into the directory before init")
-	cmdFlags.BoolVar(&init.FlagGet, "get", true, "")
-	cmdFlags.BoolVar(&init.FlagUpgrade, "upgrade", false, "")
-	cmdFlags.Var(&init.FlagPluginPath, "plugin-dir", "plugin directory")
-	cmdFlags.StringVar(&init.FlagLockfile, "lockfile", "", "Set a dependency lockfile mode")
-	cmdFlags.StringVar(&init.TestsDirectory, "test-directory", "tests", "test-directory")
+	flags := Flags{}
+	init, hooks := BindInit(flags)
 
-	init.ViewOptions.AddFlags(cmdFlags, true)
+	cmdFlags := defaultFlagSet("init", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -90,13 +108,19 @@ func ParseInit(args []string) (*Init, func(), tfdiags.Diagnostics) {
 		))
 	}
 
-	closer, moreDiags := init.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-	if diags.HasErrors() {
-		return init, closer, diags
+	if len(cmdFlags.Args()) > 0 {
+		diags = diags.Append(tfdiags.Sourceless(
+			tfdiags.Error,
+			"Unexpected argument",
+			"Too many command line arguments. Did you mean to use -chdir?",
+		))
 	}
-	init.BackendFlagSet = flags.FlagIsSet(cmdFlags, "backend")
-	init.CloudFlagSet = flags.FlagIsSet(cmdFlags, "cloud")
+
+	init.BackendFlagSet = flagspkg.FlagIsSet(cmdFlags, "backend")
+	init.CloudFlagSet = flagspkg.FlagIsSet(cmdFlags, "cloud")
+
+	diags = diags.Append(hooks.Pre())
+	closer := func() { hooks.Post() }
 
 	switch {
 	case init.BackendFlagSet && init.CloudFlagSet:
@@ -110,15 +134,7 @@ func ParseInit(args []string) (*Init, func(), tfdiags.Diagnostics) {
 	case init.CloudFlagSet:
 		init.FlagBackend = init.FlagCloud
 	}
-
 	diags = diags.Append(init.Backend.migrationFlagsCheck())
 
-	if len(cmdFlags.Args()) > 0 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Unexpected argument",
-			"Too many command line arguments. Did you mean to use -chdir?",
-		))
-	}
 	return init, closer, diags
 }

--- a/internal/command/arguments/init.go
+++ b/internal/command/arguments/init.go
@@ -62,10 +62,7 @@ func BindInit(cli *CommandLine) *Init {
 
 	init.Vars = BindVars(cli)
 	init.State = BindState(cli, stateFlagLock)
-
-	init.Backend = &Backend{}
-	init.Backend.bindIgnoreRemoteVersionFlag(cli)
-	init.Backend.bindMigrationFlags(cli)
+	init.Backend = BindBackendWithMigration(cli)
 
 	init.FlagConfigExtra = flagspkg.NewRawFlags("-backend-config")
 
@@ -95,7 +92,7 @@ func BindInit(cli *CommandLine) *Init {
 		case init.CloudFlagSet:
 			init.FlagBackend = init.FlagCloud
 		}
-		return init.Backend.migrationFlagsCheck()
+		return nil
 	}})
 
 	return &init

--- a/internal/command/arguments/init.go
+++ b/internal/command/arguments/init.go
@@ -76,7 +76,7 @@ func BindInit(cli *CommandLine) *Init {
 	cli.StringVar(&init.FlagLockfile, "lockfile", "", `Set a dependency lockfile mode. Currently only "readonly" is valid.`).SetDisplay("=MODE")
 	cli.StringVar(&init.TestsDirectory, "test-directory", "tests", `Set the OpenTofu test directory, defaults to "tests". When set, the test command will search for test files in the current directory and in the one specified by the flag.`).SetDisplay("=path")
 
-	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+	cli.PreHook(func() tfdiags.Diagnostics {
 		init.BackendFlagSet = backend.IsSet
 		init.CloudFlagSet = cloud.IsSet
 
@@ -93,7 +93,7 @@ func BindInit(cli *CommandLine) *Init {
 			init.FlagBackend = init.FlagCloud
 		}
 		return nil
-	}})
+	})
 
 	return &init
 }

--- a/internal/command/arguments/init_test.go
+++ b/internal/command/arguments/init_test.go
@@ -82,14 +82,14 @@ func TestParseInit_basicValidation(t *testing.T) {
 		"one plugin dir configured": {
 			[]string{"-plugin-dir=/test1"},
 			initArgsWithDefaults(func(init *Init) {
-				_ = init.FlagPluginPath.Set("/test1")
+				init.FlagPluginPath = append(init.FlagPluginPath, "/test1")
 			}),
 		},
 		"multiple plugin dirs configured": {
 			[]string{"-plugin-dir=/test1", "-plugin-dir=/test2"},
 			initArgsWithDefaults(func(init *Init) {
-				_ = init.FlagPluginPath.Set("/test1")
-				_ = init.FlagPluginPath.Set("/test2")
+				init.FlagPluginPath = append(init.FlagPluginPath, "/test1")
+				init.FlagPluginPath = append(init.FlagPluginPath, "/test2")
 			}),
 		},
 		"lock disabled": {

--- a/internal/command/arguments/login.go
+++ b/internal/command/arguments/login.go
@@ -37,7 +37,7 @@ func BindLogin(cli *CommandLine) *Login {
 	arguments.State = &State{Lock: true}
 
 	cli.ArgHelp = "The login command expects exactly one argument: the host to log in to."
-	cli.PositionalArg(&arguments.Host, "host", false)
+	cli.PositionalArg(&arguments.Host, "hostname", false)
 
 	return &arguments
 }

--- a/internal/command/arguments/login.go
+++ b/internal/command/arguments/login.go
@@ -22,55 +22,32 @@ type Login struct {
 }
 
 // BindLogin registers CLI arguments, returning a Login value and it's corresponding hooks.
-func BindLogin(flags Flags) (*Login, Hooks) {
-	var login Login
-	var hooks Hooks
+func BindLogin(cli *CommandLine) *Login {
+	var arguments Login
 
-	login.ViewOptions.bind(flags, true)
-	hooks = append(hooks, login.ViewOptions.ParseHook())
+	arguments.ViewOptions.bind(cli, true)
 
 	// Even though the command does not use the -var/-var-file content, we will keep this for the moment
 	// just to keep backwards compatibility for users (in case any of them are using these flags with this command)
-	login.Vars = &Vars{}
-	login.Vars.bind(flags)
+	arguments.Vars = &Vars{}
+	arguments.Vars.bind(cli)
 
 	// State is only initialised and no flags are registered since the login command needs to lock the
 	// state by default, with no user input on that.
-	login.State = &State{Lock: true}
+	arguments.State = &State{Lock: true}
 
-	// TODO positional arguments
+	cli.ArgHelp = "The login command expects exactly one argument: the host to log in to."
+	cli.PositionalArg(&arguments.Host, "host", false)
 
-	return &login, hooks
+	return &arguments
 }
 
 // ParseLogin processes CLI arguments, returning a Login value, a closer function, and errors.
 // If errors are encountered, a Login value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseLogin(args []string) (*Login, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	arguments, hooks := BindLogin(flags)
-
-	cmdFlags := defaultFlagSet("login", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	if len(cmdFlags.Args()) != 1 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Unexpected argument",
-			"The login command expects exactly one argument: the host to log in to.",
-		))
-	} else {
-		arguments.Host = cmdFlags.Args()[0]
-	}
-
-	return arguments, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	arguments := BindLogin(cli)
+	closer, diags := cli.Stdlib("login", args)
+	return arguments, closer, diags
 }

--- a/internal/command/arguments/login.go
+++ b/internal/command/arguments/login.go
@@ -21,22 +21,39 @@ type Login struct {
 	State *State
 }
 
+// BindLogin registers CLI arguments, returning a Login value and it's corresponding hooks.
+func BindLogin(flags Flags) (*Login, Hooks) {
+	var login Login
+	var hooks Hooks
+
+	login.ViewOptions.bind(flags, true)
+	hooks = append(hooks, login.ViewOptions.ParseHook())
+
+	// Even though the command does not use the -var/-var-file content, we will keep this for the moment
+	// just to keep backwards compatibility for users (in case any of them are using these flags with this command)
+	login.Vars = &Vars{}
+	login.Vars.bind(flags)
+
+	// State is only initialised and no flags are registered since the login command needs to lock the
+	// state by default, with no user input on that.
+	login.State = &State{Lock: true}
+
+	// TODO positional arguments
+
+	return &login, hooks
+}
+
 // ParseLogin processes CLI arguments, returning a Login value, a closer function, and errors.
 // If errors are encountered, a Login value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseLogin(args []string) (*Login, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	arguments := &Login{
-		// Even though the command does not use the -var/-var-file content, we will keep this for the moment
-		// just to keep backwards compatibility for users (in case any of them are using these flags with this command)
-		Vars: &Vars{},
-		// State is only initialised and no flags are registered since the login command needs to lock the
-		// state by default, with no user input on that.
-		State: &State{Lock: true},
-	}
 
-	cmdFlags := extendedFlagSet("login", nil, arguments.Vars)
-	arguments.ViewOptions.AddFlags(cmdFlags, true)
+	flags := Flags{}
+	arguments, hooks := BindLogin(flags)
+
+	cmdFlags := defaultFlagSet("login", flags)
+
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
@@ -45,20 +62,15 @@ func ParseLogin(args []string) (*Login, func(), tfdiags.Diagnostics) {
 		))
 	}
 
-	closer, moreDiags := arguments.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-	if diags.HasErrors() {
-		return arguments, closer, diags
-	}
-
 	if len(cmdFlags.Args()) != 1 {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Unexpected argument",
 			"The login command expects exactly one argument: the host to log in to.",
 		))
-		return arguments, closer, diags
+	} else {
+		arguments.Host = cmdFlags.Args()[0]
 	}
-	arguments.Host = cmdFlags.Args()[0]
-	return arguments, closer, diags
+
+	return arguments, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/login.go
+++ b/internal/command/arguments/login.go
@@ -29,8 +29,7 @@ func BindLogin(cli *CommandLine) *Login {
 
 	// Even though the command does not use the -var/-var-file content, we will keep this for the moment
 	// just to keep backwards compatibility for users (in case any of them are using these flags with this command)
-	arguments.Vars = &Vars{}
-	arguments.Vars.bind(cli)
+	arguments.Vars = BindVars(cli)
 
 	// State is only initialised and no flags are registered since the login command needs to lock the
 	// state by default, with no user input on that.

--- a/internal/command/arguments/login_test.go
+++ b/internal/command/arguments/login_test.go
@@ -77,7 +77,7 @@ func TestParseLogin_arguments(t *testing.T) {
 		}{
 			"no hostname": {
 				args:            []string{},
-				wantDiagSummary: "Unexpected argument",
+				wantDiagSummary: "Invalid arguments list",
 				wantDiagDetail:  "The login command expects exactly one argument: the host to log in to.",
 			},
 			"too many hostnames": {

--- a/internal/command/arguments/logout.go
+++ b/internal/command/arguments/logout.go
@@ -21,45 +21,23 @@ type Logout struct {
 }
 
 // BindLogout registers CLI arguments, returning a Logout value and it's corresponding hooks.
-func BindLogout(flags Flags) (*Logout, Hooks) {
+func BindLogout(cli *CommandLine) *Logout {
 	var arguments Logout
-	var hooks Hooks
 
-	arguments.ViewOptions.bind(flags, false)
-	hooks = append(hooks, arguments.ViewOptions.ParseHook())
+	arguments.ViewOptions.bind(cli, false)
 
-	return &arguments, hooks
+	cli.ArgHelp = "The logout command expects exactly one argument: the host to log out of."
+	cli.PositionalArg(&arguments.Host, "host", false)
+
+	return &arguments
 }
 
 // ParseLogout processes CLI arguments, returning a Logout value, a closer function, and errors.
 // If errors are encountered, a Logout value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseLogout(args []string) (*Logout, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	arguments, hooks := BindLogout(flags)
-
-	cmdFlags := defaultFlagSet("logout", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	// TODO positional args
-	if len(cmdFlags.Args()) != 1 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Unexpected argument",
-			"The logout command expects exactly one argument: the host to log out of.",
-		))
-	} else {
-		arguments.Host = cmdFlags.Args()[0]
-	}
-
-	return arguments, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	arguments := BindLogout(cli)
+	closer, diags := cli.Stdlib("logout", args)
+	return arguments, closer, diags
 }

--- a/internal/command/arguments/logout.go
+++ b/internal/command/arguments/logout.go
@@ -20,15 +20,28 @@ type Logout struct {
 	Vars *Vars
 }
 
+// BindLogout registers CLI arguments, returning a Logout value and it's corresponding hooks.
+func BindLogout(flags Flags) (*Logout, Hooks) {
+	var arguments Logout
+	var hooks Hooks
+
+	arguments.ViewOptions.bind(flags, false)
+	hooks = append(hooks, arguments.ViewOptions.ParseHook())
+
+	return &arguments, hooks
+}
+
 // ParseLogout processes CLI arguments, returning a Logout value, a closer function, and errors.
 // If errors are encountered, a Logout value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseLogout(args []string) (*Logout, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	arguments := &Logout{}
 
-	cmdFlags := defaultFlagSet("logout")
-	arguments.ViewOptions.AddFlags(cmdFlags, false)
+	flags := Flags{}
+	arguments, hooks := BindLogout(flags)
+
+	cmdFlags := defaultFlagSet("logout", flags)
+
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
@@ -37,20 +50,16 @@ func ParseLogout(args []string) (*Logout, func(), tfdiags.Diagnostics) {
 		))
 	}
 
-	closer, moreDiags := arguments.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-	if diags.HasErrors() {
-		return arguments, closer, diags
-	}
-
+	// TODO positional args
 	if len(cmdFlags.Args()) != 1 {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
 			"Unexpected argument",
 			"The logout command expects exactly one argument: the host to log out of.",
 		))
-		return arguments, closer, diags
+	} else {
+		arguments.Host = cmdFlags.Args()[0]
 	}
-	arguments.Host = cmdFlags.Args()[0]
-	return arguments, closer, diags
+
+	return arguments, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/logout.go
+++ b/internal/command/arguments/logout.go
@@ -27,7 +27,7 @@ func BindLogout(cli *CommandLine) *Logout {
 	arguments.ViewOptions.bind(cli, false)
 
 	cli.ArgHelp = "The logout command expects exactly one argument: the host to log out of."
-	cli.PositionalArg(&arguments.Host, "host", false)
+	cli.PositionalArg(&arguments.Host, "hostname", false)
 
 	return &arguments
 }

--- a/internal/command/arguments/logout_test.go
+++ b/internal/command/arguments/logout_test.go
@@ -31,7 +31,7 @@ func TestParseLogout_arguments(t *testing.T) {
 		}{
 			"no hostname": {
 				args:            []string{},
-				wantDiagSummary: "Unexpected argument",
+				wantDiagSummary: "Invalid arguments list",
 				wantDiagDetail:  "The logout command expects exactly one argument: the host to log out of.",
 			},
 			"too many hostnames": {

--- a/internal/command/arguments/metadata_functions.go
+++ b/internal/command/arguments/metadata_functions.go
@@ -21,7 +21,7 @@ func BindMetadataFunctions(cli *CommandLine) *MetadataFunctions {
 
 	arguments.ViewOptions.bindGranularFlags(cli, false, false) // Add only the -json flag
 
-	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+	cli.PreHook(func() tfdiags.Diagnostics {
 		var diags tfdiags.Diagnostics
 
 		// The 'metadata functions' command just forces the user to use the `-json` flag but any of the diagnostics should
@@ -38,7 +38,7 @@ func BindMetadataFunctions(cli *CommandLine) *MetadataFunctions {
 		arguments.ViewOptions.ViewType = ViewHuman
 
 		return diags
-	}})
+	})
 
 	return &arguments
 }

--- a/internal/command/arguments/metadata_functions.go
+++ b/internal/command/arguments/metadata_functions.go
@@ -16,14 +16,12 @@ type MetadataFunctions struct {
 }
 
 // BindMetadataFunctions registers CLI arguments, returning a MetadataFunctions value and it's corresponding hooks.
-func BindMetadataFunctions(flags Flags) (*MetadataFunctions, Hooks) {
+func BindMetadataFunctions(cli *CommandLine) *MetadataFunctions {
 	var arguments MetadataFunctions
-	var hooks Hooks
 
-	arguments.ViewOptions.bindGranularFlags(flags, false, false) // Add only the -json flag
-	hooks = append(hooks, arguments.ViewOptions.ParseHook())
+	arguments.ViewOptions.bindGranularFlags(cli, false, false) // Add only the -json flag
 
-	hooks = append(hooks, Hook{Pre: func() tfdiags.Diagnostics {
+	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
 		var diags tfdiags.Diagnostics
 
 		// The 'metadata functions' command just forces the user to use the `-json` flag but any of the diagnostics should
@@ -42,27 +40,15 @@ func BindMetadataFunctions(flags Flags) (*MetadataFunctions, Hooks) {
 		return diags
 	}})
 
-	return &arguments, hooks
+	return &arguments
 }
 
 // ParseMetadataFunctions processes CLI arguments, returning a MetadataFunctions value, a closer function, and errors.
 // If errors are encountered, a MetadataFunctions value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseMetadataFunctions(args []string) (*MetadataFunctions, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	arguments, hooks := BindMetadataFunctions(flags)
-
-	cmdFlags := defaultFlagSet("metadata functions", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	return arguments, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	arguments := BindMetadataFunctions(cli)
+	closer, diags := cli.Stdlib("metadata functions", args)
+	return arguments, closer, diags
 }

--- a/internal/command/arguments/metadata_functions.go
+++ b/internal/command/arguments/metadata_functions.go
@@ -15,15 +15,46 @@ type MetadataFunctions struct {
 	ViewOptions ViewOptions
 }
 
+// BindMetadataFunctions registers CLI arguments, returning a MetadataFunctions value and it's corresponding hooks.
+func BindMetadataFunctions(flags Flags) (*MetadataFunctions, Hooks) {
+	var arguments MetadataFunctions
+	var hooks Hooks
+
+	arguments.ViewOptions.bindGranularFlags(flags, false, false) // Add only the -json flag
+	hooks = append(hooks, arguments.ViewOptions.ParseHook())
+
+	hooks = append(hooks, Hook{Pre: func() tfdiags.Diagnostics {
+		var diags tfdiags.Diagnostics
+
+		// The 'metadata functions' command just forces the user to use the `-json` flag but any of the diagnostics should
+		// be printed as human format. This makes it clear that the success output of this command will be in json and
+		// that it needs to be processed accordingly.
+		// The print of the functions will be in JSON all the time.
+		if arguments.ViewOptions.ViewType != ViewJSON {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Invalid arguments",
+				"The `tofu metadata functions` command requires the `-json` flag.",
+			))
+		}
+		arguments.ViewOptions.ViewType = ViewHuman
+
+		return diags
+	}})
+
+	return &arguments, hooks
+}
+
 // ParseMetadataFunctions processes CLI arguments, returning a MetadataFunctions value, a closer function, and errors.
 // If errors are encountered, a MetadataFunctions value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseMetadataFunctions(args []string) (*MetadataFunctions, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	arguments := &MetadataFunctions{}
 
-	cmdFlags := defaultFlagSet("metadata functions")
-	arguments.ViewOptions.AddGranularFlags(cmdFlags, false, false) // Add only the -json flag
+	flags := Flags{}
+	arguments, hooks := BindMetadataFunctions(flags)
+
+	cmdFlags := defaultFlagSet("metadata functions", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -33,24 +64,5 @@ func ParseMetadataFunctions(args []string) (*MetadataFunctions, func(), tfdiags.
 		))
 	}
 
-	closer, moreDiags := arguments.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-	if diags.HasErrors() {
-		return arguments, closer, diags
-	}
-
-	// The 'metadata functions' command just forces the user to use the `-json` flag but any of the diagnostics should
-	// be printed as human format. This makes it clear that the success output of this command will be in json and
-	// that it needs to be processed accordingly.
-	// The print of the functions will be in JSON all the time.
-	if arguments.ViewOptions.ViewType != ViewJSON {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Invalid arguments",
-			"The `tofu metadata functions` command requires the `-json` flag.",
-		))
-	}
-	arguments.ViewOptions.ViewType = ViewHuman
-	
-	return arguments, closer, diags
+	return arguments, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/metadata_functions_test.go
+++ b/internal/command/arguments/metadata_functions_test.go
@@ -21,7 +21,7 @@ func TestParseMetadataFunctions_basicValidation(t *testing.T) {
 		"defaults": {
 			args:        nil,
 			want:        metadataFunctionsArgsWithDefaults(nil),
-			wantErrText: "Invalid arguments: The `tofu metadata functions` command requires the `-json` flag.",
+			wantErrText: "The `tofu metadata functions` command requires the `-json` flag.",
 		},
 		"json flag": {
 			args: []string{"-json"},
@@ -35,7 +35,7 @@ func TestParseMetadataFunctions_basicValidation(t *testing.T) {
 		"invalid flag": {
 			args:        []string{"-foo"},
 			want:        metadataFunctionsArgsWithDefaults(func(args *MetadataFunctions) {}),
-			wantErrText: "Failed to parse command-line flags: flag provided but not defined: -foo",
+			wantErrText: "flag provided but not defined: -foo",
 		},
 	}
 

--- a/internal/command/arguments/output.go
+++ b/internal/command/arguments/output.go
@@ -33,8 +33,7 @@ func BindOutput(cli *CommandLine) *Output {
 	output.Vars = &Vars{}
 	output.Vars.bind(cli)
 
-	output.State = &State{}
-	output.State.bind(cli, stateFlagStateIn)
+	output.State = BindState(cli, stateFlagStateIn)
 
 	rawOutput := false
 	cli.BoolVar(&rawOutput, "raw", false, `For value types that can be automatically converted to a string, will print the raw string directly, rather than a human-oriented representation of the value.

--- a/internal/command/arguments/output.go
+++ b/internal/command/arguments/output.go
@@ -25,82 +25,60 @@ type Output struct {
 }
 
 // BindOutput registers CLI arguments, returning a Output value and it's corresponding hooks.
-func BindOutput(flags Flags, raw *bool) (*Output, Hooks) {
+func BindOutput(cli *CommandLine) *Output {
 	var output Output
-	var hooks Hooks
 
-	output.ViewOptions.bind(flags, false)
-	hooks = append(hooks, output.ViewOptions.ParseHook())
+	output.ViewOptions.bind(cli, false)
 
 	output.Vars = &Vars{}
-	output.Vars.bind(flags)
+	output.Vars.bind(cli)
 
 	output.State = &State{}
-	output.State.bind(flags, stateFlagStateIn)
+	output.State.bind(cli, stateFlagStateIn)
 
-	flags.BoolVar(raw, "raw", false, "For value types that can be automatically converted to a string, will print the raw string directly, rather than a human-oriented representation of the value.")
-	flags.BoolVar(&output.ShowSensitive, "show-sensitive", false, "If specified, sensitive values will be displayed.")
+	rawOutput := false
+	cli.BoolVar(&rawOutput, "raw", false, "For value types that can be automatically converted to a string, will print the raw string directly, rather than a human-oriented representation of the value.")
+	cli.BoolVar(&output.ShowSensitive, "show-sensitive", false, "If specified, sensitive values will be displayed.")
 
-	return &output, hooks
+	cli.ArgHelp = "The output command expects exactly one argument with the name of an output variable or no arguments to show all outputs."
+	cli.PositionalArg(&output.Name, "output name", true)
+
+	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+		var diags tfdiags.Diagnostics
+		if rawOutput {
+			output.ViewOptions.ViewType = ViewRaw
+			if output.ViewOptions.jsonFlag {
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Invalid output format",
+					"The -raw and -json options are mutually-exclusive.",
+				))
+
+				// Since the desired output format is unknowable, fall back to default
+				output.ViewOptions.ViewType = ViewHuman
+				rawOutput = false
+			}
+		}
+
+		if rawOutput && output.Name == "" {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Output name required",
+				"You must give the name of a single output value when using the -raw option.",
+			))
+		}
+		return diags
+	}})
+
+	return &output
 }
 
 // ParseOutput processes CLI arguments, returning an Output value, a closer function, and errors.
 // If errors are encountered, an Output value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseOutput(args []string) (*Output, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	rawOutput := false
-
-	flags := Flags{}
-	output, hooks := BindOutput(flags, &rawOutput)
-
-	cmdFlags := defaultFlagSet("output", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	args = cmdFlags.Args()
-	if len(args) > 1 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Unexpected argument",
-			"The output command expects exactly one argument with the name of an output variable or no arguments to show all outputs.",
-		))
-	}
-
-	// TODO positional arguments
-	if rawOutput {
-		output.ViewOptions.ViewType = ViewRaw
-		if output.ViewOptions.jsonFlag {
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Invalid output format",
-				"The -raw and -json options are mutually-exclusive.",
-			))
-
-			// Since the desired output format is unknowable, fall back to default
-			output.ViewOptions.ViewType = ViewHuman
-			rawOutput = false
-		}
-	}
-
-	if len(args) > 0 {
-		output.Name = args[0]
-	}
-
-	if rawOutput && output.Name == "" {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Output name required",
-			"You must give the name of a single output value when using the -raw option.",
-		))
-	}
-
-	return output, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	output := BindOutput(cli)
+	closer, diags := cli.Stdlib("output", args)
+	return output, closer, diags
 }

--- a/internal/command/arguments/output.go
+++ b/internal/command/arguments/output.go
@@ -43,7 +43,7 @@ Use this with care when stdout is a terminal and when the output value might con
 	cli.ArgHelp = "The output command expects exactly one argument with the name of an output variable or no arguments to show all outputs."
 	cli.PositionalArg(&output.Name, "NAME", true)
 
-	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+	cli.PreHook(func() tfdiags.Diagnostics {
 		var diags tfdiags.Diagnostics
 		if rawOutput {
 			output.ViewOptions.ViewType = ViewRaw
@@ -68,7 +68,7 @@ Use this with care when stdout is a terminal and when the output value might con
 			))
 		}
 		return diags
-	}})
+	})
 
 	return &output
 }

--- a/internal/command/arguments/output.go
+++ b/internal/command/arguments/output.go
@@ -24,23 +24,38 @@ type Output struct {
 	State *State
 }
 
+// BindOutput registers CLI arguments, returning a Output value and it's corresponding hooks.
+func BindOutput(flags Flags, raw *bool) (*Output, Hooks) {
+	var output Output
+	var hooks Hooks
+
+	output.ViewOptions.bind(flags, false)
+	hooks = append(hooks, output.ViewOptions.ParseHook())
+
+	output.Vars = &Vars{}
+	output.Vars.bind(flags)
+
+	output.State = &State{}
+	output.State.bind(flags, stateFlagStateIn)
+
+	flags.BoolVar(raw, "raw", false, "For value types that can be automatically converted to a string, will print the raw string directly, rather than a human-oriented representation of the value.")
+	flags.BoolVar(&output.ShowSensitive, "show-sensitive", false, "If specified, sensitive values will be displayed.")
+
+	return &output, hooks
+}
+
 // ParseOutput processes CLI arguments, returning an Output value, a closer function, and errors.
 // If errors are encountered, an Output value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseOutput(args []string) (*Output, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	output := &Output{
-		Vars:  &Vars{},
-		State: &State{},
-	}
 
-	var rawOutput bool
-	cmdFlags := extendedFlagSet("output", nil, output.Vars)
-	cmdFlags.BoolVar(&rawOutput, "raw", false, "raw")
-	output.State.addFlags(cmdFlags, stateFlagStateIn)
-	cmdFlags.BoolVar(&output.ShowSensitive, "show-sensitive", false, "displays sensitive values")
+	rawOutput := false
 
-	output.ViewOptions.AddFlags(cmdFlags, false)
+	flags := Flags{}
+	output, hooks := BindOutput(flags, &rawOutput)
+
+	cmdFlags := defaultFlagSet("output", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -59,8 +74,7 @@ func ParseOutput(args []string) (*Output, func(), tfdiags.Diagnostics) {
 		))
 	}
 
-	closer, moreDiags := output.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
+	// TODO positional arguments
 	if rawOutput {
 		output.ViewOptions.ViewType = ViewRaw
 		if output.ViewOptions.jsonFlag {
@@ -88,5 +102,5 @@ func ParseOutput(args []string) (*Output, func(), tfdiags.Diagnostics) {
 		))
 	}
 
-	return output, closer, diags
+	return output, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/output.go
+++ b/internal/command/arguments/output.go
@@ -30,8 +30,7 @@ func BindOutput(cli *CommandLine) *Output {
 
 	output.ViewOptions.bind(cli, false)
 
-	output.Vars = &Vars{}
-	output.Vars.bind(cli)
+	output.Vars = BindVars(cli)
 
 	output.State = BindState(cli, stateFlagStateIn)
 

--- a/internal/command/arguments/output.go
+++ b/internal/command/arguments/output.go
@@ -37,11 +37,13 @@ func BindOutput(cli *CommandLine) *Output {
 	output.State.bind(cli, stateFlagStateIn)
 
 	rawOutput := false
-	cli.BoolVar(&rawOutput, "raw", false, "For value types that can be automatically converted to a string, will print the raw string directly, rather than a human-oriented representation of the value.")
+	cli.BoolVar(&rawOutput, "raw", false, `For value types that can be automatically converted to a string, will print the raw string directly, rather than a human-oriented representation of the value.
+
+Use this with care when stdout is a terminal and when the output value might contain control characters.`)
 	cli.BoolVar(&output.ShowSensitive, "show-sensitive", false, "If specified, sensitive values will be displayed.")
 
 	cli.ArgHelp = "The output command expects exactly one argument with the name of an output variable or no arguments to show all outputs."
-	cli.PositionalArg(&output.Name, "output name", true)
+	cli.PositionalArg(&output.Name, "NAME", true)
 
 	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
 		var diags tfdiags.Diagnostics

--- a/internal/command/arguments/output_test.go
+++ b/internal/command/arguments/output_test.go
@@ -48,7 +48,7 @@ func TestParseOutput_basicValidation(t *testing.T) {
 		"unknown flag": {
 			args:        []string{"-boop"},
 			want:        outputArgsWithDefaults(func(a *Output) {}),
-			wantErrText: "Failed to parse command-line flags: flag provided but not defined: -boop",
+			wantErrText: "flag provided but not defined: -boop",
 		},
 		"json and raw specified": {
 			args:        []string{"-json", "-raw"},
@@ -69,7 +69,7 @@ func TestParseOutput_basicValidation(t *testing.T) {
 				a.Name = "bar"
 				a.State.StatePath = "foo.tfstate"
 			}),
-			wantErrText: "Unexpected argument: The output command expects exactly one argument with the name of an output variable or no arguments to show all outputs.",
+			wantErrText: "The output command expects exactly one argument with the name of an output variable or no arguments to show all outputs.",
 		},
 	}
 	cmpOpts := cmpopts.IgnoreUnexported(ViewOptions{}, Vars{})

--- a/internal/command/arguments/plan.go
+++ b/internal/command/arguments/plan.go
@@ -47,8 +47,7 @@ func BindPlan(cli *CommandLine) *Plan {
 	plan.Vars = &Vars{}
 	plan.Vars.bind(cli)
 
-	plan.State = &State{}
-	plan.State.bind(cli, stateFlagAll)
+	plan.State = BindState(cli, stateFlagAll)
 
 	cli.BoolVar(&plan.DetailedExitCode, "detailed-exitcode", false,
 		`Return detailed exit codes when the command exits. The detailed exit codes are:

--- a/internal/command/arguments/plan.go
+++ b/internal/command/arguments/plan.go
@@ -35,25 +35,65 @@ type Plan struct {
 	ShowSensitive bool
 }
 
+// BindPlan registers CLI arguments, returning a Plan value and it's corresponding hooks.
+func BindPlan(flags Flags) (*Plan, []FlagGroup, Hooks) {
+	var plan Plan
+	var hooks Hooks
+
+	plan.ViewOptions.bind(flags, true)
+	hooks = append(hooks, plan.ViewOptions.ParseHook())
+
+	plan.Operation = &Operation{}
+	plan.Operation.bind(flags)
+	hooks = append(hooks, Hook{Pre: plan.Operation.Parse})
+
+	plan.Vars = &Vars{}
+	plan.Vars.bind(flags)
+
+	plan.State = &State{}
+	plan.State.bind(flags, stateFlagAll)
+
+	flags.BoolVar(&plan.DetailedExitCode, "detailed-exitcode", false,
+		`Return detailed exit codes when the command exits. The detailed exit codes are:
+  0 - Succeeded but no changes proposed
+  1 - Planning failed with an error
+  2 - Succeeded and changes are proposed`)
+	flags.StringVar(&plan.OutPath, "out", "",
+		`Write a plan file to the given path. This can be used as input to the "apply" command.`,
+	).SetDisplay("=path")
+	flags.StringVar(&plan.GenerateConfigPath, "generate-config-out", "",
+		`(Experimental) If import blocks are present in configuration, instructs OpenTofu to generate HCL for any imported resources not already present. The configuration is written to a new file at PATH, which must not already exist.
+OpenTofu may still attempt to write configuration if planning fails with an error.`,
+	).SetDisplay("=path")
+	flags.BoolVar(&plan.ShowSensitive, "show-sensitive", false,
+		`If specified, sensitive values will not be redacted in te UI output.`)
+
+	// Special handling for flag groups!
+	for _, name := range []string{"destroy", "refresh-only", "refresh", "replace", "target", "target-file", "exclude", "exclude-file", "var", "var-file"} {
+		flags[name].SetGroup("plan")
+	}
+	groups := []FlagGroup{{
+		ID:          "plan",
+		Title:       "Plan Customization Options:",
+		Description: `The following options customize how OpenTofu will produce its plan. You can also use these options when you run "tofu apply" without passing it a saved plan, in order to plan and apply in a single command.`,
+	}, {
+		Title: "Other Options:",
+	}}
+
+	return &plan, groups, hooks
+
+}
+
 // ParsePlan processes CLI arguments, returning a Plan value, a closer function, and errors.
 // If errors are encountered, a Plan value is still returned representing
 // the best effort interpretation of the arguments.
 func ParsePlan(args []string) (*Plan, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	plan := &Plan{
-		State:     &State{},
-		Operation: &Operation{},
-		Vars:      &Vars{},
-	}
 
-	cmdFlags := extendedFlagSet("plan", plan.Operation, plan.Vars)
-	plan.State.addFlags(cmdFlags, stateFlagAll)
-	cmdFlags.BoolVar(&plan.DetailedExitCode, "detailed-exitcode", false, "detailed-exitcode")
-	cmdFlags.StringVar(&plan.OutPath, "out", "", "out")
-	cmdFlags.StringVar(&plan.GenerateConfigPath, "generate-config-out", "", "generate-config-out")
-	cmdFlags.BoolVar(&plan.ShowSensitive, "show-sensitive", false, "displays sensitive values")
+	flags := Flags{}
+	plan, _, hooks := BindPlan(flags)
 
-	plan.ViewOptions.AddFlags(cmdFlags, true)
+	cmdFlags := defaultFlagSet("plan", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -73,9 +113,5 @@ func ParsePlan(args []string) (*Plan, func(), tfdiags.Diagnostics) {
 		))
 	}
 
-	diags = diags.Append(plan.Operation.Parse())
-	closer, moreDiags := plan.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-
-	return plan, closer, diags
+	return plan, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/plan.go
+++ b/internal/command/arguments/plan.go
@@ -36,41 +36,38 @@ type Plan struct {
 }
 
 // BindPlan registers CLI arguments, returning a Plan value and it's corresponding hooks.
-func BindPlan(flags Flags) (*Plan, []FlagGroup, Hooks) {
+func BindPlan(cli *CommandLine) (*Plan, []FlagGroup) {
 	var plan Plan
-	var hooks Hooks
 
-	plan.ViewOptions.bind(flags, true)
-	hooks = append(hooks, plan.ViewOptions.ParseHook())
+	plan.ViewOptions.bind(cli, true)
 
 	plan.Operation = &Operation{}
-	plan.Operation.bind(flags)
-	hooks = append(hooks, Hook{Pre: plan.Operation.Parse})
+	plan.Operation.bind(cli)
 
 	plan.Vars = &Vars{}
-	plan.Vars.bind(flags)
+	plan.Vars.bind(cli)
 
 	plan.State = &State{}
-	plan.State.bind(flags, stateFlagAll)
+	plan.State.bind(cli, stateFlagAll)
 
-	flags.BoolVar(&plan.DetailedExitCode, "detailed-exitcode", false,
+	cli.BoolVar(&plan.DetailedExitCode, "detailed-exitcode", false,
 		`Return detailed exit codes when the command exits. The detailed exit codes are:
   0 - Succeeded but no changes proposed
   1 - Planning failed with an error
   2 - Succeeded and changes are proposed`)
-	flags.StringVar(&plan.OutPath, "out", "",
+	cli.StringVar(&plan.OutPath, "out", "",
 		`Write a plan file to the given path. This can be used as input to the "apply" command.`,
 	).SetDisplay("=path")
-	flags.StringVar(&plan.GenerateConfigPath, "generate-config-out", "",
+	cli.StringVar(&plan.GenerateConfigPath, "generate-config-out", "",
 		`(Experimental) If import blocks are present in configuration, instructs OpenTofu to generate HCL for any imported resources not already present. The configuration is written to a new file at PATH, which must not already exist.
 OpenTofu may still attempt to write configuration if planning fails with an error.`,
 	).SetDisplay("=path")
-	flags.BoolVar(&plan.ShowSensitive, "show-sensitive", false,
+	cli.BoolVar(&plan.ShowSensitive, "show-sensitive", false,
 		`If specified, sensitive values will not be redacted in te UI output.`)
 
 	// Special handling for flag groups!
 	for _, name := range []string{"destroy", "refresh-only", "refresh", "replace", "target", "target-file", "exclude", "exclude-file", "var", "var-file"} {
-		flags[name].SetGroup("plan")
+		cli.Flags[name].SetGroup("plan")
 	}
 	groups := []FlagGroup{{
 		ID:          "plan",
@@ -80,7 +77,7 @@ OpenTofu may still attempt to write configuration if planning fails with an erro
 		Title: "Other Options:",
 	}}
 
-	return &plan, groups, hooks
+	return &plan, groups
 
 }
 
@@ -88,30 +85,8 @@ OpenTofu may still attempt to write configuration if planning fails with an erro
 // If errors are encountered, a Plan value is still returned representing
 // the best effort interpretation of the arguments.
 func ParsePlan(args []string) (*Plan, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	plan, _, hooks := BindPlan(flags)
-
-	cmdFlags := defaultFlagSet("plan", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	args = cmdFlags.Args()
-
-	if len(args) > 0 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Too many command line arguments",
-			"To specify a working directory for the plan, use the global -chdir flag.",
-		))
-	}
-
-	return plan, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	plan, _ := BindPlan(cli)
+	closer, diags := cli.Stdlib("plan", args)
+	return plan, closer, diags
 }

--- a/internal/command/arguments/plan.go
+++ b/internal/command/arguments/plan.go
@@ -36,7 +36,7 @@ type Plan struct {
 }
 
 // BindPlan registers CLI arguments, returning a Plan value and it's corresponding hooks.
-func BindPlan(cli *CommandLine) (*Plan, []FlagGroup) {
+func BindPlan(cli *CommandLine) *Plan {
 	var plan Plan
 
 	plan.ViewOptions.bind(cli, true)
@@ -69,7 +69,7 @@ OpenTofu may still attempt to write configuration if planning fails with an erro
 	for _, name := range []string{"destroy", "refresh-only", "refresh", "replace", "target", "target-file", "exclude", "exclude-file", "var", "var-file"} {
 		cli.Flags[name].SetGroup("plan")
 	}
-	groups := []FlagGroup{{
+	cli.FlagGroups = []FlagGroup{{
 		ID:          "plan",
 		Title:       "Plan Customization Options:",
 		Description: `The following options customize how OpenTofu will produce its plan. You can also use these options when you run "tofu apply" without passing it a saved plan, in order to plan and apply in a single command.`,
@@ -77,7 +77,7 @@ OpenTofu may still attempt to write configuration if planning fails with an erro
 		Title: "Other Options:",
 	}}
 
-	return &plan, groups
+	return &plan
 
 }
 
@@ -86,7 +86,7 @@ OpenTofu may still attempt to write configuration if planning fails with an erro
 // the best effort interpretation of the arguments.
 func ParsePlan(args []string) (*Plan, func(), tfdiags.Diagnostics) {
 	cli := new(CommandLine)
-	plan, _ := BindPlan(cli)
+	plan := BindPlan(cli)
 	closer, diags := cli.Stdlib("plan", args)
 	return plan, closer, diags
 }

--- a/internal/command/arguments/plan.go
+++ b/internal/command/arguments/plan.go
@@ -41,12 +41,8 @@ func BindPlan(cli *CommandLine) *Plan {
 
 	plan.ViewOptions.bind(cli, true)
 
-	plan.Operation = &Operation{}
-	plan.Operation.bind(cli)
-
-	plan.Vars = &Vars{}
-	plan.Vars.bind(cli)
-
+	plan.Operation = BindOperation(cli)
+	plan.Vars = BindVars(cli)
 	plan.State = BindState(cli, stateFlagAll)
 
 	cli.BoolVar(&plan.DetailedExitCode, "detailed-exitcode", false,

--- a/internal/command/arguments/providers.go
+++ b/internal/command/arguments/providers.go
@@ -20,17 +20,32 @@ type Providers struct {
 	ViewOptions ViewOptions
 }
 
+// BindProviders registers CLI arguments, returning a Providers value and it's corresponding hooks.
+func BindProviders(flags Flags) (*Providers, Hooks) {
+	var providers Providers
+	var hooks Hooks
+
+	// we only parse but do not register the views flags since this command does not need it
+	hooks = append(hooks, providers.ViewOptions.ParseHook())
+
+	providers.Vars = &Vars{}
+	providers.Vars.bind(flags)
+
+	flags.StringVar(&providers.TestsDirectory, "test-directory", "tests", `Set the OpenTofu test directory, defaults to "tests". When set, the test command will search for test files in the current directory and in the one specified by the flag.`).SetDisplay("=path")
+
+	return &providers, hooks
+}
+
 // ParseProviders processes CLI arguments, returning a Providers value, a closer function, and errors.
 // If errors are encountered, a Providers value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseProviders(args []string) (*Providers, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	arguments := &Providers{
-		Vars: &Vars{},
-	}
 
-	cmdFlags := extendedFlagSet("providers", nil, arguments.Vars)
-	cmdFlags.StringVar(&arguments.TestsDirectory, "test-directory", "tests", "test-directory")
+	flags := Flags{}
+	arguments, hooks := BindProviders(flags)
+
+	cmdFlags := defaultFlagSet("providers", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -40,12 +55,6 @@ func ParseProviders(args []string) (*Providers, func(), tfdiags.Diagnostics) {
 		))
 	}
 
-	// we only parse but do not register the views flags since this command does not need it
-	closer, moreDiags := arguments.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-	if diags.HasErrors() {
-		return arguments, closer, diags
-	}
 	if len(cmdFlags.Args()) > 0 {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
@@ -54,5 +63,5 @@ func ParseProviders(args []string) (*Providers, func(), tfdiags.Diagnostics) {
 		))
 	}
 
-	return arguments, closer, diags
+	return arguments, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/providers.go
+++ b/internal/command/arguments/providers.go
@@ -27,8 +27,7 @@ func BindProviders(cli *CommandLine) *Providers {
 	// we only parse but do not register the views flags since this command does not need it
 	arguments.ViewOptions.ParseHook(cli)
 
-	arguments.Vars = &Vars{}
-	arguments.Vars.bind(cli)
+	arguments.Vars = BindVars(cli)
 
 	cli.StringVar(&arguments.TestsDirectory, "test-directory", "tests", `Set the OpenTofu test directory, defaults to "tests". When set, the test command will search for test files in the current directory and in the one specified by the flag.`).SetDisplay("=path")
 

--- a/internal/command/arguments/providers.go
+++ b/internal/command/arguments/providers.go
@@ -21,47 +21,26 @@ type Providers struct {
 }
 
 // BindProviders registers CLI arguments, returning a Providers value and it's corresponding hooks.
-func BindProviders(flags Flags) (*Providers, Hooks) {
+func BindProviders(cli *CommandLine) *Providers {
 	var providers Providers
-	var hooks Hooks
 
 	// we only parse but do not register the views flags since this command does not need it
-	hooks = append(hooks, providers.ViewOptions.ParseHook())
+	providers.ViewOptions.ParseHook(cli)
 
 	providers.Vars = &Vars{}
-	providers.Vars.bind(flags)
+	providers.Vars.bind(cli)
 
-	flags.StringVar(&providers.TestsDirectory, "test-directory", "tests", `Set the OpenTofu test directory, defaults to "tests". When set, the test command will search for test files in the current directory and in the one specified by the flag.`).SetDisplay("=path")
+	cli.StringVar(&providers.TestsDirectory, "test-directory", "tests", `Set the OpenTofu test directory, defaults to "tests". When set, the test command will search for test files in the current directory and in the one specified by the flag.`).SetDisplay("=path")
 
-	return &providers, hooks
+	return &providers
 }
 
 // ParseProviders processes CLI arguments, returning a Providers value, a closer function, and errors.
 // If errors are encountered, a Providers value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseProviders(args []string) (*Providers, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	arguments, hooks := BindProviders(flags)
-
-	cmdFlags := defaultFlagSet("providers", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	if len(cmdFlags.Args()) > 0 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Unexpected argument",
-			"Too many command line arguments. Did you mean to use -chdir?",
-		))
-	}
-
-	return arguments, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	arguments := BindProviders(cli)
+	closer, diags := cli.Stdlib("providers", args)
+	return arguments, closer, diags
 }

--- a/internal/command/arguments/providers.go
+++ b/internal/command/arguments/providers.go
@@ -22,17 +22,17 @@ type Providers struct {
 
 // BindProviders registers CLI arguments, returning a Providers value and it's corresponding hooks.
 func BindProviders(cli *CommandLine) *Providers {
-	var providers Providers
+	var arguments Providers
 
 	// we only parse but do not register the views flags since this command does not need it
-	providers.ViewOptions.ParseHook(cli)
+	arguments.ViewOptions.ParseHook(cli)
 
-	providers.Vars = &Vars{}
-	providers.Vars.bind(cli)
+	arguments.Vars = &Vars{}
+	arguments.Vars.bind(cli)
 
-	cli.StringVar(&providers.TestsDirectory, "test-directory", "tests", `Set the OpenTofu test directory, defaults to "tests". When set, the test command will search for test files in the current directory and in the one specified by the flag.`).SetDisplay("=path")
+	cli.StringVar(&arguments.TestsDirectory, "test-directory", "tests", `Set the OpenTofu test directory, defaults to "tests". When set, the test command will search for test files in the current directory and in the one specified by the flag.`).SetDisplay("=path")
 
-	return &providers
+	return &arguments
 }
 
 // ParseProviders processes CLI arguments, returning a Providers value, a closer function, and errors.

--- a/internal/command/arguments/providers_lock.go
+++ b/internal/command/arguments/providers_lock.go
@@ -63,7 +63,7 @@ The argument is a Level 1 URI template as defined by RFC 6570, used to map provi
 
 	cli.VariadicArg(&arguments.Providers, "providers")
 
-	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+	cli.PreHook(func() tfdiags.Diagnostics {
 		var diags tfdiags.Diagnostics
 
 		mirrorSet := false
@@ -91,7 +91,7 @@ The argument is a Level 1 URI template as defined by RFC 6570, used to map provi
 		}
 
 		return diags
-	}})
+	})
 
 	return &arguments
 }

--- a/internal/command/arguments/providers_lock.go
+++ b/internal/command/arguments/providers_lock.go
@@ -8,7 +8,6 @@ package arguments
 import (
 	"fmt"
 
-	"github.com/opentofu/opentofu/internal/command/flags"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 	"github.com/opentofu/svchost/uritemplates"
 )
@@ -20,7 +19,7 @@ type ProvidersLock struct {
 	// OptPlatforms contains the platforms that the user requested for the locks to be updated for.
 	// Having this empty, only the checksum for the host platform will be updated, but the user
 	// can use this to update the hashes for other platforms too.
-	OptPlatforms flags.FlagStringSlice
+	OptPlatforms []string
 	// FsMirrorDir represents a path from where OpenTofu should check for providers instead to reach
 	// out for the registry.
 	FsMirrorDir string
@@ -37,21 +36,66 @@ type ProvidersLock struct {
 	Vars *Vars
 }
 
+// BindProvidersLock registers CLI arguments, returning a ProvidersLock value and it's corresponding hooks.
+func BindProvidersLock(flags Flags) (*ProvidersLock, Hooks) {
+	var arguments ProvidersLock
+	var hooks Hooks
+
+	arguments.ViewOptions.bind(flags, false)
+	hooks = append(hooks, arguments.ViewOptions.ParseHook())
+
+	arguments.Vars = &Vars{}
+	arguments.Vars.bind(flags)
+
+	flags.StringArrayVar(&arguments.OptPlatforms, "platform", nil, "target platform")
+	flags.StringVar(&arguments.FsMirrorDir, "fs-mirror", "", "filesystem mirror directory")
+	flags.StringVar(&arguments.NetMirrorURL, "net-mirror", "", "network mirror base URL")
+	flags.StringVar(&arguments.OciMirrorTemplate, "oci-mirror", "", "oci mirror URI template")
+
+	hooks = append(hooks, Hook{Pre: func() tfdiags.Diagnostics {
+		var diags tfdiags.Diagnostics
+
+		mirrorSet := false
+		for _, mirror := range []string{arguments.FsMirrorDir, arguments.NetMirrorURL, arguments.OciMirrorTemplate} {
+			if mirror == "" {
+				continue
+			}
+			if mirrorSet {
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Invalid installation method options",
+					"The mirror command line options are mutually-exclusive.",
+				))
+				break
+			}
+			mirrorSet = true
+		}
+
+		if err := uritemplates.ValidateLevel1(arguments.OciMirrorTemplate); err != nil {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Invalid OCI mirror URI template",
+				fmt.Sprintf("The -oci-mirror argument is not a valid URI template: %s.", tfdiags.FormatError(err)),
+			))
+		}
+
+		return diags
+	}})
+
+	return &arguments, hooks
+}
+
 // ParseProvidersLock processes CLI arguments, returning a ProvidersLock value, a closer function, and errors.
 // If errors are encountered, a ProvidersLock value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseProvidersLock(args []string) (*ProvidersLock, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	arguments := &ProvidersLock{
-		Vars: &Vars{},
-	}
 
-	cmdFlags := extendedFlagSet("providers lock", nil, arguments.Vars)
-	cmdFlags.Var(&arguments.OptPlatforms, "platform", "target platform")
-	cmdFlags.StringVar(&arguments.FsMirrorDir, "fs-mirror", "", "filesystem mirror directory")
-	cmdFlags.StringVar(&arguments.NetMirrorURL, "net-mirror", "", "network mirror base URL")
-	cmdFlags.StringVar(&arguments.OciMirrorTemplate, "oci-mirror", "", "oci mirror URI template")
-	arguments.ViewOptions.AddFlags(cmdFlags, false)
+	flags := Flags{}
+	arguments, hooks := BindProvidersLock(flags)
+
+	cmdFlags := defaultFlagSet("providers lock", flags)
+
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
@@ -59,36 +103,9 @@ func ParseProvidersLock(args []string) (*ProvidersLock, func(), tfdiags.Diagnost
 			err.Error(),
 		))
 	}
-	mirrorSet := false
-	for _, mirror := range []string{arguments.FsMirrorDir, arguments.NetMirrorURL, arguments.OciMirrorTemplate} {
-		if mirror == "" {
-			continue
-		}
-		if mirrorSet {
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Invalid installation method options",
-				"The mirror command line options are mutually-exclusive.",
-			))
-			break
-		}
-		mirrorSet = true
-	}
 
-	if err := uritemplates.ValidateLevel1(arguments.OciMirrorTemplate); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Invalid OCI mirror URI template",
-			fmt.Sprintf("The -oci-mirror argument is not a valid URI template: %s.", tfdiags.FormatError(err)),
-		))
-	}
-
-	closer, moreDiags := arguments.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-	if diags.HasErrors() {
-		return arguments, closer, diags
-	}
+	// TODO positional arguments
 	arguments.Providers = cmdFlags.Args()
 
-	return arguments, closer, diags
+	return arguments, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/providers_lock.go
+++ b/internal/command/arguments/providers_lock.go
@@ -45,10 +45,22 @@ func BindProvidersLock(cli *CommandLine) *ProvidersLock {
 	arguments.Vars = &Vars{}
 	arguments.Vars.bind(cli)
 
-	cli.StringArrayVar(&arguments.OptPlatforms, "platform", nil, "target platform")
-	cli.StringVar(&arguments.FsMirrorDir, "fs-mirror", "", "filesystem mirror directory")
-	cli.StringVar(&arguments.NetMirrorURL, "net-mirror", "", "network mirror base URL")
-	cli.StringVar(&arguments.OciMirrorTemplate, "oci-mirror", "", "oci mirror URI template")
+	cli.StringArrayVar(&arguments.OptPlatforms, "platform", nil, `Choose a target platform to request package checksums for.
+
+By default OpenTofu will request package checksums suitable only for the platform where you run this command. Use this option multiple times to include checksums for multiple target systems.
+
+Target names consist of an operating system and a CPU architecture. For example, "linux_amd64" selects the Linux operating system running on an AMD64 or x86_64 CPU. Each provider is available only for a limited set of target platforms.`).SetDisplay("=os_arch")
+	cli.StringVar(&arguments.FsMirrorDir, "fs-mirror", "", `Consult the given filesystem mirror directory instead of the origin registry for each of the given providers.
+
+This would be necessary to generate lock file entries for a provider that is available only via a mirror, and not published in an upstream registry. In this case, the set of valid checksums will be limited only to what OpenTofu can learn from the data in the mirror directory.`).SetDisplay("=dir")
+	cli.StringVar(&arguments.NetMirrorURL, "net-mirror", "", `Consult the given network mirror (given as a base URL) instead of the origin registry for each of the given providers.
+
+This would be necessary to generate lock file entries for a provider that is available only via a mirror, and not published in an upstream registry. In this case, the set of valid checksums will be limited only to what OpenTofu can learn from the data in the mirror indices.`).SetDisplay("=url")
+	cli.StringVar(&arguments.OciMirrorTemplate, "oci-mirror", "", `Consult the given OCI registry mirror (given as a template) instead of the origin registry for each of the given providers.
+
+This would be necessary to generate lock file entries for a provider that is available only via an OCI mirror, and not published in an upstream registry.
+
+The argument is a Level 1 URI template as defined by RFC 6570, used to map provider source addresses to OCI repository addresses. The template can contain {hostname} {namespace} and {type}.`).SetDisplay("=tmpl")
 
 	cli.VariadicArg(&arguments.Providers, "providers")
 

--- a/internal/command/arguments/providers_lock.go
+++ b/internal/command/arguments/providers_lock.go
@@ -37,22 +37,22 @@ type ProvidersLock struct {
 }
 
 // BindProvidersLock registers CLI arguments, returning a ProvidersLock value and it's corresponding hooks.
-func BindProvidersLock(flags Flags) (*ProvidersLock, Hooks) {
+func BindProvidersLock(cli *CommandLine) *ProvidersLock {
 	var arguments ProvidersLock
-	var hooks Hooks
 
-	arguments.ViewOptions.bind(flags, false)
-	hooks = append(hooks, arguments.ViewOptions.ParseHook())
+	arguments.ViewOptions.bind(cli, false)
 
 	arguments.Vars = &Vars{}
-	arguments.Vars.bind(flags)
+	arguments.Vars.bind(cli)
 
-	flags.StringArrayVar(&arguments.OptPlatforms, "platform", nil, "target platform")
-	flags.StringVar(&arguments.FsMirrorDir, "fs-mirror", "", "filesystem mirror directory")
-	flags.StringVar(&arguments.NetMirrorURL, "net-mirror", "", "network mirror base URL")
-	flags.StringVar(&arguments.OciMirrorTemplate, "oci-mirror", "", "oci mirror URI template")
+	cli.StringArrayVar(&arguments.OptPlatforms, "platform", nil, "target platform")
+	cli.StringVar(&arguments.FsMirrorDir, "fs-mirror", "", "filesystem mirror directory")
+	cli.StringVar(&arguments.NetMirrorURL, "net-mirror", "", "network mirror base URL")
+	cli.StringVar(&arguments.OciMirrorTemplate, "oci-mirror", "", "oci mirror URI template")
 
-	hooks = append(hooks, Hook{Pre: func() tfdiags.Diagnostics {
+	cli.VariadicArg(&arguments.Providers, "providers")
+
+	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
 		var diags tfdiags.Diagnostics
 
 		mirrorSet := false
@@ -82,30 +82,15 @@ func BindProvidersLock(flags Flags) (*ProvidersLock, Hooks) {
 		return diags
 	}})
 
-	return &arguments, hooks
+	return &arguments
 }
 
 // ParseProvidersLock processes CLI arguments, returning a ProvidersLock value, a closer function, and errors.
 // If errors are encountered, a ProvidersLock value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseProvidersLock(args []string) (*ProvidersLock, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	arguments, hooks := BindProvidersLock(flags)
-
-	cmdFlags := defaultFlagSet("providers lock", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	// TODO positional arguments
-	arguments.Providers = cmdFlags.Args()
-
-	return arguments, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	arguments := BindProvidersLock(cli)
+	closer, diags := cli.Stdlib("providers lock", args)
+	return arguments, closer, diags
 }

--- a/internal/command/arguments/providers_lock.go
+++ b/internal/command/arguments/providers_lock.go
@@ -42,8 +42,7 @@ func BindProvidersLock(cli *CommandLine) *ProvidersLock {
 
 	arguments.ViewOptions.bind(cli, false)
 
-	arguments.Vars = &Vars{}
-	arguments.Vars.bind(cli)
+	arguments.Vars = BindVars(cli)
 
 	cli.StringArrayVar(&arguments.OptPlatforms, "platform", nil, `Choose a target platform to request package checksums for.
 

--- a/internal/command/arguments/providers_lock_test.go
+++ b/internal/command/arguments/providers_lock_test.go
@@ -96,7 +96,7 @@ func TestParseProvidersLock_basicValidation(t *testing.T) {
 		"unknown flag": {
 			args:        []string{"-unknown-flag"},
 			want:        providersLockArgsWithDefaults(func(v *ProvidersLock) {}),
-			wantErrText: "Failed to parse command-line flags: flag provided but not defined: -unknown-flag",
+			wantErrText: "flag provided but not defined: -unknown-flag",
 		},
 	}
 
@@ -117,8 +117,10 @@ func TestParseProvidersLock_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n%s\nwanted: %s\n", errStr, tc.wantErrText)
 				}
 			}
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
-				t.Errorf("unexpected result\n%s", diff)
+			if !diags.HasErrors() {
+				if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+					t.Errorf("unexpected result\n%s", diff)
+				}
 			}
 		})
 	}

--- a/internal/command/arguments/providers_lock_test.go
+++ b/internal/command/arguments/providers_lock_test.go
@@ -73,6 +73,7 @@ func TestParseProvidersLock_basicValidation(t *testing.T) {
 		"invalid oci-mirror flag": {
 			args: []string{"-oci-mirror=invalid{template"},
 			want: providersLockArgsWithDefaults(func(v *ProvidersLock) {
+				v.Providers = []string{}
 				v.OciMirrorTemplate = "invalid{template"
 			}),
 			wantErrText: "The -oci-mirror argument is not a valid URI template",
@@ -80,6 +81,7 @@ func TestParseProvidersLock_basicValidation(t *testing.T) {
 		"all mirrors error": {
 			args: []string{"-fs-mirror=/path", "-net-mirror=https://example.com", "-oci-mirror=https://example.com/mirror"},
 			want: providersLockArgsWithDefaults(func(v *ProvidersLock) {
+				v.Providers = []string{}
 				v.FsMirrorDir = "/path"
 				v.NetMirrorURL = "https://example.com"
 				v.OciMirrorTemplate = "https://example.com/mirror"
@@ -89,13 +91,16 @@ func TestParseProvidersLock_basicValidation(t *testing.T) {
 		"mixed flags and providers": {
 			args: []string{"-platform=linux_amd64", "-platform=darwin_arm64", "test_ns/test_provider", "test_ns2/test_provider2"},
 			want: providersLockArgsWithDefaults(func(v *ProvidersLock) {
+				v.Providers = []string{}
 				v.OptPlatforms = []string{"linux_amd64", "darwin_arm64"}
 				v.Providers = []string{"test_ns/test_provider", "test_ns2/test_provider2"}
 			}),
 		},
 		"unknown flag": {
-			args:        []string{"-unknown-flag"},
-			want:        providersLockArgsWithDefaults(func(v *ProvidersLock) {}),
+			args: []string{"-unknown-flag"},
+			want: providersLockArgsWithDefaults(func(v *ProvidersLock) {
+				v.Providers = []string{}
+			}),
 			wantErrText: "flag provided but not defined: -unknown-flag",
 		},
 	}
@@ -117,10 +122,8 @@ func TestParseProvidersLock_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n%s\nwanted: %s\n", errStr, tc.wantErrText)
 				}
 			}
-			if !diags.HasErrors() {
-				if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
-					t.Errorf("unexpected result\n%s", diff)
-				}
+			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+				t.Errorf("unexpected result\n%s", diff)
 			}
 		})
 	}

--- a/internal/command/arguments/providers_mirror.go
+++ b/internal/command/arguments/providers_mirror.go
@@ -29,8 +29,7 @@ func BindProvidersMirror(cli *CommandLine) *ProvidersMirror {
 
 	arguments.ViewOptions.bind(cli, false)
 
-	arguments.Vars = &Vars{}
-	arguments.Vars.bind(cli)
+	arguments.Vars = BindVars(cli)
 
 	cli.StringArrayVar(&arguments.OptPlatforms, "platform", nil, `Choose which target platform to build a mirror for. By default OpenTofu will obtain plugin packages suitable for the platform where you run this command. Use this flag multiple times to include packages for multiple target systems.
 

--- a/internal/command/arguments/providers_mirror.go
+++ b/internal/command/arguments/providers_mirror.go
@@ -24,50 +24,28 @@ type ProvidersMirror struct {
 }
 
 // BindProvidersMirror registers CLI arguments, returning a ProvidersMirror value and it's corresponding hooks.
-func BindProvidersMirror(flags Flags) (*ProvidersMirror, Hooks) {
+func BindProvidersMirror(cli *CommandLine) *ProvidersMirror {
 	var arguments ProvidersMirror
-	var hooks Hooks
 
-	arguments.ViewOptions.bind(flags, false)
-	hooks = append(hooks, arguments.ViewOptions.ParseHook())
+	arguments.ViewOptions.bind(cli, false)
 
 	arguments.Vars = &Vars{}
-	arguments.Vars.bind(flags)
+	arguments.Vars.bind(cli)
 
-	flags.StringArrayVar(&arguments.OptPlatforms, "platform", nil, "target platform")
+	cli.StringArrayVar(&arguments.OptPlatforms, "platform", nil, "target platform")
 
-	return &arguments, hooks
+	cli.ArgHelp = "The providers mirror command requires an output directory as a command-line argument."
+	cli.PositionalArg(&arguments.Directory, "directory", false)
+
+	return &arguments
 }
 
 // ParseProvidersMirror processes CLI arguments, returning a ProvidersMirror value, a closer function, and errors.
 // If errors are encountered, a ProvidersMirror value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseProvidersMirror(args []string) (*ProvidersMirror, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	arguments, hooks := BindProvidersMirror(flags)
-
-	cmdFlags := defaultFlagSet("providers mirror", flags)
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	// TODO positional arguments
-	remainingArgs := cmdFlags.Args()
-	if len(remainingArgs) != 1 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Wrong number of arguments",
-			"The providers mirror command requires an output directory as a command-line argument.",
-		))
-	} else {
-		arguments.Directory = remainingArgs[0]
-	}
-
-	return arguments, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	arguments := BindProvidersMirror(cli)
+	closer, diags := cli.Stdlib("providers mirror", args)
+	return arguments, closer, diags
 }

--- a/internal/command/arguments/providers_mirror.go
+++ b/internal/command/arguments/providers_mirror.go
@@ -32,10 +32,12 @@ func BindProvidersMirror(cli *CommandLine) *ProvidersMirror {
 	arguments.Vars = &Vars{}
 	arguments.Vars.bind(cli)
 
-	cli.StringArrayVar(&arguments.OptPlatforms, "platform", nil, "target platform")
+	cli.StringArrayVar(&arguments.OptPlatforms, "platform", nil, `Choose which target platform to build a mirror for. By default OpenTofu will obtain plugin packages suitable for the platform where you run this command. Use this flag multiple times to include packages for multiple target systems.
+
+ Target names consist of an operating system and a CPU architecture. For example, "linux_amd64" selects the Linux operating system running on an AMD64 or x86_64 CPU. Each provider is available only for a limited set of target platforms.`).SetDisplay("=os_arch")
 
 	cli.ArgHelp = "The providers mirror command requires an output directory as a command-line argument."
-	cli.PositionalArg(&arguments.Directory, "directory", false)
+	cli.PositionalArg(&arguments.Directory, "target-dir", false)
 
 	return &arguments
 }

--- a/internal/command/arguments/providers_mirror.go
+++ b/internal/command/arguments/providers_mirror.go
@@ -6,7 +6,6 @@
 package arguments
 
 import (
-	"github.com/opentofu/opentofu/internal/command/flags"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
@@ -16,7 +15,7 @@ type ProvidersMirror struct {
 	Directory string
 	// OptPlatforms contains the platforms that the user requested to have the providers
 	// copy for
-	OptPlatforms flags.FlagStringSlice
+	OptPlatforms []string
 
 	// ViewOptions specifies which view options to use
 	ViewOptions ViewOptions
@@ -24,18 +23,32 @@ type ProvidersMirror struct {
 	Vars *Vars
 }
 
+// BindProvidersMirror registers CLI arguments, returning a ProvidersMirror value and it's corresponding hooks.
+func BindProvidersMirror(flags Flags) (*ProvidersMirror, Hooks) {
+	var arguments ProvidersMirror
+	var hooks Hooks
+
+	arguments.ViewOptions.bind(flags, false)
+	hooks = append(hooks, arguments.ViewOptions.ParseHook())
+
+	arguments.Vars = &Vars{}
+	arguments.Vars.bind(flags)
+
+	flags.StringArrayVar(&arguments.OptPlatforms, "platform", nil, "target platform")
+
+	return &arguments, hooks
+}
+
 // ParseProvidersMirror processes CLI arguments, returning a ProvidersMirror value, a closer function, and errors.
 // If errors are encountered, a ProvidersMirror value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseProvidersMirror(args []string) (*ProvidersMirror, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	arguments := &ProvidersMirror{
-		Vars: &Vars{},
-	}
 
-	cmdFlags := extendedFlagSet("providers mirror", nil, arguments.Vars)
-	cmdFlags.Var(&arguments.OptPlatforms, "platform", "target platform")
-	arguments.ViewOptions.AddFlags(cmdFlags, false)
+	flags := Flags{}
+	arguments, hooks := BindProvidersMirror(flags)
+
+	cmdFlags := defaultFlagSet("providers mirror", flags)
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,
@@ -43,6 +56,8 @@ func ParseProvidersMirror(args []string) (*ProvidersMirror, func(), tfdiags.Diag
 			err.Error(),
 		))
 	}
+
+	// TODO positional arguments
 	remainingArgs := cmdFlags.Args()
 	if len(remainingArgs) != 1 {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -54,11 +69,5 @@ func ParseProvidersMirror(args []string) (*ProvidersMirror, func(), tfdiags.Diag
 		arguments.Directory = remainingArgs[0]
 	}
 
-	closer, moreDiags := arguments.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-	if diags.HasErrors() {
-		return arguments, closer, diags
-	}
-
-	return arguments, closer, diags
+	return arguments, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/providers_mirror_test.go
+++ b/internal/command/arguments/providers_mirror_test.go
@@ -25,8 +25,10 @@ func TestParseProvidersMirror_basicValidation(t *testing.T) {
 			wantErrText: "The providers mirror command requires an output directory as a command-line argument.",
 		},
 		"too many arguments": {
-			args:        []string{"/path/to/mirror", "/another/path"},
-			want:        providersMirrorArgsWithDefaults(func(v *ProvidersMirror) {}),
+			args: []string{"/path/to/mirror", "/another/path"},
+			want: providersMirrorArgsWithDefaults(func(v *ProvidersMirror) {
+				v.Directory = "/path/to/mirror"
+			}),
 			wantErrText: "The providers mirror command requires an output directory as a command-line argument.",
 		},
 		"single directory": {
@@ -75,10 +77,8 @@ func TestParseProvidersMirror_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n\t%s\nwanted:\n\t%s\n", errStr, tc.wantErrText)
 				}
 			}
-			if !diags.HasErrors() {
-				if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
-					t.Errorf("unexpected result\n%s", diff)
-				}
+			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+				t.Errorf("unexpected result\n%s", diff)
 			}
 		})
 	}

--- a/internal/command/arguments/providers_mirror_test.go
+++ b/internal/command/arguments/providers_mirror_test.go
@@ -22,12 +22,12 @@ func TestParseProvidersMirror_basicValidation(t *testing.T) {
 		"no directory": {
 			args:        nil,
 			want:        providersMirrorArgsWithDefaults(nil),
-			wantErrText: "Wrong number of arguments: The providers mirror command requires an output directory as a command-line argument.",
+			wantErrText: "The providers mirror command requires an output directory as a command-line argument.",
 		},
 		"too many arguments": {
 			args:        []string{"/path/to/mirror", "/another/path"},
 			want:        providersMirrorArgsWithDefaults(func(v *ProvidersMirror) {}),
-			wantErrText: "Wrong number of arguments: The providers mirror command requires an output directory as a command-line argument.",
+			wantErrText: "The providers mirror command requires an output directory as a command-line argument.",
 		},
 		"single directory": {
 			args: []string{"/path/to/mirror"},
@@ -54,7 +54,7 @@ func TestParseProvidersMirror_basicValidation(t *testing.T) {
 			want: providersMirrorArgsWithDefaults(func(v *ProvidersMirror) {
 				v.Directory = "/path/to/mirror"
 			}),
-			wantErrText: "Failed to parse command-line flags: flag provided but not defined: -unknown-flag",
+			wantErrText: "flag provided but not defined: -unknown-flag",
 		},
 	}
 
@@ -75,8 +75,10 @@ func TestParseProvidersMirror_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n\t%s\nwanted:\n\t%s\n", errStr, tc.wantErrText)
 				}
 			}
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
-				t.Errorf("unexpected result\n%s", diff)
+			if !diags.HasErrors() {
+				if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+					t.Errorf("unexpected result\n%s", diff)
+				}
 			}
 		})
 	}

--- a/internal/command/arguments/providers_schema.go
+++ b/internal/command/arguments/providers_schema.go
@@ -26,7 +26,7 @@ func BindProvidersSchema(cli *CommandLine) *ProvidersSchema {
 
 	schema.Vars = BindVars(cli)
 
-	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+	cli.PreHook(func() tfdiags.Diagnostics {
 		if schema.ViewOptions.ViewType != ViewJSON {
 			return tfdiags.New(tfdiags.Sourceless(
 				tfdiags.Error,
@@ -41,7 +41,7 @@ func BindProvidersSchema(cli *CommandLine) *ProvidersSchema {
 		schema.ViewOptions.ViewType = ViewHuman
 
 		return nil
-	}})
+	})
 
 	return &schema
 }

--- a/internal/command/arguments/providers_schema.go
+++ b/internal/command/arguments/providers_schema.go
@@ -24,8 +24,7 @@ func BindProvidersSchema(cli *CommandLine) *ProvidersSchema {
 
 	schema.ViewOptions.bindGranularFlags(cli, false, false)
 
-	schema.Vars = &Vars{}
-	schema.Vars.bind(cli)
+	schema.Vars = BindVars(cli)
 
 	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
 		if schema.ViewOptions.ViewType != ViewJSON {

--- a/internal/command/arguments/providers_schema.go
+++ b/internal/command/arguments/providers_schema.go
@@ -19,17 +19,15 @@ type ProvidersSchema struct {
 }
 
 // BindProvidersSchema registers CLI arguments, returning a ProvidersSchema value and it's corresponding hooks.
-func BindProvidersSchema(flags Flags) (*ProvidersSchema, Hooks) {
+func BindProvidersSchema(cli *CommandLine) *ProvidersSchema {
 	var schema ProvidersSchema
-	var hooks Hooks
 
-	schema.ViewOptions.bindGranularFlags(flags, false, false)
-	hooks = append(hooks, schema.ViewOptions.ParseHook())
+	schema.ViewOptions.bindGranularFlags(cli, false, false)
 
 	schema.Vars = &Vars{}
-	schema.Vars.bind(flags)
+	schema.Vars.bind(cli)
 
-	hooks = append(hooks, Hook{Pre: func() tfdiags.Diagnostics {
+	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
 		if schema.ViewOptions.ViewType != ViewJSON {
 			return tfdiags.New(tfdiags.Sourceless(
 				tfdiags.Error,
@@ -46,36 +44,15 @@ func BindProvidersSchema(flags Flags) (*ProvidersSchema, Hooks) {
 		return nil
 	}})
 
-	return &schema, hooks
+	return &schema
 }
 
 // ParseProvidersSchema processes CLI arguments, returning a ProvidersSchema value, a closer function, and errors.
 // If errors are encountered, a ProvidersSchema value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseProvidersSchema(args []string) (*ProvidersSchema, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	schema, hooks := BindProvidersSchema(flags)
-
-	cmdFlags := defaultFlagSet("providers schema", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	args = cmdFlags.Args()
-	if len(args) > 0 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Too many command line arguments",
-			"Expected at most zero positional arguments.",
-		))
-	}
-
-	return schema, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	schema := BindProvidersSchema(cli)
+	closer, diags := cli.Stdlib("providers schema", args)
+	return schema, closer, diags
 }

--- a/internal/command/arguments/providers_schema.go
+++ b/internal/command/arguments/providers_schema.go
@@ -18,19 +18,47 @@ type ProvidersSchema struct {
 	Vars *Vars
 }
 
+// BindProvidersSchema registers CLI arguments, returning a ProvidersSchema value and it's corresponding hooks.
+func BindProvidersSchema(flags Flags) (*ProvidersSchema, Hooks) {
+	var schema ProvidersSchema
+	var hooks Hooks
+
+	schema.ViewOptions.bindGranularFlags(flags, false, false)
+	hooks = append(hooks, schema.ViewOptions.ParseHook())
+
+	schema.Vars = &Vars{}
+	schema.Vars.bind(flags)
+
+	hooks = append(hooks, Hook{Pre: func() tfdiags.Diagnostics {
+		if schema.ViewOptions.ViewType != ViewJSON {
+			return tfdiags.New(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Output only in json is allowed",
+				"The `tofu providers schema` command requires the `-json` flag.",
+			))
+		}
+
+		// The 'providers schema' command just forces the user to use the `-json` flag but any of the diagnostics should
+		// be printed as human format.
+		// The print of the schema will be in JSON all the time.
+		schema.ViewOptions.ViewType = ViewHuman
+
+		return nil
+	}})
+
+	return &schema, hooks
+}
+
 // ParseProvidersSchema processes CLI arguments, returning a ProvidersSchema value, a closer function, and errors.
 // If errors are encountered, a ProvidersSchema value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseProvidersSchema(args []string) (*ProvidersSchema, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	schema := &ProvidersSchema{
-		Vars: &Vars{},
-	}
+	flags := Flags{}
+	schema, hooks := BindProvidersSchema(flags)
 
-	cmdFlags := extendedFlagSet("providers schema", nil, schema.Vars)
-
-	schema.ViewOptions.AddGranularFlags(cmdFlags, false, false)
+	cmdFlags := defaultFlagSet("providers schema", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -49,21 +77,5 @@ func ParseProvidersSchema(args []string) (*ProvidersSchema, func(), tfdiags.Diag
 		))
 	}
 
-	closer, moreDiags := schema.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-
-	if schema.ViewOptions.ViewType != ViewJSON {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Output only in json is allowed",
-			"The `tofu providers schema` command requires the `-json` flag.",
-		))
-	}
-
-	// The 'providers schema' command just forces the user to use the `-json` flag but any of the diagnostics should
-	// be printed as human format.
-	// The print of the schema will be in JSON all the time.
-	schema.ViewOptions.ViewType = ViewHuman
-
-	return schema, closer, diags
+	return schema, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/providers_schema_test.go
+++ b/internal/command/arguments/providers_schema_test.go
@@ -33,7 +33,6 @@ func TestParseProvidersSchema_basicValidation(t *testing.T) {
 			wantDiags: true,
 			want:      providersSchemaArgsWithDefaults(nil),
 			wantContain: []string{
-				"Output only in json is allowed",
 				"The `tofu providers schema` command requires the `-json` flag.",
 			},
 		},
@@ -46,8 +45,7 @@ func TestParseProvidersSchema_basicValidation(t *testing.T) {
 			}),
 			wantDiags: true,
 			wantContain: []string{
-				"Too many command line arguments",
-				"Expected at most zero positional arguments.",
+				"Too many command line arguments. Did you mean to use -chdir",
 			},
 		},
 		"multiple positional arguments with json": {
@@ -59,8 +57,7 @@ func TestParseProvidersSchema_basicValidation(t *testing.T) {
 			}),
 			wantDiags: true,
 			wantContain: []string{
-				"Too many command line arguments",
-				"Expected at most zero positional arguments.",
+				"Too many command line arguments. Did you mean to use -chdir",
 			},
 		},
 	}

--- a/internal/command/arguments/providers_test.go
+++ b/internal/command/arguments/providers_test.go
@@ -32,12 +32,12 @@ func TestParseProviders_basicValidation(t *testing.T) {
 		"unknown flag": {
 			args:        []string{"-json"},
 			want:        providersArgsWithDefaults(func(v *Providers) {}),
-			wantErrText: "Failed to parse command-line flags: flag provided but not defined: -json",
+			wantErrText: "flag provided but not defined: -json",
 		},
 		"unknown flag2": {
 			args:        []string{"-json-into"},
 			want:        providersArgsWithDefaults(func(v *Providers) {}),
-			wantErrText: "Failed to parse command-line flags: flag provided but not defined: -json-into",
+			wantErrText: "flag provided but not defined: -json-into",
 		},
 		"too many args": {
 			args:        []string{"foo"},

--- a/internal/command/arguments/refresh.go
+++ b/internal/command/arguments/refresh.go
@@ -21,53 +21,29 @@ type Refresh struct {
 }
 
 // BindRefresh registers CLI arguments, returning a Refresh value and it's corresponding hooks.
-func BindRefresh(flags Flags) (*Refresh, Hooks) {
+func BindRefresh(cli *CommandLine) *Refresh {
 	var refresh Refresh
-	var hooks Hooks
 
-	refresh.ViewOptions.bind(flags, true)
-	hooks = append(hooks, refresh.ViewOptions.ParseHook())
+	refresh.ViewOptions.bind(cli, true)
 
 	refresh.Vars = &Vars{}
-	refresh.Vars.bind(flags)
+	refresh.Vars.bind(cli)
 
 	refresh.Operation = &Operation{}
-	refresh.Operation.bind(flags)
-	hooks = append(hooks, Hook{Pre: refresh.Operation.Parse})
+	refresh.Operation.bind(cli)
 
 	refresh.State = &State{}
-	refresh.State.bind(flags, stateFlagAll)
+	refresh.State.bind(cli, stateFlagAll)
 
-	return &refresh, hooks
+	return &refresh
 }
 
 // ParseRefresh processes CLI arguments, returning a Refresh value, a closer function, and errors.
 // If errors are encountered, a Refresh value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseRefresh(args []string) (*Refresh, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	refresh, hooks := BindRefresh(flags)
-
-	cmdFlags := defaultFlagSet("refresh", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	args = cmdFlags.Args()
-	if len(args) > 0 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Too many command line arguments",
-			"Expected at most one positional argument.",
-		))
-	}
-
-	return refresh, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	refresh := BindRefresh(cli)
+	closer, diags := cli.Stdlib("refresh", args)
+	return refresh, closer, diags
 }

--- a/internal/command/arguments/refresh.go
+++ b/internal/command/arguments/refresh.go
@@ -32,8 +32,7 @@ func BindRefresh(cli *CommandLine) *Refresh {
 	refresh.Operation = &Operation{}
 	refresh.Operation.bind(cli)
 
-	refresh.State = &State{}
-	refresh.State.bind(cli, stateFlagAll)
+	refresh.State = BindState(cli, stateFlagAll)
 
 	return &refresh
 }

--- a/internal/command/arguments/refresh.go
+++ b/internal/command/arguments/refresh.go
@@ -20,20 +20,37 @@ type Refresh struct {
 	ViewOptions ViewOptions
 }
 
+// BindRefresh registers CLI arguments, returning a Refresh value and it's corresponding hooks.
+func BindRefresh(flags Flags) (*Refresh, Hooks) {
+	var refresh Refresh
+	var hooks Hooks
+
+	refresh.ViewOptions.bind(flags, true)
+	hooks = append(hooks, refresh.ViewOptions.ParseHook())
+
+	refresh.Vars = &Vars{}
+	refresh.Vars.bind(flags)
+
+	refresh.Operation = &Operation{}
+	refresh.Operation.bind(flags)
+	hooks = append(hooks, Hook{Pre: refresh.Operation.Parse})
+
+	refresh.State = &State{}
+	refresh.State.bind(flags, stateFlagAll)
+
+	return &refresh, hooks
+}
+
 // ParseRefresh processes CLI arguments, returning a Refresh value, a closer function, and errors.
 // If errors are encountered, a Refresh value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseRefresh(args []string) (*Refresh, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	refresh := &Refresh{
-		State:     &State{},
-		Operation: &Operation{},
-		Vars:      &Vars{},
-	}
 
-	cmdFlags := extendedFlagSet("refresh", refresh.Operation, refresh.Vars)
-	refresh.State.addFlags(cmdFlags, stateFlagAll)
-	refresh.ViewOptions.AddFlags(cmdFlags, true)
+	flags := Flags{}
+	refresh, hooks := BindRefresh(flags)
+
+	cmdFlags := defaultFlagSet("refresh", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -52,9 +69,5 @@ func ParseRefresh(args []string) (*Refresh, func(), tfdiags.Diagnostics) {
 		))
 	}
 
-	diags = diags.Append(refresh.Operation.Parse())
-	closer, moreDiags := refresh.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-
-	return refresh, closer, diags
+	return refresh, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/refresh.go
+++ b/internal/command/arguments/refresh.go
@@ -26,11 +26,8 @@ func BindRefresh(cli *CommandLine) *Refresh {
 
 	refresh.ViewOptions.bind(cli, true)
 
-	refresh.Vars = &Vars{}
-	refresh.Vars.bind(cli)
-
-	refresh.Operation = &Operation{}
-	refresh.Operation.bind(cli)
+	refresh.Vars = BindVars(cli)
+	refresh.Operation = BindOperation(cli)
 
 	refresh.State = BindState(cli, stateFlagAll)
 

--- a/internal/command/arguments/show.go
+++ b/internal/command/arguments/show.go
@@ -96,7 +96,7 @@ func BindShow(cli *CommandLine) *Show {
 	cli.BoolVar(&show.ShowSensitive, "show-sensitive", false, "If specified, sensitive values will be displayed.")
 
 	cli.VariadicArg(&args, "arguments")
-	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+	cli.PreHook(func() tfdiags.Diagnostics {
 		// If -config or -module=... is selected, -json is required
 		if configTarget && !show.ViewOptions.jsonFlag {
 			return tfdiags.New(tfdiags.Sourceless(
@@ -176,7 +176,7 @@ func BindShow(cli *CommandLine) *Show {
 			))
 		}
 		return nil
-	}})
+	})
 
 	return &show
 }

--- a/internal/command/arguments/show.go
+++ b/internal/command/arguments/show.go
@@ -64,139 +64,118 @@ const (
 )
 
 // BindShow registers CLI arguments, returning a Show value and it's corresponding hooks.
-func BindShow(flags Flags,
-	stateTarget *bool,
-	planTarget *string,
-	configTarget *bool,
-	moduleTarget *string,
-) (*Show, Hooks) {
+func BindShow(cli *CommandLine) *Show {
 	var show Show
-	var hooks Hooks
 
-	show.ViewOptions.bind(flags, false)
-	hooks = append(hooks, show.ViewOptions.ParseHook())
+	show.ViewOptions.bind(cli, false)
 
 	show.Vars = &Vars{}
-	show.Vars.bind(flags)
+	show.Vars.bind(cli)
 
-	flags.BoolVar(&show.ShowSensitive, "show-sensitive", false, "displays sensitive values")
-	flags.BoolVar(stateTarget, "state", false, "show the latest state snapshot")
-	flags.StringVar(planTarget, "plan", "", "show the plan from a saved plan file")
-	flags.BoolVar(configTarget, "config", false, "show the current configuration")
-	flags.StringVar(moduleTarget, "module", "", "show metadata about one module")
+	var stateTarget bool
+	var planTarget string
+	var configTarget bool
+	var moduleTarget string
+	var args []string
 
-	return &show, hooks
+	cli.BoolVar(&show.ShowSensitive, "show-sensitive", false, "displays sensitive values")
+	cli.BoolVar(&stateTarget, "state", false, "show the latest state snapshot")
+	cli.StringVar(&planTarget, "plan", "", "show the plan from a saved plan file")
+	cli.BoolVar(&configTarget, "config", false, "show the current configuration")
+	cli.StringVar(&moduleTarget, "module", "", "show metadata about one module")
+
+	cli.VariadicArg(&args, "arguments")
+	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+		// If -config or -module=... is selected, -json is required
+		if configTarget && !show.ViewOptions.jsonFlag {
+			return tfdiags.New(tfdiags.Sourceless(
+				tfdiags.Error,
+				"JSON output required for configuration",
+				"The -config option requires -json to be specified.",
+			))
+		}
+		if moduleTarget != "" && !show.ViewOptions.jsonFlag {
+			return tfdiags.New(tfdiags.Sourceless(
+				tfdiags.Error,
+				"JSON output required for module",
+				"The -module=DIR option requires -json to be specified.",
+			))
+		}
+
+		if planTarget == "" && moduleTarget == "" && !stateTarget && !configTarget {
+			// If none of the target type options was provided then we're
+			// in the legacy mode where the target type is implied by
+			// the number of arguments.
+			switch len(args) {
+			case 0:
+				show.TargetType = ShowState
+				show.TargetArg = ""
+			case 1:
+				// This case is ambiguous: the argument could be either
+				// a saved plan file or a local state snapshot such as
+				// the output from "tofu state pull". The caller will need
+				// to probe TargetArg to decide which it is.
+				show.TargetType = ShowUnknownType
+				show.TargetArg = args[0]
+			default:
+				return tfdiags.New(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Too many command line arguments",
+					"Expected at most one positional argument for the legacy positional argument mode.",
+				))
+			}
+			return nil
+		}
+
+		// The following handles the modern mode where the target type is
+		// chosen based on which target type option was used.
+		if len(args) != 0 {
+			return tfdiags.New(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Unexpected command line arguments",
+				"This command does not expect any positional arguments when using a target-selection option.",
+			))
+		}
+		targetTypes := 0
+		if stateTarget {
+			targetTypes++
+			show.TargetType = ShowState
+			show.TargetArg = ""
+		}
+		if planTarget != "" {
+			targetTypes++
+			show.TargetType = ShowPlan
+			show.TargetArg = planTarget
+		}
+		if configTarget {
+			targetTypes++
+			show.TargetType = ShowConfig
+			show.TargetArg = ""
+		}
+		if moduleTarget != "" {
+			targetTypes++
+			show.TargetType = ShowModule
+			show.TargetArg = moduleTarget
+		}
+		if targetTypes != 1 {
+			return tfdiags.New(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Conflicting object types to show",
+				"The -state, -plan=FILENAME, -config, and -module=DIR options are mutually-exclusive, to specify which kind of object to show.",
+			))
+		}
+		return nil
+	}})
+
+	return &show
 }
 
 // ParseShow processes CLI arguments, returning a Show value, a closer function, and errors.
 // If errors are encountered, a Show value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseShow(args []string) (*Show, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	var stateTarget bool
-	var planTarget string
-	var configTarget bool
-	var moduleTarget string
-
-	flags := Flags{}
-	show, hooks := BindShow(flags, &stateTarget, &planTarget, &configTarget, &moduleTarget)
-	cmdFlags := defaultFlagSet("show", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line options",
-			err.Error(),
-		))
-	}
-
-	diags = diags.Append(hooks.Pre())
-	closer := func() { hooks.Post() }
-
-	// TODO positional arguments
-
-	// If -config or -module=... is selected, -json is required
-	if configTarget && !show.ViewOptions.jsonFlag {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"JSON output required for configuration",
-			"The -config option requires -json to be specified.",
-		))
-		return show, closer, diags
-	}
-	if moduleTarget != "" && !show.ViewOptions.jsonFlag {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"JSON output required for module",
-			"The -module=DIR option requires -json to be specified.",
-		))
-		return show, closer, diags
-	}
-
-	if planTarget == "" && moduleTarget == "" && !stateTarget && !configTarget {
-		// If none of the target type options was provided then we're
-		// in the legacy mode where the target type is implied by
-		// the number of arguments.
-		args = cmdFlags.Args()
-		switch len(args) {
-		case 0:
-			show.TargetType = ShowState
-			show.TargetArg = ""
-		case 1:
-			// This case is ambiguous: the argument could be either
-			// a saved plan file or a local state snapshot such as
-			// the output from "tofu state pull". The caller will need
-			// to probe TargetArg to decide which it is.
-			show.TargetType = ShowUnknownType
-			show.TargetArg = args[0]
-		default:
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Too many command line arguments",
-				"Expected at most one positional argument for the legacy positional argument mode.",
-			))
-		}
-		return show, closer, diags
-	}
-
-	// The following handles the modern mode where the target type is
-	// chosen based on which target type option was used.
-	if len(cmdFlags.Args()) != 0 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Unexpected command line arguments",
-			"This command does not expect any positional arguments when using a target-selection option.",
-		))
-		return show, closer, diags
-	}
-	targetTypes := 0
-	if stateTarget {
-		targetTypes++
-		show.TargetType = ShowState
-		show.TargetArg = ""
-	}
-	if planTarget != "" {
-		targetTypes++
-		show.TargetType = ShowPlan
-		show.TargetArg = planTarget
-	}
-	if configTarget {
-		targetTypes++
-		show.TargetType = ShowConfig
-		show.TargetArg = ""
-	}
-	if moduleTarget != "" {
-		targetTypes++
-		show.TargetType = ShowModule
-		show.TargetArg = moduleTarget
-	}
-	if targetTypes != 1 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Conflicting object types to show",
-			"The -state, -plan=FILENAME, -config, and -module=DIR options are mutually-exclusive, to specify which kind of object to show.",
-		))
-	}
+	cli := new(CommandLine)
+	show := BindShow(cli)
+	closer, diags := cli.Stdlib("show", args)
 	return show, closer, diags
 }

--- a/internal/command/arguments/show.go
+++ b/internal/command/arguments/show.go
@@ -72,17 +72,28 @@ func BindShow(cli *CommandLine) *Show {
 	show.Vars = &Vars{}
 	show.Vars.bind(cli)
 
+	targetFlagGroup := FlagGroup{
+		ID:          "target",
+		Title:       "Target selection options:",
+		Description: `Use one of the following options to specify what to show.`,
+		Suffix:      `If no target selection options are provided, -state is the default.`,
+	}
+	defaultFlagGroup := FlagGroup{
+		ID:    "",
+		Title: "Other options:",
+	}
+	cli.FlagGroups = []FlagGroup{targetFlagGroup, defaultFlagGroup}
+
 	var stateTarget bool
 	var planTarget string
 	var configTarget bool
 	var moduleTarget string
 	var args []string
 
-	cli.BoolVar(&show.ShowSensitive, "show-sensitive", false, "displays sensitive values")
-	cli.BoolVar(&stateTarget, "state", false, "show the latest state snapshot")
-	cli.StringVar(&planTarget, "plan", "", "show the plan from a saved plan file")
-	cli.BoolVar(&configTarget, "config", false, "show the current configuration")
-	cli.StringVar(&moduleTarget, "module", "", "show metadata about one module")
+	cli.BoolVar(&stateTarget, "state", false, "The latest state snapshot, if any.").SetGroup(targetFlagGroup.ID)
+	cli.StringVar(&planTarget, "plan", "", "The plan from a saved plan file.").SetDisplay("=FILENAME").SetGroup(targetFlagGroup.ID)
+	cli.BoolVar(&configTarget, "config", false, "Show the current configuration (requires -json).").SetGroup(targetFlagGroup.ID)
+	cli.StringVar(&moduleTarget, "module", "", "Show the specified module configuration (requires -json)").SetDisplay("=DIR").SetGroup(targetFlagGroup.ID)
 
 	cli.VariadicArg(&args, "arguments")
 	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {

--- a/internal/command/arguments/show.go
+++ b/internal/command/arguments/show.go
@@ -69,8 +69,7 @@ func BindShow(cli *CommandLine) *Show {
 
 	show.ViewOptions.bind(cli, false)
 
-	show.Vars = &Vars{}
-	show.Vars.bind(cli)
+	show.Vars = BindVars(cli)
 
 	targetFlagGroup := FlagGroup{
 		ID:          "target",

--- a/internal/command/arguments/show.go
+++ b/internal/command/arguments/show.go
@@ -63,27 +63,45 @@ const (
 	ShowModule
 )
 
+// BindShow registers CLI arguments, returning a Show value and it's corresponding hooks.
+func BindShow(flags Flags,
+	stateTarget *bool,
+	planTarget *string,
+	configTarget *bool,
+	moduleTarget *string,
+) (*Show, Hooks) {
+	var show Show
+	var hooks Hooks
+
+	show.ViewOptions.bind(flags, false)
+	hooks = append(hooks, show.ViewOptions.ParseHook())
+
+	show.Vars = &Vars{}
+	show.Vars.bind(flags)
+
+	flags.BoolVar(&show.ShowSensitive, "show-sensitive", false, "displays sensitive values")
+	flags.BoolVar(stateTarget, "state", false, "show the latest state snapshot")
+	flags.StringVar(planTarget, "plan", "", "show the plan from a saved plan file")
+	flags.BoolVar(configTarget, "config", false, "show the current configuration")
+	flags.StringVar(moduleTarget, "module", "", "show metadata about one module")
+
+	return &show, hooks
+}
+
 // ParseShow processes CLI arguments, returning a Show value, a closer function, and errors.
 // If errors are encountered, a Show value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseShow(args []string) (*Show, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	show := &Show{
-		Vars: &Vars{},
-	}
 
 	var stateTarget bool
 	var planTarget string
 	var configTarget bool
 	var moduleTarget string
-	cmdFlags := extendedFlagSet("show", nil, show.Vars)
-	cmdFlags.BoolVar(&show.ShowSensitive, "show-sensitive", false, "displays sensitive values")
-	cmdFlags.BoolVar(&stateTarget, "state", false, "show the latest state snapshot")
-	cmdFlags.StringVar(&planTarget, "plan", "", "show the plan from a saved plan file")
-	cmdFlags.BoolVar(&configTarget, "config", false, "show the current configuration")
-	cmdFlags.StringVar(&moduleTarget, "module", "", "show metadata about one module")
 
-	show.ViewOptions.AddFlags(cmdFlags, false)
+	flags := Flags{}
+	show, hooks := BindShow(flags, &stateTarget, &planTarget, &configTarget, &moduleTarget)
+	cmdFlags := defaultFlagSet("show", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -93,8 +111,10 @@ func ParseShow(args []string) (*Show, func(), tfdiags.Diagnostics) {
 		))
 	}
 
-	closer, moreDiags := show.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
+	diags = diags.Append(hooks.Pre())
+	closer := func() { hooks.Post() }
+
+	// TODO positional arguments
 
 	// If -config or -module=... is selected, -json is required
 	if configTarget && !show.ViewOptions.jsonFlag {

--- a/internal/command/arguments/show.go
+++ b/internal/command/arguments/show.go
@@ -93,6 +93,7 @@ func BindShow(cli *CommandLine) *Show {
 	cli.StringVar(&planTarget, "plan", "", "The plan from a saved plan file.").SetDisplay("=FILENAME").SetGroup(targetFlagGroup.ID)
 	cli.BoolVar(&configTarget, "config", false, "Show the current configuration (requires -json).").SetGroup(targetFlagGroup.ID)
 	cli.StringVar(&moduleTarget, "module", "", "Show the specified module configuration (requires -json)").SetDisplay("=DIR").SetGroup(targetFlagGroup.ID)
+	cli.BoolVar(&show.ShowSensitive, "show-sensitive", false, "If specified, sensitive values will be displayed.")
 
 	cli.VariadicArg(&args, "arguments")
 	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {

--- a/internal/command/arguments/state_list.go
+++ b/internal/command/arguments/state_list.go
@@ -25,21 +25,35 @@ type StateList struct {
 	State *State
 }
 
+// BindStateList registers CLI arguments, returning a StateList value and it's corresponding hooks.
+func BindStateList(flags Flags) (*StateList, Hooks) {
+	var ret StateList
+	var hooks Hooks
+
+	ret.ViewOptions.bind(flags, false)
+	hooks = append(hooks, ret.ViewOptions.ParseHook())
+
+	ret.Vars = &Vars{}
+	ret.Vars.bind(flags)
+
+	ret.State = &State{}
+	ret.State.bind(flags, stateFlagStateIn)
+
+	flags.StringVar(&ret.LookupId, "id", "", `Filters the results to include only instances whose resource types have an attribute named "id" whose value equals the given id string.`)
+
+	return &ret, hooks
+}
+
 // ParseStateList processes CLI arguments, returning a StateList value, a closer function, and errors.
 // If errors are encountered, a StateList value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseStateList(args []string) (*StateList, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	ret := &StateList{
-		Vars:  &Vars{},
-		State: &State{},
-	}
+	flags := Flags{}
+	ret, hooks := BindStateList(flags)
 
-	cmdFlags := extendedFlagSet("state list", nil, ret.Vars)
-	cmdFlags.StringVar(&ret.LookupId, "id", "", "Restrict output to paths with a resource having the specified ID.")
-	ret.State.addFlags(cmdFlags, stateFlagStateIn)
-	ret.ViewOptions.AddFlags(cmdFlags, false)
+	cmdFlags := defaultFlagSet("state list", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -49,10 +63,8 @@ func ParseStateList(args []string) (*StateList, func(), tfdiags.Diagnostics) {
 		))
 	}
 
+	// TODO positional arguments
 	ret.InstancesRawAddr = cmdFlags.Args()
 
-	closer, moreDiags := ret.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-
-	return ret, closer, diags
+	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/state_list.go
+++ b/internal/command/arguments/state_list.go
@@ -34,8 +34,7 @@ func BindStateList(cli *CommandLine) *StateList {
 	ret.Vars = &Vars{}
 	ret.Vars.bind(cli)
 
-	ret.State = &State{}
-	ret.State.bind(cli, stateFlagStateIn)
+	ret.State = BindState(cli, stateFlagStateIn)
 
 	cli.StringVar(&ret.LookupId, "id", "", `Filters the results to include only instances whose resource types have an attribute named "id" whose value equals the given id string.`).SetDisplay("ID")
 

--- a/internal/command/arguments/state_list.go
+++ b/internal/command/arguments/state_list.go
@@ -26,45 +26,30 @@ type StateList struct {
 }
 
 // BindStateList registers CLI arguments, returning a StateList value and it's corresponding hooks.
-func BindStateList(flags Flags) (*StateList, Hooks) {
+func BindStateList(cli *CommandLine) *StateList {
 	var ret StateList
-	var hooks Hooks
 
-	ret.ViewOptions.bind(flags, false)
-	hooks = append(hooks, ret.ViewOptions.ParseHook())
+	ret.ViewOptions.bind(cli, false)
 
 	ret.Vars = &Vars{}
-	ret.Vars.bind(flags)
+	ret.Vars.bind(cli)
 
 	ret.State = &State{}
-	ret.State.bind(flags, stateFlagStateIn)
+	ret.State.bind(cli, stateFlagStateIn)
 
-	flags.StringVar(&ret.LookupId, "id", "", `Filters the results to include only instances whose resource types have an attribute named "id" whose value equals the given id string.`)
+	cli.StringVar(&ret.LookupId, "id", "", `Filters the results to include only instances whose resource types have an attribute named "id" whose value equals the given id string.`)
 
-	return &ret, hooks
+	cli.VariadicArg(&ret.InstancesRawAddr, "instances")
+
+	return &ret
 }
 
 // ParseStateList processes CLI arguments, returning a StateList value, a closer function, and errors.
 // If errors are encountered, a StateList value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseStateList(args []string) (*StateList, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	ret, hooks := BindStateList(flags)
-
-	cmdFlags := defaultFlagSet("state list", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	// TODO positional arguments
-	ret.InstancesRawAddr = cmdFlags.Args()
-
-	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	ret := BindStateList(cli)
+	closer, diags := cli.Stdlib("state list", args)
+	return ret, closer, diags
 }

--- a/internal/command/arguments/state_list.go
+++ b/internal/command/arguments/state_list.go
@@ -31,8 +31,7 @@ func BindStateList(cli *CommandLine) *StateList {
 
 	ret.ViewOptions.bind(cli, false)
 
-	ret.Vars = &Vars{}
-	ret.Vars.bind(cli)
+	ret.Vars = BindVars(cli)
 
 	ret.State = BindState(cli, stateFlagStateIn)
 

--- a/internal/command/arguments/state_list.go
+++ b/internal/command/arguments/state_list.go
@@ -37,9 +37,9 @@ func BindStateList(cli *CommandLine) *StateList {
 	ret.State = &State{}
 	ret.State.bind(cli, stateFlagStateIn)
 
-	cli.StringVar(&ret.LookupId, "id", "", `Filters the results to include only instances whose resource types have an attribute named "id" whose value equals the given id string.`)
+	cli.StringVar(&ret.LookupId, "id", "", `Filters the results to include only instances whose resource types have an attribute named "id" whose value equals the given id string.`).SetDisplay("ID")
 
-	cli.VariadicArg(&ret.InstancesRawAddr, "instances")
+	cli.VariadicArg(&ret.InstancesRawAddr, "address")
 
 	return &ret
 }

--- a/internal/command/arguments/state_list.go
+++ b/internal/command/arguments/state_list.go
@@ -35,7 +35,7 @@ func BindStateList(cli *CommandLine) *StateList {
 
 	ret.State = BindState(cli, stateFlagStateIn)
 
-	cli.StringVar(&ret.LookupId, "id", "", `Filters the results to include only instances whose resource types have an attribute named "id" whose value equals the given id string.`).SetDisplay("ID")
+	cli.StringVar(&ret.LookupId, "id", "", `Filters the results to include only instances whose resource types have an attribute named "id" whose value equals the given id string.`).SetDisplay("=ID")
 
 	cli.VariadicArg(&ret.InstancesRawAddr, "address")
 

--- a/internal/command/arguments/state_list_test.go
+++ b/internal/command/arguments/state_list_test.go
@@ -58,7 +58,7 @@ func TestParseStateList_basicValidation(t *testing.T) {
 		"invalid flags": {
 			args:        []string{"-unknown"},
 			want:        stateListArgsWithDefaults(nil),
-			wantErrText: "Failed to parse command-line flags: flag provided but not defined: -unknown",
+			wantErrText: "flag provided but not defined: -unknown",
 		},
 	}
 

--- a/internal/command/arguments/state_mv.go
+++ b/internal/command/arguments/state_mv.go
@@ -32,61 +32,37 @@ type StateMv struct {
 }
 
 // BindStateMv registers CLI arguments, returning a StateMv value and it's corresponding hooks.
-func BindStateMv(flags Flags) (*StateMv, Hooks) {
+func BindStateMv(cli *CommandLine) *StateMv {
 	var ret StateMv
-	var hooks Hooks
 
-	ret.ViewOptions.bind(flags, false)
-	hooks = append(hooks, ret.ViewOptions.ParseHook())
+	ret.ViewOptions.bind(cli, false)
 
 	ret.Vars = &Vars{}
-	ret.Vars.bind(flags)
+	ret.Vars.bind(cli)
 
 	ret.Backend = &Backend{}
-	ret.Backend.bindIgnoreRemoteVersionFlag(flags)
+	ret.Backend.bindIgnoreRemoteVersionFlag(cli)
 
 	ret.State = &State{}
-	ret.State.bind(flags, stateFlagLock|stateFlagStateIn|stateFlagStateOut)
-	ret.State.bindBackupFlag(flags, "-")
+	ret.State.bind(cli, stateFlagLock|stateFlagStateIn|stateFlagStateOut)
+	ret.State.bindBackupFlag(cli, "-")
 	// StateFlagBackup omitted here to be added later with a different default value
 
-	flags.BoolVar(&ret.DryRun, "dry-run", false, "dry run")
-	flags.StringVar(&ret.BackupPathOut, "backup-out", "-", "backup")
+	cli.BoolVar(&ret.DryRun, "dry-run", false, "dry run")
+	cli.StringVar(&ret.BackupPathOut, "backup-out", "-", "backup")
 
-	return &ret, hooks
+	cli.PositionalArg(&ret.RawSrcAddr, "src addr", false)
+	cli.PositionalArg(&ret.RawDestAddr, "dest addr", false)
+
+	return &ret
 }
 
 // ParseStateMv processes CLI arguments, returning a StateMv value, a closer function, and errors.
 // If errors are encountered, a StateMv value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseStateMv(args []string) (*StateMv, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	ret, hooks := BindStateMv(flags)
-
-	cmdFlags := defaultFlagSet("state mv", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	// TODO positional arguments
-	args = cmdFlags.Args()
-	if len(args) != 2 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Invalid number of arguments",
-			"Exactly two arguments expected",
-		))
-	} else {
-		ret.RawSrcAddr = args[0]
-		ret.RawDestAddr = args[1]
-	}
-
-	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	ret := BindStateMv(cli)
+	closer, diags := cli.Stdlib("state mv", args)
+	return ret, closer, diags
 }

--- a/internal/command/arguments/state_mv.go
+++ b/internal/command/arguments/state_mv.go
@@ -37,8 +37,7 @@ func BindStateMv(cli *CommandLine) *StateMv {
 
 	ret.ViewOptions.bind(cli, false)
 
-	ret.Vars = &Vars{}
-	ret.Vars.bind(cli)
+	ret.Vars = BindVars(cli)
 
 	ret.Backend = &Backend{}
 	ret.Backend.bindIgnoreRemoteVersionFlag(cli)

--- a/internal/command/arguments/state_mv.go
+++ b/internal/command/arguments/state_mv.go
@@ -31,27 +31,41 @@ type StateMv struct {
 	State   *State
 }
 
+// BindStateMv registers CLI arguments, returning a StateMv value and it's corresponding hooks.
+func BindStateMv(flags Flags) (*StateMv, Hooks) {
+	var ret StateMv
+	var hooks Hooks
+
+	ret.ViewOptions.bind(flags, false)
+	hooks = append(hooks, ret.ViewOptions.ParseHook())
+
+	ret.Vars = &Vars{}
+	ret.Vars.bind(flags)
+
+	ret.Backend = &Backend{}
+	ret.Backend.bindIgnoreRemoteVersionFlag(flags)
+
+	ret.State = &State{}
+	ret.State.bind(flags, stateFlagLock|stateFlagStateIn|stateFlagStateOut)
+	ret.State.bindBackupFlag(flags, "-")
+	// StateFlagBackup omitted here to be added later with a different default value
+
+	flags.BoolVar(&ret.DryRun, "dry-run", false, "dry run")
+	flags.StringVar(&ret.BackupPathOut, "backup-out", "-", "backup")
+
+	return &ret, hooks
+}
+
 // ParseStateMv processes CLI arguments, returning a StateMv value, a closer function, and errors.
 // If errors are encountered, a StateMv value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseStateMv(args []string) (*StateMv, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	ret := &StateMv{
-		Vars:    &Vars{},
-		Backend: &Backend{},
-		State:   &State{},
-	}
+	flags := Flags{}
+	ret, hooks := BindStateMv(flags)
 
-	cmdFlags := extendedFlagSet("state mv", nil, ret.Vars)
-	ret.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
-	// StateFlagBackup omitted here to be added later with a different default value
-	ret.State.addFlags(cmdFlags, stateFlagLock|stateFlagStateIn|stateFlagStateOut)
-	ret.State.AddBackupFlag(cmdFlags, "-")
-	cmdFlags.BoolVar(&ret.DryRun, "dry-run", false, "dry run")
-	cmdFlags.StringVar(&ret.BackupPathOut, "backup-out", "-", "backup")
-
-	ret.ViewOptions.AddFlags(cmdFlags, false)
+	cmdFlags := defaultFlagSet("state mv", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -61,6 +75,7 @@ func ParseStateMv(args []string) (*StateMv, func(), tfdiags.Diagnostics) {
 		))
 	}
 
+	// TODO positional arguments
 	args = cmdFlags.Args()
 	if len(args) != 2 {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -73,8 +88,5 @@ func ParseStateMv(args []string) (*StateMv, func(), tfdiags.Diagnostics) {
 		ret.RawDestAddr = args[1]
 	}
 
-	closer, moreDiags := ret.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-
-	return ret, closer, diags
+	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/state_mv.go
+++ b/internal/command/arguments/state_mv.go
@@ -38,10 +38,7 @@ func BindStateMv(cli *CommandLine) *StateMv {
 	ret.ViewOptions.bind(cli, false)
 
 	ret.Vars = BindVars(cli)
-
-	ret.Backend = &Backend{}
-	ret.Backend.bindIgnoreRemoteVersionFlag(cli)
-
+	ret.Backend = BindBackend(cli)
 	ret.State = BindState(cli, stateFlagAll)
 
 	cli.BoolVar(&ret.DryRun, "dry-run", false, "If set, prints out what would've been moved but doesn't actually move anything.")

--- a/internal/command/arguments/state_mv.go
+++ b/internal/command/arguments/state_mv.go
@@ -47,12 +47,12 @@ func BindStateMv(cli *CommandLine) *StateMv {
 	cli.PositionalArg(&ret.RawSrcAddr, "SOURCE", false)
 	cli.PositionalArg(&ret.RawDestAddr, "DESTINATION", false)
 
-	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+	cli.PreHook(func() tfdiags.Diagnostics {
 		if ret.State.BackupPath == "" {
 			ret.State.BackupPath = "-"
 		}
 		return nil
-	}})
+	})
 
 	return &ret
 }

--- a/internal/command/arguments/state_mv.go
+++ b/internal/command/arguments/state_mv.go
@@ -43,16 +43,20 @@ func BindStateMv(cli *CommandLine) *StateMv {
 	ret.Backend = &Backend{}
 	ret.Backend.bindIgnoreRemoteVersionFlag(cli)
 
-	ret.State = &State{}
-	ret.State.bind(cli, stateFlagLock|stateFlagStateIn|stateFlagStateOut)
-	ret.State.bindBackupFlag(cli, "-")
-	// StateFlagBackup omitted here to be added later with a different default value
+	ret.State = BindState(cli, stateFlagAll)
 
 	cli.BoolVar(&ret.DryRun, "dry-run", false, "If set, prints out what would've been moved but doesn't actually move anything.")
 	cli.StringVar(&ret.BackupPathOut, "backup-out", "-", "Legacy state backup option").SetHidden(true)
 
 	cli.PositionalArg(&ret.RawSrcAddr, "SOURCE", false)
 	cli.PositionalArg(&ret.RawDestAddr, "DESTINATION", false)
+
+	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+		if ret.State.BackupPath == "" {
+			ret.State.BackupPath = "-"
+		}
+		return nil
+	}})
 
 	return &ret
 }

--- a/internal/command/arguments/state_mv.go
+++ b/internal/command/arguments/state_mv.go
@@ -48,11 +48,11 @@ func BindStateMv(cli *CommandLine) *StateMv {
 	ret.State.bindBackupFlag(cli, "-")
 	// StateFlagBackup omitted here to be added later with a different default value
 
-	cli.BoolVar(&ret.DryRun, "dry-run", false, "dry run")
-	cli.StringVar(&ret.BackupPathOut, "backup-out", "-", "backup")
+	cli.BoolVar(&ret.DryRun, "dry-run", false, "If set, prints out what would've been moved but doesn't actually move anything.")
+	cli.StringVar(&ret.BackupPathOut, "backup-out", "-", "Legacy state backup option").SetHidden(true)
 
-	cli.PositionalArg(&ret.RawSrcAddr, "src addr", false)
-	cli.PositionalArg(&ret.RawDestAddr, "dest addr", false)
+	cli.PositionalArg(&ret.RawSrcAddr, "SOURCE", false)
+	cli.PositionalArg(&ret.RawDestAddr, "DESTINATION", false)
 
 	return &ret
 }

--- a/internal/command/arguments/state_mv_test.go
+++ b/internal/command/arguments/state_mv_test.go
@@ -115,17 +115,17 @@ func TestParseStateMv_basicValidation(t *testing.T) {
 		"no arguments": {
 			args:        []string{},
 			want:        stateMvArgsWithDefaults(nil),
-			wantErrText: "Invalid number of arguments",
+			wantErrText: "Expected exactly two positional arguments",
 		},
 		"only one argument": {
 			args:        []string{"source"},
 			want:        stateMvArgsWithDefaults(nil),
-			wantErrText: "Invalid number of arguments",
+			wantErrText: "Expected exactly two positional arguments",
 		},
 		"too many arguments": {
 			args:        []string{"source", "dest", "extra"},
 			want:        stateMvArgsWithDefaults(nil),
-			wantErrText: "Invalid number of arguments",
+			wantErrText: "Expected exactly two positional arguments.",
 		},
 	}
 
@@ -149,8 +149,10 @@ func TestParseStateMv_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n%s\nwanted: %s\n", errStr, tc.wantErrText)
 				}
 			}
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
-				t.Errorf("unexpected result\n%s", diff)
+			if !diags.HasErrors() {
+				if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+					t.Errorf("unexpected result\n%s", diff)
+				}
 			}
 		})
 	}

--- a/internal/command/arguments/state_mv_test.go
+++ b/internal/command/arguments/state_mv_test.go
@@ -118,13 +118,18 @@ func TestParseStateMv_basicValidation(t *testing.T) {
 			wantErrText: "Expected exactly two positional arguments",
 		},
 		"only one argument": {
-			args:        []string{"source"},
-			want:        stateMvArgsWithDefaults(nil),
+			args: []string{"source"},
+			want: stateMvArgsWithDefaults(func(stateMv *StateMv) {
+				stateMv.RawSrcAddr = "source"
+			}),
 			wantErrText: "Expected exactly two positional arguments",
 		},
 		"too many arguments": {
-			args:        []string{"source", "dest", "extra"},
-			want:        stateMvArgsWithDefaults(nil),
+			args: []string{"source", "dest", "extra"},
+			want: stateMvArgsWithDefaults(func(stateMv *StateMv) {
+				stateMv.RawSrcAddr = "source"
+				stateMv.RawDestAddr = "dest"
+			}),
 			wantErrText: "Expected exactly two positional arguments.",
 		},
 	}
@@ -149,10 +154,8 @@ func TestParseStateMv_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n%s\nwanted: %s\n", errStr, tc.wantErrText)
 				}
 			}
-			if !diags.HasErrors() {
-				if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
-					t.Errorf("unexpected result\n%s", diff)
-				}
+			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+				t.Errorf("unexpected result\n%s", diff)
 			}
 		})
 	}

--- a/internal/command/arguments/state_pull.go
+++ b/internal/command/arguments/state_pull.go
@@ -26,8 +26,7 @@ func BindStatePull(cli *CommandLine) *StatePull {
 	// prints the state in json format
 	ret.ViewOptions.ParseHook(cli)
 
-	ret.Vars = &Vars{}
-	ret.Vars.bind(cli)
+	ret.Vars = BindVars(cli)
 
 	return &ret
 }

--- a/internal/command/arguments/state_pull.go
+++ b/internal/command/arguments/state_pull.go
@@ -19,46 +19,25 @@ type StatePull struct {
 }
 
 // BindStatePull registers CLI arguments, returning a StatePull value and it's corresponding hooks.
-func BindStatePull(flags Flags) (*StatePull, Hooks) {
+func BindStatePull(cli *CommandLine) *StatePull {
 	var ret StatePull
-	var hooks Hooks
 
 	// we only parse but do not register the views flags since this command does not need it because it already
 	// prints the state in json format
-	hooks = append(hooks, ret.ViewOptions.ParseHook())
+	ret.ViewOptions.ParseHook(cli)
 
 	ret.Vars = &Vars{}
-	ret.Vars.bind(flags)
+	ret.Vars.bind(cli)
 
-	return &ret, hooks
+	return &ret
 }
 
 // ParseStatePull processes CLI arguments, returning a StatePull value, a closer function, and errors.
 // If errors are encountered, a StatePull value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseStatePull(args []string) (*StatePull, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	ret, hooks := BindStatePull(flags)
-
-	cmdFlags := defaultFlagSet("state pull", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	if len(cmdFlags.Args()) > 0 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Unexpected argument",
-			"Too many command line arguments. Did you mean to use -chdir?",
-		))
-	}
-
-	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	ret := BindStatePull(cli)
+	closer, diags := cli.Stdlib("state pull", args)
+	return ret, closer, diags
 }

--- a/internal/command/arguments/state_pull.go
+++ b/internal/command/arguments/state_pull.go
@@ -18,16 +18,31 @@ type StatePull struct {
 	Vars *Vars
 }
 
+// BindStatePull registers CLI arguments, returning a StatePull value and it's corresponding hooks.
+func BindStatePull(flags Flags) (*StatePull, Hooks) {
+	var ret StatePull
+	var hooks Hooks
+
+	// we only parse but do not register the views flags since this command does not need it because it already
+	// prints the state in json format
+	hooks = append(hooks, ret.ViewOptions.ParseHook())
+
+	ret.Vars = &Vars{}
+	ret.Vars.bind(flags)
+
+	return &ret, hooks
+}
+
 // ParseStatePull processes CLI arguments, returning a StatePull value, a closer function, and errors.
 // If errors are encountered, a StatePull value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseStatePull(args []string) (*StatePull, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	ret := &StatePull{
-		Vars: &Vars{},
-	}
-	cmdFlags := extendedFlagSet("state pull", nil, ret.Vars)
+	flags := Flags{}
+	ret, hooks := BindStatePull(flags)
+
+	cmdFlags := defaultFlagSet("state pull", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -45,10 +60,5 @@ func ParseStatePull(args []string) (*StatePull, func(), tfdiags.Diagnostics) {
 		))
 	}
 
-	// we only parse but do not register the views flags since this command does not need it because it already
-	// prints the state in json format
-	closer, moreDiags := ret.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-
-	return ret, closer, diags
+	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/state_pull_test.go
+++ b/internal/command/arguments/state_pull_test.go
@@ -32,7 +32,7 @@ func TestParseStatePull_basicValidation(t *testing.T) {
 		"unknown flag": {
 			args:        []string{"-unknown"},
 			want:        statePullArgsWithDefaults(nil),
-			wantErrText: "Failed to parse command-line flags",
+			wantErrText: "Failed to parse command-line options",
 		},
 	}
 

--- a/internal/command/arguments/state_push.go
+++ b/internal/command/arguments/state_push.go
@@ -25,22 +25,38 @@ type StatePush struct {
 	State   *State
 }
 
+// BindStatePush registers CLI arguments, returning a StatePush value and it's corresponding hooks.
+func BindStatePush(flags Flags) (*StatePush, Hooks) {
+	var ret StatePush
+	var hooks Hooks
+
+	ret.ViewOptions.bind(flags, false)
+	hooks = append(hooks, ret.ViewOptions.ParseHook())
+
+	ret.Vars = &Vars{}
+	ret.Vars.bind(flags)
+
+	ret.Backend = &Backend{}
+	ret.Backend.bindIgnoreRemoteVersionFlag(flags)
+
+	ret.State = &State{}
+	ret.State.bind(flags, stateFlagLock)
+
+	flags.BoolVar(&ret.Force, "force", false, "Write the state even if lineages don't match or the remote serial is higher.")
+
+	return &ret, hooks
+}
+
 // ParseStatePush processes CLI arguments, returning a StatePush value, a closer function, and errors.
 // If errors are encountered, a StatePush value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseStatePush(args []string) (*StatePush, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	ret := &StatePush{
-		Vars:    &Vars{},
-		Backend: &Backend{},
-		State:   &State{},
-	}
-	cmdFlags := extendedFlagSet("state push", nil, ret.Vars)
-	ret.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
-	ret.State.addFlags(cmdFlags, stateFlagLock)
-	cmdFlags.BoolVar(&ret.Force, "force", false, "")
-	ret.ViewOptions.AddFlags(cmdFlags, false)
+	flags := Flags{}
+	ret, hooks := BindStatePush(flags)
+
+	cmdFlags := defaultFlagSet("state push", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -50,6 +66,7 @@ func ParseStatePush(args []string) (*StatePush, func(), tfdiags.Diagnostics) {
 		))
 	}
 
+	// TODO positional arguments
 	args = cmdFlags.Args()
 	if len(args) != 1 {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -61,8 +78,5 @@ func ParseStatePush(args []string) (*StatePush, func(), tfdiags.Diagnostics) {
 		ret.StateSrc = args[0]
 	}
 
-	closer, moreDiags := ret.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-
-	return ret, closer, diags
+	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/state_push.go
+++ b/internal/command/arguments/state_push.go
@@ -32,10 +32,7 @@ func BindStatePush(cli *CommandLine) *StatePush {
 	ret.ViewOptions.bind(cli, false)
 
 	ret.Vars = BindVars(cli)
-
-	ret.Backend = &Backend{}
-	ret.Backend.bindIgnoreRemoteVersionFlag(cli)
-
+	ret.Backend = BindBackend(cli)
 	ret.State = BindState(cli, stateFlagLock)
 
 	cli.BoolVar(&ret.Force, "force", false, "Write the state even if lineages don't match or the remote serial is higher.")

--- a/internal/command/arguments/state_push.go
+++ b/internal/command/arguments/state_push.go
@@ -31,8 +31,7 @@ func BindStatePush(cli *CommandLine) *StatePush {
 
 	ret.ViewOptions.bind(cli, false)
 
-	ret.Vars = &Vars{}
-	ret.Vars.bind(cli)
+	ret.Vars = BindVars(cli)
 
 	ret.Backend = &Backend{}
 	ret.Backend.bindIgnoreRemoteVersionFlag(cli)

--- a/internal/command/arguments/state_push.go
+++ b/internal/command/arguments/state_push.go
@@ -42,7 +42,7 @@ func BindStatePush(cli *CommandLine) *StatePush {
 
 	cli.BoolVar(&ret.Force, "force", false, "Write the state even if lineages don't match or the remote serial is higher.")
 
-	cli.PositionalArg(&ret.StateSrc, "state", false)
+	cli.PositionalArg(&ret.StateSrc, "PATH", false)
 
 	return &ret
 }

--- a/internal/command/arguments/state_push.go
+++ b/internal/command/arguments/state_push.go
@@ -26,57 +26,33 @@ type StatePush struct {
 }
 
 // BindStatePush registers CLI arguments, returning a StatePush value and it's corresponding hooks.
-func BindStatePush(flags Flags) (*StatePush, Hooks) {
+func BindStatePush(cli *CommandLine) *StatePush {
 	var ret StatePush
-	var hooks Hooks
 
-	ret.ViewOptions.bind(flags, false)
-	hooks = append(hooks, ret.ViewOptions.ParseHook())
+	ret.ViewOptions.bind(cli, false)
 
 	ret.Vars = &Vars{}
-	ret.Vars.bind(flags)
+	ret.Vars.bind(cli)
 
 	ret.Backend = &Backend{}
-	ret.Backend.bindIgnoreRemoteVersionFlag(flags)
+	ret.Backend.bindIgnoreRemoteVersionFlag(cli)
 
 	ret.State = &State{}
-	ret.State.bind(flags, stateFlagLock)
+	ret.State.bind(cli, stateFlagLock)
 
-	flags.BoolVar(&ret.Force, "force", false, "Write the state even if lineages don't match or the remote serial is higher.")
+	cli.BoolVar(&ret.Force, "force", false, "Write the state even if lineages don't match or the remote serial is higher.")
 
-	return &ret, hooks
+	cli.PositionalArg(&ret.StateSrc, "state", false)
+
+	return &ret
 }
 
 // ParseStatePush processes CLI arguments, returning a StatePush value, a closer function, and errors.
 // If errors are encountered, a StatePush value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseStatePush(args []string) (*StatePush, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	ret, hooks := BindStatePush(flags)
-
-	cmdFlags := defaultFlagSet("state push", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	// TODO positional arguments
-	args = cmdFlags.Args()
-	if len(args) != 1 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Invalid number of arguments",
-			"Exactly one argument expected",
-		))
-	} else {
-		ret.StateSrc = args[0]
-	}
-
-	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	ret := BindStatePush(cli)
+	closer, diags := cli.Stdlib("state push", args)
+	return ret, closer, diags
 }

--- a/internal/command/arguments/state_push.go
+++ b/internal/command/arguments/state_push.go
@@ -37,8 +37,7 @@ func BindStatePush(cli *CommandLine) *StatePush {
 	ret.Backend = &Backend{}
 	ret.Backend.bindIgnoreRemoteVersionFlag(cli)
 
-	ret.State = &State{}
-	ret.State.bind(cli, stateFlagLock)
+	ret.State = BindState(cli, stateFlagLock)
 
 	cli.BoolVar(&ret.Force, "force", false, "Write the state even if lineages don't match or the remote serial is higher.")
 

--- a/internal/command/arguments/state_push_test.go
+++ b/internal/command/arguments/state_push_test.go
@@ -25,8 +25,10 @@ func TestParseStatePush_basicValidation(t *testing.T) {
 			wantErrText: "Expected exactly one positional argument",
 		},
 		"too many arguments": {
-			args:        []string{"state1.tfstate", "state2.tfstate"},
-			want:        statePushArgsWithDefaults(nil),
+			args: []string{"state1.tfstate", "state2.tfstate"},
+			want: statePushArgsWithDefaults(func(v *StatePush) {
+				v.StateSrc = "state1.tfstate"
+			}),
 			wantErrText: "Expected exactly one positional argument",
 		},
 		"valid state file path": {
@@ -104,10 +106,8 @@ func TestParseStatePush_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n%s\nwanted: %s\n", errStr, tc.wantErrText)
 				}
 			}
-			if !diags.HasErrors() {
-				if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
-					t.Errorf("unexpected result\n%s", diff)
-				}
+			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+				t.Errorf("unexpected result\n%s", diff)
 			}
 		})
 	}

--- a/internal/command/arguments/state_push_test.go
+++ b/internal/command/arguments/state_push_test.go
@@ -22,12 +22,12 @@ func TestParseStatePush_basicValidation(t *testing.T) {
 		"no arguments": {
 			args:        nil,
 			want:        statePushArgsWithDefaults(nil),
-			wantErrText: "Exactly one argument expected",
+			wantErrText: "Expected exactly one positional argument",
 		},
 		"too many arguments": {
 			args:        []string{"state1.tfstate", "state2.tfstate"},
 			want:        statePushArgsWithDefaults(nil),
-			wantErrText: "Exactly one argument expected",
+			wantErrText: "Expected exactly one positional argument",
 		},
 		"valid state file path": {
 			args: []string{"terraform.tfstate"},
@@ -83,7 +83,7 @@ func TestParseStatePush_basicValidation(t *testing.T) {
 			want: statePushArgsWithDefaults(func(v *StatePush) {
 				v.StateSrc = "terraform.tfstate"
 			}),
-			wantErrText: "Failed to parse command-line flags: flag provided but not defined: -unknown-flag",
+			wantErrText: "flag provided but not defined: -unknown-flag",
 		},
 	}
 
@@ -104,8 +104,10 @@ func TestParseStatePush_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n%s\nwanted: %s\n", errStr, tc.wantErrText)
 				}
 			}
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
-				t.Errorf("unexpected result\n%s", diff)
+			if !diags.HasErrors() {
+				if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+					t.Errorf("unexpected result\n%s", diff)
+				}
 			}
 		})
 	}

--- a/internal/command/arguments/state_replace_provider.go
+++ b/internal/command/arguments/state_replace_provider.go
@@ -36,10 +36,7 @@ func BindStateReplaceProvider(cli *CommandLine) *StateReplaceProvider {
 	ret.ViewOptions.bind(cli, false)
 
 	ret.Vars = BindVars(cli)
-
-	ret.Backend = &Backend{}
-	ret.Backend.bindIgnoreRemoteVersionFlag(cli)
-
+	ret.Backend = BindBackend(cli)
 	ret.State = BindState(cli, stateFlagLock|stateFlagStateIn|stateFlagBackup)
 
 	cli.BoolVar(&ret.AutoApprove, "auto-approve", false, "Skip interactive approval.")

--- a/internal/command/arguments/state_replace_provider.go
+++ b/internal/command/arguments/state_replace_provider.go
@@ -29,25 +29,53 @@ type StateReplaceProvider struct {
 	State   *State
 }
 
+// BindStateReplaceProvider registers CLI arguments, returning a StateReplaceProvider value and it's corresponding hooks.
+func BindStateReplaceProvider(flags Flags) (*StateReplaceProvider, Hooks) {
+	var ret StateReplaceProvider
+	var hooks Hooks
+
+	ret.ViewOptions.bind(flags, false)
+	hooks = append(hooks, ret.ViewOptions.ParseHook())
+
+	ret.Vars = &Vars{}
+	ret.Vars.bind(flags)
+
+	ret.Backend = &Backend{}
+	ret.Backend.bindIgnoreRemoteVersionFlag(flags)
+
+	ret.State = &State{}
+	// StateFlagBackup omitted here to be added later with a different default value
+	ret.State.bind(flags, stateFlagLock|stateFlagStateIn)
+	ret.State.bindBackupFlag(flags, "-")
+
+	flags.BoolVar(&ret.AutoApprove, "auto-approve", false, "Skip interactive approval.")
+
+	hooks = append(hooks, Hook{Pre: func() tfdiags.Diagnostics {
+		// In OpenTofu, there is no way to run a command with `-json` flag and allow asking for user input in the same time.
+		// Therefore, the JSON view can used only when the `-auto-approve` is provided too.
+		if ret.ViewOptions.ViewType == ViewJSON && !ret.AutoApprove {
+			return tfdiags.New(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Invalid usage",
+				"OpenTofu cannot ask user input when `-json` flag is used. Therefore, `-auto-approve` is required too",
+			))
+		}
+		return nil
+	}})
+
+	return &ret, hooks
+}
+
 // ParseReplaceProvider processes CLI arguments, returning a StateReplaceProvider value, a closer function, and errors.
 // If errors are encountered, a StateReplaceProvider value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseReplaceProvider(args []string) (*StateReplaceProvider, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	ret := &StateReplaceProvider{
-		Vars:    &Vars{},
-		Backend: &Backend{},
-		State:   &State{},
-	}
+	flags := Flags{}
+	ret, hooks := BindStateReplaceProvider(flags)
 
-	cmdFlags := extendedFlagSet("state replace-provider", nil, ret.Vars)
-	cmdFlags.BoolVar(&ret.AutoApprove, "auto-approve", false, "skip interactive approval of replacements")
-	ret.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
-	// StateFlagBackup omitted here to be added later with a different default value
-	ret.State.addFlags(cmdFlags, stateFlagLock|stateFlagStateIn)
-	ret.State.AddBackupFlag(cmdFlags, "-")
-	ret.ViewOptions.AddFlags(cmdFlags, false)
+	cmdFlags := defaultFlagSet("state replace-provider", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -57,6 +85,7 @@ func ParseReplaceProvider(args []string) (*StateReplaceProvider, func(), tfdiags
 		))
 	}
 
+	// TODO positional arguments
 	args = cmdFlags.Args()
 	if len(args) != 2 {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -68,17 +97,6 @@ func ParseReplaceProvider(args []string) (*StateReplaceProvider, func(), tfdiags
 		ret.RawSrcAddr = args[0]
 		ret.RawDestAddr = args[1]
 	}
-	closer, moreDiags := ret.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-	// In OpenTofu, there is no way to run a command with `-json` flag and allow asking for user input in the same time.
-	// Therefore, the JSON view can used only when the `-auto-approve` is provided too.
-	if ret.ViewOptions.ViewType == ViewJSON && !ret.AutoApprove {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Invalid usage",
-			"OpenTofu cannot ask user input when `-json` flag is used. Therefore, `-auto-approve` is required too",
-		))
-	}
 
-	return ret, closer, diags
+	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/state_replace_provider.go
+++ b/internal/command/arguments/state_replace_provider.go
@@ -35,8 +35,7 @@ func BindStateReplaceProvider(cli *CommandLine) *StateReplaceProvider {
 
 	ret.ViewOptions.bind(cli, false)
 
-	ret.Vars = &Vars{}
-	ret.Vars.bind(cli)
+	ret.Vars = BindVars(cli)
 
 	ret.Backend = &Backend{}
 	ret.Backend.bindIgnoreRemoteVersionFlag(cli)

--- a/internal/command/arguments/state_replace_provider.go
+++ b/internal/command/arguments/state_replace_provider.go
@@ -48,7 +48,6 @@ func BindStateReplaceProvider(cli *CommandLine) *StateReplaceProvider {
 
 	cli.BoolVar(&ret.AutoApprove, "auto-approve", false, "Skip interactive approval.")
 
-	cli.ArgHelp = "Exactly two arguments expected"
 	cli.PositionalArg(&ret.RawSrcAddr, "src addr", false)
 	cli.PositionalArg(&ret.RawDestAddr, "dest addr", false)
 

--- a/internal/command/arguments/state_replace_provider.go
+++ b/internal/command/arguments/state_replace_provider.go
@@ -30,27 +30,29 @@ type StateReplaceProvider struct {
 }
 
 // BindStateReplaceProvider registers CLI arguments, returning a StateReplaceProvider value and it's corresponding hooks.
-func BindStateReplaceProvider(flags Flags) (*StateReplaceProvider, Hooks) {
+func BindStateReplaceProvider(cli *CommandLine) *StateReplaceProvider {
 	var ret StateReplaceProvider
-	var hooks Hooks
 
-	ret.ViewOptions.bind(flags, false)
-	hooks = append(hooks, ret.ViewOptions.ParseHook())
+	ret.ViewOptions.bind(cli, false)
 
 	ret.Vars = &Vars{}
-	ret.Vars.bind(flags)
+	ret.Vars.bind(cli)
 
 	ret.Backend = &Backend{}
-	ret.Backend.bindIgnoreRemoteVersionFlag(flags)
+	ret.Backend.bindIgnoreRemoteVersionFlag(cli)
 
 	ret.State = &State{}
 	// StateFlagBackup omitted here to be added later with a different default value
-	ret.State.bind(flags, stateFlagLock|stateFlagStateIn)
-	ret.State.bindBackupFlag(flags, "-")
+	ret.State.bind(cli, stateFlagLock|stateFlagStateIn)
+	ret.State.bindBackupFlag(cli, "-")
 
-	flags.BoolVar(&ret.AutoApprove, "auto-approve", false, "Skip interactive approval.")
+	cli.BoolVar(&ret.AutoApprove, "auto-approve", false, "Skip interactive approval.")
 
-	hooks = append(hooks, Hook{Pre: func() tfdiags.Diagnostics {
+	cli.ArgHelp = "Exactly two arguments expected"
+	cli.PositionalArg(&ret.RawSrcAddr, "src addr", false)
+	cli.PositionalArg(&ret.RawDestAddr, "dest addr", false)
+
+	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
 		// In OpenTofu, there is no way to run a command with `-json` flag and allow asking for user input in the same time.
 		// Therefore, the JSON view can used only when the `-auto-approve` is provided too.
 		if ret.ViewOptions.ViewType == ViewJSON && !ret.AutoApprove {
@@ -63,40 +65,15 @@ func BindStateReplaceProvider(flags Flags) (*StateReplaceProvider, Hooks) {
 		return nil
 	}})
 
-	return &ret, hooks
+	return &ret
 }
 
 // ParseReplaceProvider processes CLI arguments, returning a StateReplaceProvider value, a closer function, and errors.
 // If errors are encountered, a StateReplaceProvider value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseReplaceProvider(args []string) (*StateReplaceProvider, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	ret, hooks := BindStateReplaceProvider(flags)
-
-	cmdFlags := defaultFlagSet("state replace-provider", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Error parsing command-line flags",
-			err.Error(),
-		))
-	}
-
-	// TODO positional arguments
-	args = cmdFlags.Args()
-	if len(args) != 2 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Invalid number of arguments",
-			"Exactly two arguments expected",
-		))
-	} else {
-		ret.RawSrcAddr = args[0]
-		ret.RawDestAddr = args[1]
-	}
-
-	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	ret := BindStateReplaceProvider(cli)
+	closer, diags := cli.Stdlib("state replace-provider", args)
+	return ret, closer, diags
 }

--- a/internal/command/arguments/state_replace_provider.go
+++ b/internal/command/arguments/state_replace_provider.go
@@ -44,7 +44,7 @@ func BindStateReplaceProvider(cli *CommandLine) *StateReplaceProvider {
 	cli.PositionalArg(&ret.RawSrcAddr, "FROM_PROVIDER_FQN", false)
 	cli.PositionalArg(&ret.RawDestAddr, "TO_PROVIDER_FQN", false)
 
-	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+	cli.PreHook(func() tfdiags.Diagnostics {
 		if ret.State.BackupPath == "" {
 			ret.State.BackupPath = "-"
 		}
@@ -58,7 +58,7 @@ func BindStateReplaceProvider(cli *CommandLine) *StateReplaceProvider {
 			))
 		}
 		return nil
-	}})
+	})
 
 	return &ret
 }

--- a/internal/command/arguments/state_replace_provider.go
+++ b/internal/command/arguments/state_replace_provider.go
@@ -41,10 +41,7 @@ func BindStateReplaceProvider(cli *CommandLine) *StateReplaceProvider {
 	ret.Backend = &Backend{}
 	ret.Backend.bindIgnoreRemoteVersionFlag(cli)
 
-	ret.State = &State{}
-	// StateFlagBackup omitted here to be added later with a different default value
-	ret.State.bind(cli, stateFlagLock|stateFlagStateIn)
-	ret.State.bindBackupFlag(cli, "-")
+	ret.State = BindState(cli, stateFlagLock|stateFlagStateIn|stateFlagBackup)
 
 	cli.BoolVar(&ret.AutoApprove, "auto-approve", false, "Skip interactive approval.")
 
@@ -52,6 +49,9 @@ func BindStateReplaceProvider(cli *CommandLine) *StateReplaceProvider {
 	cli.PositionalArg(&ret.RawDestAddr, "TO_PROVIDER_FQN", false)
 
 	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+		if ret.State.BackupPath == "" {
+			ret.State.BackupPath = "-"
+		}
 		// In OpenTofu, there is no way to run a command with `-json` flag and allow asking for user input in the same time.
 		// Therefore, the JSON view can used only when the `-auto-approve` is provided too.
 		if ret.ViewOptions.ViewType == ViewJSON && !ret.AutoApprove {

--- a/internal/command/arguments/state_replace_provider.go
+++ b/internal/command/arguments/state_replace_provider.go
@@ -48,8 +48,8 @@ func BindStateReplaceProvider(cli *CommandLine) *StateReplaceProvider {
 
 	cli.BoolVar(&ret.AutoApprove, "auto-approve", false, "Skip interactive approval.")
 
-	cli.PositionalArg(&ret.RawSrcAddr, "src addr", false)
-	cli.PositionalArg(&ret.RawDestAddr, "dest addr", false)
+	cli.PositionalArg(&ret.RawSrcAddr, "FROM_PROVIDER_FQN", false)
+	cli.PositionalArg(&ret.RawDestAddr, "TO_PROVIDER_FQN", false)
 
 	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
 		// In OpenTofu, there is no way to run a command with `-json` flag and allow asking for user input in the same time.

--- a/internal/command/arguments/state_replace_provider_test.go
+++ b/internal/command/arguments/state_replace_provider_test.go
@@ -96,13 +96,18 @@ func TestParseReplaceProvider_basicValidation(t *testing.T) {
 			wantErrText: "Expected exactly two positional arguments",
 		},
 		"only one argument": {
-			args:        []string{"source"},
-			want:        stateReplaceProviderArgsWithDefaults(nil),
+			args: []string{"source"},
+			want: stateReplaceProviderArgsWithDefaults(func(srp *StateReplaceProvider) {
+				srp.RawSrcAddr = "source"
+			}),
 			wantErrText: "Expected exactly two positional arguments",
 		},
 		"too many arguments": {
-			args:        []string{"source", "dest", "extra"},
-			want:        stateReplaceProviderArgsWithDefaults(nil),
+			args: []string{"source", "dest", "extra"},
+			want: stateReplaceProviderArgsWithDefaults(func(srp *StateReplaceProvider) {
+				srp.RawSrcAddr = "source"
+				srp.RawDestAddr = "dest"
+			}),
 			wantErrText: "Expected exactly two positional arguments",
 		},
 		"json without auto-approve": {
@@ -145,10 +150,8 @@ func TestParseReplaceProvider_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n%s\nwanted: %s\n", errStr, tc.wantErrText)
 				}
 			}
-			if !diags.HasErrors() {
-				if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
-					t.Errorf("unexpected result\n%s", diff)
-				}
+			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+				t.Errorf("unexpected result\n%s", diff)
 			}
 		})
 	}

--- a/internal/command/arguments/state_replace_provider_test.go
+++ b/internal/command/arguments/state_replace_provider_test.go
@@ -93,17 +93,17 @@ func TestParseReplaceProvider_basicValidation(t *testing.T) {
 		"no arguments": {
 			args:        []string{},
 			want:        stateReplaceProviderArgsWithDefaults(nil),
-			wantErrText: "Invalid number of arguments",
+			wantErrText: "Expected exactly two positional arguments",
 		},
 		"only one argument": {
 			args:        []string{"source"},
 			want:        stateReplaceProviderArgsWithDefaults(nil),
-			wantErrText: "Invalid number of arguments",
+			wantErrText: "Expected exactly two positional arguments",
 		},
 		"too many arguments": {
 			args:        []string{"source", "dest", "extra"},
 			want:        stateReplaceProviderArgsWithDefaults(nil),
-			wantErrText: "Invalid number of arguments",
+			wantErrText: "Expected exactly two positional arguments",
 		},
 		"json without auto-approve": {
 			args: []string{"-json", "source", "dest"},
@@ -145,8 +145,10 @@ func TestParseReplaceProvider_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n%s\nwanted: %s\n", errStr, tc.wantErrText)
 				}
 			}
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
-				t.Errorf("unexpected result\n%s", diff)
+			if !diags.HasErrors() {
+				if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+					t.Errorf("unexpected result\n%s", diff)
+				}
 			}
 		})
 	}

--- a/internal/command/arguments/state_rm.go
+++ b/internal/command/arguments/state_rm.go
@@ -26,25 +26,40 @@ type StateRm struct {
 	State   *State
 }
 
+// BindStateRm registers CLI arguments, returning a StateRm value and it's corresponding hooks.
+func BindStateRm(flags Flags) (*StateRm, Hooks) {
+	var ret StateRm
+	var hooks Hooks
+
+	ret.ViewOptions.bind(flags, false)
+	hooks = append(hooks, ret.ViewOptions.ParseHook())
+
+	ret.Vars = &Vars{}
+	ret.Vars.bind(flags)
+
+	ret.Backend = &Backend{}
+	ret.Backend.bindIgnoreRemoteVersionFlag(flags)
+
+	ret.State = &State{}
+	// StateFlagBackup omitted here to be added later with a different default value
+	ret.State.bind(flags, stateFlagLock|stateFlagStateIn)
+	ret.State.bindBackupFlag(flags, "-")
+
+	flags.BoolVar(&ret.DryRun, "dry-run", false, "If set, prints out what would've been removed but doesn't actually remove anything.")
+
+	return &ret, hooks
+}
+
 // ParseStateRm processes CLI arguments, returning a StateRm value, a closer function, and errors.
 // If errors are encountered, a StateRm value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseStateRm(args []string) (*StateRm, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	ret := &StateRm{
-		Vars:    &Vars{},
-		Backend: &Backend{},
-		State:   &State{},
-	}
-	cmdFlags := extendedFlagSet("state rm", nil, ret.Vars)
-	ret.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
-	// StateFlagBackup omitted here to be added later with a different default value
-	ret.State.addFlags(cmdFlags, stateFlagLock|stateFlagStateIn)
-	ret.State.AddBackupFlag(cmdFlags, "-")
-	cmdFlags.BoolVar(&ret.DryRun, "dry-run", false, "dry run")
+	flags := Flags{}
+	ret, hooks := BindStateRm(flags)
 
-	ret.ViewOptions.AddFlags(cmdFlags, false)
+	cmdFlags := defaultFlagSet("state rm", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -54,6 +69,7 @@ func ParseStateRm(args []string) (*StateRm, func(), tfdiags.Diagnostics) {
 		))
 	}
 
+	// TODO positional arguments
 	args = cmdFlags.Args()
 	if len(args) == 0 {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -65,8 +81,5 @@ func ParseStateRm(args []string) (*StateRm, func(), tfdiags.Diagnostics) {
 		ret.TargetAddrs = args
 	}
 
-	closer, moreDiags := ret.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-
-	return ret, closer, diags
+	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/state_rm.go
+++ b/internal/command/arguments/state_rm.go
@@ -32,8 +32,7 @@ func BindStateRm(cli *CommandLine) *StateRm {
 
 	ret.ViewOptions.bind(cli, false)
 
-	ret.Vars = &Vars{}
-	ret.Vars.bind(cli)
+	ret.Vars = BindVars(cli)
 
 	ret.Backend = &Backend{}
 	ret.Backend.bindIgnoreRemoteVersionFlag(cli)

--- a/internal/command/arguments/state_rm.go
+++ b/internal/command/arguments/state_rm.go
@@ -38,16 +38,17 @@ func BindStateRm(cli *CommandLine) *StateRm {
 	ret.Backend = &Backend{}
 	ret.Backend.bindIgnoreRemoteVersionFlag(cli)
 
-	ret.State = &State{}
-	// StateFlagBackup omitted here to be added later with a different default value
-	ret.State.bind(cli, stateFlagLock|stateFlagStateIn)
-	ret.State.bindBackupFlag(cli, "-")
+	ret.State = BindState(cli, stateFlagLock|stateFlagStateIn|stateFlagBackup)
 
 	cli.BoolVar(&ret.DryRun, "dry-run", false, "If set, prints out what would've been removed but doesn't actually remove anything.")
 
 	cli.VariadicArg(&ret.TargetAddrs, "ADDRESS")
 
 	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+		if ret.State.BackupPath == "" {
+			ret.State.BackupPath = "-"
+		}
+
 		if len(ret.TargetAddrs) == 0 {
 			return tfdiags.New(tfdiags.Sourceless(
 				tfdiags.Error,

--- a/internal/command/arguments/state_rm.go
+++ b/internal/command/arguments/state_rm.go
@@ -33,10 +33,7 @@ func BindStateRm(cli *CommandLine) *StateRm {
 	ret.ViewOptions.bind(cli, false)
 
 	ret.Vars = BindVars(cli)
-
-	ret.Backend = &Backend{}
-	ret.Backend.bindIgnoreRemoteVersionFlag(cli)
-
+	ret.Backend = BindBackend(cli)
 	ret.State = BindState(cli, stateFlagLock|stateFlagStateIn|stateFlagBackup)
 
 	cli.BoolVar(&ret.DryRun, "dry-run", false, "If set, prints out what would've been removed but doesn't actually remove anything.")

--- a/internal/command/arguments/state_rm.go
+++ b/internal/command/arguments/state_rm.go
@@ -40,7 +40,7 @@ func BindStateRm(cli *CommandLine) *StateRm {
 
 	cli.VariadicArg(&ret.TargetAddrs, "ADDRESS")
 
-	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+	cli.PreHook(func() tfdiags.Diagnostics {
 		if ret.State.BackupPath == "" {
 			ret.State.BackupPath = "-"
 		}
@@ -53,7 +53,7 @@ func BindStateRm(cli *CommandLine) *StateRm {
 			))
 		}
 		return nil
-	}})
+	})
 
 	return &ret
 }

--- a/internal/command/arguments/state_rm.go
+++ b/internal/command/arguments/state_rm.go
@@ -27,59 +27,46 @@ type StateRm struct {
 }
 
 // BindStateRm registers CLI arguments, returning a StateRm value and it's corresponding hooks.
-func BindStateRm(flags Flags) (*StateRm, Hooks) {
+func BindStateRm(cli *CommandLine) *StateRm {
 	var ret StateRm
-	var hooks Hooks
 
-	ret.ViewOptions.bind(flags, false)
-	hooks = append(hooks, ret.ViewOptions.ParseHook())
+	ret.ViewOptions.bind(cli, false)
 
 	ret.Vars = &Vars{}
-	ret.Vars.bind(flags)
+	ret.Vars.bind(cli)
 
 	ret.Backend = &Backend{}
-	ret.Backend.bindIgnoreRemoteVersionFlag(flags)
+	ret.Backend.bindIgnoreRemoteVersionFlag(cli)
 
 	ret.State = &State{}
 	// StateFlagBackup omitted here to be added later with a different default value
-	ret.State.bind(flags, stateFlagLock|stateFlagStateIn)
-	ret.State.bindBackupFlag(flags, "-")
+	ret.State.bind(cli, stateFlagLock|stateFlagStateIn)
+	ret.State.bindBackupFlag(cli, "-")
 
-	flags.BoolVar(&ret.DryRun, "dry-run", false, "If set, prints out what would've been removed but doesn't actually remove anything.")
+	cli.BoolVar(&ret.DryRun, "dry-run", false, "If set, prints out what would've been removed but doesn't actually remove anything.")
 
-	return &ret, hooks
+	cli.VariadicArg(&ret.TargetAddrs, "target addresses")
+
+	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+		if len(ret.TargetAddrs) == 0 {
+			return tfdiags.New(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Invalid number of arguments",
+				"At least one address is required",
+			))
+		}
+		return nil
+	}})
+
+	return &ret
 }
 
 // ParseStateRm processes CLI arguments, returning a StateRm value, a closer function, and errors.
 // If errors are encountered, a StateRm value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseStateRm(args []string) (*StateRm, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	ret, hooks := BindStateRm(flags)
-
-	cmdFlags := defaultFlagSet("state rm", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	// TODO positional arguments
-	args = cmdFlags.Args()
-	if len(args) == 0 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Invalid number of arguments",
-			"At least one address is required",
-		))
-	} else {
-		ret.TargetAddrs = args
-	}
-
-	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	ret := BindStateRm(cli)
+	closer, diags := cli.Stdlib("state rm", args)
+	return ret, closer, diags
 }

--- a/internal/command/arguments/state_rm.go
+++ b/internal/command/arguments/state_rm.go
@@ -45,7 +45,7 @@ func BindStateRm(cli *CommandLine) *StateRm {
 
 	cli.BoolVar(&ret.DryRun, "dry-run", false, "If set, prints out what would've been removed but doesn't actually remove anything.")
 
-	cli.VariadicArg(&ret.TargetAddrs, "target addresses")
+	cli.VariadicArg(&ret.TargetAddrs, "ADDRESS")
 
 	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
 		if len(ret.TargetAddrs) == 0 {

--- a/internal/command/arguments/state_rm_test.go
+++ b/internal/command/arguments/state_rm_test.go
@@ -115,8 +115,10 @@ func TestParseStateRm_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n%s\nwanted: %s\n", errStr, tc.wantErrText)
 				}
 			}
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
-				t.Errorf("unexpected result\n%s", diff)
+			if !diags.HasErrors() {
+				if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+					t.Errorf("unexpected result\n%s", diff)
+				}
 			}
 		})
 	}

--- a/internal/command/arguments/state_rm_test.go
+++ b/internal/command/arguments/state_rm_test.go
@@ -115,10 +115,8 @@ func TestParseStateRm_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n%s\nwanted: %s\n", errStr, tc.wantErrText)
 				}
 			}
-			if !diags.HasErrors() {
-				if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
-					t.Errorf("unexpected result\n%s", diff)
-				}
+			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+				t.Errorf("unexpected result\n%s", diff)
 			}
 		})
 	}
@@ -126,7 +124,8 @@ func TestParseStateRm_basicValidation(t *testing.T) {
 
 func stateRmArgsWithDefaults(mutate func(stateRm *StateRm)) *StateRm {
 	ret := &StateRm{
-		DryRun: false,
+		TargetAddrs: []string{},
+		DryRun:      false,
 		ViewOptions: ViewOptions{
 			ViewType:     ViewHuman,
 			InputEnabled: false,

--- a/internal/command/arguments/state_show.go
+++ b/internal/command/arguments/state_show.go
@@ -32,8 +32,7 @@ func BindStateShow(cli *CommandLine) *StateShow {
 
 	ret.ViewOptions.bind(cli, false)
 
-	ret.Vars = &Vars{}
-	ret.Vars.bind(cli)
+	ret.Vars = BindVars(cli)
 
 	ret.State = BindState(cli, stateFlagStateIn)
 

--- a/internal/command/arguments/state_show.go
+++ b/internal/command/arguments/state_show.go
@@ -40,7 +40,7 @@ func BindStateShow(cli *CommandLine) *StateShow {
 
 	cli.BoolVar(&ret.ShowSensitive, "show-sensitive", false, "If specified, sensitive values will be displayed.")
 
-	cli.PositionalArg(&ret.TargetRawAddr, "target address", false)
+	cli.PositionalArg(&ret.TargetRawAddr, "ADDRESS", false)
 
 	return &ret
 }

--- a/internal/command/arguments/state_show.go
+++ b/internal/command/arguments/state_show.go
@@ -27,54 +27,30 @@ type StateShow struct {
 }
 
 // BindStateShow registers CLI arguments, returning a StateShow value and it's corresponding hooks.
-func BindStateShow(flags Flags) (*StateShow, Hooks) {
+func BindStateShow(cli *CommandLine) *StateShow {
 	var ret StateShow
-	var hooks Hooks
 
-	ret.ViewOptions.bind(flags, false)
-	hooks = append(hooks, ret.ViewOptions.ParseHook())
+	ret.ViewOptions.bind(cli, false)
 
 	ret.Vars = &Vars{}
-	ret.Vars.bind(flags)
+	ret.Vars.bind(cli)
 
 	ret.State = &State{}
-	ret.State.bind(flags, stateFlagStateIn)
+	ret.State.bind(cli, stateFlagStateIn)
 
-	flags.BoolVar(&ret.ShowSensitive, "show-sensitive", false, "If specified, sensitive values will be displayed.")
+	cli.BoolVar(&ret.ShowSensitive, "show-sensitive", false, "If specified, sensitive values will be displayed.")
 
-	return &ret, hooks
+	cli.PositionalArg(&ret.TargetRawAddr, "target address", false)
+
+	return &ret
 }
 
 // ParseStateShow processes CLI arguments, returning a StateShow value, a closer function, and errors.
 // If errors are encountered, a StateShow value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseStateShow(args []string) (*StateShow, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	ret, hooks := BindStateShow(flags)
-
-	cmdFlags := defaultFlagSet("state show", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	// TODO positional arguments
-	args = cmdFlags.Args()
-	if len(args) != 1 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Invalid number of arguments",
-			"Exactly one argument expected",
-		))
-	} else {
-		ret.TargetRawAddr = args[0]
-	}
-
-	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	ret := BindStateShow(cli)
+	closer, diags := cli.Stdlib("state show", args)
+	return ret, closer, diags
 }

--- a/internal/command/arguments/state_show.go
+++ b/internal/command/arguments/state_show.go
@@ -26,21 +26,35 @@ type StateShow struct {
 	State *State
 }
 
+// BindStateShow registers CLI arguments, returning a StateShow value and it's corresponding hooks.
+func BindStateShow(flags Flags) (*StateShow, Hooks) {
+	var ret StateShow
+	var hooks Hooks
+
+	ret.ViewOptions.bind(flags, false)
+	hooks = append(hooks, ret.ViewOptions.ParseHook())
+
+	ret.Vars = &Vars{}
+	ret.Vars.bind(flags)
+
+	ret.State = &State{}
+	ret.State.bind(flags, stateFlagStateIn)
+
+	flags.BoolVar(&ret.ShowSensitive, "show-sensitive", false, "If specified, sensitive values will be displayed.")
+
+	return &ret, hooks
+}
+
 // ParseStateShow processes CLI arguments, returning a StateShow value, a closer function, and errors.
 // If errors are encountered, a StateShow value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseStateShow(args []string) (*StateShow, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	ret := &StateShow{
-		Vars:  &Vars{},
-		State: &State{},
-	}
-	cmdFlags := extendedFlagSet("state show", nil, ret.Vars)
-	cmdFlags.BoolVar(&ret.ShowSensitive, "show-sensitive", false, "displays sensitive values")
-	ret.State.addFlags(cmdFlags, stateFlagStateIn)
+	flags := Flags{}
+	ret, hooks := BindStateShow(flags)
 
-	ret.ViewOptions.AddFlags(cmdFlags, false)
+	cmdFlags := defaultFlagSet("state show", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -50,6 +64,7 @@ func ParseStateShow(args []string) (*StateShow, func(), tfdiags.Diagnostics) {
 		))
 	}
 
+	// TODO positional arguments
 	args = cmdFlags.Args()
 	if len(args) != 1 {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -61,8 +76,5 @@ func ParseStateShow(args []string) (*StateShow, func(), tfdiags.Diagnostics) {
 		ret.TargetRawAddr = args[0]
 	}
 
-	closer, moreDiags := ret.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-
-	return ret, closer, diags
+	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/state_show.go
+++ b/internal/command/arguments/state_show.go
@@ -35,8 +35,7 @@ func BindStateShow(cli *CommandLine) *StateShow {
 	ret.Vars = &Vars{}
 	ret.Vars.bind(cli)
 
-	ret.State = &State{}
-	ret.State.bind(cli, stateFlagStateIn)
+	ret.State = BindState(cli, stateFlagStateIn)
 
 	cli.BoolVar(&ret.ShowSensitive, "show-sensitive", false, "If specified, sensitive values will be displayed.")
 

--- a/internal/command/arguments/state_show_test.go
+++ b/internal/command/arguments/state_show_test.go
@@ -56,17 +56,17 @@ func TestParseStateShow_basicValidation(t *testing.T) {
 		"no arguments": {
 			args:        []string{},
 			want:        stateShowArgsWithDefaults(nil),
-			wantErrText: "Invalid number of arguments",
+			wantErrText: "Expected exactly one positional argument",
 		},
 		"too many arguments": {
 			args:        []string{"resource_address", "extra"},
 			want:        stateShowArgsWithDefaults(nil),
-			wantErrText: "Invalid number of arguments",
+			wantErrText: "Expected exactly one positional argument",
 		},
 		"unknown flag": {
-			args:        []string{"-unknown-flag"},
+			args:        []string{"-unknown-flag", "resource_address"},
 			want:        stateShowArgsWithDefaults(func(v *StateShow) {}),
-			wantErrText: "Failed to parse command-line flags: flag provided but not defined: -unknown-flag",
+			wantErrText: "flag provided but not defined: -unknown-flag",
 		},
 	}
 
@@ -90,8 +90,10 @@ func TestParseStateShow_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n%s\nwanted: %s\n", errStr, tc.wantErrText)
 				}
 			}
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
-				t.Errorf("unexpected result\n%s", diff)
+			if !diags.HasErrors() {
+				if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+					t.Errorf("unexpected result\n%s", diff)
+				}
 			}
 		})
 	}

--- a/internal/command/arguments/state_show_test.go
+++ b/internal/command/arguments/state_show_test.go
@@ -59,13 +59,17 @@ func TestParseStateShow_basicValidation(t *testing.T) {
 			wantErrText: "Expected exactly one positional argument",
 		},
 		"too many arguments": {
-			args:        []string{"resource_address", "extra"},
-			want:        stateShowArgsWithDefaults(nil),
+			args: []string{"resource_address", "extra"},
+			want: stateShowArgsWithDefaults(func(stateShow *StateShow) {
+				stateShow.TargetRawAddr = "resource_address"
+			}),
 			wantErrText: "Expected exactly one positional argument",
 		},
 		"unknown flag": {
-			args:        []string{"-unknown-flag", "resource_address"},
-			want:        stateShowArgsWithDefaults(func(v *StateShow) {}),
+			args: []string{"-unknown-flag", "resource_address"},
+			want: stateShowArgsWithDefaults(func(stateShow *StateShow) {
+				stateShow.TargetRawAddr = "resource_address"
+			}),
 			wantErrText: "flag provided but not defined: -unknown-flag",
 		},
 	}
@@ -90,10 +94,8 @@ func TestParseStateShow_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n%s\nwanted: %s\n", errStr, tc.wantErrText)
 				}
 			}
-			if !diags.HasErrors() {
-				if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
-					t.Errorf("unexpected result\n%s", diff)
-				}
+			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+				t.Errorf("unexpected result\n%s", diff)
 			}
 		})
 	}

--- a/internal/command/arguments/taint.go
+++ b/internal/command/arguments/taint.go
@@ -33,61 +33,26 @@ type Taint struct {
 }
 
 // BindTaint registers CLI arguments, returning a Taint value and it's corresponding hooks.
-func BindTaint(flags Flags) (*Taint, Hooks) {
+func BindTaint(cli *CommandLine, isTaint bool) *Taint {
 	var arguments Taint
-	var hooks Hooks
 
-	arguments.ViewOptions.bind(flags, false)
-	hooks = append(hooks, arguments.ViewOptions.ParseHook())
+	arguments.ViewOptions.bind(cli, false)
 
 	arguments.Vars = &Vars{}
-	arguments.Vars.bind(flags)
+	arguments.Vars.bind(cli)
 
 	arguments.Backend = &Backend{}
-	arguments.Backend.bindIgnoreRemoteVersionFlag(flags)
+	arguments.Backend.bindIgnoreRemoteVersionFlag(cli)
 
 	arguments.State = &State{}
-	arguments.State.bind(flags, stateFlagAll)
+	arguments.State.bind(cli, stateFlagAll)
 
-	flags.BoolVar(&arguments.AllowMissing, "allow-missing", false, "If specified, the command will succeed (exit code 0) even if the resource is missing.")
+	cli.BoolVar(&arguments.AllowMissing, "allow-missing", false, "If specified, the command will succeed (exit code 0) even if the resource is missing.")
 
-	return &arguments, hooks
-}
-
-// ParseTaint processes CLI arguments, returning a Taint value, a closer function, and errors.
-// If errors are encountered, a Taint value is still returned representing
-// the best effort interpretation of the arguments.
-func ParseTaint(isTaint bool, args []string) (*Taint, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	arguments, hooks := BindTaint(flags)
-
-	cmd := "taint"
-	if !isTaint {
-		cmd = "untaint"
-	}
-	cmdFlags := defaultFlagSet(cmd, flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	// TODO positional args
-	args = cmdFlags.Args()
-	if len(args) != 1 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Invalid arguments",
-			fmt.Sprintf("The %s command expects exactly one argument.", cmd),
-		))
-	} else {
-		addr, addrDiags := addrs.ParseAbsResourceInstanceStr(args[0])
-		diags = diags.Append(addrDiags)
+	var rawAddr string
+	cli.PositionalArg(&rawAddr, "resource address", false)
+	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+		addr, diags := addrs.ParseAbsResourceInstanceStr(rawAddr)
 		arguments.TargetAddress = addr
 		if !diags.HasErrors() {
 			if addr.Resource.Resource.Mode != addrs.ManagedResourceMode && isTaint {
@@ -98,8 +63,23 @@ func ParseTaint(isTaint bool, args []string) (*Taint, func(), tfdiags.Diagnostic
 				))
 			}
 		}
+		return diags
+	}})
 
+	return &arguments
+}
+
+// ParseTaint processes CLI arguments, returning a Taint value, a closer function, and errors.
+// If errors are encountered, a Taint value is still returned representing
+// the best effort interpretation of the arguments.
+func ParseTaint(isTaint bool, args []string) (*Taint, func(), tfdiags.Diagnostics) {
+	cmd := "taint"
+	if !isTaint {
+		cmd = "untaint"
 	}
 
-	return arguments, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	arguments := BindTaint(cli, isTaint)
+	closer, diags := cli.Stdlib(cmd, args)
+	return arguments, closer, diags
 }

--- a/internal/command/arguments/taint.go
+++ b/internal/command/arguments/taint.go
@@ -44,8 +44,7 @@ func BindTaint(cli *CommandLine, isTaint bool) *Taint {
 	arguments.Backend = &Backend{}
 	arguments.Backend.bindIgnoreRemoteVersionFlag(cli)
 
-	arguments.State = &State{}
-	arguments.State.bind(cli, stateFlagAll)
+	arguments.State = BindState(cli, stateFlagAll)
 
 	cli.BoolVar(&arguments.AllowMissing, "allow-missing", false, "If specified, the command will succeed (exit code 0) even if the resource is missing.")
 

--- a/internal/command/arguments/taint.go
+++ b/internal/command/arguments/taint.go
@@ -32,25 +32,42 @@ type Taint struct {
 	Backend *Backend
 }
 
+// BindTaint registers CLI arguments, returning a Taint value and it's corresponding hooks.
+func BindTaint(flags Flags) (*Taint, Hooks) {
+	var arguments Taint
+	var hooks Hooks
+
+	arguments.ViewOptions.bind(flags, false)
+	hooks = append(hooks, arguments.ViewOptions.ParseHook())
+
+	arguments.Vars = &Vars{}
+	arguments.Vars.bind(flags)
+
+	arguments.Backend = &Backend{}
+	arguments.Backend.bindIgnoreRemoteVersionFlag(flags)
+
+	arguments.State = &State{}
+	arguments.State.bind(flags, stateFlagAll)
+
+	flags.BoolVar(&arguments.AllowMissing, "allow-missing", false, "If specified, the command will succeed (exit code 0) even if the resource is missing.")
+
+	return &arguments, hooks
+}
+
 // ParseTaint processes CLI arguments, returning a Taint value, a closer function, and errors.
 // If errors are encountered, a Taint value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseTaint(isTaint bool, args []string) (*Taint, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	arguments := &Taint{
-		Vars:    &Vars{},
-		State:   &State{},
-		Backend: &Backend{},
-	}
+
+	flags := Flags{}
+	arguments, hooks := BindTaint(flags)
+
 	cmd := "taint"
 	if !isTaint {
 		cmd = "untaint"
 	}
-	cmdFlags := extendedFlagSet(cmd, nil, arguments.Vars)
-	arguments.State.addFlags(cmdFlags, stateFlagAll)
-	cmdFlags.BoolVar(&arguments.AllowMissing, "allow-missing", false, "allow missing")
-	arguments.Backend.AddIgnoreRemoteVersionFlag(cmdFlags)
-	arguments.ViewOptions.AddFlags(cmdFlags, false)
+	cmdFlags := defaultFlagSet(cmd, flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -60,11 +77,7 @@ func ParseTaint(isTaint bool, args []string) (*Taint, func(), tfdiags.Diagnostic
 		))
 	}
 
-	closer, moreDiags := arguments.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-	if diags.HasErrors() {
-		return arguments, closer, diags
-	}
+	// TODO positional args
 	args = cmdFlags.Args()
 	if len(args) != 1 {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -88,5 +101,5 @@ func ParseTaint(isTaint bool, args []string) (*Taint, func(), tfdiags.Diagnostic
 
 	}
 
-	return arguments, closer, diags
+	return arguments, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/taint.go
+++ b/internal/command/arguments/taint.go
@@ -38,8 +38,7 @@ func BindTaint(cli *CommandLine, isTaint bool) *Taint {
 
 	arguments.ViewOptions.bind(cli, false)
 
-	arguments.Vars = &Vars{}
-	arguments.Vars.bind(cli)
+	arguments.Vars = BindVars(cli)
 
 	arguments.Backend = &Backend{}
 	arguments.Backend.bindIgnoreRemoteVersionFlag(cli)

--- a/internal/command/arguments/taint.go
+++ b/internal/command/arguments/taint.go
@@ -49,14 +49,12 @@ func BindTaint(cli *CommandLine, isTaint bool) *Taint {
 	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
 		addr, diags := addrs.ParseAbsResourceInstanceStr(rawAddr)
 		arguments.TargetAddress = addr
-		if !diags.HasErrors() {
-			if addr.Resource.Resource.Mode != addrs.ManagedResourceMode && isTaint {
-				diags = diags.Append(tfdiags.Sourceless(
-					tfdiags.Error,
-					"Invalid resource address",
-					fmt.Sprintf("Resource instance %s cannot be tainted", addr),
-				))
-			}
+		if addr.Resource.Resource.Mode != addrs.ManagedResourceMode && isTaint {
+			diags = diags.Append(tfdiags.Sourceless(
+				tfdiags.Error,
+				"Invalid resource address",
+				fmt.Sprintf("Resource instance %s cannot be tainted", addr),
+			))
 		}
 		return diags
 	}})

--- a/internal/command/arguments/taint.go
+++ b/internal/command/arguments/taint.go
@@ -46,7 +46,7 @@ func BindTaint(cli *CommandLine, isTaint bool) *Taint {
 
 	var rawAddr string
 	cli.PositionalArg(&rawAddr, "resource address", false)
-	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+	cli.PreHook(func() tfdiags.Diagnostics {
 		addr, diags := addrs.ParseAbsResourceInstanceStr(rawAddr)
 		arguments.TargetAddress = addr
 		if addr.Resource.Resource.Mode != addrs.ManagedResourceMode && isTaint {
@@ -57,7 +57,7 @@ func BindTaint(cli *CommandLine, isTaint bool) *Taint {
 			))
 		}
 		return diags
-	}})
+	})
 
 	return &arguments
 }

--- a/internal/command/arguments/taint.go
+++ b/internal/command/arguments/taint.go
@@ -39,10 +39,7 @@ func BindTaint(cli *CommandLine, isTaint bool) *Taint {
 	arguments.ViewOptions.bind(cli, false)
 
 	arguments.Vars = BindVars(cli)
-
-	arguments.Backend = &Backend{}
-	arguments.Backend.bindIgnoreRemoteVersionFlag(cli)
-
+	arguments.Backend = BindBackend(cli)
 	arguments.State = BindState(cli, stateFlagAll)
 
 	cli.BoolVar(&arguments.AllowMissing, "allow-missing", false, "If specified, the command will succeed (exit code 0) even if the resource is missing.")

--- a/internal/command/arguments/taint_test.go
+++ b/internal/command/arguments/taint_test.go
@@ -29,8 +29,14 @@ func TestParseTaint_basicValidation(t *testing.T) {
 			forTaintCmd: true,
 		},
 		"too many arguments": {
-			args:        []string{"test_instance.foo", "test_instance.bar"},
-			want:        taintArgsWithDefaults(nil),
+			args: []string{"test_instance.foo", "test_instance.bar"},
+			want: taintArgsWithDefaults(func(v *Taint) {
+				v.TargetAddress = addrs.Resource{
+					Mode: addrs.ManagedResourceMode,
+					Type: "test_instance",
+					Name: "foo",
+				}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance)
+			}),
 			wantErrText: "Expected exactly one positional argument",
 			forTaintCmd: true,
 		},
@@ -97,8 +103,14 @@ func TestParseTaint_basicValidation(t *testing.T) {
 			}),
 		},
 		"unknown flag": {
-			args:        []string{"-unknown-flag", "test_instance.foo"},
-			want:        taintArgsWithDefaults(func(v *Taint) {}),
+			args: []string{"-unknown-flag", "test_instance.foo"},
+			want: taintArgsWithDefaults(func(v *Taint) {
+				v.TargetAddress = addrs.Resource{
+					Mode: addrs.ManagedResourceMode,
+					Type: "test_instance",
+					Name: "foo",
+				}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance)
+			}),
 			wantErrText: "flag provided but not defined: -unknown-flag",
 		},
 	}
@@ -120,10 +132,8 @@ func TestParseTaint_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n%s\nwanted: %s\n", errStr, tc.wantErrText)
 				}
 			}
-			if !diags.HasErrors() {
-				if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
-					t.Errorf("unexpected result\n%s", diff)
-				}
+			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+				t.Errorf("unexpected result\n%s", diff)
 			}
 		})
 	}

--- a/internal/command/arguments/taint_test.go
+++ b/internal/command/arguments/taint_test.go
@@ -25,13 +25,13 @@ func TestParseTaint_basicValidation(t *testing.T) {
 		"no arguments": {
 			args:        nil,
 			want:        taintArgsWithDefaults(nil),
-			wantErrText: "The taint command expects exactly one argument.",
+			wantErrText: "Expected exactly one positional argument",
 			forTaintCmd: true,
 		},
 		"too many arguments": {
 			args:        []string{"test_instance.foo", "test_instance.bar"},
 			want:        taintArgsWithDefaults(nil),
-			wantErrText: "The taint command expects exactly one argument.",
+			wantErrText: "Expected exactly one positional argument",
 			forTaintCmd: true,
 		},
 		"valid resource address": {
@@ -99,7 +99,7 @@ func TestParseTaint_basicValidation(t *testing.T) {
 		"unknown flag": {
 			args:        []string{"-unknown-flag", "test_instance.foo"},
 			want:        taintArgsWithDefaults(func(v *Taint) {}),
-			wantErrText: "Failed to parse command-line flags: flag provided but not defined: -unknown-flag",
+			wantErrText: "flag provided but not defined: -unknown-flag",
 		},
 	}
 
@@ -120,8 +120,10 @@ func TestParseTaint_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n%s\nwanted: %s\n", errStr, tc.wantErrText)
 				}
 			}
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
-				t.Errorf("unexpected result\n%s", diff)
+			if !diags.HasErrors() {
+				if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+					t.Errorf("unexpected result\n%s", diff)
+				}
 			}
 		})
 	}

--- a/internal/command/arguments/test.go
+++ b/internal/command/arguments/test.go
@@ -39,8 +39,7 @@ func BindTest(cli *CommandLine) *Test {
 
 	test.ViewOptions.bind(cli, false)
 
-	test.Vars = &Vars{}
-	test.Vars.bind(cli)
+	test.Vars = BindVars(cli)
 
 	cli.StringArrayVar(&test.Filter, "filter", nil, "If specified, OpenTofu will only execute the test files specified by this flag. You can use this option multiple times to execute more than one test file. The path should be relative to the current working directory, even if -test-directory is set.").SetDisplay("=testfile")
 	cli.StringVar(&test.TestDirectory, "test-directory", "tests", `Set the OpenTofu test directory, defaults to "tests". When set, the test command will search for test files in the current directory and in the one specified by the flag.`).SetDisplay("=path")

--- a/internal/command/arguments/test.go
+++ b/internal/command/arguments/test.go
@@ -6,8 +6,6 @@
 package arguments
 
 import (
-	"github.com/opentofu/opentofu/internal/command/flags"
-	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
@@ -35,19 +33,31 @@ type Test struct {
 	Verbose bool
 }
 
+// BindTest registers CLI arguments, returning a Test value and it's corresponding hooks.
+func BindTest(flags Flags) (*Test, Hooks) {
+	var test Test
+	var hooks Hooks
+
+	test.ViewOptions.bind(flags, false)
+	hooks = append(hooks, test.ViewOptions.ParseHook())
+
+	test.Vars = &Vars{}
+	test.Vars.bind(flags)
+
+	flags.StringArrayVar(&test.Filter, "filter", nil, "If specified, OpenTofu will only execute the test files specified by this flag. You can use this option multiple times to execute more than one test file. The path should be relative to the current working directory, even if -test-directory is set.").SetDisplay("=testfile")
+	flags.StringVar(&test.TestDirectory, "test-directory", "tests", `Set the OpenTofu test directory, defaults to "tests". When set, the test command will search for test files in the current directory and in the one specified by the flag.`).SetDisplay("=path")
+	flags.BoolVar(&test.Verbose, "verbose", false, "Print the plan or state for each test run block as it executes.")
+
+	return &test, hooks
+}
+
 func ParseTest(args []string) (*Test, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	test := Test{
-		Vars: new(Vars),
-	}
+	flags := Flags{}
+	test, hooks := BindTest(flags)
 
-	cmdFlags := extendedFlagSet("test", nil, test.Vars)
-	cmdFlags.Var((*flags.FlagStringSlice)(&test.Filter), "filter", "filter")
-	cmdFlags.StringVar(&test.TestDirectory, "test-directory", configs.DefaultTestDirectory, "test-directory")
-	cmdFlags.BoolVar(&test.Verbose, "verbose", false, "verbose")
-
-	test.ViewOptions.AddFlags(cmdFlags, false)
+	cmdFlags := defaultFlagSet("test", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -56,8 +66,5 @@ func ParseTest(args []string) (*Test, func(), tfdiags.Diagnostics) {
 			err.Error()))
 	}
 
-	closer, moreDiags := test.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-
-	return &test, closer, diags
+	return test, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/test.go
+++ b/internal/command/arguments/test.go
@@ -34,37 +34,24 @@ type Test struct {
 }
 
 // BindTest registers CLI arguments, returning a Test value and it's corresponding hooks.
-func BindTest(flags Flags) (*Test, Hooks) {
+func BindTest(cli *CommandLine) *Test {
 	var test Test
-	var hooks Hooks
 
-	test.ViewOptions.bind(flags, false)
-	hooks = append(hooks, test.ViewOptions.ParseHook())
+	test.ViewOptions.bind(cli, false)
 
 	test.Vars = &Vars{}
-	test.Vars.bind(flags)
+	test.Vars.bind(cli)
 
-	flags.StringArrayVar(&test.Filter, "filter", nil, "If specified, OpenTofu will only execute the test files specified by this flag. You can use this option multiple times to execute more than one test file. The path should be relative to the current working directory, even if -test-directory is set.").SetDisplay("=testfile")
-	flags.StringVar(&test.TestDirectory, "test-directory", "tests", `Set the OpenTofu test directory, defaults to "tests". When set, the test command will search for test files in the current directory and in the one specified by the flag.`).SetDisplay("=path")
-	flags.BoolVar(&test.Verbose, "verbose", false, "Print the plan or state for each test run block as it executes.")
+	cli.StringArrayVar(&test.Filter, "filter", nil, "If specified, OpenTofu will only execute the test files specified by this flag. You can use this option multiple times to execute more than one test file. The path should be relative to the current working directory, even if -test-directory is set.").SetDisplay("=testfile")
+	cli.StringVar(&test.TestDirectory, "test-directory", "tests", `Set the OpenTofu test directory, defaults to "tests". When set, the test command will search for test files in the current directory and in the one specified by the flag.`).SetDisplay("=path")
+	cli.BoolVar(&test.Verbose, "verbose", false, "Print the plan or state for each test run block as it executes.")
 
-	return &test, hooks
+	return &test
 }
 
 func ParseTest(args []string) (*Test, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	test, hooks := BindTest(flags)
-
-	cmdFlags := defaultFlagSet("test", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error()))
-	}
-
-	return test, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	test := BindTest(cli)
+	closer, diags := cli.Stdlib("test", args)
+	return test, closer, diags
 }

--- a/internal/command/arguments/test_test.go
+++ b/internal/command/arguments/test_test.go
@@ -135,7 +135,7 @@ func TestParseTest(t *testing.T) {
 			wantDiags: tfdiags.Diagnostics{
 				tfdiags.Sourceless(
 					tfdiags.Error,
-					"Failed to parse command-line flags",
+					"Failed to parse command-line options",
 					"flag provided but not defined: -boop",
 				),
 			},

--- a/internal/command/arguments/types.go
+++ b/internal/command/arguments/types.go
@@ -60,74 +60,65 @@ type ViewOptions struct {
 	JSONInto *os.File
 }
 
-func (v *ViewOptions) bind(flags Flags, input bool) {
-	v.bindGranularFlags(flags, input, true)
+func (v *ViewOptions) bind(cli *CommandLine, input bool) {
+	v.bindGranularFlags(cli, input, true)
 }
 
-// bindGranularFlags registers view-related flags on flags. Use input=true to
+// bindGranularFlags registers view-related flags on cli. Use input=true to
 // register the -input flag and jsonInto=true to register the -json-into flag.
 // Commands that only support -json (not -json-into) should pass jsonInto=false.
-func (v *ViewOptions) bindGranularFlags(flags Flags, input bool, jsonInto bool) {
+func (v *ViewOptions) bindGranularFlags(cli *CommandLine, input bool, jsonInto bool) {
 	if input {
-		flags.BoolVar(&v.InputEnabled, "input", true,
+		cli.BoolVar(&v.InputEnabled, "input", true,
 			`Disable prompting for required input variables that are not set some other way.`,
 		).SetDisplay("=false")
 	}
 
-	flags.BoolVar(&v.jsonFlag, "json", false,
+	cli.BoolVar(&v.jsonFlag, "json", false,
 		`Produce output in a machine-readable JSON format, suitable for use in text editor integrations and other automated systems.`)
 	if jsonInto {
-		flags.StringVar(&v.jsonIntoFlag, "json-into", "",
+		cli.StringVar(&v.jsonIntoFlag, "json-into", "",
 			`Produce the same output as -json, but sent directly to the given file. This allows automation to preserve the original human-readable output streams, while capturing more detailed logs for machine analysis.`,
 		).SetDisplay("=out.json")
 	}
+
+	v.ParseHook(cli)
 }
 
-// TODO merge with ParseHook
-func (v *ViewOptions) Parse() (func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
+func (v *ViewOptions) ParseHook(cli *CommandLine) {
 	closer := func() {}
+	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+		var diags tfdiags.Diagnostics
 
-	if v.jsonIntoFlag != "" {
-		// Although it seems odd to add complex logic to the arguments
-		// package, it is currently the most reasonable place for this
-		// particular concern. The only other reasonable spot currently
-		// in the codebase is within the view constructor. Unfortunately
-		// that is not an option due to command code paths opening
-		// multiple concurrent views.
-		v.JSONInto, closer, diags = OpenJSONIntoFile(v.jsonIntoFlag)
-	}
-
-	// Default to Human
-	v.ViewType = ViewHuman
-	if v.jsonFlag {
-		v.ViewType = ViewJSON
-		// JSON view currently does not support input, so we disable it here
-		v.InputEnabled = false
 		if v.jsonIntoFlag != "" {
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Invalid output format",
-				"The -json and -json-into arguments are mutually exclusive",
-			))
+			// Although it seems odd to add complex logic to the arguments
+			// package, it is currently the most reasonable place for this
+			// particular concern. The only other reasonable spot currently
+			// in the codebase is within the view constructor. Unfortunately
+			// that is not an option due to command code paths opening
+			// multiple concurrent views.
+			v.JSONInto, closer, diags = OpenJSONIntoFile(v.jsonIntoFlag)
 		}
-	}
-	return closer, diags
-}
 
-func (v *ViewOptions) ParseHook() Hook {
-	var closer func()
-	return Hook{
-		Pre: func() tfdiags.Diagnostics {
-			var diags tfdiags.Diagnostics
-			closer, diags = v.Parse()
-			return diags
-		},
-		Post: func() tfdiags.Diagnostics {
-			closer()
-			return nil
-		},
-	}
+		// Default to Human
+		v.ViewType = ViewHuman
+		if v.jsonFlag {
+			v.ViewType = ViewJSON
+			// JSON view currently does not support input, so we disable it here
+			v.InputEnabled = false
+			if v.jsonIntoFlag != "" {
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Invalid output format",
+					"The -json and -json-into arguments are mutually exclusive",
+				))
+			}
+		}
+		return diags
+	}, Post: func() tfdiags.Diagnostics {
+		closer()
+		return nil
+	}})
 }
 
 func OpenJSONIntoFile(jsonIntoFlag string) (*os.File, func(), tfdiags.Diagnostics) {

--- a/internal/command/arguments/types.go
+++ b/internal/command/arguments/types.go
@@ -87,7 +87,7 @@ func (v *ViewOptions) bindGranularFlags(cli *CommandLine, input bool, jsonInto b
 
 func (v *ViewOptions) ParseHook(cli *CommandLine) {
 	closer := func() {}
-	cli.Hook(Hook{Pre: func() tfdiags.Diagnostics {
+	cli.PreHook(func() tfdiags.Diagnostics {
 		var diags tfdiags.Diagnostics
 
 		if v.jsonIntoFlag != "" {
@@ -115,10 +115,11 @@ func (v *ViewOptions) ParseHook(cli *CommandLine) {
 			}
 		}
 		return diags
-	}, Post: func() tfdiags.Diagnostics {
+	})
+	cli.PostHook(func() tfdiags.Diagnostics {
 		closer()
 		return nil
-	}})
+	})
 }
 
 func OpenJSONIntoFile(jsonIntoFlag string) (*os.File, func(), tfdiags.Diagnostics) {

--- a/internal/command/arguments/types.go
+++ b/internal/command/arguments/types.go
@@ -6,7 +6,6 @@
 package arguments
 
 import (
-	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -61,24 +60,30 @@ type ViewOptions struct {
 	JSONInto *os.File
 }
 
-func (v *ViewOptions) AddFlags(cmdFlags *flag.FlagSet, input bool) {
-	v.AddGranularFlags(cmdFlags, input, true)
+func (v *ViewOptions) bind(flags Flags, input bool) {
+	v.bindGranularFlags(flags, input, true)
 }
 
-// AddGranularFlags registers view-related flags on cmdFlags. Use input=true to
+// bindGranularFlags registers view-related flags on flags. Use input=true to
 // register the -input flag and jsonInto=true to register the -json-into flag.
 // Commands that only support -json (not -json-into) should pass jsonInto=false.
-func (v *ViewOptions) AddGranularFlags(cmdFlags *flag.FlagSet, input bool, jsonInto bool) {
+func (v *ViewOptions) bindGranularFlags(flags Flags, input bool, jsonInto bool) {
 	if input {
-		cmdFlags.BoolVar(&v.InputEnabled, "input", true, "input")
+		flags.BoolVar(&v.InputEnabled, "input", true,
+			`Disable prompting for required input variables that are not set some other way.`,
+		).SetDisplay("=false")
 	}
 
-	cmdFlags.BoolVar(&v.jsonFlag, "json", false, "json")
+	flags.BoolVar(&v.jsonFlag, "json", false,
+		`Produce output in a machine-readable JSON format, suitable for use in text editor integrations and other automated systems.`)
 	if jsonInto {
-		cmdFlags.StringVar(&v.jsonIntoFlag, "json-into", "", "json-into")
+		flags.StringVar(&v.jsonIntoFlag, "json-into", "",
+			`Produce the same output as -json, but sent directly to the given file. This allows automation to preserve the original human-readable output streams, while capturing more detailed logs for machine analysis.`,
+		).SetDisplay("=out.json")
 	}
 }
 
+// TODO merge with ParseHook
 func (v *ViewOptions) Parse() (func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	closer := func() {}
@@ -108,6 +113,21 @@ func (v *ViewOptions) Parse() (func(), tfdiags.Diagnostics) {
 		}
 	}
 	return closer, diags
+}
+
+func (v *ViewOptions) ParseHook() Hook {
+	var closer func()
+	return Hook{
+		Pre: func() tfdiags.Diagnostics {
+			var diags tfdiags.Diagnostics
+			closer, diags = v.Parse()
+			return diags
+		},
+		Post: func() tfdiags.Diagnostics {
+			closer()
+			return nil
+		},
+	}
 }
 
 func OpenJSONIntoFile(jsonIntoFlag string) (*os.File, func(), tfdiags.Diagnostics) {

--- a/internal/command/arguments/unlock.go
+++ b/internal/command/arguments/unlock.go
@@ -28,8 +28,7 @@ func BindUnlock(cli *CommandLine) *Unlock {
 
 	arguments.ViewOptions.bind(cli, false)
 
-	arguments.Vars = &Vars{}
-	arguments.Vars.bind(cli)
+	arguments.Vars = BindVars(cli)
 
 	cli.BoolVar(&arguments.Force, "force", false, "Don't ask for input for unlock confirmation.")
 

--- a/internal/command/arguments/unlock.go
+++ b/internal/command/arguments/unlock.go
@@ -22,18 +22,32 @@ type Unlock struct {
 	ViewOptions ViewOptions
 }
 
+// BindUnlock registers CLI arguments, returning a Unlock value and it's corresponding hooks.
+func BindUnlock(flags Flags) (*Unlock, Hooks) {
+	var arguments Unlock
+	var hooks Hooks
+
+	arguments.ViewOptions.bind(flags, false)
+	hooks = append(hooks, arguments.ViewOptions.ParseHook())
+
+	arguments.Vars = &Vars{}
+	arguments.Vars.bind(flags)
+
+	flags.BoolVar(&arguments.Force, "force", false, "Don't ask for input for unlock confirmation.")
+
+	return &arguments, hooks
+}
+
 // ParseUnlock processes CLI arguments, returning a Unlock value, a closer function, and errors.
 // If errors are encountered, a Unlock value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseUnlock(args []string) (*Unlock, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	arguments := &Unlock{
-		Vars: &Vars{},
-	}
 
-	cmdFlags := extendedFlagSet("force-unlock", nil, arguments.Vars)
-	cmdFlags.BoolVar(&arguments.Force, "force", false, "force")
-	arguments.ViewOptions.AddFlags(cmdFlags, false)
+	flags := Flags{}
+	arguments, hooks := BindUnlock(flags)
+
+	cmdFlags := defaultFlagSet("force-unlock", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -43,11 +57,7 @@ func ParseUnlock(args []string) (*Unlock, func(), tfdiags.Diagnostics) {
 		))
 	}
 
-	closer, moreDiags := arguments.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-	if diags.HasErrors() {
-		return arguments, closer, diags
-	}
+	// TODO positional args
 	args = cmdFlags.Args()
 	if len(args) != 1 {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -59,5 +69,5 @@ func ParseUnlock(args []string) (*Unlock, func(), tfdiags.Diagnostics) {
 		arguments.LockID = args[0]
 	}
 
-	return arguments, closer, diags
+	return arguments, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/unlock.go
+++ b/internal/command/arguments/unlock.go
@@ -23,51 +23,28 @@ type Unlock struct {
 }
 
 // BindUnlock registers CLI arguments, returning a Unlock value and it's corresponding hooks.
-func BindUnlock(flags Flags) (*Unlock, Hooks) {
+func BindUnlock(cli *CommandLine) *Unlock {
 	var arguments Unlock
-	var hooks Hooks
 
-	arguments.ViewOptions.bind(flags, false)
-	hooks = append(hooks, arguments.ViewOptions.ParseHook())
+	arguments.ViewOptions.bind(cli, false)
 
 	arguments.Vars = &Vars{}
-	arguments.Vars.bind(flags)
+	arguments.Vars.bind(cli)
 
-	flags.BoolVar(&arguments.Force, "force", false, "Don't ask for input for unlock confirmation.")
+	cli.BoolVar(&arguments.Force, "force", false, "Don't ask for input for unlock confirmation.")
 
-	return &arguments, hooks
+	cli.ArgHelp = "Expected a single argument: LOCK_ID"
+	cli.PositionalArg(&arguments.LockID, "LOCK_ID", false)
+
+	return &arguments
 }
 
 // ParseUnlock processes CLI arguments, returning a Unlock value, a closer function, and errors.
 // If errors are encountered, a Unlock value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseUnlock(args []string) (*Unlock, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	arguments, hooks := BindUnlock(flags)
-
-	cmdFlags := defaultFlagSet("force-unlock", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	// TODO positional args
-	args = cmdFlags.Args()
-	if len(args) != 1 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Wrong number of arguments",
-			"Expected a single argument: LOCK_ID",
-		))
-	} else {
-		arguments.LockID = args[0]
-	}
-
-	return arguments, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	arguments := BindUnlock(cli)
+	closer, diags := cli.Stdlib("force-unlock", args)
+	return arguments, closer, diags
 }

--- a/internal/command/arguments/unlock_test.go
+++ b/internal/command/arguments/unlock_test.go
@@ -27,6 +27,7 @@ func TestParseUnlock_basicValidation(t *testing.T) {
 		"too many arguments": {
 			args: []string{"lockid1", "lockid2"},
 			want: unlockArgsWithDefaults(func(a *Unlock) {
+				a.LockID = "lockid1"
 			}),
 			wantErrText: "Expected a single argument: LOCK_ID",
 		},
@@ -38,8 +39,10 @@ func TestParseUnlock_basicValidation(t *testing.T) {
 			}),
 		},
 		"invalid flag": {
-			args:        []string{"-invalid", "lockid"},
-			want:        unlockArgsWithDefaults(func(a *Unlock) {}),
+			args: []string{"-invalid", "lockid"},
+			want: unlockArgsWithDefaults(func(a *Unlock) {
+				a.LockID = "lockid"
+			}),
 			wantErrText: "flag provided but not defined: -invalid",
 		},
 	}
@@ -61,10 +64,8 @@ func TestParseUnlock_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n%s\nwanted: %s\n", errStr, tc.wantErrText)
 				}
 			}
-			if !diags.HasErrors() {
-				if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
-					t.Errorf("unexpected result\n%s", diff)
-				}
+			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+				t.Errorf("unexpected result\n%s", diff)
 			}
 		})
 	}

--- a/internal/command/arguments/unlock_test.go
+++ b/internal/command/arguments/unlock_test.go
@@ -22,13 +22,13 @@ func TestParseUnlock_basicValidation(t *testing.T) {
 		"without arguments": {
 			args:        nil,
 			want:        unlockArgsWithDefaults(nil),
-			wantErrText: "Wrong number of arguments: Expected a single argument: LOCK_ID",
+			wantErrText: "Expected a single argument: LOCK_ID",
 		},
 		"too many arguments": {
 			args: []string{"lockid1", "lockid2"},
 			want: unlockArgsWithDefaults(func(a *Unlock) {
 			}),
-			wantErrText: "Wrong number of arguments: Expected a single argument: LOCK_ID",
+			wantErrText: "Expected a single argument: LOCK_ID",
 		},
 		"with force": {
 			args: []string{"-force", "lockid"},
@@ -40,7 +40,7 @@ func TestParseUnlock_basicValidation(t *testing.T) {
 		"invalid flag": {
 			args:        []string{"-invalid", "lockid"},
 			want:        unlockArgsWithDefaults(func(a *Unlock) {}),
-			wantErrText: "Failed to parse command-line flags: flag provided but not defined: -invalid",
+			wantErrText: "flag provided but not defined: -invalid",
 		},
 	}
 
@@ -61,8 +61,10 @@ func TestParseUnlock_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n%s\nwanted: %s\n", errStr, tc.wantErrText)
 				}
 			}
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
-				t.Errorf("unexpected result\n%s", diff)
+			if !diags.HasErrors() {
+				if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+					t.Errorf("unexpected result\n%s", diff)
+				}
 			}
 		})
 	}

--- a/internal/command/arguments/validate.go
+++ b/internal/command/arguments/validate.go
@@ -31,55 +31,29 @@ type Validate struct {
 }
 
 // BindValidate registers CLI arguments, returning a Validate value and it's corresponding hooks.
-func BindValidate(flags Flags) (*Validate, Hooks) {
+func BindValidate(cli *CommandLine) *Validate {
 	var validate Validate
-	var hooks Hooks
 
-	validate.ViewOptions.bind(flags, false)
-	hooks = append(hooks, validate.ViewOptions.ParseHook())
+	validate.ViewOptions.bind(cli, false)
 
 	validate.Vars = &Vars{}
-	validate.Vars.bind(flags)
+	validate.Vars.bind(cli)
 
-	flags.StringVar(&validate.TestDirectory, "test-directory", "tests", `Set the OpenTofu test directory, defaults to "tests". When set, the test command will search for test files in the current directory and in the one specified by the flag.`).SetDisplay("=path")
-	flags.BoolVar(&validate.NoTests, "no-tests", false, "If specified, OpenTofu will not validate test files.")
+	cli.StringVar(&validate.TestDirectory, "test-directory", "tests", `Set the OpenTofu test directory, defaults to "tests". When set, the test command will search for test files in the current directory and in the one specified by the flag.`).SetDisplay("=path")
+	cli.BoolVar(&validate.NoTests, "no-tests", false, "If specified, OpenTofu will not validate test files.")
 
-	return &validate, hooks
+	validate.Path = "."
+	cli.PositionalArg(&validate.Path, "path", true)
+
+	return &validate
 }
 
 // ParseValidate processes CLI arguments, returning a Validate value, a closer function, and errors.
 // If errors are encountered, a Validate value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseValidate(args []string) (*Validate, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	validate, hooks := BindValidate(flags)
-
-	cmdFlags := defaultFlagSet("validate", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	// TODO positional arguments
-	args = cmdFlags.Args()
-	if len(args) > 1 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Too many command line arguments",
-			"Expected at most one positional argument.",
-		))
-	}
-
-	validate.Path = "."
-	if len(args) > 0 {
-		validate.Path = args[0]
-	}
-
-	return validate, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	validate := BindValidate(cli)
+	closer, diags := cli.Stdlib("validate", args)
+	return validate, closer, diags
 }

--- a/internal/command/arguments/validate.go
+++ b/internal/command/arguments/validate.go
@@ -30,22 +30,33 @@ type Validate struct {
 	Vars *Vars
 }
 
+// BindValidate registers CLI arguments, returning a Validate value and it's corresponding hooks.
+func BindValidate(flags Flags) (*Validate, Hooks) {
+	var validate Validate
+	var hooks Hooks
+
+	validate.ViewOptions.bind(flags, false)
+	hooks = append(hooks, validate.ViewOptions.ParseHook())
+
+	validate.Vars = &Vars{}
+	validate.Vars.bind(flags)
+
+	flags.StringVar(&validate.TestDirectory, "test-directory", "tests", `Set the OpenTofu test directory, defaults to "tests". When set, the test command will search for test files in the current directory and in the one specified by the flag.`).SetDisplay("=path")
+	flags.BoolVar(&validate.NoTests, "no-tests", false, "If specified, OpenTofu will not validate test files.")
+
+	return &validate, hooks
+}
+
 // ParseValidate processes CLI arguments, returning a Validate value, a closer function, and errors.
 // If errors are encountered, a Validate value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseValidate(args []string) (*Validate, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	validate := &Validate{
-		Path: ".",
-		Vars: &Vars{},
-	}
+	flags := Flags{}
+	validate, hooks := BindValidate(flags)
 
-	cmdFlags := extendedFlagSet("validate", nil, validate.Vars)
-	cmdFlags.StringVar(&validate.TestDirectory, "test-directory", "tests", "test-directory")
-	cmdFlags.BoolVar(&validate.NoTests, "no-tests", false, "no-tests")
-
-	validate.ViewOptions.AddFlags(cmdFlags, false)
+	cmdFlags := defaultFlagSet("validate", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -55,6 +66,7 @@ func ParseValidate(args []string) (*Validate, func(), tfdiags.Diagnostics) {
 		))
 	}
 
+	// TODO positional arguments
 	args = cmdFlags.Args()
 	if len(args) > 1 {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -64,12 +76,10 @@ func ParseValidate(args []string) (*Validate, func(), tfdiags.Diagnostics) {
 		))
 	}
 
+	validate.Path = "."
 	if len(args) > 0 {
 		validate.Path = args[0]
 	}
 
-	closer, moreDiags := validate.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-
-	return validate, closer, diags
+	return validate, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/validate.go
+++ b/internal/command/arguments/validate.go
@@ -36,8 +36,7 @@ func BindValidate(cli *CommandLine) *Validate {
 
 	validate.ViewOptions.bind(cli, false)
 
-	validate.Vars = &Vars{}
-	validate.Vars.bind(cli)
+	validate.Vars = BindVars(cli)
 
 	cli.StringVar(&validate.TestDirectory, "test-directory", "tests", `Set the OpenTofu test directory, defaults to "tests". When set, the test command will search for test files in the current directory and in the one specified by the flag.`).SetDisplay("=path")
 	cli.BoolVar(&validate.NoTests, "no-tests", false, "If specified, OpenTofu will not validate test files.")

--- a/internal/command/arguments/validate_test.go
+++ b/internal/command/arguments/validate_test.go
@@ -93,7 +93,7 @@ func TestParseValidate_invalid(t *testing.T) {
 			tfdiags.Diagnostics{
 				tfdiags.Sourceless(
 					tfdiags.Error,
-					"Failed to parse command-line flags",
+					"Failed to parse command-line options",
 					"flag provided but not defined: -boop",
 				),
 			},
@@ -108,8 +108,8 @@ func TestParseValidate_invalid(t *testing.T) {
 			tfdiags.Diagnostics{
 				tfdiags.Sourceless(
 					tfdiags.Error,
-					"Too many command line arguments",
-					"Expected at most one positional argument.",
+					"Unexpected argument",
+					"Too many command line arguments. Expected at most one positional argument.",
 				),
 			},
 		},

--- a/internal/command/arguments/version.go
+++ b/internal/command/arguments/version.go
@@ -16,42 +16,28 @@ type Version struct {
 }
 
 // BindVersion registers CLI arguments, returning a Version value and it's corresponding hooks.
-func BindVersion(flags Flags) (*Version, Hooks) {
+func BindVersion(cli *CommandLine) *Version {
 	var ret Version
-	var hooks Hooks
 
-	ret.ViewOptions.bindGranularFlags(flags, false, false) // Add only the -json flag
-	hooks = append(hooks, ret.ViewOptions.ParseHook())
+	ret.ViewOptions.bindGranularFlags(cli, false, false) // Add only the -json flag
 
-	// Enable but ignore the global version flags. In main.go, if any of the
+	// Enable but ignore the global version cli. In main.go, if any of the
 	// arguments are -v, -version, or --version, this command will be called
 	// with the rest of the arguments, so we need to be able to cope with
 	// those.
 	var nop bool
-	flags.BoolVar(&nop, "v", true, "version").SetHidden(true)
-	flags.BoolVar(&nop, "version", true, "version").SetHidden(true)
+	cli.BoolVar(&nop, "v", true, "version").SetHidden(true)
+	cli.BoolVar(&nop, "version", true, "version").SetHidden(true)
 
-	return &ret, hooks
+	return &ret
 }
 
 // ParseVersion processes CLI arguments, returning a Version value, a closer function, and errors.
 // If errors are encountered, a Version value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseVersion(args []string) (*Version, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	ret, hooks := BindVersion(flags)
-
-	cmdFlags := defaultFlagSet("version", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	ret := BindVersion(cli)
+	closer, diags := cli.Stdlib("version", args)
+	return ret, closer, diags
 }

--- a/internal/command/arguments/version.go
+++ b/internal/command/arguments/version.go
@@ -15,21 +15,35 @@ type Version struct {
 	ViewOptions ViewOptions
 }
 
+// BindVersion registers CLI arguments, returning a Version value and it's corresponding hooks.
+func BindVersion(flags Flags) (*Version, Hooks) {
+	var ret Version
+	var hooks Hooks
+
+	ret.ViewOptions.bindGranularFlags(flags, false, false) // Add only the -json flag
+	hooks = append(hooks, ret.ViewOptions.ParseHook())
+
+	// Enable but ignore the global version flags. In main.go, if any of the
+	// arguments are -v, -version, or --version, this command will be called
+	// with the rest of the arguments, so we need to be able to cope with
+	// those.
+	var nop bool
+	flags.BoolVar(&nop, "v", true, "version").SetHidden(true)
+	flags.BoolVar(&nop, "version", true, "version").SetHidden(true)
+
+	return &ret, hooks
+}
+
 // ParseVersion processes CLI arguments, returning a Version value, a closer function, and errors.
 // If errors are encountered, a Version value is still returned representing
 // the best effort interpretation of the arguments.
 func ParseVersion(args []string) (*Version, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-	ret := &Version{}
 
-	cmdFlags := defaultFlagSet("version")
-	// Enable but ignore the global version flags. In main.go, if any of the
-	// arguments are -v, -version, or --version, this command will be called
-	// with the rest of the arguments, so we need to be able to cope with
-	// those.
-	cmdFlags.Bool("v", true, "version")
-	cmdFlags.Bool("version", true, "version")
-	ret.ViewOptions.AddGranularFlags(cmdFlags, false, false) // Add only the -json flag
+	flags := Flags{}
+	ret, hooks := BindVersion(flags)
+
+	cmdFlags := defaultFlagSet("version", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -39,7 +53,5 @@ func ParseVersion(args []string) (*Version, func(), tfdiags.Diagnostics) {
 		))
 	}
 
-	closer, moreDiags := ret.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-	return ret, closer, diags
+	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/version_test.go
+++ b/internal/command/arguments/version_test.go
@@ -48,7 +48,7 @@ func TestParseVersion_basicValidation(t *testing.T) {
 		"invalid flag": {
 			args:        []string{"-foo"},
 			want:        versionArgsWithDefaults(func(version *Version) {}),
-			wantErrText: "Failed to parse command-line flags: flag provided but not defined: -foo",
+			wantErrText: "flag provided but not defined: -foo",
 		},
 	}
 

--- a/internal/command/arguments/workspace.go
+++ b/internal/command/arguments/workspace.go
@@ -15,11 +15,24 @@ type Workspace struct {
 	ViewOptions ViewOptions
 }
 
+// BindWorkspace registers CLI arguments, returning a Workspace value and it's corresponding hooks.
+func BindWorkspace(flags Flags) (*Workspace, Hooks) {
+	var get Workspace
+	var hooks Hooks
+
+	// we only parse but do not register the views flags since this command does not need it
+	hooks = append(hooks, get.ViewOptions.ParseHook())
+
+	return &get, hooks
+}
+
 func ParseWorkspace(args []string) (*Workspace, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	ret := &Workspace{}
-	cmdFlags := defaultFlagSet("workspace")
+	flags := Flags{}
+	ret, hooks := BindWorkspace(flags)
+
+	cmdFlags := defaultFlagSet("workspace", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -36,8 +49,5 @@ func ParseWorkspace(args []string) (*Workspace, func(), tfdiags.Diagnostics) {
 		))
 	}
 
-	// we only parse but do not register the views flags since this command does not need it
-	closer, moreDiags := ret.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-	return ret, closer, diags
+	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/workspace.go
+++ b/internal/command/arguments/workspace.go
@@ -16,38 +16,18 @@ type Workspace struct {
 }
 
 // BindWorkspace registers CLI arguments, returning a Workspace value and it's corresponding hooks.
-func BindWorkspace(flags Flags) (*Workspace, Hooks) {
+func BindWorkspace(cli *CommandLine) *Workspace {
 	var get Workspace
-	var hooks Hooks
 
 	// we only parse but do not register the views flags since this command does not need it
-	hooks = append(hooks, get.ViewOptions.ParseHook())
+	get.ViewOptions.ParseHook(cli)
 
-	return &get, hooks
+	return &get
 }
 
 func ParseWorkspace(args []string) (*Workspace, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	ret, hooks := BindWorkspace(flags)
-
-	cmdFlags := defaultFlagSet("workspace", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-	if len(cmdFlags.Args()) > 0 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Unexpected argument",
-			"Too many command line arguments. Did you mean to use -chdir?",
-		))
-	}
-
-	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	ret := BindWorkspace(cli)
+	closer, diags := cli.Stdlib("workspace", args)
+	return ret, closer, diags
 }

--- a/internal/command/arguments/workspace_delete.go
+++ b/internal/command/arguments/workspace_delete.go
@@ -32,8 +32,7 @@ func BindWorkspaceDelete(cli *CommandLine) *WorkspaceDelete {
 
 	ret.ViewOptions.bind(cli, false)
 
-	ret.Vars = &Vars{}
-	ret.Vars.bind(cli)
+	ret.Vars = BindVars(cli)
 
 	ret.State = BindState(cli, stateFlagLock)
 

--- a/internal/command/arguments/workspace_delete.go
+++ b/internal/command/arguments/workspace_delete.go
@@ -26,18 +26,32 @@ type WorkspaceDelete struct {
 	State *State
 }
 
+// BindWorkspaceDelete registers CLI arguments, returning a WorkspaceDelete value and it's corresponding hooks.
+func BindWorkspaceDelete(flags Flags) (*WorkspaceDelete, Hooks) {
+	var ret WorkspaceDelete
+	var hooks Hooks
+
+	ret.ViewOptions.bind(flags, false)
+	hooks = append(hooks, ret.ViewOptions.ParseHook())
+
+	ret.Vars = &Vars{}
+	ret.Vars.bind(flags)
+
+	ret.State = &State{}
+	ret.State.bind(flags, stateFlagLock)
+
+	flags.BoolVar(&ret.Force, "force", false, "Remove a workspace even if it is managing resources. OpenTofu can no longer track or manage the workspace's infrastructure.")
+
+	return &ret, hooks
+}
+
 func ParseWorkspaceDelete(args []string) (*WorkspaceDelete, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	ret := &WorkspaceDelete{
-		Vars:  &Vars{},
-		State: &State{},
-	}
+	flags := Flags{}
+	ret, hooks := BindWorkspaceDelete(flags)
 
-	cmdFlags := extendedFlagSet("workspace delete", nil, ret.Vars)
-	cmdFlags.BoolVar(&ret.Force, "force", false, "force removal of a non-empty workspace")
-	ret.State.addFlags(cmdFlags, stateFlagLock)
-	ret.ViewOptions.AddFlags(cmdFlags, false)
+	cmdFlags := defaultFlagSet("workspace delete", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -47,6 +61,7 @@ func ParseWorkspaceDelete(args []string) (*WorkspaceDelete, func(), tfdiags.Diag
 		))
 	}
 
+	// TODO positional arguments
 	args = cmdFlags.Args()
 	if len(args) != 1 {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -58,7 +73,5 @@ func ParseWorkspaceDelete(args []string) (*WorkspaceDelete, func(), tfdiags.Diag
 		ret.WorkspaceName = args[0]
 	}
 
-	closer, moreDiags := ret.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-	return ret, closer, diags
+	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/workspace_delete.go
+++ b/internal/command/arguments/workspace_delete.go
@@ -27,51 +27,28 @@ type WorkspaceDelete struct {
 }
 
 // BindWorkspaceDelete registers CLI arguments, returning a WorkspaceDelete value and it's corresponding hooks.
-func BindWorkspaceDelete(flags Flags) (*WorkspaceDelete, Hooks) {
+func BindWorkspaceDelete(cli *CommandLine) *WorkspaceDelete {
 	var ret WorkspaceDelete
-	var hooks Hooks
 
-	ret.ViewOptions.bind(flags, false)
-	hooks = append(hooks, ret.ViewOptions.ParseHook())
+	ret.ViewOptions.bind(cli, false)
 
 	ret.Vars = &Vars{}
-	ret.Vars.bind(flags)
+	ret.Vars.bind(cli)
 
 	ret.State = &State{}
-	ret.State.bind(flags, stateFlagLock)
+	ret.State.bind(cli, stateFlagLock)
 
-	flags.BoolVar(&ret.Force, "force", false, "Remove a workspace even if it is managing resources. OpenTofu can no longer track or manage the workspace's infrastructure.")
+	cli.BoolVar(&ret.Force, "force", false, "Remove a workspace even if it is managing resources. OpenTofu can no longer track or manage the workspace's infrastructure.")
 
-	return &ret, hooks
+	cli.ArgHelp = "Expected a single argument: NAME."
+	cli.PositionalArg(&ret.WorkspaceName, "NAME", false)
+
+	return &ret
 }
 
 func ParseWorkspaceDelete(args []string) (*WorkspaceDelete, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	ret, hooks := BindWorkspaceDelete(flags)
-
-	cmdFlags := defaultFlagSet("workspace delete", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	// TODO positional arguments
-	args = cmdFlags.Args()
-	if len(args) != 1 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Invalid arguments list",
-			"Expected a single argument: NAME.",
-		))
-	} else {
-		ret.WorkspaceName = args[0]
-	}
-
-	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	ret := BindWorkspaceDelete(cli)
+	closer, diags := cli.Stdlib("workspace delete", args)
+	return ret, closer, diags
 }

--- a/internal/command/arguments/workspace_delete.go
+++ b/internal/command/arguments/workspace_delete.go
@@ -35,8 +35,7 @@ func BindWorkspaceDelete(cli *CommandLine) *WorkspaceDelete {
 	ret.Vars = &Vars{}
 	ret.Vars.bind(cli)
 
-	ret.State = &State{}
-	ret.State.bind(cli, stateFlagLock)
+	ret.State = BindState(cli, stateFlagLock)
 
 	cli.BoolVar(&ret.Force, "force", false, "Remove a workspace even if it is managing resources. OpenTofu can no longer track or manage the workspace's infrastructure.")
 

--- a/internal/command/arguments/workspace_list.go
+++ b/internal/command/arguments/workspace_list.go
@@ -19,42 +19,20 @@ type WorkspaceList struct {
 }
 
 // BindWorkspaceList registers CLI arguments, returning a WorkspaceList value and it's corresponding hooks.
-func BindWorkspaceList(flags Flags) (*WorkspaceList, Hooks) {
+func BindWorkspaceList(cli *CommandLine) *WorkspaceList {
 	var ret WorkspaceList
-	var hooks Hooks
 
-	ret.ViewOptions.bind(flags, false)
-	hooks = append(hooks, ret.ViewOptions.ParseHook())
+	ret.ViewOptions.bind(cli, false)
 
 	ret.Vars = &Vars{}
-	ret.Vars.bind(flags)
+	ret.Vars.bind(cli)
 
-	return &ret, hooks
+	return &ret
 }
 
 func ParseWorkspaceList(args []string) (*WorkspaceList, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	ret, hooks := BindWorkspaceList(flags)
-
-	cmdFlags := defaultFlagSet("workspace list", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	if len(cmdFlags.Args()) > 0 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Unexpected argument",
-			"Too many command line arguments. Did you mean to use -chdir?",
-		))
-	}
-
-	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	ret := BindWorkspaceList(cli)
+	closer, diags := cli.Stdlib("workspace list", args)
+	return ret, closer, diags
 }

--- a/internal/command/arguments/workspace_list.go
+++ b/internal/command/arguments/workspace_list.go
@@ -24,8 +24,7 @@ func BindWorkspaceList(cli *CommandLine) *WorkspaceList {
 
 	ret.ViewOptions.bind(cli, false)
 
-	ret.Vars = &Vars{}
-	ret.Vars.bind(cli)
+	ret.Vars = BindVars(cli)
 
 	return &ret
 }

--- a/internal/command/arguments/workspace_list.go
+++ b/internal/command/arguments/workspace_list.go
@@ -18,15 +18,27 @@ type WorkspaceList struct {
 	Vars *Vars
 }
 
+// BindWorkspaceList registers CLI arguments, returning a WorkspaceList value and it's corresponding hooks.
+func BindWorkspaceList(flags Flags) (*WorkspaceList, Hooks) {
+	var ret WorkspaceList
+	var hooks Hooks
+
+	ret.ViewOptions.bind(flags, false)
+	hooks = append(hooks, ret.ViewOptions.ParseHook())
+
+	ret.Vars = &Vars{}
+	ret.Vars.bind(flags)
+
+	return &ret, hooks
+}
+
 func ParseWorkspaceList(args []string) (*WorkspaceList, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	ret := &WorkspaceList{
-		Vars: &Vars{},
-	}
+	flags := Flags{}
+	ret, hooks := BindWorkspaceList(flags)
 
-	cmdFlags := extendedFlagSet("workspace list", nil, ret.Vars)
-	ret.ViewOptions.AddFlags(cmdFlags, false)
+	cmdFlags := defaultFlagSet("workspace list", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -44,7 +56,5 @@ func ParseWorkspaceList(args []string) (*WorkspaceList, func(), tfdiags.Diagnost
 		))
 	}
 
-	closer, moreDiags := ret.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-	return ret, closer, diags
+	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/workspace_new.go
+++ b/internal/command/arguments/workspace_new.go
@@ -23,49 +23,26 @@ type WorkspaceNew struct {
 }
 
 // BindWorkspaceNew registers CLI arguments, returning a WorkspaceNew value and it's corresponding hooks.
-func BindWorkspaceNew(flags Flags) (*WorkspaceNew, Hooks) {
+func BindWorkspaceNew(cli *CommandLine) *WorkspaceNew {
 	var ret WorkspaceNew
-	var hooks Hooks
 
-	ret.ViewOptions.bind(flags, false)
-	hooks = append(hooks, ret.ViewOptions.ParseHook())
+	ret.ViewOptions.bind(cli, false)
 
 	ret.Vars = &Vars{}
-	ret.Vars.bind(flags)
+	ret.Vars.bind(cli)
 
 	ret.State = &State{}
-	ret.State.bind(flags, stateFlagLock|stateFlagStateIn)
+	ret.State.bind(cli, stateFlagLock|stateFlagStateIn)
 
-	return &ret, hooks
+	cli.ArgHelp = "Expected a single argument: NAME."
+	cli.PositionalArg(&ret.WorkspaceName, "NAME", false)
+
+	return &ret
 }
 
 func ParseWorkspaceNew(args []string) (*WorkspaceNew, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	ret, hooks := BindWorkspaceNew(flags)
-
-	cmdFlags := defaultFlagSet("workspace new", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	// TODO positional args
-	args = cmdFlags.Args()
-	if len(args) != 1 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Invalid arguments list",
-			"Expected a single argument: NAME.",
-		))
-	} else {
-		ret.WorkspaceName = args[0]
-	}
-
-	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	ret := BindWorkspaceNew(cli)
+	closer, diags := cli.Stdlib("workspace new", args)
+	return ret, closer, diags
 }

--- a/internal/command/arguments/workspace_new.go
+++ b/internal/command/arguments/workspace_new.go
@@ -28,8 +28,7 @@ func BindWorkspaceNew(cli *CommandLine) *WorkspaceNew {
 
 	ret.ViewOptions.bind(cli, false)
 
-	ret.Vars = &Vars{}
-	ret.Vars.bind(cli)
+	ret.Vars = BindVars(cli)
 
 	ret.State = BindState(cli, stateFlagLock|stateFlagStateIn)
 

--- a/internal/command/arguments/workspace_new.go
+++ b/internal/command/arguments/workspace_new.go
@@ -31,8 +31,7 @@ func BindWorkspaceNew(cli *CommandLine) *WorkspaceNew {
 	ret.Vars = &Vars{}
 	ret.Vars.bind(cli)
 
-	ret.State = &State{}
-	ret.State.bind(cli, stateFlagLock|stateFlagStateIn)
+	ret.State = BindState(cli, stateFlagLock|stateFlagStateIn)
 
 	cli.ArgHelp = "Expected a single argument: NAME."
 	cli.PositionalArg(&ret.WorkspaceName, "NAME", false)

--- a/internal/command/arguments/workspace_new.go
+++ b/internal/command/arguments/workspace_new.go
@@ -22,17 +22,30 @@ type WorkspaceNew struct {
 	State *State
 }
 
+// BindWorkspaceNew registers CLI arguments, returning a WorkspaceNew value and it's corresponding hooks.
+func BindWorkspaceNew(flags Flags) (*WorkspaceNew, Hooks) {
+	var ret WorkspaceNew
+	var hooks Hooks
+
+	ret.ViewOptions.bind(flags, false)
+	hooks = append(hooks, ret.ViewOptions.ParseHook())
+
+	ret.Vars = &Vars{}
+	ret.Vars.bind(flags)
+
+	ret.State = &State{}
+	ret.State.bind(flags, stateFlagLock|stateFlagStateIn)
+
+	return &ret, hooks
+}
+
 func ParseWorkspaceNew(args []string) (*WorkspaceNew, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	ret := &WorkspaceNew{
-		Vars:  &Vars{},
-		State: &State{},
-	}
+	flags := Flags{}
+	ret, hooks := BindWorkspaceNew(flags)
 
-	cmdFlags := extendedFlagSet("workspace new", nil, ret.Vars)
-	ret.State.addFlags(cmdFlags, stateFlagLock|stateFlagStateIn)
-	ret.ViewOptions.AddFlags(cmdFlags, false)
+	cmdFlags := defaultFlagSet("workspace new", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -42,6 +55,7 @@ func ParseWorkspaceNew(args []string) (*WorkspaceNew, func(), tfdiags.Diagnostic
 		))
 	}
 
+	// TODO positional args
 	args = cmdFlags.Args()
 	if len(args) != 1 {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -53,7 +67,5 @@ func ParseWorkspaceNew(args []string) (*WorkspaceNew, func(), tfdiags.Diagnostic
 		ret.WorkspaceName = args[0]
 	}
 
-	closer, moreDiags := ret.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-	return ret, closer, diags
+	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/workspace_select.go
+++ b/internal/command/arguments/workspace_select.go
@@ -30,8 +30,7 @@ func BindWorkspaceSelect(cli *CommandLine) *WorkspaceSelect {
 
 	ret.ViewOptions.bind(cli, false)
 
-	ret.Vars = &Vars{}
-	ret.Vars.bind(cli)
+	ret.Vars = BindVars(cli)
 
 	cli.BoolVar(&ret.CreateIfMissing, "or-create", false, "Create the OpenTofu workspace if it doesn't exist.")
 

--- a/internal/command/arguments/workspace_select.go
+++ b/internal/command/arguments/workspace_select.go
@@ -24,16 +24,29 @@ type WorkspaceSelect struct {
 	Vars *Vars
 }
 
+// BindWorkspaceSelect registers CLI arguments, returning a WorkspaceSelect value and it's corresponding hooks.
+func BindWorkspaceSelect(flags Flags) (*WorkspaceSelect, Hooks) {
+	var ret WorkspaceSelect
+	var hooks Hooks
+
+	ret.ViewOptions.bind(flags, false)
+	hooks = append(hooks, ret.ViewOptions.ParseHook())
+
+	ret.Vars = &Vars{}
+	ret.Vars.bind(flags)
+
+	flags.BoolVar(&ret.CreateIfMissing, "or-create", false, "Create the OpenTofu workspace if it doesn't exist.")
+
+	return &ret, hooks
+}
+
 func ParseWorkspaceSelect(args []string) (*WorkspaceSelect, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	ret := &WorkspaceSelect{
-		Vars: &Vars{},
-	}
+	flags := Flags{}
+	ret, hooks := BindWorkspaceSelect(flags)
 
-	cmdFlags := extendedFlagSet("workspace select", nil, ret.Vars)
-	cmdFlags.BoolVar(&ret.CreateIfMissing, "or-create", false, "create workspace if it does not exist")
-	ret.ViewOptions.AddFlags(cmdFlags, false)
+	cmdFlags := defaultFlagSet("workspace select", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -43,6 +56,7 @@ func ParseWorkspaceSelect(args []string) (*WorkspaceSelect, func(), tfdiags.Diag
 		))
 	}
 
+	// TODO positional args
 	args = cmdFlags.Args()
 	if len(args) != 1 {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -54,7 +68,5 @@ func ParseWorkspaceSelect(args []string) (*WorkspaceSelect, func(), tfdiags.Diag
 		ret.WorkspaceName = args[0]
 	}
 
-	closer, moreDiags := ret.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-	return ret, closer, diags
+	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/workspace_select.go
+++ b/internal/command/arguments/workspace_select.go
@@ -25,48 +25,25 @@ type WorkspaceSelect struct {
 }
 
 // BindWorkspaceSelect registers CLI arguments, returning a WorkspaceSelect value and it's corresponding hooks.
-func BindWorkspaceSelect(flags Flags) (*WorkspaceSelect, Hooks) {
+func BindWorkspaceSelect(cli *CommandLine) *WorkspaceSelect {
 	var ret WorkspaceSelect
-	var hooks Hooks
 
-	ret.ViewOptions.bind(flags, false)
-	hooks = append(hooks, ret.ViewOptions.ParseHook())
+	ret.ViewOptions.bind(cli, false)
 
 	ret.Vars = &Vars{}
-	ret.Vars.bind(flags)
+	ret.Vars.bind(cli)
 
-	flags.BoolVar(&ret.CreateIfMissing, "or-create", false, "Create the OpenTofu workspace if it doesn't exist.")
+	cli.BoolVar(&ret.CreateIfMissing, "or-create", false, "Create the OpenTofu workspace if it doesn't exist.")
 
-	return &ret, hooks
+	cli.ArgHelp = "Expected a single argument: NAME."
+	cli.PositionalArg(&ret.WorkspaceName, "NAME", false)
+
+	return &ret
 }
 
 func ParseWorkspaceSelect(args []string) (*WorkspaceSelect, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	ret, hooks := BindWorkspaceSelect(flags)
-
-	cmdFlags := defaultFlagSet("workspace select", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	// TODO positional args
-	args = cmdFlags.Args()
-	if len(args) != 1 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Invalid arguments list",
-			"Expected a single argument: NAME.",
-		))
-	} else {
-		ret.WorkspaceName = args[0]
-	}
-
-	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	ret := BindWorkspaceSelect(cli)
+	closer, diags := cli.Stdlib("workspace select", args)
+	return ret, closer, diags
 }

--- a/internal/command/arguments/workspace_show.go
+++ b/internal/command/arguments/workspace_show.go
@@ -19,42 +19,21 @@ type WorkspaceShow struct {
 }
 
 // BindWorkspaceShow registers CLI arguments, returning a WorkspaceShow value and it's corresponding hooks.
-func BindWorkspaceShow(flags Flags) (*WorkspaceShow, Hooks) {
+func BindWorkspaceShow(cli *CommandLine) *WorkspaceShow {
 	var ret WorkspaceShow
-	var hooks Hooks
 
 	// we only parse but do not register the views flags since this command does not need it
-	hooks = append(hooks, ret.ViewOptions.ParseHook())
+	ret.ViewOptions.ParseHook(cli)
 
 	ret.Vars = &Vars{}
-	ret.Vars.bind(flags)
+	ret.Vars.bind(cli)
 
-	return &ret, hooks
+	return &ret
 }
 
 func ParseWorkspaceShow(args []string) (*WorkspaceShow, func(), tfdiags.Diagnostics) {
-	var diags tfdiags.Diagnostics
-
-	flags := Flags{}
-	ret, hooks := BindWorkspaceShow(flags)
-
-	cmdFlags := defaultFlagSet("workspace show", flags)
-
-	if err := cmdFlags.Parse(args); err != nil {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Failed to parse command-line flags",
-			err.Error(),
-		))
-	}
-
-	if len(cmdFlags.Args()) > 0 {
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Unexpected argument",
-			"Too many command line arguments. Did you mean to use -chdir?",
-		))
-	}
-
-	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
+	cli := new(CommandLine)
+	ret := BindWorkspaceShow(cli)
+	closer, diags := cli.Stdlib("workspace show", args)
+	return ret, closer, diags
 }

--- a/internal/command/arguments/workspace_show.go
+++ b/internal/command/arguments/workspace_show.go
@@ -18,14 +18,27 @@ type WorkspaceShow struct {
 	Vars *Vars
 }
 
+// BindWorkspaceShow registers CLI arguments, returning a WorkspaceShow value and it's corresponding hooks.
+func BindWorkspaceShow(flags Flags) (*WorkspaceShow, Hooks) {
+	var ret WorkspaceShow
+	var hooks Hooks
+
+	// we only parse but do not register the views flags since this command does not need it
+	hooks = append(hooks, ret.ViewOptions.ParseHook())
+
+	ret.Vars = &Vars{}
+	ret.Vars.bind(flags)
+
+	return &ret, hooks
+}
+
 func ParseWorkspaceShow(args []string) (*WorkspaceShow, func(), tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
-	ret := &WorkspaceShow{
-		Vars: &Vars{},
-	}
+	flags := Flags{}
+	ret, hooks := BindWorkspaceShow(flags)
 
-	cmdFlags := extendedFlagSet("workspace show", nil, ret.Vars)
+	cmdFlags := defaultFlagSet("workspace show", flags)
 
 	if err := cmdFlags.Parse(args); err != nil {
 		diags = diags.Append(tfdiags.Sourceless(
@@ -43,8 +56,5 @@ func ParseWorkspaceShow(args []string) (*WorkspaceShow, func(), tfdiags.Diagnost
 		))
 	}
 
-	// we only parse but do not register the views flags since this command does not need it
-	closer, moreDiags := ret.ViewOptions.Parse()
-	diags = diags.Append(moreDiags)
-	return ret, closer, diags
+	return ret, func() { hooks.Post() }, diags.Append(hooks.Pre())
 }

--- a/internal/command/arguments/workspace_show.go
+++ b/internal/command/arguments/workspace_show.go
@@ -25,8 +25,7 @@ func BindWorkspaceShow(cli *CommandLine) *WorkspaceShow {
 	// we only parse but do not register the views flags since this command does not need it
 	ret.ViewOptions.ParseHook(cli)
 
-	ret.Vars = &Vars{}
-	ret.Vars.bind(cli)
+	ret.Vars = BindVars(cli)
 
 	return &ret
 }

--- a/internal/command/graph.go
+++ b/internal/command/graph.go
@@ -286,7 +286,7 @@ Options:
 
   -type=plan       Type of graph to output. Can be: plan, plan-refresh-only,
                    plan-destroy, or apply. By default OpenTofu chooses
-				   "plan", or "apply" if you also set the -plan=... option.
+                   "plan", or "apply" if you also set the -plan=... option.
 
   -module-depth=n  (deprecated) In prior versions of OpenTofu, specified the
 				   depth of modules to show in the output.

--- a/internal/command/import.go
+++ b/internal/command/import.go
@@ -44,8 +44,13 @@ func (c *ImportCommand) Run(rawArgs []string) int {
 	c.View.DiagsWithNewline()
 
 	// Parse and validate flags
-	args, closer, diags := arguments.ParseImport(rawArgs, c.WorkingDir)
+	args, closer, diags := arguments.ParseImport(rawArgs)
 	defer closer()
+
+	if args.ConfigPath == "" {
+		// pwd is our default -config flag value
+		args.ConfigPath = c.WorkingDir.NormalizePath(c.WorkingDir.RootModuleDir())
+	}
 
 	// Instantiate the view, even if there are flag errors, so that we render
 	// diagnostics according to the desired view

--- a/internal/command/meta_test.go
+++ b/internal/command/meta_test.go
@@ -90,22 +90,8 @@ func TestMetaInputMode_disable(t *testing.T) {
 	m := &Meta{
 		WorkingDir: workdir.NewDir("."),
 		stateArgs:  arguments.State{Lock: true},
+		input:      false,
 	}
-	// TODO meta-refactor: these assignments are needed because the extendedFlagSet was used here before,
-	//   which had these with defaults as "true". In a future iteration, once these are not needed, we need to remove them.
-	m.input = true
-	args := []string{"-input=false"}
-
-	fs := flag.NewFlagSet("foo", flag.ContinueOnError)
-	var viewOpts arguments.ViewOptions
-	viewOpts.AddFlags(fs, true)
-	if err := fs.Parse(args); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if _, diags := viewOpts.Parse(); len(diags) > 0 {
-		t.Fatalf("unexpected diagnostics: %s", diags)
-	}
-	m.input = viewOpts.InputEnabled
 
 	if m.InputMode() > 0 {
 		t.Fatalf("bad: %#v", m.InputMode())

--- a/internal/command/providers_mirror_test.go
+++ b/internal/command/providers_mirror_test.go
@@ -46,7 +46,7 @@ func TestProvidersMirror(t *testing.T) {
 		}
 
 		got := output.Stderr()
-		if !strings.Contains(got, "Error: Wrong number of arguments") {
+		if !strings.Contains(got, "The providers mirror command requires an output directory") {
 			t.Fatalf("missing directory error from output, got:\n%s\n", got)
 		}
 	})

--- a/internal/command/state_replace_provider_test.go
+++ b/internal/command/state_replace_provider_test.go
@@ -253,7 +253,7 @@ func TestStateReplaceProvider(t *testing.T) {
 			t.Fatalf("successful exit; want error")
 		}
 
-		if got, want := output.Stderr(), "Exactly two arguments expected"; !strings.Contains(got, want) {
+		if got, want := output.Stderr(), "Expected exactly two positional arguments"; !strings.Contains(got, want) {
 			t.Fatalf("missing expected error message\nwant: %s\nfull output:\n%s", want, got)
 		}
 	})

--- a/internal/command/state_replace_provider_test.go
+++ b/internal/command/state_replace_provider_test.go
@@ -230,7 +230,7 @@ func TestStateReplaceProvider(t *testing.T) {
 			t.Fatalf("successful exit; want error")
 		}
 
-		if got, want := output.Stderr(), "Error parsing command-line flags"; !strings.Contains(got, want) {
+		if got, want := output.Stderr(), "Failed to parse command-line options"; !strings.Contains(got, want) {
 			t.Fatalf("missing expected error message\nwant: %s\nfull output:\n%s", want, got)
 		}
 	})


### PR DESCRIPTION
This primarily mechanical change lays the groundwork for re-building the user facing parts of OpenTofu's command line.

Goals:
* Change the purpose of the arguments package to both handle parsing logic, as well as defining the metadata around the arguments themselves. This will be used for automatically generated help text and auto-completion logic.
* Abstract away the specific command line implementation to allow swapping in different flag and argument parsing libraries.
* Reduce the copy-paste of logic shared between commands which has diverged over time.

Part of #3595

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
