### PR TITLE
Improve performance of depends on transformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ BUG FIXES:
 - `tofu plan -out` no longer fails when the plan includes a resource with `lifecycle { destroy = false }` that needs replacement, which previously errored with `invalid change action ForgetThenCreate`. ([#4324](https://github.com/opentofu/opentofu/issues/4324))
 - `connection.script_path` is escaped correctly not allowing anymore additional commands to be executed on the remote host together with the script path indicated by the argument. ([#4330](https://github.com/opentofu/opentofu/pull/4330))
 - `tofu plan`: Fixed Incorrect warnings produced for `tofu plan -replace=ADDR`. ([#4368](https://github.com/opentofu/opentofu/issues/4368))
+- `tofu plan`: Performance improved for large depends_on chains. ([#4465](https://github.com/opentofu/opentofu/4465))
 - SSH connections through an HTTP proxy now report a connection error instead of crashing when the proxy fails to answer the CONNECT request. ([#4358](https://github.com/opentofu/opentofu/issues/4358))
 
 ## Previous Releases

--- a/internal/tofu/transform_reference.go
+++ b/internal/tofu/transform_reference.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"maps"
 	"sort"
 
 	"github.com/hashicorp/hcl/v2"
@@ -286,10 +287,20 @@ func isDependableResource(v dag.Vertex) bool {
 	return false
 }
 
+type dependsOnCacheEntry struct {
+	set       dag.Set
+	dependsOn bool
+}
+
 // ReferenceMap is a structure that can be used to efficiently check
 // for references on a graph, mapping internal reference keys (as produced by
 // the mapKey method) to one or more vertices that are identified by each key.
-type ReferenceMap map[string][]dag.Vertex
+type ReferenceMap struct {
+	refMap map[string][]dag.Vertex
+
+	dependsOnCache       map[dag.Vertex]dependsOnCacheEntry
+	parentDependsOnCache map[dag.Vertex]dependsOnCacheEntry
+}
 
 // References returns the set of vertices that the given vertex refers to,
 // and any referenced addresses that do not have corresponding vertices.
@@ -332,7 +343,7 @@ func (m ReferenceMap) addReference(path addrs.Module, current dag.Vertex, ref *a
 	subject := ref.Subject
 
 	key := m.mapKey(path, subject)
-	if _, exists := m[key]; !exists {
+	if _, exists := m.refMap[key]; !exists {
 		// If what we were looking for was a ResourceInstance then we
 		// might be in a resource-oriented graph rather than an
 		// instance-oriented graph, and so we'll see if we have the
@@ -354,7 +365,7 @@ func (m ReferenceMap) addReference(path addrs.Module, current dag.Vertex, ref *a
 		}
 		key = m.mapKey(path, subject)
 	}
-	vertices := m[key]
+	vertices := m.refMap[key]
 	for _, rv := range vertices {
 		// don't include self-references
 		if rv == current {
@@ -368,8 +379,12 @@ func (m ReferenceMap) addReference(path addrs.Module, current dag.Vertex, ref *a
 // dependsOn returns the set of vertices that the given vertex refers to from
 // the configured depends_on. The bool return value indicates if depends_on was
 // found in a parent module configuration.
-func (m ReferenceMap) dependsOn(g *Graph, depender graphNodeDependsOn) ([]dag.Vertex, bool) {
-	var res []dag.Vertex
+func (m ReferenceMap) dependsOn(g *Graph, depender graphNodeDependsOn) (dag.Set, bool) {
+	if cached, ok := m.dependsOnCache[depender]; ok {
+		return cached.set, cached.dependsOn
+	}
+
+	res := dag.Set{}
 	fromModule := false
 
 	refs := depender.DependsOn()
@@ -386,7 +401,7 @@ func (m ReferenceMap) dependsOn(g *Graph, depender graphNodeDependsOn) ([]dag.Ve
 		subject := ref.Subject
 
 		key := m.referenceMapKey(depender, subject)
-		vertices, ok := m[key]
+		vertices, ok := m.refMap[key]
 		if !ok {
 			// the ReferenceMap generates all possible keys, so any warning
 			// here is probably not useful for this implementation.
@@ -397,7 +412,7 @@ func (m ReferenceMap) dependsOn(g *Graph, depender graphNodeDependsOn) ([]dag.Ve
 			if rv == depender {
 				continue
 			}
-			res = append(res, rv)
+			res.Add(rv)
 
 			// Check any ancestors for transitive dependencies when we're
 			// not pointed directly at a resource. We can't be much more
@@ -410,7 +425,7 @@ func (m ReferenceMap) dependsOn(g *Graph, depender graphNodeDependsOn) ([]dag.Ve
 				ans, _ := g.Ancestors(rv)
 				for _, v := range ans {
 					if isDependableResource(v) {
-						res = append(res, v)
+						res.Add(v)
 					}
 				}
 			}
@@ -418,9 +433,14 @@ func (m ReferenceMap) dependsOn(g *Graph, depender graphNodeDependsOn) ([]dag.Ve
 	}
 
 	parentDeps, fromParentModule := m.parentModuleDependsOn(g, depender)
-	res = append(res, parentDeps...)
+	maps.Copy(res, parentDeps)
 
-	return res, fromModule || fromParentModule
+	cached := dependsOnCacheEntry{
+		set:       res,
+		dependsOn: fromModule || fromParentModule,
+	}
+	m.dependsOnCache[depender] = cached
+	return cached.set, cached.dependsOn
 }
 
 // Return extra depends_on references if "depender" is a data source or an ephemeral resource.
@@ -467,8 +487,12 @@ func (m ReferenceMap) nodeDependencies(depender graphNodeDependsOn) []*addrs.Ref
 // parentModuleDependsOn returns the state of vertices that a data sources parent
 // module references through the module call's depends_on. The bool return
 // value indicates if depends_on was found in a parent module configuration.
-func (m ReferenceMap) parentModuleDependsOn(g *Graph, depender graphNodeDependsOn) ([]dag.Vertex, bool) {
-	var res []dag.Vertex
+func (m ReferenceMap) parentModuleDependsOn(g *Graph, depender graphNodeDependsOn) (dag.Set, bool) {
+	if cached, ok := m.parentDependsOnCache[depender]; ok {
+		return cached.set, cached.dependsOn
+	}
+
+	res := dag.Set{}
 	fromModule := false
 
 	// Look for containing modules with DependsOn.
@@ -484,20 +508,25 @@ func (m ReferenceMap) parentModuleDependsOn(g *Graph, depender graphNodeDependsO
 		deps, fromParentModule := m.dependsOn(g, mod)
 		for _, dep := range deps {
 			// add the dependency
-			res = append(res, dep)
+			res.Add(dep)
 
 			// and check any transitive resource dependencies for more resources
 			ans, _ := g.Ancestors(dep)
 			for _, v := range ans {
 				if isDependableResource(v) {
-					res = append(res, v)
+					res.Add(v)
 				}
 			}
 		}
 		fromModule = fromModule || fromParentModule
 	}
 
-	return res, fromModule
+	cached := dependsOnCacheEntry{
+		set:       res,
+		dependsOn: fromModule,
+	}
+	m.parentDependsOnCache[depender] = cached
+	return cached.set, cached.dependsOn
 }
 
 func (m *ReferenceMap) mapKey(path addrs.Module, addr addrs.Referenceable) string {
@@ -570,7 +599,12 @@ func (m *ReferenceMap) referenceMapKey(referrer dag.Vertex, addr addrs.Reference
 // given set of vertices.
 func NewReferenceMap(vs []dag.Vertex) ReferenceMap {
 	// Build the lookup table
-	m := make(ReferenceMap)
+	m := ReferenceMap{
+		refMap: map[string][]dag.Vertex{},
+
+		dependsOnCache:       map[dag.Vertex]dependsOnCacheEntry{},
+		parentDependsOnCache: map[dag.Vertex]dependsOnCacheEntry{},
+	}
 	for _, v := range vs {
 		// We're only looking for referenceable nodes
 		rn, ok := v.(GraphNodeReferenceable)
@@ -583,7 +617,7 @@ func NewReferenceMap(vs []dag.Vertex) ReferenceMap {
 		// Go through and cache them
 		for _, addr := range rn.ReferenceableAddrs() {
 			key := m.mapKey(path, addr)
-			m[key] = append(m[key], v)
+			m.refMap[key] = append(m.refMap[key], v)
 		}
 	}
 


### PR DESCRIPTION
When there is a wide and deep chain of modules with interlinked depends_on, the transformer calls can get quite expensive.  This was identified in https://github.com/opentofu/opentofu-performance-testing/pull/7

To alleviate this, I memoized the ReferenceMap dependsOn functions. This has significantly improved the runtime in the test case (4 minutes to ~1 second)

There is definitely still some optimization left on the table, but this keeps the original structure of the code as similar to the original as possible. Additionally, with the new runtime on the horizon, this code is already on the chopping block.

<!--

** Thank you for your contribution! Please read this carefully! **

Please make sure you go through the checklist below. If your PR does not meet all requirements, please file it
as a draft PR. Core team members will only review your PR once it meets all the requirements below (unless your
change is something as trivial as a typo fix).

-->

<!-- If your PR resolves an issue, please add it here. -->
Resolves #2987 

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.

