### PR TITLE
feat(command): display downloaded module versions in tofu version human and JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ ENHANCEMENTS:
 - `tofu plan` no longer prints the explanatory paragraph that followed the "No changes. Your infrastructure matches the configuration." message, since it only restated that message in more words. ([#4340](https://github.com/opentofu/opentofu/issues/4340))
 - On Windows systems, OpenTofu uses a heuristic to detect when it seems to be running in a legacy terminal emulator that uses a named pipe instead of a true pseudoterminal, such as with Cygwin and MSYS. This heuristic is now updated to be more reliable on recent versions of Windows that report slightly different names for those pipes. ([#4459](https://github.com/opentofu/opentofu/issues/4459))
 - `tofu init` in our official releases when running on a 32-bit CPU architecture now warns about our plan to stop publishing official builds for these platforms starting in OpenTofu v1.14. ([#4018](https://github.com/opentofu/opentofu/issues/4018))
+- `tofu version` and `tofu version -json` now display downloaded module versions alongside provider selections. ([#4464](https://github.com/opentofu/opentofu/pull/4464))
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ UPGRADE NOTES:
 ENHANCEMENTS:
 
 - `tofu plan` no longer prints iterative warnings for multiple resources but instead it shows one warning with all of the affected resources. ([#4201](https://github.com/opentofu/opentofu/issues/4201))
+- `tofu version` and `tofu version -json` now display downloaded module versions alongside provider selections. ([#4464](https://github.com/opentofu/opentofu/pull/4464))
 
 BUG FIXES:
 

--- a/internal/command/version.go
+++ b/internal/command/version.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opentofu/opentofu/internal/command/arguments"
 	"github.com/opentofu/opentofu/internal/command/views"
 	"github.com/opentofu/opentofu/internal/getproviders"
+	"github.com/opentofu/opentofu/internal/modsdir"
 )
 
 // VersionCommand is a Command implementation prints the version.
@@ -75,7 +76,27 @@ func (c *VersionCommand) Run(rawArgs []string) int {
 			providerVersions[providerAddr.String()] = lock.Version().String()
 		}
 	}
-	if !view.PrintVersion(c.Version, c.VersionPrerelease, c.Platform.String(), fips140.Enabled(), providerVersions) {
+
+	// Read downloaded module versions from the module manifest if available
+	moduleVersions := map[string]string{}
+	if c.WorkingDir != nil {
+		if manifest, err := modsdir.ReadManifestSnapshotForDir(c.WorkingDir.ModulesDir()); err == nil {
+			for _, record := range manifest {
+				if record.SourceAddr == "" {
+					continue
+				}
+				vStr := ""
+				if record.Version != nil {
+					vStr = record.Version.String()
+				} else if record.VersionStr != "" {
+					vStr = record.VersionStr
+				}
+				moduleVersions[record.SourceAddr] = vStr
+			}
+		}
+	}
+
+	if !view.PrintVersion(c.Version, c.VersionPrerelease, c.Platform.String(), fips140.Enabled(), providerVersions, moduleVersions) {
 		return 1
 	}
 	return 0

--- a/internal/command/version.go
+++ b/internal/command/version.go
@@ -11,6 +11,7 @@ import (
 	"github.com/opentofu/opentofu/internal/command/arguments"
 	"github.com/opentofu/opentofu/internal/command/views"
 	"github.com/opentofu/opentofu/internal/getproviders"
+	"github.com/opentofu/opentofu/internal/modsdir"
 )
 
 func VersionCommander(version string, versionPrerelease string, platform getproviders.Platform) Command {
@@ -59,7 +60,27 @@ func (c VersionCommand) Execute(view views.Version) int {
 			providerVersions[providerAddr.String()] = lock.Version().String()
 		}
 	}
-	if !view.PrintVersion(c.Version, c.VersionPrerelease, c.Platform.String(), fips140.Enabled(), providerVersions) {
+
+	// Read downloaded module versions from the module manifest if available
+	moduleVersions := map[string]string{}
+	if c.WorkingDir != nil {
+		if manifest, err := modsdir.ReadManifestSnapshotForDir(c.WorkingDir.ModulesDir()); err == nil {
+			for _, record := range manifest {
+				if record.SourceAddr == "" {
+					continue
+				}
+				vStr := ""
+				if record.Version != nil {
+					vStr = record.Version.String()
+				} else if record.VersionStr != "" {
+					vStr = record.VersionStr
+				}
+				moduleVersions[record.SourceAddr] = vStr
+			}
+		}
+	}
+
+	if !view.PrintVersion(c.Version, c.VersionPrerelease, c.Platform.String(), fips140.Enabled(), providerVersions, moduleVersions) {
 		return 1
 	}
 	return 0

--- a/internal/command/version_test.go
+++ b/internal/command/version_test.go
@@ -7,6 +7,8 @@ package command
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -183,5 +185,86 @@ func TestVersion_json(t *testing.T) {
 `)
 	if diff := cmp.Diff(expected, actual); diff != "" {
 		t.Fatalf("wrong output\n%s", diff)
+	}
+}
+
+func TestVersion_modules(t *testing.T) {
+	td := t.TempDir()
+	t.Chdir(td)
+
+	// Create a module manifest snapshot file (.terraform/modules/modules.json)
+	modulesDir := workdir.NewDir(".").ModulesDir()
+	if err := os.MkdirAll(modulesDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	manifestJSON := `{
+  "Modules": [
+    {
+      "Key": "",
+      "Source": "",
+      "Dir": "."
+    },
+    {
+      "Key": "iam",
+      "Source": "myregistry.foo.com/namespace/iam/aws",
+      "Version": "1.4.2",
+      "Dir": ".terraform/modules/iam"
+    }
+  ]
+}`
+	if err := os.WriteFile(filepath.Join(modulesDir, "modules.json"), []byte(manifestJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 1. Human output test
+	view, done := testView(t)
+	c := &VersionCommand{
+		Meta: Meta{
+			WorkingDir: workdir.NewDir("."),
+			View:       view,
+		},
+		Version:  "1.10.6",
+		Platform: getproviders.Platform{OS: "linux", Arch: "amd64"},
+	}
+	code := c.Run([]string{})
+	output := done(t)
+	if code != 0 {
+		t.Fatalf("bad: \n%s", output.Stderr())
+	}
+	actual := strings.TrimSpace(output.Stdout())
+	expected := "OpenTofu v1.10.6\non linux_amd64\n+ module myregistry.foo.com/namespace/iam/aws v1.4.2"
+	if actual != expected {
+		t.Fatalf("wrong human output\ngot:\n%s\nwant:\n%s", actual, expected)
+	}
+
+	// 2. JSON output test
+	viewJSON, doneJSON := testView(t)
+	cJSON := &VersionCommand{
+		Meta: Meta{
+			WorkingDir: workdir.NewDir("."),
+			View:       viewJSON,
+		},
+		Version:  "1.10.6",
+		Platform: getproviders.Platform{OS: "linux", Arch: "amd64"},
+	}
+	codeJSON := cJSON.Run([]string{"-json"})
+	outputJSON := doneJSON(t)
+	if codeJSON != 0 {
+		t.Fatalf("bad: \n%s", outputJSON.Stderr())
+	}
+	actualJSON := strings.TrimSpace(outputJSON.Stdout())
+	expectedJSON := strings.TrimSpace(`
+{
+  "terraform_version": "1.10.6",
+  "platform": "linux_amd64",
+  "provider_selections": {},
+  "module_selections": {
+    "myregistry.foo.com/namespace/iam/aws": "1.4.2"
+  }
+}
+`)
+	if diff := cmp.Diff(expectedJSON, actualJSON); diff != "" {
+		t.Fatalf("wrong JSON output\n%s", diff)
 	}
 }

--- a/internal/command/version_test.go
+++ b/internal/command/version_test.go
@@ -7,6 +7,8 @@ package command
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -167,5 +169,86 @@ func TestVersion_json(t *testing.T) {
 `)
 	if diff := cmp.Diff(expected, actual); diff != "" {
 		t.Fatalf("wrong output\n%s", diff)
+	}
+}
+
+func TestVersion_modules(t *testing.T) {
+	td := t.TempDir()
+	t.Chdir(td)
+
+	// Create a module manifest snapshot file (.terraform/modules/modules.json)
+	modulesDir := workdir.NewDir(".").ModulesDir()
+	if err := os.MkdirAll(modulesDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	manifestJSON := `{
+  "Modules": [
+    {
+      "Key": "",
+      "Source": "",
+      "Dir": "."
+    },
+    {
+      "Key": "iam",
+      "Source": "myregistry.foo.com/namespace/iam/aws",
+      "Version": "1.4.2",
+      "Dir": ".terraform/modules/iam"
+    }
+  ]
+}`
+	if err := os.WriteFile(filepath.Join(modulesDir, "modules.json"), []byte(manifestJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 1. Human output test
+	view, done := testView(t)
+	c := &VersionCommand{
+		Meta: Meta{
+			WorkingDir: workdir.NewDir("."),
+			View:       view,
+		},
+		Version:  "1.10.6",
+		Platform: getproviders.Platform{OS: "linux", Arch: "amd64"},
+	}
+	code := c.Run([]string{})
+	output := done(t)
+	if code != 0 {
+		t.Fatalf("bad: \n%s", output.Stderr())
+	}
+	actual := strings.TrimSpace(output.Stdout())
+	expected := "OpenTofu v1.10.6\non linux_amd64\n+ module myregistry.foo.com/namespace/iam/aws v1.4.2"
+	if actual != expected {
+		t.Fatalf("wrong human output\ngot:\n%s\nwant:\n%s", actual, expected)
+	}
+
+	// 2. JSON output test
+	viewJSON, doneJSON := testView(t)
+	cJSON := &VersionCommand{
+		Meta: Meta{
+			WorkingDir: workdir.NewDir("."),
+			View:       viewJSON,
+		},
+		Version:  "1.10.6",
+		Platform: getproviders.Platform{OS: "linux", Arch: "amd64"},
+	}
+	codeJSON := cJSON.Run([]string{"-json"})
+	outputJSON := doneJSON(t)
+	if codeJSON != 0 {
+		t.Fatalf("bad: \n%s", outputJSON.Stderr())
+	}
+	actualJSON := strings.TrimSpace(outputJSON.Stdout())
+	expectedJSON := strings.TrimSpace(`
+{
+  "terraform_version": "1.10.6",
+  "platform": "linux_amd64",
+  "provider_selections": {},
+  "module_selections": {
+    "myregistry.foo.com/namespace/iam/aws": "1.4.2"
+  }
+}
+`)
+	if diff := cmp.Diff(expectedJSON, actualJSON); diff != "" {
+		t.Fatalf("wrong JSON output\n%s", diff)
 	}
 }

--- a/internal/command/views/version.go
+++ b/internal/command/views/version.go
@@ -19,7 +19,7 @@ import (
 type Version interface {
 	Diagnostics(diags tfdiags.Diagnostics)
 	// PrintVersion returns true if the printing has been done successfully and false otherwise.
-	PrintVersion(version string, versionPrerelease string, platform string, fipsEnabled bool, providerVersions map[string]string) bool
+	PrintVersion(version string, versionPrerelease string, platform string, fipsEnabled bool, providerVersions map[string]string, moduleVersions map[string]string) bool
 }
 
 // NewVersion returns an initialized Version implementation for the given ViewType.
@@ -43,14 +43,14 @@ func (v *VersionMixed) Diagnostics(diags tfdiags.Diagnostics) {
 	v.view.Diagnostics(diags)
 }
 
-func (v *VersionMixed) PrintVersion(version string, versionPrerelease string, platform string, fipsEnabled bool, providerVersions map[string]string) bool {
+func (v *VersionMixed) PrintVersion(version string, versionPrerelease string, platform string, fipsEnabled bool, providerVersions map[string]string, moduleVersions map[string]string) bool {
 	if v.json {
-		return v.printJsonVersion(version, versionPrerelease, platform, fipsEnabled, providerVersions)
+		return v.printJsonVersion(version, versionPrerelease, platform, fipsEnabled, providerVersions, moduleVersions)
 	}
-	return v.printHumanVersion(version, versionPrerelease, platform, fipsEnabled, providerVersions)
+	return v.printHumanVersion(version, versionPrerelease, platform, fipsEnabled, providerVersions, moduleVersions)
 }
 
-func (v *VersionMixed) printJsonVersion(version string, versionPrerelease string, platform string, fipsEnabled bool, providerVersions map[string]string) bool {
+func (v *VersionMixed) printJsonVersion(version string, versionPrerelease string, platform string, fipsEnabled bool, providerVersions map[string]string, moduleVersions map[string]string) bool {
 	finalVersion := version
 	if versionPrerelease != "" {
 		finalVersion = fmt.Sprintf("%s-%s", finalVersion, versionPrerelease)
@@ -60,6 +60,7 @@ func (v *VersionMixed) printJsonVersion(version string, versionPrerelease string
 		Version:            finalVersion,
 		Platform:           platform,
 		ProviderSelections: providerVersions,
+		ModuleSelections:   moduleVersions,
 		FIPS140Enabled:     fipsEnabled,
 	}
 	jsonOutput, err := json.MarshalIndent(output, "", "  ")
@@ -71,7 +72,7 @@ func (v *VersionMixed) printJsonVersion(version string, versionPrerelease string
 	return true
 }
 
-func (v *VersionMixed) printHumanVersion(version string, versionPrerelease string, platform string, fipsEnabled bool, providerVersions map[string]string) bool {
+func (v *VersionMixed) printHumanVersion(version string, versionPrerelease string, platform string, fipsEnabled bool, providerVersions map[string]string, moduleVersions map[string]string) bool {
 	formattedVersion := fmt.Sprintf("OpenTofu v%s", version)
 	if versionPrerelease != "" {
 		formattedVersion = fmt.Sprintf("%s-%s", formattedVersion, versionPrerelease)
@@ -95,6 +96,20 @@ func (v *VersionMixed) printHumanVersion(version string, versionPrerelease strin
 			_, _ = v.view.streams.Println(fmt.Sprintf("+ provider %s v%s", provAddr, provVers))
 		}
 	}
+
+	moduleAddrs := slices.Collect(maps.Keys(moduleVersions))
+	sort.Strings(moduleAddrs)
+	for _, modAddr := range moduleAddrs {
+		modVers, ok := moduleVersions[modAddr]
+		if !ok {
+			continue
+		}
+		if modVers == "" || modVers == "0.0.0" {
+			_, _ = v.view.streams.Println(fmt.Sprintf("+ module %s (unversioned)", modAddr))
+		} else {
+			_, _ = v.view.streams.Println(fmt.Sprintf("+ module %s v%s", modAddr, modVers))
+		}
+	}
 	return true
 }
 
@@ -103,4 +118,5 @@ type versionOutput struct {
 	Platform           string            `json:"platform"`
 	FIPS140Enabled     bool              `json:"fips140,omitempty"`
 	ProviderSelections map[string]string `json:"provider_selections"`
+	ModuleSelections   map[string]string `json:"module_selections,omitempty"`
 }

--- a/internal/command/views/version_test.go
+++ b/internal/command/views/version_test.go
@@ -25,11 +25,27 @@ func TestVersionViews(t *testing.T) {
 			viewCall: func(v Version) {
 				v.PrintVersion("0.1.0", "dev", "darwin_arm64", false, map[string]string{
 					"registry.opentofu.org/test/test": "0.2.0",
+				}, nil)
+			},
+			wantStdout: `OpenTofu v0.1.0-dev
+on darwin_arm64
++ provider registry.opentofu.org/test/test v0.2.0
+`,
+			wantStderr: "",
+		},
+		"human printVersion with module selections": {
+			viewType: arguments.ViewHuman,
+			viewCall: func(v Version) {
+				v.PrintVersion("0.1.0", "dev", "darwin_arm64", false, map[string]string{
+					"registry.opentofu.org/test/test": "0.2.0",
+				}, map[string]string{
+					"myregistry.foo.com/namespace/iam/aws": "1.4.2",
 				})
 			},
 			wantStdout: `OpenTofu v0.1.0-dev
 on darwin_arm64
 + provider registry.opentofu.org/test/test v0.2.0
++ module myregistry.foo.com/namespace/iam/aws v1.4.2
 `,
 			wantStderr: "",
 		},
@@ -38,7 +54,7 @@ on darwin_arm64
 			viewCall: func(v Version) {
 				v.PrintVersion("0.1.0", "dev", "darwin_arm64", true, map[string]string{
 					"registry.opentofu.org/test/test": "0.2.0",
-				})
+				}, nil)
 			},
 			wantStdout: `OpenTofu v0.1.0-dev
 on darwin_arm64
@@ -52,7 +68,7 @@ running in FIPS 140-3 mode (not yet supported)
 			viewCall: func(v Version) {
 				v.PrintVersion("0.1.0", "dev", "darwin_arm64", false, map[string]string{
 					"registry.opentofu.org/test/test": "0.0.0",
-				})
+				}, nil)
 			},
 			wantStdout: `OpenTofu v0.1.0-dev
 on darwin_arm64
@@ -65,7 +81,7 @@ on darwin_arm64
 			viewCall: func(v Version) {
 				v.PrintVersion("0.1.0", "dev", "darwin_arm64", false, map[string]string{
 					"registry.opentofu.org/test/test": "0.2.0",
-				})
+				}, nil)
 			},
 			wantStdout: `{
   "terraform_version": "0.1.0-dev",
@@ -77,12 +93,34 @@ on darwin_arm64
 `,
 			wantStderr: "",
 		},
+		"json printVersion with module selections": {
+			viewType: arguments.ViewJSON,
+			viewCall: func(v Version) {
+				v.PrintVersion("0.1.0", "dev", "darwin_arm64", false, map[string]string{
+					"registry.opentofu.org/test/test": "0.2.0",
+				}, map[string]string{
+					"myregistry.foo.com/namespace/iam/aws": "1.4.2",
+				})
+			},
+			wantStdout: `{
+  "terraform_version": "0.1.0-dev",
+  "platform": "darwin_arm64",
+  "provider_selections": {
+    "registry.opentofu.org/test/test": "0.2.0"
+  },
+  "module_selections": {
+    "myregistry.foo.com/namespace/iam/aws": "1.4.2"
+  }
+}
+`,
+			wantStderr: "",
+		},
 		"json printVersion with fips enabled": {
 			viewType: arguments.ViewJSON,
 			viewCall: func(v Version) {
 				v.PrintVersion("0.1.0", "dev", "darwin_arm64", true, map[string]string{
 					"registry.opentofu.org/test/test": "0.2.0",
-				})
+				}, nil)
 			},
 			wantStdout: `{
   "terraform_version": "0.1.0-dev",
@@ -100,7 +138,7 @@ on darwin_arm64
 			viewCall: func(v Version) {
 				v.PrintVersion("0.1.0", "dev", "darwin_arm64", false, map[string]string{
 					"registry.opentofu.org/test/test": "0.0.0",
-				})
+				}, nil)
 			},
 			wantStdout: `{
   "terraform_version": "0.1.0-dev",


### PR DESCRIPTION
Fixes #3270

### Summary
Extends `tofu version` and `tofu version -json` to read and display downloaded module versions from the module manifest snapshot (`.terraform/modules/modules.json`) alongside provider selections.

### Details
- Updated `VersionCommand.Run` to inspect `WorkingDir.ModulesDir()` and parse downloaded module versions via `modsdir.ReadManifestSnapshotForDir`.
- Updated `Version` interface and `VersionMixed` view implementation in `internal/command/views/version.go` to render module versions:
  - In human text mode: formatted as `+ module <source_addr> v<version>` (or `(unversioned)` for unversioned / local modules).
  - In JSON mode: formatted under `"module_selections"` object map (`"module_selections": { "myregistry.foo.com/namespace/iam/aws": "1.4.2" }`).
- Added comprehensive unit tests in `internal/command/version_test.go` (`TestVersion_modules`) and `internal/command/views/version_test.go` covering both human and JSON output formats.
