### PR TITLE
Add lockWrittenByThisCall function for lock validation

### DIFF
--- a/internal/backend/remote-state/s3/client.go
+++ b/internal/backend/remote-state/s3/client.go
@@ -276,6 +276,12 @@ func (c *RemoteClient) Lock(ctx context.Context, info *statemgr.LockInfo) (strin
 	return info.ID, nil
 }
 
+// was the lock in the backing store written by the current acquisition?
+// statemgr.LockInfo#ID is a UUID, minted per Lock() call, so a match here is ours.
+func lockWrittenByThisCall(stored, info *statemgr.LockInfo) bool {
+	return stored != nil && info != nil && info.ID != "" && stored.ID == info.ID
+}
+
 // dynamoDBLock expects the statemgr.LockInfo#ID to be filled already
 func (c *RemoteClient) dynamoDBLock(ctx context.Context, info *statemgr.LockInfo) error {
 	if c.ddbTable == "" {
@@ -297,6 +303,11 @@ func (c *RemoteClient) dynamoDBLock(ctx context.Context, info *statemgr.LockInfo
 		lockInfo, infoErr := c.getLockInfoFromDynamoDB(ctx)
 		if infoErr != nil {
 			err = multierror.Append(err, infoErr)
+		}
+
+		if lockWrittenByThisCall(lockInfo, info) {
+			log.Printf("[WARN] dynamodb lock %q written but not detected; PutItem outcome was not observed %v.  Lock is held.", info.ID, err)
+			return nil
 		}
 
 		lockErr := &statemgr.LockError{
@@ -337,6 +348,11 @@ func (c *RemoteClient) s3Lock(ctx context.Context, info *statemgr.LockInfo) erro
 		lockInfo, infoErr := c.getLockInfoFromS3(ctx)
 		if infoErr != nil {
 			err = multierror.Append(err, infoErr)
+		}
+
+		if lockWrittenByThisCall(lockInfo, info) {
+			log.Printf("[WARN] dynamodb lock %q written but not detected; PutItem outcome was not observed %v.  Lock is held.", info.ID, err)
+			return nil
 		}
 
 		lockErr := &statemgr.LockError{


### PR DESCRIPTION

Proof-of-concept for handling 4405.  On-error, read the lock state.  If it matches the same UUID, we succeeded the lock, but failed to be told about it.

<!-- If your PR resolves an issue, please add it here. -->
Resolves # 4405

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [ X] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [ X] I have not used an AI coding assistant to create this PR.
- [ X] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [ X] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [ ] I have run golangci-lint on my change and receive no errors relevant to my code.
- [ ] I have run existing tests to ensure my code doesn't break anything.
- [ ] I have added tests for all relevant use cases of my code, and those tests are passing.
- [X ] I have only exported functions, variables and structs that should be used from other packages.
- [ X] I have added meaningful comments to all exported functions, variables, and structs.


