### PR TITLE
Produce official release packages for windows_arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
           - {goos: "solaris", goarch: "amd64", runson: "ubuntu-latest", cgo-enabled: "0"}
           - {goos: "windows", goarch: "386", runson: "ubuntu-latest", cgo-enabled: "0"}
           - {goos: "windows", goarch: "amd64", runson: "ubuntu-latest", cgo-enabled: "0"}
+          - {goos: "windows", goarch: "arm64", runson: "ubuntu-latest", cgo-enabled: "0"}
           - {goos: "darwin", goarch: "amd64", runson: "macos-latest", cgo-enabled: "1"}
           - {goos: "darwin", goarch: "arm64", runson: "macos-latest", cgo-enabled: "1"}
       fail-fast: false
@@ -62,6 +63,7 @@ jobs:
           # - { runson: ubuntu-24.04-arm, goos: linux, goarch: "arm64" } Disabled due to missing `template` provider, should switch it in the tests
           - { runson: macos-latest, goos: darwin, goarch: "amd64" }
           - { runson: windows-latest, goos: windows, goarch: "amd64" }
+          - { runson: windows-11-arm, goos: windows, goarch: "arm64" }
           - { runson: windows-latest, goos: windows, goarch: "386" }
       fail-fast: false
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -65,6 +65,7 @@ jobs:
           - { runson: ubuntu-latest, goos: linux, goarch: "arm" }
           - { runson: macos-latest, goos: darwin, goarch: "arm64" }
           - { runson: windows-latest, goos: windows, goarch: "amd64" }
+          - { runson: windows-11-arm, goos: windows, goarch: "arm64" }
       fail-fast: false
     steps:
       # 👇🏾 GH actions supports only "AMD64 arch", so we are using this action

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -54,8 +54,6 @@ builds:
         goarch: arm64
       - goos: windows
         goarch: arm
-      - goos: windows
-        goarch: arm64
       - goos: darwin
         goarch: "386"
       - goos: darwin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ UPGRADE NOTES:
 
 ENHANCEMENTS:
 
+- Windows on ARM64 is now an officially-supported platform for OpenTofu itself, though this new platform may not be supported by all available provider plugins. ([#4450](https://github.com/opentofu/opentofu/pull/4450))
 - The `gcp_kms` key provider now supports an optional `additional_authenticated_data` as part of the encryption and decryption operations. ([#4287](https://github.com/opentofu/opentofu/pull/4287))
 - The AWS KMS key provider for state encryption now supports an `encryption_context` field, allowing key-value string pairs to be passed to AWS KMS with every `GenerateDataKey` and `Decrypt` call. ([#4298](https://github.com/opentofu/opentofu/pull/4298))
 - The `cidrsubnets` function now supports prefix extensions greater than 32 bits when the base CIDR block uses an IPv6 address. ([#4042](https://github.com/opentofu/opentofu/pull/4042))

--- a/website/docs/language/v1-compatibility-promises.mdx
+++ b/website/docs/language/v1-compatibility-promises.mdx
@@ -340,7 +340,7 @@ the extent that the maintainers frequently test OpenTofu on these platforms and
 aim to prioritize fixing any regressions that are reported:
 
 * macOS on Apple Silicon (`darwin_arm64`)
-* Windows on x64 CPUs (`windows_amd64`)
+* Windows on x64 and 64-bit ARM (`windows_amd64` and `windows_arm64` respectively)
 * Linux on x64 and 64-bit ARM (`linux_amd64` and `linux_arm64` respectively)
 
 Over time we may require newer versions of these operating systems. For


### PR DESCRIPTION
This platform is now available for GitHub Actions jobs, so we can now officially support it.

This changes our goreleaser configuration to produce packages for that platform, and also updates our various testing workflows to include this platform in their test matrix.

Closes https://github.com/opentofu/opentofu/issues/798

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
