### PR TITLE
workspace new: add actionable hint when workspace already exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
+- `tofu workspace new` now includes a hint to use `tofu workspace select` when the given workspace name already exists, instead of just reporting that it already exists. ([#4428](https://github.com/opentofu/opentofu/issues/4428))
 - `tofu apply -json` now emits periodic `apply_progress` heartbeat messages for the full duration of a resource operation, instead of stopping after the first one. ([#4107](https://github.com/opentofu/opentofu/pull/4318))
 - The built-in function `contains` now accepts `null` as its second argument, to test whether a collection contains any null values. ([#4043](https://github.com/opentofu/opentofu/issues/4043))
 - The built-in function `merge` no longer fails when its only argument is a null value of an object type. ([#4043](https://github.com/opentofu/opentofu/issues/4043))

--- a/internal/command/views/workspace.go
+++ b/internal/command/views/workspace.go
@@ -181,7 +181,8 @@ func (v *WorkspaceHuman) WorkspaceAlreadyExists(name string) {
 	v.Diagnostics(tfdiags.Diagnostics{tfdiags.Sourceless(
 		tfdiags.Error,
 		fmt.Sprintf("Workspace %q already exists", name),
-		"A workspace having the given name already exists",
+		fmt.Sprintf(`A workspace having the given name already exists.
+Use "tofu workspace select %s" to switch to it.`, name),
 	)})
 }
 
@@ -304,7 +305,7 @@ func (v *WorkspaceJSON) Diagnostics(diags tfdiags.Diagnostics) {
 }
 
 func (v *WorkspaceJSON) WorkspaceAlreadyExists(name string) {
-	v.view.Error(fmt.Sprintf("Workspace %q already exists", name))
+	v.view.Error(fmt.Sprintf("Workspace %q already exists. Use \"tofu workspace select %s\" to switch to it", name, name))
 }
 
 func (v *WorkspaceJSON) WorkspaceDoesNotExist(name string) {

--- a/internal/command/views/workspace_test.go
+++ b/internal/command/views/workspace_test.go
@@ -28,14 +28,15 @@ func TestWorkspaceViews(t *testing.T) {
 			wantJson: []map[string]any{
 				{
 					"@level":   "error",
-					"@message": `Workspace "test-workspace" already exists`,
+					"@message": `Workspace "test-workspace" already exists. Use "tofu workspace select test-workspace" to switch to it`,
 					"@module":  "tofu.ui",
 				},
 			},
 			wantStderr: `
 Error: Workspace "test-workspace" already exists
 
-A workspace having the given name already exists
+A workspace having the given name already exists.
+Use "tofu workspace select test-workspace" to switch to it.
 `,
 		},
 		"workspace_does_not_exist": {


### PR DESCRIPTION
Closes #4428

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

## Description

`tofu workspace new <name>` on a workspace that already exists reported only:

    Error: Workspace "staging" already exists

with no guidance on how to proceed. This mirrors the existing `workspace does not exist` error, which already tells the user to run `tofu workspace new`, so the `already exists` case should symmetrically point at `tofu workspace select`.

## Changes

- `internal/command/views/workspace.go`: both `WorkspaceHuman.WorkspaceAlreadyExists` and `WorkspaceJSON.WorkspaceAlreadyExists` now include a hint to run `tofu workspace select <name>`.
- `internal/command/views/workspace_test.go`: updated expected output for the new message.
- `CHANGELOG.md`: added a BUG FIXES entry.

## Output after this change

    Error: Workspace "staging" already exists

    A workspace having the given name already exists. Use "tofu workspace select staging" to switch to it.