### PR TITLE
go.mod: Upgrade to Go 1.27.1 [v1.13 backport]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opentofu/opentofu
 
-go 1.27
+go 1.27.1
 
 // At the time of adding this configuration, the new Go feature introduced here https://github.com/golang/go/issues/67061,
 // was having a good amount of issues linked to, affecting AWS Firewall, GCP various services and a lot more.


### PR DESCRIPTION
This is just a routine upgrade. This upstream release has an assortment of fixes that are not yet known to cause any problems for OpenTofu, but upgrading this now means that we can begin the OpenTofu v1.13 series on the latest available version of Go.

I dithered a little about whether to submit this during the v1.13.0 prerelease period: [the changes in this release](https://github.com/golang/go/issues?q=milestone%3AGo1.27.1+label%3ACherryPickApproved) all seem relatively low-risk, but also we aren't yet aware of any of the problems fixed there actually causing problems for OpenTofu.

My conclusion was that overall it seems better to incorporate these smaller fixes now, rather than waiting until v1.13.1, since we upgraded to go1.27 late in our v1.13 development period and so it hasn't had a lot of time to bake yet. If we were already at the release candidate phase then I would be more cautious here, but personally I think the risk tradeoff here favors accepting this for inclusion in v1.13.1-rc1.

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
