### PR TITLE
e2etest: More fixes for `windows_arm64`

### DIFF
--- a/internal/command/e2etest/init_test.go
+++ b/internal/command/e2etest/init_test.go
@@ -25,13 +25,13 @@ func TestInitProviders(t *testing.T) {
 	t.Parallel()
 
 	// This test reaches out to registry.opentofu.org to download the
-	// template provider, so it can only run if network access is allowed.
+	// cloudinit provider, so it can only run if network access is allowed.
 	// We intentionally don't try to stub this here, because there's already
 	// a stubbed version of this in the "command" package and so the goal here
 	// is to test the interaction with the real repository.
 	skipIfCannotAccessNetwork(t)
 
-	fixturePath := filepath.Join("testdata", "template-provider")
+	fixturePath := filepath.Join("testdata", "cloudinit-provider")
 	tf := e2e.NewBinary(t, tofuBin, fixturePath)
 
 	stdout, stderr, err := tf.Run("init")
@@ -47,7 +47,7 @@ func TestInitProviders(t *testing.T) {
 		t.Errorf("success message is missing from output:\n%s", stdout)
 	}
 
-	if !strings.Contains(stdout, "- Installing hashicorp/template v") {
+	if !strings.Contains(stdout, "- Installing hashicorp/cloudinit v") {
 		t.Errorf("provider download message is missing from output:\n%s", stdout)
 		t.Logf("(this can happen if you have a copy of the plugin in one of the global plugin search dirs)")
 	}

--- a/internal/command/e2etest/init_test.go
+++ b/internal/command/e2etest/init_test.go
@@ -379,17 +379,25 @@ func TestInit_fromModule(t *testing.T) {
 	t.Parallel()
 
 	// This test reaches out to registry.opentofu.org and github.com to lookup
-	// and fetch a module.
+	// and fetch the hashicorp/cloudinit provider.
 	skipIfCannotAccessNetwork(t)
 
 	fixturePath := filepath.Join("testdata", "empty")
 	tf := e2e.NewBinary(t, tofuBin, fixturePath)
 
-	cmd := tf.Cmd("init", "-from-module=hashicorp/vault/aws")
+	// Using an absolute path here forces the use of go-getter's "file getter",
+	// which means we can exercise many of the same codepaths from the module
+	// installer without actually needing to publish a remote module somewhere.
+	fromModuleFixturePath, err := filepath.Abs(filepath.Join("testdata", "init-from-module"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := tf.Cmd("init", "-from-module="+fromModuleFixturePath)
 	cmd.Stdin = nil
 	cmd.Stderr = &bytes.Buffer{}
 
-	err := cmd.Run()
+	err = cmd.Run()
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	}
@@ -399,12 +407,12 @@ func TestInit_fromModule(t *testing.T) {
 		t.Errorf("unexpected stderr output:\n%s", stderr)
 	}
 
-	content, err := tf.ReadFile("main.tf")
+	content, err := tf.ReadFile("init-from-module.tf")
 	if err != nil {
-		t.Fatalf("failed to read main.tf: %s", err)
+		t.Fatalf("failed to read init-from-module.tf: %s", err)
 	}
-	if !bytes.Contains(content, []byte("vault")) {
-		t.Fatalf("main.tf doesn't appear to be a vault configuration: \n%s", content)
+	if !bytes.Contains(content, []byte("cloudinit_config")) {
+		t.Fatalf("init-from-module.tf doesn't seem to include a cloudinit_config data resource: \n%s", content)
 	}
 }
 

--- a/internal/command/e2etest/testdata/cloudinit-provider/main.tf
+++ b/internal/command/e2etest/testdata/cloudinit-provider/main.tf
@@ -1,0 +1,9 @@
+provider "cloudinit" {
+
+}
+
+data "cloudinit_config" "test" {
+  part {
+    content = "Hello World"
+  }
+}

--- a/internal/command/e2etest/testdata/init-from-module/init-from-module.tf
+++ b/internal/command/e2etest/testdata/init-from-module/init-from-module.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    cloudinit = {
+      source = "hashicorp/cloudinit"
+    }
+  }
+}
+
+data "cloudinit_config" "example" {
+  part {
+    content = "hello world"
+  }
+}

--- a/internal/command/e2etest/testdata/template-provider/main.tf
+++ b/internal/command/e2etest/testdata/template-provider/main.tf
@@ -1,7 +1,0 @@
-provider "template" {
-
-}
-
-data "template_file" "test" {
-  template = "Hello World"
-}

--- a/internal/command/e2etest/version_test.go
+++ b/internal/command/e2etest/version_test.go
@@ -47,11 +47,11 @@ func TestVersionWithProvider(t *testing.T) {
 	t.Parallel()
 
 	// This test reaches out to registry.opentofu.org to download the
-	// template and null providers, so it can only run if network access is
+	// cloudinit provider, so it can only run if network access is
 	// allowed.
 	skipIfCannotAccessNetwork(t)
 
-	fixturePath := filepath.Join("testdata", "template-provider")
+	fixturePath := filepath.Join("testdata", "cloudinit-provider")
 	tf := e2e.NewBinary(t, tofuBin, fixturePath)
 
 	// Initial run (before "init") should work without error but will not
@@ -80,7 +80,7 @@ func TestVersionWithProvider(t *testing.T) {
 	}
 
 	// After running init, we additionally include information about the
-	// selected version of the "template" provider.
+	// selected version of the "cloudinit" provider.
 	{
 		stdout, stderr, err := tf.Run("version")
 		if err != nil {
@@ -91,7 +91,7 @@ func TestVersionWithProvider(t *testing.T) {
 			t.Errorf("unexpected stderr output:\n%s", stderr)
 		}
 
-		wantMsg := "+ provider registry.opentofu.org/hashicorp/template v" // we don't know which version we'll get here
+		wantMsg := "+ provider registry.opentofu.org/hashicorp/cloudinit v" // we don't know which version we'll get here
 		if !strings.Contains(stdout, wantMsg) {
 			t.Errorf("output does not contain provider information %q:\n%s", wantMsg, stdout)
 		}


### PR DESCRIPTION
Unfortunately for https://github.com/opentofu/opentofu/pull/4479 I was once again caught out by the fact that my browser's "Find in Page" mechanism is not reliable on the GitHub Actions logs since they stream in the logs to the UI gradually rather than loading them all up front. So I missed a few `FAIL:` when I was looking for the tests that needed updating.

These commits should take care of the three remaining failing tests.

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
