### PR TITLE
tofu: Remove obsolete "SkipExperimental" flags

### DIFF
--- a/internal/tofu/context_apply2_test.go
+++ b/internal/tofu/context_apply2_test.go
@@ -112,7 +112,6 @@ func TestContext2Apply_createBeforeDestroy_deposedKeyPreApply(t *testing.T) {
 // This tests that when a CBD (C) resource depends on a non-CBD (B) resource that depends on another CBD resource (A)
 // Check that create_before_destroy is still set on the B resource after only the B resource is updated
 func TestContext2Apply_createBeforeDestroy_dependsNonCBDUpdate(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureCBD)
 	m := testModule(t, "apply-cbd-depends-non-cbd-update")
 	p := simpleMockProvider()
 
@@ -180,7 +179,7 @@ func TestContext2Apply_createBeforeDestroy_dependsNonCBDUpdate(t *testing.T) {
 		t.Log(legacyDiffComparisonString(plan.Changes))
 	}
 
-	SkipExperimental(t, ExperimentalBugMissingProvider, ExperimentalBugStateCBD)
+	SkipExperimental(t, ExperimentalBugStateCBD)
 	state, diags = ctx.Apply(context.Background(), plan, m, nil)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
@@ -369,7 +368,7 @@ resource "test_instance" "a" {
 
 // verify that dependencies are updated in the state during refresh and apply
 func TestApply_updateDependencies(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureStateDependencies, ExperimentalFeatureRefresh)
+	SkipExperimental(t, ExperimentalFeatureRefresh)
 
 	state := states.NewState()
 	root := state.EnsureModule(addrs.RootModuleInstance)
@@ -736,8 +735,6 @@ func TestContext2Apply_sensitiveInsideUnknown(t *testing.T) {
 }
 
 func TestContext2Apply_ignoreImpureFunctionChanges(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureIgnoreChanges)
-
 	// The impure function call should not cause a planned change with
 	// ignore_changes
 	m := testModuleInline(t, map[string]string{
@@ -830,7 +827,6 @@ resource "test_object" "x" {
 		}, nil),
 	})
 
-	SkipExperimental(t, ExperimentalFeatureCBD)
 	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
@@ -887,7 +883,6 @@ resource "test_object" "x" {
 		}, nil),
 	})
 
-	SkipExperimental(t, ExperimentalFeatureCBD)
 	plan, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.DestroyMode,
 	})
@@ -902,8 +897,6 @@ resource "test_object" "x" {
 }
 
 func TestContext2Apply_nullableVariables(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureRootOutput)
-
 	m := testModule(t, "apply-nullable-variables")
 	state := states.NewState()
 	ctx := testContext2(t, &ContextOpts{})
@@ -937,8 +930,6 @@ func TestContext2Apply_nullableVariables(t *testing.T) {
 }
 
 func TestContext2Apply_targetedDestroyWithMoved(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureMoved, ExperimentalBugDeclareProvider)
-
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 module "modb" {
@@ -989,7 +980,7 @@ resource "test_object" "s" {
 
 // This test is inspired by the above test TestContext2Apply_targetedDestroyWithMoved
 func TestContext2Apply_excludedDestroyWithMoved(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureMoved, ExperimentalBugDeclareProvider)
+	SkipExperimental(t, ExperimentalFeatureMoved)
 
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
@@ -1749,8 +1740,6 @@ func TestContext2Apply_resourceConditionApplyTimeFail(t *testing.T) {
 // pass an input through some expanded values, and back to a provider to make
 // sure we can fully evaluate a provider configuration during a destroy plan.
 func TestContext2Apply_destroyWithConfiguredProvider(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
-
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 variable "in" {
@@ -2008,7 +1997,6 @@ resource "test_object" "x" {
 }
 
 func TestContext2Apply_missingOrphanedResource(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugStateProvider)
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 # changed resource address to create a new object
@@ -2056,7 +2044,7 @@ resource "test_object" "y" {
 // Check eval from both root level outputs and module outputs, which are
 // handled differently during apply.
 func TestContext2Apply_outputsNotToEvaluate(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureRootOutput, ExperimentalBugDataResource)
+	SkipExperimental(t, ExperimentalBugDataResource)
 
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
@@ -2411,8 +2399,6 @@ output "a" {
 }
 
 func TestContext2Apply_destroyNullModuleOutput(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureRootOutput)
-
 	p := testProvider("test")
 	ctx := testContext2(t, &ContextOpts{
 		Plugins: plugins.NewLibrary(map[addrs.Provider]providers.Factory{
@@ -2623,8 +2609,6 @@ resource "test_resource" "b" {
 }
 
 func TestContext2Apply_destroyUnusedModuleProvider(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugStateProvider, ExperimentalFeatureDestroy)
-
 	// an unused provider within a module should not be called during destroy
 	unusedProvider := testProvider("unused")
 	testProvider := testProvider("test")
@@ -2668,7 +2652,7 @@ resource "unused_resource" "test" {
 }
 
 func TestContext2Apply_import(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureImport, ExperimentalFeatureHooks)
+	SkipExperimental(t, ExperimentalFeatureImport)
 
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
@@ -2828,7 +2812,7 @@ locals {
 }
 
 func TestContext2Apply_forgetOrphanAndDeposed(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugStateProvider, ExperimentalFeatureDeposed)
+	SkipExperimental(t, ExperimentalFeatureDeposed)
 
 	desposedKey := states.DeposedKey("deposed")
 	addr := "aws_instance.baz"
@@ -2940,7 +2924,6 @@ func TestContext2Apply_forgetOrphanAndDeposedWithDynamicProvider(t *testing.T) {
 
 	p.PlanResourceChangeFn = testDiffFn
 
-	SkipExperimental(t, ExperimentalFeatureCBD)
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	assertNoErrors(t, diags)
 
@@ -4783,8 +4766,6 @@ func TestContext2Apply_excludedModuleRecursive(t *testing.T) {
 }
 
 func TestContext2Apply_providerResourceIteration(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProviderInstances)
-
 	localComplete := `
 locals {
 	direct = "primary"
@@ -5010,8 +4991,6 @@ data "test_data_source" "b_direct" {
 }
 
 func TestContext2Apply_providerModuleIteration(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProviderInstances)
-
 	localComplete := `
 locals {
 	direct = "primary"
@@ -5153,7 +5132,6 @@ data "test_data_source" "b" {
 
 		_, diags = destroy(t, complete, state)
 		if diags.HasErrors() {
-			SkipExperimental(t, ExperimentalFeatureDestroy)
 			t.Fatal(diags.Err())
 		}
 	})
@@ -5200,7 +5178,6 @@ data "test_data_source" "b" {
 
 		_, diags = destroy(t, partial, state)
 		if diags.HasErrors() {
-			SkipExperimental(t, ExperimentalFeatureDestroy)
 			t.Fatal(diags.Err())
 		}
 	})
@@ -5239,7 +5216,7 @@ data "test_data_source" "b" {
 				return
 			}
 		}
-		SkipExperimental(t, ExperimentalBugStateProvider, ExperimentalChangeDiagWording)
+		SkipExperimental(t, ExperimentalChangeDiagWording)
 		t.Fatal(diags.Err())
 	})
 }
@@ -6226,7 +6203,7 @@ resource "test_instance" "a" {
 // the variable values given in ApplyArgs are getting merged correctly with
 // the plan ones.
 func TestContext2Apply_planVariablesAndApplyArgsGetMergedCorrectly(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureRootOutput, ExperimentalFlagUnknown)
+	SkipExperimental(t, ExperimentalFlagUnknown)
 
 	m := testModuleInline(t, map[string]string{
 		`main.tf`: `
@@ -6711,7 +6688,7 @@ func TestMergePlanAndApplyVariables(t *testing.T) {
 }
 
 func TestContext2Apply_enabledForResource(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureRootOutput, ExperimentalFeatureChanges)
+	SkipExperimental(t, ExperimentalFeatureChanges)
 
 	m := testModule(t, "apply-enabled-resource")
 	p := &MockProvider{
@@ -6977,8 +6954,6 @@ func TestContext2Apply_enabledForModule(t *testing.T) {
 // provider function can be used by referencing it in a dynamic block inside
 // a resource.
 func TestContext2Apply_callingProviderFunctionFromDynamicBlock(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProviderFunctions)
-
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 terraform {

--- a/internal/tofu/context_apply_test.go
+++ b/internal/tofu/context_apply_test.go
@@ -349,8 +349,6 @@ aws_instance.bar:
 }
 
 func TestContext2Apply_resourceCountOneList(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureRootOutput)
-
 	m := testModule(t, "apply-resource-count-one-list")
 	p := testProvider("null")
 	p.PlanResourceChangeFn = testDiffFn
@@ -380,8 +378,6 @@ test = [foo]`)
 	}
 }
 func TestContext2Apply_resourceCountZeroList(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureRootOutput)
-
 	m := testModule(t, "apply-resource-count-zero-list")
 	p := testProvider("null")
 	p.PlanResourceChangeFn = testDiffFn
@@ -410,8 +406,6 @@ test = []`)
 }
 
 func TestContext2Apply_resourceDependsOnModule(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDependsOn)
-
 	m := testModule(t, "apply-resource-depends-on-module")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -464,8 +458,6 @@ func TestContext2Apply_resourceDependsOnModule(t *testing.T) {
 // Test that without a config, the Dependencies in the state are enough
 // to maintain proper ordering.
 func TestContext2Apply_resourceDependsOnModuleStateOnly(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDependsOn, ExperimentalBugStateProvider)
-
 	m := testModule(t, "apply-resource-depends-on-module-empty")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -537,8 +529,6 @@ func TestContext2Apply_resourceDependsOnModuleStateOnly(t *testing.T) {
 }
 
 func TestContext2Apply_resourceDependsOnModuleDestroy(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDependsOn, ExperimentalFeatureDestroy)
-
 	m := testModule(t, "apply-resource-depends-on-module")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -611,8 +601,6 @@ func TestContext2Apply_resourceDependsOnModuleDestroy(t *testing.T) {
 }
 
 func TestContext2Apply_resourceDependsOnModuleGrandchild(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDependsOn)
-
 	m := testModule(t, "apply-resource-depends-on-module-deep")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -664,8 +652,6 @@ func TestContext2Apply_resourceDependsOnModuleGrandchild(t *testing.T) {
 }
 
 func TestContext2Apply_resourceDependsOnModuleInModule(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureDependsOn)
-
 	m := testModule(t, "apply-resource-depends-on-module-in-module")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -717,7 +703,7 @@ func TestContext2Apply_resourceDependsOnModuleInModule(t *testing.T) {
 }
 
 func TestContext2Apply_mapVarBetweenModules(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalChangeModuleOutput)
+	SkipExperimental(t, ExperimentalChangeModuleOutput)
 
 	m := testModule(t, "apply-map-var-through-module")
 	p := testProvider("null")
@@ -757,7 +743,7 @@ module.test:
 }
 
 func TestContext2Apply_refCount(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureStateDependencies, ExperimentalChangeDependencies)
+	SkipExperimental(t, ExperimentalChangeDependencies)
 
 	m := testModule(t, "apply-ref-count")
 	p := testProvider("aws")
@@ -934,8 +920,6 @@ aws_instance.foo:
 }
 
 func TestContext2Apply_emptyModule(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureRootOutput)
-
 	// A module with only outputs (no resources)
 	m := testModule(t, "apply-empty-module")
 	p := testProvider("aws")
@@ -963,8 +947,6 @@ func TestContext2Apply_emptyModule(t *testing.T) {
 }
 
 func TestContext2Apply_createBeforeDestroy(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureCBD)
-
 	m := testModule(t, "apply-good-create-before")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -993,7 +975,6 @@ func TestContext2Apply_createBeforeDestroy(t *testing.T) {
 		t.Logf("%s", legacyDiffComparisonString(plan.Changes))
 	}
 
-	SkipExperimental(t, ExperimentalBugMissingProvider)
 	state, diags = ctx.Apply(context.Background(), plan, m, nil)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
@@ -1069,7 +1050,6 @@ func TestContext2Apply_createBeforeDestroyUpdate(t *testing.T) {
 		}, nil),
 	})
 
-	SkipExperimental(t, ExperimentalBugMissingProvider)
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
@@ -1097,8 +1077,6 @@ func TestContext2Apply_createBeforeDestroyUpdate(t *testing.T) {
 // This tests that when a CBD resource depends on a non-CBD resource,
 // we can still properly apply changes that require new for both.
 func TestContext2Apply_createBeforeDestroy_dependsNonCBD(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureCBD)
-
 	m := testModule(t, "apply-cbd-depends-non-cbd")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -1138,7 +1116,6 @@ func TestContext2Apply_createBeforeDestroy_dependsNonCBD(t *testing.T) {
 		t.Logf("%s", legacyDiffComparisonString(plan.Changes))
 	}
 
-	SkipExperimental(t, ExperimentalBugMissingProvider)
 	state, diags = ctx.Apply(context.Background(), plan, m, nil)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
@@ -1170,8 +1147,6 @@ aws_instance.foo:
 }
 
 func TestContext2Apply_createBeforeDestroy_hook(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureCBD, ExperimentalFeatureHooks)
-
 	h := new(MockHook)
 	m := testModule(t, "apply-good-create-before")
 	p := testProvider("aws")
@@ -1288,7 +1263,6 @@ func TestContext2Apply_createBeforeDestroy_deposedCount(t *testing.T) {
 		}, nil),
 	})
 
-	SkipExperimental(t, ExperimentalFeatureCBD)
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
@@ -1351,7 +1325,6 @@ func TestContext2Apply_createBeforeDestroy_deposedOnly(t *testing.T) {
 		}, nil),
 	})
 
-	SkipExperimental(t, ExperimentalFeatureCBD)
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
@@ -1359,7 +1332,6 @@ func TestContext2Apply_createBeforeDestroy_deposedOnly(t *testing.T) {
 		t.Logf("%s", legacyDiffComparisonString(plan.Changes))
 	}
 
-	SkipExperimental(t, ExperimentalBugMissingProvider)
 	state, diags = ctx.Apply(context.Background(), plan, m, nil)
 	if diags.HasErrors() {
 		t.Fatalf("diags: %s", diags.Err())
@@ -1374,8 +1346,6 @@ aws_instance.bar:
 }
 
 func TestContext2Apply_destroyComputed(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDestroy)
-
 	m := testModule(t, "apply-destroy-computed")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -1414,8 +1384,6 @@ func TestContext2Apply_destroyComputed(t *testing.T) {
 
 // Test that the destroy operation uses depends_on as a source of ordering.
 func TestContext2Apply_destroyDependsOn(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDependsOn)
-
 	// It is possible for this to be racy, so we loop a number of times
 	// just to check.
 	for i := 0; i < 10; i++ {
@@ -1424,7 +1392,6 @@ func TestContext2Apply_destroyDependsOn(t *testing.T) {
 }
 
 func testContext2Apply_destroyDependsOn(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDestroy)
 	m := testModule(t, "apply-destroy-depends-on")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -1488,8 +1455,6 @@ func testContext2Apply_destroyDependsOn(t *testing.T) {
 // Test that destroy ordering is correct with dependencies only
 // in the state.
 func TestContext2Apply_destroyDependsOnStateOnly(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDependsOn, ExperimentalBugStateProvider)
-
 	newState := states.NewState()
 	root := newState.EnsureModule(addrs.RootModuleInstance)
 	root.SetResourceInstanceCurrent(
@@ -1546,8 +1511,6 @@ func TestContext2Apply_destroyDependsOnStateOnly(t *testing.T) {
 }
 
 func testContext2Apply_destroyDependsOnStateOnly(t *testing.T, state *states.State) {
-	SkipExperimental(t, ExperimentalFeatureDependsOn)
-
 	state = state.DeepCopy()
 	m := testModule(t, "empty")
 	p := testProvider("aws")
@@ -1588,8 +1551,6 @@ func testContext2Apply_destroyDependsOnStateOnly(t *testing.T, state *states.Sta
 // Test that destroy ordering is correct with dependencies only
 // in the state within a module (GH-11749)
 func TestContext2Apply_destroyDependsOnStateOnlyModule(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDependsOn, ExperimentalBugStateProvider)
-
 	newState := states.NewState()
 	child := newState.EnsureModule(addrs.RootModuleInstance.Child("child", addrs.NoKey))
 	child.SetResourceInstanceCurrent(
@@ -1646,8 +1607,6 @@ func TestContext2Apply_destroyDependsOnStateOnlyModule(t *testing.T) {
 }
 
 func testContext2Apply_destroyDependsOnStateOnlyModule(t *testing.T, state *states.State) {
-	SkipExperimental(t, ExperimentalFeatureDependsOn)
-
 	state = state.DeepCopy()
 	m := testModule(t, "empty")
 	p := testProvider("aws")
@@ -1792,7 +1751,6 @@ func TestContext2Apply_destroyData(t *testing.T) {
 		t.Fatalf("state has %d resources after destroy; want 0", got)
 	}
 
-	SkipExperimental(t, ExperimentalFeatureHooks)
 	wantHookCalls := []*testHookCall{
 		{"PreApply", "data.null_data_source.testing"},
 		{"PostApply", "data.null_data_source.testing"},
@@ -1805,8 +1763,6 @@ func TestContext2Apply_destroyData(t *testing.T) {
 
 // https://github.com/hashicorp/terraform/pull/5096
 func TestContext2Apply_destroySkipsCBD(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureCBD)
-
 	// Config contains CBD resource depending on non-CBD resource, which triggers
 	// a cycle if they are both replaced, but should _not_ trigger a cycle when
 	// just doing a `tofu destroy`.
@@ -1855,8 +1811,6 @@ func TestContext2Apply_destroySkipsCBD(t *testing.T) {
 }
 
 func TestContext2Apply_destroyModuleVarProviderConfig(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDestroy)
-
 	m := testModule(t, "apply-destroy-mod-var-provider-config")
 	p := func() (providers.Interface, error) {
 		p := testProvider("aws")
@@ -2146,7 +2100,7 @@ aws_instance.foo:
 }
 
 func TestContext2Apply_cancelProvisioner(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner, ExperimentalBugCancel)
+	SkipExperimental(t, ExperimentalBugCancel)
 
 	m := testModule(t, "apply-cancel-provisioner")
 	p := testProvider("aws")
@@ -2228,8 +2182,6 @@ aws_instance.foo: (tainted)
 }
 
 func TestContext2Apply_compute(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureStateDependencies)
-
 	m := testModule(t, "apply-compute")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -2354,7 +2306,7 @@ func TestContext2Apply_countDecrease(t *testing.T) {
 }
 
 func TestContext2Apply_countDecreaseToOneX(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugStateProvider, ExperimentalFeatureMoved)
+	SkipExperimental(t, ExperimentalFeatureMoved)
 	m := testModule(t, "apply-count-dec-one")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -2597,7 +2549,7 @@ func TestContext2Apply_countVariable(t *testing.T) {
 }
 
 func TestContext2Apply_countVariableRef(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureStateDependencies, ExperimentalChangeDependencies)
+	SkipExperimental(t, ExperimentalChangeDependencies)
 
 	m := testModule(t, "apply-count-variable-ref")
 	p := testProvider("aws")
@@ -2625,8 +2577,6 @@ func TestContext2Apply_countVariableRef(t *testing.T) {
 }
 
 func TestContext2Apply_provisionerInterpCount(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
-
 	// This test ensures that a provisioner can interpolate a resource count
 	// even though the provisioner expression is evaluated during the plan
 	// walk. https://github.com/hashicorp/terraform/issues/16840
@@ -2678,7 +2628,7 @@ func TestContext2Apply_provisionerInterpCount(t *testing.T) {
 }
 
 func TestContext2Apply_winrmConnectionMigrationMessage(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner, ExperimentalChangeDiagWording)
+	SkipExperimental(t, ExperimentalChangeDiagWording)
 
 	// This is testing for an error diagnostic we've added temporarily
 	// for the v1.13 series to help folks migrate from the no-longer-supported
@@ -2750,8 +2700,6 @@ func TestContext2Apply_winrmConnectionMigrationMessage(t *testing.T) {
 }
 
 func TestContext2Apply_foreachVariable(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureStateDependencies)
-
 	m := testModule(t, "plan-for-each-unknown-value")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -2811,8 +2759,6 @@ func TestContext2Apply_moduleBasic(t *testing.T) {
 }
 
 func TestContext2Apply_moduleDestroyOrder(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugExecGraph, ExperimentalFeatureDestroy)
-
 	m := testModule(t, "apply-module-destroy-order")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -2948,7 +2894,7 @@ module.child:
 }
 
 func TestContext2Apply_orphanResource(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugStateProvider, ExperimentalFeatureChecks)
+	SkipExperimental(t, ExperimentalFeatureChecks)
 
 	// This is a two-step test:
 	// 1. Apply a configuration with resources that have count set.
@@ -3243,8 +3189,6 @@ func TestContext2Apply_moduleGrandchildProvider(t *testing.T) {
 // case: aws is explicitly added to root, but "test" should be added to.
 // With the bug, it wasn't.
 func TestContext2Apply_moduleOnlyProvider(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
-
 	m := testModule(t, "apply-module-only-provider")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -3276,8 +3220,6 @@ func TestContext2Apply_moduleOnlyProvider(t *testing.T) {
 }
 
 func TestContext2Apply_moduleProviderAlias(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugReferenceProvider)
-
 	m := testModule(t, "apply-module-provider-alias")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -3345,8 +3287,6 @@ func TestContext2Apply_moduleProviderAliasTargets(t *testing.T) {
 }
 
 func TestContext2Apply_moduleProviderCloseNested(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugStateProvider)
-
 	m := testModule(t, "apply-module-provider-close-nested")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -3384,8 +3324,6 @@ func TestContext2Apply_moduleProviderCloseNested(t *testing.T) {
 // accessing "non-existent" resources (they existed, just not in the graph
 // cause they weren't in the diff).
 func TestContext2Apply_moduleVarRefExisting(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugExecGraph, ExperimentalFeatureStateDependencies, ExperimentalFeatureUpgradeState)
-
 	m := testModule(t, "apply-ref-existing")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -3424,8 +3362,6 @@ func TestContext2Apply_moduleVarRefExisting(t *testing.T) {
 }
 
 func TestContext2Apply_moduleVarResourceCount(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
-
 	m := testModule(t, "apply-module-var-resource-count")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -3820,8 +3756,6 @@ func TestContext2Apply_multiProviderDestroyChild(t *testing.T) {
 }
 
 func TestContext2Apply_multiVar(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureRootOutput)
-
 	m := testModule(t, "apply-multi-var")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -3904,8 +3838,6 @@ func TestContext2Apply_multiVar(t *testing.T) {
 // parts of OpenTofu and so here we want to assert the expected behavior and
 // ensure that it remains consistent in future.
 func TestContext2Apply_multiVarComprehensive(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureRootOutput)
-
 	m := testModule(t, "apply-multi-var-comprehensive")
 	p := testProvider("test")
 
@@ -4130,8 +4062,6 @@ func TestContext2Apply_multiVarComprehensive(t *testing.T) {
 // Test that multi-var (splat) access is ordered by count, not by
 // value.
 func TestContext2Apply_multiVarOrder(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureRootOutput)
-
 	m := testModule(t, "apply-multi-var-order")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -4166,8 +4096,6 @@ func TestContext2Apply_multiVarOrder(t *testing.T) {
 // Test that multi-var (splat) access is ordered by count, not by
 // value, through interpolations.
 func TestContext2Apply_multiVarOrderInterp(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugExecGraph, ExperimentalFeatureRootOutput)
-
 	m := testModule(t, "apply-multi-var-order-interp")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -4346,8 +4274,6 @@ func TestContext2Apply_multiVarCountDec(t *testing.T) {
 // exist yet.
 // https://github.com/hashicorp/terraform/issues/14438
 func TestContext2Apply_multiVarMissingState(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
-
 	m := testModule(t, "apply-multi-var-missing-state")
 	p := testProvider("test")
 	p.PlanResourceChangeFn = testDiffFn
@@ -4381,7 +4307,7 @@ func TestContext2Apply_multiVarMissingState(t *testing.T) {
 }
 
 func TestContext2Apply_outputOrphan(t *testing.T) {
-	SkipExperimental(t, ExperimentalFlagUnknown, ExperimentalFeatureRootOutput)
+	SkipExperimental(t, ExperimentalFlagUnknown)
 
 	m := testModule(t, "apply-output-orphan")
 	p := testProvider("aws")
@@ -4414,7 +4340,7 @@ func TestContext2Apply_outputOrphan(t *testing.T) {
 }
 
 func TestContext2Apply_outputOrphanModule(t *testing.T) {
-	SkipExperimental(t, ExperimentalFlagUnknown, ExperimentalFeatureRootOutput)
+	SkipExperimental(t, ExperimentalFlagUnknown)
 
 	m := testModule(t, "apply-output-orphan-module")
 	p := testProvider("aws")
@@ -4541,8 +4467,6 @@ func TestContext2Apply_providerConfigureDisabled(t *testing.T) {
 }
 
 func TestContext2Apply_provisionerModule(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
-
 	m := testModule(t, "apply-provisioner-module")
 
 	p := testProvider("aws")
@@ -4587,8 +4511,6 @@ func TestContext2Apply_provisionerModule(t *testing.T) {
 }
 
 func TestContext2Apply_Provisioner_compute(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
-
 	m := testModule(t, "apply-provisioner-compute")
 	p := testProvider("aws")
 	pr := testProvisioner()
@@ -4651,8 +4573,6 @@ func TestContext2Apply_Provisioner_compute(t *testing.T) {
 }
 
 func TestContext2Apply_provisionerCreateFail(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
-
 	m := testModule(t, "apply-provisioner-fail-create")
 	p := testProvider("aws")
 	pr := testProvisioner()
@@ -4689,8 +4609,6 @@ func TestContext2Apply_provisionerCreateFail(t *testing.T) {
 }
 
 func TestContext2Apply_provisionerCreateFailNoId(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
-
 	m := testModule(t, "apply-provisioner-fail-create")
 	p := testProvider("aws")
 	pr := testProvisioner()
@@ -4725,8 +4643,6 @@ func TestContext2Apply_provisionerCreateFailNoId(t *testing.T) {
 }
 
 func TestContext2Apply_provisionerFail(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
-
 	m := testModule(t, "apply-provisioner-fail")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -4761,8 +4677,6 @@ func TestContext2Apply_provisionerFail(t *testing.T) {
 }
 
 func TestContext2Apply_provisionerFail_createBeforeDestroy(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureCBD, ExperimentalFeatureProvisioner)
-
 	m := testModule(t, "apply-provisioner-fail-create-before")
 	p := testProvider("aws")
 	pr := testProvisioner()
@@ -4809,8 +4723,6 @@ func TestContext2Apply_provisionerFail_createBeforeDestroy(t *testing.T) {
 }
 
 func TestContext2Apply_error_createBeforeDestroy(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureCBD)
-
 	m := testModule(t, "apply-error-create-before")
 	p := testProvider("aws")
 
@@ -4858,8 +4770,6 @@ func TestContext2Apply_error_createBeforeDestroy(t *testing.T) {
 }
 
 func TestContext2Apply_errorDestroy_createBeforeDestroy(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureCBD)
-
 	m := testModule(t, "apply-error-create-before")
 	p := testProvider("aws")
 
@@ -4909,8 +4819,6 @@ func TestContext2Apply_errorDestroy_createBeforeDestroy(t *testing.T) {
 }
 
 func TestContext2Apply_multiDepose_createBeforeDestroy(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureCBD)
-
 	m := testModule(t, "apply-multi-depose-create-before-destroy")
 	p := testProvider("aws")
 	ps := map[addrs.Provider]providers.Factory{addrs.NewDefaultProvider("aws"): testProviderFuncFixed(p)}
@@ -5122,8 +5030,6 @@ aws_instance.web:
 // Verify that a normal provisioner with on_failure "continue" set won't
 // taint the resource and continues executing.
 func TestContext2Apply_provisionerFailContinue(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
-
 	m := testModule(t, "apply-provisioner-fail-continue")
 	p := testProvider("aws")
 	pr := testProvisioner()
@@ -5168,8 +5074,6 @@ aws_instance.foo:
 // Verify that a normal provisioner with on_failure "continue" records
 // the error with the hook.
 func TestContext2Apply_provisionerFailContinueHook(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
-
 	h := new(MockHook)
 	m := testModule(t, "apply-provisioner-fail-continue")
 	p := testProvider("aws")
@@ -5205,8 +5109,6 @@ func TestContext2Apply_provisionerFailContinueHook(t *testing.T) {
 }
 
 func TestContext2Apply_provisionerDestroy(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
-
 	m := testModule(t, "apply-provisioner-destroy")
 	p := testProvider("aws")
 	pr := testProvisioner()
@@ -5258,8 +5160,6 @@ func TestContext2Apply_provisionerDestroy(t *testing.T) {
 
 // Verify that on destroy provisioner failure, nothing happens to the instance
 func TestContext2Apply_provisionerDestroyFail(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
-
 	m := testModule(t, "apply-provisioner-destroy")
 	p := testProvider("aws")
 	pr := testProvisioner()
@@ -5313,8 +5213,6 @@ aws_instance.foo["a"]:
 // Verify that on destroy provisioner failure with "continue" that
 // we continue to the next provisioner.
 func TestContext2Apply_provisionerDestroyFailContinue(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
-
 	m := testModule(t, "apply-provisioner-destroy-continue")
 	p := testProvider("aws")
 	pr := testProvisioner()
@@ -5382,8 +5280,6 @@ func TestContext2Apply_provisionerDestroyFailContinue(t *testing.T) {
 // we continue to the next provisioner. But if the next provisioner defines
 // to fail, then we fail after running it.
 func TestContext2Apply_provisionerDestroyFailContinueFail(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
-
 	m := testModule(t, "apply-provisioner-destroy-fail")
 	p := testProvider("aws")
 	pr := testProvisioner()
@@ -5453,7 +5349,7 @@ aws_instance.foo:
 
 // Verify destroy provisioners are not run for tainted instances.
 func TestContext2Apply_provisionerDestroyTainted(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner, ExperimentalFeatureTaint)
+	SkipExperimental(t, ExperimentalFeatureTaint)
 
 	m := testModule(t, "apply-provisioner-destroy")
 	p := testProvider("aws")
@@ -5529,8 +5425,6 @@ aws_instance.foo["a"]:
 }
 
 func TestContext2Apply_provisionerResourceRef(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
-
 	m := testModule(t, "apply-provisioner-resource-ref")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -5575,8 +5469,6 @@ func TestContext2Apply_provisionerResourceRef(t *testing.T) {
 }
 
 func TestContext2Apply_provisionerSelfRef(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
-
 	m := testModule(t, "apply-provisioner-self-ref")
 	p := testProvider("aws")
 	pr := testProvisioner()
@@ -5620,8 +5512,6 @@ func TestContext2Apply_provisionerSelfRef(t *testing.T) {
 }
 
 func TestContext2Apply_provisionerMultiSelfRef(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
-
 	var lock sync.Mutex
 	commands := make([]string, 0, 5)
 
@@ -5679,7 +5569,7 @@ func TestContext2Apply_provisionerMultiSelfRef(t *testing.T) {
 }
 
 func TestContext2Apply_provisionerMultiSelfRefSingle(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner, ExperimentalChangeCursedSelfRef)
+	SkipExperimental(t, ExperimentalChangeCursedSelfRef)
 
 	var lock sync.Mutex
 	order := make([]string, 0, 5)
@@ -5738,8 +5628,6 @@ func TestContext2Apply_provisionerMultiSelfRefSingle(t *testing.T) {
 }
 
 func TestContext2Apply_provisionerExplicitSelfRef(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
-
 	m := testModule(t, "apply-provisioner-explicit-self-ref")
 	p := testProvider("aws")
 	pr := testProvisioner()
@@ -5838,8 +5726,6 @@ func TestContext2Apply_provisionerForEachSelfRef(t *testing.T) {
 
 // Provisioner should NOT run on a diff, only create
 func TestContext2Apply_Provisioner_Diff(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
-
 	m := testModule(t, "apply-provisioner-diff")
 	p := testProvider("aws")
 	pr := testProvisioner()
@@ -5918,18 +5804,6 @@ func TestContext2Apply_Provisioner_Diff(t *testing.T) {
 }
 
 func TestContext2Apply_outputDiffVars(t *testing.T) {
-	// Unfortunately in experimental mode this test is currently flaking with
-	// errors like this, but not consistently on every run:
-	//
-	//     [ERROR] Provider instance not available: Cannot plan aws_instance.bar because its associated provider instance provider["registry.opentofu.org/hashicorp/aws"] cannot initialize.
-	//     [ERROR] Provider instance not available: Cannot plan aws_instance.bar because its associated provider instance provider["registry.opentofu.org/hashicorp/aws"] cannot initialize.
-	//     [ERROR] Provider instance not available: Cannot plan aws_instance.bar because its associated provider instance provider["registry.opentofu.org/hashicorp/aws"] cannot initialize.
-	//
-	// When this occurs it's raised from the check for diagnostics just after
-	// the call to ctx.Plan below, so it seems like something's not working
-	// quite right in how the plan phase handles provider configurations.
-	SkipExperimental(t, ExperimentalBugMissingProvider)
-
 	m := testModule(t, "apply-good")
 	p := testProvider("aws")
 
@@ -6034,7 +5908,6 @@ func TestContext2Apply_destroyX(t *testing.T) {
 	}
 
 	// Test that things were destroyed _in the right order_
-	SkipExperimental(t, ExperimentalFeatureHooks)
 	expected2 := []string{"aws_instance.bar", "aws_instance.foo"}
 	actual2 := h.IDs
 	if !reflect.DeepEqual(actual2, expected2) {
@@ -6091,7 +5964,6 @@ func TestContext2Apply_destroyOrder(t *testing.T) {
 		t.Fatalf("wrong result\n\ngot:\n%s\n\nwant:\n%s", actual, expected)
 	}
 
-	SkipExperimental(t, ExperimentalFeatureHooks)
 	// Test that things were destroyed _in the right order_
 	expected2 := []string{"aws_instance.bar", "aws_instance.foo"}
 	actual2 := h.IDs
@@ -6102,8 +5974,6 @@ func TestContext2Apply_destroyOrder(t *testing.T) {
 
 // https://github.com/hashicorp/terraform/issues/2767
 func TestContext2Apply_destroyModulePrefix(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugStateProvider, ExperimentalFeatureHooks)
-
 	m := testModule(t, "apply-destroy-module-resource-prefix")
 	h := new(MockHook)
 	p := testProvider("aws")
@@ -6155,8 +6025,6 @@ func TestContext2Apply_destroyModulePrefix(t *testing.T) {
 }
 
 func TestContext2Apply_destroyNestedModule(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugStateProvider)
-
 	m := testModule(t, "apply-destroy-nested-module")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -6196,8 +6064,6 @@ func TestContext2Apply_destroyNestedModule(t *testing.T) {
 }
 
 func TestContext2Apply_destroyDeeplyNestedModule(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugStateProvider)
-
 	m := testModule(t, "apply-destroy-deeply-nested-module")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -6237,8 +6103,6 @@ func TestContext2Apply_destroyDeeplyNestedModule(t *testing.T) {
 
 // https://github.com/hashicorp/terraform/issues/5440
 func TestContext2Apply_destroyModuleWithAttrsReferencingResource(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureDestroy, ExperimentalFeatureHooks)
-
 	m, snap := testModuleWithSnapshot(t, "apply-destroy-module-with-attrs")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -6317,8 +6181,6 @@ func TestContext2Apply_destroyModuleWithAttrsReferencingResource(t *testing.T) {
 }
 
 func TestContext2Apply_destroyWithModuleVariableAndCount(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureDestroy, ExperimentalFeatureHooks)
-
 	m, snap := testModuleWithSnapshot(t, "apply-destroy-mod-var-and-count")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -6467,8 +6329,6 @@ func TestContext2Apply_destroyTargetWithModuleVariableAndCount(t *testing.T) {
 }
 
 func TestContext2Apply_destroyWithModuleVariableAndCountNested(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureDestroy, ExperimentalFeatureHooks)
-
 	m, snap := testModuleWithSnapshot(t, "apply-destroy-mod-var-and-count-nested")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -6645,8 +6505,6 @@ func TestContext2Apply_destroyOrphan(t *testing.T) {
 }
 
 func TestContext2Apply_destroyTaintedProvisioner(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
-
 	m := testModule(t, "apply-destroy-provisioner")
 	p := testProvider("aws")
 	pr := testProvisioner()
@@ -6733,8 +6591,6 @@ func TestContext2Apply_error(t *testing.T) {
 }
 
 func TestContext2Apply_errorDestroy(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugStateProvider)
-
 	m := testModule(t, "empty")
 	p := testProvider("test")
 
@@ -7121,8 +6977,6 @@ func TestContext2Apply_idAttr(t *testing.T) {
 }
 
 func TestContext2Apply_outputBasic(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureRootOutput)
-
 	m := testModule(t, "apply-output")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -7149,8 +7003,6 @@ func TestContext2Apply_outputBasic(t *testing.T) {
 }
 
 func TestContext2Apply_outputAdd(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureRootOutput)
-
 	m1 := testModule(t, "apply-output-add-before")
 	p1 := testProvider("aws")
 	p1.ApplyResourceChangeFn = testApplyFn
@@ -7196,8 +7048,6 @@ func TestContext2Apply_outputAdd(t *testing.T) {
 }
 
 func TestContext2Apply_outputList(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureRootOutput)
-
 	m := testModule(t, "apply-output-list")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -7224,8 +7074,6 @@ func TestContext2Apply_outputList(t *testing.T) {
 }
 
 func TestContext2Apply_outputMulti(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureRootOutput)
-
 	m := testModule(t, "apply-output-multi")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -7252,8 +7100,6 @@ func TestContext2Apply_outputMulti(t *testing.T) {
 }
 
 func TestContext2Apply_outputMultiIndex(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureRootOutput)
-
 	m := testModule(t, "apply-output-multi-index")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -7398,7 +7244,7 @@ func TestContext2Apply_taintDep(t *testing.T) {
 }
 
 func TestContext2Apply_taintDepRequiresNew(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugExecGraph, ExperimentalFeatureTaint)
+	SkipExperimental(t, ExperimentalFeatureTaint)
 
 	m := testModule(t, "apply-taint-dep-requires-new")
 	p := testProvider("aws")
@@ -8330,8 +8176,6 @@ func TestContext2Apply_varsEnv(t *testing.T) {
 }
 
 func TestContext2Apply_createBefore_depends(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureHooks)
-
 	m := testModule(t, "apply-depends-create-before")
 	h := new(HookRecordApplyOrder)
 	p := testProvider("aws")
@@ -8598,19 +8442,6 @@ func TestContext2Apply_issue7824(t *testing.T) {
 // This deals with the situation where a splat expression is used referring
 // to another resource whose count is non-constant.
 func TestContext2Apply_issue5254(t *testing.T) {
-	// Unfortunately in experimental mode this test is currently flaking with
-	// errors like this, but not consistently on every run:
-	//
-	//     err: 2 problems:
-	//
-	//     - missing configuration for provider["registry.opentofu.org/hashicorp/template"]
-	//     - missing configuration for provider["registry.opentofu.org/hashicorp/template"]
-	//
-	// When this occurs it's raised from the check for diagnostics just after
-	// the call to ctx.Apply below, so it seems like something's not working
-	// quite right in how the apply phase handles provider configurations.
-	SkipExperimental(t, ExperimentalBugMissingProvider)
-
 	// Create a provider. We use "template" here just to match the repro
 	// we got from the issue itself.
 	p := testProvider("template")
@@ -8828,8 +8659,6 @@ aws_instance.foo:
 }
 
 func TestContext2Apply_ignoreChangesWithDep(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureIgnoreChanges)
-
 	m := testModule(t, "apply-ignore-changes-dep")
 	p := testProvider("aws")
 
@@ -8975,8 +8804,6 @@ aws_instance.foo:
 
 // https://github.com/hashicorp/terraform/issues/7378
 func TestContext2Apply_destroyNestedModuleWithAttrsReferencingResource(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureDestroy)
-
 	m, snap := testModuleWithSnapshot(t, "apply-destroy-nested-module-with-attrs")
 	p := testProvider("null")
 	p.PlanResourceChangeFn = testDiffFn
@@ -9041,7 +8868,7 @@ func TestContext2Apply_destroyNestedModuleWithAttrsReferencingResource(t *testin
 // If a data source explicitly depends on another resource, it's because we need
 // that resource to be applied first.
 func TestContext2Apply_dataDependsOn(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDependsOn, ExperimentalBugDataResource)
+	SkipExperimental(t, ExperimentalBugDataResource)
 
 	p := testProvider("null")
 	m := testModuleInline(t, map[string]string{
@@ -9170,8 +8997,6 @@ resource "null_instance" "depends" {
 }
 
 func TestContext2Apply_tfWorkspace(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeaturePathAttrs, ExperimentalFeatureRootOutput)
-
 	m := testModule(t, "apply-tf-workspace")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -9199,8 +9024,6 @@ func TestContext2Apply_tfWorkspace(t *testing.T) {
 }
 
 func TestContext2Apply_tofuWorkspace(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeaturePathAttrs, ExperimentalFeatureRootOutput)
-
 	m := testModule(t, "apply-tofu-workspace")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -9229,7 +9052,7 @@ func TestContext2Apply_tofuWorkspace(t *testing.T) {
 
 // verify that multiple config references only create a single depends_on entry
 func TestContext2Apply_multiRef(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureTarget, ExperimentalFeatureDependsOn)
+	SkipExperimental(t, ExperimentalFeatureTarget)
 
 	m := testModule(t, "apply-multi-ref")
 	p := testProvider("aws")
@@ -9255,7 +9078,7 @@ func TestContext2Apply_multiRef(t *testing.T) {
 }
 
 func TestContext2Apply_targetedModuleRecursive(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureTarget, ExperimentalBugDeclareProvider)
+	SkipExperimental(t, ExperimentalFeatureTarget)
 
 	m := testModule(t, "apply-targeted-module-recursive")
 	p := testProvider("aws")
@@ -9302,8 +9125,6 @@ module.child.subchild:
 }
 
 func TestContext2Apply_localVal(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureRootOutput)
-
 	m := testModule(t, "apply-local-val")
 	ctx := testContext2(t, &ContextOpts{
 		Plugins: plugins.NewLibrary(map[addrs.Provider]providers.Factory{}, nil),
@@ -9331,8 +9152,6 @@ result_3 = hello world
 }
 
 func TestContext2Apply_destroyWithLocals(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureRootOutput)
-
 	m := testModule(t, "apply-destroy-with-locals")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -9374,8 +9193,6 @@ func TestContext2Apply_destroyWithLocals(t *testing.T) {
 }
 
 func TestContext2Apply_providerWithLocals(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDestroy)
-
 	m := testModule(t, "provider-with-locals")
 	p := testProvider("aws")
 
@@ -9486,8 +9303,6 @@ func TestContext2Apply_destroyWithProviders(t *testing.T) {
 }
 
 func TestContext2Apply_providersFromState(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugStateProvider)
-
 	m := configs.NewEmptyConfig()
 	// Hack for new engine
 	m.Module.SourceDir = "."
@@ -9589,20 +9404,6 @@ func TestContext2Apply_providersFromState(t *testing.T) {
 }
 
 func TestContext2Apply_plannedInterpolatedCount(t *testing.T) {
-	// Unfortunately in experimental mode this test is currently flaking with
-	// errors like this, but not consistently on every run:
-	//
-	//     err: 3 problems:
-	//
-	//     - missing configuration for provider["registry.opentofu.org/hashicorp/aws"]
-	//     - missing configuration for provider["registry.opentofu.org/hashicorp/aws"]
-	//     - missing configuration for provider["registry.opentofu.org/hashicorp/aws"]
-	//
-	// When this occurs it's raised from the check for diagnostics just after
-	// the call to ctx.Apply below, so it seems like something's not working
-	// quite right in how the apply phase handles provider configurations.
-	SkipExperimental(t, ExperimentalBugMissingProvider)
-
 	m, snap := testModuleWithSnapshot(t, "apply-interpolated-count")
 
 	p := testProvider("aws")
@@ -9655,8 +9456,6 @@ func TestContext2Apply_plannedInterpolatedCount(t *testing.T) {
 }
 
 func TestContext2Apply_plannedDestroyInterpolatedCount(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureRootOutput)
-
 	m, snap := testModuleWithSnapshot(t, "plan-destroy-interpolated-count")
 
 	p := testProvider("aws")
@@ -10140,7 +9939,7 @@ func TestContext2Apply_moduleReplaceCycle(t *testing.T) {
 }
 
 func TestContext2Apply_destroyDataCycle(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDestroy, ExperimentalFlagUnknown)
+	SkipExperimental(t, ExperimentalFlagUnknown)
 
 	m, snap := testModuleWithSnapshot(t, "apply-destroy-data-cycle")
 	p := testProvider("null")
@@ -10494,7 +10293,7 @@ func TestContext2Apply_plannedConnectionRefs(t *testing.T) {
 }
 
 func TestContext2Apply_cbdCycle(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureCBD, ExperimentalFlagUnknown)
+	SkipExperimental(t, ExperimentalFlagUnknown)
 
 	m, snap := testModuleWithSnapshot(t, "apply-cbd-cycle")
 	p := testProvider("test")
@@ -11466,7 +11265,7 @@ func TestContext2Apply_ProviderMeta_refreshdata_setInvalid(t *testing.T) {
 }
 
 func TestContext2Apply_expandModuleVariables(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureRootOutput, ExperimentalFeatureStateDependencies, ExperimentalChangeModuleOutput)
+	SkipExperimental(t, ExperimentalChangeModuleOutput)
 
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
@@ -11542,8 +11341,6 @@ module.mod2:
 }
 
 func TestContext2Apply_inheritAndStoreCBD(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureCBD)
-
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 resource "aws_instance" "foo" {
@@ -11584,7 +11381,7 @@ resource "aws_instance" "cbd" {
 }
 
 func TestContext2Apply_moduleDependsOn(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDependsOn, ExperimentalBugDataResource) // Requires data dependency status tracking
+	SkipExperimental(t, ExperimentalBugDataResource) // Requires data dependency status tracking
 
 	m := testModule(t, "apply-module-depends-on")
 
@@ -11734,8 +11531,6 @@ output "c" {
 }
 
 func TestContext2Apply_moduleExpandDependsOn(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDependsOn)
-
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 module "child" {
@@ -11797,15 +11592,12 @@ output "myoutput" {
 		t.Fatal(diags.ErrWithWarnings())
 	}
 
-	SkipExperimental(t, ExperimentalFeatureDestroy)
-
 	if !state.Empty() {
 		t.Fatal("expected empty state, got:", state)
 	}
 }
 
 func TestContext2Apply_scaleInCBD(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureCBD)
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 variable "ct" {
@@ -12189,7 +11981,7 @@ func TestContext2Apply_destroyProviderReference(t *testing.T) {
 // Destroying properly requires pruning out all unneeded config nodes to
 // prevent incorrect expansion evaluation.
 func TestContext2Apply_destroyInterModuleExpansion(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDestroy, ExperimentalFlagUnknown)
+	SkipExperimental(t, ExperimentalFlagUnknown)
 
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
@@ -12288,7 +12080,6 @@ output "outputs" {
 }
 
 func TestContext2Apply_createBeforeDestroyWithModule(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureCBD)
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 variable "v" {}
@@ -12368,7 +12159,6 @@ resource "test_resource" "a" {
 	})
 	assertNoErrors(t, diags)
 
-	SkipExperimental(t, ExperimentalBugMissingProvider)
 	_, diags = ctx.Apply(context.Background(), plan, m, nil)
 	if diags.HasErrors() {
 		t.Fatalf("apply errors: %s", diags.Err())
@@ -12376,19 +12166,6 @@ resource "test_resource" "a" {
 }
 
 func TestContext2Apply_forcedCBD(t *testing.T) {
-	// Unfortunately in experimental mode this test is currently flaking with
-	// errors like this, but not consistently on every run:
-	//
-	//     err: 2 problems:
-	//
-	//     - missing configuration for provider["registry.opentofu.org/hashicorp/template"]
-	//     - missing configuration for provider["registry.opentofu.org/hashicorp/template"]
-	//
-	// When this occurs it's raised from the check for diagnostics just after
-	// the call to ctx.Apply below, so it seems like something's not working
-	// quite right in how the apply phase handles provider configurations.
-	SkipExperimental(t, ExperimentalBugMissingProvider)
-
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 variable "v" {}
@@ -12452,7 +12229,6 @@ resource "test_instance" "b" {
 }
 
 func TestContext2Apply_removeReferencedResource(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDestroy)
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 variable "ct" {
@@ -12921,8 +12697,6 @@ resource "test_resource" "foo" {
 }
 
 func TestContext2Apply_moduleVariableOptionalAttributes(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureRootOutput)
-
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 variable "in" {
@@ -12995,8 +12769,6 @@ output "out" {
 }
 
 func TestContext2Apply_moduleVariableOptionalAttributesDefault(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureRootOutput)
-
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 variable "in" {
@@ -13047,8 +12819,6 @@ output "out" {
 }
 
 func TestContext2Apply_moduleVariableOptionalAttributesDefaultNull(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureRootOutput)
-
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 variable "in" {
@@ -13095,8 +12865,6 @@ output "out" {
 }
 
 func TestContext2Apply_moduleVariableOptionalAttributesDefaultChild(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureRootOutput)
-
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 variable "in" {
@@ -13161,8 +12929,6 @@ output "out" {
 }
 
 func TestContext2Apply_provisionerSensitive(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
-
 	m := testModule(t, "apply-provisioner-sensitive")
 	p := testProvider("aws")
 
@@ -13376,7 +13142,7 @@ func TestContext2Apply_dataSensitive(t *testing.T) {
 }
 
 func TestContext2Apply_errorRestorePrivateData(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugStateProvider, ExperimentalFlagUnknown)
+	SkipExperimental(t, ExperimentalFlagUnknown)
 
 	// empty config to remove our resource
 	m := testModuleInline(t, map[string]string{
@@ -13418,7 +13184,7 @@ func TestContext2Apply_errorRestorePrivateData(t *testing.T) {
 }
 
 func TestContext2Apply_errorRestoreStatus(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugStateProvider, ExperimentalFeatureTaint)
+	SkipExperimental(t, ExperimentalFeatureTaint)
 
 	// empty config to remove our resource
 	m := testModuleInline(t, map[string]string{

--- a/internal/tofu/context_functions_test.go
+++ b/internal/tofu/context_functions_test.go
@@ -285,8 +285,6 @@ func TestFunctions(t *testing.T) {
 
 // Standard scenario using root provider explicitly passed
 func TestContext2Functions_providerFunctions(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProviderFunctions)
-
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
@@ -376,8 +374,6 @@ variable "obfmod" {
 
 // Explicitly passed provider with custom function
 func TestContext2Functions_providerFunctionsCustom(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProviderFunctions)
-
 	p := testProvider("aws")
 	p.GetFunctionsResponse = &providers.GetFunctionsResponse{
 		Functions: map[string]providers.FunctionSpec{
@@ -475,8 +471,6 @@ variable "obfmod" {
 
 // Defaulted stub provider with non-custom function
 func TestContext2Functions_providerFunctionsStub(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProviderFunctions)
-
 	p := testProvider("aws")
 
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
@@ -569,8 +563,6 @@ variable "obfmod" {
 
 // Defaulted stub provider with custom function (no allowed)
 func TestContext2Functions_providerFunctionsStubCustom(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProviderFunctions)
-
 	p := testProvider("aws")
 
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
@@ -647,8 +639,6 @@ variable "obfmod" {
 
 // Defaulted stub provider
 func TestContext2Functions_providerFunctionsForEachCount(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProviderFunctions)
-
 	p := testProvider("aws")
 
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
@@ -749,8 +739,6 @@ variable "obfmod" {
 
 // Functions used as variable values are evaluated correctly
 func TestContext2Functions_providerFunctionsVariableCustom(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProviderFunctions)
-
 	p := testProvider("aws")
 	p.GetFunctionsResponse = &providers.GetFunctionsResponse{
 		Functions: map[string]providers.FunctionSpec{

--- a/internal/tofu/context_plan2_test.go
+++ b/internal/tofu/context_plan2_test.go
@@ -40,7 +40,7 @@ import (
 )
 
 func TestContext2Plan_removedDuringRefresh(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureUpgradeState, ExperimentalFeatureTaint)
+	SkipExperimental(t, ExperimentalFeatureTaint)
 
 	// This tests the situation where an object tracked in the previous run
 	// state has been deleted outside OpenTofu, which we should detect
@@ -341,8 +341,6 @@ resource "test_object" "a" {
 }
 
 func TestContext2Plan_dataReferencesResourceInModules(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
-
 	p := testProvider("test")
 	p.ReadDataSourceFn = func(req providers.ReadDataSourceRequest) (resp providers.ReadDataSourceResponse) {
 		cfg := req.Config.AsValueMap()
@@ -429,7 +427,7 @@ resource "test_resource" "b" {
 }
 
 func TestContext2Plan_resourceChecksInExpandedModule(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureChecks)
+	SkipExperimental(t, ExperimentalFeatureChecks)
 
 	// When a resource is in a nested module we have two levels of expansion
 	// to do: first expand the module the resource is declared in, and then
@@ -1071,7 +1069,7 @@ resource "test_object" "a" {
 }
 
 func TestContext2Plan_destroyWithRefresh_skipImport(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureImport, ExperimentalFeatureDestroy)
+	SkipExperimental(t, ExperimentalFeatureImport)
 
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
@@ -3390,8 +3388,6 @@ data "test_data_source" "foo" {
 }
 
 func TestContext2Plan_forceReplace(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureForceReplace)
-
 	addrA := mustResourceInstanceAddr("test_object.a")
 	addrB := mustResourceInstanceAddr("test_object.b")
 	m := testModuleInline(t, map[string]string{
@@ -3467,8 +3463,6 @@ func TestContext2Plan_forceReplace(t *testing.T) {
 }
 
 func TestContext2Plan_forceReplaceIncompleteAddr(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureForceReplace)
-
 	addr0 := mustResourceInstanceAddr("test_object.a[0]")
 	addr1 := mustResourceInstanceAddr("test_object.a[1]")
 	addrBare := mustResourceInstanceAddr("test_object.a")
@@ -3563,7 +3557,6 @@ func TestContext2Plan_forceReplaceIncompleteAddr(t *testing.T) {
 // I've added all the required test cases that are needed to verify the fix for the issue.
 // This will cover the scope of issue #4368
 func TestContext2Plan_forceReplaceIncompleteAddr_multipleResources(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureForceReplace)
 	rootAddr0 := mustResourceInstanceAddr("test_object.foo[0]")
 	rootAddr1 := mustResourceInstanceAddr("test_object.foo[1]")
 	childAddr0 := mustResourceInstanceAddr("module.child.test_object.foo[0]")
@@ -3637,8 +3630,6 @@ func TestContext2Plan_forceReplaceIncompleteAddr_multipleResources(t *testing.T)
 // Verify that adding a module instance does force existing module data sources
 // to be deferred
 func TestContext2Plan_noChangeDataSourceAddingModuleInstance(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
-
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 locals {
@@ -3749,7 +3740,7 @@ output "output" {
 }
 
 func TestContext2Plan_moduleImplicitMove(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureMoved)
+	SkipExperimental(t, ExperimentalFeatureMoved)
 
 	// Modules are being moved implicitly to use the `enabled` field when nothing
 	// is declared on the block. Alternatively, they are implicitly being moved from
@@ -4694,7 +4685,7 @@ output "a" {
 }
 
 func TestContext2Plan_preconditionErrors(t *testing.T) {
-	SkipExperimental(t, ExperimentalChangeDiagWording, ExperimentalBugVariableInput)
+	SkipExperimental(t, ExperimentalChangeDiagWording)
 
 	testCases := []struct {
 		condition   string
@@ -4851,8 +4842,6 @@ output "a" {
 }
 
 func TestContext2Plan_triggeredBy(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureReplaceTB)
-
 	type TestConfiguration struct {
 		Description         string
 		inlineConfiguration map[string]string
@@ -5168,8 +5157,6 @@ resource "test_object" "b" {
 // plan a destroy with no state where configuration could fail to evaluate
 // expansion indexes.
 func TestContext2Plan_emptyDestroy(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
-
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 locals {
@@ -5278,7 +5265,6 @@ resource "test_object" "b" {
 		}, nil),
 	})
 
-	SkipExperimental(t, ExperimentalBugMissingProvider)
 	_, diags := ctx.Plan(context.Background(), m, state, &PlanOpts{
 		Mode: plans.NormalMode,
 	})
@@ -5472,7 +5458,6 @@ output "out" {
 }
 
 func TestContext2Plan_destroyPartialStateLocalRef(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 module "already_destroyed" {
@@ -8309,12 +8294,7 @@ import {
 }
 
 func TestContext2Plan_providerForEachWithOrphanResourceInstanceNotUsingForEach(t *testing.T) {
-	// This currently fails in the new runtime because it doesn't have the
-	// special check for the situation where prior state has a resource instance
-	// belonging to a provider instance that isn't in the latest configuration.
-	// It just treats it as a general provider initialization failure:
-	//    Cannot plan test_thing.a["orphaned"] because its associated provider instance provider["terraform.io/builtin/test"].multi cannot initialize.
-	SkipExperimental(t, ExperimentalBugMissingProvider, ExperimentalChangeDiagWording)
+	SkipExperimental(t, ExperimentalChangeDiagWording)
 
 	// This test is to cover the bug reported in this issue:
 	//    https://github.com/opentofu/opentofu/issues/2334
@@ -8455,7 +8435,7 @@ locals {
 }
 
 func TestContext2Plan_removedResourceBasic(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureRemoved)
+	SkipExperimental(t, ExperimentalFeatureRemoved)
 
 	desposedKey := states.DeposedKey("deposed")
 	addr := mustResourceInstanceAddr("test_object.a")
@@ -8538,7 +8518,7 @@ func TestContext2Plan_removedResourceBasic(t *testing.T) {
 }
 
 func TestContext2Plan_removedModuleBasic(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureRemoved)
+	SkipExperimental(t, ExperimentalFeatureRemoved)
 
 	desposedKey := states.DeposedKey("deposed")
 	addr := mustResourceInstanceAddr("module.mod.test_object.a")
@@ -8621,7 +8601,7 @@ func TestContext2Plan_removedModuleBasic(t *testing.T) {
 }
 
 func TestContext2Plan_removedModuleForgetsAllInstances(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureRemoved)
+	SkipExperimental(t, ExperimentalFeatureRemoved)
 
 	addrFirst := mustResourceInstanceAddr("module.mod[0].test_object.a")
 	addrSecond := mustResourceInstanceAddr("module.mod[1].test_object.a")
@@ -8689,7 +8669,7 @@ func TestContext2Plan_removedModuleForgetsAllInstances(t *testing.T) {
 }
 
 func TestContext2Plan_removedResourceForgetsAllInstances(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureRemoved)
+	SkipExperimental(t, ExperimentalFeatureRemoved)
 
 	addrFirst := mustResourceInstanceAddr("test_object.a[0]")
 	addrSecond := mustResourceInstanceAddr("test_object.a[1]")
@@ -8757,7 +8737,7 @@ func TestContext2Plan_removedResourceForgetsAllInstances(t *testing.T) {
 }
 
 func TestContext2Plan_removedResourceInChildModuleFromParentModule(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureRemoved)
+	SkipExperimental(t, ExperimentalFeatureRemoved)
 
 	addr := mustResourceInstanceAddr("module.mod.test_object.a")
 	m := testModuleInline(t, map[string]string{
@@ -8821,7 +8801,7 @@ func TestContext2Plan_removedResourceInChildModuleFromParentModule(t *testing.T)
 }
 
 func TestContext2Plan_removedResourceInChildModuleFromChildModule(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureRemoved)
+	SkipExperimental(t, ExperimentalFeatureRemoved)
 
 	addr := mustResourceInstanceAddr("module.mod.test_object.a")
 	m := testModuleInline(t, map[string]string{
@@ -8885,7 +8865,7 @@ func TestContext2Plan_removedResourceInChildModuleFromChildModule(t *testing.T) 
 }
 
 func TestContext2Plan_removedResourceInGrandchildModuleFromRootModule(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureRemoved)
+	SkipExperimental(t, ExperimentalFeatureRemoved)
 
 	addr := mustResourceInstanceAddr("module.child.module.grandchild.test_object.a")
 	m := testModuleInline(t, map[string]string{
@@ -8950,7 +8930,7 @@ func TestContext2Plan_removedResourceInGrandchildModuleFromRootModule(t *testing
 }
 
 func TestContext2Plan_removedChildModuleForgetsResourceInGrandchildModule(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureRemoved)
+	SkipExperimental(t, ExperimentalFeatureRemoved)
 
 	addr := mustResourceInstanceAddr("module.child.module.grandchild.test_object.a")
 	m := testModuleInline(t, map[string]string{
@@ -9628,8 +9608,6 @@ func featuresBlockTestSchema() *configschema.Block {
 // use a shared submodule containing a check block with a nested data source,
 // this should not cause a dependency cycle.
 func TestContext2Plan_moduleDependsOnWithCheck(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDependsOn, ExperimentalBugDeclareProvider)
-
 	m := testModule(t, "plan-module-depends-on-check")
 
 	p := &MockProvider{

--- a/internal/tofu/context_plan_test.go
+++ b/internal/tofu/context_plan_test.go
@@ -119,7 +119,6 @@ func TestContext2Plan_createBefore_deposed(t *testing.T) {
 		}, nil),
 	})
 
-	SkipExperimental(t, ExperimentalFeatureCBD)
 	plan, diags := ctx.Plan(context.Background(), m, state, DefaultPlanOpts)
 	if diags.HasErrors() {
 		t.Fatalf("unexpected errors: %s", diags.Err())
@@ -519,8 +518,6 @@ func TestContext2Plan_moduleCycle(t *testing.T) {
 }
 
 func TestContext2Plan_moduleDeadlock(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
-
 	testCheckDeadlock(t, func() {
 		m := testModule(t, "plan-module-deadlock")
 		p := testProvider("aws")
@@ -798,7 +795,6 @@ func TestContext2Plan_moduleMultiVar(t *testing.T) {
 }
 
 func TestContext2Plan_moduleOrphans(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugStateProvider)
 	m := testModule(t, "plan-modules-remove")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -1092,8 +1088,6 @@ func TestContext2Plan_moduleProviderInheritDeep(t *testing.T) {
 }
 
 func TestContext2Plan_moduleProviderDefaultsVar(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugReferenceProvider)
-
 	var l sync.Mutex
 	var calls []string
 
@@ -1166,8 +1160,6 @@ func TestContext2Plan_moduleProviderDefaultsVar(t *testing.T) {
 }
 
 func TestContext2Plan_moduleProviderVar(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugReferenceProvider)
-
 	m := testModule(t, "plan-module-provider-var")
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
@@ -1370,8 +1362,6 @@ func TestContext2Plan_moduleVarComputed(t *testing.T) {
 }
 
 func TestContext2Plan_preventDestroy_bad(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeaturePreventDestroy)
-
 	m := testModule(t, "plan-prevent-destroy-bad")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -1444,8 +1434,6 @@ func TestContext2Plan_preventDestroy_good(t *testing.T) {
 }
 
 func TestContext2Plan_preventDestroy_dynamic(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeaturePreventDestroy)
-
 	// We'll run the same set of tests with equivalent configuration written
 	// with different syntaxes.
 	fixtures := map[string]string{
@@ -1595,8 +1583,6 @@ func TestContext2Plan_preventDestroy_dynamic(t *testing.T) {
 }
 
 func TestContext2Plan_preventDestroy_dynamicEphemeral(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeaturePreventDestroy)
-
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 			variable "prevent_destroy" {
@@ -1703,8 +1689,6 @@ func TestContext2Plan_preventDestroy_dynamicDeprecated(t *testing.T) {
 }
 
 func TestContext2Plan_preventDestroy_dynamicFromDataResource(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeaturePreventDestroy)
-
 	// This test is intentionally a little redundant with
 	// [TestContext2Plan_preventDestroy_dynamic], but intentionally involves
 	// a dependency on another resource so that we're more likely to catch
@@ -1825,8 +1809,6 @@ func TestContext2Plan_preventDestroy_dynamicFromDataResource(t *testing.T) {
 }
 
 func TestContext2Plan_preventDestroy_dynamicFromManagedResourceDestroyMode(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeaturePreventDestroy)
-
 	// This test is verifying that a prevent_destroy argument's dependencies
 	// are respected even when we're in plans.DestroyMode, which has separate
 	// rules for how its graph gets built.
@@ -1914,8 +1896,6 @@ func TestContext2Plan_preventDestroy_dynamicFromManagedResourceDestroyMode(t *te
 }
 
 func TestContext2Plan_preventDestroy_countBad(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeaturePreventDestroy)
-
 	// This test is quite buggy and relies on some old broken functionality in the old engine as far as I can tell.
 	SkipExperimental(t, ExperimentalFlagUnknown)
 
@@ -2062,8 +2042,6 @@ func TestContext2Plan_preventDestroy_countGoodNoChange(t *testing.T) {
 }
 
 func TestContext2Plan_preventDestroy_destroyPlan(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeaturePreventDestroy)
-
 	m := testModule(t, "plan-prevent-destroy-good")
 	p := testProvider("aws")
 
@@ -2099,7 +2077,6 @@ func TestContext2Plan_preventDestroy_destroyPlan(t *testing.T) {
 }
 
 func TestContext2Plan_provisionerCycle(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
 	m := testModule(t, "plan-provisioner-cycle")
 	p := testProvider("aws")
 	pr := testProvisioner()
@@ -2757,8 +2734,6 @@ func TestContext2Plan_countComputedModule(t *testing.T) {
 }
 
 func TestContext2Plan_countModuleStatic(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
-
 	m := testModule(t, "plan-count-module-static")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -2811,8 +2786,6 @@ func TestContext2Plan_countModuleStatic(t *testing.T) {
 }
 
 func TestContext2Plan_countModuleStaticGrandchild(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
-
 	m := testModule(t, "plan-count-module-static-grandchild")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -3561,8 +3534,6 @@ func TestContext2Plan_countIncreaseWithSplatReference(t *testing.T) {
 }
 
 func TestContext2Plan_forEach(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugForEach)
-
 	m := testModule(t, "plan-for-each")
 	p := testProvider("aws")
 	ctx := testContext2(t, &ContextOpts{
@@ -3638,8 +3609,6 @@ func TestContext2Plan_forEachUnknownValue(t *testing.T) {
 }
 
 func TestContext2Plan_destroy(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDestroy)
-
 	m := testModule(t, "plan-destroy")
 	p := testProvider("aws")
 
@@ -3702,8 +3671,6 @@ func TestContext2Plan_destroy(t *testing.T) {
 }
 
 func TestContext2Plan_moduleDestroy(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDestroy)
-
 	m := testModule(t, "plan-module-destroy")
 	p := testProvider("aws")
 
@@ -3767,8 +3734,6 @@ func TestContext2Plan_moduleDestroy(t *testing.T) {
 
 // GH-1835
 func TestContext2Plan_moduleDestroyCycle(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureDestroy)
-
 	m := testModule(t, "plan-module-destroy-gh-1835")
 	p := testProvider("aws")
 
@@ -3832,8 +3797,6 @@ func TestContext2Plan_moduleDestroyCycle(t *testing.T) {
 }
 
 func TestContext2Plan_moduleDestroyMultivar(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureDestroy)
-
 	m := testModule(t, "plan-module-destroy-multivar")
 	p := testProvider("aws")
 
@@ -3896,8 +3859,6 @@ func TestContext2Plan_moduleDestroyMultivar(t *testing.T) {
 }
 
 func TestContext2Plan_pathVar(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeaturePathAttrs)
-
 	cwd, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -4028,8 +3989,6 @@ func TestContext2Plan_diffVar(t *testing.T) {
 }
 
 func TestContext2Plan_hook(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureHooks)
-
 	m := testModule(t, "plan-good")
 	h := new(MockHook)
 	p := testProvider("aws")
@@ -4054,8 +4013,6 @@ func TestContext2Plan_hook(t *testing.T) {
 }
 
 func TestContext2Plan_closeProvider(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugReferenceProvider)
-
 	// this fixture only has an aliased provider located in the module, to make
 	// sure that the provider name contains a path more complex than
 	// "provider.aws".
@@ -4837,7 +4794,7 @@ func TestContext2Plan_actionInteractions(t *testing.T) {
 }
 
 func TestContext2Plan_taint(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureChanges)
+	SkipExperimental(t, ExperimentalFeatureChanges)
 
 	m := testModule(t, "plan-taint")
 	p := testProvider("aws")
@@ -4915,7 +4872,7 @@ func TestContext2Plan_taint(t *testing.T) {
 }
 
 func TestContext2Plan_taintIgnoreChanges(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureIgnoreChanges, ExperimentalBugDeclareProvider, ExperimentalFeatureTaint)
+	SkipExperimental(t, ExperimentalFeatureTaint)
 
 	m := testModule(t, "plan-taint-ignore-changes")
 	p := testProvider("aws")
@@ -4992,7 +4949,7 @@ func TestContext2Plan_taintIgnoreChanges(t *testing.T) {
 
 // Fails about 50% of the time before the fix for GH-4982, covers the fix.
 func TestContext2Plan_taintDestroyInterpolatedCountRace(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureTaint)
+	SkipExperimental(t, ExperimentalFeatureTaint)
 
 	m := testModule(t, "plan-taint-interpolated-count")
 	p := testProvider("aws")
@@ -6012,8 +5969,6 @@ func TestContext2Plan_varListErr(t *testing.T) {
 }
 
 func TestContext2Plan_ignoreChanges(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureIgnoreChanges)
-
 	m := testModule(t, "plan-ignore-changes")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -6079,8 +6034,6 @@ func TestContext2Plan_ignoreChanges(t *testing.T) {
 }
 
 func TestContext2Plan_ignoreChangesWildcard(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureIgnoreChanges)
-
 	m := testModule(t, "plan-ignore-changes-wildcard")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = func(req providers.PlanResourceChangeRequest) (resp providers.PlanResourceChangeResponse) {
@@ -6141,8 +6094,6 @@ func TestContext2Plan_ignoreChangesWildcard(t *testing.T) {
 }
 
 func TestContext2Plan_ignoreChangesInMap(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureIgnoreChanges)
-
 	p := testProvider("test")
 
 	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
@@ -6219,8 +6170,6 @@ func TestContext2Plan_ignoreChangesInMap(t *testing.T) {
 }
 
 func TestContext2Plan_ignoreChangesSensitive(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureIgnoreChanges)
-
 	m := testModule(t, "plan-ignore-changes-sensitive")
 	p := testProvider("aws")
 	p.PlanResourceChangeFn = testDiffFn
@@ -6286,8 +6235,6 @@ func TestContext2Plan_ignoreChangesSensitive(t *testing.T) {
 }
 
 func TestContext2Plan_moduleMapLiteral(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
-
 	m := testModule(t, "plan-module-map-literal")
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
@@ -6399,8 +6346,6 @@ func TestContext2Plan_computedValueInMap(t *testing.T) {
 }
 
 func TestContext2Plan_moduleVariableFromSplat(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
-
 	m := testModule(t, "plan-module-variable-from-splat")
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
@@ -6602,8 +6547,6 @@ func TestContext2Plan_listOrder(t *testing.T) {
 // ignored, we need to filter the diff properly to properly update rather than
 // replace.
 func TestContext2Plan_ignoreChangesWithFlatmaps(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureIgnoreChanges)
-
 	m := testModule(t, "plan-ignore-changes-with-flatmaps")
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
@@ -7136,7 +7079,7 @@ func TestContext2Plan_variableSensitivity(t *testing.T) {
 }
 
 func TestContext2Plan_variableSensitivityModule(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureSensitivity)
+	SkipExperimental(t, ExperimentalFeatureSensitivity)
 
 	m := testModule(t, "plan-variable-sensitivity-module")
 
@@ -7366,7 +7309,7 @@ func TestContext2Plan_requiredModuleObject(t *testing.T) {
 }
 
 func TestContext2Plan_expandOrphan(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureChanges)
+	SkipExperimental(t, ExperimentalFeatureChanges)
 
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
@@ -7433,8 +7376,6 @@ resource "aws_instance" "foo" {
 }
 
 func TestContext2Plan_indexInVar(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
-
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 module "a" {
@@ -7477,7 +7418,7 @@ output"out" {
 }
 
 func TestContext2Plan_targetExpandedAddress(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureTarget)
+	SkipExperimental(t, ExperimentalFeatureTarget)
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 module "mod" {
@@ -7543,7 +7484,7 @@ resource "aws_instance" "foo" {
 }
 
 func TestContext2Plan_excludeExpandedAddress(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureTarget)
+	SkipExperimental(t, ExperimentalFeatureTarget)
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 module "mod" {
@@ -7610,7 +7551,7 @@ resource "aws_instance" "foo" {
 }
 
 func TestContext2Plan_targetResourceInModuleInstance(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureTarget)
+	SkipExperimental(t, ExperimentalFeatureTarget)
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 module "mod" {
@@ -7666,7 +7607,7 @@ resource "aws_instance" "foo" {
 }
 
 func TestContext2Plan_excludeResourceInModuleInstance(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureTarget)
+	SkipExperimental(t, ExperimentalFeatureTarget)
 
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
@@ -7724,8 +7665,6 @@ resource "aws_instance" "foo" {
 }
 
 func TestContext2Plan_moduleRefIndex(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugVariableInput, ExperimentalBugDeclareProvider)
-
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 module "mod" {
@@ -8242,8 +8181,6 @@ resource "test_instance" "a" {
 }
 
 func TestContext2Plan_dataInModuleDependsOn(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
-
 	p := testProvider("test")
 
 	readDataSourceB := false
@@ -8348,7 +8285,6 @@ resource "test_instance" "a" {
 // ignore_changes needs to be re-applied to the planned value for provider
 // using the LegacyTypeSystem
 func TestContext2Plan_legacyProviderIgnoreChanges(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureIgnoreChanges)
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 resource "test_instance" "a" {
@@ -8470,7 +8406,6 @@ resource "test_instance" "a" {
 }
 
 func TestContext2Plan_legacyProviderIgnoreAll(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureIgnoreChanges)
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 resource "test_instance" "a" {
@@ -8536,7 +8471,7 @@ resource "test_instance" "a" {
 }
 
 func TestContext2Plan_dataRemovalNoProvider(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugStateProvider, ExperimentalBugDataResource)
+	SkipExperimental(t, ExperimentalBugDataResource)
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 resource "test_instance" "a" {

--- a/internal/tofu/context_refresh_test.go
+++ b/internal/tofu/context_refresh_test.go
@@ -849,7 +849,7 @@ func TestContext2Refresh_ignoreUncreated(t *testing.T) {
 }
 
 func TestContext2Refresh_hook(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureRefresh, ExperimentalFeatureHooks)
+	SkipExperimental(t, ExperimentalFeatureRefresh)
 
 	h := new(MockHook)
 	p := testProvider("aws")
@@ -926,7 +926,6 @@ func TestContext2Refresh_modules(t *testing.T) {
 }
 
 func TestContext2Refresh_moduleInputComputedOutput(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugVariableInput)
 	m := testModule(t, "refresh-module-input-computed-output")
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
@@ -960,8 +959,6 @@ func TestContext2Refresh_moduleInputComputedOutput(t *testing.T) {
 }
 
 func TestContext2Refresh_moduleVarModule(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalBugVariableInput)
-
 	m := testModule(t, "refresh-module-var-module")
 	p := testProvider("aws")
 	ctx := testContext2(t, &ContextOpts{
@@ -1450,7 +1447,6 @@ func TestContext2Refresh_vars(t *testing.T) {
 }
 
 func TestContext2Refresh_orphanModule(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalBugStateProvider)
 	p := testProvider("aws")
 	m := testModule(t, "refresh-module-orphan")
 
@@ -1550,8 +1546,6 @@ func TestContext2Validate(t *testing.T) {
 }
 
 func TestContext2Refresh_updateProviderInState(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureUpgradeState)
-
 	m := testModule(t, "update-resource-provider")
 	p := testProvider("aws")
 
@@ -1582,7 +1576,7 @@ aws_instance.bar:
 }
 
 func TestContext2Refresh_schemaUpgradeFlatmap(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureUpgradeState, ExperimentalObsoleteFlatAttrs)
+	SkipExperimental(t, ExperimentalObsoleteFlatAttrs)
 
 	m := testModule(t, "refresh-schema-upgrade")
 	p := testProvider("test")
@@ -1669,8 +1663,6 @@ test_thing.bar:
 }
 
 func TestContext2Refresh_schemaUpgradeJSON(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureUpgradeState)
-
 	m := testModule(t, "refresh-schema-upgrade")
 	p := testProvider("test")
 	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
@@ -1832,7 +1824,6 @@ func TestContext2Refresh_dataResourceDependsOn(t *testing.T) {
 
 // verify that create_before_destroy is updated in the state during refresh
 func TestRefresh_updateLifecycle(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureCBD)
 	state := states.NewState()
 	root := state.EnsureModule(addrs.RootModuleInstance)
 	root.SetResourceInstanceCurrent(

--- a/internal/tofu/context_temp_runtime_test.go
+++ b/internal/tofu/context_temp_runtime_test.go
@@ -76,23 +76,14 @@ var experimentalFlagSkipMu sync.Mutex
 var (
 	ExperimentalFlagUnknown = ExperimentalFlag{"Unknown", false}
 
-	ExperimentalBugExecGraph         = ExperimentalFlag{"Bug in generated Exec Graph", true}
-	ExperimentalBugDeclareProvider   = ExperimentalFlag{"Bug Declare Provider", true}
-	ExperimentalBugVariableInput     = ExperimentalFlag{"Bug Variable Input", true}
 	ExperimentalBugCancel            = ExperimentalFlag{"Bug Context Cancel", false}
-	ExperimentalBugStateProvider     = ExperimentalFlag{"Bug State Provider", true}
 	ExperimentalBugStateCBD          = ExperimentalFlag{"Bug CreateBeforeDestroy Not Tracked In State", false}
 	ExperimentalBugStateUpdateHook   = ExperimentalFlag{"Bug State Update Hook", false}
-	ExperimentalBugReferenceProvider = ExperimentalFlag{"Bug Reference Provider", true}
-	ExperimentalBugMissingProvider   = ExperimentalFlag{"Bug Missing Configuration For Provider", true}
 	ExperimentalBugMissingResource   = ExperimentalFlag{"Bug Missing Configuration For Resource Instance", false}
 	ExperimentalBugResourceReadNull  = ExperimentalFlag{"Bug Read Resource Deleted", false}
 	ExperimentalBugDataResource      = ExperimentalFlag{"Bug Data Resource", false}
-	ExperimentalBugVariableSensitive = ExperimentalFlag{"Bug Variables Declared as Sensitive", true}
 	ExperimentalBugResourceMarks     = ExperimentalFlag{"Bug Not Transferring Marks from Resource Instance Config Value to Final Value", false}
 	ExperimentalBugTaintOnCreateFail = ExperimentalFlag{"Bug Not Tainted When Create Fails", false}
-	ExperimentalBugForEach           = ExperimentalFlag{"Bug For Each", true}
-	ExperimentalBugSpuriousReplace   = ExperimentalFlag{"Bug Spurious Replace", true} // New runtime proposes replace where old runtime would've called for update
 	ExperimentalBugProviderPrivate   = ExperimentalFlag{"Bug Provider Private Data Not Preserved", false}
 	ExperimentalBugCircularReference = ExperimentalFlag{"Bug Circular Reference", false}
 
@@ -106,46 +97,30 @@ var (
 	ExperimentalChangeModuleOutput    = ExperimentalFlag{"Change Module Outputs (test only)", false}
 	ExperimentalChangeCursedSelfRef   = ExperimentalFlag{"Change Cursed Self Reference (legacy race condition)", false}
 
-	ExperimentalFeatureStateDependencies = ExperimentalFlag{"Missing State Dependencies", true}
-	ExperimentalFeatureProviderInstances = ExperimentalFlag{"Missing Provider Instances", true}
-	ExperimentalFeatureCBD               = ExperimentalFlag{"Missing Create Before Destroy", true}
-	ExperimentalFeatureDeposed           = ExperimentalFlag{"Missing Deposed", false}
-	ExperimentalFeatureCondition         = ExperimentalFlag{"Missing Pre/Post Conditions", false}
-	ExperimentalFeatureLocalState        = ExperimentalFlag{"Missing Store locals in state", false}
-	ExperimentalFeatureChecks            = ExperimentalFlag{"Missing Checks", false}
-	ExperimentalFeatureChanges           = ExperimentalFlag{"Missing Plan Changes", false}
-	ExperimentalFeatureDeprecated        = ExperimentalFlag{"Missing Deprecated", false}
-	ExperimentalFeatureImport            = ExperimentalFlag{"Missing Importing", false}
-	ExperimentalFeatureLinting           = ExperimentalFlag{"Missing Linting", false}
-	ExperimentalFeatureRefresh           = ExperimentalFlag{"Missing Refresh", false}
-	ExperimentalFeatureRefreshOnly       = ExperimentalFlag{"Missing Refresh-only Planning Mode", false}
-	ExperimentalFeatureValidate          = ExperimentalFlag{"Missing Validate", true}
-	ExperimentalFeatureDestroy           = ExperimentalFlag{"Missing Destroy-mode Planning", true}
-	ExperimentalFeatureMoved             = ExperimentalFlag{"Missing Moved", false}
-	ExperimentalFeatureRemoved           = ExperimentalFlag{"Missing Removed", false}
-	ExperimentalFeatureSkipDestroy       = ExperimentalFlag{"Missing Lifecycle Destroy", false}
-	ExperimentalFeatureUpgradeState      = ExperimentalFlag{"Missing Upgrade Resource State", true}
-	ExperimentalFeatureUpgradeUnwanted   = ExperimentalFlag{"Missing Upgrade Orphan or Deposed Resource Instance State", false}
-	ExperimentalFeatureHooks             = ExperimentalFlag{"Missing Hooks", true}
-	ExperimentalFeatureTarget            = ExperimentalFlag{"Missing Targeting", false}
-	ExperimentalFeatureReplaceTB         = ExperimentalFlag{"Missing replace_triggered_by", true}
-	ExperimentalFeatureProvisioner       = ExperimentalFlag{"Missing Provisioners", true}
-	ExperimentalFeatureDependsOn         = ExperimentalFlag{"Missing Depends On", true}
-	ExperimentalFeatureIgnoreChanges     = ExperimentalFlag{"Missing Ignore Changes", true}
-	ExperimentalFeatureVarCondition      = ExperimentalFlag{"Missing Variable Condiitions", false}
-	ExperimentalFeaturePathAttrs         = ExperimentalFlag{"Missing Path/Terraform/Tofu Attrs", true}
-	ExperimentalFeaturePreventDestroy    = ExperimentalFlag{"Missing Prevent Destroy", true}
-	ExperimentalFeaturePlannedState      = ExperimentalFlag{"Missing Planned State", false}
-	ExperimentalFeatureForceReplace      = ExperimentalFlag{"Missing Force Replace", true}
-	ExperimentalFeatureRootOutput        = ExperimentalFlag{"Missing Root Output", true}
-	ExperimentalFeatureSensitivity       = ExperimentalFlag{"Missing Sensitivity Handling", false}
-	ExperimentalFeatureSelfReference     = ExperimentalFlag{"Missing Self Reference", false}
-	ExperimentalFeatureProviderMeta      = ExperimentalFlag{"Missing Provider Meta", false}
-	ExperimentalFeatureTaint             = ExperimentalFlag{"Missing Taint", false}
-	ExperimentalFeatureErrorHandling     = ExperimentalFlag{"Missing Error Handling", false}
-	ExperimentalFeatureProviderFunctions = ExperimentalFlag{"Missing Provider Defined Functions", true}
-	ExperimentalFeatureProviderInput     = ExperimentalFlag{"Missing Provider Input Prompting", false}
-	ExperimentalFeatureModuleEnabled     = ExperimentalFlag{"Missing Module Lifecycle Enabled", false}
+	ExperimentalFeatureDeposed         = ExperimentalFlag{"Missing Deposed", false}
+	ExperimentalFeatureCondition       = ExperimentalFlag{"Missing Pre/Post Conditions", false}
+	ExperimentalFeatureLocalState      = ExperimentalFlag{"Missing Store locals in state", false}
+	ExperimentalFeatureChecks          = ExperimentalFlag{"Missing Checks", false}
+	ExperimentalFeatureChanges         = ExperimentalFlag{"Missing Plan Changes", false}
+	ExperimentalFeatureDeprecated      = ExperimentalFlag{"Missing Deprecated", false}
+	ExperimentalFeatureImport          = ExperimentalFlag{"Missing Importing", false}
+	ExperimentalFeatureLinting         = ExperimentalFlag{"Missing Linting", false}
+	ExperimentalFeatureRefresh         = ExperimentalFlag{"Missing Refresh", false}
+	ExperimentalFeatureRefreshOnly     = ExperimentalFlag{"Missing Refresh-only Planning Mode", false}
+	ExperimentalFeatureMoved           = ExperimentalFlag{"Missing Moved", false}
+	ExperimentalFeatureRemoved         = ExperimentalFlag{"Missing Removed", false}
+	ExperimentalFeatureSkipDestroy     = ExperimentalFlag{"Missing Lifecycle Destroy", false}
+	ExperimentalFeatureUpgradeUnwanted = ExperimentalFlag{"Missing Upgrade Orphan or Deposed Resource Instance State", false}
+	ExperimentalFeatureTarget          = ExperimentalFlag{"Missing Targeting", false}
+	ExperimentalFeatureVarCondition    = ExperimentalFlag{"Missing Variable Condiitions", false}
+	ExperimentalFeaturePlannedState    = ExperimentalFlag{"Missing Planned State", false}
+	ExperimentalFeatureSensitivity     = ExperimentalFlag{"Missing Sensitivity Handling", false}
+	ExperimentalFeatureSelfReference   = ExperimentalFlag{"Missing Self Reference", false}
+	ExperimentalFeatureProviderMeta    = ExperimentalFlag{"Missing Provider Meta", false}
+	ExperimentalFeatureTaint           = ExperimentalFlag{"Missing Taint", false}
+	ExperimentalFeatureErrorHandling   = ExperimentalFlag{"Missing Error Handling", false}
+	ExperimentalFeatureProviderInput   = ExperimentalFlag{"Missing Provider Input Prompting", false}
+	ExperimentalFeatureModuleEnabled   = ExperimentalFlag{"Missing Module Lifecycle Enabled", false}
 
 	// Obsolete flags indicate a test which depends on a feature we do not
 	// intend to carry forward into the new engine

--- a/internal/tofu/context_validate_test.go
+++ b/internal/tofu/context_validate_test.go
@@ -120,8 +120,6 @@ func TestContext2Validate_varNoDefaultExplicitType(t *testing.T) {
 }
 
 func TestContext2Validate_computedVar(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureValidate)
-
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		Provider: providers.Schema{
@@ -180,7 +178,6 @@ func TestContext2Validate_computedVar(t *testing.T) {
 }
 
 func TestContext2Validate_computedInFunction(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureValidate)
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
@@ -221,7 +218,6 @@ func TestContext2Validate_computedInFunction(t *testing.T) {
 // them to fail during "plan" since we can't know if the computed values
 // can be realized during a plan.
 func TestContext2Validate_countComputed(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureValidate)
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
 		ResourceTypes: map[string]providers.Schema{
@@ -424,8 +420,6 @@ func TestContext2Validate_moduleGood(t *testing.T) {
 }
 
 func TestContext2Validate_moduleBadResource(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalFeatureValidate)
-
 	m := testModule(t, "validate-module-bad-rc")
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
@@ -455,8 +449,6 @@ func TestContext2Validate_moduleBadResource(t *testing.T) {
 }
 
 func TestContext2Validate_moduleDepsShouldNotCycle(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalBugVariableInput)
-
 	m := testModule(t, "validate-module-deps-cycle")
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
@@ -605,8 +597,6 @@ func TestContext2Validate_orphans(t *testing.T) {
 }
 
 func TestContext2Validate_providerConfig_bad(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
-
 	m := testModule(t, "validate-bad-pc")
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
@@ -749,8 +739,6 @@ func TestContext2Validate_requiredProviderConfig(t *testing.T) {
 }
 
 func TestContext2Validate_provisionerConfig_bad(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
-
 	m := testModule(t, "validate-bad-prov-conf")
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
@@ -786,8 +774,6 @@ func TestContext2Validate_provisionerConfig_bad(t *testing.T) {
 }
 
 func TestContext2Validate_badResourceConnection(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
-
 	m := testModule(t, "validate-bad-resource-connection")
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
@@ -820,8 +806,6 @@ func TestContext2Validate_badResourceConnection(t *testing.T) {
 }
 
 func TestContext2Validate_badProvisionerConnection(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
-
 	m := testModule(t, "validate-bad-prov-connection")
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
@@ -937,8 +921,6 @@ func TestContext2Validate_requiredVar(t *testing.T) {
 }
 
 func TestContext2Validate_resourceConfig_bad(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureValidate)
-
 	m := testModule(t, "validate-bad-rc")
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
@@ -1069,8 +1051,6 @@ func TestContext2Validate_targetedDestroy(t *testing.T) {
 }
 
 func TestContext2Validate_varRefUnknown(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureValidate)
-
 	m := testModule(t, "validate-variable-ref")
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
@@ -1109,8 +1089,6 @@ func TestContext2Validate_varRefUnknown(t *testing.T) {
 // Module variables weren't being interpolated during Validate phase.
 // related to https://github.com/hashicorp/terraform/issues/5322
 func TestContext2Validate_interpolateVar(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
-
 	input := new(MockUIInput)
 
 	m := testModule(t, "input-interpolate-var")
@@ -1143,7 +1121,6 @@ func TestContext2Validate_interpolateVar(t *testing.T) {
 // When module vars reference something that is actually computed, this
 // shouldn't cause validation to fail.
 func TestContext2Validate_interpolateComputedModuleVarDef(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
 	input := new(MockUIInput)
 
 	m := testModule(t, "validate-computed-module-var-ref")
@@ -1194,8 +1171,6 @@ func TestContext2Validate_interpolateMap(t *testing.T) {
 }
 
 func TestContext2Validate_varSensitive(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureValidate)
-
 	// Smoke test through validate where a variable has sensitive applied
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
@@ -1439,7 +1414,6 @@ output "out" {
 }
 
 func TestContext2Validate_invalidDependsOnResourceRef(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDependsOn, ExperimentalFeatureValidate)
 	// This test is verifying that we raise an error if depends_on
 	// refers to something that doesn't exist in configuration.
 	m := testModuleInline(t, map[string]string{
@@ -1469,7 +1443,6 @@ resource "test_instance" "bar" {
 }
 
 func TestContext2Validate_invalidResourceIgnoreChanges(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureIgnoreChanges)
 	// This test is verifying that we raise an error if ignore_changes
 	// refers to something that can be statically detected as not conforming
 	// to the resource type schema.
@@ -1556,7 +1529,6 @@ variable "test" {
 }
 
 func TestContext2Validate_expandModules(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider)
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 module "mod1" {
@@ -1679,7 +1651,6 @@ resource "aws_instance" "foo" {
 }
 
 func TestContext2Validate_expandMultipleNestedModules(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugDeclareProvider, ExperimentalBugVariableInput)
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 module "modA" {
@@ -1758,8 +1729,6 @@ output "out" {
 }
 
 func TestContext2Validate_invalidModuleDependsOn(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDependsOn, ExperimentalFeatureValidate)
-
 	// validate module and output depends_on
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
@@ -1802,8 +1771,6 @@ output "out" {
 }
 
 func TestContext2Validate_invalidOutputDependsOn(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureDependsOn, ExperimentalFeatureValidate)
-
 	// validate module and output depends_on
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
@@ -1846,8 +1813,6 @@ output "out" {
 }
 
 func TestContext2Validate_rpcDiagnostics(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureValidate)
-
 	// validate module and output depends_on
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
@@ -1896,7 +1861,6 @@ resource "test_instance" "a" {
 }
 
 func TestContext2Validate_sensitiveProvisionerConfig(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureProvisioner)
 	m := testModule(t, "validate-sensitive-provisioner-config")
 	p := testProvider("aws")
 	p.GetProviderSchemaResponse = &providers.GetProviderSchemaResponse{
@@ -1938,7 +1902,6 @@ func TestContext2Validate_sensitiveProvisionerConfig(t *testing.T) {
 }
 
 func TestContext2Plan_validateMinMaxDynamicBlock(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureValidate)
 	p := new(MockProvider)
 	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
@@ -2637,8 +2600,6 @@ resource "test_object" "t" {
 }
 
 func TestContext2Validate_providerAliasesInRootMisconfigured(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureValidate)
-
 	m := testModuleInline(t, map[string]string{
 		"main.tf": `
 terraform {
@@ -2911,7 +2872,6 @@ func TestContext2Validate_importIntoUnexistingResourceBlock(t *testing.T) {
 }
 
 func TestContext2Validate_replaceTriggeredByInvalidAttribute(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureReplaceTB)
 	p := testProvider("test")
 	p.GetProviderSchemaResponse = getProviderSchemaResponseFromProviderSchema(&ProviderSchema{
 		ResourceTypes: map[string]*configschema.Block{
@@ -3081,7 +3041,6 @@ resource "test_instance" "b" {
 // schema of the referenced resource type, not the schema of the resource
 // containing the lifecycle block.
 func TestContext2Validate_replaceTriggeredByCrossResourceType(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureReplaceTB)
 	// "test_instance" has a "value" attribute; "test_resource" does not.
 	// "test_resource" has a "output" attribute; "test_instance" does not.
 	p := testProvider("test")

--- a/internal/tofu/node_module_variable_test.go
+++ b/internal/tofu/node_module_variable_test.go
@@ -136,8 +136,6 @@ func TestNodeModuleVariableReference_grandchild(t *testing.T) {
 }
 
 func TestNodeModuleVariableConstraints(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugReferenceProvider)
-
 	// This is a little extra convoluted to poke at some edge cases that have cropped up in the past around
 	// evaluating dependent nodes between the plan -> apply and destroy cycle.
 	m := testModuleInline(t, map[string]string{

--- a/internal/tofu/skip_destroy_test.go
+++ b/internal/tofu/skip_destroy_test.go
@@ -406,7 +406,7 @@ func TestSkipDestroy_DestroyMode_ErrorOnForgotten(t *testing.T) {
 // is still present in state.
 
 func TestSkipDestroy_Orphan(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureSkipDestroy, ExperimentalBugStateProvider)
+	SkipExperimental(t, ExperimentalFeatureSkipDestroy)
 	tests := []skipDestroyTestCase{
 		{
 			// Resource aws_instance.foo has been removed from configuration and is only present in state
@@ -448,7 +448,7 @@ func TestSkipDestroy_Orphan(t *testing.T) {
 // TestSkipDestroy_Orphan_RemovedBlockOverrides tests that orphan resource's
 // SkipDestroy attribute in state should be overridden by removed block in config.
 func TestSkipDestroy_Orphan_RemovedBlockOverrides(t *testing.T) {
-	SkipExperimental(t, ExperimentalFeatureSkipDestroy, ExperimentalBugStateProvider)
+	SkipExperimental(t, ExperimentalFeatureSkipDestroy)
 	tc := skipDestroyTestCase{
 		name: "RemovedBlockOverridesStateFlag",
 		config: `
@@ -683,7 +683,6 @@ func TestSkipDestroy_Deposed(t *testing.T) {
 // - When instances are removed/reduced state attribute protects instances even if config has destroy=true
 
 func TestSkipDestroy_Enabled_Toggle(t *testing.T) {
-	SkipExperimental(t, ExperimentalBugStateProvider)
 	tests := []skipDestroyTestCase{
 		{
 			// Resource exists in state with SkipDestroy=false, but config has enabled=false and destroy=false.


### PR DESCRIPTION
Before we start the next chunk of work for https://github.com/opentofu/opentofu/issues/3414 during the v1.14 development period, let's prune out all of the skipping flags that we disabled due to having fixed whatever problem they were guarding, so it's easier to see what's left for us to deal with.

As of this commit, the tests are reporting the following statistics for which flags are being activated most often:

```
-> 372 tests were skipped due to one or more of the following...

                                                              Missing Targeting: 73
                                                                        Unknown: 43
                                                      Missing Lifecycle Destroy: 33
                                                              Missing Importing: 26
                                                                Missing Refresh: 17
                                                    Missing Pre/Post Conditions: 16
                                            Change Different Diagnostic Wording: 16
                                                                 Missing Checks: 16
                                                          Missing Provider Meta: 13
                                                                  Missing Moved: 12
                                                                Missing Removed: 11
                                                                  Missing Taint: 11
                                                              Bug Data Resource: 10
                                                   Missing Sensitivity Handling: 9
                                                           Missing Plan Changes: 6
                                                    Change Detect Error Earlier: 4
                                   Bug CreateBeforeDestroy Not Tracked In State: 4
                                                    New testing strategy needed: 4
                                                             Missing Deprecated: 4
                                                                Missing Deposed: 4
                                                             Bug Context Cancel: 4
                                               Missing Provider Input Prompting: 3
                                                          Bug State Update Hook: 3
                                   Change New Runtime Supports Deferred Actions: 2
                      Missing Upgrade Orphan or Deposed Resource Instance State: 2
                                                                Missing Linting: 2
                                                    Change Precise Dependencies: 2
                                              Change Module Outputs (test only): 2
                                             Missing Refresh-only Planning Mode: 2
                                              Bug Not Tainted When Create Fails: 2
                                                         Missing Error Handling: 2
                                 Obsolete Ephemeral Resource Instances in State: 1
                                Bug Missing Configuration For Resource Instance: 1
  Bug Not Transferring Marks from Resource Instance Config Value to Final Value: 1
                                                          Missing Planned State: 1
                                        Bug Provider Private Data Not Preserved: 1
                                                           Change Destroy Order: 1
      Change New Runtime Doesn't Inherit Full Pre "required_providers" Behavior: 1
                                               Missing Module Lifecycle Enabled: 1
                                                         Missing Self Reference: 1
                                                      Bug Read Resource Deleted: 1
                                                   Missing Variable Condiitions: 1
                                                  Missing Store locals in state: 1
                                                         Bug Circular Reference: 1
                           Change Cursed Self Reference (legacy race condition): 1
                           Obsolete Explicit Destroy of Data Resource Instances: 1
                               Change New Runtime Doesn't Generate NoOp Changes: 1
                                                Obsolete Flat Mapped Attributes: 1
```

---

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
- [x] I (and other contributors to this PR) have not looked at the Terraform source code while implementing this PR.
