### PR TITLE
planning: Properly handle the ResourceInstancePrior stubs in deletion

### DIFF
--- a/internal/engine/internal/execgraph/builder.go
+++ b/internal/engine/internal/execgraph/builder.go
@@ -351,6 +351,13 @@ func (b *Builder) MutableWaiter() (AnyResultRef, func(AnyResultRef)) {
 	idx := appendIndex(&b.graph.waiters, []AnyResultRef{})
 	ref := waiterResultRef{idx}
 	registerFunc := func(ref AnyResultRef) {
+		if ref == nil {
+			// Letting a nil be registered here causes us to have a malformed
+			// graph that misbehaves when round-tripping through
+			// marshal/unmarshal, so we'll reject it early to avoid a confusing
+			// error later.
+			panic("attempt to register nil result ref in waiter")
+		}
 		b.graph.waiters[idx] = append(b.graph.waiters[idx], ref)
 	}
 	return ref, registerFunc

--- a/internal/engine/planning/execgraph_resource.go
+++ b/internal/engine/planning/execgraph_resource.go
@@ -329,5 +329,12 @@ func (s *resourceInstanceObjectSubgraph) DeleteDependsOn(r execgraph.AnyResultRe
 	if s.addOrphanDep == nil {
 		panic("attempt to add deletion dependency for object that has no deletion leg")
 	}
+	if r == nil {
+		// The stub subgraphs we create for resource instance objects whose results
+		// are needed even though they aren't being changed have a nil deletion
+		// ref because they aren't being deleted, and so we'll silently ignore
+		// that situation here just to centralize this special case in one place.
+		return
+	}
 	s.addOrphanDep(r)
 }


### PR DESCRIPTION
For resource instance objects whose results are needed to satisfy other expressions even though they aren't actually changing in the current plan we insert stub subgraphs that include only `ResourceInstancePrior`.

Those stubs never contain a deletion ref because nothing is being deleted, but the inter-subgraph-wiring code was not checking for that. To centralize this special rule in just one place we'll silently ignore requests to add a deletion dependency to a nil result ref, so that all of the callers of this function can benefit at once.

The need for this is a little subtle: the protobuf format we use for representing a serialized execution graph can't directly represent a nil result ref and so these spurious extra edges were getting misinterpreted by the unmarshal code. To guard against similar problems arising in the future, this commit also adds a safety check which panics if a caller attempts to register a nil result as a dependency and thus we're less likely to miss a bug like this when relying on tests that don't actually exercise the marshal/unmarshal paths.

There's currently no direct testing for this situation in `package planning` or `package execgraph` because for now we're relying on the context tests in `package tofu` as our main vehicle for testing more complicated interactions between resource instance objects in the execution graph. Once the shape of the new runtime architecture starts to settle down we'll return and add more localized tests here, but we're intentionally minimizing that right now because the relevant code here is likely to be restructured at least a little more before final and the unit tests have tended to be more annoying than helpful in such work so far.

(This is the fix for the problem initially discussed in https://github.com/opentofu/opentofu/pull/4326#issuecomment-5145405857. The `nil` in `r[8]`'s "await" argument was the cause of the problem.)

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

