### PR TITLE
fix templatestring panic when vars is marked sensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ BUG FIXES:
 - The built-in function `contains` now accepts `null` as its second argument, to test whether a collection contains any null values. ([#4043](https://github.com/opentofu/opentofu/issues/4043))
 - The built-in function `merge` no longer fails when its only argument is a null value of an object type. ([#4043](https://github.com/opentofu/opentofu/issues/4043))
 - The built-in function `cidrhost` no longer returns a "panic" error when called with an out-of-range host number represented in more than 64 bits. ([#4056](https://github.com/opentofu/opentofu/pull/4056))
+- The built-in function `templatestring` no longer returns a "panic" error when its `vars` argument is a wholly sensitive collection; the result is marked sensitive instead. ([#4430](https://github.com/opentofu/opentofu/issues/4430))
 - `tofu workspace new` now includes a hint to use `tofu workspace select` when the given workspace name already exists, instead of just reporting that it already exists. ([#4428](https://github.com/opentofu/opentofu/issues/4428))
 - `tofu apply -json` now emits periodic `apply_progress` heartbeat messages for the full duration of a resource operation, instead of stopping after the first one. ([#4107](https://github.com/opentofu/opentofu/pull/4318))
 - provisioner output is no longer suppressed when `-show-sensitive` is passed. ([#3927](https://github.com/opentofu/opentofu/issues/3927))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ BUG FIXES:
 - `tofu plan -out` no longer fails when the plan includes a resource with `lifecycle { destroy = false }` that needs replacement, which previously errored with `invalid change action ForgetThenCreate`. ([#4324](https://github.com/opentofu/opentofu/issues/4324))
 - `connection.script_path` is escaped correctly not allowing anymore additional commands to be executed on the remote host together with the script path indicated by the argument. ([#4330](https://github.com/opentofu/opentofu/pull/4330))
 - `tofu plan`: Fixed Incorrect warnings produced during plan -replace ([#4368](https://github.com/opentofu/opentofu/issues/4368))
+- The `templatestring` function no longer panics when its `vars` argument is a wholly sensitive collection; the result is marked sensitive instead. ([#4430](https://github.com/opentofu/opentofu/issues/4430))
 
 ## Previous Releases
 

--- a/internal/lang/funcs/filesystem_test.go
+++ b/internal/lang/funcs/filesystem_test.go
@@ -200,6 +200,14 @@ func TestTemplateFile(t *testing.T) {
 			cty.True.Mark(marks.Sensitive),
 			``,
 		},
+		{
+			cty.StringVal("testdata/bare.tmpl"),
+			cty.ObjectVal(map[string]cty.Value{
+				"val": cty.True,
+			}).Mark(marks.Sensitive),
+			cty.True.Mark(marks.Sensitive),
+			``,
+		},
 	}
 
 	templateFileFn := MakeTemplateFileFunc(".", func() map[string]function.Function {

--- a/internal/lang/funcs/string.go
+++ b/internal/lang/funcs/string.go
@@ -211,6 +211,7 @@ func MakeTemplateStringFunc(content string, funcsCb func() map[string]function.F
 			// A template consisting only of a single interpolation can potentially
 			// return any type.
 			dataArg, dataMarks := args[0].Unmark()
+			varsArg, _ := args[1].Unmark()
 			expr, err := loadTmpl(dataArg.AsString(), dataMarks)
 			if err != nil {
 				return cty.DynamicPseudoType, err
@@ -218,17 +219,18 @@ func MakeTemplateStringFunc(content string, funcsCb func() map[string]function.F
 
 			// This is safe even if args[1] contains unknowns because the HCL
 			// template renderer itself knows how to short-circuit those.
-			val, err := renderTemplate(expr, args[1], funcsCb())
+			val, err := renderTemplate(expr, varsArg, funcsCb())
 			return val.Type(), err
 		},
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
 			dataArg, dataMarks := args[0].Unmark()
+			varsArg, varsMarks := args[1].Unmark()
 			expr, err := loadTmpl(dataArg.AsString(), dataMarks)
 			if err != nil {
 				return cty.DynamicVal, err
 			}
-			result, err := renderTemplate(expr, args[1], funcsCb())
-			return result.WithMarks(dataMarks), err
+			result, err := renderTemplate(expr, varsArg, funcsCb())
+			return result.WithMarks(dataMarks, varsMarks), err
 		},
 	})
 }

--- a/internal/lang/funcs/string_test.go
+++ b/internal/lang/funcs/string_test.go
@@ -339,6 +339,14 @@ func TestTemplateString(t *testing.T) {
 			cty.StringVal("My password is secret").Mark(marks.Sensitive),
 			``,
 		},
+		"Sensitive template variables object": {
+			cty.StringVal("My password is ${pass}"),
+			cty.ObjectVal(map[string]cty.Value{
+				"pass": cty.StringVal("secret"),
+			}).Mark(marks.Sensitive),
+			cty.StringVal("My password is secret").Mark(marks.Sensitive),
+			``,
+		},
 	}
 
 	templateStringFn := MakeTemplateStringFunc(".", func() map[string]function.Function {


### PR DESCRIPTION
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves #4430

`templatestring` declares its `vars` parameter with `AllowMarked: true`, but then passed the value straight to `renderTemplate` without unmarking it. When the whole `vars` collection carried a top-level sensitive mark, `renderTemplate`'s `AsValueMap()` call panicked with `value is marked, so must be unmarked first`.

This unmarks `vars` in both the `Type` and `Impl` callbacks before rendering, and re-applies the collected marks to the result so a sensitive `vars` collection still yields a sensitive result. Nested/element-level marks are left intact and continue to propagate through rendering as before.

`templatefile` is unaffected because its `vars` parameter does not set `AllowMarked` — the function framework strips the top-level mark before the call and re-applies it to the result. No code change was needed there; a regression test was added only to lock in that both functions stay consistent.


## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
