### PR TITLE
Re-work application of static evaluation to configuration

### DIFF
--- a/internal/command/e2etest/encryption_test.go
+++ b/internal/command/e2etest/encryption_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime/debug"
 	"strings"
 	"testing"
 
@@ -26,12 +25,11 @@ type tofuResult struct {
 }
 
 func (r tofuResult) Success() tofuResult {
+	r.t.Helper()
 	if r.stderr != "" {
-		debug.PrintStack()
 		r.t.Fatalf("unexpected stderr output:\n%s", r.stderr)
 	}
 	if r.err != nil {
-		debug.PrintStack()
 		r.t.Fatalf("unexpected error: %s", r.err)
 	}
 
@@ -39,8 +37,8 @@ func (r tofuResult) Success() tofuResult {
 }
 
 func (r tofuResult) Failure() tofuResult {
+	r.t.Helper()
 	if r.err == nil {
-		debug.PrintStack()
 		r.t.Fatal("expected error")
 	}
 	return r
@@ -58,17 +56,26 @@ func SanitizeStderr(msg string) string {
 }
 
 func (r tofuResult) StderrContains(msg string) tofuResult {
+	r.t.Helper()
 	stdErrSanitized := SanitizeStderr(r.stderr)
 	if !strings.Contains(stdErrSanitized, msg) {
-		debug.PrintStack()
 		r.t.Fatalf("expected stderr output %q:\n%s", msg, stdErrSanitized)
 	}
 	return r
 }
 
+func (r tofuResult) StdoutContains(msg string) tofuResult {
+	r.t.Helper()
+	stdoutSanitized := SanitizeStderr(r.stdout)
+	if !strings.Contains(stdoutSanitized, msg) {
+		r.t.Fatalf("expected stdout output %q:\n%s", msg, stdoutSanitized)
+	}
+	return r
+}
+
 func (r tofuResult) Contains(msg string) tofuResult {
+	r.t.Helper()
 	if !strings.Contains(r.stdout, msg) {
-		debug.PrintStack()
 		r.t.Fatalf("expected output %q:\n%s", msg, r.stdout)
 	}
 	return r

--- a/internal/command/e2etest/static_plan_test.go
+++ b/internal/command/e2etest/static_plan_test.go
@@ -43,7 +43,7 @@ func TestStaticPlanVariables(t *testing.T) {
 			run("init", stateVar, modVar).Success()
 
 			// Get
-			run("get").Failure().StderrContains(modErr)
+			run("get").Success().StdoutContains(modErr) // config errors translated to warnings
 			run("get", stateVar, modVar).Success()
 
 			// Validate

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -416,7 +416,7 @@ func (m *Meta) contextOpts(ctx context.Context) (*tofu.ContextOpts, error) {
 
 		// This gets the current directory as full path.
 		path := m.WorkingDir.NormalizePath(m.WorkingDir.RootModuleDir())
-		root, _ := loader.LoadConfigDirUneval(path, configs.SelectiveLoadAll)
+		root, _ := loader.LoadConfigDir(path)
 		opts.Modules = &newRuntimeModules{
 			loader: loader,
 			root:   root,

--- a/internal/command/meta_config.go
+++ b/internal/command/meta_config.go
@@ -84,8 +84,9 @@ func (m *Meta) loadSingleModule(ctx context.Context, dir string, load configs.Se
 		return nil, diags
 	}
 
-	module, hclDiags := m.configLoader().LoadConfigDirSelective(dir, call, load)
+	module, hclDiags := m.configLoader().LoadConfigDirSelective(dir, load)
 	diags = diags.Append(hclDiags)
+	diags = diags.Append(module.WithStaticCall(call))
 	return module, diags
 }
 
@@ -167,8 +168,9 @@ func (m *Meta) loadSingleModuleWithTests(ctx context.Context, dir string, testDi
 		return nil, diags
 	}
 
-	module, hclDiags := m.configLoader().LoadConfigDirWithTests(dir, testDir, call)
+	module, hclDiags := m.configLoader().LoadConfigDirWithTests(dir, testDir)
 	diags = diags.Append(hclDiags)
+	diags = diags.Append(module.WithStaticCall(call))
 	return module, diags
 }
 

--- a/internal/command/temp_new_runtime.go
+++ b/internal/command/temp_new_runtime.go
@@ -167,7 +167,7 @@ func (n *newRuntimeModules) ModuleConfig(ctx context.Context, source addrs.Modul
 	log.Printf("[TRACE] backend/local: Loading module from %q from local path %q", source, sourceDir)
 
 	n.mu.Lock()
-	mod, hclDiags := n.loader.LoadConfigDirUneval(sourceDir, configs.SelectiveLoadAll)
+	mod, hclDiags := n.loader.LoadConfigDir(sourceDir)
 	n.mu.Unlock()
 	diags = diags.Append(hclDiags)
 	if hclDiags.HasErrors() {

--- a/internal/configs/config_build.go
+++ b/internal/configs/config_build.go
@@ -26,13 +26,18 @@ import (
 // file-level invariants validated. If the returned diagnostics contains errors,
 // the returned module tree may be incomplete but can still be used carefully
 // for static analysis.
-func BuildConfig(ctx context.Context, root *Module, walker ModuleWalker) (*Config, hcl.Diagnostics) {
+func BuildConfig(ctx context.Context, root *Module, call StaticModuleCall, walker ModuleWalker) (*Config, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
+
+	diags = diags.Extend(root.WithStaticCall(call))
+
 	cfg := &Config{
 		Module: root,
 	}
 	cfg.Root = cfg // Root module is self-referential.
-	cfg.Children, diags = buildChildModules(ctx, cfg, walker)
+	var cDiags hcl.Diagnostics
+	cfg.Children, cDiags = buildChildModules(ctx, cfg, walker)
+	diags = diags.Extend(cDiags)
 	diags = append(diags, buildTestModules(ctx, cfg, walker)...)
 
 	// Skip provider resolution if there are any errors, since the provider
@@ -81,36 +86,36 @@ func buildTestModules(ctx context.Context, root *Config, walker ModuleWalker) hc
 				SourceAddrRange:   run.Module.SourceDeclRange,
 				VersionConstraint: run.Module.Version,
 				Parent:            root,
-				Call: NewStaticModuleCall(
-					path,
-					run.Module.DeclRange,
-					func(v *Variable) (cty.Value, hcl.Diagnostics) {
-						// Handle the case where this is overridden in the test run block
-						expr, isOverridden := run.Variables[v.Name]
-						if isOverridden {
-							identifier := StaticIdentifier{
-								Module:    path,
-								Subject:   fmt.Sprintf("var.%s", v.Name),
-								DeclRange: expr.Range(),
-							}
-							return root.Module.StaticEvaluator.Evaluate(ctx, expr, identifier)
-						}
-
-						// If we haven't had it overridden in a run block, fall back to trying our best
-						// but we do have defaults for some that we can use.
-						if v.Default != cty.NilVal {
-							return v.Default, nil
-						}
-						return cty.DynamicVal, nil
-					},
-					root.Module.SourceDir,
-					root.Module.StaticEvaluator.call.workspace,
-				),
 
 				CallRange: run.Module.DeclRange,
 			}
 
-			cfg, modDiags := loadModule(ctx, root, &req, walker)
+			staticCall := NewStaticModuleCall(
+				path,
+				run.Module.DeclRange,
+				func(v *Variable) (cty.Value, hcl.Diagnostics) {
+					// Handle the case where this is overridden in the test run block
+					expr, isOverridden := run.Variables[v.Name]
+					if isOverridden {
+						identifier := StaticIdentifier{
+							Module:    path,
+							Subject:   fmt.Sprintf("var.%s", v.Name),
+							DeclRange: expr.Range(),
+						}
+						return root.Module.StaticEvaluator.Evaluate(ctx, expr, identifier)
+					}
+
+					// If we haven't had it overridden in a run block, fall back to trying our best
+					// but we do have defaults for some that we can use.
+					if v.Default != cty.NilVal {
+						return v.Default, nil
+					}
+					return cty.DynamicVal, nil
+				},
+				root.Module.SourceDir,
+				root.Module.StaticEvaluator.call.workspace,
+			)
+			cfg, modDiags := loadModule(ctx, root, &req, staticCall, walker)
 			diags = append(diags, modDiags...)
 
 			if cfg != nil {
@@ -168,13 +173,13 @@ func buildChildModules(ctx context.Context, parent *Config, walker ModuleWalker)
 			VersionConstraint: call.Version,
 			Parent:            parent,
 			CallRange:         call.DeclRange,
-			Call:              NewStaticModuleCall(path, call.DeclRange, call.Variables, parent.Root.Module.SourceDir, call.Workspace),
 		}
 		if call.Source != nil {
 			// Invalid modules sometimes have a nil source field which is handled through loadModule below
 			req.SourceAddrRange = call.Source.Range()
 		}
-		child, modDiags := loadModule(ctx, parent.Root, &req, walker)
+		staticCall := NewStaticModuleCall(path, call.DeclRange, call.Variables, parent.Root.Module.SourceDir, call.Workspace)
+		child, modDiags := loadModule(ctx, parent.Root, &req, staticCall, walker)
 		diags = append(diags, modDiags...)
 		if child == nil {
 			// This means an error occurred, there should be diagnostics within
@@ -188,7 +193,7 @@ func buildChildModules(ctx context.Context, parent *Config, walker ModuleWalker)
 	return ret, diags
 }
 
-func loadModule(ctx context.Context, root *Config, req *ModuleRequest, walker ModuleWalker) (*Config, hcl.Diagnostics) {
+func loadModule(ctx context.Context, root *Config, req *ModuleRequest, call StaticModuleCall, walker ModuleWalker) (*Config, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 
 	mod, ver, modDiags := walker.LoadModule(ctx, req)
@@ -199,6 +204,8 @@ func loadModule(ctx context.Context, root *Config, req *ModuleRequest, walker Mo
 		// returned at least one error diagnostic in that case.
 		return nil, diags
 	}
+
+	diags = diags.Extend(mod.WithStaticCall(call))
 
 	cfg := &Config{
 		Parent:          req.Parent,
@@ -329,10 +336,6 @@ type ModuleRequest struct {
 	// subject of an error diagnostic that relates to the module call itself,
 	// rather than to either its source address or its version number.
 	CallRange hcl.Range
-
-	// This is where variables and other information from the calling module
-	// are propagated to the child module for use in the static evaluator
-	Call StaticModuleCall
 }
 
 // DisabledModuleWalker is a ModuleWalker that doesn't support

--- a/internal/configs/config_build_test.go
+++ b/internal/configs/config_build_test.go
@@ -24,14 +24,14 @@ import (
 
 func TestBuildConfig(t *testing.T) {
 	parser := NewParser(nil)
-	mod, diags := parser.LoadConfigDir("testdata/config-build", RootModuleCallForTesting())
+	mod, diags := parser.LoadConfigDir("testdata/config-build")
 	assertNoDiagnostics(t, diags)
 	if mod == nil {
 		t.Fatal("got nil root module; want non-nil")
 	}
 
 	versionI := 0
-	cfg, diags := BuildConfig(t.Context(), mod, ModuleWalkerFunc(
+	cfg, diags := BuildConfig(t.Context(), mod, RootModuleCallForTesting(), ModuleWalkerFunc(
 		func(_ context.Context, req *ModuleRequest) (*Module, *version.Version, hcl.Diagnostics) {
 			// For the sake of this test we're going to just treat our
 			// SourceAddr as a path relative to our fixture directory.
@@ -39,7 +39,7 @@ func TestBuildConfig(t *testing.T) {
 			// various different source address syntaxes OpenTofu supports.
 			sourcePath := filepath.Join("testdata/config-build", req.SourceAddr.String())
 
-			mod, modDiags := parser.LoadConfigDir(sourcePath, req.Call)
+			mod, modDiags := parser.LoadConfigDir(sourcePath)
 			version, _ := version.NewVersion(fmt.Sprintf("1.0.%d", versionI))
 			versionI++
 			return mod, version, modDiags
@@ -80,14 +80,14 @@ func TestBuildConfig(t *testing.T) {
 
 func TestBuildConfigDiags(t *testing.T) {
 	parser := NewParser(nil)
-	mod, diags := parser.LoadConfigDir("testdata/nested-errors", RootModuleCallForTesting())
+	mod, diags := parser.LoadConfigDir("testdata/nested-errors")
 	assertNoDiagnostics(t, diags)
 	if mod == nil {
 		t.Fatal("got nil root module; want non-nil")
 	}
 
 	versionI := 0
-	cfg, diags := BuildConfig(t.Context(), mod, ModuleWalkerFunc(
+	cfg, diags := BuildConfig(t.Context(), mod, RootModuleCallForTesting(), ModuleWalkerFunc(
 		func(_ context.Context, req *ModuleRequest) (*Module, *version.Version, hcl.Diagnostics) {
 			// For the sake of this test we're going to just treat our
 			// SourceAddr as a path relative to our fixture directory.
@@ -95,7 +95,7 @@ func TestBuildConfigDiags(t *testing.T) {
 			// various different source address syntaxes OpenTofu supports.
 			sourcePath := filepath.Join("testdata/nested-errors", req.SourceAddr.String())
 
-			mod, modDiags := parser.LoadConfigDir(sourcePath, req.Call)
+			mod, modDiags := parser.LoadConfigDir(sourcePath)
 			version, _ := version.NewVersion(fmt.Sprintf("1.0.%d", versionI))
 			versionI++
 			return mod, version, modDiags
@@ -125,13 +125,13 @@ func TestBuildConfigDiags(t *testing.T) {
 
 func TestBuildConfigChildModuleBackend(t *testing.T) {
 	parser := NewParser(nil)
-	mod, diags := parser.LoadConfigDir("testdata/nested-backend-warning", RootModuleCallForTesting())
+	mod, diags := parser.LoadConfigDir("testdata/nested-backend-warning")
 	assertNoDiagnostics(t, diags)
 	if mod == nil {
 		t.Fatal("got nil root module; want non-nil")
 	}
 
-	cfg, diags := BuildConfig(t.Context(), mod, ModuleWalkerFunc(
+	cfg, diags := BuildConfig(t.Context(), mod, RootModuleCallForTesting(), ModuleWalkerFunc(
 		func(_ context.Context, req *ModuleRequest) (*Module, *version.Version, hcl.Diagnostics) {
 			// For the sake of this test we're going to just treat our
 			// SourceAddr as a path relative to our fixture directory.
@@ -139,7 +139,7 @@ func TestBuildConfigChildModuleBackend(t *testing.T) {
 			// various different source address syntaxes OpenTofu supports.
 			sourcePath := filepath.Join("testdata/nested-backend-warning", req.SourceAddr.String())
 
-			mod, modDiags := parser.LoadConfigDir(sourcePath, req.Call)
+			mod, modDiags := parser.LoadConfigDir(sourcePath)
 			version, _ := version.NewVersion("1.0.0")
 			return mod, version, modDiags
 		},
@@ -176,7 +176,7 @@ func TestBuildConfigInvalidModules(t *testing.T) {
 			parser := NewParser(nil)
 			path := filepath.Join(testDir, name)
 
-			mod, diags := parser.LoadConfigDirWithTests(path, "tests", RootModuleCallForTesting())
+			mod, diags := parser.LoadConfigDirWithTests(path, "tests")
 			if diags.HasErrors() {
 				// these tests should only trigger errors that are caught in
 				// the config loader.
@@ -217,12 +217,12 @@ func TestBuildConfigInvalidModules(t *testing.T) {
 			expectedErrs := readDiags(os.ReadFile(filepath.Join(testDir, name, "errors")))
 			expectedWarnings := readDiags(os.ReadFile(filepath.Join(testDir, name, "warnings")))
 
-			_, buildDiags := BuildConfig(t.Context(), mod, ModuleWalkerFunc(
+			_, buildDiags := BuildConfig(t.Context(), mod, RootModuleCallForTesting(), ModuleWalkerFunc(
 				func(_ context.Context, req *ModuleRequest) (*Module, *version.Version, hcl.Diagnostics) {
 					// for simplicity, these tests will treat all source
 					// addresses as relative to the root module
 					sourcePath := filepath.Join(path, req.SourceAddr.String())
-					mod, diags := parser.LoadConfigDir(sourcePath, req.Call)
+					mod, diags := parser.LoadConfigDir(sourcePath)
 					version, _ := version.NewVersion("1.0.0")
 					return mod, version, diags
 				},
@@ -297,13 +297,13 @@ func TestBuildConfigInvalidModules(t *testing.T) {
 
 func TestBuildConfig_WithNestedTestModules(t *testing.T) {
 	parser := NewParser(nil)
-	mod, diags := parser.LoadConfigDirWithTests("testdata/valid-modules/with-tests-nested-module", "tests", RootModuleCallForTesting())
+	mod, diags := parser.LoadConfigDirWithTests("testdata/valid-modules/with-tests-nested-module", "tests")
 	assertNoDiagnostics(t, diags)
 	if mod == nil {
 		t.Fatal("got nil root module; want non-nil")
 	}
 
-	cfg, diags := BuildConfig(t.Context(), mod, ModuleWalkerFunc(
+	cfg, diags := BuildConfig(t.Context(), mod, RootModuleCallForTesting(), ModuleWalkerFunc(
 		func(_ context.Context, req *ModuleRequest) (*Module, *version.Version, hcl.Diagnostics) {
 
 			// Bit of a hack to get the test working, but we know all the source
@@ -318,7 +318,7 @@ func TestBuildConfig_WithNestedTestModules(t *testing.T) {
 			}
 			sourcePath := filepath.Join("testdata/valid-modules/with-tests-nested-module", addr)
 
-			mod, modDiags := parser.LoadConfigDir(sourcePath, req.Call)
+			mod, modDiags := parser.LoadConfigDir(sourcePath)
 			version, _ := version.NewVersion("1.0.0")
 			return mod, version, modDiags
 		},
@@ -377,13 +377,13 @@ func TestBuildConfig_WithNestedTestModules(t *testing.T) {
 
 func TestBuildConfig_WithTestModule(t *testing.T) {
 	parser := NewParser(nil)
-	mod, diags := parser.LoadConfigDirWithTests("testdata/valid-modules/with-tests-module", "tests", RootModuleCallForTesting())
+	mod, diags := parser.LoadConfigDirWithTests("testdata/valid-modules/with-tests-module", "tests")
 	assertNoDiagnostics(t, diags)
 	if mod == nil {
 		t.Fatal("got nil root module; want non-nil")
 	}
 
-	cfg, diags := BuildConfig(t.Context(), mod, ModuleWalkerFunc(
+	cfg, diags := BuildConfig(t.Context(), mod, RootModuleCallForTesting(), ModuleWalkerFunc(
 		func(_ context.Context, req *ModuleRequest) (*Module, *version.Version, hcl.Diagnostics) {
 			// For the sake of this test we're going to just treat our
 			// SourceAddr as a path relative to our fixture directory.
@@ -391,7 +391,7 @@ func TestBuildConfig_WithTestModule(t *testing.T) {
 			// various different source address syntaxes OpenTofu supports.
 			sourcePath := filepath.Join("testdata/valid-modules/with-tests-module", req.SourceAddr.String())
 
-			mod, modDiags := parser.LoadConfigDir(sourcePath, req.Call)
+			mod, modDiags := parser.LoadConfigDir(sourcePath)
 			version, _ := version.NewVersion("1.0.0")
 			return mod, version, modDiags
 		},
@@ -441,14 +441,14 @@ func TestBuildConfig_UninitModuleAndProviderValidation(t *testing.T) {
 	fixtureDir := "testdata/uninit-module-and-provider-refs"
 
 	parser := NewParser(nil)
-	mod, diags := parser.LoadConfigDir(fixtureDir, RootModuleCallForTesting())
+	mod, diags := parser.LoadConfigDir(fixtureDir)
 	assertNoDiagnostics(t, diags)
 	if mod == nil {
 		t.Fatal("got nil root module; want non-nil")
 	}
 
 	const diagSummary = "Not available in TestBuildConfig_UninitModuleAndProviderValidation"
-	_, diags = BuildConfig(t.Context(), mod, ModuleWalkerFunc(
+	_, diags = BuildConfig(t.Context(), mod, RootModuleCallForTesting(), ModuleWalkerFunc(
 		func(_ context.Context, req *ModuleRequest) (*Module, *version.Version, hcl.Diagnostics) {
 			switch req.Name {
 			case "child":
@@ -457,7 +457,7 @@ func TestBuildConfig_UninitModuleAndProviderValidation(t *testing.T) {
 				// A "real" implementation of ModuleWalker should accept the
 				// various different source address syntaxes OpenTofu supports.
 				sourcePath := filepath.Join(fixtureDir, req.SourceAddr.String())
-				mod, diags := parser.LoadConfigDir(sourcePath, req.Call)
+				mod, diags := parser.LoadConfigDir(sourcePath)
 				return mod, nil, diags
 			default:
 				// No other modules (including the one declared as "uninit"

--- a/internal/configs/configload/lazy.go
+++ b/internal/configs/configload/lazy.go
@@ -171,22 +171,13 @@ func (c *lazyLoader) ModuleLocalPath(ctx context.Context, req *configs.ModuleReq
 
 // configs.Parser related methods
 
-// LoadConfigDirUneval implements Loader
-func (c *lazyLoader) LoadConfigDirUneval(path string, load configs.SelectiveLoader) (*configs.Module, hcl.Diagnostics) {
-	l, err := c.init()
-	if err != nil {
-		return nil, initErrorToDiagnostic(err)
-	}
-	return l.LoadConfigDirUneval(path, load)
-}
-
 // LoadConfigDir implements Loader
-func (c *lazyLoader) LoadConfigDir(path string, call configs.StaticModuleCall) (*configs.Module, hcl.Diagnostics) {
+func (c *lazyLoader) LoadConfigDir(path string) (*configs.Module, hcl.Diagnostics) {
 	l, err := c.init()
 	if err != nil {
 		return nil, initErrorToDiagnostic(err)
 	}
-	return l.LoadConfigDir(path, call)
+	return l.LoadConfigDir(path)
 }
 
 // LoadHCLFile implements Loader
@@ -199,21 +190,21 @@ func (c *lazyLoader) LoadHCLFile(path string) (hcl.Body, hcl.Diagnostics) {
 }
 
 // LoadConfigDirSelective implements Loader
-func (c *lazyLoader) LoadConfigDirSelective(path string, call configs.StaticModuleCall, load configs.SelectiveLoader) (*configs.Module, hcl.Diagnostics) {
+func (c *lazyLoader) LoadConfigDirSelective(path string, load configs.SelectiveLoader) (*configs.Module, hcl.Diagnostics) {
 	l, err := c.init()
 	if err != nil {
 		return nil, initErrorToDiagnostic(err)
 	}
-	return l.LoadConfigDirSelective(path, call, load)
+	return l.LoadConfigDirSelective(path, load)
 }
 
 // LoadConfigDirWithTests implements Loader
-func (c *lazyLoader) LoadConfigDirWithTests(path string, testDirectory string, call configs.StaticModuleCall) (*configs.Module, hcl.Diagnostics) {
+func (c *lazyLoader) LoadConfigDirWithTests(path string, testDirectory string) (*configs.Module, hcl.Diagnostics) {
 	l, err := c.init()
 	if err != nil {
 		return nil, initErrorToDiagnostic(err)
 	}
-	return l.LoadConfigDirWithTests(path, testDirectory, call)
+	return l.LoadConfigDirWithTests(path, testDirectory)
 }
 
 // ForceFileSource allows to add synthetic additional source

--- a/internal/configs/configload/lazy_test.go
+++ b/internal/configs/configload/lazy_test.go
@@ -411,44 +411,12 @@ func TestLoaderInitializationDuringMethodCalls(t *testing.T) {
 				}
 			},
 		},
-		"loader ok - LoadConfigDirUneval": {
-			setup: func(t *testing.T, wd string) {
-				writeConfigFile(t, filepath.Join(wd, "main.tf"), []byte(`variable "in" {}`))
-			},
-			act: func(t *testing.T, wd string, l Loader) {
-				c, diags := l.LoadConfigDirUneval(wd, configs.SelectiveLoadAll)
-				if diags.HasErrors() {
-					t.Errorf("expected to have no diagnostics but got: %s", diags)
-				}
-				if _, ok := c.Variables["in"]; !ok {
-					t.Errorf("expected to have a variable named 'in' but got nothing. variables: %v", c.Variables)
-				}
-			},
-		},
-		"loader uninitializable - LoadConfigDirUneval": {
-			setup: func(t *testing.T, wd string) {
-				writeManifestFile(t, wd, []byte("invalid content")) // to break the loader initialization
-			},
-			act: func(t *testing.T, wd string, l Loader) {
-				c, diags := l.LoadConfigDirUneval(wd, configs.SelectiveLoadAll)
-				if !diags.HasErrors() {
-					t.Errorf("expected to have no diagnostics but got: %s", diags)
-				}
-				expectedErrMsg := "Failed to initialise a config loader: failed to read module manifest: error unmarshalling snapshot: invalid character 'i' looking for beginning of value"
-				if !strings.Contains(diags.Error(), expectedErrMsg) {
-					t.Errorf("expected the diags to contain %q but it didn't: %s", expectedErrMsg, diags)
-				}
-				if c != nil {
-					t.Errorf("expected no config but got a non-nil one")
-				}
-			},
-		},
 		"loader ok - LoadConfigDir": {
 			setup: func(t *testing.T, wd string) {
 				writeConfigFile(t, filepath.Join(wd, "main.tf"), []byte(`variable "in" {}`))
 			},
 			act: func(t *testing.T, wd string, l Loader) {
-				c, diags := l.LoadConfigDir(wd, configs.StaticModuleCall{})
+				c, diags := l.LoadConfigDir(wd)
 				if diags.HasErrors() {
 					t.Errorf("expected to have no diagnostics but got: %s", diags)
 				}
@@ -462,7 +430,7 @@ func TestLoaderInitializationDuringMethodCalls(t *testing.T) {
 				writeManifestFile(t, wd, []byte("invalid content")) // to break the loader initialization
 			},
 			act: func(t *testing.T, wd string, l Loader) {
-				c, diags := l.LoadConfigDir(wd, configs.StaticModuleCall{})
+				c, diags := l.LoadConfigDir(wd)
 				if !diags.HasErrors() {
 					t.Errorf("expected to have no diagnostics but got: %s", diags)
 				}
@@ -512,7 +480,7 @@ func TestLoaderInitializationDuringMethodCalls(t *testing.T) {
 				writeConfigFile(t, filepath.Join(wd, "main.tf"), []byte(`variable "in" {}`))
 			},
 			act: func(t *testing.T, wd string, l Loader) {
-				m, diags := l.LoadConfigDirSelective(wd, configs.StaticModuleCall{}, configs.SelectiveLoadAll)
+				m, diags := l.LoadConfigDirSelective(wd, configs.SelectiveLoadAll)
 				if diags.HasErrors() {
 					t.Errorf("expected to have no diagnostics but got: %s", diags)
 				}
@@ -529,7 +497,7 @@ func TestLoaderInitializationDuringMethodCalls(t *testing.T) {
 				writeManifestFile(t, wd, []byte("invalid content")) // to break the loader initialization
 			},
 			act: func(t *testing.T, wd string, l Loader) {
-				m, diags := l.LoadConfigDirSelective(wd, configs.StaticModuleCall{}, configs.SelectiveLoadAll)
+				m, diags := l.LoadConfigDirSelective(wd, configs.SelectiveLoadAll)
 				if !diags.HasErrors() {
 					t.Errorf("expected to have no diagnostics but got: %s", diags)
 				}
@@ -547,7 +515,7 @@ func TestLoaderInitializationDuringMethodCalls(t *testing.T) {
 				writeConfigFile(t, filepath.Join(wd, "main.tf"), []byte(`variable "in" {}`))
 			},
 			act: func(t *testing.T, wd string, l Loader) {
-				m, diags := l.LoadConfigDirWithTests(wd, ".", configs.StaticModuleCall{})
+				m, diags := l.LoadConfigDirWithTests(wd, ".")
 				if diags.HasErrors() {
 					t.Errorf("expected to have no diagnostics but got: %s", diags)
 				}
@@ -564,7 +532,7 @@ func TestLoaderInitializationDuringMethodCalls(t *testing.T) {
 				writeManifestFile(t, wd, []byte("invalid content")) // to break the loader initialization
 			},
 			act: func(t *testing.T, wd string, l Loader) {
-				m, diags := l.LoadConfigDirWithTests(wd, ".", configs.StaticModuleCall{})
+				m, diags := l.LoadConfigDirWithTests(wd, ".")
 				if !diags.HasErrors() {
 					t.Errorf("expected to have no diagnostics but got: %s", diags)
 				}

--- a/internal/configs/configload/loader.go
+++ b/internal/configs/configload/loader.go
@@ -40,11 +40,10 @@ type Loader interface {
 
 	// configs.Parser proxy methods
 
-	LoadConfigDirUneval(path string, load configs.SelectiveLoader) (*configs.Module, hcl.Diagnostics)
-	LoadConfigDir(path string, call configs.StaticModuleCall) (*configs.Module, hcl.Diagnostics)
+	LoadConfigDir(path string) (*configs.Module, hcl.Diagnostics)
 	LoadHCLFile(path string) (hcl.Body, hcl.Diagnostics)
-	LoadConfigDirSelective(path string, call configs.StaticModuleCall, load configs.SelectiveLoader) (*configs.Module, hcl.Diagnostics)
-	LoadConfigDirWithTests(path string, testDirectory string, call configs.StaticModuleCall) (*configs.Module, hcl.Diagnostics)
+	LoadConfigDirSelective(path string, load configs.SelectiveLoader) (*configs.Module, hcl.Diagnostics)
+	LoadConfigDirWithTests(path string, testDirectory string) (*configs.Module, hcl.Diagnostics)
 	ForceFileSource(filename string, src []byte)
 }
 

--- a/internal/configs/configload/loader_load.go
+++ b/internal/configs/configload/loader_load.go
@@ -27,29 +27,32 @@ import (
 // LoadConfig performs the basic syntax and uniqueness validations that are
 // required to process the individual modules
 func (l *loader) LoadConfig(ctx context.Context, rootDir string, call configs.StaticModuleCall) (*configs.Config, hcl.Diagnostics) {
-	config, diags := l.parser.LoadConfigDir(rootDir, call)
-	return l.loadConfig(ctx, config, diags)
+	config, diags := l.parser.LoadConfigDir(rootDir)
+	return l.loadConfig(ctx, config, call, diags)
 }
 
 // LoadConfigWithTests matches LoadConfig, except the configs.Config contains
 // any relevant .tftest.hcl files.
 func (l *loader) LoadConfigWithTests(ctx context.Context, rootDir string, testDir string, call configs.StaticModuleCall) (*configs.Config, hcl.Diagnostics) {
-	config, diags := l.parser.LoadConfigDirWithTests(rootDir, testDir, call)
-	return l.loadConfig(ctx, config, diags)
+	config, diags := l.parser.LoadConfigDirWithTests(rootDir, testDir)
+	return l.loadConfig(ctx, config, call, diags)
 }
 
-func (l *loader) loadConfig(ctx context.Context, rootMod *configs.Module, diags hcl.Diagnostics) (*configs.Config, hcl.Diagnostics) {
+func (l *loader) loadConfig(ctx context.Context, rootMod *configs.Module, call configs.StaticModuleCall, diags hcl.Diagnostics) (*configs.Config, hcl.Diagnostics) {
 	if rootMod == nil || diags.HasErrors() {
 		// Ensure we return any parsed modules here so that required_version
 		// constraints can be verified even when encountering errors.
 		cfg := &configs.Config{
 			Module: rootMod,
 		}
+		if rootMod != nil {
+			diags = diags.Extend(rootMod.WithStaticCall(call))
+		}
 
 		return cfg, diags
 	}
 
-	cfg, cDiags := configs.BuildConfig(ctx, rootMod, configs.ModuleWalkerFunc(l.moduleWalkerLoad))
+	cfg, cDiags := configs.BuildConfig(ctx, rootMod, call, configs.ModuleWalkerFunc(l.moduleWalkerLoad))
 	diags = append(diags, cDiags...)
 
 	l.lastLoadedRoot = cfg
@@ -124,7 +127,7 @@ func (l *loader) moduleWalkerLoad(ctx context.Context, req *configs.ModuleReques
 		return nil, nil, diags
 	}
 
-	mod, mDiags := l.parser.LoadConfigDir(record.Dir, req.Call)
+	mod, mDiags := l.parser.LoadConfigDir(record.Dir)
 	diags = append(diags, mDiags...)
 	if mod == nil {
 		// nil specifically indicates that the directory does not exist or

--- a/internal/configs/configload/loader_parser.go
+++ b/internal/configs/configload/loader_parser.go
@@ -14,14 +14,9 @@ import (
 	"github.com/opentofu/opentofu/internal/configs"
 )
 
-// LoadConfigDirUneval implements Loader
-func (l *loader) LoadConfigDirUneval(path string, load configs.SelectiveLoader) (*configs.Module, hcl.Diagnostics) {
-	return l.parser.LoadConfigDirUneval(path, load)
-}
-
 // LoadConfigDir implements Loader
-func (l *loader) LoadConfigDir(path string, call configs.StaticModuleCall) (*configs.Module, hcl.Diagnostics) {
-	return l.parser.LoadConfigDir(path, call)
+func (l *loader) LoadConfigDir(path string) (*configs.Module, hcl.Diagnostics) {
+	return l.parser.LoadConfigDir(path)
 }
 
 // LoadHCLFile implements Loader
@@ -30,13 +25,13 @@ func (l *loader) LoadHCLFile(path string) (hcl.Body, hcl.Diagnostics) {
 }
 
 // LoadConfigDirSelective implements Loader
-func (l *loader) LoadConfigDirSelective(path string, call configs.StaticModuleCall, load configs.SelectiveLoader) (*configs.Module, hcl.Diagnostics) {
-	return l.parser.LoadConfigDirSelective(path, call, load)
+func (l *loader) LoadConfigDirSelective(path string, load configs.SelectiveLoader) (*configs.Module, hcl.Diagnostics) {
+	return l.parser.LoadConfigDirSelective(path, load)
 }
 
 // LoadConfigDirWithTests implements Loader
-func (l *loader) LoadConfigDirWithTests(path string, testDirectory string, call configs.StaticModuleCall) (*configs.Module, hcl.Diagnostics) {
-	return l.parser.LoadConfigDirWithTests(path, testDirectory, call)
+func (l *loader) LoadConfigDirWithTests(path string, testDirectory string) (*configs.Module, hcl.Diagnostics) {
+	return l.parser.LoadConfigDirWithTests(path, testDirectory)
 }
 
 // ForceFileSource implements Loader

--- a/internal/configs/configload/loader_snapshot.go
+++ b/internal/configs/configload/loader_snapshot.go
@@ -26,7 +26,7 @@ import (
 // creates an in-memory snapshot of the configuration files used, which can
 // be later used to create a loader that may read only from this snapshot.
 func (l *loader) LoadConfigWithSnapshot(ctx context.Context, rootDir string, call configs.StaticModuleCall) (*configs.Config, *Snapshot, hcl.Diagnostics) {
-	rootMod, diags := l.parser.LoadConfigDir(rootDir, call)
+	rootMod, diags := l.parser.LoadConfigDir(rootDir)
 	if rootMod == nil {
 		return nil, nil, diags
 	}
@@ -35,7 +35,7 @@ func (l *loader) LoadConfigWithSnapshot(ctx context.Context, rootDir string, cal
 		Modules: map[string]*SnapshotModule{},
 	}
 	walker := l.makeModuleWalkerSnapshot(snap)
-	cfg, cDiags := configs.BuildConfig(ctx, rootMod, walker)
+	cfg, cDiags := configs.BuildConfig(ctx, rootMod, call, walker)
 	diags = append(diags, cDiags...)
 
 	addDiags := l.addModuleToSnapshot(snap, "", rootDir, "", nil)

--- a/internal/configs/escaping_blocks_test.go
+++ b/internal/configs/escaping_blocks_test.go
@@ -40,7 +40,7 @@ func TestEscapingBlockResource(t *testing.T) {
 	// they only appear nested inside resource blocks.)
 
 	parser := NewParser(nil)
-	mod, diags := parser.LoadConfigDir("testdata/escaping-blocks/resource", RootModuleCallForTesting())
+	mod, diags := parser.LoadConfigDir("testdata/escaping-blocks/resource")
 	assertNoDiagnostics(t, diags)
 	if mod == nil {
 		t.Fatal("got nil root module; want non-nil")
@@ -138,7 +138,7 @@ func TestEscapingBlockResource(t *testing.T) {
 
 func TestEscapingBlockData(t *testing.T) {
 	parser := NewParser(nil)
-	mod, diags := parser.LoadConfigDir("testdata/escaping-blocks/data", RootModuleCallForTesting())
+	mod, diags := parser.LoadConfigDir("testdata/escaping-blocks/data")
 	assertNoDiagnostics(t, diags)
 	if mod == nil {
 		t.Fatal("got nil root module; want non-nil")
@@ -204,7 +204,7 @@ func TestEscapingBlockData(t *testing.T) {
 
 func TestEscapingBlockModule(t *testing.T) {
 	parser := NewParser(nil)
-	mod, diags := parser.LoadConfigDir("testdata/escaping-blocks/module", RootModuleCallForTesting())
+	mod, diags := parser.LoadConfigDir("testdata/escaping-blocks/module")
 	assertNoDiagnostics(t, diags)
 	if mod == nil {
 		t.Fatal("got nil root module; want non-nil")
@@ -270,7 +270,7 @@ func TestEscapingBlockModule(t *testing.T) {
 
 func TestEscapingBlockProvider(t *testing.T) {
 	parser := NewParser(nil)
-	mod, diags := parser.LoadConfigDir("testdata/escaping-blocks/provider", RootModuleCallForTesting())
+	mod, diags := parser.LoadConfigDir("testdata/escaping-blocks/provider")
 	assertNoDiagnostics(t, diags)
 	if mod == nil {
 		t.Fatal("got nil root module; want non-nil")

--- a/internal/configs/module.go
+++ b/internal/configs/module.go
@@ -149,23 +149,23 @@ func (s SelectiveLoader) filter(input []*File) []*File {
 
 // NewModuleWithTests matches NewModule except it will also load in the provided
 // test files.
-func NewModuleWithTests(primaryFiles, overrideFiles []*File, testFiles map[string]*TestFile, call StaticModuleCall, sourceDir string) (*Module, hcl.Diagnostics) {
-	mod, diags := NewModule(primaryFiles, overrideFiles, call, sourceDir, SelectiveLoadAll)
+func NewModuleWithTests(primaryFiles, overrideFiles []*File, testFiles map[string]*TestFile, sourceDir string) (*Module, hcl.Diagnostics) {
+	mod, diags := NewModule(primaryFiles, overrideFiles, sourceDir, SelectiveLoadAll)
 	if mod != nil {
 		mod.Tests = testFiles
 	}
 	return mod, diags
 }
 
-// NewModuleUneval is a variation of [NewModule] which performs only the
-// static decoding steps and stops before performing any of the "early eval"
-// steps, instead just returning with the results of early eval unpopulated.
+// NewModule takes a list of primary files and a list of override files and
+// produces a *Module by combining the files together.
 //
-// This is currently here only in support of the experiment in
-// internal/lang/eval, which wants to handle the situations where we currently
-// rely on early eval in a different way. Outside of that experiment we should
-// keep using [NewModule] in its entirety for now.
-func NewModuleUneval(primaryFiles, overrideFiles []*File, sourceDir string, load SelectiveLoader) (*Module, hcl.Diagnostics) {
+// If there are any conflicting declarations in the given files -- for example,
+// if the same variable name is defined twice -- then the resulting module
+// will be incomplete and error diagnostics will be returned. Careful static
+// analysis of the returned Module is still possible in this case, but the
+// module will probably not be semantically valid.
+func NewModule(primaryFiles, overrideFiles []*File, sourceDir string, load SelectiveLoader) (*Module, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 	mod := &Module{
 		ProviderConfigs:    map[string]*Provider{},
@@ -235,59 +235,55 @@ func NewModuleUneval(primaryFiles, overrideFiles []*File, sourceDir string, load
 	return mod, diags
 }
 
-// NewModule takes a list of primary files and a list of override files and
-// produces a *Module by combining the files together.
-//
-// If there are any conflicting declarations in the given files -- for example,
-// if the same variable name is defined twice -- then the resulting module
-// will be incomplete and error diagnostics will be returned. Careful static
-// analysis of the returned Module is still possible in this case, but the
-// module will probably not be semantically valid.
-func NewModule(primaryFiles, overrideFiles []*File, call StaticModuleCall, sourceDir string, load SelectiveLoader) (*Module, hcl.Diagnostics) {
-	mod, diags := NewModuleUneval(primaryFiles, overrideFiles, sourceDir, load)
+func (m *Module) WithStaticCall(call StaticModuleCall) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+
+	if m.StaticEvaluator != nil {
+		panic("applying Static Evaluation to a module twice, this is a critical bug in OpenTofu")
+	}
 
 	// Static evaluation to build a StaticContext now that module has all relevant Locals / Variables
-	mod.StaticEvaluator = NewStaticEvaluator(mod, call)
+	m.StaticEvaluator = NewStaticEvaluator(m, call)
 
 	// If we have a backend, it may have fields that require locals/vars
-	if mod.Backend != nil {
+	if m.Backend != nil {
 		// We don't know the backend type / loader at this point so we save the context for later use
-		mod.Backend.Eval = mod.StaticEvaluator
+		m.Backend.Eval = m.StaticEvaluator
 	}
-	if mod.CloudConfig != nil {
-		mod.CloudConfig.eval = mod.StaticEvaluator
+	if m.CloudConfig != nil {
+		m.CloudConfig.eval = m.StaticEvaluator
 	}
 
 	// Process all module calls now that we have the static context
-	for _, mc := range mod.ModuleCalls {
-		mDiags := mc.decodeStaticFields(context.TODO(), mod.StaticEvaluator)
+	for _, mc := range m.ModuleCalls {
+		mDiags := mc.decodeStaticFields(context.TODO(), m.StaticEvaluator)
 		diags = append(diags, mDiags...)
 	}
 
-	for _, pc := range mod.ProviderConfigs {
-		pDiags := pc.decodeStaticFields(context.TODO(), mod.StaticEvaluator)
+	for _, pc := range m.ProviderConfigs {
+		pDiags := pc.decodeStaticFields(context.TODO(), m.StaticEvaluator)
 		diags = append(diags, pDiags...)
 	}
 
 	// Generate the FQN -> LocalProviderName map
-	mod.gatherProviderLocalNames()
+	m.gatherProviderLocalNames()
 
 	// Ensure const variables are actually const
 	var constRefs []*addrs.Reference
-	for _, variable := range mod.Variables {
+	for _, variable := range m.Variables {
 		if variable.Const {
 			constRefs = append(constRefs, &addrs.Reference{
 				Subject: addrs.InputVariable{Name: variable.Name},
 			})
 		}
 	}
-	_, vDiags := mod.StaticEvaluator.EvalContext(context.TODO(), StaticIdentifier{
-		Module:    mod.StaticEvaluator.call.addr,
-		DeclRange: mod.StaticEvaluator.call.declRange,
+	_, vDiags := m.StaticEvaluator.EvalContext(context.TODO(), StaticIdentifier{
+		Module:    m.StaticEvaluator.call.addr,
+		DeclRange: m.StaticEvaluator.call.declRange,
 	}, constRefs)
 	diags = append(diags, vDiags...)
 
-	return mod, diags
+	return diags
 }
 
 // ResourceByAddr returns the configuration for the resource with the given

--- a/internal/configs/module_call_test.go
+++ b/internal/configs/module_call_test.go
@@ -247,7 +247,7 @@ func TestModuleCallWithVersion(t *testing.T) {
 	}
 
 	// Create a module from the loaded file
-	mod, diags := NewModule([]*File{file}, nil, RootModuleCallForTesting(), "testdata", SelectiveLoadAll)
+	mod, diags := NewModule([]*File{file}, nil, "testdata", SelectiveLoadAll)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors creating module: %s", diags.Error())
 	}
@@ -425,7 +425,10 @@ variable "path" {
 				}
 				tFiles = append(tFiles, f)
 			}
-			_, diags := NewModule(tFiles, nil, call, "testdata", SelectiveLoadAll)
+			mod, diags := NewModule(tFiles, nil, "testdata", SelectiveLoadAll)
+			if mod != nil {
+				diags = diags.Extend(mod.WithStaticCall(call))
+			}
 			if tc.err == "" {
 				if diags.HasErrors() {
 					t.Errorf("unexpected errors creating module: %s", diags.Error())

--- a/internal/configs/moved_test.go
+++ b/internal/configs/moved_test.go
@@ -202,7 +202,7 @@ func TestMovedBlock_decode(t *testing.T) {
 
 func TestMovedBlock_inModule(t *testing.T) {
 	parser := NewParser(nil)
-	mod, diags := parser.LoadConfigDir("testdata/valid-modules/moved-blocks", RootModuleCallForTesting())
+	mod, diags := parser.LoadConfigDir("testdata/valid-modules/moved-blocks")
 	if diags.HasErrors() {
 		t.Errorf("unexpected error: %s", diags.Error())
 	}

--- a/internal/configs/parser_config_dir.go
+++ b/internal/configs/parser_config_dir.go
@@ -51,10 +51,10 @@ const (
 //
 // .tf files are parsed using the HCL native syntax while .tf.json files are
 // parsed using the HCL JSON syntax.
-func (p *Parser) LoadConfigDir(path string, call StaticModuleCall) (*Module, hcl.Diagnostics) {
-	return p.LoadConfigDirSelective(path, call, SelectiveLoadAll)
+func (p *Parser) LoadConfigDir(path string) (*Module, hcl.Diagnostics) {
+	return p.LoadConfigDirSelective(path, SelectiveLoadAll)
 }
-func (p *Parser) LoadConfigDirSelective(path string, call StaticModuleCall, load SelectiveLoader) (*Module, hcl.Diagnostics) {
+func (p *Parser) LoadConfigDirSelective(path string, load SelectiveLoader) (*Module, hcl.Diagnostics) {
 	primaryPaths, overridePaths, _, diags := p.dirFiles(path, "")
 	if diags.HasErrors() {
 		return nil, diags
@@ -65,32 +65,7 @@ func (p *Parser) LoadConfigDirSelective(path string, call StaticModuleCall, load
 	override, fDiags := p.loadFiles(overridePaths, true)
 	diags = append(diags, fDiags...)
 
-	mod, modDiags := NewModule(primary, override, call, path, load)
-	diags = append(diags, modDiags...)
-
-	diags = finalizeModuleLoadDiagnostics(diags)
-	return mod, diags
-}
-
-// LoadConfigDirUneval is a variant of [Parser.LoadConfigDir] that only performs
-// the static decoding step and does not perform early evaluation.
-//
-// This is currently intended only for the experiment in internal/lang/eval,
-// which wants to use a different strategy to meet the "early evaluation"
-// use-cases. We should continue to use [Parser.LoadConfigDir] for all other
-// callers for now.
-func (p *Parser) LoadConfigDirUneval(path string, load SelectiveLoader) (*Module, hcl.Diagnostics) {
-	primaryPaths, overridePaths, _, diags := p.dirFiles(path, "")
-	if diags.HasErrors() {
-		return nil, diags
-	}
-
-	primary, fDiags := p.loadFiles(primaryPaths, false)
-	diags = append(diags, fDiags...)
-	override, fDiags := p.loadFiles(overridePaths, true)
-	diags = append(diags, fDiags...)
-
-	mod, modDiags := NewModuleUneval(primary, override, path, load)
+	mod, modDiags := NewModule(primary, override, path, load)
 	diags = append(diags, modDiags...)
 
 	diags = finalizeModuleLoadDiagnostics(diags)
@@ -99,7 +74,7 @@ func (p *Parser) LoadConfigDirUneval(path string, load SelectiveLoader) (*Module
 
 // LoadConfigDirWithTests matches LoadConfigDir, but the return Module also
 // contains any relevant .tftest.hcl files.
-func (p *Parser) LoadConfigDirWithTests(path string, testDirectory string, call StaticModuleCall) (*Module, hcl.Diagnostics) {
+func (p *Parser) LoadConfigDirWithTests(path string, testDirectory string) (*Module, hcl.Diagnostics) {
 	primaryPaths, overridePaths, testPaths, diags := p.dirFiles(path, testDirectory)
 	if diags.HasErrors() {
 		return nil, diags
@@ -112,7 +87,7 @@ func (p *Parser) LoadConfigDirWithTests(path string, testDirectory string, call 
 	tests, fDiags := p.loadTestFiles(path, testPaths)
 	diags = append(diags, fDiags...)
 
-	mod, modDiags := NewModuleWithTests(primary, override, tests, call, path)
+	mod, modDiags := NewModuleWithTests(primary, override, tests, path)
 	diags = append(diags, modDiags...)
 
 	diags = finalizeModuleLoadDiagnostics(diags)

--- a/internal/configs/parser_config_dir_test.go
+++ b/internal/configs/parser_config_dir_test.go
@@ -39,7 +39,7 @@ func TestParserLoadConfigDirSuccess(t *testing.T) {
 			parser := NewParser(nil)
 			path := filepath.Join("testdata/valid-modules", name)
 
-			mod, diags := parser.LoadConfigDir(path, RootModuleCallForTesting())
+			mod, diags := parser.LoadConfigDir(path)
 			if len(diags) != 0 {
 				t.Errorf("unexpected diagnostics")
 				for _, diag := range diags {
@@ -78,14 +78,18 @@ func TestParserLoadConfigDirSuccess(t *testing.T) {
 				"mod/" + name: string(src),
 			})
 
-			_, diags := parser.LoadConfigDir("mod", NewStaticModuleCall(addrs.RootModule, hcl.Range{},
-				func(v *Variable) (cty.Value, hcl.Diagnostics) {
-					if !v.Required() {
-						// Allow defaults in this test
-						return v.Default, nil
-					}
-					panic("Variables not configured for this test!")
-				}, "<testing>", ""))
+			mod, diags := parser.LoadConfigDir("mod")
+			if mod != nil {
+				call := NewStaticModuleCall(addrs.RootModule, hcl.Range{},
+					func(v *Variable) (cty.Value, hcl.Diagnostics) {
+						if !v.Required() {
+							// Allow defaults in this test
+							return v.Default, nil
+						}
+						panic("Variables not configured for this test!")
+					}, "<testing>", "")
+				diags = diags.Extend(mod.WithStaticCall(call))
+			}
 			if diags.HasErrors() {
 				t.Errorf("unexpected error diagnostics")
 				for _, diag := range diags {
@@ -115,7 +119,7 @@ func TestParserLoadConfigDirWithTests(t *testing.T) {
 			}
 
 			parser := NewParser(nil)
-			mod, diags := parser.LoadConfigDirWithTests(directory, testDirectory, RootModuleCallForTesting())
+			mod, diags := parser.LoadConfigDirWithTests(directory, testDirectory)
 			if len(diags) > 0 { // We don't want any warnings or errors.
 				t.Errorf("unexpected diagnostics")
 				for _, diag := range diags {
@@ -132,7 +136,7 @@ func TestParserLoadConfigDirWithTests(t *testing.T) {
 
 func TestParserLoadConfigDirWithTests_ReturnsWarnings(t *testing.T) {
 	parser := NewParser(nil)
-	mod, diags := parser.LoadConfigDirWithTests("testdata/valid-modules/with-tests", "not_real", RootModuleCallForTesting())
+	mod, diags := parser.LoadConfigDirWithTests("testdata/valid-modules/with-tests", "not_real")
 	if len(diags) != 1 {
 		t.Errorf("expected exactly 1 diagnostic, but found %d", len(diags))
 	} else {
@@ -179,7 +183,7 @@ func TestParserLoadConfigDirFailure(t *testing.T) {
 			parser := NewParser(nil)
 			path := filepath.Join("testdata/invalid-modules", name)
 
-			_, diags := parser.LoadConfigDir(path, RootModuleCallForTesting())
+			_, diags := parser.LoadConfigDir(path)
 			if !diags.HasErrors() {
 				t.Errorf("no errors; want at least one")
 				for _, diag := range diags {
@@ -208,7 +212,7 @@ func TestParserLoadConfigDirFailure(t *testing.T) {
 				"mod/" + name: string(src),
 			})
 
-			_, diags := parser.LoadConfigDir("mod", RootModuleCallForTesting())
+			_, diags := parser.LoadConfigDir("mod")
 			if !diags.HasErrors() {
 				t.Errorf("no errors; want at least one")
 				for _, diag := range diags {
@@ -248,7 +252,7 @@ func TestParserLoadConfigDirWithTests_TofuFiles(t *testing.T) {
 			parser := NewParser(nil)
 			path := tt.path
 
-			mod, diags := parser.LoadConfigDirWithTests(path, "test", RootModuleCallForTesting())
+			mod, diags := parser.LoadConfigDirWithTests(path, "test")
 			if len(diags) != 0 {
 				t.Errorf("unexpected diagnostics")
 				for _, diag := range diags {

--- a/internal/configs/parser_test.go
+++ b/internal/configs/parser_test.go
@@ -49,9 +49,9 @@ func testParser(files map[string]string) *Parser {
 func testModuleConfigFromFile(ctx context.Context, filename string) (*Config, hcl.Diagnostics) {
 	parser := NewParser(nil)
 	f, diags := parser.LoadConfigFile(filename)
-	mod, modDiags := NewModule([]*File{f}, nil, RootModuleCallForTesting(), filename, SelectiveLoadAll)
+	mod, modDiags := NewModule([]*File{f}, nil, filename, SelectiveLoadAll)
 	diags = append(diags, modDiags...)
-	cfg, moreDiags := BuildConfig(ctx, mod, nil)
+	cfg, moreDiags := BuildConfig(ctx, mod, RootModuleCallForTesting(), nil)
 	return cfg, append(diags, moreDiags...)
 }
 
@@ -59,15 +59,17 @@ func testModuleConfigFromFile(ctx context.Context, filename string) (*Config, hc
 // a module and returns it. This is a helper for use in unit tests.
 func testModuleFromDir(path string) (*Module, hcl.Diagnostics) {
 	parser := NewParser(nil)
-	return parser.LoadConfigDir(path, RootModuleCallForTesting())
+	mod, diags := parser.LoadConfigDir(path)
+	diags = diags.Extend(mod.WithStaticCall(RootModuleCallForTesting()))
+	return mod, diags
 }
 
 // testModuleFromDir reads configuration from the given directory path as a
 // module and returns its configuration. This is a helper for use in unit tests.
 func testModuleConfigFromDir(ctx context.Context, path string) (*Config, hcl.Diagnostics) {
 	parser := NewParser(nil)
-	mod, diags := parser.LoadConfigDir(path, RootModuleCallForTesting())
-	cfg, moreDiags := BuildConfig(ctx, mod, nil)
+	mod, diags := parser.LoadConfigDir(path)
+	cfg, moreDiags := BuildConfig(ctx, mod, RootModuleCallForTesting(), nil)
 	return cfg, append(diags, moreDiags...)
 }
 
@@ -77,7 +79,7 @@ func testNestedModuleConfigFromDirWithTests(t *testing.T, path string) (*Config,
 	t.Helper()
 
 	parser := NewParser(nil)
-	mod, diags := parser.LoadConfigDirWithTests(path, "tests", RootModuleCallForTesting())
+	mod, diags := parser.LoadConfigDirWithTests(path, "tests")
 	if mod == nil {
 		t.Fatal("got nil root module; want non-nil")
 	}
@@ -95,7 +97,7 @@ func testNestedModuleConfigFromDir(t *testing.T, path string) (*Config, hcl.Diag
 	t.Helper()
 
 	parser := NewParser(nil)
-	mod, diags := parser.LoadConfigDir(path, RootModuleCallForTesting())
+	mod, diags := parser.LoadConfigDir(path)
 	if mod == nil {
 		t.Fatal("got nil root module; want non-nil")
 	}
@@ -108,7 +110,7 @@ func testNestedModuleConfigFromDir(t *testing.T, path string) (*Config, hcl.Diag
 
 func buildNestedModuleConfig(ctx context.Context, mod *Module, path string, parser *Parser) (*Config, hcl.Diagnostics) {
 	versionI := 0
-	return BuildConfig(ctx, mod, ModuleWalkerFunc(
+	return BuildConfig(ctx, mod, RootModuleCallForTesting(), ModuleWalkerFunc(
 		func(_ context.Context, req *ModuleRequest) (*Module, *version.Version, hcl.Diagnostics) {
 			// For the sake of this test we're going to just treat our
 			// SourceAddr as a path relative to the calling module.
@@ -124,7 +126,7 @@ func buildNestedModuleConfig(ctx context.Context, mod *Module, path string, pars
 			paths = append([]string{path}, paths...)
 			sourcePath := filepath.Join(paths...)
 
-			mod, diags := parser.LoadConfigDir(sourcePath, RootModuleCallForTesting())
+			mod, diags := parser.LoadConfigDir(sourcePath)
 			version, _ := version.NewVersion(fmt.Sprintf("1.0.%d", versionI))
 			versionI++
 			return mod, version, diags

--- a/internal/configs/removed_test.go
+++ b/internal/configs/removed_test.go
@@ -428,7 +428,7 @@ func TestRemovedBlock_decode(t *testing.T) {
 
 func TestRemovedBlock_inModule(t *testing.T) {
 	parser := NewParser(nil)
-	mod, diags := parser.LoadConfigDir("testdata/valid-modules/removed-blocks", RootModuleCallForTesting())
+	mod, diags := parser.LoadConfigDir("testdata/valid-modules/removed-blocks")
 	if diags.HasErrors() {
 		t.Errorf("unexpected error: %s", diags.Error())
 	}

--- a/internal/configs/static_evaluator_test.go
+++ b/internal/configs/static_evaluator_test.go
@@ -95,7 +95,8 @@ resource "foo" "bar" {}
 	dummyIdentifier := StaticIdentifier{Subject: "local.test"}
 
 	t.Run("Empty Eval", func(t *testing.T) {
-		mod, _ := NewModule([]*File{file}, nil, RootModuleCallForTesting(), "dir", SelectiveLoadAll)
+		mod, _ := NewModule([]*File{file}, nil, "dir", SelectiveLoadAll)
+		_ = mod.WithStaticCall(RootModuleCallForTesting())
 		emptyEval := StaticEvaluator{}
 
 		// Expr with no traversals shouldn't access any fields
@@ -118,7 +119,8 @@ resource "foo" "bar" {}
 	})
 
 	t.Run("Simple static cases", func(t *testing.T) {
-		mod, _ := NewModule([]*File{file}, nil, RootModuleCallForTesting(), "dir", SelectiveLoadAll)
+		mod, _ := NewModule([]*File{file}, nil, "dir", SelectiveLoadAll)
+		_ = mod.WithStaticCall(RootModuleCallForTesting())
 		eval := NewStaticEvaluator(mod, RootModuleCallForTesting())
 
 		locals := []struct {
@@ -155,7 +157,8 @@ resource "foo" "bar" {}
 			}
 			return v.Default, nil
 		}, "<testing>", "")
-		mod, _ := NewModule([]*File{file}, nil, call, "dir", SelectiveLoadAll)
+		mod, _ := NewModule([]*File{file}, nil, "dir", SelectiveLoadAll)
+		_ = mod.WithStaticCall(call)
 		eval := NewStaticEvaluator(mod, call)
 
 		locals := []struct {
@@ -181,7 +184,8 @@ resource "foo" "bar" {}
 	})
 
 	t.Run("Bad References", func(t *testing.T) {
-		mod, _ := NewModule([]*File{file}, nil, RootModuleCallForTesting(), "dir", SelectiveLoadAll)
+		mod, _ := NewModule([]*File{file}, nil, "dir", SelectiveLoadAll)
+		_ = mod.WithStaticCall(RootModuleCallForTesting())
 		eval := NewStaticEvaluator(mod, RootModuleCallForTesting())
 
 		locals := []struct {
@@ -201,7 +205,8 @@ resource "foo" "bar" {}
 	})
 
 	t.Run("Circular References", func(t *testing.T) {
-		mod, _ := NewModule([]*File{file}, nil, RootModuleCallForTesting(), "dir", SelectiveLoadAll)
+		mod, _ := NewModule([]*File{file}, nil, "dir", SelectiveLoadAll)
+		_ = mod.WithStaticCall(RootModuleCallForTesting())
 		eval := NewStaticEvaluator(mod, RootModuleCallForTesting())
 
 		locals := []struct {
@@ -238,7 +243,8 @@ resource "foo" "bar" {}
 				Subject:  v.DeclRange.Ptr(),
 			}}
 		}, "<testing>", "")
-		mod, _ := NewModule([]*File{file}, nil, call, "dir", SelectiveLoadAll)
+		mod, _ := NewModule([]*File{file}, nil, "dir", SelectiveLoadAll)
+		_ = mod.WithStaticCall(call)
 		eval := NewStaticEvaluator(mod, call)
 
 		badref := mod.Locals["ref_c"]
@@ -252,7 +258,8 @@ resource "foo" "bar" {}
 	})
 
 	t.Run("Missing References", func(t *testing.T) {
-		mod, _ := NewModule([]*File{file}, nil, RootModuleCallForTesting(), "dir", SelectiveLoadAll)
+		mod, _ := NewModule([]*File{file}, nil, "dir", SelectiveLoadAll)
+		_ = mod.WithStaticCall(RootModuleCallForTesting())
 		eval := NewStaticEvaluator(mod, RootModuleCallForTesting())
 
 		locals := []struct {
@@ -273,7 +280,8 @@ resource "foo" "bar" {}
 
 	t.Run("Workspace", func(t *testing.T) {
 		call := NewStaticModuleCall(nil, hcl.Range{}, nil, "<testing>", "my-workspace")
-		mod, _ := NewModule([]*File{file}, nil, call, "dir", SelectiveLoadAll)
+		mod, _ := NewModule([]*File{file}, nil, "dir", SelectiveLoadAll)
+		_ = mod.WithStaticCall(call)
 		eval := NewStaticEvaluator(mod, call)
 
 		value, diags := eval.Evaluate(t.Context(), mod.Locals["ws"].Expr, dummyIdentifier)
@@ -286,7 +294,8 @@ resource "foo" "bar" {}
 	})
 
 	t.Run("Functions", func(t *testing.T) {
-		mod, _ := NewModule([]*File{file}, nil, RootModuleCallForTesting(), "dir", SelectiveLoadAll)
+		mod, _ := NewModule([]*File{file}, nil, "dir", SelectiveLoadAll)
+		_ = mod.WithStaticCall(RootModuleCallForTesting())
 		eval := NewStaticEvaluator(mod, RootModuleCallForTesting())
 
 		value, diags := eval.Evaluate(t.Context(), mod.Locals["func"].Expr, dummyIdentifier)
@@ -311,7 +320,8 @@ func TestStaticEvaluator_DecodeExpression(t *testing.T) {
 	if fileDiags.HasErrors() {
 		t.Fatal(fileDiags)
 	}
-	mod, _ := NewModule([]*File{file}, nil, RootModuleCallForTesting(), "dir", SelectiveLoadAll)
+	mod, _ := NewModule([]*File{file}, nil, "dir", SelectiveLoadAll)
+	_ = mod.WithStaticCall(RootModuleCallForTesting())
 	mod.Locals["my_ephemeral_local"] = &Local{
 		Name:      "my_ephemeral_local",
 		Expr:      hcl.StaticExpr(cty.StringVal("ephemeral local value").Mark(marks.Ephemeral), hcl.Range{}),
@@ -443,7 +453,8 @@ terraform {
 					return v.Default, nil
 				},
 			}
-			mod, _ := NewModule([]*File{file}, nil, modCall, "dir", SelectiveLoadAll)
+			mod, _ := NewModule([]*File{file}, nil, "dir", SelectiveLoadAll)
+			_ = mod.WithStaticCall(modCall)
 
 			_, diags := mod.Backend.Hash(t.Context(), schema)
 			if diags.HasErrors() {

--- a/internal/configs/static_scope_test.go
+++ b/internal/configs/static_scope_test.go
@@ -185,7 +185,8 @@ func TestStaticScope_GetInputVariable(t *testing.T) {
 			".",
 			"irrelevant",
 		)
-		mod, diags := p.LoadConfigDir(".", call)
+		mod, diags := p.LoadConfigDir(".")
+		diags = diags.Extend(mod.WithStaticCall(call))
 		assertNoDiagnostics(t, diags)
 
 		// We'll make sure the config and the test cases remain consistent
@@ -235,7 +236,8 @@ func TestStaticScope_GetInputVariable(t *testing.T) {
 			".",
 			"irrelevant",
 		)
-		mod, diags := p.LoadConfigDir(".", call)
+		mod, diags := p.LoadConfigDir(".")
+		diags = diags.Extend(mod.WithStaticCall(call))
 		assertNoDiagnostics(t, diags)
 
 		eval := NewStaticEvaluator(mod, call)
@@ -273,7 +275,8 @@ func TestStaticScope_GetInputVariable(t *testing.T) {
 			".",
 			"irrelevant",
 		)
-		mod, diags := p.LoadConfigDir(".", call)
+		mod, diags := p.LoadConfigDir(".")
+		diags = diags.Extend(mod.WithStaticCall(call))
 		assertNoDiagnostics(t, diags)
 
 		eval := NewStaticEvaluator(mod, call)
@@ -315,7 +318,8 @@ func TestStaticScope_GetLocalValue(t *testing.T) {
 			".",
 			"irrelevant",
 		)
-		mod, diags := p.LoadConfigDir(".", call)
+		mod, diags := p.LoadConfigDir(".")
+		diags = diags.Extend(mod.WithStaticCall(call))
 		assertNoDiagnostics(t, diags)
 
 		eval := NewStaticEvaluator(mod, call)
@@ -346,7 +350,8 @@ func TestStaticScope_GetLocalValue(t *testing.T) {
 			".",
 			"irrelevant",
 		)
-		mod, diags := p.LoadConfigDir(".", call)
+		mod, diags := p.LoadConfigDir(".")
+		diags = diags.Extend(mod.WithStaticCall(call))
 		assertNoDiagnostics(t, diags)
 
 		eval := NewStaticEvaluator(mod, call)

--- a/internal/configs/testing_helpers.go
+++ b/internal/configs/testing_helpers.go
@@ -111,7 +111,7 @@ func moduleFromStringForTesting(t testing.TB, src string, fakeFilename string) *
 		return nil
 	}
 
-	ret, diags := NewModuleUneval([]*File{file}, nil, fakeFilename, SelectiveLoadAll)
+	ret, diags := NewModule([]*File{file}, nil, fakeFilename, SelectiveLoadAll)
 	if diags.HasErrors() {
 		t.Errorf("unexpected module analysis error: %s", diags.Error())
 		return nil

--- a/internal/initwd/from_module.go
+++ b/internal/initwd/from_module.go
@@ -152,6 +152,7 @@ func DirFromModule(ctx context.Context, loader configload.Loader, rootDir, modul
 				Name:       initFromModuleRootCallName,
 				SourceAddr: sourceAddr,
 				Source:     hcl.StaticExpr(cty.StringVal(sourceAddrStr), rng),
+				Config:     hcl.EmptyBody(),
 				DeclRange:  rng,
 				Variables: func(v *configs.Variable) (cty.Value, hcl.Diagnostics) {
 					if v.Default != cty.NilVal {
@@ -178,7 +179,8 @@ func DirFromModule(ctx context.Context, loader configload.Loader, rootDir, modul
 	}
 
 	walker := inst.moduleInstallWalker(ctx, instManifest, true, wrapHooks, remoteFetcher)
-	_, cDiags := inst.installDescendentModules(ctx, fakeRootModule, instManifest, walker, true)
+	fakeRootCall := configs.NewStaticModuleCall(addrs.RootModule, hcl.Range{}, nil, "", "")
+	_, cDiags := inst.installDescendentModules(ctx, fakeRootModule, fakeRootCall, instManifest, walker, true)
 	if cDiags.HasErrors() {
 		return diags.Append(cDiags)
 	}
@@ -223,13 +225,16 @@ func DirFromModule(ctx context.Context, loader configload.Loader, rootDir, modul
 			// and must thus be rewritten to be absolute addresses again.
 			// For now we can't do this rewriting automatically, but we'll
 			// generate an error to help the user do it manually.
-			mod, _ := loader.LoadConfigDir(rootDir, configs.NewStaticModuleCall(addrs.RootModule, hcl.Range{}, func(v *configs.Variable) (cty.Value, hcl.Diagnostics) { // ignore diagnostics since we're just doing value-add here anyway
-				if v.Default != cty.NilVal {
-					return v.Default, nil
-				}
-				return cty.DynamicVal, nil
-			}, rootDir, ""))
+			mod, _ := loader.LoadConfigDir(rootDir)
 			if mod != nil {
+				call := configs.NewStaticModuleCall(addrs.RootModule, hcl.Range{}, func(v *configs.Variable) (cty.Value, hcl.Diagnostics) { // ignore diagnostics since we're just doing value-add here anyway
+					if v.Default != cty.NilVal {
+						return v.Default, nil
+					}
+					return cty.DynamicVal, nil
+				}, rootDir, "")
+				_ = mod.WithStaticCall(call)
+
 				for _, mc := range mod.ModuleCalls {
 					if pathTraversesUp(mc.SourceAddrRaw) {
 						packageAddr, givenSubdir := getmodules.SplitPackageSubdir(sourceAddrStr)

--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -195,10 +195,10 @@ func (i *ModuleInstaller) InstallModules(ctx context.Context, rootDir, testsDir 
 
 		return cfg, diags
 	} else {
-		rootMod, mDiags := i.loader.LoadConfigDirWithTests(rootDir, testsDir, call)
+		rootMod, mDiags := i.loader.LoadConfigDirWithTests(rootDir, testsDir)
 		diags = diags.Append(mDiags)
 
-		cfg, instDiags := i.installDescendentModules(ctx, rootMod, manifest, walker, installErrsOnly)
+		cfg, instDiags := i.installDescendentModules(ctx, rootMod, call, manifest, walker, installErrsOnly)
 		diags = append(diags, instDiags...)
 
 		return cfg, diags
@@ -316,7 +316,7 @@ func (i *ModuleInstaller) moduleInstallWalker(_ context.Context, manifest modsdi
 				// keep our existing record.
 				info, err := os.Stat(record.Dir)
 				if err == nil && info.IsDir() {
-					mod, mDiags := i.loader.LoadConfigDir(record.Dir, req.Call)
+					mod, mDiags := i.loader.LoadConfigDir(record.Dir)
 					if mod == nil {
 						// nil indicates an unreadable module, which should never happen,
 						// so we return the full loader diagnostics here.
@@ -366,7 +366,7 @@ func (i *ModuleInstaller) moduleInstallWalker(_ context.Context, manifest modsdi
 	)
 }
 
-func (i *ModuleInstaller) installDescendentModules(ctx context.Context, rootMod *configs.Module, manifest modsdir.Manifest, installWalker configs.ModuleWalker, installErrsOnly bool) (*configs.Config, tfdiags.Diagnostics) {
+func (i *ModuleInstaller) installDescendentModules(ctx context.Context, rootMod *configs.Module, call configs.StaticModuleCall, manifest modsdir.Manifest, installWalker configs.ModuleWalker, installErrsOnly bool) (*configs.Config, tfdiags.Diagnostics) {
 	var diags tfdiags.Diagnostics
 
 	// When attempting to initialize the current directory with a module
@@ -386,7 +386,7 @@ func (i *ModuleInstaller) installDescendentModules(ctx context.Context, rootMod 
 		})
 	}
 
-	cfg, cDiags := configs.BuildConfig(ctx, rootMod, walker)
+	cfg, cDiags := configs.BuildConfig(ctx, rootMod, call, walker)
 	diags = diags.Append(cDiags)
 	if installErrsOnly {
 		// We can't continue if there was an error during installation, but
@@ -460,7 +460,7 @@ func (i *ModuleInstaller) installLocalModule(ctx context.Context, req *configs.M
 	}
 
 	// Finally we are ready to try actually loading the module.
-	mod, mDiags := i.loader.LoadConfigDir(newDir, req.Call)
+	mod, mDiags := i.loader.LoadConfigDir(newDir)
 	if mod == nil {
 		// nil indicates missing or unreadable directory, so we'll
 		// discard the returned diags and return a more specific
@@ -811,7 +811,7 @@ func (i *ModuleInstaller) installRegistryModule(ctx context.Context, req *config
 	log.Printf("[TRACE] ModuleInstaller: %s %q was downloaded to %s", key, packageLocation.UILabel(), modDir)
 
 	// Finally we are ready to try actually loading the module.
-	mod, mDiags := i.loader.LoadConfigDir(modDir, req.Call)
+	mod, mDiags := i.loader.LoadConfigDir(modDir)
 	if mod == nil {
 
 		subDir := packageLocation.Subdir()
@@ -931,7 +931,7 @@ func (i *ModuleInstaller) installGoGetterModule(ctx context.Context, req *config
 	log.Printf("[TRACE] ModuleInstaller: %s %q was downloaded to %s", key, addr, modDir)
 
 	// Finally we are ready to try actually loading the module.
-	mod, mDiags := i.loader.LoadConfigDir(modDir, req.Call)
+	mod, mDiags := i.loader.LoadConfigDir(modDir)
 	if mod == nil {
 		// nil indicates missing or unreadable directory, so we'll
 		// discard the returned diags and return a more specific

--- a/internal/initwd/module_install_runtime.go
+++ b/internal/initwd/module_install_runtime.go
@@ -43,7 +43,7 @@ func (i *ModuleInstaller) installDescendentModulesNewRuntime(ctx context.Context
 		})
 	}
 
-	root, hclDiags := i.loader.LoadConfigDirUneval(rootDir, configs.SelectiveLoadAll)
+	root, hclDiags := i.loader.LoadConfigDir(rootDir)
 	diags = diags.Append(hclDiags)
 	if diags.HasErrors() {
 		return nil, diags


### PR DESCRIPTION
This change makes it explicit where the static evaluation is applied and reduces the number of locations where it needs to be directly considered.

Notably, the module walker installers no longer need to care about static evaluation.  That concern is now entirely handled by ConfigBuild.

This has a few distinct benefits for upcoming work:
* The new engine is taking a different approach to static eval and this helps untagle it
* Symbol libraries are being implemented as a pre-processing step before static eval. By making the applications explicit, it allows us to be confident that we are applying symbol library processing in the correct locations and at the correct times.

<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Part of [Pending RFC Tracker Issue for Symbol Libraries]

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.