### PR TITLE
[v1.12] go.mod: Upgrade to Go 1.26.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The v1.12.x release series is supported until **February 1 2027**.
 SECURITY ADVISORIES:
 
 - When interacting with OCI Distribution registries for module or provider package installation, earlier versions of OpenTofu could incorrectly resend credentials intended for the original origin to the target of an HTTP redirect. ([#4422](https://github.com/opentofu/opentofu/pull/4422))
+- When interacting with an attacker-controlled remote state backend or provider/module registry, `tofu init` in earlier versions of OpenTofu could potentially cause high CPU usage and/or high memory usage resolving crafted relative URLs in the API responses. ([#4472](https://github.com/opentofu/opentofu/pull/4472))
 
 ## 1.12.5
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opentofu/opentofu
 
-go 1.26.5
+go 1.26.6
 
 // At the time of adding this configuration, the new Go feature introduced here https://github.com/golang/go/issues/67061,
 // was having a good amount of issues linked to, affecting AWS Firewall, GCP various services and a lot more.


### PR DESCRIPTION
This is an upstream security release, with changes described in [the 1.26.6 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.26.6+label%3ACherryPickApproved).

For now this will remain as a draft while we review the changes and determine which of them are relevant to OpenTofu.

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
