### PR TITLE
Use the stopCtx when tofu asks for provider config attributes

### DIFF
--- a/internal/backend/local/backend_apply_test.go
+++ b/internal/backend/local/backend_apply_test.go
@@ -397,6 +397,18 @@ func applyFixtureSchema() providers.ProviderSchema {
 	}
 }
 
+// providerSchemaRequiredAttribute returns a provider schema with a required attribute
+func providerSchemaRequiredAttribute() providers.ProviderSchema {
+	return providers.ProviderSchema{
+		Provider: providers.Schema{
+			Block: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"required": {Type: cty.String, Required: true}, // <- here
+				},
+			},
+		},
+	}
+}
 func TestApply_applyCanceledAutoApprove(t *testing.T) {
 	b := TestLocal(t)
 

--- a/internal/backend/local/backend_local.go
+++ b/internal/backend/local/backend_local.go
@@ -129,7 +129,7 @@ func (b *Local) localRun(ctx context.Context, stopCtx context.Context, op *backe
 			mode := tofu.InputModeProvider
 
 			log.Printf("[TRACE] backend/local: requesting interactive input, if necessary")
-			inputDiags := ret.Core.Input(ctx, ret.Config, mode)
+			inputDiags := ret.Core.Input(stopCtx, ret.Config, mode)
 			diags = diags.Append(inputDiags)
 			if inputDiags.HasErrors() {
 				return nil, nil, nil, diags

--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -96,6 +96,43 @@ func TestLocalRun_ErrorWhenUiInputIsCancelled(t *testing.T) {
 	}
 }
 
+func TestLocalRun_ErrorWhenUiInputIsCancelledForTheProviderInformation(t *testing.T) {
+	b := TestLocal(t)
+
+	p := TestLocalProvider(t, b, "test", providerSchemaRequiredAttribute())
+	p.ApplyResourceChangeResponse = &providers.ApplyResourceChangeResponse{NewState: cty.ObjectVal(map[string]cty.Value{
+		"id":  cty.StringVal("yes"),
+		"ami": cty.StringVal("bar"),
+	})}
+
+	op, done := testOperationApply(t, "./testdata/apply-with-required-provider-configs")
+	op.Variables = map[string]backend.UnparsedVariableValue{}
+	op.UIIn = testInputWithCancel(t, 10*time.Second)
+	b.OpInput = true
+	run, err := b.Operation(context.Background(), op)
+	if err != nil {
+		t.Fatalf("bad: %s", err)
+	}
+	go func() {
+		<-time.After(1 * time.Second)
+		run.Stop()
+	}()
+
+	select {
+	case <-run.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatalf("hit the timeout. expected for the operation to finish before the timeout")
+	}
+	if run.Result != backend.OperationFailure {
+		t.Fatal("operation suceeded but expected to fail")
+	}
+
+	expectedErrHeader := "Error: execution halted"
+	if errOutput := done(t).Stderr(); !strings.Contains(errOutput, expectedErrHeader) {
+		t.Fatalf("unexpected error output. Expected to contain %q but it does not:\n%s", expectedErrHeader, errOutput)
+	}
+}
+
 func TestLocalRun_error(t *testing.T) {
 	configDir := "./testdata/invalid"
 	b := TestLocal(t)
@@ -321,4 +358,24 @@ func (s *stateStorageThatFailsRefresh) RefreshState(_ context.Context) error {
 
 func (s *stateStorageThatFailsRefresh) PersistState(_ context.Context, schemas *tofu.Schemas) error {
 	return fmt.Errorf("unimplemented")
+}
+
+// mockInput is a mock implementation of tofu.UIInput.
+type mockInput struct {
+	after time.Duration
+}
+
+func (m *mockInput) Input(ctx context.Context, _ *tofu.InputOpts) (string, error) {
+	select {
+	case <-ctx.Done():
+		return "", fmt.Errorf("interrupted")
+	case <-time.After(m.after):
+		return "", fmt.Errorf("ui input was not closed after 10s")
+	}
+	return "", fmt.Errorf("mock input invalid case")
+}
+
+func testInputWithCancel(t *testing.T, after time.Duration) *mockInput {
+	t.Helper()
+	return &mockInput{after: after}
 }

--- a/internal/backend/local/backend_local_test.go
+++ b/internal/backend/local/backend_local_test.go
@@ -372,7 +372,6 @@ func (m *mockInput) Input(ctx context.Context, _ *tofu.InputOpts) (string, error
 	case <-time.After(m.after):
 		return "", fmt.Errorf("ui input was not closed after 10s")
 	}
-	return "", fmt.Errorf("mock input invalid case")
 }
 
 func testInputWithCancel(t *testing.T, after time.Duration) *mockInput {

--- a/internal/backend/local/testdata/apply-with-required-provider-configs/main.tf
+++ b/internal/backend/local/testdata/apply-with-required-provider-configs/main.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    test = {
+      source = "test"
+    }
+  }
+}
+
+provider "test" {
+
+}

--- a/internal/tofu/context_input.go
+++ b/internal/tofu/context_input.go
@@ -150,15 +150,7 @@ func (c *Context) Input(ctx context.Context, config *configs.Config, mode InputM
 				}
 
 				log.Printf("[TRACE] Context.Input: Prompting for %s argument %s", pa, key)
-				// NOTE: Historically we were just passing a context.Background into
-				// this, because we didn't have any other context.Context to use.
-				// We're now passing in our given context but intentionally ignoring
-				// its cancellation because the main UIInput implementation (in
-				// package command) already/ had direct SIGINT handling and we want to
-				// preserve that behavior.
-				// FIXME: Remove the UIInput's own SIGINT handling and rely on the
-				// cancellation of ctx instead.
-				rawVal, err := input.Input(context.WithoutCancel(ctx), &InputOpts{
+				rawVal, err := input.Input(ctx, &InputOpts{
 					Id:          key,
 					Query:       key,
 					Description: attrS.Description,


### PR DESCRIPTION
During #4051, forgot to propagate the stopCtx on the path that asks for provider attributes.
Without this fix, if the `provider` block is present with no attributes specified and the provider schema specfies required attributes, when cancelling (ctrl+c) the input prompt, it will not exit right away, but only after cancelling it again.

No need for a changelog since this is part of #4051
<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves # 

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

### Website/documentation checklist

<!-- If you have changed the website, please follow this checklist: -->

- [ ] I have locally started the website as [described here](https://github.com/opentofu/opentofu/blob/main/website/README.md) and checked my changes.
