### PR TITLE
Revert earlier fix for opentofu/opentofu#3067

### DIFF
--- a/internal/tofu/evaluate.go
+++ b/internal/tofu/evaluate.go
@@ -69,10 +69,6 @@ type Evaluator struct {
 	// ensures they can be safely accessed and modified concurrently.
 	Changes *plans.ChangesSync
 
-	// InstanceExpander tracks the expansion of modules and resources, which
-	// is used to determine the set of instance keys for count and for_each.
-	InstanceExpander *instances.Expander
-
 	PlanTimestamp time.Time
 }
 
@@ -444,25 +440,6 @@ func (d *evaluationStateData) GetModule(_ context.Context, addr addrs.ModuleCall
 	// Build up all the module objects, creating a map of values for each
 	// module instance.
 	moduleInstances := map[addrs.InstanceKey]map[string]cty.Value{}
-
-	// Pre-populate moduleInstances using InstanceExpander to handle modules with no outputs.
-	// This ensures that expressions like length(module.foo) work correctly even when a module
-	// has no output values defined, by consulting the expansion state to determine which
-	// module instances exist based on count/for_each.
-	// We only do this during non-validation operations (plan, apply, etc.) because during
-	// validation, the InstanceExpander may not be fully populated yet.
-	if d.Evaluator.InstanceExpander != nil && d.Evaluator.Operation != walkValidate {
-		childModuleAddr := d.ModulePath.Module().Child(addr.Name)
-		moduleInstanceAddrs := d.Evaluator.InstanceExpander.ExpandModule(childModuleAddr)
-
-		for _, moduleInstanceAddr := range moduleInstanceAddrs {
-			_, callInstance := moduleInstanceAddr.CallInstance()
-			key := callInstance.Key
-			if _, exists := moduleInstances[key]; !exists {
-				moduleInstances[key] = map[string]cty.Value{}
-			}
-		}
-	}
 
 	// create a dummy object type for validation below
 	unknownMap := map[string]cty.Type{}

--- a/internal/tofu/evaluate_test.go
+++ b/internal/tofu/evaluate_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
-	"github.com/opentofu/opentofu/internal/instances"
 	"github.com/opentofu/opentofu/internal/lang/marks"
 	"github.com/opentofu/opentofu/internal/plans"
 	"github.com/opentofu/opentofu/internal/providers"
@@ -943,187 +942,7 @@ func TestEvaluatorGetModule(t *testing.T) {
 	}
 }
 
-// TestEvaluatorGetModule_ForEach verifies that GetModule correctly evaluates
-// a module with for_each that has output values defined in state.
-// This is a regression test to ensure the fix for (modules without outputs)
-// doesn't break the existing behavior for modules WITH outputs.
-func TestEvaluatorGetModule_ForEach(t *testing.T) {
-	expander := instances.NewExpander()
-	expander.SetModuleForEach(
-		addrs.RootModuleInstance,
-		addrs.ModuleCall{Name: "mods"},
-		map[string]cty.Value{
-			"a": cty.StringVal("first"),
-			"b": cty.StringVal("second"),
-		},
-	)
-
-	stateSync := states.BuildState(func(ss *states.SyncState) {
-		ss.SetOutputValue(
-			addrs.OutputValue{Name: "result"}.Absolute(addrs.ModuleInstance{
-				addrs.ModuleInstanceStep{Name: "mods", InstanceKey: addrs.StringKey("a")},
-			}),
-			cty.StringVal("output_a"),
-			false,
-			"",
-		)
-		ss.SetOutputValue(
-			addrs.OutputValue{Name: "result"}.Absolute(addrs.ModuleInstance{
-				addrs.ModuleInstanceStep{Name: "mods", InstanceKey: addrs.StringKey("b")},
-			}),
-			cty.StringVal("output_b"),
-			false,
-			"",
-		)
-	}).SyncWrapper()
-
-	evaluator := &Evaluator{
-		Meta: &ContextMeta{
-			Env: "test",
-		},
-		Config: &configs.Config{
-			Module: &configs.Module{
-				ModuleCalls: map[string]*configs.ModuleCall{
-					"mods": {
-						Name: "mods",
-						ForEach: hcl.StaticExpr(cty.MapVal(map[string]cty.Value{
-							"a": cty.StringVal("first"),
-							"b": cty.StringVal("second"),
-						}), hcl.Range{}),
-					},
-				},
-			},
-			Children: map[string]*configs.Config{
-				"mods": {
-					Path: addrs.Module{"module.mods"},
-					Module: &configs.Module{
-						Outputs: map[string]*configs.Output{
-							"result": {
-								Name: "result",
-							},
-						},
-					},
-				},
-			},
-		},
-		State:            stateSync,
-		Changes:          plans.NewChanges().SyncWrapper(),
-		InstanceExpander: expander,
-	}
-
-	data := &evaluationStateData{
-		Evaluator: evaluator,
-	}
-	scope := evaluator.Scope(data, nil, nil, nil)
-
-	got, diags := scope.Data.GetModule(t.Context(), addrs.ModuleCall{
-		Name: "mods",
-	}, tfdiags.SourceRange{})
-
-	if len(diags) != 0 {
-		t.Errorf("unexpected diagnostics %s", spew.Sdump(diags))
-	}
-
-	want := cty.ObjectVal(map[string]cty.Value{
-		"a": cty.ObjectVal(map[string]cty.Value{
-			"result": cty.StringVal("output_a"),
-		}),
-		"b": cty.ObjectVal(map[string]cty.Value{
-			"result": cty.StringVal("output_b"),
-		}),
-	})
-
-	if !got.RawEquals(want) {
-		t.Errorf("wrong result:\ngot:  %#v\nwant: %#v", got, want)
-	}
-
-	if got.LengthInt() != 2 {
-		t.Errorf("wrong length: got %d, want 2", got.LengthInt())
-	}
-}
-
-// TestEvaluatorGetModule_ForEachWithoutOutputs verifies that GetModule correctly returns
-// the expected length for a module with for_each but no output values defined.
-// This tests the fix for (modules without outputs) where length(module.empty) would incorrectly
-// return 0 for modules without outputs, even when for_each has multiple keys.
-func TestEvaluatorGetModule_ForEachWithoutOutputs(t *testing.T) {
-	expander := instances.NewExpander()
-	expander.SetModuleForEach(
-		addrs.RootModuleInstance,
-		addrs.ModuleCall{Name: "empty"},
-		map[string]cty.Value{
-			"x": cty.StringVal("first"),
-			"y": cty.StringVal("second"),
-			"z": cty.StringVal("third"),
-		},
-	)
-
-	evaluator := &Evaluator{
-		Meta: &ContextMeta{
-			Env: "test",
-		},
-		Config: &configs.Config{
-			Module: &configs.Module{
-				ModuleCalls: map[string]*configs.ModuleCall{
-					"empty": {
-						Name: "empty",
-						ForEach: hcl.StaticExpr(cty.MapVal(map[string]cty.Value{
-							"x": cty.StringVal("first"),
-							"y": cty.StringVal("second"),
-							"z": cty.StringVal("third"),
-						}), hcl.Range{}),
-					},
-				},
-			},
-			Children: map[string]*configs.Config{
-				"empty": {
-					Path: addrs.Module{"module.empty"},
-					Module: &configs.Module{
-						Outputs: map[string]*configs.Output{},
-					},
-				},
-			},
-		},
-		State:            states.NewState().SyncWrapper(),
-		Changes:          plans.NewChanges().SyncWrapper(),
-		InstanceExpander: expander,
-	}
-
-	data := &evaluationStateData{
-		Evaluator: evaluator,
-	}
-	scope := evaluator.Scope(data, nil, nil, nil)
-
-	got, diags := scope.Data.GetModule(t.Context(), addrs.ModuleCall{
-		Name: "empty",
-	}, tfdiags.SourceRange{})
-
-	if len(diags) != 0 {
-		t.Errorf("unexpected diagnostics %s", spew.Sdump(diags))
-	}
-
-	want := cty.ObjectVal(map[string]cty.Value{
-		"x": cty.EmptyObjectVal,
-		"y": cty.EmptyObjectVal,
-		"z": cty.EmptyObjectVal,
-	})
-
-	if !got.RawEquals(want) {
-		t.Errorf("wrong result:\ngot:  %#v\nwant: %#v", got, want)
-	}
-
-	if got.LengthInt() != 3 {
-		t.Errorf("wrong length: got %d, want 3 (module has for_each with 3 keys)", got.LengthInt())
-	}
-}
-
 func evaluatorForModule(stateSync *states.SyncState, changesSync *plans.ChangesSync) *Evaluator {
-	expander := instances.NewExpander()
-	expander.SetModuleSingle(
-		addrs.RootModuleInstance,
-		addrs.ModuleCall{Name: "mod"},
-	)
-
 	return &Evaluator{
 		Meta: &ContextMeta{
 			Env: "foo",
@@ -1154,8 +973,7 @@ func evaluatorForModule(stateSync *states.SyncState, changesSync *plans.ChangesS
 				},
 			},
 		},
-		State:            stateSync,
-		Changes:          changesSync,
-		InstanceExpander: expander,
+		State:   stateSync,
+		Changes: changesSync,
 	}
 }

--- a/internal/tofu/graph_walk_context.go
+++ b/internal/tofu/graph_walk_context.go
@@ -92,7 +92,6 @@ func (w *ContextGraphWalker) EvalContext() EvalContext {
 		Plugins:            w.Context.plugins,
 		VariableValues:     w.variableValues,
 		VariableValuesLock: &w.variableValuesLock,
-		InstanceExpander:   w.InstanceExpander,
 		PlanTimestamp:      w.PlanTimestamp,
 	}
 

--- a/internal/tofu/test_context.go
+++ b/internal/tofu/test_context.go
@@ -96,9 +96,6 @@ func (tc *TestContext) evaluate(state *states.SyncState, changes *plans.ChangesS
 			}(),
 			VariableValuesLock: new(sync.Mutex),
 			PlanTimestamp:      tc.Plan.Timestamp,
-			// InstanceExpander is intentionally nil for test contexts
-			// The GetModule function will fall back to using state/changes when it's nil
-			InstanceExpander: nil,
 		},
 		ModulePath:      nil, // nil for the root module
 		InstanceKeyData: EvalDataForNoInstanceKey,


### PR DESCRIPTION
The initial attempted fix for https://github.com/opentofu/opentofu/issues/3067 unfortunately caused the regression previously discussed in https://github.com/opentofu/opentofu/issues/4019, but at the time we reverted it only on the v1.12 branch (in https://github.com/opentofu/opentofu/pull/4033) because we were hoping we'd find a different way to fix it during the v1.13 period.

Unfortunately we did not find an alternative approach, and so our new decision for https://github.com/opentofu/opentofu/issues/3067 is to leave it unfixed for now and instead make sure that the new runtime we're developing in https://github.com/opentofu/opentofu/issues/3414 handles this in a better way from the start.

Therefore we need to now also revert the change from the `main` branch to avoid re-causing the same reported problem in the forthcoming v1.13.0-beta1 release. This change has never actually been in a stable release, so there's no need for a changelog entry describing its removal here.

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

