### PR TITLE
[v1.11] go.mod: Upgrade to Go 1.25.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The v1.11.x release series is supported until **August 1 2026**.
 
 SECURITY ADVISORIES:
 
+> [!NOTE]
+> This is the final patch release planned for the OpenTofu v1.11 series. We recommend upgrading to a newer release series as soon as possible.
+
 - When interacting with OCI Distribution registries for module or provider package installation, previous versions of OpenTofu could incorrectly resend credentials intended for the original origin to the target of an HTTP redirect. ([#4423](https://github.com/opentofu/opentofu/pull/4423))
 - When interacting with an attacker-controlled remote state backend or provider/module registry, `tofu init` in earlier versions of OpenTofu could potentially cause high CPU usage and/or high memory usage resolving crafted relative URLs in the API responses. ([#4473](https://github.com/opentofu/opentofu/pull/4473))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The v1.11.x release series is supported until **August 1 2026**.
 SECURITY ADVISORIES:
 
 - When interacting with OCI Distribution registries for module or provider package installation, previous versions of OpenTofu could incorrectly resend credentials intended for the original origin to the target of an HTTP redirect. ([#4423](https://github.com/opentofu/opentofu/pull/4423))
+- When interacting with an attacker-controlled remote state backend or provider/module registry, `tofu init` in earlier versions of OpenTofu could potentially cause high CPU usage and/or high memory usage resolving crafted relative URLs in the API responses. ([#4473](https://github.com/opentofu/opentofu/pull/4473))
 
 ## 1.11.13
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opentofu/opentofu
 
-go 1.25.12
+go 1.25.13
 
 // At the time of adding this configuration, the new Go feature introduced here https://github.com/golang/go/issues/67061,
 // was having a good amount of issues linked to, affecting AWS Firewall, GCP various services and a lot more.


### PR DESCRIPTION
This is an upstream security release, with changes described in [the 1.25.13 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.25.13+label%3ACherryPickApproved).

For now this will remain as a draft while we review the changes and determine which of them are relevant to OpenTofu.

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
