### PR TITLE
e2etest: Use a newer version of `hashicorp/null` in provider cache test

### DIFF
--- a/internal/command/e2etest/init_test.go
+++ b/internal/command/e2etest/init_test.go
@@ -364,12 +364,12 @@ func TestInitProviders_pluginCache(t *testing.T) {
 		t.Errorf("template plugin was not installed from local cache")
 	}
 
-	nullLinkPath := filepath.FromSlash(fmt.Sprintf(".terraform/providers/registry.opentofu.org/hashicorp/null/2.1.0/%s_%s/terraform-provider-null", runtime.GOOS, runtime.GOARCH)) + extension
+	nullLinkPath := filepath.FromSlash(fmt.Sprintf(".terraform/providers/registry.opentofu.org/hashicorp/null/3.3.1/%s_%s/terraform-provider-null", runtime.GOOS, runtime.GOARCH)) + extension
 	if !tf.FileExists(nullLinkPath) {
 		t.Errorf("null plugin was not installed into %s", nullLinkPath)
 	}
 
-	nullCachePath := filepath.FromSlash(fmt.Sprintf("cache/registry.opentofu.org/hashicorp/null/2.1.0/%s_%s/terraform-provider-null", runtime.GOOS, runtime.GOARCH)) + extension
+	nullCachePath := filepath.FromSlash(fmt.Sprintf("cache/registry.opentofu.org/hashicorp/null/3.3.1/%s_%s/terraform-provider-null", runtime.GOOS, runtime.GOARCH)) + extension
 	if !tf.FileExists(nullCachePath) {
 		t.Errorf("null plugin is not in cache after install. expected in: %s", nullCachePath)
 	}

--- a/internal/command/e2etest/testdata/plugin-cache/main.tf
+++ b/internal/command/e2etest/testdata/plugin-cache/main.tf
@@ -3,5 +3,5 @@ provider "template" {
 }
 
 provider "null" {
-  version = "2.1.0"
+  version = "3.3.1"
 }


### PR DESCRIPTION
The version we were previously using does not have builds for either `linux_arm64` or `windows_arm64`.

It didn't show as a failure while working on https://github.com/opentofu/opentofu/pull/4479 and https://github.com/opentofu/opentofu/pull/4487 because there's a `t.Skip()` whenever `runtime.GOOS == "windows"`, but this now prepares this test to run on both platforms if we eventually fix the preexisting TODO in there about adapting the dependency lock file to expect the Windows-style executable filename.

This is a followup from https://github.com/opentofu/opentofu/pull/4530 dealing with a problem that wasn't evident until after it was merged, because we (intentionally) only run the full suite of end-to-end tests on pushes to the `main` branch.

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

