### PR TITLE
Ensure correct worker and stack in symlib functioncalls

### DIFF
--- a/internal/configs/symlib/compiler.go
+++ b/internal/configs/symlib/compiler.go
@@ -229,7 +229,7 @@ func CompileLibrary(files []*SymbolFile, loader Loader, builtinFuncs map[string]
 	for name, once := range libScope.functions {
 		f, fDiags := once.Value(w)
 		diags = diags.Extend(fDiags)
-		lib.functions[name] = f(w, nil)
+		lib.functions[name] = f.Standalone()
 	}
 
 	return lib, diags

--- a/internal/configs/symlib/compiler.go
+++ b/internal/configs/symlib/compiler.go
@@ -229,7 +229,7 @@ func CompileLibrary(files []*SymbolFile, loader Loader, builtinFuncs map[string]
 	for name, once := range libScope.functions {
 		f, fDiags := once.Value(w)
 		diags = diags.Extend(fDiags)
-		lib.functions[name] = f.Standalone()
+		lib.functions[name] = f.ForExternalCaller()
 	}
 
 	return lib, diags

--- a/internal/configs/symlib/compiler_test.go
+++ b/internal/configs/symlib/compiler_test.go
@@ -6,7 +6,9 @@
 package symlib
 
 import (
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -161,6 +163,57 @@ function "get_list" {
 	if diff := cmp.Diff(wanted, got, ctyCmpOpts); diff != "" {
 		t.Fatal(diff)
 	}
+}
+
+// TestFunctionParallelExternalCalls ensures that functions
+// called from outside the current symbol library have their
+// own dedicated workgraph worker.
+func TestFunctionParallelExternalCalls(t *testing.T) {
+	files := map[string]string{
+		"./functions.sym.hcl": `
+function "outer" {
+	parameter "value" {
+		type = string
+	}
+	return = symbols::inner(param.value)
+}
+function "inner" {
+	parameter "value" {
+		type = string
+	}
+	return = "Value: ${param.value}"
+}
+`,
+	}
+
+	lib, diags := testCompile(t, files)
+	assertNoDiags(t, diags)
+	f, ok := lib.functions["outer"]
+	if !ok {
+		t.Fatal("Failed to find function get_list")
+	}
+
+	var w sync.WaitGroup
+	for i := range 2048 {
+		w.Go(func() {
+			str := fmt.Sprintf("hi %v", i)
+			got, err := f.Call([]cty.Value{cty.StringVal(str)})
+			if err != nil {
+				t.Fatalf("Error during function call: %v", err)
+			}
+
+			if !got.Type().Equals(cty.String) {
+				t.Fatalf("Unexpected return type, expected list(string), got %s", got.Type().FriendlyName())
+			}
+
+			wanted := cty.StringVal(fmt.Sprintf("Value: %s", str))
+			if diff := cmp.Diff(wanted, got, ctyCmpOpts); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+
+	w.Wait()
 }
 
 // This initial set of tests mirrors what is in the RFC (rfc/20260424-symbol-libraries.md)

--- a/internal/configs/symlib/compiler_test.go
+++ b/internal/configs/symlib/compiler_test.go
@@ -190,7 +190,7 @@ function "inner" {
 	assertNoDiags(t, diags)
 	f, ok := lib.functions["outer"]
 	if !ok {
-		t.Fatal("Failed to find function get_list")
+		t.Fatal("Failed to find function outer")
 	}
 
 	var w sync.WaitGroup
@@ -203,7 +203,7 @@ function "inner" {
 			}
 
 			if !got.Type().Equals(cty.String) {
-				t.Fatalf("Unexpected return type, expected list(string), got %s", got.Type().FriendlyName())
+				t.Fatalf("Unexpected return type, expected string, got %s", got.Type().FriendlyName())
 			}
 
 			wanted := cty.StringVal(fmt.Sprintf("Value: %s", str))

--- a/internal/configs/symlib/functions.go
+++ b/internal/configs/symlib/functions.go
@@ -174,11 +174,17 @@ func decodeFunctionBlock(block *hcl.Block) (*Function, hcl.Diagnostics) {
 
 type functionWithStack func(w func() *workgraph.Worker, stack []string) function.Function
 
-func (f functionWithStack) ForWorker(w *workgraph.Worker, stack []string) function.Function {
+// ForInternalCaller produces a function for use within a symlib scope where the worker is already known
+func (f functionWithStack) ForInternalCaller(w *workgraph.Worker, stack []string) function.Function {
 	return f(func() *workgraph.Worker { return w }, stack)
 }
 
-func (f functionWithStack) Standalone() function.Function {
+// ForExternalCaller produces a function for use outside of the scope that it resides in. This is helpful
+// when exposing symlib to callers that may be calling the same function from multiple go-routines.
+//
+// Future Note: We may want OpenTofu's new runtime to share it's current worker with the symlib function it's
+// calling, though the benefits of that are still to be debated.
+func (f functionWithStack) ForExternalCaller() function.Function {
 	return f(func() *workgraph.Worker { return workgraph.NewWorker() }, nil)
 }
 

--- a/internal/configs/symlib/functions.go
+++ b/internal/configs/symlib/functions.go
@@ -7,6 +7,7 @@ package symlib
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/apparentlymart/go-workgraph/workgraph"
 	"github.com/hashicorp/hcl/v2"
@@ -171,7 +172,15 @@ func decodeFunctionBlock(block *hcl.Block) (*Function, hcl.Diagnostics) {
 	return fn, diags
 }
 
-type functionWithStack func(w *workgraph.Worker, stack []string) function.Function
+type functionWithStack func(w func() *workgraph.Worker, stack []string) function.Function
+
+func (f functionWithStack) ForWorker(w *workgraph.Worker, stack []string) function.Function {
+	return f(func() *workgraph.Worker { return w }, stack)
+}
+
+func (f functionWithStack) Standalone() function.Function {
+	return f(func() *workgraph.Worker { return workgraph.NewWorker() }, nil)
+}
 
 func (fn *Function) Compile(w *workgraph.Worker, libScope *symbolScope) (functionWithStack, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
@@ -225,17 +234,20 @@ func (fn *Function) Compile(w *workgraph.Worker, libScope *symbolScope) (functio
 		spec.VarParam = &fnp
 	}
 
-	return func(w *workgraph.Worker, stack []string) function.Function {
+	return func(wf func() *workgraph.Worker, stack []string) function.Function {
 		// This is safe because of struct copies
 		spec.Impl = func(args []cty.Value, retType cty.Type) (cty.Value, error) {
 			var diags hcl.Diagnostics
 
+			// Ensure each call to this function has it's own copy of the stack
+			stack := slices.Clone(stack)
+			// Ensure each call uses the correct worker
+			w := wf()
+
 			callName := TypeSymbols + "::" + fn.Name
-			if len(stack) > 1024 {
-				for _, entry := range stack {
-					if entry == callName {
-						return cty.NilVal, fmt.Errorf("Recursive call to %s detected", callName)
-					}
+			for _, entry := range stack {
+				if entry == callName {
+					return cty.NilVal, fmt.Errorf("Recursive call to %s detected", callName)
 				}
 			}
 			stack = append(stack, callName)

--- a/internal/configs/symlib/scope.go
+++ b/internal/configs/symlib/scope.go
@@ -162,7 +162,7 @@ func (s *symbolScope) functionFor(w *workgraph.Worker, fn hcl.Traversal, stack [
 			}}
 		}
 		fn, diags := found.Value(w)
-		sfn := fn.ForWorker(w, stack)
+		sfn := fn.ForInternalCaller(w, stack)
 		return &sfn, diags
 	case 3:
 		return s.table.Function(FunctionRef{

--- a/internal/configs/symlib/scope.go
+++ b/internal/configs/symlib/scope.go
@@ -162,7 +162,7 @@ func (s *symbolScope) functionFor(w *workgraph.Worker, fn hcl.Traversal, stack [
 			}}
 		}
 		fn, diags := found.Value(w)
-		sfn := fn(w, stack)
+		sfn := fn.ForWorker(w, stack)
 		return &sfn, diags
 	case 3:
 		return s.table.Function(FunctionRef{


### PR DESCRIPTION
Calls from outside of the symbol library should have a dedicated worker and stack that is distinct from the internal scope.

<!-- If your PR resolves an issue, please add it here. -->
Resolves #4536

Needs backport to v1.13 branch after merge.

## Checklist

<!-- Please check of ALL items in this list for all PRs: -->

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.

### Go checklist

<!-- If your PR contains Go code, please make sure you check off all items on this list: --> 

- [x] I have run golangci-lint on my change and receive no errors relevant to my code.
- [x] I have run existing tests to ensure my code doesn't break anything.
- [x] I have added tests for all relevant use cases of my code, and those tests are passing.
- [x] I have only exported functions, variables and structs that should be used from other packages.
- [x] I have added meaningful comments to all exported functions, variables, and structs.
