### PR TITLE
Additional tweaks to command/arguments integration

### DIFF
--- a/internal/command/apply.go
+++ b/internal/command/apply.go
@@ -87,14 +87,6 @@ func (c ApplyCommand) Execute(args *arguments.Apply, view views.Apply) int {
 		return 1
 	}
 
-	// FIXME: the -input flag value is needed to initialize the backend and the
-	// operation, but there is no clear path to pass this value down, so we
-	// continue to mutate the Meta object state for now.
-	c.Meta.input = args.View.InputEnabled
-
-	// Inject variables from args into meta for static evaluation
-	c.Meta.variableArgs = args.Vars.All()
-
 	// Load the encryption configuration
 	enc, encDiags := c.Encryption(ctx)
 	diags = diags.Append(encDiags)
@@ -109,14 +101,6 @@ func (c ApplyCommand) Execute(args *arguments.Apply, view views.Apply) int {
 		view.Diagnostics(diags)
 		return 1
 	}
-
-	// FIXME: the -parallelism flag is used to control the concurrency of
-	// OpenTofu operations. At the moment, this value is used both to
-	// initialize the backend via the ContextOpts field inside CLIOpts, and to
-	// set a largely unused field on the Operation request. Again, there is no
-	// clear path to pass this value down, so we continue to mutate the Meta
-	// object state for now.
-	c.Meta.parallelism = args.Operation.Parallelism
 
 	// Prepare the backend, passing the plan file if present, and the
 	// backend-specific arguments
@@ -215,8 +199,6 @@ func (c *ApplyCommand) LoadPlanFile(path string, enc encryption.Encryption) (*pl
 
 func (c *ApplyCommand) PrepareBackend(ctx context.Context, planFile *planfile.WrappedPlanFile, args *arguments.State, backendView views.Backend, enc encryption.StateEncryption) (backend.Enhanced, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-
-	c.Meta.stateArgs = *args
 
 	// Load the backend
 	var be backend.Enhanced

--- a/internal/command/arguments/apply_test.go
+++ b/internal/command/arguments/apply_test.go
@@ -10,11 +10,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
-	"github.com/opentofu/opentofu/internal/command/flags"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/plans"
 )
@@ -102,15 +100,13 @@ func TestParseApply_basicValid(t *testing.T) {
 		},
 	}
 
-	cmpOpts := cmpopts.IgnoreUnexported(Operation{}, Vars{}, State{})
-
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got, _, diags := ParseApply(tc.args)
 			if len(diags) > 0 {
 				t.Fatalf("unexpected diags: %v", diags)
 			}
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected result\n%s", diff)
 			}
 		})
@@ -717,21 +713,21 @@ func TestParseApply_replace(t *testing.T) {
 func TestParseApply_vars(t *testing.T) {
 	testCases := map[string]struct {
 		args []string
-		want []flags.RawFlag
+		want Vars
 	}{
 		"no var flags by default": {
 			args: nil,
-			want: nil,
+			want: Vars{},
 		},
 		"one var": {
 			args: []string{"-var", "foo=bar"},
-			want: []flags.RawFlag{
+			want: Vars{
 				{Name: "-var", Value: "foo=bar"},
 			},
 		},
 		"one var-file": {
 			args: []string{"-var-file", "cool.tfvars"},
-			want: []flags.RawFlag{
+			want: Vars{
 				{Name: "-var-file", Value: "cool.tfvars"},
 			},
 		},
@@ -741,7 +737,7 @@ func TestParseApply_vars(t *testing.T) {
 				"-var-file", "cool.tfvars",
 				"-var", "boop=beep",
 			},
-			want: []flags.RawFlag{
+			want: Vars{
 				{Name: "-var", Value: "foo=bar"},
 				{Name: "-var-file", Value: "cool.tfvars"},
 				{Name: "-var", Value: "boop=beep"},
@@ -808,15 +804,13 @@ func TestParseApplyDestroy_basicValid(t *testing.T) {
 		},
 	}
 
-	cmpOpts := cmpopts.IgnoreUnexported(Operation{}, Vars{}, State{})
-
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got, _, diags := ParseApplyDestroy(tc.args)
 			if len(diags) > 0 {
 				t.Fatalf("unexpected diags: %v", diags)
 			}
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected result\n%s", diff)
 			}
 		})

--- a/internal/command/arguments/backend.go
+++ b/internal/command/arguments/backend.go
@@ -23,6 +23,7 @@ type Backend struct {
 
 func BindBackend(cli *CommandLine) *Backend {
 	var b Backend
+	cli.Backend = &b
 	cli.BoolVar(&b.IgnoreRemoteVersion, "ignore-remote-version", false, "A rare option used for the remote backend only. See the remote backend documentation for more information.")
 	return &b
 }

--- a/internal/command/arguments/common.go
+++ b/internal/command/arguments/common.go
@@ -44,6 +44,12 @@ type CommandLine struct {
 
 	// This is a bit of a hack so we can correctly report diagnostics before actually executing the command
 	View *View
+
+	// These are hacks for the meta struct that should be removed as the meta struct is broken up and removed
+	Backend   *Backend
+	Operation *Operation
+	State     *State
+	Vars      *Vars
 }
 
 // PositionalError is the common error handling of remaining positional arguments

--- a/internal/command/arguments/console_test.go
+++ b/internal/command/arguments/console_test.go
@@ -40,25 +40,25 @@ func TestParseConsole_basicValidation(t *testing.T) {
 		"single var": {
 			args: []string{"-var=key=value"},
 			want: consoleArgsWithDefaults(func(console *Console) {
-				// Vars would be updated, but we ignore it in cmp
+				console.Vars = &Vars{{Name: "-var", Value: "key=value"}}
 			}),
 		},
 		"multiple vars": {
 			args: []string{"-var=key1=value1", "-var=key2=value2"},
 			want: consoleArgsWithDefaults(func(console *Console) {
-				// Vars would be updated, but we ignore it in cmp
+				console.Vars = &Vars{{Name: "-var", Value: "key1=value1"}, {Name: "-var", Value: "key2=value2"}}
 			}),
 		},
 		"var-file": {
 			args: []string{"-var-file=test.tfvars"},
 			want: consoleArgsWithDefaults(func(console *Console) {
-				// Vars would be updated, but we ignore it in cmp
+				console.Vars = &Vars{{Name: "-var-file", Value: "test.tfvars"}}
 			}),
 		},
 		"mixed vars and var-files": {
 			args: []string{"-var=key=value", "-var-file=test.tfvars", "-var=another=val"},
 			want: consoleArgsWithDefaults(func(console *Console) {
-				// Vars would be updated, but we ignore it in cmp
+				console.Vars = &Vars{{Name: "-var", Value: "key=value"}, {Name: "-var-file", Value: "test.tfvars"}, {Name: "-var", Value: "another=val"}}
 			}),
 		},
 		"only lock-timeout": {
@@ -77,7 +77,6 @@ func TestParseConsole_basicValidation(t *testing.T) {
 	}
 
 	cmpOpts := cmp.Options{
-		cmpopts.IgnoreUnexported(Vars{}),
 		cmpopts.IgnoreFields(View{}, "JSONInto"), // We ignore JSONInto because it contains a file which is not really diffable
 	}
 

--- a/internal/command/arguments/extended.go
+++ b/internal/command/arguments/extended.go
@@ -67,6 +67,7 @@ type State struct {
 // bind is the sole logic of registering the state related flags in OpenTofu.
 func BindState(cli *CommandLine, mask stateFlag) *State {
 	var s State
+	cli.State = &s
 	if mask&stateFlagLock != 0 {
 		cli.BoolVar(&s.Lock, "lock", true,
 			`Don't hold a state lock during the operation. This is dangerous if others might concurrently run commands against the same workspace.`,
@@ -350,6 +351,8 @@ func (v *Vars) Empty() bool {
 // bind registers all Operation flags
 func BindOperation(cli *CommandLine) *Operation {
 	var operation Operation
+	cli.Operation = &operation
+
 	cli.IntVar(&operation.Parallelism, "parallelism", DefaultParallelism,
 		`Limit the number of parallel resource operations. Defaults to 10.`,
 	).SetDisplay("=n")
@@ -384,6 +387,8 @@ func BindOperation(cli *CommandLine) *Operation {
 // bind registers all Vars flags
 func BindVars(cli *CommandLine) *Vars {
 	var vars Vars
+	cli.Vars = &vars
+
 	varsFlags := flags.NewRawFlags("-var")
 	varFilesFlags := varsFlags.Alias("-var-file")
 	vars.vars = &varsFlags

--- a/internal/command/arguments/extended.go
+++ b/internal/command/arguments/extended.go
@@ -129,17 +129,6 @@ type Operation struct {
 	// a module all at once. We could potentially loosen this later if we
 	// learn a use-case for broader matching.
 	ForceReplace []addrs.AbsResourceInstance
-
-	// These private fields are used only temporarily during decoding. Use
-	// method Parse to populate the exported fields from these, validating
-	// the raw values in the process.
-	targetsRaw       []string
-	targetsFilesRaw  []string
-	excludesRaw      []string
-	excludesFilesRaw []string
-	forceReplaceRaw  []string
-	destroyRaw       bool
-	refreshOnlyRaw   bool
 }
 
 // parseDirectTargetables gets a list of strings passed from directly from the CLI
@@ -254,74 +243,118 @@ func parseRawTargetsAndExcludes(targetsDirect, excludesDirect []string, targetFi
 	return allParsedTargets, allParsedExcludes, diags
 }
 
-// Parse must be called on Operation after initial flag parse. This processes
-// the raw target flags into addrs.Targetable values, returning diagnostics if
-// invalid.
-func (o *Operation) Parse() tfdiags.Diagnostics {
-	var diags tfdiags.Diagnostics
+// bind registers all Operation flags
+func BindOperation(cli *CommandLine) *Operation {
+	var o Operation
+	cli.Operation = &o
 
-	var parseDiags tfdiags.Diagnostics
-	o.Targets, o.Excludes, parseDiags = parseRawTargetsAndExcludes(o.targetsRaw, o.excludesRaw, o.targetsFilesRaw, o.excludesFilesRaw)
-	diags = diags.Append(parseDiags)
+	// These private fields are used only temporarily during decoding. Use
+	// method Parse to populate the exported fields from these, validating
+	// the raw values in the process.
+	var targetsRaw []string
+	var targetsFilesRaw []string
+	var excludesRaw []string
+	var excludesFilesRaw []string
+	var forceReplaceRaw []string
+	var destroyRaw bool
+	var refreshOnlyRaw bool
 
-	for _, raw := range o.forceReplaceRaw {
-		traversal, syntaxDiags := hclsyntax.ParseTraversalAbs([]byte(raw), "", hcl.Pos{Line: 1, Column: 1})
-		if syntaxDiags.HasErrors() {
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				fmt.Sprintf("Invalid force-replace address %q", raw),
-				syntaxDiags[0].Detail,
-			))
-			continue
+	cli.IntVar(&o.Parallelism, "parallelism", DefaultParallelism,
+		`Limit the number of parallel resource operations. Defaults to 10.`,
+	).SetDisplay("=n")
+	cli.BoolVar(&o.Refresh, "refresh", true,
+		`Skip checking for external changes to remote objects while creating the plan. This can potentially make planning faster, but at the expense of possibly planning against a stale record of the remote system state.`,
+	).SetDisplay("=false")
+	cli.BoolVar(&destroyRaw, "destroy", false,
+		`Select the "destroy" planning mode, which creates a plan to destroy all objects currently managed by this OpenTofu configuration instead of the usual behavior.`)
+	cli.BoolVar(&refreshOnlyRaw, "refresh-only", false,
+		`Select the "refresh only" planning mode, which checks whether remote objects still match the outcome of the most recent OpenTofu apply but does not propose any actions to undo any changes made outside of OpenTofu.`)
+	cli.StringArrayVar(&targetsRaw, "target", nil,
+		`Limit the planning operation to only the given module, resource, or resource instance and all of its dependencies. You can use this option multiple times to include more than one object. This is for exceptional use only. Cannot be used alongside the -exclude option.`,
+	).SetDisplay("=resource")
+	cli.StringArrayVar(&targetsFilesRaw, "target-file", nil,
+		`Similar to -target, but specifies zero or more resource addresses from a file.`,
+	).SetDisplay("=filename")
+	cli.StringArrayVar(&excludesRaw, "exclude", nil,
+		`Limit the planning operation to not operate on the given module, resource, or resource instance and all of the resources and modules that depend on it. You can use this option multiple times to exclude more than one object. This is for exceptional use only. Cannot be used together with the -target option.`,
+	).SetDisplay("=resource")
+	cli.StringArrayVar(&excludesFilesRaw, "exclude-file", nil,
+		`Similar to -exclude, but specifies zero or more resource addresses from a file.`,
+	).SetDisplay("=filename")
+	cli.StringArrayVar(&forceReplaceRaw, "replace", nil,
+		`Force replacement of a particular resource instance using its resource address. If the plan would've otherwise produced an update or no-op action for this instance, OpenTofu will plan to replace it instead. You can use this option multiple times to replace more than one object.`,
+	).SetDisplay("=resource")
+
+	// This processes the raw target flags into addrs.Targetable values, returning diagnostics if invalid.
+	cli.PreHook(func() tfdiags.Diagnostics {
+		var diags tfdiags.Diagnostics
+
+		var parseDiags tfdiags.Diagnostics
+		o.Targets, o.Excludes, parseDiags = parseRawTargetsAndExcludes(targetsRaw, excludesRaw, targetsFilesRaw, excludesFilesRaw)
+		diags = diags.Append(parseDiags)
+
+		for _, raw := range forceReplaceRaw {
+			traversal, syntaxDiags := hclsyntax.ParseTraversalAbs([]byte(raw), "", hcl.Pos{Line: 1, Column: 1})
+			if syntaxDiags.HasErrors() {
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					fmt.Sprintf("Invalid force-replace address %q", raw),
+					syntaxDiags[0].Detail,
+				))
+				continue
+			}
+
+			addr, addrDiags := addrs.ParseAbsResourceInstance(traversal)
+			if addrDiags.HasErrors() {
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					fmt.Sprintf("Invalid force-replace address %q", raw),
+					addrDiags[0].Description().Detail,
+				))
+				continue
+			}
+
+			if addr.Resource.Resource.Mode != addrs.ManagedResourceMode {
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					fmt.Sprintf("Invalid force-replace address %q", raw),
+					"Only managed resources can be used with the -replace=... option.",
+				))
+				continue
+			}
+
+			o.ForceReplace = append(o.ForceReplace, addr)
 		}
 
-		addr, addrDiags := addrs.ParseAbsResourceInstance(traversal)
-		if addrDiags.HasErrors() {
+		// If you add a new possible value for o.PlanMode here, consider also
+		// adding a specialized error message for it in ParseApplyDestroy.
+		switch {
+		case destroyRaw && refreshOnlyRaw:
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
-				fmt.Sprintf("Invalid force-replace address %q", raw),
-				addrDiags[0].Description().Detail,
+				"Incompatible plan mode options",
+				"The -destroy and -refresh-only options are mutually-exclusive.",
 			))
-			continue
+		case destroyRaw:
+			o.PlanMode = plans.DestroyMode
+		case refreshOnlyRaw:
+			o.PlanMode = plans.RefreshOnlyMode
+			if !o.Refresh {
+				diags = diags.Append(tfdiags.Sourceless(
+					tfdiags.Error,
+					"Incompatible refresh options",
+					"It doesn't make sense to use -refresh-only at the same time as -refresh=false, because OpenTofu would have nothing to do.",
+				))
+			}
+		default:
+			o.PlanMode = plans.NormalMode
 		}
 
-		if addr.Resource.Resource.Mode != addrs.ManagedResourceMode {
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				fmt.Sprintf("Invalid force-replace address %q", raw),
-				"Only managed resources can be used with the -replace=... option.",
-			))
-			continue
-		}
+		return diags
 
-		o.ForceReplace = append(o.ForceReplace, addr)
-	}
+	})
 
-	// If you add a new possible value for o.PlanMode here, consider also
-	// adding a specialized error message for it in ParseApplyDestroy.
-	switch {
-	case o.destroyRaw && o.refreshOnlyRaw:
-		diags = diags.Append(tfdiags.Sourceless(
-			tfdiags.Error,
-			"Incompatible plan mode options",
-			"The -destroy and -refresh-only options are mutually-exclusive.",
-		))
-	case o.destroyRaw:
-		o.PlanMode = plans.DestroyMode
-	case o.refreshOnlyRaw:
-		o.PlanMode = plans.RefreshOnlyMode
-		if !o.Refresh {
-			diags = diags.Append(tfdiags.Sourceless(
-				tfdiags.Error,
-				"Incompatible refresh options",
-				"It doesn't make sense to use -refresh-only at the same time as -refresh=false, because OpenTofu would have nothing to do.",
-			))
-		}
-	default:
-		o.PlanMode = plans.NormalMode
-	}
-
-	return diags
+	return &o
 }
 
 // Vars describes arguments which specify non-default variable values. This
@@ -329,75 +362,35 @@ func (o *Operation) Parse() tfdiags.Diagnostics {
 // determines the final value of the gathered variables. In future it might be
 // desirable for the arguments package to handle the gathering of variables
 // directly, returning a map of variable values.
-type Vars struct {
-	vars     *flags.RawFlags
-	varFiles *flags.RawFlags
+type Vars []flags.RawFlag
+
+func (v Vars) All() Vars {
+	return v
 }
 
-func (v *Vars) All() []flags.RawFlag {
-	if v.vars == nil {
-		return nil
-	}
-	return v.vars.AllItems()
-}
-
-func (v *Vars) Empty() bool {
-	if v.vars == nil {
-		return true
-	}
-	return v.vars.Empty()
-}
-
-// bind registers all Operation flags
-func BindOperation(cli *CommandLine) *Operation {
-	var operation Operation
-	cli.Operation = &operation
-
-	cli.IntVar(&operation.Parallelism, "parallelism", DefaultParallelism,
-		`Limit the number of parallel resource operations. Defaults to 10.`,
-	).SetDisplay("=n")
-	cli.BoolVar(&operation.Refresh, "refresh", true,
-		`Skip checking for external changes to remote objects while creating the plan. This can potentially make planning faster, but at the expense of possibly planning against a stale record of the remote system state.`,
-	).SetDisplay("=false")
-	cli.BoolVar(&operation.destroyRaw, "destroy", false,
-		`Select the "destroy" planning mode, which creates a plan to destroy all objects currently managed by this OpenTofu configuration instead of the usual behavior.`)
-	cli.BoolVar(&operation.refreshOnlyRaw, "refresh-only", false,
-		`Select the "refresh only" planning mode, which checks whether remote objects still match the outcome of the most recent OpenTofu apply but does not propose any actions to undo any changes made outside of OpenTofu.`)
-	cli.StringArrayVar(&operation.targetsRaw, "target", nil,
-		`Limit the planning operation to only the given module, resource, or resource instance and all of its dependencies. You can use this option multiple times to include more than one object. This is for exceptional use only. Cannot be used alongside the -exclude option.`,
-	).SetDisplay("=resource")
-	cli.StringArrayVar(&operation.targetsFilesRaw, "target-file", nil,
-		`Similar to -target, but specifies zero or more resource addresses from a file.`,
-	).SetDisplay("=filename")
-	cli.StringArrayVar(&operation.excludesRaw, "exclude", nil,
-		`Limit the planning operation to not operate on the given module, resource, or resource instance and all of the resources and modules that depend on it. You can use this option multiple times to exclude more than one object. This is for exceptional use only. Cannot be used together with the -target option.`,
-	).SetDisplay("=resource")
-	cli.StringArrayVar(&operation.excludesFilesRaw, "exclude-file", nil,
-		`Similar to -exclude, but specifies zero or more resource addresses from a file.`,
-	).SetDisplay("=filename")
-	cli.StringArrayVar(&operation.forceReplaceRaw, "replace", nil,
-		`Force replacement of a particular resource instance using its resource address. If the plan would've otherwise produced an update or no-op action for this instance, OpenTofu will plan to replace it instead. You can use this option multiple times to replace more than one object.`,
-	).SetDisplay("=resource")
-
-	cli.PreHook(operation.Parse)
-
-	return &operation
+func (v Vars) Empty() bool {
+	return len(v) == 0
 }
 
 // bind registers all Vars flags
 func BindVars(cli *CommandLine) *Vars {
-	var vars Vars
-	cli.Vars = &vars
-
 	varsFlags := flags.NewRawFlags("-var")
 	varFilesFlags := varsFlags.Alias("-var-file")
-	vars.vars = &varsFlags
-	vars.varFiles = &varFilesFlags
 	cli.RawFlags(varsFlags, "var",
 		`Set a value for one of the input variables in the root module of the configuration. Use this option more than once to set more than one variable.`,
 	).SetDisplay(" 'foo=bar'")
 	cli.RawFlags(varFilesFlags, "var-file",
 		`Load variable values from the given file, in addition to the default files terraform.tfvars and *.auto.tfvars. Use this option more than once to include more than one variables file.`,
 	).SetDisplay("=filename")
-	return &vars
+
+	vars := &Vars{}
+	cli.Vars = vars
+	cli.PreHook(func() tfdiags.Diagnostics {
+		if !varsFlags.Empty() {
+			*vars = varsFlags.AllItems()
+		}
+		return nil
+	})
+
+	return vars
 }

--- a/internal/command/arguments/extended_test.go
+++ b/internal/command/arguments/extended_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
@@ -195,8 +194,6 @@ func TestStateFlagsParsing(t *testing.T) {
 		},
 	}
 
-	cmpOpts := cmpopts.IgnoreUnexported()
-
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			var cli CommandLine
@@ -207,7 +204,7 @@ func TestStateFlagsParsing(t *testing.T) {
 			if want, got := fmt.Sprintf("%s", tc.wantErr), fmt.Sprintf("%s", diags.Err()); !strings.Contains(got, want) {
 				t.Errorf("wanted error: %q, got error %q", want, got)
 			}
-			if diff := cmp.Diff(tc.want, s, cmpOpts); diff != "" {
+			if diff := cmp.Diff(tc.want, s); diff != "" {
 				t.Errorf("unexpected result (-want,+got)\n%s", diff)
 			}
 		})
@@ -320,8 +317,6 @@ func TestStateFlagsRegistering(t *testing.T) {
 			}),
 		},
 	}
-	cmpOpts := cmpopts.IgnoreUnexported()
-
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			var cli CommandLine
@@ -330,7 +325,7 @@ func TestStateFlagsRegistering(t *testing.T) {
 			if want, got := fmt.Sprintf("%s", tc.wantErr), fmt.Sprintf("%s", diags.Err()); !strings.Contains(got, want) {
 				t.Errorf("wanted error: %q, got error %q", want, got)
 			}
-			if diff := cmp.Diff(tc.want, s, cmpOpts); diff != "" {
+			if diff := cmp.Diff(tc.want, s); diff != "" {
 				t.Errorf("unexpected result (-want,+got)\n%s", diff)
 			}
 		})

--- a/internal/command/arguments/get_test.go
+++ b/internal/command/arguments/get_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestParseGet_basicValidation(t *testing.T) {
@@ -43,8 +42,6 @@ func TestParseGet_basicValidation(t *testing.T) {
 		},
 	}
 
-	cmpOpts := cmpopts.IgnoreUnexported(Vars{})
-
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got, closer, diags := ParseGet(tc.args)
@@ -53,7 +50,7 @@ func TestParseGet_basicValidation(t *testing.T) {
 			if len(diags) > 0 {
 				t.Fatalf("unexpected diags: %v", diags)
 			}
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected result\n%s", diff)
 			}
 		})

--- a/internal/command/arguments/graph_test.go
+++ b/internal/command/arguments/graph_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestParseGraph_basicValidation(t *testing.T) {
@@ -95,8 +94,6 @@ func TestParseGraph_basicValidation(t *testing.T) {
 		},
 	}
 
-	cmpOpts := cmpopts.IgnoreUnexported(Vars{})
-
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got, closer, diags := ParseGraph(tc.args)
@@ -105,7 +102,7 @@ func TestParseGraph_basicValidation(t *testing.T) {
 			if len(diags) > 0 {
 				t.Fatalf("unexpected diags: %v", diags)
 			}
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected result\n%s", diff)
 			}
 		})

--- a/internal/command/arguments/import_test.go
+++ b/internal/command/arguments/import_test.go
@@ -11,8 +11,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/opentofu/opentofu/internal/command/flags"
 )
 
 func TestParseImport_basicValidation(t *testing.T) {
@@ -77,6 +75,7 @@ func TestParseImport_basicValidation(t *testing.T) {
 			want: importArgsWithDefaults(func(imp *Import) {
 				imp.ResourceAddress = "addr"
 				imp.ResourceID = "id"
+				imp.Vars = &Vars{{Name: "-var", Value: "foo=bar"}, {Name: "-var-file", Value: "vars.tfvars"}}
 			}),
 		},
 		"input flag": {
@@ -118,8 +117,6 @@ func TestParseImport_basicValidation(t *testing.T) {
 		},
 	}
 
-	cmpOpts := cmpopts.IgnoreUnexported(Vars{})
-
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got, closer, diags := ParseImport(tc.args)
@@ -135,7 +132,7 @@ func TestParseImport_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n%s\nwanted: %s\n", errStr, tc.wantErrText)
 				}
 			}
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected result\n%s", diff)
 			}
 		})
@@ -189,8 +186,6 @@ func TestParseImport_vars(t *testing.T) {
 }
 
 func importArgsWithDefaults(mutate func(imp *Import)) *Import {
-	v := flags.NewRawFlags("-var")
-	vf := flags.NewRawFlags("-var-file")
 	ret := &Import{
 		ResourceAddress: "",
 		ResourceID:      "",
@@ -201,10 +196,7 @@ func importArgsWithDefaults(mutate func(imp *Import)) *Import {
 			ViewType:            ViewHuman,
 			InputEnabled:        true,
 		},
-		Vars: &Vars{
-			vars:     &v,
-			varFiles: &vf,
-		},
+		Vars: &Vars{},
 		State: &State{
 			Lock:      true,
 			StatePath: "",

--- a/internal/command/arguments/init_test.go
+++ b/internal/command/arguments/init_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/opentofu/opentofu/internal/command/flags"
 )
 
@@ -106,8 +105,6 @@ func TestParseInit_basicValidation(t *testing.T) {
 		},
 	}
 
-	cmpOpts := cmpopts.IgnoreUnexported(Vars{})
-
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got, closer, diags := ParseInit(tc.args)
@@ -116,7 +113,7 @@ func TestParseInit_basicValidation(t *testing.T) {
 			if len(diags) > 0 {
 				t.Fatalf("unexpected diags: %v", diags)
 			}
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected result\n%s", diff)
 			}
 		})

--- a/internal/command/arguments/output_test.go
+++ b/internal/command/arguments/output_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestParseOutput_basicValidation(t *testing.T) {
@@ -72,7 +71,6 @@ func TestParseOutput_basicValidation(t *testing.T) {
 			wantErrText: "The output command expects exactly one argument with the name of an output variable or no arguments to show all outputs.",
 		},
 	}
-	cmpOpts := cmpopts.IgnoreUnexported(Vars{})
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got, closer, diags := ParseOutput(tc.args)
@@ -87,7 +85,7 @@ func TestParseOutput_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n%s\nwanted: %s\n", errStr, tc.wantErrText)
 				}
 			}
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected result\n%s", diff)
 			}
 		})

--- a/internal/command/arguments/plan_test.go
+++ b/internal/command/arguments/plan_test.go
@@ -9,11 +9,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/opentofu/opentofu/internal/command/flags"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/plans"
@@ -83,15 +81,13 @@ func TestParsePlan_basicValid(t *testing.T) {
 		},
 	}
 
-	cmpOpts := cmpopts.IgnoreUnexported(Operation{}, Vars{}, State{})
-
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got, _, diags := ParsePlan(tc.args)
 			if len(diags) > 0 {
 				t.Fatalf("unexpected diags: %v", diags)
 			}
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected result\n%s", diff)
 			}
 		})
@@ -615,21 +611,21 @@ func TestParsePlan_excludeAndTarget(t *testing.T) {
 func TestParsePlan_vars(t *testing.T) {
 	testCases := map[string]struct {
 		args []string
-		want []flags.RawFlag
+		want Vars
 	}{
 		"no var flags by default": {
 			args: nil,
-			want: nil,
+			want: Vars{},
 		},
 		"one var": {
 			args: []string{"-var", "foo=bar"},
-			want: []flags.RawFlag{
+			want: Vars{
 				{Name: "-var", Value: "foo=bar"},
 			},
 		},
 		"one var-file": {
 			args: []string{"-var-file", "cool.tfvars"},
-			want: []flags.RawFlag{
+			want: Vars{
 				{Name: "-var-file", Value: "cool.tfvars"},
 			},
 		},
@@ -639,7 +635,7 @@ func TestParsePlan_vars(t *testing.T) {
 				"-var-file", "cool.tfvars",
 				"-var", "boop=beep",
 			},
-			want: []flags.RawFlag{
+			want: Vars{
 				{Name: "-var", Value: "foo=bar"},
 				{Name: "-var-file", Value: "cool.tfvars"},
 				{Name: "-var", Value: "boop=beep"},

--- a/internal/command/arguments/providers_lock_test.go
+++ b/internal/command/arguments/providers_lock_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestParseProvidersLock_basicValidation(t *testing.T) {
@@ -105,8 +104,6 @@ func TestParseProvidersLock_basicValidation(t *testing.T) {
 		},
 	}
 
-	cmpOpts := cmpopts.IgnoreUnexported(Vars{})
-
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got, closer, diags := ParseProvidersLock(tc.args)
@@ -122,7 +119,7 @@ func TestParseProvidersLock_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n%s\nwanted: %s\n", errStr, tc.wantErrText)
 				}
 			}
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected result\n%s", diff)
 			}
 		})

--- a/internal/command/arguments/providers_mirror_test.go
+++ b/internal/command/arguments/providers_mirror_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestParseProvidersMirror_basicValidation(t *testing.T) {
@@ -60,8 +59,6 @@ func TestParseProvidersMirror_basicValidation(t *testing.T) {
 		},
 	}
 
-	cmpOpts := cmpopts.IgnoreUnexported(Vars{})
-
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got, closer, diags := ParseProvidersMirror(tc.args)
@@ -77,7 +74,7 @@ func TestParseProvidersMirror_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n\t%s\nwanted:\n\t%s\n", errStr, tc.wantErrText)
 				}
 			}
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected result\n%s", diff)
 			}
 		})

--- a/internal/command/arguments/providers_schema_test.go
+++ b/internal/command/arguments/providers_schema_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestParseProvidersSchema_basicValidation(t *testing.T) {
@@ -62,16 +61,12 @@ func TestParseProvidersSchema_basicValidation(t *testing.T) {
 		},
 	}
 
-	cmpOpts := cmp.Options{
-		cmpopts.IgnoreUnexported(Vars{}),
-	}
-
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got, closer, diags := ParseProvidersSchema(tc.args)
 			defer closer()
 
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected result\n%s", diff)
 			}
 

--- a/internal/command/arguments/providers_test.go
+++ b/internal/command/arguments/providers_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestParseProviders_basicValidation(t *testing.T) {
@@ -46,8 +45,6 @@ func TestParseProviders_basicValidation(t *testing.T) {
 		},
 	}
 
-	cmpOpts := cmpopts.IgnoreUnexported(Vars{})
-
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got, closer, diags := ParseProviders(tc.args)
@@ -63,7 +60,7 @@ func TestParseProviders_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n%s\nwanted: %s\n", errStr, tc.wantErrText)
 				}
 			}
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected result\n%s", diff)
 			}
 		})

--- a/internal/command/arguments/refresh_test.go
+++ b/internal/command/arguments/refresh_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/opentofu/opentofu/internal/addrs"
-	"github.com/opentofu/opentofu/internal/command/flags"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
@@ -443,21 +442,21 @@ func TestParseRefresh_excludeAndTarget(t *testing.T) {
 func TestParseRefresh_vars(t *testing.T) {
 	testCases := map[string]struct {
 		args []string
-		want []flags.RawFlag
+		want Vars
 	}{
 		"no var flags by default": {
 			args: nil,
-			want: nil,
+			want: Vars{},
 		},
 		"one var": {
 			args: []string{"-var", "foo=bar"},
-			want: []flags.RawFlag{
+			want: Vars{
 				{Name: "-var", Value: "foo=bar"},
 			},
 		},
 		"one var-file": {
 			args: []string{"-var-file", "cool.tfvars"},
-			want: []flags.RawFlag{
+			want: Vars{
 				{Name: "-var-file", Value: "cool.tfvars"},
 			},
 		},
@@ -467,7 +466,7 @@ func TestParseRefresh_vars(t *testing.T) {
 				"-var-file", "cool.tfvars",
 				"-var", "boop=beep",
 			},
-			want: []flags.RawFlag{
+			want: Vars{
 				{Name: "-var", Value: "foo=bar"},
 				{Name: "-var-file", Value: "cool.tfvars"},
 				{Name: "-var", Value: "boop=beep"},

--- a/internal/command/arguments/show_test.go
+++ b/internal/command/arguments/show_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
@@ -102,8 +101,6 @@ func TestParseShow_valid(t *testing.T) {
 		},
 	}
 
-	cmpOpts := cmpopts.IgnoreUnexported(Operation{}, Vars{}, State{})
-
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got, _, diags := ParseShow(tc.args)
@@ -111,7 +108,7 @@ func TestParseShow_valid(t *testing.T) {
 			if len(diags) > 0 {
 				t.Fatalf("unexpected diags: %v", diags)
 			}
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected result\n%s", diff)
 			}
 		})
@@ -308,13 +305,11 @@ func TestParseShow_invalid(t *testing.T) {
 		},
 	}
 
-	cmpOpts := cmpopts.IgnoreUnexported(Operation{}, Vars{}, State{})
-
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got, _, gotDiags := ParseShow(tc.args)
 			got.Vars = nil
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected result\n%s", diff)
 			}
 			if !reflect.DeepEqual(gotDiags, tc.wantDiags) {

--- a/internal/command/arguments/state_list_test.go
+++ b/internal/command/arguments/state_list_test.go
@@ -63,7 +63,6 @@ func TestParseStateList_basicValidation(t *testing.T) {
 	}
 
 	cmpOpts := cmp.Options{
-		cmpopts.IgnoreUnexported(Vars{}),
 		cmpopts.IgnoreFields(View{}, "JSONInto"), // We ignore JSONInto because it contains a file which is not really diffable
 	}
 

--- a/internal/command/arguments/state_mv_test.go
+++ b/internal/command/arguments/state_mv_test.go
@@ -109,7 +109,7 @@ func TestParseStateMv_basicValidation(t *testing.T) {
 				stateMv.RawSrcAddr = "source"
 				stateMv.RawDestAddr = "dest"
 				stateMv.Backend.IgnoreRemoteVersion = true
-				// Vars would be updated, but we ignore it in cmp
+				stateMv.Vars = &Vars{{Name: "-var", Value: "key=value"}}
 			}),
 		},
 		"no arguments": {
@@ -135,7 +135,6 @@ func TestParseStateMv_basicValidation(t *testing.T) {
 	}
 
 	cmpOpts := cmp.Options{
-		cmpopts.IgnoreUnexported(Vars{}, State{}),
 		cmpopts.IgnoreFields(View{}, "JSONInto"), // We ignore JSONInto because it contains a file which is not really diffable
 	}
 

--- a/internal/command/arguments/state_pull_test.go
+++ b/internal/command/arguments/state_pull_test.go
@@ -37,7 +37,6 @@ func TestParseStatePull_basicValidation(t *testing.T) {
 	}
 
 	cmpOpts := cmp.Options{
-		cmpopts.IgnoreUnexported(Vars{}),
 		cmpopts.IgnoreFields(View{}, "JSONInto"), // We ignore JSONInto because it contains a file which is not really diffable
 	}
 

--- a/internal/command/arguments/state_push_test.go
+++ b/internal/command/arguments/state_push_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestParseStatePush_basicValidation(t *testing.T) {
@@ -89,8 +88,6 @@ func TestParseStatePush_basicValidation(t *testing.T) {
 		},
 	}
 
-	cmpOpts := cmpopts.IgnoreUnexported(Vars{}, Backend{})
-
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got, closer, diags := ParseStatePush(tc.args)
@@ -106,7 +103,7 @@ func TestParseStatePush_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n%s\nwanted: %s\n", errStr, tc.wantErrText)
 				}
 			}
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected result\n%s", diff)
 			}
 		})

--- a/internal/command/arguments/state_replace_provider_test.go
+++ b/internal/command/arguments/state_replace_provider_test.go
@@ -87,7 +87,7 @@ func TestParseReplaceProvider_basicValidation(t *testing.T) {
 				srp.State.Lock = true
 				srp.RawSrcAddr = "source"
 				srp.RawDestAddr = "dest"
-				// Vars would be updated, but we ignore it in cmp
+				srp.Vars = &Vars{{Name: "-var", Value: "key=value"}}
 			}),
 		},
 		"no arguments": {
@@ -131,7 +131,6 @@ func TestParseReplaceProvider_basicValidation(t *testing.T) {
 	}
 
 	cmpOpts := cmp.Options{
-		cmpopts.IgnoreUnexported(Vars{}),
 		cmpopts.IgnoreFields(View{}, "JSONInto"), // We ignore JSONInto because it contains a file which is not really diffable
 	}
 

--- a/internal/command/arguments/state_rm_test.go
+++ b/internal/command/arguments/state_rm_test.go
@@ -85,7 +85,7 @@ func TestParseStateRm_basicValidation(t *testing.T) {
 				stateRm.State.LockTimeout = 15 * time.Second
 				stateRm.State.Lock = true
 				stateRm.TargetAddrs = []string{"resource.foo", "resource.bar"}
-				// Vars would be updated, but we ignore it in cmp
+				stateRm.Vars = &Vars{{Name: "-var", Value: "key=value"}}
 			}),
 		},
 		"no arguments": {
@@ -96,7 +96,6 @@ func TestParseStateRm_basicValidation(t *testing.T) {
 	}
 
 	cmpOpts := cmp.Options{
-		cmpopts.IgnoreUnexported(Vars{}, State{}),
 		cmpopts.IgnoreFields(View{}, "JSONInto"), // We ignore JSONInto because it contains a file which is not really diffable
 	}
 

--- a/internal/command/arguments/state_show_test.go
+++ b/internal/command/arguments/state_show_test.go
@@ -50,7 +50,7 @@ func TestParseStateShow_basicValidation(t *testing.T) {
 				stateShow.View.ShowSensitive = true
 				stateShow.State.StatePath = "/path/to/state.tfstate"
 				stateShow.TargetRawAddr = "resource_address"
-				// Vars would be updated, but we ignore it in cmp
+				stateShow.Vars = &Vars{{Name: "-var", Value: "key=value"}}
 			}),
 		},
 		"no arguments": {
@@ -75,7 +75,6 @@ func TestParseStateShow_basicValidation(t *testing.T) {
 	}
 
 	cmpOpts := cmp.Options{
-		cmpopts.IgnoreUnexported(Vars{}),
 		cmpopts.IgnoreFields(View{}, "JSONInto"), // We ignore JSONInto because it contains a file which is not really diffable
 	}
 

--- a/internal/command/arguments/taint_test.go
+++ b/internal/command/arguments/taint_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/opentofu/opentofu/internal/addrs"
 )
 
@@ -115,8 +114,6 @@ func TestParseTaint_basicValidation(t *testing.T) {
 		},
 	}
 
-	cmpOpts := cmpopts.IgnoreUnexported(Vars{}, View{}, State{}, Backend{})
-
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got, closer, diags := ParseTaint(tc.forTaintCmd, tc.args)
@@ -132,7 +129,7 @@ func TestParseTaint_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n%s\nwanted: %s\n", errStr, tc.wantErrText)
 				}
 			}
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected result\n%s", diff)
 			}
 		})

--- a/internal/command/arguments/test_test.go
+++ b/internal/command/arguments/test_test.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/opentofu/opentofu/internal/command/flags"
 
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
@@ -20,21 +18,21 @@ import (
 func TestParseTest_Vars(t *testing.T) {
 	tcs := map[string]struct {
 		args []string
-		want []flags.RawFlag
+		want Vars
 	}{
 		"no var flags by default": {
 			args: nil,
-			want: nil,
+			want: Vars{},
 		},
 		"one var": {
 			args: []string{"-var", "foo=bar"},
-			want: []flags.RawFlag{
+			want: Vars{
 				{Name: "-var", Value: "foo=bar"},
 			},
 		},
 		"one var-file": {
 			args: []string{"-var-file", "cool.tfvars"},
-			want: []flags.RawFlag{
+			want: Vars{
 				{Name: "-var-file", Value: "cool.tfvars"},
 			},
 		},
@@ -44,7 +42,7 @@ func TestParseTest_Vars(t *testing.T) {
 				"-var-file", "cool.tfvars",
 				"-var", "boop=beep",
 			},
-			want: []flags.RawFlag{
+			want: Vars{
 				{Name: "-var", Value: "foo=bar"},
 				{Name: "-var-file", Value: "cool.tfvars"},
 				{Name: "-var", Value: "boop=beep"},
@@ -142,13 +140,11 @@ func TestParseTest(t *testing.T) {
 		},
 	}
 
-	cmpOpts := cmpopts.IgnoreUnexported(Operation{}, Vars{}, State{})
-
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
 			got, _, diags := ParseTest(tc.args)
 
-			if diff := cmp.Diff(tc.want, got, cmpOpts); len(diff) > 0 {
+			if diff := cmp.Diff(tc.want, got); len(diff) > 0 {
 				t.Errorf("diff:\n%s", diff)
 			}
 

--- a/internal/command/arguments/unlock_test.go
+++ b/internal/command/arguments/unlock_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestParseUnlock_basicValidation(t *testing.T) {
@@ -47,8 +46,6 @@ func TestParseUnlock_basicValidation(t *testing.T) {
 		},
 	}
 
-	cmpOpts := cmpopts.IgnoreUnexported(Vars{})
-
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got, closer, diags := ParseUnlock(tc.args)
@@ -64,7 +61,7 @@ func TestParseUnlock_basicValidation(t *testing.T) {
 					t.Errorf("the returned diagnostics does not contain the expected error message.\ndiags:\n%s\nwanted: %s\n", errStr, tc.wantErrText)
 				}
 			}
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected result\n%s", diff)
 			}
 		})

--- a/internal/command/arguments/workspace_delete_test.go
+++ b/internal/command/arguments/workspace_delete_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestParseWorkspaceDelete_viewOptions(t *testing.T) {
@@ -85,8 +84,6 @@ func TestParseWorkspaceDelete_basicValidation(t *testing.T) {
 		},
 	}
 
-	cmpOpts := cmpopts.IgnoreUnexported(Vars{})
-
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got, closer, diags := ParseWorkspaceDelete(tc.args)
@@ -95,7 +92,7 @@ func TestParseWorkspaceDelete_basicValidation(t *testing.T) {
 			if len(diags) > 0 {
 				t.Fatalf("unexpected diags: %v", diags)
 			}
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected result\n%s", diff)
 			}
 		})

--- a/internal/command/arguments/workspace_new_test.go
+++ b/internal/command/arguments/workspace_new_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestParseWorkspaceNew_viewOptions(t *testing.T) {
@@ -127,8 +126,6 @@ func TestParseWorkspaceNew_basicValidation(t *testing.T) {
 		},
 	}
 
-	cmpOpts := cmpopts.IgnoreUnexported(Vars{})
-
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got, closer, diags := ParseWorkspaceNew(tc.args)
@@ -137,7 +134,7 @@ func TestParseWorkspaceNew_basicValidation(t *testing.T) {
 			if len(diags) > 0 {
 				t.Fatalf("unexpected diags: %v", diags)
 			}
-			if diff := cmp.Diff(tc.want, got, cmpOpts); diff != "" {
+			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected result\n%s", diff)
 			}
 		})

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -347,6 +347,26 @@ func RunCli(namespace string, cmd Command, meta Meta, diags tfdiags.Diagnostics)
 	// continue to mutate the Meta object state for now.
 	meta.input = cmd.CommandLine.View.InputEnabled
 
+	if cmd.CommandLine.State != nil {
+		meta.stateArgs = *cmd.CommandLine.State
+	}
+	if cmd.CommandLine.Backend != nil {
+		meta.backendArgs = *cmd.CommandLine.Backend
+	}
+	if cmd.CommandLine.Operation != nil {
+		// FIXME: the -parallelism flag is used to control the concurrency of
+		// OpenTofu operations. At the moment, this value is used both to
+		// initialize the backend via the ContextOpts field inside CLIOpts, and to
+		// set a largely unused field on the Operation request. Again, there is no
+		// clear path to pass this value down, so we continue to mutate the Meta
+		// object state for now.
+		meta.parallelism = cmd.CommandLine.Operation.Parallelism
+	}
+	if cmd.CommandLine.Vars != nil {
+		// Inject variables from args into meta for static evaluation
+		meta.variableArgs = cmd.CommandLine.Vars.All()
+	}
+
 	return cmd.Run(meta)
 }
 

--- a/internal/command/console.go
+++ b/internal/command/console.go
@@ -56,9 +56,6 @@ func (c ConsoleCommand) Execute(args *arguments.Console, view views.Console) int
 
 	ctx := c.CommandContext()
 
-	c.Meta.stateArgs = *args.State
-	c.Meta.variableArgs = args.Vars.All()
-
 	configPath := c.WorkingDir.NormalizePath(c.WorkingDir.RootModuleDir())
 
 	// Check for user-supplied plugin path

--- a/internal/command/get.go
+++ b/internal/command/get.go
@@ -50,8 +50,6 @@ func (c GetCommand) Execute(args *arguments.Get, view views.Get) int {
 	ctx, span := tracing.Tracer().Start(ctx, "Get")
 	defer span.End()
 
-	c.Meta.variableArgs = args.Vars.All()
-
 	// Initialization can be aborted by interruption signals
 	ctx, done := c.InterruptibleContext(ctx)
 	defer done()

--- a/internal/command/import.go
+++ b/internal/command/import.go
@@ -67,14 +67,6 @@ func (c ImportCommand) Execute(args *arguments.Import, view views.Import) int {
 		args.ConfigPath = c.WorkingDir.NormalizePath(c.WorkingDir.RootModuleDir())
 	}
 
-	c.Meta.variableArgs = args.Vars.All()
-	c.stateArgs = *args.State
-	c.backendArgs = *args.Backend
-
-	// TODO meta-refactor: remove this only when there is clear path of passing these from the "arguments" package to
-	// the place where these needs to be used
-	c.Meta.parallelism = args.Parallelism
-
 	// Parse the provided resource address.
 	traversalSrc := []byte(args.ResourceAddress)
 	traversal, travDiags := hclsyntax.ParseTraversalAbs(traversalSrc, "<import-address>", hcl.Pos{Line: 1, Column: 1})

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -83,9 +83,6 @@ func (c InitCommand) Execute(args *arguments.Init, view views.Init) int {
 	if len(args.FlagPluginPath) > 0 {
 		c.pluginPath = args.FlagPluginPath
 	}
-	c.Meta.variableArgs = args.Vars.All()
-	c.Meta.stateArgs = *args.State
-	c.Meta.backendArgs = *args.Backend
 
 	// This gets the current directory as full path.
 	path := c.WorkingDir.NormalizePath(c.WorkingDir.RootModuleDir())

--- a/internal/command/login.go
+++ b/internal/command/login.go
@@ -81,8 +81,6 @@ func (c LoginCommand) Execute(args *arguments.Login, view views.Login) int {
 	ctx, span := tracing.Tracer().Start(ctx, "Login")
 	defer span.End()
 
-	c.Meta.stateArgs = *args.State
-
 	if !c.input {
 		diags = diags.Append(tfdiags.Sourceless(
 			tfdiags.Error,

--- a/internal/command/output.go
+++ b/internal/command/output.go
@@ -44,9 +44,6 @@ func (c *OutputCommand) Run(rawArgs []string) int {
 func (c OutputCommand) Execute(args *arguments.Output, view views.Output) int {
 	ctx := c.CommandContext()
 
-	// Inject variables from args into meta for static evaluation
-	c.Meta.variableArgs = args.Vars.All()
-
 	// Load the encryption configuration
 	enc, diags := c.Encryption(ctx)
 	if diags.HasErrors() {
@@ -76,11 +73,6 @@ func (c OutputCommand) Execute(args *arguments.Output, view views.Output) int {
 
 func (c *OutputCommand) Outputs(ctx context.Context, statePath string, enc encryption.Encryption) (map[string]*states.OutputValue, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
-
-	// Allow state path override
-	if statePath != "" {
-		c.Meta.stateArgs.StatePath = statePath
-	}
 
 	// Load the backend
 	b, backendDiags := c.Backend(ctx, nil, enc.State())

--- a/internal/command/plan.go
+++ b/internal/command/plan.go
@@ -58,18 +58,7 @@ func (c PlanCommand) Execute(args *arguments.Plan, view views.Plan) int {
 		return 1
 	}
 
-	// FIXME: the -parallelism flag is used to control the concurrency of
-	// OpenTofu operations. At the moment, this value is used both to
-	// initialize the backend via the ContextOpts field inside CLIOpts, and to
-	// set a largely unused field on the Operation request. Again, there is no
-	// clear path to pass this value down, so we continue to mutate the Meta
-	// object state for now.
-	c.Meta.parallelism = args.Operation.Parallelism
-
 	diags = diags.Append(c.providerDevOverrideRuntimeWarnings())
-
-	// Inject variables from args into meta for static evaluation
-	c.Meta.variableArgs = args.Vars.All()
 
 	// Load the encryption configuration
 	enc, encDiags := c.Encryption(ctx)
@@ -119,8 +108,6 @@ func (c PlanCommand) Execute(args *arguments.Plan, view views.Plan) int {
 }
 
 func (c *PlanCommand) PrepareBackend(ctx context.Context, args *arguments.State, view views.Plan, enc encryption.Encryption) (backend.Enhanced, tfdiags.Diagnostics) {
-	c.Meta.stateArgs = *args
-
 	backendConfig, diags := c.loadBackendConfig(ctx, ".")
 	if diags.HasErrors() {
 		return nil, diags

--- a/internal/command/providers.go
+++ b/internal/command/providers.go
@@ -56,7 +56,6 @@ func (c ProvidersCommand) Execute(args *arguments.Providers, view views.Provider
 
 	ctx := c.CommandContext()
 
-	c.Meta.variableArgs = args.Vars.All()
 	// This gets the current directory as full path.
 	configPath := c.WorkingDir.NormalizePath(c.WorkingDir.RootModuleDir())
 

--- a/internal/command/providers_lock.go
+++ b/internal/command/providers_lock.go
@@ -79,8 +79,6 @@ func (c ProvidersLockCommand) Execute(args *arguments.ProvidersLock, view views.
 	ctx, span := tracing.Tracer().Start(ctx, "Providers lock")
 	defer span.End()
 
-	c.Meta.variableArgs = args.Vars.All()
-
 	span.SetAttributes(traceattrs.StringSlice("opentofu.provider.lock.targetplatforms", args.OptPlatforms))
 	if args.FsMirrorDir != "" {
 		span.SetAttributes(traceattrs.String("opentofu.provider.lock.fsmirror", args.FsMirrorDir))

--- a/internal/command/providers_mirror.go
+++ b/internal/command/providers_mirror.go
@@ -62,8 +62,6 @@ func (c *ProvidersMirrorCommand) Run(rawArgs []string) int {
 func (c ProvidersMirrorCommand) Execute(args *arguments.ProvidersMirror, view views.ProvidersMirror) int {
 	var diags tfdiags.Diagnostics
 
-	c.Meta.variableArgs = args.Vars.All()
-
 	outputDir := args.Directory
 
 	var platforms []getproviders.Platform

--- a/internal/command/providers_schema.go
+++ b/internal/command/providers_schema.go
@@ -53,8 +53,6 @@ func (c ProvidersSchemaCommand) Execute(args *arguments.ProvidersSchema, view vi
 	var diags tfdiags.Diagnostics
 	ctx := c.CommandContext()
 
-	c.Meta.variableArgs = args.Vars.All()
-
 	// Check for user-supplied plugin path
 	var err error
 	if c.pluginPath, err = c.loadPluginPath(); err != nil {

--- a/internal/command/refresh.go
+++ b/internal/command/refresh.go
@@ -56,17 +56,6 @@ func (c RefreshCommand) Execute(args *arguments.Refresh, view views.Refresh) int
 		return 1
 	}
 
-	// FIXME: the -parallelism flag is used to control the concurrency of
-	// OpenTofu operations. At the moment, this value is used both to
-	// initialize the backend via the ContextOpts field inside CLIOpts, and to
-	// set a largely unused field on the Operation request. Again, there is no
-	// clear path to pass this value down, so we continue to mutate the Meta
-	// object state for now.
-	c.Meta.parallelism = args.Operation.Parallelism
-
-	// Inject variables from args into meta for static evaluation
-	c.Meta.variableArgs = args.Vars.All()
-
 	// Load the encryption configuration
 	enc, encDiags := c.Encryption(ctx)
 	diags = diags.Append(encDiags)
@@ -112,8 +101,6 @@ func (c RefreshCommand) Execute(args *arguments.Refresh, view views.Refresh) int
 }
 
 func (c *RefreshCommand) PrepareBackend(ctx context.Context, args *arguments.State, view views.Refresh, enc encryption.Encryption) (backend.Enhanced, tfdiags.Diagnostics) {
-	c.Meta.stateArgs = *args
-
 	backendConfig, diags := c.loadBackendConfig(ctx, ".")
 	if diags.HasErrors() {
 		return nil, diags

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -99,9 +99,6 @@ func (c ShowCommand) Execute(args *arguments.Show, view views.Show) int {
 		return 1
 	}
 
-	// Inject variables from args into meta for static evaluation
-	c.Meta.variableArgs = args.Vars.All()
-
 	// Load the encryption configuration
 	enc, encDiags := c.Encryption(ctx)
 	diags = diags.Append(encDiags)

--- a/internal/command/state_list.go
+++ b/internal/command/state_list.go
@@ -59,12 +59,6 @@ func (c StateListCommand) Execute(args *arguments.StateList, view views.State) i
 
 	ctx := c.CommandContext()
 
-	c.Meta.variableArgs = args.Vars.All()
-
-	if args.State.StatePath != "" {
-		c.Meta.stateArgs.StatePath = args.State.StatePath
-	}
-
 	// Load the encryption configuration
 	enc, encDiags := c.Encryption(ctx)
 	if encDiags.HasErrors() {

--- a/internal/command/state_mv.go
+++ b/internal/command/state_mv.go
@@ -58,18 +58,12 @@ func (c StateMvCommand) Execute(args *arguments.StateMv, view views.State) int {
 
 	c.backendArgs = *args.Backend
 
-	c.Meta.variableArgs = args.Vars.All()
 	// NOTE: We intentionally configure the stateArgs here like this, ignoring the stateOutPath, because the c.stateArgs
 	// are used for loading the state which stores internally the output path which in the context of this command
 	// will have unwanted side effects, ending in writing the source state in the target state.
 	// TODO meta-refactor: when we move the backend logic to its own component, maybe there is a way to change the
 	//  arguments.State in such way to be reused with/without the stateOut.
-	c.Meta.stateArgs = arguments.State{
-		Lock:        args.State.Lock,
-		LockTimeout: args.State.LockTimeout,
-		StatePath:   args.State.StatePath,
-		BackupPath:  args.State.BackupPath,
-	}
+	c.Meta.stateArgs.StateOutPath = ""
 
 	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {
 		view.Diagnostics(diags)

--- a/internal/command/state_pull.go
+++ b/internal/command/state_pull.go
@@ -53,8 +53,6 @@ func (c StatePullCommand) Execute(args *arguments.StatePull, view views.State) i
 	var diags tfdiags.Diagnostics
 	ctx := c.CommandContext()
 
-	c.Meta.variableArgs = args.Vars.All()
-
 	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {
 		view.Diagnostics(diags)
 		return 1

--- a/internal/command/state_push.go
+++ b/internal/command/state_push.go
@@ -60,10 +60,6 @@ func (c StatePushCommand) Execute(args *arguments.StatePush, view views.State) i
 
 	ctx := c.CommandContext()
 
-	c.Meta.variableArgs = args.Vars.All()
-	c.Meta.stateArgs = *args.State
-	c.Meta.backendArgs = *args.Backend
-
 	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {
 		view.Diagnostics(diags)
 		return 1

--- a/internal/command/state_replace_provider.go
+++ b/internal/command/state_replace_provider.go
@@ -52,10 +52,6 @@ func (c StateReplaceProviderCommand) Execute(args *arguments.StateReplaceProvide
 
 	ctx := c.CommandContext()
 
-	c.Meta.stateArgs = *args.State
-	c.Meta.variableArgs = args.Vars.All()
-	c.Meta.backendArgs = *args.Backend
-
 	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {
 		view.Diagnostics(diags)
 		return 1

--- a/internal/command/state_rm.go
+++ b/internal/command/state_rm.go
@@ -53,10 +53,6 @@ func (c StateRmCommand) Execute(args *arguments.StateRm, view views.State) int {
 
 	ctx := c.CommandContext()
 
-	c.Meta.variableArgs = args.Vars.All()
-	c.Meta.stateArgs = *args.State
-	c.Meta.backendArgs = *args.Backend
-
 	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {
 		view.Diagnostics(diags)
 		return 1

--- a/internal/command/state_show.go
+++ b/internal/command/state_show.go
@@ -53,9 +53,6 @@ func (c StateShowCommand) Execute(args *arguments.StateShow, view views.State) i
 
 	ctx := c.CommandContext()
 
-	c.Meta.variableArgs = args.Vars.All()
-	c.Meta.stateArgs = *args.State
-
 	// Check for user-supplied plugin path
 	var err error
 	if c.pluginPath, err = c.loadPluginPath(); err != nil {

--- a/internal/command/taint.go
+++ b/internal/command/taint.go
@@ -62,9 +62,6 @@ func (c TaintCommand) Execute(args *arguments.Taint, view views.Taint) int {
 
 	ctx := c.CommandContext()
 
-	c.Meta.variableArgs = args.Vars.All()
-	c.Meta.stateArgs = *args.State
-
 	addr := args.TargetAddress
 
 	if diags := c.Meta.checkRequiredVersion(ctx); diags != nil {

--- a/internal/command/test.go
+++ b/internal/command/test.go
@@ -150,10 +150,6 @@ func (c TestCommand) Execute(args *arguments.Test, view views.Test) int {
 	var diags tfdiags.Diagnostics
 	ctx := c.CommandContext()
 
-	// Users can also specify variables via the command line, so we'll parse
-	// all that here.
-	c.variableArgs = args.Vars.All()
-
 	variables, variableDiags := c.collectVariableValuesWithTests(args.TestDirectory)
 	diags = diags.Append(variableDiags)
 	if variableDiags.HasErrors() {

--- a/internal/command/unlock.go
+++ b/internal/command/unlock.go
@@ -54,8 +54,6 @@ func (c UnlockCommand) Execute(args *arguments.Unlock, view views.Unlock) int {
 	ctx, span := tracing.Tracer().Start(ctx, "Unlock")
 	defer span.End()
 
-	c.Meta.variableArgs = args.Vars.All()
-
 	lockID := args.LockID
 
 	// This gets the current directory as full path.

--- a/internal/command/untaint.go
+++ b/internal/command/untaint.go
@@ -54,9 +54,6 @@ func (c UntaintCommand) Execute(args *arguments.Taint, view views.Taint) int {
 
 	ctx := c.CommandContext()
 
-	c.Meta.variableArgs = args.Vars.All()
-	c.Meta.stateArgs = *args.State
-
 	addr := args.TargetAddress
 
 	// Load the encryption configuration

--- a/internal/command/validate.go
+++ b/internal/command/validate.go
@@ -76,9 +76,6 @@ func (c ValidateCommand) Execute(args *arguments.Validate, view views.Validate) 
 		return view.Results(diags)
 	}
 
-	// Inject variables from args into meta for static evaluation
-	c.Meta.variableArgs = args.Vars.All()
-
 	validateDiags := c.validate(ctx, dir, args.TestDirectory, args.NoTests)
 	diags = diags.Append(validateDiags)
 

--- a/internal/command/workspace_delete.go
+++ b/internal/command/workspace_delete.go
@@ -49,9 +49,6 @@ func (c WorkspaceDeleteCommand) Execute(args *arguments.WorkspaceDelete, view vi
 	var diags tfdiags.Diagnostics
 	ctx := c.CommandContext()
 
-	c.Meta.variableArgs = args.Vars.All()
-	c.Meta.stateArgs = *args.State
-
 	view.WarnWhenUsedAsEnvCmd(c.LegacyName)
 
 	configPath := c.WorkingDir.NormalizePath(c.WorkingDir.RootModuleDir())

--- a/internal/command/workspace_list.go
+++ b/internal/command/workspace_list.go
@@ -46,8 +46,6 @@ func (c WorkspaceListCommand) Execute(args *arguments.WorkspaceList, view views.
 
 	ctx := c.CommandContext()
 
-	c.Meta.variableArgs = args.Vars.All()
-
 	view.WarnWhenUsedAsEnvCmd(c.LegacyName)
 
 	configPath := c.WorkingDir.NormalizePath(c.WorkingDir.RootModuleDir())

--- a/internal/command/workspace_new.go
+++ b/internal/command/workspace_new.go
@@ -52,9 +52,6 @@ func (c WorkspaceNewCommand) Execute(args *arguments.WorkspaceNew, view views.Wo
 
 	ctx := c.CommandContext()
 
-	c.Meta.variableArgs = args.Vars.All()
-	c.Meta.stateArgs = *args.State
-
 	view.WarnWhenUsedAsEnvCmd(c.LegacyName)
 
 	configPath := c.WorkingDir.NormalizePath(c.WorkingDir.RootModuleDir())

--- a/internal/command/workspace_select.go
+++ b/internal/command/workspace_select.go
@@ -45,8 +45,6 @@ func (c WorkspaceSelectCommand) Execute(args *arguments.WorkspaceSelect, view vi
 	var diags tfdiags.Diagnostics
 	ctx := c.CommandContext()
 
-	c.Meta.variableArgs = args.Vars.All()
-
 	view.WarnWhenUsedAsEnvCmd(c.LegacyName)
 
 	configPath := c.WorkingDir.NormalizePath(c.WorkingDir.RootModuleDir())

--- a/internal/command/workspace_show.go
+++ b/internal/command/workspace_show.go
@@ -42,8 +42,6 @@ func (c *WorkspaceShowCommand) Run(rawArgs []string) int {
 func (c WorkspaceShowCommand) Execute(args *arguments.WorkspaceShow, view views.Workspace) int {
 	ctx := c.CommandContext()
 
-	c.Meta.variableArgs = args.Vars.All()
-
 	workspace, err := c.Workspace(ctx)
 	if err != nil {
 		view.Diagnostics(tfdiags.Diagnostics{tfdiags.Sourceless(


### PR DESCRIPTION
This is not a long term approach and should be removed as soon as more stuff is broken out of the meta struct.

However, we have manually injected args into the meta struct all over the place, which is error prone and can easily cause hard to trace bugs.

Although I don't *love* this approach, it does prevent easy to miss bugs from occurring when minor changes are made to commands.

Cleanup for #3595

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
