### PR TITLE
Upgrade to golangci-lint v2.31.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ protobuf:
 # Golangci-lint is installed first and then run twice to cover all platforms.
 .PHONY: golangci-lint
 golangci-lint:
-	GOBIN=$(PWD)/tools go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.6.0
+	GOBIN=$(PWD)/tools go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.1
 	GOOS=windows tools/golangci-lint${EXT} run --timeout 60m ./...
 	GOOS=linux tools/golangci-lint${EXT} run --timeout 60m ./...
 

--- a/cmd/tofu/help.go
+++ b/cmd/tofu/help.go
@@ -92,7 +92,7 @@ func listCommands(allCommands map[string]cli.CommandFactory, order []string, max
 		}
 
 		key = fmt.Sprintf("%s%s", key, strings.Repeat(" ", maxKeyLen-len(key)))
-		buf.WriteString(fmt.Sprintf("  %s  %s\n", key, command.Synopsis()))
+		fmt.Fprintf(&buf, "  %s  %s\n", key, command.Synopsis())
 	}
 
 	return buf.String()

--- a/internal/addrs/parse_ref.go
+++ b/internal/addrs/parse_ref.go
@@ -50,7 +50,7 @@ func (r *Reference) DisplayString() string {
 			ret.WriteByte('[')
 			switch tStep.Key.Type() {
 			case cty.String:
-				ret.WriteString(fmt.Sprintf("%q", tStep.Key.AsString()))
+				fmt.Fprintf(&ret, "%q", tStep.Key.AsString())
 			case cty.Number:
 				bf := tStep.Key.AsBigFloat()
 				ret.WriteString(bf.Text('g', 10))

--- a/internal/addrs/traversal.go
+++ b/internal/addrs/traversal.go
@@ -33,7 +33,7 @@ func TraversalStr(traversal hcl.Traversal) string {
 			buf.WriteByte('[')
 			switch tStep.Key.Type() {
 			case cty.String:
-				buf.WriteString(fmt.Sprintf("%q", tStep.Key.AsString()))
+				fmt.Fprintf(&buf, "%q", tStep.Key.AsString())
 			case cty.Number:
 				bf := tStep.Key.AsBigFloat()
 				buf.WriteString(bf.Text('g', 10))

--- a/internal/backend/remote-state/s3/backend.go
+++ b/internal/backend/remote-state/s3/backend.go
@@ -1159,12 +1159,12 @@ func pathString(path cty.Path) string {
 			default:
 				s = fmt.Sprintf("<unexpected index: %s>", typ.FriendlyName())
 			}
-			buf.WriteString(fmt.Sprintf("[%s]", s))
+			fmt.Fprintf(&buf, "[%s]", s)
 		default:
 			if i != 0 {
 				buf.WriteString(".")
 			}
-			buf.WriteString(fmt.Sprintf("<unexpected step: %[1]T %[1]v>", x))
+			fmt.Fprintf(&buf, "<unexpected step: %[1]T %[1]v>", x)
 		}
 	}
 	return buf.String()

--- a/internal/command/format/diagnostic.go
+++ b/internal/command/format/diagnostic.go
@@ -216,29 +216,29 @@ func DiagnosticWarningsCompact(diags tfdiags.Diagnostics, color *colorstring.Col
 	b.WriteString(color.Color("[bold][yellow]Warnings:[reset]\n\n"))
 	for _, diag := range diags {
 		sources := tfdiags.ConsolidatedGroupSourceRanges(diag)
-		b.WriteString(fmt.Sprintf("- %s\n", diag.Description().Summary))
+		fmt.Fprintf(&b, "- %s\n", diag.Description().Summary)
 		if len(sources) > 0 {
 			mainSource := sources[0]
 			if mainSource.Subject != nil {
 				if len(sources) > 1 {
-					b.WriteString(fmt.Sprintf(
+					fmt.Fprintf(&b,
 						"  on %s line %d (and %d more)\n",
 						mainSource.Subject.Filename,
 						mainSource.Subject.Start.Line,
 						len(sources)-1,
-					))
+					)
 				} else {
-					b.WriteString(fmt.Sprintf(
+					fmt.Fprintf(&b,
 						"  on %s line %d\n",
 						mainSource.Subject.Filename,
 						mainSource.Subject.Start.Line,
-					))
+					)
 				}
 			} else if len(sources) > 1 {
-				b.WriteString(fmt.Sprintf(
+				fmt.Fprintf(&b,
 					"  (%d occurrences of this warning)\n",
 					len(sources),
-				))
+				)
 			}
 		}
 	}

--- a/internal/command/jsonformat/computed/renderers/block.go
+++ b/internal/command/jsonformat/computed/renderers/block.go
@@ -75,15 +75,15 @@ func (renderer blockRenderer) RenderHuman(diff computed.Diff, indent int, opts c
 	attributeOpts := opts.Clone()
 
 	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("{%s\n", forcesReplacement(diff.Replace, opts)))
+	fmt.Fprintf(&buf, "{%s\n", forcesReplacement(diff.Replace, opts))
 	for _, key := range attributeKeys {
 		attribute := renderer.attributes[key]
 		if importantAttribute(key) {
 			// Always display the important attributes.
 			for _, warning := range attribute.WarningsHuman(indent+1, importantAttributeOpts) {
-				buf.WriteString(fmt.Sprintf("%s%s\n", formatIndent(indent+1), warning))
+				fmt.Fprintf(&buf, "%s%s\n", formatIndent(indent+1), warning)
 			}
-			buf.WriteString(fmt.Sprintf("%s%s%-*s = %s\n", formatIndent(indent+1), writeDiffActionSymbol(attribute.Action, importantAttributeOpts), maximumAttributeKeyLen, key, attribute.RenderHuman(indent+1, importantAttributeOpts)))
+			fmt.Fprintf(&buf, "%s%s%-*s = %s\n", formatIndent(indent+1), writeDiffActionSymbol(attribute.Action, importantAttributeOpts), maximumAttributeKeyLen, key, attribute.RenderHuman(indent+1, importantAttributeOpts))
 			continue
 		}
 		if attribute.Action == plans.NoOp && !opts.ShowUnchangedChildren {
@@ -92,13 +92,13 @@ func (renderer blockRenderer) RenderHuman(diff computed.Diff, indent int, opts c
 		}
 
 		for _, warning := range attribute.WarningsHuman(indent+1, opts) {
-			buf.WriteString(fmt.Sprintf("%s%s\n", formatIndent(indent+1), warning))
+			fmt.Fprintf(&buf, "%s%s\n", formatIndent(indent+1), warning)
 		}
-		buf.WriteString(fmt.Sprintf("%s%s%-*s = %s\n", formatIndent(indent+1), writeDiffActionSymbol(attribute.Action, attributeOpts), maximumAttributeKeyLen, escapedAttributeKeys[key], attribute.RenderHuman(indent+1, attributeOpts)))
+		fmt.Fprintf(&buf, "%s%s%-*s = %s\n", formatIndent(indent+1), writeDiffActionSymbol(attribute.Action, attributeOpts), maximumAttributeKeyLen, escapedAttributeKeys[key], attribute.RenderHuman(indent+1, attributeOpts))
 	}
 
 	if unchangedAttributes > 0 {
-		buf.WriteString(fmt.Sprintf("%s%s%s\n", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts), unchanged("attribute", unchangedAttributes, opts)))
+		fmt.Fprintf(&buf, "%s%s%s\n", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts), unchanged("attribute", unchangedAttributes, opts))
 	}
 
 	blockKeys := renderer.blocks.GetAllKeys()
@@ -140,9 +140,9 @@ func (renderer blockRenderer) RenderHuman(diff computed.Diff, indent int, opts c
 			blockOpts.OverrideForcesReplacement = renderer.blocks.ReplaceBlocks[key]
 
 			for _, warning := range diff.WarningsHuman(indent+1, blockOpts) {
-				buf.WriteString(fmt.Sprintf("%s%s\n", formatIndent(indent+1), warning))
+				fmt.Fprintf(&buf, "%s%s\n", formatIndent(indent+1), warning)
 			}
-			buf.WriteString(fmt.Sprintf("%s%s%s%s %s\n", formatIndent(indent+1), writeDiffActionSymbol(diff.Action, blockOpts), EnsureValidAttributeName(key), mapKey, diff.RenderHuman(indent+1, blockOpts)))
+			fmt.Fprintf(&buf, "%s%s%s%s %s\n", formatIndent(indent+1), writeDiffActionSymbol(diff.Action, blockOpts), EnsureValidAttributeName(key), mapKey, diff.RenderHuman(indent+1, blockOpts))
 		}
 
 		switch {
@@ -173,9 +173,9 @@ func (renderer blockRenderer) RenderHuman(diff computed.Diff, indent int, opts c
 	}
 
 	if unchangedBlocks > 0 {
-		buf.WriteString(fmt.Sprintf("\n%s%s%s\n", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts), unchanged("block", unchangedBlocks, opts)))
+		fmt.Fprintf(&buf, "\n%s%s%s\n", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts), unchanged("block", unchangedBlocks, opts))
 	}
 
-	buf.WriteString(fmt.Sprintf("%s%s}", formatIndent(indent), writeDiffActionSymbol(plans.NoOp, opts)))
+	fmt.Fprintf(&buf, "%s%s}", formatIndent(indent), writeDiffActionSymbol(plans.NoOp, opts))
 	return buf.String()
 }

--- a/internal/command/jsonformat/computed/renderers/list.go
+++ b/internal/command/jsonformat/computed/renderers/list.go
@@ -54,7 +54,7 @@ func (renderer listRenderer) RenderHuman(diff computed.Diff, indent int, opts co
 	renderNext := false
 
 	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("[%s\n", forcesReplacement(diff.Replace, opts)))
+	fmt.Fprintf(&buf, "[%s\n", forcesReplacement(diff.Replace, opts))
 	for _, element := range renderer.elements {
 		if element.Action == plans.NoOp && !renderNext && !opts.ShowUnchangedChildren {
 			unchangedElements = append(unchangedElements, element)
@@ -76,14 +76,14 @@ func (renderer listRenderer) RenderHuman(diff computed.Diff, indent int, opts co
 			// minus 1 as the most recent unchanged element will be printed out
 			// in full.
 			if len(unchangedElements) > 1 {
-				buf.WriteString(fmt.Sprintf("%s%s%s\n", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts), unchanged("element", len(unchangedElements)-1, opts)))
+				fmt.Fprintf(&buf, "%s%s%s\n", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts), unchanged("element", len(unchangedElements)-1, opts))
 			}
 			// If our list of unchanged elements contains at least one entry,
 			// we're going to print out the most recent change in full. That's
 			// what happens here.
 			if len(unchangedElements) > 0 {
 				lastElement := unchangedElements[len(unchangedElements)-1]
-				buf.WriteString(fmt.Sprintf("%s%s%s,\n", formatIndent(indent+1), writeDiffActionSymbol(lastElement.Action, unchangedElementOpts), lastElement.RenderHuman(indent+1, unchangedElementOpts)))
+				fmt.Fprintf(&buf, "%s%s%s,\n", formatIndent(indent+1), writeDiffActionSymbol(lastElement.Action, unchangedElementOpts), lastElement.RenderHuman(indent+1, unchangedElementOpts))
 			}
 			// We now reset the unchanged elements list, we've printed out a
 			// count of all the elements we skipped so we start counting from
@@ -109,9 +109,9 @@ func (renderer listRenderer) RenderHuman(diff computed.Diff, indent int, opts co
 		}
 
 		for _, warning := range element.WarningsHuman(indent+1, opts) {
-			buf.WriteString(fmt.Sprintf("%s%s\n", formatIndent(indent+1), warning))
+			fmt.Fprintf(&buf, "%s%s\n", formatIndent(indent+1), warning)
 		}
-		buf.WriteString(fmt.Sprintf("%s%s%s,\n", formatIndent(indent+1), writeDiffActionSymbol(element.Action, opts), element.RenderHuman(indent+1, opts)))
+		fmt.Fprintf(&buf, "%s%s%s,\n", formatIndent(indent+1), writeDiffActionSymbol(element.Action, opts), element.RenderHuman(indent+1, opts))
 	}
 
 	// If we were not displaying any context alongside our changes then the
@@ -121,9 +121,9 @@ func (renderer listRenderer) RenderHuman(diff computed.Diff, indent int, opts co
 	// If we were displaying context, then this will contain any unchanged
 	// elements since our last change, so we should also print it out.
 	if len(unchangedElements) > 0 {
-		buf.WriteString(fmt.Sprintf("%s%s%s\n", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts), unchanged("element", len(unchangedElements), opts)))
+		fmt.Fprintf(&buf, "%s%s%s\n", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts), unchanged("element", len(unchangedElements), opts))
 	}
 
-	buf.WriteString(fmt.Sprintf("%s%s]%s", formatIndent(indent), writeDiffActionSymbol(plans.NoOp, opts), nullSuffix(diff.Action, opts)))
+	fmt.Fprintf(&buf, "%s%s]%s", formatIndent(indent), writeDiffActionSymbol(plans.NoOp, opts), nullSuffix(diff.Action, opts))
 	return buf.String()
 }

--- a/internal/command/jsonformat/computed/renderers/map.go
+++ b/internal/command/jsonformat/computed/renderers/map.go
@@ -75,7 +75,7 @@ func (renderer mapRenderer) RenderHuman(diff computed.Diff, indent int, opts com
 	elementOpts.OverrideForcesReplacement = forcesReplacementChildren
 
 	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("{%s\n", forcesReplacement(forcesReplacementSelf, opts)))
+	fmt.Fprintf(&buf, "{%s\n", forcesReplacement(forcesReplacementSelf, opts))
 	for _, key := range keys {
 		element := renderer.elements[key]
 
@@ -86,7 +86,7 @@ func (renderer mapRenderer) RenderHuman(diff computed.Diff, indent int, opts com
 		}
 
 		for _, warning := range element.WarningsHuman(indent+1, opts) {
-			buf.WriteString(fmt.Sprintf("%s%s\n", formatIndent(indent+1), warning))
+			fmt.Fprintf(&buf, "%s%s\n", formatIndent(indent+1), warning)
 		}
 		// Only show commas between elements for objects.
 		comma := ""
@@ -95,17 +95,17 @@ func (renderer mapRenderer) RenderHuman(diff computed.Diff, indent int, opts com
 		}
 
 		if renderer.alignKeys {
-			buf.WriteString(fmt.Sprintf("%s%s%-*s = %s%s\n", formatIndent(indent+1), writeDiffActionSymbol(element.Action, elementOpts), maximumKeyLen, escapedKeys[key], element.RenderHuman(indent+1, elementOpts), comma))
+			fmt.Fprintf(&buf, "%s%s%-*s = %s%s\n", formatIndent(indent+1), writeDiffActionSymbol(element.Action, elementOpts), maximumKeyLen, escapedKeys[key], element.RenderHuman(indent+1, elementOpts), comma)
 		} else {
-			buf.WriteString(fmt.Sprintf("%s%s%s = %s%s\n", formatIndent(indent+1), writeDiffActionSymbol(element.Action, elementOpts), escapedKeys[key], element.RenderHuman(indent+1, elementOpts), comma))
+			fmt.Fprintf(&buf, "%s%s%s = %s%s\n", formatIndent(indent+1), writeDiffActionSymbol(element.Action, elementOpts), escapedKeys[key], element.RenderHuman(indent+1, elementOpts), comma)
 		}
 
 	}
 
 	if unchangedElements > 0 {
-		buf.WriteString(fmt.Sprintf("%s%s%s\n", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts), unchanged("element", unchangedElements, opts)))
+		fmt.Fprintf(&buf, "%s%s%s\n", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts), unchanged("element", unchangedElements, opts))
 	}
 
-	buf.WriteString(fmt.Sprintf("%s%s}%s", formatIndent(indent), writeDiffActionSymbol(plans.NoOp, opts), nullSuffix(diff.Action, opts)))
+	fmt.Fprintf(&buf, "%s%s}%s", formatIndent(indent), writeDiffActionSymbol(plans.NoOp, opts), nullSuffix(diff.Action, opts))
 	return buf.String()
 }

--- a/internal/command/jsonformat/computed/renderers/object.go
+++ b/internal/command/jsonformat/computed/renderers/object.go
@@ -64,7 +64,7 @@ func (renderer objectRenderer) RenderHuman(diff computed.Diff, indent int, opts 
 
 	unchangedAttributes := 0
 	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("{%s\n", forcesReplacement(diff.Replace, opts)))
+	fmt.Fprintf(&buf, "{%s\n", forcesReplacement(diff.Replace, opts))
 	for _, key := range keys {
 		attribute := renderer.attributes[key]
 
@@ -73,9 +73,9 @@ func (renderer objectRenderer) RenderHuman(diff computed.Diff, indent int, opts 
 			importantAttributeOpts.ShowUnchangedChildren = true
 
 			for _, warning := range attribute.WarningsHuman(indent+1, importantAttributeOpts) {
-				buf.WriteString(fmt.Sprintf("%s%s\n", formatIndent(indent+1), warning))
+				fmt.Fprintf(&buf, "%s%s\n", formatIndent(indent+1), warning)
 			}
-			buf.WriteString(fmt.Sprintf("%s%s%-*s = %s\n", formatIndent(indent+1), writeDiffActionSymbol(attribute.Action, importantAttributeOpts), maximumKeyLen, escapedKeys[key], attribute.RenderHuman(indent+1, importantAttributeOpts)))
+			fmt.Fprintf(&buf, "%s%s%-*s = %s\n", formatIndent(indent+1), writeDiffActionSymbol(attribute.Action, importantAttributeOpts), maximumKeyLen, escapedKeys[key], attribute.RenderHuman(indent+1, importantAttributeOpts))
 			continue
 		}
 
@@ -86,15 +86,15 @@ func (renderer objectRenderer) RenderHuman(diff computed.Diff, indent int, opts 
 		}
 
 		for _, warning := range attribute.WarningsHuman(indent+1, opts) {
-			buf.WriteString(fmt.Sprintf("%s%s\n", formatIndent(indent+1), warning))
+			fmt.Fprintf(&buf, "%s%s\n", formatIndent(indent+1), warning)
 		}
-		buf.WriteString(fmt.Sprintf("%s%s%-*s = %s\n", formatIndent(indent+1), writeDiffActionSymbol(attribute.Action, attributeOpts), maximumKeyLen, escapedKeys[key], attribute.RenderHuman(indent+1, attributeOpts)))
+		fmt.Fprintf(&buf, "%s%s%-*s = %s\n", formatIndent(indent+1), writeDiffActionSymbol(attribute.Action, attributeOpts), maximumKeyLen, escapedKeys[key], attribute.RenderHuman(indent+1, attributeOpts))
 	}
 
 	if unchangedAttributes > 0 {
-		buf.WriteString(fmt.Sprintf("%s%s%s\n", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts), unchanged("attribute", unchangedAttributes, opts)))
+		fmt.Fprintf(&buf, "%s%s%s\n", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts), unchanged("attribute", unchangedAttributes, opts))
 	}
 
-	buf.WriteString(fmt.Sprintf("%s%s}%s", formatIndent(indent), writeDiffActionSymbol(plans.NoOp, opts), nullSuffix(diff.Action, opts)))
+	fmt.Fprintf(&buf, "%s%s}%s", formatIndent(indent), writeDiffActionSymbol(plans.NoOp, opts), nullSuffix(diff.Action, opts))
 	return buf.String()
 }

--- a/internal/command/jsonformat/computed/renderers/set.go
+++ b/internal/command/jsonformat/computed/renderers/set.go
@@ -55,7 +55,7 @@ func (renderer setRenderer) RenderHuman(diff computed.Diff, indent int, opts com
 	unchangedElements := 0
 
 	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("[%s\n", forcesReplacement(displayForcesReplacementInSelf, opts)))
+	fmt.Fprintf(&buf, "[%s\n", forcesReplacement(displayForcesReplacementInSelf, opts))
 	for _, element := range renderer.elements {
 		if element.Action == plans.NoOp && !opts.ShowUnchangedChildren {
 			unchangedElements++
@@ -63,15 +63,15 @@ func (renderer setRenderer) RenderHuman(diff computed.Diff, indent int, opts com
 		}
 
 		for _, warning := range element.WarningsHuman(indent+1, opts) {
-			buf.WriteString(fmt.Sprintf("%s%s\n", formatIndent(indent+1), warning))
+			fmt.Fprintf(&buf, "%s%s\n", formatIndent(indent+1), warning)
 		}
-		buf.WriteString(fmt.Sprintf("%s%s%s,\n", formatIndent(indent+1), writeDiffActionSymbol(element.Action, elementOpts), element.RenderHuman(indent+1, elementOpts)))
+		fmt.Fprintf(&buf, "%s%s%s,\n", formatIndent(indent+1), writeDiffActionSymbol(element.Action, elementOpts), element.RenderHuman(indent+1, elementOpts))
 	}
 
 	if unchangedElements > 0 {
-		buf.WriteString(fmt.Sprintf("%s%s%s\n", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts), unchanged("element", unchangedElements, opts)))
+		fmt.Fprintf(&buf, "%s%s%s\n", formatIndent(indent+1), writeDiffActionSymbol(plans.NoOp, opts), unchanged("element", unchangedElements, opts))
 	}
 
-	buf.WriteString(fmt.Sprintf("%s%s]%s", formatIndent(indent), writeDiffActionSymbol(plans.NoOp, opts), nullSuffix(diff.Action, opts)))
+	fmt.Fprintf(&buf, "%s%s]%s", formatIndent(indent), writeDiffActionSymbol(plans.NoOp, opts), nullSuffix(diff.Action, opts))
 	return buf.String()
 }

--- a/internal/command/jsonformat/plan.go
+++ b/internal/command/jsonformat/plan.go
@@ -408,7 +408,7 @@ func renderHumanDiff(renderer Renderer, diff diff, cause string) (string, bool) 
 	}
 	opts.ShowUnchangedChildren = diff.Importing()
 
-	buf.WriteString(fmt.Sprintf("%s %s %s", renderer.Colorize.Color(renderers.DiffActionSymbol(action)), resourceChangeHeader(diff.change), diff.diff.RenderHuman(0, opts)))
+	fmt.Fprintf(&buf, "%s %s %s", renderer.Colorize.Color(renderers.DiffActionSymbol(action)), resourceChangeHeader(diff.change), diff.diff.RenderHuman(0, opts))
 	return buf.String(), true
 }
 
@@ -424,9 +424,9 @@ func resourceChangeComment(resource jsonplan.ResourceChange, action plans.Action
 
 	switch action {
 	case plans.Create:
-		buf.WriteString(fmt.Sprintf("[bold]  # %s[reset] will be created", dispAddr))
+		fmt.Fprintf(&buf, "[bold]  # %s[reset] will be created", dispAddr)
 	case plans.Read:
-		buf.WriteString(fmt.Sprintf("[bold]  # %s[reset] will be read during apply", dispAddr))
+		fmt.Fprintf(&buf, "[bold]  # %s[reset] will be read during apply", dispAddr)
 		switch resource.ActionReason {
 		case jsonplan.ResourceInstanceReadBecauseConfigUnknown:
 			buf.WriteString("\n  # (config refers to values not yet known)")
@@ -438,31 +438,31 @@ func resourceChangeComment(resource jsonplan.ResourceChange, action plans.Action
 	case plans.Update:
 		switch changeCause {
 		case proposedChange:
-			buf.WriteString(fmt.Sprintf("[bold]  # %s[reset] will be updated in-place", dispAddr))
+			fmt.Fprintf(&buf, "[bold]  # %s[reset] will be updated in-place", dispAddr)
 		case detectedDrift:
-			buf.WriteString(fmt.Sprintf("[bold]  # %s[reset] has changed", dispAddr))
+			fmt.Fprintf(&buf, "[bold]  # %s[reset] has changed", dispAddr)
 		default:
-			buf.WriteString(fmt.Sprintf("[bold]  # %s[reset] update (unknown reason %s)", dispAddr, changeCause))
+			fmt.Fprintf(&buf, "[bold]  # %s[reset] update (unknown reason %s)", dispAddr, changeCause)
 		}
 	case plans.CreateThenDelete, plans.DeleteThenCreate:
 		switch resource.ActionReason {
 		case jsonplan.ResourceInstanceReplaceBecauseTainted:
-			buf.WriteString(fmt.Sprintf("[bold]  # %s[reset] is tainted, so it must be [bold][red]replaced[reset]", dispAddr))
+			fmt.Fprintf(&buf, "[bold]  # %s[reset] is tainted, so it must be [bold][red]replaced[reset]", dispAddr)
 		case jsonplan.ResourceInstanceReplaceByRequest:
-			buf.WriteString(fmt.Sprintf("[bold]  # %s[reset] will be [bold][red]replaced[reset], as requested", dispAddr))
+			fmt.Fprintf(&buf, "[bold]  # %s[reset] will be [bold][red]replaced[reset], as requested", dispAddr)
 		case jsonplan.ResourceInstanceReplaceByTriggers:
-			buf.WriteString(fmt.Sprintf("[bold]  # %s[reset] will be [bold][red]replaced[reset] due to changes in replace_triggered_by", dispAddr))
+			fmt.Fprintf(&buf, "[bold]  # %s[reset] will be [bold][red]replaced[reset] due to changes in replace_triggered_by", dispAddr)
 		default:
-			buf.WriteString(fmt.Sprintf("[bold]  # %s[reset] must be [bold][red]replaced[reset]", dispAddr))
+			fmt.Fprintf(&buf, "[bold]  # %s[reset] must be [bold][red]replaced[reset]", dispAddr)
 		}
 	case plans.Delete:
 		switch changeCause {
 		case proposedChange:
-			buf.WriteString(fmt.Sprintf("[bold]  # %s[reset] will be [bold][red]destroyed[reset]", dispAddr))
+			fmt.Fprintf(&buf, "[bold]  # %s[reset] will be [bold][red]destroyed[reset]", dispAddr)
 		case detectedDrift:
-			buf.WriteString(fmt.Sprintf("[bold]  # %s[reset] has been deleted", dispAddr))
+			fmt.Fprintf(&buf, "[bold]  # %s[reset] has been deleted", dispAddr)
 		default:
-			buf.WriteString(fmt.Sprintf("[bold]  # %s[reset] delete (unknown reason %s)", dispAddr, changeCause))
+			fmt.Fprintf(&buf, "[bold]  # %s[reset] delete (unknown reason %s)", dispAddr, changeCause)
 		}
 		// We can sometimes give some additional detail about why we're
 		// proposing to delete. We show this as additional notes, rather than
@@ -471,16 +471,16 @@ func resourceChangeComment(resource jsonplan.ResourceChange, action plans.Action
 		// in all cases, for easier scanning of this often-risky action.
 		switch resource.ActionReason {
 		case jsonplan.ResourceInstanceDeleteBecauseNoResourceConfig:
-			buf.WriteString(fmt.Sprintf("\n  # (because %s.%s is not in configuration)", resource.Type, resource.Name))
+			fmt.Fprintf(&buf, "\n  # (because %s.%s is not in configuration)", resource.Type, resource.Name)
 		case jsonplan.ResourceInstanceDeleteBecauseNoMoveTarget:
-			buf.WriteString(fmt.Sprintf("\n  # (because %s was moved to %s, which is not in configuration)", resource.PreviousAddress, resource.Address))
+			fmt.Fprintf(&buf, "\n  # (because %s was moved to %s, which is not in configuration)", resource.PreviousAddress, resource.Address)
 		case jsonplan.ResourceInstanceDeleteBecauseNoModule:
 			// FIXME: Ideally we'd truncate addr.Module to reflect the earliest
 			// step that doesn't exist, so it's clearer which call this refers
 			// to, but we don't have enough information out here in the UI layer
 			// to decide that; only the "expander" in OpenTofu Core knows
 			// which module instance keys are actually declared.
-			buf.WriteString(fmt.Sprintf("\n  # (because %s is not in configuration)", resource.ModuleAddress))
+			fmt.Fprintf(&buf, "\n  # (because %s is not in configuration)", resource.ModuleAddress)
 		case jsonplan.ResourceInstanceDeleteBecauseWrongRepetition:
 			var index interface{}
 			if resource.Index != nil {
@@ -499,11 +499,11 @@ func resourceChangeComment(resource jsonplan.ResourceChange, action plans.Action
 				buf.WriteString("\n  # (because resource does not use for_each)")
 			}
 		case jsonplan.ResourceInstanceDeleteBecauseCountIndex:
-			buf.WriteString(fmt.Sprintf("\n  # (because index [%s] is out of range for count)", resource.Index))
+			fmt.Fprintf(&buf, "\n  # (because index [%s] is out of range for count)", resource.Index)
 		case jsonplan.ResourceInstanceDeleteBecauseEnabledFalse:
 			buf.WriteString("\n  # (because enabled is false)")
 		case jsonplan.ResourceInstanceDeleteBecauseEachKey:
-			buf.WriteString(fmt.Sprintf("\n  # (because key [%s] is not in for_each map)", resource.Index))
+			fmt.Fprintf(&buf, "\n  # (because key [%s] is not in for_each map)", resource.Index)
 		}
 		if len(resource.Deposed) != 0 {
 			// In the case where we partially failed to replace a resource
@@ -513,7 +513,7 @@ func resourceChangeComment(resource jsonplan.ResourceChange, action plans.Action
 			buf.WriteString("\n  # (left over from a partially-failed replacement of this instance)")
 		}
 	case plans.Forget:
-		buf.WriteString(fmt.Sprintf("[bold]  # %s[reset] will be removed from the OpenTofu state [bold][red]but will not be destroyed[reset]", dispAddr))
+		fmt.Fprintf(&buf, "[bold]  # %s[reset] will be removed from the OpenTofu state [bold][red]but will not be destroyed[reset]", dispAddr)
 
 		// We need to identify a special case where the resource is being forgotten instead of destroyed due to lifecycle.destroy attribute
 		// There are two cases where this can happen: when lifecycle.destroy = false is set in the configuration, and when lifecycle.destroy = false is persisted in state.
@@ -538,13 +538,13 @@ func resourceChangeComment(resource jsonplan.ResourceChange, action plans.Action
 	case plans.ForgetThenCreate:
 		switch resource.ActionReason {
 		case jsonplan.ResourceInstanceReplaceBecauseTainted:
-			buf.WriteString(fmt.Sprintf("[bold]  # %s[reset] is tainted, so it must be [bold][red]replaced[reset]", dispAddr))
+			fmt.Fprintf(&buf, "[bold]  # %s[reset] is tainted, so it must be [bold][red]replaced[reset]", dispAddr)
 		case jsonplan.ResourceInstanceReplaceByRequest:
-			buf.WriteString(fmt.Sprintf("[bold]  # %s[reset] will be [bold][red]replaced[reset], as requested", dispAddr))
+			fmt.Fprintf(&buf, "[bold]  # %s[reset] will be [bold][red]replaced[reset], as requested", dispAddr)
 		case jsonplan.ResourceInstanceReplaceByTriggers:
-			buf.WriteString(fmt.Sprintf("[bold]  # %s[reset] will be [bold][red]replaced[reset] due to changes in replace_triggered_by", dispAddr))
+			fmt.Fprintf(&buf, "[bold]  # %s[reset] will be [bold][red]replaced[reset] due to changes in replace_triggered_by", dispAddr)
 		default:
-			buf.WriteString(fmt.Sprintf("[bold]  # %s[reset] must be [bold][red]replaced[reset]", dispAddr))
+			fmt.Fprintf(&buf, "[bold]  # %s[reset] must be [bold][red]replaced[reset]", dispAddr)
 		}
 		buf.WriteString(" - [yellow]older instance will [bold]not[reset][yellow] be destroyed [reset]([bold]lifecycle.destroy = false[reset])")
 
@@ -557,12 +557,12 @@ func resourceChangeComment(resource jsonplan.ResourceChange, action plans.Action
 		}
 	case plans.NoOp:
 		if len(resource.PreviousAddress) > 0 && resource.PreviousAddress != resource.Address {
-			buf.WriteString(fmt.Sprintf("[bold]  # %s[reset] has moved to [bold]%s[reset]", resource.PreviousAddress, dispAddr))
+			fmt.Fprintf(&buf, "[bold]  # %s[reset] has moved to [bold]%s[reset]", resource.PreviousAddress, dispAddr)
 			printedMoved = true
 			break
 		}
 		if resource.Change.Importing != nil {
-			buf.WriteString(fmt.Sprintf("[bold]  # %s[reset] will be imported", dispAddr))
+			fmt.Fprintf(&buf, "[bold]  # %s[reset] will be imported", dispAddr)
 			if len(resource.Change.GeneratedConfig) > 0 {
 				buf.WriteString("\n  #[reset] (config will be generated)")
 			}
@@ -571,12 +571,12 @@ func resourceChangeComment(resource jsonplan.ResourceChange, action plans.Action
 		fallthrough
 	default:
 		// should never happen, since the above is exhaustive
-		buf.WriteString(fmt.Sprintf("%s has an action the plan renderer doesn't support (this is a bug)", dispAddr))
+		fmt.Fprintf(&buf, "%s has an action the plan renderer doesn't support (this is a bug)", dispAddr)
 	}
 	buf.WriteString("\n")
 
 	if len(resource.PreviousAddress) > 0 && resource.PreviousAddress != resource.Address && !printedMoved {
-		buf.WriteString(fmt.Sprintf("  # [reset](moved from %s)\n", resource.PreviousAddress))
+		fmt.Fprintf(&buf, "  # [reset](moved from %s)\n", resource.PreviousAddress)
 	}
 	if resource.Change.Importing != nil {
 		// We want to make this as forward compatible as possible, and we know
@@ -586,7 +586,7 @@ func resourceChangeComment(resource jsonplan.ResourceChange, action plans.Action
 		// being removed in the future will mean this renderer will receive it
 		// as an empty string
 		if len(resource.Change.Importing.ID) > 0 {
-			buf.WriteString(fmt.Sprintf("  # [reset](imported from \"%s\")\n", resource.Change.Importing.ID))
+			fmt.Fprintf(&buf, "  # [reset](imported from \"%s\")\n", resource.Change.Importing.ID)
 		} else if len(resource.Change.Importing.Identity) > 0 {
 			// We want to render the identity here in it's json format for now, in the future we should reconsider how this is rendered by for now this is good enough
 			var jsonOut bytes.Buffer
@@ -594,10 +594,10 @@ func resourceChangeComment(resource jsonplan.ResourceChange, action plans.Action
 			if err != nil {
 				// If we fail to indent the JSON for any reason, we should still render the raw identity string,
 				// as it's better than rendering nothing at all and this is just an extra detail for the user
-				buf.WriteString(fmt.Sprintf("  # [reset]imported using resource identity \"%s\"\n", resource.Change.Importing.Identity))
+				fmt.Fprintf(&buf, "  # [reset]imported using resource identity \"%s\"\n", resource.Change.Importing.Identity)
 			} else {
 				// If we successfully indented the JSON, we should render it in a more human friendly way with new lines and indentation
-				buf.WriteString(fmt.Sprintf("  # [reset]imported using resource identity: %s\n", jsonOut.String()))
+				fmt.Fprintf(&buf, "  # [reset]imported using resource identity: %s\n", jsonOut.String())
 			}
 		} else {
 			buf.WriteString("  # [reset](will be imported first)\n")

--- a/internal/command/meta_providers.go
+++ b/internal/command/meta_providers.go
@@ -162,7 +162,7 @@ func (m *Meta) providerDevOverrideInitWarnings() tfdiags.Diagnostics {
 	var detailMsg strings.Builder
 	detailMsg.WriteString("The following provider development overrides are set in the CLI configuration:\n")
 	for addr, path := range m.ProviderDevOverrides {
-		detailMsg.WriteString(fmt.Sprintf(" - %s in %s\n", addr.ForDisplay(), path))
+		fmt.Fprintf(&detailMsg, " - %s in %s\n", addr.ForDisplay(), path)
 	}
 	detailMsg.WriteString("\nSkip tofu init when using provider development overrides. It is not necessary and may error unexpectedly.")
 	return tfdiags.Diagnostics{
@@ -194,7 +194,7 @@ func (m *Meta) providerDevOverrideRuntimeWarnings() tfdiags.Diagnostics {
 	var detailMsg strings.Builder
 	detailMsg.WriteString("The following provider development overrides are set in the CLI configuration:\n")
 	for addr, path := range m.ProviderDevOverrides {
-		detailMsg.WriteString(fmt.Sprintf(" - %s in %s\n", addr.ForDisplay(), path))
+		fmt.Fprintf(&detailMsg, " - %s in %s\n", addr.ForDisplay(), path)
 	}
 	detailMsg.WriteString("\nThe behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.")
 	return tfdiags.Diagnostics{

--- a/internal/command/ui_input.go
+++ b/internal/command/ui_input.go
@@ -97,11 +97,11 @@ func (i *UIInput) Input(ctx context.Context, opts *tofu.InputOpts) (string, erro
 	// Build the output format for asking
 	var buf bytes.Buffer
 	buf.WriteString("[reset]")
-	buf.WriteString(fmt.Sprintf("[bold]%s[reset]\n", opts.Query))
+	fmt.Fprintf(&buf, "[bold]%s[reset]\n", opts.Query)
 	if opts.Description != "" {
 		s := bufio.NewScanner(strings.NewReader(opts.Description))
 		for s.Scan() {
-			buf.WriteString(fmt.Sprintf("  %s\n", s.Text()))
+			fmt.Fprintf(&buf, "  %s\n", s.Text())
 		}
 		buf.WriteString("\n")
 	}

--- a/internal/command/views/hook_ui.go
+++ b/internal/command/views/hook_ui.go
@@ -277,7 +277,7 @@ func (h *UiHook) ProvisionOutput(addr addrs.AbsResourceInstance, typeName string
 	for s.Scan() {
 		line := strings.TrimRightFunc(s.Text(), unicode.IsSpace)
 		if line != "" {
-			buf.WriteString(fmt.Sprintf("%s%s\n", prefix, line))
+			fmt.Fprintf(&buf, "%s%s\n", prefix, line)
 		}
 	}
 

--- a/internal/command/views/json/change_summary.go
+++ b/internal/command/views/json/change_summary.go
@@ -36,11 +36,11 @@ func (cs *ChangeSummary) String() string {
 	case OperationApplied:
 		builder.WriteString("Apply complete! Resources: ")
 		if cs.Import > 0 {
-			builder.WriteString(fmt.Sprintf("%d imported, ", cs.Import))
+			fmt.Fprintf(&builder, "%d imported, ", cs.Import)
 		}
-		builder.WriteString(fmt.Sprintf("%d added, %d changed, %d destroyed", cs.Add, cs.Change, cs.Remove))
+		fmt.Fprintf(&builder, "%d added, %d changed, %d destroyed", cs.Add, cs.Change, cs.Remove)
 		if cs.Forget > 0 {
-			builder.WriteString(fmt.Sprintf(", %d forgotten.", cs.Forget))
+			fmt.Fprintf(&builder, ", %d forgotten.", cs.Forget)
 		} else {
 			builder.WriteString(".")
 		}
@@ -50,11 +50,11 @@ func (cs *ChangeSummary) String() string {
 	case OperationPlanned:
 		builder.WriteString("Plan: ")
 		if cs.Import > 0 {
-			builder.WriteString(fmt.Sprintf("%d to import, ", cs.Import))
+			fmt.Fprintf(&builder, "%d to import, ", cs.Import)
 		}
-		builder.WriteString(fmt.Sprintf("%d to add, %d to change, %d to destroy", cs.Add, cs.Change, cs.Remove))
+		fmt.Fprintf(&builder, "%d to add, %d to change, %d to destroy", cs.Add, cs.Change, cs.Remove)
 		if cs.Forget > 0 {
-			builder.WriteString(fmt.Sprintf(", %d to forget.", cs.Forget))
+			fmt.Fprintf(&builder, ", %d to forget.", cs.Forget)
 		} else {
 			builder.WriteString(".")
 		}

--- a/internal/command/views/test.go
+++ b/internal/command/views/test.go
@@ -430,7 +430,7 @@ func (t *TestJSON) Conclusion(suite *moduletest.Suite) {
 		// Then no tests.
 		message.WriteString("Executed 0 tests")
 		if summary.Skipped > 0 {
-			message.WriteString(fmt.Sprintf(", %d skipped.", summary.Skipped))
+			fmt.Fprintf(&message, ", %d skipped.", summary.Skipped)
 		} else {
 			message.WriteString(".")
 		}
@@ -441,9 +441,9 @@ func (t *TestJSON) Conclusion(suite *moduletest.Suite) {
 			message.WriteString("Failure!")
 		}
 
-		message.WriteString(fmt.Sprintf(" %d passed, %d failed", summary.Passed, summary.Failed+summary.Errored))
+		fmt.Fprintf(&message, " %d passed, %d failed", summary.Passed, summary.Failed+summary.Errored)
 		if summary.Skipped > 0 {
-			message.WriteString(fmt.Sprintf(", %d skipped.", summary.Skipped))
+			fmt.Fprintf(&message, ", %d skipped.", summary.Skipped)
 		} else {
 			message.WriteString(".")
 		}

--- a/internal/configs/config_test.go
+++ b/internal/configs/config_test.go
@@ -859,7 +859,7 @@ func TestTransformForTest(t *testing.T) {
 	str := func(providers map[string]string) string {
 		var buffer bytes.Buffer
 		for key, config := range providers {
-			buffer.WriteString(fmt.Sprintf("%s: %s\n", key, config))
+			fmt.Fprintf(&buffer, "%s: %s\n", key, config)
 		}
 		return buffer.String()
 	}

--- a/internal/dag/dot.go
+++ b/internal/dag/dot.go
@@ -111,7 +111,7 @@ func (v *marshalVertex) dot(g *marshalGraph, opts *DotOpts) []byte {
 		attrs = newAttrs
 	}
 
-	buf.WriteString(fmt.Sprintf(`"[%s] %s"`, graphName, name))
+	fmt.Fprintf(&buf, `"[%s] %s"`, graphName, name)
 	writeAttrs(&buf, attrs)
 	buf.WriteByte('\n')
 

--- a/internal/dag/graph.go
+++ b/internal/dag/graph.go
@@ -279,7 +279,7 @@ func (g *Graph) StringWithNodeTypes() string {
 		v := mapping[name]
 		targets := g.downEdges[hashcode(v)]
 
-		buf.WriteString(fmt.Sprintf("%s - %T\n", name, v))
+		fmt.Fprintf(&buf, "%s - %T\n", name, v)
 
 		// Alphabetize dependencies
 		deps := make([]string, 0, targets.Len())
@@ -293,7 +293,7 @@ func (g *Graph) StringWithNodeTypes() string {
 
 		// Write dependencies
 		for _, d := range deps {
-			buf.WriteString(fmt.Sprintf("  %s - %T\n", d, targetNodes[d]))
+			fmt.Fprintf(&buf, "  %s - %T\n", d, targetNodes[d])
 		}
 	}
 
@@ -321,7 +321,7 @@ func (g *Graph) String() string {
 		v := mapping[name]
 		targets := g.downEdges[hashcode(v)]
 
-		buf.WriteString(fmt.Sprintf("%s\n", name))
+		fmt.Fprintf(&buf, "%s\n", name)
 
 		// Alphabetize dependencies
 		deps := make([]string, 0, targets.Len())
@@ -332,7 +332,7 @@ func (g *Graph) String() string {
 
 		// Write dependencies
 		for _, d := range deps {
-			buf.WriteString(fmt.Sprintf("  %s\n", d))
+			fmt.Fprintf(&buf, "  %s\n", d)
 		}
 	}
 

--- a/internal/dag/marshal.go
+++ b/internal/dag/marshal.go
@@ -162,7 +162,7 @@ func newMarshalGraph(name string, g *Graph) *marshalGraph {
 func marshalVertexID(v Vertex) string {
 	val := reflect.ValueOf(v)
 	switch val.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Slice, reflect.UnsafePointer:
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.Slice, reflect.UnsafePointer:
 		return strconv.Itoa(int(val.Pointer()))
 	case reflect.Interface:
 		// A vertex shouldn't contain another layer of interface, but handle

--- a/internal/encryption/compliancetest/config_struct.go
+++ b/internal/encryption/compliancetest/config_struct.go
@@ -22,7 +22,7 @@ func ConfigStruct[TConfig any](t *testing.T, configStruct any) {
 	}
 
 	configStructPtrType := reflect.TypeOf(configStruct)
-	if configStructPtrType.Kind() != reflect.Ptr {
+	if configStructPtrType.Kind() != reflect.Pointer {
 		Fail(t, "The ConfigStruct() method returns a %T, but it should return a pointer to a struct.", configStruct)
 	} else {
 		Log(t, "The ConfigStruct() method returned a pointer.")

--- a/internal/genconfig/generate_config.go
+++ b/internal/genconfig/generate_config.go
@@ -39,7 +39,7 @@ func GenerateResourceContents(addr addrs.AbsResourceInstance,
 
 	if pc.LocalName != addr.Resource.Resource.ImpliedProvider() || pc.Alias != "" {
 		buf.WriteString(strings.Repeat(" ", 2))
-		buf.WriteString(fmt.Sprintf("provider = %s\n", pc.StringCompact()))
+		fmt.Fprintf(&buf, "provider = %s\n", pc.StringCompact())
 	}
 
 	stateVal = omitUnknowns(stateVal)
@@ -59,7 +59,7 @@ func GenerateResourceContents(addr addrs.AbsResourceInstance,
 func WrapResourceContents(addr addrs.AbsResourceInstance, config string) string {
 	var buf strings.Builder
 
-	buf.WriteString(fmt.Sprintf("resource %q %q {\n", addr.Resource.Resource.Type, addr.Resource.Resource.Name))
+	fmt.Fprintf(&buf, "resource %q %q {\n", addr.Resource.Resource.Type, addr.Resource.Resource.Name)
 	buf.WriteString(config)
 	buf.WriteString("}")
 

--- a/internal/lang/funcs/crypto.go
+++ b/internal/lang/funcs/crypto.go
@@ -184,6 +184,12 @@ var RsaDecryptFunc = function.New(&function.Spec{
 			return cty.UnknownVal(cty.String), function.NewArgErrorf(1, "invalid private key type %t", rawKey)
 		}
 
+		// TODO: Consider whether there's any possible migration path away from
+		// using PKCS #1 v1.5 here without breaking compatibility. If not, then
+		// we should echo the upstream deprecation by documenting that our own
+		// rsadecrypt function is deprecated too. For now though, we'll just
+		// quiet the linter.
+		//nolint:staticcheck // The upstream function is deprecated, but the behavior of our rsadecrypt function is protected by compatibility promises
 		out, err := rsa.DecryptPKCS1v15(nil, privateKey, b)
 		if err != nil {
 			return cty.UnknownVal(cty.String), fmt.Errorf("failed to decrypt: %w", err)

--- a/internal/legacy/helper/hashcode/hashcode.go
+++ b/internal/legacy/helper/hashcode/hashcode.go
@@ -40,7 +40,7 @@ func Strings(strings []string) string {
 	var buf bytes.Buffer
 
 	for _, s := range strings {
-		buf.WriteString(fmt.Sprintf("%s-", s))
+		fmt.Fprintf(&buf, "%s-", s)
 	}
 
 	return fmt.Sprintf("%d", String(buf.String()))

--- a/internal/legacy/helper/schema/field_reader_config_test.go
+++ b/internal/legacy/helper/schema/field_reader_config_test.go
@@ -463,8 +463,8 @@ func TestConfigFieldReader_computedComplexSet(t *testing.T) {
 	hashfunc := func(v interface{}) int {
 		var buf bytes.Buffer
 		m := v.(map[string]interface{})
-		buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
-		buf.WriteString(fmt.Sprintf("%s-", m["vhd_uri"].(string)))
+		fmt.Fprintf(&buf, "%s-", m["name"].(string))
+		fmt.Fprintf(&buf, "%s-", m["vhd_uri"].(string))
 		return hashcode.String(buf.String())
 	}
 

--- a/internal/legacy/helper/schema/resource_data.go
+++ b/internal/legacy/helper/schema/resource_data.go
@@ -182,7 +182,7 @@ func (d *ResourceData) Set(key string, value interface{}) error {
 	// use that. This allows Set to take a pointer to primitives to
 	// simplify the interface.
 	reflectVal := reflect.ValueOf(value)
-	if reflectVal.Kind() == reflect.Ptr {
+	if reflectVal.Kind() == reflect.Pointer {
 		if reflectVal.IsNil() {
 			// If the pointer is nil, then the value is just nil
 			value = nil

--- a/internal/legacy/helper/schema/schema_test.go
+++ b/internal/legacy/helper/schema/schema_test.go
@@ -1958,8 +1958,8 @@ func TestSchemaMap_Diff(t *testing.T) {
 					Set: func(v interface{}) int {
 						var buf bytes.Buffer
 						m := v.(map[string]interface{})
-						buf.WriteString(fmt.Sprintf("%s-", m["device_name"].(string)))
-						buf.WriteString(fmt.Sprintf("%t-", m["delete_on_termination"].(bool)))
+						fmt.Fprintf(&buf, "%s-", m["device_name"].(string))
+						fmt.Fprintf(&buf, "%t-", m["delete_on_termination"].(bool))
 						return hashcode.String(buf.String())
 					},
 				},

--- a/internal/legacy/helper/schema/shims_test.go
+++ b/internal/legacy/helper/schema/shims_test.go
@@ -2259,8 +2259,8 @@ func TestShimSchemaMap_Diff(t *testing.T) {
 					Set: func(v interface{}) int {
 						var buf bytes.Buffer
 						m := v.(map[string]interface{})
-						buf.WriteString(fmt.Sprintf("%s-", m["device_name"].(string)))
-						buf.WriteString(fmt.Sprintf("%t-", m["delete_on_termination"].(bool)))
+						fmt.Fprintf(&buf, "%s-", m["device_name"].(string))
+						fmt.Fprintf(&buf, "%t-", m["delete_on_termination"].(bool))
 						return hashcode.String(buf.String())
 					},
 				},

--- a/internal/legacy/tofu/diff.go
+++ b/internal/legacy/tofu/diff.go
@@ -212,11 +212,11 @@ func (d *Diff) String() string {
 			continue
 		}
 
-		buf.WriteString(fmt.Sprintf("%s:\n", key))
+		fmt.Fprintf(&buf, "%s:\n", key)
 
 		s := bufio.NewScanner(strings.NewReader(mStr))
 		for s.Scan() {
-			buf.WriteString(fmt.Sprintf("  %s\n", s.Text()))
+			fmt.Fprintf(&buf, "  %s\n", s.Text())
 		}
 	}
 

--- a/internal/legacy/tofu/state.go
+++ b/internal/legacy/tofu/state.go
@@ -756,7 +756,7 @@ func (s *State) String() string {
 			continue
 		}
 
-		buf.WriteString(fmt.Sprintf("module.%s:\n", strings.Join(m.Path[1:], ".")))
+		fmt.Fprintf(&buf, "module.%s:\n", strings.Join(m.Path[1:], "."))
 
 		s := bufio.NewScanner(strings.NewReader(mStr))
 		for s.Scan() {
@@ -765,7 +765,7 @@ func (s *State) String() string {
 				text = "  " + text
 			}
 
-			buf.WriteString(fmt.Sprintf("%s\n", text))
+			fmt.Fprintf(&buf, "%s\n", text)
 		}
 	}
 
@@ -1255,10 +1255,10 @@ func (m *ModuleState) String() string {
 			deposedStr = fmt.Sprintf(" (%d deposed)", len(rs.Deposed))
 		}
 
-		buf.WriteString(fmt.Sprintf("%s:%s%s\n", k, taintStr, deposedStr))
-		buf.WriteString(fmt.Sprintf("  ID = %s\n", id))
+		fmt.Fprintf(&buf, "%s:%s%s\n", k, taintStr, deposedStr)
+		fmt.Fprintf(&buf, "  ID = %s\n", id)
 		if rs.Provider != "" {
-			buf.WriteString(fmt.Sprintf("  provider = %s\n", rs.Provider))
+			fmt.Fprintf(&buf, "  provider = %s\n", rs.Provider)
 		}
 
 		var attributes map[string]string
@@ -1278,7 +1278,7 @@ func (m *ModuleState) String() string {
 
 		for _, ak := range attrKeys {
 			av := attributes[ak]
-			buf.WriteString(fmt.Sprintf("  %s = %s\n", ak, av))
+			fmt.Fprintf(&buf, "  %s = %s\n", ak, av)
 		}
 
 		for idx, t := range rs.Deposed {
@@ -1286,13 +1286,13 @@ func (m *ModuleState) String() string {
 			if t.Tainted {
 				taintStr = " (tainted)"
 			}
-			buf.WriteString(fmt.Sprintf("  Deposed ID %d = %s%s\n", idx+1, t.ID, taintStr))
+			fmt.Fprintf(&buf, "  Deposed ID %d = %s%s\n", idx+1, t.ID, taintStr)
 		}
 
 		if len(rs.Dependencies) > 0 {
-			buf.WriteString(fmt.Sprintf("\n  Dependencies:\n"))
+			fmt.Fprintf(&buf, "\n  Dependencies:\n")
 			for _, dep := range rs.Dependencies {
-				buf.WriteString(fmt.Sprintf("    %s\n", dep))
+				fmt.Fprintf(&buf, "    %s\n", dep)
 			}
 		}
 	}
@@ -1311,9 +1311,9 @@ func (m *ModuleState) String() string {
 			v := m.Outputs[k]
 			switch vTyped := v.Value.(type) {
 			case string:
-				buf.WriteString(fmt.Sprintf("%s = %s\n", k, vTyped))
+				fmt.Fprintf(&buf, "%s = %s\n", k, vTyped)
 			case []interface{}:
-				buf.WriteString(fmt.Sprintf("%s = %s\n", k, vTyped))
+				fmt.Fprintf(&buf, "%s = %s\n", k, vTyped)
 			case map[string]interface{}:
 				var mapKeys []string
 				for key, _ := range vTyped {
@@ -1324,11 +1324,11 @@ func (m *ModuleState) String() string {
 				var mapBuf bytes.Buffer
 				mapBuf.WriteString("{")
 				for _, key := range mapKeys {
-					mapBuf.WriteString(fmt.Sprintf("%s:%s ", key, vTyped[key]))
+					fmt.Fprintf(&mapBuf, "%s:%s ", key, vTyped[key])
 				}
 				mapBuf.WriteString("}")
 
-				buf.WriteString(fmt.Sprintf("%s = %s\n", k, mapBuf.String()))
+				fmt.Fprintf(&buf, "%s = %s\n", k, mapBuf.String())
 			}
 		}
 	}
@@ -1611,7 +1611,7 @@ func (s *ResourceState) String() string {
 	defer s.Unlock()
 
 	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("Type = %s", s.Type))
+	fmt.Fprintf(&buf, "Type = %s", s.Type)
 	return buf.String()
 }
 
@@ -1857,7 +1857,7 @@ func (s *InstanceState) String() string {
 		return notCreated
 	}
 
-	buf.WriteString(fmt.Sprintf("ID = %s\n", s.ID))
+	fmt.Fprintf(&buf, "ID = %s\n", s.ID)
 
 	attributes := s.Attributes
 	attrKeys := make([]string, 0, len(attributes))
@@ -1872,10 +1872,10 @@ func (s *InstanceState) String() string {
 
 	for _, ak := range attrKeys {
 		av := attributes[ak]
-		buf.WriteString(fmt.Sprintf("%s = %s\n", ak, av))
+		fmt.Fprintf(&buf, "%s = %s\n", ak, av)
 	}
 
-	buf.WriteString(fmt.Sprintf("Tainted = %t\n", s.Tainted))
+	fmt.Fprintf(&buf, "Tainted = %t\n", s.Tainted)
 
 	return buf.String()
 }

--- a/internal/states/state_string.go
+++ b/internal/states/state_string.go
@@ -72,7 +72,7 @@ func (s *State) String() string {
 				text = "  " + text
 			}
 
-			buf.WriteString(fmt.Sprintf("%s\n", text))
+			fmt.Fprintf(&buf, "%s\n", text)
 		}
 	}
 
@@ -136,9 +136,9 @@ func (ms *Module) testString() string {
 			deposedStr = fmt.Sprintf(" (%d deposed)", len(is.Deposed))
 		}
 
-		buf.WriteString(fmt.Sprintf("%s:%s%s\n", k, taintStr, deposedStr))
-		buf.WriteString(fmt.Sprintf("  ID = %s\n", id))
-		buf.WriteString(fmt.Sprintf("  provider = %s\n", rs.ProviderConfig.String()))
+		fmt.Fprintf(&buf, "%s:%s%s\n", k, taintStr, deposedStr)
+		fmt.Fprintf(&buf, "  ID = %s\n", id)
+		fmt.Fprintf(&buf, "  provider = %s\n", rs.ProviderConfig.String())
 
 		// Attributes were a flatmap before, but are not anymore. To preserve
 		// our old output as closely as possible we need to do a conversion
@@ -184,7 +184,7 @@ func (ms *Module) testString() string {
 
 		for _, ak := range attrKeys {
 			av := attributes[ak]
-			buf.WriteString(fmt.Sprintf("  %s = %s\n", ak, av))
+			fmt.Fprintf(&buf, "  %s = %s\n", ak, av)
 		}
 
 		// CAUTION: Since deposed keys are now random strings instead of
@@ -197,14 +197,14 @@ func (ms *Module) testString() string {
 			if t.Status == ObjectTainted {
 				taintStr = " (tainted)"
 			}
-			buf.WriteString(fmt.Sprintf("  Deposed ID %d = %s%s\n", i, id, taintStr))
+			fmt.Fprintf(&buf, "  Deposed ID %d = %s%s\n", i, id, taintStr)
 			i++
 		}
 
 		if obj := is.Current; obj != nil && len(obj.Dependencies) > 0 {
 			buf.WriteString("\n  Dependencies:\n")
 			for _, dep := range obj.Dependencies {
-				buf.WriteString(fmt.Sprintf("    %s\n", dep.String()))
+				fmt.Fprintf(&buf, "    %s\n", dep.String())
 			}
 		}
 	}
@@ -227,9 +227,9 @@ func (ms *Module) testString() string {
 			lv := hcl2shim.ConfigValueFromHCL2(v.Value)
 			switch vTyped := lv.(type) {
 			case string:
-				buf.WriteString(fmt.Sprintf("%s = %s\n", k, vTyped))
+				fmt.Fprintf(&buf, "%s = %s\n", k, vTyped)
 			case []interface{}:
-				buf.WriteString(fmt.Sprintf("%s = %s\n", k, vTyped))
+				fmt.Fprintf(&buf, "%s = %s\n", k, vTyped)
 			case map[string]interface{}:
 				var mapKeys []string
 				for key := range vTyped {
@@ -240,13 +240,13 @@ func (ms *Module) testString() string {
 				var mapBuf bytes.Buffer
 				mapBuf.WriteString("{")
 				for _, key := range mapKeys {
-					mapBuf.WriteString(fmt.Sprintf("%s:%s ", key, vTyped[key]))
+					fmt.Fprintf(&mapBuf, "%s:%s ", key, vTyped[key])
 				}
 				mapBuf.WriteString("}")
 
-				buf.WriteString(fmt.Sprintf("%s = %s\n", k, mapBuf.String()))
+				fmt.Fprintf(&buf, "%s = %s\n", k, mapBuf.String())
 			default:
-				buf.WriteString(fmt.Sprintf("%s = %#v\n", k, lv))
+				fmt.Fprintf(&buf, "%s = %#v\n", k, lv)
 			}
 		}
 	}

--- a/internal/tofu/context_test.go
+++ b/internal/tofu/context_test.go
@@ -901,7 +901,7 @@ func legacyDiffComparisonString(changes *plans.Changes) string {
 		fmt.Fprintf(&buf, "%s:\n", moduleKey)
 		s := bufio.NewScanner(&mBuf)
 		for s.Scan() {
-			buf.WriteString(fmt.Sprintf("  %s\n", s.Text()))
+			fmt.Fprintf(&buf, "  %s\n", s.Text())
 		}
 	}
 


### PR DESCRIPTION
I was not actually intending to do this right now, but it turns out that upgrading to the latest golangci-lint is the most straightforward way to make it work under Go 1.27 and so I'm proposing this as part of https://github.com/opentofu/opentofu/issues/4308, as a prerequisite for https://github.com/opentofu/opentofu/pull/4496.

We previously agreed that, aside from a few historical exceptions we tolerate out of pragmatism, we broadly accept the default set of linting rules in golangci-lint as a good enough configuration for this repository, rather than micro-managing a local ruleset. Therefore this PR also includes updates for a few different new checks that come from this upgrade, with one commit each in case you'd like to [review on a commit-by-commit basis](https://github.com/opentofu/opentofu/pull/4500/commits).

If we accept and merge this then I intend to rebase https://github.com/opentofu/opentofu/pull/4496 on top if it after removing the commits there where I initially tried to do the golangci-lint upgrade inline.

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
