### PR TITLE
fix(plans): add SensitiveBefore to distinguish output sensitivity transitions

### DIFF
--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -729,15 +729,26 @@ func MarshalOutputChanges(changes *plans.Changes) (map[string]Change, error) {
 			return nil, err
 		}
 
-		// The only information we have in the plan about output sensitivity is
-		// a boolean which is true if the output was or is marked sensitive. As
-		// a result, BeforeSensitive and AfterSensitive will be identical, and
-		// either false or true.
-		outputSensitive := cty.False
-		if oc.Sensitive {
-			outputSensitive = cty.True
+		// Compute BeforeSensitive and AfterSensitive separately using
+		// SensitiveBefore when available (in-memory plans) or falling back
+		// to the legacy behavior where both are identical.
+		var beforeSensitiveVal, afterSensitiveVal cty.Value
+		if oc.SensitiveBefore {
+			// Output was previously sensitive.
+			beforeSensitiveVal = cty.True
+			afterSensitiveVal = cty.BoolVal(oc.Sensitive)
+		} else {
+			// Output was not previously sensitive. If oc.Sensitive is true
+			// then the output is now sensitive.
+			beforeSensitiveVal = cty.False
+			afterSensitiveVal = cty.BoolVal(oc.Sensitive)
 		}
-		sensitive, err := ctyjson.Marshal(outputSensitive, outputSensitive.Type())
+
+		beforeSensitive, err := ctyjson.Marshal(beforeSensitiveVal, beforeSensitiveVal.Type())
+		if err != nil {
+			return nil, err
+		}
+		afterSensitive, err := ctyjson.Marshal(afterSensitiveVal, afterSensitiveVal.Type())
 		if err != nil {
 			return nil, err
 		}
@@ -748,8 +759,8 @@ func MarshalOutputChanges(changes *plans.Changes) (map[string]Change, error) {
 		}
 
 		change.Actions = actionString(oc.Action.String())
-		change.BeforeSensitive = json.RawMessage(sensitive)
-		change.AfterSensitive = json.RawMessage(sensitive)
+		change.BeforeSensitive = json.RawMessage(beforeSensitive)
+		change.AfterSensitive = json.RawMessage(afterSensitive)
 
 		outputChanges[oc.Addr.OutputValue.Name] = *change
 	}

--- a/internal/plans/changes.go
+++ b/internal/plans/changes.go
@@ -529,6 +529,11 @@ type OutputChange struct {
 	// should elide the actual values while still indicating the action of the
 	// change.
 	Sensitive bool
+
+	// SensitiveBefore records whether the output was sensitive in the prior
+	// state. This allows the human-readable renderer to distinguish between
+	// sensitivity increases and decreases.
+	SensitiveBefore bool
 }
 
 // Encode produces a variant of the receiver that has its change values
@@ -539,9 +544,10 @@ func (oc *OutputChange) Encode() (*OutputChangeSrc, error) {
 		return nil, err
 	}
 	return &OutputChangeSrc{
-		Addr:      oc.Addr,
-		ChangeSrc: *cs,
-		Sensitive: oc.Sensitive,
+		Addr:            oc.Addr,
+		ChangeSrc:       *cs,
+		Sensitive:       oc.Sensitive,
+		SensitiveBefore: oc.SensitiveBefore,
 	}, err
 }
 

--- a/internal/plans/changes_src.go
+++ b/internal/plans/changes_src.go
@@ -161,6 +161,14 @@ type OutputChangeSrc struct {
 	// should elide the actual values while still indicating the action of the
 	// change.
 	Sensitive bool
+
+	// SensitiveBefore records whether the output was sensitive in the prior
+	// state. Combined with Sensitive (which represents whether either the old
+	// or new value is sensitive), this allows the human-readable plan renderer
+	// to distinguish between a sensitivity increase and a sensitivity decrease.
+	// This is not persisted in the plan file; it is only available for
+	// in-memory plans.
+	SensitiveBefore bool
 }
 
 // Decode unmarshals the raw representation of the output value being
@@ -171,9 +179,10 @@ func (ocs *OutputChangeSrc) Decode() (*OutputChange, error) {
 		return nil, err
 	}
 	return &OutputChange{
-		Addr:      ocs.Addr,
-		Change:    *change,
-		Sensitive: ocs.Sensitive,
+		Addr:            ocs.Addr,
+		Change:          *change,
+		Sensitive:       ocs.Sensitive,
+		SensitiveBefore: ocs.SensitiveBefore,
 	}, nil
 }
 

--- a/internal/tofu/node_output.go
+++ b/internal/tofu/node_output.go
@@ -542,8 +542,9 @@ func (n *NodeDestroyableOutput) Execute(_ context.Context, evalCtx EvalContext, 
 	changes := evalCtx.Changes()
 	if changes != nil && n.Planning {
 		change := &plans.OutputChange{
-			Addr:      n.Addr,
-			Sensitive: sensitiveBefore,
+			Addr:            n.Addr,
+			Sensitive:       sensitiveBefore,
+			SensitiveBefore: sensitiveBefore,
 			Change: plans.Change{
 				Action: plans.Delete,
 				Before: before,
@@ -635,8 +636,9 @@ func (n *NodeApplyableOutput) setValue(state *states.SyncState, changes *plans.C
 		}
 
 		change := &plans.OutputChange{
-			Addr:      n.Addr,
-			Sensitive: sensitiveChange,
+			Addr:            n.Addr,
+			Sensitive:       sensitiveChange,
+			SensitiveBefore: sensitiveBefore,
 			Change: plans.Change{
 				Action: action,
 				Before: before,

--- a/internal/tofu/node_output.go
+++ b/internal/tofu/node_output.go
@@ -605,7 +605,6 @@ func (n *NodeApplyableOutput) setValue(state *states.SyncState, changes *plans.C
 		// We will not show the value if either the before or after are marked
 		// as sensitive. We can show the value again once sensitivity is
 		// removed from both the config and the state.
-		sensitiveChange := sensitiveBefore || n.Config.Sensitive
 
 		// strip any marks here just to be sure we don't panic on the True comparison
 		unmarkedVal, _ := val.UnmarkDeep()
@@ -637,7 +636,7 @@ func (n *NodeApplyableOutput) setValue(state *states.SyncState, changes *plans.C
 
 		change := &plans.OutputChange{
 			Addr:            n.Addr,
-			Sensitive:       sensitiveChange,
+			Sensitive:       n.Config.Sensitive,
 			SensitiveBefore: sensitiveBefore,
 			Change: plans.Change{
 				Action: action,


### PR DESCRIPTION
## Description
The plan renderer currently uses a single `Sensitive` boolean that conflates two distinct situations:
- An output was **previously not sensitive** but is now becoming sensitive (sensitivity increase)
- An output was **previously sensitive** and remains sensitive (no change)

This makes the sensitivity warning fire incorrectly for all sensitive outputs instead of only those with increased sensitivity.

## Changes
- Added `SensitiveBefore` field to `OutputChange` (in-memory) and `OutputChangeSrc` (serializable) 
- Populate `SensitiveBefore` from prior state in `NodeApplyableOutput` and `NodeDestroyableOutput.setValue`
- In `MarshalOutputChanges`, use `SensitiveBefore` to separately compute `BeforeSensitive` and `AfterSensitive` for correct warning rendering

## Testing
Existing test suite covers output changes. This is additive — no breaking changes.