### PR TITLE
backend/s3: recover lock acquisition after a self-collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
+- The `s3` backend no longer leaves an orphaned lock behind when a lock acquisition collides with the lock it just wrote. A conditional write is not idempotent under retry, so a lost or late response to the lock write could make the retry fail its precondition against the caller's own lock, which was then reported as another process's and never released. ([#4405](https://github.com/opentofu/opentofu/issues/4405))
 - `tofu apply -json` now emits periodic `apply_progress` heartbeat messages for the full duration of a resource operation, instead of stopping after the first one. ([#4107](https://github.com/opentofu/opentofu/pull/4318))
 - The built-in function `contains` now accepts `null` as its second argument, to test whether a collection contains any null values. ([#4043](https://github.com/opentofu/opentofu/issues/4043))
 - The built-in function `merge` no longer fails when its only argument is a null value of an object type. ([#4043](https://github.com/opentofu/opentofu/issues/4043))

--- a/internal/backend/remote-state/s3/client.go
+++ b/internal/backend/remote-state/s3/client.go
@@ -276,6 +276,23 @@ func (c *RemoteClient) Lock(ctx context.Context, info *statemgr.LockInfo) (strin
 	return info.ID, nil
 }
 
+// lockWrittenByThisCall reports whether the lock recorded in the backing store is
+// the one the current acquisition just wrote.
+//
+// A conditional write is not idempotent under retry. If the first attempt reaches
+// the store but its response does not reach us, the retry fails its precondition
+// against the object that attempt created, and the lock we then read back to
+// explain the failure is our own. statemgr.LockInfo#ID is a UUID minted per
+// Lock() call, so a stored lock carrying it cannot belong to another process.
+//
+// Reporting that as a foreign holder is what turns a transient fault into a
+// persistent one: Lock() returns no ID, so nothing is registered for release and
+// the object blocks every later operation on the state until someone with write
+// access to the backing store removes it by hand.
+func lockWrittenByThisCall(stored, info *statemgr.LockInfo) bool {
+	return stored != nil && info != nil && info.ID != "" && stored.ID == info.ID
+}
+
 // dynamoDBLock expects the statemgr.LockInfo#ID to be filled already
 func (c *RemoteClient) dynamoDBLock(ctx context.Context, info *statemgr.LockInfo) error {
 	if c.ddbTable == "" {
@@ -297,6 +314,11 @@ func (c *RemoteClient) dynamoDBLock(ctx context.Context, info *statemgr.LockInfo
 		lockInfo, infoErr := c.getLockInfoFromDynamoDB(ctx)
 		if infoErr != nil {
 			err = multierror.Append(err, infoErr)
+		}
+
+		if lockWrittenByThisCall(lockInfo, info) {
+			log.Printf("[WARN] dynamodb lock %q was written by this acquisition, but the outcome of its PutItem was not observed (%v). Treating the lock as held.", info.ID, err)
+			return nil
 		}
 
 		lockErr := &statemgr.LockError{
@@ -337,6 +359,11 @@ func (c *RemoteClient) s3Lock(ctx context.Context, info *statemgr.LockInfo) erro
 		lockInfo, infoErr := c.getLockInfoFromS3(ctx)
 		if infoErr != nil {
 			err = multierror.Append(err, infoErr)
+		}
+
+		if lockWrittenByThisCall(lockInfo, info) {
+			log.Printf("[WARN] s3 lock %q was written by this acquisition, but the outcome of its PutObject was not observed (%v). Treating the lock as held.", info.ID, err)
+			return nil
 		}
 
 		lockErr := &statemgr.LockError{

--- a/internal/backend/remote-state/s3/client_selflock_test.go
+++ b/internal/backend/remote-state/s3/client_selflock_test.go
@@ -182,7 +182,7 @@ func TestS3Lock_412WithUnreadableLockStillFails(t *testing.T) {
 		},
 	}}
 
-	if err := newLockingClient(t, httpCl).Lock(t.Context(), mine); err == nil {
+	if _, err := newLockingClient(t, httpCl).Lock(t.Context(), mine); err == nil {
 		t.Fatal("expected an unreadable lock object to fail the acquisition")
 	}
 }

--- a/internal/backend/remote-state/s3/client_selflock_test.go
+++ b/internal/backend/remote-state/s3/client_selflock_test.go
@@ -1,0 +1,188 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package s3
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	awsbase "github.com/hashicorp/aws-sdk-go-base/v2"
+	"github.com/opentofu/opentofu/internal/states/statemgr"
+)
+
+// routingHttpClient answers per HTTP method so a single test can make the
+// conditional PUT fail while the follow-up GET still serves a lock object. The
+// shared mockHttpClient returns one fixed response and cannot express that.
+type routingHttpClient struct {
+	byMethod map[string]*http.Response
+	byTarget map[string]*http.Response
+	seen     []string
+}
+
+func (m *routingHttpClient) Do(r *http.Request) (*http.Response, error) {
+	target := r.Header.Get("X-Amz-Target")
+	if target != "" {
+		m.seen = append(m.seen, target)
+		if resp, ok := m.byTarget[target]; ok {
+			return resp, nil
+		}
+	}
+
+	m.seen = append(m.seen, r.Method)
+	if resp, ok := m.byMethod[r.Method]; ok {
+		return resp, nil
+	}
+	return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(""))}, nil
+}
+
+func newLockingClient(t *testing.T, httpCl *routingHttpClient) *RemoteClient {
+	t.Helper()
+	_, awsCfg, _ := awsbase.GetAwsConfig(context.Background(), &awsbase.Config{Region: "us-east-1", AccessKey: "test", SecretKey: "key"})
+	s3Cl := s3.NewFromConfig(awsCfg, func(options *s3.Options) {
+		options.HTTPClient = httpCl
+	})
+	return &RemoteClient{
+		s3Client:    s3Cl,
+		bucketName:  "test-bucket",
+		path:        "state-file",
+		useLockfile: true,
+	}
+}
+
+func newDynamoLockingClient(t *testing.T, httpCl *routingHttpClient) *RemoteClient {
+	t.Helper()
+	_, awsCfg, _ := awsbase.GetAwsConfig(context.Background(), &awsbase.Config{Region: "us-east-1", AccessKey: "test", SecretKey: "key"})
+	dynCl := dynamodb.NewFromConfig(awsCfg, func(options *dynamodb.Options) {
+		options.HTTPClient = httpCl
+	})
+	return &RemoteClient{
+		dynClient:  dynCl,
+		bucketName: "test-bucket",
+		path:       "state-file",
+		ddbTable:   "test-locks",
+	}
+}
+
+// A conditional PUT is not idempotent under retry: when the first attempt lands
+// but its response is lost, the retry 412s against the object that attempt
+// created. Acquisition must recognise its own lock rather than report it as a
+// foreign holder, because a LockError leaves Lock() with no ID to release and
+// the orphan then blocks every later operation on the state.
+func TestS3Lock_412AgainstOwnLockIsAcquired(t *testing.T) {
+	info := &statemgr.LockInfo{ID: "11111111-1111-1111-1111-111111111111", Info: "test"}
+
+	httpCl := &routingHttpClient{byMethod: map[string]*http.Response{
+		http.MethodPut: {
+			StatusCode: http.StatusPreconditionFailed,
+			Body:       io.NopCloser(strings.NewReader(`<Error><Code>PreconditionFailed</Code></Error>`)),
+		},
+		http.MethodGet: {
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(string(info.Marshal()))),
+		},
+	}}
+
+	if err := newLockingClient(t, httpCl).s3Lock(t.Context(), info); err != nil {
+		t.Fatalf("expected the acquisition to succeed against its own lock, got: %s", err)
+	}
+	if !strings.Contains(strings.Join(httpCl.seen, ","), "GET") {
+		t.Errorf("expected the lock to be read back after the failed PUT, saw %v", httpCl.seen)
+	}
+}
+
+// DynamoDB uses the same ownership predicate as S3 but reaches it through a
+// different conditional-write and read-back protocol. This guards against one
+// call site losing the recovery behavior while the other remains covered.
+func TestDynamoDBLock_ConditionalFailureAgainstOwnLockIsAcquired(t *testing.T) {
+	info := &statemgr.LockInfo{ID: "11111111-1111-1111-1111-111111111111", Info: "test"}
+	getBody, err := json.Marshal(map[string]any{
+		"Item": map[string]any{
+			"LockID": map[string]string{"S": "test-bucket/state-file"},
+			"Info":   map[string]string{"S": string(info.Marshal())},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	httpCl := &routingHttpClient{byTarget: map[string]*http.Response{
+		"DynamoDB_20120810.PutItem": {
+			StatusCode: http.StatusBadRequest,
+			Header:     http.Header{"Content-Type": {"application/x-amz-json-1.0"}, "X-Amzn-Errortype": {"ConditionalCheckFailedException"}},
+			Body:       io.NopCloser(strings.NewReader(`{"__type":"com.amazonaws.dynamodb.v20120810#ConditionalCheckFailedException","message":"The conditional request failed"}`)),
+		},
+		"DynamoDB_20120810.GetItem": {
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": {"application/x-amz-json-1.0"}},
+			Body:       io.NopCloser(strings.NewReader(string(getBody))),
+		},
+	}}
+
+	if err := newDynamoLockingClient(t, httpCl).dynamoDBLock(t.Context(), info); err != nil {
+		t.Fatalf("expected the acquisition to succeed against its own lock, got: %s", err)
+	}
+	if !strings.Contains(strings.Join(httpCl.seen, ","), "DynamoDB_20120810.GetItem") {
+		t.Errorf("expected the lock to be read back after the failed PutItem, saw %v", httpCl.seen)
+	}
+}
+
+// Negative control: a lock belonging to someone else must still fail, or the fix
+// above would silently let two operations write the same state.
+func TestS3Lock_412AgainstForeignLockStillFails(t *testing.T) {
+	held := &statemgr.LockInfo{ID: "22222222-2222-2222-2222-222222222222", Who: "someone@elsewhere"}
+	mine := &statemgr.LockInfo{ID: "11111111-1111-1111-1111-111111111111", Info: "test"}
+
+	httpCl := &routingHttpClient{byMethod: map[string]*http.Response{
+		http.MethodPut: {
+			StatusCode: http.StatusPreconditionFailed,
+			Body:       io.NopCloser(strings.NewReader(`<Error><Code>PreconditionFailed</Code></Error>`)),
+		},
+		http.MethodGet: {
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(string(held.Marshal()))),
+		},
+	}}
+
+	err := newLockingClient(t, httpCl).s3Lock(t.Context(), mine)
+	if err == nil {
+		t.Fatal("expected a foreign lock to block acquisition")
+	}
+	lockErr, ok := err.(*statemgr.LockError)
+	if !ok {
+		t.Fatalf("expected a *statemgr.LockError, got %T: %s", err, err)
+	}
+	if lockErr.Info == nil || lockErr.Info.ID != held.ID {
+		t.Errorf("expected the reported holder to be the foreign lock %q, got %#v", held.ID, lockErr.Info)
+	}
+}
+
+// An unreadable lock object must not be mistaken for our own: lockInfo is nil on
+// a read failure, and a nil-deref or a false ownership claim would both be worse
+// than reporting the original error.
+func TestS3Lock_412WithUnreadableLockStillFails(t *testing.T) {
+	mine := &statemgr.LockInfo{ID: "11111111-1111-1111-1111-111111111111"}
+
+	httpCl := &routingHttpClient{byMethod: map[string]*http.Response{
+		http.MethodPut: {
+			StatusCode: http.StatusPreconditionFailed,
+			Body:       io.NopCloser(strings.NewReader(`<Error><Code>PreconditionFailed</Code></Error>`)),
+		},
+		http.MethodGet: {
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{not json`)),
+		},
+	}}
+
+	if err := newLockingClient(t, httpCl).s3Lock(t.Context(), mine); err == nil {
+		t.Fatal("expected an unreadable lock object to fail the acquisition")
+	}
+}

--- a/internal/backend/remote-state/s3/client_selflock_test.go
+++ b/internal/backend/remote-state/s3/client_selflock_test.go
@@ -91,7 +91,7 @@ func TestS3Lock_412AgainstOwnLockIsAcquired(t *testing.T) {
 		},
 	}}
 
-	if err := newLockingClient(t, httpCl).s3Lock(t.Context(), info); err != nil {
+	if err := newLockingClient(t, httpCl).Lock(t.Context(), info); err != nil {
 		t.Fatalf("expected the acquisition to succeed against its own lock, got: %s", err)
 	}
 	if !strings.Contains(strings.Join(httpCl.seen, ","), "GET") {
@@ -127,7 +127,7 @@ func TestDynamoDBLock_ConditionalFailureAgainstOwnLockIsAcquired(t *testing.T) {
 		},
 	}}
 
-	if err := newDynamoLockingClient(t, httpCl).dynamoDBLock(t.Context(), info); err != nil {
+	if err := newDynamoLockingClient(t, httpCl).Lock(t.Context(), info); err != nil {
 		t.Fatalf("expected the acquisition to succeed against its own lock, got: %s", err)
 	}
 	if !strings.Contains(strings.Join(httpCl.seen, ","), "DynamoDB_20120810.GetItem") {
@@ -152,7 +152,7 @@ func TestS3Lock_412AgainstForeignLockStillFails(t *testing.T) {
 		},
 	}}
 
-	err := newLockingClient(t, httpCl).s3Lock(t.Context(), mine)
+	err := newLockingClient(t, httpCl).Lock(t.Context(), mine)
 	if err == nil {
 		t.Fatal("expected a foreign lock to block acquisition")
 	}
@@ -182,7 +182,7 @@ func TestS3Lock_412WithUnreadableLockStillFails(t *testing.T) {
 		},
 	}}
 
-	if err := newLockingClient(t, httpCl).s3Lock(t.Context(), mine); err == nil {
+	if err := newLockingClient(t, httpCl).Lock(t.Context(), mine); err == nil {
 		t.Fatal("expected an unreadable lock object to fail the acquisition")
 	}
 }

--- a/internal/backend/remote-state/s3/client_selflock_test.go
+++ b/internal/backend/remote-state/s3/client_selflock_test.go
@@ -91,8 +91,12 @@ func TestS3Lock_412AgainstOwnLockIsAcquired(t *testing.T) {
 		},
 	}}
 
-	if _, err := newLockingClient(t, httpCl).Lock(t.Context(), info); err != nil {
+	lockID, err := newLockingClient(t, httpCl).Lock(t.Context(), info)
+	if err != nil {
 		t.Fatalf("expected the acquisition to succeed against its own lock, got: %s", err)
+	}
+	if lockID != info.ID {
+		t.Fatalf("expected lock ID %q, got %q", info.ID, lockID)
 	}
 	if !strings.Contains(strings.Join(httpCl.seen, ","), "GET") {
 		t.Errorf("expected the lock to be read back after the failed PUT, saw %v", httpCl.seen)
@@ -127,8 +131,12 @@ func TestDynamoDBLock_ConditionalFailureAgainstOwnLockIsAcquired(t *testing.T) {
 		},
 	}}
 
-	if _, err := newDynamoLockingClient(t, httpCl).Lock(t.Context(), info); err != nil {
+	lockID, err := newDynamoLockingClient(t, httpCl).Lock(t.Context(), info)
+	if err != nil {
 		t.Fatalf("expected the acquisition to succeed against its own lock, got: %s", err)
+	}
+	if lockID != info.ID {
+		t.Fatalf("expected lock ID %q, got %q", info.ID, lockID)
 	}
 	if !strings.Contains(strings.Join(httpCl.seen, ","), "DynamoDB_20120810.GetItem") {
 		t.Errorf("expected the lock to be read back after the failed PutItem, saw %v", httpCl.seen)

--- a/internal/backend/remote-state/s3/client_selflock_test.go
+++ b/internal/backend/remote-state/s3/client_selflock_test.go
@@ -91,7 +91,7 @@ func TestS3Lock_412AgainstOwnLockIsAcquired(t *testing.T) {
 		},
 	}}
 
-	if err := newLockingClient(t, httpCl).Lock(t.Context(), info); err != nil {
+	if _, err := newLockingClient(t, httpCl).Lock(t.Context(), info); err != nil {
 		t.Fatalf("expected the acquisition to succeed against its own lock, got: %s", err)
 	}
 	if !strings.Contains(strings.Join(httpCl.seen, ","), "GET") {
@@ -127,7 +127,7 @@ func TestDynamoDBLock_ConditionalFailureAgainstOwnLockIsAcquired(t *testing.T) {
 		},
 	}}
 
-	if err := newDynamoLockingClient(t, httpCl).Lock(t.Context(), info); err != nil {
+	if _, err := newDynamoLockingClient(t, httpCl).Lock(t.Context(), info); err != nil {
 		t.Fatalf("expected the acquisition to succeed against its own lock, got: %s", err)
 	}
 	if !strings.Contains(strings.Join(httpCl.seen, ","), "DynamoDB_20120810.GetItem") {
@@ -152,7 +152,7 @@ func TestS3Lock_412AgainstForeignLockStillFails(t *testing.T) {
 		},
 	}}
 
-	err := newLockingClient(t, httpCl).Lock(t.Context(), mine)
+	_, err := newLockingClient(t, httpCl).Lock(t.Context(), mine)
 	if err == nil {
 		t.Fatal("expected a foreign lock to block acquisition")
 	}


### PR DESCRIPTION
A conditional lock write can reach the backing store while its response is lost. A retry then fails its precondition against the lock created by the same acquisition, causing Lock to return without an ID and leave the lock orphaned.

Compare the stored lock ID with the current acquisition ID for both S3 and DynamoDB paths.  When they match, treat the lock as acquired so normal unlock handling can release it.  Different UUIDs or unreadable locks remain errors.

Add transport level regression coverage for these lock mechanisms.  Document the user visible fix in changelog.

<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves #4405

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
