### PR TITLE
plugins: Adopt the `Schemas` type that was previously in `package tofu`

### DIFF
--- a/internal/command/jsonconfig/config.go
+++ b/internal/command/jsonconfig/config.go
@@ -17,7 +17,7 @@ import (
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/getproviders"
-	"github.com/opentofu/opentofu/internal/tofu"
+	"github.com/opentofu/opentofu/internal/plugins"
 )
 
 // Config represents the complete configuration source
@@ -128,7 +128,7 @@ type provisioner struct {
 }
 
 // Marshal returns the json encoding of tofu configuration.
-func Marshal(c *configs.Config, schemas *tofu.Schemas) ([]byte, error) {
+func Marshal(c *configs.Config, schemas *plugins.Schemas) ([]byte, error) {
 	return marshal(c, schemas)
 }
 
@@ -141,7 +141,7 @@ func Marshal(c *configs.Config, schemas *tofu.Schemas) ([]byte, error) {
 // [inSingleModuleMode], and not by directly testing if schemas are nil,
 // so that it's easier for future maintainers to learn about this special
 // treatment through the centralized doc comment.
-func marshal(c *configs.Config, schemas *tofu.Schemas) ([]byte, error) {
+func marshal(c *configs.Config, schemas *plugins.Schemas) ([]byte, error) {
 	var output config
 
 	pcs := make(map[string]providerConfig)
@@ -168,7 +168,7 @@ func marshal(c *configs.Config, schemas *tofu.Schemas) ([]byte, error) {
 
 func marshalProviderConfigs(
 	c *configs.Config,
-	schemas *tofu.Schemas,
+	schemas *plugins.Schemas,
 	m map[string]providerConfig,
 ) {
 	if c == nil {
@@ -184,7 +184,7 @@ func marshalProviderConfigs(
 	// Add an entry for each provider configuration block in the module.
 	for k, pc := range c.Module.ProviderConfigs {
 		providerFqn := c.ProviderForConfigAddr(addrs.LocalProviderConfig{LocalName: pc.Name})
-		schema := mapSchema(schemas, func(schemas *tofu.Schemas) *configschema.Block {
+		schema := mapSchema(schemas, func(schemas *plugins.Schemas) *configschema.Block {
 			return schemas.ProviderConfig(providerFqn)
 		})
 
@@ -337,7 +337,7 @@ func marshalProviderConfigs(
 	}
 }
 
-func marshalModule(c *configs.Config, schemas *tofu.Schemas, addr string) (module, error) {
+func marshalModule(c *configs.Config, schemas *plugins.Schemas, addr string) (module, error) {
 	var module module
 	var rs []resource
 
@@ -448,7 +448,7 @@ func marshalModule(c *configs.Config, schemas *tofu.Schemas, addr string) (modul
 	return module, nil
 }
 
-func marshalModuleCalls(c *configs.Config, schemas *tofu.Schemas) map[string]moduleCall {
+func marshalModuleCalls(c *configs.Config, schemas *plugins.Schemas) map[string]moduleCall {
 	ret := make(map[string]moduleCall)
 
 	for name, mc := range c.Module.ModuleCalls {
@@ -459,7 +459,7 @@ func marshalModuleCalls(c *configs.Config, schemas *tofu.Schemas) map[string]mod
 	return ret
 }
 
-func marshalModuleCall(c *configs.Config, mc *configs.ModuleCall, schemas *tofu.Schemas) moduleCall {
+func marshalModuleCall(c *configs.Config, mc *configs.ModuleCall, schemas *plugins.Schemas) moduleCall {
 	// Note that "c" is always nil when in single module mode!
 	// Refer to the docs on [inSingleModuleMode] to learn about how that
 	// special situation works.
@@ -519,7 +519,7 @@ func marshalModuleCall(c *configs.Config, mc *configs.ModuleCall, schemas *tofu.
 	return ret
 }
 
-func marshalResources(resources map[string]*configs.Resource, schemas *tofu.Schemas, moduleAddr string) ([]resource, error) {
+func marshalResources(resources map[string]*configs.Resource, schemas *plugins.Schemas, moduleAddr string) ([]resource, error) {
 	var rs []resource
 	for _, v := range resources {
 		providerConfigKey := opaqueProviderKey(v.ProviderConfigAddr().StringCompact(), moduleAddr)
@@ -570,7 +570,7 @@ func marshalResources(resources map[string]*configs.Resource, schemas *tofu.Sche
 		if v.Managed != nil && len(v.Managed.Provisioners) > 0 {
 			var provisioners []provisioner
 			for _, p := range v.Managed.Provisioners {
-				schema := mapSchema(schemas, func(schema *tofu.Schemas) *configschema.Block {
+				schema := mapSchema(schemas, func(schema *plugins.Schemas) *configschema.Block {
 					return schemas.ProvisionerConfig(p.Type)
 				})
 				prov := provisioner{

--- a/internal/command/jsonconfig/single_module.go
+++ b/internal/command/jsonconfig/single_module.go
@@ -8,7 +8,7 @@ package jsonconfig
 import (
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
-	"github.com/opentofu/opentofu/internal/tofu"
+	"github.com/opentofu/opentofu/internal/plugins"
 )
 
 // MarshalSingleModule is a variant of [Marshal] that describes only a single
@@ -76,5 +76,5 @@ func mapSchema[In, Out schemaObject](schema In, f func(In) Out) Out {
 // generic over the different nilable schema types used by different parts
 // of the implementation in this package.
 type schemaObject interface {
-	*tofu.Schemas | *configschema.Block
+	*plugins.Schemas | *configschema.Block
 }

--- a/internal/command/jsonplan/plan.go
+++ b/internal/command/jsonplan/plan.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/opentofu/opentofu/internal/lang/marks"
+	"github.com/opentofu/opentofu/internal/plugins"
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 
@@ -24,7 +25,6 @@ import (
 	"github.com/opentofu/opentofu/internal/plans"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/states/statefile"
-	"github.com/opentofu/opentofu/internal/tofu"
 	"github.com/opentofu/opentofu/version"
 )
 
@@ -185,7 +185,7 @@ type Variable struct {
 // the part of the plan required by the jsonformat.Plan renderer.
 func MarshalForRenderer(
 	p *plans.Plan,
-	schemas *tofu.Schemas,
+	schemas *plugins.Schemas,
 ) (map[string]Change, []ResourceChange, []ResourceChange, []ResourceAttr, error) {
 	output := newPlan()
 
@@ -232,7 +232,7 @@ func MarshalForLog(
 	config *configs.Config,
 	p *plans.Plan,
 	sf *statefile.File,
-	schemas *tofu.Schemas,
+	schemas *plugins.Schemas,
 ) (*Plan, error) {
 	output := newPlan()
 	output.TerraformVersion = version.String()
@@ -316,7 +316,7 @@ func Marshal(
 	config *configs.Config,
 	p *plans.Plan,
 	sf *statefile.File,
-	schemas *tofu.Schemas,
+	schemas *plugins.Schemas,
 ) ([]byte, error) {
 	output, err := MarshalForLog(config, p, sf, schemas)
 	if err != nil {
@@ -386,7 +386,7 @@ func (p *Plan) marshalPlanVariables(vars map[string]plans.DynamicValue, decls ma
 // This function is referenced directly from the structured renderer tests, to
 // ensure parity between the renderers. It probably shouldn't be used anywhere
 // else.
-func MarshalResourceChanges(resources []*plans.ResourceInstanceChangeSrc, schemas *tofu.Schemas) ([]ResourceChange, error) {
+func MarshalResourceChanges(resources []*plans.ResourceInstanceChangeSrc, schemas *plugins.Schemas) ([]ResourceChange, error) {
 	var ret []ResourceChange
 
 	var sortedResources []*plans.ResourceInstanceChangeSrc
@@ -757,7 +757,7 @@ func MarshalOutputChanges(changes *plans.Changes) (map[string]Change, error) {
 	return outputChanges, nil
 }
 
-func (p *Plan) marshalPlannedValues(changes *plans.Changes, schemas *tofu.Schemas) error {
+func (p *Plan) marshalPlannedValues(changes *plans.Changes, schemas *plugins.Schemas) error {
 	// marshal the planned changes into a module
 	plan, err := marshalPlannedValues(changes, schemas)
 	if err != nil {

--- a/internal/command/jsonplan/values.go
+++ b/internal/command/jsonplan/values.go
@@ -17,8 +17,8 @@ import (
 	"github.com/opentofu/opentofu/internal/command/jsonstate"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/plans"
+	"github.com/opentofu/opentofu/internal/plugins"
 	"github.com/opentofu/opentofu/internal/states"
-	"github.com/opentofu/opentofu/internal/tofu"
 )
 
 // StateValues is the common representation of resolved values for both the
@@ -94,7 +94,7 @@ func marshalPlannedOutputs(changes *plans.Changes) (map[string]Output, error) {
 	return ret, nil
 }
 
-func marshalPlannedValues(changes *plans.Changes, schemas *tofu.Schemas) (Module, error) {
+func marshalPlannedValues(changes *plans.Changes, schemas *plugins.Schemas) (Module, error) {
 	var ret Module
 
 	// build three maps:
@@ -180,7 +180,7 @@ func marshalPlannedValues(changes *plans.Changes, schemas *tofu.Schemas) (Module
 }
 
 // marshalPlanResources
-func marshalPlanResources(changeMap map[string]*plans.ResourceInstanceChangeSrc, ris []addrs.AbsResourceInstance, schemas *tofu.Schemas) ([]Resource, error) {
+func marshalPlanResources(changeMap map[string]*plans.ResourceInstanceChangeSrc, ris []addrs.AbsResourceInstance, schemas *plugins.Schemas) ([]Resource, error) {
 	var ret []Resource
 
 	for _, ri := range ris {
@@ -276,7 +276,7 @@ func marshalPlanResources(changeMap map[string]*plans.ResourceInstanceChangeSrc,
 // the full module tree.
 func marshalPlanModules(
 	changeMap map[string]*plans.ResourceInstanceChangeSrc,
-	schemas *tofu.Schemas,
+	schemas *plugins.Schemas,
 	childModules []addrs.ModuleInstance,
 	moduleMap map[string][]addrs.ModuleInstance,
 	moduleResourceMap map[string][]addrs.AbsResourceInstance,

--- a/internal/command/jsonprovider/provider.go
+++ b/internal/command/jsonprovider/provider.go
@@ -8,8 +8,8 @@ package jsonprovider
 import (
 	"encoding/json"
 
+	"github.com/opentofu/opentofu/internal/plugins"
 	"github.com/opentofu/opentofu/internal/providers"
-	"github.com/opentofu/opentofu/internal/tofu"
 )
 
 // FormatVersion represents the version of the json format and will be
@@ -24,12 +24,12 @@ type Providers struct {
 }
 
 type Provider struct {
-	Provider                 *Schema                                `json:"provider,omitempty"`
-	ResourceSchemas          map[string]*Schema                     `json:"resource_schemas,omitempty"`
-	DataSourceSchemas        map[string]*Schema                     `json:"data_source_schemas,omitempty"`
-	EphemeralResourceSchemas map[string]*Schema                     `json:"ephemeral_resource_schemas,omitempty"`
-	Functions                map[string]*Function                   `json:"functions,omitempty"`
-	ResourceIdentitySchemas  map[string]*ResourceIdentitySchema     `json:"resource_identity_schemas,omitempty"`
+	Provider                 *Schema                            `json:"provider,omitempty"`
+	ResourceSchemas          map[string]*Schema                 `json:"resource_schemas,omitempty"`
+	DataSourceSchemas        map[string]*Schema                 `json:"data_source_schemas,omitempty"`
+	EphemeralResourceSchemas map[string]*Schema                 `json:"ephemeral_resource_schemas,omitempty"`
+	Functions                map[string]*Function               `json:"functions,omitempty"`
+	ResourceIdentitySchemas  map[string]*ResourceIdentitySchema `json:"resource_identity_schemas,omitempty"`
 }
 
 func newProviders() *Providers {
@@ -44,7 +44,7 @@ func newProviders() *Providers {
 // schema into the public structured JSON versions.
 //
 // This is a format that can be read by the structured plan renderer.
-func MarshalForRenderer(s *tofu.Schemas) map[string]*Provider {
+func MarshalForRenderer(s *plugins.Schemas) map[string]*Provider {
 	schemas := make(map[string]*Provider, len(s.Providers))
 	for k, v := range s.Providers {
 		schemas[k.String()] = marshalProvider(v)
@@ -52,7 +52,7 @@ func MarshalForRenderer(s *tofu.Schemas) map[string]*Provider {
 	return schemas
 }
 
-func Marshal(s *tofu.Schemas) ([]byte, error) {
+func Marshal(s *plugins.Schemas) ([]byte, error) {
 	providers := newProviders()
 	providers.Schemas = MarshalForRenderer(s)
 	ret, err := json.Marshal(providers)

--- a/internal/command/jsonstate/state.go
+++ b/internal/command/jsonstate/state.go
@@ -16,9 +16,9 @@ import (
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/command/jsonchecks"
 	"github.com/opentofu/opentofu/internal/lang/marks"
+	"github.com/opentofu/opentofu/internal/plugins"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/states/statefile"
-	"github.com/opentofu/opentofu/internal/tofu"
 )
 
 const (
@@ -155,7 +155,7 @@ func newState() *State {
 
 // MarshalForRenderer returns the pre-json encoding changes of the state, in a
 // format available to the structured renderer.
-func MarshalForRenderer(sf *statefile.File, schemas *tofu.Schemas) (Module, map[string]Output, error) {
+func MarshalForRenderer(sf *statefile.File, schemas *plugins.Schemas) (Module, map[string]Output, error) {
 	if sf.State.Modules == nil {
 		// Empty state case.
 		return Module{}, nil, nil
@@ -176,7 +176,7 @@ func MarshalForRenderer(sf *statefile.File, schemas *tofu.Schemas) (Module, map[
 
 // MarshalForLog returns the origin JSON compatible state, read for a logging
 // package to marshal further.
-func MarshalForLog(sf *statefile.File, schemas *tofu.Schemas) (*State, error) {
+func MarshalForLog(sf *statefile.File, schemas *plugins.Schemas) (*State, error) {
 	output := newState()
 
 	if sf == nil || sf.State.Empty() {
@@ -202,7 +202,7 @@ func MarshalForLog(sf *statefile.File, schemas *tofu.Schemas) (*State, error) {
 }
 
 // Marshal returns the json encoding of a tofu state.
-func Marshal(sf *statefile.File, schemas *tofu.Schemas) ([]byte, error) {
+func Marshal(sf *statefile.File, schemas *plugins.Schemas) ([]byte, error) {
 	output, err := MarshalForLog(sf, schemas)
 	if err != nil {
 		return nil, err
@@ -212,7 +212,7 @@ func Marshal(sf *statefile.File, schemas *tofu.Schemas) ([]byte, error) {
 	return ret, err
 }
 
-func (jsonstate *State) marshalStateValues(s *states.State, schemas *tofu.Schemas) error {
+func (jsonstate *State) marshalStateValues(s *states.State, schemas *plugins.Schemas) error {
 	var sv StateValues
 	var err error
 
@@ -261,7 +261,7 @@ func MarshalOutputs(outputs map[string]*states.OutputValue) (map[string]Output, 
 	return ret, nil
 }
 
-func marshalRootModule(s *states.State, schemas *tofu.Schemas) (Module, error) {
+func marshalRootModule(s *states.State, schemas *plugins.Schemas) (Module, error) {
 	var ret Module
 	var err error
 
@@ -308,7 +308,7 @@ func marshalRootModule(s *states.State, schemas *tofu.Schemas) (Module, error) {
 // out of tofu state.
 func marshalModules(
 	s *states.State,
-	schemas *tofu.Schemas,
+	schemas *plugins.Schemas,
 	modules []addrs.ModuleInstance,
 	moduleMap map[string][]addrs.ModuleInstance,
 ) ([]Module, error) {
@@ -346,7 +346,7 @@ func marshalModules(
 	return ret, nil
 }
 
-func marshalResources(resources map[string]*states.Resource, module addrs.ModuleInstance, schemas *tofu.Schemas) ([]Resource, error) {
+func marshalResources(resources map[string]*states.Resource, module addrs.ModuleInstance, schemas *plugins.Schemas) ([]Resource, error) {
 	var ret []Resource
 
 	var sortedResources []*states.Resource

--- a/internal/plugins/schemas.go
+++ b/internal/plugins/schemas.go
@@ -1,0 +1,58 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package plugins
+
+import (
+	"github.com/opentofu/opentofu/internal/addrs"
+	"github.com/opentofu/opentofu/internal/configs/configschema"
+	"github.com/opentofu/opentofu/internal/providers"
+)
+
+// Schemas is a container for various kinds of schema that OpenTofu needs
+// during processing.
+//
+// Although not all schemas necessarily come from plugins, this type lives here
+// out of pragmatism because plugins are the most common place that schemas
+// come from.
+type Schemas struct {
+	Providers    map[addrs.Provider]providers.ProviderSchema
+	Provisioners map[string]*configschema.Block
+}
+
+// ProviderSchema returns the entire ProviderSchema object that was produced
+// by the plugin for the given provider, or nil if no such schema is available.
+//
+// It's usually better to go use the more precise methods offered by type
+// Schemas to handle this detail automatically.
+func (ss *Schemas) ProviderSchema(provider addrs.Provider) providers.ProviderSchema {
+	return ss.Providers[provider]
+}
+
+// ProviderConfig returns the schema for the provider configuration of the
+// given provider type, or nil if no such schema is available.
+func (ss *Schemas) ProviderConfig(provider addrs.Provider) *configschema.Block {
+	return ss.ProviderSchema(provider).Provider.Block
+}
+
+// ResourceTypeConfig returns the schema for the configuration of a given
+// resource type belonging to a given provider type, or nil of no such
+// schema is available.
+//
+// In many cases the provider type is inferable from the resource type name,
+// but this is not always true because users can override the provider for
+// a resource using the "provider" meta-argument. Therefore, it's important to
+// always pass the correct provider name, even though it many cases it feels
+// redundant.
+func (ss *Schemas) ResourceTypeConfig(provider addrs.Provider, resourceMode addrs.ResourceMode, resourceType string) (block *providers.Schema, schemaVersion uint64) {
+	ps := ss.ProviderSchema(provider)
+	return ps.SchemaForResourceType(resourceMode, resourceType)
+}
+
+// ProvisionerConfig returns the schema for the configuration of a given
+// provisioner, or nil of no such schema is available.
+func (ss *Schemas) ProvisionerConfig(name string) *configschema.Block {
+	return ss.Provisioners[name]
+}

--- a/internal/tofu/schemas.go
+++ b/internal/tofu/schemas.go
@@ -14,52 +14,17 @@ import (
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
+	"github.com/opentofu/opentofu/internal/plugins"
 	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/states"
 	"github.com/opentofu/opentofu/internal/tfdiags"
 )
 
-// Schemas is a container for various kinds of schema that OpenTofu needs
-// during processing.
-type Schemas struct {
-	Providers    map[addrs.Provider]providers.ProviderSchema
-	Provisioners map[string]*configschema.Block
-}
-
-// ProviderSchema returns the entire ProviderSchema object that was produced
-// by the plugin for the given provider, or nil if no such schema is available.
+// Schemas is the original name for [plugins.Schemas], preserved as an alias
+// here for now to preserve existing references to this type.
 //
-// It's usually better to go use the more precise methods offered by type
-// Schemas to handle this detail automatically.
-func (ss *Schemas) ProviderSchema(provider addrs.Provider) providers.ProviderSchema {
-	return ss.Providers[provider]
-}
-
-// ProviderConfig returns the schema for the provider configuration of the
-// given provider type, or nil if no such schema is available.
-func (ss *Schemas) ProviderConfig(provider addrs.Provider) *configschema.Block {
-	return ss.ProviderSchema(provider).Provider.Block
-}
-
-// ResourceTypeConfig returns the schema for the configuration of a given
-// resource type belonging to a given provider type, or nil of no such
-// schema is available.
-//
-// In many cases the provider type is inferable from the resource type name,
-// but this is not always true because users can override the provider for
-// a resource using the "provider" meta-argument. Therefore, it's important to
-// always pass the correct provider name, even though it many cases it feels
-// redundant.
-func (ss *Schemas) ResourceTypeConfig(provider addrs.Provider, resourceMode addrs.ResourceMode, resourceType string) (block *providers.Schema, schemaVersion uint64) {
-	ps := ss.ProviderSchema(provider)
-	return ps.SchemaForResourceType(resourceMode, resourceType)
-}
-
-// ProvisionerConfig returns the schema for the configuration of a given
-// provisioner, or nil of no such schema is available.
-func (ss *Schemas) ProvisionerConfig(name string) *configschema.Block {
-	return ss.Provisioners[name]
-}
+// Use [plugins.Schemas] directly in new code.
+type Schemas = plugins.Schemas
 
 // loadSchemas searches the given configuration, state  and plan (any of which
 // may be nil) for constructs that have an associated schema, requests the
@@ -71,7 +36,7 @@ func (ss *Schemas) ProvisionerConfig(name string) *configschema.Block {
 // either misbehavior on the part of one of the providers or of the provider
 // protocol itself. When returned with errors, the returned schemas object is
 // still valid but may be incomplete.
-func loadSchemas(ctx context.Context, config *configs.Config, state *states.State, plugins *contextPlugins) (*Schemas, error) {
+func loadSchemas(ctx context.Context, config *configs.Config, state *states.State, plugins *contextPlugins) (*plugins.Schemas, error) {
 	var diags tfdiags.Diagnostics
 
 	provisioners, provisionerDiags := loadProvisionerSchemas(ctx, config, plugins)


### PR DESCRIPTION
The `Schemas` type is a cross-cutting concern used by lots of other packages, and so it's challenging for it to live in `package tofu` due to how many other packages that central package depends on itself.

This commit therefore moves the type itself into the `plugins` package, which is not a perfect fit because not all of the components that produce schemas are actually plugins, but plugins are the most common source of schemas and so it's likely that packages which depend on schemas will also depend on the `plugins` package in some way (directly or indirectly). Therefore this is a pragmatic compromise just to make it easier for more packages to import the `Schemas` type without causing import cycles.

This also updates the various packages used to generate JSON representations of different OpenTofu models, since those packages are indirectly imported by other useful packages and thus previously those other packages could not be imported by `package tofu`.

`package tofu` retains the responsibility for constructing `plugins.Schemas` objects based on its own internal representation of plugins, since most other code that uses `plugins.Schemas` just accepts an object already constructed elsewhere rather than needing to construct its own objects of that type.

(This was motivated by https://github.com/opentofu/opentofu/pull/4396#discussion_r3905447244.)

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
