### PR TITLE
Fix "becuse" typo in find-pkg-importer comment

### DIFF
--- a/tools/find-pkg-importer/main.go
+++ b/tools/find-pkg-importer/main.go
@@ -52,7 +52,7 @@ func main() {
 		fatalf("Failed to run 'go list': %s", err)
 	}
 	defer func() {
-		// Error intentionally ignored becuse there's nothing useful we could
+		// Error intentionally ignored because there's nothing useful we could
 		// do about it anyway.
 		_ = cmd.Wait()
 	}()


### PR DESCRIPTION
Fixes a small typo in a code comment: "becuse" → "because".