### PR TITLE
Add adopters list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,29 @@
+# OpenTofu adopters
+
+Organizations listed here use OpenTofu to manage infrastructure in real-world
+environments. This list helps users understand how OpenTofu is adopted and gives
+the project evidence to guide its development.
+
+Being listed does not imply endorsement by either the organization or the
+OpenTofu project. This list is also separate from OpenTofu's
+[supporters](https://opentofu.org/supporters/), who contribute funding, people,
+infrastructure, or other resources to the project.
+
+## Add your organization
+
+If your organization uses OpenTofu and would like to be included, open a pull
+request and add a row to the table below. A short, high-level description of how
+you use OpenTofu is welcome. Please avoid confidential or security-sensitive
+information.
+
+Please follow the project's [contribution guidelines](CONTRIBUTING.md) and
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Adopters
+
+| Organization | How OpenTofu is used |
+| --- | --- |
+<!--
+Add entries above this comment using the following format:
+| [Organization](https://example.com) | A short description of how the organization uses OpenTofu. |
+-->


### PR DESCRIPTION
## What changed

Added `ADOPTERS.md` with:

- a short explanation of the adopters list
- instructions for organizations that want to add themselves
- a simple table and example entry format

## Why

This gives the project a consistent place to document real-world OpenTofu adoption.

## Impact

Documentation only. There is no runtime or user-facing product behavior change.

## Validation

- Checked the Markdown diff for whitespace errors.
- Verified the linked repository documents exist.

The repository file was authored manually. An LLM was used only for the mechanical Git and GitHub operations needed to stage, commit, push, and open this draft pull request.
