### PR TITLE
website: "External" key provider & encryption method not experimental

### DIFF
--- a/website/docs/language/state/encryption.mdx
+++ b/website/docs/language/state/encryption.mdx
@@ -309,13 +309,9 @@ It builds on OpenTofu's built-in [`external` key provider](#external-experimenta
 
 For installation and configuration instructions, see the [ovh/opentofu-kms-ovhcloud](https://github.com/ovh/opentofu-kms-ovhcloud) repository.
 
-### External (experimental)
-:::info
-At the moment of writing this note, OpenTofu team has no relevant feedback to decide if this should be out of the experimental phase or not.
-Therefore, for the foreseeable future, in lack of feedback, this `key_provider` will remain in the experimental phase.
+### External {/* #external-key-provider */}
 
-Please let us know about your experience of using this `key_provider` on [this issue](https://github.com/opentofu/opentofu/issues/2386) or on the [`#opentofu`](https://cloud-native.slack.com/archives/C05PXGAB05R) CNCF Slack channel
-:::
+<div id="#external-experimental"></div>{/* preserved fragment identifier from earlier version of these docs */}
 
 The external command provider lets you run external commands in order to obtain encryption keys. These programs must be specifically written to work with OpenTofu. This key provider has the following fields:
 
@@ -406,14 +402,9 @@ AES-GCM is a secure, industry-standard encryption algorithm, but suffers from "k
 
 :::
 
-### External (experimental)
-:::info
-At the moment of writing this note, OpenTofu team has no relevant feedback to decide if this should be out of the experimental phase or not.
-Therefore, for the foreseeable future, in lack of feedback, this `method` will remain in the experimental phase.
+### External {/* #external-encryption-method */}
 
-Please let us know about your experience of using this `method` on [this issue](https://github.com/opentofu/opentofu/issues/2386) or on the [`#opentofu`](https://cloud-native.slack.com/archives/C05PXGAB05R) CNCF Slack channel.
-
-:::
+<div id="#external-experimental-1"></div>{/* preserved fragment identifier from earlier version of these docs */}
 
 The external command method lets you run external commands in order to perform encryption and decryption. These programs must be specifically written to work with OpenTofu. This key provider has the following fields:
 


### PR DESCRIPTION
After a mixture of both explicit and informal feedback we've concluded that these two features are ready to commit to supporting under our compatibility promises, and so this removes the note about these features being experimental.

Unfortunately we previously also wrote "(experimental)" as part of the heading text without overriding the heading identifier and so that text became part of the automatically-generated URLs for these sections. Therefore there are some additional HTML elements here to handle any incoming links using the original identifiers. The new headings each have their own explicitly-overridden identifier because the literal heading text for each of them is the same, and so we need additional words in there to differentiate between them.

This closes https://github.com/opentofu/opentofu/issues/2386.

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
