### PR TITLE
communicator/ssh: fix panic when an HTTP proxy fails the CONNECT handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ BUG FIXES:
 - `tofu plan -out` no longer fails when the plan includes a resource with `lifecycle { destroy = false }` that needs replacement, which previously errored with `invalid change action ForgetThenCreate`. ([#4324](https://github.com/opentofu/opentofu/issues/4324))
 - `connection.script_path` is escaped correctly not allowing anymore additional commands to be executed on the remote host together with the script path indicated by the argument. ([#4330](https://github.com/opentofu/opentofu/pull/4330))
 - `tofu plan`: Fixed Incorrect warnings produced for `tofu plan -replace=ADDR`. ([#4368](https://github.com/opentofu/opentofu/issues/4368))
+- SSH connections through an HTTP proxy now report a connection error instead of crashing when the proxy fails to answer the CONNECT request. ([#4358](https://github.com/opentofu/opentofu/issues/4358))
 
 ## Previous Releases
 

--- a/internal/communicator/ssh/http_proxy.go
+++ b/internal/communicator/ssh/http_proxy.go
@@ -102,7 +102,6 @@ func (p *proxyDialer) Dial(network, addr string) (net.Conn, error) {
 	res, err := http.ReadResponse(bufio.NewReader(c), req)
 
 	if err != nil {
-		res.Body.Close()
 		c.Close()
 		return nil, err
 	}

--- a/internal/communicator/ssh/http_proxy_test.go
+++ b/internal/communicator/ssh/http_proxy_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ssh
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/proxy"
+)
+
+func TestProxyDialer_Dial_connectResponseError(t *testing.T) {
+	// A proxy that accepts the CONNECT request and then closes without
+	// answering must surface a dial error, not crash the process
+	addr := fakeProxy(t, func(net.Conn) {})
+
+	pd := &proxyDialer{
+		proxy:   *newProxyInfo(addr, "http", "", ""),
+		forward: proxy.Direct,
+	}
+
+	conn, err := pd.Dial("tcp", "192.0.2.1:22")
+	if err == nil {
+		conn.Close()
+		t.Fatal("expected an error, got nil")
+	}
+}
+
+func TestProxyDialer_Dial_success(t *testing.T) {
+	// A proxy that answers the CONNECT request with 200 must yield a connection
+	addr := fakeProxy(t, func(c net.Conn) {
+		_, _ = c.Write([]byte("HTTP/1.1 200 Connection established\r\n\r\n"))
+	})
+
+	pd := &proxyDialer{
+		proxy:   *newProxyInfo(addr, "http", "", ""),
+		forward: proxy.Direct,
+	}
+
+	conn, err := pd.Dial("tcp", "192.0.2.1:22")
+	if err != nil {
+		t.Fatalf("Dial returned error: %v, want nil", err)
+	}
+	defer conn.Close()
+}
+
+func TestProxyDialer_Dial_nonOKStatus(t *testing.T) {
+	// A proxy that rejects the CONNECT request must surface its status code as a dial error
+	addr := fakeProxy(t, func(c net.Conn) {
+		_, _ = c.Write([]byte("HTTP/1.1 407 Proxy Authentication Required\r\nContent-Length: 0\r\n\r\n"))
+	})
+
+	pd := &proxyDialer{
+		proxy:   *newProxyInfo(addr, "http", "", ""),
+		forward: proxy.Direct,
+	}
+
+	conn, err := pd.Dial("tcp", "192.0.2.1:22")
+	if err == nil {
+		conn.Close()
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "407") {
+		t.Fatalf("error = %v, want it to mention 407", err)
+	}
+}
+
+// fakeProxy starts an HTTP proxy on the loopback interface and returns its address.
+// It accepts one connection, reads the CONNECT request, calls respond and then
+// closes: a respond that writes nothing models a proxy that hangs up without answering
+func fakeProxy(t *testing.T, respond func(net.Conn)) string {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		_, _ = http.ReadRequest(bufio.NewReader(conn))
+		respond(conn)
+	}()
+
+	t.Cleanup(func() {
+		ln.Close()
+		<-done
+	})
+
+	return ln.Addr().String()
+}


### PR DESCRIPTION
Resolves #4358

`http.ReadResponse` returns `nil` on every error path, so the removed `res.Body.Close()` never had a body to close. `c.Close()` stays, so the TCP connection is still released.

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
