### PR TITLE
json*: Don't import `package tofu` from test files

### DIFF
--- a/internal/command/jsonconfig/config_test.go
+++ b/internal/command/jsonconfig/config_test.go
@@ -12,12 +12,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
+	"github.com/opentofu/opentofu/internal/plugins"
 	"github.com/opentofu/opentofu/internal/providers"
-	"github.com/opentofu/opentofu/internal/tofu"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func TestFindSourceProviderConfig(t *testing.T) {
@@ -116,7 +117,7 @@ func TestFindSourceProviderConfig(t *testing.T) {
 }
 
 func TestMarshalModule(t *testing.T) {
-	emptySchemas := &tofu.Schemas{}
+	emptySchemas := &plugins.Schemas{}
 	providerAddr := addrs.NewProvider("host", "namespace", "type")
 	resSchema := map[string]providers.Schema{
 		"test_type": {
@@ -134,7 +135,7 @@ func TestMarshalModule(t *testing.T) {
 
 	tests := map[string]struct {
 		Input   *configs.Config
-		Schemas *tofu.Schemas
+		Schemas *plugins.Schemas
 		Want    module
 	}{
 		"empty": {
@@ -306,7 +307,7 @@ func TestMarshalModule(t *testing.T) {
 					},
 				},
 			},
-			Schemas: &tofu.Schemas{
+			Schemas: &plugins.Schemas{
 				Providers: map[addrs.Provider]providers.ProviderSchema{
 					providerAddr: {
 						ResourceTypes:      resSchema,

--- a/internal/command/jsonplan/values_test.go
+++ b/internal/command/jsonplan/values_test.go
@@ -15,9 +15,9 @@ import (
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/plans"
+	"github.com/opentofu/opentofu/internal/plugins"
 	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/states"
-	"github.com/opentofu/opentofu/internal/tofu"
 )
 
 func TestMarshalAttributeValues(t *testing.T) {
@@ -375,8 +375,8 @@ func TestMarshalPlanValuesNoopDeposed(t *testing.T) {
 	}
 }
 
-func testSchemas() *tofu.Schemas {
-	return &tofu.Schemas{
+func testSchemas() *plugins.Schemas {
+	return &plugins.Schemas{
 		Providers: map[addrs.Provider]providers.ProviderSchema{
 			addrs.NewDefaultProvider("test"): providers.ProviderSchema{
 				ResourceTypes: map[string]providers.Schema{

--- a/internal/command/jsonstate/state_test.go
+++ b/internal/command/jsonstate/state_test.go
@@ -17,9 +17,9 @@ import (
 	"github.com/opentofu/opentofu/internal/addrs"
 	"github.com/opentofu/opentofu/internal/configs/configschema"
 	"github.com/opentofu/opentofu/internal/lang/marks"
+	"github.com/opentofu/opentofu/internal/plugins"
 	"github.com/opentofu/opentofu/internal/providers"
 	"github.com/opentofu/opentofu/internal/states"
-	"github.com/opentofu/opentofu/internal/tofu"
 )
 
 func TestMarshalOutputs(t *testing.T) {
@@ -202,7 +202,7 @@ func TestMarshalResources(t *testing.T) {
 	deposedKey := states.NewDeposedKey()
 	tests := map[string]struct {
 		Resources map[string]*states.Resource
-		Schemas   *tofu.Schemas
+		Schemas   *plugins.Schemas
 		Want      []Resource
 		ErrMsg    string
 	}{
@@ -938,8 +938,8 @@ func TestMarshalModules_parent_no_resources(t *testing.T) {
 	}
 }
 
-func testSchemas() *tofu.Schemas {
-	return &tofu.Schemas{
+func testSchemas() *plugins.Schemas {
+	return &plugins.Schemas{
 		Providers: map[addrs.Provider]providers.ProviderSchema{
 			addrs.NewDefaultProvider("test"): {
 				ResourceTypes: map[string]providers.Schema{


### PR DESCRIPTION
In https://github.com/opentofu/opentofu/pull/4544 I removed imports of `package tofu` from the main source files, but left some references in the test files that would make the tests in these packages fail to build if `package tofu` imported `package format`.

This change should make it okay for `package tofu` to import `package format` without making the tests in these packages fail.

In particular, rebasing https://github.com/opentofu/opentofu/pull/4396 on top of this change should allow its test runs to begin passing.

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
