### PR TITLE
Add warning when language experiments are enabled

### DIFF
--- a/internal/configs/language.go
+++ b/internal/configs/language.go
@@ -216,8 +216,9 @@ func validateOpenTofuCoreVersionConstraint(constraint VersionConstraint) hcl.Dia
 	return diags
 }
 
-func sniffLanguageExperiments(body hcl.Body) (experiments.Set, hcl.Diagnostics) {
+func sniffLanguageExperiments(body hcl.Body) (experiments.Set, hcl.Range, hcl.Diagnostics) {
 	current := experiments.Set{}
+	var rng hcl.Range
 
 	rootContent, _, diags := body.PartialContent(configFileLanguageExperimentSniffRootSchema)
 
@@ -226,13 +227,16 @@ func sniffLanguageExperiments(body hcl.Body) (experiments.Set, hcl.Diagnostics) 
 		diags = diags.Extend(cDiags)
 
 		if attr, ok := content.Attributes["experiments"]; ok {
+			// Choose a single range for warning reporting, we mostly need this for consolidation
+			rng = attr.Range
+
 			found, moreDiags := decodeReservedExperimentsAttr(attr)
 			diags = append(diags, moreDiags...)
 			maps.Copy(current, found)
 		}
 	}
 
-	return current, diags
+	return current, rng, diags
 }
 
 // decodeReservedExperimentsAttr decodes the "experiments" attribute in a

--- a/internal/configs/module.go
+++ b/internal/configs/module.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 
@@ -71,7 +72,8 @@ type Module struct {
 	StaticEvaluator *StaticEvaluator
 
 	// LanguageExperiments is where language experiments are stored.
-	LanguageExperiments experiments.Set
+	LanguageExperiments      experiments.Set
+	LanguageExperimentsRange hcl.Range
 }
 
 // GetProviderConfig uses name and alias to find the respective Provider configuration.
@@ -118,7 +120,8 @@ type File struct {
 
 	Checks []*Check
 
-	LanguageExperiments experiments.Set
+	LanguageExperiments      experiments.Set
+	LanguageExperimentsRange hcl.Range
 }
 
 // SelectiveLoader allows the consumer to only load and validate the portions of files needed for the given operations/contexts
@@ -245,6 +248,21 @@ func NewModule(primaryFiles, overrideFiles []*File, sourceDir string, load Selec
 	for _, file := range overrideFiles {
 		fileDiags := mod.mergeFile(file)
 		diags = append(diags, fileDiags...)
+	}
+
+	if load == SelectiveLoadAll && len(mod.LanguageExperiments) != 0 {
+		// Include warning if any experiments are present
+		var names []string
+		for exp := range mod.LanguageExperiments {
+			names = append(names, string(exp))
+		}
+		expStr := strings.Join(names, ", ")
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Summary:  "Experiments are active",
+			Detail:   fmt.Sprintf("Experiments should not be used in production and are subject to change. The following experiments are active: %s", expStr),
+			Subject:  mod.LanguageExperimentsRange.Ptr(),
+		})
 	}
 
 	if !mod.LanguageExperiments.Has(experiments.SymbolLibraries) {
@@ -641,6 +659,9 @@ func (m *Module) appendFile(file *File) hcl.Diagnostics {
 	m.Removed = append(m.Removed, file.Removed...)
 
 	maps.Copy(m.LanguageExperiments, file.LanguageExperiments)
+	if !file.LanguageExperimentsRange.Empty() {
+		m.LanguageExperimentsRange = file.LanguageExperimentsRange
+	}
 
 	return diags
 }

--- a/internal/configs/module.go
+++ b/internal/configs/module.go
@@ -259,8 +259,8 @@ func NewModule(primaryFiles, overrideFiles []*File, sourceDir string, load Selec
 		expStr := strings.Join(names, ", ")
 		diags = diags.Append(&hcl.Diagnostic{
 			Severity: hcl.DiagWarning,
-			Summary:  "Experiments are active",
-			Detail:   fmt.Sprintf("Experiments should not be used in production and are subject to change. The following experiments are active: %s", expStr),
+			Summary:  "Experimental features are active",
+			Detail:   fmt.Sprintf("Experimental features are subject to breaking changes or total removal in later versions, based on feedback. We recommend against using experimental features in production.\n\nThe following experiments are enabled: %s", expStr),
 			Subject:  mod.LanguageExperimentsRange.Ptr(),
 		})
 	}

--- a/internal/configs/parser_config.go
+++ b/internal/configs/parser_config.go
@@ -86,9 +86,10 @@ func loadConfigFileBody(body hcl.Body, _ string, override bool) (*File, hcl.Diag
 	reqDiags := checkVersionRequirements(body, version.SemVer)
 	diags = append(diags, reqDiags...)
 
-	langExperiments, expDiags := sniffLanguageExperiments(body)
+	langExperiments, langRange, expDiags := sniffLanguageExperiments(body)
 	diags = append(diags, expDiags...)
 	file.LanguageExperiments = langExperiments
+	file.LanguageExperimentsRange = langRange
 
 	// We still continue here even if there was a version compatibility problem
 	// because we want to gather as complete as possible a map of the content


### PR DESCRIPTION
This was removed during the rework of where experiments are placed within the configuration.

I don't love the Range detection, but it produces a sane value and allows for warning consolidation

This is in support of #4052 

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
