### PR TITLE
e2etest: Only use provider versions that have `windows_arm64` packages available

### DIFF
--- a/internal/command/e2etest/automation_test.go
+++ b/internal/command/e2etest/automation_test.go
@@ -41,8 +41,8 @@ func TestPlanApplyInAutomation(t *testing.T) {
 
 	// Make sure we actually downloaded the plugins, rather than picking up
 	// copies that might be already installed globally on the system.
-	if !strings.Contains(stdout, "Installing hashicorp/template v") {
-		t.Errorf("template provider download message is missing from init output:\n%s", stdout)
+	if !strings.Contains(stdout, "Installing hashicorp/cloudinit v") {
+		t.Errorf("cloudinit provider download message is missing from init output:\n%s", stdout)
 		t.Logf("(this can happen if you have a copy of the plugin in one of the global plugin search dirs)")
 	}
 	if !strings.Contains(stdout, "Installing hashicorp/null v") {
@@ -114,7 +114,7 @@ func TestPlanApplyInAutomation(t *testing.T) {
 	sort.Strings(gotResources)
 
 	wantResources := []string{
-		"data.template_file.test",
+		"data.cloudinit_config.test",
 		"null_resource.test",
 	}
 
@@ -148,8 +148,8 @@ func TestAutoApplyInAutomation(t *testing.T) {
 
 	// Make sure we actually downloaded the plugins, rather than picking up
 	// copies that might be already installed globally on the system.
-	if !strings.Contains(stdout, "Installing hashicorp/template v") {
-		t.Errorf("template provider download message is missing from init output:\n%s", stdout)
+	if !strings.Contains(stdout, "Installing hashicorp/cloudinit v") {
+		t.Errorf("cloudinit provider download message is missing from init output:\n%s", stdout)
 		t.Logf("(this can happen if you have a copy of the plugin in one of the global plugin search dirs)")
 	}
 	if !strings.Contains(stdout, "Installing hashicorp/null v") {
@@ -180,7 +180,7 @@ func TestAutoApplyInAutomation(t *testing.T) {
 	sort.Strings(gotResources)
 
 	wantResources := []string{
-		"data.template_file.test",
+		"data.cloudinit_config.test",
 		"null_resource.test",
 	}
 
@@ -214,8 +214,8 @@ func TestPlanOnlyInAutomation(t *testing.T) {
 
 	// Make sure we actually downloaded the plugins, rather than picking up
 	// copies that might be already installed globally on the system.
-	if !strings.Contains(stdout, "Installing hashicorp/template v") {
-		t.Errorf("template provider download message is missing from init output:\n%s", stdout)
+	if !strings.Contains(stdout, "Installing hashicorp/cloudinit v") {
+		t.Errorf("cloudinit provider download message is missing from init output:\n%s", stdout)
 		t.Logf("(this can happen if you have a copy of the plugin in one of the global plugin search dirs)")
 	}
 	if !strings.Contains(stdout, "Installing hashicorp/null v") {
@@ -243,4 +243,3 @@ func TestPlanOnlyInAutomation(t *testing.T) {
 		t.Error("plan file was created, but was not expected")
 	}
 }
-

--- a/internal/command/e2etest/primary_test.go
+++ b/internal/command/e2etest/primary_test.go
@@ -51,8 +51,8 @@ func TestPrimarySeparatePlan(t *testing.T) {
 
 	// Make sure we actually downloaded the plugins, rather than picking up
 	// copies that might be already installed globally on the system.
-	if !strings.Contains(stdout, "Installing hashicorp/template v") {
-		t.Errorf("template provider download message is missing from init output:\n%s", stdout)
+	if !strings.Contains(stdout, "Installing hashicorp/cloudinit v") {
+		t.Errorf("cloudinit provider download message is missing from init output:\n%s", stdout)
 		t.Logf("(this can happen if you have a copy of the plugin in one of the global plugin search dirs)")
 	}
 	if !strings.Contains(stdout, "Installing hashicorp/null v") {
@@ -124,7 +124,7 @@ func TestPrimarySeparatePlan(t *testing.T) {
 	sort.Strings(gotResources)
 
 	wantResources := []string{
-		"data.template_file.test",
+		"data.cloudinit_config.test",
 		"null_resource.test",
 	}
 

--- a/internal/command/e2etest/provider_network_mirror_test.go
+++ b/internal/command/e2etest/provider_network_mirror_test.go
@@ -115,13 +115,13 @@ func TestProviderNetworkMirrorRetries(t *testing.T) {
 			}
 			cliConfigFile := filepath.Join(tempDir, "cliconfig.tfrc")
 			cliConfigSrc := fmt.Sprintf(`
-		provider_installation {
-			network_mirror {
-                url = "%s"
-				%s
-			}
-		}
-	`, registryAddr, tt.tofurcRetriesConfigEntry)
+				provider_installation {
+					network_mirror {
+						url = "%s"
+						%s
+					}
+				}
+			`, registryAddr, tt.tofurcRetriesConfigEntry)
 			if err := os.WriteFile(cliConfigFile, []byte(cliConfigSrc), os.ModePerm); err != nil {
 				t.Fatalf("failed to create temporary CLI configuration file: %s", err)
 			}
@@ -142,6 +142,8 @@ func TestProviderNetworkMirrorRetries(t *testing.T) {
 			cleanStderr := SanitizeStderr(stderr)
 			if contains := tt.expectedErrMsg; !strings.Contains(cleanStderr, contains) {
 				t.Fatalf("expected the error from the installation to contain %q but it doesn't", contains)
+			} else {
+				t.Log("(the above error message is the expected outcome of this test)")
 			}
 		})
 	}

--- a/internal/command/e2etest/providers_tamper_test.go
+++ b/internal/command/e2etest/providers_tamper_test.go
@@ -25,7 +25,7 @@ import (
 // providerTamperingFixtureNullProviderVersion must contain a string
 // representation of the same version number used for "hashicorp/null" in the
 // "provider-tampering-base" fixture.
-const providerTamperingFixtureNullProviderVersion = "3.1.0"
+const providerTamperingFixtureNullProviderVersion = "3.3.1"
 
 // TestProviderTampering tests various ways that the provider plugins in the
 // local cache directory might be modified after an initial "tofu init",
@@ -86,7 +86,7 @@ func TestProviderTampering(t *testing.T) {
 		if err == nil {
 			t.Fatalf("unexpected plan success\nstdout:\n%s", stdout)
 		}
-		if want := `there is no package for registry.opentofu.org/hashicorp/null 3.1.0 cached in ` + providerCacheDir; !strings.Contains(SanitizeStderr(stderr), want) {
+		if want := `there is no package for registry.opentofu.org/hashicorp/null 3.3.1 cached in ` + providerCacheDir; !strings.Contains(SanitizeStderr(stderr), want) {
 			t.Errorf("missing expected error message\nwant substring: %s\ngot:\n%s", want, stderr)
 		}
 		if want := `tofu init`; !strings.Contains(stderr, want) {
@@ -151,7 +151,7 @@ func TestProviderTampering(t *testing.T) {
 		if err == nil {
 			t.Fatalf("unexpected plan success\nstdout:\n%s", stdout)
 		}
-		if want := `the cached package for registry.opentofu.org/hashicorp/null 3.1.0 (in ` + providerCacheDir + `) does not match any of the checksums recorded in the dependency lock file`; !strings.Contains(SanitizeStderr(stderr), want) {
+		if want := `the cached package for registry.opentofu.org/hashicorp/null 3.3.1 (in ` + providerCacheDir + `) does not match any of the checksums recorded in the dependency lock file`; !strings.Contains(SanitizeStderr(stderr), want) {
 			t.Errorf("missing expected error message\nwant substring: %s\ngot:\n%s", want, stderr)
 		}
 		if want := `tofu init`; !strings.Contains(stderr, want) {
@@ -180,7 +180,7 @@ func TestProviderTampering(t *testing.T) {
 		if err == nil {
 			t.Fatalf("unexpected plan success\nstdout:\n%s", stdout)
 		}
-		if want := `provider registry.opentofu.org/hashicorp/null: locked version selection 3.1.0 doesn't match the updated version constraints "1.0.0"`; !strings.Contains(stderr, want) {
+		if want := `provider registry.opentofu.org/hashicorp/null: locked version selection 3.3.1 doesn't match the updated version constraints "1.0.0"`; !strings.Contains(stderr, want) {
 			t.Errorf("missing expected error message\nwant substring: %s\ngot:\n%s", want, stderr)
 		}
 		if want := `tofu init -upgrade`; !strings.Contains(stderr, want) {
@@ -256,7 +256,7 @@ func TestProviderTampering(t *testing.T) {
 		if err == nil {
 			t.Fatalf("unexpected apply success\nstdout:\n%s", stdout)
 		}
-		if want := `there is no package for registry.opentofu.org/hashicorp/null 3.1.0 cached in ` + providerCacheDir; !strings.Contains(SanitizeStderr(stderr), want) {
+		if want := `there is no package for registry.opentofu.org/hashicorp/null 3.3.1 cached in ` + providerCacheDir; !strings.Contains(SanitizeStderr(stderr), want) {
 			t.Errorf("missing expected error message\nwant substring: %s\ngot:\n%s", want, stderr)
 		}
 	})
@@ -278,7 +278,7 @@ func TestProviderTampering(t *testing.T) {
 		if err == nil {
 			t.Fatalf("unexpected apply success\nstdout:\n%s", stdout)
 		}
-		if want := `the cached package for registry.opentofu.org/hashicorp/null 3.1.0 (in ` + providerCacheDir + `) does not match any of the checksums recorded in the dependency lock file`; !strings.Contains(SanitizeStderr(stderr), want) {
+		if want := `the cached package for registry.opentofu.org/hashicorp/null 3.3.1 (in ` + providerCacheDir + `) does not match any of the checksums recorded in the dependency lock file`; !strings.Contains(SanitizeStderr(stderr), want) {
 			t.Errorf("missing expected error message\nwant substring: %s\ngot:\n%s", want, stderr)
 		}
 	})

--- a/internal/command/e2etest/testdata/full-workflow-null/main.tf
+++ b/internal/command/e2etest/testdata/full-workflow-null/main.tf
@@ -3,17 +3,20 @@ variable "name" {
   default = "world"
 }
 
-data "template_file" "test" {
-  template = "Hello, $${name}"
-
-  vars = {
-    name = "${var.name}"
+# We're using cloudinit_config from the hashicorp/cloudinit provider here
+# just because this test originally used template_file from hashicorp/template,
+# but that provider is now deprecated and we want a replacement that's also
+# purely local-only while still testing our ability to use a data resource
+# type from an external provider plugin.
+data "cloudinit_config" "test" {
+  part {
+    content  = "Hello, ${var.name}"
   }
 }
 
 resource "null_resource" "test" {
   triggers = {
-    greeting = "${data.template_file.test.rendered}"
+    greeting = "${data.cloudinit_config.test.part[0].content}"
   }
 }
 

--- a/internal/command/e2etest/testdata/provider-tampering-base/provider-tampering-base.tf
+++ b/internal/command/e2etest/testdata/provider-tampering-base/provider-tampering-base.tf
@@ -6,7 +6,7 @@ terraform {
       # if e.g. Terraform stops supporting plugin protocol 5, or if
       # the null provider is yanked from the registry for some reason.
       source  = "hashicorp/null"
-      version = "3.1.0"
+      version = "3.3.1"
     }
   }
 }


### PR DESCRIPTION
After https://github.com/opentofu/opentofu/pull/4450 we're now running the end-to-end tests on `windows_arm64` since that's now an officially-supported platform.

Unfortunately some of the tests were trying to use provider releases that predate us publishing packages for that platform, and so they were failing.

Now we'll use providers that are known to have `windows_amd64` packages already available. In particular, because `hashicorp/template` was deprecated long ago it is never expected to support any new platforms and so we'll now use `hashicorp/cloudinit` as a close-enough replacement for that one.

While I was debugging this I found it off-putting that the test for provider network mirrors has some _intended_ error messages printed in its log output, and so I also added an extra log line to try to clarify that for future maintainers.

This changeset should cause the end-to-end tests to begin working when run on `windows_arm64`.

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
