### PR TITLE
go.mod: Upgrade to Go 1.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ UPGRADE NOTES:
 
     [Modern Windows versions now support OpenSSH](https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse), and so we suggest that anyone currently relying on WinRM plan to migrate to using SSH instead.
 
+
+- The `base64gzip` function now generates results that are equivalent to _but not equal to_ the results from previous releases, as a result of a new optimized DEFLATE compression implementation.
+
+    If you use this function as part of an argument to a managed resource then OpenTofu is likely to propose to update or replace the instances of that resource, depending on how the provider responds to the differing base64 data. The new compressed form should nonetheless still decompress to the same sequence of bytes.
+
+- OpenTofu on macOS now requires macOS 13 Ventura or later. Earlier versions are no longer supported.
+
 - OpenTofu v1.13 is the final release series that will include official builds for 32-bit CPU architectures (`*_386` and `*_arm` platforms).
 
     If you are currently relying on our official releases of OpenTofu on one of these platforms then we suggest that you begin planning to migrate to running OpenTofu on a 64-bit CPU architecture (`*_amd64` or `*_arm64` platforms) before the v1.13 series reaches end-of-life.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opentofu/opentofu
 
-go 1.26.5
+go 1.27
 
 // At the time of adding this configuration, the new Go feature introduced here https://github.com/golang/go/issues/67061,
 // was having a good amount of issues linked to, affecting AWS Firewall, GCP various services and a lot more.

--- a/internal/command/apply_test.go
+++ b/internal/command/apply_test.go
@@ -2561,11 +2561,9 @@ func applyFixturePlanFileMatchState(t *testing.T, stateMeta statemgr.SnapshotMet
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
-		ChangeSrc: plans.ChangeSrc{
-			Action: plans.Create,
-			Before: priorValRaw,
-			After:  plannedValRaw,
-		},
+		Action: plans.Create,
+		Before: priorValRaw,
+		After:  plannedValRaw,
 	})
 	return testPlanFileMatchState(
 		t,

--- a/internal/command/arguments/init.go
+++ b/internal/command/arguments/init.go
@@ -61,9 +61,9 @@ func BindInit(cli *CommandLine) *Init {
 		Vars:    BindVars(cli),
 		State:   BindState(cli, stateFlagLock),
 		Backend: BindBackendWithMigration(cli),
-	}
 
-	init.FlagConfigExtra = flagspkg.NewRawFlags("-backend-config")
+		FlagConfigExtra: flagspkg.NewRawFlags("-backend-config"),
+	}
 
 	backend := cli.BoolVar(&init.FlagBackend, "backend", true, "Disable backend or cloud backend initialization for this configuration and use what was previously initialized instead.").SetDisplay("=false")
 	cloud := cli.BoolVar(&init.FlagCloud, "cloud", true, "").SetHidden(true)

--- a/internal/command/arguments/login.go
+++ b/internal/command/arguments/login.go
@@ -28,11 +28,11 @@ func BindLogin(cli *CommandLine) *Login {
 		// Even though the command does not use the -var/-var-file content, we will keep this for the moment
 		// just to keep backwards compatibility for users (in case any of them are using these flags with this command)
 		Vars: BindVars(cli),
-	}
 
-	// State is only initialised and no flags are registered since the login command needs to lock the
-	// state by default, with no user input on that.
-	arguments.State = &State{Lock: true}
+		// State is only initialised and no flags are registered since the login command needs to lock the
+		// state by default, with no user input on that.
+		State: &State{Lock: true},
+	}
 
 	cli.ArgHelp = "The login command expects exactly one argument: the host to log in to."
 	cli.PositionalArg(&arguments.Host, "hostname", false)

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -248,19 +248,19 @@ func CommandUsage(namespace string, cmd Command, w io.Writer) {
 	if cmd.UsageOverride.Usage != "" {
 		printHeader(fmt.Sprintf("Usage: %s\n", cmd.UsageOverride.Usage))
 	} else {
-		positionalArgs := ""
+		var positionalArgs strings.Builder
 		for _, arg := range cmd.CommandLine.Args {
 			name := arg.Name
 			if arg.Variadic {
 				name = name + "..."
 			}
 			if arg.Optional {
-				positionalArgs += fmt.Sprintf(" [%s]", name)
+				fmt.Fprintf(&positionalArgs, " [%s]", name)
 			} else {
-				positionalArgs += fmt.Sprintf(" <%s>", name)
+				fmt.Fprintf(&positionalArgs, " <%s>", name)
 			}
 		}
-		printHeader(fmt.Sprintf("Usage: tofu [global options] %s [options]%s\n", namespace+cmd.Name, positionalArgs))
+		printHeader(fmt.Sprintf("Usage: tofu [global options] %s [options]%s\n", namespace+cmd.Name, positionalArgs.String()))
 	}
 
 	if cmd.Long != "" {

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -1251,11 +1251,9 @@ func TestVarsParsing(t *testing.T) {
 		t.Cleanup(testStdinPipe(t, strings.NewReader("var.foo\nvar.snack\n")))
 		streams, done := terminal.StreamsForTesting(t)
 		c := &ConsoleCommand{
-			Meta: Meta{
-				WorkingDir:       workdir.NewDir("."),
-				testingOverrides: metaOverridesForProvider(p),
-				View:             views.NewView(streams),
-			},
+			WorkingDir:       workdir.NewDir("."),
+			testingOverrides: metaOverridesForProvider(p),
+			View:             views.NewView(streams),
 		}
 
 		args := append([]string{"-no-color", "-lock=false"}, varArgs...)

--- a/internal/command/graph_test.go
+++ b/internal/command/graph_test.go
@@ -121,11 +121,9 @@ func TestGraph_plan(t *testing.T) {
 			Type: "test_instance",
 			Name: "bar",
 		}.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
-		ChangeSrc: plans.ChangeSrc{
-			Action: plans.Delete,
-			Before: plans.DynamicValue(`{}`),
-			After:  plans.DynamicValue(`null`),
-		},
+		Action: plans.Delete,
+		Before: plans.DynamicValue(`{}`),
+		After:  plans.DynamicValue(`null`),
 		ProviderAddr: addrs.AbsProviderConfig{
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -1781,7 +1781,7 @@ func TestInit_providerSource(t *testing.T) {
 			getproviders.MustParseVersionConstraints("= 1.2.4"),
 			[]getproviders.Hash{
 				getproviders.HashScheme1.New("vEthLkqAecdQimaW6JHZ0SBRNtHibLnOb31tX9ZXlcI="),
-				getproviders.HashSchemeZip.New("ec7c3fd6eb575c06f0e6957e1ee8531a588805c4eeb8abb5e4156911e080eb31"),
+				getproviders.HashSchemeZip.New("4115ba79e1745c9236f24ce18e643cfc1893140cbc963066348d2dde9c7c55c5"),
 			},
 		),
 		addrs.NewDefaultProvider("test"): depsfile.NewProviderLock(
@@ -1790,7 +1790,7 @@ func TestInit_providerSource(t *testing.T) {
 			getproviders.MustParseVersionConstraints("= 1.2.3"),
 			[]getproviders.Hash{
 				getproviders.HashScheme1.New("8CjxaUBuegKZSFnRos39Fs+CS78ax0Dyb7aIA5XBiNI="),
-				getproviders.HashSchemeZip.New("6f85a1f747dd09455cd77683c0e06da647d8240461b8b36b304b9056814d91f2"),
+				getproviders.HashSchemeZip.New("ac90a1419dd4648431af93b6695b6d6efcad87950ee608de4198df8e6debff23"),
 			},
 		),
 		addrs.NewDefaultProvider("source"): depsfile.NewProviderLock(
@@ -1799,7 +1799,7 @@ func TestInit_providerSource(t *testing.T) {
 			getproviders.MustParseVersionConstraints("= 1.2.3"),
 			[]getproviders.Hash{
 				getproviders.HashScheme1.New("ACYytVQ2Q6JfoEs7xxCqa1yGFf9HwF3SEHzJKBoJfo0="),
-				getproviders.HashSchemeZip.New("69f700dbf9eda586abef22ab08e3a3896760e01885f6cbda4460ceeca4e3c0ba"),
+				getproviders.HashSchemeZip.New("4932d637b6c33444920bf945d6ee17de83ab4b193c1707b35c84d828de880158"),
 			},
 		),
 	}
@@ -2037,7 +2037,7 @@ func TestInit_getUpgradePlugins(t *testing.T) {
 			getproviders.MustParseVersionConstraints("> 1.0.0, < 3.0.0"),
 			[]getproviders.Hash{
 				getproviders.HashScheme1.New("ntfa04OlRqIfGL/Gkd+nGMJSHGWyAgMQplFWk7WEsOk="),
-				getproviders.HashSchemeZip.New("29e1045215056680ac59fe95554f0eb1323534a3d411aae2a7a04495ac884258"),
+				getproviders.HashSchemeZip.New("cf1650d77dfe5681ebd7917a813c0c982d0d2e951ded422a83fbf22a1e0e6bc3"),
 			},
 		),
 		addrs.NewDefaultProvider("exact"): depsfile.NewProviderLock(
@@ -2046,7 +2046,7 @@ func TestInit_getUpgradePlugins(t *testing.T) {
 			getproviders.MustParseVersionConstraints("= 1.2.3"),
 			[]getproviders.Hash{
 				getproviders.HashScheme1.New("Xgk+LFrzi9Mop6+d01TCTaD3kgSrUASCAUU1aDsEsJU="),
-				getproviders.HashSchemeZip.New("9cb7a3006b9c1344b2d838a5bb03c1e0f04b8c046beb38901eaf3cc99fceb870"),
+				getproviders.HashSchemeZip.New("604a3ebf14e83ef19aab2e8e4063c4cd7d53c9c4c30ad22db0d9ce4f8f6edc83"),
 			},
 		),
 		addrs.NewDefaultProvider("greater-than"): depsfile.NewProviderLock(
@@ -2055,7 +2055,7 @@ func TestInit_getUpgradePlugins(t *testing.T) {
 			getproviders.MustParseVersionConstraints(">= 2.3.3"),
 			[]getproviders.Hash{
 				getproviders.HashScheme1.New("8M5DXICmUiVjbkxNNO0zXNsV6duCVNWzq3/Kf0mNIo4="),
-				getproviders.HashSchemeZip.New("bfb683ee94027efb191986484352ada8219cd45e856d25c2ddcb489e100a9a02"),
+				getproviders.HashSchemeZip.New("4c638927fcf2d35eb1c3a91c6745c0bef1a5365294641d4a8fca9c529cb8521f"),
 			},
 		),
 	}
@@ -2228,7 +2228,7 @@ provider "registry.opentofu.org/hashicorp/test" {
   constraints = "1.2.3"
   hashes = [
     "h1:8CjxaUBuegKZSFnRos39Fs+CS78ax0Dyb7aIA5XBiNI=",
-    "zh:6f85a1f747dd09455cd77683c0e06da647d8240461b8b36b304b9056814d91f2",
+    "zh:ac90a1419dd4648431af93b6695b6d6efcad87950ee608de4198df8e6debff23",
   ]
 }
 `)
@@ -2261,7 +2261,7 @@ provider "registry.opentofu.org/hashicorp/test" {
   version     = "1.2.3"
   constraints = "1.2.3"
   hashes = [
-    "zh:6f85a1f747dd09455cd77683c0e06da647d8240461b8b36b304b9056814d91f2",
+    "zh:ac90a1419dd4648431af93b6695b6d6efcad87950ee608de4198df8e6debff23",
   ]
 }
 `)
@@ -2288,7 +2288,7 @@ provider "registry.opentofu.org/hashicorp/test" {
   constraints = "1.2.3"
   hashes = [
     "h1:8CjxaUBuegKZSFnRos39Fs+CS78ax0Dyb7aIA5XBiNI=",
-    "zh:6f85a1f747dd09455cd77683c0e06da647d8240461b8b36b304b9056814d91f2",
+    "zh:ac90a1419dd4648431af93b6695b6d6efcad87950ee608de4198df8e6debff23",
   ]
 }
 `)

--- a/internal/command/login_test.go
+++ b/internal/command/login_test.go
@@ -101,12 +101,10 @@ func TestLogin(t *testing.T) {
 			})
 
 			c := &LoginCommand{
-				Meta: Meta{
-					WorkingDir:      workdir.NewDir("."),
-					View:            loginView,
-					BrowserLauncher: browserLauncher,
-					Services:        svcs,
-				},
+				WorkingDir:      workdir.NewDir("."),
+				View:            loginView,
+				BrowserLauncher: browserLauncher,
+				Services:        svcs,
 			}
 
 			test(t, c, loginDone)
@@ -418,13 +416,11 @@ func TestLoginOAuthCallbackRace(t *testing.T) {
 
 			abortCh := make(chan struct{})
 			c := &LoginCommand{
-				Meta: Meta{
-					WorkingDir:      workdir.NewDir("."),
-					View:            loginView,
-					BrowserLauncher: webbrowser.NewMockLauncher(ctx),
-					Services:        svcs,
-					ShutdownCh:      abortCh,
-				},
+				WorkingDir:      workdir.NewDir("."),
+				View:            loginView,
+				BrowserLauncher: webbrowser.NewMockLauncher(ctx),
+				Services:        svcs,
+				ShutdownCh:      abortCh,
 			}
 
 			defer testInputMap(t, map[string]string{
@@ -495,12 +491,10 @@ func TestLoginOAuthCallbackNoPanicOnAbort(t *testing.T) {
 			// is the only way to unblock the command.
 			abortCh := make(chan struct{})
 			c := &LoginCommand{
-				Meta: Meta{
-					WorkingDir: workdir.NewDir("."),
-					View:       loginView,
-					Services:   svcs,
-					ShutdownCh: abortCh,
-				},
+				WorkingDir: workdir.NewDir("."),
+				View:       loginView,
+				Services:   svcs,
+				ShutdownCh: abortCh,
 			}
 
 			defer testInputMap(t, map[string]string{

--- a/internal/command/logout_test.go
+++ b/internal/command/logout_test.go
@@ -27,13 +27,11 @@ func TestLogout(t *testing.T) {
 	t.Run("with no hostname", func(t *testing.T) {
 		logoutView, logoutDone := testView(t)
 		c := &LogoutCommand{
-			Meta: Meta{
-				WorkingDir: workdir.NewDir("."),
-				View:       logoutView,
-				Services: disco.New(
-					disco.WithCredentials(credsSrc),
-				),
-			},
+			WorkingDir: workdir.NewDir("."),
+			View:       logoutView,
+			Services: disco.New(
+				disco.WithCredentials(credsSrc),
+			),
 		}
 		status := c.Run([]string{})
 		output := logoutDone(t)
@@ -76,13 +74,11 @@ func TestLogout(t *testing.T) {
 			}
 			logoutView, logoutDone := testView(t)
 			c := &LogoutCommand{
-				Meta: Meta{
-					WorkingDir: workdir.NewDir("."),
-					View:       logoutView,
-					Services: disco.New(
-						disco.WithCredentials(credsSrc),
-					),
-				},
+				WorkingDir: workdir.NewDir("."),
+				View:       logoutView,
+				Services: disco.New(
+					disco.WithCredentials(credsSrc),
+				),
 			}
 			status := c.Run(tc.args)
 			output := logoutDone(t)

--- a/internal/command/meta_backend_test.go
+++ b/internal/command/meta_backend_test.go
@@ -2130,11 +2130,11 @@ func testMetaBackend(t *testing.T) *Meta {
 		stateArgs:  arguments.State{Lock: true},
 		// metaBackend tests are verifying migrate actions
 		backendArgs: arguments.Backend{MigrateState: true},
-	}
 
-	// TODO meta-refactor: these assignments are needed because the extendedFlagSet was used here before,
-	//   which had these with defaults as "true". In a future iteration, once these are not needed, we need to remove them.
-	m.input = true
+		// TODO meta-refactor: these assignments are needed because the extendedFlagSet was used here before,
+		//   which had these with defaults as "true". In a future iteration, once these are not needed, we need to remove them.
+		input: true,
+	}
 
 	t.Cleanup(func() {
 		// Trigger garbage collection to ensure that all open file handles are closed.

--- a/internal/command/meta_vars.go
+++ b/internal/command/meta_vars.go
@@ -103,11 +103,11 @@ func (m *Meta) collectVariableValues() (map[string]backend.UnparsedVariableValue
 			}
 			name := raw[:eq]
 			rawVal := raw[eq+1:]
-			if strings.HasSuffix(name, " ") {
+			if before, ok := strings.CutSuffix(name, " "); ok {
 				diags = diags.Append(tfdiags.Sourceless(
 					tfdiags.Error,
 					"Invalid -var option",
-					fmt.Sprintf("Variable name %q is invalid due to trailing space. Did you mean -var=\"%s=%s\"?", name, strings.TrimSuffix(name, " "), strings.TrimPrefix(rawVal, " ")),
+					fmt.Sprintf("Variable name %q is invalid due to trailing space. Did you mean -var=\"%s=%s\"?", name, before, strings.TrimPrefix(rawVal, " ")),
 				))
 				continue
 			}

--- a/internal/command/plan_test.go
+++ b/internal/command/plan_test.go
@@ -1839,7 +1839,7 @@ func TestPlan_parallelism(t *testing.T) {
 	// here. They will all have the same mock implementation function assigned
 	// but crucially they will each have their own mutex.
 	providerFactories := map[addrs.Provider]providers.Factory{}
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		name := fmt.Sprintf("test%d", i)
 		provider := &tofu.MockProvider{}
 		provider.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{

--- a/internal/command/providers_mirror.go
+++ b/internal/command/providers_mirror.go
@@ -295,8 +295,8 @@ func (c ProvidersMirrorCommand) Execute(args *arguments.ProvidersMirror, view vi
 		indexDir := filepath.Dir(getproviders.PackedFilePathForPackage(
 			outputDir, provider, versions.Unspecified, getproviders.CurrentPlatform,
 		))
-		indexVersions := map[string]interface{}{}
-		indexArchives := map[getproviders.Version]map[string]interface{}{}
+		indexVersions := map[string]any{}
+		indexArchives := map[getproviders.Version]map[string]any{}
 		for _, meta := range metas {
 			archivePath, ok := meta.Location.(getproviders.PackageLocalArchive)
 			if !ok {
@@ -328,16 +328,16 @@ func (c ProvidersMirrorCommand) Execute(args *arguments.ProvidersMirror, view vi
 				hashes = append(hashes, hash.String())
 			}
 			slices.Sort(hashes)
-			indexVersions[meta.Version.String()] = map[string]interface{}{}
+			indexVersions[meta.Version.String()] = map[string]any{}
 			if _, ok := indexArchives[version]; !ok {
-				indexArchives[version] = map[string]interface{}{}
+				indexArchives[version] = map[string]any{}
 			}
-			indexArchives[version][platform.String()] = map[string]interface{}{
+			indexArchives[version][platform.String()] = map[string]any{
 				"url":    archiveFilename, // a relative URL from the index file's URL
 				"hashes": hashes,          // an array to allow for additional hash formats in future
 			}
 		}
-		mainIndex := map[string]interface{}{
+		mainIndex := map[string]any{
 			"versions": indexVersions,
 		}
 		mainIndexJSON, err := json.MarshalIndent(mainIndex, "", "  ")
@@ -362,7 +362,7 @@ func (c ProvidersMirrorCommand) Execute(args *arguments.ProvidersMirror, view vi
 			))
 		}
 		for version, archiveIndex := range indexArchives {
-			versionIndex := map[string]interface{}{
+			versionIndex := map[string]any{
 				"archives": archiveIndex,
 			}
 			versionIndexJSON, err := json.MarshalIndent(versionIndex, "", "  ")

--- a/internal/command/providers_test.go
+++ b/internal/command/providers_test.go
@@ -108,7 +108,7 @@ func TestProviders_modules(t *testing.T) {
 	wantOutput := []string{
 		"provider[registry.opentofu.org/hashicorp/foo] 1.0.0", // from required_providers
 		"provider[registry.opentofu.org/hashicorp/bar] 2.0.0", // from provider config
-		"── module.kiddo", //                                                                                           tree node for child module
+		"── module.kiddo",                               // tree node for child module
 		"provider[registry.opentofu.org/hashicorp/baz]", // implied by a resource in the child module
 	}
 

--- a/internal/command/show.go
+++ b/internal/command/show.go
@@ -290,10 +290,7 @@ func (c *ShowCommand) legacyShowFromPath(ctx context.Context, path string, enc e
 			// ones (which are likely to be something unhelpful like "not a
 			// valid zip file"). If not, we can fall back to dumping whatever
 			// we've got.
-			var unLocal *planfile.ErrUnusableLocalPlan
-			var unState *statefile.ErrUnusableState
-			var unMisc *errUnusableDataMisc
-			if errors.As(planErr, &unLocal) {
+			if unLocal, ok := errors.AsType[*planfile.ErrUnusableLocalPlan](planErr); ok {
 				diags = diags.Append(
 					tfdiags.Sourceless(
 						tfdiags.Error,
@@ -301,7 +298,7 @@ func (c *ShowCommand) legacyShowFromPath(ctx context.Context, path string, enc e
 						fmt.Sprintf("Plan read error: %s", unLocal),
 					),
 				)
-			} else if errors.As(planErr, &unMisc) {
+			} else if unMisc, ok := errors.AsType[*errUnusableDataMisc](planErr); ok {
 				diags = diags.Append(
 					tfdiags.Sourceless(
 						tfdiags.Error,
@@ -309,7 +306,7 @@ func (c *ShowCommand) legacyShowFromPath(ctx context.Context, path string, enc e
 						fmt.Sprintf("Plan read error: %s", unMisc),
 					),
 				)
-			} else if errors.As(stateErr, &unState) {
+			} else if unState, ok := errors.AsType[*statefile.ErrUnusableState](stateErr); ok {
 				diags = diags.Append(
 					tfdiags.Sourceless(
 						tfdiags.Error,

--- a/internal/command/show_test.go
+++ b/internal/command/show_test.go
@@ -404,11 +404,9 @@ func TestShow_planWithForceReplaceChange(t *testing.T) {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
-		ChangeSrc: plans.ChangeSrc{
-			Action: plans.CreateThenDelete,
-			Before: priorValRaw,
-			After:  plannedValRaw,
-		},
+		Action:       plans.CreateThenDelete,
+		Before:       priorValRaw,
+		After:        plannedValRaw,
 		ActionReason: plans.ResourceInstanceReplaceByRequest,
 	})
 	planFilePath := testPlanFile(
@@ -1423,11 +1421,9 @@ func showFixturePlanFile(t *testing.T, action plans.Action) string {
 			Provider: addrs.NewDefaultProvider("test"),
 			Module:   addrs.RootModule,
 		},
-		ChangeSrc: plans.ChangeSrc{
-			Action: action,
-			Before: priorValRaw,
-			After:  plannedValRaw,
-		},
+		Action: action,
+		Before: priorValRaw,
+		After:  plannedValRaw,
 	})
 	return testPlanFile(
 		t,

--- a/internal/command/state_mv_test.go
+++ b/internal/command/state_mv_test.go
@@ -1260,7 +1260,7 @@ func TestStateMv_stateOutNew_count(t *testing.T) {
 func TestStateMv_stateOutNew_largeCount(t *testing.T) {
 	state := states.BuildState(func(s *states.SyncState) {
 		// test_instance.foo has 11 instances, all the same except for their ids
-		for i := 0; i < 11; i++ {
+		for i := range 11 {
 			s.SetResourceInstanceCurrent(
 				addrs.Resource{
 					Mode: addrs.ManagedResourceMode,

--- a/internal/command/state_push_test.go
+++ b/internal/command/state_push_test.go
@@ -249,10 +249,8 @@ func TestStatePush_forceRemoteState(t *testing.T) {
 	// init the backend
 	initView, initDone := testView(t)
 	initCmd := &InitCommand{
-		Meta: Meta{
-			WorkingDir: workdir.NewDir("."),
-			View:       initView,
-		},
+		WorkingDir: workdir.NewDir("."),
+		View:       initView,
 	}
 	code := initCmd.Run([]string{})
 	initOutput := initDone(t)
@@ -263,10 +261,8 @@ func TestStatePush_forceRemoteState(t *testing.T) {
 	// create a new workspace
 	wsView, wsDone := testView(t)
 	newCmd := &WorkspaceNewCommand{
-		Meta: Meta{
-			WorkingDir: workdir.NewDir("."),
-			View:       wsView,
-		},
+		WorkingDir: workdir.NewDir("."),
+		View:       wsView,
 	}
 	wsCode := newCmd.Run([]string{"test"})
 	wsOutput := wsDone(t)

--- a/internal/command/test_test.go
+++ b/internal/command/test_test.go
@@ -200,11 +200,9 @@ func TestTest(t *testing.T) {
 			view, done := testView(t)
 
 			c := &TestCommand{
-				Meta: Meta{
-					WorkingDir:       workdir.NewDir("."),
-					testingOverrides: metaOverridesForProvider(provider.Provider),
-					View:             view,
-				},
+				WorkingDir:       workdir.NewDir("."),
+				testingOverrides: metaOverridesForProvider(provider.Provider),
+				View:             view,
 			}
 
 			code := c.Run(tc.args)
@@ -290,11 +288,9 @@ func TestTest_Full_Output(t *testing.T) {
 			view, done := testView(t)
 
 			c := &TestCommand{
-				Meta: Meta{
-					WorkingDir:       workdir.NewDir("."),
-					testingOverrides: metaOverridesForProvider(provider.Provider),
-					View:             view,
-				},
+				WorkingDir:       workdir.NewDir("."),
+				testingOverrides: metaOverridesForProvider(provider.Provider),
+				View:             view,
 			}
 
 			code := c.Run(tc.args)
@@ -327,12 +323,10 @@ func TestTest_Interrupt(t *testing.T) {
 	provider.Interrupt = interrupt
 
 	c := &TestCommand{
-		Meta: Meta{
-			WorkingDir:       workdir.NewDir("."),
-			testingOverrides: metaOverridesForProvider(provider.Provider),
-			View:             view,
-			ShutdownCh:       interrupt,
-		},
+		WorkingDir:       workdir.NewDir("."),
+		testingOverrides: metaOverridesForProvider(provider.Provider),
+		View:             view,
+		ShutdownCh:       interrupt,
 	}
 
 	c.Run(nil)
@@ -360,12 +354,10 @@ func TestTest_DoubleInterrupt(t *testing.T) {
 	provider.Interrupt = interrupt
 
 	c := &TestCommand{
-		Meta: Meta{
-			WorkingDir:       workdir.NewDir("."),
-			testingOverrides: metaOverridesForProvider(provider.Provider),
-			View:             view,
-			ShutdownCh:       interrupt,
-		},
+		WorkingDir:       workdir.NewDir("."),
+		testingOverrides: metaOverridesForProvider(provider.Provider),
+		View:             view,
+		ShutdownCh:       interrupt,
 	}
 
 	c.Run(nil)
@@ -553,11 +545,9 @@ func TestTest_CatchesErrorsBeforeDestroy(t *testing.T) {
 	view, done := testView(t)
 
 	c := &TestCommand{
-		Meta: Meta{
-			WorkingDir:       workdir.NewDir("."),
-			testingOverrides: metaOverridesForProvider(provider.Provider),
-			View:             view,
-		},
+		WorkingDir:       workdir.NewDir("."),
+		testingOverrides: metaOverridesForProvider(provider.Provider),
+		View:             view,
 	}
 
 	code := c.Run([]string{"-no-color"})
@@ -609,11 +599,9 @@ func TestTest_Verbose(t *testing.T) {
 	view, done := testView(t)
 
 	c := &TestCommand{
-		Meta: Meta{
-			WorkingDir:       workdir.NewDir("."),
-			testingOverrides: metaOverridesForProvider(provider.Provider),
-			View:             view,
-		},
+		WorkingDir:       workdir.NewDir("."),
+		testingOverrides: metaOverridesForProvider(provider.Provider),
+		View:             view,
 	}
 
 	code := c.Run([]string{"-verbose", "-no-color"})
@@ -1192,11 +1180,9 @@ Condition expression could not be evaluated at this time.
 			view, done := testView(t)
 
 			c := &TestCommand{
-				Meta: Meta{
-					WorkingDir:       workdir.NewDir("."),
-					testingOverrides: metaOverridesForProvider(provider.Provider),
-					View:             view,
-				},
+				WorkingDir:       workdir.NewDir("."),
+				testingOverrides: metaOverridesForProvider(provider.Provider),
+				View:             view,
 			}
 
 			code := c.Run([]string{"-no-color"})

--- a/internal/command/ui_input.go
+++ b/internal/command/ui_input.go
@@ -41,7 +41,7 @@ type UIInput struct {
 	Reader io.Reader
 	Writer io.Writer
 
-	listening int32
+	listening atomic.Int32
 	result    chan string
 	err       chan string
 
@@ -120,10 +120,10 @@ func (i *UIInput) Input(ctx context.Context, opts *tofu.InputOpts) (string, erro
 	// Listen for the input in a goroutine. This will allow us to
 	// interrupt this if we are interrupted (SIGINT).
 	go func() {
-		if !atomic.CompareAndSwapInt32(&i.listening, 0, 1) {
+		if !i.listening.CompareAndSwap(0, 1) {
 			return // We are already listening for input.
 		}
-		defer atomic.CompareAndSwapInt32(&i.listening, 1, 0)
+		defer i.listening.CompareAndSwap(1, 0)
 
 		var line string
 		var err error

--- a/internal/command/ui_input_test.go
+++ b/internal/command/ui_input_test.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -66,7 +65,7 @@ func TestUIInputInput_canceled(t *testing.T) {
 	}
 
 	// As the context was canceled we should still be listening.
-	listening := atomic.LoadInt32(&i.listening)
+	listening := i.listening.Load()
 	if listening != 1 {
 		t.Fatalf("expected listening to be 1, got: %d", listening)
 	}

--- a/internal/command/validate_test.go
+++ b/internal/command/validate_test.go
@@ -53,11 +53,9 @@ func setupTest(t *testing.T, fixturepath string, args ...string) (*terminal.Test
 		},
 	}
 	c := &ValidateCommand{
-		Meta: Meta{
-			WorkingDir:       workdir.NewDir("."),
-			testingOverrides: metaOverridesForProvider(p),
-			View:             view,
-		},
+		WorkingDir:       workdir.NewDir("."),
+		testingOverrides: metaOverridesForProvider(p),
+		View:             view,
 	}
 
 	args = append(args, "-no-color")
@@ -82,11 +80,9 @@ func TestValidateCommandWithTfvarsFile(t *testing.T) {
 
 	view, done := testView(t)
 	c := &ValidateCommand{
-		Meta: Meta{
-			WorkingDir:       workdir.NewDir("."),
-			testingOverrides: metaOverridesForProvider(testProvider()),
-			View:             view,
-		},
+		WorkingDir:       workdir.NewDir("."),
+		testingOverrides: metaOverridesForProvider(testProvider()),
+		View:             view,
 	}
 
 	args := []string{}
@@ -264,11 +260,9 @@ func TestValidateWithInvalidTestFile(t *testing.T) {
 	view, done := testView(t)
 	provider := testing_command.NewProvider(nil)
 	c := &ValidateCommand{
-		Meta: Meta{
-			WorkingDir:       workdir.NewDir("."),
-			testingOverrides: metaOverridesForProvider(provider.Provider),
-			View:             view,
-		},
+		WorkingDir:       workdir.NewDir("."),
+		testingOverrides: metaOverridesForProvider(provider.Provider),
+		View:             view,
 	}
 
 	var args []string

--- a/internal/command/version_test.go
+++ b/internal/command/version_test.go
@@ -46,10 +46,8 @@ func TestVersion(t *testing.T) {
 
 	view, done := testView(t)
 	c := &VersionCommand{
-		Meta: Meta{
-			WorkingDir: workdir.NewDir("."),
-			View:       view,
-		},
+		WorkingDir:        workdir.NewDir("."),
+		View:              view,
 		Version:           "4.5.6",
 		VersionPrerelease: "foo",
 		Platform:          getproviders.Platform{OS: "aros", Arch: "riscv64"},

--- a/internal/command/workspace_select.go
+++ b/internal/command/workspace_select.go
@@ -7,6 +7,7 @@ package command
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/opentofu/opentofu/internal/command/arguments"
@@ -105,13 +106,7 @@ func (c WorkspaceSelectCommand) Execute(args *arguments.WorkspaceSelect, view vi
 		return 0
 	}
 
-	found := false
-	for _, s := range states {
-		if name == s {
-			found = true
-			break
-		}
-	}
+	found := slices.Contains(states, name)
 
 	var newState bool
 

--- a/internal/lang/funcs/encoding_test.go
+++ b/internal/lang/funcs/encoding_test.go
@@ -137,7 +137,7 @@ func TestBase64Gzip(t *testing.T) {
 	}{
 		{
 			cty.StringVal("test"),
-			cty.StringVal("H4sIAAAAAAAA/ypJLS4BAAAA//8BAAD//wx+f9gEAAAA"),
+			cty.StringVal("H4sIAAAAAAAA/wAEAPv/dGVzdAAAAP//AwAMfn/YBAAAAA=="),
 			false,
 		},
 	}
@@ -168,6 +168,11 @@ func TestBase64Gunzip(t *testing.T) {
 		Want   cty.Value
 		Err    string
 	}{
+		{
+			cty.StringVal("H4sIAAAAAAAA/wAEAPv/dGVzdAAAAP//AwAMfn/YBAAAAA=="),
+			cty.StringVal("test"),
+			"",
+		},
 		{
 			cty.StringVal("H4sIAAAAAAAA/ypJLS4BAAAA//8BAAD//wx+f9gEAAAA"),
 			cty.StringVal("test"),

--- a/internal/lang/functions_test.go
+++ b/internal/lang/functions_test.go
@@ -223,13 +223,13 @@ func TestFunctions(t *testing.T) {
 		"base64gzip": {
 			{
 				`base64gzip("test")`,
-				cty.StringVal("H4sIAAAAAAAA/ypJLS4BAAAA//8BAAD//wx+f9gEAAAA"),
+				cty.StringVal("H4sIAAAAAAAA/wAEAPv/dGVzdAAAAP//AwAMfn/YBAAAAA=="),
 			},
 		},
 
 		"base64gunzip": {
 			{
-				`base64gunzip("H4sIAAAAAAAA/ypJLS4BAAAA//8BAAD//wx+f9gEAAAA")`,
+				`base64gunzip("H4sIAAAAAAAA/wAEAPv/dGVzdAAAAP//AwAMfn/YBAAAAA==")`,
 				cty.StringVal("test"),
 			},
 		},

--- a/internal/plans/internal/planproto/planfile.pb.go
+++ b/internal/plans/internal/planproto/planfile.pb.go
@@ -666,14 +666,14 @@ type Change struct {
 	// the documentation for any message that embeds Change.
 	Action Action `protobuf:"varint,1,opt,name=action,proto3,enum=tfplan.Action" json:"action,omitempty"`
 	// msgpack-encoded HCL values involved in the change.
-	//   - For update and replace, two values are provided that give the old and new values,
-	//     respectively.
-	//   - For create, one value is provided that gives the new value to be created
-	//   - For delete, one value is provided that describes the value being deleted
-	//   - For read, two values are provided that give the prior value for this object
-	//     (or null, if no prior value exists) and the value that was or will be read,
-	//     respectively.
-	//   - For no-op, one value is provided that is left unmodified by this non-change.
+	// - For update and replace, two values are provided that give the old and new values,
+	//   respectively.
+	// - For create, one value is provided that gives the new value to be created
+	// - For delete, one value is provided that describes the value being deleted
+	// - For read, two values are provided that give the prior value for this object
+	//   (or null, if no prior value exists) and the value that was or will be read,
+	//   respectively.
+	// - For no-op, one value is provided that is left unmodified by this non-change.
 	Values []*DynamicValue `protobuf:"bytes,2,rep,name=values,proto3" json:"values,omitempty"`
 	// An unordered set of paths into the old value which are marked as
 	// sensitive. Values at these paths should be obscured in human-readable

--- a/internal/tfplugin5/tfplugin5.pb.go
+++ b/internal/tfplugin5/tfplugin5.pb.go
@@ -4536,9 +4536,9 @@ type PlanResourceChange_Response struct {
 	// specific details of the legacy SDK type system, and are not a general
 	// mechanism to avoid proper type handling in providers.
 	//
-	//	====              DO NOT USE THIS              ====
-	//	==== THIS MUST BE LEFT UNSET IN ALL OTHER SDKS ====
-	//	====              DO NOT USE THIS              ====
+	//     ====              DO NOT USE THIS              ====
+	//     ==== THIS MUST BE LEFT UNSET IN ALL OTHER SDKS ====
+	//     ====              DO NOT USE THIS              ====
 	LegacyTypeSystem bool `protobuf:"varint,5,opt,name=legacy_type_system,json=legacyTypeSystem,proto3" json:"legacy_type_system,omitempty"`
 	// deferred is set if the provider is deferring the change. If set the caller
 	// needs to handle the deferral.
@@ -4732,9 +4732,9 @@ type ApplyResourceChange_Response struct {
 	// specific details of the legacy SDK type system, and are not a general
 	// mechanism to avoid proper type handling in providers.
 	//
-	//	====              DO NOT USE THIS              ====
-	//	==== THIS MUST BE LEFT UNSET IN ALL OTHER SDKS ====
-	//	====              DO NOT USE THIS              ====
+	//     ====              DO NOT USE THIS              ====
+	//     ==== THIS MUST BE LEFT UNSET IN ALL OTHER SDKS ====
+	//     ====              DO NOT USE THIS              ====
 	LegacyTypeSystem bool                  `protobuf:"varint,4,opt,name=legacy_type_system,json=legacyTypeSystem,proto3" json:"legacy_type_system,omitempty"`
 	NewIdentity      *ResourceIdentityData `protobuf:"bytes,5,opt,name=new_identity,json=newIdentity,proto3" json:"new_identity,omitempty"`
 	unknownFields    protoimpl.UnknownFields

--- a/internal/tfplugin5/tfplugin5_grpc.pb.go
+++ b/internal/tfplugin5/tfplugin5_grpc.pb.go
@@ -93,9 +93,9 @@ type ProviderClient interface {
 	// UpgradeResourceIdentityData should return the upgraded resource identity
 	// data for a managed resource type.
 	UpgradeResourceIdentity(ctx context.Context, in *UpgradeResourceIdentity_Request, opts ...grpc.CallOption) (*UpgradeResourceIdentity_Response, error)
-	// ////// One-time initialization, called before other functions below
+	//////// One-time initialization, called before other functions below
 	Configure(ctx context.Context, in *Configure_Request, opts ...grpc.CallOption) (*Configure_Response, error)
-	// ////// Managed Resource Lifecycle
+	//////// Managed Resource Lifecycle
 	ReadResource(ctx context.Context, in *ReadResource_Request, opts ...grpc.CallOption) (*ReadResource_Response, error)
 	PlanResourceChange(ctx context.Context, in *PlanResourceChange_Request, opts ...grpc.CallOption) (*PlanResourceChange_Response, error)
 	ApplyResourceChange(ctx context.Context, in *ApplyResourceChange_Request, opts ...grpc.CallOption) (*ApplyResourceChange_Response, error)
@@ -103,23 +103,23 @@ type ProviderClient interface {
 	MoveResourceState(ctx context.Context, in *MoveResourceState_Request, opts ...grpc.CallOption) (*MoveResourceState_Response, error)
 	ReadDataSource(ctx context.Context, in *ReadDataSource_Request, opts ...grpc.CallOption) (*ReadDataSource_Response, error)
 	GenerateResourceConfig(ctx context.Context, in *GenerateResourceConfig_Request, opts ...grpc.CallOption) (*GenerateResourceConfig_Response, error)
-	// ////// Ephemeral Resource Lifecycle
+	//////// Ephemeral Resource Lifecycle
 	ValidateEphemeralResourceConfig(ctx context.Context, in *ValidateEphemeralResourceConfig_Request, opts ...grpc.CallOption) (*ValidateEphemeralResourceConfig_Response, error)
 	OpenEphemeralResource(ctx context.Context, in *OpenEphemeralResource_Request, opts ...grpc.CallOption) (*OpenEphemeralResource_Response, error)
 	RenewEphemeralResource(ctx context.Context, in *RenewEphemeralResource_Request, opts ...grpc.CallOption) (*RenewEphemeralResource_Response, error)
 	CloseEphemeralResource(ctx context.Context, in *CloseEphemeralResource_Request, opts ...grpc.CallOption) (*CloseEphemeralResource_Response, error)
-	// ///// List
+	/////// List
 	ListResource(ctx context.Context, in *ListResource_Request, opts ...grpc.CallOption) (Provider_ListResourceClient, error)
 	ValidateListResourceConfig(ctx context.Context, in *ValidateListResourceConfig_Request, opts ...grpc.CallOption) (*ValidateListResourceConfig_Response, error)
 	// GetFunctions returns the definitions of all functions.
 	GetFunctions(ctx context.Context, in *GetFunctions_Request, opts ...grpc.CallOption) (*GetFunctions_Response, error)
-	// ////// Provider-contributed Functions
+	//////// Provider-contributed Functions
 	CallFunction(ctx context.Context, in *CallFunction_Request, opts ...grpc.CallOption) (*CallFunction_Response, error)
-	// ////// Actions
+	//////// Actions
 	PlanAction(ctx context.Context, in *PlanAction_Request, opts ...grpc.CallOption) (*PlanAction_Response, error)
 	InvokeAction(ctx context.Context, in *InvokeAction_Request, opts ...grpc.CallOption) (Provider_InvokeActionClient, error)
 	ValidateActionConfig(ctx context.Context, in *ValidateActionConfig_Request, opts ...grpc.CallOption) (*ValidateActionConfig_Response, error)
-	// ////// Graceful Shutdown
+	//////// Graceful Shutdown
 	Stop(ctx context.Context, in *Stop_Request, opts ...grpc.CallOption) (*Stop_Response, error)
 }
 
@@ -452,9 +452,9 @@ type ProviderServer interface {
 	// UpgradeResourceIdentityData should return the upgraded resource identity
 	// data for a managed resource type.
 	UpgradeResourceIdentity(context.Context, *UpgradeResourceIdentity_Request) (*UpgradeResourceIdentity_Response, error)
-	// ////// One-time initialization, called before other functions below
+	//////// One-time initialization, called before other functions below
 	Configure(context.Context, *Configure_Request) (*Configure_Response, error)
-	// ////// Managed Resource Lifecycle
+	//////// Managed Resource Lifecycle
 	ReadResource(context.Context, *ReadResource_Request) (*ReadResource_Response, error)
 	PlanResourceChange(context.Context, *PlanResourceChange_Request) (*PlanResourceChange_Response, error)
 	ApplyResourceChange(context.Context, *ApplyResourceChange_Request) (*ApplyResourceChange_Response, error)
@@ -462,23 +462,23 @@ type ProviderServer interface {
 	MoveResourceState(context.Context, *MoveResourceState_Request) (*MoveResourceState_Response, error)
 	ReadDataSource(context.Context, *ReadDataSource_Request) (*ReadDataSource_Response, error)
 	GenerateResourceConfig(context.Context, *GenerateResourceConfig_Request) (*GenerateResourceConfig_Response, error)
-	// ////// Ephemeral Resource Lifecycle
+	//////// Ephemeral Resource Lifecycle
 	ValidateEphemeralResourceConfig(context.Context, *ValidateEphemeralResourceConfig_Request) (*ValidateEphemeralResourceConfig_Response, error)
 	OpenEphemeralResource(context.Context, *OpenEphemeralResource_Request) (*OpenEphemeralResource_Response, error)
 	RenewEphemeralResource(context.Context, *RenewEphemeralResource_Request) (*RenewEphemeralResource_Response, error)
 	CloseEphemeralResource(context.Context, *CloseEphemeralResource_Request) (*CloseEphemeralResource_Response, error)
-	// ///// List
+	/////// List
 	ListResource(*ListResource_Request, Provider_ListResourceServer) error
 	ValidateListResourceConfig(context.Context, *ValidateListResourceConfig_Request) (*ValidateListResourceConfig_Response, error)
 	// GetFunctions returns the definitions of all functions.
 	GetFunctions(context.Context, *GetFunctions_Request) (*GetFunctions_Response, error)
-	// ////// Provider-contributed Functions
+	//////// Provider-contributed Functions
 	CallFunction(context.Context, *CallFunction_Request) (*CallFunction_Response, error)
-	// ////// Actions
+	//////// Actions
 	PlanAction(context.Context, *PlanAction_Request) (*PlanAction_Response, error)
 	InvokeAction(*InvokeAction_Request, Provider_InvokeActionServer) error
 	ValidateActionConfig(context.Context, *ValidateActionConfig_Request) (*ValidateActionConfig_Response, error)
-	// ////// Graceful Shutdown
+	//////// Graceful Shutdown
 	Stop(context.Context, *Stop_Request) (*Stop_Response, error)
 	mustEmbedUnimplementedProviderServer()
 }

--- a/internal/tfplugin6/tfplugin6.pb.go
+++ b/internal/tfplugin6/tfplugin6.pb.go
@@ -5102,9 +5102,9 @@ type PlanResourceChange_Response struct {
 	// specific details of the legacy SDK type system, and are not a general
 	// mechanism to avoid proper type handling in providers.
 	//
-	//	====              DO NOT USE THIS              ====
-	//	==== THIS MUST BE LEFT UNSET IN ALL OTHER SDKS ====
-	//	====              DO NOT USE THIS              ====
+	//     ====              DO NOT USE THIS              ====
+	//     ==== THIS MUST BE LEFT UNSET IN ALL OTHER SDKS ====
+	//     ====              DO NOT USE THIS              ====
 	LegacyTypeSystem bool `protobuf:"varint,5,opt,name=legacy_type_system,json=legacyTypeSystem,proto3" json:"legacy_type_system,omitempty"`
 	// deferred is set if the provider is deferring the change. If set the caller
 	// needs to handle the deferral.
@@ -5298,9 +5298,9 @@ type ApplyResourceChange_Response struct {
 	// specific details of the legacy SDK type system, and are not a general
 	// mechanism to avoid proper type handling in providers.
 	//
-	//	====              DO NOT USE THIS              ====
-	//	==== THIS MUST BE LEFT UNSET IN ALL OTHER SDKS ====
-	//	====              DO NOT USE THIS              ====
+	//     ====              DO NOT USE THIS              ====
+	//     ==== THIS MUST BE LEFT UNSET IN ALL OTHER SDKS ====
+	//     ====              DO NOT USE THIS              ====
 	LegacyTypeSystem bool                  `protobuf:"varint,4,opt,name=legacy_type_system,json=legacyTypeSystem,proto3" json:"legacy_type_system,omitempty"`
 	NewIdentity      *ResourceIdentityData `protobuf:"bytes,5,opt,name=new_identity,json=newIdentity,proto3" json:"new_identity,omitempty"`
 	unknownFields    protoimpl.UnknownFields

--- a/internal/tfplugin6/tfplugin6_grpc.pb.go
+++ b/internal/tfplugin6/tfplugin6_grpc.pb.go
@@ -101,9 +101,9 @@ type ProviderClient interface {
 	// UpgradeResourceIdentityData should return the upgraded resource identity
 	// data for a managed resource type.
 	UpgradeResourceIdentity(ctx context.Context, in *UpgradeResourceIdentity_Request, opts ...grpc.CallOption) (*UpgradeResourceIdentity_Response, error)
-	// ////// One-time initialization, called before other functions below
+	//////// One-time initialization, called before other functions below
 	ConfigureProvider(ctx context.Context, in *ConfigureProvider_Request, opts ...grpc.CallOption) (*ConfigureProvider_Response, error)
-	// ////// Managed Resource Lifecycle
+	//////// Managed Resource Lifecycle
 	ReadResource(ctx context.Context, in *ReadResource_Request, opts ...grpc.CallOption) (*ReadResource_Response, error)
 	PlanResourceChange(ctx context.Context, in *PlanResourceChange_Request, opts ...grpc.CallOption) (*PlanResourceChange_Response, error)
 	ApplyResourceChange(ctx context.Context, in *ApplyResourceChange_Request, opts ...grpc.CallOption) (*ApplyResourceChange_Response, error)
@@ -111,17 +111,17 @@ type ProviderClient interface {
 	MoveResourceState(ctx context.Context, in *MoveResourceState_Request, opts ...grpc.CallOption) (*MoveResourceState_Response, error)
 	ReadDataSource(ctx context.Context, in *ReadDataSource_Request, opts ...grpc.CallOption) (*ReadDataSource_Response, error)
 	GenerateResourceConfig(ctx context.Context, in *GenerateResourceConfig_Request, opts ...grpc.CallOption) (*GenerateResourceConfig_Response, error)
-	// ////// Ephemeral Resource Lifecycle
+	//////// Ephemeral Resource Lifecycle
 	ValidateEphemeralResourceConfig(ctx context.Context, in *ValidateEphemeralResourceConfig_Request, opts ...grpc.CallOption) (*ValidateEphemeralResourceConfig_Response, error)
 	OpenEphemeralResource(ctx context.Context, in *OpenEphemeralResource_Request, opts ...grpc.CallOption) (*OpenEphemeralResource_Response, error)
 	RenewEphemeralResource(ctx context.Context, in *RenewEphemeralResource_Request, opts ...grpc.CallOption) (*RenewEphemeralResource_Response, error)
 	CloseEphemeralResource(ctx context.Context, in *CloseEphemeralResource_Request, opts ...grpc.CallOption) (*CloseEphemeralResource_Response, error)
-	// ///// List
+	/////// List
 	ListResource(ctx context.Context, in *ListResource_Request, opts ...grpc.CallOption) (Provider_ListResourceClient, error)
 	ValidateListResourceConfig(ctx context.Context, in *ValidateListResourceConfig_Request, opts ...grpc.CallOption) (*ValidateListResourceConfig_Response, error)
 	// GetFunctions returns the definitions of all functions.
 	GetFunctions(ctx context.Context, in *GetFunctions_Request, opts ...grpc.CallOption) (*GetFunctions_Response, error)
-	// ////// Provider-contributed Functions
+	//////// Provider-contributed Functions
 	CallFunction(ctx context.Context, in *CallFunction_Request, opts ...grpc.CallOption) (*CallFunction_Response, error)
 	// ValidateStateStoreConfig performs configuration validation
 	ValidateStateStoreConfig(ctx context.Context, in *ValidateStateStore_Request, opts ...grpc.CallOption) (*ValidateStateStore_Response, error)
@@ -139,11 +139,11 @@ type ProviderClient interface {
 	GetStates(ctx context.Context, in *GetStates_Request, opts ...grpc.CallOption) (*GetStates_Response, error)
 	// DeleteState instructs a given state store to delete a specific state (i.e. a CE workspace)
 	DeleteState(ctx context.Context, in *DeleteState_Request, opts ...grpc.CallOption) (*DeleteState_Response, error)
-	// ////// Actions
+	//////// Actions
 	PlanAction(ctx context.Context, in *PlanAction_Request, opts ...grpc.CallOption) (*PlanAction_Response, error)
 	InvokeAction(ctx context.Context, in *InvokeAction_Request, opts ...grpc.CallOption) (Provider_InvokeActionClient, error)
 	ValidateActionConfig(ctx context.Context, in *ValidateActionConfig_Request, opts ...grpc.CallOption) (*ValidateActionConfig_Response, error)
-	// ////// Graceful Shutdown
+	//////// Graceful Shutdown
 	StopProvider(ctx context.Context, in *StopProvider_Request, opts ...grpc.CallOption) (*StopProvider_Response, error)
 }
 
@@ -596,9 +596,9 @@ type ProviderServer interface {
 	// UpgradeResourceIdentityData should return the upgraded resource identity
 	// data for a managed resource type.
 	UpgradeResourceIdentity(context.Context, *UpgradeResourceIdentity_Request) (*UpgradeResourceIdentity_Response, error)
-	// ////// One-time initialization, called before other functions below
+	//////// One-time initialization, called before other functions below
 	ConfigureProvider(context.Context, *ConfigureProvider_Request) (*ConfigureProvider_Response, error)
-	// ////// Managed Resource Lifecycle
+	//////// Managed Resource Lifecycle
 	ReadResource(context.Context, *ReadResource_Request) (*ReadResource_Response, error)
 	PlanResourceChange(context.Context, *PlanResourceChange_Request) (*PlanResourceChange_Response, error)
 	ApplyResourceChange(context.Context, *ApplyResourceChange_Request) (*ApplyResourceChange_Response, error)
@@ -606,17 +606,17 @@ type ProviderServer interface {
 	MoveResourceState(context.Context, *MoveResourceState_Request) (*MoveResourceState_Response, error)
 	ReadDataSource(context.Context, *ReadDataSource_Request) (*ReadDataSource_Response, error)
 	GenerateResourceConfig(context.Context, *GenerateResourceConfig_Request) (*GenerateResourceConfig_Response, error)
-	// ////// Ephemeral Resource Lifecycle
+	//////// Ephemeral Resource Lifecycle
 	ValidateEphemeralResourceConfig(context.Context, *ValidateEphemeralResourceConfig_Request) (*ValidateEphemeralResourceConfig_Response, error)
 	OpenEphemeralResource(context.Context, *OpenEphemeralResource_Request) (*OpenEphemeralResource_Response, error)
 	RenewEphemeralResource(context.Context, *RenewEphemeralResource_Request) (*RenewEphemeralResource_Response, error)
 	CloseEphemeralResource(context.Context, *CloseEphemeralResource_Request) (*CloseEphemeralResource_Response, error)
-	// ///// List
+	/////// List
 	ListResource(*ListResource_Request, Provider_ListResourceServer) error
 	ValidateListResourceConfig(context.Context, *ValidateListResourceConfig_Request) (*ValidateListResourceConfig_Response, error)
 	// GetFunctions returns the definitions of all functions.
 	GetFunctions(context.Context, *GetFunctions_Request) (*GetFunctions_Response, error)
-	// ////// Provider-contributed Functions
+	//////// Provider-contributed Functions
 	CallFunction(context.Context, *CallFunction_Request) (*CallFunction_Response, error)
 	// ValidateStateStoreConfig performs configuration validation
 	ValidateStateStoreConfig(context.Context, *ValidateStateStore_Request) (*ValidateStateStore_Response, error)
@@ -634,11 +634,11 @@ type ProviderServer interface {
 	GetStates(context.Context, *GetStates_Request) (*GetStates_Response, error)
 	// DeleteState instructs a given state store to delete a specific state (i.e. a CE workspace)
 	DeleteState(context.Context, *DeleteState_Request) (*DeleteState_Response, error)
-	// ////// Actions
+	//////// Actions
 	PlanAction(context.Context, *PlanAction_Request) (*PlanAction_Response, error)
 	InvokeAction(*InvokeAction_Request, Provider_InvokeActionServer) error
 	ValidateActionConfig(context.Context, *ValidateActionConfig_Request) (*ValidateActionConfig_Response, error)
-	// ////// Graceful Shutdown
+	//////// Graceful Shutdown
 	StopProvider(context.Context, *StopProvider_Request) (*StopProvider_Response, error)
 	mustEmbedUnimplementedProviderServer()
 }


### PR DESCRIPTION
The first commit in this PR upgrades to Go 1.27 and also deals with an immediate consequence of doing so: the DEFLATE algorithm in the upstream standard library has been optimized in a way that causes it to produce different (but nonetheless equivalent) compressed bytes for given input.

This means that OpenTofu's own `gzip` functions change their results in the same way (mentioned in the changelog) and some of our internal test helpers that produce temporary placeholder provider package archives now produce archives with differing checksums despite having the same uncompressed content.

In the second commit I ran `go fix` on the `command` and `command/arguments` packages per our policy previously agreed in https://github.com/opentofu/opentofu/issues/3773. This development period already saw lots of significant changes to those packages in preparation for adopting a different arguments-processing library and so it's a good candidate for modernization during this development period. Normally I would've done this as a separate PR but I'm combining these together here just because we're getting quite close to the v1.13.0 freeze and so I want to avoid doing two separate code review round-trips.

You can check these two changes separately by [reviewing on a commit-by-commit basis](https://github.com/opentofu/opentofu/pull/4496/commits).

Closes https://github.com/opentofu/opentofu/issues/4308.

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
