### PR TITLE
fmt: avoid path normalization for input paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ BUG FIXES:
 - `tofu plan -out` no longer fails when the plan includes a resource with `lifecycle { destroy = false }` that needs replacement, which previously errored with `invalid change action ForgetThenCreate`. ([#4324](https://github.com/opentofu/opentofu/issues/4324))
 - `connection.script_path` is escaped correctly not allowing anymore additional commands to be executed on the remote host together with the script path indicated by the argument. ([#4330](https://github.com/opentofu/opentofu/pull/4330))
 - `tofu plan`: Fixed Incorrect warnings produced during plan -replace ([#4368](https://github.com/opentofu/opentofu/issues/4368))
+- `tofu fmt` no longer fails when given an absolute path while the working directory is reached through a symlink: the given paths are now used as-is instead of being normalized to working-directory-relative paths. ([#3879](https://github.com/opentofu/opentofu/issues/3879))
 
 ## Previous Releases
 

--- a/internal/command/fmt.go
+++ b/internal/command/fmt.go
@@ -119,7 +119,11 @@ func (c *FmtCommand) fmt(paths []string, stdin io.Reader, stdout io.Writer, args
 	}
 
 	for _, path := range paths {
-		path = c.Meta.WorkingDir.NormalizePath(path)
+		// We intentionally don't normalize the given path to be relative to
+		// the working directory: "tofu fmt" doesn't persist paths anywhere,
+		// and normalization can produce a path that doesn't resolve
+		// correctly when the working directory is reached through a
+		// symlink. See https://github.com/opentofu/opentofu/issues/3879 .
 		info, err := os.Stat(path)
 		if err != nil {
 			diags = diags.Append(tfdiags.Sourceless(
@@ -148,7 +152,7 @@ func (c *FmtCommand) fmt(paths []string, stdin io.Reader, stdout io.Writer, args
 						continue
 					}
 
-					fileDiags := c.processFile(c.Meta.WorkingDir.NormalizePath(path), f, stdout, args)
+					fileDiags := c.processFile(path, f, stdout, args)
 					diags = diags.Append(fileDiags)
 					_ = f.Close()
 
@@ -312,7 +316,7 @@ func (c *FmtCommand) processDir(path string, stdout io.Writer, args arguments.Fm
 					continue
 				}
 
-				fileDiags := c.processFile(c.Meta.WorkingDir.NormalizePath(subPath), f, stdout, args)
+				fileDiags := c.processFile(subPath, f, stdout, args)
 				diags = diags.Append(fileDiags)
 				_ = f.Close()
 

--- a/internal/command/fmt_test.go
+++ b/internal/command/fmt_test.go
@@ -469,10 +469,8 @@ func TestFmt_check(t *testing.T) {
 		t.Fatalf("wrong exit code. expected 3")
 	}
 
-	// Given that we give relative paths back to the user, normalize this temp
-	// dir so that we're comparing against a relative-ized (normalized) path
-	tempDir = c.Meta.WorkingDir.NormalizePath(tempDir)
-
+	// The paths given back to the user are based on the path they gave us,
+	// so the output here should include the temporary directory path as-is.
 	if actual := output.Stdout(); !strings.Contains(actual, tempDir) {
 		t.Fatalf("expected:\n%s\n\nto include: %q", actual, tempDir)
 	}
@@ -506,6 +504,82 @@ func TestFmt_checkStdin(t *testing.T) {
 	if len(stdout) > 0 {
 		t.Fatalf("expected no output, got: %q", stdout)
 	}
+}
+
+func TestFmt_symlinkedWorkingDir(t *testing.T) {
+	// Regression test for the problem described in
+	// https://github.com/opentofu/opentofu/issues/3879 : when the
+	// working directory is reached through a symlink whose target is at
+	// a different directory depth, normalizing an absolute path into a
+	// working-directory-relative path produces a path that doesn't
+	// resolve correctly, so "tofu fmt" must use the given path as-is.
+	tempDir := testTempDirRealpath(t)
+
+	// The symlink and its target are at different depths:
+	//   tempDir/a/b/c/test.tf
+	//   tempDir/z -> tempDir/a/b
+	targetDir := filepath.Join(tempDir, "a", "b", "c")
+	if err := os.MkdirAll(targetDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	targetFile := filepath.Join(targetDir, "test.tf")
+	symlinkDir := filepath.Join(tempDir, "z")
+	if err := os.Symlink(filepath.Join(tempDir, "a", "b"), symlinkDir); err != nil {
+		t.Skipf("cannot create symlink: %s", err)
+	}
+
+	t.Chdir(symlinkDir)
+
+	run := func(t *testing.T, pathArg string) string {
+		t.Helper()
+
+		if err := os.WriteFile(targetFile, fmtFixture.input, 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		view, done := testView(t)
+		c := &FmtCommand{
+			Meta: Meta{
+				WorkingDir:       workdir.NewDir("."),
+				testingOverrides: metaOverridesForProvider(testProvider()),
+				View:             view,
+			},
+		}
+
+		code := c.Run([]string{pathArg})
+		output := done(t)
+		if code != 0 {
+			t.Fatalf("wrong exit code. got %d. errors: \n%s", code, output.Stderr())
+		}
+		if stderr := output.Stderr(); strings.Contains(stderr, "No file or directory") {
+			t.Fatalf("unexpected missing-path diagnostic:\n%s", stderr)
+		}
+
+		got, err := os.ReadFile(targetFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, fmtFixture.golden) {
+			t.Fatalf("target file was not formatted\ngot:  %q\nwant: %q", got, fmtFixture.golden)
+		}
+
+		return strings.TrimSpace(output.Stdout())
+	}
+
+	t.Run("absolute path", func(t *testing.T) {
+		gotPath := run(t, targetFile)
+		if gotPath != targetFile {
+			t.Fatalf("wrong path in output\ngot:  %s\nwant: %s", gotPath, targetFile)
+		}
+	})
+
+	t.Run("relative path", func(t *testing.T) {
+		relPath := filepath.Join("c", "test.tf")
+		gotPath := run(t, relPath)
+		if gotPath != relPath {
+			t.Fatalf("wrong path in output\ngot:  %s\nwant: %s", gotPath, relPath)
+		}
+	})
 }
 
 var fmtFixture = struct {


### PR DESCRIPTION
Resolves #3879

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [ ] I have not used an AI coding assistant to create this PR.
- [ ] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

> **Disclosure on the two unchecked items above:** this PR was written with the help of an AI coding assistant (Claude Code). I reviewed every line, ran the linters and the full `internal/command` test suite myself, and wrote the issue analysis and reproduction by hand — but I can't truthfully check the "no AI coding assistant" box, so I'm flagging it rather than ticking it. If that's disqualifying under your policy, say so and I'll close this and the issue stays open for someone else. No Terraform source was consulted at any point.

### Go checklist

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

---

## Summary

- Removes path normalization for `tofu fmt` only, as decided by the maintainers in https://github.com/opentofu/opentofu/issues/3879#issuecomment-5110447352.
- Preserves the supplied path for filesystem operations and output.
- Adds regression coverage for absolute paths from symlinked working directories.

All three `NormalizePath` call sites were local to `internal/command/fmt.go`, so the change is fully self-contained — no shared command infrastructure was touched and no refactoring was needed.

`TestFmt_check` was updated accordingly: `-check`/`-list` output now reports the path as the user supplied it instead of a working-directory-relative form.

## Why

`tofu fmt` does not persist input paths, so normalization provides no important functional benefit for this command and can produce invalid relative paths when the working directory is reached through a symlink. For example, with `z -> a/b` as the working directory, an absolute path to `a/b/c/test.tf` was normalized to `../a/b/c/test.tf`, which resolves through the physical directory to a nonexistent location, failing with:

```
Error: No file or directory at ../a/b/c/test.tf
```

## Scope

This change is intentionally limited to `tofu fmt`.

It does not modify normalization behavior for `tofu plan`, `tofu apply`, plan files, state snapshots, or other persistent workflows. `workdir.Dir.NormalizePath` itself is unchanged, and no use of `filepath.EvalSymlinks` was introduced.

## Testing

- `go test ./internal/command/ -run TestFmt_symlinkedWorkingDir -v` — the new regression test (symlinked working directory whose target is at a different depth; absolute and relative path subtests). Before the fix the absolute-path subtest fails with `No file or directory at ../a/b/c/test.tf`; after the fix both subtests pass.
- `go test ./internal/command/ -run TestFmt -v` — all `fmt` tests pass (covers relative paths, absolute paths, directory arguments, stdin, `-check`, multiple arguments).
- `go test ./internal/command/...` — full package tree passes.
- `GOOS=linux tools/golangci-lint run ./internal/command/...` (golangci-lint v2.6.0, per Makefile) — 0 issues.
- `GOOS=windows tools/golangci-lint run ./internal/command/...` — 0 issues.
- `gofmt -l` on modified files — clean.
- Manual end-to-end run of the exact reproduction script from #3879 against a freshly built `tofu` — exits 0 and formats the file at the supplied absolute path.

## Risk

Low, provided the change remains isolated to `fmt`.

The main regression risk is changing behavior for relative paths, directory arguments, recursive formatting, or standard input. These cases are covered by existing or newly added tests. One user-visible behavior change: `-list`/`-check` output and diagnostics now show paths as supplied by the user rather than normalized to working-directory-relative form.
