### PR TITLE
command/fmt: Fix path resolution when the working directory is a symlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ UPGRADE NOTES:
 
     Third parties may continue to offer their own OpenTofu builds targeting platforms that we don't officially support. This only affects the official packages published directly by the OpenTofu project in this repository's release artifacts.
 
+BUG FIXES:
+
+- `tofu fmt`: Fixed wrong resolution of paths when the working directory is a symlink; output now shows absolute file paths instead of giving error `Invalid file or directory path`. ([#3879](https://github.com/opentofu/opentofu/issues/3879))
+
 ## Previous Releases
 
 For information on prior major and minor releases, refer to their changelogs:

--- a/internal/command/fmt.go
+++ b/internal/command/fmt.go
@@ -123,7 +123,6 @@ func (c *FmtCommand) fmt(paths []string, stdin io.Reader, stdout io.Writer, args
 	}
 
 	for _, path := range paths {
-		path = c.Meta.WorkingDir.NormalizePath(path)
 		info, err := os.Stat(path)
 		if err != nil {
 			diags = diags.Append(tfdiags.Sourceless(
@@ -152,7 +151,7 @@ func (c *FmtCommand) fmt(paths []string, stdin io.Reader, stdout io.Writer, args
 						continue
 					}
 
-					fileDiags := c.processFile(c.Meta.WorkingDir.NormalizePath(path), f, stdout, args)
+					fileDiags := c.processFile(path, f, stdout, args)
 					diags = diags.Append(fileDiags)
 					_ = f.Close()
 
@@ -316,7 +315,7 @@ func (c *FmtCommand) processDir(path string, stdout io.Writer, args arguments.Fm
 					continue
 				}
 
-				fileDiags := c.processFile(c.Meta.WorkingDir.NormalizePath(subPath), f, stdout, args)
+				fileDiags := c.processFile(subPath, f, stdout, args)
 				diags = diags.Append(fileDiags)
 				_ = f.Close()
 

--- a/internal/command/fmt_test.go
+++ b/internal/command/fmt_test.go
@@ -576,6 +576,8 @@ func fmtFixtureWriteDir(t *testing.T) string {
 	return dir
 }
 
+// fmtSymlinkedWorkingDir is a t.Helper function that creates the real dir and symlink dir.
+// Chdir into symlink path. Because of this, tests using this helper cannot call t.Parallel().
 func fmtSymlinkedWorkingDir(t *testing.T) (realDir string, realFilePath string) {
 	t.Helper()
 

--- a/internal/command/fmt_test.go
+++ b/internal/command/fmt_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -456,10 +457,6 @@ func TestFmt_check(t *testing.T) {
 		t.Fatalf("wrong exit code. expected 3")
 	}
 
-	// Given that we give relative paths back to the user, normalize this temp
-	// dir so that we're comparing against a relative-ized (normalized) path
-	tempDir = meta.WorkingDir.NormalizePath(tempDir)
-
 	if actual := output.Stdout(); !strings.Contains(actual, tempDir) {
 		t.Fatalf("expected:\n%s\n\nto include: %q", actual, tempDir)
 	}
@@ -493,6 +490,63 @@ func TestFmt_checkStdin(t *testing.T) {
 	}
 }
 
+// TestFmt_symlinkedWorkingDir verifies that an absolute path still resolves
+// when the working directory is reached through a symlink.
+// Regression test for https://github.com/opentofu/opentofu/issues/3879
+func TestFmt_symlinkedWorkingDir(t *testing.T) {
+	t.Run("file", func(t *testing.T) {
+		_, realFilePath := fmtSymlinkedWorkingDir(t)
+
+		view, done := testView(t)
+		meta := Meta{
+			WorkingDir:       workdir.NewDir("."),
+			testingOverrides: metaOverridesForProvider(testProvider()),
+			View:             view,
+		}
+		args := []string{realFilePath}
+		code := RunCommander(t, FmtCommander(nil), meta, args)
+		output := done(t)
+
+		if code != 0 {
+			t.Fatalf("fmt command was unsuccessful:\n%s", output.Stderr())
+		}
+
+		got, err := os.ReadFile(realFilePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(string(fmtFixture.golden), string(got)); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+
+	t.Run("directory", func(t *testing.T) {
+		realDir, realFilePath := fmtSymlinkedWorkingDir(t)
+
+		view, done := testView(t)
+		meta := Meta{
+			WorkingDir:       workdir.NewDir("."),
+			testingOverrides: metaOverridesForProvider(testProvider()),
+			View:             view,
+		}
+		args := []string{realDir}
+		code := RunCommander(t, FmtCommander(nil), meta, args)
+		output := done(t)
+
+		if code != 0 {
+			t.Fatalf("fmt command was unsuccessful:\n%s", output.Stderr())
+		}
+
+		got, err := os.ReadFile(realFilePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(string(fmtFixture.golden), string(got)); diff != "" {
+			t.Errorf("wrong result\n%s", diff)
+		}
+	})
+}
+
 var fmtFixture = struct {
 	filename      string
 	altFilename   string
@@ -520,4 +574,33 @@ func fmtFixtureWriteDir(t *testing.T) string {
 	}
 
 	return dir
+}
+
+func fmtSymlinkedWorkingDir(t *testing.T) (realDir string, realFilePath string) {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	realDir = filepath.Join(tempDir, "dir1", "dir2")
+	realFilePath = filepath.Join(realDir, "test.tf")
+	symlinkPath := filepath.Join(tempDir, "symlink_dir")
+
+	if err := os.MkdirAll(realDir, 0755); err != nil {
+		t.Fatalf("failed to create the folders: %s", err)
+	}
+
+	if err := os.WriteFile(realFilePath, fmtFixture.input, 0600); err != nil {
+		t.Fatalf("failed to create the test file: %s", err)
+	}
+
+	if err := os.Symlink(realDir, symlinkPath); err != nil {
+		if runtime.GOOS == "windows" {
+			// By default Windows does not allow creation of symlinks; avoid false-negatives
+			t.Skipf("can't create symlink on this Windows system: %s", err)
+		}
+		t.Fatalf("failed to make symlink: %s", err)
+	}
+	// Chdir affects the whole process, a test using this should never call t.Parallel()
+	t.Chdir(symlinkPath)
+
+	return realDir, realFilePath
 }


### PR DESCRIPTION
`tofu fmt` does not need to normalize paths, since it never stores them. Normalization made the path relative to the directory reported by `os.Getwd`, which prefers `$PWD` and therefore keeps the symlinked path, while the kernel resolves relative paths from the real one. The resulting path did not exist, so files could not be found or written. Absolute paths are now shown as-is in the output.

Resolves #3879

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.