### PR TITLE
New runtime: Resource Instance Object Metadata

### DIFF
--- a/internal/addrs/resource_instance_object.go
+++ b/internal/addrs/resource_instance_object.go
@@ -11,6 +11,46 @@ import (
 	"time"
 )
 
+// ResourceInstanceObject represents a single object associated with a
+// resource instance inside a module that's implied by context rather than
+// represented directly in the value.
+//
+// This is a module-relative version of [AbsResourceInstanceObject] for
+// specialist situations where the containing module instance is specified
+// some other way, such as by being implied by the reciever of a method call.
+type ResourceInstanceObject struct {
+	// InstanceAddr is the address of the resource instance that this object
+	// belongs to.
+	InstanceAddr ResourceInstance
+
+	// DeposedKey is the deposed key of a deposed object, or [NotDeposed] when
+	// representing the "current" object for a resource instance.
+	DeposedKey DeposedKey
+}
+
+// IsCurrent returns true if this represents the "current" object of some
+// resource instance.
+func (o ResourceInstanceObject) IsCurrent() bool {
+	return o.DeposedKey == NotDeposed
+}
+
+// IsDeposed returns true if this represents a "deposed" object of some
+// resource instance.
+func (o ResourceInstanceObject) IsDeposed() bool {
+	return o.DeposedKey != NotDeposed
+}
+
+func (o ResourceInstanceObject) String() string {
+	if o.DeposedKey == NotDeposed {
+		return o.InstanceAddr.String()
+	}
+	return fmt.Sprintf("%s deposed object %q", o.InstanceAddr.String(), o.DeposedKey.String())
+}
+
+func (o ResourceInstanceObject) Equal(other ResourceInstanceObject) bool {
+	return o.DeposedKey == other.DeposedKey && o.InstanceAddr.Equal(other.InstanceAddr)
+}
+
 // AbsResourceInstanceObject represents a single object associated with a
 // resource instance.
 //
@@ -58,6 +98,16 @@ func (o AbsResourceInstanceObject) IsCurrent() bool {
 // resource instance.
 func (o AbsResourceInstanceObject) IsDeposed() bool {
 	return o.DeposedKey != NotDeposed
+}
+
+// ModuleRelative returns the [ResourceInstanceObject] value that identifies
+// the same object when used relative to the module instance that the receiver
+// belongs to.
+func (o AbsResourceInstanceObject) ModuleRelative() ResourceInstanceObject {
+	return ResourceInstanceObject{
+		InstanceAddr: o.InstanceAddr.Resource,
+		DeposedKey:   o.DeposedKey,
+	}
 }
 
 func (o AbsResourceInstanceObject) String() string {

--- a/internal/engine/applying/operations.go
+++ b/internal/engine/applying/operations.go
@@ -126,7 +126,8 @@ func (ops *execOperations) Finish(ctx context.Context) (*states.State, tfdiags.D
 	moreDiags := ops.configOracle.Close(ctx)
 	diags = diags.Append(moreDiags)
 
-	// Snapshot the working SyncState
+	// Take a snapshot of some of our state objects
+	priorState := ops.priorState.Close()
 	finalState := ops.workingState.Close()
 
 	// This operations object is now invalid and must not be used any further,
@@ -157,7 +158,7 @@ func (ops *execOperations) Finish(ctx context.Context) (*states.State, tfdiags.D
 				deprecated := "" // TODO
 				finalState.EnsureModule(addrs.RootModuleInstance).SetOutputValue(k, unmarkedVal, sensitive, deprecated)
 			} else {
-				prev := ops.priorState.OutputValue(addrs.AbsOutputValue{OutputValue: addrs.OutputValue{Name: k}})
+				prev := priorState.OutputValue(addrs.AbsOutputValue{OutputValue: addrs.OutputValue{Name: k}})
 				if prev != nil {
 					finalState.EnsureModule(addrs.RootModuleInstance).SetOutputValue(k, prev.Value, prev.Sensitive, prev.Deprecated)
 				}

--- a/internal/engine/applying/operations_provisioners.go
+++ b/internal/engine/applying/operations_provisioners.go
@@ -9,25 +9,24 @@ import (
 	"context"
 	"log"
 
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/addrs"
-	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/lang/eval"
 	"github.com/opentofu/opentofu/internal/tfdiags"
-	"github.com/zclconf/go-cty/cty"
 )
 
-func (ops *execOperations) runProvisioner(ctx context.Context, objAddr addrs.AbsResourceInstanceObject, prov eval.Provisioner, selfVal cty.Value) (bool, tfdiags.Diagnostics) {
+func (ops *execOperations) runProvisioner(ctx context.Context, objAddr addrs.AbsResourceInstanceObject, prov *eval.ResourceProvisioner, selfVal cty.Value) (bool, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	tracer := contextTracer(ctx)
+	log.Printf("[TRACE] apply phase: running %q provisioner for %s", prov.Type, objAddr)
 
-	provConfig, moreDiags := prov.Config(ctx, selfVal)
+	provConfig, moreDiags := prov.BuildConfig(ctx, selfVal)
 	diags = diags.Append(moreDiags)
 	if moreDiags.HasErrors() {
 		return false, diags
 	}
-
-	// Based on NodeAbstractInstance.applyProvisioners
 
 	// Call pre hook
 	if cb := tracer.StartProvisionInstanceStep; cb != nil {
@@ -38,8 +37,8 @@ func (ops *execOperations) runProvisioner(ctx context.Context, objAddr addrs.Abs
 	// those are stripped out before sending to the provisioner. Unlike
 	// resources, we have no need to capture the marked paths and reapply
 	// later.
-	unmarkedConfig, configMarks := provConfig.Value.UnmarkDeep()
-	unmarkedConnInfo, _ := provConfig.Connection.UnmarkDeep()
+	unmarkedConfig, configMarks := provConfig.MainConfig.UnmarkDeep()
+	unmarkedConnInfo, _ := provConfig.ConnectionConfig.UnmarkDeep()
 
 	// The output function passes the config marks to hooks so they can
 	// inspect them (e.g. sensitive) and decide how to handle output.
@@ -50,35 +49,40 @@ func (ops *execOperations) runProvisioner(ctx context.Context, objAddr addrs.Abs
 		}
 	}
 
-	resp := ops.plugins.ProvisionResource(
+	// FIXME: this function is allowed to return contextual diagnostics
+	// that use attribute paths instead of source locations, and so we
+	// ought to actually resolve them to their approximate source locations
+	// before we return here. We don't have direct access to the HCL body
+	// but perhaps we could add a new callback to [eval.ResourceProvisioner]
+	// that is responsible for finalizing the diagnostics, and then the
+	// tofu2024 package can implement that in terms of the real HCL body?
+	applyDiags := ops.plugins.ProvisionResource(
 		ctx,
 		prov.Type,
 		unmarkedConfig,
 		unmarkedConnInfo,
 		outputFn,
 	)
-	applyDiags := resp //.InConfigBody(prov.Config, n.Addr.String())
 
 	// Call post hook
 	if cb := tracer.StopProvisionInstanceStep; cb != nil {
 		cb(ctx, objAddr.InstanceAddr, prov.Type, applyDiags)
 	}
 
-	switch prov.OnFailure {
-	case configs.ProvisionerOnFailureContinue:
+	if prov.ContinueOnFailure {
 		if applyDiags.HasErrors() {
 			log.Printf("[WARN] Errors while provisioning %s with %q, but continuing as requested in configuration", objAddr, prov.Type)
 		} else {
 			// Maybe there are warnings that we still want to see
 			diags = diags.Append(applyDiags)
 		}
-	default:
-		diags = diags.Append(applyDiags)
-		if applyDiags.HasErrors() {
-			log.Printf("[WARN] Errors while provisioning %s with %q, so aborting", objAddr, prov.Type)
-			return false, diags
-		}
+		return true, diags
 	}
 
+	diags = diags.Append(applyDiags)
+	if applyDiags.HasErrors() {
+		log.Printf("[WARN] Errors while provisioning %s with %q, so aborting", objAddr, prov.Type)
+		return false, diags
+	}
 	return true, diags
 }

--- a/internal/engine/applying/operations_resource.go
+++ b/internal/engine/applying/operations_resource.go
@@ -63,19 +63,29 @@ func (ops *execOperations) resourceDependenciesMissingMarks(cfgVal cty.Value) (c
 }
 
 // ResourceInstanceCurrentMeta implements [exec.Operations].
-func (ops *execOperations) ResourceInstanceCurrentMeta(ctx context.Context, instAddr addrs.AbsResourceInstance) (*exec.ResourceInstanceObjectMeta, tfdiags.Diagnostics) {
+func (ops *execOperations) ResourceInstanceCurrentMeta(ctx context.Context, instAddr addrs.AbsResourceInstance, prior *exec.ResourceInstanceObject) (*exec.ResourceInstanceObjectMeta, tfdiags.Diagnostics) {
 	log.Printf("[TRACE] apply phase: ResourceInstanceCurrentMeta %s", instAddr)
-	// TODO: Implement
-	panic("unimplemented")
+
+	objAddr := instAddr.CurrentObject()
+	configMeta := ops.configOracle.ResourceInstanceObjectMeta(ctx, objAddr)
+	var state *states.ResourceInstanceObjectFull
+	if prior != nil {
+		state = prior.State
+	}
+
+	return exec.BuildResourceInstanceObjectMeta(objAddr, configMeta, state), nil
 }
 
 // ResourceInstanceDesired implements [exec.Operations].
 func (ops *execOperations) ResourceInstanceDesired(
 	ctx context.Context,
-	instAddr addrs.AbsResourceInstance,
+	meta *exec.ResourceInstanceObjectMeta,
 ) (*eval.DesiredResourceInstance, tfdiags.Diagnostics) {
-	log.Printf("[TRACE] apply phase: ResourceInstanceDesired %s", instAddr)
-	return ops.configOracle.DesiredResourceInstance(ctx, instAddr)
+	log.Printf("[TRACE] apply phase: ResourceInstanceDesired %s", meta.Addr)
+	if !meta.Addr.IsCurrent() {
+		panic(fmt.Sprintf("no desired state for %s", meta.Addr))
+	}
+	return ops.configOracle.DesiredResourceInstance(ctx, meta.Addr.InstanceAddr)
 }
 
 // ResourceInstancePrior implements [exec.Operations].

--- a/internal/engine/applying/operations_resource.go
+++ b/internal/engine/applying/operations_resource.go
@@ -62,6 +62,13 @@ func (ops *execOperations) resourceDependenciesMissingMarks(cfgVal cty.Value) (c
 	return cfgVal, marks
 }
 
+// ResourceInstanceCurrentMeta implements [exec.Operations].
+func (ops *execOperations) ResourceInstanceCurrentMeta(ctx context.Context, instAddr addrs.AbsResourceInstance) (*exec.ResourceInstanceObjectMeta, tfdiags.Diagnostics) {
+	log.Printf("[TRACE] apply phase: ResourceInstanceCurrentMeta %s", instAddr)
+	// TODO: Implement
+	panic("unimplemented")
+}
+
 // ResourceInstanceDesired implements [exec.Operations].
 func (ops *execOperations) ResourceInstanceDesired(
 	ctx context.Context,

--- a/internal/engine/applying/operations_resource_managed.go
+++ b/internal/engine/applying/operations_resource_managed.go
@@ -34,10 +34,9 @@ func (ops *execOperations) ManagedFinalPlan(
 
 	var instAddr addrs.AbsResourceInstance
 	var providerConfigAddr addrs.AbsProviderInstanceCorrect
-	var createProvisioners []eval.Provisioner
-	var destroyProvisioners []eval.Provisioner
 	var resourceTypeName string
 	var requiredConfigResources addrs.Set[addrs.AbsResourceInstance]
+	var provisionersBefore, provisionersAfter []*eval.ResourceProvisioner
 	deposedKey := states.NotDeposed
 	if desired != nil {
 		// By the time we're in the apply phase the desired and prior addresses
@@ -51,21 +50,11 @@ func (ops *execOperations) ManagedFinalPlan(
 		// TODO possibly nil here
 		providerConfigAddr = *desired.ProviderInstance
 		requiredConfigResources = desired.RequiredResourceInstances
-
-		createProvisioners = desired.CreateProvisioners
 	} else if prior != nil {
 		instAddr = prior.Addr.InstanceAddr
 		deposedKey = prior.Addr.DeposedKey
 		resourceTypeName = prior.State.ResourceType
 		providerConfigAddr = prior.State.ProviderInstanceAddr
-
-		if prior.State.Status == states.ObjectTainted {
-			// No point in provisioning an object that is already tainted, since
-			// it's going to get recreated on the next apply anyway.
-			log.Printf("[TRACE] %s is tainted, so skipping provisioning", instAddr)
-		} else {
-			destroyProvisioners = ops.configOracle.DestroyProvisioners(ctx, instAddr)
-		}
 	} else {
 		// Both should not be nil but if they are then we'll treat it the same
 		// way as if we dynamically discover that no change is actually
@@ -75,6 +64,18 @@ func (ops *execOperations) ManagedFinalPlan(
 	}
 	objAddr := instAddr.Object(deposedKey)
 	log.Printf("[TRACE] apply phase: ManagedFinalPlan %s using %s", objAddr, providerConfigAddr)
+
+	if desired != nil && prior == nil { // creating
+		provisionersAfter = metadata.PostCreateProvisioners
+	} else if prior != nil && desired == nil { // deleting
+		if prior.State.Status == states.ObjectTainted {
+			// No point in provisioning an object that is already tainted, since
+			// it's going to get recreated on the next apply anyway.
+			log.Printf("[TRACE] %s is tainted, so skipping provisioning", instAddr)
+		} else {
+			provisionersBefore = metadata.PreDeleteProvisioners
+		}
+	}
 
 	tracer := contextTracer(ctx)
 	if cb := tracer.StartManagedResourceInstanceObjectFinalPlan; cb != nil {
@@ -154,8 +155,8 @@ func (ops *execOperations) ManagedFinalPlan(
 		PriorStateVal:             resp.Current.Value,
 		ConfigVal:                 resp.DesiredValue,
 		PlannedVal:                resp.Planned.Value,
-		CreateProvisioners:        createProvisioners,
-		DestroyProvisioners:       destroyProvisioners,
+		ProvisionersBefore:        provisionersBefore,
+		ProvisionersAfter:         provisionersAfter,
 		ProviderInstance:          providerConfigAddr,
 		ProviderPrivate:           resp.Planned.Private,
 	}, diags
@@ -271,15 +272,17 @@ func (ops *execOperations) ManagedApply(
 		return nil, diags
 	}
 
-	// Destroy Provisioners
-	if plannedValUnmarked.IsNull() {
-		for _, prov := range plan.DestroyProvisioners {
-			cont, provDiags := ops.runProvisioner(ctx, objAddr, prov, priorValUnmarked)
+	if provs := plan.ProvisionersBefore; len(provs) != 0 {
+		log.Printf("[TRACE] apply phase: ManagedApply running %d pre-apply provisioner(s) for %s", len(provs), plan.Addr)
+		for _, prov := range provs {
+			cont, provDiags := ops.runProvisioner(ctx, objAddr, prov, plan.PriorStateVal)
 			diags = diags.Append(provDiags)
 			if !cont {
+				log.Printf("[TRACE] apply phase: ManagedApply %s pre-apply provisioner failed, so aborting", plan.Addr)
 				return nil, diags
 			}
 		}
+		log.Printf("[TRACE] apply phase: ManagedApply %s pre-apply provisioners finished", plan.Addr)
 	}
 
 	resp := providerClient.ApplyResourceChange(ctx, providers.ApplyResourceChangeRequest{
@@ -325,15 +328,21 @@ func (ops *execOperations) ManagedApply(
 		return result, diags
 	}
 
-	// Create Provisioners
-	if !plannedValUnmarked.IsNull() && priorValUnmarked.IsNull() {
-		for _, prov := range plan.CreateProvisioners {
+	if provs := plan.ProvisionersAfter; len(provs) != 0 {
+		log.Printf("[TRACE] apply phase: ManagedApply running %d post-apply provisioner(s) for %s", len(provs), plan.Addr)
+		for _, prov := range provs {
+			// FIXME: resp.NewState isn't the correct value to use here because
+			// it hasn't yet had marks applied to it, and so provisioner
+			// execution won't be able to notice when arguments are sensitive,
+			// etc.
 			cont, provDiags := ops.runProvisioner(ctx, objAddr, prov, resp.NewState)
 			diags = diags.Append(provDiags)
 			if !cont {
+				log.Printf("[TRACE] apply phase: ManagedApply %s post-apply provisioner failed, so aborting", plan.Addr)
 				break
 			}
 		}
+		log.Printf("[TRACE] apply phase: ManagedApply %s post-apply provisioners finished", plan.Addr)
 	}
 
 	// TODO: objchange.AssertObjectCompatible to verify that the result is

--- a/internal/engine/applying/operations_resource_managed.go
+++ b/internal/engine/applying/operations_resource_managed.go
@@ -438,6 +438,13 @@ func (ops *execOperations) ManagedPerformDepose(
 	return currentObj.IntoDeposed(deposedKey), diags
 }
 
+// ManagedDeposedMeta implements [exec.Operations].
+func (ops *execOperations) ManagedDeposedMeta(ctx context.Context, instAddr addrs.AbsResourceInstance, deposedKey states.DeposedKey) (*exec.ResourceInstanceObjectMeta, tfdiags.Diagnostics) {
+	log.Printf("[TRACE] apply phase: ManagedDeposedMeta %s deposed object %s", instAddr, deposedKey)
+	// TODO: Implement
+	panic("unimplemented")
+}
+
 // ManagedAlreadyDeposed implements [exec.Operations].
 func (ops *execOperations) ManagedAlreadyDeposed(
 	ctx context.Context,

--- a/internal/engine/applying/operations_resource_managed.go
+++ b/internal/engine/applying/operations_resource_managed.go
@@ -25,6 +25,7 @@ import (
 // ManagedFinalPlan implements [exec.Operations].
 func (ops *execOperations) ManagedFinalPlan(
 	ctx context.Context,
+	metadata *exec.ResourceInstanceObjectMeta,
 	desired *eval.DesiredResourceInstance,
 	prior *exec.ResourceInstanceObject,
 	initialPlannedVal cty.Value,
@@ -439,10 +440,17 @@ func (ops *execOperations) ManagedPerformDepose(
 }
 
 // ManagedDeposedMeta implements [exec.Operations].
-func (ops *execOperations) ManagedDeposedMeta(ctx context.Context, instAddr addrs.AbsResourceInstance, deposedKey states.DeposedKey) (*exec.ResourceInstanceObjectMeta, tfdiags.Diagnostics) {
+func (ops *execOperations) ManagedDeposedMeta(ctx context.Context, instAddr addrs.AbsResourceInstance, deposedKey states.DeposedKey, prior *exec.ResourceInstanceObject) (*exec.ResourceInstanceObjectMeta, tfdiags.Diagnostics) {
 	log.Printf("[TRACE] apply phase: ManagedDeposedMeta %s deposed object %s", instAddr, deposedKey)
-	// TODO: Implement
-	panic("unimplemented")
+
+	objAddr := instAddr.Object(deposedKey)
+	configMeta := ops.configOracle.ResourceInstanceObjectMeta(ctx, objAddr)
+	var state *states.ResourceInstanceObjectFull
+	if prior != nil {
+		state = prior.State
+	}
+
+	return exec.BuildResourceInstanceObjectMeta(objAddr, configMeta, state), nil
 }
 
 // ManagedAlreadyDeposed implements [exec.Operations].

--- a/internal/engine/internal/exec/operations.go
+++ b/internal/engine/internal/exec/operations.go
@@ -57,11 +57,15 @@ type Operations interface {
 	ResourceInstanceCurrentMeta(
 		ctx context.Context,
 		instAddr addrs.AbsResourceInstance,
+		prior *ResourceInstanceObject,
 	) (*ResourceInstanceObjectMeta, tfdiags.Diagnostics)
 
 	// ResourceInstanceDesired returns a representation of the "desired state"
-	// for the given resource instance, or a nil pointer if the given resource
-	// instance is not currently declared at all.
+	// for the resource instance object whose metadata is provided, or a nil
+	// pointer if the given resource instance is not currently declared at all.
+	//
+	// Deposed objects cannot be "desired", so only metadata for current objects
+	// may be passed to this operation.
 	//
 	// Real implementations of this use the configuration evaluator to finalize
 	// the resource instance configuration based on other values that have been
@@ -74,7 +78,7 @@ type Operations interface {
 	// resource instance.
 	ResourceInstanceDesired(
 		ctx context.Context,
-		instAddr addrs.AbsResourceInstance,
+		meta *ResourceInstanceObjectMeta,
 	) (*eval.DesiredResourceInstance, tfdiags.Diagnostics)
 
 	// ResourceInstancePrior returns a representation of the "prior state" for
@@ -123,6 +127,7 @@ type Operations interface {
 	// or must return at least one error diagnostic.
 	ManagedFinalPlan(
 		ctx context.Context,
+		metadata *ResourceInstanceObjectMeta,
 		desired *eval.DesiredResourceInstance,
 		prior *ResourceInstanceObject,
 		plannedVal cty.Value,
@@ -198,6 +203,7 @@ type Operations interface {
 		ctx context.Context,
 		instAddr addrs.AbsResourceInstance,
 		deposedKey states.DeposedKey,
+		prior *ResourceInstanceObject,
 	) (*ResourceInstanceObjectMeta, tfdiags.Diagnostics)
 
 	// ManagedAlreadyDeposed returns a deposed object from the prior state,

--- a/internal/engine/internal/exec/operations.go
+++ b/internal/engine/internal/exec/operations.go
@@ -48,6 +48,17 @@ type Operations interface {
 	//// (mode-specific operations follow below)
 	//////////////////////////////////////////////////////////////////////////////
 
+	// ResourceInstanceCurrentMeta returns the metadata for the given resource
+	// instance's "current" (non-deposed) object address, providing information
+	// that is relevant regardless of what action is being taken for the object
+	// or whether it is "desired" or not.
+	//
+	// For deposed object metadata, use [Operations.ManagedDeposedMeta] instead.
+	ResourceInstanceCurrentMeta(
+		ctx context.Context,
+		instAddr addrs.AbsResourceInstance,
+	) (*ResourceInstanceObjectMeta, tfdiags.Diagnostics)
+
 	// ResourceInstanceDesired returns a representation of the "desired state"
 	// for the given resource instance, or a nil pointer if the given resource
 	// instance is not currently declared at all.
@@ -176,6 +187,18 @@ type Operations interface {
 		object *ResourceInstanceObject,
 		deletePlan *ManagedResourceObjectFinalPlan,
 	) (*ResourceInstanceObject, tfdiags.Diagnostics)
+
+	// ManagedDeposedMeta returns the metadata for a deposed object belonging
+	// to the given resource instance, providing information that might be
+	// needed in order to delete the object.
+	//
+	// For current object metadata, use [Operations.ResourceInstanceCurrentMeta]
+	// instead.
+	ManagedDeposedMeta(
+		ctx context.Context,
+		instAddr addrs.AbsResourceInstance,
+		deposedKey states.DeposedKey,
+	) (*ResourceInstanceObjectMeta, tfdiags.Diagnostics)
 
 	// ManagedAlreadyDeposed returns a deposed object from the prior state,
 	// nor nil if there is no such object.

--- a/internal/engine/internal/exec/resource.go
+++ b/internal/engine/internal/exec/resource.go
@@ -79,12 +79,16 @@ type ManagedResourceObjectFinalPlan struct {
 	// TODO: Anything else we'd need to populate an "ApplyResourceChanges"
 	// request to the associated provider.
 
-	// CreateProvisioners are the provisioners to execute if the resource
-	// instance is being created.
-	CreateProvisioners []eval.Provisioner
-	// DestroyProvisioners are the provisioners to execute if the resource
-	// instance is being destroyed.
-	DestroyProvisioners []eval.Provisioner
+	// ProvisionersBefore and ProvisionersAfter are provisioners to run
+	// before or after applying the plan, respectively.
+	//
+	// If ProvisionersBefore fail and are not configured to continue on failure
+	// then the changes are not applied at all.
+	//
+	// ProvisionersAfter run only if the changes are applied successfully, and
+	// then if they fail the object is left in a "tainted" state so that the
+	// next plan/apply round knows that the object is not yet ready to use.
+	ProvisionersBefore, ProvisionersAfter []*eval.ResourceProvisioner
 }
 
 // IntoDeposed returns a new [ManagedResourceObjectFinalPlan] that represents
@@ -240,15 +244,15 @@ type ResourceInstanceObjectMeta struct {
 	// The contents of this field can only be relied on during a round where
 	// the apply phase would create a resource instance object at the associated
 	// address. Its contents are unspecified in other cases.
-	PostCreateProvisioners []eval.ResourceProvisioner
+	PostCreateProvisioners []*eval.ResourceProvisioner
 
 	// PreDeleteProvisioners are the provisioners to execute immediately before
-	// the resource instance object will be deleted.
+	// the resource instance object would be deleted.
 	//
 	// The contents of this field can only be relied on during a round where
 	// the apply phase would delete a resource instance object at the associated
 	// address. Its contents are unspecified in other cases.
-	PreDeleteProvisioners []eval.ResourceProvisioner
+	PreDeleteProvisioners []*eval.ResourceProvisioner
 }
 
 // BuildResourceInstanceObjectMeta constructs a [ResourceInstanceObjectMeta]
@@ -282,16 +286,25 @@ func BuildResourceInstanceObjectMeta(
 	}
 
 	// If both state and fromConfig are present then we'll start with state
-	// so that the config values can potentially override.
+	// so that the config values can potentially override the state values.
 	if state != nil {
 		// Note that if this object is participating in a cross-resource-type
 		// move in this plan/apply round this will initially reflect the
 		// old resource type, but then we'll overwrite it with the new resource
 		// type from the configuration object below.
 		ret.ResourceType = state.ResourceType
+
+		// TODO: Everything else
 	}
 
-	// TODO: The rest of this
+	if fromConfig != nil {
+		ret.ResourceType = fromConfig.ResourceType
+
+		ret.PostCreateProvisioners = fromConfig.PostCreateProvisioners
+		ret.PreDeleteProvisioners = fromConfig.PreDestroyProvisioners
+
+		// TODO: Everything else
+	}
 
 	return ret
 }

--- a/internal/engine/internal/exec/resource.go
+++ b/internal/engine/internal/exec/resource.go
@@ -175,3 +175,75 @@ func (o *ResourceInstanceObject) WithNewState(newState *states.ResourceInstanceO
 		State: newState,
 	}
 }
+
+// ResourceInstanceObjectMeta represents various metadata for a resource
+// instance object.
+//
+// "Metadata" is loosely defined as including the sort of information we rely
+// on even when an object is no longer "desired" and thus we'd plan to delete
+// it, and so there's no normal declaration for the resource instance left
+// in the configuration anymore but nonetheless there might be other information
+// assembled from any combination of the following:
+//   - Metadata that was copied from configuration into prior state in the
+//     previous round.
+//   - Arguments in a "removed" block that's acting as a sort of "tombstone" for
+//     a previously-present resource block.
+//   - The resource block that an "orphan" resource instance was previously
+//     declared from, which remains in the configuration and possibly declares
+//     some settings that apply to all instances of the resource.
+//
+// This type lives at the execution engine layer because it's an abstraction
+// over a mixture of information from the configuration and information from
+// the prior state, whereas the "evaluator"'s scope is strictly limited only
+// to the configuration.
+type ResourceInstanceObjectMeta struct {
+	// Addr identifies which resource instance object this metadata applies to.
+	//
+	// When an existing object will be moved to a new address during the
+	// apply phase, for example using a "moved" block, this reflects the address
+	// it's expected to have at the end of a successful apply phase. The address
+	// in this field must therefore NOT be used to identify objects to retrieve
+	// from the prior state.
+	//
+	// However, for objects being replaced in the create-then-destroy order note
+	// that successful execution causes the original object to be deleted and a
+	// new one to be created at the same address, and in that case we use the
+	// address where the new object would be placed instead of the address
+	// that the old object would be temporarily deposed to during the process.
+	// This reflects a small inconsistency/ambiguity in our usual terminology
+	// where "object" normally refers to the actual remote object, but in this
+	// case it refers only to the _object address_ from OpenTofu's perspective,
+	// and two different remote objects will appear at this address over
+	// the course of the apply phase.
+	Addr addrs.AbsResourceInstanceObject
+
+	// ProviderInstance is the address of the provider instance that is
+	// currently considered responsible for this resource instance object.
+	//
+	// A resource instance object is associated with a specific provider
+	// instance throughout a plan/apply round, but may change which provider
+	// instance it is associated with between rounds based on changes in the
+	// configuration.
+	ProviderInstance addrs.AbsProviderInstanceCorrect
+
+	// ResourceType is the resource type of the object this metadata is for,
+	// as would be understood by the provider identified in
+	// [ResourceInstanceObjectMeta.ProviderInstance].
+	ResourceType string
+
+	// CreateProvisioners are the provisioners to execute immediately after the
+	// resource instance object has been created.
+	//
+	// The contents of this field can only be relied on during a round where
+	// the apply phase would create a resource instance object at the associated
+	// address. Its contents are unspecified in other cases.
+	PostCreateProvisioners []eval.Provisioner
+
+	// DeleteProvisioners are the provisioners to execute immediately before the
+	// resource instance object will be deleted.
+	//
+	// The contents of this field can only be relied on during a round where
+	// the apply phase would delete a resource instance object at the associated
+	// address. Its contents are unspecified in other cases.
+	PreDeleteProvisioners []eval.Provisioner
+}

--- a/internal/engine/internal/exec/resource.go
+++ b/internal/engine/internal/exec/resource.go
@@ -6,10 +6,13 @@
 package exec
 
 import (
+	"fmt"
+
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/lang/eval"
+	"github.com/opentofu/opentofu/internal/lang/exprs"
 	"github.com/opentofu/opentofu/internal/states"
 )
 
@@ -224,26 +227,71 @@ type ResourceInstanceObjectMeta struct {
 	// instance throughout a plan/apply round, but may change which provider
 	// instance it is associated with between rounds based on changes in the
 	// configuration.
-	ProviderInstance addrs.AbsProviderInstanceCorrect
+	ProviderInstance exprs.FromValue[addrs.AbsProviderInstanceCorrect]
 
 	// ResourceType is the resource type of the object this metadata is for,
 	// as would be understood by the provider identified in
 	// [ResourceInstanceObjectMeta.ProviderInstance].
 	ResourceType string
 
-	// CreateProvisioners are the provisioners to execute immediately after the
-	// resource instance object has been created.
+	// PostCreateProvisioners are the provisioners to execute immediately after
+	// the resource instance object has been created.
 	//
 	// The contents of this field can only be relied on during a round where
 	// the apply phase would create a resource instance object at the associated
 	// address. Its contents are unspecified in other cases.
-	PostCreateProvisioners []eval.Provisioner
+	PostCreateProvisioners []eval.ResourceProvisioner
 
-	// DeleteProvisioners are the provisioners to execute immediately before the
-	// resource instance object will be deleted.
+	// PreDeleteProvisioners are the provisioners to execute immediately before
+	// the resource instance object will be deleted.
 	//
 	// The contents of this field can only be relied on during a round where
 	// the apply phase would delete a resource instance object at the associated
 	// address. Its contents are unspecified in other cases.
-	PreDeleteProvisioners []eval.Provisioner
+	PreDeleteProvisioners []eval.ResourceProvisioner
+}
+
+// BuildResourceInstanceObjectMeta constructs a [ResourceInstanceObjectMeta]
+// object that incorporates information from both the configuration and the
+// prior state, generally preferring to use the configuration information when
+// possible but using the prior state as a fallback.
+//
+// This is our primary logic for deciding the effective metadata for a resource
+// instance object based on all of the information currently known. The planning
+// and applying engines should both use this function to ensure that they always
+// agree about the metadata for a given resource instance object.
+//
+// It's the caller's responsibility to ensure that all of the arguments agree
+// about which resource instance object they are describing. The given object
+// address will be the value of [ResourceInstanceObjectMeta.Addr] and so must
+// be consistent with the documentation of that field.
+//
+// At least one of fromConfig and state must be non-nil, or this function will
+// panic. There is no reason to ask for metadata for an object that exists in
+// neither the desired nor the prior state.
+func BuildResourceInstanceObjectMeta(
+	addr addrs.AbsResourceInstanceObject,
+	fromConfig *eval.ConfiguredResourceInstanceObjectMeta,
+	state *states.ResourceInstanceObjectFull,
+) *ResourceInstanceObjectMeta {
+	if fromConfig == nil && state == nil {
+		panic(fmt.Sprintf("cannot build resource instance object metadata for %s with neither configured nor prior state metadata", addr))
+	}
+	ret := &ResourceInstanceObjectMeta{
+		Addr: addr,
+	}
+
+	// If both state and fromConfig are present then we'll start with state
+	// so that the config values can potentially override.
+	if state != nil {
+		// Note that if this object is participating in a cross-resource-type
+		// move in this plan/apply round this will initially reflect the
+		// old resource type, but then we'll overwrite it with the new resource
+		// type from the configuration object below.
+		ret.ResourceType = state.ResourceType
+	}
+
+	// TODO: The rest of this
+
+	return ret
 }

--- a/internal/engine/internal/execgraph/builder.go
+++ b/internal/engine/internal/execgraph/builder.go
@@ -93,8 +93,26 @@ func (b *Builder) ConstantProviderInstAddr(addr addrs.AbsProviderInstanceCorrect
 	return ret
 }
 
+// ResourceInstanceCurrentMeta asks the evaluator for the configured metadata
+// for the current object of the identified resource instance and then combines
+// it with the prior state of that object (if any) to produce the effective
+// metadata for that resource instance object.
+//
+// For objects that exist in the prior state, set "prior" to the result of a
+// call to [Builder.ResourceInstancePrior]. Otherwise leave it set to nil to
+// indicate that there is no prior state available.
+func (b *Builder) ResourceInstanceCurrentMeta(
+	addr ResultRef[addrs.AbsResourceInstance],
+	prior ResourceInstanceResultRef,
+) ResultRef[*exec.ResourceInstanceObjectMeta] {
+	return operationRef[*exec.ResourceInstanceObjectMeta](b, operationDesc{
+		opCode:   opResourceInstanceCurrentMeta,
+		operands: []AnyResultRef{addr, prior},
+	})
+}
+
 // ResourceInstanceDesired asks the evaluator for the desired state of the
-// resource instance that has the given address.
+// resource instance object whose metadata is provided.
 //
 // This operation automatically blocks awaiting the results of any upstream
 // resource instances that the requested instance's configuration depends on,
@@ -102,12 +120,15 @@ func (b *Builder) ConstantProviderInstAddr(addr addrs.AbsProviderInstanceCorrect
 // are any evaluation errors, even if those errors originate upstream in one
 // of the configuration's dependencies and thus would get reported separately
 // by another return path.
+//
+// Only current (i.e. not "deposed") objects can be "desired", so this operation
+// must not be sent a result from [Builder.ManagedDeposedMeta].
 func (b *Builder) ResourceInstanceDesired(
-	addr ResultRef[addrs.AbsResourceInstance],
+	meta ResultRef[*exec.ResourceInstanceObjectMeta],
 ) ResultRef[*eval.DesiredResourceInstance] {
 	return operationRef[*eval.DesiredResourceInstance](b, operationDesc{
 		opCode:   opResourceInstanceDesired,
-		operands: []AnyResultRef{addr},
+		operands: []AnyResultRef{meta},
 	})
 }
 
@@ -154,13 +175,14 @@ func (b *Builder) ResourceInstancePrior(
 // and the other has a nil priorState. desiredInst and priorState should only
 // both be set when handling an in-place update.
 func (b *Builder) ManagedFinalPlan(
+	metadata ResultRef[*exec.ResourceInstanceObjectMeta],
 	desiredInst ResultRef[*eval.DesiredResourceInstance],
 	priorState ResourceInstanceResultRef,
 	plannedVal ResultRef[cty.Value],
 ) ResultRef[*exec.ManagedResourceObjectFinalPlan] {
 	return operationRef[*exec.ManagedResourceObjectFinalPlan](b, operationDesc{
 		opCode:   opManagedFinalPlan,
-		operands: []AnyResultRef{desiredInst, priorState, plannedVal},
+		operands: []AnyResultRef{metadata, desiredInst, priorState, plannedVal},
 	})
 }
 
@@ -223,6 +245,17 @@ func (b *Builder) ManagedPerformDepose(
 	})
 }
 
+func (b *Builder) ManagedDeposedMeta(
+	instAddr ResultRef[addrs.AbsResourceInstance],
+	deposedKey ResultRef[states.DeposedKey],
+	prior ResourceInstanceResultRef,
+) ResultRef[*exec.ResourceInstanceObjectMeta] {
+	return operationRef[*exec.ResourceInstanceObjectMeta](b, operationDesc{
+		opCode:   opManagedDesposedMeta,
+		operands: []AnyResultRef{instAddr, deposedKey, prior},
+	})
+}
+
 func (b *Builder) ManagedAlreadyDeposed(
 	instAddr ResultRef[addrs.AbsResourceInstance],
 	deposedKey ResultRef[states.DeposedKey],
@@ -244,6 +277,7 @@ func (b *Builder) ManagedChangeAddr(
 }
 
 func (b *Builder) DataRead(
+	metadata ResultRef[*exec.ResourceInstanceObjectMeta],
 	desiredInst ResultRef[*eval.DesiredResourceInstance],
 	plannedVal ResultRef[cty.Value],
 	waitFor AnyResultRef,
@@ -251,7 +285,7 @@ func (b *Builder) DataRead(
 	waiter := b.ensureWaiterRef(waitFor)
 	return operationRef[*exec.ResourceInstanceObject](b, operationDesc{
 		opCode:   opDataRead,
-		operands: []AnyResultRef{desiredInst, plannedVal, waiter},
+		operands: []AnyResultRef{metadata, desiredInst, plannedVal, waiter},
 	})
 }
 

--- a/internal/engine/internal/execgraph/compiler.go
+++ b/internal/engine/internal/execgraph/compiler.go
@@ -102,6 +102,8 @@ func (c *compiler) Compile() (*CompiledGraph, tfdiags.Diagnostics) {
 		operands := newCompilerOperands(opDesc.opCode, c.compileOperands(opDesc.operands))
 		var compileFunc func(operands *compilerOperands) nodeExecuteRaw
 		switch opDesc.opCode {
+		case opResourceInstanceCurrentMeta:
+			compileFunc = c.compileOpResourceInstanceCurrentMeta
 		case opResourceInstanceDesired:
 			compileFunc = c.compileOpResourceInstanceDesired
 		case opResourceInstancePrior:
@@ -114,6 +116,8 @@ func (c *compiler) Compile() (*CompiledGraph, tfdiags.Diagnostics) {
 			compileFunc = c.compileOpManagedPrepareDepose
 		case opManagedPerformDepose:
 			compileFunc = c.compileOpManagedPerformDepose
+		case opManagedDesposedMeta:
+			compileFunc = c.compileOpManagedDeposedMeta
 		case opManagedAlreadyDeposed:
 			compileFunc = c.compileOpManagedAlreadyDeposed
 		case opManagedChangeAddr:

--- a/internal/engine/internal/execgraph/compiler_ops.go
+++ b/internal/engine/internal/execgraph/compiler_ops.go
@@ -20,9 +20,10 @@ import (
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
-func (c *compiler) compileOpResourceInstanceDesired(operands *compilerOperands) nodeExecuteRaw {
+func (c *compiler) compileOpResourceInstanceCurrentMeta(operands *compilerOperands) nodeExecuteRaw {
 	ops := c.ops
 	getInstAddr := nextOperand[addrs.AbsResourceInstance](operands)
+	getPrior := nextOperand[*exec.ResourceInstanceObject](operands)
 	diags := operands.Finish()
 	c.diags = c.diags.Append(diags)
 	if diags.HasErrors() {
@@ -37,8 +38,38 @@ func (c *compiler) compileOpResourceInstanceDesired(operands *compilerOperands) 
 		if !ok {
 			return nil, false, diags
 		}
+		prior, ok, moreDiags := getPrior(ctx)
+		diags = diags.Append(moreDiags)
+		if !ok {
+			return nil, false, diags
+		}
 
-		ret, moreDiags := ops.ResourceInstanceDesired(ctx, instAddr)
+		ret, moreDiags := ops.ResourceInstanceCurrentMeta(ctx, instAddr, prior)
+		diags = diags.Append(moreDiags)
+
+		return ret, !diags.HasErrors(), diags
+	}
+}
+
+func (c *compiler) compileOpResourceInstanceDesired(operands *compilerOperands) nodeExecuteRaw {
+	ops := c.ops
+	getMeta := nextOperand[*exec.ResourceInstanceObjectMeta](operands)
+	diags := operands.Finish()
+	c.diags = c.diags.Append(diags)
+	if diags.HasErrors() {
+		return nil
+	}
+
+	return func(ctx context.Context) (any, bool, tfdiags.Diagnostics) {
+		var diags tfdiags.Diagnostics
+
+		meta, ok, moreDiags := getMeta(ctx)
+		diags = diags.Append(moreDiags)
+		if !ok {
+			return nil, false, diags
+		}
+
+		ret, moreDiags := ops.ResourceInstanceDesired(ctx, meta)
 		diags = diags.Append(moreDiags)
 
 		if ret != nil && ret.ConfigVal.HasMarkDeep(exprs.EvalError) {
@@ -50,7 +81,7 @@ func (c *compiler) compileOpResourceInstanceDesired(operands *compilerOperands) 
 			// expected to be clear from other diagnostics reported upstream,
 			// but just in case that isn't true due to a bug we'll include
 			// a log line to note why we're intentionally halting here.
-			log.Printf("[DEBUG] Cannot finalize desired object for %s because something it depends on encountered an error.", instAddr)
+			log.Printf("[DEBUG] Cannot finalize desired object for %s because something it depends on encountered an error.", meta.Addr)
 			return ret, false, diags
 		}
 
@@ -83,6 +114,7 @@ func (c *compiler) compileOpResourceInstancePrior(operands *compilerOperands) no
 }
 
 func (c *compiler) compileOpManagedFinalPlan(operands *compilerOperands) nodeExecuteRaw {
+	getMetadata := nextOperand[*exec.ResourceInstanceObjectMeta](operands)
 	getDesired := nextOperand[*eval.DesiredResourceInstance](operands)
 	getPrior := nextOperand[*exec.ResourceInstanceObject](operands)
 	getInitialPlanned := nextOperand[cty.Value](operands)
@@ -94,7 +126,15 @@ func (c *compiler) compileOpManagedFinalPlan(operands *compilerOperands) nodeExe
 	ops := c.ops
 
 	return func(ctx context.Context) (any, bool, tfdiags.Diagnostics) {
+		// We intentionally ask for "desired" before "metadata" here, despite
+		// the argument order, because if both of them would fail then we'd
+		// prefer to return the diagnostics from "desired".
 		desired, ok, moreDiags := getDesired(ctx)
+		diags = diags.Append(moreDiags)
+		if !ok {
+			return nil, false, diags
+		}
+		metadata, ok, moreDiags := getMetadata(ctx)
 		diags = diags.Append(moreDiags)
 		if !ok {
 			return nil, false, diags
@@ -110,7 +150,7 @@ func (c *compiler) compileOpManagedFinalPlan(operands *compilerOperands) nodeExe
 			return nil, false, diags
 		}
 
-		ret, moreDiags := ops.ManagedFinalPlan(ctx, desired, prior, initialPlanned)
+		ret, moreDiags := ops.ManagedFinalPlan(ctx, metadata, desired, prior, initialPlanned)
 		diags = diags.Append(moreDiags)
 		return ret, !diags.HasErrors(), diags
 	}
@@ -247,6 +287,43 @@ func (c *compiler) compileOpManagedPerformDepose(operands *compilerOperands) nod
 				diags = diags.Append(fmt.Errorf("opManagedPerformDepose for %s result has wrong instance address %s; this is a bug in OpenTofu", currentObj.Addr.InstanceAddr, ret.Addr.InstanceAddr))
 			}
 		}
+		return ret, !diags.HasErrors(), diags
+	}
+}
+
+func (c *compiler) compileOpManagedDeposedMeta(operands *compilerOperands) nodeExecuteRaw {
+	ops := c.ops
+	getInstAddr := nextOperand[addrs.AbsResourceInstance](operands)
+	getDeposedKey := nextOperand[states.DeposedKey](operands)
+	getPrior := nextOperand[*exec.ResourceInstanceObject](operands)
+	diags := operands.Finish()
+	c.diags = c.diags.Append(diags)
+	if diags.HasErrors() {
+		return nil
+	}
+
+	return func(ctx context.Context) (any, bool, tfdiags.Diagnostics) {
+		var diags tfdiags.Diagnostics
+
+		instAddr, ok, moreDiags := getInstAddr(ctx)
+		diags = diags.Append(moreDiags)
+		if !ok {
+			return nil, false, diags
+		}
+		deposedKey, ok, moreDiags := getDeposedKey(ctx)
+		diags = diags.Append(moreDiags)
+		if !ok {
+			return nil, false, diags
+		}
+		prior, ok, moreDiags := getPrior(ctx)
+		diags = diags.Append(moreDiags)
+		if !ok {
+			return nil, false, diags
+		}
+
+		ret, moreDiags := ops.ManagedDeposedMeta(ctx, instAddr, deposedKey, prior)
+		diags = diags.Append(moreDiags)
+
 		return ret, !diags.HasErrors(), diags
 	}
 }

--- a/internal/engine/internal/execgraph/compiler_test.go
+++ b/internal/engine/internal/execgraph/compiler_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/engine/internal/exec"
 	"github.com/opentofu/opentofu/internal/lang/eval"
+	"github.com/opentofu/opentofu/internal/lang/exprs"
 	"github.com/opentofu/opentofu/internal/lang/grapheval"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
@@ -58,9 +59,11 @@ func TestCompiler_resourceInstanceBasics(t *testing.T) {
 		"name": cty.StringVal("thingy"),
 	}))
 	instAddrResult := builder.ConstantResourceInstAddr(resourceInstAddr)
-	desiredInst := builder.ResourceInstanceDesired(instAddrResult)
 	priorState := builder.ResourceInstancePrior(instAddrResult)
+	metadata := builder.ResourceInstanceCurrentMeta(instAddrResult, priorState)
+	desiredInst := builder.ResourceInstanceDesired(metadata)
 	finalPlan := builder.ManagedFinalPlan(
+		metadata,
 		desiredInst,
 		priorState,
 		initialPlannedValue,
@@ -79,19 +82,29 @@ func TestCompiler_resourceInstanceBasics(t *testing.T) {
 	// focused only on testing the compiler and our ability to execute what
 	// it produces.
 	ops := &mockOperations{
-		ResourceInstanceDesiredFunc: func(ctx context.Context, addr addrs.AbsResourceInstance) (*eval.DesiredResourceInstance, tfdiags.Diagnostics) {
-			if !addr.Equal(resourceInstAddr) {
+		ResourceInstanceCurrentMetaFunc: func(ctx context.Context, instAddr addrs.AbsResourceInstance, prior *exec.ResourceInstanceObject) (*exec.ResourceInstanceObjectMeta, tfdiags.Diagnostics) {
+			if !instAddr.Equal(resourceInstAddr) {
+				return nil, nil
+			}
+			return &exec.ResourceInstanceObjectMeta{
+				Addr:             instAddr.CurrentObject(),
+				ProviderInstance: exprs.Known(providerInstAddr),
+				ResourceType:     instAddr.Resource.Resource.Type,
+			}, nil
+		},
+		ResourceInstanceDesiredFunc: func(ctx context.Context, meta *exec.ResourceInstanceObjectMeta) (*eval.DesiredResourceInstance, tfdiags.Diagnostics) {
+			if !meta.Addr.InstanceAddr.Equal(resourceInstAddr) {
 				return nil, nil
 			}
 			return &eval.DesiredResourceInstance{
-				Addr: addr,
+				Addr: meta.Addr.InstanceAddr,
 				ConfigVal: cty.ObjectVal(map[string]cty.Value{
 					"name": cty.StringVal("thingy"),
 				}),
 				Provider:         providerAddr,
 				ProviderInstance: &providerInstAddr,
 				ResourceMode:     addrs.ManagedResourceMode,
-				ResourceType:     addr.Resource.Resource.Type,
+				ResourceType:     meta.Addr.InstanceAddr.Resource.Resource.Type,
 			}, nil
 		},
 		ResourceInstancePriorFunc: func(ctx context.Context, addr addrs.AbsResourceInstance) (*exec.ResourceInstanceObject, tfdiags.Diagnostics) {
@@ -113,7 +126,7 @@ func TestCompiler_resourceInstanceBasics(t *testing.T) {
 				},
 			}, nil
 		},
-		ManagedFinalPlanFunc: func(ctx context.Context, desired *eval.DesiredResourceInstance, prior *exec.ResourceInstanceObject, plannedVal cty.Value) (*exec.ManagedResourceObjectFinalPlan, tfdiags.Diagnostics) {
+		ManagedFinalPlanFunc: func(ctx context.Context, _ *exec.ResourceInstanceObjectMeta, desired *eval.DesiredResourceInstance, prior *exec.ResourceInstanceObject, plannedVal cty.Value) (*exec.ManagedResourceObjectFinalPlan, tfdiags.Diagnostics) {
 			return &exec.ManagedResourceObjectFinalPlan{
 				Addr:          desired.Addr.CurrentObject(),
 				ResourceType:  desired.ResourceType,
@@ -243,7 +256,11 @@ func TestCompiler_resourceInstanceBasics(t *testing.T) {
 		{
 			MethodName: "ResourceInstanceDesired",
 			Args: []any{
-				resourceInstAddr,
+				&exec.ResourceInstanceObjectMeta{
+					Addr:             resourceInstAddr.CurrentObject(),
+					ProviderInstance: exprs.Known(providerInstAddr),
+					ResourceType:     resourceInstAddr.Resource.Resource.Type,
+				},
 			},
 			Result: &eval.DesiredResourceInstance{
 				Addr:             resourceInstAddr,
@@ -251,6 +268,17 @@ func TestCompiler_resourceInstanceBasics(t *testing.T) {
 				Provider:         providerAddr,
 				ProviderInstance: &providerInstAddr,
 				ResourceMode:     addrs.ManagedResourceMode,
+				ResourceType:     resourceInstAddr.Resource.Resource.Type,
+			},
+		},
+		{
+			MethodName: "ResourceInstanceObjectMeta",
+			Args: []any{
+				resourceInstAddr,
+			},
+			Result: &exec.ResourceInstanceObjectMeta{
+				Addr:             resourceInstAddr.CurrentObject(),
+				ProviderInstance: exprs.Known(providerInstAddr),
 				ResourceType:     resourceInstAddr.Resource.Resource.Type,
 			},
 		},

--- a/internal/engine/internal/execgraph/graph_test.go
+++ b/internal/engine/internal/execgraph/graph_test.go
@@ -68,12 +68,14 @@ func TestGraphMarshalUnmarshalValid(t *testing.T) {
 					Name: "example",
 				}.Absolute(addrs.RootModuleInstance).Instance(addrs.NoKey)
 				instAddrResult := builder.ConstantResourceInstAddr(instAddr)
-				desiredInst := builder.ResourceInstanceDesired(instAddrResult)
 				priorState := builder.ResourceInstancePrior(instAddrResult)
+				meta := builder.ResourceInstanceCurrentMeta(instAddrResult, priorState)
+				desiredInst := builder.ResourceInstanceDesired(meta)
 				plannedVal := builder.ConstantValue(cty.ObjectVal(map[string]cty.Value{
 					"name": cty.StringVal("thingy"),
 				}))
 				finalPlan := builder.ManagedFinalPlan(
+					meta,
 					desiredInst,
 					priorState,
 					plannedVal,
@@ -91,12 +93,13 @@ func TestGraphMarshalUnmarshalValid(t *testing.T) {
 					"name": cty.StringVal("thingy"),
 				});
 
-				r[0] = ResourceInstanceDesired(test.example);
-				r[1] = ResourceInstancePrior(test.example);
-				r[2] = ManagedFinalPlan(r[0], r[1], v[0]);
-				r[3] = ManagedApply(r[2], nil, await());
+				r[0] = ResourceInstancePrior(test.example);
+				r[1] = ResourceInstanceCurrentMeta(test.example, r[0]);
+				r[2] = ResourceInstanceDesired(r[1]);
+				r[3] = ManagedFinalPlan(r[1], r[2], r[0], v[0]);
+				r[4] = ManagedApply(r[3], nil, await());
 
-				test.example = r[3];
+				test.example = r[4];
 			`,
 		},
 		"data resource instance read": {
@@ -109,20 +112,22 @@ func TestGraphMarshalUnmarshalValid(t *testing.T) {
 					Name: "example",
 				}.Absolute(addrs.RootModuleInstance).Instance(addrs.NoKey)
 				instAddrResult := builder.ConstantResourceInstAddr(instAddr)
-				desiredInst := builder.ResourceInstanceDesired(instAddrResult)
+				meta := builder.ResourceInstanceCurrentMeta(instAddrResult, nil)
+				desiredInst := builder.ResourceInstanceDesired(meta)
 
 				plannedVal := builder.ConstantValue(cty.DynamicVal)
-				newState := builder.DataRead(desiredInst, plannedVal, nil)
+				newState := builder.DataRead(meta, desiredInst, plannedVal, nil)
 				builder.SetResourceInstanceFinalStateResult(instAddr, newState)
 				return builder.Finish()
 			},
 			`
 				v[0] = cty.UnknownVal(cty.DynamicPseudoType);
 
-				r[0] = ResourceInstanceDesired(data.test.example);
-				r[1] = DataRead(r[0], v[0], await());
+				r[0] = ResourceInstanceCurrentMeta(data.test.example, nil);
+				r[1] = ResourceInstanceDesired(r[0]);
+				r[2] = DataRead(r[0], r[1], v[0], await());
 
-				data.test.example = r[1];
+				data.test.example = r[2];
 			`,
 		},
 		"data resource instance reads with dependency": {
@@ -139,10 +144,12 @@ func TestGraphMarshalUnmarshalValid(t *testing.T) {
 				}.Absolute(addrs.RootModuleInstance).Instance(addrs.NoKey)
 
 				plannedVal := builder.ConstantValue(cty.DynamicVal)
-				desiredInst1 := builder.ResourceInstanceDesired(builder.ConstantResourceInstAddr(instAddr1))
-				newState1 := builder.DataRead(desiredInst1, plannedVal, nil)
-				desiredInst2 := builder.ResourceInstanceDesired(builder.ConstantResourceInstAddr(instAddr2))
-				newState2 := builder.DataRead(desiredInst2, plannedVal, builder.Waiter(newState1))
+				meta1 := builder.ResourceInstanceCurrentMeta(builder.ConstantResourceInstAddr(instAddr1), nil)
+				desiredInst1 := builder.ResourceInstanceDesired(meta1)
+				newState1 := builder.DataRead(meta1, desiredInst1, plannedVal, nil)
+				meta2 := builder.ResourceInstanceCurrentMeta(builder.ConstantResourceInstAddr(instAddr2), nil)
+				desiredInst2 := builder.ResourceInstanceDesired(meta2)
+				newState2 := builder.DataRead(meta2, desiredInst2, plannedVal, builder.Waiter(newState1))
 				builder.SetResourceInstanceFinalStateResult(instAddr1, newState1)
 				builder.SetResourceInstanceFinalStateResult(instAddr2, newState2)
 				return builder.Finish()
@@ -150,13 +157,15 @@ func TestGraphMarshalUnmarshalValid(t *testing.T) {
 			`
 				v[0] = cty.UnknownVal(cty.DynamicPseudoType);
 
-				r[0] = ResourceInstanceDesired(data.test.example1);
-				r[1] = DataRead(r[0], v[0], await());
-				r[2] = ResourceInstanceDesired(data.test.example2);
-				r[3] = DataRead(r[2], v[0], await(r[1]));
+				r[0] = ResourceInstanceCurrentMeta(data.test.example1, nil);
+				r[1] = ResourceInstanceDesired(r[0]);
+				r[2] = DataRead(r[0], r[1], v[0], await());
+				r[3] = ResourceInstanceCurrentMeta(data.test.example2, nil);
+				r[4] = ResourceInstanceDesired(r[3]);
+				r[5] = DataRead(r[3], r[4], v[0], await(r[2]));
 
-				data.test.example1 = r[1];
-				data.test.example2 = r[3];
+				data.test.example1 = r[2];
+				data.test.example2 = r[5];
 			`,
 		},
 

--- a/internal/engine/internal/execgraph/graph_unmarshal.go
+++ b/internal/engine/internal/execgraph/graph_unmarshal.go
@@ -121,6 +121,8 @@ func UnmarshalGraph(src []byte) (*Graph, error) {
 
 func unmarshalOperationElem(protoOp *execgraphproto.Operation, prevResults []AnyResultRef, builder *Builder) (AnyResultRef, error) {
 	switch c := protoOp.GetOpcode(); opCode(c) {
+	case opResourceInstanceCurrentMeta:
+		return unmarshalOpResourceInstanceCurrentMeta(protoOp.GetOperands(), prevResults, builder)
 	case opResourceInstanceDesired:
 		return unmarshalOpResourceInstanceDesired(protoOp.GetOperands(), prevResults, builder)
 	case opResourceInstancePrior:
@@ -133,6 +135,8 @@ func unmarshalOperationElem(protoOp *execgraphproto.Operation, prevResults []Any
 		return unmarshalOpManagedPrepareDepose(protoOp.GetOperands(), prevResults, builder)
 	case opManagedPerformDepose:
 		return unmarshalOpManagedPerformDepose(protoOp.GetOperands(), prevResults, builder)
+	case opManagedDesposedMeta:
+		return unmarshalOpManagedDeposedMeta(protoOp.GetOperands(), prevResults, builder)
 	case opManagedAlreadyDeposed:
 		return unmarshalOpManagedAlreadyDeposed(protoOp.GetOperands(), prevResults, builder)
 	case opManagedChangeAddr:
@@ -147,15 +151,30 @@ func unmarshalOperationElem(protoOp *execgraphproto.Operation, prevResults []Any
 	}
 }
 
+func unmarshalOpResourceInstanceCurrentMeta(rawOperands []uint64, prevResults []AnyResultRef, builder *Builder) (AnyResultRef, error) {
+	if len(rawOperands) != 2 {
+		return nil, fmt.Errorf("wrong number of operands (%d) for opResourceInstanceCurrentMeta", len(rawOperands))
+	}
+	instAddr, err := unmarshalGetPrevResultOf[addrs.AbsResourceInstance](prevResults, rawOperands[0])
+	if err != nil {
+		return nil, fmt.Errorf("invalid opResourceInstanceCurrentMeta instAddr: %w", err)
+	}
+	prior, err := unmarshalGetPrevResultOf[*exec.ResourceInstanceObject](prevResults, rawOperands[1])
+	if err != nil {
+		return nil, fmt.Errorf("invalid opResourceInstanceCurrentMeta prior: %w", err)
+	}
+	return builder.ResourceInstanceCurrentMeta(instAddr, prior), nil
+}
+
 func unmarshalOpResourceInstanceDesired(rawOperands []uint64, prevResults []AnyResultRef, builder *Builder) (AnyResultRef, error) {
 	if len(rawOperands) != 1 {
 		return nil, fmt.Errorf("wrong number of operands (%d) for opResourceInstanceDesired", len(rawOperands))
 	}
-	addr, err := unmarshalGetPrevResultOf[addrs.AbsResourceInstance](prevResults, rawOperands[0])
+	meta, err := unmarshalGetPrevResultOf[*exec.ResourceInstanceObjectMeta](prevResults, rawOperands[0])
 	if err != nil {
-		return nil, fmt.Errorf("invalid opResourceInstanceDesired addr: %w", err)
+		return nil, fmt.Errorf("invalid opResourceInstanceDesired meta: %w", err)
 	}
-	return builder.ResourceInstanceDesired(addr), nil
+	return builder.ResourceInstanceDesired(meta), nil
 }
 
 func unmarshalOpResourceInstancePrior(rawOperands []uint64, prevResults []AnyResultRef, builder *Builder) (AnyResultRef, error) {
@@ -170,22 +189,26 @@ func unmarshalOpResourceInstancePrior(rawOperands []uint64, prevResults []AnyRes
 }
 
 func unmarshalOpManagedFinalPlan(rawOperands []uint64, prevResults []AnyResultRef, builder *Builder) (AnyResultRef, error) {
-	if len(rawOperands) != 3 {
+	if len(rawOperands) != 4 {
 		return nil, fmt.Errorf("wrong number of operands (%d) for opManagedFinalPlan", len(rawOperands))
 	}
-	desiredInst, err := unmarshalGetPrevResultOf[*eval.DesiredResourceInstance](prevResults, rawOperands[0])
+	metadata, err := unmarshalGetPrevResultOf[*exec.ResourceInstanceObjectMeta](prevResults, rawOperands[0])
+	if err != nil {
+		return nil, fmt.Errorf("invalid opManagedFinalPlan metadata: %w", err)
+	}
+	desiredInst, err := unmarshalGetPrevResultOf[*eval.DesiredResourceInstance](prevResults, rawOperands[1])
 	if err != nil {
 		return nil, fmt.Errorf("invalid opManagedFinalPlan desiredInst: %w", err)
 	}
-	priorState, err := unmarshalGetPrevResultOf[*exec.ResourceInstanceObject](prevResults, rawOperands[1])
+	priorState, err := unmarshalGetPrevResultOf[*exec.ResourceInstanceObject](prevResults, rawOperands[2])
 	if err != nil {
 		return nil, fmt.Errorf("invalid opManagedFinalPlan priorState: %w", err)
 	}
-	plannedVal, err := unmarshalGetPrevResultOf[cty.Value](prevResults, rawOperands[2])
+	plannedVal, err := unmarshalGetPrevResultOf[cty.Value](prevResults, rawOperands[3])
 	if err != nil {
 		return nil, fmt.Errorf("invalid opManagedFinalPlan plannedVal: %w", err)
 	}
-	return builder.ManagedFinalPlan(desiredInst, priorState, plannedVal), nil
+	return builder.ManagedFinalPlan(metadata, desiredInst, priorState, plannedVal), nil
 }
 
 func unmarshalOpManagedApply(rawOperands []uint64, prevResults []AnyResultRef, builder *Builder) (AnyResultRef, error) {
@@ -241,6 +264,25 @@ func unmarshalOpManagedPerformDepose(rawOperands []uint64, prevResults []AnyResu
 	return builder.ManagedPerformDepose(currentObj, finalDeletePlan, waitFor), nil
 }
 
+func unmarshalOpManagedDeposedMeta(rawOperands []uint64, prevResults []AnyResultRef, builder *Builder) (AnyResultRef, error) {
+	if len(rawOperands) != 3 {
+		return nil, fmt.Errorf("wrong number of operands (%d) for unmarshalOpManagedDeposedMeta", len(rawOperands))
+	}
+	instAddr, err := unmarshalGetPrevResultOf[addrs.AbsResourceInstance](prevResults, rawOperands[0])
+	if err != nil {
+		return nil, fmt.Errorf("invalid unmarshalOpManagedDeposedMeta instAddr: %w", err)
+	}
+	deposedKey, err := unmarshalGetPrevResultOf[states.DeposedKey](prevResults, rawOperands[1])
+	if err != nil {
+		return nil, fmt.Errorf("invalid unmarshalOpManagedDeposedMeta deposedKey: %w", err)
+	}
+	prior, err := unmarshalGetPrevResultOf[*exec.ResourceInstanceObject](prevResults, rawOperands[2])
+	if err != nil {
+		return nil, fmt.Errorf("invalid unmarshalOpManagedDeposedMeta prior: %w", err)
+	}
+	return builder.ManagedDeposedMeta(instAddr, deposedKey, prior), nil
+}
+
 func unmarshalOpManagedAlreadyDeposed(rawOperands []uint64, prevResults []AnyResultRef, builder *Builder) (AnyResultRef, error) {
 	if len(rawOperands) != 2 {
 		return nil, fmt.Errorf("wrong number of operands (%d) for opManagedAlreadyDeposed", len(rawOperands))
@@ -272,22 +314,26 @@ func unmarshalOpManagedChangeAddr(rawOperands []uint64, prevResults []AnyResultR
 }
 
 func unmarshalOpDataRead(rawOperands []uint64, prevResults []AnyResultRef, builder *Builder) (AnyResultRef, error) {
-	if len(rawOperands) != 3 {
+	if len(rawOperands) != 4 {
 		return nil, fmt.Errorf("wrong number of operands (%d) for opDataRead", len(rawOperands))
 	}
-	desiredInst, err := unmarshalGetPrevResultOf[*eval.DesiredResourceInstance](prevResults, rawOperands[0])
+	metadata, err := unmarshalGetPrevResultOf[*exec.ResourceInstanceObjectMeta](prevResults, rawOperands[0])
+	if err != nil {
+		return nil, fmt.Errorf("invalid opDataRead metadata: %w", err)
+	}
+	desiredInst, err := unmarshalGetPrevResultOf[*eval.DesiredResourceInstance](prevResults, rawOperands[1])
 	if err != nil {
 		return nil, fmt.Errorf("invalid opDataRead desiredInst: %w", err)
 	}
-	plannedVal, err := unmarshalGetPrevResultOf[cty.Value](prevResults, rawOperands[1])
+	plannedVal, err := unmarshalGetPrevResultOf[cty.Value](prevResults, rawOperands[2])
 	if err != nil {
 		return nil, fmt.Errorf("invalid opDataRead plannedVal: %w", err)
 	}
-	waitFor, err := unmarshalGetPrevResultWaiter(prevResults, rawOperands[2])
+	waitFor, err := unmarshalGetPrevResultWaiter(prevResults, rawOperands[3])
 	if err != nil {
 		return nil, fmt.Errorf("invalid opDataRead waitFor: %w", err)
 	}
-	return builder.DataRead(desiredInst, plannedVal, waitFor), nil
+	return builder.DataRead(metadata, desiredInst, plannedVal, waitFor), nil
 }
 
 func unmarshalWaiterElem(protoWaiter *execgraphproto.Waiter, prevResults []AnyResultRef, builder *Builder) (AnyResultRef, error) {

--- a/internal/engine/internal/execgraph/opcode_string.go
+++ b/internal/engine/internal/execgraph/opcode_string.go
@@ -8,20 +8,22 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
-	_ = x[opResourceInstanceDesired-1]
-	_ = x[opResourceInstancePrior-2]
-	_ = x[opManagedFinalPlan-3]
-	_ = x[opManagedApply-4]
-	_ = x[opManagedPrepareDepose-5]
-	_ = x[opManagedPerformDepose-6]
-	_ = x[opManagedAlreadyDeposed-7]
-	_ = x[opManagedChangeAddr-8]
-	_ = x[opDataRead-9]
+	_ = x[opResourceInstanceCurrentMeta-1]
+	_ = x[opResourceInstanceDesired-2]
+	_ = x[opResourceInstancePrior-3]
+	_ = x[opManagedFinalPlan-4]
+	_ = x[opManagedApply-5]
+	_ = x[opManagedPrepareDepose-6]
+	_ = x[opManagedPerformDepose-7]
+	_ = x[opManagedDesposedMeta-8]
+	_ = x[opManagedAlreadyDeposed-9]
+	_ = x[opManagedChangeAddr-10]
+	_ = x[opDataRead-11]
 }
 
-const _opCode_name = "opResourceInstanceDesiredopResourceInstancePrioropManagedFinalPlanopManagedApplyopManagedPrepareDeposeopManagedPerformDeposeopManagedAlreadyDeposedopManagedChangeAddropDataRead"
+const _opCode_name = "opResourceInstanceCurrentMetaopResourceInstanceDesiredopResourceInstancePrioropManagedFinalPlanopManagedApplyopManagedPrepareDeposeopManagedPerformDeposeopManagedDesposedMetaopManagedAlreadyDeposedopManagedChangeAddropDataRead"
 
-var _opCode_index = [...]uint8{0, 25, 48, 66, 80, 102, 124, 147, 166, 176}
+var _opCode_index = [...]uint8{0, 29, 54, 77, 95, 109, 131, 153, 174, 197, 216, 226}
 
 func (i opCode) String() string {
 	idx := int(i) - 1

--- a/internal/engine/internal/execgraph/operation.go
+++ b/internal/engine/internal/execgraph/operation.go
@@ -25,6 +25,7 @@ type opCode int
 const (
 	_ = opCode(iota) // the zero value is not a valid operation
 
+	opResourceInstanceCurrentMeta
 	opResourceInstanceDesired
 	opResourceInstancePrior
 
@@ -32,6 +33,7 @@ const (
 	opManagedApply
 	opManagedPrepareDepose
 	opManagedPerformDepose
+	opManagedDesposedMeta
 	opManagedAlreadyDeposed
 	opManagedChangeAddr
 

--- a/internal/engine/internal/execgraph/operations_test.go
+++ b/internal/engine/internal/execgraph/operations_test.go
@@ -26,11 +26,11 @@ type mockOperations struct {
 	ManagedAlreadyDeposedFunc          func(ctx context.Context, instAddr addrs.AbsResourceInstance, deposedKey states.DeposedKey) (*exec.ResourceInstanceObject, tfdiags.Diagnostics)
 	ManagedApplyFunc                   func(ctx context.Context, plan *exec.ManagedResourceObjectFinalPlan, fallback *exec.ResourceInstanceObject) (*exec.ResourceInstanceObject, tfdiags.Diagnostics)
 	ManagedChangeAddrFunc              func(ctx context.Context, currentObj *exec.ResourceInstanceObject, newAddr addrs.AbsResourceInstance) (*exec.ResourceInstanceObject, tfdiags.Diagnostics)
-	ManagedDeposedMetaFunc             func(ctx context.Context, instAddr addrs.AbsResourceInstance, deposedKey states.DeposedKey) (*exec.ResourceInstanceObjectMeta, tfdiags.Diagnostics)
+	ManagedDeposedMetaFunc             func(ctx context.Context, instAddr addrs.AbsResourceInstance, deposedKey states.DeposedKey, prior *exec.ResourceInstanceObject) (*exec.ResourceInstanceObjectMeta, tfdiags.Diagnostics)
 	ManagedPerformDeposeFunc           func(ctx context.Context, currentObj *exec.ResourceInstanceObject, deletePlan *exec.ManagedResourceObjectFinalPlan) (*exec.ResourceInstanceObject, tfdiags.Diagnostics)
-	ManagedFinalPlanFunc               func(ctx context.Context, desired *eval.DesiredResourceInstance, prior *exec.ResourceInstanceObject, plannedVal cty.Value) (*exec.ManagedResourceObjectFinalPlan, tfdiags.Diagnostics)
-	ResourceInstanceDesiredFunc        func(ctx context.Context, instAddr addrs.AbsResourceInstance) (*eval.DesiredResourceInstance, tfdiags.Diagnostics)
-	ResourceInstanceCurrentMetaFunc    func(ctx context.Context, instAddr addrs.AbsResourceInstance) (*exec.ResourceInstanceObjectMeta, tfdiags.Diagnostics)
+	ManagedFinalPlanFunc               func(ctx context.Context, metadata *exec.ResourceInstanceObjectMeta, desired *eval.DesiredResourceInstance, prior *exec.ResourceInstanceObject, plannedVal cty.Value) (*exec.ManagedResourceObjectFinalPlan, tfdiags.Diagnostics)
+	ResourceInstanceDesiredFunc        func(ctx context.Context, meta *exec.ResourceInstanceObjectMeta) (*eval.DesiredResourceInstance, tfdiags.Diagnostics)
+	ResourceInstanceCurrentMetaFunc    func(ctx context.Context, instAddr addrs.AbsResourceInstance, prior *exec.ResourceInstanceObject) (*exec.ResourceInstanceObjectMeta, tfdiags.Diagnostics)
 	ResourceInstancePostconditionsFunc func(ctx context.Context, result *exec.ResourceInstanceObject) tfdiags.Diagnostics
 	ResourceInstancePriorFunc          func(ctx context.Context, instAddr addrs.AbsResourceInstance) (*exec.ResourceInstanceObject, tfdiags.Diagnostics)
 
@@ -84,11 +84,11 @@ func (m *mockOperations) ManagedChangeAddr(ctx context.Context, currentObj *exec
 }
 
 // ManagedDeposedMeta implements [exec.Operations].
-func (m *mockOperations) ManagedDeposedMeta(ctx context.Context, instAddr addrs.AbsResourceInstance, deposedKey states.DeposedKey) (*exec.ResourceInstanceObjectMeta, tfdiags.Diagnostics) {
+func (m *mockOperations) ManagedDeposedMeta(ctx context.Context, instAddr addrs.AbsResourceInstance, deposedKey states.DeposedKey, prior *exec.ResourceInstanceObject) (*exec.ResourceInstanceObjectMeta, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	var result *exec.ResourceInstanceObjectMeta
-	if m.ManagedChangeAddrFunc != nil {
-		result, diags = m.ManagedDeposedMetaFunc(ctx, instAddr, deposedKey)
+	if m.ManagedDeposedMetaFunc != nil {
+		result, diags = m.ManagedDeposedMetaFunc(ctx, instAddr, deposedKey, prior)
 	}
 	m.appendLog("ManagedDeposedMeta", []any{instAddr, deposedKey}, result)
 	return result, diags
@@ -106,33 +106,33 @@ func (m *mockOperations) ManagedPerformDepose(ctx context.Context, currentObj *e
 }
 
 // ManagedFinalPlan implements [exec.Operations].
-func (m *mockOperations) ManagedFinalPlan(ctx context.Context, desired *eval.DesiredResourceInstance, prior *exec.ResourceInstanceObject, plannedVal cty.Value) (*exec.ManagedResourceObjectFinalPlan, tfdiags.Diagnostics) {
+func (m *mockOperations) ManagedFinalPlan(ctx context.Context, metadata *exec.ResourceInstanceObjectMeta, desired *eval.DesiredResourceInstance, prior *exec.ResourceInstanceObject, plannedVal cty.Value) (*exec.ManagedResourceObjectFinalPlan, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	var result *exec.ManagedResourceObjectFinalPlan
 	if m.ManagedFinalPlanFunc != nil {
-		result, diags = m.ManagedFinalPlanFunc(ctx, desired, prior, plannedVal)
+		result, diags = m.ManagedFinalPlanFunc(ctx, metadata, desired, prior, plannedVal)
 	}
 	m.appendLog("ManagedFinalPlan", []any{desired, prior, plannedVal}, result)
 	return result, diags
 }
 
 // ResourceInstanceDesired implements [exec.Operations].
-func (m *mockOperations) ResourceInstanceDesired(ctx context.Context, instAddr addrs.AbsResourceInstance) (*eval.DesiredResourceInstance, tfdiags.Diagnostics) {
+func (m *mockOperations) ResourceInstanceDesired(ctx context.Context, meta *exec.ResourceInstanceObjectMeta) (*eval.DesiredResourceInstance, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	var result *eval.DesiredResourceInstance
 	if m.ResourceInstanceDesiredFunc != nil {
-		result, diags = m.ResourceInstanceDesiredFunc(ctx, instAddr)
+		result, diags = m.ResourceInstanceDesiredFunc(ctx, meta)
 	}
-	m.appendLog("ResourceInstanceDesired", []any{instAddr}, result)
+	m.appendLog("ResourceInstanceDesired", []any{meta}, result)
 	return result, diags
 }
 
 // ResourceInstanceCurrentMeta implements [exec.Operations].
-func (m *mockOperations) ResourceInstanceCurrentMeta(ctx context.Context, instAddr addrs.AbsResourceInstance) (*exec.ResourceInstanceObjectMeta, tfdiags.Diagnostics) {
+func (m *mockOperations) ResourceInstanceCurrentMeta(ctx context.Context, instAddr addrs.AbsResourceInstance, prior *exec.ResourceInstanceObject) (*exec.ResourceInstanceObjectMeta, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 	var result *exec.ResourceInstanceObjectMeta
-	if m.ResourceInstanceDesiredFunc != nil {
-		result, diags = m.ResourceInstanceCurrentMetaFunc(ctx, instAddr)
+	if m.ResourceInstanceCurrentMetaFunc != nil {
+		result, diags = m.ResourceInstanceCurrentMetaFunc(ctx, instAddr, prior)
 	}
 	m.appendLog("ResourceInstanceObjectMeta", []any{instAddr}, result)
 	return result, diags

--- a/internal/engine/internal/execgraph/operations_test.go
+++ b/internal/engine/internal/execgraph/operations_test.go
@@ -26,9 +26,11 @@ type mockOperations struct {
 	ManagedAlreadyDeposedFunc          func(ctx context.Context, instAddr addrs.AbsResourceInstance, deposedKey states.DeposedKey) (*exec.ResourceInstanceObject, tfdiags.Diagnostics)
 	ManagedApplyFunc                   func(ctx context.Context, plan *exec.ManagedResourceObjectFinalPlan, fallback *exec.ResourceInstanceObject) (*exec.ResourceInstanceObject, tfdiags.Diagnostics)
 	ManagedChangeAddrFunc              func(ctx context.Context, currentObj *exec.ResourceInstanceObject, newAddr addrs.AbsResourceInstance) (*exec.ResourceInstanceObject, tfdiags.Diagnostics)
+	ManagedDeposedMetaFunc             func(ctx context.Context, instAddr addrs.AbsResourceInstance, deposedKey states.DeposedKey) (*exec.ResourceInstanceObjectMeta, tfdiags.Diagnostics)
 	ManagedPerformDeposeFunc           func(ctx context.Context, currentObj *exec.ResourceInstanceObject, deletePlan *exec.ManagedResourceObjectFinalPlan) (*exec.ResourceInstanceObject, tfdiags.Diagnostics)
 	ManagedFinalPlanFunc               func(ctx context.Context, desired *eval.DesiredResourceInstance, prior *exec.ResourceInstanceObject, plannedVal cty.Value) (*exec.ManagedResourceObjectFinalPlan, tfdiags.Diagnostics)
 	ResourceInstanceDesiredFunc        func(ctx context.Context, instAddr addrs.AbsResourceInstance) (*eval.DesiredResourceInstance, tfdiags.Diagnostics)
+	ResourceInstanceCurrentMetaFunc    func(ctx context.Context, instAddr addrs.AbsResourceInstance) (*exec.ResourceInstanceObjectMeta, tfdiags.Diagnostics)
 	ResourceInstancePostconditionsFunc func(ctx context.Context, result *exec.ResourceInstanceObject) tfdiags.Diagnostics
 	ResourceInstancePriorFunc          func(ctx context.Context, instAddr addrs.AbsResourceInstance) (*exec.ResourceInstanceObject, tfdiags.Diagnostics)
 
@@ -81,6 +83,17 @@ func (m *mockOperations) ManagedChangeAddr(ctx context.Context, currentObj *exec
 	return result, diags
 }
 
+// ManagedDeposedMeta implements [exec.Operations].
+func (m *mockOperations) ManagedDeposedMeta(ctx context.Context, instAddr addrs.AbsResourceInstance, deposedKey states.DeposedKey) (*exec.ResourceInstanceObjectMeta, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	var result *exec.ResourceInstanceObjectMeta
+	if m.ManagedChangeAddrFunc != nil {
+		result, diags = m.ManagedDeposedMetaFunc(ctx, instAddr, deposedKey)
+	}
+	m.appendLog("ManagedDeposedMeta", []any{instAddr, deposedKey}, result)
+	return result, diags
+}
+
 // ManagedPerformDepose implements [exec.Operations].
 func (m *mockOperations) ManagedPerformDepose(ctx context.Context, currentObj *exec.ResourceInstanceObject, deletePlan *exec.ManagedResourceObjectFinalPlan) (*exec.ResourceInstanceObject, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
@@ -111,6 +124,17 @@ func (m *mockOperations) ResourceInstanceDesired(ctx context.Context, instAddr a
 		result, diags = m.ResourceInstanceDesiredFunc(ctx, instAddr)
 	}
 	m.appendLog("ResourceInstanceDesired", []any{instAddr}, result)
+	return result, diags
+}
+
+// ResourceInstanceCurrentMeta implements [exec.Operations].
+func (m *mockOperations) ResourceInstanceCurrentMeta(ctx context.Context, instAddr addrs.AbsResourceInstance) (*exec.ResourceInstanceObjectMeta, tfdiags.Diagnostics) {
+	var diags tfdiags.Diagnostics
+	var result *exec.ResourceInstanceObjectMeta
+	if m.ResourceInstanceDesiredFunc != nil {
+		result, diags = m.ResourceInstanceCurrentMetaFunc(ctx, instAddr)
+	}
+	m.appendLog("ResourceInstanceObjectMeta", []any{instAddr}, result)
 	return result, diags
 }
 

--- a/internal/engine/planning/execgraph_managed.go
+++ b/internal/engine/planning/execgraph_managed.go
@@ -61,10 +61,8 @@ func (b *execGraphBuilder) ManagedResourceInstanceSubgraph(
 	// The shape of execution subgraph we generate here varies depending on
 	// which change action was planned.
 	switch changeAction {
-	case plans.Create:
-		return b.managedResourceInstanceSubgraphCreate(plannedChange)
-	case plans.Update:
-		return b.managedResourceInstanceSubgraphUpdate(plannedChange)
+	case plans.Create, plans.Update:
+		return b.managedResourceInstanceSubgraphCreateOrUpdate(plannedChange)
 	case plans.Delete:
 		return b.managedResourceInstanceSubgraphDelete(plannedChange)
 	case plans.Forget:
@@ -86,37 +84,21 @@ func (b *execGraphBuilder) ManagedResourceInstanceSubgraph(
 	}
 }
 
-func (b *execGraphBuilder) managedResourceInstanceSubgraphCreate(
+func (b *execGraphBuilder) managedResourceInstanceSubgraphCreateOrUpdate(
 	plannedChange *plans.ResourceInstanceChange,
 ) resourceInstanceObjectSubgraph {
-	instAddrRef, _ := b.managedResourceInstanceChangeAddrAndPriorStateRefs(plannedChange)
-	// Per the conventions in the old engine, After contains a marked value
-	unmarkedAfter, _ := plannedChange.After.UnmarkDeep()
-	plannedValRef := b.lower.ConstantValue(unmarkedAfter)
-	desiredInstRef := b.lower.ResourceInstanceDesired(instAddrRef)
-	valueRef, addDesiredDep := b.managedResourceInstanceSubgraphPlanAndApply(
-		desiredInstRef,
-		execgraph.NilResultRef[*exec.ResourceInstanceObject](),
-		plannedValRef,
+	metadataRef, desiredRef, priorRef, plannedValueRef := b.managedResourceInstanceChangeInputs(plannedChange)
+	finalPlanRef := b.lower.ManagedFinalPlan(
+		metadataRef,
+		desiredRef,
+		priorRef,
+		plannedValueRef,
 	)
-	return resourceInstanceObjectSubgraph{
-		valueRef:      valueRef,
-		addDesiredDep: addDesiredDep,
-	}
-}
-
-func (b *execGraphBuilder) managedResourceInstanceSubgraphUpdate(
-	plannedChange *plans.ResourceInstanceChange,
-) resourceInstanceObjectSubgraph {
-	instAddrRef, priorStateRef := b.managedResourceInstanceChangeAddrAndPriorStateRefs(plannedChange)
-	// Per the conventions in the old engine, After contains a marked value
-	unmarkedAfter, _ := plannedChange.After.UnmarkDeep()
-	plannedValRef := b.lower.ConstantValue(unmarkedAfter)
-	desiredInstRef := b.lower.ResourceInstanceDesired(instAddrRef)
-	valueRef, addDesiredDep := b.managedResourceInstanceSubgraphPlanAndApply(
-		desiredInstRef,
-		priorStateRef,
-		plannedValRef,
+	waitFor, addDesiredDep := b.lower.MutableWaiter()
+	valueRef := b.lower.ManagedApply(
+		finalPlanRef,
+		execgraph.NilResultRef[*exec.ResourceInstanceObject](),
+		waitFor,
 	)
 	return resourceInstanceObjectSubgraph{
 		valueRef:      valueRef,
@@ -127,15 +109,13 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphUpdate(
 func (b *execGraphBuilder) managedResourceInstanceSubgraphDelete(
 	plannedChange *plans.ResourceInstanceChange,
 ) resourceInstanceObjectSubgraph {
-	_, priorStateRef := b.managedResourceInstanceChangeAddrAndPriorStateRefs(plannedChange)
-	// Per the conventions in the old engine, After contains a marked value
-	unmarkedAfter, _ := plannedChange.After.UnmarkDeep()
-	plannedValRef := b.lower.ConstantValue(unmarkedAfter)
+	metadataRef, desiredRef, priorRef, plannedValueRef := b.managedResourceInstanceChangeInputs(plannedChange)
 	waitFor, addDeleteDep := b.lower.MutableWaiter()
 	finalPlanRef := b.lower.ManagedFinalPlan(
-		execgraph.NilResultRef[*eval.DesiredResourceInstance](),
-		priorStateRef,
-		plannedValRef,
+		metadataRef,
+		desiredRef, // always produces nil in this case
+		priorRef,
+		plannedValueRef,
 	)
 	deletionRef := b.lower.ManagedApply(
 		finalPlanRef,
@@ -150,7 +130,7 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphDelete(
 		// to refer to an object being deleted in that case, so that ephemeral
 		// objects like provider instances can configure themselves based on
 		// the prior state before the object is deleted.
-		valueRef:     priorStateRef,
+		valueRef:     priorRef,
 		deletionRef:  deletionRef,
 		addOrphanDep: addDeleteDep,
 	}
@@ -180,24 +160,22 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphDeleteOrForgetThenCrea
 	// actions chained together, but we arrange the operations in such a
 	// way that the delete leg can't start unless the desired state is
 	// successfully evaluated.
-	instAddrRef, priorStateRef := b.managedResourceInstanceChangeAddrAndPriorStateRefs(plannedChange)
-	// Per the conventions in the old engine, After contains a marked value
-	unmarkedAfter, _ := plannedChange.After.UnmarkDeep()
-	plannedValRef := b.lower.ConstantValue(unmarkedAfter)
-	desiredInstRef := b.lower.ResourceInstanceDesired(instAddrRef)
+	metadataRef, desiredRef, priorRef, plannedValueRef := b.managedResourceInstanceChangeInputs(plannedChange)
 
 	// We plan both the create and destroy parts of this process before we
 	// make any real changes, to reduce the risk that we'll be left in a
 	// partially-applied state where neither object exists. (Though of course
 	// that's always possible, if the "create" step fails at apply.)
 	createPlanRef := b.lower.ManagedFinalPlan(
-		desiredInstRef,
+		metadataRef,
+		desiredRef,
 		execgraph.NilResultRef[*exec.ResourceInstanceObject](),
-		plannedValRef,
+		plannedValueRef,
 	)
 	destroyPlanRef := b.lower.ManagedFinalPlan(
+		metadataRef,
 		execgraph.NilResultRef[*eval.DesiredResourceInstance](),
-		priorStateRef,
+		priorRef,
 		b.lower.ConstantValue(cty.NullVal(
 			// TODO: is this okay or do we need to use the type constraint derived from the schema?
 			// The two could differ for resource types that have cty.DynamicPseudoType
@@ -235,28 +213,26 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphCreateThenDelete(
 	desiredWaitFor, addCreateDep := b.lower.MutableWaiter()
 	deleteWaitFor, addDeleteDep := b.lower.MutableWaiter()
 
-	// This has much the same effect as the separate delete and create
+	// This has much the same effect as the separate create and delete
 	// actions chained together, but we arrange the operations in such a
 	// way that we don't make any changes unless we can produce valid final
 	// plans for both changes.
-	instAddrRef, priorStateRef := b.managedResourceInstanceChangeAddrAndPriorStateRefs(plannedChange)
-	// Per the conventions in the old engine, After contains a marked value
-	unmarkedAfter, _ := plannedChange.After.UnmarkDeep()
-	plannedValRef := b.lower.ConstantValue(unmarkedAfter)
-	desiredInstRef := b.lower.ResourceInstanceDesired(instAddrRef)
+	metadataRef, desiredRef, priorRef, plannedValueRef := b.managedResourceInstanceChangeInputs(plannedChange)
 
 	// We plan both the create and destroy parts of this process before we
 	// make any real changes, to reduce the risk that we'll be left in a
 	// partially-applied state where we're left with a deposed object present
 	// in the final state.
 	createPlanRef := b.lower.ManagedFinalPlan(
-		desiredInstRef,
+		metadataRef,
+		desiredRef,
 		execgraph.NilResultRef[*exec.ResourceInstanceObject](),
-		plannedValRef,
+		plannedValueRef,
 	)
 	destroyPlanRef := b.lower.ManagedFinalPlan(
+		metadataRef,
 		execgraph.NilResultRef[*eval.DesiredResourceInstance](),
-		priorStateRef,
+		priorRef,
 		b.lower.ConstantValue(cty.NullVal(
 			// TODO: is this okay or do we need to use the type constraint derived from the schema?
 			// The two could differ for resource types that have cty.DynamicPseudoType
@@ -282,7 +258,7 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphCreateThenDelete(
 	// dependencies that ManagedPerformDepose does not also have.
 	addCreateDep(createPlanRef) // don't depose unless we successfully create a plan
 	deposedObjRef := b.lower.ManagedPerformDepose(
-		priorStateRef,
+		priorRef,
 		destroyPlanRef,
 		desiredWaitFor,
 	)
@@ -314,61 +290,60 @@ func (b *execGraphBuilder) managedResourceInstanceSubgraphCreateThenDelete(
 	}
 }
 
-// managedResourceInstanceSubgraphPlanAndApply deals with the simple case
-// of "create a final plan and then apply it" that is shared between "create"
-// and "update", but not for deleting or for the more complicated ones involving
-// multiple primitive actions that need to be carefully coordinated with each
-// other.
-func (b *execGraphBuilder) managedResourceInstanceSubgraphPlanAndApply(
-	desiredInstRef execgraph.ResultRef[*eval.DesiredResourceInstance],
-	priorStateRef execgraph.ResourceInstanceResultRef,
-	plannedValRef execgraph.ResultRef[cty.Value],
-) (
-	resultRef execgraph.ResourceInstanceResultRef,
-	addApplyDep func(execgraph.AnyResultRef),
-) {
-	finalPlanRef := b.lower.ManagedFinalPlan(
-		desiredInstRef,
-		priorStateRef,
-		plannedValRef,
-	)
-	waitFor, addApplyDep := b.lower.MutableWaiter()
-	return b.lower.ManagedApply(
-		finalPlanRef,
-		execgraph.NilResultRef[*exec.ResourceInstanceObject](),
-		waitFor,
-	), addApplyDep
-}
-
-func (b *execGraphBuilder) managedResourceInstanceChangeAddrAndPriorStateRefs(
+// managedResourceInstanceChangeInputs adds to the graph the operations needed
+// to obtain the metadata, desired object, and prior object needed to
+// perform the given resource instance change during the apply phase.
+//
+// The "metadata" result always provides a non-nil value if it succeeds. The
+// "desired" and "prior" results may each produce a nil value depending on
+// the action specified in the resource instance change.
+func (b *execGraphBuilder) managedResourceInstanceChangeInputs(
 	plannedChange *plans.ResourceInstanceChange,
 ) (
-	newAddr execgraph.ResultRef[addrs.AbsResourceInstance],
-	priorState execgraph.ResourceInstanceResultRef,
+	metadata execgraph.ResultRef[*exec.ResourceInstanceObjectMeta],
+	desired execgraph.ResultRef[*eval.DesiredResourceInstance],
+	prior execgraph.ResourceInstanceResultRef,
+	plannedValue execgraph.ResultRef[cty.Value],
 ) {
-	if plannedChange.Action == plans.Create {
-		// For a create change there is no prior state at all, but we still
-		// need the new instance address.
-		newAddrRef := b.lower.ConstantResourceInstAddr(plannedChange.Addr)
-		return newAddrRef, execgraph.NilResultRef[*exec.ResourceInstanceObject]()
-	}
+	unmarkedAfter, _ := plannedChange.After.UnmarkDeep()
+	plannedValue = b.lower.ConstantValue(unmarkedAfter)
 	if plannedChange.DeposedKey != states.NotDeposed {
-		// We need to use a different operation to access deposed objects.
+		// We use different operations to access deposed objects.
+		if plannedChange.Action != plans.Delete {
+			// Delete is the only reasonable action for a deposed object.
+			panic(fmt.Sprintf("cannot perform %s on %s", plannedChange.Action, plannedChange.PrevRunAddr))
+		}
 		prevAddrRef := b.lower.ConstantResourceInstAddr(plannedChange.PrevRunAddr)
 		dkRef := b.lower.ConstantDeposedKey(plannedChange.DeposedKey)
-		stateRef := b.lower.ManagedAlreadyDeposed(prevAddrRef, dkRef)
-		return execgraph.NilResultRef[addrs.AbsResourceInstance](), stateRef
+		prior = b.lower.ManagedAlreadyDeposed(prevAddrRef, dkRef)
+		metadata = b.lower.ManagedDeposedMeta(prevAddrRef, dkRef, prior)
+		return metadata, execgraph.NilResultRef[*eval.DesiredResourceInstance](), prior, plannedValue
 	}
-	prevAddrRef := b.lower.ConstantResourceInstAddr(plannedChange.PrevRunAddr)
-	priorStateRef := b.lower.ResourceInstancePrior(prevAddrRef)
-	retAddrRef := prevAddrRef
-	retStateRef := priorStateRef
-	if !plannedChange.PrevRunAddr.Equal(plannedChange.Addr) {
-		// If the address is changing then we'll also include the
-		// "change address" operation so that the object will get rebound
-		// to its new address before we do any other work.
-		retAddrRef = b.lower.ConstantResourceInstAddr(plannedChange.Addr)
-		retStateRef = b.lower.ManagedChangeAddr(retStateRef, retAddrRef)
+
+	switch plannedChange.Action {
+	case plans.Create:
+		newAddrRef := b.lower.ConstantResourceInstAddr(plannedChange.Addr)
+		metadata = b.lower.ResourceInstanceCurrentMeta(newAddrRef, execgraph.NilResultRef[*exec.ResourceInstanceObject]())
+		desired = b.lower.ResourceInstanceDesired(metadata)
+	case plans.Delete:
+		prevAddrRef := b.lower.ConstantResourceInstAddr(plannedChange.PrevRunAddr)
+		prior = b.lower.ResourceInstancePrior(prevAddrRef)
+		metadata = b.lower.ResourceInstanceCurrentMeta(prevAddrRef, prior)
+	default:
+		var newAddrRef, prevAddrRef execgraph.ResultRef[addrs.AbsResourceInstance]
+		newAddrRef = b.lower.ConstantResourceInstAddr(plannedChange.Addr)
+		if plannedChange.PrevRunAddr.Equal(plannedChange.Addr) {
+			prevAddrRef = newAddrRef
+		} else {
+			prevAddrRef = b.lower.ConstantResourceInstAddr(plannedChange.PrevRunAddr)
+		}
+
+		prior = b.lower.ResourceInstancePrior(prevAddrRef)
+		metadata = b.lower.ResourceInstanceCurrentMeta(newAddrRef, prior)
+		desired = b.lower.ResourceInstanceDesired(metadata)
+		if !plannedChange.PrevRunAddr.Equal(plannedChange.Addr) {
+			prior = b.lower.ManagedChangeAddr(prior, newAddrRef)
+		}
 	}
-	return retAddrRef, retStateRef
+	return metadata, desired, prior, plannedValue
 }

--- a/internal/engine/planning/execgraph_managed_test.go
+++ b/internal/engine/planning/execgraph_managed_test.go
@@ -56,12 +56,13 @@ func TestExecGraphBuilder_ManagedResourceInstanceSubgraph(t *testing.T) {
 			},
 			`
 				v[0] = cty.EmptyObjectVal;
-				
-				r[0] = ResourceInstanceDesired(test.placeholder);
-				r[1] = ManagedFinalPlan(r[0], nil, v[0]);
-				r[2] = ManagedApply(r[1], nil, await());
 
-				test.placeholder = r[2];
+				r[0] = ResourceInstanceCurrentMeta(test.placeholder, nil);
+				r[1] = ResourceInstanceDesired(r[0]);
+				r[2] = ManagedFinalPlan(r[0], r[1], nil, v[0]);
+				r[3] = ManagedApply(r[2], nil, await());
+
+				test.placeholder = r[3];
 			`,
 		},
 		"update": {
@@ -81,13 +82,14 @@ func TestExecGraphBuilder_ManagedResourceInstanceSubgraph(t *testing.T) {
 			},
 			`
 				v[0] = cty.StringVal("after");
-				
-				r[0] = ResourceInstancePrior(test.placeholder);
-				r[1] = ResourceInstanceDesired(test.placeholder);
-				r[2] = ManagedFinalPlan(r[1], r[0], v[0]);
-				r[3] = ManagedApply(r[2], nil, await());
 
-				test.placeholder = r[3];
+				r[0] = ResourceInstancePrior(test.placeholder);
+				r[1] = ResourceInstanceCurrentMeta(test.placeholder, r[0]);
+				r[2] = ResourceInstanceDesired(r[1]);
+				r[3] = ManagedFinalPlan(r[1], r[2], r[0], v[0]);
+				r[4] = ManagedApply(r[3], nil, await());
+
+				test.placeholder = r[4];
 			`,
 		},
 		"update with move": {
@@ -114,12 +116,13 @@ func TestExecGraphBuilder_ManagedResourceInstanceSubgraph(t *testing.T) {
 				v[0] = cty.StringVal("after");
 
 				r[0] = ResourceInstancePrior(test.old);
-				r[1] = ManagedChangeAddr(r[0], test.placeholder);
-				r[2] = ResourceInstanceDesired(test.placeholder);
-				r[3] = ManagedFinalPlan(r[2], r[1], v[0]);
-				r[4] = ManagedApply(r[3], nil, await());
+				r[1] = ResourceInstanceCurrentMeta(test.placeholder, r[0]);
+				r[2] = ResourceInstanceDesired(r[1]);
+				r[3] = ManagedChangeAddr(r[0], test.placeholder);
+				r[4] = ManagedFinalPlan(r[1], r[2], r[3], v[0]);
+				r[5] = ManagedApply(r[4], nil, await());
 
-				test.placeholder = r[4];
+				test.placeholder = r[5];
 			`,
 		},
 		"delete": {
@@ -141,8 +144,9 @@ func TestExecGraphBuilder_ManagedResourceInstanceSubgraph(t *testing.T) {
 				v[0] = cty.NullVal(cty.EmptyObject);
 				
 				r[0] = ResourceInstancePrior(test.placeholder);
-				r[1] = ManagedFinalPlan(nil, r[0], v[0]);
-				r[2] = ManagedApply(r[1], nil, await());
+				r[1] = ResourceInstanceCurrentMeta(test.placeholder, r[0]);
+				r[2] = ManagedFinalPlan(r[1], nil, r[0], v[0]);
+				r[3] = ManagedApply(r[2], nil, await());
 
 				test.placeholder = r[0];
 			`,
@@ -176,13 +180,14 @@ func TestExecGraphBuilder_ManagedResourceInstanceSubgraph(t *testing.T) {
 				v[1] = cty.NullVal(cty.String);
 				
 				r[0] = ResourceInstancePrior(test.placeholder);
-				r[1] = ResourceInstanceDesired(test.placeholder);
-				r[2] = ManagedFinalPlan(r[1], nil, v[0]);
-				r[3] = ManagedFinalPlan(nil, r[0], v[1]);
-				r[4] = ManagedApply(r[3], nil, await(r[2]));
-				r[5] = ManagedApply(r[2], nil, await(r[4]));
+				r[1] = ResourceInstanceCurrentMeta(test.placeholder, r[0]);
+				r[2] = ResourceInstanceDesired(r[1]);
+				r[3] = ManagedFinalPlan(r[1], r[2], nil, v[0]);
+				r[4] = ManagedFinalPlan(r[1], nil, r[0], v[1]);
+				r[5] = ManagedApply(r[4], nil, await(r[3]));
+				r[6] = ManagedApply(r[3], nil, await(r[5]));
 
-				test.placeholder = r[5];
+				test.placeholder = r[6];
 			`,
 		},
 		"delete then create with move": {
@@ -210,14 +215,15 @@ func TestExecGraphBuilder_ManagedResourceInstanceSubgraph(t *testing.T) {
 				v[1] = cty.NullVal(cty.String);
 
 				r[0] = ResourceInstancePrior(test.old);
-				r[1] = ManagedChangeAddr(r[0], test.placeholder);
-				r[2] = ResourceInstanceDesired(test.placeholder);
-				r[3] = ManagedFinalPlan(r[2], nil, v[0]);
-				r[4] = ManagedFinalPlan(nil, r[1], v[1]);
-				r[5] = ManagedApply(r[4], nil, await(r[3]));
-				r[6] = ManagedApply(r[3], nil, await(r[5]));
+				r[1] = ResourceInstanceCurrentMeta(test.placeholder, r[0]);
+				r[2] = ResourceInstanceDesired(r[1]);
+				r[3] = ManagedChangeAddr(r[0], test.placeholder);
+				r[4] = ManagedFinalPlan(r[1], r[2], nil, v[0]);
+				r[5] = ManagedFinalPlan(r[1], nil, r[3], v[1]);
+				r[6] = ManagedApply(r[5], nil, await(r[4]));
+				r[7] = ManagedApply(r[4], nil, await(r[6]));
 
-				test.placeholder = r[6];
+				test.placeholder = r[7];
 			`,
 		},
 		"create then delete": {
@@ -240,15 +246,16 @@ func TestExecGraphBuilder_ManagedResourceInstanceSubgraph(t *testing.T) {
 				v[1] = cty.NullVal(cty.String);
 
 				r[0] = ResourceInstancePrior(test.placeholder);
-				r[1] = ResourceInstanceDesired(test.placeholder);
-				r[2] = ManagedFinalPlan(r[1], nil, v[0]);
-				r[3] = ManagedFinalPlan(nil, r[0], v[1]);
-				r[4] = ManagedPrepareDepose(r[3], "00000001");
-				r[5] = ManagedPerformDepose(r[0], r[4], await(r[2]));
-				r[6] = ManagedApply(r[2], r[5], await());
-				r[7] = ManagedApply(r[4], nil, await(r[6]));
+				r[1] = ResourceInstanceCurrentMeta(test.placeholder, r[0]);
+				r[2] = ResourceInstanceDesired(r[1]);
+				r[3] = ManagedFinalPlan(r[1], r[2], nil, v[0]);
+				r[4] = ManagedFinalPlan(r[1], nil, r[0], v[1]);
+				r[5] = ManagedPrepareDepose(r[4], "00000001");
+				r[6] = ManagedPerformDepose(r[0], r[5], await(r[3]));
+				r[7] = ManagedApply(r[3], r[6], await());
+				r[8] = ManagedApply(r[5], nil, await(r[7]));
 
-				test.placeholder = r[6];
+				test.placeholder = r[7];
 			`,
 		},
 		"create then delete with move": {
@@ -276,16 +283,17 @@ func TestExecGraphBuilder_ManagedResourceInstanceSubgraph(t *testing.T) {
 				v[1] = cty.NullVal(cty.String);
 
 				r[0] = ResourceInstancePrior(test.old);
-				r[1] = ManagedChangeAddr(r[0], test.placeholder);
-				r[2] = ResourceInstanceDesired(test.placeholder);
-				r[3] = ManagedFinalPlan(r[2], nil, v[0]);
-				r[4] = ManagedFinalPlan(nil, r[1], v[1]);
-				r[5] = ManagedPrepareDepose(r[4], "00000001");
-				r[6] = ManagedPerformDepose(r[1], r[5], await(r[3]));
-				r[7] = ManagedApply(r[3], r[6], await());
-				r[8] = ManagedApply(r[5], nil, await(r[7]));
+				r[1] = ResourceInstanceCurrentMeta(test.placeholder, r[0]);
+				r[2] = ResourceInstanceDesired(r[1]);
+				r[3] = ManagedChangeAddr(r[0], test.placeholder);
+				r[4] = ManagedFinalPlan(r[1], r[2], nil, v[0]);
+				r[5] = ManagedFinalPlan(r[1], nil, r[3], v[1]);
+				r[6] = ManagedPrepareDepose(r[5], "00000001");
+				r[7] = ManagedPerformDepose(r[3], r[6], await(r[4]));
+				r[8] = ManagedApply(r[4], r[7], await());
+				r[9] = ManagedApply(r[6], nil, await(r[8]));
 
-				test.placeholder = r[7];
+				test.placeholder = r[8];
 			`,
 		},
 	}

--- a/internal/engine/planning/plan_managed.go
+++ b/internal/engine/planning/plan_managed.go
@@ -620,11 +620,20 @@ func (p *planGlue) planUnwantedManagedResourceInstanceObject(
 	}
 
 	// Include destroy provisioner dependencies
-	for _, prov := range p.oracle.DestroyProvisioners(ctx, addr.InstanceAddr) {
-		for ri := range prov.Dependencies {
-			ret.ConfigDependencies.Add(ri.Addr.CurrentObject())
+	// FIXME: Use the resource instance object metadata API to do this, which
+	// means extending [evalglue.ResourceProvisionerConfig] to include a set
+	// of resource instances required for each provisioner configuration.
+	// (Intentionally leaving this unresolved for now because the work to
+	// implement "moved" blocks is likely to cause significant changes to how
+	// we handle "unwanted" resource instances, so don't want to change the
+	// flow of things here too much right now.)
+	/*
+		for _, prov := range p.oracle.DestroyProvisioners(ctx, addr.InstanceAddr) {
+			for ri := range prov.Dependencies {
+				ret.ConfigDependencies.Add(ri.Addr.CurrentObject())
+			}
 		}
-	}
+	*/
 
 	// TODO: Call providerClient.ReadResource and update the "refreshed state"
 	// and reassign this refreshedVal to the refreshed result.

--- a/internal/lang/eval/config_apply.go
+++ b/internal/lang/eval/config_apply.go
@@ -157,6 +157,35 @@ type ApplyOracle struct {
 	providers *managedProviders
 }
 
+// ResourceInstanceObjectMeta returns the subset of metadata for the given
+// resource instance that's defined in the configuration.
+//
+// The apply engine will generally need to combine the result with information
+// from the prior state to produce the full set of metadata for a resource
+// instance object, since this result only reflects what's currently present
+// in the configuration and so is likely to be lacking some or all information
+// for non-desired objects.
+//
+// If the given address identifies an object in a module instance that is not
+// currently in the configuration then the result is nil. Otherwise, whatever
+// language edition implementation is responsible for the relevant module
+// instance uses its own rules to decide the metadata for the requested object.
+//
+// This function always succeeds but may include unknown values as placeholders
+// for metadata whose configuration is defined in an invalid way. The caller
+// is expected to concurrently connect diagnostics from module instances in
+// the configuration, which would then include any errors related to with the
+// metadata settings.
+func (o *ApplyOracle) ResourceInstanceObjectMeta(ctx context.Context, addr addrs.AbsResourceInstanceObject) *ConfiguredResourceInstanceObjectMeta {
+	moduleInst := evalglue.ModuleInstance(ctx, o.root, addr.InstanceAddr.Module)
+	if moduleInst == nil {
+		// The relevant module instance is not currently configured at all,
+		// so the caller will need to rely on the state exclusively for this one.
+		return nil
+	}
+	return moduleInst.ResourceInstanceObjectMeta(ctx, addr.ModuleRelative())
+}
+
 // DesiredResourceInstance returns the [DesiredResourceInstance] object
 // associated with the given resource instance address, or nil if the given
 // address does not match a desired resource instance.

--- a/internal/lang/eval/config_apply.go
+++ b/internal/lang/eval/config_apply.go
@@ -245,13 +245,8 @@ func (o *ApplyOracle) DesiredResourceInstance(ctx context.Context, addr addrs.Ab
 		ResourceMode:              addr.Resource.Resource.Mode,
 		ResourceType:              addr.Resource.Resource.Type,
 		RequiredResourceInstances: riDeps,
-		CreateProvisioners:        inst.CreateProvisioners,
 	}
 	return ret, diags
-}
-
-func (o *ApplyOracle) DestroyProvisioners(ctx context.Context, addr addrs.AbsResourceInstance) []Provisioner {
-	return evalglue.DestroyProvisioners(ctx, o.root, addr)
 }
 
 // ProviderInstanceConfig returns the configuration value for the given

--- a/internal/lang/eval/config_plan_oracle.go
+++ b/internal/lang/eval/config_plan_oracle.go
@@ -44,10 +44,6 @@ func (o *PlanningOracle) ProviderInstance(ctx context.Context, addr addrs.AbsPro
 	return o.providers.ProviderInstance(ctx, addr)
 }
 
-func (o *PlanningOracle) DestroyProvisioners(ctx context.Context, addr addrs.AbsResourceInstance) []Provisioner {
-	return evalglue.DestroyProvisioners(ctx, o.root, addr)
-}
-
 func (o *PlanningOracle) PreventDestroy(ctx context.Context, addr addrs.AbsResourceInstance) (cty.Value, *tfdiags.SourceRange, tfdiags.Diagnostics) {
 	mod := evalglue.ModuleInstance(ctx, o.root, addr.Module)
 	if mod == nil {

--- a/internal/lang/eval/internal/evalglue/module_instance.go
+++ b/internal/lang/eval/internal/evalglue/module_instance.go
@@ -370,16 +370,3 @@ func ProviderInstance(ctx context.Context, root CompiledModuleInstance, addr add
 	}
 	return moduleInst.ProviderInstance(ctx, addr.LocalConfig())
 }
-
-func DestroyProvisioners(ctx context.Context, root CompiledModuleInstance, addr addrs.AbsResourceInstance) []configgraph.Provisioner {
-	// TODO removed block provisioners
-	mod := ModuleInstance(ctx, root, addr.Module)
-	if mod == nil {
-		return nil
-	}
-	resource := mod.Resource(ctx, addr.Resource.Resource)
-	if resource == nil {
-		return nil
-	}
-	return resource.DestroyProvisioners(ctx, addr.Resource)
-}

--- a/internal/lang/eval/internal/evalglue/module_instance.go
+++ b/internal/lang/eval/internal/evalglue/module_instance.go
@@ -74,6 +74,41 @@ type CompiledModuleInstance interface {
 	// panics or other misbehavior.
 	ResultValuer(ctx context.Context) exprs.Valuer
 
+	// ResourceInstanceObjectMeta returns whatever metadata applies to the
+	// given resource instance object based only on information available in
+	// the configuration.
+	//
+	// Calling this function is likely to force parts of the configuration to
+	// be evaluated, but no diagnostics are returned since callers are expected
+	// to also use [CompiledModuleInstance.CheckAll] to collect the diagnostics
+	// from all parts of the module instance content at once. If errors in
+	// the configuration prevent producing the full metadata for the resource
+	// instance then the result may include unknown values as placeholders for
+	// the erroneous configuration values.
+	//
+	// It's up to the implementer of this method to decide what exactly it
+	// means for some metadata to be associated with a specific resource
+	// instance object. In practice the metadata could actually be defined
+	// on a per-resource or per-resource-instance basis instead, but that
+	// decision is an implementation detail of the specific language
+	// implementation so that it can potentially vary between language editions.
+	//
+	// This method never returns a nil result. If the configuration contains no
+	// metadata at all for the requested object then the implementer is expected
+	// to return some reasonable default settings to use as a baseline.
+	//
+	// DO NOT MODIFY ANYTHING REACHABLE THROUGH THE RETURNED POINTER! A resource
+	// instance metadata object is treated as immutable by convention.
+	//
+	// Note that from the perspective of the planning and applying engines the
+	// full metadata for a resource instance object is defined as a melding of
+	// this result along with information taken from the prior state, and so
+	// unless you're implementing the code responsible for merging those two
+	// sources of metadata you probably shouldn't be using the result of this
+	// method directly. Use higher-level wrappers in the planning and applying
+	// engines instead.
+	ResourceInstanceObjectMeta(ctx context.Context, addr addrs.ResourceInstanceObject) *ConfiguredResourceInstanceObjectMeta
+
 	// ChildModuleCalls returns a sequence of addresses of all of the module
 	// calls that are declared in this module instance.
 	//

--- a/internal/lang/eval/internal/evalglue/resource.go
+++ b/internal/lang/eval/internal/evalglue/resource.go
@@ -77,12 +77,12 @@ type ConfiguredResourceInstanceObjectMeta struct {
 	// engine will use to force a "replace" action where an "update" might
 	// otherwise have been sufficient.
 
-	// CreateProvisioners and DestroyProvisioners both represent a sequence
-	// of provisioners configured for this resource instance object.
+	// PostCreateProvisioners and PreDestroyProvisioners both represent a
+	// sequence of provisioners configured for this resource instance object.
 	//
 	// These fields are relevant only for managed resource mode and their
 	// content is unspecified for other resource modes.
-	CreateProvisioners, DestroyProvisioners []*ResourceProvisioner
+	PostCreateProvisioners, PreDestroyProvisioners []*ResourceProvisioner
 }
 
 // ResourceProvisioner represents a single provisioner configured for a

--- a/internal/lang/eval/internal/evalglue/resource.go
+++ b/internal/lang/eval/internal/evalglue/resource.go
@@ -1,0 +1,102 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package evalglue
+
+import (
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/lang/exprs"
+)
+
+// ConfiguredResourceInstanceObjectMeta is the true internal name of what
+// external packages know as [eval.ConfiguredResourceInstanceObjectMeta],
+// defined here to avoid import cycles when this is used by language edition
+// and configgraph code.
+type ConfiguredResourceInstanceObjectMeta struct {
+	// Provider, ResourceMode, and ResourceType together identify a specific
+	// resource type in the terms expected by the provider.
+	//
+	// In particular the resource type given here is the one to send in requests
+	// to the identified provider, and not for use elsewhere. Use
+	// [addrs.Resource.Type] (from an address value describing the same object)
+	// as the resource type internally within the language runtime and execution
+	// engines.
+	Provider     addrs.Provider
+	ResourceMode addrs.ResourceMode
+	ResourceType string
+
+	// ProviderInstance is the address of the specific provider instance that
+	// this object is currently configured to belong to.
+	//
+	// This value is unknown if the configured selection is derived from
+	// an unknown value, or nil if there is no configured selection at all. In
+	// the absence of a configured selection, callers should probably try to
+	// fall back to a selection from the prior state instead.
+	ProviderInstance exprs.FromValue[*addrs.AbsProviderInstanceCorrect]
+
+	// CreateBeforeDelete is true if this object is configured to force creating
+	// a new remote object before destroying the current one when performing
+	// a "replace" action. Otherwise either ordering is allowed and delete
+	// happens first by default unless the other ordering is forced by a
+	// dependent object having this set to true.
+	//
+	// This setting also affects how actions for this object may be ordered
+	// with actions from other objects even when not replacing, in order to
+	// produce a well-defined execution order when this object's actions are
+	// combined with actions of other objects in the apply-time execution graph.
+	//
+	// This field is relevant only for managed resource mode and its value is
+	// unspecified for other resource modes.
+	CreateBeforeDelete exprs.FromValue[bool]
+
+	// DeleteWhenRemoved is true if the expected treatment for a non-desired
+	// object at this address is to ask the associated provider to delete it,
+	// or false if the expected treatment is just to "forget" it by removing
+	// the binding from the state without notifying the provider.
+	//
+	// This field is relevant only for managed resource mode and its value is
+	// unspecified for other resource modes.
+	DeleteWhenRemoved exprs.FromValue[bool]
+
+	// DeletionInvalid is true if the author has configured that any execution
+	// plan that involves deleting this object should be considered immediately
+	// invalid. If false then deleting is a valid action to include.
+	//
+	// This field is relevant only for managed resource mode and its value is
+	// unspecified for other resource modes.
+	DeletionInvalid exprs.FromValue[bool]
+
+	// TODO: Some representation of "ignore_changes", which the planning engine
+	// will use as part of deciding which action to take.
+
+	// TODO: Some representation of "replace_triggered_by", which the planning
+	// engine will use to force a "replace" action where an "update" might
+	// otherwise have been sufficient.
+
+	// CreateProvisioners and DestroyProvisioners both represent a sequence
+	// of provisioners configured for this resource instance object.
+	//
+	// These fields are relevant only for managed resource mode and their
+	// content is unspecified for other resource modes.
+	CreateProvisioners, DestroyProvisioners []*ResourceProvisioner
+}
+
+// ResourceProvisioner represents a single provisioner configured for a
+// resource instance object.
+type ResourceProvisioner struct {
+	// Type and Config represent the type of provisioner to run (e.g "local-exec")
+	// and a configuration object suitable for that provisioner type.
+	Type   string
+	Config cty.Value
+
+	// ConnectionConfig is an object representation of the configuration for how
+	// to connect to a remote system to run the provisioner.
+	//
+	// Not all provisioner types make remote connections. Those that don't need
+	// it will just ignore this field completely.
+	ConnectionConfig cty.Value
+}

--- a/internal/lang/eval/internal/evalglue/resource.go
+++ b/internal/lang/eval/internal/evalglue/resource.go
@@ -6,10 +6,13 @@
 package evalglue
 
 import (
+	"context"
+
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/lang/exprs"
+	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
 // ConfiguredResourceInstanceObjectMeta is the true internal name of what
@@ -88,13 +91,30 @@ type ConfiguredResourceInstanceObjectMeta struct {
 // ResourceProvisioner represents a single provisioner configured for a
 // resource instance object.
 type ResourceProvisioner struct {
-	// Type and Config represent the type of provisioner to run (e.g "local-exec")
-	// and a configuration object suitable for that provisioner type.
-	Type   string
-	Config cty.Value
+	// Type represents the type of provisioner to run (e.g "local-exec").
+	Type string
 
-	// ConnectionConfig is an object representation of the configuration for how
-	// to connect to a remote system to run the provisioner.
+	// BuildConfig takes a value representing the object that is being
+	// provisioned and returns the final configuration values to use when
+	// actually executing the provisioner.
+	BuildConfig func(ctx context.Context, selfValue cty.Value) (ResourceProvisionerConfig, tfdiags.Diagnostics)
+
+	// ContinueOnFailure is set if a failure to run the provisioner should not
+	// block running any subsequent provisioners in the same sequence and should
+	// not block any other work that is blocked until the provisioner has
+	// finished running.
+	ContinueOnFailure bool
+}
+
+// ResourceProvisionerConfig represents the fully-evaluated configuration for
+// a [ResourceProvisioner], constructed only once we know the value of the
+// resource instance object that is being provisioned.
+type ResourceProvisionerConfig struct {
+	// MainConfig is the direct configuration for this specific provisioner.
+	MainConfig cty.Value
+
+	// ConnectionConfig is configuration for how to connect to a remote system
+	// if this provisioner will take a remote action.
 	//
 	// Not all provisioner types make remote connections. Those that don't need
 	// it will just ignore this field completely.

--- a/internal/lang/eval/internal/tofu2024/module_instance.go
+++ b/internal/lang/eval/internal/tofu2024/module_instance.go
@@ -15,6 +15,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/getproviders"
 	"github.com/opentofu/opentofu/internal/lang/eval/internal/configgraph"
 	"github.com/opentofu/opentofu/internal/lang/eval/internal/evalglue"
@@ -104,10 +105,6 @@ func (c *CompiledModuleInstance) ResultValuer(ctx context.Context) exprs.Valuer 
 
 // ResourceInstanceObjectMeta implements [evalglue.CompiledModuleInstance].
 func (c *CompiledModuleInstance) ResourceInstanceObjectMeta(ctx context.Context, addr addrs.ResourceInstanceObject) *evalglue.ConfiguredResourceInstanceObjectMeta {
-	// TODO: The logic here should also consider whether any "removed" block
-	// matches the requested object, and return information derived from
-	// that block if so.
-
 	// We'll start with a suitable placeholder to use if there's no mention
 	// of this object in the configuration at all, and then improve it gradually
 	// as we find relevant information in the configuration.
@@ -124,6 +121,10 @@ func (c *CompiledModuleInstance) ResourceInstanceObjectMeta(ctx context.Context,
 		// the prior state, if any.
 		ProviderInstance: exprs.Known[*addrs.AbsProviderInstanceCorrect](nil),
 	}
+
+	// TODO: The logic here should also consider whether any "removed" block
+	// matches the requested object, and incorporate information derived from
+	// that block if so.
 
 	rsrc, ok := c.resourceNodes[addr.InstanceAddr.Resource]
 	if !ok {
@@ -149,6 +150,9 @@ func (c *CompiledModuleInstance) ResourceInstanceObjectMeta(ctx context.Context,
 	})
 	ret.DeletionInvalid = preventDestroy
 
+	destroyProvisioners := rsrc.DestroyProvisioners(ctx, addr.InstanceAddr)
+	ret.PreDestroyProvisioners = prepareResourceProvisioners(destroyProvisioners)
+
 	insts := rsrc.Instances(ctx)
 	inst, ok := insts[addr.InstanceAddr.Key]
 	if !ok {
@@ -162,8 +166,34 @@ func (c *CompiledModuleInstance) ResourceInstanceObjectMeta(ctx context.Context,
 		return &providerInst.Addr, nil
 	})
 
+	ret.PostCreateProvisioners = prepareResourceProvisioners(inst.CreateProvisioners)
+
 	// TODO: All of the other fields of ConfiguredResourceInstanceObjectMeta
 
+	return ret
+}
+
+func prepareResourceProvisioners(pcs []configgraph.Provisioner) []*evalglue.ResourceProvisioner {
+	if len(pcs) == 0 {
+		return nil
+	}
+	ret := make([]*evalglue.ResourceProvisioner, 0, len(pcs))
+	for _, pc := range pcs {
+		provisioner := &evalglue.ResourceProvisioner{
+			Type: pc.Type,
+			BuildConfig: func(ctx context.Context, selfValue cty.Value) (evalglue.ResourceProvisionerConfig, tfdiags.Diagnostics) {
+				cfg, diags := pc.Config(ctx, selfValue)
+				return evalglue.ResourceProvisionerConfig{
+					MainConfig:       cfg.Value,
+					ConnectionConfig: cfg.Connection,
+				}, diags
+			},
+		}
+		if pc.OnFailure == configs.ProvisionerOnFailureContinue {
+			provisioner.ContinueOnFailure = true
+		}
+		ret = append(ret, provisioner)
+	}
 	return ret
 }
 

--- a/internal/lang/eval/internal/tofu2024/module_instance.go
+++ b/internal/lang/eval/internal/tofu2024/module_instance.go
@@ -7,10 +7,12 @@ package tofu2024
 
 import (
 	"context"
+	"fmt"
 	"iter"
 	"maps"
 
 	"github.com/apparentlymart/go-workgraph/workgraph"
+	"github.com/zclconf/go-cty/cty"
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/getproviders"
@@ -98,6 +100,71 @@ func (c *CompiledModuleInstance) ResultValuer(ctx context.Context) exprs.Valuer 
 	// the calling module instance, without the caller needing to be aware
 	// of that implementation detail.
 	return c.moduleInstanceNode
+}
+
+// ResourceInstanceObjectMeta implements [evalglue.CompiledModuleInstance].
+func (c *CompiledModuleInstance) ResourceInstanceObjectMeta(ctx context.Context, addr addrs.ResourceInstanceObject) *evalglue.ConfiguredResourceInstanceObjectMeta {
+	// TODO: The logic here should also consider whether any "removed" block
+	// matches the requested object, and return information derived from
+	// that block if so.
+
+	// We'll start with a suitable placeholder to use if there's no mention
+	// of this object in the configuration at all, and then improve it gradually
+	// as we find relevant information in the configuration.
+	ret := &evalglue.ConfiguredResourceInstanceObjectMeta{
+		// In this language edition the author-specified resource type always
+		// matches the provider's chosen resource type name, so we can just
+		// derive these directly from the resource address.
+		Provider:     addrs.ImpliedProviderForUnqualifiedType(addr.InstanceAddr.Resource.ImpliedProvider()),
+		ResourceMode: addr.InstanceAddr.Resource.Mode,
+		ResourceType: addr.InstanceAddr.Resource.Type,
+
+		// An undeclared resource has no configured provider instance, which
+		// means that a caller can know to fall back to an address specified in
+		// the prior state, if any.
+		ProviderInstance: exprs.Known[*addrs.AbsProviderInstanceCorrect](nil),
+	}
+
+	rsrc, ok := c.resourceNodes[addr.InstanceAddr.Resource]
+	if !ok {
+		// We'll just return the placeholder, then!
+		return ret
+	}
+
+	// In the remaining code we intentionally ignore all diagnostics from
+	// accessing the configgraph.Resource and configgraph.ResourceInstance
+	// methods because our caller is expected to collect them separately
+	// using [CompiledModuleInstance.CheckAll].
+
+	preventDestroyVal, _, _ := rsrc.PreventDestroy(ctx)
+	preventDestroy, _ := exprs.DeriveFromValue(preventDestroyVal, func(v cty.Value) (bool, error) {
+		if v.True() {
+			return true, nil
+		}
+		if v.False() {
+			return false, nil
+		}
+		// No other value is expected, based on the documentation of [configgraph.Resource.PreventDestroy].
+		panic(fmt.Sprintf("method PreventDestroy for %s returned unexpected value %#v", addr.InstanceAddr.Resource, v))
+	})
+	ret.DeletionInvalid = preventDestroy
+
+	insts := rsrc.Instances(ctx)
+	inst, ok := insts[addr.InstanceAddr.Key]
+	if !ok {
+		// Only the resource-level settings are used when we're dealing with
+		// a resource instance that is not currently declared in the configuration.
+		return ret
+	}
+
+	providerInst, _ := inst.ProviderInstance(ctx)
+	ret.ProviderInstance, _ = exprs.DeriveFromDerived(providerInst, func(providerInst *configgraph.ProviderInstance) (*addrs.AbsProviderInstanceCorrect, error) {
+		return &providerInst.Addr, nil
+	})
+
+	// TODO: All of the other fields of ConfiguredResourceInstanceObjectMeta
+
+	return ret
 }
 
 // ChildModuleCalls implements evalglue.CompiledModuleInstance.

--- a/internal/lang/eval/resource_instance.go
+++ b/internal/lang/eval/resource_instance.go
@@ -175,20 +175,7 @@ type DesiredResourceInstance struct {
 	// Any resource instance mentioned in this collection will always also
 	// appear in RequiredResourceInstances.
 	ReplaceTriggeredBy []ResourceInstanceAttributePath
-
-	// CreateProvisioners are the provisioners that will be run if the resource
-	// is created
-	CreateProvisioners []Provisioner
 }
-
-// ResourceProvisioner represents a single provisioner configured for a
-// resource instance object.
-type ResourceProvisioner = evalglue.ResourceProvisioner
-
-// Exposing configgraph details is not idea, but it's a very simple structure
-// that is probably not worth duplicating right now
-type Provisioner = configgraph.Provisioner
-type ResourceInstanceAttributePath = configgraph.ResourceInstanceAttributePath
 
 // IsPlaceholder returns true if this object is acting as a placeholder for
 // zero or more resource instances whose full expansion is not yet known.
@@ -210,3 +197,12 @@ type ResourceInstanceAttributePath = configgraph.ResourceInstanceAttributePath
 func (ri *DesiredResourceInstance) IsPlaceholder() bool {
 	return ri.Addr.IsPlaceholder()
 }
+
+// ResourceProvisioner represents a single provisioner configured for a
+// resource instance object.
+type ResourceProvisioner = evalglue.ResourceProvisioner
+
+// FIXME: Don't directly expose a configgraph type here, since that package
+// is supposed to be an implementation detail of tofu2024 and any other future
+// HCL-based language editions.
+type ResourceInstanceAttributePath = configgraph.ResourceInstanceAttributePath

--- a/internal/lang/eval/resource_instance.go
+++ b/internal/lang/eval/resource_instance.go
@@ -10,7 +10,33 @@ import (
 
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/lang/eval/internal/configgraph"
+	"github.com/opentofu/opentofu/internal/lang/eval/internal/evalglue"
 )
+
+// ConfiguredResourceInstanceObjectMeta represents the subset of metadata
+// about a resource instance object that comes from the configuration, based
+// on configuration arguments that could potentially vary between language
+// editions.
+//
+// It's up to the specific language edition implementation to decide how to
+// populate an object of this type. Some fields will be based on per-resource
+// or per-resource-instance configuration elements shared across multiple
+// objects, but at this level of abstraction those decisions are already made
+// and we must not assume anything is necessarily shared by objects belonging
+// to the same resource or resource instance.
+//
+// Note that this is NOT what you should use directly in the planning or
+// applying engines as the full metadata for a resource instance object.
+// Instead, this should typically be combined with information taken from the
+// prior state (in a way that's outside the scope of this package) to determine
+// the full effective metadata for an object.
+//
+// The design of this type is biased towards the needs of the "managed" resource
+// mode since that represents our primary functionality and the most complicated
+// set of available metadata features. Nonetheless we do still use this type
+// for other resource modes and just leave the irrelevant fields unpopulated
+// for objects of those modes.
+type ConfiguredResourceInstanceObjectMeta = evalglue.ConfiguredResourceInstanceObjectMeta
 
 // DesiredResourceInstance describes a resource instance that is part of
 // the desired state (i.e. declared in the configuration).
@@ -154,6 +180,10 @@ type DesiredResourceInstance struct {
 	// is created
 	CreateProvisioners []Provisioner
 }
+
+// ResourceProvisioner represents a single provisioner configured for a
+// resource instance object.
+type ResourceProvisioner = evalglue.ResourceProvisioner
 
 // Exposing configgraph details is not idea, but it's a very simple structure
 // that is probably not worth duplicating right now


### PR DESCRIPTION
(This is part of https://github.com/opentofu/opentofu/issues/3414.)

So far we've been modelling resource instance objects with strict separation between their desired state and prior state, where "desired state" means information derived exclusively from the configuration.

However, we keep encountering friction with that because in practice there's various metadata about a resource instance object that OpenTofu can potentially collect and merge from three different locations:

1. From the main `resource` block that declared the object.
2. From a `removed` block that acts as a "tombstone" for a `resource` block that is no longer present.
3. From snapshots captured in the prior state during the previous plan/apply round.

We were therefore gradually littering different subsystems with locally-implemented fallback logic between these, instead of having a central definition of that priority-merging logic in a single place.

This PR is a starting point for improving that situation by introducing a first-class concept of "resource instance object metadata", dealing mainly with some cross-cutting wiring to introduce that concept, but then arranging for provisioners to be handled in this way just to demonstrate how this new design fits together. (More wiring of other metadata-based features, such as `prevent_destroy`, to follow in later PRs.)

The compiler package for each language edition determines the rules for selecting the configuration-based metadata values. For `tofu2024` these settings are actually generally specified on a per-resource or per-resource-instance basis instead of on a per-object basis, but those decisions are encapsulated inside the compiler so that the rest of the system can just treat each resource instance object as having its own independent settings.

A function in the `exec` package then owns the responsibility of combining metadata from the configuration with metadata from the state to produce the final effective metadata for a specific object, falling back to state-based values where configuration-based values are not available.

This initial PR focuses primarily on giving the apply engine access to metadata. I split it up in this way mainly because https://github.com/opentofu/opentofu/issues/4229 is under concurrent development, and based on earlier discussion I'm assuming that's going to cause some significant refactoring of `package planning` that I don't want to collide with. Focusing on just the provisioners feature here matches that compromise because provisioners are primarily an apply-phase feature.

If this is merged then I intend to open followup PRs, first to also give the planning engine access to resource instance object metadata, and then to gradually rework each of the metadata-related features we previously implemented to fit within this new structure.

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

